### PR TITLE
[Kernel] [vLLM IR] [Perf] Add support for mixed input/weight dtype to rms norm quant fusion ops

### DIFF
--- a/benchmarks/fused_kernels/layernorm_rms_benchmarks.py
+++ b/benchmarks/fused_kernels/layernorm_rms_benchmarks.py
@@ -26,6 +26,7 @@ class bench_params_t:
     hidden_size: int
     add_residual: bool
     dtype: torch.dtype
+    wt_dtype: torch.dtype
     group_size: list[int]
 
     def description(self):
@@ -34,6 +35,7 @@ class bench_params_t:
             f"x D {self.hidden_size} "
             f"x R {self.add_residual} "
             f"x DT {self.dtype}"
+            f"x WDT {self.wt_dtype}"
             f"x GS {self.group_size}"
         )
 
@@ -44,11 +46,14 @@ def get_bench_params() -> list[bench_params_t]:
     HIDDEN_SIZES = list(range(1024, 8129, 1024))
     ADD_RESIDUAL = [True, False]
     DTYPES = [torch.bfloat16, torch.float]
+    WT_DTYPES = [torch.bfloat16, torch.float]
     GROUP_SIZES = [[1, 64], [1, 128]]
 
-    combinations = product(NUM_TOKENS, HIDDEN_SIZES, ADD_RESIDUAL, DTYPES, GROUP_SIZES)
+    combinations = product(
+        NUM_TOKENS, HIDDEN_SIZES, ADD_RESIDUAL, DTYPES, WT_DTYPES, GROUP_SIZES
+    )
     bench_params = list(
-        map(lambda x: bench_params_t(x[0], x[1], x[2], x[3], x[4]), combinations)
+        map(lambda x: bench_params_t(x[0], x[1], x[2], x[3], x[4], x[5]), combinations)
     )
     return bench_params
 
@@ -173,7 +178,7 @@ def bench_fn(
 
 def bench(params: bench_params_t, label: str, sub_label: str) -> Iterable[TMeasurement]:
     # Make inputs
-    layer = RMSNorm(params.hidden_size, 1e-6).to(dtype=params.dtype)
+    layer = RMSNorm(params.hidden_size, 1e-6, dtype=params.wt_dtype)
     # Make weights
     layer.weight.data.normal_(mean=1.0, std=0.1)
     # Make inputs

--- a/benchmarks/fused_kernels/layernorm_rms_benchmarks.py
+++ b/benchmarks/fused_kernels/layernorm_rms_benchmarks.py
@@ -34,8 +34,8 @@ class bench_params_t:
             f"N {self.num_tokens} "
             f"x D {self.hidden_size} "
             f"x R {self.add_residual} "
-            f"x DT {self.dtype}"
-            f"x WDT {self.wt_dtype}"
+            f"x DT {self.dtype} "
+            f"x WDT {self.wt_dtype} "
             f"x GS {self.group_size}"
         )
 

--- a/csrc/libtorch_stable/layernorm_quant_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_quant_kernels.cu
@@ -253,7 +253,7 @@ void rms_norm_static_fp8_quant(
                         out.mutable_data_ptr<fp8_t>(),                         \
                         input.mutable_data_ptr<scalar_in_t>(), input_stride,   \
                         residual.mutable_data_ptr<scalar_in_t>(),              \
-                        weight.const_data_ptr<scalar_t>(),                  \
+                        weight.const_data_ptr<scalar_t>(),                     \
                         scale.const_data_ptr<float>(), epsilon, num_tokens,    \
                         hidden_size);                                          \
               });                                                              \

--- a/csrc/libtorch_stable/layernorm_quant_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_quant_kernels.cu
@@ -115,7 +115,6 @@ fused_add_rms_norm_static_fp8_quant_kernel(
     _f16Vec<scalar_t, width> temp = input_v[stride_id];
     temp += residual_v[id];
     variance += temp.sum_squares();
-    residual_v[id] = temp;
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -131,7 +130,9 @@ fused_add_rms_norm_static_fp8_quant_kernel(
   float const scale_inv = 1.0f / *scale;
 
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
+    int stride_id = blockIdx.x * vec_input_stride + idx;
     int id = blockIdx.x * vec_hidden_size + idx;
+    _f16Vec<scalar_t, width> inp = input_v[stride_id];
     _f16Vec<scalar_t, width> res = residual_v[id];
     _f16Vec<scalar_wt_t, width> w = weight_v[idx];
     using Converter = _typeConvert<scalar_t>;
@@ -139,7 +140,8 @@ fused_add_rms_norm_static_fp8_quant_kernel(
     using HipT = typename Converter::hip_type;
 #pragma unroll
     for (int i = 0; i < width; ++i) {
-      float x = Converter::convert(res.data[i]);
+      float x = Converter::convert(inp.data[i]);
+      x += Converter::convert(res.data[i]);
       // Multiply in weight's native dtype to match fused_add_rms_norm_kernel.
       // temp hack to convert from wt_dtype -> float -> inp_dtype 
       // as direct wt_dtype -> inp_dtype isn't available 
@@ -147,6 +149,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
       out[id * width + i] = scaled_fp8_conversion<true, fp8_type>(
           Converter::convert(out_norm_h), scale_inv);
     }
+    residual_v[id] += inp;
   }
 }
 
@@ -167,11 +170,9 @@ fused_add_rms_norm_static_fp8_quant_kernel(
   float variance = 0.0f;
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    scalar_t z = input[blockIdx.x * input_stride + idx];
-    z += residual[blockIdx.x * hidden_size + idx];
-    float x = (float)z;
+    float x = input[blockIdx.x * input_stride + idx];
+    x += residual[blockIdx.x * hidden_size + idx];
     variance += x * x;
-    residual[blockIdx.x * hidden_size + idx] = z;
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -187,11 +188,13 @@ fused_add_rms_norm_static_fp8_quant_kernel(
   float const scale_inv = 1.0f / *scale;
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float)residual[blockIdx.x * hidden_size + idx];
+    float x = (float)input[blockIdx.x * input_stride + idx];
+    x += residual[blockIdx.x * hidden_size + idx];
     // Multiply in weight's native dtype to match fused_add_rms_norm_kernel.
     scalar_t out_norm = static_cast<scalar_t>(static_cast<scalar_wt_t>(x * s_variance) * weight[idx]);
     out[blockIdx.x * hidden_size + idx] = scaled_fp8_conversion<true, fp8_type>(
         static_cast<float>(out_norm), scale_inv);
+    residual[blockIdx.x * hidden_size + idx] = static_cast<scalar_t>(x);
   }
 }
 

