### PR TITLE
[Bugfix] Fix trtllm fused allreduce+rms_norm for transformers backend

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -155,6 +155,7 @@ if flashinfer_comm is not None:
         scale_factor: torch.Tensor | None = None,
         weight_bias: float = 0.0,
     ) -> None:
+        # handle transformers backend passing outer batch dim.
         if allreduce_in.dim() != 2:
             hidden = allreduce_in.shape[-1]
             allreduce_in = allreduce_in.view(-1, hidden)

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -155,6 +155,12 @@ if flashinfer_comm is not None:
         scale_factor: torch.Tensor | None = None,
         weight_bias: float = 0.0,
     ) -> None:
+        if allreduce_in.dim() != 2:
+            hidden = allreduce_in.shape[-1]
+            allreduce_in = allreduce_in.view(-1, hidden)
+            residual = residual.view(-1, hidden)
+            if norm_out is not None:
+                norm_out = norm_out.view(-1, hidden)
         num_tokens, hidden_size = allreduce_in.shape
         element_size = allreduce_in.element_size()
         current_tensor_size = num_tokens * hidden_size * element_size


### PR DESCRIPTION
## Purpose

The following currently crashes on main:
```python3
from vllm import LLM, SamplingParams

if __name__ == '__main__':
  llm = LLM(
    model="Qwen/Qwen3-1.7B",
    model_impl="transformers",
    tensor_parallel_size=2,
    dtype="bfloat16",
    max_model_len=1024,
    gpu_memory_utilization=0.4,
  )
  print(llm.generate(["The capital of France is"],
    SamplingParams(temperature=0.0, max_tokens=8))[0].outputs[0].text)
```
gives:
```
(Worker_TP0 pid=98122) ERROR 06-11 18:56:58 [multiproc_executor.py:987]   File "/opt/conda/lib/python3.12/site-packages/torch/_ops.py", line 865, in __call__
(Worker_TP0 pid=98122) ERROR 06-11 18:56:58 [multiproc_executor.py:987]     return self._op(*args, **kwargs)
(Worker_TP0 pid=98122) ERROR 06-11 18:56:58 [multiproc_executor.py:987]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=98122) ERROR 06-11 18:56:58 [multiproc_executor.py:987]   File "/workspace/vllm/vllm/compilation/passes/fusion/allreduce_rms_fusion.py", line 158, in call_trtllm_fused_allreduce_norm
(Worker_TP0 pid=98122) ERROR 06-11 18:56:58 [multiproc_executor.py:987]     num_tokens, hidden_size = allreduce_in.shape
(Worker_TP0 pid=98122) ERROR 06-11 18:56:58 [multiproc_executor.py:987]     ^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=98122) ERROR 06-11 18:56:58 [multiproc_executor.py:987] ValueError: too many values to unpack (expected 2)
```
## Test Plan

See reproducer above.

## Test Result

Works fine after fix.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

