### PR TITLE
[Kernel] Fix strict-aliasing UB in scalar_type and minimax RMS kernel

### DIFF
--- a/csrc/core/scalar_type.hpp
+++ b/csrc/core/scalar_type.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <bit>
 #include <cstdint>
 #include <string>
 #include <tuple>
@@ -182,7 +183,7 @@ class ScalarType {
   constexpr bool has_bias() const { return bias != 0; }
 
  private:
-  double _floating_point_max() const {
+  constexpr double _floating_point_max() const {
     STD_TORCH_CHECK(mantissa <= 52 && exponent <= 11,
                     "Cannot represent max/min as a double for type ", str());
 
@@ -216,7 +217,7 @@ class ScalarType {
     uint64_t double_raw =
         (max_mantissa << (52 - mantissa)) | (max_exponent_double << 52);
 
-    return *reinterpret_cast<double*>(&double_raw);
+    return std::bit_cast<double>(double_raw);
   }
 
   constexpr std::variant<int64_t, double> _raw_max() const {
@@ -237,9 +238,9 @@ class ScalarType {
       constexpr uint64_t sign_bit_double = (uint64_t(1) << 63);
 
       double max = _floating_point_max();
-      uint64_t max_raw = *reinterpret_cast<uint64_t*>(&max);
+      uint64_t max_raw = std::bit_cast<uint64_t>(max);
       uint64_t min_raw = max_raw | sign_bit_double;
-      return {*reinterpret_cast<double*>(&min_raw)};
+      return {std::bit_cast<double>(min_raw)};
     } else {
       STD_TORCH_CHECK(!is_signed() || size_bits() <= 64,
                       "Cannot represent min as a int64_t");

--- a/csrc/core/scalar_type.hpp
+++ b/csrc/core/scalar_type.hpp
@@ -235,12 +235,8 @@ class ScalarType {
       STD_TORCH_CHECK(
           is_signed(),
           "We currently assume all floating point types are signed");
-      constexpr uint64_t sign_bit_double = (uint64_t(1) << 63);
-
-      double max = _floating_point_max();
-      uint64_t max_raw = std::bit_cast<uint64_t>(max);
-      uint64_t min_raw = max_raw | sign_bit_double;
-      return {std::bit_cast<double>(min_raw)};
+      // For symmetric IEEE-754 float types, min is just the negation of max.
+      return {-_floating_point_max()};
     } else {
       STD_TORCH_CHECK(!is_signed() || size_bits() <= 64,
                       "Cannot represent min as a int64_t");

--- a/csrc/libtorch_stable/minimax_reduce_rms_kernel.cu
+++ b/csrc/libtorch_stable/minimax_reduce_rms_kernel.cu
@@ -81,7 +81,7 @@ struct LamportComm {
 };
 
 __device__ __forceinline__ bool is_neg_zero(float v) {
-  return *reinterpret_cast<uint32_t*>(&v) == 0x80000000;
+  return __float_as_uint(v) == 0x80000000;
 }
 
 __device__ __forceinline__ bool is_neg_zero(float4 v) {
@@ -90,12 +90,7 @@ __device__ __forceinline__ bool is_neg_zero(float4 v) {
 }
 
 __device__ __forceinline__ float4 get_neg_zero() {
-  float4 vec;
-#pragma unroll
-  for (int i = 0; i < 4; ++i) {
-    reinterpret_cast<uint32_t*>(&vec)[i] = 0x80000000;
-  }
-  return vec;
+  return make_float4(-0.0f, -0.0f, -0.0f, -0.0f);
 }
 
 template <int Dim>


### PR DESCRIPTION

## Purpose

Remove strict-aliasing UB (type-punning via `reinterpret_cast`) flagged by `-Wstrict-aliasing` under C++20, without behavior changes.

## Test Plan
Use current test suite.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

