### PR TITLE
[Bugfix][Core] Count per-iteration scheduled sequences for max_num_seqs under async scheduling

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -143,6 +143,150 @@ def test_async_scheduling_pp_allows_rescheduling_with_output_placeholders():
     assert req.request_id in output.num_scheduled_tokens
 
 
+@pytest.mark.parametrize("max_num_seqs", [2, 3])
+def test_async_scheduling_skipped_running_reqs_do_not_block_admission(
+    max_num_seqs: int,
+):
+    scheduler = create_scheduler(
+        async_scheduling=True,
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=128,
+    )
+    requests = create_requests(
+        num_requests=2 * max_num_seqs,
+        num_tokens=10,
+        max_tokens=1,
+    )
+    for request in requests:
+        scheduler.add_request(request)
+
+    first_output = scheduler.schedule()
+
+    assert len(first_output.scheduled_new_reqs) == max_num_seqs
+    assert len(first_output.num_scheduled_tokens) == max_num_seqs
+    assert len(scheduler.running) == max_num_seqs
+    assert len(scheduler.waiting) == max_num_seqs
+    assert all(req.num_output_placeholders == 1 for req in scheduler.running)
+
+    second_output = scheduler.schedule()
+
+    assert len(second_output.scheduled_new_reqs) == max_num_seqs
+    assert len(second_output.num_scheduled_tokens) == max_num_seqs
+    assert set(second_output.num_scheduled_tokens) == {
+        request.request_id for request in requests[max_num_seqs:]
+    }
+    assert all(
+        num_tokens == 10 for num_tokens in second_output.num_scheduled_tokens.values()
+    )
+    assert len(scheduler.running) == 2 * max_num_seqs
+    assert len(scheduler.waiting) == 0
+
+
+def test_async_scheduling_skipped_running_reqs_do_not_trigger_watermark():
+    scheduler = create_scheduler(
+        async_scheduling=True,
+        max_num_seqs=1,
+        max_num_batched_tokens=128,
+        num_blocks=3,
+        watermark=1 / 3,
+    )
+    requests = create_requests(num_requests=2, num_tokens=10, max_tokens=1)
+    for request in requests:
+        scheduler.add_request(request)
+
+    first_output = scheduler.schedule()
+
+    assert set(first_output.num_scheduled_tokens) == {requests[0].request_id}
+    assert len(scheduler.running) == 1
+    assert len(scheduler.waiting) == 1
+    assert scheduler.running[0].num_output_placeholders == 1
+
+    second_output = scheduler.schedule()
+
+    assert set(second_output.num_scheduled_tokens) == {requests[1].request_id}
+    assert len(scheduler.running) == 2
+    assert len(scheduler.waiting) == 0
+
+
+def _make_model_runner_output(output: SchedulerOutput) -> ModelRunnerOutput:
+    req_ids = list(output.num_scheduled_tokens)
+    return ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+        sampled_token_ids=[[0]] * len(req_ids),
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
+def test_async_scheduling_over_limit_running_reqs_drain():
+    max_num_seqs = 2
+    scheduler = create_scheduler(
+        async_scheduling=True,
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=128,
+    )
+    requests = create_requests(
+        num_requests=2 * max_num_seqs,
+        num_tokens=10,
+        max_tokens=1,
+    )
+    for request in requests:
+        scheduler.add_request(request)
+
+    first_output = scheduler.schedule()
+    second_output = scheduler.schedule()
+
+    assert len(first_output.num_scheduled_tokens) == max_num_seqs
+    assert len(second_output.num_scheduled_tokens) == max_num_seqs
+    assert len(scheduler.running) == 2 * max_num_seqs
+
+    scheduler.update_from_output(first_output, _make_model_runner_output(first_output))
+    assert len(scheduler.running) == max_num_seqs
+    scheduler.update_from_output(
+        second_output, _make_model_runner_output(second_output)
+    )
+
+    assert scheduler.get_num_unfinished_requests() == 0
+    assert len(scheduler.running) == 0
+    assert len(scheduler.waiting) == 0
+
+
+def test_async_scheduling_pp_ineligible_running_reqs_do_not_block_admission():
+    max_num_seqs = 2
+    scheduler = create_scheduler(
+        async_scheduling=True,
+        pipeline_parallel_size=2,
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=128,
+    )
+    scheduler.use_v2_model_runner = True
+    requests = create_requests(
+        num_requests=2 * max_num_seqs,
+        num_tokens=10,
+        max_tokens=4,
+    )
+    for request in requests:
+        scheduler.add_request(request)
+
+    first_output = scheduler.schedule()
+    second_output = scheduler.schedule()
+
+    assert set(first_output.num_scheduled_tokens) == {
+        request.request_id for request in requests[:max_num_seqs]
+    }
+    assert set(second_output.num_scheduled_tokens) == {
+        request.request_id for request in requests[max_num_seqs:]
+    }
+    assert all(
+        requests[i].next_decode_eligible_step > scheduler.current_step
+        for i in range(max_num_seqs)
+    )
+    assert len(scheduler.running) == 2 * max_num_seqs
+    assert len(scheduler.waiting) == 0
+
+
 def test_schedule_partial_requests():
     """Test scheduling behavior with partial requests.
 

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -58,6 +58,7 @@ def create_scheduler(
     pipeline_parallel_size: int = 1,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    watermark: float = 0.0,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -91,7 +92,7 @@ def create_scheduler(
         async_scheduling=async_scheduling,
         is_encoder_decoder=model_config.is_encoder_decoder,
         # Ensure admission/preemption mechanics are deterministic
-        watermark=0.0,
+        watermark=watermark,
     )
     # Cache config, optionally force APC
     cache_config = CacheConfig(

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -63,6 +63,10 @@ class SchedulerConfig:
     max_num_seqs: int = Field(default=DEFAULT_MAX_NUM_SEQS, ge=1)
     """Maximum number of sequences to be processed in a single iteration.
 
