### PR TITLE
[Core][KV-transfer] MoRIIO: multi-node TP prefill→decode dispatch via published host list

### DIFF
--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -75,6 +75,7 @@ def _listen_for_register(hostname, port):
                     "dp_size": data["dp_size"],
                     "tp_size": data["tp_size"],
                     "transfer_mode": data["transfer_mode"],
+                    "node_hosts": data.get("node_hosts", []),
                 }
                 # zmq_address format: "host:IP,handshake:PORT,notify:PORT"
                 # Stored verbatim; embedded into the request_id by handle_request.
@@ -311,6 +312,11 @@ async def handle_request(api: str, request: Request):
             decode_instance_endpoint["tp_size"]
         )
         req_data_to_prefill["kv_transfer_params"]["transfer_id"] = transfer_id
+        decode_hosts = decode_instance_endpoint.get("node_hosts") or []
+        if decode_hosts:
+            req_data_to_prefill["kv_transfer_params"]["remote_hosts"] = list(
+                decode_hosts
+            )
 
         prefill_request_url = prefill_instance_endpoint["request_address"] + api
         send_prefill_task = asyncio.create_task(
@@ -348,6 +354,13 @@ async def handle_request(api: str, request: Request):
                 "remote_block_ids"
             ]
             req_data["kv_transfer_params"]["transfer_id"] = prefill_kv["transfer_id"]
