### PR TITLE
Fix Responses Harmony instructions placement

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -9,6 +9,7 @@ from tests.entrypoints.openai.utils import verify_harmony_messages
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
 from vllm.entrypoints.openai.parser.harmony_utils import (
     auto_drop_analysis_messages,
+    build_harmony_preamble,
     create_tool_definition,
     extract_function_from_recipient,
     get_system_message,
@@ -27,6 +28,21 @@ _TOOL_PARAMETERS = {
     "required": ["status"],
     "additionalProperties": False,
 }
+
+
+def test_build_harmony_preamble_can_force_developer_instructions(monkeypatch):
+    monkeypatch.setenv("VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS", "1")
+    instructions = "ZXQ_7429_OK"
+
+    messages = build_harmony_preamble(
+        instructions=instructions,
+        force_developer_instructions=True,
+    )
+
+    assert messages[0].author.role == Role.SYSTEM
+    assert instructions not in (messages[0].content[0].model_identity or "")
+    assert messages[1].author.role == Role.DEVELOPER
+    assert messages[1].content[0].instructions == instructions
 
 
 class TestCreateToolDefinition:

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -163,9 +163,13 @@ def create_tool_definition(tool: ChatCompletionToolsParam | Tool):
 def get_developer_message(
     instructions: str | None = None,
     tools: list[Tool | ChatCompletionToolsParam] | None = None,
+    *,
+    force_instructions: bool = False,
 ) -> Message:
     dev_msg_content = DeveloperContent.new()
-    if instructions is not None and not envs.VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS:
+    if instructions is not None and (
+        force_instructions or not envs.VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS
+    ):
         dev_msg_content = dev_msg_content.with_instructions(instructions)
     if tools is not None:
         function_tools: list[Tool | ChatCompletionToolsParam] = []
@@ -318,12 +322,15 @@ def build_harmony_preamble(
     python_description: str | None = None,
     container_description: str | None = None,
     with_custom_tools: bool = False,
+    force_developer_instructions: bool = False,
 ) -> list[Message]:
     """
     Build the standard Harmony system/developer prefix for a request.
     """
     developer_instructions = system_instructions = None
-    if envs.VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS:
+    if force_developer_instructions:
+        developer_instructions = instructions
+    elif envs.VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS:
         system_instructions = instructions
     else:
         developer_instructions = instructions
@@ -343,6 +350,7 @@ def build_harmony_preamble(
             get_developer_message(
                 instructions=developer_instructions,
                 tools=tools,
+                force_instructions=force_developer_instructions,
             )
         )
     return messages

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1153,6 +1153,7 @@ class OpenAIServingResponses(OpenAIServing):
                         request.reasoning.effort if request.reasoning else None
                     ),
                     with_custom_tools=with_custom_tools,
+                    force_developer_instructions=True,
                     **tool_descriptions,
                 )
             )


### PR DESCRIPTION
## Summary

For GPT-OSS Responses API requests, top-level `instructions` should be rendered as Harmony developer instructions. Previously, the Harmony Responses path could route those instructions through the system/model-identity path when `VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS=1` was set. That made the text visible in the prompt, but not in the instruction channel expected for Responses API behavior.

This change lets the Responses path force `instructions` into the Harmony developer message while preserving the existing env-controlled behavior for other Harmony callers.

## Test

Added a focused helper test for `build_harmony_preamble(..., force_developer_instructions=True)`.