### PR TITLE
Add a debug tool to detect non-explicitly returned outputs under BCG

### DIFF
--- a/tests/v1/cudagraph/conftest.py
+++ b/tests/v1/cudagraph/conftest.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+
+@pytest.fixture(autouse=True)
+def _reset_breakable_tls():
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+
+    BreakableCUDAGraphCapture._tls.active = None
+    yield
+    BreakableCUDAGraphCapture._tls.active = None
+
+
+@pytest.fixture
+def cuda_capture_stream():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        yield stream
+    torch.cuda.current_stream().wait_stream(stream)

--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
@@ -15,33 +15,6 @@ import torch
 os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
 
 
-@pytest.fixture(autouse=True)
-def _reset_breakable_tls():
-    """Defensively clear thread-local capture state between tests so a
-    failure in one test can't leak "nested capture" errors into the next."""
-    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
-
-    BreakableCUDAGraphCapture._tls.active = None
-    yield
-    BreakableCUDAGraphCapture._tls.active = None
-
-
-@pytest.fixture
-def cuda_capture_stream():
-    """A non-default CUDA stream suitable for cudagraph capture.
-
-    ``CUDAGraph.capture_begin`` refuses to capture from the default
-    stream, so all capture-using tests need to run under
-    ``torch.cuda.stream(...)`` for a separate stream.
-    """
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
-    stream = torch.cuda.Stream()
-    with torch.cuda.stream(stream):
-        yield stream
-    torch.cuda.current_stream().wait_stream(stream)
-
-
 # ---------------------------------------------------------------------------
 # eager_break_during_capture: outside capture
 # ---------------------------------------------------------------------------

