### PR TITLE
[CI] ci-fetch-log.sh: fetch all failed jobs from a build URL or PR number

### DIFF
--- a/.buildkite/scripts/ci-clean-log.sh
+++ b/.buildkite/scripts/ci-clean-log.sh
@@ -13,5 +13,8 @@ INPUT_FILE="$1"
 # Strip timestamps
 sed -i 's/^\[[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}Z\] //' "$INPUT_FILE"
 
+# Strip Buildkite inline timestamp markers (ESC _bk;t=<ms> BEL)
+sed -i 's/\x1B_bk;t=[0-9]*\x07//g' "$INPUT_FILE"
+
 # Strip colorization
 sed -i -r 's/\x1B\[[0-9;]*[mK]//g' "$INPUT_FILE"

--- a/.buildkite/scripts/ci-fetch-log.sh
+++ b/.buildkite/scripts/ci-fetch-log.sh
@@ -1,74 +1,158 @@
 #!/bin/bash
-# Usage: ./ci-fetch-log.sh <buildkite_job_url> [output_file]
-#        ./ci-fetch-log.sh <build_number> <job_uuid> [output_file]
+# Fetch vLLM Buildkite CI logs (public; no login required).
 #
-# Downloads the raw log for a Buildkite job from the public, unauthenticated
-# /organizations/<org>/pipelines/<pipeline>/builds/<n>/jobs/<uuid>/download
-# endpoint, then strips ANSI/timestamps via ci-clean-log.sh.
+# Usage:
+#   ci-fetch-log.sh --pr [<PR>]               all failed jobs in the PR's latest
+#                                             build (current branch if omitted)
+#   ci-fetch-log.sh <buildkite_url> [output]  builds/<N> -> all failed jobs;
+#                                             #<job_uuid> / ?sid=<id> -> that job
+#   ci-fetch-log.sh <build> <job_uuid> [output]
 #
-# Find <build_number> and <job_uuid> via:
-#   gh pr checks <PR> --repo vllm-project/vllm
-# Each failing row's URL is .../builds/<build_number>#<job_uuid>.
-#
-# Default output path: ci-<build>-<uuid_first_13_chars>.log (e.g.
-# ci-68478-019e6b07-daae.log). Jobs in the same build share the UUID's
-# first 8 chars, so the second segment is needed for uniqueness when
-# fetching multiple jobs in parallel. The script refuses to overwrite an
-# existing output file; pass an explicit path or set CI_FETCH_LOG_FORCE=1
-# to override.
+# Saves each log as ci-<build>-<job-name>.log (ANSI/timestamps stripped) and
+# prints "<file>\t<job name>" per job. [output] is single-job only; "-"
+# streams to stdout. Existing files are kept; CI_FETCH_LOG_FORCE=1 refetches.
 
 set -euo pipefail
 
 ORG="vllm"
 PIPELINE="ci"
+UA="vllm-ci-fetch-log"
+UUID_RE='[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
 usage() {
-    echo "Usage: $0 <buildkite_job_url> [output_file]"
-    echo "       $0 <build_number> <job_uuid> [output_file]"
+    sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'
     exit 1
 }
 
