### PR TITLE
[Bugfix] Pre-compile _zero_kv_blocks_kernel and _compute_slot_mapping_kernel during warmup

### DIFF
--- a/tests/test_jit_monitor.py
+++ b/tests/test_jit_monitor.py
@@ -7,6 +7,10 @@ from unittest import mock
 
 import pytest
 
+from vllm.model_executor.warmup.kernel_warmup import (
+    _warmup_slot_mapping,
+    _warmup_zero_kv_blocks,
+)
 from vllm.triton_utils import jit_monitor
 
 
@@ -238,3 +242,82 @@ class TestTritonJitHookIntegration:
         w.assert_called()
         msg = w.call_args[0][0] % w.call_args[0][1:]
         assert "_add_kernel" in msg
+
+
+# ------------------------------------------------------------------
+# Unit tests for infrastructure kernel warmup helpers (no GPU needed)
+# ------------------------------------------------------------------
+
+
+def _make_worker(*, has_zeroer=True, zeroer_meta=True, has_block_tables=True):
+    """Build a minimal fake Worker / model_runner for warmup helper tests."""
+    zeroer = None
+    if has_zeroer:
+        zeroer = SimpleNamespace(_meta=object() if zeroer_meta else None)
+        zeroer.zero_block_ids = mock.MagicMock()
+
+    block_tables = None
+    if has_block_tables:
+        block_tables = SimpleNamespace()
+        block_tables.compute_slot_mapping = mock.MagicMock()
+
+    runner = SimpleNamespace(
+        _kv_block_zeroer=zeroer,
+        input_batch=SimpleNamespace(block_table=block_tables)
+        if has_block_tables
+        else None,
+        device="cpu",
+    )
+    if not has_zeroer:
+        del runner._kv_block_zeroer
+
+    return SimpleNamespace(model_runner=runner), zeroer, block_tables
+
+
+class TestWarmupZeroKvBlocks:
+    def test_calls_zero_block_ids(self):
+        worker, zeroer, _ = _make_worker()
+        _warmup_zero_kv_blocks(worker)
+        zeroer.zero_block_ids.assert_called_once_with([0])
+
+    def test_noop_when_no_zeroer(self):
+        worker, _, _ = _make_worker(has_zeroer=False)
+        # Should not raise
+        _warmup_zero_kv_blocks(worker)
+
+    def test_noop_when_zeroer_meta_is_none(self):
+        worker, zeroer, _ = _make_worker(zeroer_meta=False)
+        _warmup_zero_kv_blocks(worker)
+        zeroer.zero_block_ids.assert_not_called()
+
+    def test_exception_is_swallowed(self):
+        worker, zeroer, _ = _make_worker()
+        zeroer.zero_block_ids.side_effect = RuntimeError("boom")
+        # Must not propagate
+        _warmup_zero_kv_blocks(worker)
+
+
+class TestWarmupSlotMapping:
+    def test_calls_compute_slot_mapping(self):
+        worker, _, block_tables = _make_worker()
+        _warmup_slot_mapping(worker)
+        block_tables.compute_slot_mapping.assert_called_once()
+        call_kwargs = block_tables.compute_slot_mapping.call_args
+        assert call_kwargs.kwargs["num_reqs"] == 1
+
+    def test_noop_when_no_input_batch(self):
+        worker, _, _ = _make_worker(has_block_tables=False)
+        # input_batch exists but block_table attr is None-like; also test
+        # without input_batch entirely.
+        worker.model_runner.input_batch = None
+        _warmup_slot_mapping(worker)
+
+    def test_noop_when_no_block_table(self):
+        worker, _, _ = _make_worker()
+        worker.model_runner.input_batch.block_table = None
+        _warmup_slot_mapping(worker)
+
+    def test_exception_is_swallowed(self):
+        worker, _, block_tables = _make_worker()
+        block_tables.compute_slot_mapping.side_effect = RuntimeError("boom")
+        _warmup_slot_mapping(worker)

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -52,6 +52,65 @@ def _resolve_flashinfer_autotune_file(runner: "GPUModelRunner") -> Path:
     return output_dir / "autotune_configs.json"
 
 
