### PR TITLE
[Spec Decode] Avoid materializing target probabilities in rejection sampling

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -571,8 +571,6 @@ def native_sample_recovered_tokens(
         # state because RNG state advances after each call.
         generator.set_state(states[i])
 
-    inv_q = q.reciprocal()
-
     out = torch.empty_like(draft_token_ids)
 
     for req_idx in range(batch_size):
@@ -595,7 +593,7 @@ def native_sample_recovered_tokens(
                     0.0
                 )
 
-            score = prob * inv_q[req_idx]
+            score = prob / q[req_idx]
             recovered_id = torch.argmax(score, dim=-1)
             out[token_idx] = recovered_id
     return out
@@ -1089,6 +1087,321 @@ def test_sample_recovered_tokens_vocab_boundary(vocab_size: int, no_draft_probs:
         f"Recovered token IDs >= vocab_size ({vocab_size}): "
         f"{recovered[recovered >= vocab_size].tolist()}"
     )
+
+
+def _run_forced_recovery(
+    target_probs: torch.Tensor,
+    draft_probs: torch.Tensor,
+    draft_token_ids: list[list[int]],
+    generators: dict[int, torch.Generator] | None = None,
+    use_fp64_gumbel: bool = False,
+) -> torch.Tensor:
+    batch_size = len(draft_token_ids)
+    sampler = _make_synthetic_sampler([0.0])
+    sampler.use_fp64_gumbel = use_fp64_gumbel
+    target_logits = target_probs.log()
+    bonus_token_ids = torch.zeros(batch_size, dtype=torch.int64, device=DEVICE_TYPE)
+    temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE_TYPE)
+    metadata = create_sampling_metadata(
+        all_greedy=False,
+        temperature=temperature,
+        generators=generators,
+    )
+    spec_decode_metadata = create_spec_decode_metadata(draft_token_ids, target_logits)
+
+    mock_sampler_output(sampler, bonus_token_ids)
+    output = sampler(
+        spec_decode_metadata,
+        draft_probs=draft_probs,
+        logits=target_logits,
+        sampling_metadata=metadata,
+    )
+    return output.sampled_token_ids
+
+
+@pytest.mark.parametrize("use_fp64_gumbel", [False, True])
+def test_lazy_recovery_distribution_matches_residual_distribution(
+    use_fp64_gumbel: bool,
+):
+    torch.manual_seed(0)
+    vocab_size = 6
+    target_base = torch.tensor(
+        [0.05, 0.20, 0.05, 0.25, 0.10, 0.35],
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+    draft_base = torch.tensor(
+        [0.20, 0.05, 0.10, 0.05, 0.25, 0.35],
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+    residual_ref = (target_base - draft_base).clamp_min(0.0)
+    residual_ref = residual_ref / residual_ref.sum()
+
+    tv_distances: list[float] = []
+    for num_samples in (1_000, 10_000, 100_000):
+        target_probs = target_base.repeat(num_samples, 1)
+        draft_probs = draft_base.repeat(num_samples, 1)
+        draft_token_ids = [[0] for _ in range(num_samples)]
+
+        recovered = _run_forced_recovery(
+            target_probs,
+            draft_probs,
+            draft_token_ids,
+            use_fp64_gumbel=use_fp64_gumbel,
+        )[:, 0]
+        hist = torch.bincount(recovered, minlength=vocab_size).to(torch.float32)
+        empirical = hist / hist.sum()
+        tv = 0.5 * torch.sum(torch.abs(empirical - residual_ref)).item()
+        tv_distances.append(tv)
+
+    assert tv_distances[-1] < 0.015
+    assert tv_distances[0] > tv_distances[-1]
+
+
+def test_lazy_recovery_distribution_matches_residual_distribution_multitile():
+    torch.manual_seed(0)
+    vocab_size = 128256
+    num_samples = 1024
+    residual_ids = torch.tensor(
+        [3, 8197, 32771, 65537, 81919, 98317, 120001, 128255],
+        dtype=torch.int64,
+        device=DEVICE_TYPE,
+    )
+    residual_probs = torch.tensor(
+        [0.05, 0.08, 0.11, 0.14, 0.17, 0.13, 0.20, 0.12],
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+    residual_probs = residual_probs / residual_probs.sum()
+
+    target_base = torch.zeros(vocab_size, dtype=torch.float32, device=DEVICE_TYPE)
+    target_base[residual_ids] = residual_probs
+    target_probs = target_base.repeat(num_samples, 1)
+    draft_probs = torch.zeros_like(target_probs)
+    draft_token_ids = [[0] for _ in range(num_samples)]
+
+    recovered = _run_forced_recovery(
+        target_probs,
+        draft_probs,
+        draft_token_ids,
+    )[:, 0]
+    assert torch.isin(recovered, residual_ids).all()
+
+    residual_id_to_bin = {
+        int(token_id.item()): idx for idx, token_id in enumerate(residual_ids)
+    }
+    recovered_bins = torch.tensor(
+        [residual_id_to_bin[int(token_id.item())] for token_id in recovered],
+        dtype=torch.int64,
+        device=DEVICE_TYPE,
+    )
+    hist = torch.bincount(recovered_bins, minlength=len(residual_ids)).to(torch.float32)
+    empirical = hist / hist.sum()
+    tv = 0.5 * torch.sum(torch.abs(empirical - residual_probs)).item()
+
+    assert tv < 0.08
+
+
+@pytest.mark.parametrize("no_draft_probs", [True, False])
+def test_lazy_recovery_distribution_matches_eager_helper(no_draft_probs: bool):
+    """Compare lazy recovery directly against the eager recovery helper.
+
+    The production lazy path and eager helper use different RNG streams, so this
+    is intentionally a distributional two-sample check rather than a bitwise
+    comparison.  Synthetic rejection forces the lazy path to recover on every
+    sample, and fixed seeds make the test reproducible.
+    """
+    vocab_size = 6
+    num_samples = 100_000
+    target_base = torch.tensor(
+        [0.05, 0.20, 0.05, 0.25, 0.10, 0.35],
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+    draft_base = torch.tensor(
+        [0.20, 0.05, 0.10, 0.05, 0.25, 0.35],
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+    target_probs = target_base.repeat(num_samples, 1)
+    draft_probs = None if no_draft_probs else draft_base.repeat(num_samples, 1)
+    draft_token_ids = torch.zeros(num_samples, dtype=torch.int32, device=DEVICE_TYPE)
+    num_draft_tokens = [1] * num_samples
+    cu_num_draft_tokens = torch.arange(
+        1, num_samples + 1, dtype=torch.int32, device=DEVICE_TYPE
+    )
+    sampling_metadata = create_sampling_metadata(
+        all_greedy=False,
+        temperature=torch.ones(num_samples, dtype=torch.float32, device=DEVICE_TYPE),
+    )
+
+    torch.manual_seed(123)
+    eager = sample_recovered_tokens(
+        1,
+        num_draft_tokens,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        draft_probs,
+        target_probs,
+        sampling_metadata,
+        device=DEVICE_TYPE,
+    )
+
+    torch.manual_seed(456)
+    lazy = _run_forced_recovery(
+        target_probs,
+        draft_probs,
+        [[0] for _ in range(num_samples)],
+    )[:, 0]
+
+    eager_hist = torch.bincount(eager, minlength=vocab_size).to(torch.float32)
+    lazy_hist = torch.bincount(lazy, minlength=vocab_size).to(torch.float32)
+    eager_empirical = eager_hist / eager_hist.sum()
+    lazy_empirical = lazy_hist / lazy_hist.sum()
+    tv = 0.5 * torch.sum(torch.abs(eager_empirical - lazy_empirical)).item()
+
+    assert tv < 0.02
+
+
+def test_lazy_recovery_zero_residual_mass_falls_back_to_target_argmax():
+    target_base = torch.tensor(
+        [0.05, 0.60, 0.25, 0.10],
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+    target_probs = target_base.reshape(1, -1)
+    draft_probs = target_probs.clone()
+
+    recovered = _run_forced_recovery(
+        target_probs,
+        draft_probs,
+        [[1]],
+    )
+
+    assert recovered[0, 0].item() == 1
+
+
+def test_lazy_recovery_supports_fp64_gumbel():
+    target_base = torch.tensor(
+        [0.05, 0.20, 0.05, 0.25, 0.10, 0.35],
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+    draft_base = torch.tensor(
+        [0.20, 0.05, 0.10, 0.05, 0.25, 0.35],
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+
+    recovered = _run_forced_recovery(
+        target_base.reshape(1, -1),
+        draft_base.reshape(1, -1),
+        [[0]],
+        {0: torch.Generator(device=DEVICE_TYPE).manual_seed(123)},
+        use_fp64_gumbel=True,
+    )
+
+    residual_support = (target_base - draft_base).clamp_min(0.0).nonzero().flatten()
+    assert torch.isin(recovered[0, 0], residual_support)
+
+
+def test_lazy_recovery_reject_at_last_position():
+    vocab_size = 16
+    max_spec_len = 3
+    sampler = _make_synthetic_sampler([1.0, 1.0, 0.0])
+    target_probs = torch.full(
+        (max_spec_len, vocab_size),
+        1e-3,
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+    target_probs[:, 7] = 1.0
+    target_probs = target_probs / target_probs.sum(dim=-1, keepdim=True)
+    draft_probs = torch.zeros_like(target_probs)
+    target_logits = target_probs.log()
+    draft_token_ids = [[1, 2, 3]]
+    bonus_token_ids = torch.tensor([5], dtype=torch.int64, device=DEVICE_TYPE)
+    metadata = create_sampling_metadata(
+        all_greedy=False,
+        temperature=torch.ones(1, dtype=torch.float32, device=DEVICE_TYPE),
+    )
+    spec_decode_metadata = create_spec_decode_metadata(draft_token_ids, target_logits)
+
+    mock_sampler_output(sampler, bonus_token_ids)
+    output = sampler(
+        spec_decode_metadata,
+        draft_probs=draft_probs,
+        logits=target_logits,
+        sampling_metadata=metadata,
+    )
+
+    assert output.sampled_token_ids[0, 0].item() == 1
+    assert output.sampled_token_ids[0, 1].item() == 2
+    assert output.sampled_token_ids[0, 2].item() != PLACEHOLDER_TOKEN_ID
+    assert output.sampled_token_ids[0, 3].item() == PLACEHOLDER_TOKEN_ID
+
+
+def test_mixed_greedy_and_random_batch():
+    sampler = _make_synthetic_sampler([1.0, 0.0])
+    spec_tokens = [[1, 2], [3, 4]]
+    output_tokens = [[1, 9, 11], [7, 8, 12]]
+    logits = create_logits_tensor(output_tokens)
+    bonus_token_ids = torch.tensor([11, 12], dtype=torch.int64, device=DEVICE_TYPE)
+    metadata = create_sampling_metadata(
+        all_greedy=False,
+        temperature=torch.tensor([0.0, 1.0], dtype=torch.float32, device=DEVICE_TYPE),
+    )
+    metadata.all_random = False
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
+
+    mock_sampler_output(sampler, bonus_token_ids)
+    output = sampler(
+        spec_decode_metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=metadata,
+    )
+
+    assert output.sampled_token_ids[0].tolist() == [
+        1,
+        9,
+        PLACEHOLDER_TOKEN_ID,
+    ]
+    assert output.sampled_token_ids[1, 0].item() == 3
+    assert output.sampled_token_ids[1, 1].item() != PLACEHOLDER_TOKEN_ID
+    assert output.sampled_token_ids[1, 2].item() == PLACEHOLDER_TOKEN_ID
+
+
+def test_seeded_lazy_recovery_isolated_from_other_requests():
+    target_base = torch.tensor(
+        [0.05, 0.20, 0.05, 0.25, 0.10, 0.35],
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+    draft_base = torch.tensor(
+        [0.20, 0.05, 0.10, 0.05, 0.25, 0.35],
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+
+    generator_single = {0: torch.Generator(device=DEVICE_TYPE).manual_seed(123)}
+    single = _run_forced_recovery(
+        target_base.reshape(1, -1),
+        draft_base.reshape(1, -1),
+        [[0]],
+        generator_single,
+    )
+
+    generator_mixed = {0: torch.Generator(device=DEVICE_TYPE).manual_seed(123)}
+    mixed = _run_forced_recovery(
+        target_base.repeat(2, 1),
+        draft_base.repeat(2, 1),
+        [[0], [0]],
+        generator_mixed,
+    )
+
+    assert mixed[0, 0].item() == single[0, 0].item()
 
 
 ########################### Tests for Synthetic Rejection Sampling #########

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -14,6 +14,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (
     PLACEHOLDER_TOKEN_ID,
     RejectionSampler,
+    compute_target_lse,
     sample_recovered_tokens,
 )
 from vllm.v1.sample.sampler import Sampler, SamplerOutput
@@ -1087,6 +1088,115 @@ def test_sample_recovered_tokens_vocab_boundary(vocab_size: int, no_draft_probs:
         f"Recovered token IDs >= vocab_size ({vocab_size}): "
         f"{recovered[recovered >= vocab_size].tolist()}"
     )
+
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_lse_target_prob_acceptance_matches_softmax_outside_tolerance():
+    """LSE probabilities should make the same accept/reject decisions.
+
+    Floating point reductions can differ by a few ULPs, so the decision claim is
+    parity except for rows whose probability ratio is on the uniform threshold.
+    Use the production fused LSE path so this binds the claim to the kernel.
+    """
+    torch.manual_seed(0)
+    device = "cuda"
+    num_tokens = 256
+    vocab_size = 2048
+    logits = torch.randn(num_tokens, vocab_size, dtype=torch.float32, device=device)
+
+    # Simulate top-k/top-p style masks. Keep at least one valid token per row.
+    mask = torch.rand(num_tokens, vocab_size, device=device) < 0.2
+    logits = logits.masked_fill(mask, float("-inf"))
+    logits[:, 0] = torch.maximum(logits[:, 0], torch.zeros_like(logits[:, 0]))
+
+    draft_token_ids = torch.randint(
+        0, vocab_size, (num_tokens,), dtype=torch.int64, device=device
+    )
+    draft_probs = F.softmax(
+        torch.randn(num_tokens, vocab_size, dtype=torch.float32, device=device),
+        dim=-1,
+    )
+    draft_prob = draft_probs[
+        torch.arange(num_tokens, device=device), draft_token_ids
+    ]
+    uniform_probs = torch.rand(num_tokens, dtype=torch.float64, device=device)
+
+    target_probs = F.softmax(logits, dim=-1, dtype=torch.float32)
+    softmax_prob = target_probs[
+        torch.arange(num_tokens, device=device), draft_token_ids
+    ]
+    lse = compute_target_lse(logits, vocab_size, block_size=1024)
+    lse_prob = torch.exp(
+        logits[torch.arange(num_tokens, device=device), draft_token_ids] - lse
+    )
+
+    softmax_ratio = softmax_prob / draft_prob
+    lse_ratio = lse_prob / draft_prob
+    softmax_accepted = softmax_ratio >= uniform_probs
+    lse_accepted = lse_ratio >= uniform_probs
+
+    tolerance = 1e-5
+    knife_edge = torch.minimum(
+        torch.abs(softmax_ratio - uniform_probs),
+        torch.abs(lse_ratio - uniform_probs),
+    ) < tolerance
+    mismatches = softmax_accepted != lse_accepted
+
+    assert mismatches.logical_and(~knife_edge).sum().item() == 0
+    assert torch.max(torch.abs(softmax_prob - lse_prob)).item() < 1e-6
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fused_target_lse_matches_fp64_reference():
+    """Fused LSE should match an fp64 logsumexp oracle closely.
+
+    The production kernel consumes LSE to reconstruct target probabilities.
+    Compare against fp64 rather than torch's fp32 logsumexp so the test bounds
+    numerical error against a stronger reference.
+    """
+    torch.manual_seed(0)
+    num_tokens = 64
+    vocab_size = 8193
+    logits = torch.randn(
+        num_tokens, vocab_size, dtype=torch.float32, device="cuda"
+    )
+
+    # Simulate top-k/top-p masks. Keep at least one finite value per row.
+    mask = torch.rand(num_tokens, vocab_size, device="cuda") < 0.2
+    logits = logits.masked_fill(mask, float("-inf"))
+    logits[:, 0] = torch.maximum(logits[:, 0], torch.zeros_like(logits[:, 0]))
+
+    fused_lse = compute_target_lse(logits, vocab_size, block_size=4096)
+    fp64_lse = torch.logsumexp(logits.double(), dim=-1).float()
+
+    assert torch.max(torch.abs(fused_lse - fp64_lse)).item() < 2e-6
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fused_target_lse_handles_full_negative_infinity_tiles():
+    """Rows with entire masked tiles must not poison online LSE with NaNs.
+
+    Top-k/top-p can mask complete vocab tiles to -inf. The online update must
+    skip those tiles instead of evaluating -inf - -inf into a persistent NaN.
+    """
+    block_size = 4096
+    vocab_size = block_size * 3 + 17
+    logits = torch.full((2, vocab_size), float("-inf"), device="cuda")
+
+    # First two full tiles are -inf; all finite values are in the final tile.
+    logits[0, block_size * 2 + 3] = 0.25
+    logits[0, block_size * 2 + 11] = -1.0
+    logits[1, block_size * 3 + 7] = 2.0
+
+    fused_lse = compute_target_lse(logits, vocab_size, block_size=block_size)
+    fp64_lse = torch.logsumexp(logits.double(), dim=-1).float()
+
+    assert torch.isfinite(fused_lse).all()
+    torch.testing.assert_close(fused_lse, fp64_lse, atol=2e-6, rtol=0)
 
 
 def _run_forced_recovery(

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 
 from vllm.logger import init_logger
-from vllm.triton_utils import tl, triton
+from vllm.triton_utils import HAS_TRITON, tl, triton
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
 from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -32,6 +32,13 @@ GREEDY_TEMPERATURE: tl.constexpr = 0
 # Maximum number of speculative draft tokens allowed per request in a single
 # step. This value is chosen to be large enough to handle typical use cases.
 MAX_SPEC_LEN = 128
+_FP32_RECOVERY_EPS = (
+    tl.constexpr(float.fromhex("0x1p-24")) if HAS_TRITON else float.fromhex("0x1p-24")
+)
+_FP64_RECOVERY_EPS = (
+    tl.constexpr(float.fromhex("0x1p-64")) if HAS_TRITON else float.fromhex("0x1p-64")
+)
+_MAX_RECOVERY_SEED = 2**63 - 1
 
 
 class RejectionSampler(nn.Module):
@@ -343,6 +350,7 @@ class RejectionSampler(nn.Module):
                 predict_bonus_token=False,
                 spec_token_ids=sampling_metadata.spec_token_ids,
             )
+
         return logits
 
     @staticmethod
@@ -468,23 +476,22 @@ def rejection_sample(
         if sampling_metadata.all_greedy:
             return output_token_ids
 
-    # Compute probability distribution from target logits.
     target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
     assert target_probs.is_contiguous()
 
-    # Sample recovered tokens for each position.
-    # [num_tokens]
-    recovered_token_ids = sample_recovered_tokens(
-        max_spec_len,
+    # Precompute one Philox seed per speculative token. Lazy recovery keeps the
+    # same exponential-race distribution as the eager helper while generating
+    # per-vocab noise in-kernel only after the first rejection.
+    recovery_seeds = generate_recovery_seeds(
+        num_tokens,
         num_draft_tokens,
-        cu_num_draft_tokens,
-        draft_token_ids,
-        draft_probs,
-        target_probs,
-        sampling_metadata,
+        sampling_metadata.generators,
         device,
-        use_fp64_gumbel,
     )
+
+    # Triton tile size for vocab reduction during lazy recovery.
+    # Kept large to reduce loop iterations but still fit in SRAM.
+    BLOCK_SIZE: tl.constexpr = 8192
 
     # Rejection sampling for random sampling requests.
     assert uniform_probs is not None
@@ -495,14 +502,16 @@ def rejection_sample(
         draft_probs,
         target_probs,
         bonus_token_ids,
-        recovered_token_ids,
+        recovery_seeds,
         uniform_probs,
         is_greedy,
         max_spec_len,
         vocab_size,
         synthetic_conditional_rates,
+        BLOCK_SIZE,
         NO_DRAFT_PROBS=draft_probs is None,
         SYNTHETIC_MODE=synthetic_mode,
+        USE_FP64_GUMBEL=use_fp64_gumbel,
     )
     return output_token_ids
 
@@ -641,15 +650,14 @@ def generate_uniform_probs(
     # uniform_prob is sampled to be exact 0.0 as reported in
     # https://github.com/pytorch/pytorch/issues/16706. Using float64
     # mitigates the issue.
-    uniform_probs = torch.rand(
+    uniform_probs = torch.empty(
         (num_tokens,),
         dtype=torch.float64,
         device=device,
     )
+    uniform_probs.uniform_()
     start_idx = 0
     for req_idx, n in enumerate(num_draft_tokens):
-        # Do not generate random numbers for requests with no draft tokens.
-        # This can be important for reproducibility.
         if n == 0:
             continue
         end_idx = start_idx + n
@@ -658,6 +666,60 @@ def generate_uniform_probs(
             uniform_probs[start_idx:end_idx].uniform_(generator=generator)
         start_idx = end_idx
     return uniform_probs
+
+
+def generate_recovery_seeds(
+    num_tokens: int,
+    num_draft_tokens: list[int],
+    generators: dict[int, torch.Generator],
+    device: torch.device,
+) -> torch.Tensor:
+    """Generate one in-kernel recovery RNG seed per speculative token."""
+    seeds = torch.randint(
+        _MAX_RECOVERY_SEED,
+        (num_tokens,),
+        dtype=torch.int64,
+        device=device,
+    )
+    start_idx = 0
+    for req_idx, n in enumerate(num_draft_tokens):
+        if n == 0:
+            continue
+        end_idx = start_idx + n
+        generator = generators.get(req_idx)
+        if generator is not None:
+            seeds[start_idx:end_idx] = torch.randint(
+                _MAX_RECOVERY_SEED,
+                (n,),
+                dtype=torch.int64,
+                device=device,
+                generator=generator,
+            )
+        start_idx = end_idx
+    return seeds
+
+
+def generate_recovery_noise(
+    batch_size: int,
+    vocab_size: int,
+    num_draft_tokens: list[int],
+    generators: dict[int, torch.Generator],
+    device: torch.device,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    # NOTE(woosuk): Create only one distribution for each request.
+    q = torch.empty(
+        (batch_size, vocab_size),
+        dtype=dtype,
+        device=device,
+    )
+    q.exponential_()
+    for i, generator in generators.items():
+        # Do not generate random numbers for requests with no draft tokens.
+        # This can be important for reproducibility.
+        if num_draft_tokens[i] > 0:
+            q[i].exponential_(generator=generator)
+    return q
 
 
 def sample_recovered_tokens(
@@ -675,23 +737,24 @@ def sample_recovered_tokens(
     device: torch.device,
     use_fp64_gumbel: bool = False,
 ) -> torch.Tensor:
-    # NOTE(woosuk): Create only one distribution for each request.
+    """
+    Compatibility helper for tests and callers that need eager recovery.
+
+    The production rejection path computes recovery lazily inside
+    rejection_random_sample_kernel, but this helper remains useful for
+    correctness tests against the previous eager implementation.
+    """
     batch_size = len(num_draft_tokens)
     vocab_size = target_probs.shape[-1]
     q_dtype = torch.float64 if use_fp64_gumbel else torch.float32
-    q = torch.empty(
-        (batch_size, vocab_size),
-        dtype=q_dtype,
-        device=device,
+    q = generate_recovery_noise(
+        batch_size,
+        vocab_size,
+        num_draft_tokens,
+        sampling_metadata.generators,
+        device,
+        q_dtype,
     )
-    q.exponential_()
-    for i, generator in sampling_metadata.generators.items():
-        # Do not generate random numbers for requests with no draft tokens.
-        # This can be important for reproducibility.
-        if num_draft_tokens[i] > 0:
-            q[i].exponential_(generator=generator)
-
-    inv_q = q.reciprocal()
 
     recovered_token_ids = torch.empty_like(draft_token_ids)
     BLOCK_SIZE = 8192
@@ -701,7 +764,7 @@ def sample_recovered_tokens(
         draft_token_ids,
         draft_probs,
         target_probs,
-        inv_q,
+        q,
         vocab_size,
         BLOCK_SIZE,
         NO_DRAFT_PROBS=draft_probs is None,
@@ -764,6 +827,21 @@ def rejection_greedy_sample_kernel(
         )
 
 
+@triton.jit
+def tl_rand64(seed, offset, includes_zero: tl.constexpr):
+    lo, hi, _, _ = tl.randint4x(seed, offset)
+    lo = lo.to(tl.uint32, bitcast=True).to(tl.uint64)
+    hi = hi.to(tl.uint32, bitcast=True).to(tl.uint64)
+    r = (hi << 32) | lo
+
+    # 1 / 2**64
+    scale = 5.421010862427522170037e-20
+    u = r.to(tl.float64) * scale
+    if not includes_zero:
+        u = tl.maximum(u, 2.2250738585072014e-308)  # float64 tiny
+    return u
+
+
 # NOTE(woosuk): Avoid specialization to prevent unnecessary recompilation.
 @triton.jit(do_not_specialize=["max_spec_len"])
 def rejection_random_sample_kernel(
@@ -773,14 +851,16 @@ def rejection_random_sample_kernel(
     draft_probs_ptr,  # [num_tokens, vocab_size] or None
     target_probs_ptr,  # [num_tokens, vocab_size]
     bonus_token_ids_ptr,  # [batch_size]
-    recovered_token_ids_ptr,  # [num_tokens]
+    recovery_seeds_ptr,  # [num_tokens]
     uniform_probs_ptr,  # [num_tokens]
     is_greedy_ptr,  # [batch_size]
     max_spec_len,
     vocab_size,
     synthetic_conditional_rates_ptr,  # [num_speculative_tokens] or None
+    BLOCK_SIZE: tl.constexpr,
     NO_DRAFT_PROBS: tl.constexpr,
     SYNTHETIC_MODE: tl.constexpr,
+    USE_FP64_GUMBEL: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
     is_greedy = tl.load(is_greedy_ptr + req_idx)
@@ -795,34 +875,104 @@ def rejection_random_sample_kernel(
     rejected = False
     for pos in range(num_draft_tokens):
         if not rejected:
-            draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
-            uniform_prob = tl.load(uniform_probs_ptr + start_idx + pos)
+            token_idx = start_idx + pos
+            draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
+            uniform_prob = tl.load(uniform_probs_ptr + token_idx)
             if SYNTHETIC_MODE:
                 rate = tl.load(synthetic_conditional_rates_ptr + pos)
                 accepted = uniform_prob < rate
             else:
                 if NO_DRAFT_PROBS:
-                    draft_prob = 1
+                    draft_prob = 1.0
                 else:
                     draft_prob = tl.load(
-                        draft_probs_ptr
-                        + (start_idx + pos) * vocab_size
-                        + draft_token_id
+                        draft_probs_ptr + token_idx * vocab_size + draft_token_id
                     )
                 target_prob = tl.load(
-                    target_probs_ptr + (start_idx + pos) * vocab_size + draft_token_id
+                    target_probs_ptr + token_idx * vocab_size + draft_token_id
                 )
                 # NOTE(woosuk): While the draft probability should never be 0,
                 # we check it to avoid NaNs. If it happens to be 0, we reject.
                 accepted = draft_prob > 0 and target_prob / draft_prob >= uniform_prob
+
             if accepted:
-                token_id = draft_token_id
+                tl.store(
+                    output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos,
+                    draft_token_id,
+                )
             else:
                 rejected = True
-                token_id = tl.load(recovered_token_ids_ptr + start_idx + pos)
-            tl.store(
-                output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos, token_id
-            )
+
+                # Lazy recovery: compute recovered token only after the first
+                # rejection. This uses the same exponential-race distribution
+                # as the eager helper, but generates Philox noise in-kernel in
+                # one vocab pass instead of materializing full recovery buffers.
+                token_seed = tl.randint(
+                    tl.load(recovery_seeds_ptr + token_idx), token_idx
+                )
+                if USE_FP64_GUMBEL:
+                    max_val = tl.full((), 0.0, tl.float64)
+                else:
+                    max_val = tl.full((), 0.0, tl.float32)
+                recovered_id = 0
+                fallback_max = tl.full((), float("-inf"), tl.float32)
+                fallback_id = 0
+                for v in range(0, vocab_size, BLOCK_SIZE):
+                    vocab_offset = v + tl.arange(0, BLOCK_SIZE)
+                    vocab_mask = vocab_offset < vocab_size
+
+                    target_prob_v = tl.load(
+                        target_probs_ptr + token_idx * vocab_size + vocab_offset,
+                        mask=vocab_mask,
+                        other=0.0,
+                    )
+                    target_for_argmax = tl.where(
+                        vocab_mask, target_prob_v, float("-inf")
+                    )
+                    local_fallback_max, local_fallback_id = tl.max(
+                        target_for_argmax, axis=0, return_indices=True
+                    )
+                    if local_fallback_max > fallback_max:
+                        fallback_max = local_fallback_max
+                        fallback_id = v + local_fallback_id
+
+                    if NO_DRAFT_PROBS:
+                        prob = tl.where(
+                            vocab_offset != draft_token_id, target_prob_v, 0.0
+                        )
+                    else:
+                        draft_prob_v = tl.load(
+                            draft_probs_ptr + token_idx * vocab_size + vocab_offset,
+                            mask=vocab_mask,
+                            other=0.0,
+                        )
+                        prob = tl.maximum(target_prob_v - draft_prob_v, 0.0)
+
+                    if USE_FP64_GUMBEL:
+                        u = tl_rand64(token_seed, vocab_offset, includes_zero=False)
+                        e = -tl.log(1.0 - u)
+                        e = tl.maximum(e, _FP64_RECOVERY_EPS)
+                        score = prob.to(tl.float64) / e
+                    else:
+                        u = tl.rand(token_seed, vocab_offset)
+                        e = -tl.log(1.0 - u)
+                        # Match fp32 uniform grid resolution: a rare u=0 draw
+                        # should not create an effectively infinite race score.
+                        e = tl.maximum(e, _FP32_RECOVERY_EPS)
+                        score = prob / e
+                    score = tl.where((prob > 0.0) & vocab_mask, score, 0.0)
+                    local_max, local_id = tl.max(score, axis=0, return_indices=True)
+
+                    if local_max > max_val:
+                        max_val = local_max
+                        recovered_id = v + local_id
+
+                recovered_id = tl.where(max_val > 0.0, recovered_id, fallback_id)
+
+                tl.store(
+                    output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos,
+                    recovered_id,
+                )
 
     if not rejected:
         # If all tokens are accepted, append the bonus token.
@@ -864,7 +1014,7 @@ def sample_recovered_tokens_kernel(
     draft_token_ids_ptr,  # [num_tokens]
     draft_probs_ptr,  # [num_tokens, vocab_size] or None
     target_probs_ptr,  # [num_tokens, vocab_size]
-    inv_q_ptr,  # [batch_size, vocab_size]
+    q_ptr,  # [batch_size, vocab_size]
     vocab_size,
     BLOCK_SIZE: tl.constexpr,
     NO_DRAFT_PROBS: tl.constexpr,
@@ -912,20 +1062,20 @@ def sample_recovered_tokens_kernel(
                 other=0.0,
             )
             prob = tl.maximum(target_prob - draft_prob, 0.0)
-            # NOTE(woosuk): We don't need `prob = prob / tl.sum(prob)` here because
-            # `tl.argmax` will select the maximum value.
+            # NOTE(woosuk): We don't need `prob = prob / tl.sum(prob)` here
+            # because `tl.argmax` will select the maximum value.
 
-        inv_q = tl.load(
-            inv_q_ptr + req_idx * vocab_size + vocab_offset,
+        q = tl.load(
+            q_ptr + req_idx * vocab_size + vocab_offset,
             mask=vocab_mask,
-            other=0.0,
+            other=1.0,
         )
 
         # Local tile reduction.
         # Mask out-of-vocabulary entries to -inf so they can never win
         # the argmax — prevents producing recovered_id >= vocab_size
         # when all valid entries in the last tile have zero probability.
-        score = prob * inv_q
+        score = prob / q
         score = tl.where(vocab_mask, score, float("-inf"))
         local_max, local_id = tl.max(score, axis=0, return_indices=True)
 

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -476,8 +476,18 @@ def rejection_sample(
         if sampling_metadata.all_greedy:
             return output_token_ids
 
-    target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
-    assert target_probs.is_contiguous()
+    # Avoid materializing the full [num_tokens, vocab_size] target_probs tensor.
+    # The random rejection kernel reconstructs probabilities as
+    # exp(logit - logsumexp(row)) at the point of use. This is algebraically
+    # identical to softmax in exact arithmetic and keeps normalization after
+    # temperature/top-k/top-p constraints.
+    #
+    # Use a one-pass Triton producer instead of torch.logsumexp here. ATen
+    # logsumexp may materialize full-row temporaries, which defeats the point
+    # of avoiding target_probs.
+    BLOCK_SIZE: tl.constexpr = 8192
+    target_lse = compute_target_lse(target_logits, vocab_size, BLOCK_SIZE)
+    assert target_lse.is_contiguous()
 
     # Precompute one Philox seed per speculative token. Lazy recovery keeps the
     # same exponential-race distribution as the eager helper while generating
@@ -489,10 +499,6 @@ def rejection_sample(
         device,
     )
 
-    # Triton tile size for vocab reduction during lazy recovery.
-    # Kept large to reduce loop iterations but still fit in SRAM.
-    BLOCK_SIZE: tl.constexpr = 8192
-
     # Rejection sampling for random sampling requests.
     assert uniform_probs is not None
     rejection_random_sample_kernel[(batch_size,)](
@@ -500,7 +506,8 @@ def rejection_sample(
         cu_num_draft_tokens,
         draft_token_ids,
         draft_probs,
-        target_probs,
+        target_logits,
+        target_lse,
         bonus_token_ids,
         recovery_seeds,
         uniform_probs,
@@ -773,6 +780,69 @@ def sample_recovered_tokens(
     return recovered_token_ids
 
 
+def compute_target_lse(
+    target_logits: torch.Tensor,
+    vocab_size: int,
+    block_size: int,
+) -> torch.Tensor:
+    """Compute per-row logsumexp without materializing target probabilities."""
+    if target_logits.is_cuda and HAS_TRITON:
+        target_lse = torch.empty(
+            (target_logits.shape[0],),
+            dtype=torch.float32,
+            device=target_logits.device,
+        )
+        target_lse_kernel[(target_logits.shape[0],)](
+            target_logits,
+            target_lse,
+            vocab_size,
+            BLOCK_SIZE=block_size,
+            num_warps=8,
+        )
+        return target_lse
+    return torch.logsumexp(target_logits, dim=-1)
+
+
+@triton.jit
+def target_lse_kernel(
+    target_logits_ptr,  # [num_tokens, vocab_size]
+    target_lse_ptr,  # [num_tokens]
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0)
+
+    m = tl.full((), float("-inf"), tl.float32)
+    s = tl.full((), 0.0, tl.float32)
+    for v in range(0, vocab_size, BLOCK_SIZE):
+        vocab_offset = v + tl.arange(0, BLOCK_SIZE)
+        vocab_mask = vocab_offset < vocab_size
+        logits = tl.load(
+            target_logits_ptr + row * vocab_size + vocab_offset,
+            mask=vocab_mask,
+            other=float("-inf"),
+        ).to(tl.float32)
+        tile_max = tl.max(logits, axis=0)
+        new_m = tl.maximum(m, tile_max)
+        # If all visited tiles are -inf so far, new_m is -inf. Avoid forming
+        # -inf - -inf in either branch; masked contributions should be zero.
+        finite_new_m = tl.where(new_m > float("-inf"), new_m, 0.0)
+        old_scale = tl.where(
+            m > float("-inf"),
+            tl.exp2((m - finite_new_m) * 1.4426950408889634),
+            0.0,
+        )
+        tile_contrib = tl.where(
+            logits > float("-inf"),
+            tl.exp2((logits - finite_new_m) * 1.4426950408889634),
+            0.0,
+        )
+        s = s * old_scale + tl.sum(tile_contrib, axis=0)
+        m = new_m
+
+    tl.store(target_lse_ptr + row, m + tl.log(s))
+
+
 # NOTE(woosuk): Avoid specialization to prevent unnecessary recompilation.
 @triton.jit(do_not_specialize=["max_spec_len"])
 def rejection_greedy_sample_kernel(
@@ -849,7 +919,8 @@ def rejection_random_sample_kernel(
     cu_num_draft_tokens_ptr,  # [batch_size]
     draft_token_ids_ptr,  # [num_tokens]
     draft_probs_ptr,  # [num_tokens, vocab_size] or None
-    target_probs_ptr,  # [num_tokens, vocab_size]
+    target_logits_ptr,  # [num_tokens, vocab_size]
+    target_lse_ptr,  # [num_tokens]
     bonus_token_ids_ptr,  # [batch_size]
     recovery_seeds_ptr,  # [num_tokens]
     uniform_probs_ptr,  # [num_tokens]
@@ -878,6 +949,7 @@ def rejection_random_sample_kernel(
             token_idx = start_idx + pos
             draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
             uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+            target_lse = tl.load(target_lse_ptr + token_idx)
             if SYNTHETIC_MODE:
                 rate = tl.load(synthetic_conditional_rates_ptr + pos)
                 accepted = uniform_prob < rate
@@ -888,9 +960,10 @@ def rejection_random_sample_kernel(
                     draft_prob = tl.load(
                         draft_probs_ptr + token_idx * vocab_size + draft_token_id
                     )
-                target_prob = tl.load(
-                    target_probs_ptr + token_idx * vocab_size + draft_token_id
+                target_logit = tl.load(
+                    target_logits_ptr + token_idx * vocab_size + draft_token_id
                 )
+                target_prob = tl.exp(target_logit - target_lse)
                 # NOTE(woosuk): While the draft probability should never be 0,
                 # we check it to avoid NaNs. If it happens to be 0, we reject.
                 accepted = draft_prob > 0 and target_prob / draft_prob >= uniform_prob
@@ -921,16 +994,14 @@ def rejection_random_sample_kernel(
                     vocab_offset = v + tl.arange(0, BLOCK_SIZE)
                     vocab_mask = vocab_offset < vocab_size
 
-                    target_prob_v = tl.load(
-                        target_probs_ptr + token_idx * vocab_size + vocab_offset,
+                    target_logit_v = tl.load(
+                        target_logits_ptr + token_idx * vocab_size + vocab_offset,
                         mask=vocab_mask,
-                        other=0.0,
+                        other=float("-inf"),
                     )
-                    target_for_argmax = tl.where(
-                        vocab_mask, target_prob_v, float("-inf")
-                    )
+                    target_prob_v = tl.exp(target_logit_v - target_lse)
                     local_fallback_max, local_fallback_id = tl.max(
-                        target_for_argmax, axis=0, return_indices=True
+                        target_logit_v, axis=0, return_indices=True
                     )
                     if local_fallback_max > fallback_max:
                         fallback_max = local_fallback_max


### PR DESCRIPTION
## Summary

This PR builds on #41258 and removes another full-vocab materialization from the non-greedy speculative rejection sampler.

#41258 makes recovery sampling lazy. Instead of preparing recovered tokens before knowing whether a rejection happens, recovery is computed only when needed.

This PR applies the same idea one step earlier. The sampler no longer materializes:

```python
target_probs = softmax(target_logits)
```

Instead, it computes one logsumexp value per row and reconstructs only the probabilities needed by the rejection kernel.

```python
softmax(logits)[i] = exp(logits[i] - logsumexp(logits))
```

I am calling this **streaming LSE probability reconstruction** in the code and tests. It keeps the same softmax math, but avoids writing and reading the full `[num_tokens, vocab]` probability tensor.

## Why this helps

The main win is reduced transient memory and HBM traffic in the speculative rejection path.

The old path materializes one fp32 `target_probs` tensor with shape:

```text
num_draft_tokens_total x vocab_size
```

At batch 64, k=16, this tensor is:

| vocab | removed `target_probs` tensor |
|---:|---:|
| 50,272 | 205.9 MB, 196.4 MiB |
| 128,256 | 525.3 MB, 501.0 MiB |
| 151,936 | 622.3 MB, 593.5 MiB |

Together with #41258, which removes the eager recovery buffer, the transient sampler tensor reduction is about:

| vocab | #41258 recovery buffer | this PR `target_probs` tensor | combined fp32 reduction |
|---:|---:|---:|---:|
| 128,256 | 32.8 MB | 525.3 MB | 558.2 MB, 532.3 MiB |
| 151,936 | 38.9 MB | 622.3 MB | 661.2 MB, 630.6 MiB |

This is a reduction in transient sampler tensors and memory bandwidth. It is not a claim that every deployment will get more KV-cache blocks, because vLLM's startup KV profiling may not include this transient peak.

## What changed

- Added a fused Triton producer for per-row logsumexp.
- Passed `target_logits` and per-row LSE into `rejection_random_sample_kernel` instead of materialized `target_probs`.
- Reconstructed target probabilities inside the rejection kernel with `exp(logit - lse)`.
- Kept the eager probability-based helper for tests and compatibility.
- Added coverage for:
  - acceptance parity against softmax outside ULP-level threshold cases
  - fp64-reference LSE accuracy
  - fully masked `-inf` vocab tiles from top-k/top-p style masking
  - existing eager/lazy distribution equivalence and recovery edge cases

## Implementation note

A naive version using `torch.logsumexp` was slower than materialized softmax in the mechanism benchmark. That path appears to create large intermediate tensors, which defeats the purpose of removing `target_probs`.

The final implementation uses a one-pass Triton kernel. It streams the logits once, keeps the online max and sum in registers, and writes one scalar LSE per row.

There is one important edge case: top-k/top-p can leave full vocab tiles at `-inf`. The online LSE recurrence guards this case so it does not form `-inf - -inf`. A regression test covers rows where the only finite logits appear after fully masked tiles.

## Correctness

The sampling algorithm is unchanged. The PR only changes how target probabilities are produced:

```text
softmax(logits)[i] == exp(logits[i] - logsumexp(logits))
```

In floating point, the reduction order is different from materialized softmax, so random sampling is distribution-preserving rather than bit-identical to the previous softmax tensor path. The greedy path is unchanged.

A100 validation:

- ruff passed
- full-tile `-inf` LSE regression passed
- LSE acceptance parity bound to the fused producer passed
- fp64-reference LSE oracle passed
- eager/lazy equivalence passed
- full rejection sampler suite passed: 87 passed

## Performance

A100 paired A/B/C mechanism sweep, same 20 shapes used for #41258:

- A: upstream main
- B: #41258
- C: #41258 plus this PR

Result:

- this PR vs #41258: 29.28% to 68.86% faster across all 20 mechanism rows
- this PR plus #41258 vs main: 36.43% to 79.54% faster across all 20 mechanism rows

Key target cell:

| vocab | draft_probs | reject_pos | main | #41258 | this PR | this PR vs #41258 | this PR vs main |
|---:|---|---|---:|---:|---:|---:|---:|
| 128,256 | false | none | 2.1572 ms | 1.3922 ms | 0.4532 ms | 67.45% faster | 78.99% faster |

Selected rows:

| vocab | draft_probs | reject_pos | main | #41258 | this PR | this PR vs #41258 |
|---:|---|---:|---:|---:|---:|---:|
| 50,272 | false | none | 0.9906 ms | 0.6215 ms | 0.2585 ms | 58.41% faster |
| 50,272 | true | none | 0.9662 ms | 0.6257 ms | 0.2628 ms | 57.99% faster |
| 128,256 | false | none | 2.1572 ms | 1.3922 ms | 0.4532 ms | 67.45% faster |
| 128,256 | true | none | 2.1870 ms | 1.4370 ms | 0.4475 ms | 68.86% faster |
| 128,256 | false | 0 | 2.2222 ms | 1.6998 ms | 0.9979 ms | 41.30% faster |
| 128,256 | true | 0 | 2.1766 ms | 1.8200 ms | 1.0573 ms | 41.91% faster |

Only the post-fix A100 stamp is used for the numbers above.

## End-to-end note

I also ran one high-vocab offline batch-64 cell with Qwen3-0.6B, ngram k=16, temperature 1.0, top-p 1.0, fixed lengths, and 5 paired reps.

Median output token throughput:

| Line | median output tok/s |
|---|---:|
| main | 4248.93 |
| #41258 | 4333.21 |
| this PR | 4324.10 |

Paired deltas:

| Comparison | ratio-of-medians delta | paired median delta | paired bootstrap 95% CI |
|---|---:|---:|---:|
| #41258 vs main | +1.98% | +1.72% | [-6.52%, +3.82%] |
| this PR vs #41258 | -0.21% | -0.29% | [-3.48%, +8.14%] |
| this PR vs main | +1.77% | +1.77% | [-1.82%, +3.83%] |

Speculative decoding counters confirmed that ngram ran. Median drafted tokens were about 19k to 21k per 512-prompt run, with median mean acceptance length about 3.1 to 3.4. That is about 20k draft-token normalization rows for 49,152 output tokens, or about 1,250 k=16 proposal groups. The e2e result is neutral within noise, which is consistent with the changed code being a minority of the full decode work in this cell. I am not claiming an e2e throughput win from this run.

## Duplicate-work check

I searched open vLLM issues and PRs before opening this. I did not find an open PR that removes `target_probs` from the rejection sampler or adds a fused LSE producer for this path.

Searches included:

- `target_probs rejection_sampler`
- `logsumexp rejection sampler`
- `target probabilities rejection sampling`
- `speculative rejection softmax`
- `compute_target_lse`

Related open work I found is different in scope, including #41258 lazy recovery, #40819 block-wise verification rules, #42722 empty spec-decode output handling, #42802 min_p handling, #38007 greedy shortcut, and #36657 dynamic speculation length RFC.

## Test plan

Local static checks:

```bash
uv pip install --python .venv/bin/python -q ruff
.venv/bin/python -m py_compile vllm/v1/sample/rejection_sampler.py tests/v1/sample/test_rejection_sampler.py
.venv/bin/python -m ruff check vllm/v1/sample/rejection_sampler.py tests/v1/sample/test_rejection_sampler.py
```

A100 validation jobs:

```text
vllm-lse-postfix-tests-20260611t193433
vllm-lse-postfix-mech-20260611t193433
vllm-lse-qwen-e2e-20260611t162621
```

A100 result: 87 passed for `tests/v1/sample/test_rejection_sampler.py`.

## AI assistance disclosure

The commit includes DCO sign-off: `Signed-off-by: Foad Abo Dahood <foad.abo.dahood@ibm.com>`.

AI assistance was used to help implement, test, benchmark, and draft this PR. I reviewed the changed code, duplicate-work search, test results, and benchmark evidence before submitting.
