### PR TITLE
[Backport][v0.19.1] Fix GLM5.1 Codex Responses API Bad Request

### DIFF
--- a/tests/entrypoints/openai/responses/test_function_call_parsing.py
+++ b/tests/entrypoints/openai/responses/test_function_call_parsing.py
@@ -156,6 +156,52 @@ def test_invalid_function_call_fallback():
         ResponsesRequest(**request_data)
 
 
+def test_function_call_with_dict_arguments():
+    """Codex may send arguments as a JSON object instead of a string."""
+    request_data = {
+        "model": "gpt-oss",
+        "input": [
+            {
+                "type": "function_call",
+                "call_id": "fc_dict",
+                "name": "shell",
+                "arguments": {"command": "ls", "workdir": "/tmp"},
+            }
+        ],
+    }
+
+    request = ResponsesRequest(**request_data)
+
+    assert len(request.input) == 1
+    assert isinstance(request.input[0], ResponseFunctionToolCall)
+    import json
+
+    assert json.loads(request.input[0].arguments) == {
+        "command": "ls",
+        "workdir": "/tmp",
+    }
+
+
+def test_function_call_with_extra_data_arguments():
+    """History replay may contain concatenated JSON in arguments."""
+    request_data = {
+        "model": "gpt-oss",
+        "input": [
+            {
+                "type": "function_call",
+                "call_id": "fc_extra",
+                "name": "shell",
+                "arguments": '{"command":"ls"}{"command":"pwd"}',
+            }
+        ],
+    }
+
+    request = ResponsesRequest(**request_data)
+    import json
+
+    assert json.loads(request.input[0].arguments) == {"command": "ls"}
+
+
 def test_string_input_not_affected():
     """Test that string input is not affected by the validator."""
     request_data = {"model": "gpt-oss", "input": "This is a simple string input"}

--- a/tests/entrypoints/openai/responses/test_function_call_parsing.py
+++ b/tests/entrypoints/openai/responses/test_function_call_parsing.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 from openai.types.responses import ResponseFunctionToolCall
+from openai.types.responses.response_output_message import ResponseOutputMessage
 
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
@@ -328,3 +329,83 @@ def test_validator_handles_empty_iterator():
 
     request = ResponsesRequest(**mock_data)
     assert request.input == []
+
+
+def test_assistant_message_in_multi_turn_conversation():
+    """Test that assistant messages in input are parsed to ResponseOutputMessage.
+
+    Codex sends prior assistant turns in multi-turn conversations without id,
+    status, or annotations. Without explicit parsing, Pydantic may mis-match
+    the item to ResponseCustomToolCallOutputItem and reject the request.
+    """
+    request_data = {
+        "model": "gpt-oss",
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Hello"}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "Hello! How can I help you?",
+                    }
+                ],
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Tell me a joke"}],
+            },
+        ],
+    }
+
+    request = ResponsesRequest(**request_data)
+
+    assert len(request.input) == 3
+    assert request.input[0]["type"] == "message"
+    assert isinstance(request.input[1], ResponseOutputMessage)
+    assert request.input[1].role == "assistant"
+    assert request.input[1].status == "completed"
+    assert request.input[1].id.startswith("msg_")
+    assert request.input[1].content[0].annotations == []
+    assert request.input[2]["type"] == "message"
+
+
+def test_assistant_message_with_string_content():
+    """Assistant messages may use a plain string for content."""
+    request_data = {
+        "model": "gpt-oss",
+        "input": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": "Hello from string content",
+            },
+        ],
+    }
+    request = ResponsesRequest(**request_data)
+    assert isinstance(request.input[0], ResponseOutputMessage)
+    assert request.input[0].content[0].text == "Hello from string content"
+
+
+def test_assistant_message_with_input_text_content_type():
+    """Codex may send input_text type in assistant history content."""
+    request_data = {
+        "model": "gpt-oss",
+        "input": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "input_text", "text": "Prior reply"}],
+            },
+        ],
+    }
+    request = ResponsesRequest(**request_data)
+    assert isinstance(request.input[0], ResponseOutputMessage)
+    assert request.input[0].content[0].type == "output_text"
+    assert request.input[0].content[0].text == "Prior reply"

--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -22,6 +22,8 @@ from vllm.entrypoints.openai.responses.utils import (
     _construct_single_message_from_response_item,
     _maybe_combine_reasoning_and_tool_call,
     construct_chat_messages_with_tool_call,
+    construct_input_messages,
+    construct_tool_dicts,
     convert_tool_responses_to_completions_format,
     should_continue_final_message,
 )
