### PR TITLE
[Bugfix][Model] Pass revision by name in Run:ai and bitsandbytes index downloads

### DIFF
--- a/tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_loader.py
+++ b/tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_loader.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import types
+from unittest.mock import patch
+
 import pytest
 
 from vllm import SamplingParams
 from vllm.config.load import LoadConfig
 from vllm.model_executor.model_loader import get_model_loader
+from vllm.model_executor.model_loader import runai_streamer_loader as rsl
 
 load_format = "runai_streamer"
 test_model = "openai-community/gpt2"
@@ -53,3 +57,24 @@ def test_runai_model_loader_download_files_gcs(
     with vllm_runner(test_gcs_model, load_format=load_format) as llm:
         deserialized_outputs = llm.generate(prompts, sampling_params)
         assert deserialized_outputs
+
+
+def test_runai_passes_revision_by_name():
+    # revision must reach download_safetensors_index_file_from_hf as the
+    # ``revision`` keyword, not the positional ``subfolder`` slot.
+    fake_self = types.SimpleNamespace(
+        load_config=types.SimpleNamespace(download_dir="/cache", ignore_patterns=[])
+    )
+    with (
+        patch.object(rsl, "is_runai_obj_uri", return_value=False),
+        patch.object(rsl, "download_weights_from_hf", return_value="/folder"),
+        patch.object(
+            rsl, "list_safetensors", return_value=["/folder/model.safetensors"]
+        ),
+        patch.object(rsl, "download_safetensors_index_file_from_hf") as mock_idx,
+    ):
+        rsl.RunaiModelStreamerLoader._prepare_weights(fake_self, "org/model", "myrev")
+
+    mock_idx.assert_called_once()
+    assert mock_idx.call_args.kwargs.get("revision") == "myrev"
+    assert "myrev" not in mock_idx.call_args.args

--- a/tests/models/quantization/test_bitsandbytes.py
+++ b/tests/models/quantization/test_bitsandbytes.py
@@ -5,12 +5,16 @@
 Run `pytest tests/quantization/test_bitsandbytes.py`.
 """
 
+import types
+from unittest.mock import MagicMock, patch
+
 import pytest
 from packaging.version import Version
 from transformers import BitsAndBytesConfig
 from transformers import __version__ as TRANSFORMERS_VERSION
 
 from tests.quantization.utils import is_quant_method_supported
+from vllm.model_executor.model_loader import bitsandbytes_loader as bnb
 from vllm.platforms import current_platform
 
 from ...utils import compare_two_settings, multi_gpu_test
@@ -300,3 +304,27 @@ def validate_generated_texts(
             f"HF Output: '{hf_str}'\n"
             f"vLLM Output: '{vllm_str}'"
         )
+
+
+def test_bitsandbytes_passes_revision_by_name():
+    # revision must reach download_safetensors_index_file_from_hf as the
+    # ``revision`` keyword, not a positional slot.
+    fake_self = types.SimpleNamespace(
+        load_config=types.SimpleNamespace(download_dir="/cache"),
+        _get_weight_files=MagicMock(
+            return_value=("/folder", ["/folder/model.safetensors"], "*.safetensors")
+        ),
+    )
+    with (
+        patch.object(bnb, "download_safetensors_index_file_from_hf") as mock_idx,
+        patch.object(
+            bnb,
+            "filter_duplicate_safetensors_files",
+            return_value=["/folder/model.safetensors"],
+        ),
+    ):
+        bnb.BitsAndBytesModelLoader._prepare_weights(fake_self, "org/model", "myrev")
+
+    mock_idx.assert_called_once()
+    assert mock_idx.call_args.kwargs.get("revision") == "myrev"
+    assert "myrev" not in mock_idx.call_args.args

--- a/vllm/model_executor/model_loader/bitsandbytes_loader.py
+++ b/vllm/model_executor/model_loader/bitsandbytes_loader.py
@@ -140,8 +140,8 @@ class BitsAndBytesModelLoader(BaseModelLoader):
                 download_safetensors_index_file_from_hf(
                     model_name_or_path,
                     index_file,
-                    self.load_config.download_dir,
-                    revision,
+                    cache_dir=self.load_config.download_dir,
+                    revision=revision,
                 )
             hf_weights_files = filter_duplicate_safetensors_files(
                 hf_weights_files, hf_folder, index_file

--- a/vllm/model_executor/model_loader/runai_streamer_loader.py
+++ b/vllm/model_executor/model_loader/runai_streamer_loader.py
@@ -70,7 +70,10 @@ class RunaiModelStreamerLoader(BaseModelLoader):
 
         if not is_local and not is_object_storage_path:
             download_safetensors_index_file_from_hf(
-                model_name_or_path, index_file, self.load_config.download_dir, revision
+                model_name_or_path,
+                index_file,
+                cache_dir=self.load_config.download_dir,
+                revision=revision,
             )
 
         if not hf_weights_files:


### PR DESCRIPTION

## Purpose

`RunaiModelStreamerLoader._prepare_weights` and `BitsAndBytesModelLoader._prepare_weights` call `download_safetensors_index_file_from_hf` with `revision` as the fourth positional argument.

The callee signature is:

```python
download_safetensors_index_file_from_hf(
    model_name_or_path,
    index_file,
    cache_dir,
    subfolder=None,
    revision=None,
)
```

So the requested revision is bound to `subfolder`, while the real `revision` parameter remains `None`. When a non default revision is requested, the safetensors index can be downloaded from the wrong ref. `DefaultModelLoader` already passes these arguments by name.

The fix changes both loaders to pass `cache_dir=` and `revision=` by keyword.

## Test Plan

Added two focused routing tests in the existing Run:ai loader and bitsandbytes test files. Each test drives the loader's `_prepare_weights` helper with mocked download helpers, then asserts that `download_safetensors_index_file_from_hf` receives `revision="myrev"` as a keyword argument rather than a positional slot.

Validation:

- Run both focused routing tests with the fix.
- Revert only the source changes and keep the tests.
- Reapply the source changes.
- Run the full pre-commit suite on the changed files.

## Test Result

| Check | Result |
|---|---|
| Focused routing tests with fix | `2 passed` |
| Source reverted, tests kept | `2 failed`; both saw `revision` as `None` and `"myrev"` in positional args |
| Pre-commit on changed files | Passed |

AI assistance was used to investigate, reproduce, and draft this change; the author reviewed the diff and validation output.

cc @22quinn @DarkLight1337