+            req_data["kv_transfer_params"]["remote_hosts"] = prefill_kv.get(
+                "remote_hosts"
+            )
+
+        prefill_hosts = prefill_instance_endpoint.get("node_hosts") or []
+        if prefill_hosts:
+            req_data["kv_transfer_params"]["remote_hosts"] = list(prefill_hosts)
 
         req_data["kv_transfer_params"]["remote_dp_size"] = prefill_instance_endpoint[
             "dp_size"
@@ -355,6 +368,7 @@ async def handle_request(api: str, request: Request):
         req_data["kv_transfer_params"]["remote_tp_size"] = prefill_instance_endpoint[
             "tp_size"
         ]
+        req_data["kv_transfer_params"]["tp_size"] = prefill_instance_endpoint["tp_size"]
 
         if selected_prefill_dp_rank is not None:
             req_data["kv_transfer_params"]["remote_dp_rank"] = selected_prefill_dp_rank

--- a/tests/v1/kv_connector/unit/test_moriio_multinode_hosts.py
+++ b/tests/v1/kv_connector/unit/test_moriio_multinode_hosts.py
@@ -1,0 +1,772 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import copy
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config import KVTransferConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
+    MoRIIOConnectorMetadata,
+    MoRIIOConstants,
+    MoRIIOMode,
+    get_moriio_node_hosts,
+    get_moriio_request_id_trusted_hosts,
+    get_moriio_trusted_remote_hosts,
+    validate_moriio_remote_host,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector import (
+    MoRIIOConnectorScheduler,
+    MoRIIOConnectorWorker,
+    _pick_remote_rank_host,
+)
+
+
+@pytest.mark.parametrize(
+    ("node_hosts", "expected"),
+    [
+        ("prefill-a, prefill-b, ", ["prefill-a", "prefill-b"]),
+        (["prefill-a", " prefill-b ", ""], ["prefill-a", "prefill-b"]),
+        (None, ["local-host"]),
+    ],
+)
+def test_moriio_node_hosts_come_from_explicit_config_or_local_fallback(
+    node_hosts, expected
+):
+    config = KVTransferConfig(
+        kv_connector_extra_config={}
+        if node_hosts is None
+        else {"node_hosts": node_hosts}
+    )
+
+    assert get_moriio_node_hosts(config, "local-host") == expected
+
+
+def test_moriio_trusted_remote_hosts_explicit_or_empty():
+    config = KVTransferConfig(
+        kv_connector_extra_config={
+            "trusted_remote_hosts": "peer-a, peer-b",
+            "node_hosts": ["local-a"],
+        }
+    )
+    assert get_moriio_trusted_remote_hosts(config, ["local-a"]) == frozenset(
+        {"peer-a", "peer-b"}
+    )
+
+    config = KVTransferConfig(kv_connector_extra_config={})
+    # Opt-in: unconfigured -> empty allowlist (no enforcement), NOT the local
+    # node_hosts, so the default multi-node cross-host READ flow is not rejected.
+    assert get_moriio_trusted_remote_hosts(config, ["local-a"]) == frozenset()
+
+
+def test_connector_metadata_accepts_remote_hosts_when_trusted_unconfigured():
+    # Regression: with no trusted_remote_hosts configured the plural remote_hosts
+    # path must be a no-op (accept) so the default multi-node cross-host READ
+    # works. The earlier fallback to local node_hosts rejected every cross-host
+    # peer forwarded by the proxy.
+    metadata = MoRIIOConnectorMetadata(trusted_remote_hosts=frozenset())
+
+    metadata.add_new_req(
+        request_id="plain-request-id",
+        local_block_ids=[1],
+        kv_transfer_params={
+            "transfer_id": "tx-1",
+            "remote_block_ids": [2],
+            "remote_engine_id": "prefill-engine",
+            "remote_hosts": ["prefill-a", "prefill-b"],
+            "remote_tp_size": 16,
+        },
+    )
+
+    req_meta = metadata.reqs_to_recv["plain-request-id"]
+    assert req_meta.remote_hosts == ["prefill-a", "prefill-b"]
+
+
+@pytest.mark.parametrize(
+    ("tp_rank", "expected"),
+    [
+        (0, "prefill-a"),
+        (7, "prefill-a"),
+        (8, "prefill-b"),
+        (15, "prefill-b"),
+    ],
+)
+def test_remote_rank_host_uses_tp_rank_for_multi_host_tp(tp_rank, expected):
+    assert (
+        _pick_remote_rank_host(
+            "fallback",
+            ["prefill-a", "prefill-b"],
+            tp_size=16,
+            tp_rank=tp_rank,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("remote_dp_rank", "expected"),
+    [
+        (0, "prefill-a"),
+        (7, "prefill-a"),
+        (8, "prefill-b"),
+        (15, "prefill-b"),
+    ],
+)
+def test_remote_rank_host_uses_dp_rank_when_remote_dp_spans_hosts(
+    remote_dp_rank, expected
+):
+    assert (
+        _pick_remote_rank_host(
+            "fallback",
+            ["prefill-a", "prefill-b"],
+            tp_size=1,
+            tp_rank=0,
+            remote_dp_size=16,
+            remote_dp_rank=remote_dp_rank,
+        )
+        == expected
+    )
+
+
+def test_connector_metadata_uses_remote_hosts_for_plain_request_id():
+    metadata = MoRIIOConnectorMetadata(trusted_remote_hosts={"prefill-a", "prefill-b"})
+
+    metadata.add_new_req(
+        request_id="plain-request-id",
+        local_block_ids=[1],
+        kv_transfer_params={
+            "transfer_id": "tx-1",
+            "remote_block_ids": [2],
+            "remote_engine_id": "prefill-engine",
+            "remote_hosts": ["prefill-a", "prefill-b"],
+            "remote_tp_size": 16,
+            "remote_dp_size": 16,
+            "remote_dp_rank": 8,
+        },
+    )
+
+    req_meta = metadata.reqs_to_recv["plain-request-id"]
+    assert req_meta.remote_host == "prefill-a"
+    assert req_meta.remote_handshake_port == int(MoRIIOConstants.DEFAULT_HANDSHAKE_PORT)
+    assert req_meta.remote_notify_port == int(MoRIIOConstants.DEFAULT_NOTIFY_PORT)
+    assert req_meta.remote_hosts == ["prefill-a", "prefill-b"]
+    assert req_meta.tp_size == 16
+    assert req_meta.remote_dp_size == 16
+    assert req_meta.remote_dp_rank == 8
+
+
+def test_connector_metadata_rejects_untrusted_remote_hosts():
+    metadata = MoRIIOConnectorMetadata(trusted_remote_hosts={"prefill-a"})
+
+    with pytest.raises(ValueError, match="untrusted remote_hosts"):
+        metadata.add_new_req(
+            request_id="plain-request-id",
+            local_block_ids=[1],
+            kv_transfer_params={
+                "transfer_id": "tx-1",
+                "remote_block_ids": [2],
+                "remote_engine_id": "prefill-engine",
+                "remote_hosts": ["prefill-a", "metadata.example"],
+                "remote_tp_size": 16,
+            },
+        )
+
+
+def test_scheduler_rejects_untrusted_remote_hosts_before_notify(monkeypatch):
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.mode = MoRIIOMode.WRITE
+    scheduler.tp_size = 2
+    scheduler.dp_rank = 0
+    scheduler.transfer_id_to_request_id = {}
+    scheduler.request_id_to_transfer_id = {}
+    scheduler.trusted_remote_hosts = frozenset({"prefill-a"})
+    scheduler._request_id_trusted_hosts = frozenset()
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "send_notify_block",
+        lambda **kwargs: sent.append(kwargs),
+    )
+    request = SimpleNamespace(
+        request_id=(
+            "___prefill_addr_host:prefill-a,handshake:6301,notify:61005"
+            "___decode_addr_host:decode-a,handshake:6301,notify:61005"
+            "_0123456789abcdef0123456789abcdef"
+        ),
+        kv_transfer_params={
+            "transfer_id": "tx-1",
+            "do_remote_prefill": True,
+            "remote_hosts": ["prefill-a", "notify.example"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="untrusted remote_hosts"):
+        scheduler.update_state_after_alloc(
+            request,
+            SimpleNamespace(get_block_ids=lambda: ([1, 2],)),
+            0,
+        )
+
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_toy_proxy_forwards_node_hosts_to_prefill_and_decode(monkeypatch):
+    from examples.disaggregated.disaggregated_serving import (
+        moriio_toy_proxy_server as proxy,
+    )
+
+    captured_prefill = {}
+    captured_decode = {}
+    prefill_hosts = ["prefill-a", "prefill-b"]
+    decode_hosts = ["decode-a", "decode-b"]
+
+    class FakeRequest:
+        async def get_json(self):
+            return {"model": "test-model", "prompt": "hello", "max_tokens": 2}
+
+    async def fake_send_request_to_prefill(
+        endpoint, req_data, request_id, selected_prefill_dp_rank
+    ):
+        captured_prefill.update(
+            {
+                "endpoint": endpoint,
+                "request_id": request_id,
+                "selected_prefill_dp_rank": selected_prefill_dp_rank,
+                "req_data": copy.deepcopy(req_data),
+            }
+        )
+        return {
+            "kv_transfer_params": {
+                "remote_engine_id": "prefill-engine",
+                "remote_block_ids": [1, 2],
+                "transfer_id": req_data["kv_transfer_params"]["transfer_id"],
+                "remote_hosts": ["unused-read-mode-host"],
+            }
+        }
+
+    async def fake_start_decode_request(endpoint, req_data, request_id):
+        captured_decode.update(
+            {
+                "endpoint": endpoint,
+                "request_id": request_id,
+                "req_data": copy.deepcopy(req_data),
+            }
+        )
+        return object(), SimpleNamespace(headers={})
+
+    def fake_stream_decode_response(session, response, request_id):
+        async def stream():
+            yield b"ok"
+
+        return stream()
+
+    async def fake_make_response(response):
+        return SimpleNamespace(headers={})
+
+    monkeypatch.setattr(
+        proxy,
+        "prefill_instances",
+        [
+            {
+                "request_address": "http://prefill.example/v1",
+                "zmq_address": "host:prefill-a,handshake:6301,notify:61005",
+                "dp_size": 1,
+                "tp_size": 16,
+                "node_hosts": prefill_hosts,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        proxy,
+        "decode_instances",
+        [
+            {
+                "request_address": "http://decode.example/v1",
+                "zmq_address": "host:decode-a,handshake:6301,notify:61005",
+                "dp_size": 1,
+                "tp_size": 16,
+                "node_hosts": decode_hosts,
+            }
+        ],
+    )
+    monkeypatch.setattr(proxy, "TRANSFER_TYPE", "READ")
+    monkeypatch.setattr(proxy, "request_nums", 0)
+    monkeypatch.setattr(proxy, "send_request_to_prefill", fake_send_request_to_prefill)
+    monkeypatch.setattr(proxy, "start_decode_request", fake_start_decode_request)
+    monkeypatch.setattr(proxy, "stream_decode_response", fake_stream_decode_response)
+    monkeypatch.setattr(proxy, "make_response", fake_make_response)
+
+    await proxy.handle_request("/chat/completions", FakeRequest())
+
+    assert captured_prefill["endpoint"] == (
+        "http://prefill.example/v1/chat/completions"
+    )
+    assert (
+        captured_prefill["req_data"]["kv_transfer_params"]["remote_hosts"]
+        == decode_hosts
+    )
+    assert captured_decode["endpoint"] == "http://decode.example/v1/chat/completions"
+    assert (
+        captured_decode["req_data"]["kv_transfer_params"]["remote_hosts"]
+        == prefill_hosts
+    )
+    assert captured_decode["req_data"]["kv_transfer_params"]["tp_size"] == 16
+
+
+def _multi_host_recv_meta():
+    """Decode-side ReqMeta for a 2-node prefill peer (TP=16, DP=16)."""
+    metadata = MoRIIOConnectorMetadata(trusted_remote_hosts={"prefill-a", "prefill-b"})
+    metadata.add_new_req(
+        request_id="glue-multihost",
+        local_block_ids=[1],
+        kv_transfer_params={
+            "transfer_id": "tx-1",
+            "remote_block_ids": [2],
+            "remote_engine_id": "prefill-engine",
+            "remote_hosts": ["prefill-a", "prefill-b"],
+            "remote_tp_size": 16,
+            "remote_dp_size": 16,
+        },
+    )
+    return metadata.reqs_to_recv["glue-multihost"]
+
+
+@pytest.mark.parametrize(
+    ("tp_rank", "expected"),
+    [
+        (0, "prefill-a"),
+        (8, "prefill-b"),
+        (15, "prefill-b"),
+    ],
+)
+def test_worker_pick_remote_host_routes_by_tp_rank(tp_rank, expected):
+    # Proves _pick_remote_host feeds self.tp_rank + meta.remote_hosts into the
+    # pure picker (TP branch), so each decode worker targets its own peer node.
+    meta = _multi_host_recv_meta()
+    worker = MoRIIOConnectorWorker.__new__(MoRIIOConnectorWorker)
+    worker.tp_rank = tp_rank
+    assert worker._pick_remote_host(meta) == expected
+
+
+@pytest.mark.parametrize(
+    ("dp_rank", "expected"),
+    [
+        (0, "prefill-a"),
+        (8, "prefill-b"),
+        (15, "prefill-b"),
+    ],
+)
+def test_worker_pick_host_for_dp_rank_routes_by_dp_rank(dp_rank, expected):
+    # Proves _pick_host_for_dp_rank forwards meta.remote_dp_size + the dp_rank
+    # arg (DP branch). tp_rank is pinned to 0 so only dp_rank can move the host.
+    meta = _multi_host_recv_meta()
+    worker = MoRIIOConnectorWorker.__new__(MoRIIOConnectorWorker)
+    worker.tp_rank = 0
+    assert worker._pick_host_for_dp_rank(meta, dp_rank) == expected
+
+
+@pytest.mark.parametrize("tp_rank", [0, 7])
+def test_worker_pick_remote_host_single_host_passthrough(tp_rank):
+    # Proves the TP<=8 / single-host path is untouched: no host list means
+    # _pick_remote_host returns meta.remote_host unchanged for any tp_rank.
+    metadata = MoRIIOConnectorMetadata()
+    metadata.add_new_req(
+        request_id="glue-singlehost",
+        local_block_ids=[1],
+        kv_transfer_params={
+            "transfer_id": "tx-1",
+            "remote_block_ids": [2],
+            "remote_engine_id": "prefill-engine",
+            "remote_host": "prefill-solo",
+            "remote_handshake_port": 6301,
+            "remote_notify_port": 61005,
+            "remote_tp_size": 8,
+        },
+    )
+    meta = metadata.reqs_to_recv["glue-singlehost"]
+    assert meta.remote_hosts is None
+    worker = MoRIIOConnectorWorker.__new__(MoRIIOConnectorWorker)
+    worker.tp_rank = tp_rank
+    assert worker._pick_remote_host(meta) == "prefill-solo"
+
+
+def test_validate_moriio_remote_host():
+    trusted = frozenset({"prefill-a"})
+    key = "kv_transfer_params['remote_host']"
+
+    # (a) value=None: singular path is optional, so a missing host is a no-op.
+    validate_moriio_remote_host(None, trusted, key)
+    # (b) no trust list configured: default single-host flow stays unenforced.
+    validate_moriio_remote_host("anything.example", (), key)
+    # (c) host present in the trust list is accepted.
+    validate_moriio_remote_host("prefill-a", trusted, key)
+    # (d) host absent from a non-empty trust list is rejected.
+    with pytest.raises(ValueError, match="untrusted host"):
+        validate_moriio_remote_host("evil.example", trusted, key)
+
+
+def test_connector_metadata_rejects_untrusted_remote_host_singular():
+    metadata = MoRIIOConnectorMetadata(trusted_remote_hosts={"prefill-a"})
+
+    # Ports are supplied so the request_id parse branch is skipped: without the
+    # singular-host guard the untrusted host would be accepted outright.
+    with pytest.raises(ValueError, match="untrusted host"):
+        metadata.add_new_req(
+            request_id="plain-request-id",
+            local_block_ids=[1],
+            kv_transfer_params={
+                "transfer_id": "tx-1",
+                "remote_block_ids": [2],
+                "remote_engine_id": "prefill-engine",
+                "remote_host": "evil.example",
+                "remote_handshake_port": 6301,
+                "remote_notify_port": 61005,
+                "remote_tp_size": 16,
+            },
+        )
+
+
+def test_connector_metadata_accepts_trusted_remote_host_singular():
+    metadata = MoRIIOConnectorMetadata(trusted_remote_hosts={"prefill-a"})
+
+    metadata.add_new_req(
+        request_id="plain-request-id",
+        local_block_ids=[1],
+        kv_transfer_params={
+            "transfer_id": "tx-1",
+            "remote_block_ids": [2],
+            "remote_engine_id": "prefill-engine",
+            "remote_host": "prefill-a",
+            "remote_handshake_port": 6301,
+            "remote_notify_port": 61005,
+            "remote_tp_size": 16,
+        },
+    )
+
+    # A trusted singular host survives validation and is registered as the peer.
+    assert metadata.reqs_to_recv["plain-request-id"].remote_host == "prefill-a"
+
+
+def test_scheduler_release_write_rejects_untrusted_remote_host(monkeypatch):
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.trusted_remote_hosts = frozenset({"prefill-a"})
+    scheduler.tp_size = 1
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "_send_transfer_release",
+        lambda *args, **kwargs: sent.append((args, kwargs)),
+    )
+
+    # remote_notify_port present -> request_id parse is skipped; the guard must
+    # fail closed before any release dial reaches the untrusted host.
+    with pytest.raises(ValueError, match="untrusted host"):
+        scheduler._release_write_prefill_blocks(
+            "req",
+            {
+                "transfer_id": "tx",
+                "remote_host": "evil.example",
+                "remote_notify_port": 6100,
+            },
+        )
+
+    assert sent == []
+
+
+def test_scheduler_release_write_sends_for_trusted_remote_host(monkeypatch):
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.trusted_remote_hosts = frozenset({"prefill-a"})
+    scheduler._request_id_trusted_hosts = frozenset()
+    scheduler.tp_size = 1
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "_send_transfer_release",
+        lambda transfer_id, host, port: sent.append((transfer_id, host, port)),
+    )
+
+    scheduler._release_write_prefill_blocks(
+        "req",
+        {"transfer_id": "tx", "remote_host": "prefill-a", "remote_notify_port": 6100},
+    )
+
+    # A trusted host reaches the release dial with the resolved transfer target.
+    assert sent == [("tx", "prefill-a", 6100)]
+
+
+def test_scheduler_release_write_none_host_uses_request_id(monkeypatch):
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.trusted_remote_hosts = frozenset({"prefill-a"})
+    scheduler._request_id_trusted_hosts = frozenset()
+    scheduler.tp_size = 1
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "_send_transfer_release",
+        lambda transfer_id, host, port: sent.append((transfer_id, host, port)),
+    )
+
+    request_id = (
+        "___prefill_addr_host:prefill-a,handshake:6301,notify:6100"
+        "___decode_addr_host:decode-a,handshake:6301,notify:6100"
+        "_0123456789abcdef0123456789abcdef"
+    )
+
+    # remote_host omitted: the guard returns early (no false reject) and the
+    # notify address is recovered from the request_id, then dialed.
+    scheduler._release_write_prefill_blocks(request_id, {"transfer_id": "tx"})
+
+    assert sent == [("tx", "prefill-a", 6100)]
+
+
+def test_scheduler_update_state_rejects_untrusted_remote_host_singular(monkeypatch):
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.mode = MoRIIOMode.WRITE
+    scheduler.tp_size = 2
+    scheduler.dp_rank = 0
+    scheduler.transfer_id_to_request_id = {}
+    scheduler.request_id_to_transfer_id = {}
+    scheduler.trusted_remote_hosts = frozenset({"prefill-a"})
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "send_notify_block",
+        lambda **kwargs: sent.append(kwargs),
+    )
+    request = SimpleNamespace(
+        request_id=(
+            "___prefill_addr_host:prefill-a,handshake:6301,notify:61005"
+            "___decode_addr_host:decode-a,handshake:6301,notify:61005"
+            "_0123456789abcdef0123456789abcdef"
+        ),
+        kv_transfer_params={
+            "transfer_id": "tx-1",
+            "do_remote_prefill": True,
+            "remote_host": "evil.example",
+            "remote_notify_port": 61005,
+        },
+    )
+
+    # remote_notify_port present -> parse skipped; the singular host must be
+    # rejected before any notify is emitted to the untrusted peer.
+    with pytest.raises(ValueError, match="untrusted host"):
+        scheduler.update_state_after_alloc(
+            request,
+            SimpleNamespace(get_block_ids=lambda: ([1, 2],)),
+            0,
+        )
+
+    assert sent == []
+
+
+def _request_id_with_prefill_host(host):
+    """Router request_id whose embedded *prefill* peer host is ``host``.
+
+    Consumer-side resolution (``is_producer=False``) matches ``_PREFILL_ZMQ_RE``
+    and parses the prefill zmq_address, so ``host`` becomes the
+    request_id-derived ``remote_host`` (notify port 6100).
+    """
+    return (
+        f"___prefill_addr_host:{host},handshake:6301,notify:6100"
+        "___decode_addr_host:decode-a,handshake:6301,notify:6100"
+        "_0123456789abcdef0123456789abcdef"
+    )
+
+
+def test_request_id_trusted_hosts_empty_when_unconfigured():
+    # Opt-in: without an explicit trusted_remote_hosts the allowlist is empty,
+    # which makes the request_id-derived validate a no-op (default flow intact).
+    config = KVTransferConfig(kv_connector_extra_config={})
+    assert get_moriio_request_id_trusted_hosts(config, ["local-1"]) == frozenset()
+
+
+def test_request_id_trusted_hosts_union_node_hosts_when_configured():
+    # Configured: explicit peers UNION this instance's own node_hosts (the local
+    # host is trivially safe to accept from a request_id).
+    config = KVTransferConfig(
+        kv_connector_extra_config={"trusted_remote_hosts": "prefill-a"}
+    )
+    assert get_moriio_request_id_trusted_hosts(config, ["local-1"]) == frozenset(
+        {"prefill-a", "local-1"}
+    )
+
+
+def test_add_new_req_rejects_untrusted_request_id_host():
+    # No direct remote_host -> host is resolved from the client-controllable
+    # request_id; with a configured allowlist an untrusted host must be rejected.
+    metadata = MoRIIOConnectorMetadata(request_id_trusted_hosts={"prefill-a"})
+
+    with pytest.raises(ValueError, match="untrusted host"):
+        metadata.add_new_req(
+            request_id=_request_id_with_prefill_host("evil.example"),
+            local_block_ids=[1],
+            kv_transfer_params={"transfer_id": "tx-1"},
+        )
+
+    assert metadata.reqs_to_recv == {}
+
+
+def test_add_new_req_accepts_trusted_request_id_host():
+    metadata = MoRIIOConnectorMetadata(request_id_trusted_hosts={"prefill-a"})
+    request_id = _request_id_with_prefill_host("prefill-a")
+
+    metadata.add_new_req(
+        request_id=request_id,
+        local_block_ids=[1],
+        kv_transfer_params={"transfer_id": "tx-1", "remote_block_ids": [2]},
+    )
+
+    # A request_id host inside the allowlist survives and is registered.
+    assert metadata.reqs_to_recv[request_id].remote_host == "prefill-a"
+
+
+def test_add_new_req_skips_request_id_validation_when_unconfigured():
+    # No-regression: unconfigured allowlist (empty) -> the request_id-derived
+    # host is NOT validated, so an arbitrary embedded host flows through exactly
+    # as it did before the opt-in guard existed.
+    metadata = MoRIIOConnectorMetadata()
+    request_id = _request_id_with_prefill_host("evil.example")
+
+    metadata.add_new_req(
+        request_id=request_id,
+        local_block_ids=[1],
+        kv_transfer_params={"transfer_id": "tx-1"},
+    )
+
+    assert metadata.reqs_to_recv[request_id].remote_host == "evil.example"
+
+
+def test_scheduler_release_rejects_untrusted_request_id_host(monkeypatch):
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.trusted_remote_hosts = frozenset({"prefill-a"})
+    scheduler._request_id_trusted_hosts = frozenset({"prefill-a"})
+    scheduler.tp_size = 1
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "_send_transfer_release",
+        lambda *args, **kwargs: sent.append((args, kwargs)),
+    )
+
+    # remote_host omitted -> host recovered from the request_id; an untrusted
+    # host must fail closed before any release dial leaves the box.
+    with pytest.raises(ValueError, match="untrusted host"):
+        scheduler._release_write_prefill_blocks(
+            _request_id_with_prefill_host("evil.example"),
+            {"transfer_id": "tx"},
+        )
+
+    assert sent == []
+
+
+def test_scheduler_release_accepts_trusted_request_id_host(monkeypatch):
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.trusted_remote_hosts = frozenset({"prefill-a"})
+    scheduler._request_id_trusted_hosts = frozenset({"prefill-a"})
+    scheduler.tp_size = 1
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "_send_transfer_release",
+        lambda transfer_id, host, port: sent.append((transfer_id, host, port)),
+    )
+
+    scheduler._release_write_prefill_blocks(
+        _request_id_with_prefill_host("prefill-a"),
+        {"transfer_id": "tx"},
+    )
+
+    # A request_id host inside the allowlist reaches the release dial.
+    assert sent == [("tx", "prefill-a", 6100)]
+
+
+def test_scheduler_release_skips_request_id_validation_when_unconfigured(monkeypatch):
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    # Effective direct-host trust list is populated (its unconfigured default is
+    # node_hosts), but the request_id allowlist is empty. The request_id host
+    # must be checked against the EMPTY allowlist, not the effective one -- else
+    # the opt-in default flow would false-reject legitimate peers.
+    scheduler.trusted_remote_hosts = frozenset({"prefill-a"})
+    scheduler._request_id_trusted_hosts = frozenset()
+    scheduler.tp_size = 1
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "_send_transfer_release",
+        lambda transfer_id, host, port: sent.append((transfer_id, host, port)),
+    )
+
+    scheduler._release_write_prefill_blocks(
+        _request_id_with_prefill_host("evil.example"),
+        {"transfer_id": "tx"},
+    )
+
+    # Unconfigured request_id trust -> arbitrary embedded host flows through.
+    assert sent == [("tx", "evil.example", 6100)]
+
+
+def test_scheduler_update_state_rejects_untrusted_request_id_host(monkeypatch):
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.mode = MoRIIOMode.WRITE
+    scheduler.tp_size = 2
+    scheduler.dp_rank = 0
+    scheduler.transfer_id_to_request_id = {}
+    scheduler.request_id_to_transfer_id = {}
+    scheduler.trusted_remote_hosts = frozenset({"prefill-a"})
+    scheduler._request_id_trusted_hosts = frozenset({"prefill-a"})
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "send_notify_block",
+        lambda **kwargs: sent.append(kwargs),
+    )
+    request = SimpleNamespace(
+        request_id=_request_id_with_prefill_host("evil.example"),
+        kv_transfer_params={"transfer_id": "tx-1", "do_remote_prefill": True},
+    )
+
+    # remote_host omitted -> resolved from request_id; the untrusted host must be
+    # rejected before any notify reaches the peer.
+    with pytest.raises(ValueError, match="untrusted host"):
+        scheduler.update_state_after_alloc(
+            request,
+            SimpleNamespace(get_block_ids=lambda: ([1, 2],)),
+            0,
+        )
+
+    assert sent == []
+
+
+def test_scheduler_update_state_skips_request_id_validation_when_unconfigured(
+    monkeypatch,
+):
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.mode = MoRIIOMode.WRITE
+    scheduler.tp_size = 1
+    scheduler.dp_rank = 0
+    scheduler.transfer_id_to_request_id = {}
+    scheduler.request_id_to_transfer_id = {}
+    scheduler.trusted_remote_hosts = frozenset({"prefill-a"})
+    scheduler._request_id_trusted_hosts = frozenset()
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "send_notify_block",
+        lambda **kwargs: sent.append(kwargs),
+    )
+    request = SimpleNamespace(
+        request_id=_request_id_with_prefill_host("evil.example"),
+        kv_transfer_params={"transfer_id": "tx-1", "do_remote_prefill": True},
+    )
+
+    # No-regression: unconfigured request_id trust -> arbitrary embedded host is
+    # accepted and the notify path proceeds to the resolved peer.
+    scheduler.update_state_after_alloc(
+        request,
+        SimpleNamespace(get_block_ids=lambda: ([1, 2],)),
+        0,
+    )
+
+    assert [kw["host"] for kw in sent] == ["evil.example"]

