### PR TITLE
[Model][Spec Decode] MiMo-V2.5-Pro-FP4 DFlash speculative decoding + AL fix

### DIFF
--- a/tests/models/test_mimo_v2.py
+++ b/tests/models/test_mimo_v2.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+    scaled_dequantize,
+    scaled_quantize,
+)
+from vllm.model_executor.models.mimo_v2 import (
+    MiMoV2Model,
+    _shard_fp8_qkv_proj,
+)
+
+
+def _expanded_scales(
+    scales: torch.Tensor,
+    shape: torch.Size | tuple[int, int],
+    block: int,
+) -> torch.Tensor:
+    return scales.repeat_interleave(block, 0).repeat_interleave(block, 1)[
+        : shape[0], : shape[1]
+    ]
+
+
+def _qkv_rows_per_group(
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    v_head_dim: int,
+) -> int:
+    return (num_heads // num_kv_heads) * head_dim + head_dim + v_head_dim
+
+
+def _make_pro_format_fp8_qkv(
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    v_head_dim: int,
+    hidden_size: int,
+    block: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows_per_group = _qkv_rows_per_group(
+        num_heads, num_kv_heads, head_dim, v_head_dim
+    )
+    full = (
+        torch.randn(num_kv_heads * rows_per_group, hidden_size, dtype=torch.float32)
+        * 0.1
+    )
+
+    weights: list[torch.Tensor] = []
+    scales: list[torch.Tensor] = []
+    for group_idx in range(num_kv_heads):
+        group_start = group_idx * rows_per_group
+        group = full[group_start : group_start + rows_per_group]
+        pad_rows = (-rows_per_group) % block
+        if pad_rows:
+            group = torch.cat(
+                [
+                    group,
+                    torch.zeros((pad_rows, hidden_size), dtype=group.dtype),
+                ],
+                dim=0,
+            )
+        group_weight, group_scales = scaled_quantize(
+            group,
+            GroupShape(block, block),
+            torch.float8_e4m3fn,
+            compute_dtype=torch.float32,
+        )
+        weights.append(group_weight[:rows_per_group])
+        scales.append(group_scales)
+
+    return torch.cat(weights), torch.cat(scales)
+
+
+def _expected_rank_dequant(
+    weight: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    v_head_dim: int,
+    tp_rank: int,
+    tp_size: int,
+    block: int,
+) -> torch.Tensor:
+    kv_heads_per_rank = num_kv_heads // tp_size
+    q_rows_per_group = (num_heads // num_kv_heads) * head_dim
+    k_rows_per_group = head_dim
+    rows_per_group = _qkv_rows_per_group(
+        num_heads, num_kv_heads, head_dim, v_head_dim
+    )
+    scale_rows_per_group = scales.shape[0] // num_kv_heads
+
+    qs: list[torch.Tensor] = []
+    ks: list[torch.Tensor] = []
+    vs: list[torch.Tensor] = []
+    for group_idx in range(
+        tp_rank * kv_heads_per_rank, (tp_rank + 1) * kv_heads_per_rank
+    ):
+        row_start = group_idx * rows_per_group
+        scale_start = group_idx * scale_rows_per_group
+        group_weight = weight[row_start : row_start + rows_per_group].float()
+        group_scales = scales[
+            scale_start : scale_start + scale_rows_per_group
+        ].float()
+        group_dequant = group_weight * _expanded_scales(
+            group_scales, group_weight.shape, block
+        )
+        qs.append(group_dequant[:q_rows_per_group])
+        ks.append(
+            group_dequant[
+                q_rows_per_group : q_rows_per_group + k_rows_per_group
+            ]
+        )
+        vs.append(group_dequant[q_rows_per_group + k_rows_per_group :])
+
+    return torch.cat([torch.cat(qs), torch.cat(ks), torch.cat(vs)], dim=0)
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "float8_e4m3fn"),
+    reason="MiMo FP8 QKV sharding requires torch.float8_e4m3fn",
+)
+def test_mimo_v2_fp8_qkv_tp_sharding_reorders_multiple_kv_groups():
+    torch.manual_seed(7)
+
+    block = 128
+    num_heads = 128
+    num_kv_heads = 8
+    head_dim = 192
+    v_head_dim = 128
+    tp_size = 4
+    hidden_size = 128
+    weight, scales = _make_pro_format_fp8_qkv(
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        v_head_dim=v_head_dim,
+        hidden_size=hidden_size,
+        block=block,
+    )
+
+    assert weight.shape == (27136, 128)
+    assert scales.shape == (216, 1)
+
+    for tp_rank in range(tp_size):
+        rank_weight, rank_scales = _shard_fp8_qkv_proj(
+            weight,
+            scales,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            v_head_dim=v_head_dim,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            block=block,
+        )
+        assert rank_weight.shape == (6784, 128)
+        assert rank_scales.shape == (53, 1)
+
+        actual = scaled_dequantize(
+            rank_weight, rank_scales, GroupShape(block, block)
+        )
+        expected = _expected_rank_dequant(
+            weight,
+            scales,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            v_head_dim=v_head_dim,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            block=block,
+        )
+
+        torch.testing.assert_close(actual, expected, atol=0.025, rtol=0)
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "float8_e4m3fn"),
+    reason="MiMo FP8 QKV loading requires torch.float8_e4m3fn",
+)
+def test_mimo_v2_fp8_qkv_loader_pairs_weight_and_scale():
+    torch.manual_seed(7)
+
+    block = 128
+    num_heads = 128
+    num_kv_heads = 8
+    head_dim = 192
+    v_head_dim = 128
+    tp_size = 4
+    hidden_size = 128
+    weight, scales = _make_pro_format_fp8_qkv(
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        v_head_dim=v_head_dim,
+        hidden_size=hidden_size,
+        block=block,
+    )
+
+    class FakeModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attn = SimpleNamespace(
+                total_num_heads=num_heads,
+                total_num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                v_head_dim=v_head_dim,
+            )
+
+        def get_submodule(self, target: str):
+            assert target == "layers.0.self_attn"
+            return self.attn
+
+    pending: dict[str, dict[str, torch.Tensor]] = {}
+    loaded: set[str] = set()
+    params = {
+        "layers.0.self_attn.qkv_proj.weight": nn.Parameter(
+            torch.empty((6784, 128), dtype=torch.float8_e4m3fn),
+            requires_grad=False,
+        ),
+        "layers.0.self_attn.qkv_proj.weight_scale_inv": nn.Parameter(
+            torch.empty((53, 1), dtype=torch.float32),
+            requires_grad=False,
+        ),
+    }
+
+    consumed = MiMoV2Model._try_load_fp8_qkv_proj(
+        FakeModel(),
+        "layers.0.self_attn.qkv_proj.weight",
+        weight,
+        pending,
+        params,
+        loaded,
+        tp_rank=0,
+        tp_size=tp_size,
+    )
+    assert consumed
+    assert pending
+    assert not loaded
+
+    consumed = MiMoV2Model._try_load_fp8_qkv_proj(
+        FakeModel(),
+        "layers.0.self_attn.qkv_proj.weight_scale_inv",
+        scales,
+        pending,
+        params,
+        loaded,
+        tp_rank=0,
+        tp_size=tp_size,
+    )
+    assert consumed
+    assert not pending
+    assert loaded == set(params)
+
+    actual = scaled_dequantize(
+        params["layers.0.self_attn.qkv_proj.weight"].data,
+        params["layers.0.self_attn.qkv_proj.weight_scale_inv"].data,
+        GroupShape(block, block),
+    )
+    expected = _expected_rank_dequant(
+        weight,
+        scales,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        v_head_dim=v_head_dim,
+        tp_rank=0,
+        tp_size=tp_size,
+        block=block,
+    )
+    torch.testing.assert_close(actual, expected, atol=0.025, rtol=0)

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1793,16 +1793,30 @@ def test_get_kv_cache_config_one_worker():
         ],
     )
 
-    # different hidden size that cannot be aligned by using different block size
+    # different hidden size that cannot be aligned by using different block size,
+    # but can be aligned by padding the smaller physical page.
     kv_cache_specs_hybrid = {
         "layer_1": new_kv_cache_spec(head_size=64),
         "layer_2": new_sliding_window_spec(head_size=96),
     }
 
-    with pytest.raises(NotImplementedError):
-        get_kv_cache_configs(
-            vllm_config, [kv_cache_specs_hybrid], [mem_per_block_per_layer * 2 * 32]
-        )[0]
+    kv_cache_config_hybrid = get_kv_cache_configs(
+        vllm_config, [kv_cache_specs_hybrid], [mem_per_block_per_layer * 2 * 32]
+    )[0]
+    padded_page_size = new_sliding_window_spec(head_size=96).page_size_bytes
+    assert kv_cache_config_hybrid == KVCacheConfig(
+        num_blocks=42,
+        kv_cache_tensors=[
+            KVCacheTensor(size=padded_page_size * 42, shared_by=["layer_1", "layer_2"]),
+        ],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer_1"],
+                new_kv_cache_spec(head_size=64, page_size_padded=padded_page_size),
+            ),
+            KVCacheGroupSpec(["layer_2"], new_sliding_window_spec(head_size=96)),
+        ],
+    )
 
     # Test num_gpu_blocks_override
     vllm_config.cache_config.num_gpu_blocks_override = 16
@@ -2314,6 +2328,42 @@ def test_check_enough_kv_cache_memory_respects_num_gpu_blocks_override():
 
     with pytest.raises(ValueError, match="max seq len"):
         get_kv_cache_configs(vllm_config, [kv_cache_specs], [large_available_memory])
+
+
+def test_unify_kv_cache_page_size_uses_padding_for_non_divisible_sizes():
+    """DFlash drafters can have a smaller head size than the target model.
+
+    For example, MiMo uses 192-dim target KV heads while its DFlash draft uses
+    128-dim KV heads. The resulting page sizes are 3:2 rather than an integer
+    block-size multiple, so the smaller page must be padded instead.
+    """
+    target_spec = new_kv_cache_spec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=192,
+        dtype=torch.bfloat16,
+    )
+    draft_spec = new_sliding_window_spec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+        sliding_window=1024,
+    )
+
+    unified_specs = kv_cache_utils.unify_kv_cache_spec_page_size(
+        {
+            "target_attn": target_spec,
+            "draft_attn": draft_spec,
+        }
+    )
+
+    assert unified_specs["target_attn"] == target_spec
+    unified_draft_spec = unified_specs["draft_attn"]
+    assert unified_draft_spec.block_size == draft_spec.block_size
+    assert unified_draft_spec.real_page_size_bytes == draft_spec.real_page_size_bytes
+    assert unified_draft_spec.page_size_padded == target_spec.page_size_bytes
+    assert unified_draft_spec.page_size_bytes == target_spec.page_size_bytes
 
 
 def test_unify_hybrid_kv_cache_specs():

--- a/tests/v1/spec_decode/test_dflash_lookahead.py
+++ b/tests/v1/spec_decode/test_dflash_lookahead.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from tests.v1.core.utils import create_requests
@@ -20,6 +21,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
 )
