### PR TITLE
[Bugfix] Skip Ray actor kill after the driver has disconnected

### DIFF
--- a/tests/v1/engine/test_core_engine_actor_manager.py
+++ b/tests/v1/engine/test_core_engine_actor_manager.py
@@ -355,3 +355,37 @@ def test_ray_dp_addresses_resolved_before_actor_creation(
                 "time they DEALER-connect. See PR #42585 / Ray-DP "
                 "multi-API-server regression."
             )
+
+
+def test_shutdown_skips_ray_cleanup_after_driver_disconnect(monkeypatch):
+    """Regression test for https://github.com/vllm-project/vllm/issues/45318.
+
+    When ``CoreEngineActorManager.shutdown()`` runs after Ray's atexit hook
+    has disconnected the driver (e.g. via a finalizer during interpreter
+    exit), calling ``ray.kill`` would auto-init a brand-new Ray job and fail
+    with ``ActorHandleNotFoundError``, burying the original error. The
+    shutdown must skip actor/placement-group cleanup in that state.
+    """
+    import threading
+
+    manager = CoreEngineActorManager.__new__(CoreEngineActorManager)
+    manager.manager_stopped = threading.Event()
+    manager.local_engine_actors = [object()]
+    manager.remote_engine_actors = [object()]
+    manager.created_placement_groups = [object()]
+
+    kills: list[Any] = []
+    removed: list[Any] = []
+    monkeypatch.setattr(ray, "kill", kills.append)
+    monkeypatch.setattr(ray.util, "remove_placement_group", removed.append)
+
+    # Driver already disconnected: no Ray calls may happen.
+    monkeypatch.setattr(ray, "is_initialized", lambda: False)
+    manager.shutdown()
+    assert manager.manager_stopped.is_set()
+    assert kills == [] and removed == []
+
+    # Driver still connected: normal cleanup proceeds.
+    monkeypatch.setattr(ray, "is_initialized", lambda: True)
+    manager.shutdown()
+    assert len(kills) == 2 and len(removed) == 1

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -991,6 +991,12 @@ class CoreEngineActorManager:
         import ray
 
         self.manager_stopped.set()
+        # Skip actor/placement-group cleanup if Ray's atexit hook already
+        # disconnected this driver: both are reclaimed with the owning job,
+        # and these calls would auto-init a new Ray job and fail with
+        # ActorHandleNotFoundError (#45318).
+        if not ray.is_initialized():
+            return
         for actor in self.local_engine_actors + self.remote_engine_actors:
             ray.kill(actor)
         for pg in self.created_placement_groups:

--- a/vllm/v1/executor/ray_executor.py
+++ b/vllm/v1/executor/ray_executor.py
@@ -108,8 +108,13 @@ class RayDistributedExecutor(Executor):
             self.forward_dag.teardown()
             import ray
 
-            for worker in self.workers:
-                ray.kill(worker)
+            # Skip the kill if Ray's atexit hook already disconnected this
+            # driver: the actors are fate-shared with the disconnected job,
+            # and ray.kill() would auto-init a new Ray job and fail with
+            # ActorHandleNotFoundError (#45318).
+            if ray.is_initialized():
+                for worker in self.workers:
+                    ray.kill(worker)
             self.forward_dag = None
 
     def _configure_ray_workers_use_nsight(self, ray_remote_kwargs) -> dict[str, Any]:

--- a/vllm/v1/executor/ray_executor_v2.py
+++ b/vllm/v1/executor/ray_executor_v2.py
@@ -508,12 +508,27 @@ class RayExecutorV2(MultiprocExecutor):
 
         self._join_monitor_thread()
 
