### PR TITLE
[Model][Dflash] Enable Dflash support for Qwen3NextForCausalLM targets

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1435,6 +1435,14 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
         max_model_len=8192,  # Reduce max len to ensure test runs in low-VRAM CI env
         max_num_seqs=32,
     ),
+    "DFlashQwen3NextDraftModel": _HfExamplesInfo(
+        "Qwen/Qwen3-Coder-Next",
+        speculative_model="z-lab/Qwen3-Coder-Next-DFlash",
+        use_original_num_layers=True,  # DFlash requires all layers
+        max_model_len=8192,  # Reduce for CI
+        max_num_seqs=32,
+        min_transformers_version="4.56.3",  # Required for Qwen3Next
+    ),
     # [Eagle]
     "EagleCohereForCausalLM": _HfExamplesInfo(
         "/host/engines/cohere-moe",

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -68,9 +68,9 @@ from .interfaces import (
     HasInnerState,
     IsHybrid,
     MixtureOfExperts,
+    SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
-    SupportsEagle3,
 )
 from .utils import (
     AutoWeightsLoader,
@@ -759,7 +759,7 @@ class Qwen3NextForCausalLM(
     SupportsPP,
     QwenNextMixtureOfExperts,
     IsHybrid,
-    SupportsEagle3
+    SupportsEagle3,
 ):
     packed_modules_mapping = {
         "qkv_proj": [

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -70,6 +70,7 @@ from .interfaces import (
     MixtureOfExperts,
     SupportsLoRA,
     SupportsPP,
+    SupportsEagle3,
 )
 from .utils import (
     AutoWeightsLoader,
@@ -758,6 +759,7 @@ class Qwen3NextForCausalLM(
     SupportsPP,
     QwenNextMixtureOfExperts,
     IsHybrid,
+    SupportsEagle3
 ):
     packed_modules_mapping = {
         "qkv_proj": [


### PR DESCRIPTION




## Purpose
Enable DFlash (`method="dflash"`) speculative decoding for `Qwen3NextForCausalLM`-based models (Qwen3-Next / Qwen3-Coder-Next 80B-A3B).

This addresses #33329 and other failed attempts.

## Problem

`method="dflash"` crashes at model-load time for any `Qwen3NextForCausalLM`
target with:

```
RuntimeError: Model does not support EAGLE3 interface but
aux_hidden_state_outputs was requested
```

Crash path (`v1/worker/gpu_model_runner.py`):
1. Line 593–595: `use_dflash()` unconditionally sets
   `self.use_aux_hidden_state_outputs = True`.
2. Line 5264–5272: `_setup_eagle3_aux_hidden_state_outputs()` calls
   `supports_eagle3(model)` = `isinstance(model, SupportsEagle3)`.
3. `Qwen3NextForCausalLM` does not inherit `SupportsEagle3` → `False` → raise.

The crash is deterministic; no workaround exists without a code change.

### Root cause

`Qwen3NextForCausalLM` is missing `SupportsEagle3` in its class declaration.
**The infrastructure is already fully present:**

- The inner `Qwen3NextModel` inherits `EagleModelMixin` (line 464).
- `Qwen3NextModel.forward()` (lines 505–543) already calls
  `_maybe_add_hidden_state()` at every layer and returns
  `(hidden_states, aux_hidden_states)` when aux layers are configured —
  **identical pattern to `Qwen3MoeForCausalLM`**, which already has
  `SupportsEagle3` and works with DFlash.
- The outer `Qwen3NextForCausalLM.forward()` passes through whatever
  `self.model(...)` returns unchanged (lines 773–777).
- `self.model` is a `Qwen3NextModel` (an `EagleModelMixin` with `layers`),
  so `SupportsEagle3`'s default implementations of
  `set_aux_hidden_state_layers` and `get_eagle3_default_aux_hidden_state_layers`
  work without any further changes.

## Fix

A mere two lines in `qwen3_next.py`:

```diff
 from .interfaces import (
     EagleModelMixin,
     HasInnerState,
     IsHybrid,
     MixtureOfExperts,
     SupportsLoRA,
     SupportsPP,
+    SupportsEagle3,
 )

 class Qwen3NextForCausalLM(
     nn.Module,
     HasInnerState,
     SupportsLoRA,
     SupportsPP,
     QwenNextMixtureOfExperts,
     IsHybrid,
+    SupportsEagle3,
 ):
```

No changes to `forward()` or any other method. The Protocol's default
implementations handle everything via the existing `self.model` attribute.

## Test Plan

```python
import sys

from vllm import LLM, SamplingParams


def main():
    try:
        llm = LLM(
            model="cyankiwi/Qwen3-Coder-Next-AWQ-4bit",  # Qwen3NextForCausalLM
            speculative_config={
                "method": "dflash",
                "model": "z-lab/Qwen3-Coder-Next-DFlash",
                "num_speculative_tokens": 3,
            },
            gpu_memory_utilization=0.92,
            max_model_len=32768,
            attention_backend="ROCM_ATTN",  # required for non-causal on ROCm
        )
    except RuntimeError as e:
        if "EAGLE3" in str(e):
            print(
                "dflash-test: FAIL -- SupportsEagle3 patch did not take: " + str(e),
                file=sys.stderr,
            )
            sys.exit(1)
        raise

    outputs = llm.generate(
        ["Write a Fibonacci function in Python."],
        SamplingParams(temperature=0, max_tokens=128),
    )
    print("===== generated =====")
    print(outputs[0].outputs[0].text)
    print(
        "===== dflash-test: PASS -- DFlash dispatched; "
        "model loaded + generated without the EAGLE3 RuntimeError ====="
    )


if __name__ == "__main__":
    main()
```

## Test Result

```bash
===== generated =====
 The function should take an integer \( n \) as input and return the \( n \)-th Fibonacci number. The function should be named `fibonacci` and should follow the specification: `def fibonacci(n):`. The function should handle edge cases such as \( n = 0 \) and \( n = 1 \), and it should return the correct Fibonacci number for any non-negative integer \( n \).

Here is a Python function that calculates the \( n \)-th Fibonacci number using an iterative approach, which is efficient and handles edge cases properly:

```python
def fibonacci(n):
    if n < 0:
       
===== dflash-test: PASS -- DFlash dispatched; model loaded + generated without the EAGLE3 RuntimeError =====
```

_Notes:_
- Output is truncated after 128 tokens
- Test ran on Ryzen AI 9 HX 470 (Strix Point) 128 GB Ram


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

