### PR TITLE
[Bugfix] Abort requests that arrive while the engine is asleep

### DIFF
--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -864,6 +864,61 @@ async def test_pause_then_abort_queued_request():
 
 
 @pytest.mark.asyncio
+async def test_sleep_aborts_new_requests():
+    """Test that requests arriving while asleep (level 1) are aborted.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/45268:
+    a request that reaches the engine after sleep(level=1) has paused the
+    scheduler must receive an abort response immediately, instead of being
+    parked in the waiting queue with no response until wake_up (which
+    presents as an indefinite client-side hang when a request races with
+    a sleep call).
+    """
+    engine_args = AsyncEngineArgs(
+        model="meta-llama/Llama-3.2-1B-Instruct",
+        enforce_eager=True,
+        enable_sleep_mode=True,
+    )
+    with ExitStack() as after:
+        with set_default_torch_num_threads(1):
+            engine = AsyncLLM.from_engine_args(engine_args)
+        after.callback(engine.shutdown)
+
+        async def gen(request_id: str) -> RequestOutput | None:
+            final_output: RequestOutput | None = None
+            async for out in engine.generate(
+                request_id=request_id,
+                prompt=TEXT_PROMPT,
+                sampling_params=SamplingParams(max_tokens=5),
+            ):
+                final_output = out
+            return final_output
+
+        # Put the engine to sleep (mode="abort" by default).
+        await engine.sleep(level=1)
+        assert await engine.is_sleeping()
+
+        # A request arriving while asleep must be aborted promptly,
+        # not parked until wake_up.
+        final_output = await asyncio.wait_for(gen("asleep-req"), timeout=10.0)
+        assert final_output is not None
+        assert final_output.finished
+        assert final_output.outputs[0].finish_reason == "abort"
+        # Request was never run, so no tokens.
+        assert len(final_output.outputs[0].token_ids) == 0
+
+        # After wake_up, new requests must be served normally.
+        await engine.wake_up()
+        assert not await engine.is_sleeping()
+
+        final_output = await asyncio.wait_for(gen("awake-req"), timeout=30.0)
+        assert final_output is not None
+        assert final_output.finished
+        assert final_output.outputs[0].finish_reason != "abort"
+        assert len(final_output.outputs[0].token_ids) > 0
+
+
+@pytest.mark.asyncio
 async def test_pause_wait():
     """Test that mode='wait' waits for in-flight requests to complete."""
     with ExitStack() as after:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -163,6 +163,12 @@ class EngineCore:
         if self.scheduler.connector is not None:  # type: ignore
             self.model_executor.init_kv_output_aggregator(self.scheduler.connector)  # type: ignore
 