--- a/tests/v1/kv_connector/unit/test_moriio_routing_fairness.py
+++ b/tests/v1/kv_connector/unit/test_moriio_routing_fairness.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Hardware-fair KV-read routing across MoRIIO heterogeneous P/D configs.
+
+Dependency-light (no GPU / ROCm / mori): builds bare ``MoRIIOConnectorWorker``
+instances via ``object.__new__`` and drives the REAL read-source routing
+decision (``_resolve_read_source`` / ``_next_flex_tp_rank``) directly -- no
+routing logic is re-implemented here, so a future change to those functions is
+what these tests exercise.
+
+Scope -- the CONNECTOR (decode-side) read routing. The connector never selects
+the prefill instance; the proxy does and hands the connector a ``remote_host`` +
+``remote_dp_rank`` per request. The connector's only fairness lever is WHICH
+prefill (dp, tp) rank each read targets, and the RFC's deployments collapse to
+three real connector behaviours:
+
+    symmetric TP  (TP prefill + TP decode)  -> decode tp_k reads prefill tp_k
+    flexible      (TP prefill + DP decode)  -> round-robin over prefill tp0..N-1
+    owner DP      (DP prefill, any decode)  -> read the owner rank, tp0
+
+These assume the proxy delivers a FAIR request stream (each prefill instance +
+owner dp-rank an equal share) and verify the connector never re-introduces a
+bottleneck. That proxy contract is checked separately against the real
+``flat_interleaved_dp_route`` in the toy-proxy tests (PR #46115).
+
+A node runs one of two modes (8 GPUs each):
+  * TP8   -> (dp_size, tp_size) = (1, 8); MLA latent KV REPLICATED on all ranks.
+  * DP8EP -> (dp_size, tp_size) = (8, 1); KV PARTITIONED, one owner rank/request.
+"""
+
+from collections import Counter
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
+    ReqMeta,
+    get_port_offset,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector import (
+    MoRIIOConnectorWorker,
+)
+
+MODE_DIMS = {"TP8": (1, 8), "DP8EP": (8, 1)}  # (dp_size, tp_size), 8 GPUs/node
+
+
+@dataclass(frozen=True)
+class PDConfig:
+    name: str
+    p_mode: str
+    d_mode: str
+
+    @property
+    def p_dp(self) -> int:
+        return MODE_DIMS[self.p_mode][0]
+
+    @property
+    def p_tp(self) -> int:
+        return MODE_DIMS[self.p_mode][1]
+
+    @property
+    def d_dp(self) -> int:
+        return MODE_DIMS[self.d_mode][0]
+
+    @property
+    def d_tp(self) -> int:
+        return MODE_DIMS[self.d_mode][1]
+
+    @property
+    def n_prefill_gpus(self) -> int:
+        return self.p_dp * self.p_tp
+
+
+CONFIGS = [
+    PDConfig("1P_TP8:1D_TP8", "TP8", "TP8"),
+    PDConfig("2P_TP8:1D_DP8EP", "TP8", "DP8EP"),
+    PDConfig("2P_TP8:2D_TP8", "TP8", "TP8"),
+    PDConfig("2P_DP8EP:3D_DP8EP", "DP8EP", "DP8EP"),
+    PDConfig("2P_DP8EP:4D_TP8", "DP8EP", "TP8"),
+]
+CONFIG_IDS = [c.name for c in CONFIGS]
+
+
+def make_decode_worker(*, world_size: int, tp_rank: int, dp_rank: int):
+    w = object.__new__(MoRIIOConnectorWorker)
+    w.world_size = world_size
+    w.tp_rank = tp_rank
+    w.dp_rank = dp_rank
+    w.use_mla = True
+    return w
+
+
+def make_meta(*, p_tp: int, p_dp: int, remote_dp_rank: int, host: str = "phost0"):
+    return ReqMeta(
+        transfer_id="t",
+        local_block_ids=[1],
+        remote_block_ids=[2],
+        remote_host=host,
+        remote_port=1234,
+        remote_handshake_port=6301,
+        remote_notify_port=61005,
+        remote_engine_id=f"{host}:6301",
+        tp_size=p_tp,
+        remote_dp_size=p_dp,
+        remote_dp_rank=remote_dp_rank,
+    )
+
+
+def build_decode_workers(cfg: PDConfig) -> list:
+    """Decode workers that issue reads for one prefill instance. A TP decode
+    instance reads from every tp rank; a DP decode instance from each dp-rank
+    worker. Reused across requests so per-worker round-robin state advances."""
+    if cfg.d_tp > 1:
+        return [
+            make_decode_worker(world_size=cfg.d_tp, tp_rank=r, dp_rank=0)
+            for r in range(cfg.d_tp)
+        ]
+    return [
+        make_decode_worker(world_size=1, tp_rank=0, dp_rank=d)
+        for d in range(cfg.d_dp)
+    ]
+
+
+def prefill_target_multiset(cfg: PDConfig, rounds: int) -> Counter:
+    """Drive the REAL _resolve_read_source over a fair input stream; tally which
+    prefill GPU each read targets. The only modelled assumption is the proxy
+    contract -- each owner dp-rank delivered equally (``for owner_dp in
+    range(p_dp)``); no proxy algorithm is reproduced."""
+    workers = build_decode_workers(cfg)
+    hits: Counter = Counter()
+    for _ in range(rounds):
+        for owner_dp in range(cfg.p_dp):
+            for worker in workers:
+                meta = make_meta(
+                    p_tp=cfg.p_tp, p_dp=cfg.p_dp, remote_dp_rank=owner_dp
+                )
+                chosen_tp, _flexible = worker._resolve_read_source(meta)
+                target = get_port_offset(owner_dp, chosen_tp, cfg.p_tp)
+                assert 0 <= target < cfg.n_prefill_gpus
+                hits[target] += 1
+    return hits
+
+
+@pytest.mark.parametrize("cfg", CONFIGS, ids=CONFIG_IDS)
+def test_kv_read_load_is_hardware_fair(cfg: PDConfig) -> None:
+    # rounds a multiple of p_tp so the round-robin closes on an exact cycle.
+    hits = prefill_target_multiset(cfg, rounds=16)
+    gpus = set(range(cfg.n_prefill_gpus))
+    assert set(hits) == gpus, f"unused prefill GPUs: {sorted(gpus - set(hits))}"
+    assert max(hits.values()) == min(hits.values()), dict(sorted(hits.items()))
+
+
+@pytest.mark.parametrize("cfg", CONFIGS, ids=CONFIG_IDS)
+def test_flexible_gate_fires_only_for_tp_prefill_dp_decode(cfg: PDConfig) -> None:
+    flags = set()
+    for worker in build_decode_workers(cfg):
+        meta = make_meta(p_tp=cfg.p_tp, p_dp=cfg.p_dp, remote_dp_rank=0)
+        _chosen, flexible = worker._resolve_read_source(meta)
+        flags.add(flexible)
+    is_mirror = cfg.d_tp == 1 and cfg.p_dp == 1 and cfg.p_tp > 1
+    assert flags == {is_mirror}
+
+
+def test_symmetric_tp_is_a_bijection() -> None:
+    targets = []
+    for tp_rank in range(8):
+        worker = make_decode_worker(world_size=8, tp_rank=tp_rank, dp_rank=0)
+        chosen_tp, flexible = worker._resolve_read_source(
+            make_meta(p_tp=8, p_dp=1, remote_dp_rank=0)
+        )
+        assert not flexible
+        targets.append(chosen_tp)
+    assert sorted(targets) == list(range(8))
+
+
+def test_owner_dp_read_is_faithful_and_covers_every_rank() -> None:
+    worker = make_decode_worker(world_size=8, tp_rank=3, dp_rank=0)
+    targets = []
+    for owner_dp in range(8):
+        chosen_tp, flexible = worker._resolve_read_source(
+            make_meta(p_tp=1, p_dp=8, remote_dp_rank=owner_dp)
+        )
+        assert not flexible
+        assert chosen_tp == 0  # p_tp == 1, only tp0 exists
+        targets.append(get_port_offset(owner_dp, chosen_tp, 1))
+    assert sorted(targets) == list(range(8))
+
+
+def test_flexible_round_robin_is_deterministic_uniform_and_staggered() -> None:
+    w0 = make_decode_worker(world_size=1, tp_rank=0, dp_rank=0)
+    seq = [w0._next_flex_tp_rank(8) for _ in range(64)]
+    assert seq[:8] == list(range(8))
+    assert Counter(seq) == Counter({t: 8 for t in range(8)})
+
+    first_pick = [
+        make_decode_worker(
+            world_size=1, tp_rank=0, dp_rank=d
+        )._next_flex_tp_rank(8)
+        for d in range(8)
+    ]
+    assert sorted(first_pick) == list(range(8))
+
+
+def test_read_blocks_for_req_threads_chosen_tp() -> None:
+    # The resolved (chosen_tp, flexible) must reach _read_blocks, which keys the
+    # session AND the notify port off that single value -- so a read and its
+    # completion notify address the same prefill rank.
+    worker = make_decode_worker(world_size=1, tp_rank=0, dp_rank=3)
+    worker._read_blocks = MagicMock()
+    worker._read_blocks_for_req("r", make_meta(p_tp=8, p_dp=1, remote_dp_rank=0))
+    kw = worker._read_blocks.call_args.kwargs
+    assert kw["flexible"] is True
+    assert kw["chosen_tp"] == 3  # first flexible pick = dp_rank seed
+    assert get_port_offset(0, kw["chosen_tp"], 8) == 3

--- a/tests/v1/kv_connector/unit/test_moriio_routing_fairness.py
+++ b/tests/v1/kv_connector/unit/test_moriio_routing_fairness.py
@@ -117,8 +117,7 @@ def build_decode_workers(cfg: PDConfig) -> list:
             for r in range(cfg.d_tp)
         ]
     return [
-        make_decode_worker(world_size=1, tp_rank=0, dp_rank=d)
-        for d in range(cfg.d_dp)
+        make_decode_worker(world_size=1, tp_rank=0, dp_rank=d) for d in range(cfg.d_dp)
     ]
 
 
@@ -132,9 +131,7 @@ def prefill_target_multiset(cfg: PDConfig, rounds: int) -> Counter:
     for _ in range(rounds):
         for owner_dp in range(cfg.p_dp):
             for worker in workers:
-                meta = make_meta(
-                    p_tp=cfg.p_tp, p_dp=cfg.p_dp, remote_dp_rank=owner_dp
-                )
+                meta = make_meta(p_tp=cfg.p_tp, p_dp=cfg.p_dp, remote_dp_rank=owner_dp)
                 chosen_tp, _flexible = worker._resolve_read_source(meta)
                 target = get_port_offset(owner_dp, chosen_tp, cfg.p_tp)
                 assert 0 <= target < cfg.n_prefill_gpus
@@ -194,9 +191,7 @@ def test_flexible_round_robin_is_deterministic_uniform_and_staggered() -> None:
     assert Counter(seq) == Counter({t: 8 for t in range(8)})
 
     first_pick = [
-        make_decode_worker(
-            world_size=1, tp_rank=0, dp_rank=d
-        )._next_flex_tp_rank(8)
+        make_decode_worker(world_size=1, tp_rank=0, dp_rank=d)._next_flex_tp_rank(8)
         for d in range(8)
     ]
     assert sorted(first_pick) == list(range(8))

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -422,6 +422,10 @@ class ReqMeta:
     remote_engine_id: str
     tp_size: int
     remote_dp_size: int
+    # Prefill DP rank that owns this request's KV (forwarded by the proxy). The
+    # read must target this rank's memory registration; the default 0 preserves
+    # the symmetric single-DP behaviour.
+    remote_dp_rank: int = 0
 
 
 class MoRIIOConnectorMetadata(KVConnectorMetadata):
@@ -475,6 +479,7 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             remote_notify_port=int(remote_notify_port),
             tp_size=kv_transfer_params.get("tp_size", 1),
             remote_dp_size=kv_transfer_params.get("remote_dp_size", 1),
+            remote_dp_rank=kv_transfer_params.get("remote_dp_rank", 0),
         )
         if write_mode:
             self.reqs_to_save[request_id] = _req

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -4,7 +4,7 @@ import contextlib
 import os
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Collection, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -203,6 +203,106 @@ def resolve_host_ip(extra_config: dict) -> str:
     return extra_config.get("host_ip") or get_ip()
 
 
+def _normalize_node_hosts(value: Any, config_key: str) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [host.strip() for host in value.split(",") if host.strip()]
+    try:
+        return [str(host).strip() for host in value if str(host).strip()]
+    except TypeError as exc:
+        raise ValueError(
+            f"{config_key} must be a comma-separated string or iterable of hosts"
+        ) from exc
+
+
+def get_moriio_node_hosts(
+    kv_transfer_config: KVTransferConfig, default_host: str
+) -> list[str]:
+    extra_config = kv_transfer_config.kv_connector_extra_config
+    node_hosts = _normalize_node_hosts(
+        extra_config.get("node_hosts"),
+        "kv_connector_extra_config['node_hosts']",
+    )
+    if node_hosts:
+        return node_hosts
+
+    return [default_host]
+
+
+def get_moriio_trusted_remote_hosts(
+    kv_transfer_config: KVTransferConfig,
+    node_hosts: Collection[str],
+) -> frozenset[str]:
+    extra_config = kv_transfer_config.kv_connector_extra_config
+    trusted_remote_hosts = _normalize_node_hosts(
+        extra_config.get("trusted_remote_hosts"),
+        "kv_connector_extra_config['trusted_remote_hosts']",
+    )
+    # Opt-in: only enforce when ``trusted_remote_hosts`` is explicitly set, so
+    # the default cross-host flow is unchanged (mirrors the singular and
+    # request_id trusted-host paths). Empty means "no allowlist configured".
+    return frozenset(trusted_remote_hosts)
+
+
+def validate_moriio_remote_hosts(
+    value: Any,
+    trusted_remote_hosts: Collection[str],
+    config_key: str,
+) -> list[str]:
+    remote_hosts = _normalize_node_hosts(value, config_key)
+    if not remote_hosts:
+        return []
+    if not trusted_remote_hosts:
+        # No allowlist configured -> opt-in no-op (accept), matching
+        # ``validate_moriio_remote_host`` and the request_id path.
+        return remote_hosts
+    untrusted_hosts = sorted(set(remote_hosts).difference(trusted_remote_hosts))
+    if untrusted_hosts:
+        raise ValueError(
+            f"{config_key} contains untrusted remote_hosts: {untrusted_hosts}"
+        )
+    return remote_hosts
+
+
+def validate_moriio_remote_host(
+    value: str | None,
+    trusted_remote_hosts: Collection[str],
+    config_key: str,
+) -> None:
+    """Reject a directly-supplied peer host that is not trusted.
+
+    Mirrors ``validate_moriio_remote_hosts`` for the single-host path. Only
+    enforced when ``trusted_remote_hosts`` is configured, so the default
+    single-host flow is unchanged when no trust list is set.
+    """
+    if value is None or not trusted_remote_hosts:
+        return
+    if value not in trusted_remote_hosts:
+        raise ValueError(f"{config_key} contains untrusted host: {value!r}")
+
+
+def get_moriio_request_id_trusted_hosts(
+    kv_transfer_config: KVTransferConfig,
+    node_hosts: Collection[str],
+) -> frozenset[str]:
+    """Allowlist for peer hosts parsed from the request_id.
+
+    The request_id can carry a client-supplied ``X-Request-Id``, so a host
+    parsed from it is only trusted when the operator explicitly set
+    ``trusted_remote_hosts``. Returns an empty set when unconfigured (the
+    default flow is left unvalidated); otherwise the configured peers plus this
+    instance's own ``node_hosts`` (the local host is trivially safe).
+    """
+    explicit = _normalize_node_hosts(
+        kv_transfer_config.kv_connector_extra_config.get("trusted_remote_hosts"),
+        "kv_connector_extra_config['trusted_remote_hosts']",
+    )
+    if not explicit:
+        return frozenset()
+    return frozenset(explicit) | frozenset(node_hosts)
+
+
 _DEPRECATED_ENV_VARS: dict[str, str] = {
     "VLLM_MORIIO_CONNECTOR_READ_MODE": "read_mode",
     "VLLM_MORIIO_QP_PER_TRANSFER": "qp_per_transfer",
@@ -244,6 +344,7 @@ class MoRIIOConfig:
     post_batch_size: int = -1
     num_workers: int = 1
     backend: str = "rdma"
+    node_hosts: list[str] = field(default_factory=list)
 
     @classmethod
     def from_vllm_config(cls, vllm_config: VllmConfig) -> "MoRIIOConfig":
@@ -301,8 +402,10 @@ class MoRIIOConfig:
             extra_config.get("defer_timeout", MoRIIOConstants.DEFAULT_DEFER_TIMEOUT)
         )
 
+        local_ip = resolve_host_ip(extra_config)
+
         return cls(
-            local_ip=resolve_host_ip(extra_config),
+            local_ip=local_ip,
             local_kv_port=get_open_port(),
             proxy_ip=extra_config["proxy_ip"],
             local_ping_port=get_open_port(),
@@ -319,6 +422,7 @@ class MoRIIOConfig:
             post_batch_size=int(extra_config.get("post_batch_size", -1)),
             num_workers=int(extra_config.get("num_workers", 1)),
             backend=backend,
+            node_hosts=get_moriio_node_hosts(kv_transfer_config, local_ip),
             transfer_timeout=transfer_timeout,
             defer_timeout=defer_timeout,
         )
@@ -426,14 +530,25 @@ class ReqMeta:
     # read must target this rank's memory registration; the default 0 preserves
     # the symmetric single-DP behaviour.
     remote_dp_rank: int = 0
+    # Ordered list of all prefill-instance host IPs for multi-node TP.
+    # Each decode worker picks remote_hosts[tp_rank // ranks_per_node] as its
+    # actual peer host for handshake + post-transfer notify. None or len<=1
+    # falls back to single-host behaviour (remote_host).
+    remote_hosts: list[str] | None = None
 
 
 class MoRIIOConnectorMetadata(KVConnectorMetadata):
-    def __init__(self):
+    def __init__(
+        self,
+        trusted_remote_hosts: Collection[str] = (),
+        request_id_trusted_hosts: Collection[str] = (),
+    ):
         self.reqs_to_recv: dict[ReqId, ReqMeta] = {}
         self.reqs_to_save: dict[ReqId, ReqMeta] = {}
         self.reqs_to_send: dict[ReqId, float] = {}
         self.transfer_id_to_request_id: dict[TransferId, ReqId] = {}
+        self.trusted_remote_hosts = frozenset(trusted_remote_hosts)
+        self._request_id_trusted_hosts = frozenset(request_id_trusted_hosts)
 
     def __repr__(self):
         return (
@@ -453,8 +568,18 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
         transfer_id = kv_transfer_params["transfer_id"]
 
         remote_host = kv_transfer_params.get("remote_host")
+        validate_moriio_remote_host(
+            remote_host,
+            self.trusted_remote_hosts,
+            "kv_transfer_params['remote_host']",
+        )
         remote_handshake_port = kv_transfer_params.get("remote_handshake_port")
         remote_notify_port = kv_transfer_params.get("remote_notify_port")
+        remote_hosts = validate_moriio_remote_hosts(
+            kv_transfer_params.get("remote_hosts"),
+            self.trusted_remote_hosts,
+            "kv_transfer_params['remote_hosts']",
+        )
         if (
             remote_host is None
             or remote_handshake_port is None
@@ -463,23 +588,58 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             # Parse host/ports from the request_id. The router embeds both
             # zmq_addresses in PD request IDs, but WRITE decode requests may carry
             # a plain request ID and get the remote address via kv_transfer_params.
-            peer_zmq = get_peer_zmq_from_request_id(request_id, is_producer=write_mode)
-            remote_host, remote_handshake_port, remote_notify_port = (
-                parse_moriio_zmq_address(peer_zmq)
-            )
+            try:
+                peer_zmq = get_peer_zmq_from_request_id(
+                    request_id, is_producer=write_mode
+                )
+                remote_host, remote_handshake_port, remote_notify_port = (
+                    parse_moriio_zmq_address(peer_zmq)
+                )
+            except ValueError:
+                # Normalize remote_hosts: callers may pass a list (per-rank
+                # host vector from the proxy) or a single host string from
+                # older proxy versions. A bare string would silently slice
+                # into "1." for "172.30.0.1" if we just did remote_hosts[0].
+                if not remote_hosts:
+                    raise ValueError(
+                        f"MoRIIO add_new_req: could not resolve peer host/ports "
+                        f"for {request_id!r}; neither request_id parse nor "
+                        f"kv_transfer_params.remote_hosts provided them"
+                    ) from None
+                remote_host = remote_hosts[0]
+                remote_handshake_port = int(MoRIIOConstants.DEFAULT_HANDSHAKE_PORT)
+                remote_notify_port = int(MoRIIOConstants.DEFAULT_NOTIFY_PORT)
 
+        # request_id-derived peer host: the request_id can carry a client
+        # X-Request-Id, so validate it against the operator's allowlist when
+        # configured (empty set = unconfigured = no-op, keeping the default
+        # flow unchanged). Direct/plural hosts were already checked above.
+        validate_moriio_remote_host(
+            remote_host,
+            self._request_id_trusted_hosts,
+            "request_id-derived remote_host",
+        )
+
+        # If remote block metadata is absent, use empty defaults so the request
+        # remains a no-op.
         _req = ReqMeta(
             transfer_id=transfer_id,
             local_block_ids=local_block_ids,
-            remote_block_ids=kv_transfer_params["remote_block_ids"],
-            remote_engine_id=kv_transfer_params["remote_engine_id"],
+            remote_block_ids=kv_transfer_params.get("remote_block_ids", []),
+            remote_engine_id=kv_transfer_params.get("remote_engine_id", ""),
             remote_host=remote_host,
             remote_port=int(remote_handshake_port),
             remote_handshake_port=int(remote_handshake_port),
             remote_notify_port=int(remote_notify_port),
-            tp_size=kv_transfer_params.get("tp_size", 1),
+            # Callers may forward `remote_tp_size` without `tp_size`.
+            # Prefer `tp_size`, then fall back to `remote_tp_size`, then 1.
+            tp_size=kv_transfer_params.get(
+                "tp_size",
+                kv_transfer_params.get("remote_tp_size", 1),
+            ),
             remote_dp_size=kv_transfer_params.get("remote_dp_size", 1),
             remote_dp_rank=kv_transfer_params.get("remote_dp_rank", 0),
+            remote_hosts=remote_hosts or None,
         )
         if write_mode:
             self.reqs_to_save[request_id] = _req

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -37,12 +37,17 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     TransferId,
     WriteTask,
     get_moriio_mode,
+    get_moriio_node_hosts,
+    get_moriio_request_id_trusted_hosts,
+    get_moriio_trusted_remote_hosts,
     get_peer_zmq_from_request_id,
     get_port_offset,
     get_role,
     parse_moriio_zmq_address,
     resolve_host_ip,
     set_role,
+    validate_moriio_remote_host,
+    validate_moriio_remote_hosts,
     zmq_ctx,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_engine import (
@@ -184,6 +189,28 @@ def resolve_moriio_transfer_ack(
     notification_counts.pop(transfer_id, None)
     completed_transfer_ids.add(transfer_id)
     return transfer_id
+
+
+def _pick_remote_rank_host(
+    default_host: str,
+    remote_hosts: list[str] | None,
+    tp_size: int,
+    tp_rank: int,
+    remote_dp_size: int = 1,
+    remote_dp_rank: int = 0,
+) -> str:
+    if remote_hosts and len(remote_hosts) > 1:
+        n_hosts = len(remote_hosts)
+        if int(remote_dp_size) >= n_hosts:
+            dp_per_node = max(1, int(remote_dp_size) // n_hosts)
+            node_idx = int(remote_dp_rank) // dp_per_node
+            if 0 <= node_idx < n_hosts:
+                return remote_hosts[node_idx]
+        ranks_per_node = max(1, int(tp_size) // n_hosts)
+        node_idx = int(tp_rank) // ranks_per_node
+        if 0 <= node_idx < n_hosts:
+            return remote_hosts[node_idx]
+    return default_host
 
 
 class MoRIIOConnector(KVConnectorBase_V1):
@@ -364,10 +391,25 @@ class MoRIIOConnectorScheduler:
         self.host_ip = resolve_host_ip(
             self.kv_transfer_config.kv_connector_extra_config
         )
+        # Multi-node TP: node_hosts holds the ordered host IPs in this
+        # engine's TP group (rank 0 first). Surfaced to the peer side via
+        # request_finished's kv_transfer_params so workers can dial the rank
+        # owner. Single-node TP falls back to [host_ip].
+        self.node_hosts = get_moriio_node_hosts(self.kv_transfer_config, self.host_ip)
+        self.trusted_remote_hosts = get_moriio_trusted_remote_hosts(
+            self.kv_transfer_config, self.node_hosts
+        )
+        self._request_id_trusted_hosts = get_moriio_request_id_trusted_hosts(
+            self.kv_transfer_config, self.node_hosts
+        )
         self.handshake_port = self.kv_transfer_config.kv_connector_extra_config[
             "handshake_port"
         ]
-        logger.info("Initializing MoRIIO Scheduler engine_id = %s", engine_id)
+        logger.info(
+            "Initializing MoRIIO Scheduler engine_id = %s node_hosts = %s",
+            engine_id,
+            self.node_hosts,
+        )
 
         self.side_notify_port = self.kv_transfer_config.kv_connector_extra_config[
             "notify_port"
@@ -509,6 +551,11 @@ class MoRIIOConnectorScheduler:
 
         remote_dp_rank = params.get("remote_dp_rank", 0)
         remote_host = params.get("remote_host")
+        validate_moriio_remote_host(
+            remote_host,
+            self.trusted_remote_hosts,
+            "kv_transfer_params['remote_host']",
+        )
         remote_notify_port = params.get("remote_notify_port")
         if remote_host is None or remote_notify_port is None:
             try:
@@ -522,6 +569,11 @@ class MoRIIOConnectorScheduler:
                 )
                 return
 
+        validate_moriio_remote_host(
+            remote_host,
+            self._request_id_trusted_hosts,
+            "request_id-derived remote_host",
+        )
         remote_notify_port = int(remote_notify_port)
         for tp_index in range(self.tp_size):
             target_port = remote_notify_port + get_port_offset(remote_dp_rank, tp_index)
@@ -583,6 +635,11 @@ class MoRIIOConnectorScheduler:
 
                 remote_dp_rank = request.kv_transfer_params.get("remote_dp_rank", 0)
                 remote_host = request.kv_transfer_params.get("remote_host")
+                validate_moriio_remote_host(
+                    remote_host,
+                    self.trusted_remote_hosts,
+                    "kv_transfer_params['remote_host']",
+                )
                 remote_notify_port = request.kv_transfer_params.get(
                     "remote_notify_port"
                 )
@@ -593,6 +650,11 @@ class MoRIIOConnectorScheduler:
                     remote_host, _, remote_notify_port = parse_moriio_zmq_address(
                         peer_zmq
                     )
+                validate_moriio_remote_host(
+                    remote_host,
+                    self._request_id_trusted_hosts,
+                    "request_id-derived remote_host",
+                )
                 remote_notify_port = int(remote_notify_port)
 
                 # num_external_tokens == 0: nothing to push, so don't tell the
@@ -601,16 +663,30 @@ class MoRIIOConnectorScheduler:
                     blocks.get_block_ids()[0] if num_external_tokens > 0 else []
                 )
 
+                remote_hosts = validate_moriio_remote_hosts(
+                    request.kv_transfer_params.get("remote_hosts"),
+                    self.trusted_remote_hosts,
+                    "kv_transfer_params['remote_hosts']",
+                )
+
                 for tp_index in range(self.tp_size):
                     target_port = remote_notify_port + get_port_offset(
                         remote_dp_rank, tp_index
+                    )
+                    target_host = _pick_remote_rank_host(
+                        remote_host,
+                        remote_hosts,
+                        self.tp_size,
+                        tp_index,
+                        int(request.kv_transfer_params.get("remote_dp_size", 1)),
+                        int(remote_dp_rank),
                     )
 
                     self.send_notify_block(
                         req_id=request.request_id,
                         transfer_id=request.kv_transfer_params["transfer_id"],
                         block_notify_list=block_notify_list,
-                        host=remote_host,
+                        host=target_host,
                         port=target_port,
                     )
 
@@ -622,7 +698,9 @@ class MoRIIOConnectorScheduler:
         self,
         scheduler_output: SchedulerOutput,
     ) -> KVConnectorMetadata:
-        meta = MoRIIOConnectorMetadata()
+        meta = MoRIIOConnectorMetadata(
+            self.trusted_remote_hosts, self._request_id_trusted_hosts
+        )
         meta.transfer_id_to_request_id = self.transfer_id_to_request_id
 
         if self.mode == MoRIIOMode.WRITE and get_role() == ROLE.PRODUCER:
@@ -770,6 +848,10 @@ class MoRIIOConnectorScheduler:
             remote_dp_size=self.vllm_config.parallel_config.data_parallel_size,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
             transfer_id=params["transfer_id"],
+            # Multi-node TP: list of all prefill-instance host IPs in this
+            # engine's TP group (rank 0 first). Decode workers use this to
+            # pick the correct producer host per their tp_rank.
+            remote_hosts=self.node_hosts,
         )
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
@@ -876,6 +958,7 @@ class MoRIIOConnectorWorker:
         self.http_port = self.moriio_config.http_port
         self.handshake_port = self.moriio_config.handshake_port
         self.notify_port = self.moriio_config.notify_port
+        self.node_hosts = self.moriio_config.node_hosts
 
         self.zmq_context = zmq.Context()
         self.metadata_address = (
@@ -1151,6 +1234,7 @@ class MoRIIOConnectorWorker:
                         # READ (prefill-then-decode, sequential) from WRITE (concurrent)
                         # scheduling.
                         "transfer_mode": self.mode.name,
+                        "node_hosts": list(self.node_hosts),
                     }
 
                     sock.send(msgpack.dumps(data))
@@ -1353,6 +1437,22 @@ class MoRIIOConnectorWorker:
     def _remote_tp_rank(self, remote_tp_size: int) -> int:
         return get_moriio_remote_tp_rank(self.tp_rank, self.world_size, remote_tp_size)
 
+    def _pick_remote_host(self, meta: ReqMeta) -> str:
+        """Resolve the per-worker peer host for multi-node TP prefill-decode."""
+        return _pick_remote_rank_host(
+            meta.remote_host, meta.remote_hosts, int(meta.tp_size), self.tp_rank
+        )
+
+    def _pick_host_for_dp_rank(self, meta: ReqMeta, dp_rank: int) -> str:
+        return _pick_remote_rank_host(
+            meta.remote_host,
+            meta.remote_hosts,
+            int(meta.tp_size),
+            self.tp_rank,
+            int(meta.remote_dp_size),
+            dp_rank,
+        )
+
     def _background_moriio_handshake(
         self, req_id: ReqId, remote_engine_id: EngineId, meta: ReqMeta
     ):
@@ -1361,7 +1461,6 @@ class MoRIIOConnectorWorker:
         if remote_engine_id is not None:
             fut = self._handshake_futures.get(remote_engine_id)
         if fut is None:
-            host = meta.remote_host
             port = int(meta.remote_handshake_port)
             tp_size = int(meta.tp_size)
             remote_dp_size = int(meta.remote_dp_size)
@@ -1378,6 +1477,7 @@ class MoRIIOConnectorWorker:
 
         for cur_dp_rank in range(remote_dp_size):
             dp_engine_id = self.get_engine_name_with_dp(remote_engine_id, cur_dp_rank)
+            host = self._pick_host_for_dp_rank(meta, cur_dp_rank)
             future = self._handshake_initiation_executor.submit(
                 self._moriio_handshake, host, port, tp_size, dp_engine_id, cur_dp_rank
             )
@@ -2025,13 +2125,20 @@ class MoRIIOConnectorWorker:
             req_id,
         )
         chosen_tp, flexible = self._resolve_read_source(meta)
+        # Multi-node TP: remote_host here is used by _read_blocks to record the
+        # post-transfer notify callback address (so prefill can free its KV
+        # blocks). For multi-node prefill the notify must go to the prefill
+        # node that actually owns this worker's KV slice, not the prefill
+        # head. _pick_remote_host returns meta.remote_host unchanged for
+        # single-host setups, preserving TP=8 / monolithic behaviour.
+        actual_remote_host = self._pick_remote_host(meta)
         self._read_blocks(
             request_id=req_id,
             transfer_id=meta.transfer_id,
             dst_engine_id=meta.remote_engine_id,
             local_block_ids=meta.local_block_ids,
             remote_block_ids=meta.remote_block_ids,
-            remote_host=meta.remote_host,
+            remote_host=actual_remote_host,
             remote_notify_port=meta.remote_notify_port,
             remote_tp_size=meta.tp_size,
             remote_dp_rank=meta.remote_dp_rank,
@@ -2049,7 +2156,7 @@ class MoRIIOConnectorWorker:
             layer_name=layer_name,
             kv_layer=kv_layer,
             remote_notify_port=meta.remote_notify_port,
-            remote_ip=meta.remote_host,
+            remote_ip=self._pick_remote_host(meta),
         )
 
     def merge_contiguous_blocks(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -1810,6 +1810,7 @@ class MoRIIOConnectorWorker:
             )
             # (engine_id, dp_rank, tp_rank_or_None); tp_rank is None on the legacy
             # path so _moriio_handshake falls back to its _remote_tp_rank mapping.
+            targets: list[tuple[Any, int, int | None]]
             if flexible:
                 targets = [
                     (self.get_engine_name_with_dp_tp(remote_engine_id, dp, tp), dp, tp)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -1824,6 +1824,7 @@ class MoRIIOConnectorWorker:
             remote_host=meta.remote_host,
             remote_notify_port=meta.remote_notify_port,
             remote_tp_size=meta.tp_size,
+            remote_dp_rank=meta.remote_dp_rank,
         )
 
     def _write_blocks_for_req(self, req_id: ReqId, meta: ReqMeta, layer_name, kv_layer):
@@ -1976,12 +1977,20 @@ class MoRIIOConnectorWorker:
         remote_host: str,
         remote_notify_port: int,
         remote_tp_size: int,
+        remote_dp_rank: int = 0,
     ) -> None:
         if self.mode == MoRIIOMode.WRITE:
             return
 
-        dp0_engine_id = self.get_engine_name_with_dp(dst_engine_id, 0)
-        sessions, remote_moriio_meta = self._get_built_session(dp0_engine_id)
+        # Read from the prefill DP rank that actually computed this request's KV
+        # (forwarded by the proxy). Hardcoding DP0 reads from a different rank's
+        # memory registration; per-DP num_blocks differ, so high block ids can
+        # overrun the wrong rank's region. remote_dp_rank == 0 keeps the
+        # symmetric single-DP behaviour byte-for-byte.
+        remote_dp_engine_id = self.get_engine_name_with_dp(
+            dst_engine_id, int(remote_dp_rank)
+        )
+        sessions, remote_moriio_meta = self._get_built_session(remote_dp_engine_id)
 
         # SQ-full backpressure deadline, shared across this request's layers.
         _sq_deadline = time.monotonic() + self.moriio_config.transfer_timeout
@@ -2030,6 +2039,13 @@ class MoRIIOConnectorWorker:
                 self._recving_transfers[request_id].append(transfer_status)
                 self._recving_transfers_callback_addr[request_id] = (
                     remote_host,
-                    str(remote_notify_port + self._remote_tp_rank(remote_tp_size)),
+                    str(
+                        remote_notify_port
+                        + get_port_offset(
+                            int(remote_dp_rank),
+                            self._remote_tp_rank(remote_tp_size),
+                            remote_tp_size,
+                        )
+                    ),
                     transfer_id,
                 )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -1263,8 +1263,16 @@ class MoRIIOConnectorWorker:
         remote_tp_size: int,
         expected_engine_id: str,
         remote_dp_rank: int = 0,
+        remote_tp_rank: int | None = None,
     ) -> set[str]:
-        """Do a MoRIIO handshake with a remote instance."""
+        """Do a MoRIIO handshake with a remote instance.
+
+        remote_tp_rank: explicit remote TP index to dial. Flexible-read callers
+        pass the chosen prefill TP rank so the handshake, the (dp, tp) session
+        key and the notify port all address the SAME rank. None falls back to the
+        local-rank mapping _remote_tp_rank -- byte-identical for callers not yet
+        TP-aware.
+        """
 
         start_time = time.perf_counter()
 
@@ -1272,9 +1280,12 @@ class MoRIIOConnectorWorker:
         # a hack to keep us moving. We will switch when moving to etcd
         # or where we have a single ZMQ socket in the scheduler.
 
-        port_offset = get_port_offset(
-            remote_dp_rank, self._remote_tp_rank(remote_tp_size)
+        dial_tp_rank = (
+            self._remote_tp_rank(remote_tp_size)
+            if remote_tp_rank is None
+            else int(remote_tp_rank)
         )
+        port_offset = get_port_offset(remote_dp_rank, dial_tp_rank, remote_tp_size)
         path = make_zmq_path("tcp", host, port + port_offset)
         logger.debug("handshake Querying metadata on path: %s", path)
 
@@ -1731,6 +1742,12 @@ class MoRIIOConnectorWorker:
     def get_engine_name_with_dp(self, engine_name, dp_rank):
         return f"{engine_name}_dp{dp_rank}"
 
+    def get_engine_name_with_dp_tp(self, engine_name, dp_rank, tp_rank):
+        # Per-(dp, tp) session key. The flexible mirror read keys sessions per
+        # (dp, tp) so one decode worker can hold a session to EACH prefill TP
+        # rank and spread reads across them; other configs keep the DP-only key.
+        return f"{engine_name}_dp{dp_rank}_tp{tp_rank}"
+
     def _eager_handshake_all_dp_ranks(self, metadata: MoRIIOConnectorMetadata) -> None:
         """Handshake EVERY remote prefill DP rank BEFORE the decode forward pass,
         identically across all local TP workers.
@@ -1779,15 +1796,40 @@ class MoRIIOConnectorWorker:
             port = int(meta.remote_handshake_port)
             tp_size = int(meta.tp_size)
 
-            # Submit handshakes for every not-yet-known DP rank UNDER the lock; do
+            # Flexible mirror (TP prefill + MLA, world_size==1 decode): the read
+            # round-robins over prefill TP ranks, so pre-warm a session to EVERY
+            # (dp, tp) rank. Other configs pre-warm per DP rank (tp resolved by
+            # the fixed local-rank mapping) -- byte-identical to before. The
+            # mirror's decode is DP+EP, whose forward all-to-all is the collective
+            # that the eager barrier keeps everyone in step for.
+            flexible = (
+                self.world_size == 1
+                and self.use_mla
+                and remote_dp_size == 1
+                and tp_size > 1
+            )
+            # (engine_id, dp_rank, tp_rank_or_None); tp_rank is None on the legacy
+            # path so _moriio_handshake falls back to its _remote_tp_rank mapping.
+            if flexible:
+                targets = [
+                    (self.get_engine_name_with_dp_tp(remote_engine_id, dp, tp), dp, tp)
+                    for dp in range(remote_dp_size)
+                    for tp in range(max(1, tp_size))
+                ]
+            else:
+                targets = [
+                    (self.get_engine_name_with_dp(remote_engine_id, dp), dp, None)
+                    for dp in range(remote_dp_size)
+                ]
+
+            # Submit handshakes for every not-yet-known target UNDER the lock; do
             # NOT hold it across the join or the collective (a stalled recv must
             # not block another thread's lock acquisition). Gate on BOTH
             # _remote_agents AND layer metadata: a rank with an agent entry but no
             # layer metadata is half-handshaked and would KeyError at read time.
             futures: list[tuple[str, Future[set[str]]]] = []
             with self._handshake_lock:
-                for cur_dp_rank in range(remote_dp_size):
-                    eid = self.get_engine_name_with_dp(remote_engine_id, cur_dp_rank)
+                for eid, cur_dp_rank, cur_tp_rank in targets:
                     if (
                         eid in self._remote_agents
                         and eid in self.layer_name_to_remote_kv_cache_metadata
@@ -1800,6 +1842,7 @@ class MoRIIOConnectorWorker:
                         tp_size,
                         eid,
                         cur_dp_rank,
+                        cur_tp_rank,
                     )
                     futures.append((eid, fut))
 
@@ -1876,8 +1919,15 @@ class MoRIIOConnectorWorker:
                 str(meta.remote_host) + ":" + str(meta.remote_handshake_port)
             )
             meta.remote_engine_id = remote_engine_id