+def _warmup_zero_kv_blocks(worker: "Worker") -> None:
+    """Pre-compile _zero_kv_blocks_kernel before the JIT monitor activates.
+
+    The kernel is only invoked during real inference (when new blocks need
+    zeroing), so it never fires during _dummy_run warmup.  A single call with
+    block_id=0 is enough to trigger Triton compilation for the exact constexpr
+    combination (N_SEGS, PAGE_SIZE_EL, BLOCK_SIZE) determined at KV-cache
+    allocation time.
+    """
+    runner = worker.model_runner
+    zeroer = getattr(runner, "_kv_block_zeroer", None)
+    if zeroer is None or zeroer._meta is None:
+        return
+    try:
+        with torch.inference_mode():
+            zeroer.zero_block_ids([0])
+    except Exception:
+        logger.debug("Skipping _zero_kv_blocks_kernel warmup.", exc_info=True)
+
+
+def _warmup_slot_mapping(worker: "Worker") -> None:
+    """Pre-compile _compute_slot_mapping_kernel before the JIT monitor activates.
+
+    _compute_slot_mapping_kernel is called from the real _prepare_inputs path,
+    not from _dummy_run, so it misses the normal warmup phase.  A single call
+    with a minimal 1-request dummy is enough to compile the kernel for the
+    constexpr combination (TOTAL_CP_WORLD_SIZE, TOTAL_CP_RANK,
+    CP_KV_CACHE_INTERLEAVE_SIZE, PAD_ID, BLOCK_SIZE=1024) that is fixed for
+    the lifetime of this worker.
+
+    The block table is not modified: the zero-initialized block-number tensors
+    already present at this point are sufficient for Triton to compile and
+    execute the kernel without error.
+    """
+    runner = worker.model_runner
+    input_batch = getattr(runner, "input_batch", None)
+    if input_batch is None:
+        return
+    block_tables = getattr(input_batch, "block_table", None)
+    if block_tables is None:
+        return
+
+    device = runner.device
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    positions = torch.zeros(1, dtype=torch.int64, device=device)
+
+    try:
+        with torch.inference_mode():
+            block_tables.compute_slot_mapping(
+                num_reqs=1,
+                query_start_loc=query_start_loc,
+                positions=positions,
+            )
+    except Exception:
+        logger.debug(
+            "Skipping _compute_slot_mapping_kernel warmup.", exc_info=True
+        )
+
+
 def kernel_warmup(worker: "Worker"):
     # Deep GEMM warmup
     do_deep_gemm_warmup = (
@@ -104,6 +163,13 @@ def kernel_warmup(worker: "Worker"):
             force_attention=True,
             create_mixed_batch=True,
         )
+
+    # Pre-compile infrastructure Triton kernels that are not exercised by
+    # _dummy_run.  These kernels fire on the very first inference request
+    # otherwise, causing a latency spike (and, in some TP configurations,
+    # an NCCL deadlock while one rank stalls in Triton JIT).
+    _warmup_zero_kv_blocks(worker)
+    _warmup_slot_mapping(worker)
 
 
 # TODO: remove once FlashInfer upstream fixes the persistent file cache


### PR DESCRIPTION
## Summary

Fixes #45198 and #43009.

`_zero_kv_blocks_kernel` and `_compute_slot_mapping_kernel` are infrastructure-level Triton kernels that are never called during the `_dummy_run` warmup phase:

- `_zero_kv_blocks_kernel` — only fires when the scheduler emits `new_block_ids_to_zero`, which never happens in dummy runs.
- `_compute_slot_mapping_kernel` — only called from the real `_prepare_inputs` path, not from `_dummy_run`'s simplified input-preparation path.

Both JIT-compile on the **very first inference request** after warmup completes. Under TP>1 this Triton stall on one rank — while another waits inside an NCCL collective — can deadlock the server (confirmed by multiple users in #43009; #45198 is a fresh report on vLLM 0.22).

**Why not duplicate of draft PR #43879?**  
PR #43879 (DRAFT, last updated 2026-06-03, no review activity) modifies the block-table state during warmup (`clear()` / `add_row()`) and only covers the FlashInfer-backend code path. This PR:
- Does not mutate block-table state (zero-initialised tensors at warmup time are sufficient for Triton to compile the kernel).
- Calls `_warmup_zero_kv_blocks` / `_warmup_slot_mapping` from `kernel_warmup()`, which is called unconditionally for **both** V1 and V2 model runners.

## Changes

- `vllm/model_executor/warmup/kernel_warmup.py` — add `_warmup_zero_kv_blocks` and `_warmup_slot_mapping`; call both at the end of `kernel_warmup()`.
- `tests/test_jit_monitor.py` — 8 new unit tests (no GPU required).

## Test plan

- [x] `pytest tests/test_jit_monitor.py -v` — 21 passed (13 pre-existing + 8 new)
- [x] `ruff check vllm/model_executor/warmup/kernel_warmup.py tests/test_jit_monitor.py` — no issues
- [ ] Full GPU integration test (TP=2 with a Mamba/MoE model triggering the hang) requires multi-GPU hardware not available locally; the fix is straightforward and the unit tests cover all defensive branches (missing zeroer, `_meta=None`, exceptions).

> **AI assistance disclosure:** This fix was developed with Claude Code assistance. All changed lines have been reviewed by the human submitter. This is not a duplicate of any existing open PR.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)