### PR TITLE
Fix non-contiguous seq_lens in DeepSeek V4 sparse attention indexer

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -296,7 +296,11 @@ def sparse_attn_indexer(
         batch_size = padded_q_quant_decode_tokens.shape[0]
         next_n = padded_q_quant_decode_tokens.shape[1]
         num_padded_tokens = batch_size * next_n
-        seq_lens = decode_metadata.seq_lens[:batch_size]
+        # Force contiguous: this slice is 2D (B, next_n) under MTP spec-decode and
+        # is non-contiguous under batched decode; persistent_topk (csrc/topk.cu)
+        # and deep_gemm paged-MQA both assert lengths.is_contiguous(), otherwise
+        # EngineCore dies with "lengths must be contiguous".
+        seq_lens = decode_metadata.seq_lens[:batch_size].contiguous()
         # seq_lens is always 2D: (B, next_n) for native spec decode, (B, 1)
         # otherwise. deep_gemm fp8_fp4_paged_mqa_logits requires 2D context_lens;
         # the downstream topk kernels accept both 1D and 2D.


### PR DESCRIPTION
## Summary

- Force `decode_metadata.seq_lens[:batch_size]` to be contiguous in `sparse_attn_indexer` before passing to `persistent_topk` and DeepGEMM paged-MQA kernels.
- Fixes `RuntimeError: lengths must be contiguous` under batched MTP speculative decode on DeepSeek V4, which can crash EngineCore ranks under load.

This complements the NVFP4 MoE quant selection fix in #45054 (RoutedExperts dispatch). Together these changes unblock loading and serving NVFP4 DeepSeek V4 checkpoints.

## Context

Under batched decode with MTP speculative decoding, the `seq_lens` slice is 2D `(B, next_n)` and non-contiguous. Both `torch.ops._C.persistent_topk` (`csrc/topk.cu`) and DeepGEMM's `fp8_fp4_paged_mqa_logits` assert `lengths.is_contiguous()`. Single/low-concurrency requests often appear contiguous, so the failure only shows under load.

`.contiguous()` is a no-op when already contiguous and preserves shape/dtype.

## Test plan

- [ ] Load a DeepSeek V4 NVFP4 checkpoint and run batched decode with MTP speculative decoding enabled
- [ ] Verify no `lengths must be contiguous` errors under concurrent requests
- [ ] Confirm sparse attention indexer output matches single-request baseline


Made with [Cursor](https://cursor.com)