--- a/tests/v1/cudagraph/test_breakable_cudagraph_debug.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph_debug.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+# Distinctive size so a freed block is reused cleanly by an equally-sized alloc.
+N = 1_000_003
+
+
+@pytest.fixture(autouse=True)
+def _reset_breakable_tls():
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+
+    BreakableCUDAGraphCapture._tls.active = None
+    yield
+    BreakableCUDAGraphCapture._tls.active = None
+
+
+@pytest.fixture
+def cuda_capture_stream():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        yield stream
+    torch.cuda.current_stream().wait_stream(stream)
+
+
+def test_good_inplace_mutation(cuda_capture_stream):
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+
+    buf = torch.zeros(1024, device="cuda")
+    src = torch.ones(1024, device="cuda")
+
+    def clean_break():
+        # In-place into a pre-existing buffer; the intermediate is freed.
+        buf.copy_(src * 2.0)
+
+    cap = BreakableCUDAGraphCapture(debug=True)
+    with cap:
+        x = torch.zeros(4, device="cuda")
+        x.add_(1.0)
+        cap.add_eager(clean_break)
+        x.add_(1.0)
+    assert cap.num_eager_breaks == 1
+
+
+def test_good_new_alloc(cuda_capture_stream):
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+
+    src = torch.ones(1024, device="cuda")
+
+    def returns_break():
+        # A fresh tensor that IS returned is the explicit output, not a leak.
+        return src * 2.0
+
+    cap = BreakableCUDAGraphCapture(debug=True)
+    with cap:
+        x = torch.zeros(4, device="cuda")
+        x.add_(1.0)
+        cap.add_eager(returns_break)
+        x.add_(1.0)
+    assert cap.num_eager_breaks == 1
+
+
+def test_non_explicit_output_raises(cuda_capture_stream):
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+
+    sink = []
+    src = torch.ones(1024, device="cuda")
+
+    def leaky_break():
+        # Fresh alloc survives via the side channel but isn't returned.
+        sink.append(src * 3.0)
+
+    cap = BreakableCUDAGraphCapture(debug=True)
+    with pytest.raises(RuntimeError, match="eager break"), cap:
+        x = torch.zeros(4, device="cuda")
+        x.add_(1.0)
+        cap.add_eager(leaky_break)
+        x.add_(1.0)
+
+
+def test_non_explicit_output_reused_address_raises(cuda_capture_stream):
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+
+    sink = []
+    holder = {"a": torch.empty(N, device="cuda")}
+    torch.accelerator.synchronize()
+
+    def reuse_break():
+        # Free a pre-existing block, then reuse its address for a survivor.
+        # The live-segment diff is blind to this; the event log is not.
+        del holder["a"]
+        sink.append(torch.empty(N, device="cuda"))
+
+    cap = BreakableCUDAGraphCapture(debug=True)
+    with pytest.raises(RuntimeError, match="eager break"), cap:
+        x = torch.zeros(4, device="cuda")
+        x.add_(1.0)
+        cap.add_eager(reuse_break)
+        x.add_(1.0)
+
+
+def test_non_explicit_output_custom_op_raises(cuda_capture_stream):
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+
+    sink = []
+    lib = torch.library.Library("bcg_dbg_test", "FRAGMENT")
+    lib.define("leak(Tensor x) -> Tensor")
+
+    def _leak_impl(x):
+        # Allocation inside an opaque op is still seen at the allocator level.
+        sink.append(x + 1.0)
+        return x.clone()
+
+    lib.impl("leak", _leak_impl, "CUDA")
+    leak_op = torch.ops.bcg_dbg_test.leak.default
+    inp = torch.ones(1024, device="cuda")
+
+    def opaque_break():
+        return leak_op(inp)
+
+    cap = BreakableCUDAGraphCapture(debug=True)
+    with pytest.raises(RuntimeError, match="eager break"), cap:
+        x = torch.zeros(4, device="cuda")
+        x.add_(1.0)
+        cap.add_eager(opaque_break)
+        x.add_(1.0)
+
+
+def test_good_marked_non_explicit_output(cuda_capture_stream):
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+    from vllm.compilation.breakable_cudagraph_debug import mark_bcg_output
+
+    sink = []
+    src = torch.ones(1024, device="cuda")
+
+    def marked_break():
+        out = src * 3.0
+        sink.append(out)
+        mark_bcg_output(out)
+
+    cap = BreakableCUDAGraphCapture(debug=True)
+    with cap:
+        x = torch.zeros(4, device="cuda")
+        x.add_(1.0)
+        cap.add_eager(marked_break)
+        x.add_(1.0)
+    assert cap.num_eager_breaks == 1
+
+
+def test_non_explicit_output_not_flagged_when_debug_off(cuda_capture_stream):
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+
+    sink = []
+    src = torch.ones(1024, device="cuda")
+
+    def leaky_break():
+        sink.append(src * 3.0)
+
+    cap = BreakableCUDAGraphCapture(debug=False)
+    with cap:
+        x = torch.zeros(4, device="cuda")
+        x.add_(1.0)
+        cap.add_eager(leaky_break)
+        x.add_(1.0)
+    assert cap.num_eager_breaks == 1

--- a/tests/v1/cudagraph/test_breakable_cudagraph_debug.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph_debug.py
@@ -10,25 +10,6 @@ import torch
 N = 1_000_003
 
 
-@pytest.fixture(autouse=True)
-def _reset_breakable_tls():
-    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
-
-    BreakableCUDAGraphCapture._tls.active = None
-    yield
-    BreakableCUDAGraphCapture._tls.active = None
-
-
-@pytest.fixture
-def cuda_capture_stream():
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
-    stream = torch.cuda.Stream()
-    with torch.cuda.stream(stream):
-        yield stream
-    torch.cuda.current_stream().wait_stream(stream)
-
-
 def test_good_inplace_mutation(cuda_capture_stream):
     from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
 
@@ -169,3 +150,31 @@ def test_non_explicit_output_not_flagged_when_debug_off(cuda_capture_stream):
         cap.add_eager(leaky_break)
         x.add_(1.0)
     assert cap.num_eager_breaks == 1
+
+
+def test_check_non_explicit_outputs_rejects_user_memory_history(cuda_capture_stream):
+    from vllm.compilation.breakable_cudagraph_debug import check_non_explicit_outputs
+
+    def device_trace_actions():
+        trace = torch._C._cuda_memorySnapshot(None).get("device_traces", [])
+        return [e["action"] for e in trace[torch.cuda.current_device()]]
+
+    torch.cuda.memory._record_memory_history(None, clear_history=True)
+    try:
+        torch.cuda.memory._record_memory_history(
+            "all", context="alloc", stacks="python", clear_history=True
+        )
+        torch.empty(17, device="cuda")
+        assert device_trace_actions()
+
+        def inner():
+            return torch.empty(19, device="cuda")
+
+        with pytest.raises(RuntimeError, match="PyTorch CUDA memory history"):
+            check_non_explicit_outputs(inner, (), {})
+
+        torch.empty(23, device="cuda")
+        assert "alloc" in device_trace_actions()
+        assert torch._C._cuda_isHistoryEnabled()
+    finally:
+        torch.cuda.memory._record_memory_history(None, clear_history=True)

