### PR TITLE
fix(tool_parser): emit closing brace when param and function end arrive in same delta

### DIFF
--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -1381,6 +1381,43 @@ def test_streaming_multi_param_single_chunk(qwen3_tool_parser, qwen3_tokenizer):
     assert args["unit"] == "fahrenheit"
 
 
+def test_streaming_param_and_function_end_in_same_chunk(
+    qwen3_tool_parser, qwen3_tokenizer
+):
+    """Regression: closing </parameter> and </function> in same delta (#45256).
+
+    With stream_interval > 1, a single delta can contain both the end of the
+    last parameter and the </function> tag. Previously the parser returned
+    after emitting the parameter fragment without also emitting the closing
+    "}", producing invalid JSON like '{"page": 1' instead of '{"page": 1}'.
+    """
+    request = ChatCompletionRequest(model=MODEL, messages=[])
+
+    deltas = [
+        "<tool_call>",
+        "\n<function=get_current_weather>",
+        "\n",
+        "<parameter=city>\nDallas\n</parameter>\n<parameter=state>\nTX\n</",
+        "parameter>\n</function>\n</tool_call>",
+    ]
+
+    from tests.tool_parsers.utils import (
+        run_tool_extraction_streaming,
+    )
+
+    reconstructor = run_tool_extraction_streaming(
+        qwen3_tool_parser,
+        deltas,
+        request,
+        assert_one_tool_per_delta=False,
+    )
+
+    assert len(reconstructor.tool_calls) == 1
+    args_str = reconstructor.tool_calls[0].function.arguments
+    args = json.loads(args_str)
+    assert args == {"city": "Dallas", "state": "TX"}
+
+
 def test_no_double_serialization_string_args(qwen3_tool_parser):
     """Regression: string arguments must not be double-serialized (PR #35615)."""
     tools = [

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -511,33 +511,11 @@ class Qwen3CoderToolParser(ToolParser):
                 self.param_count += 1
                 json_fragments.append(json_fragment)
 
-            if json_fragments:
-                combined = "".join(json_fragments)
-
-                if self.current_tool_index < len(self.streamed_args_for_tool):
-                    self.streamed_args_for_tool[self.current_tool_index] += combined
-                else:
-                    logger.warning(
-                        "streamed_args_for_tool out of sync: index=%d len=%d",
-                        self.current_tool_index,
-                        len(self.streamed_args_for_tool),
-                    )
-
-                return DeltaMessage(
-                    tool_calls=[
-                        DeltaToolCall(
-                            index=self.current_tool_index,
-                            function=DeltaFunctionCall(arguments=combined),
-                        )
-                    ]
-                )
-
-            # Check for function end AFTER processing parameters.
-            # This ordering is critical: with speculative decoding a
-            # burst can deliver the final parameter value together with
-            # </function>. If the close check ran first it would emit
-            # "}" and set in_function=False before the parameter loop
-            # ever ran, causing the parameter to be silently dropped.
+            # Check for function end. When a single delta delivers
+            # both the final parameter and </function>, we must emit
+            # the closing "}" in the same response to avoid the next
+            # (possibly empty/EOS) delta never reaching this branch.
+            close_brace = ""
             if not self.json_closed and self.function_end_token in tool_text:
                 self.json_closed = True
 
@@ -564,8 +542,15 @@ class Qwen3CoderToolParser(ToolParser):
                             exc_info=True,
                         )
 
+                close_brace = "}"
+                self.in_function = False
+                self.accumulated_params = {}
+
+            combined = "".join(json_fragments) + close_brace
+
+            if combined:
                 if self.current_tool_index < len(self.streamed_args_for_tool):
-                    self.streamed_args_for_tool[self.current_tool_index] += "}"
+                    self.streamed_args_for_tool[self.current_tool_index] += combined
                 else:
                     logger.warning(
                         "streamed_args_for_tool out of sync: index=%d len=%d",
@@ -573,20 +558,14 @@ class Qwen3CoderToolParser(ToolParser):
                         len(self.streamed_args_for_tool),
                     )
 
-                result = DeltaMessage(
+                return DeltaMessage(
                     tool_calls=[
                         DeltaToolCall(
                             index=self.current_tool_index,
-                            function=DeltaFunctionCall(arguments="}"),
+                            function=DeltaFunctionCall(arguments=combined),
                         )
                     ]
                 )
-
-                self.in_function = False
-                self.json_closed = True
-                self.accumulated_params = {}
-
-                return result
 
         return None
 


### PR DESCRIPTION
Fixes #45256

When stream_interval > 1, a single delta can deliver both the final </parameter> and </function> tags. The early return after emitting parameter fragments prevented the closing "}" from ever being emitted, producing invalid JSON. Restructured the control flow so the function-end check always runs after parameter processing.

Test: pytest tests/tool_parsers/test_qwen3coder_tool_parser.py (58 passed)