### PR TITLE
[Bugfix][KV-transfer] MoRIIO: READ-mode stability fixes (completion IDs, DP routing, drain, keepalive)

### DIFF
--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -75,6 +75,7 @@ def _listen_for_register(hostname, port):
                     "dp_size": data["dp_size"],
                     "tp_size": data["tp_size"],
                     "transfer_mode": data["transfer_mode"],
+                    "node_hosts": data.get("node_hosts", []),
                 }
                 # zmq_address format: "host:IP,handshake:PORT,notify:PORT"
                 # Stored verbatim; embedded into the request_id by handle_request.
@@ -277,6 +278,11 @@ async def handle_request(api: str, request: Request):
             decode_instance_endpoint["tp_size"]
         )
         req_data_to_prefill["kv_transfer_params"]["transfer_id"] = transfer_id
+        decode_hosts = decode_instance_endpoint.get("node_hosts") or []
+        if decode_hosts:
+            req_data_to_prefill["kv_transfer_params"]["remote_hosts"] = list(
+                decode_hosts
+            )
 
         prefill_request_url = prefill_instance_endpoint["request_address"] + api
         send_prefill_task = asyncio.create_task(
@@ -308,6 +314,13 @@ async def handle_request(api: str, request: Request):
                 "remote_block_ids"
             ]
             req_data["kv_transfer_params"]["transfer_id"] = prefill_kv["transfer_id"]