-if [ $# -lt 1 ]; then usage; fi
+die() {
+    echo "$1" >&2
+    exit 1
+}
 
-if [[ "$1" == https://* ]]; then
+BUILD="" JOB="" SID="" OUT=""
+
+case "${1:-}" in
+--pr)
+    PR="${2:-}"
+    # gh pr checks exits non-zero when checks are failing; that is the
+    # expected case here.
+    URL=$(gh pr checks ${PR:+"$PR"} --repo vllm-project/vllm 2>/dev/null |
+        grep -oE "https://buildkite.com/${ORG}/${PIPELINE}/builds/[0-9]+" |
+        sort -t/ -k7 -n | tail -1 || true)
+    [ -n "$URL" ] || die "No Buildkite build found via: gh pr checks ${PR:-<current branch>}"
+    BUILD="${URL##*/}"
+    ;;
+https://*)
     BUILD=$(echo "$1" | sed -nE 's#.*/builds/([0-9]+).*#\1#p')
-    JOB=$(echo "$1" | grep -oE '[0-9a-f]{8}-[0-9a-f-]+' | head -n 1)
+    JOB=$(echo "$1" | grep -oE "#${UUID_RE}" | head -n 1 | cut -c2- || true)
+    SID=$(echo "$1" | grep -oE "[?&]sid=${UUID_RE}" | head -n 1 | sed 's/.*sid=//' || true)
     OUT="${2:-}"
-else
-    if [ $# -lt 2 ]; then usage; fi
+    [ -n "$BUILD" ] || die "Could not parse build number from: $1"
+    ;;
+[0-9]*)
+    [ $# -ge 2 ] || usage
     BUILD="$1"
     JOB="$2"
     OUT="${3:-}"
-fi
-
-if [ -z "$BUILD" ] || [ -z "$JOB" ]; then
-    echo "Could not parse build number or job UUID from: $1" >&2
+    ;;
+*)
     usage
-fi
-
-# Jobs in the same build share the UUID's first segment, so include the
-# second segment (chars 9-13, e.g. "019e6b07-daae") to keep default filenames
-# unique when fetching multiple jobs from one build in parallel.
-if [ -z "$OUT" ]; then
-    OUT="ci-${BUILD}-${JOB:0:13}.log"
-fi
-
-if [ -e "$OUT" ] && [ -z "${CI_FETCH_LOG_FORCE:-}" ]; then
-    echo "Refusing to overwrite existing $OUT (set CI_FETCH_LOG_FORCE=1 or pass an explicit output path)." >&2
-    exit 1
-fi
+    ;;
+esac
 
 COOKIES=$(mktemp)
-trap 'rm -f "$COOKIES"' EXIT
+JOBS_TSV=$(mktemp)
+trap 'rm -f "$COOKIES" "$JOBS_TSV"' EXIT
 
-# Buildkite issues a session cookie on first hit; subsequent /download needs it.
-curl -fsSL -c "$COOKIES" -A "vllm-ci-fetch-log" \
+# Buildkite issues a session cookie on first hit; later requests need it.
+curl -fsSL -c "$COOKIES" -A "$UA" \
     "https://buildkite.com/${ORG}/${PIPELINE}/builds/${BUILD}" -o /dev/null
 
-curl -fsSL -b "$COOKIES" -A "vllm-ci-fetch-log" \
-    "https://buildkite.com/organizations/${ORG}/pipelines/${PIPELINE}/builds/${BUILD}/jobs/${JOB}/download" \
-    -o "$OUT"
+# The build's job list (id, step uuid, state, name) is served as JSON from
+# the user-facing /data/jobs endpoint. Flatten it to TSV for easy filtering:
+#   job_id  step_uuid  failed  soft_failed  finished  slug  name
+curl -fsSL -b "$COOKIES" -A "$UA" \
+    "https://buildkite.com/${ORG}/${PIPELINE}/builds/${BUILD}/data/jobs" |
+    python3 -c '
+import json, re, sys
 
-bash "$(dirname "$0")/ci-clean-log.sh" "$OUT"
+data = json.load(sys.stdin)
+if data.get("has_next_page"):
+    print("warning: job list is paginated; some jobs not shown", file=sys.stderr)
+for r in data["records"]:
+    if r.get("type") != "script":
+        continue
+    name = (r.get("name") or "").replace("\t", " ").replace("\n", " ")
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")[:60]
+    print("\t".join([
+        r["id"],
+        r.get("step_uuid") or "",
+        str(r.get("passed") is False),
+        str(bool(r.get("soft_failed"))),
+        str(bool(r.get("finished_at"))),
+        slug,
+        name,
+    ]))
+' >"$JOBS_TSV" || die "Could not list jobs for build ${BUILD}"
 
-echo "$OUT"
+if [ -n "$SID" ] && [ -z "$JOB" ]; then
+    # The ?sid= in builds/<N>/list URLs is the *step* uuid, not the job uuid.
+    JOB=$(awk -F'\t' -v s="$SID" '$1 == s || $2 == s {print $1; exit}' "$JOBS_TSV")
+    [ -n "$JOB" ] || die "No job matching sid=${SID} in build ${BUILD}"
+fi
+
+fetch_job() { # <job_uuid> <output_file>
+    curl -fsSL -b "$COOKIES" -A "$UA" \
+        "https://buildkite.com/organizations/${ORG}/pipelines/${PIPELINE}/builds/${BUILD}/jobs/$1/download" \
+        -o "$2"
+    bash "$(dirname "$0")/ci-clean-log.sh" "$2"
+}
+
+if [ -n "$JOB" ]; then
+    # Single-job mode.
+    NAME=$(awk -F'\t' -v j="$JOB" '$1 == j {print $7; exit}' "$JOBS_TSV")
+    SLUG=$(awk -F'\t' -v j="$JOB" '$1 == j {print $6; exit}' "$JOBS_TSV")
+    [ -n "$OUT" ] || OUT="ci-${BUILD}-${SLUG:-${JOB:0:13}}.log"
+    if [ "$OUT" = "-" ]; then
+        TMP=$(mktemp)
+        fetch_job "$JOB" "$TMP"
+        cat "$TMP"
+        rm -f "$TMP"
+        exit 0
+    fi
+    if [ -e "$OUT" ] && [ -z "${CI_FETCH_LOG_FORCE:-}" ]; then
+        die "Refusing to overwrite existing ${OUT} (set CI_FETCH_LOG_FORCE=1 or pass an output path)."
+    fi
+    fetch_job "$JOB" "$OUT"
+    printf '%s\t%s\n' "$OUT" "${NAME:-$JOB}"
+    exit 0
+fi
+
+# Build-wide mode: fetch every finished, hard-failed job.
+[ -z "$OUT" ] || die "[output_file] is only valid when fetching a single job."
+
+SOFT=$(awk -F'\t' '$3 == "True" && $4 == "True"' "$JOBS_TSV" | wc -l)
+[ "$SOFT" -eq 0 ] || echo "Skipping ${SOFT} soft-failed job(s)." >&2
+
+FOUND=0
+EMITTED=" "
+while IFS=$'\t' read -r job_id _ _ _ _ slug name; do
+    FOUND=$((FOUND + 1))
+    out="ci-${BUILD}-${slug:-${job_id:0:13}}.log"
+    # Retries share a name with the original job; disambiguate by uuid.
+    case "$EMITTED" in
+    *" $out "*) out="ci-${BUILD}-${slug:-job}-${job_id:0:13}.log" ;;
+    esac
+    EMITTED="${EMITTED}${out} "
+    if [ -e "$out" ] && [ -z "${CI_FETCH_LOG_FORCE:-}" ]; then
+        echo "Keeping existing ${out} (set CI_FETCH_LOG_FORCE=1 to refetch)." >&2
+    elif ! fetch_job "$job_id" "$out"; then
+        echo "Failed to download log for job ${job_id} (${name})." >&2
+        continue
+    fi
+    printf '%s\t%s\n' "$out" "$name"
+done < <(awk -F'\t' '$3 == "True" && $4 == "False" && $5 == "True"' "$JOBS_TSV")
+
+if [ "$FOUND" -eq 0 ]; then
+    echo "No (hard-)failed jobs in build ${BUILD}." >&2
+fi

--- a/.buildkite/scripts/ci-fetch-log.sh
+++ b/.buildkite/scripts/ci-fetch-log.sh
@@ -2,12 +2,14 @@
 # Fetch vLLM Buildkite CI logs (public; no login required).
 #
 # Usage:
-#   ci-fetch-log.sh --pr [<PR>]               all failed jobs in the PR's latest
-#                                             build (current branch if omitted)
-#   ci-fetch-log.sh <buildkite_url> [output]  builds/<N> -> all failed jobs;
-#                                             #<job_uuid> / ?sid=<id> -> that job
+#   ci-fetch-log.sh [--soft|--all] --pr [<PR>]  failed jobs in the PR's latest
+#                                               build (current branch if omitted)
+#   ci-fetch-log.sh [--soft|--all] <build_url>  failed jobs in that build
+#   ci-fetch-log.sh <job_url> [output]          one job; both #<job_uuid> and
+#                                               ?sid=<id> URL forms work
 #   ci-fetch-log.sh <build> <job_uuid> [output]
 #
+# --soft also fetches soft-failed jobs; --all fetches every finished job.
 # Saves each log as ci-<build>-<job-name>.log (ANSI/timestamps stripped) and
 # prints "<file>\t<job name>" per job. [output] is single-job only; "-"
 # streams to stdout. Existing files are kept; CI_FETCH_LOG_FORCE=1 refetches.
@@ -20,7 +22,7 @@ UA="vllm-ci-fetch-log"
 UUID_RE='[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
 usage() {
-    sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
     exit 1
 }
 
@@ -30,6 +32,16 @@ die() {
 }
 
 BUILD="" JOB="" SID="" OUT=""
+SCOPE="failed"
+
+while :; do
+    case "${1:-}" in
+    --soft) SCOPE="soft" ;;
+    --all) SCOPE="all" ;;
+    *) break ;;
+    esac
+    shift
+done
 
 case "${1:-}" in
 --pr)
