### PR TITLE
Reduce prompt logprobs memory usage

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -201,6 +201,7 @@ from vllm.v1.worker.cp_utils import (
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.ec_connector_model_runner_mixin import ECConnectorModelRunnerMixin
 from vllm.v1.worker.gpu.pool.late_interaction_runner import LateInteractionRunner
+from vllm.v1.worker.gpu.sample.logprob import compute_topk_logprobs
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
 from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
@@ -5468,9 +5469,8 @@ class GPUModelRunner(
             tgt_token_ids = prompt_token_ids[start_tok : start_tok + num_logits]
 
             # Compute prompt logprobs.
-            logprobs = self.sampler.compute_logprobs(logits)
-            token_ids, logprobs, ranks, _ = self.sampler.gather_logprobs(
-                logprobs, num_prompt_logprobs, tgt_token_ids
+            token_ids, logprobs, ranks, _ = compute_topk_logprobs(
+                logits, num_prompt_logprobs, tgt_token_ids
             )
 
             # Transfer GPU->CPU async.


### PR DESCRIPTION
Summary:
- Reuse the existing `compute_topk_logprobs` path when computing prompt logprobs in `GPUModelRunner`.
- Avoid materializing the full `log_softmax` tensor over the vocabulary for prompt logprobs.
- Preserve the existing target-token-first output ordering expected by `LogprobsTensors`.

Testing:
- `git diff --check -- vllm/v1/worker/gpu_model_runner.py`
- `python3 -m py_compile vllm/v1/worker/gpu_model_runner.py`