+from vllm.v1.spec_decode.utils import copy_and_expand_dflash_inputs_kernel
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
@@ -152,3 +154,84 @@ def test_dflash_drafter_window_reserves_bonus_token():
         speculative_config=SimpleNamespace(use_dflash=lambda: False),
     )
     assert input_fits_in_drafter(plain_runner, SimpleNamespace(max_seq_len=97))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize(
+    ("sliding_window", "expected_context_slots"),
+    [
+        (0, [40, 41, 42, 43, 44, 45]),
+        (3, [-1, -1, -1, -1, 44, 45]),
+    ],
+)
+def test_dflash_input_copy_filters_context_by_sliding_window(
+    sliding_window: int,
+    expected_context_slots: list[int],
+):
+    device = "cuda"
+    num_reqs = 1
+    block_size = 4
+    num_speculative_tokens = 2
+    num_query_per_req = num_speculative_tokens + 1
+    total_input_tokens = 6
+    kernel_block_size = 16
+
+    next_token_ids = torch.tensor([99], dtype=torch.int64, device=device)
+    target_positions = torch.arange(
+        total_input_tokens, dtype=torch.int64, device=device
+    )
+    block_table = torch.tensor([[10, 11, 12]], dtype=torch.int64, device=device)
+    query_start_loc = torch.tensor(
+        [0, total_input_tokens], dtype=torch.int32, device=device
+    )
+    empty_rejected_tokens = torch.empty(0, dtype=torch.int32, device=device)
+
+    out_input_ids = torch.full(
+        (num_reqs * num_query_per_req,), -1, dtype=torch.int64, device=device
+    )
+    out_context_positions = torch.full(
+        (total_input_tokens,), -1, dtype=torch.int64, device=device
+    )
+    out_query_positions = torch.full(
+        (num_reqs * num_query_per_req,), -1, dtype=torch.int64, device=device
+    )
+    out_context_slot_mapping = torch.full(
+        (total_input_tokens,), -9, dtype=torch.int64, device=device
+    )
+    out_query_slot_mapping = torch.full(
+        (num_reqs * num_query_per_req,), -9, dtype=torch.int64, device=device
+    )
+    out_token_indices = torch.full(
+        (num_reqs * num_speculative_tokens,), -1, dtype=torch.int64, device=device
+    )
+
+    copy_and_expand_dflash_inputs_kernel[(num_reqs, 1)](
+        next_token_ids,
+        target_positions,
+        out_input_ids,
+        out_context_positions,
+        out_query_positions,
+        out_context_slot_mapping,
+        out_query_slot_mapping,
+        out_token_indices,
+        block_table,
+        block_table.stride(0),
+        query_start_loc,
+        empty_rejected_tokens,
+        32000,
+        block_size,
+        sliding_window,
+        num_query_per_req,
+        num_speculative_tokens,
+        total_input_tokens,
+        BLOCK_SIZE=kernel_block_size,
+        HAS_NUM_REJECTED=False,
+    )
+    torch.cuda.synchronize()
+
+    assert out_context_positions.cpu().tolist() == list(range(total_input_tokens))
+    assert out_query_positions.cpu().tolist() == [6, 7, 8]
+    assert out_input_ids.cpu().tolist() == [99, 32000, 32000]
+    assert out_token_indices.cpu().tolist() == [1, 2]
+    assert out_context_slot_mapping.cpu().tolist() == expected_context_slots
+    assert out_query_slot_mapping.cpu().tolist() == [46, 47, 48]

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVQuantMode
+from vllm.v1.worker.gpu.attn_utils import _reshape_kv_cache
+from vllm.v1.worker.utils import AttentionGroup
+
+
+class FakeFlashAttentionBackend:
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        return (num_blocks, 2, block_size, num_kv_heads, head_size)
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        assert not include_num_layers_dimension
+        return (0, 1, 2, 3, 4)
+
+
+class FakeHNDFlashAttentionBackend(FakeFlashAttentionBackend):
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        assert not include_num_layers_dimension
+        return (0, 1, 3, 2, 4)
+
+
+def test_reshape_padded_flash_attention_kv_cache_strides_by_page():
+    num_blocks = 3
+    spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=2,
+        dtype=torch.float32,
+        page_size_padded=384,
+    )
+    assert spec.real_page_size_bytes == 256
+
+    raw_tensors = {
+        "layer": torch.zeros(spec.page_size_bytes * num_blocks, dtype=torch.int8)
+    }
+    attn_groups = [
+        AttentionGroup(
+            backend=FakeFlashAttentionBackend,
+            layer_names=["layer"],
+            kv_cache_spec=spec,
+            kv_cache_group_id=0,
+        )
+    ]
+
+    kv_cache = _reshape_kv_cache(
+        attn_groups,
+        raw_tensors,
+        "auto",
+        [spec.block_size],
+        {},
+    )["layer"]
+
+    assert kv_cache.shape == (num_blocks, 2, 16, 1, 2)
+    assert kv_cache.stride(0) == spec.page_size_bytes // 4
+    assert kv_cache.stride(1) == spec.real_page_size_bytes // 2 // 4
+    assert kv_cache[1, 0].storage_offset() == spec.page_size_bytes // 4
+    assert (
+        kv_cache[1, 1].storage_offset()
+        == (spec.page_size_bytes + spec.real_page_size_bytes // 2) // 4
+    )
+
+
+def test_reshape_padded_hnd_flash_attention_kv_cache_strides_by_page():
+    num_blocks = 3
+    spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=3,
+        head_size=2,
+        dtype=torch.float32,
+        page_size_padded=1024,
+    )
+    assert spec.real_page_size_bytes == 768
+
+    raw_tensors = {
+        "layer": torch.zeros(spec.page_size_bytes * num_blocks, dtype=torch.int8)
+    }
+    attn_groups = [
+        AttentionGroup(
+            backend=FakeHNDFlashAttentionBackend,
+            layer_names=["layer"],
+            kv_cache_spec=spec,
+            kv_cache_group_id=0,
+        )
+    ]
+
+    kv_cache = _reshape_kv_cache(
+        attn_groups,
+        raw_tensors,
+        "auto",
+        [spec.block_size],
+        {},
+    )["layer"]
+
+    assert kv_cache.shape == (num_blocks, 2, 16, 3, 2)
+    assert kv_cache.stride(0) == spec.page_size_bytes // 4
+    assert kv_cache.stride(1) == spec.real_page_size_bytes // 2 // 4
+    assert kv_cache.stride(2) == 2
+    assert kv_cache.stride(3) == spec.block_size * spec.head_size
+    assert kv_cache[1, 0].storage_offset() == spec.page_size_bytes // 4
+    assert (
+        kv_cache[1, 1].storage_offset()
+        == (spec.page_size_bytes + spec.real_page_size_bytes // 2) // 4
+    )
+    assert (
+        kv_cache[1, 1, 3, 2].storage_offset()
+        == (
+            spec.page_size_bytes
+            + spec.real_page_size_bytes // 2
+            + 3 * spec.head_size * 4
+            + 2 * spec.block_size * spec.head_size * 4
+        )
+        // 4
+    )
+
+
+class FakeDiffKVBackend:
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        return (num_blocks, block_size, num_kv_heads, head_size * 2)
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        assert not include_num_layers_dimension
+        return (0, 1, 2, 3)
+
+
+def test_reshape_padded_diff_kv_cache_does_not_infer_kv_dim():
+    num_blocks = 3
+    spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=2,
+        dtype=torch.float32,
+        page_size_padded=384,
+    )
+
+    raw_tensors = {
+        "layer": torch.zeros(spec.page_size_bytes * num_blocks, dtype=torch.int8)
+    }
+    attn_groups = [
+        AttentionGroup(
+            backend=FakeDiffKVBackend,
+            layer_names=["layer"],
+            kv_cache_spec=spec,
+            kv_cache_group_id=0,
+        )
+    ]
+
+    kv_cache = _reshape_kv_cache(
+        attn_groups,
+        raw_tensors,
+        "auto",
+        [spec.block_size],
+        {},
+    )["layer"]
+
+    assert kv_cache.shape == (num_blocks, 16, 1, 4)
+    assert kv_cache.stride(0) == spec.page_size_bytes // 4
+    assert kv_cache.stride(1) == 4
+
+
+class FakePerTokenScaleBackend:
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        return (num_blocks, 2, block_size, num_kv_heads, head_size + 4)
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        assert not include_num_layers_dimension
+        return (0, 1, 2, 3, 4)
+
+
+def test_reshape_padded_quantized_kv_cache_preserves_scale_stride():
+    num_blocks = 3
+    spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=4,
+        dtype=torch.int8,
+        kv_quant_mode=KVQuantMode.INT8_PER_TOKEN_HEAD,
+        page_size_padded=384,
+    )
+    assert spec.real_page_size_bytes == 128
+    assert spec.page_size_bytes == 384
+
+    raw_tensors = {
+        "layer": torch.zeros(spec.page_size_bytes * num_blocks, dtype=torch.int8)
+    }
+    attn_groups = [
+        AttentionGroup(
+            backend=FakePerTokenScaleBackend,
+            layer_names=["layer"],
+            kv_cache_spec=spec,
+            kv_cache_group_id=0,
+        )
+    ]
+
+    kv_cache = _reshape_kv_cache(
+        attn_groups,
+        raw_tensors,
+        "int8_per_token_head",
+        [spec.block_size],
+        {},
+    )["layer"]
+
+    assert kv_cache.shape == (num_blocks, 2, 16, 1, 8)
+    assert kv_cache.stride(0) == spec.page_size_bytes
+    assert kv_cache.stride(1) == 16 * 1 * 8
+    assert kv_cache[1, 1].storage_offset() == spec.page_size_bytes + 16 * 1 * 8

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -522,6 +522,25 @@ class SpeculativeConfig:
 
         return hf_config
 
+    @staticmethod
+    def _get_dflash_block_size(hf_config: PretrainedConfig) -> int | None:
+        """Return DFlash's configured query block size, if present."""
+        dflash_config = getattr(hf_config, "dflash_config", None) or {}
+        if not isinstance(dflash_config, dict):
+            return None
+
+        block_size = dflash_config.get("block_size")
+        if block_size is None:
+            return None
+
+        block_size = int(block_size)
+        if block_size <= 1:
+            raise ValueError(
+                "DFlash draft config `dflash_config.block_size` must be greater "
+                f"than 1, got {block_size}."
+            )
+        return block_size
+
     def __post_init__(self):
         # Note: "method" is a new parameter that helps to extend the
         # configuration of non-model-based proposers, and the "model" parameter
@@ -754,6 +773,34 @@ class SpeculativeConfig:
 
                 if self.method == "dflash":
                     self.parallel_drafting = True