@@ -128,11 +140,19 @@ if [ -n "$JOB" ]; then
     exit 0
 fi
 
-# Build-wide mode: fetch every finished, hard-failed job.
+# Build-wide mode: fetch finished jobs matching $SCOPE.
 [ -z "$OUT" ] || die "[output_file] is only valid when fetching a single job."
 
-SOFT=$(awk -F'\t' '$3 == "True" && $4 == "True"' "$JOBS_TSV" | wc -l)
-[ "$SOFT" -eq 0 ] || echo "Skipping ${SOFT} soft-failed job(s)." >&2
+case "$SCOPE" in
+failed) FILTER='$3 == "True" && $4 == "False" && $5 == "True"' ;;
+soft) FILTER='$3 == "True" && $5 == "True"' ;;
+all) FILTER='$5 == "True"' ;;
+esac
+
+if [ "$SCOPE" = "failed" ]; then
+    SOFT=$(awk -F'\t' '$3 == "True" && $4 == "True"' "$JOBS_TSV" | wc -l)
+    [ "$SOFT" -eq 0 ] || echo "Skipping ${SOFT} soft-failed job(s); use --soft to include them." >&2
+fi
 
 FOUND=0
 EMITTED=" "
@@ -151,8 +171,8 @@ while IFS=$'\t' read -r job_id _ _ _ _ slug name; do
         continue
     fi
     printf '%s\t%s\n' "$out" "$name"