--- a/csrc/libtorch_stable/layernorm_quant_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_quant_kernels.cu
@@ -19,12 +19,12 @@
 namespace vllm {
 
 // TODO(woosuk): Further optimize this kernel.
-template <typename scalar_t, typename fp8_type, int VEC_SIZE>
+template <typename scalar_t, typename scalar_wt_t, typename fp8_type, int VEC_SIZE>
 __global__ void rms_norm_static_fp8_quant_kernel(
     fp8_type* __restrict__ out,          // [..., hidden_size]
     const scalar_t* __restrict__ input,  // [..., hidden_size]
     const int input_stride,
-    const scalar_t* __restrict__ weight,  // [hidden_size]
+    const scalar_wt_t* __restrict__ weight,  // [hidden_size]
     const float* __restrict__ scale,      // [1]
     const float epsilon, const int num_tokens, const int hidden_size) {
   __shared__ float s_variance;
@@ -59,15 +59,15 @@ __global__ void rms_norm_static_fp8_quant_kernel(
   float const scale_inv = 1.0f / *scale;
 
   auto* v_in = reinterpret_cast<const vec_n_t<scalar_t, VEC_SIZE>*>(input_row);
-  auto* v_w = reinterpret_cast<const vec_n_t<scalar_t, VEC_SIZE>*>(weight);
+  auto* v_w = reinterpret_cast<const vec_n_t<scalar_wt_t, VEC_SIZE>*>(weight);
   for (int idx = threadIdx.x; idx < hidden_size / VEC_SIZE; idx += blockDim.x) {
     vec_n_t<scalar_t, VEC_SIZE> src1 = v_in[idx];
-    vec_n_t<scalar_t, VEC_SIZE> src2 = v_w[idx];
+    vec_n_t<scalar_wt_t, VEC_SIZE> src2 = v_w[idx];
 #pragma unroll
     for (int j = 0; j < VEC_SIZE; j++) {
       float x = static_cast<float>(src1.val[j]);
       // Multiply in weight's native dtype to match rms_norm_kernel.
-      scalar_t out_norm = static_cast<scalar_t>(x * s_variance) * src2.val[j];
+      scalar_wt_t out_norm = static_cast<scalar_wt_t>(x * s_variance) * src2.val[j];
       out[blockIdx.x * hidden_size + idx * VEC_SIZE + j] =
           scaled_fp8_conversion<true, fp8_type>(static_cast<float>(out_norm),
                                                 scale_inv);
@@ -79,19 +79,21 @@ __global__ void rms_norm_static_fp8_quant_kernel(
    Additional optimizations we can make in this case are
    packed and vectorized operations, which help with the
    memory latency bottleneck. */
-template <typename scalar_t, int width, typename fp8_type>
-__global__ std::enable_if_t<(width > 0) && _typeConvert<scalar_t>::exists>
+template <typename scalar_t, typename scalar_wt_t, int width, typename fp8_type>
+__global__ std::enable_if_t<(width > 0) && _typeConvert<scalar_t>::exists && _typeConvert<scalar_wt_t>::exists>
 fused_add_rms_norm_static_fp8_quant_kernel(
     fp8_type* __restrict__ out,    // [..., hidden_size]
     scalar_t* __restrict__ input,  // [..., hidden_size]
     const int input_stride,
     scalar_t* __restrict__ residual,      // [..., hidden_size]
-    const scalar_t* __restrict__ weight,  // [hidden_size]
+    const scalar_wt_t* __restrict__ weight,  // [hidden_size]
     const float* __restrict__ scale,      // [1]
     const float epsilon, const int num_tokens, const int hidden_size) {
   // Sanity checks on our vector struct and type-punned pointer arithmetic
   static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
+  static_assert(std::is_pod_v<_f16Vec<scalar_wt_t, width>>);
   static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
+  static_assert(sizeof(_f16Vec<scalar_wt_t, width>) == sizeof(scalar_wt_t) * width);
 
   const int vec_hidden_size = hidden_size / width;
   const int vec_input_stride = input_stride / width;
@@ -105,7 +107,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
   auto* __restrict__ residual_v =
       reinterpret_cast<_f16Vec<scalar_t, width>*>(residual);
   auto* __restrict__ weight_v =
-      reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
+      reinterpret_cast<const _f16Vec<scalar_wt_t, width>*>(weight);
 
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
     int stride_id = blockIdx.x * vec_input_stride + idx;
@@ -131,16 +133,17 @@ fused_add_rms_norm_static_fp8_quant_kernel(
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
     int id = blockIdx.x * vec_hidden_size + idx;
     _f16Vec<scalar_t, width> res = residual_v[id];
-    _f16Vec<scalar_t, width> w = weight_v[idx];
+    _f16Vec<scalar_wt_t, width> w = weight_v[idx];
     using Converter = _typeConvert<scalar_t>;
+    using WeightConverter = _typeConvert<scalar_wt_t>;
     using HipT = typename Converter::hip_type;
 #pragma unroll
     for (int i = 0; i < width; ++i) {
       float x = Converter::convert(res.data[i]);
       // Multiply in weight's native dtype to match fused_add_rms_norm_kernel.
-      HipT out_norm_h = Converter::convert(x * s_variance) * w.data[i];
+      HipT out_norm_h = WeightConverter::convert(WeightConverter::convert(x * s_variance) * w.data[i]);
       out[id * width + i] = scaled_fp8_conversion<true, fp8_type>(
-          Converter::convert(out_norm_h), scale_inv);
+          WeightConverter::convert(out_norm_h), scale_inv);
     }
   }
 }
@@ -148,14 +151,14 @@ fused_add_rms_norm_static_fp8_quant_kernel(
 /* Generic fused_add_rms_norm_kernel
    The width field is not used here but necessary for other specializations.
  */
-template <typename scalar_t, int width, typename fp8_type>
-__global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists>
+template <typename scalar_t, typename scalar_wt_t, int width, typename fp8_type>
+__global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists || !_typeConvert<scalar_wt_t>::exists>
 fused_add_rms_norm_static_fp8_quant_kernel(
     fp8_type* __restrict__ out,    // [..., hidden_size]
     scalar_t* __restrict__ input,  // [..., hidden_size]
     const int input_stride,
     scalar_t* __restrict__ residual,      // [..., hidden_size]
-    const scalar_t* __restrict__ weight,  // [hidden_size]
+    const scalar_wt_t* __restrict__ weight,  // [hidden_size]
     const float* __restrict__ scale,      // [1]
     const float epsilon, const int num_tokens, const int hidden_size) {
   __shared__ float s_variance;
@@ -184,7 +187,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
     float x = (float)residual[blockIdx.x * hidden_size + idx];
     // Multiply in weight's native dtype to match fused_add_rms_norm_kernel.
-    scalar_t out_norm = static_cast<scalar_t>(x * s_variance) * weight[idx];
+    scalar_wt_t out_norm = static_cast<scalar_wt_t>(x * s_variance) * weight[idx];
     out[blockIdx.x * hidden_size + idx] = scaled_fp8_conversion<true, fp8_type>(
         static_cast<float>(out_norm), scale_inv);
   }
@@ -211,43 +214,51 @@ void rms_norm_static_fp8_quant(
   const cudaStream_t stream = get_current_cuda_stream();
   VLLM_STABLE_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "rms_norm_kernel_scalar_type", [&] {
-        VLLM_STABLE_DISPATCH_FP8_TYPES(
-            out.scalar_type(), "rms_norm_kernel_fp8_type", [&] {
-              const int calculated_vec_size =
-                  std::gcd(16 / sizeof(scalar_t), hidden_size);
-              const int block_size =
-                  std::min(hidden_size / calculated_vec_size, max_block_size);
-              dim3 block(block_size);
-              VLLM_STABLE_DISPATCH_VEC_SIZE(calculated_vec_size, [&] {
-                vllm::rms_norm_static_fp8_quant_kernel<scalar_t, fp8_t,
-                                                       vec_size>
-                    <<<grid, block, 0, stream>>>(
-                        out.mutable_data_ptr<fp8_t>(),
-                        input.const_data_ptr<scalar_t>(), input_stride,
-                        weight.const_data_ptr<scalar_t>(),
-                        scale.const_data_ptr<float>(), epsilon, num_tokens,
-                        hidden_size);
+        using scalar_in_t = scalar_t;
+        VLLM_STABLE_DISPATCH_FLOATING_TYPES(
+          weight.scalar_type(), "rms_norm_kernel_wt_type", [&] {
+            VLLM_STABLE_DISPATCH_FP8_TYPES(
+              out.scalar_type(), "rms_norm_kernel_fp8_type", [&] {
+                const int calculated_vec_size =
+                    std::gcd(16 / sizeof(scalar_t), hidden_size);
+                const int block_size =
+                    std::min(hidden_size / calculated_vec_size, max_block_size);
+                dim3 block(block_size);
+                VLLM_STABLE_DISPATCH_VEC_SIZE(calculated_vec_size, [&] {
+                  vllm::rms_norm_static_fp8_quant_kernel<scalar_in_t, scalar_t, fp8_t,
+                                                        vec_size>
+                      <<<grid, block, 0, stream>>>(
+                          out.mutable_data_ptr<fp8_t>(),
+                          input.const_data_ptr<scalar_in_t>(), input_stride,
+                          weight.const_data_ptr<scalar_t>(),
+                          scale.const_data_ptr<float>(), epsilon, num_tokens,
+                          hidden_size);
+                });
               });
-            });
+          });
       });
 }
 
-#define LAUNCH_FUSED_ADD_RMS_NORM(width)                                     \
-  VLLM_STABLE_DISPATCH_FLOATING_TYPES(                                       \
-      input.scalar_type(), "fused_add_rms_norm_kernel_scalar_type", [&] {    \
-        VLLM_STABLE_DISPATCH_FP8_TYPES(                                      \
-            out.scalar_type(), "fused_add_rms_norm_kernel_fp8_type", [&] {   \
-              vllm::fused_add_rms_norm_static_fp8_quant_kernel<scalar_t,     \
-                                                               width, fp8_t> \
-                  <<<grid, block, 0, stream>>>(                              \
-                      out.mutable_data_ptr<fp8_t>(),                         \
-                      input.mutable_data_ptr<scalar_t>(), input_stride,      \
-                      residual.mutable_data_ptr<scalar_t>(),                 \
-                      weight.const_data_ptr<scalar_t>(),                     \
-                      scale.const_data_ptr<float>(), epsilon, num_tokens,    \
-                      hidden_size);                                          \
-            });                                                              \
-      });
+#define LAUNCH_FUSED_ADD_RMS_NORM(width)                                       \
+  VLLM_STABLE_DISPATCH_FLOATING_TYPES(                                         \
+      input.scalar_type(), "fused_add_rms_norm_kernel_scalar_type", [&] {      \
+        using scalar_in_t = scalar_t;                                          \
+        VLLM_STABLE_DISPATCH_FLOATING_TYPES(                                   \
+          weight.scalar_type(), "fused_add_rms_norm_kernel_wt_type", [&] {     \
+             VLLM_STABLE_DISPATCH_FP8_TYPES(                                   \
+              out.scalar_type(), "fused_add_rms_norm_kernel_fp8_type", [&] {   \
+                vllm::fused_add_rms_norm_static_fp8_quant_kernel<scalar_in_t,  \
+                                                      scalar_t, width, fp8_t>  \
+                    <<<grid, block, 0, stream>>>(                              \
+                        out.mutable_data_ptr<fp8_t>(),                         \
+                        input.mutable_data_ptr<scalar_in_t>(), input_stride,   \
+                        residual.mutable_data_ptr<scalar_in_t>(),              \
+                        weight.const_data_ptr<scalar_t>(),                  \
+                        scale.const_data_ptr<float>(), epsilon, num_tokens,    \
+                        hidden_size);                                          \
+              });                                                              \
+          });                                                                  \
+      });                                                                      
 void fused_add_rms_norm_static_fp8_quant(
     torch::stable::Tensor& out,       // [..., hidden_size],
     torch::stable::Tensor& input,     // [..., hidden_size]
@@ -258,7 +269,6 @@ void fused_add_rms_norm_static_fp8_quant(
   STD_TORCH_CHECK(out.is_contiguous());
   STD_TORCH_CHECK(residual.is_contiguous());
   STD_TORCH_CHECK(residual.scalar_type() == input.scalar_type());
-  STD_TORCH_CHECK(weight.scalar_type() == input.scalar_type());
   int hidden_size = input.size(-1);
   int input_stride = input.stride(-2);
   int num_tokens = input.numel() / hidden_size;

--- a/csrc/libtorch_stable/layernorm_quant_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_quant_kernels.cu
@@ -67,7 +67,7 @@ __global__ void rms_norm_static_fp8_quant_kernel(
     for (int j = 0; j < VEC_SIZE; j++) {
       float x = static_cast<float>(src1.val[j]);
       // Multiply in weight's native dtype to match rms_norm_kernel.
-      scalar_wt_t out_norm = static_cast<scalar_wt_t>(x * s_variance) * src2.val[j];
+      scalar_t out_norm = static_cast<scalar_t>(static_cast<scalar_wt_t>(x * s_variance) * src2.val[j]);
       out[blockIdx.x * hidden_size + idx * VEC_SIZE + j] =
           scaled_fp8_conversion<true, fp8_type>(static_cast<float>(out_norm),
                                                 scale_inv);
@@ -141,9 +141,11 @@ fused_add_rms_norm_static_fp8_quant_kernel(
     for (int i = 0; i < width; ++i) {
       float x = Converter::convert(res.data[i]);
       // Multiply in weight's native dtype to match fused_add_rms_norm_kernel.
-      HipT out_norm_h = WeightConverter::convert(WeightConverter::convert(x * s_variance) * w.data[i]);
+      // temp hack to convert from wt_dtype -> float -> inp_dtype 
+      // as direct wt_dtype -> inp_dtype isn't available 
+      HipT out_norm_h = Converter::convert(WeightConverter::convert(WeightConverter::convert(x * s_variance) * w.data[i]));
       out[id * width + i] = scaled_fp8_conversion<true, fp8_type>(
-          WeightConverter::convert(out_norm_h), scale_inv);
+          Converter::convert(out_norm_h), scale_inv);
     }
   }
 }
@@ -187,7 +189,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
     float x = (float)residual[blockIdx.x * hidden_size + idx];
     // Multiply in weight's native dtype to match fused_add_rms_norm_kernel.
-    scalar_wt_t out_norm = static_cast<scalar_wt_t>(x * s_variance) * weight[idx];
+    scalar_t out_norm = static_cast<scalar_t>(static_cast<scalar_wt_t>(x * s_variance) * weight[idx]);
     out[blockIdx.x * hidden_size + idx] = scaled_fp8_conversion<true, fp8_type>(
         static_cast<float>(out_norm), scale_inv);
   }

--- a/csrc/libtorch_stable/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
+++ b/csrc/libtorch_stable/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
@@ -7,12 +7,12 @@
 
 namespace vllm {
 
-template <typename scalar_t, typename scalar_out_t, bool has_residual = false>
+template <typename scalar_t, typename scalar_wt_t, typename scalar_out_t, bool has_residual = false>
 __device__ void rms_norm_dynamic_per_token_quant_vec(
     scalar_out_t* __restrict__ out,       // [..., hidden_size]
     float* __restrict__ scales,           // [num_tokens]
     scalar_t const* __restrict__ input,   // [..., hidden_size]
-    scalar_t const* __restrict__ weight,  // [hidden_size]
+    scalar_wt_t const* __restrict__ weight,  // [hidden_size]
     float const* scale_ub, float const var_epsilon, int32_t const hidden_size,
     int32_t const input_stride, scalar_t* __restrict__ residual = nullptr) {
   float rms = 0.0f;
@@ -23,7 +23,7 @@ __device__ void rms_norm_dynamic_per_token_quant_vec(
       &rms, input, hidden_size, input_stride, var_epsilon, residual);
 
   // Compute scale
-  vllm::vectorized::compute_dynamic_per_token_scales<scalar_t, scalar_out_t,
+  vllm::vectorized::compute_dynamic_per_token_scales<scalar_t, scalar_wt_t, scalar_out_t,
                                                      has_residual>(
       &token_scale, scales, input, weight, rms, scale_ub, hidden_size,
       input_stride, residual);
@@ -31,13 +31,13 @@ __device__ void rms_norm_dynamic_per_token_quant_vec(
   // RMS Norm + Quant
   if constexpr (std::is_same_v<scalar_out_t, int8_t>) {
     token_scale = 1.0f / token_scale;
-    vllm::vectorized::norm_and_quant<scalar_t, scalar_out_t, true,
+    vllm::vectorized::norm_and_quant<scalar_t, scalar_wt_t, scalar_out_t, true,
                                      has_residual>(out, input, weight, rms,
                                                    &token_scale, hidden_size,
                                                    input_stride, residual);
   } else {
     // FP8 - Do not invert token_scale for exact match with FBGemm
-    vllm::vectorized::norm_and_quant<scalar_t, scalar_out_t, false,
+    vllm::vectorized::norm_and_quant<scalar_t, scalar_wt_t, scalar_out_t, false,
                                      has_residual>(out, input, weight, rms,
                                                    &token_scale, hidden_size,
                                                    input_stride, residual);
@@ -45,12 +45,12 @@ __device__ void rms_norm_dynamic_per_token_quant_vec(
 }
 
 // RMS norm + quant kernel
-template <typename scalar_t, typename scalar_out_t, bool has_residual = false>
+template <typename scalar_t, typename scalar_wt_t, typename scalar_out_t, bool has_residual = false>
 __global__ void rms_norm_dynamic_per_token_quant_kernel(
     scalar_out_t* __restrict__ out,       // [..., hidden_size]
     float* __restrict__ scales,           // [num_tokens]
     scalar_t const* __restrict__ input,   // [..., hidden_size]
-    scalar_t const* __restrict__ weight,  // [hidden_size]
+    scalar_wt_t const* __restrict__ weight,  // [hidden_size]
     float const* scale_ub, float const var_epsilon, int32_t const hidden_size,
     int32_t const input_stride, scalar_t* __restrict__ residual = nullptr) {
   // For vectorization, token_input and token_output pointers need to be
@@ -58,7 +58,7 @@ __global__ void rms_norm_dynamic_per_token_quant_kernel(
   bool const can_vectorize = hidden_size % 4 == 0 and input_stride % 4 == 0;
 
   if (can_vectorize) {
-    return rms_norm_dynamic_per_token_quant_vec<scalar_t, scalar_out_t,
+    return rms_norm_dynamic_per_token_quant_vec<scalar_t, scalar_wt_t, scalar_out_t,
                                                 has_residual>(
         out, scales, input, weight, scale_ub, var_epsilon, hidden_size,
         input_stride, residual);
@@ -71,26 +71,26 @@ __global__ void rms_norm_dynamic_per_token_quant_kernel(
   vllm::compute_rms<scalar_t, has_residual>(
       &rms, input, hidden_size, input_stride, var_epsilon, residual);
   // Compute Scale
-  vllm::compute_dynamic_per_token_scales<scalar_t, scalar_out_t, has_residual>(
+  vllm::compute_dynamic_per_token_scales<scalar_t, scalar_wt_t, scalar_out_t, has_residual>(
       &token_scale, scales, input, weight, rms, scale_ub, hidden_size,
       input_stride, residual);
 
   // RMS Norm + Quant
   if constexpr (std::is_same_v<scalar_out_t, int8_t>) {
     token_scale = 1.0f / token_scale;
-    vllm::norm_and_quant<scalar_t, scalar_out_t, true, has_residual>(
+    vllm::norm_and_quant<scalar_t, scalar_wt_t, scalar_out_t, true, has_residual>(
         out, input, weight, rms, &token_scale, hidden_size, input_stride,
         residual);
   } else {
     // FP8 - Do not invert s_token_scale for exact match with FBGemm
-    vllm::norm_and_quant<scalar_t, scalar_out_t, false, has_residual>(
+    vllm::norm_and_quant<scalar_t, scalar_wt_t, scalar_out_t, false, has_residual>(
         out, input, weight, rms, &token_scale, hidden_size, input_stride,
         residual);
   }
 }
 
 // RMS norm + quant kernel
-template <typename scalar_t, typename scalar_out_t, bool has_residual = false,
+template <typename scalar_t, typename scalar_wt_t, typename scalar_out_t, bool has_residual = false,
           bool is_scale_transposed = false, int32_t group_size = 0>
 __global__ void rms_norm_per_block_quant_kernel(
     scalar_out_t* __restrict__ out,  // [..., hidden_size]
@@ -98,7 +98,7 @@ __global__ void rms_norm_per_block_quant_kernel(
                                      // or
                                      // [hidden_size / group_size, num_tokens]
     scalar_t const* __restrict__ input,   // [..., hidden_size]
-    scalar_t const* __restrict__ weight,  // [hidden_size]
+    scalar_wt_t const* __restrict__ weight,  // [hidden_size]
     float const* scale_ub, float const var_epsilon, int32_t const hidden_size,
     int32_t const input_stride, scalar_t* __restrict__ residual = nullptr,
     int64_t outer_scale_stride = 1) {
@@ -111,7 +111,7 @@ __global__ void rms_norm_per_block_quant_kernel(
   // Compute Scale
   // Always able to vectorize due to constraints on hidden_size and group_size
   vllm::vectorized::compute_dynamic_per_token_scales<
-      scalar_t, scalar_out_t, has_residual, is_scale_transposed, group_size>(
+      scalar_t, scalar_wt_t, scalar_out_t, has_residual, is_scale_transposed, group_size>(
       nullptr, scales, input, weight, rms, scale_ub, hidden_size, input_stride,
       residual, outer_scale_stride);
 
@@ -122,7 +122,7 @@ __global__ void rms_norm_per_block_quant_kernel(
   // between multiple threads, so this way, we avoid extra synchronization
   // overhead.
   vllm::vectorized::norm_and_quant<
-      scalar_t, scalar_out_t, std::is_same_v<scalar_out_t, int8_t>,
+      scalar_t, scalar_wt_t, scalar_out_t, std::is_same_v<scalar_out_t, int8_t>,
       has_residual, is_scale_transposed, group_size>(
       out, input, weight, rms, scales, hidden_size, input_stride, residual,
       outer_scale_stride);
@@ -131,7 +131,7 @@ __global__ void rms_norm_per_block_quant_kernel(
 }  // namespace vllm
 
 // Residual add + RMS norm + dynamic per token
-template <typename scalar_in_t>
+template <typename scalar_in_t, typename scalar_wt_t>
 void rms_norm_dynamic_per_token_quant_dispatch(
     torch::stable::Tensor& out,           // [..., hidden_size]
     torch::stable::Tensor const& input,   // [..., hidden_size]
@@ -154,13 +154,13 @@ void rms_norm_dynamic_per_token_quant_dispatch(
   VLLM_STABLE_DISPATCH_BOOL(residual.has_value(), has_residual, [&] {
     VLLM_STABLE_DISPATCH_QUANT_TYPES(
         out.scalar_type(), "rms_norm_dynamic_per_token_quant_kernel", [&] {
-          vllm::rms_norm_dynamic_per_token_quant_kernel<scalar_in_t, scalar_t,
+          vllm::rms_norm_dynamic_per_token_quant_kernel<scalar_in_t, scalar_wt_t, scalar_t,
                                                         has_residual>
               <<<grid, block, 0, stream>>>(
                   out.mutable_data_ptr<scalar_t>(),
                   scales.mutable_data_ptr<float>(),
                   input.const_data_ptr<scalar_in_t>(),
-                  weight.const_data_ptr<scalar_in_t>(),
+                  weight.const_data_ptr<scalar_wt_t>(),
                   scale_ub.has_value() ? scale_ub->const_data_ptr<float>()
                                        : nullptr,
                   var_epsilon, hidden_size, input_stride,
@@ -190,7 +190,6 @@ void rms_norm_dynamic_per_token_quant(
   if (scale_ub.has_value()) {
     STD_TORCH_CHECK(out.scalar_type() == kFp8Type);
   }
-  STD_TORCH_CHECK(weight.scalar_type() == input.scalar_type());
   STD_TORCH_CHECK(scales.scalar_type() == torch::headeronly::ScalarType::Float);
   if (residual) {
     STD_TORCH_CHECK(residual->scalar_type() == input.scalar_type());
@@ -199,8 +198,13 @@ void rms_norm_dynamic_per_token_quant(
 
   VLLM_STABLE_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "rms_norm_dynamic_per_token_quant_dispatch", [&] {
-        rms_norm_dynamic_per_token_quant_dispatch<scalar_t>(
+        using scalar_in_t = scalar_t;
+        VLLM_STABLE_DISPATCH_FLOATING_TYPES(
+          weight.scalar_type(), "rms_norm_dynamic_per_token_quant_dispatch", [&] {
+            rms_norm_dynamic_per_token_quant_dispatch<scalar_in_t, scalar_t>(
             out, input, weight, scales, var_epsilon, scale_ub, residual);
+          }
+        );
       });
 }
 
@@ -240,32 +244,36 @@ void rms_norm_per_block_quant_dispatch(
   VLLM_STABLE_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "rms_norm_per_block_quant_fp_dispatch", [&] {
         using scalar_in_t = scalar_t;
-        VLLM_STABLE_DISPATCH_GROUP_SIZE(group_size, gs, [&] {
-          VLLM_STABLE_DISPATCH_BOOL(residual.has_value(), has_residual, [&] {
-            VLLM_STABLE_DISPATCH_BOOL(
-                is_scale_transposed, transpose_scale, [&] {
-                  VLLM_STABLE_DISPATCH_QUANT_TYPES(
-                      out.scalar_type(), "rms_norm_per_block_quant_kernel",
-                      [&] {
-                        vllm::rms_norm_per_block_quant_kernel<
-                            scalar_in_t, scalar_t, has_residual,
-                            transpose_scale, gs><<<grid, block, 0, stream>>>(
-                            out.mutable_data_ptr<scalar_t>(),
-                            scales.mutable_data_ptr<float>(),
-                            input.const_data_ptr<scalar_in_t>(),
-                            weight.const_data_ptr<scalar_in_t>(),
-                            scale_ub.has_value()
-                                ? scale_ub->const_data_ptr<float>()
-                                : nullptr,
-                            var_epsilon, hidden_size, input_stride,
-                            has_residual
-                                ? residual->mutable_data_ptr<scalar_in_t>()
-                                : nullptr,
-                            scales.stride(1));
-                      });
-                });
+        VLLM_STABLE_DISPATCH_FLOATING_TYPES(
+          weight.scalar_type(), "rms_norm_per_block_quant_wt_dispatch", [&] {
+            using scalar_wt_t = scalar_t;
+            VLLM_STABLE_DISPATCH_GROUP_SIZE(group_size, gs, [&] {
+              VLLM_STABLE_DISPATCH_BOOL(residual.has_value(), has_residual, [&] {
+                VLLM_STABLE_DISPATCH_BOOL(
+                    is_scale_transposed, transpose_scale, [&] {
+                      VLLM_STABLE_DISPATCH_QUANT_TYPES(
+                          out.scalar_type(), "rms_norm_per_block_quant_kernel",
+                          [&] {
+                            vllm::rms_norm_per_block_quant_kernel<
+                                scalar_in_t, scalar_wt_t, scalar_t, has_residual,
+                                transpose_scale, gs><<<grid, block, 0, stream>>>(
+                                out.mutable_data_ptr<scalar_t>(),
+                                scales.mutable_data_ptr<float>(),
+                                input.const_data_ptr<scalar_in_t>(),
+                                weight.const_data_ptr<scalar_wt_t>(),
+                                scale_ub.has_value()
+                                    ? scale_ub->const_data_ptr<float>()
+                                    : nullptr,
+                                var_epsilon, hidden_size, input_stride,
+                                has_residual
+                                    ? residual->mutable_data_ptr<scalar_in_t>()
+                                    : nullptr,
+                                scales.stride(1));
+                          });
+                    });
+              });
+            });
           });
-        });
       });
 }
 
@@ -289,7 +297,6 @@ void rms_norm_per_block_quant(torch::stable::Tensor& out,
   if (scale_ub.has_value()) {
     STD_TORCH_CHECK(out.scalar_type() == kFp8Type);
   }
-  STD_TORCH_CHECK(weight.scalar_type() == input.scalar_type());
   STD_TORCH_CHECK(scales.scalar_type() == torch::headeronly::ScalarType::Float);
   if (residual) {
     STD_TORCH_CHECK(residual->scalar_type() == input.scalar_type());

--- a/csrc/libtorch_stable/quantization/fused_kernels/layernorm_utils.cuh
+++ b/csrc/libtorch_stable/quantization/fused_kernels/layernorm_utils.cuh
@@ -70,11 +70,11 @@ __device__ float warpReduceMaxSpecialized(volatile float* val, int64_t tid,
   return val[tid];
 }
 
-template <typename scalar_t, typename scalar_out_t, bool has_residual = false,
+template <typename scalar_t, typename scalar_wt_t, typename scalar_out_t, bool has_residual = false,
           bool is_scale_transposed = false>
 __device__ void compute_dynamic_per_token_scales(
     float* __restrict__ token_scale, float* __restrict__ all_token_scales,
-    scalar_t const* __restrict__ input, scalar_t const* __restrict__ weight,
+    scalar_t const* __restrict__ input, scalar_wt_t const* __restrict__ weight,
     float const rms, float const* __restrict__ scale_ub,
     int32_t const hidden_size, int32_t const input_stride,
     scalar_t const* __restrict__ residual = nullptr,
@@ -101,7 +101,7 @@ __device__ void compute_dynamic_per_token_scales(
       if constexpr (has_residual) {
         x += static_cast<float>(residual[token_offset + i]);
       }
-      x = static_cast<float>(static_cast<scalar_t>(x * rms) * weight[i]);
+      x = static_cast<float>(static_cast<scalar_wt_t>(x * rms) * weight[i]);
       block_absmax_val_maybe = fmaxf(block_absmax_val_maybe, fabsf(x));
     }
     s_max_vals[threadIdx.x] = block_absmax_val_maybe;
@@ -158,7 +158,7 @@ __device__ void compute_dynamic_per_token_scales(
         x += static_cast<float>(residual[token_offset + i]);
       }
 
-      x = static_cast<float>(static_cast<scalar_t>(x * rms) * weight[i]);
+      x = static_cast<float>(static_cast<scalar_wt_t>(x * rms) * weight[i]);
       block_absmax_val_maybe = fmaxf(block_absmax_val_maybe, fabsf(x));
     }
     using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -186,11 +186,11 @@ __device__ void compute_dynamic_per_token_scales(
   }
 }
 
-template <typename scalar_t, typename scalar_out_t, bool is_scale_inverted,
+template <typename scalar_t, typename scalar_wt_t, typename scalar_out_t, bool is_scale_inverted,
           bool has_residual = false, bool is_scale_transposed = false>
 __device__ void norm_and_quant(
     scalar_out_t* __restrict__ output, scalar_t const* __restrict__ input,
-    scalar_t const* __restrict__ weight, float const rms, float* const scale,
+    scalar_wt_t const* __restrict__ weight, float const rms, float* const scale,
     int32_t const hidden_size, int32_t const input_stride,
     scalar_t* __restrict__ residual = nullptr, int32_t const group_size = 0,
     int64_t outer_scale_stride = 1) {
@@ -205,7 +205,7 @@ __device__ void norm_and_quant(
       residual[token_offset + i] = static_cast<scalar_t>(x);
     }
     // Norm
-    x = static_cast<float>(static_cast<scalar_t>(x * rms) * weight[i]);
+    x = static_cast<float>(static_cast<scalar_wt_t>(x * rms) * weight[i]);
     // Quant
     // If groupwise is_scale_inverted is true, so we invert the scale here.
     int64_t scale_idx = 0;
@@ -294,11 +294,11 @@ __device__ void compute_rms(float* rms, scalar_t const* __restrict__ input,
 
 // Vectorized version of vllm::compute_dynamic_per_token_scales
 // hidden_size must be a multiple of 4
-template <typename scalar_t, typename scalar_out_t, bool has_residual = false,
+template <typename scalar_t, typename scalar_wt_t, typename scalar_out_t, bool has_residual = false,
           bool is_scale_transposed = false, int32_t group_size = 0>
 __device__ void compute_dynamic_per_token_scales(
     float* __restrict__ token_scale, float* __restrict__ all_token_scales,
-    scalar_t const* __restrict__ input, scalar_t const* __restrict__ weight,
+    scalar_t const* __restrict__ input, scalar_wt_t const* __restrict__ weight,
     float const rms, float const* __restrict__ scale_ub,
     int32_t const hidden_size, int32_t const input_stride,
     scalar_t const* __restrict__ residual = nullptr,
@@ -310,7 +310,7 @@ __device__ void compute_dynamic_per_token_scales(
 
   // Vectorized input/weight/residual to better utilize memory bandwidth.
   vec4_t<scalar_t> const* vec_input = nullptr;
-  vec4_t<scalar_t> const* vec_weight = nullptr;
+  vec4_t<scalar_wt_t> const* vec_weight = nullptr;
   vec4_t<scalar_t> const* vec_residual = nullptr;
 
   int64_t const input_token_offset =
@@ -330,7 +330,7 @@ __device__ void compute_dynamic_per_token_scales(
                                    static_cast<int64_t>(hidden_size >> 2));
     vec_input =
         reinterpret_cast<vec4_t<scalar_t> const*>(&input[input_token_offset]);
-    vec_weight = reinterpret_cast<vec4_t<scalar_t> const*>(weight);
+    vec_weight = reinterpret_cast<vec4_t<scalar_wt_t> const*>(weight);
     if constexpr (has_residual) {
       vec_residual =
           reinterpret_cast<vec4_t<scalar_t> const*>(&residual[token_offset]);
@@ -340,7 +340,7 @@ __device__ void compute_dynamic_per_token_scales(
 #pragma unroll 4
     for (auto i = thread_offset; i < num_vec_elems; i += threads_per_group) {
       vec4_t<scalar_t> in = vec_input[i];
-      vec4_t<scalar_t> const w = vec_weight[i];
+      vec4_t<scalar_wt_t> const w = vec_weight[i];
 
       vec4_t<float> x;
 #pragma unroll
@@ -360,7 +360,7 @@ __device__ void compute_dynamic_per_token_scales(
       for (int j = 0; j < VEC_SIZE; ++j) {
         block_absmax_val_maybe =
             fmaxf(block_absmax_val_maybe,
-                  fabs(static_cast<scalar_t>(x.val[j] * rms) * w.val[j]));
+                  fabs(static_cast<scalar_wt_t>(x.val[j] * rms) * w.val[j]));
       }
     }
 
@@ -415,7 +415,7 @@ __device__ void compute_dynamic_per_token_scales(
   } else {
     vec_input =
         reinterpret_cast<vec4_t<scalar_t> const*>(&input[input_token_offset]);
-    vec_weight = reinterpret_cast<vec4_t<scalar_t> const*>(weight);
+    vec_weight = reinterpret_cast<vec4_t<scalar_wt_t> const*>(weight);
     if constexpr (has_residual) {
       vec_residual =
           reinterpret_cast<vec4_t<scalar_t> const*>(&residual[token_offset]);
@@ -426,7 +426,7 @@ __device__ void compute_dynamic_per_token_scales(
 #pragma unroll 4
     for (auto i = threadIdx.x; i < num_vec_elems; i += blockDim.x) {
       vec4_t<scalar_t> in = vec_input[i];
-      vec4_t<scalar_t> const w = vec_weight[i];
+      vec4_t<scalar_wt_t> const w = vec_weight[i];
 
       vec4_t<float> x;
 #pragma unroll
@@ -446,7 +446,7 @@ __device__ void compute_dynamic_per_token_scales(
       for (int j = 0; j < VEC_SIZE; ++j) {
         block_absmax_val_maybe =
             fmaxf(block_absmax_val_maybe,
-                  fabs(static_cast<scalar_t>(x.val[j] * rms) * w.val[j]));
+                  fabs(static_cast<scalar_wt_t>(x.val[j] * rms) * w.val[j]));
       }
     }
 
@@ -476,12 +476,12 @@ __device__ void compute_dynamic_per_token_scales(
 }
 
 // hidden_size must be a multiple of 4
-template <typename scalar_t, typename scalar_out_t, bool is_scale_inverted,
+template <typename scalar_t, typename scalar_wt_t, typename scalar_out_t, bool is_scale_inverted,
           bool has_residual = false, bool is_scale_transposed = false,
           int32_t group_size = 0>
 __device__ void norm_and_quant(
     scalar_out_t* __restrict__ output, scalar_t const* __restrict__ input,
-    scalar_t const* __restrict__ weight, float const rms, float* const scale,
+    scalar_wt_t const* __restrict__ weight, float const rms, float* const scale,
     int32_t const hidden_size, int32_t const input_stride,
     scalar_t* __restrict__ residual = nullptr, int64_t outer_scale_stride = 1) {
   int64_t const input_token_offset =
@@ -491,8 +491,8 @@ __device__ void norm_and_quant(
   // Vectorized input/output/weight/residual to better utilize memory bandwidth.
   vec4_t<scalar_t> const* vec_input =
       reinterpret_cast<vec4_t<scalar_t> const*>(&input[input_token_offset]);
-  vec4_t<scalar_t> const* vec_weight =
-      reinterpret_cast<vec4_t<scalar_t> const*>(weight);
+  vec4_t<scalar_wt_t> const* vec_weight =
+      reinterpret_cast<vec4_t<scalar_wt_t> const*>(weight);
   q8x4_t<scalar_out_t>* vec_output =
       reinterpret_cast<q8x4_t<scalar_out_t>*>(&output[token_offset]);
   vec4_t<scalar_t>* vec_residual = nullptr;
@@ -508,7 +508,7 @@ __device__ void norm_and_quant(
 #pragma unroll 4
   for (auto i = threadIdx.x; i < num_vec_elems; i += blockDim.x) {
     vec4_t<scalar_t> const in = vec_input[i];
-    vec4_t<scalar_t> const w = vec_weight[i];
+    vec4_t<scalar_wt_t> const w = vec_weight[i];
 
     vec4_t<float> x;
 #pragma unroll
@@ -552,7 +552,7 @@ __device__ void norm_and_quant(
 #pragma unroll
     for (int j = 0; j < VEC_SIZE; ++j) {
       out.val[j] = ScaledQuant<scalar_out_t, is_scale_inverted>::quant_fn(
-          static_cast<scalar_t>(x.val[j] * rms) * w.val[j], scale_val);
+          static_cast<scalar_wt_t>(x.val[j] * rms) * w.val[j], scale_val);
     }
     vec_output[i] = out;
   }

--- a/csrc/libtorch_stable/quantization/fused_kernels/layernorm_utils.cuh
+++ b/csrc/libtorch_stable/quantization/fused_kernels/layernorm_utils.cuh
@@ -101,7 +101,7 @@ __device__ void compute_dynamic_per_token_scales(
       if constexpr (has_residual) {
         x += static_cast<float>(residual[token_offset + i]);
       }
-      x = static_cast<float>(static_cast<scalar_wt_t>(x * rms) * weight[i]);
+      x = static_cast<float>(static_cast<scalar_t>(static_cast<scalar_wt_t>(x * rms) * weight[i]));
       block_absmax_val_maybe = fmaxf(block_absmax_val_maybe, fabsf(x));
     }
     s_max_vals[threadIdx.x] = block_absmax_val_maybe;
@@ -158,7 +158,7 @@ __device__ void compute_dynamic_per_token_scales(
         x += static_cast<float>(residual[token_offset + i]);
       }
 
-      x = static_cast<float>(static_cast<scalar_wt_t>(x * rms) * weight[i]);
+      x = static_cast<float>(static_cast<scalar_t>(static_cast<scalar_wt_t>(x * rms) * weight[i]));
       block_absmax_val_maybe = fmaxf(block_absmax_val_maybe, fabsf(x));
     }
     using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -205,7 +205,7 @@ __device__ void norm_and_quant(
       residual[token_offset + i] = static_cast<scalar_t>(x);
     }
     // Norm
-    x = static_cast<float>(static_cast<scalar_wt_t>(x * rms) * weight[i]);
+    x = static_cast<float>(static_cast<scalar_t>(static_cast<scalar_wt_t>(x * rms) * weight[i]));
     // Quant
     // If groupwise is_scale_inverted is true, so we invert the scale here.
     int64_t scale_idx = 0;
@@ -360,7 +360,7 @@ __device__ void compute_dynamic_per_token_scales(
       for (int j = 0; j < VEC_SIZE; ++j) {
         block_absmax_val_maybe =
             fmaxf(block_absmax_val_maybe,
-                  fabs(static_cast<scalar_wt_t>(x.val[j] * rms) * w.val[j]));
+                  fabs(static_cast<scalar_t>(static_cast<scalar_wt_t>(x.val[j] * rms) * w.val[j])));
       }
     }
 
@@ -446,7 +446,7 @@ __device__ void compute_dynamic_per_token_scales(
       for (int j = 0; j < VEC_SIZE; ++j) {
         block_absmax_val_maybe =
             fmaxf(block_absmax_val_maybe,
-                  fabs(static_cast<scalar_wt_t>(x.val[j] * rms) * w.val[j]));
+                  fabs(static_cast<scalar_t>(static_cast<scalar_wt_t>(x.val[j] * rms) * w.val[j])));
       }
     }
 
@@ -552,7 +552,7 @@ __device__ void norm_and_quant(
 #pragma unroll
     for (int j = 0; j < VEC_SIZE; ++j) {
       out.val[j] = ScaledQuant<scalar_out_t, is_scale_inverted>::quant_fn(
-          static_cast<scalar_wt_t>(x.val[j] * rms) * w.val[j], scale_val);
+          static_cast<scalar_t>(static_cast<scalar_wt_t>(x.val[j] * rms) * w.val[j]), scale_val);
     }
     vec_output[i] = out;
   }

--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -158,6 +158,7 @@ def ops_impl(
 @pytest.mark.parametrize("add_residual", ADD_RESIDUAL)
 @pytest.mark.parametrize("has_scale_ub", SCALE_UBS)
 @pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("wt_dtype", DTYPES)
 @pytest.mark.parametrize("quant_dtype", QUANT_DTYPES)
 @pytest.mark.parametrize(
     "group_size, tma_alignment",
@@ -174,6 +175,7 @@ def test_rms_norm(
     add_residual: bool,
     has_scale_ub: bool,
     dtype: torch.dtype,
+    wt_dtype: torch.dtype,
     quant_dtype: torch.dtype,
     group_size: list[int] | None,
     tma_alignment: int,
@@ -211,7 +213,7 @@ def test_rms_norm(
         # skip
         pytest.skip("scale_ub only supported for fp8 quantization")
 
-    layer = RMSNorm(hidden_size, EPS).to(dtype=dtype)
+    layer = RMSNorm(hidden_size, EPS, dtype=wt_dtype)
 
     # Make weights
     layer.weight.data.normal_(mean=1.0, std=0.1)

--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -213,6 +213,13 @@ def test_rms_norm(
         # skip
         pytest.skip("scale_ub only supported for fp8 quantization")
 
+    if (
+        dtype != wt_dtype
+        and dtype in (torch.half, torch.bfloat16)
+        and wt_dtype in (torch.half, torch.bfloat16)
+    ):
+        pytest.skip("unsupported input and weight dtype combination")
+
     layer = RMSNorm(hidden_size, EPS, dtype=wt_dtype)
 
     # Make weights

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -167,11 +167,16 @@ def test_fused_rms_norm_quant(
             (out_quant_fused, x, rms_layer.weight, quant_scale_t, 1e-6),
         )
 
+    if dtype in (torch.half, torch.bfloat16):
+        atol, rtol = 1e-1, 1e-1
+    else:
+        atol, rtol = 1e-2, 1e-2
+
     torch.testing.assert_close(
-        out_quant.to(dtype=torch.float32),
-        out_quant_fused.to(dtype=torch.float32),
-        atol=1e-3,
-        rtol=1e-3,
+        out_quant.to(dtype=torch.float32) * quant_scale,
+        out_quant_fused.to(dtype=torch.float32) * quant_scale,
+        atol=atol,
+        rtol=rtol,
     )
 
 

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -90,7 +90,9 @@ def test_rms_norm(
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 @pytest.mark.parametrize("strided_input", [False, True])
+@torch.inference_mode()
 def test_fused_rms_norm_quant(
+    default_vllm_config,
     num_tokens: int,
     hidden_size: int,
     add_residual: bool,
@@ -101,6 +103,13 @@ def test_fused_rms_norm_quant(
     device: str,
     strided_input: bool,
 ) -> None:
+    if (
+        dtype != wt_dtype
+        and dtype in (torch.half, torch.bfloat16)
+        and wt_dtype in (torch.half, torch.bfloat16)
+    ):
+        pytest.skip()
+
     set_random_seed(seed)
     torch.set_default_device(device)
 
@@ -134,7 +143,7 @@ def test_fused_rms_norm_quant(
         x_unfused_base = x_base.clone()
         x_unfused = x_unfused_base[..., :hidden_size]
         assert x_unfused.is_contiguous() != strided_input
-        x_unfused, _ = rms_layer.forward_native(x_unfused, residual)
+        x_unfused, residual = rms_layer.forward_native(x_unfused, residual)
         torch.ops._C.static_scaled_fp8_quant(
             out_quant, x_unfused.contiguous(), quant_scale_t
         )

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -108,7 +108,7 @@ def test_fused_rms_norm_quant(
         and dtype in (torch.half, torch.bfloat16)
         and wt_dtype in (torch.half, torch.bfloat16)
     ):
-        pytest.skip()
+        pytest.skip("unsupported input and weight dtype combination")
 
     set_random_seed(seed)
     torch.set_default_device(device)

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -85,6 +85,7 @@ def test_rms_norm(
 @pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
 @pytest.mark.parametrize("add_residual", ADD_RESIDUAL)
 @pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("wt_dtype", DTYPES)
 @pytest.mark.parametrize("quant_scale", [0.01, 1.0, 10.0])
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
@@ -94,6 +95,7 @@ def test_fused_rms_norm_quant(
     hidden_size: int,
     add_residual: bool,
     dtype: torch.dtype,
+    wt_dtype: torch.dtype,
     quant_scale: float,
     seed: int,
     device: str,
@@ -102,7 +104,8 @@ def test_fused_rms_norm_quant(
     set_random_seed(seed)
     torch.set_default_device(device)
 
-    weight = torch.empty(hidden_size, dtype=dtype).normal_(mean=1.0, std=0.1)
+    rms_layer = RMSNorm(hidden_size, eps=1e-6, dtype=wt_dtype)
+    rms_layer.weight.data.normal_(mean=1, std=0.1)
     scale = 1 / (2 * hidden_size)
     last_dim = 2 * hidden_size if strided_input else hidden_size
     x_base = torch.randn(num_tokens, last_dim, dtype=dtype)
@@ -116,7 +119,6 @@ def test_fused_rms_norm_quant(
     else:
         residual = residual_fused = None
 
-    out_norm = torch.empty_like(x)
     out_quant = torch.empty_like(x, dtype=FP8_DTYPE)
     out_quant_fused = torch.empty_like(out_quant)
 
@@ -124,7 +126,7 @@ def test_fused_rms_norm_quant(
 
     if add_residual:
         torch.ops._C.fused_add_rms_norm_static_fp8_quant(
-            out_quant_fused, x, residual_fused, weight, quant_scale_t, 1e-6
+            out_quant_fused, x, residual_fused, rms_layer.weight, quant_scale_t, 1e-6
         )
 
         # Unfused kernel is in-place so it goes second
@@ -132,7 +134,7 @@ def test_fused_rms_norm_quant(
         x_unfused_base = x_base.clone()
         x_unfused = x_unfused_base[..., :hidden_size]
         assert x_unfused.is_contiguous() != strided_input
-        torch.ops._C.fused_add_rms_norm(x_unfused, residual, weight, 1e-6)
+        x_unfused, _ = rms_layer.forward_native(x_unfused, residual)
         torch.ops._C.static_scaled_fp8_quant(
             out_quant, x_unfused.contiguous(), quant_scale_t
         )
@@ -141,19 +143,19 @@ def test_fused_rms_norm_quant(
         torch.testing.assert_close(residual_fused, residual, atol=1e-2, rtol=1e-2)
         opcheck(
             torch.ops._C.fused_add_rms_norm_static_fp8_quant,
-            (out_quant_fused, x, residual_fused, weight, quant_scale_t, 1e-6),
+            (out_quant_fused, x, residual_fused, rms_layer.weight, quant_scale_t, 1e-6),
         )
     else:
         torch.ops._C.rms_norm_static_fp8_quant(
-            out_quant_fused, x, weight, quant_scale_t, 1e-6
+            out_quant_fused, x, rms_layer.weight, quant_scale_t, 1e-6
         )
 
-        torch.ops._C.rms_norm(out_norm, x, weight, 1e-6)
+        out_norm = rms_layer.forward_native(x)
         torch.ops._C.static_scaled_fp8_quant(out_quant, out_norm, quant_scale_t)
 
         opcheck(
             torch.ops._C.rms_norm_static_fp8_quant,
-            (out_quant_fused, x, weight, quant_scale_t, 1e-6),
+            (out_quant_fused, x, rms_layer.weight, quant_scale_t, 1e-6),
         )
 
     torch.testing.assert_close(

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -42,24 +42,6 @@ _RMS_NORM_OP = torch.ops.vllm_ir.rms_norm.default
 _FUSED_ADD_RMS_NORM_OP = torch.ops.vllm_ir.fused_add_rms_norm.default
 
 
-# TODO: extend rmsnorm quant kernels to support mixed input/weight dtypes,
-# and remove this check.
-def _rms_input_weight_dtype_match(match: pm.Match) -> bool:
-    """Prevent fusion when rms_norm input and weight dtypes differ."""
-    for node in match.nodes:
-        if node.target == _RMS_NORM_OP:
-            # rms_norm(x, weight, epsilon, variance_size)
-            x, weight = node.args[0], node.args[1]
-        elif node.target == _FUSED_ADD_RMS_NORM_OP:
-            # fused_add_rms_norm(x, residual, weight, epsilon, variance_size)
-            x, weight = node.args[0], node.args[2]
-        else:
-            continue
-        if isinstance(x, fx.Node) and isinstance(weight, fx.Node):
-            return x.meta["val"].dtype == weight.meta["val"].dtype
-    return True
-
-
 def empty_bf16(*args: Any, **kwargs: Any) -> torch.Tensor:
     return torch.empty(
         *args, **kwargs, dtype=torch.bfloat16, device=current_platform.device_type
@@ -219,7 +201,6 @@ class RMSNormStaticQuantPattern(RMSNormQuantPattern):
             inputs,
             pm.fwd_only,
             pm_pass,
-            extra_check=_rms_input_weight_dtype_match,
         )
 
 
@@ -286,7 +267,6 @@ class FusedAddRMSNormStaticQuantPattern(RMSNormQuantPattern):
             inputs,
             pm.fwd_only,
             pm_pass,
-            extra_check=_rms_input_weight_dtype_match,
         )
 
 
@@ -393,7 +373,6 @@ class FusedAddRMSNormGroupQuantPattern(RMSNormQuantPattern):
             inputs,
             pm.fwd_only,
             pm_pass,
-            extra_check=_rms_input_weight_dtype_match,
         )
 
 
@@ -487,7 +466,6 @@ class RMSNormGroupQuantPattern(RMSNormQuantPattern):
             ],
             pm.fwd_only,
             pm_pass,
-            extra_check=_rms_input_weight_dtype_match,
         )
 
 
@@ -546,7 +524,6 @@ class RMSNormDynamicQuantPattern(RMSNormQuantPattern):
             ],
             pm.fwd_only,
             pm_pass,
-            extra_check=_rms_input_weight_dtype_match,
         )
 
 
@@ -611,7 +588,6 @@ class FusedAddRMSNormDynamicQuantPattern(RMSNormQuantPattern):
             inputs,
             pm.fwd_only,
             pm_pass,
-            extra_check=_rms_input_weight_dtype_match,
         )
 
 

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -38,10 +38,6 @@ FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
 
 
-_RMS_NORM_OP = torch.ops.vllm_ir.rms_norm.default
-_FUSED_ADD_RMS_NORM_OP = torch.ops.vllm_ir.fused_add_rms_norm.default
-
-
 def empty_bf16(*args: Any, **kwargs: Any) -> torch.Tensor:
     return torch.empty(
         *args, **kwargs, dtype=torch.bfloat16, device=current_platform.device_type


### PR DESCRIPTION
## Purpose
Add support for mixed input/weight dtypes to fused rms norm quant ops . This is applicable to models like `Qwen3.5-35B-A3B-FP8` (mostly models that use gemma rms norm) where the input dtype is bf16 and the weight dtype is float.

## Test Plan
`python -m pytest tests/kernels/core/test_layernorm.py`
`python -m pytest tests/kernels/core/test_fused_quant_layernorm.py`

`python benchmarks/fused_kernels/layernorm_rms_benchmarks.py` (microbenchmark run on both main and pr branch with no regression with rtx 4060)

## Test Result

Correctness tests are passing.

Benchmark (times in microseconds):
<details>
<summary>Main benchmark (RTX 4060)</summary>

| Config | Unfused INT8 | Unfused FP8 | Fused INT8 | Fused FP8 | Unfused Groupwise FP8 | Fused Groupwise FP8 |
|--------|--------------|--------------|-------------|-----------|------------------------|----------------------|
| N1024 D1024 RTrue GS[1,64]  | 348.4 | 369.4 | 88.2  | 88.2  | 376.9 | 101.4 |
| N1024 D1024 RTrue GS[1,128] | 336.8 | 368.7 | 88.6  | 88.8  | 376.2 | 100.8 |
| N1024 D1024 RFalse GS[1,64] | 280.5 | 306.4 | 85.5  | 87.2  | 311.8 | 99.4 |
| N1024 D1024 RFalse GS[1,128]| 283.7 | 306.9 | 86.4  | 84.4  | 314.0 | 99.9 |
| N1024 D2048 RTrue GS[1,64]  | 385.5 | 408.3 | 88.1  | 93.0  | 409.0 | 100.9 |
| N1024 D2048 RTrue GS[1,128] | 389.1 | 434.7 | 89.8  | 89.1  | 407.9 | 101.8 |
| N1024 D2048 RFalse GS[1,64] | 295.9 | 317.8 | 86.4  | 87.7  | 322.4 | 100.4 |
| N1024 D2048 RFalse GS[1,128]| 280.0 | 312.9 | 86.5  | 90.6  | 323.7 | 100.9 |
| N1024 D3072 RTrue GS[1,64]  | 724.5 | 775.8 | 89.5  | 103.2 | 794.7 | 103.3 |
| N1024 D3072 RTrue GS[1,128] | 747.8 | 840.2 | 89.2  | 98.3  | 754.2 | 101.8 |
| N1024 D3072 RFalse GS[1,64] | 384.2 | 374.1 | 88.8  | 92.5  | 382.1 | 102.2 |
| N1024 D3072 RFalse GS[1,128]| 352.1 | 374.8 | 88.4  | 93.8  | 385.5 | 100.6 |
| N1024 D4096 RTrue GS[1,64]  | 1188.1 | 1123.5 | 96.1  | 105.5 | 1124.3 | 109.6 |
| N1024 D4096 RTrue GS[1,128] | 1154.8 | 1179.3 | 97.6  | 110.1 | 1083.2 | 103.3 |
| N1024 D4096 RFalse GS[1,64] | 509.2  | 561.4  | 91.2  | 101.5 | 569.3  | 112.1 |
| N1024 D4096 RFalse GS[1,128]| 526.5  | 573.3  | 90.7  | 99.8  | 530.0  | 101.4 |
| N1024 D5120 RTrue GS[1,64]  | 1935.8 | 1948.9 | 109.4 | 122.5 | 1872.3 | 135.9 |
| N1024 D5120 RTrue GS[1,128] | 1791.6 | 1942.5 | 105.5 | 124.4 | 1991.3 | 116.9 |
| N1024 D5120 RFalse GS[1,64] | 975.3  | 969.3  | 99.0  | 112.6 | 925.8  | 129.4 |
| N1024 D5120 RFalse GS[1,128]| 935.3  | 988.9  | 98.2  | 115.6 | 913.8  | 111.8 |
| N1024 D6144 RTrue GS[1,64]  | 2559.2 | 2520.6 | 110.2 | 130.2 | 2581.0 | 157.1 |
| N1024 D6144 RTrue GS[1,128] | 2620.0 | 2533.8 | 119.6 | 131.4 | 2500.5 | 135.2 |
| N1024 D6144 RFalse GS[1,64] | 1372.1 | 1342.6 | 100.0 | 120.6 | 1399.1 | 141.6 |
| N1024 D6144 RFalse GS[1,128]| 1285.7 | 1354.8 | 99.8  | 116.5 | 1397.5 | 118.8 |
| N1024 D7168 RTrue GS[1,64]  | 3047.8 | 3066.3 | 302.0 | 338.5 | 3015.5 | 453.3 |
| N1024 D7168 RTrue GS[1,128] | 3062.0 | 2848.7 | 327.9 | 336.7 | 3179.6 | 428.6 |
| N1024 D7168 RFalse GS[1,64] | 1747.0 | 1815.9 | 105.3 | 120.2 | 1879.2 | 149.5 |
| N1024 D7168 RFalse GS[1,128]| 1658.3 | 1642.6 | 101.7 | 123.4 | 1828.7 | 126.0 |
</details>

<details>
<summary>PR benchmark (RTX 4060) (bf16 / fp32 weights)</summary>

| Config | Unfused INT8 | Unfused FP8 | Fused INT8 | Fused FP8 | Unfused Groupwise FP8 | Fused Groupwise FP8 |
|--------|--------------|--------------|-------------|-----------|------------------------|----------------------|
| N1024 D1024 RTrue GS[1,64]  | 338.8 | 340.9 | 82.7 | 84.3 | 354.6 | 97.4 |
| N1024 D1024 RTrue GS[1,128] | 321.6 | 337.5 | 83.1 | 84.2 | 367.3 | 97.2 |
| N1024 D1024 RFalse GS[1,64] | 275.7 | 286.0 | 83.3 | 83.2 | 304.4 | 96.8 |
| N1024 D1024 RFalse GS[1,128]| 272.8 | 287.9 | 81.3 | 82.4 | 304.1 | 95.8 |
| N1024 D2048 RTrue GS[1,64]  | 329.1 | 344.2 | 83.1 | 85.0 | 360.5 | 98.3 |
| N1024 D2048 RTrue GS[1,128] | 328.5 | 344.1 | 83.6 | 83.6 | 353.8 | 98.4 |
| N1024 D2048 RFalse GS[1,64] | 274.9 | 283.1 | 81.6 | 82.3 | 305.1 | 96.0 |
| N1024 D2048 RFalse GS[1,128]| 272.6 | 287.2 | 81.8 | 83.2 | 302.8 | 96.2 |
| N1024 D3072 RTrue GS[1,64]  | 414.1 | 440.2 | 82.6 | 83.3 | 447.5 | 96.9 |
| N1024 D3072 RTrue GS[1,128] | 425.0 | 406.2 | 83.5 | 84.5 | 428.8 | 96.8 |
| N1024 D3072 RFalse GS[1,64] | 279.2 | 289.1 | 81.6 | 82.8 | 306.4 | 96.2 |
| N1024 D3072 RFalse GS[1,128]| 278.5 | 290.7 | 81.7 | 82.5 | 304.4 | 97.1 |
| N1024 D4096 RTrue GS[1,64]  | 593.3 | 613.1 | 82.9 | 84.0 | 606.9 | 96.8 |
| N1024 D4096 RTrue GS[1,128] | 592.9 | 621.9 | 83.5 | 84.5 | 596.1 | 96.8 |
| N1024 D4096 RFalse GS[1,64] | 309.9 | 312.4 | 81.9 | 82.7 | 323.8 | 96.7 |
| N1024 D4096 RFalse GS[1,128]| 304.8 | 310.9 | 82.2 | 83.0 | 321.3 | 96.7 |
| N1024 D5120 RTrue GS[1,64]  | 1046.3 | 1089.8 | 84.7 | 85.3 | 1106.2 | 99.9 |
| N1024 D5120 RTrue GS[1,128] | 1064.4 | 1075.2 | 83.9 | 86.4 | 1081.4 | 97.6 |
| N1024 D5120 RFalse GS[1,64] | 573.6 | 562.3 | 82.2 | 84.0 | 609.1 | 97.9 |
| N1024 D5120 RFalse GS[1,128]| 575.3 | 590.9 | 82.6 | 84.9 | 586.8 | 97.8 |
| N1024 D6144 RTrue GS[1,64]  | 1465.9 | 1458.1 | 83.0 | 88.0 | 1526.3 | 122.1 |
| N1024 D6144 RTrue GS[1,128] | 1428.8 | 1524.2 | 82.7 | 90.0 | 1490.5 | 101.1 |
| N1024 D6144 RFalse GS[1,64] | 848.6 | 894.1 | 82.6 | 85.3 | 886.6 | 99.2 |
| N1024 D6144 RFalse GS[1,128]| 819.1 | 864.6 | 83.8 | 84.7 | 867.2 | 98.2 |
| N1024 D7168 RTrue GS[1,64]  | 1856.9 | 1795.9 | 175.7 | 179.6 | 1858.7 | 259.0 |
| N1024 D7168 RTrue GS[1,128] | 1798.1 | 1859.3 | 175.7 | 182.0 | 1817.7 | 223.0 |
| N1024 D7168 RFalse GS[1,64] | 1109.6 | 1113.8 | 81.4 | 85.0 | 1154.3 | 112.3 |
| N1024 D7168 RFalse GS[1,128]| 1119.4 | 1138.2 | 82.1 | 84.6 | 1105.1 | 98.3 |
</details>

Can do a more rigorous benchmark if needed, this was mainly to show no regression