### PR TITLE
[Bugfix] Restrict FlashInfer cuDNN FP8 ViT attention gate to Blackwell (SM 100)

### DIFF
--- a/vllm/model_executor/layers/attention/mm_encoder_attention.py
+++ b/vllm/model_executor/layers/attention/mm_encoder_attention.py
@@ -396,8 +396,9 @@ class MMEncoderAttention(CustomOp):
         if not is_flashinfer_cudnn_fp8_prefill_attn_supported():
             raise ValueError(
                 "mm_encoder_attn_dtype='fp8' requires the FlashInfer "
-                "cuDNN backend with cuDNN >= 9.17.1 on a GPU with native "
-                "FP8 support."
+                "cuDNN backend with cuDNN >= 9.17.1 on Blackwell (SM 100) "
+                "or newer. cuDNN's FP8 SDPA path with bf16/fp16 output is "
+                "not available on Hopper (H100/H200) or earlier."
             )
 
         self.fp8_enabled = True

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -934,20 +934,27 @@ def should_use_flashinfer_for_blockscale_fp8_gemm(
     return should_use_flashinfer
 
 
-_MIN_CUDNN_FP8 = 91701  # cuDNN >= 9.17.1 required for FP8 attention
+_MIN_CUDNN_FP8 = 91701  # cuDNN >= 9.17.1 required for FP8 ViT attention
 
 
 @functools.cache
 def is_flashinfer_cudnn_fp8_prefill_attn_supported() -> bool:
     """Check if FP8 ViT attention is supported on this platform.
 
-    Requires native FP8 hardware support, the FlashInfer cuDNN backend,
+    Requires Blackwell (SM 100) or newer, the FlashInfer cuDNN backend,
     and cuDNN >= 9.17.1.
+
+    cuDNN's FP8 SDPA forward path with bf16/fp16 output (used by
+    ``MMEncoderAttention._forward_flashinfer``) gates internally on
+    ``prop.major >= 10``; on Hopper it raises a misleading
+    ``cudnnGraphNotSupportedError: ... cuDNN version 9.13.0 and newer``
+    even when the installed cuDNN is new enough. See PR #38065 for the
+    original Blackwell-only design intent.
     """
     from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-    # cuDNN SDPA FP8 requires Hopper (SM 90) or newer.
-    if not current_platform.has_device_capability(90):
+    # cuDNN SDPA FP8 with bf16/fp16 output requires Blackwell (SM 100) or newer.
+    if not current_platform.has_device_capability(100):
         return False
 
     try:


### PR DESCRIPTION
## Purpose

`is_flashinfer_cudnn_fp8_prefill_attn_supported()` currently returns `True` on SM 90 GPUs (Hopper, e.g. H100 / H200 / H20), but the underlying cuDNN FP8 SDPA forward path requires Blackwell (SM 100) when the output dtype is `bf16`/`fp16` — which is exactly the configuration `MMEncoderAttention._forward_flashinfer` uses (`o_data_type=self.dtype`, where `self.dtype` is the model dtype, typically `bf16`).

As a result, on Hopper the gate returns `True`, `MMEncoderAttention.__init__` enables `fp8_enabled`, and the first cuDNN call crashes inside the graph build with a misleading error:

```
cudnn._compiled_module.cudnnGraphNotSupportedError:
sdpa fp8 forward operation is only supported on cuDNN version 9.13.0 and newer.
Please consider upgrading your current version.
```

The error message hides the real reason. Inspecting libcudnn binaries (`strings cudnn/_compiled_module.*.so`) reveals the actual compound check:

```cpp
(output_data_type == DataType_t::HALF || output_data_type == DataType_t::BFLOAT16)
    && (detail::get_backend_version() < 91300 || prop.major < 10)
```

So the failure trips on **either** old cuDNN **or** non-Blackwell GPU. cuDNN only emits one message; on H100/H200/H20 with cuDNN 9.17+ the `prop.major < 10` branch trips but the message only mentions the version.

This PR fixes the gate to require SM 100, matching the design intent already documented in #38065:

> "Requires FlashInfer cuDNN backend + cuDNN >= 9.17.1, e.g. **(Blackwell)**: `uv pip install -U nvidia-cudnn-cu13==9.18.1 nvidia-cudnn-frontend==1.18.9`"

It also tightens the user-facing `ValueError` raised by `MMEncoderAttention` so users requesting `--mm-encoder-attn-dtype fp8` on Hopper get a clear up-front error instead of a confusing later cuDNN crash.

## Reproducer

On any Hopper GPU (H100 / H200 / H20) with cuDNN ≥ 9.17.1 and FlashInfer's cuDNN backend installed:

```bash
pytest -v tests/kernels/core/test_vit_fp8_attn.py::test_fp8_vs_bf16_close
```

All parametrizations crash with the misleading "9.13.0 and newer" cuDNN error. With this fix, the fixture's existing `pytest.skip("FlashInfer cuDNN FP8 prefill attention not supported")` triggers cleanly on non-Blackwell GPUs.

## Changes

- `vllm/utils/flashinfer.py`:
  - `current_platform.has_device_capability(90)` → `has_device_capability(100)`
  - Update docstring + comment to "Blackwell (SM 100) or newer", with a note about the misleading "9.13.0" error message that hides the real `prop.major < 10` check.
- `vllm/model_executor/layers/attention/mm_encoder_attention.py`:
  - Update the `ValueError` message to state the Blackwell requirement explicitly, instead of the vague "GPU with native FP8 support".

## Test Plan

- [x] On H20 (SM 9.0) with cuDNN 9.19.0: `test_fp8_vs_bf16_close` skips cleanly via the existing fixture-level skip (was: hard cuDNN crash). Verified locally.
- [ ] On B200 / GB200 / GB300 (SM 10.x): `test_fp8_vs_bf16_close` continues to PASS — gate behavior on supported HW is unchanged. (I do not have access to Blackwell hardware; would appreciate verification from a Blackwell CI run.)
- [ ] `--mm-encoder-attn-dtype fp8` on H100 now fails fast at `MMEncoderAttention.__init__` with the updated `ValueError`, instead of crashing later inside cuDNN graph build.

## Related

- #38065 — original PR introducing FP8 ViT attention. PR description states "Requires ... Blackwell" but the gate was implemented as `SM ≥ 90`.

Signed-off-by: Wentian Byte <3400259131@qq.com>