-done < <(awk -F'\t' '$3 == "True" && $4 == "False" && $5 == "True"' "$JOBS_TSV")
+done < <(awk -F'\t' "$FILTER" "$JOBS_TSV")
 
 if [ "$FOUND" -eq 0 ]; then
-    echo "No (hard-)failed jobs in build ${BUILD}." >&2
+    echo "No matching jobs in build ${BUILD} (scope: ${SCOPE})." >&2
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,17 @@ The line length limit for Python code is 88 characters. If you are not sure, use
 
 Use [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) (`Args:`/`Returns:`/`Raises:` sections), not reStructuredText/Sphinx fields (`:param:`, `:return:`, `:rtype:`).
 
+### Diagnosing CI failures
+
+Buildkite logs are public; no login needed. Details: [docs/contributing/ci/failures.md](docs/contributing/ci/failures.md).
+
+```bash
+# All failed-job logs for a PR's latest build (current branch's PR if omitted):
+.buildkite/scripts/ci-fetch-log.sh --pr <PR>
+# Any Buildkite build or job URL also works:
+.buildkite/scripts/ci-fetch-log.sh "<buildkite_url>"
+```
+
 ### Commit messages
 
 Add attribution using commit trailers such as `Co-authored-by:` (other projects use `Assisted-by:` or `Generated-by:`). For example:

--- a/docs/contributing/ci/failures.md
+++ b/docs/contributing/ci/failures.md
@@ -60,15 +60,20 @@ the failure?
 
 ## Logs Wrangling
 
-Download a job's log (no Buildkite login required):
-
+Logs are public; no Buildkite login needed.
 [.buildkite/scripts/ci-fetch-log.sh](../../../.buildkite/scripts/ci-fetch-log.sh)