+            # The eager handshake above already covered every referenced engine
+            # (and keys the mirror per (dp, tp), which the DP-only dp0 probe below
+            # would miss). Only fall back to the lazy background handshake for an
+            # engine it did not cover.
             dp0_remote_engine_id = self.get_engine_name_with_dp(remote_engine_id, 0)
-            if dp0_remote_engine_id not in self._remote_agents:
+            if (
+                remote_engine_id not in self._eager_handshaked_engines
+                and dp0_remote_engine_id not in self._remote_agents
+            ):
                 # Initiate handshake with remote engine to exchange metadata.
                 with self._handshake_lock:
                     if remote_engine_id not in self._remote_agents:
@@ -1927,12 +1977,53 @@ class MoRIIOConnectorWorker:
                 self.save_kv_layer(metadata, layer_name, kv_layer, None)
             self._writer.seal_pending_transfers()
 
+    def _next_flex_tp_rank(self, remote_tp_size: int) -> int:
+        """Deterministic round-robin over prefill tp0..N-1 for the flexible read.
+
+        Round-robin (not random): exactly uniform and testable, with the same
+        prefill-NIC balancing. Seeded from this decode rank's dp_rank so
+        concurrent decode DP ranks are phase-staggered -- at a given read index
+        distinct decode ranks target distinct prefill TP ranks.
+        """
+        rr = getattr(self, "_flex_tp_rr", None)
+        if rr is None:
+            rr = int(getattr(self, "dp_rank", 0) or 0)
+        self._flex_tp_rr = rr + 1
+        return rr % remote_tp_size
+
+    def _resolve_read_source(self, meta: ReqMeta) -> tuple[int, bool]:
+        """Resolve (chosen_tp, flexible) for reading this request's KV.
+
+        Flexible mirror (decode world_size==1 + MLA + pure-TP prefill): MLA
+        replicates the latent KV across the prefill TP ranks, so any is a valid
+        source; round-robin across them to spread RDMA/NIC load. Otherwise the
+        source TP rank is fixed by the local-rank mapping (_remote_tp_rank) --
+        forward DP8EP->TP8 -> tp0; symmetric TP -> tp_rank -- byte-identical to
+        prior behaviour. chosen_tp is the single value threaded into the (dp, tp)
+        session key, the handshake dial and the notify port, so all three address
+        the SAME prefill rank (drift -> read one rank but notify another -> the
+        read rank's prefill buffer is never freed).
+        """
+        remote_tp_size = int(meta.tp_size)
+        flexible = (
+            self.world_size == 1
+            and self.use_mla
+            and int(meta.remote_dp_size) == 1
+            and remote_tp_size > 1
+        )
+        if flexible:
+            chosen_tp = self._next_flex_tp_rank(remote_tp_size)
+        else:
+            chosen_tp = self._remote_tp_rank(remote_tp_size)
+        return chosen_tp, flexible
+
     def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
         logger.debug(
             "Remote agent %s available, calling _read_blocks for req %s",
             meta.remote_engine_id,
             req_id,
         )