-        for handle in getattr(self, "ray_worker_handles", []):
-            try:
-                ray.kill(handle.actor)
-                logger.debug("Killed actor rank=%d", handle.rank)
-            except Exception:
-                logger.exception("Failed to kill actor rank=%d", handle.rank)
+        if ray.is_initialized():
+            for handle in getattr(self, "ray_worker_handles", []):
+                try:
+                    ray.kill(handle.actor)
+                    logger.debug("Killed actor rank=%d", handle.rank)
+                except Exception:
+                    logger.exception("Failed to kill actor rank=%d", handle.rank)
+        else:
+            # Ray's atexit hook already disconnected this driver (e.g. this
+            # shutdown is running via weakref.finalize during interpreter
+            # exit after an EngineCore init failure). The worker actors are
+            # fate-shared with the disconnected job and are reclaimed by
+            # Ray; calling ray.kill() here would auto-init a NEW Ray job
+            # and fail with ActorHandleNotFoundError, burying the original
+            # error (https://github.com/vllm-project/vllm/issues/45318).
+            # Unlike most ray APIs, ray.is_initialized() does not auto-init.
+            logger.debug(
+                "Ray is no longer initialized; skipping actor kill "
+                "(workers are reclaimed by Ray with the owning job)."
+            )
+        self.ray_worker_handles = []
 
         if rpc_broadcast_mq := getattr(self, "rpc_broadcast_mq", None):
             rpc_broadcast_mq.shutdown()


### PR DESCRIPTION
## Purpose

Fixes #45318.

The reported `ActorHandleNotFoundError` ("created in job 01000000, but the current job is 02000000") is **not a ray-2.55 executor incompatibility** — it's teardown noise that buries the user's real init error, and the same defect exists on the CI-pinned ray 2.48.0, just silently:

1. Any EngineCore init failure after the Ray workers spawn aborts `run_engine_core` before a normal shutdown exists, so `RayExecutorV2.shutdown()` only runs at interpreter exit via `weakref.finalize`.
2. Ray's own atexit hook (registered at `import ray`) runs first (LIFO) and disconnects the driver job.
3. `ray.kill()` is auto-init wrapped → the finalizer silently opens a **new** Ray job (a second "Connecting to existing Ray cluster" appears in the log) and kills a handle owned by the old job → `ActorHandleNotFoundError`.
4. On ray ≤2.53 the identical sequence instead aborts with a one-line C++ `actor_manager.cc:55 Check failed` — ray-project/ray#59425 (shipped in ray 2.54.0) merely made the failure legible. That's the only 2.48→2.55 delta; the happy path on ray 2.55.1 is clean.

Fix: guard the cleanup with `ray.is_initialized()` (which, unlike most ray APIs, does **not** auto-init). When the owning job has disconnected, non-detached actors and placement groups are fate-shared with it and reclaimed by Ray, so skipping is safe. The same guard is applied to the two identical patterns: `RayDistributedExecutor.shutdown` (`ray_executor.py`) and `CoreEngineActorManager.shutdown` (`engine/utils.py`).

## Test Plan

```
.venv/bin/python -m pytest tests/v1/engine/test_core_engine_actor_manager.py::test_shutdown_skips_ray_cleanup_after_driver_disconnect -q
# e2e (single node, external cluster, ray 2.55.1):
ray start --head --port=6380
RAY_ADDRESS=127.0.0.1:6380 vllm serve Qwen/Qwen3-0.6B --distributed-executor-backend ray -tp 1 --gpu-memory-utilization 0.25 --enforce-eager   # induced worker-init failure
```

## Test Result

- New unit test passes (disconnected → no `ray.kill`/`remove_placement_group` calls; connected → normal cleanup).
- E2E induced-failure run, before → after: `ActorHandleNotFoundError` occurrences 1 → **0**; "Connecting to existing Ray cluster" 2 → **1** (no spurious teardown job); the real root-cause traceback surfaces directly above "Engine core initialization failed".
- E2E happy path (same cluster, serve + completion request + SIGTERM): clean shutdown, 0 errors — the kill path still runs normally while connected.
- `pre-commit` (ruff check/format, mypy) passes on all changed files.

Single-node TP=1 reproduces the reporter's 4-node symptom byte-for-byte (full analysis in my issue comment); the reporter offered to test on the 4-node setup — with this patch their run will surface the actual init failure instead.

## Duplicate-work check

`gh issue view 45318 --comments`: no assignee, no other investigators. `gh pr list --search "45318 in:body"`, `--search "ActorHandleNotFoundError"`, `--search "ray 2.55"`: no open PRs. No competing work as of 2026-06-12.

## AI assistance disclosure

Developed with AI assistance (Claude Code). I reviewed every changed line and ran the tests above.

---
 Generated with [Claude Code](https://claude.com/claude-code)