@@ -166,6 +168,19 @@ class TestResponsesUtils:
         formatted_item = _construct_single_message_from_response_item(output_item)
         assert formatted_item["role"] == "assistant"
         assert formatted_item["content"] == "dongyi"
+
+    def test_construct_message_from_output_message_with_empty_content(self):
+        """Empty content must not raise IndexError (Codex may send this)."""
+        output_item = ResponseOutputMessage(
+            id="msg_empty",
+            content=[],
+            role="assistant",
+            status="completed",
+            type="message",
+        )
+        formatted_item = _construct_single_message_from_response_item(output_item)
+        assert formatted_item["role"] == "assistant"
+        assert formatted_item["content"] == ""
 
 
 class TestReasoningItemContentPriority:
@@ -738,3 +753,77 @@ class TestMaybeCombineReasoningAndToolCall:
         result = _maybe_combine_reasoning_and_tool_call(item, messages)
 
         assert result is None
+
+
+class TestConstructInputMessagesInstructionsLeak:
+    """Regression tests for #37697: instructions from a prior response
+    should NOT leak through previous_response_id."""
+
+    def test_old_instructions_stripped_from_prev_msg(self):
+        """System message in prev_msg must be dropped so the new request's
+        instructions are the only system message in the conversation."""
+        prev = [
+            {"role": "system", "content": "old instructions"},
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "4"},
+        ]
+        msgs = construct_input_messages(
+            request_instructions="new instructions",
+            request_input="What is 3+3?",
+            prev_msg=prev,
+        )
+        system_msgs = [m for m in msgs if m.get("role") == "system"]
+        assert len(system_msgs) == 1
+        assert system_msgs[0]["content"] == "new instructions"
+
+    def test_no_instructions_in_new_request(self):
+        """If the new request has no instructions, old ones should still
+        be stripped -- they must not carry over."""
+        prev = [
+            {"role": "system", "content": "old instructions"},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello"},
+        ]
+        msgs = construct_input_messages(
+            request_instructions=None,
+            request_input="What is 3+3?",
+            prev_msg=prev,
+        )
+        system_msgs = [m for m in msgs if m.get("role") == "system"]
+        assert len(system_msgs) == 0
+
+    def test_non_system_messages_preserved(self):
+        """User/assistant messages from prev_msg must remain intact."""
+        prev = [
+            {"role": "system", "content": "old instructions"},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello"},
+        ]
+        msgs = construct_input_messages(
+            request_instructions="new instructions",
+            request_input="Follow up",
+            prev_msg=prev,
+        )
+        roles = [m["role"] for m in msgs]
+        assert roles == ["system", "user", "assistant", "user"]
+        assert msgs[0]["content"] == "new instructions"
+        assert msgs[1]["content"] == "Hi"
+        assert msgs[2]["content"] == "Hello"
+        assert msgs[3]["content"] == "Follow up"
+
+    def test_no_prev_msg(self):
+        """Baseline: when there's no prev_msg, instructions work normally."""
+        msgs = construct_input_messages(
+            request_instructions="be helpful",
+            request_input="hello",
+            prev_msg=None,
+        )
+        assert len(msgs) == 2
+        assert msgs[0] == {"role": "system", "content": "be helpful"}
+        assert msgs[1] == {"role": "user", "content": "hello"}
+
+
+class TestConstructToolDicts:
+    def test_empty_tools_returns_none(self):
+        assert construct_tool_dicts([], "auto") is None
+        assert construct_tool_dicts([], "none") is None

--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -25,6 +25,7 @@ from vllm.entrypoints.openai.responses.utils import (
     construct_input_messages,
     construct_tool_dicts,
     convert_tool_responses_to_completions_format,
+    normalize_function_call_arguments,
     should_continue_final_message,
 )
 
@@ -827,3 +828,51 @@ class TestConstructToolDicts:
     def test_empty_tools_returns_none(self):
         assert construct_tool_dicts([], "auto") is None
         assert construct_tool_dicts([], "none") is None
