### PR TITLE
Fix relative allowed local media paths

### DIFF
--- a/tests/multimodal/media/test_connector.py
+++ b/tests/multimodal/media/test_connector.py
@@ -153,6 +153,23 @@ async def test_fetch_image_local_files(image_url: str):
 
 
 @pytest.mark.asyncio
+async def test_fetch_image_local_files_relative_allowed_path(tmp_path, monkeypatch):
+    media_dir = tmp_path / "media"
+    media_dir.mkdir()
+    image_path = media_dir / "image.png"
+    Image.new("RGB", (1, 1), color=(255, 0, 0)).save(image_path)
+
+    monkeypatch.chdir(tmp_path)
+    local_connector = MediaConnector(allowed_local_media_path="media")
+
+    image_sync = local_connector.fetch_image(image_path.as_uri())
+    image_async = await local_connector.fetch_image_async(image_path.as_uri())
+
+    assert image_sync.size == (1, 1)
+    assert not ImageChops.difference(image_sync, image_async).getbbox()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("image_url", [TEST_IMAGE_ASSETS[0]], indirect=True)
 async def test_fetch_image_local_files_with_space_in_name(image_url: str):
     connector = MediaConnector()

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -105,7 +105,7 @@ class MediaConnector:
         self.connection = connection
 
         if allowed_local_media_path:
-            allowed_local_media_path_ = Path(allowed_local_media_path)
+            allowed_local_media_path_ = Path(allowed_local_media_path).resolve()
 
             if not allowed_local_media_path_.exists():
                 raise ValueError(


### PR DESCRIPTION
Fixes handling of relative `allowed_local_media_path` values in `MediaConnector`.

Previously, the allowed path could remain relative while file URLs were resolved
to absolute paths, causing valid local media files to be rejected.

This resolves the allowed local media path during connector initialization and
adds a regression test covering sync and async local image loading.