### PR TITLE
[Quant] Support modelopt_mixed on Ampere (SM80/SM86)

### DIFF
--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -2299,7 +2299,13 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        return 89
+        # Ampere (SM80/SM86): NVFP4 routed experts run via Marlin W4A16, and FP8
+        # weight-only dense layers run via MarlinFP8 (W8A16, compute in
+        # bf16/fp16). FP8 MoE, if present, also routes to Marlin because
+        # TritonExperts gates its FP8 schemes behind supports_fp8() (cc>=89).
+        # None of these paths require native FP8 tensor cores, so SM80 is
+        # sufficient.
+        return 80
 
     @classmethod
     def override_quantization_method(


### PR DESCRIPTION
# Support modelopt_mixed on Ampere (SM80/SM86)

## Purpose

Enables `modelopt_mixed` checkpoints (NVFP4 routed experts + FP8 weight-only
dense layers) on Ampere — A100/SM80 and RTX 30-series/SM86.

`ModelOptMixedPrecisionConfig` rejected these GPUs at engine-config validation
("Minimum capability: 89"), even though `modelopt_mixed` does not require
native FP8 tensor cores. Its layers run on Marlin, which needs only cc ≥ 7.5:

- NVFP4 routed experts → Marlin W4A16 (the CUTLASS/FlashInfer NVFP4 MoE backends
  self-reject on SM80).
- FP8 dense layers → `MarlinFP8ScaledMMLinearKernel` (W8A16, bf16/fp16 compute),
  first in `_POSSIBLE_FP8_KERNELS`.
- FP8 MoE, if present → Marlin; `TritonExperts` gates its FP8 schemes behind
  `current_platform.supports_fp8()` (cc ≥ 89), so it self-rejects on SM80.

Changes (`vllm/model_executor/layers/quantization/modelopt.py`):

1. `ModelOptMixedPrecisionConfig.get_min_capability()`: 89 → 80.
2. `ModelOptFp8LinearMethod.create_weights()`: set `layer.orig_dtype`.
   `prepare_fp8_layer_for_marlin()` casts the weight scale through it; the other
   FP8 methods already set it, and without it the FP8 Marlin path raises
   `AttributeError`.

KV cache scope: this enables NVFP4 weights on Ampere.

The KV Cache type supported depends on the Attention function:
* FlashInfer already supports fp8 kv cache even on systems without FP8 support using software emulation. (At presen broken for T4, patch https://github.com/flashinfer-ai/flashinfer/pull/3621 pending.)
* Triton Attention does not support fp8 kv cache out of the box, so it wuld error out.  https://github.com/vllm-project/vllm/pull/43914 creates a clean error message.

## Test Plan

On an A100 (SM80), serve two `modelopt_mixed` NVFP4 checkpoints with a bf16 KV
cache and confirm the engine selects Marlin and answers chat requests.
```bash
# Gemma-4-26B-A4B-NVFP4, TP1
vllm serve nvidia/Gemma-4-26B-A4B-NVFP4 \
  --quantization modelopt --kv-cache-dtype bfloat16 \
  --tensor-parallel-size 1 --trust-remote-code \
  --tool-call-parser gemma4 --reasoning-parser gemma4
--enable-auto-tool-choice \
  --max-model-len 4096 --max-num-seqs 1 --gpu-memory-utilization 0.85

# Nemotron-3-Super-120B-A12B-NVFP4, TP4
vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
  --quantization modelopt --kv-cache-dtype bfloat16 \
  --tensor-parallel-size 4 --trust-remote-code \
  --max-model-len 4096 --max-num-seqs 1 --gpu-memory-utilization 0.85

# In both cases, send a chat completion and check for HTTP 200.
curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
  -d '{"model":"<served-model>","messages":[{"role":"user","content":"hi"}]}'
```

Test Result

Both checkpoints serve on A100/SM80:

- Gemma-4-26B-A4B-NVFP4 (TP1): engine selects Using 'MARLIN' NvFp4 MoE
   backend; marlin_utils_fp4 weight-only FP4 notice; server reaches startup
   complete; 3× /v1/chat/completions return 200 OK with correct content.
- Nemotron-3-Super-120B-A12B-NVFP4 (TP4): engine selects Using 'MARLIN' NvFp4
   MoE backend; server serves and answers chat requests; job exits 0.

No "Minimum capability" rejection at startup in either run.

Supersedes #42610 (same enablement, minimal diff, without Triton import-time patch)."

PS: the A100 runs used a branch that also carries the Marlin TP-padding work. 