### PR TITLE
[Bugfix][ToolParser] Make Hermes streaming tool call boundaries JSON string aware

### DIFF
--- a/tests/tool_parsers/test_hermes_tool_parser.py
+++ b/tests/tool_parsers/test_hermes_tool_parser.py
@@ -412,3 +412,25 @@ def test_hermes_streaming_content_and_tool_call_in_single_chunk(
     assert tool_parts[0].function.name == "f"
     args_str = "".join(tc.function.arguments or "" for tc in tool_parts)
     assert json.loads(args_str) == {"x": 1}
+
+
+@pytest.mark.parametrize("stream_interval", [1, 2, 3, 5, 8, 9999])
+def test_hermes_streaming_close_tag_in_arguments(
+    qwen_tokenizer: TokenizerLike,
+    any_chat_request: ChatCompletionRequest,
+    stream_interval: int,
+) -> None:
+    """End tag text inside arguments must stream as argument text."""
+    text = (
+        '<tool_call>{"name": "echo", '
+        '"arguments": {"text": "literal </tool_call> inside"}}</tool_call>'
+    )
+    parser = Hermes2ProToolParser(qwen_tokenizer)
+    deltas = _simulate_streaming(
+        qwen_tokenizer, parser, any_chat_request, text, stream_interval
+    )
+
+    tool_parts = [tc for d in deltas if d.tool_calls for tc in d.tool_calls]
+    assert tool_parts[0].function.name == "echo"
+    args_str = "".join(tc.function.arguments or "" for tc in tool_parts)
+    assert json.loads(args_str) == {"text": "literal </tool_call> inside"}

--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -137,6 +137,25 @@ class Hermes2ProToolParser(ToolParser):
             return content
         return None
 
+    @staticmethod
+    def _find_end_token_outside_string(text: str, end_token: str, start: int) -> int:
+        """Return the next end_token outside a JSON string."""
+        in_string = False
+        escaped = False
+
+        for i in range(start, len(text)):
+            char = text[i]
+            if escaped:
+                escaped = False
+            elif in_string and char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = not in_string
+            elif not in_string and text.startswith(end_token, i):
+                return i
+
+        return -1
+
     def _extract_tool_call_jsons(self, text: str) -> list[tuple[str, bool]]:
         """Extract (json_text, is_complete) for each <tool_call> region."""
         results: list[tuple[str, bool]] = []
@@ -146,7 +165,9 @@ class Hermes2ProToolParser(ToolParser):
             if start == -1:
                 break
             json_start = start + len(self.tool_call_start_token)
-            json_end = text.find(self.tool_call_end_token, json_start)
+            json_end = self._find_end_token_outside_string(
+                text, self.tool_call_end_token, json_start
+            )
             if json_end != -1:
                 results.append((text[json_start:json_end].strip(), True))
                 pos = json_end + len(self.tool_call_end_token)


### PR DESCRIPTION

## Purpose

Refs #45167. This is the streaming follow-up to #45168 by @Incheonkirin. This PR only covers the Hermes streaming parser path. #45168 covers the non streaming path and explicitly leaves streaming as follow-up work.

`Hermes2ProToolParser._extract_tool_call_jsons` used a plain `str.find("</tool_call>")` to locate the end of a streamed tool call. If a tool argument string contains the literal `</tool_call>` text, that string content is treated as the closing tag and the JSON fragment is cut before `json.loads`.

The fix adds a JSON string aware scanner for the streaming boundary search. It tracks quote and escape state and only accepts `</tool_call>` as a boundary when it is outside a JSON string. Non streaming extraction is unchanged.

## Test Plan

Added a regression test to the existing Hermes parser test file that streams a tool call whose argument contains a literal `</tool_call>` string across intervals `1, 2, 3, 5, 8, 9999`.

Validation:

- Run the full Hermes parser test file with the fix.
- Revert only the source change and keep the new streaming regression test.
- Reapply the source change and rerun the focused regression test.
- Run the full pre-commit suite on the changed files.

## Test Result

| Check | Result |
|---|---|
| Full Hermes parser test file with fix | `36 passed, 1 skipped` |
| Source reverted, new regression test kept | `6 failed` with `JSONDecodeError: Unterminated string` |
| Focused regression test after reapplying fix | `6 passed` |
| Pre-commit on changed files | Passed |

<details>
<summary>End-to-end reproduction (server, streaming client, before/after output)</summary>

This is the real OpenAI server path for the Hermes streaming parser. The parser-level regression test in this PR exercises the same boundary scanner directly; this run drives it through `vllm serve` and `/v1/chat/completions` streaming.

Hardware and model setup used for the recorded run:

- GPU: NVIDIA A800-SXM4-80GB
- Models: `Qwen/Qwen3-4B` and `Qwen/Qwen3-8B`
- Parser: `--enable-auto-tool-choice --tool-call-parser hermes`
- Sampling: `temperature=0`
- Prompt target: call `echo` with `text` exactly `alpha </tool_call> omega`

Server:

```bash
cd /path/to/vllm
export PYTHONPATH="$PWD"
export CUDA_VISIBLE_DEVICES=0
export VLLM_USE_FLASHINFER_SAMPLER=0
export VLLM_ATTENTION_BACKEND=FLASH_ATTN

MODEL=Qwen/Qwen3-4B
PORT=8027

python -m vllm.entrypoints.openai.api_server \
  --model "$MODEL" \
  --served-model-name qwen \
  --host 127.0.0.1 \
  --port "$PORT" \
  --enable-auto-tool-choice \
  --tool-call-parser hermes \
  --enforce-eager \
  --max-model-len 4096 \
  --gpu-memory-utilization 0.70 \
  --default-chat-template-kwargs '{"enable_thinking": false}'
```

Client:

```bash
cat >/tmp/hermes_inner_tag_stream_client.py <<'PY'
import json
import os
import urllib.request

PORT = int(os.environ.get("PORT", "8027"))
MODEL = os.environ.get("SERVED_MODEL", "qwen")
URL = f"http://127.0.0.1:{PORT}/v1/chat/completions"

TOOLS = [{
    "type": "function",
    "function": {
        "name": "echo",
        "description": "Echo the input text exactly.",
        "parameters": {
            "type": "object",
            "properties": {"text": {"type": "string"}},
            "required": ["text"],
            "additionalProperties": False,
        },
    },
}]

payload = {
    "model": MODEL,
    "messages": [{
        "role": "user",
        "content": (
            "Call the echo tool with text exactly: "
            "alpha </tool_call> omega. Do not add other words."
        ),
    }],
    "tools": TOOLS,
    "tool_choice": "auto",
    "temperature": 0,
    "max_tokens": 96,
    "stream": True,
    "chat_template_kwargs": {"enable_thinking": False},
}

req = urllib.request.Request(
    URL,
    data=json.dumps(payload).encode(),
    headers={"Content-Type": "application/json"},
    method="POST",
)

arguments = []
with urllib.request.urlopen(req, timeout=180) as resp:
    for raw in resp:
        line = raw.decode(errors="replace").strip()
        if not line.startswith("data: "):
            continue
        body = line[6:]
        if body == "[DONE]":
            break
        event = json.loads(body)
        for choice in event.get("choices", []):
            delta = choice.get("delta") or {}
            for tool_call in delta.get("tool_calls") or []:
                fn = tool_call.get("function") or {}
                if fn.get("arguments"):
                    arguments.append(fn["arguments"])

text = "".join(arguments)
print("raw_arguments:", repr(text))
try:
    print("parsed:", json.loads(text))
except Exception as exc:
    print("json_error:", type(exc).__name__, str(exc))
PY

PORT="$PORT" SERVED_MODEL=qwen python /tmp/hermes_inner_tag_stream_client.py
```

Observed output:

```text
# stock main, Qwen/Qwen3-4B
raw_arguments: '{"text": "alpha'
json_error: JSONDecodeError Unterminated string starting at: line 1 column 10 (char 9)

# this PR, Qwen/Qwen3-4B
raw_arguments: '{"text": "alpha </tool_call> omega"}'
parsed: {'text': 'alpha </tool_call> omega'}

# stock main, Qwen/Qwen3-8B
raw_arguments: '{"text": "alpha'
json_error: JSONDecodeError Unterminated string starting at: line 1 column 10 (char 9)

# this PR, Qwen/Qwen3-8B
raw_arguments: '{"text": "alpha </tool_call> omega"}'
parsed: {'text': 'alpha </tool_call> omega'}
```

The same Qwen3-0.6B prompt did not emit the literal `</tool_call>` string in the tool argument value, so that run was inconclusive rather than a negative control.

</details>

AI assistance was used to prepare this PR.

cc @sfeng33 @chaunceyjiang
