### PR TITLE
[Bugfix] Route FP8 MoE + LoRA to Marlin (W8A16) so MoE-LoRA kernels get unquantized activations

### DIFF
--- a/tests/kernels/moe/test_fp8_backend_selection.py
+++ b/tests/kernels/moe/test_fp8_backend_selection.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for FP8 MoE backend selection (oracle/fp8.py).
+
+Regression coverage for https://github.com/vllm-project/vllm/issues/45101:
+with LoRA enabled, w8a8 backends (e.g. Triton) feed fp8-quantized activations
+into the Triton MoE-LoRA shrink kernel, which crashes on the mixed
+``fp8 x bf16`` ``tl.dot``. The selection oracle must route FP8 MoE + LoRA to
+the Marlin (W8A16) backend, whose activations stay in the original dtype.
+"""
+
+import dataclasses
+
+import pytest
+
+from tests.kernels.moe.utils import make_dummy_moe_config
+from vllm.model_executor.layers.fused_moe.experts.marlin_moe import MarlinExperts
+from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
+    Fp8MoeBackend,
+    select_fp8_moe_backend,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+    kFp8DynamicTokenSym,
+    kFp8Static128BlockSym,
+    kFp8StaticTensorSym,
+)
+from vllm.platforms import current_platform
+
+skipif_not_cuda = pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="Only supported on CUDA platforms.",
+)
+
+
+@skipif_not_cuda
+@pytest.mark.parametrize(
+    "weight_key,activation_key",
+    [
+        # Block-quantized FP8 checkpoint (e.g. Qwen3.5/3.6-MoE-FP8).
+        (kFp8Static128BlockSym, kFp8Dynamic128Sym),
+        # Per-tensor FP8 checkpoint.
+        (kFp8StaticTensorSym, kFp8DynamicTokenSym),
+    ],
+)
+def test_fp8_moe_with_lora_selects_marlin(weight_key, activation_key):
+    """FP8 MoE + LoRA must select the W8A16 Marlin backend so the MoE-LoRA
+    kernels receive unquantized (bf16/fp16) activations."""
+    moe_config = dataclasses.replace(
+        make_dummy_moe_config(
+            num_experts=8,
+            experts_per_token=2,
+            hidden_dim=2048,
+            intermediate_size=512,
+        ),
+        is_lora_enabled=True,
+    )
+
+    backend, experts_cls = select_fp8_moe_backend(
+        config=moe_config,
+        weight_key=weight_key,
+        activation_key=activation_key,
+        allow_vllm_cutlass=False,
+    )
+
+    assert backend == Fp8MoeBackend.MARLIN
+    assert experts_cls is MarlinExperts
+    assert experts_cls.supports_lora()

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -401,6 +401,25 @@ def select_fp8_moe_backend(
                 backend, config, weight_key, activation_key, activation_format
             )
 
+    # LoRA: w8a8 backends quantize the activations to fp8 before the experts
+    # run, but the Triton MoE-LoRA shrink/expand kernels require bf16/fp16
+    # activations (a mixed fp8 x bf16 tl.dot is unsupported and crashes with
+    # "Unsupported lhs dtype fp8e4nv"). Marlin runs W8A16 -- activations stay
+    # in the original dtype -- and natively supports LoRA, so prefer it.
+    # See https://github.com/vllm-project/vllm/issues/45101.
+    if config.is_lora_enabled and current_platform.is_cuda():
+        logger.info_once(
+            "LoRA is enabled with an FP8 MoE: selecting the MARLIN (W8A16) "
+            "backend so the MoE-LoRA kernels receive unquantized activations."
+        )
+        return _return_or_raise(
+            Fp8MoeBackend.MARLIN,
+            config,
+            weight_key,
+            activation_key,
+            activation_format,
+        )
+
     if not allow_vllm_cutlass:
         AVAILABLE_BACKENDS.remove(Fp8MoeBackend.VLLM_CUTLASS)
         AVAILABLE_BACKENDS.remove(Fp8MoeBackend.BATCHED_VLLM_CUTLASS)


### PR DESCRIPTION
## Purpose

Fixes the remaining actionable part of #45101: make FP8 MoE + `--enable-lora` actually work, instead of crashing (today) or failing fast (#45130).

**Root cause** (matches the analysis in #45130 and [my writeup on the issue](https://github.com/vllm-project/vllm/issues/45101#issuecomment-4677390777)): with an FP8 base MoE, the auto-selected w8a8 backends (e.g. `TritonExperts`) quantize activations to fp8 before the experts run, so the Triton MoE-LoRA shrink kernel receives fp8 `x` and crashes on the mixed `fp8 × bf16` `tl.dot` — `AssertionError: Unsupported lhs dtype fp8e4nv` (Triton permits fp8 dot operands only when both sides are fp8). Arch-independent.

**Fix**: in `select_fp8_moe_backend`, when LoRA is enabled, route to the **Marlin (W8A16)** backend — activations stay in the original dtype and `MarlinExperts` already mixes in `LoRAExpertsMixin`, so the combination works. This mirrors the existing LoRA special case in the unquantized oracle (`oracle/unquantized.py`). Explicit `--moe-backend` / env overrides are still honored and fail with a clear reason via `is_supported_config` if incompatible.

## Why this is not duplicating an existing PR

- #45130 adds a fail-fast error for this combination (LoRA mixin layer); it does not make the combination work. This PR is complementary — with both merged, the guard remains a safety net for any path that still feeds fp8 activations to LoRA kernels.
- #34421 targets LoRA with **NVFP4** MoE models (different quant scheme and code path).
- Searched open PRs for `45101`, `fp8 moe lora marlin` — no other PR addresses backend selection for FP8+LoRA.

## Test Plan

- New unit test `tests/kernels/moe/test_fp8_backend_selection.py` (block-fp8 and per-tensor fp8 schemes → MARLIN when `is_lora_enabled`).
- End-to-end on the issue's hardware class — RTX PRO 6000 Blackwell (SM 12.0), `Qwen/Qwen3.6-35B-A3B-FP8` (block-fp8 [128,128], E=256), `enable_lora=True, max_lora_rank=64`.

## Test Result

- `pytest tests/kernels/moe/test_fp8_backend_selection.py` → 2 passed
- `pre-commit` (incl. `mypy-3.12 --hook-stage manual`) → passed on changed files
- **Before** (main): `Using TRITON Fp8 MoE backend` → profiling forward crashes: `AssertionError: Unsupported lhs dtype fp8e4nv` → `Engine core initialization failed` (exact crash from #45101)
- **After** (this PR): `LoRA is enabled with an FP8 MoE: selecting the MARLIN (W8A16) backend …` → engine initializes, coherent generation: `The capital of France is → ' Paris, a city renowned for its iconic landmarks such as the Eiffel Tower,'`

## AI assistance disclosure

AI assistance (Claude Code) was used for analysis and drafting; I reviewed every changed line, ran the tests above, and validated end-to-end on real SM120 hardware.

 Generated with [Claude Code](https://claude.com/claude-code)