+
+
+class TestNormalizeFunctionCallArguments:
+    def test_none_and_empty(self):
+        assert normalize_function_call_arguments(None) == "{}"
+        assert normalize_function_call_arguments("") == "{}"
+        assert normalize_function_call_arguments("   ") == "{}"
+
+    def test_dict_and_list(self):
+        assert normalize_function_call_arguments({"a": 1}) == '{"a": 1}'
+        assert normalize_function_call_arguments([1, 2]) == "[1, 2]"
+
+    def test_valid_json_string_preserved(self):
+        raw = '{"command": "ls", "workdir": "/tmp"}'
+        assert normalize_function_call_arguments(raw) == raw
+
+    def test_extra_data_uses_first_json_value(self):
+        raw = '{"command": "ls"}{"command": "pwd"}'
+        assert normalize_function_call_arguments(raw) == '{"command": "ls"}'
+
+    def test_construct_message_with_dict_arguments(self):
+        item = {
+            "type": "function_call",
+            "call_id": "call_abc",
+            "name": "shell",
+            "arguments": {"command": "ls", "workdir": "/tmp"},
+        }
+        msg = _construct_single_message_from_response_item(item)
+        assert msg["role"] == "assistant"
+        args = msg["tool_calls"][0]["function"]["arguments"]
+        assert args == '{"command": "ls", "workdir": "/tmp"}'
+        import json
+
+        assert json.loads(args)["command"] == "ls"
+
+    def test_construct_message_with_extra_data_arguments(self):
+        item = ResponseFunctionToolCall(
+            type="function_call",
+            call_id="call_xyz",
+            name="shell",
+            arguments='{"command":"ls"} trailing',
+            id="fc_xyz",
+        )
+        msg = _construct_single_message_from_response_item(item)
+        args = msg["tool_calls"][0]["function"]["arguments"]
+        import json
+
+        assert json.loads(args) == {"command": "ls"}

--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -817,3 +817,25 @@ def test_extract_tool_calls_numeric_deserialization(glm4_moe_tool_parser, mock_r
     # Boolean should be deserialized as bool
     assert args["enabled"] is True
     assert isinstance(args["enabled"], bool)
+
+
+def test_is_string_type_with_responses_function_tool():
+    """Responses API FunctionTool uses .name, not .function.name."""
+    from openai.types.responses import FunctionTool
+
+    tools = [
+        FunctionTool(
+            type="function",
+            name="get_weather",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "count": {"type": "integer"},
+                },
+            },
+        )
+    ]
+    assert Glm4MoeModelToolParser._is_string_type("get_weather", "city", tools)
+    assert not Glm4MoeModelToolParser._is_string_type("get_weather", "count", tools)
+    assert not Glm4MoeModelToolParser._is_string_type("unknown", "city", tools)