+            req_data["kv_transfer_params"]["remote_hosts"] = prefill_kv.get(
+                "remote_hosts"
+            )
+
+        prefill_hosts = prefill_instance_endpoint.get("node_hosts") or []
+        if prefill_hosts:
+            req_data["kv_transfer_params"]["remote_hosts"] = list(prefill_hosts)
 
         req_data["kv_transfer_params"]["remote_dp_size"] = prefill_instance_endpoint[
             "dp_size"
@@ -315,6 +328,7 @@ async def handle_request(api: str, request: Request):
         req_data["kv_transfer_params"]["remote_tp_size"] = prefill_instance_endpoint[
             "tp_size"
         ]
+        req_data["kv_transfer_params"]["tp_size"] = prefill_instance_endpoint["tp_size"]
 
         if selected_prefill_dp_rank is not None:
             req_data["kv_transfer_params"]["remote_dp_rank"] = selected_prefill_dp_rank

--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -138,6 +138,16 @@ def start_service_discovery(hostname, port):
     return _listener_thread
 
 
+def make_request_headers(request_id, data_parallel_rank=None):
+    headers = {
+        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
+        "X-Request-Id": request_id,
+    }
+    if data_parallel_rank is not None:
+        headers["X-data-parallel-rank"] = str(data_parallel_rank)
+    return headers
+
+
 async def send_request_to_prefill(
     endpoint, req_data, request_id, selected_prefill_dp_rank
 ):
@@ -160,12 +170,7 @@ async def send_request_to_prefill(
     async with aiohttp.ClientSession(
         timeout=aiohttp.ClientTimeout(total=6 * 6000 * 6000)
     ) as session:
-        headers = {
-            "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
-            "X-Request-Id": request_id,
-        }
-        if selected_prefill_dp_rank is not None:
-            headers["X-data-parallel-rank"] = str(selected_prefill_dp_rank)
+        headers = make_request_headers(request_id, selected_prefill_dp_rank)
         async with session.post(
             url=endpoint, json=req_data_copy, headers=headers
         ) as response:
@@ -182,14 +187,11 @@ async def send_request_to_prefill(
                 raise RuntimeError(error_message)
 
 
-async def start_decode_request(endpoint, req_data, request_id):
+async def start_decode_request(endpoint, req_data, request_id, data_parallel_rank=None):
     session = aiohttp.ClientSession(
         timeout=aiohttp.ClientTimeout(total=6 * 6000 * 6000)
     )
-    headers = {
-        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
-        "X-Request-Id": request_id,
-    }
+    headers = make_request_headers(request_id, data_parallel_rank)
     response = await session.post(url=endpoint, json=req_data, headers=headers)
     return session, response
 
@@ -212,7 +214,54 @@ async def stream_decode_response(session, response, request_id):
 
 
 def example_round_robin_dp_loader(request_number, dp_size):
-    return request_nums % dp_size
+    if dp_size <= 1:
+        return None
+    return request_number % dp_size
+
+
+def select_request_dp_ranks(
+    request_number, prefill_instance_endpoint, decode_instance_endpoint
+):
+    return (
+        example_round_robin_dp_loader(
+            request_number,
+            prefill_instance_endpoint["dp_size"],
+        ),
+        example_round_robin_dp_loader(
+            request_number,
+            decode_instance_endpoint["dp_size"],
+        ),
+    )
+
+
+def add_remote_decode_kv_params(
+    kv_transfer_params, decode_instance_endpoint, selected_decode_dp_rank, transfer_id
+):
+    kv_transfer_params["remote_dp_size"] = decode_instance_endpoint["dp_size"]
+    kv_transfer_params["remote_tp_size"] = decode_instance_endpoint["tp_size"]
+    kv_transfer_params["transfer_id"] = transfer_id
+    kv_transfer_params["remote_zmq_address"] = decode_instance_endpoint["zmq_address"]
+    decode_hosts = decode_instance_endpoint.get("node_hosts") or []
+    if decode_hosts:
+        kv_transfer_params["remote_hosts"] = list(decode_hosts)
+    if selected_decode_dp_rank is not None:
+        kv_transfer_params["remote_dp_rank"] = selected_decode_dp_rank
+
+
+def add_remote_prefill_kv_params(
+    kv_transfer_params, prefill_instance_endpoint, selected_prefill_dp_rank
+):
+    prefill_hosts = prefill_instance_endpoint.get("node_hosts") or []
+    if prefill_hosts:
+        kv_transfer_params["remote_hosts"] = list(prefill_hosts)
+
+    kv_transfer_params["remote_dp_size"] = prefill_instance_endpoint["dp_size"]
+    kv_transfer_params["remote_tp_size"] = prefill_instance_endpoint["tp_size"]
+    kv_transfer_params["tp_size"] = prefill_instance_endpoint["tp_size"]
+    kv_transfer_params["remote_zmq_address"] = prefill_instance_endpoint["zmq_address"]
+
+    if selected_prefill_dp_rank is not None:
+        kv_transfer_params["remote_dp_rank"] = selected_prefill_dp_rank
 
 
 @app.route("/v1/completions", methods=["POST"])
@@ -250,12 +299,11 @@ async def handle_request(api: str, request: Request):
         prefill_instance_endpoint = prefill_instances[pid]
         decode_instance_endpoint = decode_instances[did]
 
-        selected_prefill_dp_rank = None
-        if prefill_instance_endpoint["dp_size"] > 1:
-            selected_prefill_dp_rank = example_round_robin_dp_loader(
-                request_nums // len(prefill_instance_endpoint),
-                prefill_instance_endpoint["dp_size"],
-            )
+        selected_prefill_dp_rank, selected_decode_dp_rank = select_request_dp_ranks(
+            request_nums,
+            prefill_instance_endpoint,
+            decode_instance_endpoint,
+        )
 
         # Embed both zmq_addresses in the request_id so the connector can parse
         # the peer's host/ports from it, similar to P2P-NCCL
@@ -271,18 +319,12 @@ async def handle_request(api: str, request: Request):
         req_data_to_prefill = copy.deepcopy(req_data)
         req_data_to_prefill["kv_transfer_params"] = {}
         req_data["kv_transfer_params"] = {}
-        req_data_to_prefill["kv_transfer_params"]["remote_dp_size"] = (
-            decode_instance_endpoint["dp_size"]
+        add_remote_decode_kv_params(
+            req_data_to_prefill["kv_transfer_params"],
+            decode_instance_endpoint,
+            selected_decode_dp_rank,
+            transfer_id,
         )
-        req_data_to_prefill["kv_transfer_params"]["remote_tp_size"] = (
-            decode_instance_endpoint["tp_size"]
-        )
-        req_data_to_prefill["kv_transfer_params"]["transfer_id"] = transfer_id
-        decode_hosts = decode_instance_endpoint.get("node_hosts") or []
-        if decode_hosts:
-            req_data_to_prefill["kv_transfer_params"]["remote_hosts"] = list(
-                decode_hosts
-            )
 
         prefill_request_url = prefill_instance_endpoint["request_address"] + api
         send_prefill_task = asyncio.create_task(
@@ -317,25 +359,20 @@ async def handle_request(api: str, request: Request):
             req_data["kv_transfer_params"]["remote_hosts"] = prefill_kv.get(
                 "remote_hosts"
             )
-
-        prefill_hosts = prefill_instance_endpoint.get("node_hosts") or []
-        if prefill_hosts:
-            req_data["kv_transfer_params"]["remote_hosts"] = list(prefill_hosts)
-
-        req_data["kv_transfer_params"]["remote_dp_size"] = prefill_instance_endpoint[
-            "dp_size"
-        ]
-        req_data["kv_transfer_params"]["remote_tp_size"] = prefill_instance_endpoint[
-            "tp_size"
-        ]
-        req_data["kv_transfer_params"]["tp_size"] = prefill_instance_endpoint["tp_size"]
-
-        if selected_prefill_dp_rank is not None:
-            req_data["kv_transfer_params"]["remote_dp_rank"] = selected_prefill_dp_rank
+        add_remote_prefill_kv_params(
+            req_data["kv_transfer_params"],
+            prefill_instance_endpoint,
+            selected_prefill_dp_rank,
+        )
 
         decode_request_url = decode_instance_endpoint["request_address"] + api
         decode_request_task = asyncio.create_task(
-            start_decode_request(decode_request_url, req_data, request_id)
+            start_decode_request(
+                decode_request_url,
+                req_data,
+                request_id,
+                selected_decode_dp_rank,
+            )
         )
 
         session, decode_response = await decode_request_task

--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import importlib.util
+import queue
 import socket
 import uuid
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import msgspec
@@ -24,6 +26,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     MoRIIOConnectorMetadata,
     MoRIIOConstants,
     MoRIIOMode,
+    ReqMeta,
     resolve_host_ip,
     zmq_ctx,
 )
@@ -512,6 +515,391 @@ def test_send_transfer_release_sends_structured_release_message():
         "type": "release",
         "transfer_id": "xfer-7",
     }
+
+def test_read_mode_trims_remote_blocks_not_local_blocks():
+    """Read mode rejects mismatched block counts and preserves block id sides."""
+
+    class Blocks:
+        def __init__(self, block_ids):
+            self._block_ids = block_ids
+
+        def get_block_ids(self):
+            return [self._block_ids]
+
+    def build_read_metadata(remote_block_ids):
+        scheduler = object.__new__(MoRIIOConnectorScheduler)
+        scheduler.mode = MoRIIOMode.READ
+        scheduler.tp_size = 1
+        scheduler.transfer_id_to_request_id = {}
+        scheduler.request_id_to_transfer_id = {}
+        scheduler._pending_transfer_id_to_request_id = {}
+        scheduler._transfer_ids_to_forget = set()
+        scheduler._reqs_need_recv = {}
+        scheduler._reqs_need_save = {}
+        scheduler._reqs_need_pending_save = {}
+        scheduler._reqs_need_send = {}
+        scheduler.trusted_remote_hosts = ["127.0.0.1"]
+
+        request_id = "req0"
+        local_block_ids = [10, 11, 12]
+        request = SimpleNamespace(
+            request_id=request_id,
+            num_prompt_tokens=48,
+            kv_transfer_params={
+                "transfer_id": "tx0",
+                "do_remote_decode": False,
+                "do_remote_prefill": True,
+                "remote_engine_id": "prefill:6301",
+                "remote_block_ids": remote_block_ids,
+                "remote_hosts": ["127.0.0.1"],
+                "remote_zmq_address": "host:127.0.0.1,handshake:4789,notify:61005",
+            },
+        )
+        scheduler.update_state_after_alloc(
+            request, Blocks(local_block_ids), num_external_tokens=48
+        )
+        metadata = scheduler.build_connector_meta(None)
+        return metadata.reqs_to_recv[request_id], local_block_ids
+
+    with pytest.raises(AssertionError):
+        build_read_metadata([1000, 1001, 1002, 1003])
+
+    req_meta, local_block_ids = build_read_metadata([2000, 2001, 2002])
+    assert req_meta.local_block_ids == local_block_ids
+    assert req_meta.remote_block_ids == [2000, 2001, 2002]
+    assert req_meta.remote_block_ids != local_block_ids
+
+
+def test_requires_piecewise_for_cudagraph_by_default():
+    for extra_config in (
+        {},
+        {"allow_full_cudagraph": False},
+        {"allow_full_cudagraph": "0"},
+    ):
+        assert MoRIIOConnector.requires_piecewise_for_cudagraph(extra_config) is True
+
+
+def test_requires_piecewise_for_cudagraph_rejects_allow_full():
+    for extra_config in (
+        {"allow_full_cudagraph": True},
+        {"allow_full_cudagraph": "true"},
+        {"allow_full_cudagraph": "1"},
+    ):
+        with pytest.raises(ValueError, match="allow_full_cudagraph"):
+            MoRIIOConnector.requires_piecewise_for_cudagraph(extra_config)
+
+
+def test_read_mode_start_load_kv_drains_all_ready_requests():
+    class NoopLock:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    worker = object.__new__(MoRIIOConnectorWorker)
+    worker.transfer_id_to_request_id = {}
+    worker.request_id_to_transfer_id = {}
+    worker._pending_unmapped_done_tids = {}
+    worker.is_producer = False
+    worker.mode = MoRIIOMode.READ
+    worker._reqs_to_send = {}
+    worker._ready_requests = queue.Queue()
+    worker.load_ready_flag = {"127.0.0.1:4789": True}
+    worker._remote_agents = {"127.0.0.1:4789_dp0": {"agent"}}
+    worker._unmatched_write_completions = set()
+    worker._handshake_lock = NoopLock()
+    worker.moriio_config = SimpleNamespace(transfer_timeout=0.01)
+    worker._eager_handshake_all_dp_ranks = lambda _metadata: None
+
+    def make_meta(transfer_id):
+        return ReqMeta(
+            transfer_id=transfer_id,
+            local_block_ids=[1],
+            remote_block_ids=[2],
+            remote_host="127.0.0.1",
+            remote_port=4789,
+            remote_handshake_port=4789,
+            remote_notify_port=4789,
+            remote_engine_id="127.0.0.1:4789",
+            tp_size=1,
+            remote_dp_size=1,
+        )
+
+    metadata = MoRIIOConnectorMetadata()
+    metadata.reqs_to_recv["direct"] = make_meta("transfer-direct")
+    worker._ready_requests.put(("ready-1", make_meta("transfer-ready-1")))
+    worker._ready_requests.put(("ready-2", make_meta("transfer-ready-2")))
+
+    read_calls = []
+
+    def read_blocks_for_req(req_id, meta):
+        read_calls.append(req_id)
+
+    worker._read_blocks_for_req = read_blocks_for_req
+
+    worker.start_load_kv(metadata)
+
+    assert read_calls == ["direct", "ready-1", "ready-2"]
+    assert worker._ready_requests.empty()
+
+
+def _bare_worker():
+    """Build a worker without opening sockets or initializing MoRIIO."""
+    worker = MoRIIOConnectorWorker.__new__(MoRIIOConnectorWorker)
+    worker.tp_rank = 0
+    return worker
+
+
+def test_pick_host_for_dp_rank_cross_node():
+    worker = _bare_worker()
+    meta = MagicMock(
+        remote_hosts=["10.0.0.1", "10.0.0.2"],
+        remote_dp_size=16,
+        remote_host="10.0.0.1",
+        tp_size=1,
+    )
+
+    assert worker._pick_host_for_dp_rank(meta, 0) == "10.0.0.1"
+    assert worker._pick_host_for_dp_rank(meta, 7) == "10.0.0.1"
+    assert worker._pick_host_for_dp_rank(meta, 8) == "10.0.0.2"
+    assert worker._pick_host_for_dp_rank(meta, 15) == "10.0.0.2"
+
+
+def test_pick_host_for_dp_rank_single_node_fallback():
+    worker = _bare_worker()
+    meta_none = MagicMock(
+        remote_hosts=None, remote_dp_size=8, remote_host="10.0.0.1", tp_size=1
+    )
+    assert worker._pick_host_for_dp_rank(meta_none, 5) == "10.0.0.1"
+
+    meta_single = MagicMock(
+        remote_hosts=["10.0.0.1"],
+        remote_dp_size=8,
+        remote_host="10.0.0.1",
+        tp_size=1,
+    )
+    assert worker._pick_host_for_dp_rank(meta_single, 5) == "10.0.0.1"
+
+
+def _request_id_with_zmq(host: str = "10.0.0.1") -> str:
+    zmq_addr = f"host:{host},handshake:4789,notify:61005"
+    return f"___prefill_addr_{zmq_addr}___decode_addr_{zmq_addr}_{uuid.uuid4().hex}"
+
+
+def test_add_new_req_populates_remote_dp_rank():
+    base_kv = {
+        "transfer_id": "tx-1",
+        "remote_block_ids": [0, 1, 2],
+        "remote_engine_id": "engine-A",
+    }
+
+    metadata = MoRIIOConnectorMetadata()
+    metadata.add_new_req(
+        request_id=_request_id_with_zmq(),
+        local_block_ids=[10, 11],
+        kv_transfer_params=dict(base_kv, remote_dp_rank=7),
+        write_mode=True,
+    )
+    assert next(iter(metadata.reqs_to_save.values())).remote_dp_rank == 7
+
+    metadata = MoRIIOConnectorMetadata()
+    metadata.add_new_req(
+        request_id=_request_id_with_zmq(),
+        local_block_ids=[0],
+        kv_transfer_params=dict(base_kv),
+        write_mode=True,
+    )
+    assert next(iter(metadata.reqs_to_save.values())).remote_dp_rank == 0
+
+
+def test_add_new_req_uses_remote_zmq_address_when_request_id_has_no_peer():
+    metadata = MoRIIOConnectorMetadata()
+
+    metadata.add_new_req(
+        request_id="plain-request-id",
+        local_block_ids=[10, 11],
+        kv_transfer_params={
+            "transfer_id": "tx-1",
+            "remote_block_ids": [0, 1],
+            "remote_engine_id": "engine-A",
+            "remote_zmq_address": "host:prefill.example,handshake:1234,notify:2345",
+            "remote_hosts": ["prefill-a", "prefill-b"],
+        },
+        trusted_remote_hosts={"prefill.example", "prefill-a", "prefill-b"},
+    )
+
+    req_meta = next(iter(metadata.reqs_to_recv.values()))
+    assert req_meta.remote_host == "prefill.example"
+    assert req_meta.remote_handshake_port == 1234
+    assert req_meta.remote_notify_port == 2345
+    assert req_meta.remote_hosts == ["prefill-a", "prefill-b"]
+
+
+def test_add_new_req_rejects_untrusted_remote_zmq_address():
+    metadata = MoRIIOConnectorMetadata()
+
+    with pytest.raises(ValueError, match="trusted peer hosts"):
+        metadata.add_new_req(
+            request_id="plain-request-id",
+            local_block_ids=[10, 11],
+            kv_transfer_params={
+                "transfer_id": "tx-1",
+                "remote_block_ids": [0, 1],
+                "remote_engine_id": "engine-A",
+                "remote_zmq_address": "host:untrusted.example,handshake:1234,notify:2345",
+                "remote_hosts": ["prefill-a"],
+            },
+            trusted_remote_hosts={"prefill-a"},
+        )
+
+
+def test_add_new_req_rejects_remote_hosts_without_zmq_ports():
+    metadata = MoRIIOConnectorMetadata()
+
+    with pytest.raises(ValueError, match="remote_zmq_address"):
+        metadata.add_new_req(
+            request_id="plain-request-id",
+            local_block_ids=[10, 11],
+            kv_transfer_params={
+                "transfer_id": "tx-1",
+                "remote_block_ids": [0, 1],
+                "remote_engine_id": "engine-A",
+                "remote_hosts": ["prefill-a", "prefill-b"],
+            },
+        )
+
+
+def test_write_remote_blocks_uses_remote_zmq_address_without_embedded_request_id():
+    class Blocks:
+        def get_block_ids(self):
+            return [[1, 2, 3]]
+
+    scheduler = object.__new__(MoRIIOConnectorScheduler)
+    scheduler.mode = MoRIIOMode.WRITE
+    scheduler.tp_size = 1
+    scheduler.transfer_id_to_request_id = {}
+    scheduler.request_id_to_transfer_id = {}
+    scheduler._pending_transfer_id_to_request_id = {}
+    scheduler.transfer_id_to_remote_tp_size = {}
+    scheduler._pending_transfer_id_to_remote_tp_size = {}
+    scheduler.send_notify_block = MagicMock()
+    scheduler._trim_block_ids_to_token_span = lambda block_ids, _tokens: block_ids
+    scheduler.trusted_remote_hosts = ["prefill.example", "prefill-a", "prefill-b"]
+
+    request = SimpleNamespace(
+        request_id="plain-request-id",
+        num_prompt_tokens=3,
+        kv_transfer_params={
+            "transfer_id": "tx-1",
+            "do_remote_prefill": True,
+            "remote_zmq_address": "host:prefill.example,handshake:1234,notify:2345",
+            "remote_tp_size": 2,
+            "remote_dp_size": 1,
+            "remote_hosts": ["prefill-a", "prefill-b"],
+        },
+    )
+
+    scheduler.update_state_after_alloc(request, Blocks(), num_external_tokens=3)
+
+    assert scheduler.send_notify_block.call_count == 2
+    first_call = scheduler.send_notify_block.call_args_list[0].kwargs
+    second_call = scheduler.send_notify_block.call_args_list[1].kwargs
+    assert first_call["host"] == "prefill-a"
+    assert first_call["port"] == 2345
+    assert second_call["host"] == "prefill-b"
+    assert second_call["port"] == 2346
+
+
+def test_build_connector_meta_snapshots_transfer_mapping_without_delta_state():
+    scheduler = object.__new__(MoRIIOConnectorScheduler)
+    scheduler.mode = MoRIIOMode.READ
+    scheduler.transfer_id_to_request_id = {"tx0": "req0"}
+    scheduler._transfer_ids_to_forget = set()
+    scheduler._reqs_need_recv = {}
+    scheduler._reqs_need_save = {}
+    scheduler._reqs_need_pending_save = {}
+    scheduler._reqs_need_send = {}
+
+    metadata = scheduler.build_connector_meta(None)
+
+    scheduler.transfer_id_to_request_id["tx1"] = "req1"
+
+    assert metadata.transfer_id_to_request_id == {"tx0": "req0"}
+    assert metadata.transfer_id_to_request_id is not scheduler.transfer_id_to_request_id
+
+
+def test_build_connector_meta_sends_transfer_mapping_delta_once():
+    scheduler = object.__new__(MoRIIOConnectorScheduler)
+    scheduler.mode = MoRIIOMode.READ
+    scheduler.transfer_id_to_request_id = {"tx0": "req0"}
+    scheduler._pending_transfer_id_to_request_id = {"tx0": "req0"}
+    scheduler._transfer_ids_to_forget = set()
+    scheduler._reqs_need_recv = {}
+    scheduler._reqs_need_save = {}
+    scheduler._reqs_need_pending_save = {}
+    scheduler._reqs_need_send = {}
+
+    first_metadata = scheduler.build_connector_meta(None)
+    second_metadata = scheduler.build_connector_meta(None)
+
+    assert first_metadata.transfer_id_to_request_id == {"tx0": "req0"}
+    assert second_metadata.transfer_id_to_request_id == {}
+
+
+def _save_kv_worker(registered_dp_rank: int | None) -> MoRIIOConnectorWorker:
+    worker = _bare_worker()
+    worker.is_producer = True
+    worker.mode = MoRIIOMode.WRITE
+    worker.moriio_config = MagicMock(transfer_timeout=0.01)
+    worker._handshake_lock = MagicMock()
+    worker._ready_requests = queue.Queue()
+    bare_engine_id = "10.0.0.1:4789"
+    worker.write_ready_flags = {bare_engine_id: True}
+    worker._remote_agents = {}
+    if registered_dp_rank is not None:
+        worker._remote_agents[f"{bare_engine_id}_dp{registered_dp_rank}"] = {"agent"}
+    worker._write_blocks_for_req = MagicMock()
+    worker._background_moriio_handshake = MagicMock()
+    return worker
+
+
+def _req_meta_for_dp(remote_dp_rank: int) -> ReqMeta:
+    return ReqMeta(
+        transfer_id="tx-1",
+        local_block_ids=[0, 1],
+        remote_block_ids=[0, 1],
+        remote_host="10.0.0.1",
+        remote_port=4789,
+        remote_handshake_port=4789,
+        remote_notify_port=61005,
+        remote_engine_id="placeholder",
+        tp_size=1,
+        remote_dp_size=8,
+        remote_dp_rank=remote_dp_rank,
+    )
+
+
+def test_save_kv_layer_routes_to_target_dp_rank():
+    worker = _save_kv_worker(registered_dp_rank=7)
+    metadata = MoRIIOConnectorMetadata()
+    metadata.reqs_to_save = {"r1": _req_meta_for_dp(7)}
+
+    worker.save_kv_layer(metadata, "layer0", torch.zeros(1), None)
+
+    worker._write_blocks_for_req.assert_called_once()
+    worker._background_moriio_handshake.assert_not_called()
+
+
+def test_save_kv_layer_triggers_handshake_when_target_dp_missing():
+    worker = _save_kv_worker(registered_dp_rank=0)
+    metadata = MoRIIOConnectorMetadata()
+    metadata.reqs_to_save = {"r1": _req_meta_for_dp(7)}
+
+    worker.save_kv_layer(metadata, "layer0", torch.zeros(1), None)
+
+    worker._background_moriio_handshake.assert_called_once()
+    worker._write_blocks_for_req.assert_not_called()
 
 
 @pytest.mark.skipif(

--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -81,7 +81,7 @@ mori_available = importlib.util.find_spec("mori") is not None
 
 pytestmark = pytest.mark.skipif(
     not (current_platform.is_rocm() and mori_available),
-    reason="MoRIIOs are only available on ROCm with aiter package installed",
+    reason="MoRIIO tests require ROCm with the mori package installed",
 )
 
 

--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -747,7 +747,9 @@ def test_add_new_req_rejects_untrusted_remote_zmq_address():
                 "transfer_id": "tx-1",
                 "remote_block_ids": [0, 1],
                 "remote_engine_id": "engine-A",
-                "remote_zmq_address": "host:untrusted.example,handshake:1234,notify:2345",
+                "remote_zmq_address": (
+                    "host:untrusted.example,handshake:1234,notify:2345"
+                ),
                 "remote_hosts": ["prefill-a"],
             },
             trusted_remote_hosts={"prefill-a"},

--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -276,7 +276,11 @@ def create_vllm_config(
         kv_connector="MoRIIOConnector",
         kv_role=role,
         enable_permute_local_kv=enable_permute_local_kv,
-        kv_connector_extra_config={"read_mode": read_mode, "backend": "xgmi"},
+        kv_connector_extra_config={
+            "read_mode": read_mode,
+            "backend": "xgmi",
+            "trusted_remote_hosts": ["127.0.0.1"],
+        },
     )
     return VllmConfig(
         scheduler_config=scheduler_config,
@@ -516,6 +520,7 @@ def test_send_transfer_release_sends_structured_release_message():
         "transfer_id": "xfer-7",
     }
 
+
 def test_read_mode_trims_remote_blocks_not_local_blocks():
     """Read mode rejects mismatched block counts and preserves block id sides."""
 
@@ -753,6 +758,42 @@ def test_add_new_req_rejects_untrusted_remote_zmq_address():
                 "remote_hosts": ["prefill-a"],
             },
             trusted_remote_hosts={"prefill-a"},
+        )
+
+
+def test_add_new_req_rejects_untrusted_request_id_host():
+    metadata = MoRIIOConnectorMetadata()
+
+    with pytest.raises(ValueError, match="request_id host"):
+        metadata.add_new_req(
+            request_id=_request_id_with_zmq(host="untrusted.example"),
+            local_block_ids=[10, 11],
+            kv_transfer_params={
+                "transfer_id": "tx-1",
+                "remote_block_ids": [0, 1],
+                "remote_engine_id": "engine-A",
+            },
+            trusted_remote_hosts={"prefill-a"},
+        )
+
+
+def test_add_new_req_rejects_untrusted_explicit_remote_hosts():
+    metadata = MoRIIOConnectorMetadata()
+
+    with pytest.raises(ValueError, match="remote_hosts"):
+        metadata.add_new_req(
+            request_id="plain-request-id",
+            local_block_ids=[10, 11],
+            kv_transfer_params={
+                "transfer_id": "tx-1",
+                "remote_block_ids": [0, 1],
+                "remote_engine_id": "engine-A",
+                "remote_host": "prefill.example",
+                "remote_handshake_port": 1234,
+                "remote_notify_port": 2345,
+                "remote_hosts": ["untrusted.example"],
+            },
+            trusted_remote_hosts={"prefill.example"},
         )
 
 

--- a/tests/v1/kv_connector/unit/test_moriio_read_completion.py
+++ b/tests/v1/kv_connector/unit/test_moriio_read_completion.py
@@ -1,0 +1,1116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import queue
+import threading
+from collections import defaultdict
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config import KVTransferConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
+    ROLE,
+    LayerTransferPlan,
+    MoRIIOConfig,
+    MoRIIOConnectorMetadata,
+    MoRIIOMode,
+    ReqMeta,
+    get_moriio_mode,
+    get_port_offset,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector import (
+    _MAX_PENDING_UNMAPPED_DONE_TIDS,
+    MoRIIOConnector,
+    MoRIIOConnectorScheduler,
+    MoRIIOConnectorWorker,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_engine import (
+    MoRIIOWrapper,
+    MoRIIOWriter,
+)
+
+
+@pytest.fixture
+def should_do_global_cleanup_after_test() -> bool:
+    return False
+
+
+class FakeStatus:
+    def __init__(
+        self,
+        *,
+        succeeded: bool = False,
+        failed: bool = False,
+        succeed_after: int = 0,
+    ) -> None:
+        self.succeeded = succeeded
+        self.failed = failed
+        self.succeed_after = succeed_after
+        self.succeeded_calls = 0
+
+    def Succeeded(self) -> bool:
+        self.succeeded_calls += 1
+        if self.succeed_after and self.succeeded_calls >= self.succeed_after:
+            self.succeeded = True
+        return self.succeeded
+
+    def Failed(self) -> bool:
+        return self.failed
+
+    def Message(self) -> str:
+        return "fake failure"
+
+    def Code(self) -> int:
+        return 123
+
+
+class FakeWrapper:
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.notifies: list[tuple[str, str, str | int]] = []
+        self.done_req_ids: list[str] = []
+        self.done_remote_allocate_req_dict: dict[str, object] = {}
+        self.read_error: Exception | None = None
+        self.read_results: list[FakeStatus | Exception] = []
+        self.notify_error: Exception | None = None
+        self.waited_for_transfer = False
+
+    def send_notify(self, transfer_id: str, host: str, port: str) -> None:
+        if self.notify_error is not None:
+            error = self.notify_error
+            self.notify_error = None
+            raise error
+        self.notifies.append((transfer_id, host, port))
+
+    def async_wait_reqid(self) -> None:
+        pass
+
+    def pop_finished_req_ids(self) -> set[str]:
+        return set()
+
+    def read_remote_data(self, *_args):
+        if self.read_results:
+            result = self.read_results.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+        if self.read_error is not None:
+            raise self.read_error
+        return FakeStatus()
+
+    def waiting_for_transfer_complete(self) -> None:
+        self.waited_for_transfer = True
+
+    def shutdown(self) -> None:
+        pass
+
+
+class FakeTensor:
+    def numel(self) -> int:
+        return 1
+
+    def element_size(self) -> int:
+        return 1
+
+
+def make_worker() -> MoRIIOConnectorWorker:
+    worker = object.__new__(MoRIIOConnectorWorker)
+    worker.is_producer = False
+    worker.mode = MoRIIOMode.READ
+    worker.moriio_config = SimpleNamespace(
+        transfer_timeout=1.0,
+        defer_timeout=1.0,
+        max_inflight_global=0,
+        max_inflight_per_transfer=0,
+        max_dispatch_layers=0,
+    )
+    worker.moriio_wrapper = FakeWrapper()
+    worker._recving_transfers = defaultdict(dict)
+    worker._pending_read_plans = defaultdict(dict)
+    worker._recving_transfers_callback_addr = {}
+    worker._recving_transfer_local_block_ids = {}
+    worker._invalid_block_ids = queue.Queue()
+    worker._reqs_to_send = {}
+    worker.tp_rank = 0
+    worker.tp_size = 1
+    worker._pending_unmapped_done_tids = {}
+    worker._unmatched_write_completions = set()
+    worker.transfer_id_to_request_id = {}
+    worker.request_id_to_transfer_id = {}
+    worker.transfer_id_to_remote_tp_size = {}
+    worker.transfer_id_to_completion_count = {}
+    worker._read_completion_ids = defaultdict(set)
+    return worker
+
+
+def test_connector_wait_for_layer_load_forwards_only_for_read_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.distributed.kv_transfer.kv_connector.v1.moriio import (
+        moriio_connector as connector_module,
+    )
+
+    connector = object.__new__(MoRIIOConnector)
+    calls: list[str] = []
+    connector.connector_worker = SimpleNamespace(
+        wait_for_layer_load=lambda layer_name: calls.append(layer_name)
+    )
+
+    connector.mode = MoRIIOMode.READ
+    monkeypatch.setattr(connector_module, "get_role", lambda: ROLE.CONSUMER)
+    connector.wait_for_layer_load("layer0")
+    assert calls == ["layer0"]
+
+    connector.mode = MoRIIOMode.WRITE
+    connector.wait_for_layer_load("layer1")
+    assert calls == ["layer0"]
+
+
+def test_pending_unmapped_done_tids_evicts_oldest_at_cap() -> None:
+    worker = make_worker()
+
+    for idx in range(_MAX_PENDING_UNMAPPED_DONE_TIDS):
+        worker._buffer_pending_unmapped_done_tid(f"missing-{idx}")
+
+    worker._buffer_pending_unmapped_done_tid("new")
+
+    assert len(worker._pending_unmapped_done_tids) == (_MAX_PENDING_UNMAPPED_DONE_TIDS)
+    assert "missing-0" not in worker._pending_unmapped_done_tids
+    assert "missing-1" in worker._pending_unmapped_done_tids
+    assert "new" in worker._pending_unmapped_done_tids
+
+
+def test_freed_transfer_ids_drop_pending_unmapped_done_tids() -> None:
+    worker = make_worker()
+    worker.is_producer = True
+    transfer_id = "tx-00000000-0000-0000-0000-000000000001"
+    request_id = "req0-deadbeef"
+    wrapped_transfer_id = f"wrapped-{transfer_id}-suffix"
+    worker.transfer_id_to_request_id[transfer_id] = request_id
+    worker.request_id_to_transfer_id[request_id] = transfer_id
+    worker._reqs_to_send[request_id] = 1.0
+    worker._pending_unmapped_done_tids = {
+        transfer_id: None,
+        wrapped_transfer_id: None,
+        request_id: None,
+        "other": None,
+    }
+    metadata = SimpleNamespace(
+        freed_transfer_ids={transfer_id},
+        transfer_id_to_request_id={},
+    )
+
+    worker.start_load_kv(metadata)
+
+    assert transfer_id not in worker._pending_unmapped_done_tids
+    assert wrapped_transfer_id not in worker._pending_unmapped_done_tids
+    assert request_id not in worker._pending_unmapped_done_tids
+    assert "other" in worker._pending_unmapped_done_tids
+    assert transfer_id not in worker.transfer_id_to_request_id
+    assert request_id not in worker._reqs_to_send
+
+
+def test_freed_transfer_ids_filter_stale_worker_metadata_deltas() -> None:
+    worker = make_worker()
+    worker.is_producer = True
+    transfer_id = "tx-00000000-0000-0000-0000-000000000001"
+    request_id = "req0-deadbeef"
+    metadata = MoRIIOConnectorMetadata()
+    metadata.freed_transfer_ids.add(transfer_id)
+    metadata.transfer_id_to_request_id[transfer_id] = request_id
+    metadata.transfer_id_to_remote_tp_size[transfer_id] = 2
+    metadata.reqs_to_send[request_id] = 1.0
+
+    worker.start_load_kv(metadata)
+
+    assert transfer_id not in worker.transfer_id_to_request_id
+    assert transfer_id not in worker.transfer_id_to_remote_tp_size
+    assert transfer_id not in worker.transfer_id_to_completion_count
+    assert request_id not in worker.request_id_to_transfer_id
+    assert request_id not in worker._reqs_to_send
+
+
+def test_consumer_request_finished_does_not_warn_for_unscheduled_read(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    connector = object.__new__(MoRIIOConnectorScheduler)
+    connector.is_producer = False
+    connector.transfer_id_to_request_id = {}
+    connector.request_id_to_transfer_id = {}
+    connector._reqs_need_recv = {}
+    request = SimpleNamespace(
+        request_id="tx-00000000-0000-0000-0000-000000000001",
+        status=None,
+        kv_transfer_params={
+            "do_remote_prefill": True,
+            "transfer_id": "tx-00000000-0000-0000-0000-000000000001",
+        },
+    )
+
+    with caplog.at_level("WARNING"):
+        delay_free_blocks, kv_params = connector.request_finished(request, [])
+
+    assert delay_free_blocks is False
+    assert kv_params is None
+    assert request.kv_transfer_params["do_remote_prefill"] is False
+    assert "Could not find" not in caplog.text
+
+
+def test_zmq_ctx_sets_keepalive_before_bind_and_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.distributed.kv_transfer.kv_connector.v1.moriio import (
+        moriio_common as common,
+    )
+
+    class FakeSocket:
+        def __init__(self) -> None:
+            self.events: list[tuple[str, object, object | None]] = []
+
+        def setsockopt(self, option: object, value: object) -> None:
+            self.events.append(("setsockopt", option, value))
+
+        def bind(self, path: str) -> None:
+            self.events.append(("bind", path, None))
+
+        def connect(self, path: str) -> None:
+            self.events.append(("connect", path, None))
+
+    sockets: list[FakeSocket] = []
+
+    class FakeContext:
+        def socket(self, _socket_type: object) -> FakeSocket:
+            sock = FakeSocket()
+            sockets.append(sock)
+            return sock
+
+        def destroy(self, linger: int = 0) -> None:
+            pass
+
+    monkeypatch.setattr(common.zmq, "Context", FakeContext)
+    monkeypatch.setattr(
+        common.psutil,
+        "virtual_memory",
+        lambda: SimpleNamespace(total=64 * 1024**3, available=32 * 1024**3),
+    )
+
+    with common.zmq_ctx(common.zmq.ROUTER, "tcp://127.0.0.1:5555"):
+        pass
+    router_events = sockets[-1].events
+    keepalive = ("setsockopt", common.zmq.TCP_KEEPALIVE, 1)
+    assert router_events.index(keepalive) < router_events.index(
+        ("bind", "tcp://127.0.0.1:5555", None)
+    )
+
+    with common.zmq_ctx(common.zmq.DEALER, "tcp://127.0.0.1:5555"):
+        pass
+    dealer_events = sockets[-1].events
+    assert dealer_events.index(keepalive) < dealer_events.index(
+        ("connect", "tcp://127.0.0.1:5555", None)
+    )
+
+
+def test_finished_count_tracks_tensor_parallel_size() -> None:
+    connector = object.__new__(MoRIIOConnector)
+    connector._vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(tensor_parallel_size=1, data_parallel_size=8)
+    )
+
+    assert connector.get_finished_count() == 1
+
+    connector._vllm_config.parallel_config.tensor_parallel_size = 8
+    connector._vllm_config.parallel_config.data_parallel_size = 1
+
+    assert connector.get_finished_count() == 8
+
+
+def test_get_port_offset_includes_tensor_parallel_size() -> None:
+    assert get_port_offset(dp_rank=0, tp_rank=7, tp_size=16) == 7
+    assert get_port_offset(dp_rank=1, tp_rank=0, tp_size=16) == 16
+    assert get_port_offset(dp_rank=3, tp_rank=5, tp_size=16) == 53
+
+
+def test_moriio_config_notify_port_uses_tensor_parallel_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common as common
+
+    monkeypatch.setattr(common, "get_tensor_model_parallel_rank", lambda: 3)
+    monkeypatch.setattr(common, "get_tensor_model_parallel_world_size", lambda: 16)
+    monkeypatch.setattr(common, "get_ip", lambda: "127.0.0.1")
+    monkeypatch.setattr(common, "get_open_port", lambda: 12345)
+
+    vllm_config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(
+            kv_connector_extra_config={
+                "notify_port": 61005,
+                "proxy_ip": "127.0.0.1",
+                "proxy_ping_port": 36367,
+                "http_port": 8100,
+                "handshake_port": 6301,
+            }
+        ),
+        parallel_config=SimpleNamespace(
+            data_parallel_rank=2,
+            data_parallel_size=4,
+        ),
+    )
+
+    config = MoRIIOConfig.from_vllm_config(vllm_config)
+
+    assert config.notify_port == 61005 + 35
+    assert config.tp_size == 16
+    assert config.tp_rank == 3
+    assert config.dp_rank == 2
+
+
+def test_moriio_config_reads_flow_control_extra_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common as common
+
+    monkeypatch.setattr(common, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(common, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(common, "get_ip", lambda: "127.0.0.1")
+    monkeypatch.setattr(common, "get_open_port", lambda: 12345)
+
+    vllm_config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(
+            kv_connector_extra_config={
+                "notify_port": 61005,
+                "proxy_ip": "127.0.0.1",
+                "proxy_ping_port": 36367,
+                "http_port": 8100,
+                "handshake_port": 6301,
+                "handshake_timeout": 120,
+                "max_inflight_global": 16,
+                "max_inflight_per_transfer": 4,
+                "max_dispatch_layers": 4,
+            }
+        ),
+        parallel_config=SimpleNamespace(data_parallel_rank=0, data_parallel_size=1),
+    )
+
+    config = MoRIIOConfig.from_vllm_config(vllm_config)
+
+    assert config.handshake_timeout == 120
+    assert config.max_inflight_global == 16
+    assert config.max_inflight_per_transfer == 4
+    assert config.max_dispatch_layers == 4
+
+
+def test_read_mode_extra_config_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    def make_config(extra_config: dict[str, object]) -> KVTransferConfig:
+        return KVTransferConfig(kv_connector_extra_config=extra_config)
+
+    monkeypatch.setenv("VLLM_MORIIO_CONNECTOR_READ_MODE", "False")
+    assert get_moriio_mode(make_config({"read_mode": True})) == MoRIIOMode.READ
+    assert get_moriio_mode(make_config({"read_mode": "true"})) == MoRIIOMode.READ
+
+    monkeypatch.setenv("VLLM_MORIIO_CONNECTOR_READ_MODE", "True")
+    assert get_moriio_mode(make_config({"read_mode": False})) == MoRIIOMode.WRITE
+    assert get_moriio_mode(make_config({"read_mode": "False"})) == MoRIIOMode.WRITE
+    assert get_moriio_mode(make_config({"read_mode": "0"})) == MoRIIOMode.WRITE
+    assert get_moriio_mode(make_config({"read_mode": "off"})) == MoRIIOMode.WRITE
+    assert get_moriio_mode(make_config({"read_mode": None})) == MoRIIOMode.WRITE
+    assert get_moriio_mode(make_config({})) == MoRIIOMode.WRITE
+
+
+def test_requires_piecewise_for_cudagraph_rejects_allow_full() -> None:
+    for extra_config in (
+        {"allow_full_cudagraph": True},
+        {"allow_full_cudagraph": "true"},
+        {"allow_full_cudagraph": "1"},
+    ):
+        with pytest.raises(ValueError, match="allow_full_cudagraph"):
+            MoRIIOConnector.requires_piecewise_for_cudagraph(extra_config)
+
+
+def test_add_new_req_uses_remote_zmq_address_without_embedded_request_id() -> None:
+    metadata = MoRIIOConnectorMetadata()
+
+    metadata.add_new_req(
+        request_id="plain-request-id",
+        local_block_ids=[10, 11],
+        kv_transfer_params={
+            "transfer_id": "tx-1",
+            "remote_block_ids": [0, 1],
+            "remote_engine_id": "engine-A",
+            "remote_zmq_address": "host:prefill.example,handshake:1234,notify:2345",
+            "remote_hosts": ["prefill-a", "prefill-b"],
+        },
+    )
+
+    req_meta = next(iter(metadata.reqs_to_recv.values()))
+    assert req_meta.remote_host == "prefill.example"
+    assert req_meta.remote_handshake_port == 1234
+    assert req_meta.remote_notify_port == 2345
+    assert req_meta.remote_hosts == ["prefill-a", "prefill-b"]
+
+
+def test_add_new_req_rejects_remote_hosts_without_zmq_ports() -> None:
+    metadata = MoRIIOConnectorMetadata()
+
+    with pytest.raises(ValueError, match="remote_zmq_address"):
+        metadata.add_new_req(
+            request_id="plain-request-id",
+            local_block_ids=[10, 11],
+            kv_transfer_params={
+                "transfer_id": "tx-1",
+                "remote_block_ids": [0, 1],
+                "remote_engine_id": "engine-A",
+                "remote_hosts": ["prefill-a", "prefill-b"],
+            },
+        )
+
+
+def test_write_remote_blocks_uses_remote_zmq_address_without_embedded_request_id():
+    class Blocks:
+        def get_block_ids(self):
+            return [[1, 2, 3]]
+
+    scheduler = object.__new__(MoRIIOConnectorScheduler)
+    scheduler.mode = MoRIIOMode.WRITE
+    scheduler.tp_size = 1
+    scheduler.transfer_id_to_request_id = {}
+    scheduler.request_id_to_transfer_id = {}
+    scheduler._pending_transfer_id_to_request_id = {}
+    scheduler.transfer_id_to_remote_tp_size = {}
+    scheduler._pending_transfer_id_to_remote_tp_size = {}
+    sent_notifies = []
+    scheduler.send_notify_block = lambda **kwargs: sent_notifies.append(kwargs)
+    scheduler._trim_block_ids_to_token_span = lambda block_ids, _tokens: block_ids
+    request = SimpleNamespace(
+        request_id="plain-request-id",
+        num_prompt_tokens=3,
+        kv_transfer_params={
+            "transfer_id": "tx-1",
+            "do_remote_prefill": True,
+            "remote_zmq_address": "host:prefill.example,handshake:1234,notify:2345",
+            "remote_tp_size": 2,
+            "remote_dp_size": 1,
+            "remote_hosts": ["prefill-a", "prefill-b"],
+        },
+    )
+
+    scheduler.update_state_after_alloc(request, Blocks(), num_external_tokens=3)
+
+    assert [notify["host"] for notify in sent_notifies] == [
+        "prefill-a",
+        "prefill-b",
+    ]
+    assert [notify["port"] for notify in sent_notifies] == [2345, 2346]
+
+
+def test_write_producer_done_sending_translates_transfer_ids() -> None:
+    worker = make_worker()
+    worker.is_producer = True
+    worker.mode = MoRIIOMode.WRITE
+    worker.moriio_wrapper.pop_finished_req_ids = lambda: {"transfer0"}
+    worker.transfer_id_to_request_id["transfer0"] = "req0"
+    worker.request_id_to_transfer_id["req0"] = "transfer0"
+
+    done_sending, done_recving = worker.get_finished()
+
+    assert done_sending == {"req0"}
+    assert done_recving == set()
+    assert "transfer0" not in worker.transfer_id_to_request_id
+
+
+def test_write_producer_done_sending_accepts_request_id() -> None:
+    # Production WRITE path: the engine appends the *request_id* (not the
+    # transfer_id) to done_req_ids in _finalize_if_complete / _mark_request_done
+    # (moriio_engine.py). get_finished must therefore resolve a raw request_id
+    # via request_id_to_transfer_id -> transfer_id_to_request_id (case 3 of
+    # _pop_mapped_completion_id), not only the legacy transfer_id form covered
+    # by test_write_producer_done_sending_translates_transfer_ids.
+    worker = make_worker()
+    worker.is_producer = True
+    worker.mode = MoRIIOMode.WRITE
+    worker.moriio_wrapper.pop_finished_req_ids = lambda: {"req0"}
+    worker.transfer_id_to_request_id["transfer0"] = "req0"
+    worker.request_id_to_transfer_id["req0"] = "transfer0"
+
+    done_sending, done_recving = worker.get_finished()
+
+    assert done_sending == {"req0"}
+    assert done_recving == set()
+    assert "transfer0" not in worker.transfer_id_to_request_id
+    assert "req0" not in worker.request_id_to_transfer_id
+
+
+def test_write_producer_completion_waits_for_mapping() -> None:
+    worker = make_worker()
+    worker.is_producer = True
+    worker.mode = MoRIIOMode.WRITE
+    completions = [{"transfer0"}, set()]
+    worker.moriio_wrapper.pop_finished_req_ids = lambda: completions.pop(0)
+
+    done_sending, _ = worker.get_finished()
+
+    assert done_sending == set()
+    assert "transfer0" in worker._pending_unmapped_done_tids
+
+    worker.transfer_id_to_request_id["transfer0"] = "req0"
+    worker.request_id_to_transfer_id["req0"] = "transfer0"
+
+    done_sending, _ = worker.get_finished()
+
+    assert done_sending == {"req0"}
+    assert worker._pending_unmapped_done_tids == {}
+
+
+def test_read_producer_completion_waits_for_remote_tp_quorum() -> None:
+    worker = make_worker()
+    worker.is_producer = True
+    worker.mode = MoRIIOMode.READ
+    worker.tp_rank = 0
+    worker.tp_size = 1
+    worker.moriio_wrapper.pop_finished_req_ids = lambda: {"transfer0:tp0"}
+    worker.transfer_id_to_request_id["transfer0"] = "req0"
+    worker.request_id_to_transfer_id["req0"] = "transfer0"
+    worker.transfer_id_to_completion_count["transfer0"] = 2
+
+    done_sending, done_recving = worker.get_finished()
+
+    assert done_sending == set()
+    assert done_recving == set()
+    assert worker.transfer_id_to_request_id["transfer0"] == "req0"
+    assert worker._read_completion_ids["transfer0"] == {"tp0"}
+
+
+def test_read_producer_completion_ignores_duplicate_until_final_rank() -> None:
+    worker = make_worker()
+    worker.is_producer = True
+    worker.mode = MoRIIOMode.READ
+    worker.tp_rank = 0
+    worker.tp_size = 1
+    completions = [{"transfer0:tp0"}, {"transfer0:tp0"}, {"transfer0:tp1"}]
+    worker.moriio_wrapper.pop_finished_req_ids = lambda: completions.pop(0)
+    worker.transfer_id_to_request_id["transfer0"] = "req0"
+    worker.request_id_to_transfer_id["req0"] = "transfer0"
+    worker.transfer_id_to_completion_count["transfer0"] = 2
+
+    done_sending, _ = worker.get_finished()
+    assert done_sending == set()
+
+    done_sending, _ = worker.get_finished()
+    assert done_sending == set()
+    assert worker._read_completion_ids["transfer0"] == {"tp0"}
+
+    done_sending, done_recving = worker.get_finished()
+
+    assert done_sending == {"req0"}
+    assert done_recving == set()
+    assert "transfer0" not in worker.transfer_id_to_request_id
+    assert "transfer0" not in worker._read_completion_ids
+
+
+def test_read_producer_pending_completion_uses_quorum_after_mapping() -> None:
+    worker = make_worker()
+    worker.is_producer = True
+    worker.mode = MoRIIOMode.READ
+    completions = [{"transfer0:tp0", "transfer0:tp1"}, set()]
+    worker.moriio_wrapper.pop_finished_req_ids = lambda: completions.pop(0)
+
+    done_sending, _ = worker.get_finished()
+
+    assert done_sending == set()
+    assert set(worker._pending_unmapped_done_tids) == {
+        "transfer0:tp0",
+        "transfer0:tp1",
+    }
+
+    worker.transfer_id_to_request_id["transfer0"] = "req0"
+    worker.request_id_to_transfer_id["req0"] = "transfer0"
+    worker.transfer_id_to_completion_count["transfer0"] = 2
+
+    done_sending, done_recving = worker.get_finished()
+
+    assert done_sending == {"req0"}
+    assert done_recving == set()
+    assert worker._pending_unmapped_done_tids == {}
+
+
+def test_read_producer_zero_quorum_rank_finishes_without_notify() -> None:
+    worker = make_worker()
+    worker.is_producer = True
+    worker.mode = MoRIIOMode.READ
+    worker.tp_rank = 3
+    worker.tp_size = 4
+    metadata = MoRIIOConnectorMetadata()
+    metadata.transfer_id_to_request_id["transfer0"] = "req0"
+    metadata.transfer_id_to_remote_tp_size["transfer0"] = 2
+    metadata.reqs_to_send["req0"] = 1.0
+
+    worker.start_load_kv(metadata)
+    done_sending, done_recving = worker.get_finished()
+
+    assert done_sending == {"req0"}
+    assert done_recving == set()
+    assert "req0" not in worker._reqs_to_send
+    assert "transfer0" not in worker.transfer_id_to_request_id
+
+
+def test_write_finalize_reports_request_id_locally_and_transfer_id_remotely() -> None:
+    class Worker:
+        pass
+
+    worker = Worker()
+    worker.moriio_config = SimpleNamespace(defer_timeout=1.0)
+    worker.moriio_wrapper = FakeWrapper()
+    worker.num_layers = 1
+    worker.tp_rank = 2
+    worker.tp_size = 8
+    worker.moriio_wrapper.done_remote_allocate_req_dict["transfer0"] = object()
+    writer = MoRIIOWriter(worker)
+    task = SimpleNamespace(
+        request_id="req0",
+        transfer_id="transfer0",
+        remote_notify_port=61005,
+        remote_ip="10.0.0.2",
+    )
+    request_info = SimpleNamespace(writes_done=0, decode_dp_rank=1)
+
+    writer._finalize_if_complete(task, request_info)
+
+    assert worker.moriio_wrapper.notifies == [("transfer0", "10.0.0.2", 61015)]
+    assert worker.moriio_wrapper.done_req_ids == ["req0"]
+    assert "transfer0" not in worker.moriio_wrapper.done_remote_allocate_req_dict
+    assert worker.moriio_wrapper.waited_for_transfer is True
+
+
+def test_write_deferred_expiry_reports_request_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Worker:
+        pass
+
+    worker = Worker()
+    worker.moriio_config = SimpleNamespace(defer_timeout=1.0)
+    worker.moriio_wrapper = FakeWrapper()
+    worker.moriio_wrapper.done_remote_allocate_req_dict["transfer0"] = object()
+    writer = MoRIIOWriter(worker)
+    writer._deferred_tasks = [
+        SimpleNamespace(
+            enqueue_time=0.0,
+            request_id="req0",
+            transfer_id="transfer0",
+        )
+    ]
+
+    monkeypatch.setattr("time.perf_counter", lambda: 5.0)
+
+    writer._process_deferred_tasks()
+
+    assert writer._deferred_tasks == []
+    assert worker.moriio_wrapper.done_req_ids == ["req0"]
+    assert "transfer0" not in worker.moriio_wrapper.done_remote_allocate_req_dict
+
+
+def test_remote_allocation_keys_ready_and_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.distributed.kv_transfer.kv_connector.v1.moriio import (
+        moriio_engine as engine_module,
+    )
+
+    monkeypatch.setattr(engine_module, "get_role", lambda: ROLE.PRODUCER)
+    worker = make_worker()
+    writer = MoRIIOWriter(worker)
+    transfer_id = "transfer0"
+    request_id = "request0-deadbeef"
+    stripped_request_id = "request0"
+    task = SimpleNamespace(transfer_id=transfer_id, request_id=request_id)
+
+    assert writer._is_remote_ready(task) is False
+
+    MoRIIOWrapper._handle_structured_message(
+        worker.moriio_wrapper,
+        {
+            "type": "remote_blocks",
+            "transfer_id": transfer_id,
+            "req_id": request_id,
+            "block_notify_list": [21, 22],
+            "decode_rank": 3,
+        },
+    )
+
+    allocation_by_key = worker.moriio_wrapper.done_remote_allocate_req_dict
+    info = allocation_by_key[transfer_id]
+    assert allocation_by_key[request_id] is info
+    assert allocation_by_key[stripped_request_id] is info
+    assert info.block_ids == [21, 22]
+    assert info.decode_dp_rank == 3
+    assert writer._is_remote_ready(task) is True
+
+    def assert_lookup_finds(single_key, lookup_task):
+        allocation_by_key.clear()
+        allocation_by_key[single_key] = info
+        assert writer._is_remote_ready(lookup_task) is True
+        assert writer._get_remote_alloc_info(lookup_task) is info
+
+    assert_lookup_finds(
+        transfer_id,
+        SimpleNamespace(transfer_id=transfer_id, request_id="missing-deadbeef"),
+    )
+    assert_lookup_finds(
+        request_id,
+        SimpleNamespace(transfer_id="missing", request_id=request_id),
+    )
+    assert_lookup_finds(
+        stripped_request_id,
+        SimpleNamespace(transfer_id="missing", request_id=request_id),
+    )
+
+    allocation_by_key[transfer_id] = info
+    allocation_by_key[request_id] = info
+    allocation_by_key[stripped_request_id] = info
+
+    writer._mark_request_done(request_id, transfer_id)
+
+    assert worker.moriio_wrapper.done_req_ids == [request_id]
+    assert transfer_id not in allocation_by_key
+    assert request_id not in allocation_by_key
+    assert stripped_request_id not in allocation_by_key
+
+
+def make_req_meta(
+    *,
+    tp_size: int,
+    remote_dp_size: int,
+    remote_hosts: list[str] | None = None,
+) -> ReqMeta:
+    remote_hosts = remote_hosts or ["host0", "host1"]
+    return ReqMeta(
+        transfer_id="transfer0",
+        local_block_ids=[1],
+        remote_block_ids=[2],
+        remote_host="host0",
+        remote_port=1234,
+        remote_handshake_port=6301,
+        remote_notify_port=61005,
+        remote_engine_id="host0:6301",
+        tp_size=tp_size,
+        remote_dp_size=remote_dp_size,
+        remote_hosts=remote_hosts,
+    )
+
+
+def test_multi_node_tp_host_selection_prefers_tp_rank() -> None:
+    worker = object.__new__(MoRIIOConnectorWorker)
+    worker.tp_rank = 9
+
+    meta = make_req_meta(tp_size=16, remote_dp_size=1)
+
+    assert worker._pick_host_for_dp_rank(meta, dp_rank=7) == "host1"
+
+
+def test_multi_node_dp_host_selection_uses_dp_rank_when_dp_size_gt_one() -> None:
+    worker = object.__new__(MoRIIOConnectorWorker)
+    worker.tp_rank = 0
+
+    meta = make_req_meta(
+        tp_size=8,
+        remote_dp_size=8,
+        remote_hosts=[f"host{i}" for i in range(8)],
+    )
+
+    assert worker._pick_host_for_dp_rank(meta, dp_rank=7) == "host7"
+
+
+def test_multi_node_dp_host_selection_uses_dp_rank_for_tp1() -> None:
+    worker = object.__new__(MoRIIOConnectorWorker)
+    worker.tp_rank = 0
+
+    meta = make_req_meta(tp_size=1, remote_dp_size=16)
+
+    assert worker._pick_host_for_dp_rank(meta, dp_rank=12) == "host1"
+
+
+def test_wait_for_layer_load_waits_until_layer_status_succeeds() -> None:
+    worker = make_worker()
+    status = FakeStatus(succeed_after=3)
+    worker._recving_transfers["req0"]["layer0"] = status
+
+    worker.wait_for_layer_load("layer0")
+
+    assert status.succeeded_calls >= 3
+
+
+def test_read_blocks_respects_layer_dispatch_window() -> None:
+    worker = make_worker()
+    worker.moriio_config.max_dispatch_layers = 1
+    worker.tp_rank = 0
+    worker.dp_rank = 0
+    worker.kv_caches = {
+        "layer0": FakeTensor(),
+        "layer1": FakeTensor(),
+        "layer2": FakeTensor(),
+    }
+    worker.layer_name_to_local_kv_cache_metadata = {
+        "layer0": [],
+        "layer1": [],
+        "layer2": [],
+    }
+    worker._get_built_session = lambda _engine_id: (
+        ["session0", "session1", "session2"],
+        SimpleNamespace(num_blocks=1, block_len=1),
+    )
+    worker._compute_block_transfer_offsets = lambda *_args: ([0], [0], [1])
+    worker.moriio_wrapper.read_results = [FakeStatus(), FakeStatus(), FakeStatus()]
+
+    worker._read_blocks(
+        local_block_ids=[11, 12],
+        remote_block_ids=[21, 22],
+        dst_engine_id="remote",
+        request_id="req0",
+        transfer_id="transfer0",
+        remote_host="host",
+        remote_notify_port=61005,
+        remote_dp_rank=0,
+        remote_tp_size=1,
+    )
+
+    assert set(worker._recving_transfers["req0"]) == {"layer0"}
+    assert set(worker._pending_read_plans["req0"]) == {"layer1", "layer2"}
+
+    worker._recving_transfers["req0"]["layer0"].succeeded = True
+    worker.wait_for_layer_load("layer0")
+
+    assert set(worker._recving_transfers["req0"]) == {"layer0", "layer1"}
+    assert set(worker._pending_read_plans["req0"]) == {"layer2"}
+
+
+def test_wait_for_layer_load_dispatches_required_pending_layer() -> None:
+    worker = make_worker()
+    worker.moriio_config.max_dispatch_layers = 1
+    worker.moriio_wrapper.read_results = [FakeStatus(succeeded=True)]
+    worker._recving_transfers_callback_addr["req0"] = ("host", "1234", "transfer0")
+    worker._recving_transfer_local_block_ids["req0"] = {11, 12}
+    worker._pending_read_plans["req0"]["layer1"] = LayerTransferPlan(
+        request_id="req0",
+        transfer_id="transfer0",
+        layer_name="layer1",
+        sess_idx=0,
+        transfer_local_offsets=[0],
+        transfer_remote_offsets=[0],
+        transfer_sizes=[1],
+        session="session0",
+    )
+
+    worker.wait_for_layer_load("layer1")
+
+    assert "layer1" in worker._recving_transfers["req0"]
+    assert "req0" not in worker._pending_read_plans
+
+
+def test_read_blocks_respects_global_active_layer_window() -> None:
+    worker = make_worker()
+    worker.moriio_config.max_inflight_global = 2
+    worker.tp_rank = 0
+    worker.dp_rank = 0
+    worker.kv_caches = {
+        "layer0": FakeTensor(),
+        "layer1": FakeTensor(),
+        "layer2": FakeTensor(),
+    }
+    worker.layer_name_to_local_kv_cache_metadata = {
+        "layer0": [],
+        "layer1": [],
+        "layer2": [],
+    }
+    worker._get_built_session = lambda _engine_id: (
+        ["session0", "session1", "session2"],
+        SimpleNamespace(num_blocks=1, block_len=1),
+    )
+    worker._compute_block_transfer_offsets = lambda *_args: ([0], [0], [1])
+    worker.moriio_wrapper.read_results = [FakeStatus(), FakeStatus()]
+
+    worker._read_blocks(
+        local_block_ids=[11, 12],
+        remote_block_ids=[21, 22],
+        dst_engine_id="remote0",
+        request_id="req0",
+        transfer_id="transfer0",
+        remote_host="host",
+        remote_notify_port=61005,
+        remote_dp_rank=0,
+        remote_tp_size=1,
+    )
+    worker._read_blocks(
+        local_block_ids=[13, 14],
+        remote_block_ids=[23, 24],
+        dst_engine_id="remote1",
+        request_id="req1",
+        transfer_id="transfer1",
+        remote_host="host",
+        remote_notify_port=61005,
+        remote_dp_rank=0,
+        remote_tp_size=1,
+    )
+
+    assert set(worker._recving_transfers["req0"]) == {"layer0", "layer1"}
+    assert "req1" not in worker._recving_transfers
+    assert set(worker._pending_read_plans["req0"]) == {"layer2"}
+    assert set(worker._pending_read_plans["req1"]) == {
+        "layer0",
+        "layer1",
+        "layer2",
+    }
+
+
+def test_wait_for_layer_load_raises_on_failed_status() -> None:
+    worker = make_worker()
+    worker._recving_transfers["req0"]["layer0"] = FakeStatus(failed=True)
+
+    with pytest.raises(RuntimeError, match="request req0, layer layer0"):
+        worker.wait_for_layer_load("layer0")
+
+
+def test_wait_for_layer_load_failure_marks_local_blocks_invalid() -> None:
+    worker = make_worker()
+    worker._recving_transfers["req0"]["layer0"] = FakeStatus(failed=True)
+    worker._recving_transfers_callback_addr["req0"] = ("host", "1234", "transfer0")
+    worker._recving_transfer_local_block_ids["req0"] = {11, 12}
+    worker.transfer_id_to_request_id["transfer0"] = "req0"
+
+    with pytest.raises(RuntimeError, match="request req0, layer layer0"):
+        worker.wait_for_layer_load("layer0")
+
+    assert worker.moriio_wrapper.notifies == [("transfer0:tp0", "host", "1234")]
+    assert worker.get_block_ids_with_load_errors() == {11, 12}
+    assert "req0" not in worker._recving_transfers
+    assert "req0" not in worker._recving_transfers_callback_addr
+    assert "req0" not in worker._recving_transfer_local_block_ids
+    assert "transfer0" not in worker.transfer_id_to_request_id
+
+
+def test_pop_done_transfers_waits_for_all_layer_statuses() -> None:
+    worker = make_worker()
+    worker._recving_transfers["req0"]["layer0"] = FakeStatus(succeeded=True)
+    worker._recving_transfers["req0"]["layer1"] = FakeStatus()
+    worker._recving_transfers_callback_addr["req0"] = ("host", "1234", "transfer0")
+    worker._recving_transfer_local_block_ids["req0"] = {11, 12}
+    worker.transfer_id_to_request_id["transfer0"] = "req0"
+
+    assert worker._pop_done_transfers() == set()
+    assert worker.moriio_wrapper.notifies == []
+    assert "req0" in worker._recving_transfers
+
+    worker._recving_transfers["req0"]["layer1"].succeeded = True
+
+    assert worker._pop_done_transfers() == set()
+    assert worker.moriio_wrapper.notifies == [("transfer0:tp0", "host", "1234")]
+    assert "req0" not in worker._recving_transfers
+    assert "req0" not in worker._recving_transfers_callback_addr
+    assert "req0" not in worker._recving_transfer_local_block_ids
+    assert "transfer0" not in worker.transfer_id_to_request_id
+
+
+def test_pop_done_transfers_retries_success_notify_failure() -> None:
+    worker = make_worker()
+    worker._recving_transfers["req0"]["layer0"] = FakeStatus(succeeded=True)
+    worker._recving_transfers_callback_addr["req0"] = ("host", "1234", "transfer0")
+    worker._recving_transfer_local_block_ids["req0"] = {11, 12}
+    worker.transfer_id_to_request_id["transfer0"] = "req0"
+    worker.moriio_wrapper.notify_error = RuntimeError("notify failed")
+
+    assert worker._pop_done_transfers() == set()
+
+    assert worker.moriio_wrapper.notifies == []
+    assert "req0" in worker._recving_transfers
+    assert worker.transfer_id_to_request_id["transfer0"] == "req0"
+
+    assert worker._pop_done_transfers() == set()
+
+    assert worker.moriio_wrapper.notifies == [("transfer0:tp0", "host", "1234")]
+    assert "req0" not in worker._recving_transfers
+    assert "transfer0" not in worker.transfer_id_to_request_id
+
+
+def test_failed_read_marks_local_blocks_invalid() -> None:
+    worker = make_worker()
+    worker._recving_transfers["req0"]["layer0"] = FakeStatus(failed=True)
+    worker._recving_transfers_callback_addr["req0"] = ("host", "1234", "transfer0")
+    worker._recving_transfer_local_block_ids["req0"] = {11, 12}
+    worker.transfer_id_to_request_id["transfer0"] = "req0"
+
+    assert worker._pop_done_transfers() == set()
+
+    assert worker.moriio_wrapper.notifies == [("transfer0:tp0", "host", "1234")]
+    assert worker.get_block_ids_with_load_errors() == {11, 12}
+    assert worker.get_block_ids_with_load_errors() == set()
+    assert "req0" not in worker._recving_transfers
+    assert "req0" not in worker._recving_transfers_callback_addr
+    assert "req0" not in worker._recving_transfer_local_block_ids
+    assert "transfer0" not in worker.transfer_id_to_request_id
+
+
+def test_read_blocks_partial_setup_exception_marks_local_blocks_invalid() -> None:
+    worker = make_worker()
+    worker.tp_rank = 2
+    worker.dp_rank = 0
+    worker.kv_caches = {"layer0": FakeTensor(), "layer1": FakeTensor()}
+    worker.layer_name_to_local_kv_cache_metadata = {"layer0": [], "layer1": []}
+    worker._get_built_session = lambda _engine_id: (
+        ["session0", "session1"],
+        SimpleNamespace(num_blocks=1, block_len=1),
+    )
+    worker._compute_block_transfer_offsets = lambda *_args: ([0], [0], [1])
+    worker.moriio_wrapper.read_results = [
+        FakeStatus(succeeded=True),
+        RuntimeError("layer1 setup failed"),
+    ]
+
+    with pytest.raises(RuntimeError, match="layer1 setup failed"):
+        worker._read_blocks(
+            local_block_ids=[11, 12],
+            remote_block_ids=[21, 22],
+            dst_engine_id="remote",
+            request_id="req0",
+            transfer_id="transfer0",
+            remote_host="host",
+            remote_notify_port=61005,
+            remote_dp_rank=1,
+            remote_tp_size=16,
+        )
+
+    assert worker.moriio_wrapper.notifies == [("transfer0:tp2", "host", "61023")]
+    assert worker.get_block_ids_with_load_errors() == {11, 12}
+    assert "req0" not in worker._recving_transfers
+    assert "req0" not in worker._recving_transfers_callback_addr
+    assert "req0" not in worker._recving_transfer_local_block_ids
+
+
+def test_read_blocks_setup_exception_notifies_without_invalid_blocks() -> None:
+    worker = make_worker()
+    worker.tp_rank = 2
+    worker.dp_rank = 0
+    worker.kv_caches = {"layer0": FakeTensor()}
+    worker.layer_name_to_local_kv_cache_metadata = {"layer0": []}
+    worker._get_built_session = lambda _engine_id: (
+        ["session0"],
+        SimpleNamespace(num_blocks=1, block_len=1),
+    )
+    worker._compute_block_transfer_offsets = lambda *_args: ([0], [0], [1])
+    worker.moriio_wrapper.read_error = RuntimeError("setup failed")
+
+    with pytest.raises(RuntimeError, match="setup failed"):
+        worker._read_blocks(
+            local_block_ids=[11, 12],
+            remote_block_ids=[21, 22],
+            dst_engine_id="remote",
+            request_id="req0",
+            transfer_id="transfer0",
+            remote_host="host",
+            remote_notify_port=61005,
+            remote_dp_rank=1,
+            remote_tp_size=16,
+        )
+
+    assert worker.moriio_wrapper.notifies == [("transfer0:tp2", "host", "61023")]
+    assert worker.get_block_ids_with_load_errors() == set()
+    assert "req0" not in worker._recving_transfers
+    assert "req0" not in worker._recving_transfers_callback_addr
+    assert "req0" not in worker._recving_transfer_local_block_ids

--- a/tests/v1/kv_connector/unit/test_moriio_read_completion.py
+++ b/tests/v1/kv_connector/unit/test_moriio_read_completion.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Dependency-light MoRIIO worker and scheduler state-machine tests.
+
+This module must not instantiate real MoRI/MoRIIO engines. Tests that need the
+real `mori` package belong in `test_moriio_connector.py` behind its ROCm+MoRI
+collection skip.
+"""
+
 import queue
 import threading
 from collections import defaultdict
@@ -437,54 +444,6 @@ def test_read_mode_extra_config_overrides_env(monkeypatch: pytest.MonkeyPatch) -
     assert get_moriio_mode(make_config({"read_mode": "off"})) == MoRIIOMode.WRITE
     assert get_moriio_mode(make_config({"read_mode": None})) == MoRIIOMode.WRITE
     assert get_moriio_mode(make_config({})) == MoRIIOMode.WRITE
-
-
-def test_requires_piecewise_for_cudagraph_rejects_allow_full() -> None:
-    for extra_config in (
-        {"allow_full_cudagraph": True},
-        {"allow_full_cudagraph": "true"},
-        {"allow_full_cudagraph": "1"},
-    ):
-        with pytest.raises(ValueError, match="allow_full_cudagraph"):
-            MoRIIOConnector.requires_piecewise_for_cudagraph(extra_config)
-
-
-def test_add_new_req_uses_remote_zmq_address_without_embedded_request_id() -> None:
-    metadata = MoRIIOConnectorMetadata()
-
-    metadata.add_new_req(
-        request_id="plain-request-id",
-        local_block_ids=[10, 11],
-        kv_transfer_params={
-            "transfer_id": "tx-1",
-            "remote_block_ids": [0, 1],
-            "remote_engine_id": "engine-A",
-            "remote_zmq_address": "host:prefill.example,handshake:1234,notify:2345",
-            "remote_hosts": ["prefill-a", "prefill-b"],
-        },
-    )
-
-    req_meta = next(iter(metadata.reqs_to_recv.values()))
-    assert req_meta.remote_host == "prefill.example"
-    assert req_meta.remote_handshake_port == 1234
-    assert req_meta.remote_notify_port == 2345
-    assert req_meta.remote_hosts == ["prefill-a", "prefill-b"]
-
-
-def test_add_new_req_rejects_remote_hosts_without_zmq_ports() -> None:
-    metadata = MoRIIOConnectorMetadata()
-
-    with pytest.raises(ValueError, match="remote_zmq_address"):
-        metadata.add_new_req(
-            request_id="plain-request-id",
-            local_block_ids=[10, 11],
-            kv_transfer_params={
-                "transfer_id": "tx-1",
-                "remote_block_ids": [0, 1],
-                "remote_engine_id": "engine-A",
-                "remote_hosts": ["prefill-a", "prefill-b"],
-            },
-        )
 
 
 def test_write_remote_blocks_uses_remote_zmq_address_without_embedded_request_id():

--- a/tests/v1/kv_connector/unit/test_moriio_read_completion.py
+++ b/tests/v1/kv_connector/unit/test_moriio_read_completion.py
@@ -14,6 +14,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     MoRIIOConfig,
     MoRIIOConnectorMetadata,
     MoRIIOMode,
+    MoRIIOTransferAck,
     ReqMeta,
     get_moriio_mode,
     get_port_offset,
@@ -68,14 +69,17 @@ class FakeWrapper:
     def __init__(self) -> None:
         self.lock = threading.Lock()
         self.notifies: list[tuple[str, str, str | int]] = []
-        self.done_req_ids: list[str] = []
+        self.done_req_ids: list[MoRIIOTransferAck] = []
         self.done_remote_allocate_req_dict: dict[str, object] = {}
         self.read_error: Exception | None = None
         self.read_results: list[FakeStatus | Exception] = []
         self.notify_error: Exception | None = None
         self.waited_for_transfer = False
+        self._terminal_transfer_ids: set[str] = set()
 
-    def send_notify(self, transfer_id: str, host: str, port: str) -> None:
+    def send_notify(
+        self, transfer_id: str, host: str, port: str | int, **_kwargs
+    ) -> None:
         if self.notify_error is not None:
             error = self.notify_error
             self.notify_error = None
@@ -98,8 +102,23 @@ class FakeWrapper:
             raise self.read_error
         return FakeStatus()
 
-    def waiting_for_transfer_complete(self) -> None:
+    def waiting_for_transfer_complete(self, *_args) -> None:
         self.waited_for_transfer = True
+
+    def _is_transfer_terminal_locked(self, transfer_id: str) -> bool:
+        return transfer_id in self._terminal_transfer_ids
+
+    def _mark_transfer_terminal_locked(self, transfer_id: str) -> None:
+        self._terminal_transfer_ids.add(transfer_id)
+
+    def _handle_remote_blocks_message(self, data: dict) -> None:
+        MoRIIOWrapper._handle_remote_blocks_message(self, data)
+
+    def _handle_write_done_message(self, data: dict) -> None:
+        MoRIIOWrapper._handle_write_done_message(self, data)
+
+    def _handle_release_message(self, data: dict) -> None:
+        MoRIIOWrapper._handle_release_message(self, data)
 
     def shutdown(self) -> None:
         pass
@@ -133,8 +152,11 @@ def make_worker() -> MoRIIOConnectorWorker:
     worker._reqs_to_send = {}
     worker.tp_rank = 0
     worker.tp_size = 1
+    worker.world_size = 1
     worker._pending_unmapped_done_tids = {}
     worker._unmatched_write_completions = set()
+    worker._consumer_notification_counts = {}
+    worker._completed_consumer_notifications = set()
     worker.transfer_id_to_request_id = {}
     worker.request_id_to_transfer_id = {}
     worker.transfer_id_to_remote_tp_size = {}
@@ -235,6 +257,7 @@ def test_consumer_request_finished_does_not_warn_for_unscheduled_read(
 ) -> None:
     connector = object.__new__(MoRIIOConnectorScheduler)
     connector.is_producer = False
+    connector.mode = MoRIIOMode.READ
     connector.transfer_id_to_request_id = {}
     connector.request_id_to_transfer_id = {}
     connector._reqs_need_recv = {}
@@ -477,6 +500,7 @@ def test_write_remote_blocks_uses_remote_zmq_address_without_embedded_request_id
     scheduler._pending_transfer_id_to_request_id = {}
     scheduler.transfer_id_to_remote_tp_size = {}
     scheduler._pending_transfer_id_to_remote_tp_size = {}
+    scheduler.trusted_remote_hosts = ["prefill.example", "prefill-a", "prefill-b"]
     sent_notifies = []
     scheduler.send_notify_block = lambda **kwargs: sent_notifies.append(kwargs)
     scheduler._trim_block_ids_to_token_span = lambda block_ids, _tokens: block_ids
@@ -664,18 +688,21 @@ def test_write_finalize_reports_request_id_locally_and_transfer_id_remotely() ->
     worker.tp_size = 8
     worker.moriio_wrapper.done_remote_allocate_req_dict["transfer0"] = object()
     writer = MoRIIOWriter(worker)
-    task = SimpleNamespace(
-        request_id="req0",
-        transfer_id="transfer0",
-        remote_notify_port=61005,
-        remote_ip="10.0.0.2",
+    request_info = SimpleNamespace(
+        writes_done=1,
+        writes_expected=1,
+        completion_notified=False,
+        completion_request_id="req0",
+        completion_remote_notify_port=61005,
+        completion_remote_ip="10.0.0.2",
+        transfer_statuses=[],
+        decode_dp_rank=1,
     )
-    request_info = SimpleNamespace(writes_done=0, decode_dp_rank=1)
 
-    writer._finalize_if_complete(task, request_info)
+    writer._finalize_if_complete("transfer0", request_info)
 
     assert worker.moriio_wrapper.notifies == [("transfer0", "10.0.0.2", 61015)]
-    assert worker.moriio_wrapper.done_req_ids == ["req0"]
+    assert worker.moriio_wrapper.done_req_ids == [MoRIIOTransferAck("transfer0")]
     assert "transfer0" not in worker.moriio_wrapper.done_remote_allocate_req_dict
     assert worker.moriio_wrapper.waited_for_transfer is True
 
@@ -704,7 +731,7 @@ def test_write_deferred_expiry_reports_request_id(
     writer._process_deferred_tasks()
 
     assert writer._deferred_tasks == []
-    assert worker.moriio_wrapper.done_req_ids == ["req0"]
+    assert worker.moriio_wrapper.done_req_ids == [MoRIIOTransferAck("transfer0")]
     assert "transfer0" not in worker.moriio_wrapper.done_remote_allocate_req_dict
 
 
@@ -769,7 +796,7 @@ def test_remote_allocation_keys_ready_and_cleanup(
 
     writer._mark_request_done(request_id, transfer_id)
 
-    assert worker.moriio_wrapper.done_req_ids == [request_id]
+    assert worker.moriio_wrapper.done_req_ids == [MoRIIOTransferAck(transfer_id)]
     assert transfer_id not in allocation_by_key
     assert request_id not in allocation_by_key
     assert stripped_request_id not in allocation_by_key
@@ -857,7 +884,11 @@ def test_read_blocks_respects_layer_dispatch_window() -> None:
         ["session0", "session1", "session2"],
         SimpleNamespace(num_blocks=1, block_len=1),
     )
-    worker._compute_block_transfer_offsets = lambda *_args: ([0], [0], [1])
+    worker._compute_block_transfer_offsets = lambda *_args, **_kwargs: (
+        [0],
+        [0],
+        [1],
+    )
     worker.moriio_wrapper.read_results = [FakeStatus(), FakeStatus(), FakeStatus()]
 
     worker._read_blocks(
@@ -924,7 +955,11 @@ def test_read_blocks_respects_global_active_layer_window() -> None:
         ["session0", "session1", "session2"],
         SimpleNamespace(num_blocks=1, block_len=1),
     )
-    worker._compute_block_transfer_offsets = lambda *_args: ([0], [0], [1])
+    worker._compute_block_transfer_offsets = lambda *_args, **_kwargs: (
+        [0],
+        [0],
+        [1],
+    )
     worker.moriio_wrapper.read_results = [FakeStatus(), FakeStatus()]
 
     worker._read_blocks(
@@ -1050,6 +1085,7 @@ def test_failed_read_marks_local_blocks_invalid() -> None:
 def test_read_blocks_partial_setup_exception_marks_local_blocks_invalid() -> None:
     worker = make_worker()
     worker.tp_rank = 2
+    worker.world_size = 16
     worker.dp_rank = 0
     worker.kv_caches = {"layer0": FakeTensor(), "layer1": FakeTensor()}
     worker.layer_name_to_local_kv_cache_metadata = {"layer0": [], "layer1": []}
@@ -1057,7 +1093,11 @@ def test_read_blocks_partial_setup_exception_marks_local_blocks_invalid() -> Non
         ["session0", "session1"],
         SimpleNamespace(num_blocks=1, block_len=1),
     )
-    worker._compute_block_transfer_offsets = lambda *_args: ([0], [0], [1])
+    worker._compute_block_transfer_offsets = lambda *_args, **_kwargs: (
+        [0],
+        [0],
+        [1],
+    )
     worker.moriio_wrapper.read_results = [
         FakeStatus(succeeded=True),
         RuntimeError("layer1 setup failed"),
@@ -1086,6 +1126,7 @@ def test_read_blocks_partial_setup_exception_marks_local_blocks_invalid() -> Non
 def test_read_blocks_setup_exception_notifies_without_invalid_blocks() -> None:
     worker = make_worker()
     worker.tp_rank = 2
+    worker.world_size = 16
     worker.dp_rank = 0
     worker.kv_caches = {"layer0": FakeTensor()}
     worker.layer_name_to_local_kv_cache_metadata = {"layer0": []}
@@ -1093,7 +1134,11 @@ def test_read_blocks_setup_exception_notifies_without_invalid_blocks() -> None:
         ["session0"],
         SimpleNamespace(num_blocks=1, block_len=1),
     )
-    worker._compute_block_transfer_offsets = lambda *_args: ([0], [0], [1])
+    worker._compute_block_transfer_offsets = lambda *_args, **_kwargs: (
+        [0],
+        [0],
+        [1],
+    )
     worker.moriio_wrapper.read_error = RuntimeError("setup failed")
 
     with pytest.raises(RuntimeError, match="setup failed"):

--- a/tests/v1/kv_connector/unit/test_moriio_toy_proxy_server.py
+++ b/tests/v1/kv_connector/unit/test_moriio_toy_proxy_server.py
@@ -51,9 +51,7 @@ def _proxy_import_stubs():
     class _MoRIIOConstants:
         TRANSFER_PREFIX = "moriio-transfer"
 
-    common_name = (
-        "vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common"
-    )
+    common_name = "vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common"
     stubs = {
         "aiohttp": _module("aiohttp"),
         "msgpack": _module("msgpack"),
@@ -67,9 +65,7 @@ def _proxy_import_stubs():
         ),
         "vllm": _package("vllm"),
         "vllm.distributed": _package("vllm.distributed"),
-        "vllm.distributed.kv_transfer": _package(
-            "vllm.distributed.kv_transfer"
-        ),
+        "vllm.distributed.kv_transfer": _package("vllm.distributed.kv_transfer"),
         "vllm.distributed.kv_transfer.kv_connector": _package(
             "vllm.distributed.kv_transfer.kv_connector"
         ),
@@ -145,9 +141,8 @@ def test_decode_dp1_omits_header_and_keeps_prefill_remote_rank(proxy_module):
 
     assert selected_prefill_rank == 1
     assert selected_decode_rank is None
-    assert (
-        "X-data-parallel-rank"
-        not in proxy_module.make_request_headers("request-id", selected_decode_rank)
+    assert "X-data-parallel-rank" not in proxy_module.make_request_headers(
+        "request-id", selected_decode_rank
     )
 
     kv_transfer_params = {}
@@ -197,6 +192,7 @@ def test_prefill_request_omits_decode_dp_rank_for_dp1(proxy_module):
     )
     assert "remote_dp_rank" not in kv_transfer_params
 
+
 @pytest.mark.parametrize(
     ("request_number", "decode_dp_size", "expected_decode_rank"),
     [
@@ -233,9 +229,9 @@ def test_decode_header_rank_is_separate_from_prefill_remote_rank(proxy_module):
     assert selected_prefill_rank == 3
     assert selected_decode_rank == 1
     assert (
-        proxy_module.make_request_headers(
-            "request-id", selected_decode_rank
-        )["X-data-parallel-rank"]
+        proxy_module.make_request_headers("request-id", selected_decode_rank)[
+            "X-data-parallel-rank"
+        ]
         == "1"
     )
 

--- a/tests/v1/kv_connector/unit/test_moriio_toy_proxy_server.py
+++ b/tests/v1/kv_connector/unit/test_moriio_toy_proxy_server.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_MISSING = object()
+
+
+class _QuartStub:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def route(self, *args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    def post(self, *args, **kwargs):
+        return self.route(*args, **kwargs)
+
+
+class _RequestStub:
+    pass
+
+
+async def _make_response_stub(value):
+    return value
+
+
+def _module(name, **attrs):
+    module = types.ModuleType(name)
+    for attr_name, attr_value in attrs.items():
+        setattr(module, attr_name, attr_value)
+    return module
+
+
+def _package(name):
+    module = _module(name)
+    module.__path__ = []
+    return module
+
+
+@contextlib.contextmanager
+def _proxy_import_stubs():
+    class _MoRIIOConstants:
+        TRANSFER_PREFIX = "moriio-transfer"
+
+    common_name = (
+        "vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common"
+    )
+    stubs = {
+        "aiohttp": _module("aiohttp"),
+        "msgpack": _module("msgpack"),
+        "zmq": _module("zmq"),
+        "quart": _module(
+            "quart",
+            Quart=_QuartStub,
+            Request=_RequestStub,
+            make_response=_make_response_stub,
+            request=object(),
+        ),
+        "vllm": _package("vllm"),
+        "vllm.distributed": _package("vllm.distributed"),
+        "vllm.distributed.kv_transfer": _package(
+            "vllm.distributed.kv_transfer"
+        ),
+        "vllm.distributed.kv_transfer.kv_connector": _package(
+            "vllm.distributed.kv_transfer.kv_connector"
+        ),
+        "vllm.distributed.kv_transfer.kv_connector.v1": _package(
+            "vllm.distributed.kv_transfer.kv_connector.v1"
+        ),
+        "vllm.distributed.kv_transfer.kv_connector.v1.moriio": _package(
+            "vllm.distributed.kv_transfer.kv_connector.v1.moriio"
+        ),
+        common_name: _module(
+            common_name,
+            MoRIIOConstants=_MoRIIOConstants,
+        ),
+    }
+    saved_modules = {}
+    for name, module in stubs.items():
+        if name not in sys.modules:
+            saved_modules[name] = _MISSING
+            sys.modules[name] = module
+
+    try:
+        yield
+    finally:
+        for name, previous_module in saved_modules.items():
+            if previous_module is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous_module
+
+
+def _load_proxy_module():
+    module_path = (
+        Path(__file__).parents[4]
+        / "examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "moriio_toy_proxy_server_under_test", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    with _proxy_import_stubs():
+        spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def proxy_module():
+    return _load_proxy_module()
+
+
+def _instance(name, dp_size):
+    return {
+        "request_address": f"http://{name}.example/v1",
+        "http_address": f"{name}.example:8000",
+        "zmq_address": f"host:{name}.example,handshake:1000,notify:2000",
+        "dp_size": dp_size,
+        "tp_size": 1,
+        "transfer_mode": "READ",
+        "node_hosts": [f"{name}-host"],
+    }
+
+
+def test_decode_dp1_omits_header_and_keeps_prefill_remote_rank(proxy_module):
+    prefill_instance = _instance("prefill", dp_size=2)
+    decode_instance = _instance("decode", dp_size=1)
+
+    selected_prefill_rank, selected_decode_rank = proxy_module.select_request_dp_ranks(
+        1,
+        prefill_instance,
+        decode_instance,
+    )
+
+    assert selected_prefill_rank == 1
+    assert selected_decode_rank is None
+    assert (
+        "X-data-parallel-rank"
+        not in proxy_module.make_request_headers("request-id", selected_decode_rank)
+    )
+
+    kv_transfer_params = {}
+    proxy_module.add_remote_prefill_kv_params(
+        kv_transfer_params,
+        prefill_instance,
+        selected_prefill_rank,
+    )
+    assert kv_transfer_params["remote_dp_rank"] == selected_prefill_rank
+
+
+def test_prefill_request_targets_decode_dp_rank(proxy_module):
+    decode_instance = _instance("decode", dp_size=2)
+    kv_transfer_params = {}
+
+    proxy_module.add_remote_decode_kv_params(
+        kv_transfer_params,
+        decode_instance,
+        selected_decode_dp_rank=1,
+        transfer_id="transfer-0",
+    )
+
+    assert kv_transfer_params["remote_dp_size"] == 2
+    assert kv_transfer_params["remote_dp_rank"] == 1
+    assert (
+        kv_transfer_params["remote_zmq_address"]
+        == "host:decode.example,handshake:1000,notify:2000"
+    )
+    assert kv_transfer_params["transfer_id"] == "transfer-0"
+
+
+def test_prefill_request_omits_decode_dp_rank_for_dp1(proxy_module):
+    decode_instance = _instance("decode", dp_size=1)
+    kv_transfer_params = {}
+
+    proxy_module.add_remote_decode_kv_params(
+        kv_transfer_params,
+        decode_instance,
+        selected_decode_dp_rank=None,
+        transfer_id="transfer-0",
+    )
+
+    assert kv_transfer_params["remote_dp_size"] == 1
+    assert (
+        kv_transfer_params["remote_zmq_address"]
+        == "host:decode.example,handshake:1000,notify:2000"
+    )
+    assert "remote_dp_rank" not in kv_transfer_params
+
+@pytest.mark.parametrize(
+    ("request_number", "decode_dp_size", "expected_decode_rank"),
+    [
+        (1, 2, 1),
+        (2, 2, 0),
+        (5, 3, 2),
+        (6, 3, 0),
+    ],
+)
+def test_decode_dp_rank_cycles_by_decode_endpoint_size(
+    proxy_module, request_number, decode_dp_size, expected_decode_rank
+):
+    selected_prefill_rank, selected_decode_rank = proxy_module.select_request_dp_ranks(
+        request_number,
+        _instance("prefill", dp_size=8),
+        _instance("decode", dp_size=decode_dp_size),
+    )
+
+    assert selected_prefill_rank == request_number % 8
+    assert selected_decode_rank == expected_decode_rank
+    assert 0 <= selected_decode_rank < decode_dp_size
+
+
+def test_decode_header_rank_is_separate_from_prefill_remote_rank(proxy_module):
+    prefill_instance = _instance("prefill", dp_size=4)
+    decode_instance = _instance("decode", dp_size=2)
+
+    selected_prefill_rank, selected_decode_rank = proxy_module.select_request_dp_ranks(
+        3,
+        prefill_instance,
+        decode_instance,
+    )
+
+    assert selected_prefill_rank == 3
+    assert selected_decode_rank == 1
+    assert (
+        proxy_module.make_request_headers(
+            "request-id", selected_decode_rank
+        )["X-data-parallel-rank"]
+        == "1"
+    )
+
+    kv_transfer_params = {}
+    proxy_module.add_remote_prefill_kv_params(
+        kv_transfer_params,
+        prefill_instance,
+        selected_prefill_rank,
+    )
+    assert kv_transfer_params["remote_dp_rank"] == 3
+    assert (
+        kv_transfer_params["remote_zmq_address"]
+        == "host:prefill.example,handshake:1000,notify:2000"
+    )

--- a/tests/v1/kv_connector/unit/test_scheduler_late_kv_completion.py
+++ b/tests/v1/kv_connector/unit/test_scheduler_late_kv_completion.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.request import RequestStatus
+
+
+@pytest.fixture
+def should_do_global_cleanup_after_test() -> bool:
+    return False
+
+
+class DummyConnector:
+    def __init__(self) -> None:
+        self.outputs: list[KVConnectorOutput] = []
+        self.pending_deferred_sends = False
+
+    def update_connector_output(self, output: KVConnectorOutput) -> None:
+        self.outputs.append(output)
+
+    def has_pending_deferred_sends(self) -> bool:
+        return self.pending_deferred_sends
+
+
+def make_scheduler(requests: dict[str, object] | None = None) -> Scheduler:
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.connector = DummyConnector()
+    scheduler.requests = requests or {}
+    scheduler.finished_req_ids = set()
+    scheduler.finished_recving_kv_req_ids = set()
+    scheduler.waiting = []
+    scheduler.skipped_waiting = []
+    scheduler.running = []
+    return scheduler
+
+
+def test_late_finished_sending_for_removed_request_is_ignored() -> None:
+    scheduler = make_scheduler()
+
+    scheduler._update_from_kv_xfer_finished(
+        KVConnectorOutput(finished_sending={"already-finished"})
+    )
+
+    assert scheduler.requests == {}
+    assert len(scheduler.connector.outputs) == 1
+
+
+def test_late_finished_recving_for_removed_request_is_ignored() -> None:
+    scheduler = make_scheduler()
+
+    scheduler._update_from_kv_xfer_finished(
+        KVConnectorOutput(finished_recving={"already-aborted"})
+    )
+
+    assert scheduler.finished_recving_kv_req_ids == set()
+    assert len(scheduler.connector.outputs) == 1
+
+
+def test_live_finished_sending_still_frees_blocks() -> None:
+    request = SimpleNamespace(request_id="live")
+    scheduler = make_scheduler({"live": request})
+    freed: list[object] = []
+    scheduler._free_blocks = freed.append
+
+    scheduler._update_from_kv_xfer_finished(
+        KVConnectorOutput(finished_sending={"live"})
+    )
+
+    assert freed == [request]
+
+
+def test_live_finished_recving_still_marks_waiting_request() -> None:
+    request = SimpleNamespace(status=RequestStatus.WAITING_FOR_REMOTE_KVS)
+    scheduler = make_scheduler({"live": request})
+
+    scheduler._update_from_kv_xfer_finished(
+        KVConnectorOutput(finished_recving={"live"})
+    )
+
+    assert scheduler.finished_recving_kv_req_ids == {"live"}
+
+
+def test_pending_deferred_send_keeps_scheduler_active() -> None:
+    scheduler = make_scheduler()
+    assert not scheduler.has_finished_requests()
+
+    scheduler.connector.pending_deferred_sends = True
+
+    assert scheduler.has_finished_requests()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -213,6 +213,7 @@ def resolve_host_ip(extra_config: dict) -> str:
     """
     return extra_config.get("host_ip") or get_ip()
 
+
 def _normalize_node_hosts(value: Any, config_key: str) -> list[str]:
     if value is None:
         return []
@@ -601,6 +602,7 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
         remote_host = kv_transfer_params.get("remote_host")
         remote_handshake_port = kv_transfer_params.get("remote_handshake_port")
         remote_notify_port = kv_transfer_params.get("remote_notify_port")
+        remote_host_source = "kv_transfer_params.remote_host"
         # Parse host/ports from request_id. The router normally embeds both
         # zmq_addresses there. If the embedded address is absent, fall back to
         # `kv_transfer_params.remote_zmq_address`, which carries the same
@@ -610,7 +612,6 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             kv_transfer_params.get("remote_hosts"),
             "kv_transfer_params['remote_hosts']",
         )
-        used_remote_zmq_fallback = False
         if (
             remote_host is None
             or remote_handshake_port is None
@@ -623,18 +624,14 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
                 remote_host, remote_handshake_port, remote_notify_port = (
                     parse_moriio_zmq_address(peer_zmq)
                 )
+                remote_host_source = "request_id"
             except ValueError:
                 peer_zmq = kv_transfer_params.get("remote_zmq_address")
                 if peer_zmq:
                     remote_host, remote_handshake_port, remote_notify_port = (
                         parse_moriio_zmq_address(peer_zmq)
                     )
-                    used_remote_zmq_fallback = True
-                    validate_moriio_trusted_host(
-                        remote_host,
-                        trusted_remote_hosts,
-                        "kv_transfer_params.remote_zmq_address",
-                    )
+                    remote_host_source = "kv_transfer_params.remote_zmq_address"
                 elif not remote_hosts:
                     raise ValueError(
                         f"MoRIIO add_new_req: could not resolve peer host/ports "
@@ -648,7 +645,12 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
                         f"forward remote_zmq_address with the host list"
                     ) from None
 
-        if used_remote_zmq_fallback:
+        if trusted_remote_hosts is not None:
+            validate_moriio_trusted_host(
+                remote_host,
+                trusted_remote_hosts,
+                remote_host_source,
+            )
             for remote_hosts_entry in remote_hosts:
                 validate_moriio_trusted_host(
                     remote_hosts_entry,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -4,11 +4,12 @@ import contextlib
 import os
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Collection, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import msgspec
+import psutil
 import regex as re
 import torch
 import zmq
@@ -25,7 +26,8 @@ from vllm.logger import init_logger
 from vllm.utils.network_utils import (
     get_ip,
     get_open_port,
-    make_zmq_socket,
+    is_valid_ipv6_address,
+    split_zmq_path,
 )
 
 if TYPE_CHECKING:
@@ -74,6 +76,7 @@ class LayerTransferPlan:
     transfer_local_offsets: list[int]
     transfer_remote_offsets: list[int]
     transfer_sizes: list[int]
+    session: Any | None = None
     use_batch: bool = True
 
 
@@ -176,10 +179,18 @@ class TransferError(MoRIIOError):
     pass
 
 
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
 def get_moriio_mode(kv_transfer_config: KVTransferConfig) -> MoRIIOMode:
-    read_mode = str(
-        kv_transfer_config.kv_connector_extra_config.get("read_mode", "false")
-    ).lower().strip() in ("true", "1")
+    read_mode = _as_bool(
+        kv_transfer_config.kv_connector_extra_config.get("read_mode", False)
+    )
     logger.debug("MoRIIO Connector read_mode: %s", read_mode)
     if read_mode:
         return MoRIIOMode.READ
@@ -202,7 +213,6 @@ def resolve_host_ip(extra_config: dict) -> str:
     """
     return extra_config.get("host_ip") or get_ip()
 
-
 def _normalize_node_hosts(value: Any, config_key: str) -> list[str]:
     if value is None:
         return []
@@ -214,6 +224,24 @@ def _normalize_node_hosts(value: Any, config_key: str) -> list[str]:
         raise ValueError(
             f"{config_key} must be a comma-separated string or iterable of hosts"
         ) from exc
+
+
+def validate_moriio_trusted_host(
+    remote_host: str,
+    trusted_hosts: Collection[str] | None,
+    source: str,
+) -> None:
+    trusted_host_list = _normalize_node_hosts(trusted_hosts, "trusted_remote_hosts")
+    if not trusted_host_list:
+        raise ValueError(
+            f"MoRIIO {source} host {remote_host!r} is not trusted; configure "
+            "kv_connector_extra_config['node_hosts'] with trusted peer hosts"
+        )
+    if remote_host not in set(trusted_host_list):
+        raise ValueError(
+            f"MoRIIO {source} host {remote_host!r} is not in trusted peer hosts "
+            f"{trusted_host_list!r}"
+        )
 
 
 def get_moriio_node_hosts(
@@ -242,6 +270,16 @@ def get_moriio_node_hosts(
     return [default_host]
 
 
+def get_moriio_trusted_remote_hosts(
+    kv_transfer_config: KVTransferConfig,
+) -> list[str]:
+    extra_config = kv_transfer_config.kv_connector_extra_config
+    return _normalize_node_hosts(
+        extra_config.get("trusted_remote_hosts"),
+        "kv_connector_extra_config['trusted_remote_hosts']",
+    )
+
+
 _DEPRECATED_ENV_VARS: dict[str, str] = {
     "VLLM_MORIIO_CONNECTOR_READ_MODE": "read_mode",
     "VLLM_MORIIO_QP_PER_TRANSFER": "qp_per_transfer",
@@ -260,6 +298,19 @@ def _warn_deprecated_env_vars() -> None:
                 env_var,
                 new_key,
             )
+
+
+def _get_non_negative_int_extra_config(
+    extra_config: dict[str, Any],
+    key: str,
+    default: int,
+) -> int:
+    value = int(extra_config.get(key, default))
+    if value < 0:
+        raise ValueError(
+            f"Invalid MoRIIO {key}={value}; expected a non-negative integer."
+        )
+    return value
 
 
 @dataclass
@@ -284,6 +335,10 @@ class MoRIIOConfig:
     num_workers: int = 1
     backend: str = "rdma"
     node_hosts: list[str] = field(default_factory=list)
+    handshake_timeout: float = 10.0
+    max_inflight_global: int = 0
+    max_inflight_per_transfer: int = 0
+    max_dispatch_layers: int = 0
 
     @classmethod
     def from_vllm_config(cls, vllm_config: VllmConfig) -> "MoRIIOConfig":
@@ -310,7 +365,6 @@ class MoRIIOConfig:
         #                     (-1 lets the MoRI backend choose).
         # num_workers      -> Number of background worker threads the MoRI
         #                     engine uses for transfer processing.
-
         # TODO : merge notify_port and handshake_port to simplify port management
         #        supports non-contiguous ports
         assert vllm_config.kv_transfer_config is not None, (
@@ -324,7 +378,7 @@ class MoRIIOConfig:
         base_notify_port = int(extra_config["notify_port"])
         dp_size = vllm_config.parallel_config.data_parallel_size
         tp_size = get_tensor_model_parallel_world_size()
-        port_offset = get_port_offset(dp_rank, tp_rank)
+        port_offset = get_port_offset(dp_rank, tp_rank, tp_size)
         backend = str(extra_config.get("backend", "rdma")).lower()
         if backend not in ("rdma", "xgmi"):
             raise ValueError(
@@ -364,6 +418,26 @@ class MoRIIOConfig:
             node_hosts=get_moriio_node_hosts(kv_transfer_config, local_ip),
             transfer_timeout=transfer_timeout,
             defer_timeout=defer_timeout,
+            handshake_timeout=float(
+                extra_config.get(
+                    "handshake_timeout", MoRIIOConstants.DEFAULT_HANDSHAKE_TIMEOUT
+                )
+            ),
+            max_inflight_global=_get_non_negative_int_extra_config(
+                extra_config,
+                "max_inflight_global",
+                0,
+            ),
+            max_inflight_per_transfer=_get_non_negative_int_extra_config(
+                extra_config,
+                "max_inflight_per_transfer",
+                0,
+            ),
+            max_dispatch_layers=_get_non_negative_int_extra_config(
+                extra_config,
+                "max_dispatch_layers",
+                0,
+            ),
         )
 
 
@@ -391,6 +465,10 @@ class MoRIIOConstants:
     # notification is reaped and its blocks force-freed.
     # Overridable via kv_connector_extra_config["defer_timeout"].
     DEFAULT_DEFER_TIMEOUT = 60.0
+    # Timeout (seconds) for a single MoRIIO handshake metadata exchange.
+    # Bounds an unresponsive remote listener so TP workers do not block in recv().
+    # Overridable via kv_connector_extra_config["handshake_timeout"].
+    DEFAULT_HANDSHAKE_TIMEOUT = 10.0
 
 
 # The router embeds both zmq_addresses in the request_id:
@@ -403,6 +481,18 @@ _PREFILL_ZMQ_RE = re.compile(r"___prefill_addr_(.+?)___decode_addr_")
 # vLLM wraps the router's X-Request-Id as "cmpl-<id>-<seq>-<hex>" so there may
 # be a trailing "-<seq>-<hex>" suffix after the 32-char UUID.  Allow it.
 _DECODE_ZMQ_RE = re.compile(r"___decode_addr_(.+)_[0-9a-f]{32}(?:-.*)?$")
+
+
+# vLLM appends a trailing "-<8hex>" engine-local suffix to the router
+# request_id; it differs between the prefill and decode engines for the same
+# logical request. The canonical (router) request_id is the stripped base,
+# which both sides agree on — use it as a stable cross-node map key.
+_VLLM_REQUEST_SUFFIX_RE = re.compile(r"(.+)-[0-9a-fA-F]{8}$")
+
+
+def _strip_vllm_request_suffix(request_id: str) -> str:
+    match = _VLLM_REQUEST_SUFFIX_RE.fullmatch(request_id)
+    return match.group(1) if match is not None else request_id
 
 
 def parse_moriio_zmq_address(
@@ -465,6 +555,12 @@ class ReqMeta:
     remote_engine_id: str
     tp_size: int
     remote_dp_size: int
+    # DP rank that handled the prefill on the remote side. Proxy sets this
+    # from `selected_prefill_dp_rank` in kv_transfer_params. Used by
+    # `_read_blocks` to pick the correct per-rank session/MR instead of
+    # always reading from remote DP0 (which mismatches num_blocks across
+    # ranks and overflows remote DP0's MR at high concurrency).
+    remote_dp_rank: int = 0
     # Ordered list of all prefill-instance host IPs for multi-node TP.
     # Each decode worker picks remote_hosts[tp_rank // ranks_per_node] as its
     # actual peer host for handshake + post-transfer notify. None or len<=1
@@ -478,13 +574,17 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
         self.reqs_to_save: dict[ReqId, ReqMeta] = {}
         self.reqs_to_send: dict[ReqId, float] = {}
         self.transfer_id_to_request_id: dict[TransferId, ReqId] = {}
+        self.transfer_id_to_remote_tp_size: dict[TransferId, int] = {}
+        self.freed_transfer_ids: set[TransferId] = set()
 
     def __repr__(self):
         return (
             f"MoRIIOConnectorMetadata: reqs_to_recv={self.reqs_to_recv}, "
             f"reqs_to_save={self.reqs_to_save}, "
             f"reqs_to_send={self.reqs_to_send}, "
-            f"transfer_id_to_request_id={self.transfer_id_to_request_id}"
+            f"transfer_id_to_request_id={self.transfer_id_to_request_id}, "
+            f"transfer_id_to_remote_tp_size={self.transfer_id_to_remote_tp_size}, "
+            f"freed_transfer_ids={self.freed_transfer_ids}"
         )
 
     def add_new_req(
@@ -493,6 +593,7 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
         local_block_ids: list[int],
         kv_transfer_params: dict[str, Any],
         write_mode=False,
+        trusted_remote_hosts: Collection[str] | None = None,
     ):
         transfer_id = kv_transfer_params["transfer_id"]
 
@@ -501,13 +602,14 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
         remote_notify_port = kv_transfer_params.get("remote_notify_port")
         # Parse host/ports from request_id. The router normally embeds both
         # zmq_addresses there. If the embedded address is absent, fall back to
-        # `kv_transfer_params.remote_hosts` (forwarded for multi-node TP) and
-        # MoRIIO's default well-known ports. Once a valid host/port triple is
-        # available, the rest of the path is unchanged.
+        # `kv_transfer_params.remote_zmq_address`, which carries the same
+        # host/handshake/notify tuple explicitly. A host list alone is not
+        # enough because deployments may use non-default ports.
         remote_hosts = _normalize_node_hosts(
             kv_transfer_params.get("remote_hosts"),
             "kv_transfer_params['remote_hosts']",
         )
+        used_remote_zmq_fallback = False
         if (
             remote_host is None
             or remote_handshake_port is None
@@ -521,19 +623,37 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
                     parse_moriio_zmq_address(peer_zmq)
                 )
             except ValueError:
-                # Normalize remote_hosts: callers may pass a list (per-rank
-                # host vector from the proxy) or a single host string from
-                # older proxy versions. A bare string would silently slice
-                # into "1." for "172.30.0.1" if we just did remote_hosts[0].
-                if not remote_hosts:
+                peer_zmq = kv_transfer_params.get("remote_zmq_address")
+                if peer_zmq:
+                    remote_host, remote_handshake_port, remote_notify_port = (
+                        parse_moriio_zmq_address(peer_zmq)
+                    )
+                    used_remote_zmq_fallback = True
+                    validate_moriio_trusted_host(
+                        remote_host,
+                        trusted_remote_hosts,
+                        "kv_transfer_params.remote_zmq_address",
+                    )
+                elif not remote_hosts:
                     raise ValueError(
                         f"MoRIIO add_new_req: could not resolve peer host/ports "
                         f"for {request_id!r}; neither request_id parse nor "
-                        f"kv_transfer_params.remote_hosts provided them"
+                        f"kv_transfer_params.remote_zmq_address provided them"
                     ) from None
-                remote_host = remote_hosts[0]
-                remote_handshake_port = int(MoRIIOConstants.DEFAULT_HANDSHAKE_PORT)
-                remote_notify_port = int(MoRIIOConstants.DEFAULT_NOTIFY_PORT)
+                else:
+                    raise ValueError(
+                        f"MoRIIO add_new_req: kv_transfer_params.remote_hosts for "
+                        f"{request_id!r} does not include handshake/notify ports; "
+                        f"forward remote_zmq_address with the host list"
+                    ) from None
+
+        if used_remote_zmq_fallback:
+            for remote_hosts_entry in remote_hosts:
+                validate_moriio_trusted_host(
+                    remote_hosts_entry,
+                    trusted_remote_hosts,
+                    "kv_transfer_params.remote_hosts",
+                )
 
         # If remote block metadata is absent, use empty defaults so the request
         # remains a no-op.
@@ -562,8 +682,74 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             self.reqs_to_recv[request_id] = _req
 
 
+_MORIIO_ZMQ_KEEPALIVE_OPTS = (
+    (zmq.TCP_KEEPALIVE, 1),
+    (zmq.TCP_KEEPALIVE_IDLE, 30),
+    (zmq.TCP_KEEPALIVE_INTVL, 10),
+    (zmq.TCP_KEEPALIVE_CNT, 3),
+)
+
+
+def _make_moriio_zmq_socket(
+    ctx: zmq.Context,
+    path: str,
+    socket_type: Any,
+    *,
+    identity: bytes | None = None,
+    linger: int | None = None,
+    router_handover: bool = False,
+) -> zmq.Socket:
+    mem = psutil.virtual_memory()
+    total_mem = mem.total / 1024**3
+    available_mem = mem.available / 1024**3
+    buf_size = int(0.5 * 1024**3) if total_mem > 32 and available_mem > 16 else -1
+
+    sock = ctx.socket(socket_type)
+
+    if socket_type in (zmq.PULL, zmq.DEALER, zmq.ROUTER):
+        sock.setsockopt(zmq.RCVHWM, 0)
+        sock.setsockopt(zmq.RCVBUF, buf_size)
+
+    if socket_type in (zmq.PUSH, zmq.DEALER, zmq.ROUTER):
+        sock.setsockopt(zmq.SNDHWM, 0)
+        sock.setsockopt(zmq.SNDBUF, buf_size)
+
+    if socket_type == zmq.ROUTER and router_handover:
+        sock.setsockopt(zmq.ROUTER_HANDOVER, 1)
+
+    if identity is not None:
+        sock.setsockopt(zmq.IDENTITY, identity)
+
+    if linger is not None:
+        sock.setsockopt(zmq.LINGER, linger)
+
+    # Mgmt-rail notify/handshake streams are sparse; a silently dead TCP peer
+    # can park reads until the retransmit ladder expires. Keepalive applies to
+    # accepted connections too and must be set before bind/connect.
+    for option, value in _MORIIO_ZMQ_KEEPALIVE_OPTS:
+        sock.setsockopt(option, value)
+
+    scheme, host, _ = split_zmq_path(path)
+    if scheme == "tcp" and is_valid_ipv6_address(host):
+        sock.setsockopt(zmq.IPV6, 1)
+
+    if socket_type == zmq.ROUTER:
+        sock.bind(path)
+    else:
+        sock.connect(path)
+
+    return sock
+
+
 @contextlib.contextmanager
-def zmq_ctx(socket_type: Any, addr: str) -> Iterator[zmq.Socket]:
+def zmq_ctx(
+    socket_type: Any,
+    addr: str,
+    *,
+    identity: bytes | None = None,
+    linger: int | None = None,
+    router_handover: bool = False,
+) -> Iterator[zmq.Socket]:
     """Context manager for a ZMQ socket"""
 
     if socket_type not in (zmq.ROUTER, zmq.REQ, zmq.DEALER):
@@ -572,9 +758,15 @@ def zmq_ctx(socket_type: Any, addr: str) -> Iterator[zmq.Socket]:
     ctx: zmq.Context | None = None
     try:
         ctx = zmq.Context()  # type: ignore[attr-defined]
-        yield make_zmq_socket(
-            ctx=ctx, path=addr, socket_type=socket_type, bind=socket_type == zmq.ROUTER
+        sock = _make_moriio_zmq_socket(
+            ctx,
+            addr,
+            socket_type,
+            identity=identity,
+            linger=linger,
+            router_handover=router_handover,
         )
+        yield sock
     finally:
         if ctx is not None:
             ctx.destroy(linger=0)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -499,6 +499,11 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
         remote_host = kv_transfer_params.get("remote_host")
         remote_handshake_port = kv_transfer_params.get("remote_handshake_port")
         remote_notify_port = kv_transfer_params.get("remote_notify_port")
+        # Parse host/ports from request_id. The router normally embeds both
+        # zmq_addresses there. If the embedded address is absent, fall back to
+        # `kv_transfer_params.remote_hosts` (forwarded for multi-node TP) and
+        # MoRIIO's default well-known ports. Once a valid host/port triple is
+        # available, the rest of the path is unchanged.
         remote_hosts = _normalize_node_hosts(
             kv_transfer_params.get("remote_hosts"),
             "kv_transfer_params['remote_hosts']",
@@ -508,9 +513,6 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             or remote_handshake_port is None
             or remote_notify_port is None
         ):
-            # Parse host/ports from the request_id. The router embeds both
-            # zmq_addresses in PD request IDs, but WRITE decode requests may carry
-            # a plain request ID and get the remote address via kv_transfer_params.
             try:
                 peer_zmq = get_peer_zmq_from_request_id(
                     request_id, is_producer=write_mode
@@ -533,12 +535,8 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
                 remote_handshake_port = int(MoRIIOConstants.DEFAULT_HANDSHAKE_PORT)
                 remote_notify_port = int(MoRIIOConstants.DEFAULT_NOTIFY_PORT)
 
-        # Cleanup-path requests (the same "aborted before scheduling" branch
-        # that surfaces a short request_id) can also omit remote_block_ids
-        # and remote_engine_id. Use .get() defaults so we don't crash the
-        # same EngineCore the request_id fallback above is meant to keep
-        # alive — an empty block list is the correct no-op for an aborted
-        # request.
+        # If remote block metadata is absent, use empty defaults so the request
+        # remains a no-op.
         _req = ReqMeta(
             transfer_id=transfer_id,
             local_block_ids=local_block_ids,
@@ -548,9 +546,8 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             remote_port=int(remote_handshake_port),
             remote_handshake_port=int(remote_handshake_port),
             remote_notify_port=int(remote_notify_port),
-            # Defense-in-depth: callers (e.g. moriio_toy_proxy_server in
-            # READ-mode multi-node TP) may forward `remote_tp_size` only.
-            # Read `tp_size` first, fall back to `remote_tp_size`, default 1.
+            # Callers may forward `remote_tp_size` without `tp_size`.
+            # Prefer `tp_size`, then fall back to `remote_tp_size`, then 1.
             tp_size=kv_transfer_params.get(
                 "tp_size",
                 kv_transfer_params.get("remote_tp_size", 1),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -257,18 +257,6 @@ def get_moriio_node_hosts(
     if node_hosts:
         return node_hosts
 
-    env_node_hosts = os.environ.get("VLLM_MORIIO_NODE_HOSTS", "").strip()
-    if env_node_hosts:
-        logger.warning_once(
-            "The environment variable %s is deprecated. Set %r inside "
-            "kv_transfer_config.kv_connector_extra_config instead.",
-            "VLLM_MORIIO_NODE_HOSTS",
-            "node_hosts",
-        )
-        node_hosts = _normalize_node_hosts(env_node_hosts, "VLLM_MORIIO_NODE_HOSTS")
-        if node_hosts:
-            return node_hosts
-
     return [default_host]
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -203,6 +203,45 @@ def resolve_host_ip(extra_config: dict) -> str:
     return extra_config.get("host_ip") or get_ip()
 
 
+def _normalize_node_hosts(value: Any, config_key: str) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [host.strip() for host in value.split(",") if host.strip()]
+    try:
+        return [str(host).strip() for host in value if str(host).strip()]
+    except TypeError as exc:
+        raise ValueError(
+            f"{config_key} must be a comma-separated string or iterable of hosts"
+        ) from exc
+
+
+def get_moriio_node_hosts(
+    kv_transfer_config: KVTransferConfig, default_host: str
+) -> list[str]:
+    extra_config = kv_transfer_config.kv_connector_extra_config
+    node_hosts = _normalize_node_hosts(
+        extra_config.get("node_hosts"),
+        "kv_connector_extra_config['node_hosts']",
+    )
+    if node_hosts:
+        return node_hosts
+
+    env_node_hosts = os.environ.get("VLLM_MORIIO_NODE_HOSTS", "").strip()
+    if env_node_hosts:
+        logger.warning_once(
+            "The environment variable %s is deprecated. Set %r inside "
+            "kv_transfer_config.kv_connector_extra_config instead.",
+            "VLLM_MORIIO_NODE_HOSTS",
+            "node_hosts",
+        )
+        node_hosts = _normalize_node_hosts(env_node_hosts, "VLLM_MORIIO_NODE_HOSTS")
+        if node_hosts:
+            return node_hosts
+
+    return [default_host]
+
+
 _DEPRECATED_ENV_VARS: dict[str, str] = {
     "VLLM_MORIIO_CONNECTOR_READ_MODE": "read_mode",
     "VLLM_MORIIO_QP_PER_TRANSFER": "qp_per_transfer",
@@ -244,6 +283,7 @@ class MoRIIOConfig:
     post_batch_size: int = -1
     num_workers: int = 1
     backend: str = "rdma"
+    node_hosts: list[str] = field(default_factory=list)
 
     @classmethod
     def from_vllm_config(cls, vllm_config: VllmConfig) -> "MoRIIOConfig":
@@ -301,8 +341,10 @@ class MoRIIOConfig:
             extra_config.get("defer_timeout", MoRIIOConstants.DEFAULT_DEFER_TIMEOUT)
         )
 
+        local_ip = resolve_host_ip(extra_config)
+
         return cls(
-            local_ip=resolve_host_ip(extra_config),
+            local_ip=local_ip,
             local_kv_port=get_open_port(),
             proxy_ip=extra_config["proxy_ip"],
             local_ping_port=get_open_port(),
@@ -319,6 +361,7 @@ class MoRIIOConfig:
             post_batch_size=int(extra_config.get("post_batch_size", -1)),
             num_workers=int(extra_config.get("num_workers", 1)),
             backend=backend,
+            node_hosts=get_moriio_node_hosts(kv_transfer_config, local_ip),
             transfer_timeout=transfer_timeout,
             defer_timeout=defer_timeout,
         )
@@ -422,6 +465,11 @@ class ReqMeta:
     remote_engine_id: str
     tp_size: int
     remote_dp_size: int
+    # Ordered list of all prefill-instance host IPs for multi-node TP.
+    # Each decode worker picks remote_hosts[tp_rank // ranks_per_node] as its
+    # actual peer host for handshake + post-transfer notify. None or len<=1
+    # falls back to single-host behaviour (remote_host).
+    remote_hosts: list[str] | None = None
 
 
 class MoRIIOConnectorMetadata(KVConnectorMetadata):
@@ -451,6 +499,10 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
         remote_host = kv_transfer_params.get("remote_host")
         remote_handshake_port = kv_transfer_params.get("remote_handshake_port")
         remote_notify_port = kv_transfer_params.get("remote_notify_port")
+        remote_hosts = _normalize_node_hosts(
+            kv_transfer_params.get("remote_hosts"),
+            "kv_transfer_params['remote_hosts']",
+        )
         if (
             remote_host is None
             or remote_handshake_port is None
@@ -459,22 +511,53 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             # Parse host/ports from the request_id. The router embeds both
             # zmq_addresses in PD request IDs, but WRITE decode requests may carry
             # a plain request ID and get the remote address via kv_transfer_params.
-            peer_zmq = get_peer_zmq_from_request_id(request_id, is_producer=write_mode)
-            remote_host, remote_handshake_port, remote_notify_port = (
-                parse_moriio_zmq_address(peer_zmq)
-            )
+            try:
+                peer_zmq = get_peer_zmq_from_request_id(
+                    request_id, is_producer=write_mode
+                )
+                remote_host, remote_handshake_port, remote_notify_port = (
+                    parse_moriio_zmq_address(peer_zmq)
+                )
+            except ValueError:
+                # Normalize remote_hosts: callers may pass a list (per-rank
+                # host vector from the proxy) or a single host string from
+                # older proxy versions. A bare string would silently slice
+                # into "1." for "172.30.0.1" if we just did remote_hosts[0].
+                if not remote_hosts:
+                    raise ValueError(
+                        f"MoRIIO add_new_req: could not resolve peer host/ports "
+                        f"for {request_id!r}; neither request_id parse nor "
+                        f"kv_transfer_params.remote_hosts provided them"
+                    ) from None
+                remote_host = remote_hosts[0]
+                remote_handshake_port = int(MoRIIOConstants.DEFAULT_HANDSHAKE_PORT)
+                remote_notify_port = int(MoRIIOConstants.DEFAULT_NOTIFY_PORT)
 
+        # Cleanup-path requests (the same "aborted before scheduling" branch
+        # that surfaces a short request_id) can also omit remote_block_ids
+        # and remote_engine_id. Use .get() defaults so we don't crash the
+        # same EngineCore the request_id fallback above is meant to keep
+        # alive — an empty block list is the correct no-op for an aborted
+        # request.
         _req = ReqMeta(
             transfer_id=transfer_id,
             local_block_ids=local_block_ids,
-            remote_block_ids=kv_transfer_params["remote_block_ids"],
-            remote_engine_id=kv_transfer_params["remote_engine_id"],
+            remote_block_ids=kv_transfer_params.get("remote_block_ids", []),
+            remote_engine_id=kv_transfer_params.get("remote_engine_id", ""),
             remote_host=remote_host,
             remote_port=int(remote_handshake_port),
             remote_handshake_port=int(remote_handshake_port),
             remote_notify_port=int(remote_notify_port),
-            tp_size=kv_transfer_params.get("tp_size", 1),
+            # Defense-in-depth: callers (e.g. moriio_toy_proxy_server in
+            # READ-mode multi-node TP) may forward `remote_tp_size` only.
+            # Read `tp_size` first, fall back to `remote_tp_size`, default 1.
+            tp_size=kv_transfer_params.get(
+                "tp_size",
+                kv_transfer_params.get("remote_tp_size", 1),
+            ),
             remote_dp_size=kv_transfer_params.get("remote_dp_size", 1),
+            remote_dp_rank=int(kv_transfer_params.get("remote_dp_rank", 0) or 0),
+            remote_hosts=remote_hosts or None,
         )
         if write_mode:
             self.reqs_to_save[request_id] = _req

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -235,7 +235,8 @@ def validate_moriio_trusted_host(
     if not trusted_host_list:
         raise ValueError(
             f"MoRIIO {source} host {remote_host!r} is not trusted; configure "
-            "kv_connector_extra_config['node_hosts'] with trusted peer hosts"
+            "kv_connector_extra_config['trusted_remote_hosts'] with trusted peer "
+            "hosts"
         )
     if remote_host not in set(trusted_host_list):
         raise ValueError(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -37,6 +37,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     TransferId,
     WriteTask,
     get_moriio_mode,
+    get_moriio_node_hosts,
     get_peer_zmq_from_request_id,
     get_port_offset,
     get_role,
@@ -184,6 +185,28 @@ def resolve_moriio_transfer_ack(
     notification_counts.pop(transfer_id, None)
     completed_transfer_ids.add(transfer_id)
     return transfer_id
+
+
+def _pick_remote_rank_host(
+    default_host: str,
+    remote_hosts: list[str] | None,
+    tp_size: int,
+    tp_rank: int,
+    remote_dp_size: int = 1,
+    remote_dp_rank: int = 0,
+) -> str:
+    if remote_hosts and len(remote_hosts) > 1:
+        n_hosts = len(remote_hosts)
+        if int(remote_dp_size) >= n_hosts:
+            dp_per_node = max(1, int(remote_dp_size) // n_hosts)
+            node_idx = int(remote_dp_rank) // dp_per_node
+            if 0 <= node_idx < n_hosts:
+                return remote_hosts[node_idx]
+        ranks_per_node = max(1, int(tp_size) // n_hosts)
+        node_idx = int(tp_rank) // ranks_per_node
+        if 0 <= node_idx < n_hosts:
+            return remote_hosts[node_idx]
+    return default_host
 
 
 class MoRIIOConnector(KVConnectorBase_V1):
@@ -364,10 +387,19 @@ class MoRIIOConnectorScheduler:
         self.host_ip = resolve_host_ip(
             self.kv_transfer_config.kv_connector_extra_config
         )
+        # Multi-node TP: node_hosts holds the ordered host IPs in this
+        # engine's TP group (rank 0 first). Surfaced to the peer side via
+        # request_finished's kv_transfer_params so workers can dial the rank
+        # owner. Single-node TP falls back to [host_ip].
+        self.node_hosts = get_moriio_node_hosts(self.kv_transfer_config, self.host_ip)
         self.handshake_port = self.kv_transfer_config.kv_connector_extra_config[
             "handshake_port"
         ]
-        logger.info("Initializing MoRIIO Scheduler engine_id = %s", engine_id)
+        logger.info(
+            "Initializing MoRIIO Scheduler engine_id = %s node_hosts = %s",
+            engine_id,
+            self.node_hosts,
+        )
 
         self.side_notify_port = self.kv_transfer_config.kv_connector_extra_config[
             "notify_port"
@@ -595,16 +627,28 @@ class MoRIIOConnectorScheduler:
 
                 block_ids = blocks.get_block_ids()[0]
 
+                remote_hosts = request.kv_transfer_params.get("remote_hosts")
+                if isinstance(remote_hosts, str):
+                    remote_hosts = [remote_hosts] if remote_hosts else None
+
                 for tp_index in range(self.tp_size):
                     target_port = remote_notify_port + get_port_offset(
                         remote_dp_rank, tp_index
+                    )
+                    target_host = _pick_remote_rank_host(
+                        remote_host,
+                        remote_hosts,
+                        self.tp_size,
+                        tp_index,
+                        int(request.kv_transfer_params.get("remote_dp_size", 1)),
+                        int(remote_dp_rank),
                     )
 
                     self.send_notify_block(
                         req_id=request.request_id,
                         transfer_id=request.kv_transfer_params["transfer_id"],
                         block_notify_list=block_ids,
-                        host=remote_host,
+                        host=target_host,
                         port=target_port,
                     )
 
@@ -764,6 +808,10 @@ class MoRIIOConnectorScheduler:
             remote_dp_size=self.vllm_config.parallel_config.data_parallel_size,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
             transfer_id=params["transfer_id"],
+            # Multi-node TP: list of all prefill-instance host IPs in this
+            # engine's TP group (rank 0 first). Decode workers use this to
+            # pick the correct producer host per their tp_rank.
+            remote_hosts=self.node_hosts,
         )
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
@@ -870,6 +918,7 @@ class MoRIIOConnectorWorker:
         self.http_port = self.moriio_config.http_port
         self.handshake_port = self.moriio_config.handshake_port
         self.notify_port = self.moriio_config.notify_port
+        self.node_hosts = self.moriio_config.node_hosts
 
         self.zmq_context = zmq.Context()
         self.metadata_address = (
@@ -1133,6 +1182,7 @@ class MoRIIOConnectorWorker:
                         # READ (prefill-then-decode, sequential) from WRITE (concurrent)
                         # scheduling.
                         "transfer_mode": self.mode.name,
+                        "node_hosts": list(self.node_hosts),
                     }
 
                     sock.send(msgpack.dumps(data))
@@ -1324,6 +1374,22 @@ class MoRIIOConnectorWorker:
     def _remote_tp_rank(self, remote_tp_size: int) -> int:
         return get_moriio_remote_tp_rank(self.tp_rank, self.world_size, remote_tp_size)
 
+    def _pick_remote_host(self, meta: ReqMeta) -> str:
+        """Resolve the per-worker peer host for multi-node TP prefill-decode."""
+        return _pick_remote_rank_host(
+            meta.remote_host, meta.remote_hosts, int(meta.tp_size), self.tp_rank
+        )
+
+    def _pick_host_for_dp_rank(self, meta: ReqMeta, dp_rank: int) -> str:
+        return _pick_remote_rank_host(
+            meta.remote_host,
+            meta.remote_hosts,
+            int(meta.tp_size),
+            self.tp_rank,
+            int(meta.remote_dp_size),
+            dp_rank,
+        )
+
     def _background_moriio_handshake(
         self, req_id: ReqId, remote_engine_id: EngineId, meta: ReqMeta
     ):
@@ -1332,7 +1398,6 @@ class MoRIIOConnectorWorker:
         if remote_engine_id is not None:
             fut = self._handshake_futures.get(remote_engine_id)
         if fut is None:
-            host = meta.remote_host
             port = int(meta.remote_handshake_port)
             tp_size = int(meta.tp_size)
             remote_dp_size = int(meta.remote_dp_size)
@@ -1349,6 +1414,7 @@ class MoRIIOConnectorWorker:
 
         for cur_dp_rank in range(remote_dp_size):
             dp_engine_id = self.get_engine_name_with_dp(remote_engine_id, cur_dp_rank)
+            host = self._pick_host_for_dp_rank(meta, cur_dp_rank)
             future = self._handshake_initiation_executor.submit(
                 self._moriio_handshake, host, port, tp_size, dp_engine_id, cur_dp_rank
             )
@@ -1793,13 +1859,20 @@ class MoRIIOConnectorWorker:
             meta.remote_engine_id,
             req_id,
         )
+        # Multi-node TP: remote_host here is used by _read_blocks to record the
+        # post-transfer notify callback address (so prefill can free its KV
+        # blocks). For multi-node prefill the notify must go to the prefill
+        # node that actually owns this worker's KV slice, not the prefill
+        # head. _pick_remote_host returns meta.remote_host unchanged for
+        # single-host setups, preserving TP=8 / monolithic behaviour.
+        actual_remote_host = self._pick_remote_host(meta)
         self._read_blocks(
             request_id=req_id,
             transfer_id=meta.transfer_id,
             dst_engine_id=meta.remote_engine_id,
             local_block_ids=meta.local_block_ids,
             remote_block_ids=meta.remote_block_ids,
-            remote_host=meta.remote_host,
+            remote_host=actual_remote_host,
             remote_notify_port=meta.remote_notify_port,
             remote_tp_size=meta.tp_size,
         )
@@ -1814,7 +1887,7 @@ class MoRIIOConnectorWorker:
             layer_name=layer_name,
             kv_layer=kv_layer,
             remote_notify_port=meta.remote_notify_port,
-            remote_ip=meta.remote_host,
+            remote_ip=self._pick_remote_host(meta),
         )
 
     def merge_contiguous_blocks(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -8,11 +8,13 @@ import time
 from collections import defaultdict
 from collections.abc import Collection
 from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 import msgpack
 import msgspec
 import numpy as np
+import regex as re
 import torch
 import zmq
 
@@ -26,6 +28,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     ROLE,
     EngineId,
     HandshakeError,
+    LayerTransferPlan,
     MoRIIOAgentMetadata,
     MoRIIOConfig,
     MoRIIOConnectorMetadata,
@@ -36,14 +39,18 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     ReqMeta,
     TransferId,
     WriteTask,
+    _as_bool,
+    _strip_vllm_request_suffix,
     get_moriio_mode,
     get_moriio_node_hosts,
+    get_moriio_trusted_remote_hosts,
     get_peer_zmq_from_request_id,
     get_port_offset,
     get_role,
     parse_moriio_zmq_address,
     resolve_host_ip,
     set_role,
+    validate_moriio_trusted_host,
     zmq_ctx,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_engine import (
@@ -82,6 +89,54 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+_TRANSFER_ID_RE = re.compile(
+    r"(tx-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+)
+_READ_COMPLETION_ID_RE = re.compile(r"^(?P<transfer_id>.+):tp(?P<tp_rank>\d+)$")
+_MAX_PENDING_UNMAPPED_DONE_TIDS = 4096
+
+
+def _make_read_completion_id(transfer_id: TransferId, tp_rank: int) -> str:
+    return f"{transfer_id}:tp{int(tp_rank)}"
+
+
+CompletionId = str | MoRIIOTransferAck
+
+
+def _completion_id_text(completion_id: CompletionId) -> str:
+    if isinstance(completion_id, MoRIIOTransferAck):
+        return completion_id.transfer_id
+    return completion_id
+
+
+def _read_completion_transfer_id(completion_id: CompletionId) -> TransferId | None:
+    completion_id = _completion_id_text(completion_id)
+    match = _READ_COMPLETION_ID_RE.fullmatch(completion_id)
+    if match is None:
+        return None
+    return match.group("transfer_id")
+
+
+def _read_completion_key(completion_id: CompletionId) -> str:
+    completion_id = _completion_id_text(completion_id)
+    match = _READ_COMPLETION_ID_RE.fullmatch(completion_id)
+    if match is None:
+        return completion_id
+    return f"tp{match.group('tp_rank')}"
+
+
+def _read_completion_quorum(
+    remote_decode_tp_size: int,
+    producer_tp_size: int,
+    producer_tp_rank: int,
+) -> int:
+    remote_decode_tp_size = max(1, int(remote_decode_tp_size))
+    producer_tp_size = max(1, int(producer_tp_size))
+    producer_tp_rank = int(producer_tp_rank)
+    if producer_tp_rank >= remote_decode_tp_size:
+        return 0
+    return ((remote_decode_tp_size - 1 - producer_tp_rank) // producer_tp_size) + 1
 
 try:
     from mori.io import (
@@ -310,6 +365,10 @@ class MoRIIOConnector(KVConnectorBase_V1):
         assert self.connector_worker is not None
         return self.connector_worker.get_finished()
 
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        assert self.connector_worker is not None
+        return self.connector_worker.get_block_ids_with_load_errors()
+
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         assert self.connector_worker is not None
         if self.mode == MoRIIOMode.WRITE and get_role() == ROLE.CONSUMER:
@@ -319,7 +378,12 @@ class MoRIIOConnector(KVConnectorBase_V1):
         self.connector_worker.start_load_kv(self._connector_metadata)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
-        pass
+        if self.mode != MoRIIOMode.READ or get_role() == ROLE.PRODUCER:
+            return
+        assert self.connector_worker is not None, (
+            "wait_for_layer_load called on scheduler role"
+        )
+        self.connector_worker.wait_for_layer_load(layer_name)
 
     def save_kv_layer(
         self,
@@ -370,6 +434,26 @@ class MoRIIOConnector(KVConnectorBase_V1):
         except AttributeError:
             return False
 
+    def get_finished_count(self) -> int | None:
+        # Aggregation still waits for this producer TP group; each worker emits
+        # only after its per-transfer decode-rank quorum is satisfied.
+        return self._vllm_config.parallel_config.tensor_parallel_size
+
+    def has_pending_deferred_sends(self) -> bool:
+        if self.connector_scheduler is None:
+            return False
+        return self.connector_scheduler.has_pending_deferred_sends()
+
+    @classmethod
+    def requires_piecewise_for_cudagraph(cls, extra_config: dict[str, Any]) -> bool:
+        """MoRIIO needs PIECEWISE around layerwise transfer hooks."""
+        if _as_bool(extra_config.get("allow_full_cudagraph", False)):
+            raise ValueError(
+                "MoRIIO cannot honor allow_full_cudagraph=True: layerwise "
+                "KV-transfer hooks must run outside full CUDA graph replay."
+            )
+        return True
+
 
 class MoRIIOConnectorScheduler:
     """Implementation of Scheduler side methods"""
@@ -392,13 +476,18 @@ class MoRIIOConnectorScheduler:
         # request_finished's kv_transfer_params so workers can dial the rank
         # owner. Single-node TP falls back to [host_ip].
         self.node_hosts = get_moriio_node_hosts(self.kv_transfer_config, self.host_ip)
+        self.trusted_remote_hosts = get_moriio_trusted_remote_hosts(
+            self.kv_transfer_config
+        )
         self.handshake_port = self.kv_transfer_config.kv_connector_extra_config[
             "handshake_port"
         ]
         logger.info(
-            "Initializing MoRIIO Scheduler engine_id = %s node_hosts = %s",
+            "Initializing MoRIIO Scheduler engine_id = %s node_hosts = %s "
+            "trusted_remote_hosts = %s",
             engine_id,
             self.node_hosts,
+            self.trusted_remote_hosts,
         )
 
         self.side_notify_port = self.kv_transfer_config.kv_connector_extra_config[
@@ -437,15 +526,43 @@ class MoRIIOConnectorScheduler:
         self.paths: dict[str, zmq.Socket] = {}
         self.transfer_id_to_request_id: dict[TransferId, ReqId] = {}
         self.request_id_to_transfer_id: dict[ReqId, TransferId] = {}
+        self._transfer_ids_to_forget: set[TransferId] = set()
+        # Scheduler-to-worker ID mappings that have not been sent yet. The
+        # worker merges them into a persistent map, so metadata only needs the
+        # local delta instead of cloning the full map every scheduler tick.
+        self._pending_transfer_id_to_request_id: dict[TransferId, ReqId] = {}
+        self.transfer_id_to_remote_tp_size: dict[TransferId, int] = {}
+        self._pending_transfer_id_to_remote_tp_size: dict[TransferId, int] = {}
 
-    def map_request_id(self, request_id: ReqId, transfer_id: TransferId):
+    def map_request_id(
+        self,
+        request_id: ReqId,
+        transfer_id: TransferId,
+        remote_tp_size: int | None = None,
+    ):
+        previous_request_id = self.transfer_id_to_request_id.get(transfer_id)
         self.transfer_id_to_request_id[transfer_id] = request_id
         self.request_id_to_transfer_id[request_id] = transfer_id
+        if previous_request_id != request_id:
+            self._pending_transfer_id_to_request_id[transfer_id] = request_id
+        if remote_tp_size is not None:
+            if not hasattr(self, "transfer_id_to_remote_tp_size"):
+                self.transfer_id_to_remote_tp_size = {}
+            if not hasattr(self, "_pending_transfer_id_to_remote_tp_size"):
+                self._pending_transfer_id_to_remote_tp_size = {}
+            remote_tp_size = max(1, int(remote_tp_size))
+            self.transfer_id_to_remote_tp_size[transfer_id] = remote_tp_size
+            self._pending_transfer_id_to_remote_tp_size[transfer_id] = remote_tp_size
 
-    def unmap_request_id(self, request_id: ReqId):
+    def unmap_request_id(self, request_id: ReqId, warn_missing: bool = True):
         if request_id in self.request_id_to_transfer_id:
             transfer_id = self.request_id_to_transfer_id[request_id]
             del self.request_id_to_transfer_id[request_id]
+            with suppress(AttributeError):
+                self._pending_transfer_id_to_request_id.pop(transfer_id, None)
+                self._pending_transfer_id_to_remote_tp_size.pop(transfer_id, None)
+            with suppress(AttributeError):
+                self.transfer_id_to_remote_tp_size.pop(transfer_id, None)
             if transfer_id in self.transfer_id_to_request_id:
                 del self.transfer_id_to_request_id[transfer_id]
             else:
@@ -453,12 +570,30 @@ class MoRIIOConnectorScheduler:
                     "transfer id not in transfer_id_to_request_id lookup"
                     "table. there is likely a bug!"
                 )
-        else:
+        elif warn_missing:
             logger.warning(
                 "Could not find %s  in transfer_id_to_request_id"
                 "lookup table.  This could lead to a possible hang.",
                 request_id,
             )
+
+    def _get_transfer_block_count(self, num_tokens: int) -> int:
+        if num_tokens <= 0:
+            return 0
+        return (num_tokens + self.block_size - 1) // self.block_size
+
+    def _trim_block_ids_to_token_span(
+        self,
+        block_ids: list[int],
+        num_tokens: int,
+    ) -> list[int]:
+        """Limit block ids to the token span MoRIIO actually transfers."""
+        transfer_blocks = self._get_transfer_block_count(num_tokens)
+        if transfer_blocks <= 0:
+            return []
+        if len(block_ids) <= transfer_blocks:
+            return block_ids
+        return block_ids[:transfer_blocks]
 
     def get_num_new_matched_tokens(
         self,
@@ -513,7 +648,16 @@ class MoRIIOConnectorScheduler:
             "decode_rank": self.dp_rank,
             "type": "remote_blocks",
         }
-        serialized_data = msgpack.dumps(data)
+        serialized_data = msgpack.dumps(data, use_bin_type=True)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "MoRIIO remote_blocks send: path=%s transfer_id=%s req_id=%s "
+                "blocks=%d",
+                path,
+                transfer_id,
+                req_id,
+                len(block_notify_list or []),
+            )
         self.paths[path].send(serialized_data)
 
     def _send_transfer_release(self, transfer_id: TransferId, host: str, port: int):
@@ -571,9 +715,27 @@ class MoRIIOConnectorScheduler:
             return
         transfer_id = params["transfer_id"]
         request_id = request.request_id
-        self.map_request_id(request_id, transfer_id)
+        remote_tp_size = int(
+            params.get("remote_tp_size", params.get("tp_size", self.tp_size))
+            or self.tp_size
+        )
+        self.map_request_id(request_id, transfer_id, remote_tp_size=remote_tp_size)
+        logger.info(
+            "MoRIIO update_state_after_alloc: request_id=%s transfer_id=%s "
+            "mode=%s do_remote_decode=%s do_remote_prefill=%s "
+            "num_external_tokens=%d",
+            request_id,
+            transfer_id,
+            self.mode.name,
+            params.get("do_remote_decode"),
+            params.get("do_remote_prefill"),
+            num_external_tokens,
+        )
+
         if params.get("do_remote_decode"):
-            local_block_ids = blocks.get_block_ids()[0]
+            local_block_ids = self._trim_block_ids_to_token_span(
+                blocks.get_block_ids()[0], request.num_prompt_tokens
+            )
             self._reqs_need_save[request.request_id] = (request, local_block_ids)
 
         if params is not None and params.get("do_remote_prefill"):
@@ -586,13 +748,14 @@ class MoRIIOConnectorScheduler:
                         # a full prefix cache hit on the D worker. We need to call
                         # send_notify in _read_blocks to free the memory on the P.
 
-                        # Get unhashed blocks to pull from remote.
+                        # Get local blocks to pull remote KV into. The two block
+                        # lists must describe the same token span.
                         local_block_ids = blocks.get_block_ids()[0]
-                        assert len(local_block_ids) <= len(remote_block_ids)
-                        if len(local_block_ids) == len(remote_block_ids):
-                            pass
-                        else:
-                            local_block_ids = remote_block_ids[-len(local_block_ids) :]
+                        assert len(local_block_ids) == len(remote_block_ids), (
+                            "MoRIIO READ block id count mismatch: "
+                            f"local={len(local_block_ids)} "
+                            f"remote={len(remote_block_ids)}"
+                        )
 
                         self._reqs_need_recv[request.request_id] = (
                             request,
@@ -616,38 +779,102 @@ class MoRIIOConnectorScheduler:
                 remote_notify_port = request.kv_transfer_params.get(
                     "remote_notify_port"
                 )
+                used_remote_zmq_fallback = False
                 if remote_host is None or remote_notify_port is None:
-                    peer_zmq = get_peer_zmq_from_request_id(
-                        request.request_id, is_producer=False
-                    )
+                    try:
+                        peer_zmq = get_peer_zmq_from_request_id(
+                            request.request_id, is_producer=False
+                        )
+                    except ValueError:
+                        peer_zmq = request.kv_transfer_params.get("remote_zmq_address")
+                        if not peer_zmq:
+                            raise ValueError(
+                                "MoRIIO WRITE remote_blocks notification requires "
+                                "kv_transfer_params.remote_zmq_address when the "
+                                "request_id does not embed a prefill zmq address"
+                            ) from None
+                        used_remote_zmq_fallback = True
                     remote_host, _, remote_notify_port = parse_moriio_zmq_address(
                         peer_zmq
                     )
+                    if used_remote_zmq_fallback:
+                        validate_moriio_trusted_host(
+                            remote_host,
+                            self.trusted_remote_hosts,
+                            "kv_transfer_params.remote_zmq_address",
+                        )
                 remote_notify_port = int(remote_notify_port)
-
-                block_ids = blocks.get_block_ids()[0]
 
                 remote_hosts = request.kv_transfer_params.get("remote_hosts")
                 if isinstance(remote_hosts, str):
                     remote_hosts = [remote_hosts] if remote_hosts else None
 
-                for tp_index in range(self.tp_size):
+                remote_tp_size = int(
+                    request.kv_transfer_params.get(
+                        "remote_tp_size",
+                        request.kv_transfer_params.get("tp_size", self.tp_size),
+                    )
+                    or self.tp_size
+                )
+                block_notify_list = blocks.get_block_ids()[0]
+                if num_external_tokens > 0:
+                    block_notify_list = self._trim_block_ids_to_token_span(
+                        block_notify_list, num_external_tokens
+                    )
+
+                logger.info(
+                    "MoRIIO WRITE decode remote_blocks branch: request_id=%s "
+                    "transfer_id=%s mode=%s remote_host=%s remote_hosts=%s "
+                    "remote_notify_port=%s remote_dp_rank=%s remote_dp_size=%s "
+                    "remote_tp_size=%d num_external_tokens=%d blocks=%d",
+                    request.request_id,
+                    request.kv_transfer_params["transfer_id"],
+                    self.mode.name,
+                    remote_host,
+                    remote_hosts,
+                    remote_notify_port,
+                    remote_dp_rank,
+                    request.kv_transfer_params.get("remote_dp_size", 1),
+                    remote_tp_size,
+                    num_external_tokens,
+                    len(block_notify_list or []),
+                )
+
+                for tp_index in range(remote_tp_size):
                     target_port = remote_notify_port + get_port_offset(
-                        remote_dp_rank, tp_index
+                        remote_dp_rank, tp_index, remote_tp_size
                     )
                     target_host = _pick_remote_rank_host(
                         remote_host,
                         remote_hosts,
-                        self.tp_size,
+                        remote_tp_size,
                         tp_index,
                         int(request.kv_transfer_params.get("remote_dp_size", 1)),
                         int(remote_dp_rank),
                     )
 
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug(
+                            "MoRIIO WRITE decode remote_blocks target: "
+                            "transfer_id=%s tp_index=%d target_host=%s "
+                            "target_port=%d remote_tp_size=%d",
+                            request.kv_transfer_params["transfer_id"],
+                            tp_index,
+                            target_host,
+                            target_port,
+                            remote_tp_size,
+                        )
+
+                    if used_remote_zmq_fallback:
+                        validate_moriio_trusted_host(
+                            target_host,
+                            self.trusted_remote_hosts,
+                            "kv_transfer_params.remote_hosts",
+                        )
                     self.send_notify_block(
                         req_id=request.request_id,
                         transfer_id=request.kv_transfer_params["transfer_id"],
-                        block_notify_list=block_ids,
+                        block_notify_list=block_notify_list,
                         host=target_host,
                         port=target_port,
                     )
@@ -661,7 +888,29 @@ class MoRIIOConnectorScheduler:
         scheduler_output: SchedulerOutput,
     ) -> KVConnectorMetadata:
         meta = MoRIIOConnectorMetadata()
-        meta.transfer_id_to_request_id = self.transfer_id_to_request_id
+        try:
+            pending_transfer_ids = self._pending_transfer_id_to_request_id
+        except AttributeError:
+            meta.transfer_id_to_request_id = {
+                transfer_id: req_id
+                for transfer_id, req_id in self.transfer_id_to_request_id.items()
+            }
+            meta.transfer_id_to_remote_tp_size = dict(
+                getattr(self, "transfer_id_to_remote_tp_size", {})
+            )
+        else:
+            if pending_transfer_ids:
+                meta.transfer_id_to_request_id = pending_transfer_ids
+                self._pending_transfer_id_to_request_id = {}
+            pending_remote_tp_sizes = getattr(
+                self, "_pending_transfer_id_to_remote_tp_size", {}
+            )
+            if pending_remote_tp_sizes:
+                meta.transfer_id_to_remote_tp_size = pending_remote_tp_sizes
+                self._pending_transfer_id_to_remote_tp_size = {}
+        if self._transfer_ids_to_forget:
+            meta.freed_transfer_ids = set(self._transfer_ids_to_forget)
+            self._transfer_ids_to_forget.clear()
 
         if self.mode == MoRIIOMode.WRITE and get_role() == ROLE.PRODUCER:
             # This is the logic for checking against chunked prefill.
@@ -681,11 +930,16 @@ class MoRIIOConnectorScheduler:
                         len(self._reqs_need_pending_save[req_id][1]) * self.block_size
                         >= req.num_prompt_tokens
                     ):
+                        local_block_ids = self._trim_block_ids_to_token_span(
+                            self._reqs_need_pending_save[req_id][1],
+                            req.num_prompt_tokens,
+                        )
                         meta.add_new_req(
                             request_id=req_id,
-                            local_block_ids=self._reqs_need_pending_save[req_id][1],
+                            local_block_ids=local_block_ids,
                             kv_transfer_params=req.kv_transfer_params or {},
                             write_mode=True,
+                            trusted_remote_hosts=self.trusted_remote_hosts,
                         )
                         del self._reqs_need_pending_save[req_id]
 
@@ -696,19 +950,24 @@ class MoRIIOConnectorScheduler:
                 request_id=req_id,
                 local_block_ids=block_ids,
                 kv_transfer_params=req.kv_transfer_params,
+                trusted_remote_hosts=self.trusted_remote_hosts,
             )
 
         for req_id, (req, block_ids) in self._reqs_need_save.items():
             assert req.kv_transfer_params is not None
-            if req.num_prompt_tokens > len(block_ids) * self.block_size:
+            local_block_ids = self._trim_block_ids_to_token_span(
+                block_ids, req.num_prompt_tokens
+            )
+            if req.num_prompt_tokens > len(local_block_ids) * self.block_size:
                 # not last chunk prefill
-                self._reqs_need_pending_save[req_id] = (req, block_ids)
+                self._reqs_need_pending_save[req_id] = (req, local_block_ids)
                 continue
             meta.add_new_req(
                 request_id=req_id,
-                local_block_ids=block_ids,
+                local_block_ids=local_block_ids,
                 kv_transfer_params=req.kv_transfer_params,
                 write_mode=True,
+                trusted_remote_hosts=self.trusted_remote_hosts,
             )
         # Clear the list once workers start the transfers
 
@@ -739,15 +998,18 @@ class MoRIIOConnectorScheduler:
         should be freed now or will be sent asynchronously and freed later.
         """
 
-        request_id = request.request_id
-        # Consumer: can unmap transfer_id<->request_id immediately since done_recving
-        #   has fired at this point (i.e. KV has been transferred)
-        # Producer: must keep the mapping until we get notification that blocks can
-        #   be freed, which may be several scheduler steps later.
-        if not self.is_producer:
-            self.unmap_request_id(request_id)
-
         params = request.kv_transfer_params
+        request_id = request.request_id
+        # Consumer mappings can be removed once KV transfer has completed.
+        # Producer mappings stay until the block-free notification arrives.
+        if not self.is_producer:
+            mapping_was_never_created = bool(
+                params and params.get("do_remote_prefill")
+            )
+            self.unmap_request_id(
+                request_id,
+                warn_missing=not mapping_was_never_created,
+            )
         logger.debug(
             "MoriioConnector request_finished, request_status=%s, "
             "kv_transfer_params=%s",
@@ -812,6 +1074,10 @@ class MoRIIOConnectorScheduler:
             # engine's TP group (rank 0 first). Decode workers use this to
             # pick the correct producer host per their tp_rank.
             remote_hosts=self.node_hosts,
+            # Wall-clock TS captured at end of P-side prefill (request_finished
+            # runs after FINISHED_LENGTH_CAPPED). Consumed by D's OutputProcessor
+            # to derive stage-3 KV transfer time. Requires NTP sync across nodes.
+            prefill_complete_ts=time.time(),
         )
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
@@ -830,6 +1096,9 @@ class MoRIIOConnectorScheduler:
         # Consumer: unmapping already done in request_finished
         if self.is_producer and connector_output.finished_sending:
             for req_id in connector_output.finished_sending:
+                transfer_id = self.request_id_to_transfer_id.get(req_id)
+                if transfer_id is not None:
+                    self._transfer_ids_to_forget.add(transfer_id)
                 self.unmap_request_id(req_id)
 
         if not self._deferred_send_deadlines:
@@ -839,6 +1108,9 @@ class MoRIIOConnectorScheduler:
         # freed anyways.
         for req_id in connector_output.finished_sending or ():
             self._deferred_send_deadlines.pop(req_id, None)
+
+        if not self._deferred_send_deadlines:
+            return
 
         now = time.monotonic()
         expired_reqs = [
@@ -853,7 +1125,11 @@ class MoRIIOConnectorScheduler:
             connector_output.finished_sending = set()
         # Register the expired requests as finished so the scheduler frees their blocks.
         for req_id in expired_reqs:
+            transfer_id = self.request_id_to_transfer_id.get(req_id)
+            if transfer_id is not None:
+                self._transfer_ids_to_forget.add(transfer_id)
             connector_output.finished_sending.add(req_id)
+            self._reqs_need_send.pop(req_id, None)
             del self._deferred_send_deadlines[req_id]
             if self.is_producer:
                 self.unmap_request_id(req_id)
@@ -864,6 +1140,9 @@ class MoRIIOConnectorScheduler:
             len(expired_reqs),
             self._defer_timeout,
         )
+
+    def has_pending_deferred_sends(self) -> bool:
+        return bool(self._transfer_ids_to_forget or self._deferred_send_deadlines)
 
 
 class MoRIIOConnectorWorker:
@@ -881,7 +1160,11 @@ class MoRIIOConnectorWorker:
                 "is installed and properly configured."
             )
 
-        assert vllm_config.kv_transfer_config is not None
+        assert vllm_config.kv_transfer_config is not None, (
+            "kv_transfer_config must be set for MoRIIOConnector"
+        )
+        self.vllm_config = vllm_config
+        self.kv_transfer_config = vllm_config.kv_transfer_config
         self.moriio_config = MoRIIOConfig.from_vllm_config(vllm_config)
         self.mode = (
             MoRIIOMode.READ if self.moriio_config.read_mode else MoRIIOMode.WRITE
@@ -892,11 +1175,6 @@ class MoRIIOConnectorWorker:
         logging.getLogger("aiter").disabled = True
 
         # Config.
-        self.vllm_config = vllm_config
-        assert vllm_config.kv_transfer_config is not None, (
-            "kv_transfer_config must be set for MoRIIOConnector"
-        )
-        self.kv_transfer_config = vllm_config.kv_transfer_config
         self.is_producer = self.kv_transfer_config.is_kv_producer
         self.layer_to_spec = build_layer_to_spec(kv_cache_config)
 
@@ -909,6 +1187,7 @@ class MoRIIOConnectorWorker:
         self._local_rank = get_world_group().local_rank
         self.tp_rank = self.moriio_config.tp_rank
         self.dp_rank = self.moriio_config.dp_rank
+        self.tp_size = self.moriio_config.tp_size
 
         self.local_ip = self.moriio_config.local_ip
         self.local_kv_port = self.moriio_config.local_kv_port
@@ -919,6 +1198,8 @@ class MoRIIOConnectorWorker:
         self.handshake_port = self.moriio_config.handshake_port
         self.notify_port = self.moriio_config.notify_port
         self.node_hosts = self.moriio_config.node_hosts
+
+        self.dp_rank_to_host: dict[int, str] = {}
 
         self.zmq_context = zmq.Context()
         self.metadata_address = (
@@ -1015,7 +1296,7 @@ class MoRIIOConnectorWorker:
 
         self.side_channel_port: int = (
             self.moriio_config.handshake_port
-            + get_port_offset(self.dp_rank, self.tp_rank)
+            + get_port_offset(self.dp_rank, self.tp_rank, self.tp_size)
         )
         self.engine_id: EngineId = engine_id
 
@@ -1037,10 +1318,15 @@ class MoRIIOConnectorWorker:
         # Map of engine_id -> num_blocks. All ranks in the same deployment will
         # have the same number of blocks.
         self.dst_num_blocks: dict[EngineId, int] = {}
-        # In progress transfers.
-        self._recving_transfers: defaultdict[ReqId, list] = defaultdict(list)
+        # In-progress READ transfers: per request, keyed by layer name.
+        self._recving_transfers: defaultdict[ReqId, dict[str, Any]] = defaultdict(dict)
+        self._pending_read_plans: defaultdict[
+            ReqId, dict[str, LayerTransferPlan]
+        ] = defaultdict(dict)
         # Values are (remote_host, remote_notify_port, transfer_id).
         self._recving_transfers_callback_addr: dict[ReqId, tuple[str, str, str]] = {}
+        self._recving_transfer_local_block_ids: dict[ReqId, set[int]] = {}
+        self._invalid_block_ids: queue.Queue[set[int]] = queue.Queue()
 
         # Track the expiration time of requests that are waiting to be sent.
         self._reqs_to_send: dict[ReqId, float] = {}
@@ -1057,6 +1343,11 @@ class MoRIIOConnectorWorker:
         self._handshake_futures: dict[EngineId, Future[set[str]]] = {}
         # Protects _handshake_futures and _remote_agents.
         self._handshake_lock = threading.RLock()
+        # Base remote engines ("host:handshake_port") whose full DP-rank set has
+        # been eagerly handshaked AND TP-barriered. Gates
+        # _eager_handshake_all_dp_ranks to fire once per remote engine (first
+        # contact), not per request/step.
+        self._eager_handshaked_engines: set[str] = set()
 
         self.block_size = vllm_config.cache_config.block_size
         self.model_config = vllm_config.model_config
@@ -1073,10 +1364,201 @@ class MoRIIOConnectorWorker:
             use_mla=self.use_mla,
         )
         self.transfer_id_to_request_id: dict[TransferId, ReqId] = {}
+        self.request_id_to_transfer_id: dict[ReqId, TransferId] = {}
+        self.transfer_id_to_remote_tp_size: dict[TransferId, int] = {}
+        self.transfer_id_to_completion_count: dict[TransferId, int] = {}
+        self._read_completion_ids: defaultdict[TransferId, set[str]] = defaultdict(set)
+        # READ-mode producer: buffer decode-side completion ids until
+        # start_load_kv populates transfer_id_to_request_id. get_finished()
+        # retries the buffered ids in insertion order and evicts malformed
+        # notifications oldest-first at the cap.
+        self._pending_unmapped_done_tids: dict[str, CompletionId | None] = {}
 
         # TODO: consider the integration of flashinfer or other backends.
         self.backend_name = backend.get_name()
         logger.debug("Detected attention backend %s", self.backend_name)
+
+    def _remember_transfer_mapping(
+        self, transfer_id: TransferId, request_id: ReqId
+    ) -> None:
+        self.transfer_id_to_request_id[transfer_id] = request_id
+        self.request_id_to_transfer_id[request_id] = transfer_id
+        external_request_id = _strip_vllm_request_suffix(request_id)
+        if external_request_id != request_id:
+            self.request_id_to_transfer_id.setdefault(external_request_id, transfer_id)
+
+    def _forget_transfer_mapping(
+        self, transfer_id: TransferId, request_id: ReqId | None = None
+    ) -> None:
+        if request_id is None:
+            request_id = self.transfer_id_to_request_id.get(transfer_id)
+        self.transfer_id_to_request_id.pop(transfer_id, None)
+        self.transfer_id_to_remote_tp_size.pop(transfer_id, None)
+        self.transfer_id_to_completion_count.pop(transfer_id, None)
+        self._read_completion_ids.pop(transfer_id, None)
+        if request_id is None:
+            return
+        with suppress(AttributeError):
+            self._reqs_to_send.pop(request_id, None)
+        self.request_id_to_transfer_id.pop(request_id, None)
+        external_request_id = _strip_vllm_request_suffix(request_id)
+        if external_request_id != request_id:
+            mapped_transfer_id = self.request_id_to_transfer_id.get(external_request_id)
+            if mapped_transfer_id == transfer_id:
+                self.request_id_to_transfer_id.pop(external_request_id, None)
+
+    def _drop_pending_unmapped_done_tid(
+        self, transfer_id: TransferId, request_id: ReqId | None = None
+    ) -> None:
+        ids_to_drop = {transfer_id}
+        if request_id is not None:
+            ids_to_drop.add(request_id)
+            ids_to_drop.add(_strip_vllm_request_suffix(request_id))
+
+        for completion_id in list(self._pending_unmapped_done_tids):
+            if completion_id in ids_to_drop:
+                self._pending_unmapped_done_tids.pop(completion_id, None)
+                continue
+            if _read_completion_transfer_id(completion_id) == transfer_id:
+                self._pending_unmapped_done_tids.pop(completion_id, None)
+                continue
+            match = _TRANSFER_ID_RE.search(completion_id)
+            if match is not None and match.group(1) == transfer_id:
+                self._pending_unmapped_done_tids.pop(completion_id, None)
+
+    def _buffer_pending_unmapped_done_tid(self, completion_id: CompletionId) -> None:
+        completion_key = _completion_id_text(completion_id)
+        if completion_key in self._pending_unmapped_done_tids:
+            return
+        if len(self._pending_unmapped_done_tids) >= _MAX_PENDING_UNMAPPED_DONE_TIDS:
+            oldest = next(iter(self._pending_unmapped_done_tids))
+            self._pending_unmapped_done_tids.pop(oldest, None)
+            logger.warning(
+                "Dropping oldest pending READ completion id after buffer "
+                "reached %d entries",
+                _MAX_PENDING_UNMAPPED_DONE_TIDS,
+            )
+        self._pending_unmapped_done_tids[completion_key] = (
+            completion_id if isinstance(completion_id, MoRIIOTransferAck) else None
+        )
+
+    def _translate_or_buffer_completion(
+        self, completion_id: CompletionId, done_sending: set[str]
+    ) -> None:
+        resolved = self._resolve_completion_mapping(completion_id)
+        if resolved is None:
+            # Mapping not yet populated — keep pending, retry next tick.
+            # Without this buffer the notification is lost and the producer's
+            # KV blocks leak.
+            self._buffer_pending_unmapped_done_tid(completion_id)
+            return
+
+        transfer_id, request_id = resolved
+        ack = (
+            completion_id
+            if isinstance(completion_id, MoRIIOTransferAck)
+            else MoRIIOTransferAck(transfer_id)
+        )
+        resolved_transfer_id = resolve_moriio_transfer_ack(
+            ack,
+            producer_tp_size=self.world_size,
+            live_transfer_ids=self.transfer_id_to_request_id.keys(),
+            notification_counts=self._consumer_notification_counts,
+            completed_transfer_ids=self._completed_consumer_notifications,
+        )
+        if resolved_transfer_id is None:
+            return
+        self._forget_transfer_mapping(resolved_transfer_id, request_id)
+        done_sending.add(request_id)
+
+    def _translate_or_buffer_read_completion(
+        self, completion_id: CompletionId, done_sending: set[str]
+    ) -> None:
+        mapped, handled = self._pop_mapped_read_completion_id(completion_id)
+        if mapped is not None:
+            done_sending.add(mapped)
+            with suppress(AttributeError):
+                self._reqs_to_send.pop(mapped, None)
+        elif not handled:
+            self._buffer_pending_unmapped_done_tid(completion_id)
+
+    def _resolve_completion_mapping(
+        self, completion_id: CompletionId
+    ) -> tuple[TransferId, ReqId] | None:
+        completion_id = _completion_id_text(completion_id)
+        request_id = self.transfer_id_to_request_id.get(completion_id)
+        if request_id is not None:
+            return completion_id, request_id
+
+        transfer_id = _read_completion_transfer_id(completion_id)
+        if transfer_id is not None:
+            request_id = self.transfer_id_to_request_id.get(transfer_id)
+            if request_id is not None:
+                return transfer_id, request_id
+
+        match = _TRANSFER_ID_RE.search(completion_id)
+        if match is not None:
+            transfer_id = match.group(1)
+            request_id = self.transfer_id_to_request_id.get(transfer_id)
+            if request_id is not None:
+                return transfer_id, request_id
+
+        request_keys = [completion_id]
+        stripped_completion_id = _strip_vllm_request_suffix(completion_id)
+        if stripped_completion_id != completion_id:
+            request_keys.append(stripped_completion_id)
+        for request_key in request_keys:
+            transfer_id = self.request_id_to_transfer_id.get(request_key)
+            if transfer_id is None:
+                continue
+            request_id = self.transfer_id_to_request_id.get(transfer_id)
+            if request_id is None:
+                self.request_id_to_transfer_id.pop(request_key, None)
+                return None
+            return transfer_id, request_id
+        return None
+
+    def _pop_mapped_completion_id(self, completion_id: CompletionId) -> ReqId | None:
+        resolved = self._resolve_completion_mapping(completion_id)
+        if resolved is None:
+            return None
+        transfer_id, request_id = resolved
+        self._forget_transfer_mapping(transfer_id, request_id)
+        return request_id
+
+    def _pop_mapped_read_completion_id(
+        self, completion_id: CompletionId
+    ) -> tuple[ReqId | None, bool]:
+        resolved = self._resolve_completion_mapping(completion_id)
+        if resolved is None:
+            return None, False
+        transfer_id, request_id = resolved
+        expected_count = self.transfer_id_to_completion_count.get(transfer_id, 1)
+        if expected_count <= 1:
+            self._forget_transfer_mapping(transfer_id, request_id)
+            return request_id, True
+
+        completion_key = _read_completion_key(completion_id)
+        completion_ids = self._read_completion_ids[transfer_id]
+        if completion_key in completion_ids:
+            return None, True
+        completion_ids.add(completion_key)
+        if len(completion_ids) < expected_count:
+            return None, True
+
+        self._forget_transfer_mapping(transfer_id, request_id)
+        return request_id, True
+
+    def _pop_zero_quorum_read_completions(self, done_sending: set[str]) -> None:
+        for req_id in list(self._reqs_to_send):
+            transfer_id = self.request_id_to_transfer_id.get(req_id)
+            if transfer_id is None:
+                continue
+            if self.transfer_id_to_completion_count.get(transfer_id) != 0:
+                continue
+            done_sending.add(req_id)
+            self._reqs_to_send.pop(req_id, None)
+            self._forget_transfer_mapping(transfer_id, req_id)
 
     def schedule_write_blocks(
         self,
@@ -1151,7 +1633,7 @@ class MoRIIOConnectorWorker:
         ]
 
     def _ping(self, zmq_context):
-        # Use host:port format for http_address (compatible with official router)
+        # Use host:port format for http_address.
         http_address = f"{self.request_address}"
         # Include host so the router embeds it in the request_id; the connector
         # on the other side parses host/ports from there.
@@ -1173,9 +1655,8 @@ class MoRIIOConnectorWorker:
                         "type": role,  # "P" or "D"
                         "http_address": http_address,
                         "zmq_address": zmq_address,
-                        # dp_size/tp_size are not used by the official vLLM router
-                        # (routing operates at the http_address level); they are
-                        # consumed only by the toy proxy server.
+                        # The router routes by http_address; these sizes are kept
+                        # for proxy compatibility.
                         "dp_size": self.moriio_config.dp_size,
                         "tp_size": self.moriio_config.tp_size,
                         # transfer_mode is included so the router can distinguish
@@ -1288,6 +1769,17 @@ class MoRIIOConnectorWorker:
                         req_id.decode(),
                     )
 
+    def _remote_tp_rank(self, remote_tp_size: int) -> int:
+        """Map this local TP rank onto the remote TP layout for port addressing.
+
+        The request's remote_dp_rank selects the remote DP rank that holds its KV;
+        this helper only resolves the remote TP index. When remote TP size is 1,
+        every local rank maps to tp0. Equal TP sizes preserve tp_rank. Wider
+        remote TP layouts replicate MLA latent KV across remote TP ranks, so
+        modulo selects a valid remote rank.
+        """
+        return self.tp_rank % max(1, int(remote_tp_size))
+
     def _moriio_handshake(
         self,
         host: str,
@@ -1300,21 +1792,40 @@ class MoRIIOConnectorWorker:
 
         start_time = time.perf_counter()
 
-        # NOTE(rob): we need each rank to have a unique port. This is
-        # a hack to keep us moving. We will switch when moving to etcd
-        # or where we have a single ZMQ socket in the scheduler.
+        # Each worker exposes a distinct metadata endpoint. Until MoRIIO has a
+        # shared scheduler/coordinator socket, derive the endpoint from the
+        # remote DP/TP rank so handshakes land on the process that owns the
+        # transfer metadata.
 
+        # Heterogeneous-TP port mapping: dial the remote's TP index, not our own
+        # local tp_rank. For TP1/DP8 prefill ↔ TP8 decode this collapses every
+        # decode rank onto the prefill rank's tp0 (remote_dp_rank picks the DP
+        # rank). Identity for symmetric TP. See _remote_tp_rank.
         port_offset = get_port_offset(
-            remote_dp_rank, self._remote_tp_rank(remote_tp_size)
+            remote_dp_rank, self._remote_tp_rank(remote_tp_size), remote_tp_size
         )
         path = make_zmq_path("tcp", host, port + port_offset)
         logger.debug("handshake Querying metadata on path: %s", path)
 
         # Send query for the request.
+        timeout_ms = int(self.moriio_config.handshake_timeout * 1000)
         with zmq_ctx(zmq.DEALER, path) as sock:
+            # Bound the handshake so an unresponsive remote listener raises
+            # HandshakeError instead of blocking this TP worker on recv().
+            # LINGER=0 discards unsent data when the socket closes.
+            sock.setsockopt(zmq.RCVTIMEO, timeout_ms)
+            sock.setsockopt(zmq.SNDTIMEO, timeout_ms)
+            sock.setsockopt(zmq.LINGER, 0)
             logger.debug("prepare send msg INSTAZNCE: %s", path)
             sock.send(MoRIIOConstants.GET_META_MSG)
-            received_frame = sock.recv_multipart()
+            try:
+                received_frame = sock.recv_multipart()
+            except zmq.error.Again as e:
+                raise HandshakeError(
+                    f"MoRIIO handshake metadata recv timed out after "
+                    f"{timeout_ms}ms on path {path} (remote dp rank "
+                    f"{remote_dp_rank}); remote handshake listener unreachable"
+                ) from e
             if len(received_frame) != 2 or received_frame[0] != b"":
                 raise HandshakeError(f"Unexpected frame! {received_frame = }")
 
@@ -1331,6 +1842,7 @@ class MoRIIOConnectorWorker:
             remote_agent_name = self.moriio_wrapper.register_remote_engine(
                 metadata.agent_metadata
             )
+            self.dp_rank_to_host[int(remote_dp_rank)] = host
 
             logger.debug(
                 "MoRIIO handshake: registered"
@@ -1355,7 +1867,14 @@ class MoRIIOConnectorWorker:
                 )
                 self.remote_kv_cache_metadata = []
 
-            received_frame = sock.recv_multipart()
+            try:
+                received_frame = sock.recv_multipart()
+            except zmq.error.Again as e:
+                raise HandshakeError(
+                    f"MoRIIO handshake layer-metadata recv timed out after "
+                    f"{timeout_ms}ms on path {path} (remote dp rank "
+                    f"{remote_dp_rank})"
+                ) from e
             if len(received_frame) != 2 or received_frame[0] != b"":
                 raise HandshakeError(f"unexpected frame! {received_frame = }")
             buf = received_frame[1]
@@ -1596,36 +2115,56 @@ class MoRIIOConnectorWorker:
         to track which workers are done.
         """
 
-        done_sending, done_recving = set(), set()
+        done_sending: set[str] = set()
+        done_recving: set[str] = set()
 
         if self.is_producer:
-            # pop_finished_req_ids returns release ACKs sent by decode. Keep
-            # duplicate ACKs because heterogeneous TP can fan multiple decode
-            # ranks into one prefill rank for the same transfer_id.
-            finished_acks = self.moriio_wrapper.pop_finished_req_ids()
-            resolved_transfer_ids: set[TransferId] = set()
-            for ack in finished_acks:
-                transfer_id = ack if isinstance(ack, str) else ack.transfer_id
-                if transfer_id not in self.transfer_id_to_request_id:
-                    logger.warning(
-                        "Could not find %s in transfer_id_to_request_id "
-                        "lookup table. This could lead to a possible hang.",
-                        transfer_id,
+            done_sending_raw = self.moriio_wrapper.pop_finished_req_ids()
+            if self.mode == MoRIIOMode.READ:
+                # READ-mode decode notifies prefill by transfer_id. Translate it
+                # to the producer's request_id and keep unmapped notifications
+                # buffered until start_load_kv syncs the mapping.
+                pending_tids = self._pending_unmapped_done_tids
+                self._pending_unmapped_done_tids = {}
+                for tid, pending_ack in pending_tids.items():
+                    self._translate_or_buffer_read_completion(
+                        pending_ack if pending_ack is not None else tid,
+                        done_sending,
                     )
-                    continue
-                resolved_transfer_id = resolve_moriio_transfer_ack(
-                    ack,
-                    producer_tp_size=self.world_size,
-                    live_transfer_ids=self.transfer_id_to_request_id.keys(),
-                    notification_counts=self._consumer_notification_counts,
-                    completed_transfer_ids=(self._completed_consumer_notifications),
-                )
-                if resolved_transfer_id is not None:
-                    resolved_transfer_ids.add(resolved_transfer_id)
-            done_sending = {
-                self.transfer_id_to_request_id[xfer_id]
-                for xfer_id in resolved_transfer_ids
-            }
+                for completion_id in done_sending_raw:
+                    if _completion_id_text(completion_id) in pending_tids:
+                        continue
+                    self._translate_or_buffer_read_completion(
+                        completion_id, done_sending
+                    )
+                self._pop_zero_quorum_read_completions(done_sending)
+                if self._pending_unmapped_done_tids:
+                    logger.debug(
+                        "get_finished (producer READ): %d tid(s) pending "
+                        "transfer-id mapping",
+                        len(self._pending_unmapped_done_tids),
+                    )
+            else:
+                # WRITE mode: producer-local completions normally use scheduler
+                # request_ids. Normalize transfer_ids as well because completion
+                # delivery can race with start_load_kv.
+                pending_tids = self._pending_unmapped_done_tids
+                self._pending_unmapped_done_tids = {}
+                for tid, pending_ack in pending_tids.items():
+                    self._translate_or_buffer_completion(
+                        pending_ack if pending_ack is not None else tid,
+                        done_sending,
+                    )
+                for completion_id in done_sending_raw:
+                    if _completion_id_text(completion_id) in pending_tids:
+                        continue
+                    self._translate_or_buffer_completion(completion_id, done_sending)
+                if self._pending_unmapped_done_tids:
+                    logger.debug(
+                        "get_finished (producer WRITE): %d completion id(s) "
+                        "pending request-id mapping",
+                        len(self._pending_unmapped_done_tids),
+                    )
         else:
             if self.mode == MoRIIOMode.WRITE:
                 fresh = self.moriio_wrapper.pop_finished_write_req_ids()
@@ -1634,80 +2173,345 @@ class MoRIIOConnectorWorker:
                 self._unmatched_write_completions |= fresh
                 done_recving = self._unmatched_write_completions
             else:
-                # READ mode: the scheduler treats KV loads as synchronous
-                # (load_kv_async=False), so requests go directly to RUNNING
-                # instead of WAITING_FOR_REMOTE_KVS. We still call
-                # _pop_done_transfers() to send the notify to the prefill
-                # side and clean up internal state, but we must NOT report
-                # these as done_recving because the scheduler doesn't
-                # expect a finished_recving signal for RUNNING requests.
+                # READ mode: KV loads are synchronous (load_kv_async=False), so
+                # requests go directly to RUNNING. We still call
+                # _pop_done_transfers() to notify prefill and clean local state,
+                # but skip done_recving for RUNNING requests.
                 self._pop_done_transfers()
 
-        done_recving = {
-            self.transfer_id_to_request_id[id]
-            for id in filter(
-                lambda id: id in self.transfer_id_to_request_id, done_recving
-            )
-        }
+        # Translate consumer-side done_recving (transfer_ids reported by the
+        # producer via send_notify in WRITE mode) back to the consumer's own
+        # internal request_ids. Pop on success so the persistent worker map
+        # (populated incrementally in start_load_kv) does not grow unbounded.
+        translated_recving: set[str] = set()
+        matched_xfer_ids: set[str] = set()
+        for tid in done_recving:
+            mapped = self._pop_mapped_completion_id(tid)
+            if mapped is not None:
+                translated_recving.add(mapped)
+                matched_xfer_ids.add(tid)
+        done_recving = translated_recving
+
         if self.mode == MoRIIOMode.WRITE and not self.is_producer:
-            # Remove the ones we successfully matched; leave unmatched for retry.
-            matched_xfer_ids = {
-                id
-                for id in self._unmatched_write_completions
-                if id in self.transfer_id_to_request_id
-            }
             self._unmatched_write_completions -= matched_xfer_ids
 
         return done_sending, done_recving
 
+    def _handle_failed_read_transfer_locked(
+        self,
+        req_id: ReqId,
+        failed_status=None,
+        error: Exception | None = None,
+        record_invalid_blocks: bool = True,
+    ) -> None:
+        if failed_status is not None:
+            message = failed_status.Message()
+            code = failed_status.Code()
+        else:
+            message = str(error)
+            code = "setup"
+        invalid_block_ids = self._recving_transfer_local_block_ids.get(req_id, set())
+        if record_invalid_blocks and invalid_block_ids:
+            self._invalid_block_ids.put(set(invalid_block_ids))
+            self._recving_transfer_local_block_ids[req_id] = set()
+        logger.error(
+            "RDMA transfer failed for request %s: %s (code=%s). Notifying "
+            "prefill to free blocks%s.",
+            req_id,
+            message,
+            code,
+            " and marking local blocks invalid" if record_invalid_blocks else "",
+        )
+        callback_addr = self._recving_transfers_callback_addr.get(req_id)
+        if callback_addr is not None:
+            host, port, xfer_id = callback_addr
+            try:
+                self.moriio_wrapper.send_notify(
+                    _make_read_completion_id(xfer_id, self.tp_rank), host, port
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to send error notification for request %s; will retry",
+                    req_id,
+                )
+                return
+            self._forget_transfer_mapping(xfer_id, req_id)
+        else:
+            logger.warning(
+                "No READ completion callback address for failed request %s",
+                req_id,
+            )
+        self._recving_transfers.pop(req_id, None)
+        self._pending_read_plans.pop(req_id, None)
+        self._recving_transfers_callback_addr.pop(req_id, None)
+        self._recving_transfer_local_block_ids.pop(req_id, None)
+
+    @staticmethod
+    def _is_sq_full_status(status) -> bool:
+        """True if a MoRIIO transfer status is a transient RDMA send-queue-full
+        rejection (retryable backpressure), not a terminal failure.
+
+        The mori RDMA backend posts synchronously (the executor joins its worker
+        before returning — executor.cpp:174-183 — and marks the status on the
+        calling thread, backend_impl.cpp:1007), so an SQ-full rejection is a
+        Failed() status the moment batch_read() returns. mori surfaces it as a
+        generic ERR_RDMA_OP carrying "SQ full" in the message (no distinct code),
+        so we match the message. Only meaningful once status.Failed() is True.
+        """
+        try:
+            return bool(status.Failed()) and "SQ full" in (status.Message() or "")
+        except Exception:
+            return False
+
+    @staticmethod
+    def _read_status_active(status) -> bool:
+        return not status.Succeeded() and not status.Failed()
+
+    def _active_read_layer_count_locked(self) -> int:
+        return sum(
+            1
+            for status_by_layer in self._recving_transfers.values()
+            for status in status_by_layer.values()
+            if self._read_status_active(status)
+        )
+
+    def _active_read_layers_for_req_locked(self, req_id: ReqId) -> int:
+        status_by_layer = self._recving_transfers.get(req_id, {})
+        return sum(
+            1
+            for status in status_by_layer.values()
+            if self._read_status_active(status)
+        )
+
+    def _per_transfer_read_cap(self) -> int:
+        caps = [
+            cap
+            for cap in (
+                self.moriio_config.max_inflight_per_transfer,
+                self.moriio_config.max_dispatch_layers,
+            )
+            if cap > 0
+        ]
+        return min(caps) if caps else 0
+
+    def _can_dispatch_read_plan_locked(self, req_id: ReqId) -> bool:
+        active_layers = self._active_read_layers_for_req_locked(req_id)
+        per_transfer_cap = self._per_transfer_read_cap()
+        if per_transfer_cap > 0 and active_layers >= per_transfer_cap:
+            return False
+
+        global_cap = self.moriio_config.max_inflight_global
+        return global_cap <= 0 or self._active_read_layer_count_locked() < global_cap
+
+    def _take_dispatchable_read_plan(
+        self, layer_name: str | None = None
+    ) -> LayerTransferPlan | None:
+        with self.moriio_wrapper.lock:
+            for req_id, plans_by_layer in list(self._pending_read_plans.items()):
+                if layer_name is None:
+                    if not plans_by_layer:
+                        continue
+                    plan_layer_name = next(iter(plans_by_layer))
+                else:
+                    if layer_name not in plans_by_layer:
+                        continue
+                    plan_layer_name = layer_name
+
+                if not self._can_dispatch_read_plan_locked(req_id):
+                    continue
+
+                plan = plans_by_layer.pop(plan_layer_name)
+                if not plans_by_layer:
+                    self._pending_read_plans.pop(req_id, None)
+                return plan
+
+        return None
+
+    def _post_read_plan(self, plan: LayerTransferPlan) -> None:
+        _sq_deadline = time.monotonic() + self.moriio_config.transfer_timeout
+        _backoff = 0.001
+        while True:
+            try:
+                transfer_status = self.moriio_wrapper.read_remote_data(
+                    plan.transfer_sizes,
+                    plan.transfer_local_offsets,
+                    plan.transfer_remote_offsets,
+                    plan.session,
+                )
+            except Exception as e:
+                with self.moriio_wrapper.lock:
+                    has_partial_status = bool(
+                        self._recving_transfers.get(plan.request_id)
+                    )
+                    self._handle_failed_read_transfer_locked(
+                        plan.request_id,
+                        error=e,
+                        record_invalid_blocks=has_partial_status,
+                    )
+                raise
+            if not self._is_sq_full_status(transfer_status):
+                break
+            if time.monotonic() > _sq_deadline:
+                logger.warning(
+                    "MoRIIO READ send queue stayed full past transfer_timeout "
+                    "for req %s layer %s; storing failed status (handled "
+                    "non-fatally in wait_for_layer_load). Raise "
+                    "VLLM_MORIIO_QP_PER_TRANSFER and/or "
+                    "MORI_IO_SQ_BACKOFF_TIMEOUT_US if frequent.",
+                    plan.request_id,
+                    plan.layer_name,
+                )
+                break
+            time.sleep(_backoff)
+            _backoff = min(_backoff * 2, 0.05)
+
+        with self.moriio_wrapper.lock:
+            self._recving_transfers[plan.request_id][plan.layer_name] = (
+                transfer_status
+            )
+
+    def _dispatch_pending_reads(self, layer_name: str | None = None) -> None:
+        while True:
+            plan = self._take_dispatchable_read_plan(layer_name)
+            if plan is None:
+                return
+            self._post_read_plan(plan)
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        if self.is_producer or self.mode != MoRIIOMode.READ:
+            return
+
+        deadline = time.monotonic() + self.moriio_config.transfer_timeout
+        while True:
+            self._dispatch_pending_reads(layer_name)
+
+            with self.moriio_wrapper.lock:
+                pending_plan_req_ids = {
+                    req_id
+                    for req_id, plans_by_layer in self._pending_read_plans.items()
+                    if layer_name in plans_by_layer
+                }
+                pending = [
+                    (req_id, status_by_layer[layer_name])
+                    for req_id, status_by_layer in self._recving_transfers.items()
+                    if layer_name in status_by_layer
+                ]
+
+            if not pending and not pending_plan_req_ids:
+                return
+
+            still_running = False
+            for req_id, status in pending:
+                if status.Succeeded():
+                    continue
+                if status.Failed():
+                    with self.moriio_wrapper.lock:
+                        self._handle_failed_read_transfer_locked(req_id, status)
+                    if self._is_sq_full_status(status):
+                        # Treat sustained SQ-full as a request-local error: the
+                        # blocks are already invalidated and prefill has been
+                        # notified, so keep the worker alive and re-evaluate the
+                        # remaining pending transfers.
+                        logger.warning(
+                            "MoRIIO READ send queue still full for req %s "
+                            "layer %s after transfer_timeout; failed this "
+                            "request (worker stays alive). Raise "
+                            "VLLM_MORIIO_QP_PER_TRANSFER and/or "
+                            "MORI_IO_SQ_BACKOFF_TIMEOUT_US if frequent.",
+                            req_id,
+                            layer_name,
+                        )
+                        continue
+                    raise RuntimeError(
+                        "MoRIIO READ transfer failed for "
+                        f"request {req_id}, layer {layer_name}: "
+                        f"{status.Message()} (code={status.Code()})"
+                    )
+                still_running = True
+
+            if not still_running and not pending_plan_req_ids:
+                self._dispatch_pending_reads()
+                return
+
+            if time.monotonic() > deadline:
+                error = TimeoutError(
+                    "Timed out waiting for MoRIIO READ transfer for "
+                    f"layer {layer_name}; adjust with "
+                    "kv_connector_extra_config.transfer_timeout"
+                )
+                with self.moriio_wrapper.lock:
+                    req_ids = {req_id for req_id, _status in pending}
+                    req_ids.update(pending_plan_req_ids)
+                    for req_id in req_ids:
+                        self._handle_failed_read_transfer_locked(req_id, error=error)
+                raise error
+
+            time.sleep(0.001)
+
     def _pop_done_transfers(self) -> set[str]:
-        done_req_ids: set[str] = set()
+        """Pop completed remote-read transfers and notify the producer.
+
+        Sends the transfer_id (not the consumer's internal request_id) so the
+        producer can translate it back to its own internal request_id; see
+        get_finished() for the producer-side translation and the assign_request_id
+        rationale.
+
+        Returns an empty set because in READ mode the consumer scheduler does
+        not track recv-completion (get_num_new_matched_tokens returns
+        async=False, so requests never enter WAITING_FOR_REMOTE_KVS); reporting
+        a recv-completion here would trip the scheduler assertion at
+        _update_from_kv_xfer_finished. The downstream translation block in
+        get_finished() therefore receives an empty set and is a no-op.
+        """
         with self.moriio_wrapper.lock:
             to_remove = []
-            for req_id, status_list in self._recving_transfers.items():
-                last = status_list[-1]
-                if last.Succeeded():
-                    host, port, xfer_id = self._recving_transfers_callback_addr[req_id]
-                    done_req_ids.add(xfer_id)
-                    self.moriio_wrapper.send_notify(
-                        xfer_id,
-                        host,
-                        port,
-                        message_type="release",
-                        message_fields={"consumer_tp_size": self.world_size},
-                    )
-                    to_remove.append(req_id)
-                elif last.Failed():
-                    logger.error(
-                        "RDMA transfer failed for request %s: %s (code=%s). "
-                        "Notifying prefill to free blocks; request will be "
-                        "aborted by timeout.",
-                        req_id,
-                        last.Message(),
-                        last.Code(),
-                    )
+            for req_id, status_by_layer in list(self._recving_transfers.items()):
+                statuses = list(status_by_layer.values())
+                failed_status = next(
+                    (status for status in statuses if status.Failed()), None
+                )
+                if (
+                    statuses
+                    and req_id not in self._pending_read_plans
+                    and all(status.Succeeded() for status in statuses)
+                ):
                     host, port, xfer_id = self._recving_transfers_callback_addr[req_id]
                     try:
                         self.moriio_wrapper.send_notify(
-                            xfer_id,
+                            _make_read_completion_id(xfer_id, self.tp_rank),
                             host,
                             port,
-                            message_type="release",
-                            message_fields={"consumer_tp_size": self.world_size},
                         )
                     except Exception:
                         logger.exception(
-                            "Failed to send error notification for request %s",
+                            "MoRIIO READ completion notify failed for "
+                            "request %s transfer %s; will retry",
                             req_id,
+                            xfer_id,
                         )
+                        continue
+                    self._forget_transfer_mapping(xfer_id, req_id)
                     to_remove.append(req_id)
-                    # Do NOT add to done_req_ids: decode KV cache is incomplete.
+                elif failed_status is not None:
+                    self._handle_failed_read_transfer_locked(req_id, failed_status)
+                    # Do not add to done_req_ids: decode KV cache is incomplete.
                     # The request will expire via the normal request timeout.
             for req_id in to_remove:
-                del self._recving_transfers[req_id]
-                del self._recving_transfers_callback_addr[req_id]
+                self._recving_transfers.pop(req_id, None)
+                self._pending_read_plans.pop(req_id, None)
+                self._recving_transfers_callback_addr.pop(req_id, None)
+                self._recving_transfer_local_block_ids.pop(req_id, None)
 
-            return done_req_ids
+            return set()
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        result: set[int] = set()
+        while not self._invalid_block_ids.empty():
+            try:
+                result.update(self._invalid_block_ids.get_nowait())
+            except queue.Empty:
+                break
+        return result
 
     def save_kv_layer(
         self,
@@ -1721,64 +2525,217 @@ class MoRIIOConnectorWorker:
             return
         if self.mode == MoRIIOMode.READ:
             return
+        waiting_write_engine_ids: set[EngineId] = set()
+        written_req_ids: set[ReqId] = set()
         remote_engine_id = None
 
         for req_id, meta in metadata.reqs_to_save.items():
-            # we only need to check if dp0 in rank
+            # Gate on the DP rank that owns the remote allocation.
             remote_engine_id = (
                 str(meta.remote_host) + ":" + str(meta.remote_handshake_port)
             )
 
             meta.remote_engine_id = remote_engine_id
 
-            dp0_remote_engine_id = self.get_engine_name_with_dp(remote_engine_id, 0)
-            if dp0_remote_engine_id not in self._remote_agents:
+            target_remote_engine_id = self.get_engine_name_with_dp(
+                remote_engine_id, int(meta.remote_dp_rank)
+            )
+            if target_remote_engine_id not in self._remote_agents:
                 # Initiate handshake with remote engine to exchange metadata.
                 with self._handshake_lock:
-                    if remote_engine_id not in self._remote_agents:
+                    if target_remote_engine_id not in self._remote_agents:
                         self._background_moriio_handshake(
                             req_id, remote_engine_id, meta
                         )
-
+                        waiting_write_engine_ids.add(remote_engine_id)
                         continue
             self._write_blocks_for_req(req_id, meta, layer_name, kv_layer)
+            written_req_ids.add(req_id)
 
         if remote_engine_id is None:
             return
-        _deadline = time.monotonic() + self.moriio_config.transfer_timeout
-        while True:
-            if (
-                self._ready_requests.empty()
-                and remote_engine_id not in self.write_ready_flags
-            ):
+        if waiting_write_engine_ids:
+            _deadline = time.monotonic() + self.moriio_config.transfer_timeout
+            while True:
+                pending_engine_id = None
+                for engine_id in waiting_write_engine_ids:
+                    if engine_id not in self.write_ready_flags:
+                        pending_engine_id = engine_id
+                        break
+                if pending_engine_id is None:
+                    break
                 if time.monotonic() > _deadline:
                     logger.warning(
-                        "Timed out waiting for write_ready_flags[%s]; "
+                        "Timed out waiting for write_ready_flags for %s; "
                         "adjust with kv_connector_extra_config.transfer_timeout",
-                        remote_engine_id,
+                        tuple(
+                            engine_id
+                            for engine_id in waiting_write_engine_ids
+                            if engine_id not in self.write_ready_flags
+                        ),
                     )
-                    break
+                    return
                 time.sleep(0.001)
-                continue
-            elif not self._ready_requests.empty() and (
-                remote_engine_id in self.write_ready_flags
-            ):
+
+        if waiting_write_engine_ids or remote_engine_id in self.write_ready_flags:
+            while True:
+                try:
+                    ready_req_id, ready_meta = self._ready_requests.get_nowait()
+                except queue.Empty:
+                    break
+                if ready_req_id in written_req_ids:
+                    continue
                 self._write_blocks_for_req(
-                    *self._ready_requests.get_nowait(), layer_name, kv_layer
+                    ready_req_id, ready_meta, layer_name, kv_layer
                 )
-                break
-            else:
-                break
+                written_req_ids.add(ready_req_id)
 
     def get_engine_name_with_dp(self, engine_name, dp_rank):
         return f"{engine_name}_dp{dp_rank}"
+
+    def _eager_handshake_all_dp_ranks(
+        self, metadata: MoRIIOConnectorMetadata
+    ) -> None:
+        """Handshake remote prefill DP ranks uniformly across local TP workers.
+
+        Decode forward issues per-layer TP collectives, so handshake state needs
+        to stay uniform across TP workers. The engine set comes from scheduler
+        metadata shared across TP workers; each worker handshakes unresolved remote
+        DP ranks, then enters the TP all-reduce vote together.
+
+        Handshake exceptions are recorded before the collective and raised only
+        after the vote, so all TP workers observe the same outcome.
+        """
+        import torch.distributed as dist
+
+        # Distinct remote engines referenced this step, in metadata (==
+        # scheduler) order so every TP worker iterates engines identically.
+        engines: dict[str, ReqMeta] = {}
+        for _req_id, meta in metadata.reqs_to_recv.items():
+            remote_engine_id = (
+                str(meta.remote_host) + ":" + str(meta.remote_handshake_port)
+            )
+            engines.setdefault(remote_engine_id, meta)
+
+        for remote_engine_id, meta in engines.items():
+            if remote_engine_id in self._eager_handshaked_engines:
+                continue
+
+            remote_dp_size = int(meta.remote_dp_size)
+            port = int(meta.remote_handshake_port)
+            tp_size = int(meta.tp_size)
+
+            # Submit unresolved DP-rank handshakes while holding the lock; release
+            # it before waits and the TP collective so stalled recv calls do not
+            # block unrelated lock users.
+            futures: list[tuple[str, Future[set[str]]]] = []
+            with self._handshake_lock:
+                for cur_dp_rank in range(remote_dp_size):
+                    dp_engine_id = self.get_engine_name_with_dp(
+                        remote_engine_id, cur_dp_rank
+                    )
+                    if dp_engine_id in self._remote_agents:
+                        continue
+                    host = self._pick_host_for_dp_rank(meta, cur_dp_rank)
+                    fut = self._handshake_initiation_executor.submit(
+                        self._moriio_handshake,
+                        host,
+                        port,
+                        tp_size,
+                        dp_engine_id,
+                        cur_dp_rank,
+                    )
+                    futures.append((dp_engine_id, fut))
+
+            # Join outside the lock. Bounded handshake errors are recorded here
+            # and reported after the all-reduce.
+            all_ok = True
+            results: dict[str, set[str]] = {}
+            for dp_engine_id, fut in futures:
+                try:
+                    results[dp_engine_id] = fut.result()
+                except Exception:
+                    logger.exception(
+                        "Eager MoRIIO handshake failed for %s", dp_engine_id
+                    )
+                    all_ok = False
+
+            with self._handshake_lock:
+                for dp_engine_id, agents in results.items():
+                    self._remote_agents[dp_engine_id] = agents
+
+            # The CPU all-reduce is both the TP-uniform success vote and the
+            # lockstep barrier. It blocks until all TP workers arrive, gives each
+            # worker the same verdict, and stays off the model compute stream.
+            logger.info(
+                "Eager MoRIIO handshake: engine=%s dp_size=%d new_ranks=%d "
+                "ok=%s tp_rank=%d",
+                remote_engine_id,
+                remote_dp_size,
+                len(futures),
+                all_ok,
+                self.tp_rank,
+            )
+            vote = torch.tensor(
+                [1 if all_ok else 0], device="cpu", dtype=torch.int32
+            )
+            dist.all_reduce(
+                vote, group=self.tp_group.cpu_group, op=dist.ReduceOp.MIN
+            )
+            if int(vote.item()) == 0:
+                raise HandshakeError(
+                    f"Eager MoRIIO handshake failed for {remote_engine_id} on "
+                    f"at least one TP rank; failing this step fast to avoid a "
+                    f"TP collective hang"
+                )
+
+            self._eager_handshaked_engines.add(remote_engine_id)
 
     def start_load_kv(self, metadata: MoRIIOConnectorMetadata):
         """
         Start loading by triggering non-blocking moriio_xfer.
         We check for these trnxs to complete in each step().
         """
-        self.transfer_id_to_request_id = metadata.transfer_id_to_request_id
+        # Metadata carries only the scheduler-side mapping delta. Merge rather
+        # than overwrite so the worker-side mapping survives after the
+        # scheduler-side request_finished() unmaps a transfer_id. The producer
+        # needs this entry to translate the consumer's transfer_id notification
+        # (see get_finished) back to its own internal request_id, and that
+        # notification can arrive several steps after request_finished.
+        # get_finished() pops entries after a successful translation, so the
+        # dict stays bounded.
+        freed_transfer_ids = metadata.freed_transfer_ids
+        freed_request_ids: set[ReqId] = set()
+        for transfer_id in freed_transfer_ids:
+            request_id = self.transfer_id_to_request_id.get(
+                transfer_id
+            ) or metadata.transfer_id_to_request_id.get(transfer_id)
+            if request_id is not None:
+                freed_request_ids.add(request_id)
+                freed_request_ids.add(_strip_vllm_request_suffix(request_id))
+            self._forget_transfer_mapping(transfer_id, request_id)
+            self._drop_pending_unmapped_done_tid(transfer_id, request_id)
+        self._unmatched_write_completions.difference_update(freed_transfer_ids)
+        for transfer_id, remote_tp_size in getattr(
+            metadata, "transfer_id_to_remote_tp_size", {}
+        ).items():
+            if transfer_id in freed_transfer_ids:
+                continue
+            self.transfer_id_to_remote_tp_size[transfer_id] = remote_tp_size
+            self.transfer_id_to_completion_count[transfer_id] = (
+                _read_completion_quorum(remote_tp_size, self.tp_size, self.tp_rank)
+            )
+        self._reqs_to_send.update(
+            {
+                req_id: deadline
+                for req_id, deadline in getattr(metadata, "reqs_to_send", {}).items()
+                if req_id not in freed_request_ids
+            }
+        )
+        for transfer_id, req_id in metadata.transfer_id_to_request_id.items():
+            if transfer_id in freed_transfer_ids:
+                continue
+            self._remember_transfer_mapping(transfer_id, req_id)
         if self.is_producer:
             live_transfer_ids = set(self.transfer_id_to_request_id)
             self._consumer_notification_counts = {
@@ -1794,6 +2751,11 @@ class MoRIIOConnectorWorker:
         if self.mode == MoRIIOMode.WRITE:
             return
 
+        # Eager all-rank handshake (TP-lockstep safe) before any read. Fires
+        # once per remote engine; no-op on warm steps. Replaces the per-request
+        # build-on-demand handshake that desynced the TP forward collective.
+        self._eager_handshake_all_dp_ranks(metadata)
+
         wait_handshake_readd_req = False
         remote_engine_id = None
 
@@ -1802,11 +2764,13 @@ class MoRIIOConnectorWorker:
                 str(meta.remote_host) + ":" + str(meta.remote_handshake_port)
             )
             meta.remote_engine_id = remote_engine_id
-            dp0_remote_engine_id = self.get_engine_name_with_dp(remote_engine_id, 0)
-            if dp0_remote_engine_id not in self._remote_agents:
+            target_remote_engine_id = self.get_engine_name_with_dp(
+                remote_engine_id, int(meta.remote_dp_rank)
+            )
+            if target_remote_engine_id not in self._remote_agents:
                 # Initiate handshake with remote engine to exchange metadata.
                 with self._handshake_lock:
-                    if remote_engine_id not in self._remote_agents:
+                    if target_remote_engine_id not in self._remote_agents:
                         self._background_moriio_handshake(
                             req_id, remote_engine_id, meta
                         )
@@ -1840,12 +2804,11 @@ class MoRIIOConnectorWorker:
                 not self._ready_requests.empty()
                 and remote_engine_id in self.load_ready_flag
             ):
-                self._read_blocks_for_req(*self._ready_requests.get_nowait())
+                while not self._ready_requests.empty():
+                    self._read_blocks_for_req(*self._ready_requests.get_nowait())
                 break
             else:
                 break
-
-        self._reqs_to_send.update(metadata.reqs_to_send)
 
     def wait_for_save(self, metadata: MoRIIOConnectorMetadata):
         if self.mode == MoRIIOMode.WRITE and self.is_producer:
@@ -1853,19 +2816,51 @@ class MoRIIOConnectorWorker:
                 self.save_kv_layer(metadata, layer_name, kv_layer, None)
             self._writer.seal_pending_transfers()
 
+    def _ensure_remote_dp_handshaked(self, meta: ReqMeta) -> None:
+        """Build-on-demand handshake for the prefill DP rank this request reads from.
+
+        With heterogeneous parallelism, a request can target any remote DP rank.
+        If first-contact handshakes miss a rank, it has no cached metadata and
+        _get_built_session would fail.
+
+        Handshake the needed rank synchronously on first use. The result is cached
+        in layer_name_to_remote_kv_cache_metadata and built_write_session, then
+        reused thereafter; already-warmed ranks return immediately.
+        """
+        base_engine_id = str(meta.remote_host) + ":" + str(meta.remote_handshake_port)
+        dp_rank = int(meta.remote_dp_rank)
+        dp_engine_id = self.get_engine_name_with_dp(base_engine_id, dp_rank)
+        if dp_engine_id in self.layer_name_to_remote_kv_cache_metadata:
+            return
+        with self._handshake_lock:
+            # Re-check under the lock — another worker step may have just
+            # handshaked this rank.
+            if dp_engine_id in self.layer_name_to_remote_kv_cache_metadata:
+                return
+            host = self._pick_host_for_dp_rank(meta, dp_rank)
+            # Fallback only: eager handshakes normally cover every rank before
+            # reads. Reaching this path means the rank was not cached yet.
+            logger.warning(
+                "MoRIIO fallback synchronous handshake for remote dp rank %d "
+                "(%s) on the read path; eager handshake had not cached it",
+                dp_rank,
+                dp_engine_id,
+            )
+            self._remote_agents[dp_engine_id] = self._moriio_handshake(
+                host,
+                int(meta.remote_handshake_port),
+                int(meta.tp_size),
+                dp_engine_id,
+                dp_rank,
+            )
+
     def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
         logger.debug(
             "Remote agent %s available, calling _read_blocks for req %s",
             meta.remote_engine_id,
             req_id,
         )
-        # Multi-node TP: remote_host here is used by _read_blocks to record the
-        # post-transfer notify callback address (so prefill can free its KV
-        # blocks). For multi-node prefill the notify must go to the prefill
-        # node that actually owns this worker's KV slice, not the prefill
-        # head. _pick_remote_host returns meta.remote_host unchanged for
-        # single-host setups, preserving TP=8 / monolithic behaviour.
-        actual_remote_host = self._pick_remote_host(meta)
+        actual_remote_host = self._pick_host_for_dp_rank(meta, int(meta.remote_dp_rank))
         self._read_blocks(
             request_id=req_id,
             transfer_id=meta.transfer_id,
@@ -1874,7 +2869,8 @@ class MoRIIOConnectorWorker:
             remote_block_ids=meta.remote_block_ids,
             remote_host=actual_remote_host,
             remote_notify_port=meta.remote_notify_port,
-            remote_tp_size=meta.tp_size,
+            remote_dp_rank=meta.remote_dp_rank,
+            remote_tp_size=int(meta.tp_size),
         )
 
     def _write_blocks_for_req(self, req_id: ReqId, meta: ReqMeta, layer_name, kv_layer):
@@ -2009,33 +3005,58 @@ class MoRIIOConnectorWorker:
         transfer_id: str,
         remote_host: str,
         remote_notify_port: int,
-        remote_tp_size: int,
+        remote_dp_rank: int = 0,
+        remote_tp_size: int = 1,
     ) -> None:
         if self.mode == MoRIIOMode.WRITE:
             return
 
-        dp0_engine_id = self.get_engine_name_with_dp(dst_engine_id, 0)
-        sessions, remote_moriio_meta = self._get_built_session(dp0_engine_id)
+        # Use the prefill DP rank that actually computed the KV (forwarded by
+        # the proxy via kv_transfer_params["remote_dp_rank"]). Hardcoding DP0
+        # can read from a different rank's memory registration; per-DP ranks
+        # may expose different num_blocks, so high block ids can exceed the
+        # wrong rank's memory region.
+        remote_dp_engine_id = self.get_engine_name_with_dp(
+            dst_engine_id, int(remote_dp_rank)
+        )
+        sessions, remote_moriio_meta = self._get_built_session(remote_dp_engine_id)
 
-        for layer_name in self.layer_name_to_local_kv_cache_metadata:
-            sess_idx = list(self.layer_name_to_local_kv_cache_metadata.keys()).index(
-                layer_name
+        # Heterogeneous TP: target the remote TP index (tp0 for TP1 prefill).
+        # Otherwise, the read-completion notify uses a port the producer does not own.
+        notify_port = str(
+            remote_notify_port
+            + get_port_offset(
+                int(remote_dp_rank),
+                self._remote_tp_rank(int(remote_tp_size)),
+                int(remote_tp_size),
             )
-            offs = self._compute_block_transfer_offsets(
-                layer_name,
-                local_block_ids,
-                remote_block_ids,
-                remote_moriio_meta,
-                remote_tp_size=remote_tp_size,
+        )
+        with self.moriio_wrapper.lock:
+            self._recving_transfer_local_block_ids[request_id] = set(local_block_ids)
+            self._recving_transfers_callback_addr[request_id] = (
+                remote_host,
+                notify_port,
+                transfer_id,
             )
-            # TODO : apply multi-session batch-read when moriio support it
-            transfer_status = self.moriio_wrapper.read_remote_data(
-                offs[2], offs[0], offs[1], sessions[sess_idx]
-            )
-            with self.moriio_wrapper.lock:
-                self._recving_transfers[request_id].append(transfer_status)
-                self._recving_transfers_callback_addr[request_id] = (
-                    remote_host,
-                    str(remote_notify_port + self._remote_tp_rank(remote_tp_size)),
-                    transfer_id,
+            for sess_idx, layer_name in enumerate(
+                self.layer_name_to_local_kv_cache_metadata
+            ):
+                offs = self._compute_block_transfer_offsets(
+                    layer_name,
+                    local_block_ids,
+                    remote_block_ids,
+                    remote_moriio_meta,
+                    remote_tp_size=remote_tp_size,
                 )
+                self._pending_read_plans[request_id][layer_name] = LayerTransferPlan(
+                    request_id=request_id,
+                    transfer_id=transfer_id,
+                    layer_name=layer_name,
+                    sess_idx=sess_idx,
+                    transfer_local_offsets=offs[0],
+                    transfer_remote_offsets=offs[1],
+                    transfer_sizes=offs[2],
+                    session=sessions[sess_idx],
+                )
+
+        self._dispatch_pending_reads()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -138,6 +138,7 @@ def _read_completion_quorum(
         return 0
     return ((remote_decode_tp_size - 1 - producer_tp_rank) // producer_tp_size) + 1
 
+
 try:
     from mori.io import (
         BackendType,
@@ -651,8 +652,7 @@ class MoRIIOConnectorScheduler:
         serialized_data = msgpack.dumps(data, use_bin_type=True)
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
-                "MoRIIO remote_blocks send: path=%s transfer_id=%s req_id=%s "
-                "blocks=%d",
+                "MoRIIO remote_blocks send: path=%s transfer_id=%s req_id=%s blocks=%d",
                 path,
                 transfer_id,
                 req_id,
@@ -1003,9 +1003,7 @@ class MoRIIOConnectorScheduler:
         # Consumer mappings can be removed once KV transfer has completed.
         # Producer mappings stay until the block-free notification arrives.
         if not self.is_producer:
-            mapping_was_never_created = bool(
-                params and params.get("do_remote_prefill")
-            )
+            mapping_was_never_created = bool(params and params.get("do_remote_prefill"))
             self.unmap_request_id(
                 request_id,
                 warn_missing=not mapping_was_never_created,
@@ -1320,9 +1318,9 @@ class MoRIIOConnectorWorker:
         self.dst_num_blocks: dict[EngineId, int] = {}
         # In-progress READ transfers: per request, keyed by layer name.
         self._recving_transfers: defaultdict[ReqId, dict[str, Any]] = defaultdict(dict)
-        self._pending_read_plans: defaultdict[
-            ReqId, dict[str, LayerTransferPlan]
-        ] = defaultdict(dict)
+        self._pending_read_plans: defaultdict[ReqId, dict[str, LayerTransferPlan]] = (
+            defaultdict(dict)
+        )
         # Values are (remote_host, remote_notify_port, transfer_id).
         self._recving_transfers_callback_addr: dict[ReqId, tuple[str, str, str]] = {}
         self._recving_transfer_local_block_ids: dict[ReqId, set[int]] = {}
@@ -2278,9 +2276,7 @@ class MoRIIOConnectorWorker:
     def _active_read_layers_for_req_locked(self, req_id: ReqId) -> int:
         status_by_layer = self._recving_transfers.get(req_id, {})
         return sum(
-            1
-            for status in status_by_layer.values()
-            if self._read_status_active(status)
+            1 for status in status_by_layer.values() if self._read_status_active(status)
         )
 
     def _per_transfer_read_cap(self) -> int:
@@ -2366,9 +2362,7 @@ class MoRIIOConnectorWorker:
             _backoff = min(_backoff * 2, 0.05)
 
         with self.moriio_wrapper.lock:
-            self._recving_transfers[plan.request_id][plan.layer_name] = (
-                transfer_status
-            )
+            self._recving_transfers[plan.request_id][plan.layer_name] = transfer_status
 
     def _dispatch_pending_reads(self, layer_name: str | None = None) -> None:
         while True:
@@ -2593,9 +2587,7 @@ class MoRIIOConnectorWorker:
     def get_engine_name_with_dp(self, engine_name, dp_rank):
         return f"{engine_name}_dp{dp_rank}"
 
-    def _eager_handshake_all_dp_ranks(
-        self, metadata: MoRIIOConnectorMetadata
-    ) -> None:
+    def _eager_handshake_all_dp_ranks(self, metadata: MoRIIOConnectorMetadata) -> None:
         """Handshake remote prefill DP ranks uniformly across local TP workers.
 
         Decode forward issues per-layer TP collectives, so handshake state needs
@@ -2676,12 +2668,8 @@ class MoRIIOConnectorWorker:
                 all_ok,
                 self.tp_rank,
             )
-            vote = torch.tensor(
-                [1 if all_ok else 0], device="cpu", dtype=torch.int32
-            )
-            dist.all_reduce(
-                vote, group=self.tp_group.cpu_group, op=dist.ReduceOp.MIN
-            )
+            vote = torch.tensor([1 if all_ok else 0], device="cpu", dtype=torch.int32)
+            dist.all_reduce(vote, group=self.tp_group.cpu_group, op=dist.ReduceOp.MIN)
             if int(vote.item()) == 0:
                 raise HandshakeError(
                     f"Eager MoRIIO handshake failed for {remote_engine_id} on "
@@ -2722,8 +2710,8 @@ class MoRIIOConnectorWorker:
             if transfer_id in freed_transfer_ids:
                 continue
             self.transfer_id_to_remote_tp_size[transfer_id] = remote_tp_size
-            self.transfer_id_to_completion_count[transfer_id] = (
-                _read_completion_quorum(remote_tp_size, self.tp_size, self.tp_rank)
+            self.transfer_id_to_completion_count[transfer_id] = _read_completion_quorum(
+                remote_tp_size, self.tp_size, self.tp_rank
             )
         self._reqs_to_send.update(
             {

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import logging
 import threading
 import time
 from collections import OrderedDict, defaultdict
+from contextlib import suppress
 from queue import Empty, Queue
 from typing import TYPE_CHECKING, Any
 from weakref import ref as weakref_ref
@@ -14,7 +16,6 @@ import zmq
 from vllm.logger import init_logger
 from vllm.utils.network_utils import (
     make_zmq_path,
-    make_zmq_socket,
 )
 
 if TYPE_CHECKING:
@@ -32,6 +33,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     TransferError,
     TransferId,
     WriteTask,
+    _strip_vllm_request_suffix,
     get_port_offset,
     get_role,
     zmq_ctx,
@@ -98,6 +100,7 @@ class MoRIIOWriter:
         self._scheduled_layers: dict[TransferId, set[str]] = defaultdict(set)
         self._sealed_writes: dict[TransferId, int] = {}
         self._defer_timeout = worker.moriio_config.defer_timeout
+        self._remote_alloc_miss_log_count = 0
 
     @property
     def worker(self) -> "MoRIIOConnectorWorker":
@@ -194,12 +197,7 @@ class MoRIIOWriter:
 
             # Check if remote blocks are ready
             if not self._is_remote_ready(task):
-                # task.retry_count += 1
                 self._deferred_tasks.append(task)
-                # logger.debug(
-                #     "Deferred task for request %s (retry %d)",
-                #     task.request_id, task.retry_count
-                # )
                 continue
 
             # Execute the task
@@ -210,7 +208,7 @@ class MoRIIOWriter:
                     "Write task failed for request %s, marking done",
                     task.request_id,
                 )
-                self._mark_request_done(task.transfer_id)
+                self._mark_request_done(task.request_id, task.transfer_id)
 
     def _process_deferred_tasks(self) -> None:
         """Process tasks that were previously deferred."""
@@ -231,7 +229,7 @@ class MoRIIOWriter:
                     task.request_id,
                     now - task.enqueue_time,
                 )
-                self._mark_request_done(task.transfer_id)
+                self._mark_request_done(task.request_id, task.transfer_id)
                 continue
             if self._is_remote_ready(task):
                 try:
@@ -241,7 +239,7 @@ class MoRIIOWriter:
                         "Deferred write task failed for request %s, marking done",
                         task.request_id,
                     )
-                    self._mark_request_done(task.transfer_id)
+                    self._mark_request_done(task.request_id, task.transfer_id)
             else:
                 still_deferred.append(task)
 
@@ -258,17 +256,63 @@ class MoRIIOWriter:
         with wrapper.lock:
             return wrapper._is_transfer_terminal_locked(transfer_id)
 
-    def _mark_request_done(self, transfer_id: str) -> None:
-        """Mark a request done so its blocks are freed, even on transfer failure."""
+    def _mark_request_done(self, request_id: str, transfer_id: str) -> None:
+        """Mark a request done locally and drop its remote-allocation state."""
         wrapper = self.worker.moriio_wrapper
         with wrapper.lock:
             wrapper.done_req_ids.append(MoRIIOTransferAck(transfer_id))
             wrapper.done_remote_allocate_req_dict.pop(transfer_id, None)
+            wrapper.done_remote_allocate_req_dict.pop(request_id, None)
+            wrapper.done_remote_allocate_req_dict.pop(
+                _strip_vllm_request_suffix(request_id), None
+            )
             wrapper._mark_transfer_terminal_locked(transfer_id)
         self._clear_transfer_state(transfer_id)
 
+    def _remote_alloc_info_for_task(
+        self, task: WriteTask
+    ) -> RemoteAllocInfo | None:
+        wrapper = self.worker.moriio_wrapper
+        stripped_request_id = _strip_vllm_request_suffix(task.request_id)
+        key_sample: list[tuple[str, str]] | None = None
+        with wrapper.lock:
+            remote_allocations = wrapper.done_remote_allocate_req_dict
+            info = remote_allocations.get(task.transfer_id)
+            if info is None:
+                info = remote_allocations.get(task.request_id)
+            if info is None:
+                info = remote_allocations.get(stripped_request_id)
+            if info is None and self._remote_alloc_miss_log_count < 8:
+                self._remote_alloc_miss_log_count += 1
+                key_sample = []
+                for idx, key in enumerate(remote_allocations):
+                    if idx >= 8:
+                        break
+                    key_sample.append((repr(key), type(key).__name__))
+
+        if info is None and key_sample is not None:
+            logger.warning(
+                "MoRIIO remote alloc miss: transfer_id=%r transfer_id_type=%s "
+                "request_id=%r request_id_type=%s stripped_request_id=%r "
+                "stripped_request_id_type=%s key_sample=%s",
+                task.transfer_id,
+                type(task.transfer_id).__name__,
+                task.request_id,
+                type(task.request_id).__name__,
+                stripped_request_id,
+                type(stripped_request_id).__name__,
+                key_sample,
+            )
+        return info
+
     def _is_remote_ready(self, task: WriteTask) -> bool:
-        """Check if remote blocks are allocated for this task.
+        """Check if remote blocks are allocated and populated for this task.
+
+        Returns True only when the remote allocation entry exists *and*
+        carries a non-None ``block_ids`` mapping. The latter check ensures
+        that ``_execute_write_task`` is never invoked for a task whose
+        remote ``block_ids`` are still being filled in by the scheduler;
+        without it we would either drop the task or busy-loop on it.
 
         Args:
             task: The write task
@@ -276,15 +320,14 @@ class MoRIIOWriter:
         Returns:
             True if remote blocks are ready
         """
-        return (
-            task.transfer_id in self.worker.moriio_wrapper.done_remote_allocate_req_dict
-        )
+        info = self._remote_alloc_info_for_task(task)
+        return info is not None and info.block_ids is not None
 
-    def _get_remote_alloc_info(self, transfer_id: str) -> RemoteAllocInfo:
+    def _get_remote_alloc_info(self, task: WriteTask) -> RemoteAllocInfo:
         """Get remote allocation info for a request.
 
         Args:
-            transfer_id:TransferId The request ID
+            task: The write task
 
         Returns:
             Remote allocation information
@@ -292,36 +335,32 @@ class MoRIIOWriter:
         Raises:
             KeyError: If allocation info is missing
         """
-        try:
-            return self.worker.moriio_wrapper.done_remote_allocate_req_dict[transfer_id]
-        except KeyError as e:
+        info = self._remote_alloc_info_for_task(task)
+        if info is None:
             raise KeyError(
-                f"Remote allocation info missing for transfer {transfer_id}"
-            ) from e
+                f"Remote allocation info missing for transfer {task.transfer_id}"
+            )
+        return info
 
     def _execute_write_task(self, task: WriteTask) -> None:
         """Execute a single write task.
+
+        Callers must ensure ``_is_remote_ready(task)`` returned ``True``
+        before invoking this method; ``_is_remote_ready`` guarantees that
+        ``request_info.block_ids`` is non-None and the entry exists.
 
         Args:
             task: The write task to execute
 
         """
         # Get remote allocation info
-        request_info = self._get_remote_alloc_info(task.transfer_id)
+        request_info = self._get_remote_alloc_info(task)
         with self._write_state_lock:
             request_info.completion_request_id = task.request_id
             request_info.completion_remote_notify_port = task.remote_notify_port
             request_info.completion_remote_ip = task.remote_ip
             if task.transfer_id in self._sealed_writes:
                 request_info.writes_expected = self._sealed_writes[task.transfer_id]
-
-        if request_info.block_ids is None:
-            logger.debug(
-                "Request remote block IDs not ready:request_id = %s, transfer_id = %s",
-                task.request_id,
-                task.transfer_id,
-            )
-            return
 
         # Wait for CUDA event
         # The attention computation of the current layer cannot
@@ -465,16 +504,7 @@ class MoRIIOWriter:
         self.worker.moriio_wrapper.send_notify(
             transfer_id, remote_ip, remote_port, message_type="write_done"
         )
-        # mark request as done, then we can free the blocks
-        with self.worker.moriio_wrapper.lock:
-            self.worker.moriio_wrapper.done_req_ids.append(
-                MoRIIOTransferAck(transfer_id)
-            )
-            self.worker.moriio_wrapper.done_remote_allocate_req_dict.pop(
-                transfer_id, None
-            )
-            self.worker.moriio_wrapper._mark_transfer_terminal_locked(transfer_id)
-        self._clear_transfer_state(transfer_id)
+        self._mark_request_done(request_id, transfer_id)
         logger.debug(
             "Completed transfer for (request, transfer) %s, %s, notified port %d",
             request_id,
@@ -521,9 +551,7 @@ class MoRIIOWrapper:
         self.paths: dict[str, zmq.Socket] = {}
 
     def set_moriio_engine(self, moriio_engine):
-        assert moriio_engine is not None, (
-            "You Cannot pass None engine to MoRIIOWrapper!"
-        )
+        assert moriio_engine is not None, "MoRIIO engine must not be None"
         self.moriio_engine = moriio_engine
 
     def set_backend_type(
@@ -666,8 +694,7 @@ class MoRIIOWrapper:
                     continue
                 if timed_out:
                     errors.append(
-                        f"RDMA transfer timed out after {timeout:.0f}s. "
-                        f"Check NIC queue depth or reduce concurrency; "
+                        f"RDMA transfer timed out after {timeout:.0f}s; "
                         f"adjust with kv_connector_extra_config.transfer_timeout."
                     )
                 else:
@@ -706,6 +733,24 @@ class MoRIIOWrapper:
         )
         self.notify_thread.start()
 
+    @staticmethod
+    def _normalize_structured_message(data: object) -> dict | None:
+        if not isinstance(data, dict):
+            return None
+
+        normalized: dict = {}
+        for key, value in data.items():
+            if isinstance(key, bytes):
+                try:
+                    key = key.decode("utf-8")
+                except UnicodeDecodeError:
+                    continue
+            if isinstance(key, str) and isinstance(value, bytes):
+                with suppress(UnicodeDecodeError):
+                    value = value.decode("utf-8")
+            normalized[key] = value
+        return normalized
+
     def _handle_message(self, msg: bytes):
         """Handles incoming messages from remote nodes."""
         # Handles incoming remote messages:
@@ -717,8 +762,23 @@ class MoRIIOWrapper:
         msg_str = repr(msg)
         handled = False
         try:
-            data = msgpack.loads(msg)
-            if isinstance(data, dict):
+            data = self._normalize_structured_message(
+                msgpack.loads(msg, raw=False)
+            )
+            if data is not None and (
+                data.get("type") == "remote_blocks" or "transfer_id" in data
+            ):
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "MoRIIO notify received structured: type=%s "
+                        "transfer_id=%s req_id=%s blocks=%d keys=%s",
+                        data.get("type"),
+                        data.get("transfer_id"),
+                        data.get("req_id"),
+                        len(data.get("block_notify_list") or []),
+                        tuple(data.keys()),
+                    )
+
                 self._handle_structured_message(data)
                 return
         except (
@@ -731,13 +791,26 @@ class MoRIIOWrapper:
 
         try:
             msg_str = msg.decode("UTF-8")
-            if msg_str:
-                self._handle_completion_message(msg_str)
-                handled = True
+            # Completion notifications are UTF-8 identifiers. Worker-side mapping
+            # normalizes transfer_ids/request_ids before the scheduler sees
+            # finished requests. Treat UTF-8 payloads as completion IDs and drop
+            # malformed binary payloads below to keep the listener running.
+            logger.info(
+                "MoRIIO notify received completion: id=%s",
+                msg_str,
+            )
+            self._handle_completion_message(msg_str)
+            handled = True
         except UnicodeDecodeError:
-            logger.warning("Received non-UTF8 message: %r", msg)
+            # Non-UTF-8 payloads are not completion identifiers. Log and drop them
+            # instead of propagating an error through the listener loop.
+            logger.warning(
+                "Received non-UTF8 completion message of %d bytes; dropping",
+                len(msg),
+            )
+            return
         if not handled:
-            raise MoRIIOError(f"Unhandled message format: {msg_str}")
+            raise MoRIIOError(f"Unhandled message format ({len(msg)} bytes)")
 
     def _handle_structured_message(self, data: dict):
         message_type = data.get("type")
@@ -756,6 +829,7 @@ class MoRIIOWrapper:
     def _handle_remote_blocks_message(self, data: dict):
         assert get_role() == ROLE.PRODUCER, "Only prefill can get block messages"
         transfer_id = data["transfer_id"]
+        request_id = data.get("req_id")
         block_notify_list = data.get("block_notify_list", [])
         decode_dp_rank = data.get("decode_rank", 0)
         if not block_notify_list:
@@ -763,6 +837,9 @@ class MoRIIOWrapper:
                 "block_notify_list cannot be empty in remote allocate message"
             )
 
+        info = RemoteAllocInfo(
+            block_ids=block_notify_list, decode_dp_rank=decode_dp_rank
+        )
         with self.lock:
             if self._is_transfer_terminal_locked(transfer_id):
                 logger.debug(
@@ -770,8 +847,22 @@ class MoRIIOWrapper:
                     transfer_id,
                 )
                 return
-            self.done_remote_allocate_req_dict[transfer_id] = RemoteAllocInfo(
-                block_ids=block_notify_list, decode_dp_rank=decode_dp_rank
+            self.done_remote_allocate_req_dict[transfer_id] = info
+            if isinstance(request_id, str) and request_id != transfer_id:
+                self.done_remote_allocate_req_dict[request_id] = info
+                stripped_request_id = _strip_vllm_request_suffix(request_id)
+                if stripped_request_id != request_id:
+                    self.done_remote_allocate_req_dict[stripped_request_id] = info
+            remote_alloc_entries = len(self.done_remote_allocate_req_dict)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "MoRIIO remote_blocks registered: transfer_id=%s req_id=%s "
+                "blocks=%d decode_dp_rank=%s entries=%d",
+                transfer_id,
+                request_id,
+                len(block_notify_list),
+                decode_dp_rank,
+                remote_alloc_entries,
             )
 
     def _handle_write_done_message(self, data: dict):
@@ -831,9 +922,16 @@ class MoRIIOWrapper:
 
         if path not in self.paths:
             ctx = zmq.Context.instance()
-            sock = make_zmq_socket(
-                ctx=ctx, path=path, socket_type=zmq.DEALER, bind=False
-            )
+            sock = ctx.socket(zmq.DEALER)
+            # Notify uses a long-lived, sparse TCP stream. Keepalive bounds stale
+            # peer detection so ZMQ can reconnect and resend queued control traffic.
+            sock.setsockopt(zmq.TCP_KEEPALIVE, 1)
+            sock.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
+            sock.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 10)
+            sock.setsockopt(zmq.TCP_KEEPALIVE_CNT, 3)
+            sock.setsockopt(zmq.SNDHWM, 0)
+            sock.setsockopt(zmq.LINGER, 0)
+            sock.connect(path)
             self.paths[path] = sock
 
         req_list = req_ids if isinstance(req_ids, list) else [req_ids]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
@@ -269,9 +269,7 @@ class MoRIIOWriter:
             wrapper._mark_transfer_terminal_locked(transfer_id)
         self._clear_transfer_state(transfer_id)
 
-    def _remote_alloc_info_for_task(
-        self, task: WriteTask
-    ) -> RemoteAllocInfo | None:
+    def _remote_alloc_info_for_task(self, task: WriteTask) -> RemoteAllocInfo | None:
         wrapper = self.worker.moriio_wrapper
         stripped_request_id = _strip_vllm_request_suffix(task.request_id)
         key_sample: list[tuple[str, str]] | None = None
@@ -494,7 +492,9 @@ class MoRIIOWriter:
         self.worker.moriio_wrapper.waiting_for_transfer_complete(transfer_statuses)
 
         remote_port = remote_notify_port + get_port_offset(
-            request_info.decode_dp_rank, self.worker.tp_rank
+            request_info.decode_dp_rank,
+            self.worker.tp_rank,
+            self.worker.tp_size,
         )
         # Consider using RDMA immediate data in decode side
         # to eliminate the need for this notification.
@@ -762,9 +762,7 @@ class MoRIIOWrapper:
         msg_str = repr(msg)
         handled = False
         try:
-            data = self._normalize_structured_message(
-                msgpack.loads(msg, raw=False)
-            )
+            data = self._normalize_structured_message(msgpack.loads(msg, raw=False))
             if data is not None and (
                 data.get("type") == "remote_blocks" or "transfer_id" in data
             ):

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2154,7 +2154,15 @@ class Scheduler(SchedulerInterface):
         num_in_queues = (
             len(self.waiting) + len(self.skipped_waiting) + len(self.running)
         )
-        return len(self.requests) > num_in_queues
+        if len(self.requests) > num_in_queues:
+            return True
+        # MoRIIO-style connectors may hold deferred KV sends for requests
+        # already evicted from self.requests; keep the engine stepping until
+        # the connector drains them.
+        has_pending_deferred_sends = getattr(
+            self.connector, "has_pending_deferred_sends", None
+        )
+        return bool(has_pending_deferred_sends and has_pending_deferred_sends())
 
     def has_requests(self) -> bool:
         # Override the interface default to also keep the engine alive while a
@@ -2461,17 +2469,30 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.debug(
+                    "Ignoring KV recv completion for unknown request %s. "
+                    "The request may have already finished or been aborted.",
+                    req_id,
+                )
+                continue
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
             else:
                 assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                self._free_blocks(req)
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.debug(
+                    "Ignoring KV send completion for unknown request %s. "
+                    "The request may have already finished or been aborted.",
+                    req_id,
+                )
+                continue
+            self._free_blocks(req)
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Purpose

MoRIIO READ-mode stability fixes on top of the multi-node TP dispatch base in #45228:

- buffer READ completion IDs that arrive before the `transfer_id -> request_id` mapping is visible; normalize wrapped IDs before scheduler reporting;
- per-DP-rank READ routing and completion notification;
- deferred-send cleanup after scheduler eviction; tolerate late KV completions for evicted requests;
- TCP keepalive on sparse notify/handshake ZMQ streams;
- validate peer addresses (`request_id` / `remote_zmq_address` / `remote_hosts`) against `kv_connector_extra_config["trusted_remote_hosts"]` before dialing (SSRF guard).

Draft until high-concurrency runtime validation is complete.

## Test Plan

```bash
python -m pytest -q \
  tests/v1/kv_connector/unit/test_moriio_connector.py \
  tests/v1/kv_connector/unit/test_moriio_read_completion.py \
  tests/v1/kv_connector/unit/test_scheduler_late_kv_completion.py \
  tests/v1/kv_connector/unit/test_moriio_toy_proxy_server.py
```

Runtime (before leaving draft): start the toy proxy + READ-mode prefill/decode with `node_hosts` and `trusted_remote_hosts` set, run the high-concurrency DeepSeek-R1 workload, verify all prompts complete and no late-completion assertion.

## Test Result

- targeted unit tests (4 files above): 75 passed
- high-concurrency runtime validation: still pending (PR stays draft until then)