+                    dflash_block_size = SpeculativeConfig._get_dflash_block_size(
+                        self.draft_model_config.hf_config
+                    )
+                    if dflash_block_size is not None:
+                        # DFlash's block_size counts the current/bonus token plus
+                        # mask tokens. vLLM's num_speculative_tokens counts only
+                        # the speculative mask tokens.
+                        dflash_num_speculative_tokens = dflash_block_size - 1
+                        if self.num_speculative_tokens is None:
+                            self.num_speculative_tokens = dflash_num_speculative_tokens
+                            logger.info(
+                                "Defaulted num_speculative_tokens to %s from "
+                                "DFlash draft block_size=%s.",
+                                self.num_speculative_tokens,
+                                dflash_block_size,
+                            )
+                        elif (
+                            self.num_speculative_tokens != dflash_num_speculative_tokens
+                        ):
+                            raise ValueError(
+                                "DFlash draft config block_size does not match "
+                                "num_speculative_tokens. DFlash block_size includes "
+                                "the current/bonus token, so vLLM requires "
+                                "num_speculative_tokens == block_size - 1. "
+                                f"Got num_speculative_tokens="
+                                f"{self.num_speculative_tokens}, "
+                                f"dflash_config.block_size={dflash_block_size}."
+                            )
 
                 if self.num_speculative_tokens is not None and hasattr(
                     self.draft_model_config.hf_config, "num_lookahead_tokens"

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -220,6 +220,24 @@ class Fp8Config(QuantizationConfig):
             }
         )
 
