### PR TITLE
[CI][Bugfix] Un-skip musicflamingo audio feature test for transformers >= 5.5

### DIFF
--- a/tests/models/multimodal/processing/test_musicflamingo.py
+++ b/tests/models/multimodal/processing/test_musicflamingo.py
@@ -17,13 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.metadata import version
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 import torch
-from packaging.version import Version
 from transformers import PretrainedConfig
 
 from tests.models.registry import HF_EXAMPLE_MODELS
@@ -124,12 +122,9 @@ def test_musicflamingo_dummy_text_uses_plain_audio_tokens(mock_ctx):
     assert builder.get_dummy_text({"audio": 2}) == "<sound><sound>"
 
 
-@pytest.mark.skipif(
-    Version(version("transformers")) >= Version("5.5"),
-    reason="transformers v5.5 added native MusicFlamingoForConditionalGeneration "
-    "with a different get_audio_features signature (requires input_ids)",
-)
-def test_musicflamingo_audio_feature_pipeline_matches_hf_small_config():
+def test_musicflamingo_audio_feature_pipeline_matches_hf_small_config(
+    default_vllm_config,
+):
     from transformers.models.musicflamingo import (
         modeling_musicflamingo as hf_musicflamingo_modeling,
     )
@@ -162,6 +157,7 @@ def test_musicflamingo_audio_feature_pipeline_matches_hf_small_config():
         "use_mrope": False,
     }
     audio_config = {
+        "model_type": "musicflamingo_encoder",
         "hidden_size": 16,
         "num_attention_heads": 4,
         "intermediate_size": 32,
@@ -187,28 +183,44 @@ def test_musicflamingo_audio_feature_pipeline_matches_hf_small_config():
     ).eval()
 
     vllm_encoder = MusicFlamingoEncoder(config.audio_config).eval()
-    vllm_encoder.load_state_dict(hf_model.audio_tower.state_dict())
+    vllm_encoder.load_state_dict(hf_model.model.audio_tower.state_dict())
 
     vllm_projector = MusicFlamingoMultiModalProjector(config).eval()
-    vllm_projector.load_state_dict(hf_model.multi_modal_projector.state_dict())
+    vllm_projector.load_state_dict(hf_model.model.multi_modal_projector.state_dict())
 
     vllm_rope = MusicFlamingoRotaryEmbedding(config).eval()
-    vllm_rope.load_state_dict(hf_model.pos_emb.state_dict(), strict=False)
+    vllm_rope.load_state_dict(hf_model.model.pos_emb.state_dict(), strict=False)
 
+    # Model one audio split into three consecutive 30s windows (the production
+    # chunking scenario): full, full, and a partial final chunk. Each batch row
+    # is window i of the same sample, so its timestamps start at i * 30s.
     input_features = torch.randn(3, 80, 3000)
     feature_attention_mask = torch.zeros(3, 3000, dtype=torch.bool)
     feature_attention_mask[0, :3000] = True
-    feature_attention_mask[1, :2500] = True
+    feature_attention_mask[1, :3000] = True
     feature_attention_mask[2, :1500] = True
-    rote_timestamps = (
-        torch.arange(750, dtype=torch.float32).unsqueeze(0).repeat(3, 1) * 0.04
+    frame_offsets = torch.arange(750, dtype=torch.float32) * 0.04
+    window_starts = torch.arange(3, dtype=torch.float32) * (750 * 0.04)
+    rote_timestamps = window_starts.unsqueeze(1) + frame_offsets.unsqueeze(0)
+
+    # transformers >= 5.5 reconstructs rotary timestamps from runs of audio
+    # placeholder tokens in input_ids instead of accepting them directly: a
+    # single run spanning all three chunks' post-conv output lengths marks the
+    # rows as windows 0, 1 and 2 of one sample, reproducing the explicit
+    # window_start + arange(n) * frame_step timestamps used for the vLLM path.
+    _, post_lengths = hf_model.model.audio_tower._get_feat_extract_output_lengths(
+        feature_attention_mask.sum(-1).to(torch.long)
     )
+    separator = torch.tensor([config.text_config.pad_token_id], dtype=torch.long)
+    audio_run = torch.full(
+        (int(post_lengths.sum()),), config.audio_token_id, dtype=torch.long
+    )
+    input_ids = torch.cat([separator, audio_run, separator]).unsqueeze(0)
 
     hf_output = hf_model.get_audio_features(
         input_features,
         feature_attention_mask,
-        rote_timestamps=rote_timestamps,
-        return_dict=True,
+        input_ids,
     ).pooler_output
     vllm_attention_mask = _build_audio_encoder_attention_mask(
         feature_attention_mask,


### PR DESCRIPTION
## Purpose

Part of #38379 (claimed in https://github.com/vllm-project/vllm/issues/38379#issuecomment-4681071108). Removes the permanent skip on `test_musicflamingo_audio_feature_pipeline_matches_hf_small_config`: the test was gated on `transformers < 5.5`, but `requirements/common.txt` pins `transformers >= 5.5.3`, so it never ran.

The native `MusicFlamingoForConditionalGeneration` added in transformers v5.5 changed `get_audio_features` to reconstruct rotary timestamps from runs of audio placeholder tokens in `input_ids` (via `_build_audio_timestamps`) instead of accepting `rote_timestamps` directly. This PR rewrites the HF reference call for the new API and fixes the other v5 incompatibilities that surfaced once the test ran:

- `audio_config` dicts now require `model_type`
- submodules moved under `hf_model.model.*`
- direct module instantiation requires the `default_vllm_config` fixture

It also restructures the scenario as one audio split into three consecutive 30s windows (full, full, partial). The previous three-independent-samples setup relied on vLLM's `MusicFlamingoRotaryEmbedding` deriving the window axis from the batch row index; the native implementation derives it from timestamps (`round(window_start / window_duration)`), so the two silently disagreed for independent samples all starting at t=0. The chunked-single-audio case is the production scenario and the one where both formulations provably agree — reviewers may want to track the multi-audio-batch window-axis question separately.

## Non-duplication

No open PR addresses this tracker item or touches `test_musicflamingo.py`: #41532 gates ROCm CI references and #39011 adds Audio Flamingo Next checkpoint support — both unrelated to this test.

## Test Plan

```
pytest tests/models/multimodal/processing/test_musicflamingo.py -v
```

Run locally on a CPU source build (`VLLM_TARGET_DEVICE=cpu`, macOS arm64) with transformers 5.11.0.

## Test Result

```
test_musicflamingo_chunk_counting_uses_rote_timestamps PASSED
test_musicflamingo_dummy_text_uses_plain_audio_tokens PASSED
test_musicflamingo_audio_feature_pipeline_matches_hf_small_config PASSED
3 passed
```

Before this change the third test was always skipped; with only the skip removed (no other changes) it fails on the v5.5+ API (`get_audio_features` signature, config validation, module layout).

## AI assistance disclosure

AI assistance (Claude) was used in developing this change. I have reviewed every changed line and run the tests listed above.