--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -33,6 +33,7 @@ from typing import Any, ClassVar, TypeVar
 import torch
 
 import vllm.envs as envs
+from vllm.compilation.breakable_cudagraph_debug import check_non_explicit_outputs
 from vllm.compilation.monitor import validate_cudagraph_capturing_enabled
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.distributed.device_communicators.pynccl_allocator import set_graph_pool_id
@@ -147,9 +148,11 @@ class BreakableCUDAGraphCapture:
     def is_active(cls) -> bool:
         return cls.current() is not None
 
-    def __init__(self, pool: Any | None = None) -> None:
+    def __init__(self, pool: Any | None = None, debug: bool = False) -> None:
         self.pool = pool
+        self.debug = debug
         self.segments: list[Callable[[], Any]] = []
+        self._non_explicit_output_errors: list[str] = []
         self._num_graphs: int = 0
         self._num_eager_breaks: int = 0
         self._current_graph: torch.cuda.CUDAGraph | None = None
@@ -169,6 +172,8 @@ class BreakableCUDAGraphCapture:
             self._end_segment()
         finally:
             BreakableCUDAGraphCapture._tls.active = None
+        if self._non_explicit_output_errors and exc_type is None:
+            raise RuntimeError("\n\n".join(self._non_explicit_output_errors))
 
     # --- segment management ----------------------------------------------
 
