### PR TITLE
[Bugfix] Resolve explicit store=null to the documented default in Responses API

### DIFF
--- a/tests/entrypoints/openai/responses/test_store_field.py
+++ b/tests/entrypoints/openai/responses/test_store_field.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the ``store`` field semantics on ResponsesRequest.
+
+``store`` is documented as defaulting to ``true``; an explicit
+``store: null`` means "unspecified" and must resolve to that default, the
+same as omitting the field. Previously an explicit ``null`` fell through
+every ``if request.store:`` gate in the serving layer (the response was
+silently never stored, so later retrieval by id 404'd) and incorrectly
+tripped the background/store conflict validator.
+"""
+
+import pytest
+
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+
+def _make_request(**kwargs) -> ResponsesRequest:
+    return ResponsesRequest(model="test-model", input="test input", **kwargs)
+
+
+@pytest.mark.cpu_test
+def test_store_omitted_defaults_to_true():
+    assert _make_request().store is True
+
+
+@pytest.mark.cpu_test
+def test_store_explicit_true():
+    assert _make_request(store=True).store is True
+
+
+@pytest.mark.cpu_test
+def test_store_explicit_false():
+    assert _make_request(store=False).store is False
+
+
+@pytest.mark.cpu_test
+def test_store_explicit_null_resolves_to_default():
+    """Regression: explicit ``store: null`` was kept as ``None`` and treated
+    as falsy by every ``if request.store:`` consumer."""
+    assert _make_request(store=None).store is True
+
+
+@pytest.mark.cpu_test
+def test_background_with_store_null_is_allowed():
+    """Regression: ``{"background": true, "store": null}`` incorrectly raised
+    "background can only be used when `store` is true" because the validator
+    treated ``None`` as falsy rather than resolving it to the default."""
+    request = _make_request(background=True, store=None)
+    assert request.background is True
+    assert request.store is True
+
+
+@pytest.mark.cpu_test
+def test_background_with_store_false_still_rejected():
+    with pytest.raises(ValueError, match="background can only be used"):
+        _make_request(background=True, store=False)

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -52,6 +52,7 @@ from pydantic import (
     Field,
     ValidationError,
     field_serializer,
+    field_validator,
     model_validator,
 )
 
@@ -433,12 +434,21 @@ class ResponsesRequest(OpenAIBaseModel):
             and "message.output_text.logprobs" in self.include
         )
 
+    @field_validator("store", mode="after")
+    @classmethod
+    def resolve_store_default(cls, value: bool | None) -> bool:
+        # An explicit `store: null` means "unspecified" and resolves to the
+        # documented default (true), the same as omitting the field.
+        return True if value is None else value
+
     @model_validator(mode="before")
     @classmethod
     def validate_background(cls, data):
         if not data.get("background"):
             return data
-        if not data.get("store", True):
+        # Only an explicit `store: false` conflicts with background mode;
+        # `store: null` resolves to the default (true).
+        if data.get("store", True) is False:
             raise VLLMValidationError(
                 "background can only be used when `store` is true",
                 parameter="background",


### PR DESCRIPTION
## Purpose

Self-sourced bug, same class as #44948 (explicit \`parallel_tool_calls: null\` treated as \`false\`): in the Responses API, \`store\` is documented as defaulting to \`true\`, and an omitted field resolves that way — but an explicit \`store: null\` was kept as \`None\` and treated as falsy everywhere it is consumed.

Two user-visible consequences:

1. **Silent storage loss**: \`store: null\` fell through every \`if request.store:\` gate in \`vllm/entrypoints/openai/responses/serving.py\` (input-message store, response store), so a later \`GET /v1/responses/{id}\` 404'd even though the client never opted out of storage.
2. **Spurious validation error**: \`{"background": true, "store": null}\` was rejected with *"background can only be used when \`store\` is true"* because \`validate_background\` used \`not data.get("store", True)\`, which fires on \`None\`.

| \`store\` value | Before | After |
|---|---|---|
| omitted | stored (default \`true\`) | stored |
| \`true\` | stored | stored |
| \`false\` | not stored | not stored |
| \`null\` | **not stored, background rejected** ❌ | **stored, background allowed** ✅ |

**Fix**: a \`field_validator\` on \`store\` resolving \`None → True\` (the documented default, same semantics as omitting the field), which normalizes all downstream \`if request.store:\` consumers at once; plus gating the background conflict on an explicit \`store: false\` only.

### Duplicate-work check

Per \`AGENTS.md\`: searched open + closed PRs for "store null", \`request.store\`, and sibling issues — none address this. (#22185 is an old, different concern about default-processing \`store=True\` requests.)

## Test Plan

New \`tests/entrypoints/openai/responses/test_store_field.py\` (\`@pytest.mark.cpu_test\`, no GPU/network): omitted / \`true\` / \`false\` / \`null\` resolution, plus both background-validator regressions (\`store: null\` allowed, \`store: false\` still rejected).

## Test Result

\`\`\`
$ python -m pytest tests/entrypoints/openai/responses/test_store_field.py -v
==== 6 passed in 13.29s ====

$ pre-commit run --files vllm/entrypoints/openai/responses/protocol.py tests/entrypoints/openai/responses/test_store_field.py
ruff check / ruff format / typos / mypy / SPDX ... all Passed
\`\`\`

## AI assistance disclosure

This change was AI-assisted (Claude). I (the submitter) reviewed every line, ran the tests above, and stand behind the change end-to-end.