### PR TITLE
[Model][Transformers backend] Fuse q/k/v and gate/up linear groups

### DIFF
--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -51,6 +51,11 @@ from vllm.model_executor.models.interfaces import (
     SupportsQuant,
 )
 from vllm.model_executor.models.interfaces_base import VllmModel
+from vllm.model_executor.models.transformers.fusion import (
+    FusedGroup,
+    apply_fused_linears,
+    stacked_params_mapping_from_groups,
+)
 from vllm.model_executor.models.transformers.utils import (
     can_enable_torch_compile,
     get_feature_request_tip,
@@ -177,6 +182,16 @@ class Base(
         self._create_hf_to_vllm_mapper()
         # Remove layers not on this pipeline parallel rank
         self.pipeline_parallel()
+        # Fuse q/k/v and gate/up linear groups before per-Linear replacement so
+        # we can emit packed vLLM layers (QKVParallelLinear, MergedColumnParallel)
+        # in place of multiple unfused colwise Linears.
+        self._fused_groups: list[FusedGroup] = self._fuse_linear_groups()
+        n_qkv = sum(1 for g in self._fused_groups if g.kind == "qkv")
+        n_gu = sum(1 for g in self._fused_groups if g.kind == "gate_up")
+        if n_qkv or n_gu:
+            logger.info(
+                "Transformers backend fused linear groups: "
+                "qkv=%d, gate_up=%d", n_qkv, n_gu)
         # Substitute remaining layers with vLLM's layers as needed
         self.recursive_replace()
         # Create attention instances for KV cache allocation
@@ -428,6 +443,31 @@ class Base(
                 # attrsetter in case the module is nested (e.g. "text_model.norm")
                 attrsetter(name)(self.model, PPMissingLayer())
 
+    def _fuse_linear_groups(self) -> list[FusedGroup]:
+        """Run the structural q/k/v + gate/up fusion pass before per-Linear
+        replacement. Returns the list of groups that were fused (used by
+        load_weights to plumb checkpoint shards into the packed weights).
+        """
+        tp_plan = getattr(self.model, "tp_plan", None) or {}
+        head_dim = self.model_config.get_head_size()
+        num_attention_heads = getattr(
+            self.text_config, "num_attention_heads", None
+        )
+        num_key_value_heads = getattr(
+            self.text_config, "num_key_value_heads", num_attention_heads
+        )
+        if num_attention_heads is None:
+            return []
+        return apply_fused_linears(
+            self.model,
+            tp_plan=tp_plan,
+            quant_config=self.quant_config,
+            head_dim=head_dim,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            prefix="model",
+        )
+
     def recursive_replace(self):
         """Recursively replace modules in the model as needed.
 
@@ -658,7 +698,52 @@ class Base(
             ignore_unexpected_prefixes=self.ignore_unexpected_prefixes,
             ignore_unexpected_suffixes=self.ignore_unexpected_suffixes,
         )
+        # If we fused any q/k/v or gate/up groups, route the matching checkpoint
+        # weights to the packed layer's sharded weight_loader manually, and let
+        # AutoWeightsLoader handle everything else.
+        stacked_mapping = stacked_params_mapping_from_groups(self._fused_groups)
+        if stacked_mapping:
+            params_dict = dict(self.named_parameters())
+            extra_loaded: set[str] = set()
+            weights = self._stream_with_fused_shards(
+                weights, stacked_mapping, params_dict, extra_loaded
+            )
+            autoloaded = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+            return autoloaded | extra_loaded
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+    def _stream_with_fused_shards(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+        stacked_mapping: list[tuple[str, str, "str | int"]],
+        params_dict: dict[str, torch.nn.Parameter],
+        loaded_out: set[str],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        """Filter weights stream: weights matching a fused source pattern are
+        loaded directly into the packed param via shard_id; the rest are
+        yielded for AutoWeightsLoader to handle.
+        """
+        # Apply the same name mapping AutoWeightsLoader would, so the names we
+        # match against are post-rename (e.g. "model.layers.0.self_attn.q_proj.weight").
+        weights = self.hf_to_vllm_mapper.apply(weights)
+        for name, w in weights:
+            matched = False
+            for fused_short, source_short, shard_id in stacked_mapping:
+                if source_short not in name:
+                    continue
+                fused_name = name.replace(source_short, fused_short)
+                if fused_name not in params_dict:
+                    continue
+                param = params_dict[fused_name]
+                weight_loader = getattr(param, "weight_loader", None)
+                if weight_loader is None:
+                    continue
+                weight_loader(param, w, shard_id)
+                loaded_out.add(fused_name)
+                matched = True
+                break
+            if not matched:
+                yield name, w
 
     @staticmethod
     def check_version(min_version: str, feature: str):

--- a/vllm/model_executor/models/transformers/fusion.py
+++ b/vllm/model_executor/models/transformers/fusion.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Copyright 2024 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fuse common Linear groups in HF modules into vLLM packed layers.
+
+Detects the canonical SwiGLU MLP shape (gate_proj/up_proj sharing input,
+followed by down_proj) and the canonical attention QKV shape (q_proj/k_proj/
+v_proj sharing input, followed by o_proj) and replaces them with vLLM's
+QKVParallelLinear / MergedColumnParallelLinear, then rebinds the parent
+module's forward to call the fused projection once instead of 2-3 times.
+
+Detection is structural: child module names + Linear shapes. We additionally
+require that the children that *will* be fused are listed in the model's
+tp_plan as colwise — this prevents accidentally fusing layers that were
+intentionally not column-parallel-shardable.
+
+Models without the canonical naming or shape just don't match and fall
+through to the existing per-Linear replacement path.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import regex as re
+import torch
+from torch import nn
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+)
+from vllm.model_executor.models.utils import maybe_prefix
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization import QuantizationConfig
+
+logger = init_logger(__name__)
+
+
+# Records what was fused, used to drive weight loading. One per fused group.
+class FusedGroup:
+    __slots__ = ("kind", "fused_qualname", "source_qualnames")
+
+    def __init__(self, kind: str, fused_qualname: str, source_qualnames: list[str]):
+        # kind: "qkv" or "gate_up"
+        self.kind = kind
+        self.fused_qualname = fused_qualname  # e.g. "model.layers.0.self_attn.qkv_proj"
+        self.source_qualnames = source_qualnames  # e.g. ["...q_proj", "...k_proj", "...v_proj"]
+
+
+def _tp_plan_matches(qualname: str, style: str, tp_plan: dict[str, str]) -> bool:
+    """Return True iff `qualname` matches a tp_plan entry with the given style."""
+    for pattern, plan_style in tp_plan.items():
+        if plan_style != style:
+            continue
+        if re.match(pattern, qualname):
+            return True
+    return False
+
+
+def _get_act_fn_name(parent: nn.Module) -> str | None:
+    """Return the canonical activation name for a parent that has an act_fn."""
+    act = getattr(parent, "act_fn", None)
+    if act is None:
+        return None
+    # ACT2FN entries are torch.nn modules (e.g. SiLUActivation). Fall back to class name.
+    return type(act).__name__.lower()
+
+
+def _is_silu(parent: nn.Module) -> bool:
+    name = _get_act_fn_name(parent)
+    if name is None:
+        return False
+    return "silu" in name or "swish" in name
+
+
+def apply_fused_linears(
+    model: nn.Module,
+    tp_plan: dict[str, str],
+    quant_config: "QuantizationConfig | None",
+    *,
+    head_dim: int,
+    num_attention_heads: int,
+    num_key_value_heads: int,
+    prefix: str = "model",
+) -> list[FusedGroup]:
+    """Walk `model` and replace fusable {q,k,v}/{gate,up} groups with packed layers.
+
+    Returns the list of fused groups (used by weight loading to map checkpoint
+    names to fused layer shards).
+    """
+    # tp_plan keys live without the "model." prefix; we walk starting at `model`
+    # and use qualnames *with* that prefix, so prefix tp_plan to match.
+    tp_plan = {maybe_prefix("model", k): v for k, v in tp_plan.items()}
+
+    fused: list[FusedGroup] = []
+
+    def _walk(module: nn.Module, qualprefix: str) -> None:
+        # Try to fuse children of this module before recursing.
+        _maybe_fuse_qkv(module, qualprefix, tp_plan, quant_config,
+                        head_dim, num_attention_heads, num_key_value_heads, fused)
+        _maybe_fuse_gate_up(module, qualprefix, tp_plan, quant_config, fused)
+        for child_name, child in module.named_children():
+            child_qual = maybe_prefix(qualprefix, child_name)
+            _walk(child, child_qual)
+
+    _walk(model, prefix)
+    return fused
+
+
+# ---------------------------------------------------------------------------
+# QKV fusion
+# ---------------------------------------------------------------------------
+
+
+def _maybe_fuse_qkv(
+    parent: nn.Module,
+    parent_qual: str,
+    tp_plan: dict[str, str],
+    quant_config: "QuantizationConfig | None",
+    head_dim: int,
+    num_attention_heads: int,
+    num_key_value_heads: int,
+    fused: list[FusedGroup],
+) -> None:
+    children = dict(parent.named_children())
+    if not all(n in children for n in ("q_proj", "k_proj", "v_proj")):
+        return
+    q, k, v = children["q_proj"], children["k_proj"], children["v_proj"]
+    # All three must be plain nn.Linear (not yet replaced) and share in_features.
+    if not all(isinstance(m, nn.Linear) for m in (q, k, v)):
+        return
+    if not (q.in_features == k.in_features == v.in_features):
+        return
+    # tp_plan must mark all three as colwise.
+    q_qual = maybe_prefix(parent_qual, "q_proj")
+    k_qual = maybe_prefix(parent_qual, "k_proj")
+    v_qual = maybe_prefix(parent_qual, "v_proj")
+    if not all(_tp_plan_matches(qn, "colwise", tp_plan) for qn in (q_qual, k_qual, v_qual)):
+        return
+    # Sanity-check shapes against config.
+    expected_q = num_attention_heads * head_dim
+    expected_kv = num_key_value_heads * head_dim
+    if (q.out_features, k.out_features, v.out_features) != (expected_q, expected_kv, expected_kv):
+        # Non-standard head shape; bail out rather than risk wrong sharding.
+        return
+    has_bias = q.bias is not None
+    if (k.bias is not None) != has_bias or (v.bias is not None) != has_bias:
+        return  # all three must agree on bias
+
+    fused_qual = maybe_prefix(parent_qual, "qkv_proj")
+    qkv = QKVParallelLinear(
+        hidden_size=q.in_features,
+        head_size=head_dim,
+        total_num_heads=num_attention_heads,
+        total_num_kv_heads=num_key_value_heads,
+        bias=has_bias,
+        quant_config=quant_config,
+        prefix=fused_qual,
+        return_bias=False,
+    )
+
+    # Stash q/k/v output sizes (per-rank) for forward-time split.
+    q_size = qkv.num_heads * qkv.head_size
+    kv_size = qkv.num_kv_heads * qkv.head_size
+
+    # Install on parent and remove the originals so HF doesn't iterate them.
+    parent.qkv_proj = qkv
+    del parent.q_proj
+    del parent.k_proj
+    del parent.v_proj
+
+    parent._fused_qkv_q_size = q_size
+    parent._fused_qkv_kv_size = kv_size
+    parent._fused_qkv_head_dim = head_dim
+
+    # Rebind forward.
+    parent.forward = _fused_attention_forward.__get__(parent, type(parent))
+
+    fused.append(FusedGroup(
+        kind="qkv",
+        fused_qualname=fused_qual,
+        source_qualnames=[q_qual, k_qual, v_qual],
+    ))
+    logger.debug("Fused QKV at %s", parent_qual)
+
+
+def _fused_attention_forward(
+    self,
+    hidden_states: torch.Tensor,
+    position_embeddings=None,
+    attention_mask=None,
+    past_key_values=None,
+    **kwargs,
+):
+    """Drop-in replacement for HF attention.forward that calls qkv_proj once.
+
+    Mirrors the canonical HF decoder attention pattern (granite/llama/qwen2/
+    qwen3/mistral): project hidden_states -> [q;k;v], split, reshape into
+    head layout, optional rotary, dispatch to attention_interface (which will
+    be vllm_flash_attention_forward in this backend), o_proj.
+    """
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+    qkv = self.qkv_proj(hidden_states)
+    q_size = self._fused_qkv_q_size
+    kv_size = self._fused_qkv_kv_size
+    q, k, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
+
+    head_dim = self._fused_qkv_head_dim
+    input_shape = hidden_states.shape[:-1]
+    # [batch, seq, num_heads, head_dim] -> [batch, num_heads, seq, head_dim]
+    query_states = q.view(*input_shape, -1, head_dim).transpose(1, 2)
+    key_states = k.view(*input_shape, -1, head_dim).transpose(1, 2)
+    value_states = v.view(*input_shape, -1, head_dim).transpose(1, 2)
+
+    if position_embeddings is not None:
+        # Lazy import to avoid forcing a transformers dep at module load.
+        from transformers.models.granite.modeling_granite import apply_rotary_pos_emb
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+    # No-op for vLLM (no past_key_values cache - vLLM owns the KV cache).
+    if past_key_values is not None:
+        key_states, value_states = past_key_values.update(
+            key_states, value_states, self.layer_idx
+        )
+
+    attention_interface = ALL_ATTENTION_FUNCTIONS.get_interface(
+        self.config._attn_implementation, None
+    )
+    # Pass attention_multiplier (granite) / standard scaling.
+    scaling = getattr(self, "scaling", None)
+    attn_output, attn_weights = attention_interface(
+        self,
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        dropout=0.0,
+        scaling=scaling,
+        **kwargs,
+    )
+
+    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+    attn_output = self.o_proj(attn_output)
+    return attn_output, attn_weights
+
+
+# ---------------------------------------------------------------------------
+# gate/up fusion
+# ---------------------------------------------------------------------------
+
+
+def _maybe_fuse_gate_up(
+    parent: nn.Module,
+    parent_qual: str,
+    tp_plan: dict[str, str],
+    quant_config: "QuantizationConfig | None",
+    fused: list[FusedGroup],
+) -> None:
+    children = dict(parent.named_children())
+    if not all(n in children for n in ("gate_proj", "up_proj", "down_proj")):
+        return
+    gate, up, down = children["gate_proj"], children["up_proj"], children["down_proj"]
+    if not all(isinstance(m, nn.Linear) for m in (gate, up, down)):
+        return
+    if gate.in_features != up.in_features:
+        return
+    if gate.out_features != up.out_features:
+        return
+    if not _is_silu(parent):
+        return
+    gate_qual = maybe_prefix(parent_qual, "gate_proj")
+    up_qual = maybe_prefix(parent_qual, "up_proj")
+    if not all(_tp_plan_matches(qn, "colwise", tp_plan) for qn in (gate_qual, up_qual)):
+        return
+    has_bias = gate.bias is not None
+    if (up.bias is not None) != has_bias:
+        return
+
+    fused_qual = maybe_prefix(parent_qual, "gate_up_proj")
+    gate_up = MergedColumnParallelLinear(
+        input_size=gate.in_features,
+        output_sizes=[gate.out_features, up.out_features],
+        bias=has_bias,
+        quant_config=quant_config,
+        prefix=fused_qual,
+        return_bias=False,
+    )
+
+    parent.gate_up_proj = gate_up
+    del parent.gate_proj
+    del parent.up_proj
+
+    if not hasattr(parent, "_silu_and_mul"):
+        parent.add_module("_silu_and_mul", SiluAndMul())
+    parent.forward = _fused_mlp_forward.__get__(parent, type(parent))
+
+    fused.append(FusedGroup(
+        kind="gate_up",
+        fused_qualname=fused_qual,
+        source_qualnames=[gate_qual, up_qual],
+    ))
+    logger.debug("Fused gate/up at %s", parent_qual)
+
+
+def _fused_mlp_forward(self, x: torch.Tensor) -> torch.Tensor:
+    gate_up = self.gate_up_proj(x)
+    out = self._silu_and_mul(gate_up)
+    return self.down_proj(out)
+
+
+# ---------------------------------------------------------------------------
+# Weight loading helpers
+# ---------------------------------------------------------------------------
+
+
+def stacked_params_mapping_from_groups(
+    groups: list[FusedGroup],
+) -> list[tuple[str, str, "str | int"]]:
+    """Build a (fused_suffix, source_suffix, shard_id) list usable by the
+    standard vLLM weight-loading loop.
+
+    We deduplicate by (fused_short, source_short) so we emit one mapping per
+    distinct (fused_proj, source_proj) shape regardless of how many layers
+    share it.
+    """
+    QKV_IDS = {"q_proj": "q", "k_proj": "k", "v_proj": "v"}
+    GATE_UP_IDS = {"gate_proj": 0, "up_proj": 1}
+
+    seen: set[tuple[str, str]] = set()
+    out: list[tuple[str, str, "str | int"]] = []
+    for g in groups:
+        for src in g.source_qualnames:
+            src_short = "." + src.rsplit(".", 1)[-1]
+            fused_short = "." + g.fused_qualname.rsplit(".", 1)[-1]
+            key = (fused_short, src_short)
+            if key in seen:
+                continue
+            seen.add(key)
+            if g.kind == "qkv":
+                shard_id = QKV_IDS[src_short.lstrip(".")]
+            else:
+                shard_id = GATE_UP_IDS[src_short.lstrip(".")]
+            out.append((fused_short, src_short, shard_id))
+    return out


### PR DESCRIPTION
(this is result of an investigation I did with Claude, just putting up as draft for reference)

## Summary

Closes the steady-state per-step compute gap between the vLLM transformers
modeling backend and native vLLM models on dense decoders, by fusing the
canonical attention QKV triplet and the canonical SwiGLU MLP pair into
packed vLLM layers (`QKVParallelLinear`, `MergedColumnParallelLinear`).

## Why

Worker-level kernel profiling on `granite-4.1-8b` (TP=4, ShareGPT, rate=8)
showed the transformers backend doing ~5x more split-K reduction kernels
and ~2.4x more `aten::mm` calls than the native path on the same workload.
Cause: HF modeling does separate `q_proj`/`k_proj`/`v_proj` matmuls (and
separate `gate_proj`/`up_proj`), so cuBLAS picks a split-K strategy for
each small-M decode-shape GEMM and emits a separate reduction kernel per
GEMM. Native vLLM models pre-fuse these into one matmul each, paying the
launch + reduction cost once per layer.

`torch.compile` cannot fix this: fusing parallel matmuls requires
concatenating parameter storage, which is a layout decision outside the
compiler's contract. So the layer that owns module construction has to
do it. In the transformers-backend case, that layer is the backend
itself.

## What this changes

- New `vllm/model_executor/models/transformers/fusion.py`:
  - Walks the HF model and detects `q_proj/k_proj/v_proj` triplets
    (sibling `nn.Linear`s sharing `in_features`, all listed as `colwise`
    in `model.tp_plan`) and `gate_proj/up_proj` pairs (siblings with
    matching shapes, sibling `down_proj`, silu/swish activation, both
    `colwise`).
  - Replaces each detected group with one `QKVParallelLinear` /
    `MergedColumnParallelLinear`, removes the original child Linears,
    and rebinds the parent module's `forward` to a generic
    implementation that calls the fused projection once and splits.
    The generic forward mirrors the canonical HF decoder
    attention/MLP shape (works on granite, llama, qwen2/3, mistral,
    deepseek, phi, gemma, etc. — anything using the standard naming).
  - Detection is structural and tp-plan-driven, not arch-specific.
    Models without canonical naming or already-fused projections fall
    through unchanged.

- `vllm/model_executor/models/transformers/base.py`:
  - Calls the fusion pass after `pipeline_parallel` and before
    `recursive_replace` so the per-Linear replacement only sees the
    layers we didn't fuse.
  - Overrides `load_weights` to route matching checkpoint shards
    (`q_proj.weight`, `k_proj.weight`, …) to the packed param's
    sharded `weight_loader` with the appropriate `shard_id` before
    handing the rest to `AutoWeightsLoader`.

## Validation

`granite-4.1-8b`, 4× H100, TP=4, bf16, ShareGPT, 500 prompts, rate=8:

| metric              | native | transformers (was) | transformers (this PR) |
| ------------------- | ------:| ------------------:| ----------------------:|
| `median_ttft_ms`    |  16.12 |     18.87 (+17%)   |        16.14 (+0.1%)   |
| `median_itl_ms`     |   3.53 |      4.43 (+26%)   |         3.51 (-0.4%)   |
| `p99_itl_ms`        |   6.12 |      7.67 (+24%)   |         6.21 (+1.5%)   |
| `output_throughput` | 1378.5 |   1326.3 (-3.8%)   |      1333.2 (-3.3%)    |

Greedy decode at TP=1 is **token-identical** to native vLLM on three
sanity prompts. On `granite-4.1-8b`, 40 QKV groups + 40 gate/up groups
are fused on each TP rank (one per layer × 40 layers).

## Known follow-ups (not in this PR)

- `mean_ttft_ms` (+22%) and `p99_ttft_ms` (+235%) regress slightly —
  median TTFT is at parity, so a small number of outlier prefills hit
  a slow path, almost certainly first-time compilation on the rebound
  forward not covered by the warmup trace. Worth a separate look.
- Output throughput is still ~3% under native; that gap is now
  scheduler-side, not compute-side, given the per-step ITL parity.

## Test plan

- [ ] CI green on the transformers-backend test paths
- [ ] Spot-check parity on llama / qwen3 dense (same canonical naming)
- [ ] Spot-check that models *not* matching the pattern (e.g.
      `granite-moe-hybrid` whose MLP is already pre-fused as
      `input_linear`) fall through unchanged