### PR TITLE
Make mistral_common optional by deferring MistralToolCall import

### DIFF
--- a/vllm/tool_parsers/streaming.py
+++ b/vllm/tool_parsers/streaming.py
@@ -14,7 +14,6 @@ from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
     DeltaToolCall,
 )
-from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
 from vllm.tool_parsers.utils import partial_json_loads
 from vllm.utils.mistral import is_mistral_tokenizer
 
@@ -77,6 +76,9 @@ def extract_named_tool_call_streaming(
         )
     else:
         if is_mistral_tokenizer(tokenizer):
+            # Import mistral_common only if we need it.
+            from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
+
             tool_call_id = MistralToolCall.generate_random_id()
         else:
             tool_call_id = make_tool_call_id(


### PR DESCRIPTION
## Purpose

Defer the import of MistralToolCall so that we don't import mistral_common unless we actually need it.  This makes mistral_common an optional dependency and makes startup faster in the case you don't use it.

## Test Plan

  The change defers the MistralToolCall import into the is_mistral_tokenizer
  branch, making mistral_common an optional dependency. Verified in an
  environment WITHOUT mistral_common installed:
 
  1. `import vllm.tool_parsers.streaming` succeeds; after exercising the
     non-mistral path of extract_named_tool_call_streaming, neither
     `mistral_common` nor `vllm.tool_parsers.mistral_tool_parser` appears in
     sys.modules.
  2. pytest tests/tool_use/test_tool_choice_required.py  -> 135 passed
     (covers the streaming tool-call functions in the patched module).
  3. pytest tests/tool_parsers/test_hermes_tool_parser.py
            tests/tool_parsers/test_pythonic_tool_parser.py -> 48 passed
     (non-mistral tool parsers unaffected).
 
  With mistral_common installed, the deferred import resolves and the mistral
  path is unchanged:
  
  4. pip install mistral_common
     pytest tests/tool_parsers/test_mistral_tool_parser.py -> 86 passed



## Test Result

The pytest tests pass with no errors.
