### PR TITLE
[Bugfix] Scope block-fp8 fused MoE tolerance to SM120 (#45332)

### DIFF
--- a/tests/kernels/moe/test_block_fp8.py
+++ b/tests/kernels/moe/test_block_fp8.py
@@ -36,6 +36,7 @@ from vllm.model_executor.layers.quantization.utils.fp8_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
+    calc_diff,
     get_mk_alignment_for_contiguous_layout,
     is_deep_gemm_e8m0_used,
 )
@@ -242,8 +243,14 @@ def test_w8a8_block_fp8_fused_moe(
     else:
         ref_out_m = ref_out
 
-    torch.testing.assert_close(out, ref_out, atol=tol, rtol=tol)
-    torch.testing.assert_close(m_out, ref_out_m, atol=tol, rtol=tol)
+    atol = tol
+    if current_platform.is_device_capability(120):
+        assert calc_diff(out, ref_out) < 1e-3
+        assert calc_diff(m_out, ref_out_m) < 1e-3
+        atol *= 4
+
+    torch.testing.assert_close(out, ref_out, atol=atol, rtol=tol)
+    torch.testing.assert_close(m_out, ref_out_m, atol=atol, rtol=tol)
 
 
 @pytest.mark.parametrize(("M", "N", "K"), MNK_FACTORS_DG)


### PR DESCRIPTION
## Purpose

Fixes #45332.

Current-main revalidation found that #48847 changed the production-matched reference quantization and added a separate ROCm `ref_out_m` path, so this PR was rebuilt instead of replaying the stale hunks. The SM120 failure still reproduces on current main: M=8192, N=4608, K=7168, E=8, topk=2 fails with one `m_out` element at 0.042236 absolute difference versus the strict 0.039 limit.

## Fix

On exact SM120 only:

- Require `calc_diff < 1e-3` for both `out/ref_out` and `m_out/ref_out_m` to bound broad structural drift.
- Widen only the absolute tolerance to 4x the base value. The relative tolerance stays unchanged.

The exact `is_device_capability(120)` predicate keeps SM121, future architectures, ROCm, and all other platforms on the current strict tolerance. The #48847 reference split is preserved.

## Test plan / results

RTX PRO 6000 Blackwell, SM120, current main `7e85d3a42c`:

- Before: exact M=8192/N=4608/K=7168/E=8/topk=2 case fails at 0.042236 > 0.039.
- After: exact case passes.
- Full focused sweep: 160 passed, 20 skipped in 6m53s.
- Synthetic capability check: SM120 takes the widened path; SM121 and SM130 remain strict.
- Ruff check/format and `git diff --check`: pass.

AI-assisted: developed with AI assistance and reviewed end-to-end by the submitter.