+    def get_cache_scale(self, name: str) -> str | None:
+        """Per-name compat shim over ``get_cache_scale_mapper``.
+
+        Some models (e.g. MiMo-V2) still call the per-weight ``get_cache_scale``
+        in their custom ``load_weights`` loop; upstream renamed this to the
+        mapper form. Map a compressed-tensors k/v/q-cache scale name to the
+        vLLM param name, or return None if it is not a cache-scale weight.
+        """
+        if name.endswith(".output_scale") and ".k_proj" in name:
+            return name.replace(".k_proj.output_scale", ".attn.k_scale")
+        if name.endswith(".output_scale") and ".v_proj" in name:
+            return name.replace(".v_proj.output_scale", ".attn.v_scale")
+        if name.endswith(".output_scale") and ".q_proj" in name:
+            return name.replace(".q_proj.output_scale", ".attn.q_scale")
+        if name.endswith("self_attn.prob_output_scale"):
+            return name.replace(".prob_output_scale", ".attn.prob_scale")
+        return None
+
 
 class CopyNumelCounter(TorchDispatchMode):
     """

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -6,6 +6,7 @@ import torch
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
     FusedMoEConfig,
     FusedMoEMethodBase,
     FusedMoEParallelConfig,
@@ -470,6 +471,166 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
             expert_map=layer.expert_map,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
         )
+
+
+class MiMoV2Mxfp4MoEMethod(GptOssMxfp4MoEMethod):
+    """MiMo MXFP4 MoE packing compatible with its DFlash checkpoint."""
+
+    def __init__(self, moe: FusedMoEConfig, swiglu_limit: float | None = None):
+        FusedMoEMethodBase.__init__(self, moe)
+        self.weight_dtype = "mxfp4"
+        if not hasattr(moe, "max_capture_size"):
+            moe.max_capture_size = 0
+        self.mxfp4_backend, self.experts_cls = select_deepseek_v4_mxfp4_moe_backend(moe)
+        self.max_capture_size = moe.max_capture_size
+        self._cache_permute_indices: dict[torch.Size, torch.Tensor] = {}
+        self.moe_kernel: mk.FusedMoEKernel | None = None
+        self.w13_precision_config = None
+        self.w2_precision_config = None
+        self._swiglu_limit = swiglu_limit
+
+        # MiMo must use vLLM's externally computed grouped sigmoid routing.
+        # The monolithic TRT-LLM expert path re-routes internally and drops the
+        # MiMo correction-bias routing semantics.
+        from vllm.model_executor.layers.fused_moe.experts.trtllm_mxfp4_moe import (
+            TrtLlmMxfp4ExpertsModular,
+        )
+
+        self.experts_cls = TrtLlmMxfp4ExpertsModular
+
+    @property
+    def supports_eplb(self) -> bool:
+        return True
+
+    def process_weights_after_loading(self, layer: RoutedExperts) -> None:
+        from flashinfer.fp4_quantization import block_scale_interleave
+        from flashinfer.fused_moe.core import (
+            _maybe_get_cached_w3_w1_permute_indices,
+            get_w2_permute_indices_with_cache,
+        )
+
+        from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
+            reorder_w1w3_to_w3w1,
+        )
+
+        w13_weight, w13_scale = reorder_w1w3_to_w3w1(
+            layer.w13_weight.data, layer.w13_weight_scale.data, dim=-2
+        )
+        w2_weight = layer.w2_weight.data
+        w2_scale = layer.w2_weight_scale.data
+
+        num_experts = w13_weight.shape[0]
+        epilogue_tile_m = 128
+        permute_cache: dict = {}
+        shuffled_w13 = []
+        shuffled_w13_scale = []
+        shuffled_w2 = []
+        shuffled_w2_scale = []
+
+        for expert_idx in range(num_experts):
+            w13_u8 = w13_weight[expert_idx].view(torch.uint8)
+            w13_scale_u8 = w13_scale[expert_idx].view(torch.uint8)
+            w2_u8 = w2_weight[expert_idx].view(torch.uint8)
+            w2_scale_u8 = w2_scale[expert_idx].view(torch.uint8)
+
+            w13_perm = _maybe_get_cached_w3_w1_permute_indices(
+                permute_cache, w13_u8, epilogue_tile_m
+            )
+            shuffled_w13.append(w13_u8[w13_perm.to(w13_u8.device)].contiguous())
+            w13_scale_perm = _maybe_get_cached_w3_w1_permute_indices(
+                permute_cache,
+                w13_scale_u8,
+                epilogue_tile_m,
+                num_elts_per_sf=16,
+            )
+            shuffled_w13_scale.append(
+                block_scale_interleave(
+                    w13_scale_u8[w13_scale_perm.to(w13_scale_u8.device)].contiguous()
+                )
+            )
+
+            w2_perm = get_w2_permute_indices_with_cache(
+                permute_cache, w2_u8, epilogue_tile_m
+            )
+            shuffled_w2.append(w2_u8[w2_perm.to(w2_u8.device)].contiguous())
+            w2_scale_perm = get_w2_permute_indices_with_cache(
+                permute_cache,
+                w2_scale_u8,
+                epilogue_tile_m,
+                num_elts_per_sf=16,
+            )
+            shuffled_w2_scale.append(
+                block_scale_interleave(
+                    w2_scale_u8[w2_scale_perm.to(w2_scale_u8.device)].contiguous()
+                )
+            )
+
+        replace_parameter(layer, "w13_weight", torch.stack(shuffled_w13))
+        replace_parameter(layer, "w2_weight", torch.stack(shuffled_w2))
+        replace_parameter(
+            layer,
+            "w13_weight_scale",
+            torch.stack(shuffled_w13_scale)
+            .view(torch.float8_e4m3fn)
+            .reshape(num_experts, w13_weight.shape[1], -1),
+        )
+        replace_parameter(
+            layer,
+            "w2_weight_scale",
+            torch.stack(shuffled_w2_scale)
+            .view(torch.float8_e4m3fn)
+            .reshape(num_experts, w2_weight.shape[1], -1),
+        )
+
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        if self.moe_quant_config is not None and self.experts_cls is not None:
+            self.moe_kernel = make_mxfp4_moe_kernel(
+                moe_quant_config=self.moe_quant_config,
+                moe_config=self.moe,
+                mxfp4_backend=self.mxfp4_backend,
+                experts_cls=self.experts_cls,
+                routing_tables=layer._expert_routing_tables(),
+                layer=layer,
+            )
+
+    def get_fused_moe_quant_config(
+        self, layer: RoutedExperts
+    ) -> FusedMoEQuantConfig | None:
+        w1_scale = layer.w13_weight_scale
+        w2_scale = layer.w2_weight_scale
+        w1_bias = getattr(layer, "w13_bias", None)
+        w2_bias = getattr(layer, "w2_bias", None)
+
+        if self.mxfp4_backend in TRITON_BACKENDS:
+            assert self.w13_precision_config is not None
+            assert self.w2_precision_config is not None
+            w1_scale = self.w13_precision_config
+            w2_scale = self.w2_precision_config
+
+        return make_mxfp4_moe_quant_config(
+            mxfp4_backend=self.mxfp4_backend,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+            swiglu_limit=self._swiglu_limit,
+            layer=layer,
+        )
+
+
+class MiMoV2Mxfp4Config(Mxfp4Config):
+    """MXFP4 config for MiMo-V2 experts."""
+
+    SWIGLU_LIMIT = 10.0
+
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> "QuantizeMethodBase | None":
+        if isinstance(layer, FusedMoE):
+            return MiMoV2Mxfp4MoEMethod(
+                layer.moe_config, swiglu_limit=self.SWIGLU_LIMIT
+            )
+        return super().get_quant_method(layer, prefix)
 
 
 class Mxfp4MoEMethod(FusedMoEMethodBase):

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -626,7 +626,12 @@ class MiMoV2Mxfp4Config(Mxfp4Config):
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
-        if isinstance(layer, FusedMoE):
+        # NOTE: the fused-MoE refactor replaced the `FusedMoE` class with a
+        # `FusedMoE(...)` factory returning a `MoERunner`; the routed-expert
+        # module that reaches quant-method selection is a `RoutedExperts`
+        # (matching the parent `Mxfp4Config.get_quant_method`). Checking the
+        # old `FusedMoE` symbol (now a function) would raise TypeError.
+        if isinstance(layer, RoutedExperts):
             return MiMoV2Mxfp4MoEMethod(
                 layer.moe_config, swiglu_limit=self.SWIGLU_LIMIT
             )

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 from collections.abc import Iterable
 from itertools import islice
 
@@ -68,6 +69,13 @@ from .utils import (
 )
 
 logger = init_logger(__name__)
+
+# DFlash draft fidelity: the reference extracts HF output_hidden_states, where
+# the entry after the FINAL target layer is the POST-final-norm hidden state
+# (all earlier entries are raw residual-stream values). Capturing the last aux
+# feature pre-norm degrades draft acceptance. Set this to 1 to restore the old
+# pre-norm behavior for A/B testing.
+_DFLASH_PRENORM_LAST_AUX = os.environ.get("VLLM_DFLASH_PRENORM_LAST_AUX", "0") == "1"
 
 
 class MiMoV2MLP(nn.Module):
@@ -595,12 +603,24 @@ class MiMoV2Model(nn.Module, EagleModelMixin):
             residual = intermediate_tensors["residual"]
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
-        for idx, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer)
+        # The DFlash reference uses the post-final-norm hidden state as the last
+        # aux feature (HF output_hidden_states[num_layers]). When that layer id
+        # is requested, skip its pre-norm residual capture in the loop and add
+        # the normed hidden state after self.norm below.
+        num_layers = len(self.layers)
+        post_norm_final_aux = (
+            num_layers in self.aux_hidden_state_layers
+            and not _DFLASH_PRENORM_LAST_AUX
+        )
+        for layer_idx, layer in enumerate(
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
         ):
             hidden_states, residual = layer(positions, hidden_states, residual)
+            if post_norm_final_aux and layer_idx + 1 == num_layers:
+                continue
             self._maybe_add_hidden_state(
-                aux_hidden_states, idx + 1, hidden_states, residual
+                aux_hidden_states, layer_idx + 1, hidden_states, residual
             )
 
         if not get_pp_group().is_last_rank:
@@ -609,6 +629,8 @@ class MiMoV2Model(nn.Module, EagleModelMixin):
             )
 
         hidden_states, _ = self.norm(hidden_states, residual)
+        if post_norm_final_aux:
+            aux_hidden_states.append(hidden_states)
 
         if len(aux_hidden_states) > 0:
             return hidden_states, aux_hidden_states

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -35,6 +35,7 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.mxfp4 import MiMoV2Mxfp4Config
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -51,7 +52,7 @@ from vllm.v1.attention.backends.flash_attn_diffkv import (
     FlashAttentionDiffKVBackend,
 )
 
-from .interfaces import MixtureOfExperts, SupportsPP
+from .interfaces import EagleModelMixin, MixtureOfExperts, SupportsEagle3, SupportsPP
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -164,13 +165,26 @@ class MiMoV2MoE(nn.Module):
             torch.empty(config.n_routed_experts, dtype=self.gate_dtype)
         )
 
+        # MiMo V2 Pro checkpoints store attention weights as fp8 while MoE
+        # experts are stored as MXFP4. Fp8Config intentionally drops
+        # store_dtype, so inspect the raw HF quantization_config before
+        # constructing the expert module.
+        hf_quant_config = getattr(config, "quantization_config", None)
+        if isinstance(hf_quant_config, dict):
+            store_dtype = hf_quant_config.get("store_dtype")
+        else:
+            store_dtype = getattr(hf_quant_config, "store_dtype", None)
+        expert_quant_config = (
+            MiMoV2Mxfp4Config() if store_dtype == "mxfp4" else quant_config
+        )
+
         self.experts = FusedMoE(
             num_experts=self.n_routed_experts,
             top_k=config.num_experts_per_tok,
             hidden_size=config.hidden_size,
             intermediate_size=config.moe_intermediate_size,
             renormalize=config.norm_topk_prob,
-            quant_config=quant_config,
+            quant_config=expert_quant_config,
             prefix=f"{prefix}.experts",
             e_score_correction_bias=self.gate.e_score_correction_bias,
             enable_eplb=self.enable_eplb,
@@ -442,7 +456,7 @@ class MiMoV2FlashDecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class MiMoV2Model(nn.Module):
+class MiMoV2Model(nn.Module, EagleModelMixin):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -493,7 +507,7 @@ class MiMoV2Model(nn.Module):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -505,10 +519,14 @@ class MiMoV2Model(nn.Module):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
+        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer)
         ):
             hidden_states, residual = layer(positions, hidden_states, residual)
+            self._maybe_add_hidden_state(
+                aux_hidden_states, idx + 1, hidden_states, residual
+            )
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
@@ -516,6 +534,9 @@ class MiMoV2Model(nn.Module):
             )
 
         hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
 
         return hidden_states
 
@@ -554,6 +575,22 @@ class MiMoV2Model(nn.Module):
                 continue
             if "mtp" in name:
                 continue
+
+            if self.quant_config is not None:
+                cache_scale_name = self.quant_config.get_cache_scale(name)
+                if cache_scale_name is not None and cache_scale_name in params_dict:
+                    param = params_dict[cache_scale_name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+
+                    kv_scale = loaded_weight
+                    if kv_scale.dim() > 0 and kv_scale.numel() > 1:
+                        kv_scale = kv_scale.view(-1)[0]
+
+                    weight_loader(param, kv_scale)
+                    loaded_params.add(cache_scale_name)
+                    continue
 
             expert_matched = False
             for param_name, weight_name, expert_id, shard_id in expert_params_mapping:
@@ -653,7 +690,7 @@ class MiMoV2Model(nn.Module):
         return loaded_params
 
 
-class MiMoV2FlashForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
+class MiMoV2FlashForCausalLM(nn.Module, SupportsPP, SupportsEagle3, MixtureOfExperts):
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
@@ -689,6 +726,13 @@ class MiMoV2FlashForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self.model._set_aux_hidden_state_layers(layers)
+
+    def get_eagle3_default_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        num_layers = len(self.model.layers)
+        return (2, num_layers // 2, num_layers - 3)
 
     def forward(
         self,

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -36,6 +36,10 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.mxfp4 import MiMoV2Mxfp4Config
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+    scaled_quantize,
+)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -455,6 +459,77 @@ class MiMoV2FlashDecoderLayer(nn.Module):
         return self.config.hybrid_layer_pattern[self.layer_id] == 1
 
 
+def _shard_fp8_qkv_proj(
+    w_full: torch.Tensor,
+    s_full: torch.Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    v_head_dim: int,
+    tp_rank: int,
+    tp_size: int,
+    block: int = 128,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Shard Pro-format fp8 fused QKV weights for a tensor-parallel rank.
+
+    The checkpoint stores rows as per-KV-head ``[Q | K | V]`` groups and stores
+    FP8 scales per padded group, not as one flat scale table for the whole fused
+    matrix. When a TP rank owns multiple groups, vLLM expects the local rows
+    de-interleaved as ``[all Q | all K | all V]``. Since K/V boundaries can
+    split 128-row FP8 scale blocks, dequantize each checkpoint group first,
+    reorder in floating point, and quantize back to rank-local FP8 blocks.
+    """
+    assert tp_size <= num_kv_heads and num_kv_heads % tp_size == 0, (
+        "TP size must evenly split the number of KV heads."
+    )
+
+    q_rows_per_group = (num_heads // num_kv_heads) * head_dim
+    k_rows_per_group = head_dim
+    v_rows_per_group = v_head_dim
+    rows_per_group = q_rows_per_group + k_rows_per_group + v_rows_per_group
+    assert s_full.shape[0] % num_kv_heads == 0, (
+        "Pro-format qkv_proj scales must be grouped by KV head."
+    )
+    scale_rows_per_group = s_full.shape[0] // num_kv_heads
+    min_scale_rows_per_group = (rows_per_group + block - 1) // block
+    assert scale_rows_per_group >= min_scale_rows_per_group, (
+        "Pro-format qkv_proj scale group is too small for the weight group."
+    )
+    kv_heads_per_rank = num_kv_heads // tp_size
+    if kv_heads_per_rank == 1:
+        return w_full.chunk(tp_size, dim=0)[tp_rank], s_full.chunk(tp_size, dim=0)[
+            tp_rank
+        ]
+
+    qs, ks, vs = [], [], []
+    for group_idx in range(
+        tp_rank * kv_heads_per_rank, (tp_rank + 1) * kv_heads_per_rank
+    ):
+        row_start = group_idx * rows_per_group
+        scale_row_start = group_idx * scale_rows_per_group
+        w_group = w_full[row_start : row_start + rows_per_group].to(torch.float32)
+        s_group = s_full[
+            scale_row_start : scale_row_start + scale_rows_per_group
+        ].to(torch.float32)
+        s_group = s_group.repeat_interleave(block, dim=0).repeat_interleave(
+            block, dim=1
+        )[:rows_per_group]
+        dequant_group = w_group * s_group
+        qs.append(dequant_group[:q_rows_per_group])
+        ks.append(
+            dequant_group[q_rows_per_group : q_rows_per_group + k_rows_per_group]
+        )
+        vs.append(dequant_group[q_rows_per_group + k_rows_per_group :])
+
+    grouped = torch.cat([torch.cat(qs), torch.cat(ks), torch.cat(vs)], dim=0)
+    return scaled_quantize(
+        grouped,
+        GroupShape(block, block),
+        w_full.dtype,
+        compute_dtype=torch.float32,
+    )
+
+
 @support_torch_compile
 class MiMoV2Model(nn.Module, EagleModelMixin):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -568,6 +643,7 @@ class MiMoV2Model(nn.Module, EagleModelMixin):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         loaded_params: set[str] = set()
         expert_params_mapping = self.get_expert_mapping()
+        pending_fp8_qkv_proj: dict[str, dict[str, torch.Tensor]] = {}
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
                 continue
@@ -627,11 +703,15 @@ class MiMoV2Model(nn.Module, EagleModelMixin):
             if expert_matched:
                 continue
             # Support fused qkv_proj checkpoint (Pro format)
-            if "qkv_proj" in name:
-                if name in params_dict:
-                    param = params_dict[name]
-                    loaded_weight = loaded_weight.chunk(tp_size, dim=0)[tp_rank]
-                    default_weight_loader(param, loaded_weight)
+            if self._try_load_fp8_qkv_proj(
+                name,
+                loaded_weight,
+                pending_fp8_qkv_proj,
+                params_dict,
+                loaded_params,
+                tp_rank,
+                tp_size,
+            ):
                 continue
             stacked_matched = False
             for param_name, weight_name, shard_id in stacked_params_mapping:
@@ -688,6 +768,56 @@ class MiMoV2Model(nn.Module, EagleModelMixin):
                 loaded_params.add(name)
 
         return loaded_params
+
+    def _try_load_fp8_qkv_proj(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+        fp8_qkv_proj_dict: dict[str, dict[str, torch.Tensor]],
+        params_dict: dict[str, torch.nn.Parameter],
+        loaded_params: set[str],
+        tp_rank: int,
+        tp_size: int,
+    ) -> bool:
+        is_weight = (
+            name.endswith("qkv_proj.weight") and tensor.dtype == torch.float8_e4m3fn
+        )
+        is_scale = name.endswith("qkv_proj.weight_scale_inv")
+        if not is_weight and not is_scale:
+            return False
+
+        if is_pp_missing_parameter(name, self):
+            return True
+
+        prefix, qkv_kind = name.rsplit(".", 1)
+        entry = fp8_qkv_proj_dict.setdefault(prefix, {})
+        entry[qkv_kind] = tensor
+        if "weight" not in entry or "weight_scale_inv" not in entry:
+            return True
+        del fp8_qkv_proj_dict[prefix]
+
+        attn = self.get_submodule(prefix.rsplit(".", 1)[0])
+        weight, scale = _shard_fp8_qkv_proj(
+            entry["weight"],
+            entry["weight_scale_inv"],
+            num_heads=attn.total_num_heads,
+            num_kv_heads=attn.total_num_kv_heads,
+            head_dim=attn.head_dim,
+            v_head_dim=attn.v_head_dim,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+        for kind, loaded_weight in {
+            "weight": weight,
+            "weight_scale_inv": scale,
+        }.items():
+            param_name = f"{prefix}.{kind}"
+            param = params_dict[param_name]
+            if loaded_weight.shape[0] > param.shape[0]:
+                loaded_weight = loaded_weight[: param.shape[0]]
+            default_weight_loader(param, loaded_weight)
+            loaded_params.add(param_name)
+        return True
 
 
 class MiMoV2FlashForCausalLM(nn.Module, SupportsPP, SupportsEagle3, MixtureOfExperts):

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from collections.abc import Iterable
 
 import torch
@@ -11,7 +12,10 @@ from transformers import Qwen3Config
 from vllm import _custom_ops as ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -46,6 +50,38 @@ from .utils import (
 
 logger = init_logger(__name__)
 
+MASK_EMBEDDING_FILENAME = "mask_embedding.pt"
+
+
+def _find_mask_embedding_file(
+    model_path: str, revision: str | None = None
+) -> str | None:
+    """Locate the DFlash ``mask_embedding.pt`` file for a draft model.
+
+    Args:
+        model_path: Local directory or Hugging Face repo id of the draft model.
+        revision: Optional revision used when the draft lives on the HF Hub.
+
+    Returns:
+        The path to ``mask_embedding.pt`` if it can be found, otherwise None.
+    """
+    if os.path.isdir(model_path):
+        candidate = os.path.join(model_path, MASK_EMBEDDING_FILENAME)
+        return candidate if os.path.isfile(candidate) else None
+
+    # Remote draft: the weight loader only fetches *.safetensors/*.bin, so the
+    # mask embedding (a plain .pt) must be downloaded explicitly.
+    try:
+        from huggingface_hub import hf_hub_download
+
+        return hf_hub_download(
+            repo_id=model_path,
+            filename=MASK_EMBEDDING_FILENAME,
+            revision=revision,
+        )
+    except Exception:
+        return None
+
 
 class DFlashQwen3Attention(nn.Module):
     """Attention for DFlash speculative decoding.
@@ -64,6 +100,8 @@ class DFlashQwen3Attention(nn.Module):
         head_dim: int | None = None,
         rms_norm_eps: float = 1e-06,
         attention_bias: bool = False,
+        add_swa_attention_sink_bias: bool = False,
+        sliding_window: int | None = None,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
@@ -109,6 +147,14 @@ class DFlashQwen3Attention(nn.Module):
             max_position=max_position,
             rope_parameters=rope_parameters,
         )
+
+        self.attention_sink_bias = (
+            torch.nn.Parameter(torch.empty(self.num_heads), requires_grad=False)
+            if add_swa_attention_sink_bias
+            else None
+        )
+
+        self.sliding_window = sliding_window
         self.attn = Attention(
             self.num_heads,
             self.head_dim,
@@ -116,9 +162,26 @@ class DFlashQwen3Attention(nn.Module):
             num_kv_heads=self.num_kv_heads,
             cache_config=cache_config,
             quant_config=quant_config,
+            per_layer_sliding_window=sliding_window,
             prefix=f"{prefix}.attn",
             attn_type=attn_type,
+            sinks=self.attention_sink_bias,
         )
+        if sliding_window is not None:
+            # DFlash attends non-causally: the query block (bonus + mask tokens)
+            # must attend to itself bidirectionally, and the current full-
+            # attention path relies on that. Attention defaults a DECODER
+            # sliding window to the causal (w-1, 0) tuple, which would mask
+            # later query tokens from earlier ones. Widen the right edge to a
+            # symmetric (w-1, w-1) window so the windowed masking matches the
+            # non-causal reference (the FlashAttention impl stores the window as
+            # a (left, right) tuple). The KV-cache SlidingWindowSpec is still
+            # driven by the int window passed above, so block management is
+            # unchanged. For causal layers a symmetric window is equivalent,
+            # since causal masking clamps the right edge regardless.
+            impl_window = getattr(self.attn.impl, "sliding_window", None)
+            if isinstance(impl_window, tuple):
+                self.attn.impl.sliding_window = (sliding_window - 1, sliding_window - 1)
         self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
         self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
 
@@ -131,7 +194,7 @@ class DFlashQwen3Attention(nn.Module):
         with the context K/V from the target model's hidden states. This forward op
         computes attention for the query tokens only.
         See also: precompute_and_store_context_kv"""
-        qkv = F.linear(hidden_states, self.qkv_proj.weight, self.qkv_proj.bias)
+        qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
         # Per-head RMSNorm
@@ -150,6 +213,21 @@ class DFlashQwen3Attention(nn.Module):
         return output
 
 
+def _apply_dflash_rope_config(config: Qwen3Config) -> dict:
+    dflash_config = getattr(config, "dflash_config", None) or {}
+    backbone_rotary_base = dflash_config.get("backbone_rotary_base")
+    if backbone_rotary_base is None:
+        set_default_rope_theta(config, default_theta=1000000)
+        return config.rope_parameters
+
+    rope_parameters = dict(getattr(config, "rope_parameters", None) or {})
+    rope_parameters.setdefault("rope_type", rope_parameters.get("type", "default"))
+    rope_parameters["rope_theta"] = backbone_rotary_base
+    config.rope_parameters = rope_parameters
+    config.rope_theta = backbone_rotary_base
+    return rope_parameters
+
+
 class DFlashQwen3DecoderLayer(nn.Module):
     def __init__(
         self,
@@ -162,8 +240,25 @@ class DFlashQwen3DecoderLayer(nn.Module):
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
-        set_default_rope_theta(config, default_theta=1000000)
+        rope_parameters = _apply_dflash_rope_config(config)
         attn_type = AttentionType.DECODER
+
+        # DFlash drafts store the sink-bias flag inside dflash_config; fall back
+        # to the top-level attribute used by other configs.
+        dflash_config = getattr(config, "dflash_config", None) or {}
+        add_swa_attention_sink_bias = dflash_config.get(
+            "attention_sink_bias",
+            getattr(config, "add_swa_attention_sink_bias", False),
+        )
+
+        # Sliding-window attention is configured in dflash_config (use_swa /
+        # swa_window_size); fall back to the top-level sliding_window field.
+        # When disabled the draft keeps full attention (sliding_window=None).
+        sliding_window = None
+        if dflash_config.get("use_swa", False):
+            sliding_window = dflash_config.get(
+                "swa_window_size", getattr(config, "sliding_window", None)
+            )
 
         self.self_attn = DFlashQwen3Attention(
             hidden_size=self.hidden_size,
@@ -172,10 +267,12 @@ class DFlashQwen3DecoderLayer(nn.Module):
             num_kv_heads=config.num_key_value_heads,
             rms_norm_eps=config.rms_norm_eps,
             attention_bias=getattr(config, "attention_bias", False),
+            add_swa_attention_sink_bias=add_swa_attention_sink_bias,
+            sliding_window=sliding_window,
             head_dim=getattr(config, "head_dim", None),
             cache_config=cache_config,
             quant_config=quant_config,
-            rope_parameters=config.rope_parameters,
+            rope_parameters=rope_parameters,
             prefix=f"{prefix}.self_attn",
             attn_type=attn_type,
         )
@@ -243,6 +340,22 @@ class DFlashQwen3Model(nn.Module):
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 
+        # Masked query slots are fed to the draft as `mask_token_id`. The target
+        # embedding table (shared with this draft) has no trained row for that
+        # token, so DFlash ships a separately-trained vector in
+        # `mask_embedding.pt`. When that file is available, `embed_input_ids`
+        # substitutes it for masked slots instead of `embed_tokens[mask_token_id]`.
+        self.mask_token_id = drafter_config.get("mask_token_id")
+        self.register_buffer(
+            "mask_embedding",
+            torch.zeros(
+                self.config.hidden_size,
+                dtype=vllm_config.model_config.dtype,
+            ),
+            persistent=False,
+        )
+        self.has_mask_embedding = False
+
         self.layers = nn.ModuleList(
             [
                 DFlashQwen3DecoderLayer(
@@ -284,7 +397,13 @@ class DFlashQwen3Model(nn.Module):
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.embed_tokens(input_ids)
+        embeds = self.embed_tokens(input_ids)
+        if self.has_mask_embedding and self.mask_token_id is not None:
+            # Replace masked slots with the trained mask embedding. Use a
+            # data-independent torch.where so this stays CUDA-graph friendly.
+            is_mask = (input_ids == self.mask_token_id).unsqueeze(-1)
+            embeds = torch.where(is_mask, self.mask_embedding.to(embeds.dtype), embeds)
+        return embeds
 
     def _build_fused_kv_buffers(self) -> None:
         """Build fused weight buffers for precompute_and_store_context_kv.
@@ -340,6 +459,10 @@ class DFlashQwen3Model(nn.Module):
 
         # References to inner Attention layers for direct cache writes
         self._attn_layers = [layer.self_attn.attn for layer in self.layers]
+        self._use_fused_kv_precompute = all(
+            a.qkv_proj.quant_method.__class__.__name__ == "UnquantizedLinearMethod"
+            for a in layers_attn
+        )
 
     def precompute_and_store_context_kv(
         self,
@@ -372,7 +495,6 @@ class DFlashQwen3Model(nn.Module):
         hd = self._head_dim
         nkv = self._num_kv_heads
 
-        # --- Fused KV projection (one GEMM for all layers) ---
         normed_context_states = torch.empty_like(context_states)
         ops.rms_norm(
             normed_context_states,
@@ -380,6 +502,51 @@ class DFlashQwen3Model(nn.Module):
             self._hidden_norm_weight,
             self._rms_norm_eps,
         )
+
+        if not self._use_fused_kv_precompute:
+            for layer in self.layers:
+                attn_mod = layer.self_attn
+                qkv, _ = attn_mod.qkv_proj(normed_context_states)
+                _, k, v = qkv.split(
+                    [attn_mod.q_size, attn_mod.kv_size, attn_mod.kv_size],
+                    dim=-1,
+                )
+
+                k = k.view(num_ctx, nkv, hd)
+                v = v.view(num_ctx, nkv, hd)
+                k_normed = torch.empty_like(k)
+                ops.rms_norm(
+                    k_normed,
+                    k,
+                    attn_mod.k_norm.weight.data,
+                    self._rms_norm_eps,
+                )
+
+                k_flat = k_normed.view(num_ctx, kv)
+                cos_sin_cache = attn_mod.rotary_emb.cos_sin_cache
+                if cos_sin_cache.dtype != k_flat.dtype:
+                    cos_sin_cache = cos_sin_cache.to(dtype=k_flat.dtype)
+                ops.rotary_embedding(
+                    context_positions,
+                    k_flat,
+                    None,
+                    attn_mod.rotary_emb.head_size,
+                    cos_sin_cache,
+                    attn_mod.rotary_emb.is_neox_style,
+                )
+
+                if context_slot_mapping is not None:
+                    attn = attn_mod.attn
+                    attn.impl.do_kv_cache_update(
+                        attn,
+                        k_flat.view(num_ctx, nkv, hd),
+                        v,
+                        attn.kv_cache,
+                        context_slot_mapping,
+                    )
+            return
+
+        # --- Fused KV projection (one GEMM for all layers) ---
         all_kv_flat = F.linear(
             normed_context_states, self._fused_kv_weight, self._fused_kv_bias
         )
@@ -466,6 +633,8 @@ class DFlashQwen3Model(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
         for name, loaded_weight in weights:
             if "midlayer." in name:
                 name = name.replace("midlayer.", "layers.0.")
@@ -473,6 +642,20 @@ class DFlashQwen3Model(nn.Module):
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:
                     continue
+            if "attention_sink_bias" in name:
+                if name not in params_dict:
+                    continue
+
+                # Sink bias is per-head; shard it across TP ranks like the
+                # attention heads themselves.
+                param = params_dict[name]
+                heads_per_rank = loaded_weight.shape[0] // tp_size
+                head_start = tp_rank * heads_per_rank
+                narrow_weight = loaded_weight.narrow(0, head_start, heads_per_rank)
+
+                param.data.copy_(narrow_weight)
+                loaded_params.add(name)
+                continue
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:
                     continue
@@ -492,7 +675,8 @@ class DFlashQwen3Model(nn.Module):
 class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         nn.Module.__init__(self)
-        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.draft_model_config = vllm_config.speculative_config.draft_model_config
+        self.config = self.draft_model_config.hf_config
         if getattr(self.config, "draft_vocab_size", None) is None:
             self.config.draft_vocab_size = getattr(self.config, "vocab_size", None)
         target_layer_num = vllm_config.model_config.get_num_layers(
@@ -586,7 +770,9 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         includes_embed_tokens = False
         for name, loaded_weight in weights:
             assert "mask_hidden" not in name, (
-                "DFlash should use mask_token_id to embed the padding hidden state"
+                "DFlash embeds masked slots via mask_token_id (optionally "
+                "overridden by a mask_embedding.pt file); it should not ship a "
+                "mask_hidden weight."
             )
             if "t2d" in name:
                 continue
@@ -613,4 +799,66 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
             skip_substrs=skip_substrs,
         )
         loader.load_weights(model_weights.items())
+        self._load_mask_embedding()
         self.model._build_fused_kv_buffers()
+
+    def _load_mask_embedding(self) -> None:
+        """Load the trained mask embedding from ``mask_embedding.pt`` if present.
+
+        DFlash drafts ship a separately-trained embedding for the mask token in
+        a ``mask_embedding.pt`` file, because the (shared) target embedding table
+        has no meaningful row for ``mask_token_id``. When the file is available
+        the draft uses this vector for masked query slots; otherwise it falls
+        back to embedding ``mask_token_id`` through ``embed_tokens``.
+        """
+        model = self.model
+        if model.mask_token_id is None:
+            return
+
+        path = _find_mask_embedding_file(
+            self.draft_model_config.model,
+            revision=self.draft_model_config.revision,
+        )
+        if path is None:
+            logger.info(
+                "No %s found for DFlash draft; embedding mask_token_id (%s) "
+                "via the shared embed_tokens table.",
+                MASK_EMBEDDING_FILENAME,
+                model.mask_token_id,
+            )
+            return
+
+        state = torch.load(path, map_location="cpu", weights_only=True)
+        if isinstance(state, dict):
+            embedding = state["embedding"]
+            file_mask_token_id = state.get("mask_token_id")
+        else:
+            embedding = state
+            file_mask_token_id = None
+
+        if file_mask_token_id is not None and file_mask_token_id != model.mask_token_id:
+            raise ValueError(
+                f"{MASK_EMBEDDING_FILENAME} mask_token_id ({file_mask_token_id}) "
+                f"does not match dflash_config.mask_token_id "
+                f"({model.mask_token_id})."
+            )
+
+        embedding = embedding.reshape(-1)
+        if embedding.numel() != model.mask_embedding.numel():
+            raise ValueError(
+                f"{MASK_EMBEDDING_FILENAME} has {embedding.numel()} elements but "
+                f"the draft hidden size is {model.mask_embedding.numel()}."
+            )
+
+        model.mask_embedding.copy_(
+            embedding.to(
+                device=model.mask_embedding.device,
+                dtype=model.mask_embedding.dtype,
+            )
+        )
+        model.has_mask_embedding = True
+        logger.info(
+            "Loaded trained mask embedding from %s for DFlash mask_token_id %s.",
+            path,
+            model.mask_token_id,
+        )

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -20,6 +20,7 @@ from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.mem_utils import format_gib
 from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     HiddenStateCacheSpec,
@@ -1031,8 +1032,10 @@ def unify_kv_cache_spec_page_size(
 ) -> dict[str, KVCacheSpec]:
     """
     Unify the page size of the given KVCacheSpec. If the page size of all layers
-    are the same, return the original KVCacheSpec. If not same, unify the page
-    size by increasing the block size of layers with smaller page size. Raise
+    are the same, return the original KVCacheSpec. If not same, first try to
+    unify page size by increasing the block size of layers with smaller page
+    size. If a smaller attention page does not evenly divide the maximum page
+    size, keep its logical block size and pad its physical page instead. Raise
     NotImplementedError if failed to unify the page size.
 
     Args:
@@ -1053,14 +1056,17 @@ def unify_kv_cache_spec_page_size(
             new_kv_cache_spec[layer_name] = layer_spec
         else:
             layer_page_size = layer_spec.page_size_bytes
-            if max_page_size % layer_page_size != 0:
+            if max_page_size % layer_page_size == 0:
+                ratio = max_page_size // layer_page_size
+                new_block_size = layer_spec.block_size * ratio
+                new_spec = replace(layer_spec, block_size=new_block_size)
+            elif isinstance(layer_spec, AttentionSpec):
+                new_spec = replace(layer_spec, page_size_padded=max_page_size)
+            else:
                 raise NotImplementedError(
                     "The page size of the layer is not divisible by the "
-                    "maximum page size. Cannot unify by adjusting block_size."
+                    "maximum page size and the KV cache spec cannot be padded."
                 )
-            ratio = max_page_size // layer_page_size
-            new_block_size = layer_spec.block_size * ratio
-            new_spec = replace(layer_spec, block_size=new_block_size)
             assert new_spec.page_size_bytes == max_page_size
             new_kv_cache_spec[layer_name] = new_spec
     return new_kv_cache_spec

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1201,16 +1201,20 @@ def _get_kv_cache_groups_uniform_page_size(
 
 def _bucket_layers_by_page_size(
     kv_cache_groups: list[KVCacheGroupSpec],
+    *,
+    share_across_groups: bool = True,
 ) -> dict[int, list[list[str]]]:
     """Bucket layers by page size: ``result[ps][slot_idx] = [layer_names]``.
 
-    Layers from different groups at the same ``slot_idx`` share an underlying tensor
-    (they have independent block tables so block-id namespaces never collide).
+    When ``share_across_groups`` is true, layers from different groups at the
+    same ``slot_idx`` share an underlying tensor. This is valid only when those
+    groups have independent block-table namespaces.
     """
     buckets: dict[int, list[list[str]]] = defaultdict(list)
     for group in kv_cache_groups:
         spec = group.kv_cache_spec
         slot_count: dict[int, int] = defaultdict(int)
+        group_buckets: dict[int, list[list[str]]] = defaultdict(list)
         for layer_name in group.layer_names:
             if isinstance(spec, UniformTypeKVCacheSpecs):
                 ps = spec.kv_cache_specs[layer_name].page_size_bytes
@@ -1218,9 +1222,13 @@ def _bucket_layers_by_page_size(
                 ps = spec.page_size_bytes
             slot_idx = slot_count[ps]
             slot_count[ps] += 1
-            if slot_idx == len(buckets[ps]):
-                buckets[ps].append([])
-            buckets[ps][slot_idx].append(layer_name)
+            target_buckets = buckets if share_across_groups else group_buckets
+            if slot_idx == len(target_buckets[ps]):
+                target_buckets[ps].append([])
+            target_buckets[ps][slot_idx].append(layer_name)
+        if not share_across_groups:
+            for ps, slots in group_buckets.items():
+                buckets[ps].extend(slots)
     return buckets
 
 
@@ -1235,8 +1243,15 @@ def _get_kv_cache_config_deepseek_v4(
     groups at the same slot share a tensor (they have independent block
     tables so block-id namespaces never collide).
     """
+    spec_config = vllm_config.speculative_config
+    share_across_groups = not (
+        spec_config is not None and spec_config.method == "dflash"
+    )
     # buckets = {page_size: [[layer_names], [layer_names], ...]}
-    buckets = _bucket_layers_by_page_size(kv_cache_groups)
+    buckets = _bucket_layers_by_page_size(
+        kv_cache_groups,
+        share_across_groups=share_across_groups,
+    )
     total_num_bytes_per_block = sum(ps * len(slots) for ps, slots in buckets.items())
 
     num_blocks = available_memory // total_num_bytes_per_block
@@ -1312,6 +1327,32 @@ def get_kv_cache_config_from_groups(
         # (sw.1, padding) will be: (group_size = 2)
         # full.0, sw.0, sw.1: share a Tensor with size=available_memory//2
         # full.1, sw.2: share another Tensor with size=available_memory//2
+        spec_config = vllm_config.speculative_config
+        if spec_config is not None and spec_config.method == "dflash":
+            bytes_per_block = 0
+            tensor_specs: list[tuple[int, list[str]]] = []
+            for group in kv_cache_groups:
+                spec = group.kv_cache_spec
+                for layer_name in group.layer_names:
+                    if isinstance(spec, UniformTypeKVCacheSpecs):
+                        ps = spec.kv_cache_specs[layer_name].page_size_bytes
+                    else:
+                        ps = spec.page_size_bytes
+                    bytes_per_block += ps
+                    tensor_specs.append((ps, [layer_name]))
+
+            num_blocks = available_memory // bytes_per_block
+            num_blocks = may_override_num_blocks(vllm_config, num_blocks)
+            kv_cache_tensors = [
+                KVCacheTensor(size=ps * num_blocks, shared_by=shared_by)
+                for ps, shared_by in tensor_specs
+            ]
+            return KVCacheConfig(
+                num_blocks=num_blocks,
+                kv_cache_tensors=kv_cache_tensors,
+                kv_cache_groups=kv_cache_groups,
+            )
+
         group_size = max(len(group.layer_names) for group in kv_cache_groups)
 
         page_size = get_uniform_page_size(

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -68,6 +68,15 @@ class DFlashProposer(SpecDecodeBaseProposer):
         self.parallel_drafting_hidden_state_tensor = None
 
         self.dflash_causal = self.dflash_config.get("causal", False)
+        self.draft_sliding_window = 0
+        if self.dflash_config.get("use_swa", False):
+            self.draft_sliding_window = int(
+                self.dflash_config.get(
+                    "swa_window_size",
+                    getattr(self.draft_model_config.hf_config, "sliding_window", 0)
+                    or 0,
+                )
+            )
 
     @override
     def _create_draft_vllm_config(self) -> VllmConfig:
@@ -152,6 +161,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
             # Scalars
             parallel_drafting_token_id=self.parallel_drafting_token_id,
             block_size=self.block_size,
+            sliding_window=self.draft_sliding_window,
             num_query_per_req=num_query_per_req,
             num_speculative_tokens=self.num_speculative_tokens,
             total_input_tokens=num_context,
@@ -192,7 +202,6 @@ class DFlashProposer(SpecDecodeBaseProposer):
             slot_mapping=query_slot_mapping,
             causal=self.dflash_causal,
         )
-
         return num_query_total, token_indices_to_sample, new_cad
 
     @override

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -33,7 +33,6 @@ class DFlashProposer(SpecDecodeBaseProposer):
             pass_hidden_states_to_model=True,
             runner=runner,
         )
-
         # Only next_token_ids and mask tokens are query tokens, all other context is K/V
         self.max_query_tokens = self.max_batch_size * (1 + self.num_speculative_tokens)
         # Positions covers both context states + query states
@@ -267,11 +266,24 @@ class DFlashProposer(SpecDecodeBaseProposer):
         num_context = self._dflash_num_context
 
         # Pre-insert context KVs directly into cache
-        self.model.precompute_and_store_context_kv(
-            self._dflash_hidden_states,  # Shape is already [num_context, hidden_size]
-            self._context_positions_buffer[:num_context],
-            self._context_slot_mapping_buffer[:num_context],
-        )
+        context_slot_mapping = self._context_slot_mapping_buffer[:num_context]
+        valid_context = context_slot_mapping >= 0
+        if valid_context.all():
+            context_states = self._dflash_hidden_states
+            context_positions = self._context_positions_buffer[:num_context]
+        else:
+            context_states = self._dflash_hidden_states[valid_context]
+            context_positions = self._context_positions_buffer[:num_context][
+                valid_context
+            ]
+            context_slot_mapping = context_slot_mapping[valid_context]
+
+        if context_states.shape[0] > 0:
+            self.model.precompute_and_store_context_kv(
+                context_states,
+                context_positions,
+                context_slot_mapping,
+            )
         return (
             dict(
                 input_ids=self.input_ids[:num_input_tokens],

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -476,6 +476,7 @@ def copy_and_expand_dflash_inputs_kernel(
     # Scalars
     parallel_drafting_token_id,  # tl.int32
     block_size,  # tl.int32
+    sliding_window,  # tl.int32
     num_query_per_req,  # tl.int32
     num_speculative_tokens,  # tl.int32
     total_input_tokens,  # tl.int32
@@ -525,6 +526,7 @@ def copy_and_expand_dflash_inputs_kernel(
         valid_ctx_end = ctx_end
     num_valid_ctx = valid_ctx_end - ctx_start
     last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
+    visible_context_start = tl.maximum(last_pos + 2 - sliding_window, 0)
     query_pos = last_pos + 1 + query_off
 
     positions = tl.where(is_ctx, ctx_pos, query_pos)
@@ -539,6 +541,8 @@ def copy_and_expand_dflash_inputs_kernel(
     block_num = positions // block_size
     is_valid_ctx = j < num_valid_ctx
     has_context_slot = is_ctx & is_valid_ctx & (block_num < block_table_stride)
+    context_in_window = (sliding_window <= 0) | (ctx_pos >= visible_context_start)
+    has_context_slot = has_context_slot & context_in_window
     has_query_slot = is_query & (block_num < block_table_stride)
     has_slot = has_context_slot | has_query_slot
     block_id = tl.load(

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -523,6 +523,7 @@ def copy_and_expand_dflash_inputs_kernel(
         valid_ctx_end = ctx_end - num_rejected
     else:
         valid_ctx_end = ctx_end
+    num_valid_ctx = valid_ctx_end - ctx_start
     last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
     query_pos = last_pos + 1 + query_off
 
@@ -536,14 +537,17 @@ def copy_and_expand_dflash_inputs_kernel(
 
     # --- Slot mapping (block_table lookup for all positions) ---
     block_num = positions // block_size
-    # # Clamp block_number to avoid OOB when position is at max
-    block_num = tl.minimum(block_num, block_table_stride - 1)
+    is_valid_ctx = j < num_valid_ctx
+    has_context_slot = is_ctx & is_valid_ctx & (block_num < block_table_stride)
+    has_query_slot = is_query & (block_num < block_table_stride)
+    has_slot = has_context_slot | has_query_slot
     block_id = tl.load(
         block_table_ptr + req_idx * block_table_stride + block_num,
-        mask=in_bounds,
+        mask=has_slot,
         other=0,
     ).to(tl.int64)
     slot = block_id * block_size + (positions % block_size)
+    slot = tl.where(has_slot, slot, -1)
     tl.store(out_context_slot_mapping_ptr + ctx_pos_out, slot, mask=is_ctx)
     tl.store(out_query_slot_mapping_ptr + query_out, slot, mask=is_query)
 

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -166,6 +166,66 @@ def _allocate_kv_cache(
     return kv_cache_raw_tensors
 
 
+def _reshape_attention_kv_cache(
+    kv_tensor: torch.Tensor,
+    kv_cache_spec: AttentionSpec,
+    unpermuted_kv_cache_shape: tuple[int, ...],
+    kv_cache_stride_order: tuple[int, ...],
+    num_blocks: int,
+) -> torch.Tensor:
+    kv_cache_shape = tuple(unpermuted_kv_cache_shape[i] for i in kv_cache_stride_order)
+    inv_order = [
+        kv_cache_stride_order.index(i) for i in range(len(kv_cache_stride_order))
+    ]
+
+    if kv_cache_spec.page_size_padded is not None:
+        # Use strided views to skip padding between logical pages.
+        dtype_size = get_dtype_size(kv_cache_spec.dtype)
+        page_stride = kv_cache_spec.page_size_bytes // dtype_size
+
+        if unpermuted_kv_cache_shape[0] == num_blocks:
+            unpermuted_num_blocks_dim = 0
+        elif len(unpermuted_kv_cache_shape) > 1 and (
+            unpermuted_kv_cache_shape[1] == num_blocks
+        ):
+            unpermuted_num_blocks_dim = 1
+        else:
+            unpermuted_num_blocks_dim = unpermuted_kv_cache_shape.index(num_blocks)
+        num_blocks_dim = inv_order[unpermuted_num_blocks_dim]
+
+        strides = list(torch.empty(kv_cache_shape).stride())
+        unpadded_page_stride = strides[num_blocks_dim]
+        strides[num_blocks_dim] = page_stride
+
+        # FlashAttention-style layouts have an explicit K/V dimension adjacent
+        # to the block dimension. Avoid matching unrelated size-2 dims like
+        # head_size or num_kv_heads.
+        kv_dim = None
+        for dim in (
+            unpermuted_num_blocks_dim - 1,
+            unpermuted_num_blocks_dim + 1,
+        ):
+            if (
+                0 <= dim < len(unpermuted_kv_cache_shape)
+                and unpermuted_kv_cache_shape[dim] == 2
+            ):
+                kv_dim = dim
+                break
+        if kv_dim is not None:
+            strides[inv_order[kv_dim]] = unpadded_page_stride // 2
+
+        kv_cache = torch.as_strided(
+            kv_tensor,
+            size=kv_cache_shape,
+            stride=tuple(strides),
+        )
+    else:
+        # No padding — safe to use a contiguous view.
+        kv_cache = kv_tensor.view(kv_cache_shape)
+
+    return kv_cache.permute(*inv_order)
+
+
 def _reshape_kv_cache(
     attn_groups: Sequence[AttentionGroup],
     kv_cache_raw_tensors: dict[str, torch.Tensor],
@@ -206,7 +266,7 @@ def _reshape_kv_cache(
                     kv_cache_spec.storage_block_size // kernel_block_size
                 )
                 kernel_num_blocks = num_blocks * num_blocks_per_kv_block
-                kv_cache_shape = group.backend.get_kv_cache_shape(
+                unpermuted_kv_cache_shape = group.backend.get_kv_cache_shape(
                     kernel_num_blocks,
                     kernel_block_size,
                     kv_cache_spec.num_kv_heads,
@@ -217,39 +277,19 @@ def _reshape_kv_cache(
                 # FIXME(woosuk): Add kv_cache_stride_order to all attention backends.
                 try:
                     kv_cache_stride_order = group.backend.get_kv_cache_stride_order()
-                    assert len(kv_cache_stride_order) == len(kv_cache_shape)
+                    assert len(kv_cache_stride_order) == len(unpermuted_kv_cache_shape)
                 except (AttributeError, NotImplementedError):
-                    kv_cache_stride_order = tuple(range(len(kv_cache_shape)))
-
-                kv_cache_shape = tuple(kv_cache_shape[i] for i in kv_cache_stride_order)
-                inv_order = [
-                    kv_cache_stride_order.index(i)
-                    for i in range(len(kv_cache_stride_order))
-                ]
+                    kv_cache_stride_order = tuple(range(len(unpermuted_kv_cache_shape)))
 
                 dtype = kv_cache_spec.dtype
                 kv_tensor = kv_raw_tensor.view(dtype)
-                if kv_cache_spec.page_size_padded is not None:
-                    # Use strided view to handle page_size_bytes that
-                    # include padding. This follows the same pattern as
-                    # MambaSpec handling in gpu_model_runner.py.
-                    # NOTE: This assumes kv_cache_shape[0] == num_blocks
-                    # (i.e. the first physical dimension is the block
-                    # index), which holds for all current backends
-                    # (MLA, FlashAttention, TritonAttention, etc.).
-                    dtype_size = get_dtype_size(dtype)
-                    page_stride = kv_cache_spec.page_size_bytes // dtype_size
-                    strides = list(torch.empty(kv_cache_shape).stride())
-                    strides[inv_order[0]] = page_stride
-                    kv_cache = torch.as_strided(
-                        kv_tensor,
-                        size=kv_cache_shape,
-                        stride=tuple(strides),
-                    )
-                else:
-                    # No padding — safe to use a contiguous view.
-                    kv_cache = kv_tensor.view(kv_cache_shape)
-                kv_caches[layer_name] = kv_cache.permute(*inv_order)
+                kv_caches[layer_name] = _reshape_attention_kv_cache(
+                    kv_tensor,
+                    kv_cache_spec,
+                    unpermuted_kv_cache_shape,
+                    kv_cache_stride_order,
+                    kernel_num_blocks,
+                )
 
             elif isinstance(kv_cache_spec, MambaSpec):
                 has_mamba = True

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -77,6 +77,7 @@ class DFlashSpeculator(DraftModelSpeculator):
 
         self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
         self.draft_kv_cache_group_id: int = -1
+        self.draft_sliding_window: int = 0
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         # PIECEWISE cudagraphs are not supported for dflash
@@ -137,6 +138,12 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.draft_block_size = self.block_tables.block_sizes[
             self.draft_kv_cache_group_id
         ]
+        draft_kv_spec = kv_cache_config.kv_cache_groups[
+            self.draft_kv_cache_group_id
+        ].kv_cache_spec
+        self.draft_sliding_window = int(
+            getattr(draft_kv_spec, "sliding_window", 0) or 0
+        )
 
     @torch.inference_mode()
     def _run_model(
@@ -309,6 +316,7 @@ class DFlashSpeculator(DraftModelSpeculator):
             next_prefill_tokens,
             self.block_tables.input_block_tables[self.draft_kv_cache_group_id],
             self.draft_block_size,
+            self.draft_sliding_window,
             self.parallel_drafting_token_id,
             self.num_query_per_req,
             self.num_speculative_steps,
@@ -397,6 +405,7 @@ def _prepare_dflash_inputs_kernel(
     # Scalars
     parallel_drafting_token_id,
     block_size,
+    sliding_window,
     num_query_per_req,
     num_speculative_steps,
     max_num_reqs,
@@ -415,6 +424,7 @@ def _prepare_dflash_inputs_kernel(
 
     num_rejected = tl.load(num_rejected_ptr + req_idx)
     valid_ctx_end = ctx_end - num_rejected
+    num_valid_ctx = valid_ctx_end - ctx_start
 
     num_sampled = tl.load(num_sampled_ptr + req_idx)
     if num_sampled > 0:
@@ -424,10 +434,12 @@ def _prepare_dflash_inputs_kernel(
         bonus_token = tl.load(next_prefill_tokens_ptr + req_state_idx).to(tl.int32)
 
     last_valid_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
+    visible_context_start = last_valid_pos + 2 - sliding_window
+    visible_context_start = tl.maximum(visible_context_start, 0)
     query_base = req_idx * num_query_per_req
 
     j = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    is_ctx = j < num_ctx
+    is_ctx = j < num_valid_ctx
     is_query = (j >= num_ctx) & (j < num_ctx + num_query_per_req)
     query_off = j - num_ctx
 
@@ -435,13 +447,16 @@ def _prepare_dflash_inputs_kernel(
     ctx_pos_idx = ctx_start + tl.where(is_ctx, j, 0)
     ctx_pos = tl.load(target_positions_ptr + ctx_pos_idx, mask=is_ctx, other=0)
     ctx_block_num = ctx_pos // block_size
-    ctx_block_num = tl.minimum(ctx_block_num, block_table_stride - 1)
+    has_context_slot = is_ctx & (ctx_block_num < block_table_stride)
+    context_in_window = (sliding_window <= 0) | (ctx_pos >= visible_context_start)
+    has_context_slot = has_context_slot & context_in_window
     ctx_block_id = tl.load(
         block_table_ptr + req_idx * block_table_stride + ctx_block_num,
-        mask=is_ctx,
+        mask=has_context_slot,
         other=0,
     ).to(tl.int64)
     ctx_slot = ctx_block_id * block_size + (ctx_pos % block_size)
+    ctx_slot = tl.where(has_context_slot, ctx_slot, PAD_SLOT_ID)
     tl.store(out_context_positions_ptr + ctx_start + j, ctx_pos, mask=is_ctx)
     tl.store(out_context_slot_mapping_ptr + ctx_start + j, ctx_slot, mask=is_ctx)
 
@@ -452,13 +467,14 @@ def _prepare_dflash_inputs_kernel(
     input_id = tl.where(is_bonus, bonus_token, parallel_drafting_token_id)
 
     q_block_num = query_pos // block_size
-    q_block_num = tl.minimum(q_block_num, block_table_stride - 1)
+    has_query_slot = is_query & (q_block_num < block_table_stride)
     q_block_id = tl.load(
         block_table_ptr + req_idx * block_table_stride + q_block_num,
-        mask=is_query,
+        mask=has_query_slot,
         other=0,
     ).to(tl.int64)
     q_slot = q_block_id * block_size + (query_pos % block_size)
+    q_slot = tl.where(has_query_slot, q_slot, PAD_SLOT_ID)
 
     tl.store(out_input_ids_ptr + query_idx, input_id, mask=is_query)
     tl.store(out_query_positions_ptr + query_idx, query_pos, mask=is_query)
@@ -528,6 +544,7 @@ def prepare_dflash_inputs(
     # [max_num_reqs, max_num_blocks]
     block_table: torch.Tensor,
     block_size: int,
+    sliding_window: int,
     parallel_drafting_token_id: int,
     num_query_per_req: int,
     num_speculative_steps: int,
@@ -564,6 +581,7 @@ def prepare_dflash_inputs(
         block_table.stride(0),
         parallel_drafting_token_id,
         block_size,
+        sliding_window,
         num_query_per_req,
         num_speculative_steps,
         max_num_reqs,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -200,6 +200,7 @@ from vllm.v1.worker.cp_utils import (
 )
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.ec_connector_model_runner_mixin import ECConnectorModelRunnerMixin
+from vllm.v1.worker.gpu.attn_utils import _reshape_attention_kv_cache
 from vllm.v1.worker.gpu.pool.late_interaction_runner import LateInteractionRunner
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
@@ -7036,7 +7037,7 @@ class GPUModelRunner(
                     else:
                         shape_block_size = kernel_block_size
 
-                    kv_cache_shape = attn_backend.get_kv_cache_shape(
+                    unpermuted_kv_cache_shape = attn_backend.get_kv_cache_shape(
                         kernel_num_blocks,
                         shape_block_size,
                         kv_cache_spec.num_kv_heads,
@@ -7046,46 +7047,21 @@ class GPUModelRunner(
                     dtype = kv_cache_spec.dtype
                     try:
                         kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
-                        assert len(kv_cache_stride_order) == len(kv_cache_shape)
-                    except (AttributeError, NotImplementedError):
-                        kv_cache_stride_order = tuple(range(len(kv_cache_shape)))
-                    # The allocation respects the backend-defined stride order
-                    # to ensure the semantic remains consistent for each
-                    # backend. We first obtain the generic kv cache shape and
-                    # then permute it according to the stride order which could
-                    # result in a non-contiguous tensor.
-                    kv_cache_shape = tuple(
-                        kv_cache_shape[i] for i in kv_cache_stride_order
-                    )
-                    # Maintain original KV shape view.
-                    inv_order = [
-                        kv_cache_stride_order.index(i)
-                        for i in range(len(kv_cache_stride_order))
-                    ]
-
-                    raw_tensor = kv_cache_raw_tensors[layer_name].view(dtype)
-                    if kv_cache_spec.page_size_padded is not None:
-                        # Use strided view to handle page_size_bytes that
-                        # include padding. This follows
-                        # the same pattern as MambaSpec handling below.
-                        # NOTE: This assumes kv_cache_shape[0] == num_blocks
-                        # (i.e. the first physical dimension is the block
-                        # index), which holds for MLA backends but NOT for
-                        # standard attention backends whose shape starts with
-                        # a K/V dimension of size 2.
-                        dtype_size = get_dtype_size(dtype)
-                        page_stride = kv_cache_spec.page_size_bytes // dtype_size
-                        strides = list(torch.empty(kv_cache_shape).stride())
-                        strides[inv_order[0]] = page_stride
-                        kv_cache = torch.as_strided(
-                            raw_tensor,
-                            size=kv_cache_shape,
-                            stride=tuple(strides),
+                        assert len(kv_cache_stride_order) == len(
+                            unpermuted_kv_cache_shape
                         )
-                    else:
-                        # No padding — safe to use a contiguous view.
-                        kv_cache = raw_tensor.view(kv_cache_shape)
-                    kv_caches[layer_name] = kv_cache.permute(*inv_order)
+                    except (AttributeError, NotImplementedError):
+                        kv_cache_stride_order = tuple(
+                            range(len(unpermuted_kv_cache_shape))
+                        )
+                    raw_tensor = kv_cache_raw_tensors[layer_name].view(dtype)
+                    kv_caches[layer_name] = _reshape_attention_kv_cache(
+                        raw_tensor,
+                        kv_cache_spec,
+                        unpermuted_kv_cache_shape,
+                        kv_cache_stride_order,
+                        kernel_num_blocks,
+                    )
 
                 elif isinstance(kv_cache_spec, MambaSpec):
                     has_mamba = True


### PR DESCRIPTION
> **Draft / reference artifact.** Validated working (see below) but not ready-for-review: overlaps #45200 (base-model files) and carries env-gated debug. Opened to share the working config + root-cause + measured AL.

## Summary

Adds MiMo-V2.5-Pro-FP4 DFlash speculative decoding support and fixes an acceptance-length (AL) collapse.

Builds on the MiMo DFlash serving work (#45181) and base-model TP-sharding / FP4-MoE fixes (#45200). With those alone, DFlash produced **0% draft acceptance (mean accept length = 1.0)** on the `v0.22.1` runtime: that image predates the num-blocks-first KV layout (#42095), so the **draft** read its KV cache through the wrong layout and every drafted token was rejected. The target stayed correct (KV intact), disguising it as a draft-quality problem.

On a runtime that includes #42095 (build on a base at/after `3d300aecb`), two stale APIs blocked load:

- **`mxfp4.py`** — `MiMoV2Mxfp4Config.get_quant_method` checked `isinstance(layer, FusedMoE)`; the fused-MoE refactor made `FusedMoE` a factory function and the routed-expert module a `RoutedExperts`. `TypeError` at load.
- **`fp8.py`** — restores a per-name `get_cache_scale()` shim; `mimo_v2.load_weights` still calls the per-weight form (upstream renamed it `get_cache_scale_mapper`). `AttributeError` at weight load.

Also: `num_speculative_tokens` must equal DFlash `block_size - 1`.

A later commit ports the post-final-norm last-aux-feature semantics from `local-inference-lab/vllm` (gated by `VLLM_DFLASH_PRENORM_LAST_AUX`); see Notes.

## Validation (8×B200 TP8, built on a `#42095`-inclusive base, runai_streamer load from NFS)

Mean accept length by task type (temp 0), vs `local-inference-lab/vllm` reference:

| Task | This branch | local-inference-lab |
|---|---|---|
| code | 4.35 | 4.96 |
| math | 4.49 | 4.99 |
| chat / long-context summarization (3085 tok) | ~2.5 | 2.74 (chat) |
| short structured (count 1..20) | 6.4–7.3 | — |
| TP4 (math/reasoning) | 3.38 | — |

Previously **0%** at all configs. AL is task-type dependent (chat/long ≈ 2.5, code/math ≈ 4.4) and tracks the reference within ~0.5.

## Notes for reviewers

- **`#3` post-norm last-aux commit is neutral on this FLASH_ATTN path.** A same-node A/B (`VLLM_DFLASH_PRENORM_LAST_AUX` on/off) showed no AL change beyond noise — this branch already started above the reference's pre-fix ~2.0 (mask-embedding handled via #45181/Benjamin's qwen3_dflash). Kept because it matches reference semantics and is gated.
- The reference's Triton-specific fixes (non-causal+SWA block masking, SWA tile-pruning, b12x MXFP4 routing) are **not** ported — this branch uses FLASH_ATTN, which handles non-causal+window, and `MiMoV2Mxfp4MoEMethod`.
- Carries its own copy of base-model fixes (fused-QKV TP sharding incl. TP≠8, FP4 MoE), overlapping #45200 on `mimo_v2.py`/`fp8.py` — needs reconciling (supersede or rebase) before merge.
- Env-gated `DFLASH_*_DEBUG` logging should be stripped before an upstream PR.

## How to run

Build from a `#42095`-inclusive base; serve with `--load-format runai_streamer` (loads directly from NFS, no local staging) and `--speculative-config '{"method":"dflash", ..., "num_speculative_tokens": <block_size-1>}'`.
