### PR TITLE
[Bugfix][Frontend] Keep a reference to the background abort task in disagg api_router

### DIFF
--- a/vllm/entrypoints/scale_out/token_in_token_out/api_router.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/api_router.py
@@ -42,6 +42,12 @@ def engine_client(request: Request) -> EngineClient:
 
 router = APIRouter()
 
+# Tasks scheduled with asyncio.create_task() must be referenced until they
+# finish; the event loop only keeps a weak reference, so an unreferenced task
+# can be garbage-collected mid-run.
+# https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+_background_tasks: set[asyncio.Task] = set()
+
 
 @router.post(
     "/inference/v1/generate",
@@ -95,8 +101,11 @@ def attach_router(app: FastAPI):
                     status_code=HTTPStatus.BAD_REQUEST.value,
                     detail="Missing 'request_ids' in request body",
                 )
-            # Abort requests in background
-            asyncio.create_task(engine_client(raw_request).abort(request_ids))
+            # Abort requests in background. Keep a strong reference to the task
+            # so it isn't garbage-collected before the abort completes.
+            task = asyncio.create_task(engine_client(raw_request).abort(request_ids))
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
             return Response(status_code=200)
 
     app.include_router(router)


### PR DESCRIPTION
## Purpose

The `/abort_requests` endpoint (disaggregated `api_router.py`) schedules the abort with a bare `asyncio.create_task(...)` and discards the returned task:

```python
# Abort requests in background
asyncio.create_task(engine_client(raw_request).abort(request_ids))
return Response(status_code=200)
```

Per the [asyncio docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task), the event loop only keeps a **weak** reference to a task. A task with no other reference can be garbage-collected *before it finishes*. Here that means the abort coroutine can be collected mid-run, so under load the requested aborts may **silently not happen** — the endpoint returns `200` either way, so the failure is invisible.

## Fix

Keep a strong reference to the task in a module-level set and remove it on completion via `add_done_callback` (the pattern recommended in the asyncio docs):

```python
task = asyncio.create_task(engine_client(raw_request).abort(request_ids))
_background_tasks.add(task)
task.add_done_callback(_background_tasks.discard)
```

No behavior change beyond guaranteeing the abort task actually runs to completion. Single file, +9/-2.

## Test Plan

- `python -m py_compile` clean.
- No functional change to the endpoint's contract; the task is simply retained until it finishes rather than being eligible for GC.
