### PR TITLE
[Rust Frontend][Bugfix] Forward --shutdown-timeout and --disable-log-stats to the managed Python engine

### DIFF
--- a/rust/src/cmd/src/cli.rs
+++ b/rust/src/cmd/src/cli.rs
@@ -468,6 +468,8 @@ impl ServeArgs {
             self.runtime.model.clone(),
             self.runtime.max_model_len,
             self.runtime.language_model_only,
+            self.runtime.disable_log_stats,
+            self.runtime.shutdown_timeout,
             handshake_port,
         )
     }

--- a/rust/src/cmd/src/cli/tests.rs
+++ b/rust/src/cmd/src/cli/tests.rs
@@ -101,6 +101,40 @@ fn serve_args_auto_forward_enable_lora_to_python() {
 }
 
 #[test]
+fn serve_args_forward_shutdown_timeout_to_managed_engine() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "serve",
+        "Qwen/Qwen3-0.6B",
+        "--shutdown-timeout",
+        "60",
+    ])
+    .unwrap();
+
+    let Command::Serve(args) = cli.command else {
+        panic!("expected serve args");
+    };
+    assert_eq!(args.runtime.shutdown_timeout, 60);
+
+    let config = args.to_managed_engine_config(5555);
+    assert_eq!(config.python_args, vec!["--shutdown-timeout", "60"]);
+}
+
+#[test]
+fn serve_args_forward_disable_log_stats_to_managed_engine() {
+    let cli = Cli::try_parse_from(["vllm-rs", "serve", "Qwen/Qwen3-0.6B", "--disable-log-stats"])
+        .unwrap();
+
+    let Command::Serve(args) = cli.command else {
+        panic!("expected serve args");
+    };
+    assert!(args.runtime.disable_log_stats);
+
+    let config = args.to_managed_engine_config(5555);
+    assert_eq!(config.python_args, vec!["--disable-log-stats"]);
+}
+
+#[test]
 fn serve_args_auto_forward_python_multi_char_alias_without_separator() {
     let cli = Cli::try_parse_from(["vllm-rs", "serve", "Qwen/Qwen3-0.6B", "-tp", "2"]).unwrap();
 

--- a/rust/src/managed-engine/src/cli.rs
+++ b/rust/src/managed-engine/src/cli.rs
@@ -72,6 +72,8 @@ impl ManagedEngineArgs {
         model: String,
         max_model_len: Option<u32>,
         language_model_only: bool,
+        disable_log_stats: bool,
+        shutdown_timeout: u64,
         handshake_port: u16,
     ) -> ManagedEngineConfig {
         let mut python_args = self.python_args;
@@ -82,6 +84,15 @@ impl ManagedEngineArgs {
         }
         if language_model_only {
             python_args.push("--language-model-only".to_string());
+        }
+        if disable_log_stats {
+            python_args.push("--disable-log-stats".to_string());
+        }
+        // we must pass through shutdown_timeout to the engine,
+        // otherwise inflight requests get aborted on shutdown
+        if shutdown_timeout > 0 {
+            python_args.push("--shutdown-timeout".to_string());
+            python_args.push(shutdown_timeout.to_string());
         }
         if let Some(data_parallel_size_local) = self.data_parallel_size_local {
             python_args.push("--data-parallel-size-local".to_string());


### PR DESCRIPTION
## Purpose

In `vllm-rs serve` (managed mode), recognized frontend flags are kept on the Rust side by the CLI splitter, so flags the spawned Python engine must also see have to be re-forwarded explicitly in `into_config`. Two flags were missing from that list:

- `--shutdown-timeout`: the engine core always ran with its default `shutdown_timeout=0` (abort mode), so on SIGTERM it killed all in-flight requests immediately while the Rust frontend was still holding connections open to drain them. The configured drain window had no effect on actual generations.
- `--disable-log-stats`: the headless engine gates per-step scheduler stats on this flag independently of the frontend (`run_headless` passes `log_stats=not engine_args.disable_log_stats` to `CoreEngineProcManager`), so managed engines silently kept stats enabled regardless of the flag.

Fix: forward both flags into the engine's `python_args`, the same way `--max-model-len` and `--language-model-only` are already forwarded.

## Test Plan

- Regression tests at the spawn-config boundary: `cargo test -p vllm-cmd serve_args_forward` (`serve_args_forward_shutdown_timeout_to_managed_engine` fails without the fix with `python_args: []`; same for `serve_args_forward_disable_log_stats_to_managed_engine`).
- Full suites: `cargo test -p vllm-cmd -p vllm-managed-engine`, `cargo fmt`, `cargo clippy --all --benches --tests --examples --all-features`.
- E2E on an H200, `vllm-rs serve Qwen/Qwen3-0.6B` in managed mode, same binary throughout:
  - drain: streaming completion with `max_tokens=20000` in flight, SIGTERM the server 5s in, with and without `--shutdown-timeout 60`
  - stats: serve a request, scrape the frontend `/metrics`, with and without `--disable-log-stats`

## Test Result

Unit: 45 + 2 tests pass, clippy clean.

e2e with `--shutdown-timeout 60`:
```
(spawn) python3 -m vllm.entrypoints.cli.main serve ... --headless ... --shutdown-timeout 60
(EngineCore) [shutdown] EngineCore: start mode=drain timeout=60s
(EngineCore) [shutdown] EngineCore: draining in-flight requests count=1 timeout=60s
(EngineCore) [shutdown] EngineCore: request processing complete; starting resource teardown
```
Client stream received 17,113 more tokens over the 35s after SIGTERM and completed cleanly (`finish_reason: "length"`, `[DONE]`, curl exit 0).

e2e without the flag (pre-fix behavior, since the engine previously always saw timeout=0):
```
(EngineCore) [shutdown] EngineCore: start mode=abort timeout=0s
```
Stream severed mid-token ~1s after SIGTERM, no `[DONE]`, curl exit 18 (partial transfer).

e2e for `--disable-log-stats`: without the flag, scheduler-derived metrics are present and live on the frontend `/metrics` (`vllm:num_requests_running`, `vllm:kv_cache_usage_perc`, `vllm:prefix_cache_queries_total 1` after one request). With the flag, the spawn command includes `--disable-log-stats`, and all scheduler-derived metric families disappear (0 matching lines) while the rest of `/metrics` (304 `vllm:` lines of frontend-side metrics) still serves — confirming the engine core stopped emitting `SchedulerStats` rather than the endpoint breaking.

AI assistance was used for drafting the PR body and the test harness; writing the code and running the tests was done manually by myself.