+    Under async scheduling, this limit applies to the number of sequences
+    scheduled for the current model execution step; requests may remain resident
+    in the scheduler while their async outputs are still in flight.
+
     The default value here is mainly for convenience when testing.
     In real usage, this should be set in `EngineArgs.create_engine_config`.
     """

--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -12,6 +12,7 @@ logger = init_logger(__name__)
 class AsyncScheduler(Scheduler):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self.use_async_scheduling = True
         # reusable read-only placeholder list for speculative decoding.
         self._spec_token_placeholders: list[int] = [-1] * self.num_spec_tokens
         self.pp_size = self.parallel_config.pipeline_parallel_size

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -77,6 +77,7 @@ class Scheduler(SchedulerInterface):
     ) -> None:
         self.vllm_config = vllm_config
         self.scheduler_config = vllm_config.scheduler_config
+        self.use_async_scheduling = False
         self.cache_config = vllm_config.cache_config
         self.lora_config = vllm_config.lora_config
         self.kv_cache_config = kv_cache_config
@@ -389,6 +390,16 @@ class Scheduler(SchedulerInterface):
         # First, schedule the RUNNING requests.
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
+            # Async scheduling can keep in-flight requests resident in
+            # self.running while they are skipped this step. In that mode,
+            # max_num_seqs limits the model batch for this iteration rather
+            # than the resident running queue size.
+            if (
+                self.use_async_scheduling
+                and len(num_scheduled_tokens) >= self.max_num_running_reqs
+            ):
+                break
+
             request = self.running[req_index]
 
             if (
@@ -577,7 +588,10 @@ class Scheduler(SchedulerInterface):
             step_skipped_waiting = create_request_queue(self.policy)
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
-                if len(self.running) == self.max_num_running_reqs:
+                if self.use_async_scheduling:
+                    if len(num_scheduled_tokens) >= self.max_num_running_reqs:
+                        break
+                elif len(self.running) == self.max_num_running_reqs:
                     break
 
                 request_queue = self._select_waiting_queue_for_scheduling()
@@ -816,6 +830,10 @@ class Scheduler(SchedulerInterface):
                     # avoid deadlock and predictable preemptions.
                     reserved_blocks = self._inflight_prefill_reserved_blocks()
 
+                if self.use_async_scheduling:
+                    has_scheduled_reqs = bool(num_scheduled_tokens)
+                else:
+                    has_scheduled_reqs = bool(self.running)
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
                     num_new_tokens,
@@ -827,7 +845,7 @@ class Scheduler(SchedulerInterface):
                     num_encoder_tokens=num_encoder_tokens,
                     full_sequence_must_fit=self.scheduler_reserve_full_isl,
                     reserved_blocks=reserved_blocks,
-                    has_scheduled_reqs=bool(self.running),
+                    has_scheduled_reqs=has_scheduled_reqs,
                 )
 
                 if new_blocks is None:
@@ -931,7 +949,10 @@ class Scheduler(SchedulerInterface):
         assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
 
         assert token_budget >= 0
-        assert len(self.running) <= self.max_num_running_reqs
+        if self.use_async_scheduling:
+            assert len(num_scheduled_tokens) <= self.max_num_running_reqs
+        else:
+            assert len(self.running) <= self.max_num_running_reqs
         # Since some requests in the RUNNING queue may not be scheduled in
         # this step, the total number of scheduled requests can be smaller than
         # len(self.running).


### PR DESCRIPTION
## Purpose

Fixes #45257.

Under async scheduling, a request can stay resident in `self.running` with
output placeholders while being skipped in the next scheduler step, for example
a `max_tokens=1` request that already reached its limit but whose async output
has not been processed yet. The waiting-admission guard used
`len(self.running) == max_num_seqs`, so it refused to admit waiting requests
even when zero resident running requests would actually be scheduled this
iteration. That contradicts `max_num_seqs`, which is documented as a
per-iteration processed-sequence limit, and starves the waiting queue.

This PR makes async-mode admission and the KV watermark gate count sequences
actually scheduled this iteration (`len(num_scheduled_tokens)`) rather than the
resident `self.running` size. Sync scheduling is unchanged; the changed behavior
is gated behind a `use_async_scheduling` flag (`False` on `Scheduler`, `True` on
`AsyncScheduler`).

Specifically, in async mode:

- The RUNNING loop and WAITING-admission loop cap on
  `len(num_scheduled_tokens)` instead of `len(self.running)`.
- The final scheduler invariant asserts
  `len(num_scheduled_tokens) <= max_num_seqs`.
- `allocate_slots(has_scheduled_reqs=...)` is driven by
  `bool(num_scheduled_tokens)` instead of `bool(self.running)`, so
  resident-but-skipped requests no longer make the allocator apply the watermark
  when nothing is actually scheduled this step.

Allowing `len(self.running) > max_num_seqs` transiently is safe: the worker's
persistent input batch is keyed off `scheduler_output.num_scheduled_tokens` and
removes unscheduled requests each step in `gpu_model_runner._update_states`, so
the GPU batch buffers remain bounded by the capped scheduled count.

Duplicate-work check: I checked `45257 in:body` and did not find an open PR for
this issue. The closest overlap is #42568, which handles async remote KV-load
admission (`WAITING_FOR_REMOTE_KVS` / `skipped_waiting`). This PR handles
resident `RUNNING` requests skipped due to async output placeholders. It does
not address async remote-KV-load admission, KV pressure, or preemptability
concerns from #42568.

AI assistance disclosure: Codex helped implement and test this patch; Claude and
Codex helped review it. I reviewed and understand the final diff and am
responsible for the contribution.

## Test Plan

Focused async scheduler regressions:

```bash
PYTHONPATH=/private/tmp/vllm-45257 /Users/harjothk/Documents/cowork/vllm/.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -k "async_scheduling_skipped_running_reqs_do_not_block_admission or async_scheduling_skipped_running_reqs_do_not_trigger_watermark or async_scheduling_over_limit_running_reqs_drain or async_scheduling_pp_ineligible_running_reqs_do_not_block_admission" -q
```

Full scheduler unit test file:

```bash
PYTHONPATH=/private/tmp/vllm-45257 /Users/harjothk/Documents/cowork/vllm/.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -q
```

Ruff on changed files:

```bash
uvx --from ruff==0.14.0 ruff check vllm/config/scheduler.py vllm/v1/core/sched/scheduler.py vllm/v1/core/sched/async_scheduler.py tests/v1/core/test_scheduler.py tests/v1/core/utils.py
uvx --from ruff==0.14.0 ruff format --check vllm/config/scheduler.py vllm/v1/core/sched/scheduler.py vllm/v1/core/sched/async_scheduler.py tests/v1/core/test_scheduler.py tests/v1/core/utils.py
git diff --check HEAD
```

Added coverage:

- `max_tokens=1` async requests stay resident with placeholders while waiting
  requests are still admitted on the next `schedule()` call.
- The same resident-skipped case with a nonzero watermark and tight block
  capacity.
- Resident async requests drain after their delayed outputs are applied.
- PP+async decode ineligibility does not block admitting waiting work.

Negative control: reverting only the source changes makes the new async
regression tests fail.

## Test Result

Focused async scheduler regressions:

```text
5 passed, 102 deselected, 17 warnings in 4.36s
```

Full scheduler unit test file:

```text
107 passed, 17 warnings in 80.24s (0:01:20)
```

Ruff/checks:

```text
uvx --from ruff==0.14.0 ruff check ...
All checks passed!

uvx --from ruff==0.14.0 ruff format --check ...
5 files already formatted

git diff --check HEAD
passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