--- a/tests/tool_use/test_responses_request_validations.py
+++ b/tests/tool_use/test_responses_request_validations.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+SAMPLE_TOOL = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get current weather",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string", "description": "City name"}},
+        "required": ["location"],
+    },
+}
+
+NAMED_TOOL_CHOICE = {
+    "type": "function",
+    "name": "get_weather",
+}
+
+
+def test_responses_request_with_no_tools():
+    # tools key is not present — defaults tool_choice to "none"
+    request = ResponsesRequest.model_validate({"input": "Hello", "model": "test-model"})
+    assert request.tool_choice == "none"
+
+    # tools key present but empty
+    request = ResponsesRequest.model_validate(
+        {"input": "Hello", "model": "test-model", "tools": []}
+    )
+    assert request.tool_choice == "none"
+
+
+def test_responses_request_no_tools_tool_choice_none():
+    request = ResponsesRequest.model_validate(
+        {"input": "Hello", "model": "test-model", "tool_choice": "none"}
+    )
+    assert request.tool_choice == "none"
+
+
+def test_responses_request_no_tools_tool_choice_auto():
+    request = ResponsesRequest.model_validate(
+        {"input": "Hello", "model": "test-model", "tool_choice": "auto"}
+    )
+    assert request.tool_choice == "none"
+
+
+@pytest.mark.parametrize("tools", [None, []])
+def test_responses_request_required_without_tools(tools):
+    kwargs = {"input": "Hello", "model": "test-model", "tool_choice": "required"}
+    if tools is not None:
+        kwargs["tools"] = tools
+    with pytest.raises(
+        ValidationError, match="Tool choice 'required' must be specified"
+    ):
+        ResponsesRequest.model_validate(kwargs)
+
+
+def test_responses_request_named_tool_choice_without_tools():
+    with pytest.raises(ValidationError, match="not found in 'tools' parameter"):
+        ResponsesRequest.model_validate(
+            {
+                "input": "Hello",
+                "model": "test-model",
+                "tool_choice": NAMED_TOOL_CHOICE,
+            }
+        )
+
+
+def test_responses_request_with_tools_default_tool_choice():
+    request = ResponsesRequest.model_validate(
+        {"input": "Hello", "model": "test-model", "tools": [SAMPLE_TOOL]}
+    )
+    assert request.tool_choice == "auto"
+
+
+def test_responses_request_with_tools_tool_choice_none():
+    request = ResponsesRequest.model_validate(
+        {
+            "input": "Hello",
+            "model": "test-model",
+            "tools": [SAMPLE_TOOL],
+            "tool_choice": "none",
+        }
+    )
+    assert request.tool_choice == "none"
+
+
+def test_responses_request_named_tool_choice_matching():
+    request = ResponsesRequest.model_validate(
+        {
+            "input": "Hello",
+            "model": "test-model",
+            "tools": [SAMPLE_TOOL],
+            "tool_choice": NAMED_TOOL_CHOICE,
+        }
+    )
+    assert request.tool_choice.type == "function"
+    assert request.tool_choice.name == "get_weather"
+
+
+def test_responses_request_named_tool_choice_not_matching():
+    with pytest.raises(ValidationError, match="not found in 'tools' parameter"):
+        ResponsesRequest.model_validate(
+            {
+                "input": "Hello",
+                "model": "test-model",
+                "tools": [SAMPLE_TOOL],
+                "tool_choice": {"type": "function", "name": "nonexistent"},
+            }
+        )
+
+
+def test_responses_request_with_tools_tool_choice_auto():
+    request = ResponsesRequest.model_validate(
+        {
+            "input": "Hello",
+            "model": "test-model",
+            "tools": [SAMPLE_TOOL],
+            "tool_choice": "auto",
+        }
+    )
+    assert request.tool_choice == "auto"
+
+
+def test_responses_request_with_tools_tool_choice_required():
+    request = ResponsesRequest.model_validate(
+        {
+            "input": "Hello",
+            "model": "test-model",
+            "tools": [SAMPLE_TOOL],
+            "tool_choice": "required",
+        }
+    )
+    assert request.tool_choice == "required"
+
+
+def test_responses_request_empty_tools_tool_choice_none():
+    request = ResponsesRequest.model_validate(
+        {"input": "Hello", "model": "test-model", "tools": [], "tool_choice": "none"}
+    )
+    assert request.tool_choice == "none"
+
+
+def test_responses_request_empty_tools_tool_choice_auto():
+    request = ResponsesRequest.model_validate(
+        {"input": "Hello", "model": "test-model", "tools": [], "tool_choice": "auto"}
+    )
+    assert request.tool_choice == "none"
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        {"type": "function"},
+        {"type": "function", "name": ""},
+    ],
+)
+def test_responses_request_named_tool_choice_missing_name(tool_choice):
+    with pytest.raises(ValidationError, match="not found in 'tools' parameter"):
+        ResponsesRequest.model_validate(
+            {
+                "input": "Hello",
+                "model": "test-model",
+                "tools": [SAMPLE_TOOL],
+                "tool_choice": tool_choice,
+            }
+        )
+
+
+def test_responses_request_empty_tools_named_tool_choice():
+    with pytest.raises(ValidationError, match="not found in 'tools' parameter"):
+        ResponsesRequest.model_validate(
+            {
+                "input": "Hello",
+                "model": "test-model",
+                "tools": [],
+                "tool_choice": NAMED_TOOL_CHOICE,
+            }
+        )

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1552,6 +1552,17 @@ def _parse_chat_message_content(
     return result
 
 
+def _parse_tool_call_arguments(content: str) -> dict | list:
+    """Parse tool call arguments JSON, tolerating trailing extra data."""
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as e:
+        if "Extra data" not in e.msg:
+            raise
+        parsed, _ = json.JSONDecoder().raw_decode(content)
+        return parsed
+
+
 def _postprocess_messages(messages: list[ConversationMessage]) -> None:
     # per the Transformers docs & maintainers, tool call arguments in
     # assistant-role messages with tool_calls need to be dicts not JSON str -
@@ -1573,7 +1584,9 @@ def _postprocess_messages(messages: list[ConversationMessage]) -> None:
                 # if arguments is None or empty string, set to {}
                 if content := item["function"].get("arguments"):
                     if not isinstance(content, (dict, list)):
-                        item["function"]["arguments"] = json.loads(content)
+                        item["function"]["arguments"] = _parse_tool_call_arguments(
+                            content
+                        )
                 else:
                     item["function"]["arguments"] = {}
 

--- a/vllm/entrypoints/openai/responses/api_router.py
+++ b/vllm/entrypoints/openai/responses/api_router.py
@@ -39,7 +39,8 @@ async def _convert_stream_to_sse_events(
         event_type = getattr(event, "type", "unknown")
         # https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format
         event_data = (
-            f"event: {event_type}\ndata: {event.model_dump_json(indent=None)}\n\n"
+            f"event: {event_type}\ndata: "
+            f"{event.model_dump_json(indent=None, by_alias=True)}\n\n"
         )
         yield event_data
 
@@ -65,10 +66,11 @@ async def create_responses(request: ResponsesRequest, raw_request: Request):
 
     if isinstance(generator, ErrorResponse):
         return JSONResponse(
-            content=generator.model_dump(), status_code=generator.error.code
+            content=generator.model_dump(mode="json", by_alias=True),
+            status_code=generator.error.code,
         )
     elif isinstance(generator, ResponsesResponse):
-        return JSONResponse(content=generator.model_dump())
+        return JSONResponse(content=generator.model_dump(mode="json", by_alias=True))
 
     return StreamingResponse(
         content=_convert_stream_to_sse_events(generator), media_type="text/event-stream"
@@ -95,10 +97,11 @@ async def retrieve_responses(
 
     if isinstance(response, ErrorResponse):
         return JSONResponse(
-            content=response.model_dump(), status_code=response.error.code
+            content=response.model_dump(mode="json", by_alias=True),
+            status_code=response.error.code,
         )
     elif isinstance(response, ResponsesResponse):
-        return JSONResponse(content=response.model_dump())
+        return JSONResponse(content=response.model_dump(mode="json", by_alias=True))
     return StreamingResponse(
         content=_convert_stream_to_sse_events(response), media_type="text/event-stream"
     )
@@ -115,9 +118,10 @@ async def cancel_responses(response_id: str, raw_request: Request):
 
     if isinstance(response, ErrorResponse):
         return JSONResponse(
-            content=response.model_dump(), status_code=response.error.code
+            content=response.model_dump(mode="json", by_alias=True),
+            status_code=response.error.code,
         )
-    return JSONResponse(content=response.model_dump())
+    return JSONResponse(content=response.model_dump(mode="json", by_alias=True))
 
 
 def attach_router(app: FastAPI):

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -23,7 +23,9 @@ from openai.types.responses import (
     ResponseOutputItem,
     ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent,
+    ResponseOutputMessage,
     ResponsePrompt,
+    ResponseReasoningItem,
     ResponseReasoningTextDeltaEvent,
     ResponseReasoningTextDoneEvent,
     ResponseStatus,
@@ -106,7 +108,7 @@ def serialize_message(msg):
         return msg.to_dict()
     else:
         # fallback to pydantic dump
-        return msg.model_dump_json(by_alias=True)
+        return msg.model_dump(mode="json", by_alias=True)
 
 
 def serialize_messages(msgs):
@@ -425,18 +427,21 @@ class ResponsesRequest(OpenAIBaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def function_call_parsing(cls, data):
-        """Parse function_call dictionaries into ResponseFunctionToolCall objects.
-        This ensures Pydantic can properly resolve union types in the input field.
-        Function calls provided as dicts are converted to ResponseFunctionToolCall
-        objects before validation, while invalid structures are left for Pydantic
-        to reject with appropriate error messages.
-        """
+    def input_item_parsing(cls, data):
+        """Parse input items that are missing required fields or that Pydantic
+        cannot disambiguate in a Union of TypedDict / BaseModel types.
 
+        Specifically handles:
+        - function_call -> ResponseFunctionToolCall
+        - reasoning     -> ResponseReasoningItem (auto-generates id)
+        - message(role=assistant) -> ResponseOutputMessage (auto-generates
+          id/status and annotations)
+
+        Invalid structures are left for Pydantic to reject.
+        """
         input_data = data.get("input")
 
         # Early return for None, strings, or bytes
-        # (strings are iterable but shouldn't be processed)
         if input_data is None or isinstance(input_data, (str, bytes)):
             return data
 
@@ -450,20 +455,112 @@ class ResponsesRequest(OpenAIBaseModel):
 
         processed_input = []
         for item in input_data:
-            if isinstance(item, dict) and item.get("type") == "function_call":
+            if not isinstance(item, dict):
+                processed_input.append(item)
+                continue
+
+            item_type = item.get("type")
+
+            if item_type == "function_call":
                 try:
                     processed_input.append(ResponseFunctionToolCall(**item))
                 except ValidationError:
-                    # Let Pydantic handle validation for malformed function calls
                     logger.debug(
                         "Failed to parse function_call to ResponseFunctionToolCall, "
                         "leaving for Pydantic validation"
                     )
                     processed_input.append(item)
+
+            elif item_type == "reasoning":
+                if "id" not in item:
+                    item = {**item, "id": f"rs_{random_uuid()}"}
+                try:
+                    processed_input.append(ResponseReasoningItem(**item))
+                except ValidationError:
+                    logger.debug(
+                        "Failed to parse reasoning to ResponseReasoningItem, "
+                        "leaving for Pydantic validation"
+                    )
+                    processed_input.append(item)
+
+            elif item_type == "message" and item.get("role") == "assistant":
+                item = dict(item)
+                if "id" not in item:
+                    item["id"] = f"msg_{random_uuid()}"
+                if "status" not in item:
+                    item["status"] = "completed"
+                # Normalize content for ResponseOutputMessage
+                content = item.get("content")
+                if isinstance(content, str):
+                    item["content"] = [
+                        {"type": "output_text", "text": content, "annotations": []}
+                    ]
+                elif isinstance(content, list):
+                    new_content = []
+                    for c in content:
+                        if not isinstance(c, dict):
+                            new_content.append(c)
+                            continue
+                        c = dict(c)
+                        if c.get("type") in ("text", "input_text"):
+                            c["type"] = "output_text"
+                        if c.get("type") == "output_text" and "annotations" not in c:
+                            c["annotations"] = []
+                        new_content.append(c)
+                    item["content"] = new_content
+                try:
+                    processed_input.append(ResponseOutputMessage(**item))
+                except ValidationError:
+                    logger.debug(
+                        "Failed to parse assistant message to ResponseOutputMessage, "
+                        "leaving for Pydantic validation"
+                    )
+                    processed_input.append(item)
+
             else:
                 processed_input.append(item)
 
         data["input"] = processed_input
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_tool_usage(cls, data):
+        if not isinstance(data, dict):
+            return data
+
+        tools = data.get("tools")
+        tool_choice = data.get("tool_choice", "auto")
+        has_tools = tools is not None and len(tools) > 0
+        is_named_tool_choice = (
+            isinstance(tool_choice, dict) and tool_choice.get("type") == "function"
+        )
+
+        if not has_tools:
+            if tool_choice in ("auto", "none"):
+                data["tool_choice"] = "none"
+            elif tool_choice == "required":
+                raise VLLMValidationError(
+                    "Tool choice 'required' must be specified with 'tools' parameter.",
+                    parameter="tool_choice",
+                )
+            elif is_named_tool_choice:
+                raise VLLMValidationError(
+                    "Tool choice 'function' not found in 'tools' parameter.",
+                    parameter="tool_choice",
+                )
+        elif is_named_tool_choice and tools is not None:
+            tool_name = tool_choice.get("name")
+            tool_names = {
+                t.get("name") if isinstance(t, dict) else getattr(t, "name", None)
+                for t in tools
+            }
+            if not tool_name or tool_name not in tool_names:
+                raise VLLMValidationError(
+                    "Tool choice 'function' not found in 'tools' parameter.",
+                    parameter="tool_choice",
+                )
+
         return data
 
 

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -462,6 +462,15 @@ class ResponsesRequest(OpenAIBaseModel):
             item_type = item.get("type")
 
             if item_type == "function_call":
+                item = dict(item)
+                from vllm.entrypoints.openai.responses.utils import (
+                    normalize_function_call_arguments,
+                )
+
+                if "arguments" in item:
+                    item["arguments"] = normalize_function_call_arguments(
+                        item["arguments"]
+                    )
                 try:
                     processed_input.append(ResponseFunctionToolCall(**item))
                 except ValidationError:

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -94,8 +94,10 @@ def construct_input_messages(
 
     # Prepend the conversation history.
     if prev_msg is not None:
-        # Add the previous messages.
-        messages.extend(prev_msg)
+        # Filter out system messages from previous conversation -- per the
+        # OpenAI spec, instructions should NOT carry over across responses.
+        # The current request's instructions (if any) were already added above.
+        messages.extend(m for m in prev_msg if m.get("role") != "system")
     if prev_response_output is not None:
         # Add the previous output.
         for output_item in prev_response_output:
@@ -209,9 +211,12 @@ def _construct_single_message_from_response_item(
             "reasoning": reasoning,
         }
     elif isinstance(item, ResponseOutputMessage):
+        content_text = ""
+        if item.content:
+            content_text = item.content[0].text or ""
         return {
             "role": "assistant",
-            "content": item.content[0].text,
+            "content": content_text,
         }
     elif isinstance(item, ResponseFunctionToolCallOutputItem):
         return ChatCompletionToolMessageParam(
@@ -262,7 +267,7 @@ def convert_tool_responses_to_completions_format(tool: dict) -> dict:
 def construct_tool_dicts(
     tools: list[Tool], tool_choice: ToolChoice
 ) -> list[dict[str, Any]] | None:
-    if tools is None or (tool_choice == "none"):
+    if not tools or (tool_choice == "none"):
         tool_dicts = None
     else:
         tool_dicts = [

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
+from json import JSONDecodeError, JSONDecoder
 from typing import Any
 
 from openai.types.chat import (
@@ -27,6 +29,54 @@ from vllm.entrypoints.openai.responses.protocol import ResponseInputOutputItem
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+def normalize_function_call_arguments(arguments: Any) -> str:
+    """Normalize Responses API function_call.arguments for chat preprocessing.
+
+    Codex may send arguments as a JSON object, a valid JSON string, or a
+    string with trailing/consecutive JSON ("Extra data" for json.loads).
+    Chat preprocessing expects a single JSON object encoded as a string.
+    """
+    if arguments is None or arguments == "":
+        return "{}"
+    if isinstance(arguments, (dict, list)):
+        return json.dumps(arguments, ensure_ascii=False)
+    if not isinstance(arguments, str):
+        logger.warning(
+            "Unexpected function_call arguments type %s; using empty object.",
+            type(arguments).__name__,
+        )
+        return "{}"
+
+    content = arguments.strip()
+    if not content:
+        return "{}"
+
+    try:
+        json.loads(content)
+        return content
+    except JSONDecodeError as e:
+        if "Extra data" not in e.msg:
+            logger.warning(
+                "Invalid function_call arguments JSON: %s. Using empty object.",
+                e,
+            )
+            return "{}"
+        try:
+            parsed, _ = JSONDecoder().raw_decode(content)
+        except JSONDecodeError:
+            logger.warning(
+                "Failed to parse function_call arguments with extra data: %s. "
+                "Using empty object.",
+                e,
+            )
+            return "{}"
+        logger.warning(
+            "function_call arguments contained extra JSON data; "
+            "using the first JSON value only."
+        )
+        return json.dumps(parsed, ensure_ascii=False)
 
 
 def should_continue_final_message(
@@ -147,7 +197,7 @@ def _maybe_combine_reasoning_and_tool_call(
             id=item.call_id,
             function=FunctionCallTool(
                 name=item.name,
-                arguments=item.arguments,
+                arguments=normalize_function_call_arguments(item.arguments),
             ),
             type="function",
         )
@@ -174,23 +224,41 @@ def construct_chat_messages_with_tool_call(
     return messages
 
 
+def _construct_function_call_assistant_message(
+    *,
+    call_id: str,
+    name: str,
+    arguments: Any,
+) -> ChatCompletionAssistantMessageParam:
+    return ChatCompletionAssistantMessageParam(
+        role="assistant",
+        tool_calls=[
+            ChatCompletionMessageToolCallParam(
+                id=call_id,
+                function=FunctionCallTool(
+                    name=name,
+                    arguments=normalize_function_call_arguments(arguments),
+                ),
+                type="function",
+            )
+        ],
+    )
+
+
 def _construct_single_message_from_response_item(
     item: ResponseInputOutputItem,
 ) -> ChatCompletionMessageParam:
     if isinstance(item, ResponseFunctionToolCall):
-        # Append the function call as a tool call.
-        return ChatCompletionAssistantMessageParam(
-            role="assistant",
-            tool_calls=[
-                ChatCompletionMessageToolCallParam(
-                    id=item.call_id,
-                    function=FunctionCallTool(
-                        name=item.name,
-                        arguments=item.arguments,
-                    ),
-                    type="function",
-                )
-            ],
+        return _construct_function_call_assistant_message(
+            call_id=item.call_id,
+            name=item.name,
+            arguments=item.arguments,
+        )
+    elif isinstance(item, dict) and item.get("type") == "function_call":
+        return _construct_function_call_assistant_message(
+            call_id=item.get("call_id", ""),
+            name=item.get("name", ""),
+            arguments=item.get("arguments"),
         )
     elif isinstance(item, ResponseReasoningItem):
         reasoning = ""

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -36,6 +36,7 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
+from vllm.tool_parsers.utils import _extract_tool_info
 
 logger = init_logger(__name__)
 
@@ -127,14 +128,16 @@ class Glm4MoeModelToolParser(ToolParser):
         if tools is None:
             return False
         for tool in tools:
-            if tool.function.name != tool_name:
+            try:
+                name, params = _extract_tool_info(tool)
+            except TypeError:
                 continue
-            if tool.function.parameters is None:
+            if name != tool_name:
+                continue
+            if params is None:
                 return False
             arg_type = (
-                tool.function.parameters.get("properties", {})
-                .get(arg_name, {})
-                .get("type", None)
+                params.get("properties", {}).get(arg_name, {}).get("type", None)
             )
             return arg_type == "string"
         logger.debug("No tool named '%s'.", tool_name)


### PR DESCRIPTION
## Summary

Closes #45273

This backport fixes multi-turn **OpenAI `/v1/responses`** failures on **v0.19.1** when used with **Cursor Codex** and **GLM-5.1-FP8**. Single-turn requests work; multi-turn sessions with assistant history and tool calls fail with 400/500 errors.

### 1. Root cause

On v0.19.1, the Responses API request pipeline does not handle Codex-compatible multi-turn `input` items correctly:

| Layer | Problem |
|-------|---------|
| `responses/protocol.py` | `function_call_parsing` only handles `function_call`; historical `assistant` / `reasoning` messages fail Pydantic Union validation (`Field required: status`) → **400 Bad Request** |
| `responses/utils.py` | `_construct_single_message_from_response_item` assumes non-empty `content[0]` → **500 IndexError** when Codex sends empty assistant content |
| `responses/utils.py` | Stateful multi-turn leaks prior `system` instructions; `tools=[]` not handled consistently |
| `responses/api_router.py` | Response serialization missing `by_alias=True` |
| `tool_parsers/glm4_moe_tool_parser.py` | Expects Chat Completions tool schema (`tool.function.name`) but Responses API passes `FunctionTool` (`tool.name`) → streaming tool-call crash |
| `entrypoints/chat_utils.py` | `json.loads` on malformed historical `function_call.arguments` → **JSONDecodeError: Extra data** |

v0.21.0 partially fixed assistant parsing via `input_item_parsing`, but GLM-5.1 deployments are pinned to v0.19.1 due to model compatibility.

### 2. Fix approach

Minimal backport from v0.21.0 patterns plus Codex-specific hardening:

- **`protocol.py`**: Replace `function_call_parsing` with `input_item_parsing`; add `check_tool_usage`; normalize `function_call.arguments`
- **`utils.py`**: Defensive empty-content handling; filter leaked system messages; fix `construct_tool_dicts` for empty tools
- **`api_router.py`**: Add `by_alias=True` to JSON/SSE responses; fix `serialize_message` return type
- **`glm4_moe_tool_parser.py`**: Support both `FunctionTool` and Chat Completions tool formats via `_extract_tool_info`
- **`chat_utils.py`**: Add `_parse_tool_call_arguments` with `raw_decode` fallback for trailing extra data

### 3. Test verification

**Production integration (GLM-5.1-FP8, 2×8×H800, v0.19.1 Docker):**

- Multi-turn Codex conversations with assistant history — no 400/500
- Long-running agent sessions with tool calls — stable
- Before/after screenshots in #45273

**Unit tests added:**

```bash
pytest tests/entrypoints/openai/responses/test_function_call_parsing.py \
       tests/entrypoints/openai/responses/test_responses_utils.py \
       tests/tool_use/test_responses_request_validations.py \
       tests/tool_parsers/test_glm4_moe_tool_parser.py -v
```

**Minimal curl repro (Symptom 1):**

```bash
curl -X POST http://<host>:8001/v1/responses \
  -H "Content-Type: application/json" \
  -d '{
    "model": "GLM-5.1-FP8",
    "input": [
      {"type": "message", "role": "user",
       "content": [{"type": "input_text", "text": "Hello"}]},
      {"type": "message", "role": "assistant",
       "content": [{"type": "output_text", "text": "Hi there!"}]},
      {"type": "message", "role": "user",
       "content": [{"type": "input_text", "text": "Continue"}]}
    ]
  }'
```

Before patch: **400 Bad Request**. After patch: **200 OK**.

### 4. Compatibility

- Changes are scoped to **Responses API request parsing**, **response serialization**, **GLM tool parser compatibility**, and **tool-call argument normalization**
- Does not modify model kernels, scheduler, or inference logic
- Chat Completions API behavior is unchanged
- Other models using Responses API with similar multi-turn input formats should also benefit

### 5. AI-assisted disclosure

This patch was developed with AI assistance (Cursor). All changes were reviewed and validated end-to-end on a production GLM-5.1 deployment. Commits include `Co-authored-by: Cursor <cursoragent@cursor.com>` trailers per project policy.

## Changed files

```
 vllm/entrypoints/openai/responses/protocol.py
 vllm/entrypoints/openai/responses/utils.py
 vllm/entrypoints/openai/responses/api_router.py
 vllm/tool_parsers/glm4_moe_tool_parser.py
 vllm/entrypoints/chat_utils.py
 + 4 test files
```

## Test plan

- [x] Multi-turn Codex session with GLM-5.1-FP8 on v0.19.1 (production H800 cluster)
- [x] Multi-turn tool calling via Codex
- [x] curl repro for assistant history 400 → 200
- [ ] CI unit tests (added; pending upstream CI run)