@@ -201,7 +206,12 @@ class BreakableCUDAGraphCapture:
         downstream dependencies via static output buffers.
         """
         self._end_segment()
-        result = fn()
+        if self.debug:
+            result, error_msg = check_non_explicit_outputs(fn, (), {})
+            if error_msg is not None:
+                self._non_explicit_output_errors.append(error_msg)
+        else:
+            result = fn()
         self.segments.append(fn)
         self._num_eager_breaks += 1
         self._begin_segment()
@@ -378,7 +388,9 @@ class BreakableCUDAGraphWrapper:
         # pre-capture prefetches are complete and don't leak into the graph.
         get_offloader().sync_prev_onload()
 
-        capture = BreakableCUDAGraphCapture(pool=self.graph_pool)
+        capture = BreakableCUDAGraphCapture(
+            pool=self.graph_pool, debug=envs.VLLM_BCG_DEBUG
+        )
         with capture:
             output = self.runnable(*args, **kwargs)
             # Join the offloader's copy stream while we still hold the last

--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -389,7 +389,7 @@ class BreakableCUDAGraphWrapper:
         get_offloader().sync_prev_onload()
 
         capture = BreakableCUDAGraphCapture(
-            pool=self.graph_pool, debug=envs.VLLM_BCG_DEBUG
+            pool=self.graph_pool, debug=envs.VLLM_BREAKABLE_CUDAGRAPH_DEBUG
         )
         with capture:
             output = self.runnable(*args, **kwargs)

--- a/vllm/compilation/breakable_cudagraph_debug.py
+++ b/vllm/compilation/breakable_cudagraph_debug.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Debug tools for breakable CUDA graph (BCG).
+
+BCG records a sequence of CUDA graphs broken apart by eager functions that
+can't be CUDA graphed. At each eager break, we copy the tensors returned by
+the eager function in a static buffer that the next graph consumes. This
+leaves room for developer errors that could be very difficult to debug: if
+an eager function allocates a new tensor that wasn't returned explicitly but
+survives outside of the eager call (like assigning to an instance variable if
+the eager function was a class method), the new tensor won't be copied to the
+next CUDA graph, causing a potential silent correctness issue.
+
+``check_non_explicit_outputs`` detects this at capture time and returns a
+list of tensors that were not returned explicitly.
+
+We detect it from the CUDA caching allocator's own allocation history. Around
+the eager call we turn on ``torch.cuda.memory._record_memory_history`` and read
+the raw snapshot's ``device_traces`` (the public ``memory_snapshot()`` returns
+only ``segments``). Replaying those alloc/free events tells us exactly which
+blocks were allocated during the call and are still alive when it returns.
+Subtracting the explicitly-returned (and ``mark_bcg_output``-marked) tensors
+leaves the non-explicit outputs.
+
+The tool doesn't help if a tensor is allocated outside the PyTorch caching
+allocator (a raw ``cudaMalloc`` in C++) or borrowed via DLPack.
+
+If the user is confident that a non-explicitly returned tensor is safe, they
+may mark that tensor with ``mark_bcg_output`` and avoid a false detection.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import weakref
+from collections.abc import Callable
+from contextvars import ContextVar
+
+import torch
+
+# When debug capture is active this holds a list of `(weakref(storage),
+# storage.data_ptr())` tensors that the check should ignore. Holds no
+# strong reference, so it never keeps a tensor alive. Storage (not address) based: if
+# a marked tensor is freed mid-break and its address is reused by a real escape, the
+# dead weakref stops exempting that address, so the real escape is still caught.
+_safe_non_explicit_outputs: ContextVar[list | None] = ContextVar(
+    "bcg_safe_marks", default=None
+)
+
+
+def mark_bcg_output(*tensors: torch.Tensor) -> None:
+    marked_outputs = _safe_non_explicit_outputs.get()
+    if marked_outputs is None:
+        return
+    for t in tensors:
+        if torch.is_tensor(t) and t.numel() > 0:
+            st = t.untyped_storage()
+            marked_outputs.append((weakref.ref(st), st.data_ptr()))
+
+
+# TODO: probably the exact same things a tree_iter
+def _collect_tensors(obj, acc) -> None:
+    """Mirrors the BCG's ``_copy_output`` function to gather tensors."""
+    if torch.is_tensor(obj):
+        acc.append(obj)
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            _collect_tensors(v, acc)
+    elif isinstance(obj, (list, tuple)):
+        for v in obj:
+            _collect_tensors(v, acc)
+    elif hasattr(obj, "__dict__"):
+        for v in vars(obj).values():
+            _collect_tensors(v, acc)
+
+
+def _get_marked_output_ptrs(marked_outputs: list) -> set:
+    return {
+        ptr
+        for ref, ptr in marked_outputs
+        if (st := ref()) is not None and st.data_ptr() == ptr
+    }
+
+
+def _get_tensor_storage_ptrs(output) -> set:
+    tensors: list = []
+    _collect_tensors(output, tensors)
+    return {t.untyped_storage().data_ptr() for t in tensors if t.numel() > 0}
+
+
+def _get_device_mem_trace(device_idx: int) -> list:
+    # The public `torch.cuda.memory_snapshot()` exposes only `segments`
+    # `device_traces` is reachable only through the private C++ function
+    snapshot = torch._C._cuda_memorySnapshot(None)
+    trace = snapshot.get("device_traces", [])
+    if trace and isinstance(trace[0], list):
+        return trace[device_idx] if device_idx < len(trace) else []
+    return trace
+
+
+def _get_live_tensors(trace: list) -> dict:
+    live_tensors: dict = {}
+    for event in trace:
+        action = event["action"]
+        if action == "alloc":
+            live_tensors[event["addr"]] = (event["size"], event.get("frames"))
+        elif action == "free_requested":
+            live_tensors.pop(event["addr"], None)
+    return live_tensors
+
+
+def _format_frames(frames) -> str | None:
+    if not frames:
+        return None
+    return "\n".join(
+        f'File "{f.get("filename")}", line {f.get("line")}, in {f.get("name")}'
+        for f in frames
+    )
+
+
+def _make_error_msg(fn_name: str, non_explicit_outputs: list) -> str:
+    lines = [
+        f"[BCG] eager break '{fn_name}' produced "
+        f"{len(non_explicit_outputs)} output(s) that survive the call but are "
+        "not returned. On replay, these are re-allocated at fresh addresses "
+        "with no copy-back, so downstream captured segments read stale memory. "
+        "Return them from the break, or write the result in-place into a "
+        "pre-existing buffer."
+    ]
+    for i, e in enumerate(non_explicit_outputs[:5], 1):
+        lines.append(f"  #{i}: data_ptr={e['ptr']:#x} nbytes={e['nbytes']}")
+        if e["frames"]:
+            lines.append(textwrap.indent(e["frames"], "      "))
+    if len(non_explicit_outputs) > 5:
+        lines.append(f"  ... and {len(non_explicit_outputs) - 5} more")
+    return "\n".join(lines)
+
+
+def check_non_explicit_outputs(inner: Callable, args: tuple, kwargs: dict):
+    """Run an eager break under allocator history recording and report leaks.
+
+    Args:
+        inner: The eager break callable to run.
+        args: Positional args for ``inner``.
+        kwargs: Keyword args for ``inner``.
+
+    Returns:
+        A ``(output, error_message_or_None)`` tuple, where ``output`` is the
+        return value of ``inner`` and ``error_message_or_None`` describes any
+        tensors that survive the call but are not explicitly returned.
+    """
+    device_idx = torch.accelerator.current_device_index()
+    torch.cuda.memory._record_memory_history(
+        "all",
+        context="alloc",
+        stacks="python",
+        max_entries=1_000_000,
+        clear_history=True,
+    )
+    token = _safe_non_explicit_outputs.set([])
+    try:
+        output = inner(*args, **kwargs)
+    finally:
+        marked_outputs = _safe_non_explicit_outputs.get() or []
+        _safe_non_explicit_outputs.reset(token)
+        trace = _get_device_mem_trace(device_idx)
+        torch.cuda.memory._record_memory_history(None)
+
+    explicit_outputs = _get_tensor_storage_ptrs(output) | _get_marked_output_ptrs(
+        marked_outputs
+    )
+    non_explicit_outputs = [
+        {"ptr": addr, "nbytes": size, "frames": _format_frames(frames)}
+        for addr, (size, frames) in _get_live_tensors(trace).items()
+        if not any(addr <= p < addr + size for p in explicit_outputs)
+    ]
+    name = getattr(inner, "__name__", repr(inner))
+    return output, (
+        _make_error_msg(name, non_explicit_outputs) if non_explicit_outputs else None
+    )

