### PR TITLE
[CI][BugFix] Fix broken `test_mamba_prefix_cache.py` due to stale mock

### DIFF
--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -181,6 +181,7 @@ def get_fake_allocate_slots_fn(original_allocate_slots_fn: Callable):
         num_encoder_tokens: int = 0,
         full_sequence_must_fit: bool = False,
         reserved_blocks: int = 0,
+        has_scheduled_reqs: bool = True,
     ):
         ret = original_allocate_slots_fn(
             self,
@@ -194,6 +195,7 @@ def get_fake_allocate_slots_fn(original_allocate_slots_fn: Callable):
             num_encoder_tokens,
             full_sequence_must_fit,
             reserved_blocks,
+            has_scheduled_reqs,
         )
         if cur_step_action is not None:
             cur_block_ids = self.coordinator.single_type_managers[0].req_to_blocks[


### PR DESCRIPTION
Recent PR https://github.com/vllm-project/vllm/pull/44594 change the method signature of `KVCacheManager.allocate_slots()` which needs to be updated in a test mock.

I don't think the test in question wasn't chosen to run in the PR's CI which is why it was missed.