### PR TITLE
fix: handle OpenAI context length validation errors

### DIFF
--- a/tests/entrypoints/openai/test_exception_handlers.py
+++ b/tests/entrypoints/openai/test_exception_handlers.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from argparse import Namespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm.entrypoints.openai.api_server import register_exception_handlers
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        ValueError("invalid value"),
+        TypeError("invalid type"),
+        OverflowError("invalid overflow"),
+    ],
+)
+def test_validation_exception_handlers_do_not_reraise(exception: Exception):
+    app = FastAPI()
+    app.state.args = Namespace(log_error_stack=False)
+    register_exception_handlers(app)
+
+    @app.get("/")
+    async def raise_exception():
+        raise exception
+
+    response = TestClient(app).get("/")
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "BadRequestError"

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -73,6 +73,19 @@ logger = init_logger("vllm.entrypoints.openai.api_server")
 _FALLBACK_SUPPORTED_TASKS: tuple[SupportedTask, ...] = ("generate",)
 
 
+def register_exception_handlers(app: FastAPI) -> None:
+    app.exception_handler(HTTPException)(http_exception_handler)
+    app.exception_handler(RequestValidationError)(validation_exception_handler)
+    app.exception_handler(EngineGenerateError)(engine_error_handler)
+    app.exception_handler(EngineDeadError)(engine_error_handler)
+    app.exception_handler(GenerationError)(generation_error_handler)
+    app.exception_handler(VLLMValidationError)(exception_handler)
+    app.exception_handler(ValueError)(exception_handler)
+    app.exception_handler(TypeError)(exception_handler)
+    app.exception_handler(OverflowError)(exception_handler)
+    app.exception_handler(Exception)(exception_handler)
+
+
 @asynccontextmanager
 async def build_async_engine_client(
     args: Namespace,
@@ -246,13 +259,7 @@ def build_app(
         allow_headers=args.allowed_headers,
     )
 
-    app.exception_handler(HTTPException)(http_exception_handler)
-    app.exception_handler(RequestValidationError)(validation_exception_handler)
-    app.exception_handler(EngineGenerateError)(engine_error_handler)
-    app.exception_handler(EngineDeadError)(engine_error_handler)
-    app.exception_handler(GenerationError)(generation_error_handler)
-    app.exception_handler(VLLMValidationError)(exception_handler)
-    app.exception_handler(Exception)(exception_handler)
+    register_exception_handlers(app)
 
     # Ensure --api-key option from CLI takes precedence over VLLM_API_KEY
     if tokens := [key for key in (args.api_key or [envs.VLLM_API_KEY]) if key]:


### PR DESCRIPTION
## Summary

Register concrete app-wide exception handlers for `ValueError`, `TypeError`, and `OverflowError` in the OpenAI API server.

The server already had a catch-all `Exception` handler, but Starlette treats that as the `ServerErrorMiddleware` handler. That path can send the JSON error response and still re-raise the exception afterward, which lets uvicorn log noisy `Exception in ASGI application` tracebacks for expected validation errors such as oversized context requests.

Registering these expected validation exception types explicitly keeps the existing app-wide handling design while routing them through Starlette's normal exception middleware path.

## Changes

- Factor OpenAI API exception handler registration into `register_exception_handlers`.
- Register `ValueError`, `TypeError`, and `OverflowError` with the existing `exception_handler`.
- Add a regression test that verifies these validation exceptions return `BadRequestError` responses through the registered app handlers.

## Duplicate Check

I checked for existing PRs using:

```bash
gh pr list --repo vllm-project/vllm --state open --search "get_max_tokens ValueError chat completion" --limit 20
gh pr list --repo vllm-project/vllm --state open --search "Input length exceeds model maximum context length" --limit 20
gh pr list --repo vllm-project/vllm --state all --search "\"Exception in ASGI application\" \"Input length\"" --limit 20
gh pr list --repo vllm-project/vllm --state all --search "\"get_max_tokens\" \"create_error_response\"" --limit 20
```

Related PRs such as #37011, #34721, and #40072 cover error code/status semantics or streaming scheduler caps, not the Starlette catch-all re-raise behavior addressed here.

## Test Plan

```bash
/home/ubuntu/vllm-env/bin/python -m pytest -p no:cacheprovider \
  /tmp/vllm-asgi-pr/tests/entrypoints/openai/test_exception_handlers.py -q

/home/ubuntu/vllm-env/bin/python -B -c "from pathlib import Path; [compile(Path(p).read_text(), p, 'exec') for p in ['vllm/entrypoints/openai/api_server.py','tests/entrypoints/openai/test_exception_handlers.py']]"

git diff --check
```

## Test Result

```text
3 passed, 16 warnings
```

## AI Assistance

AI assistance was used to investigate the traceback, draft the patch, and run the focused local checks. The submitting human should review and defend the final diff.