### PR TITLE
[Bugfix][Frontend] Constrain forced named tool choice with empty parameters to a JSON object

### DIFF
--- a/tests/tool_use/test_tool_choice_required.py
+++ b/tests/tool_use/test_tool_choice_required.py
@@ -5,10 +5,11 @@ from copy import deepcopy
 
 import pytest
 import regex as re
-from openai.types.responses import FunctionTool, WebSearchTool
+from openai.types.responses import FunctionTool, ToolChoiceFunction, WebSearchTool
 from pydantic import TypeAdapter
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionToolsParam,
 )
 from vllm.tool_parsers.streaming import extract_required_tool_call_streaming
@@ -392,3 +393,27 @@ class TestNonFunctionToolsSkipped:
         any_of = schema["items"]["anyOf"]
         assert len(any_of) == 1
         assert any_of[0]["properties"]["name"]["enum"] == ["get_weather"]
+
+
+class TestForcedNamedToolChoiceEmptyParams:
+    """A forced named tool_choice with missing/empty parameters must still
+    constrain the generated arguments to a JSON object, like the
+    `tool_choice="required"` path, instead of leaving them unconstrained."""
+
+    @pytest.mark.parametrize("params", [None, {}])
+    def test_chat_empty_params_constrains_object(self, params):
+        tool = ChatCompletionToolsParam.model_validate(
+            {"type": "function", "function": {"name": "ping", "parameters": params}}
+        )
+        choice = ChatCompletionNamedToolChoiceParam.model_validate(
+            {"type": "function", "function": {"name": "ping"}}
+        )
+        schema = get_json_schema_from_tools(choice, [tool])
+        assert schema == {"type": "object", "properties": {}}
+
+    @pytest.mark.parametrize("params", [None, {}])
+    def test_responses_empty_params_constrains_object(self, params):
+        tool = FunctionTool(type="function", name="ping", parameters=params)
+        choice = ToolChoiceFunction(type="function", name="ping")
+        schema = get_json_schema_from_tools(choice, [tool])
+        assert schema == {"type": "object", "properties": {}}

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -182,9 +182,14 @@ def find_tool_properties(
     return {}
 
 
+def _params_or_empty_object(params: dict | None) -> dict:
+    # Empty/missing parameters still constrain arguments to a JSON object.
+    return params if params else {"type": "object", "properties": {}}
+
+
 def _get_tool_schema_from_tool(tool: Tool) -> dict:
     name, params = _extract_tool_info(tool)
-    params = params if params else {"type": "object", "properties": {}}
+    params = _params_or_empty_object(params)
     return {
         "properties": {
             "name": {"type": "string", "enum": [name]},
@@ -246,7 +251,7 @@ def get_json_schema_from_tools(
         tool_map = {tool.name: tool for tool in tools if isinstance(tool, FunctionTool)}
         if tool_name not in tool_map:
             raise ValueError(f"Tool '{tool_name}' has not been passed in `tools`.")
-        return tool_map[tool_name].parameters
+        return _params_or_empty_object(tool_map[tool_name].parameters)
     # tool_choice: Forced Function (ChatCompletion)
     if (not isinstance(tool_choice, str)) and isinstance(
         tool_choice, ChatCompletionNamedToolChoiceParam
@@ -259,7 +264,7 @@ def get_json_schema_from_tools(
         }
         if tool_name not in tool_map:
             raise ValueError(f"Tool '{tool_name}' has not been passed in `tools`.")
-        return tool_map[tool_name].function.parameters
+        return _params_or_empty_object(tool_map[tool_name].function.parameters)
     # tool_choice: "required"
     if tool_choice == "required":
         return _get_json_schema_from_tools(tools)


### PR DESCRIPTION

## Purpose

For a forced named `tool_choice`, `get_json_schema_from_tools` returns the tool's `function.parameters` directly:

```python
return tool_map[tool_name].function.parameters
```

When a tool declares no parameters, that is `None` (no guided decoding, so the generated arguments are free-form text) or `{}` (an unconstrained schema, so the arguments can be any JSON value, not necessarily an object). The `required` tool_choice path already normalizes falsey parameters via `_get_tool_schema_from_tool`:

```python
params = params if params else {"type": "object", "properties": {}}
```

Apply the same normalization to both the Responses and ChatCompletion forced-named paths, so the generated arguments are constrained to a JSON object even when the tool declares no parameters. To avoid repeating the literal in three places, the normalization is factored into a small `_params_or_empty_object()` helper reused by `_get_tool_schema_from_tool` and both forced-named branches (it returns a fresh dict, since callers such as `_get_tool_schema_defs` mutate the result).

## Test Plan

```bash
pytest tests/tool_use/test_tool_choice_required.py
```

Added a `TestForcedNamedToolChoiceEmptyParams` class to the existing `tests/tool_use/test_tool_choice_required.py` (the home for `get_json_schema_from_tools`), next to `TestNonFunctionToolsSkipped` and following its style. Both forced-named paths get a `parameters in (None, {})` case asserting `{"type": "object", "properties": {}}`.

## Test Result

With the fix all four cases pass; reverting the fix fails all four (the schema is `None` or `{}`). Full pre-commit (ruff, format, mypy, typos, SPDX) clean. (A800, base `55911db5`, patch applies clean.)

Confirmed end-to-end on a real engine (A800, `vllm serve Qwen3-4B`, a tool with empty `parameters` and `tool_choice` forcing that tool). Because the unconstrained branch returned no object schema, the model emitted a **bare JSON string, not an object**, as the tool arguments — reproduced on **both forced-named branches the fix touches**:

| path | stock main (arguments) | with fix |
| --- | --- | --- |
| `/v1/chat/completions` | `"bytes"` (Qwen3-4B), `"synced"` (Qwen3-0.6B) | `{}` |
| `/v1/responses` | `"pathological"` (Qwen3-4B) | `{}` |

So the bug is not just a schema detail: without it a forced named tool with no parameters can yield non-object arguments that downstream object-shaped consumers cannot parse. The fix constrains them to a JSON object on both paths.

<details>
<summary>End-to-end reproduction (server, client, payloads, before/after output)</summary>

Environment used for the original E2E: A800, V1, `Qwen/Qwen3-4B` and `Qwen/Qwen3-0.6B` for `/v1/chat/completions`, `Qwen/Qwen3-4B` for `/v1/responses`, `--enable-auto-tool-choice --tool-call-parser hermes`, `temperature=0`.

Server:

```bash
cd /path/to/vllm
export PYTHONPATH="$PWD"
export VLLM_USE_FLASHINFER_SAMPLER=0
export CUDA_VISIBLE_DEVICES=0

MODEL=${MODEL:-Qwen/Qwen3-4B}
python -m vllm.entrypoints.openai.api_server \
  --model "$MODEL" --served-model-name qwen \
  --host 127.0.0.1 --port 8025 \
  --enable-auto-tool-choice --tool-call-parser hermes \
  --enforce-eager --max-model-len 2048 --gpu-memory-utilization 0.80
```

Client:

```bash
cat >/tmp/forced_tool_no_params_client.py <<'PY'
import json
import urllib.request

BASE = "http://127.0.0.1:8025"


def post(path, payload):
    req = urllib.request.Request(
        BASE + path,
        data=json.dumps(payload).encode(),
        headers={"Content-Type": "application/json"},
        method="POST",
    )
    with urllib.request.urlopen(req, timeout=120) as resp:
        return json.loads(resp.read())


def chat_tool(params_marker):
    fn = {"name": "ping", "description": "Return pong."}
    if params_marker != "missing":
        fn["parameters"] = params_marker
    return {"type": "function", "function": fn}


def responses_tool(params_marker):
    tool = {"type": "function", "name": "ping", "description": "Return pong."}
    if params_marker != "missing":
        tool["parameters"] = params_marker
    return tool


def chat_payload(params_marker):
    return {
        "model": "qwen",
        "messages": [{"role": "user", "content": "Call ping. Do not write prose."}],
        "tools": [chat_tool(params_marker)],
        "tool_choice": {"type": "function", "function": {"name": "ping"}},
        "chat_template_kwargs": {"enable_thinking": False},
        "temperature": 0,
        "max_tokens": 64,
    }


def responses_payload(params_marker):
    return {
        "model": "qwen",
        "input": "Call ping. Do not write prose.",
        "tools": [responses_tool(params_marker)],
        "tool_choice": {"type": "function", "name": "ping"},
        "temperature": 0,
        "max_output_tokens": 64,
    }


def chat_args(obj):
    return obj["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"]


def responses_args(obj):
    for item in obj.get("output", []):
        if item.get("type") == "function_call":
            return item.get("arguments")
        for content in item.get("content") or []:
            if content.get("type") in {"function_call", "tool_call"}:
                return content.get("arguments")
    return json.dumps(obj, indent=2)[:500]


cases = [
    ("chat-empty", "/v1/chat/completions", chat_payload({}), chat_args),
    ("chat-missing", "/v1/chat/completions", chat_payload("missing"), chat_args),
    ("responses-empty", "/v1/responses", responses_payload({}), responses_args),
    ("responses-missing", "/v1/responses", responses_payload("missing"), responses_args),
]

for name, path, payload, extract in cases:
    obj = post(path, payload)
    print(name, repr(extract(obj)))
PY

python /tmp/forced_tool_no_params_client.py
```

Representative before/after outputs from the same forced named no-parameter path:

```text
# stock main
chat-empty       '"bytes"'                         # string, not an object
chat-missing     '<think>\nOkay, the user wants...' # not JSON
responses-empty  '"pathological"'                  # string, not an object
responses-missing '<think>\nOkay, the user wants...' # not JSON

# with this PR
chat-empty       '{}'
chat-missing     '{}'
responses-empty  '{}'
responses-missing '{}'
```

Additional model sweep with the same client:

```text
Qwen3-0.6B, empty {}:          "urls"                         -> {}
Qwen3-0.6B, omitted params:    <think>...                     -> {}
Qwen3-4B, empty {}:            ["_call_tool", "ping", {}]     -> {}
Qwen3-4B, omitted params:      <think>...                     -> {}
granite-4.0-h-micro, empty {}: {"name":"ping","arguments":{}} -> {}
granite-4.0-h-micro, omitted:  <tool_call>...</tool_call>     -> {}
```

</details>

AI assistance was used to prepare this PR.