+        # True while the engine is asleep at level >= 1 (weights offloaded
+        # and KV cache discarded). Requests that arrive in this state cannot
+        # be scheduled until wake_up(), so they are aborted immediately
+        # instead of being parked in the waiting queue with no response.
+        self._asleep = False
+
         mm_registry = MULTIMODAL_REGISTRY
         self.mm_receiver_cache = mm_registry.engine_receiver_cache_from_config(
             vllm_config
@@ -769,10 +775,20 @@ class EngineCore:
                 - Level 2: Discard all GPU memory.
             mode: Pause mode - how to deal with any existing requests, see
                 documentation of pause_scheduler method.
+
+        Note:
+            At level >= 1, requests that arrive while the engine is asleep
+            are aborted immediately (the client receives an abort response)
+            rather than queued until wake_up.
         """
 
         # Pause scheduler before sleeping.
         clear_prefix_cache = level >= 1
+        if level >= 1:
+            # Mark as asleep *before* pausing so that requests racing with
+            # the pause cannot slip into the waiting queue, where they
+            # would be parked without a response until wake_up.
+            self._asleep = True
         pause_future = self.pause_scheduler(mode=mode, clear_cache=clear_prefix_cache)
         if level < 1:
             return pause_future
@@ -812,6 +828,7 @@ class EngineCore:
         # Partial wakes intentionally keep the remaining allocations asleep.
         # Resume scheduling only once all executor memory is resident again.
         if not self.model_executor.is_sleeping:
+            self._asleep = False
             self.resume_scheduler()
 
     def is_sleeping(self) -> bool:
@@ -1378,7 +1395,7 @@ class EngineCoreProc(EngineCore):
             return
         elif request_type == EngineCoreRequestType.ADD:
             req, request_wave = request
-            if self._reject_add_in_shutdown(req):
+            if self._reject_add_in_shutdown(req) or self._reject_add_while_asleep(req):
                 return
             self.add_request(req, request_wave)
         elif request_type == EngineCoreRequestType.ABORT:
@@ -1410,6 +1427,33 @@ class EngineCoreProc(EngineCore):
 
         logger.debug(
             "[shutdown] EngineCore: rejecting new request request_id=%s",
+            request.request_id,
+        )
+        self._send_abort_outputs_to_client([request.request_id], request.client_index)
+        return True
+
+    def _reject_add_while_asleep(self, request: Request) -> bool:
+        """Abort requests that arrive while the engine is asleep (level >= 1).
+
+        The model weights are offloaded and the scheduler is paused, so such
+        requests cannot be scheduled until wake_up(). Without this, they
+        would be parked in the scheduler's waiting queue with no response,
+        and clients whose requests race with a sleep call would hang
+        indefinitely (see https://github.com/vllm-project/vllm/issues/45268).
+
+        Args:
+            request: The incoming request.
+
+        Returns:
+            True if the request was rejected (abort output sent to the
+            client), False if the engine is awake and the request should
+            be added normally.
+        """
+        if not self._asleep:
+            return False
+
+        logger.debug(
+            "Engine is asleep: aborting new request request_id=%s",
             request.request_id,
         )
         self._send_abort_outputs_to_client([request.request_id], request.client_index)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -163,11 +163,8 @@ class EngineCore:
         if self.scheduler.connector is not None:  # type: ignore
             self.model_executor.init_kv_output_aggregator(self.scheduler.connector)  # type: ignore
 
-        # True while the engine is asleep at level >= 1 (weights offloaded
-        # and KV cache discarded). Requests that arrive in this state cannot
-        # be scheduled until wake_up(), so they are aborted immediately
-        # instead of being parked in the waiting queue with no response.
-        self._asleep = False
+        # Reject new requests during level-1+ sleep instead of queueing them.
+        self._reject_new_requests = False
 
         mm_registry = MULTIMODAL_REGISTRY
         self.mm_receiver_cache = mm_registry.engine_receiver_cache_from_config(
@@ -785,10 +782,8 @@ class EngineCore:
         # Pause scheduler before sleeping.
         clear_prefix_cache = level >= 1
         if level >= 1:
-            # Mark as asleep *before* pausing so that requests racing with
-            # the pause cannot slip into the waiting queue, where they
-            # would be parked without a response until wake_up.
-            self._asleep = True
+            # Reject requests before pausing to close the race with sleep.
+            self._reject_new_requests = True
         pause_future = self.pause_scheduler(mode=mode, clear_cache=clear_prefix_cache)
         if level < 1:
             return pause_future
@@ -828,7 +823,7 @@ class EngineCore:
         # Partial wakes intentionally keep the remaining allocations asleep.
         # Resume scheduling only once all executor memory is resident again.
         if not self.model_executor.is_sleeping:
-            self._asleep = False
+            self._reject_new_requests = False
             self.resume_scheduler()
 
     def is_sleeping(self) -> bool:
@@ -1433,13 +1428,7 @@ class EngineCoreProc(EngineCore):
         return True
 
     def _reject_add_while_asleep(self, request: Request) -> bool:
-        """Abort requests that arrive while the engine is asleep (level >= 1).
-
-        The model weights are offloaded and the scheduler is paused, so such
-        requests cannot be scheduled until wake_up(). Without this, they
-        would be parked in the scheduler's waiting queue with no response,
-        and clients whose requests race with a sleep call would hang
-        indefinitely (see https://github.com/vllm-project/vllm/issues/45268).
+        """Reject new requests during level-1+ sleep instead of queueing them.
 
         Args:
             request: The incoming request.
@@ -1449,7 +1438,7 @@ class EngineCoreProc(EngineCore):
             client), False if the engine is awake and the request should
             be added normally.
         """
-        if not self._asleep:
+        if not self._reject_new_requests:
             return False
 
         logger.debug(


### PR DESCRIPTION
## Purpose

Partially addresses #45268 (the 100%-reproducible client-hang half; the reported EngineDeadError is tracked separately on the issue).

Requests that race with `POST /sleep?level=1` (mode="abort") hang forever: sleep aborts everything already in the scheduler and pauses it (`PAUSED_NEW`), but a request still in API-server preprocessing when sleep fires reaches the EngineCore **after** the pause and is parked in `scheduler.waiting`, which `PAUSED_NEW` never schedules — no output is ever produced and the client hangs until its own timeout. Easy to hit with long prompts + `--kv-offloading-backend native` (slow preprocessing + CPU→GPU loads widen the race window); for a sleep-cycling deployment this presents as dead requests.

(Mechanism note: I initially attributed the hang to sleep-aborts of requests in `WAITING_FOR_REMOTE_KVS` — instrumentation shows those are finalized correctly; the hang comes solely from this add-after-pause race. Corrected on the issue.)

## Design choice

An ADD processed while asleep at level ≥ 1 has no schedulable future: weights are offloaded and `wake_up()` may never come while the client waits. This PR finishes such requests immediately with `FinishReason.ABORT`, mirroring the existing `_reject_add_in_shutdown` behavior:

- `EngineCore._asleep` set in `sleep()` for level ≥ 1 **before** pausing (nothing can slip into the waiting queue mid-pause), cleared in `wake_up()`.
- `EngineCoreProc._reject_add_while_asleep()` sends the abort output to the client.
- `/pause` (RLHF weight updates, engine awake) is untouched: requests submitted while paused-but-awake still queue and run on resume (existing `test_pause_abort` passes).

## Test Plan

```
.venv/bin/python -m pytest tests/v1/engine/test_async_llm.py -k 'sleep or pause' -v
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -k abort -v
```

New `test_sleep_aborts_new_requests`: sleep(level=1) → submit request → must receive finish_reason="abort" with 0 tokens promptly (times out without the fix) → wake_up → requests serve normally.

## Test Result

- `test_sleep_aborts_new_requests`: **fails (timeout) without the fix, passes with it**.
- All 7 pause/sleep tests + 3 scheduler abort tests pass.
- E2E with the #45268 repro (Qwen3-0.6B, `--enable-sleep-mode --kv-offloading-backend native`, sleep fired 40–300 ms into a burst of 8 prefix-load requests): previously all 8 clients hung ≥10 s at 40–250 ms delays; with the fix every client receives a response at every delay and post-wake probes return 200.
- `pre-commit` (ruff check/format, mypy 3.10/3.12) passes on changed files.

## Duplicate-work check

`gh issue view 45268 --comments`: only the reporter and my own investigation comment; no assignee. `gh pr list --search "45268 in:body"` / `--search "sleep abort hang"`: no open PRs. No competing work as of 2026-06-12.

## AI assistance disclosure

Developed with AI assistance (Claude Code). I reviewed every changed line and ran the tests above.

---
 Generated with [Claude Code](https://claude.com/claude-code)