+saves each log as `ci-<build>-<job-name>.log`, stripped of timestamps and
+ANSI codes:
 
 ```bash
-# Find the failing job. Each row's URL is .../builds/<N>#<job_uuid>:
-gh pr checks <PR> --repo vllm-project/vllm
+# All failed jobs in a PR's latest build (current branch's PR if omitted):
+.buildkite/scripts/ci-fetch-log.sh --pr <PR>
 
-# Download + strip timestamps/ANSI in one step:
+# All failed jobs in a build:
+.buildkite/scripts/ci-fetch-log.sh "https://buildkite.com/vllm/ci/builds/<N>"
+
+# One job — `gh pr checks` URLs (#<job_uuid>) and web UI URLs (?sid=) both
+# work; pass "-" as a second argument to stream to stdout:
 .buildkite/scripts/ci-fetch-log.sh "https://buildkite.com/vllm/ci/builds/<N>#<job_uuid>"
 ```
 

--- a/docs/contributing/ci/failures.md
+++ b/docs/contributing/ci/failures.md
@@ -69,7 +69,8 @@ ANSI codes:
 # All failed jobs in a PR's latest build (current branch's PR if omitted):
 .buildkite/scripts/ci-fetch-log.sh --pr <PR>
 
-# All failed jobs in a build:
+# All failed jobs in a build (--soft also includes soft-failed jobs;
+# --all fetches every finished job):
 .buildkite/scripts/ci-fetch-log.sh "https://buildkite.com/vllm/ci/builds/<N>"
 
 # One job — `gh pr checks` URLs (#<job_uuid>) and web UI URLs (?sid=) both


### PR DESCRIPTION
## Purpose

Make CI log fetching one obvious command for humans and agents. Previously `ci-fetch-log.sh` required a job UUID, and web-UI URLs (`/list?sid=<step_uuid>`) failed with a 403 because the `sid` is a step uuid, not a job uuid.

Now:

```bash
# All failed-job logs for a PR's latest build (current branch's PR if omitted):
.buildkite/scripts/ci-fetch-log.sh --pr 44551

# A build URL fetches every hard-failed job's log (soft-fails skipped, noted on stderr):
.buildkite/scripts/ci-fetch-log.sh "https://buildkite.com/vllm/ci/builds/70411"

# Web UI URLs now work, resolved via the public /data/jobs endpoint:
.buildkite/scripts/ci-fetch-log.sh "https://buildkite.com/vllm/ci/builds/70411/list?sid=019ea0ab-...&tab=output"
```

Logs are saved as `ci-<build>-<job-name>.log` with `<file>\t<job name>` printed per job; `-` streams a single job to stdout; reruns keep existing files unless `CI_FETCH_LOG_FORCE=1`. The old `#<job_uuid>` and `<build> <uuid>` forms still work. `ci-clean-log.sh` additionally strips inline `\x1b_bk;t=<ms>\x07` timestamp markers. AGENTS.md gets a short "Diagnosing CI failures" pointer so agents find this without spelunking.

## Test Plan

All modes run against live Buildkite:

```console
$ ci-fetch-log.sh "https://buildkite.com/vllm/ci/builds/70411/list?sid=019ea0ab-f01f-...&tab=output"
ci-70411-lm-eval-qwen3-5-models-b200.log	LM Eval Qwen3.5 Models (B200)

$ ci-fetch-log.sh "https://buildkite.com/vllm/ci/builds/70411"
Skipping 4 soft-failed job(s).
ci-70411-lm-eval-qwen3-5-models-b200.log	LM Eval Qwen3.5 Models (B200)
ci-70411-model-executor.log	Model Executor

$ ci-fetch-log.sh --pr 44551
ci-71408-amd-multi-modal-models-standard-1-qwen2-mi325-1.log	AMD: Multi-Modal Models (Standard) 1: qwen2 (mi325_1)
ci-71408-async-engine-inputs-utils-worker-config-cpu.log	Async Engine, Inputs, Utils, Worker, Config (CPU)
```

Legacy `#<job_uuid>` / `<build> <uuid>` forms and `-` (stdout) also verified. `pre-commit run shellcheck` and `markdownlint-cli2` pass on the touched files.

## Notes

- No open PR touches these scripts (checked `gh pr list --search ci-fetch-log`).
- Written with AI assistance (Claude); every line reviewed and tested by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)