--- a/vllm/compilation/breakable_cudagraph_debug.py
+++ b/vllm/compilation/breakable_cudagraph_debug.py
@@ -37,6 +37,7 @@ from collections.abc import Callable
 from contextvars import ContextVar
 
 import torch
+from torch.utils._pytree import tree_iter
 
 # When debug capture is active this holds a list of `(weakref(storage),
 # storage.data_ptr())` tensors that the check should ignore. Holds no
@@ -58,22 +59,6 @@ def mark_bcg_output(*tensors: torch.Tensor) -> None:
             marked_outputs.append((weakref.ref(st), st.data_ptr()))
 
 
-# TODO: probably the exact same things a tree_iter
-def _collect_tensors(obj, acc) -> None:
-    """Mirrors the BCG's ``_copy_output`` function to gather tensors."""
-    if torch.is_tensor(obj):
-        acc.append(obj)
-    elif isinstance(obj, dict):
-        for v in obj.values():
-            _collect_tensors(v, acc)
-    elif isinstance(obj, (list, tuple)):
-        for v in obj:
-            _collect_tensors(v, acc)
-    elif hasattr(obj, "__dict__"):
-        for v in vars(obj).values():
-            _collect_tensors(v, acc)
-
-
 def _get_marked_output_ptrs(marked_outputs: list) -> set:
     return {
         ptr
@@ -83,9 +68,11 @@ def _get_marked_output_ptrs(marked_outputs: list) -> set:
 
 
 def _get_tensor_storage_ptrs(output) -> set:
-    tensors: list = []
-    _collect_tensors(output, tensors)
-    return {t.untyped_storage().data_ptr() for t in tensors if t.numel() > 0}
+    return {
+        t.untyped_storage().data_ptr()
+        for t in tree_iter(output)
+        if torch.is_tensor(t) and t.numel() > 0
+    }
 
 
 def _get_device_mem_trace(device_idx: int) -> list:
@@ -148,7 +135,19 @@ def check_non_explicit_outputs(inner: Callable, args: tuple, kwargs: dict):
         A ``(output, error_message_or_None)`` tuple, where ``output`` is the
         return value of ``inner`` and ``error_message_or_None`` describes any
         tensors that survive the call but are not explicitly returned.
+
+    Raises:
+        RuntimeError: If PyTorch CUDA memory history is already enabled. This
+        check uses PyTorch CUDA memory history internally, so users should not
+        use it while this check is active.
     """
+    if torch._C._cuda_isHistoryEnabled():
+        raise RuntimeError(
+            "BCG debug uses PyTorch CUDA memory history internally. Disable "
+            "PyTorch CUDA memory history before enabling "
+            "VLLM_BREAKABLE_CUDAGRAPH_DEBUG."
+        )
+
     device_idx = torch.accelerator.current_device_index()
     torch.cuda.memory._record_memory_history(
         "all",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -154,6 +154,7 @@ if TYPE_CHECKING:
     VLLM_USE_STANDALONE_COMPILE: bool = True
     VLLM_ENABLE_PREGRAD_PASSES: bool = True
     VLLM_USE_BREAKABLE_CUDAGRAPH: bool = False
+    VLLM_BCG_DEBUG: bool = False
     VLLM_DP_MASTER_IP: str = ""
     VLLM_DP_MASTER_PORT: int = 0
     VLLM_RANDOMIZE_DP_DUMMY_INPUTS: bool = False
@@ -725,6 +726,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_USE_BREAKABLE_CUDAGRAPH": lambda: (
         os.environ.get("VLLM_USE_BREAKABLE_CUDAGRAPH", "0") == "1"
     ),
+    # Detect non-explicitly-returned outputs of eager breaks during breakable
+    # cudagraph capture
+    "VLLM_BCG_DEBUG": lambda: os.environ.get("VLLM_BCG_DEBUG", "0") == "1",
     # Debug pattern matching inside custom passes.
     # Should be set to the fx.Node name (e.g. 'getitem_34' or 'scaled_mm_3').
     "VLLM_PATTERN_MATCH_DEBUG": lambda: os.environ.get(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -154,7 +154,7 @@ if TYPE_CHECKING:
     VLLM_USE_STANDALONE_COMPILE: bool = True
     VLLM_ENABLE_PREGRAD_PASSES: bool = True
     VLLM_USE_BREAKABLE_CUDAGRAPH: bool = False
-    VLLM_BCG_DEBUG: bool = False
+    VLLM_BREAKABLE_CUDAGRAPH_DEBUG: bool = False
     VLLM_DP_MASTER_IP: str = ""
     VLLM_DP_MASTER_PORT: int = 0
     VLLM_RANDOMIZE_DP_DUMMY_INPUTS: bool = False
@@ -728,7 +728,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Detect non-explicitly-returned outputs of eager breaks during breakable
     # cudagraph capture
-    "VLLM_BCG_DEBUG": lambda: os.environ.get("VLLM_BCG_DEBUG", "0") == "1",
+    "VLLM_BREAKABLE_CUDAGRAPH_DEBUG": lambda: (
+        os.environ.get("VLLM_BREAKABLE_CUDAGRAPH_DEBUG", "0") == "1"
+    ),
     # Debug pattern matching inside custom passes.
     # Should be set to the fx.Node name (e.g. 'getitem_34' or 'scaled_mm_3').
     "VLLM_PATTERN_MATCH_DEBUG": lambda: os.environ.get(


### PR DESCRIPTION
## Purpose

BCG records a sequence of CUDA graphs broken apart by eager functions that can't be CUDA graphed. At each eager break, we copy the tensors returned by the eager function in a static buffer that the next graph consumes. This leaves room for developer errors that could be very difficult to debug: if an eager function allocates a new tensor that wasn't returned explicitly but survives outside of the eager call (like assigning to an instance variable if the eager function was a class method), the new tensor won't be copied to the next CUDA graph, causing a potential silent correctness issue.

``check_non_explicit_outputs`` detects this at capture time and returns a list of tensors that were not returned explicitly.

## Test Plan

Tests added for the new debug tool. Run with:

```
python -m pytest tests/v1/cudagraph/test_breakable_cudagraph_debug.py -v
```

## Test Result

N/A

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