+        chosen_tp, flexible = self._resolve_read_source(meta)
         self._read_blocks(
             request_id=req_id,
             transfer_id=meta.transfer_id,
@@ -1943,6 +2034,8 @@ class MoRIIOConnectorWorker:
             remote_notify_port=meta.remote_notify_port,
             remote_tp_size=meta.tp_size,
             remote_dp_rank=meta.remote_dp_rank,
+            chosen_tp=chosen_tp,
+            flexible=flexible,
         )
 
     def _write_blocks_for_req(self, req_id: ReqId, meta: ReqMeta, layer_name, kv_layer):
@@ -2096,18 +2189,35 @@ class MoRIIOConnectorWorker:
         remote_notify_port: int,
         remote_tp_size: int,
         remote_dp_rank: int = 0,
+        chosen_tp: int | None = None,
+        flexible: bool = False,
     ) -> None:
         if self.mode == MoRIIOMode.WRITE:
             return
 
-        # Read from the prefill DP rank that actually computed this request's KV
+        # Read from the prefill rank that actually computed this request's KV
         # (forwarded by the proxy). Hardcoding DP0 reads from a different rank's
-        # memory registration; per-DP num_blocks differ, so high block ids can
-        # overrun the wrong rank's region. remote_dp_rank == 0 keeps the
-        # symmetric single-DP behaviour byte-for-byte.
-        remote_dp_engine_id = self.get_engine_name_with_dp(
-            dst_engine_id, int(remote_dp_rank)
+        # memory registration; per-rank num_blocks differ, so high block ids can
+        # overrun the wrong rank's region.
+        #
+        # eff_tp = the remote TP rank this read targets. The flexible mirror
+        # reads from a round-robin-chosen prefill TP rank and keys the session
+        # per (dp, tp); other configs use the fixed local-rank mapping (eff_tp ==
+        # _remote_tp_rank), byte-identical to before. This key MUST match the one
+        # the eager handshake stored the session under.
+        eff_tp = (
+            int(chosen_tp)
+            if chosen_tp is not None
+            else self._remote_tp_rank(remote_tp_size)
         )
+        if flexible:
+            remote_dp_engine_id = self.get_engine_name_with_dp_tp(
+                dst_engine_id, int(remote_dp_rank), eff_tp
+            )
+        else:
+            remote_dp_engine_id = self.get_engine_name_with_dp(
+                dst_engine_id, int(remote_dp_rank)
+            )
         sessions, remote_moriio_meta = self._get_built_session(remote_dp_engine_id)
 
         # SQ-full backpressure deadline, shared across this request's layers.
@@ -2161,7 +2271,7 @@ class MoRIIOConnectorWorker:
                         remote_notify_port
                         + get_port_offset(
                             int(remote_dp_rank),
-                            self._remote_tp_rank(remote_tp_size),
+                            eff_tp,
                             remote_tp_size,
                         )
                     ),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -1014,6 +1014,8 @@ class MoRIIOConnectorWorker:
         self._handshake_futures: dict[EngineId, Future[set[str]]] = {}
         # Protects _handshake_futures and _remote_agents.
         self._handshake_lock = threading.RLock()
