### PR TITLE
[Bugfix] Fix missing multimodal content in vllm bench serve profile requests

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1213,12 +1213,16 @@ async def benchmark(
     if profile:
         print("Stopping profiler...")
         profile_input = RequestFuncInput(
-            model=model_id,
+            model=model_name,
             prompt=test_prompt,
             api_url=base_url + "/stop_profile",
             prompt_len=test_prompt_len,
             output_len=test_output_len,
             logprobs=logprobs,
+            multi_modal_content=test_mm_content,
+            ignore_eos=ignore_eos,
+            extra_headers=extra_headers,
+            extra_body=extra_body,
         )
         profile_output = await request_func(
             request_func_input=profile_input, session=session


### PR DESCRIPTION
## Purpose
This PR fixes the error during multi-modal profiling (Whisper) profiling for online serving. Fixes #38586 
The multimodal content was not being returned in the profile requests. 


## Test Plan
1. Run the server
```
 vllm serve openai/whisper-medium \
        --host 0.0.0.0 \
        --port 8001 \
        --dtype bfloat16 \
        --max-model-len 448 \
        --max-num-seqs 128 \
        --profiler-config '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_record_shapes": true, "torch_profiler_with_flops": true}'
```

2. Run online benchmarking:
```
vllm bench serve \
        --backend openai-audio \
        --model openai/whisper-medium \
        --endpoint /v1/audio/transcriptions \
        --host 0.0.0.0 \
        --port 8001 \
        --dataset-name hf \
        --dataset-path openslr/librispeech_asr \
        --hf-subset clean \
        --hf-split test \
        --num-prompts 32 \
        --max-concurrency 32 \
        --no-stream \
        --no-oversample \
        --ready-check-timeout-sec 600 \
        --profile
```

## Test Result
```
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  99.49     
Total input tokens:                      224       
Total generated tokens:                  892       
Request throughput (req/s):              0.32      
Output token throughput (tok/s):         8.97      
Peak output token throughput (tok/s):    53.00     
Peak concurrent requests:                32.00     
RTFx (Inverse Real-Time Factor):         2.64      
Total token throughput (tok/s):          11.22     
---------------Time to First Token----------------
Mean TTFT (ms):                          18533.71  
Median TTFT (ms):                        18335.17  
P99 TTFT (ms):                           34541.82  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          1487.64   
Median TPOT (ms):                        1547.35   
P99 TPOT (ms):                           2083.50   
---------------Inter-token Latency----------------
Mean ITL (ms):                           1268.09   
Median ITL (ms):                         1161.13   
P99 ITL (ms):                            2303.85   
==================================================
Stopping profiler...
Profiler stopped
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

