### PR TITLE
Fix/qwen3 reasoning to content in short resp

### DIFF
--- a/tests/reasoning/test_qwen3_reasoning_parser.py
+++ b/tests/reasoning/test_qwen3_reasoning_parser.py
@@ -59,14 +59,11 @@ WITH_THINK_STREAM = {
     "content": "This is the rest",
 }
 
-# --- No think tokens at all (thinking enabled, truncated) ---
-
-# With thinking enabled (default), no think tokens means the output was
-# truncated before </think> could be generated. All output is reasoning.
+# --- No </think> in output ---
 WITHOUT_THINK = {
     "output": "This is the rest",
-    "reasoning": "This is the rest",
-    "content": None,
+    "reasoning": None,
+    "content": "This is the rest",
 }
 # In streaming, the parser cannot distinguish "thinking disabled" from
 # "reasoning in progress" when no think tokens have appeared yet.
@@ -109,12 +106,10 @@ MULTILINE_REASONING = {
     "reasoning": "This is a reasoning\nsection",
     "content": "This is the rest\nThat",
 }
-# Truncated output: <think> present but no </think> (thinking enabled).
-# Everything is reasoning because the output was cut off mid-thought.
 ONLY_OPEN_TAG = {
     "output": "<think>This is a reasoning section",
-    "reasoning": "This is a reasoning section",
-    "content": None,
+    "reasoning": None,
+    "content": "This is a reasoning section",
 }
 
 ONLY_OPEN_TAG_STREAM = {
@@ -123,15 +118,13 @@ ONLY_OPEN_TAG_STREAM = {
     "content": None,
 }
 
-# Truncated output without <think> prefix (Qwen3.5 style where <think>
-# is in the prompt). No </think> means truncation — all is reasoning.
-TRUNCATED_NO_START_TOKEN = {
+NO_THINK_CLOSE_NO_START_TOKEN = {
     "output": "This is a reasoning section",
-    "reasoning": "This is a reasoning section",
-    "content": None,
+    "reasoning": None,
+    "content": "This is a reasoning section",
 }
 
-TRUNCATED_NO_START_TOKEN_STREAM = {
+NO_THINK_CLOSE_NO_START_TOKEN_STREAM = {
     "output": "This is a reasoning section",
     "reasoning": "This is a reasoning section",
     "content": None,
@@ -210,13 +203,13 @@ TEST_CASES = [
     ),
     pytest.param(
         False,
-        TRUNCATED_NO_START_TOKEN,
-        id="truncated_no_start_token",
+        NO_THINK_CLOSE_NO_START_TOKEN,
+        id="no_think_close_no_start_token",
     ),
     pytest.param(
         True,
-        TRUNCATED_NO_START_TOKEN_STREAM,
-        id="truncated_no_start_token_stream",
+        NO_THINK_CLOSE_NO_START_TOKEN_STREAM,
+        id="no_think_close_no_start_token_stream",
     ),
     pytest.param(
         False,

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -123,11 +123,9 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         If <think> is present (e.g. from a different template), it is
         stripped before extraction.
 
-        When thinking is explicitly disabled and no </think> appears,
-        returns (None, model_output) — all output is content.
-        Otherwise (thinking enabled, default), a missing </think> means
-        the output was truncated and everything is reasoning:
-        returns (model_output, None).
+        When no </think> appears, returns (None, model_output) so direct
+        answers are routed to content. Truncated responses are indicated
+        separately by finish_reason="length".
 
         Returns:
             tuple[Optional[str], Optional[str]]: reasoning content and content
@@ -153,9 +151,9 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             reasoning = model_output[:tool_call_index]
             content = model_output[tool_call_index:]
             return reasoning or None, content or None
-        # Thinking enabled but no </think>: output was truncated.
-        # Everything generated so far is reasoning.
-        return model_output, None
+        # When thinking is explicitly disabled and no </think> appears,
+        # returns (None, model_output) — all output is content.
+        return None, model_output
 
     def extract_reasoning_streaming(
         self,


### PR DESCRIPTION
## Summary

Fix `qwen3_reasoning_parser` and patch tests for short responses by moving content from `reasoning` to `content` block.

Previously ->
```python
WITHOUT_THINK = {
    "output": "This is the rest",
    "reasoning": "This is the rest",
    "content": None,
},
ONLY_OPEN_TAG = {
    "output": "<think>This is a reasoning section",
    "reasoning": "This is a reasoning section",
    "content": None,
}
```

Now ->
```python
WITHOUT_THINK = {
    "output": "This is the rest",
    "reasoning": None,
    "content": "This is the rest",
},
ONLY_OPEN_TAG = {
    "output": "<think>This is a reasoning section",
    "reasoning": None,
    "content": "This is a reasoning section",
}
```

This PR:

- Shifts output with or without `</think>` to respond directly in the `content` block.

## Validation

-  `.venv/bin/python -m py_compile vllm/tests/reasoning/test_qwen3_reasoning_parser.py` - passed

## AI assistance

AI assistance was used to inspect the PR comments/checks, amend the DCO signoff, run targeted local validation, and update this PR description. The human submitter is responsible for reviewing and defending the change end-to-end.