+        # Remote engines already covered by the eager pre-forward handshake.
+        self._eager_handshaked_engines: set[EngineId] = set()
 
         self.block_size = vllm_config.cache_config.block_size
         self.model_config = vllm_config.model_config
@@ -1729,6 +1731,116 @@ class MoRIIOConnectorWorker:
     def get_engine_name_with_dp(self, engine_name, dp_rank):
         return f"{engine_name}_dp{dp_rank}"
 
+    def _eager_handshake_all_dp_ranks(self, metadata: MoRIIOConnectorMetadata) -> None:
+        """Handshake EVERY remote prefill DP rank BEFORE the decode forward pass,
+        identically across all local TP workers.
+
+        Why this exists (the deadlock it prevents): with heterogeneous DP prefill
+        a decode TP worker reads KV from whichever prefill DP rank owns the
+        request, so across requests every worker must reach several prefill DP
+        ranks. The decode forward issues per-layer TP collectives (e.g. an
+        all-gather) that all local TP workers must enter together. If the
+        handshakes are left to fire lazily on the read path, the workers diverge:
+        a worker whose target rank is already cached races ahead into the forward
+        collective while a peer is still blocked in a handshake recv(). The first
+        worker then waits inside the collective for the stuck peer -> 600s NCCL
+        timeout / hang. This was observed directly with mixed TP<->DP configs.
+
+        Fix: complete ALL prefill-DP-rank handshakes for every referenced remote
+        engine HERE, before any read enters the forward, so no worker is still
+        handshaking once its peers reach a collective. Fires ONCE per remote
+        engine (first contact), gated by _eager_handshaked_engines. The engine
+        set comes from scheduler-built metadata (identical on every TP worker),
+        so all workers run the same handshakes in the same order and reach the
+        all-reduce barrier below together.
+
+        Failure handling: handshake exceptions are caught, never raised before
+        the collective (raising early would hang the peers still waiting for it).
+        Every worker reaches the all-reduce(MIN) vote; if ANY worker failed, ALL
+        raise the same error AFTER the collective, so the step fails fast and
+        uniformly in ~seconds instead of one rank hanging the forward for 600s.
+        """
+        import torch.distributed as dist
+
+        # Distinct remote engines referenced this step, in metadata (==
+        # scheduler) order so every TP worker iterates engines identically.
+        engines: dict[str, ReqMeta] = {}
+        for _req_id, meta in metadata.reqs_to_recv.items():
+            remote_engine_id = (
+                str(meta.remote_host) + ":" + str(meta.remote_handshake_port)
+            )
+            engines.setdefault(remote_engine_id, meta)
+
+        for remote_engine_id, meta in engines.items():
+            if remote_engine_id in self._eager_handshaked_engines:
+                continue
+
+            remote_dp_size = int(meta.remote_dp_size)
+            port = int(meta.remote_handshake_port)
+            tp_size = int(meta.tp_size)
+
+            # Submit handshakes for every not-yet-known DP rank UNDER the lock; do
+            # NOT hold it across the join or the collective (a stalled recv must
+            # not block another thread's lock acquisition). Gate on BOTH
+            # _remote_agents AND layer metadata: a rank with an agent entry but no
+            # layer metadata is half-handshaked and would KeyError at read time.
+            futures: list[tuple[str, Future[set[str]]]] = []
+            with self._handshake_lock:
+                for cur_dp_rank in range(remote_dp_size):
+                    eid = self.get_engine_name_with_dp(remote_engine_id, cur_dp_rank)
+                    if (
+                        eid in self._remote_agents
+                        and eid in self.layer_name_to_remote_kv_cache_metadata
+                    ):
+                        continue
+                    fut = self._handshake_initiation_executor.submit(
+                        self._moriio_handshake,
+                        meta.remote_host,
+                        port,
+                        tp_size,
+                        eid,
+                        cur_dp_rank,
+                    )
+                    futures.append((eid, fut))
+
+            # Join outside the lock. Bounded handshake errors are recorded here
+            # and reported after the all-reduce.
+            all_ok = True
+            results: dict[str, set[str]] = {}
+            for eid, fut in futures:
+                try:
+                    results[eid] = fut.result()
+                except Exception:
+                    logger.exception("Eager MoRIIO handshake failed for %s", eid)
+                    all_ok = False
+
+            with self._handshake_lock:
+                for eid, agents in results.items():
+                    self._remote_agents[eid] = agents
+
+            logger.info(
+                "Eager MoRIIO handshake: engine=%s dp_size=%d new_ranks=%d "
+                "ok=%s tp_rank=%d",
+                remote_engine_id,
+                remote_dp_size,
+                len(futures),
+                all_ok,
+                self.tp_rank,
+            )
+            # CPU all-reduce = TP-uniform success vote AND lockstep barrier: it
+            # blocks until every TP worker arrives, gives them the same verdict,
+            # and stays off the model compute stream.
+            vote = torch.tensor([1 if all_ok else 0], device="cpu", dtype=torch.int32)
+            dist.all_reduce(vote, group=self.tp_group.cpu_group, op=dist.ReduceOp.MIN)
+            if int(vote.item()) == 0:
+                raise HandshakeError(
+                    f"Eager MoRIIO handshake failed for {remote_engine_id} on "
+                    "at least one TP rank; failing this step fast to avoid a "
+                    "TP collective hang"
+                )
+
+            self._eager_handshaked_engines.add(remote_engine_id)
+
     def start_load_kv(self, metadata: MoRIIOConnectorMetadata):
         """
         Start loading by triggering non-blocking moriio_xfer.
@@ -1749,6 +1861,12 @@ class MoRIIOConnectorWorker:
             return
         if self.mode == MoRIIOMode.WRITE:
             return
+
+        # Handshake every referenced remote prefill rank up front, before any
+        # read enters the forward pass. A lazy per-rank handshake on the read
+        # path lets TP workers diverge into a forward collective while a peer is
+        # still blocked handshaking -> NCCL hang (see below).
+        self._eager_handshake_all_dp_ranks(metadata)
 
         wait_handshake_readd_req = False
         remote_engine_id = None


### PR DESCRIPTION
## Purpose

MoRIIO advertised a single peer host per instance. That breaks TP prefill→decode once the peer's TP group spans more than one host: a decode worker whose matching prefill rank lives on the second host still points at the first one, handshakes and reads the wrong KV, and the request wedges. It shows up in TP16 1P1D across two hosts. Single-host and TP<=8 deployments never hit it.

## Relationship to #46116 (stacked)

This PR is **stacked on #46116** (heterogeneous TP<->DP read routing) and should land after it. The two are complementary along orthogonal axes: **#46116 decides which remote (dp, tp) rank a decode reads from; this PR decides which host that rank sits on.** This PR **consumes #46116's `ReqMeta.remote_dp_rank`** (and its `add_new_req` parsing) rather than re-adding it, and the read path composes #46116's `chosen_tp` (rank) with this PR's `_pick_remote_host` (host). Because both edit adjacent lines in the same read/metadata path, the diff above includes #46116's commits until it merges.

## How it works

An instance already knows the ordered host list of its own TP group; this PR reads it from `kv_connector_extra_config["node_hosts"]` and publishes it at worker registration. The toy proxy forwards the prefill peer's list to the decode side as `kv_transfer_params["remote_hosts"]`.

When a decode worker sets up a transfer, it resolves the peer host that actually owns the matching rank instead of always using the advertised head:

```
n_hosts        = len(remote_hosts)
ranks_per_node = tp_size // n_hosts          # 16 // 2 = 8
host           = remote_hosts[tp_rank // ranks_per_node]
```

In TP16 over two hosts, ranks 0–7 resolve to `remote_hosts[0]` and ranks 8–15 to `remote_hosts[1]`. If the peer is data-parallel and its DP ranks span the hosts, the same split runs on `remote_dp_rank` (the field #46116 adds and this PR consumes). That resolved host is exactly what the worker hands to the MoRIIO handshake and passes as `remote_ip` to the block read/write, so the transfer lands on the node that holds the slice rather than the head node.

Single-host / monolithic stays bit-for-bit: with one host in the list (or none), the picker returns the original `remote_host`, so single-host and TP<=8 keep their current behavior.

## Security — opt-in host allowlist

Peer hosts are validated against `kv_connector_extra_config["trusted_remote_hosts"]`, and validation is **opt-in**: when it is unset, validation is a no-op and the default (including cross-host) flow is unchanged — this holds for **both** directly-supplied hosts (`remote_host` / `remote_hosts`) **and** the host parsed from the request_id (which can carry a client-supplied `X-Request-Id`). Set `trusted_remote_hosts` — recommended when the endpoint is reachable by untrusted clients — and any peer host, direct or request_id-derived, that is not on the list is rejected before any handshake / notify / release. Config lives entirely in `kv_connector_extra_config`; no new environment variable.

## Test Plan

```bash
python -m pytest tests/v1/kv_connector/unit/test_moriio_multinode_hosts.py -q
python -m pytest tests/v1/kv_connector/unit/test_moriio_routing_fairness.py -q   # stacked #46116, no regression
ruff check vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
```

Multi-host serving (manual, needs a two-host RDMA setup): TP16 prefill and TP16 decode across two hosts each, `node_hosts` set for the local role and `trusted_remote_hosts` for the peer. Confirm each decode rank reads from the prefill host that holds its slice.

## Test Result

CPU (no GPU), verified on MI300 — **56 passed** total: `test_moriio_multinode_hosts.py` **42 passed** + the stacked `test_moriio_routing_fairness.py` (#46116) **14 passed**, no regression. The multinode tests are self-contained (real moriio modules, dict/`SimpleNamespace` inputs, all socket/notify I/O monkeypatched — no GPU, no network). What they pin:

- the rank→host split at the boundaries: TP16 over two hosts, ranks 0–7 → `remote_hosts[0]`, ranks 8–15 → `remote_hosts[1]` (the exact mis-route above), plus the `remote_dp_rank` variant;
- the wiring: `_pick_remote_host` / `_pick_host_for_dp_rank` feed `tp_rank` / `remote_dp_size` into the picker, and its result is the host used for handshake and block read/write;
- single-host passthrough: `remote_host` unchanged for any `tp_rank`;
- opt-in trust: with `trusted_remote_hosts` **unset**, cross-host peers are accepted (default flow works); **set**, an untrusted peer host is rejected before any handshake / notify / release, whether supplied directly or parsed from the request_id, across every site that reads a peer host.

ruff and py_compile pass on the changed files.

## Follow-up

The notify/release path currently picks the host by the worker's own `tp_rank` while the port uses the read rank (`chosen_tp`). These coincide for symmetric multi-node TP (the tested / target case) but can diverge for the flexible-MLA mirror or asymmetric-TP multi-node prefill; threading `chosen_tp` into host selection there is a follow-up.
