### PR TITLE
[Kernel][MoE] Support GELU_TANH in FlashInfer CUTLASS MoE backend

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -190,6 +190,7 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             MoEActivation.SILU,
             MoEActivation.RELU2_NO_MUL,
             MoEActivation.SWIGLUOAI,
+            MoEActivation.GELU_TANH,
         ]
 
     @staticmethod
@@ -269,6 +270,7 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             MoEActivation.SILU: ActivationType.Swiglu,  # This is the default
             MoEActivation.SWIGLUOAI: ActivationType.Swiglu,  # gpt-oss alias
             MoEActivation.RELU2_NO_MUL: ActivationType.Relu2,
+            MoEActivation.GELU_TANH: ActivationType.GegluTanh,  # gemma gated gelu-tanh
         }
         assert activation in activation_str_to_value_map, (
             f"{activation=} missing from {activation_str_to_value_map.keys()=}"


### PR DESCRIPTION
https://github.com/flashinfer-ai/flashinfer/pull/3501 just merged

See the PR for perf and acc tests

Map vLLM gated gelu_tanh (MoEActivation.GELU_TANH) to FlashInfer ActivationType.GegluTanh and add it to the FlashInfer CUTLASS experts supported-activation list. This enables --moe-backend flashinfer_cutlass for models with gated GELU-tanh MoE such as Gemma, which were previously hard-rejected.

Verified end-to-end serving gemma-4-26B-A4B on H200 (bf16, TP=1): the FlashInfer CUTLASS Unquantized MoE backend is selected and produces correct outputs.


## Purpose

## Test Plan
# TEP4 (TP4 + EP4, 4x H200) — same sweep

VLLM, ISL=1600 / OSL=600, conc 1->256, bf16, 4x H200 (TP4 EP4)
- Triton -> `Using TRITON Unquantized MoE backend` 
- FI     -> `--moe-backend flashinfer_cutlass` -> `Using FlashInfer CUTLASS Unquantized MoE backend` (GeluTanh)

## Test Result

| conc | Tri OTPS | Tri OTPS/u | Tri TTFT(ms) | Tri ITL(ms) | FI OTPS | FI OTPS/u | FI TTFT(ms) | FI ITL(ms) | FI vs Tri OTPS |
|-----:|---------:|-----------:|-------------:|------------:|--------:|----------:|------------:|-----------:|---------------:|
| 1    | 237.4    | 237.4      | 45.1         | 4.14        | 234.0   | 234.0     | 41.6        | 4.21       | -1.4%          |
| 2    | 433.7    | 216.8      | 104.8        | 4.45        | 454.5   | 227.2     | 50.9        | 4.32       | +4.8%          |
| 4    | 797.9    | 199.5      | 147.1        | 4.77        | 824.5   | 206.1     | 76.9        | 4.73       | +3.3%          |
| 8    | 1455.4   | 181.9      | 118.9        | 5.31        | 1471.2  | 183.9     | 113.6       | 5.26       | +1.1%          |
| 16   | 2496.2   | 156.0      | 178.7        | 6.12        | 2488.0  | 155.5     | 177.7       | 6.14       | -0.3%          |
| 32   | 4046.2   | 126.4      | 276.6        | 7.46        | 4127.8  | 129.0     | 291.3       | 7.27       | +2.0%          |
| 64   | 6127.6   | 95.7       | 404.1        | 9.79        | 6324.9  | 98.8      | 364.1       | 9.56       | +3.2%          |
| 128  | 8965.2   | 70.0       | 434.1        | 13.57       | 9007.4  | 70.4      | 434.3       | 13.50      | +0.5%          |
| 256  | 11263.6  | 44.0       | 696.5        | 21.56       | 11258.5 | 44.0      | 726.4       | 21.53      | -0.0%          |

OTPS = total tok/s across 4 GPUs (OTPS/gpu = OTPS/4); OTPS/u = per-user.


## Accuracy gsm8k (exact_match, ±0.0137)

| TP | max_seq_len | MoE backend                    | flexible-extract | strict-match |
|----|-------------|--------------------------------|------------------|--------------|
| 4  | 8192        | TRITON (default)               | 0.4367           | 0.4276       |
| 4  | 8192        | FlashInfer CUTLASS (GeluTanh)  | 0.4564           | 0.4450       |
| 1  | 8192        | TRITON (default)               | 0.4412           | 0.4291       |
| 1  | 8192        | FlashInfer CUTLASS (GeluTanh)  | 0.4428           | 0.4382       |
| 1  | 32768       | TRITON (default)               | 0.4466           | 0.4412       |
| 1  | 32768       | FlashInfer CUTLASS (GeluTanh)  | 0.4519           | 0.4382       |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

