### PR TITLE
[Bugfix] Register VLLM_BUILD_* and VLLM_IMAGE_TAG provenance env vars

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -98,7 +98,7 @@ if TYPE_CHECKING:
     VLLM_BUILD_COMMIT: str = "unknown"
     VLLM_BUILD_PIPELINE: str = "local"
     VLLM_BUILD_URL: str = ""
-    VLLM_IMAGE_TAG: str = "local/vllm-openai:dev"
+    VLLM_IMAGE_TAG: str = ""
     VLLM_KEEP_ALIVE_ON_ENGINE_DEATH: bool = False
     CMAKE_BUILD_TYPE: Literal["Debug", "Release", "RelWithDebInfo"] | None = None
     VERBOSE: bool = False
@@ -628,9 +628,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_BUILD_COMMIT": lambda: os.environ.get("VLLM_BUILD_COMMIT", "unknown"),
     "VLLM_BUILD_PIPELINE": lambda: os.environ.get("VLLM_BUILD_PIPELINE", "local"),
     "VLLM_BUILD_URL": lambda: os.environ.get("VLLM_BUILD_URL", ""),
-    "VLLM_IMAGE_TAG": lambda: os.environ.get(
-        "VLLM_IMAGE_TAG", "local/vllm-openai:dev"
-    ),
+    "VLLM_IMAGE_TAG": lambda: os.environ.get("VLLM_IMAGE_TAG", ""),
     # CMake build type
     # If not set, defaults to "Debug" or "RelWithDebInfo"
     # Available options: "Debug", "Release", "RelWithDebInfo"

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -95,6 +95,10 @@ if TYPE_CHECKING:
     VLLM_USE_PRECOMPILED_RUST: bool = False
     VLLM_SKIP_PRECOMPILED_VERSION_SUFFIX: bool = False
     VLLM_DOCKER_BUILD_CONTEXT: bool = False
+    VLLM_BUILD_COMMIT: str = "unknown"
+    VLLM_BUILD_PIPELINE: str = "local"
+    VLLM_BUILD_URL: str = ""
+    VLLM_IMAGE_TAG: str = "local/vllm-openai:dev"
     VLLM_KEEP_ALIVE_ON_ENGINE_DEATH: bool = False
     CMAKE_BUILD_TYPE: Literal["Debug", "Release", "RelWithDebInfo"] | None = None
     VERBOSE: bool = False
@@ -618,6 +622,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # in order to force the use of precompiled binaries.
     "VLLM_DOCKER_BUILD_CONTEXT": lambda: (
         os.environ.get("VLLM_DOCKER_BUILD_CONTEXT", "").strip().lower() in ("1", "true")
+    ),
+    # Build provenance metadata embedded in official vllm-openai images.
+    # Set via Docker ENV at image build time; informational only.
+    "VLLM_BUILD_COMMIT": lambda: os.environ.get("VLLM_BUILD_COMMIT", "unknown"),
+    "VLLM_BUILD_PIPELINE": lambda: os.environ.get("VLLM_BUILD_PIPELINE", "local"),
+    "VLLM_BUILD_URL": lambda: os.environ.get("VLLM_BUILD_URL", ""),
+    "VLLM_IMAGE_TAG": lambda: os.environ.get(
+        "VLLM_IMAGE_TAG", "local/vllm-openai:dev"
     ),
     # CMake build type
     # If not set, defaults to "Debug" or "RelWithDebInfo"


### PR DESCRIPTION
## Summary

#40653 added build provenance metadata (`VLLM_BUILD_COMMIT`, `VLLM_BUILD_PIPELINE`, `VLLM_BUILD_URL`, `VLLM_IMAGE_TAG`) as `ENV` vars baked into the official `vllm-openai` images, but did not register them in `vllm/envs.py`'s `environment_variables` dict.

As a result, every container start of an official `vllm-openai` image logs:

```
WARNING [envs.py:2057] Unknown vLLM environment variable detected: VLLM_BUILD_COMMIT
WARNING [envs.py:2057] Unknown vLLM environment variable detected: VLLM_BUILD_PIPELINE
WARNING [envs.py:2057] Unknown vLLM environment variable detected: VLLM_BUILD_URL
WARNING [envs.py:2057] Unknown vLLM environment variable detected: VLLM_IMAGE_TAG
```

This PR registers the four vars as plain `str` getters with the same defaults used in `docker/Dockerfile` (`unknown`, `local`, `""`, `local/vllm-openai:dev`), following the same pattern used in #35007 to fix the equivalent warning for `VLLM_BATCH_INVARIANT`.

Fixes #45311

## Test plan

- Loaded `vllm/envs.py` standalone and confirmed the new vars resolve to their Dockerfile defaults.
- Set the four env vars and confirmed `validate_environ(hard_fail=True)` no longer raises / warns.

## Disclaimer

I used an LLM to generate this. I think this is a reasonable submission, hope you don't consider it slop.