### PR TITLE
[Perf] Skip slot mapping for Mamba KV cache groups

### DIFF
--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -115,6 +115,11 @@ class KVCacheSpec:
     def storage_block_size(self) -> int:
         return self.block_size
 
+    @property
+    def requires_slot_mapping(self) -> bool:
+        """Whether this KV cache needs per-token slot mapping."""
+        return True
+
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         """
         The maximum possible memory usage of this KV cache in bytes.
@@ -614,6 +619,11 @@ class MambaSpec(KVCacheSpec):
     num_speculative_blocks: int = 0
 
     @property
+    def requires_slot_mapping(self) -> bool:
+        """Mamba-style caches address per-request states, not token KV slots."""
+        return False
+
+    @property
     def page_size_bytes(self) -> int:
         page_size = sum(
             prod(shape) * get_dtype_size(dtype)
@@ -731,6 +741,11 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
     @property
     def page_size_bytes(self) -> int:
         return sum(spec.page_size_bytes for spec in self.kv_cache_specs.values())
+
+    @property
+    def requires_slot_mapping(self) -> bool:
+        """Return true if any wrapped spec needs per-token KV slot mapping."""
+        return any(spec.requires_slot_mapping for spec in self.kv_cache_specs.values())
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_num_pages = max(

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -26,6 +26,7 @@ class BlockTable:
         device: torch.device,
         kernel_block_size: int,
         cp_kv_cache_interleave_size: int,
+        requires_slot_mapping: bool = True,
     ):
         """
         Args:
@@ -38,11 +39,14 @@ class BlockTable:
             kernel_block_size: The block_size of underlying attention kernel.
                 Will be the same as `block_size` if `block_size` is supported
                 by the attention kernel.
+            requires_slot_mapping: Whether this KV cache group needs per-token
+                slot mapping.
         """
         self.max_num_reqs = max_num_reqs
         self.max_num_batched_tokens = max_num_batched_tokens
         self.pin_memory = pin_memory
         self.device = device
+        self.requires_slot_mapping = requires_slot_mapping
 
         if kernel_block_size == block_size:
             # Standard case: allocation and computation use same block size
@@ -234,12 +238,21 @@ class MultiGroupBlockTable:
         kernel_block_sizes: list[int],
         max_num_blocks: list[int] | None = None,
         cp_kv_cache_interleave_size: int = 1,
+        requires_slot_mapping: list[bool] | None = None,
     ) -> None:
         if len(kernel_block_sizes) != len(block_sizes):
             raise ValueError(
                 f"kernel_block_sizes length ({len(kernel_block_sizes)}) "
                 f"must match block_sizes length ({len(block_sizes)})"
             )
+        if requires_slot_mapping is None:
+            requires_slot_mapping = [True] * len(block_sizes)
+        elif len(requires_slot_mapping) != len(block_sizes):
+            raise ValueError(
+                f"requires_slot_mapping length ({len(requires_slot_mapping)}) "
+                f"must match block_sizes length ({len(block_sizes)})"
+            )
+
         if max_num_blocks is None:
             # Note(hc): each dcp rank only store
             # (max_model_len//dcp_world_size) tokens in kvcache,
@@ -274,9 +287,18 @@ class MultiGroupBlockTable:
                 device,
                 kernel_block_size,
                 cp_kv_cache_interleave_size,
+                requires_slot_mapping_i,
             )
-            for block_size, kernel_block_size, max_num_blocks_per_req in zip(
-                block_sizes, kernel_block_sizes, max_num_blocks
+            for (
+                block_size,
+                kernel_block_size,
+                max_num_blocks_per_req,
+                requires_slot_mapping_i,
+            ) in zip(
+                block_sizes,
+                kernel_block_sizes,
+                max_num_blocks,
+                requires_slot_mapping,
             )
         ]
 
@@ -307,6 +329,10 @@ class MultiGroupBlockTable:
         positions: torch.Tensor,
     ) -> None:
         for block_table in self.block_tables:
+            if not block_table.requires_slot_mapping:
+                # State-cache groups such as Mamba/GDN do not consume token-level
+                # slot mappings; their metadata is derived from block tables.
+                continue
             block_table.compute_slot_mapping(num_reqs, query_start_loc, positions)
 
     def commit_block_table(self, num_reqs: int) -> None:

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -106,6 +106,7 @@ class InputBatch:
         is_pooling_model: bool = False,
         cp_kv_cache_interleave_size: int = 1,
         reasoning_config: ReasoningConfig | None = None,
+        requires_slot_mapping: list[bool] | None = None,
     ):
         self.thinking_budget_state_holder = maybe_create_thinking_budget_state_holder(
             reasoning_config,
@@ -178,6 +179,7 @@ class InputBatch:
             kernel_block_sizes=kernel_block_sizes,
             max_num_blocks=max_num_blocks_per_req,
             cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+            requires_slot_mapping=requires_slot_mapping,
         )
 
         # Sampling-related.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -656,6 +656,7 @@ class GPUModelRunner(
         )
         self._init_block_sizes = [placeholder_block_size]
         self._init_kernel_block_sizes = [placeholder_block_size]
+        self._init_requires_slot_mapping = [True]
         self.input_batch = InputBatch(
             max_num_reqs=self.max_num_reqs,
             # We need to use the encoder length for encoder-decoder
@@ -6902,12 +6903,16 @@ class GPUModelRunner(
         """
         block_sizes = []
         max_num_blocks = []
+        requires_slot_mapping = []
         max_model_len = max(self.max_model_len, self.max_encoder_len)
         for kv_cache_group in kv_cache_config.kv_cache_groups:
             if isinstance(kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec):
                 continue
             block_size = kv_cache_group.kv_cache_spec.block_size
             block_sizes.append(block_size)
+            requires_slot_mapping.append(
+                kv_cache_group.kv_cache_spec.requires_slot_mapping
+            )
             max_num_blocks_per_req = cdiv(
                 max_model_len, block_size * get_total_cp_world_size()
             )
@@ -6922,9 +6927,11 @@ class GPUModelRunner(
         if (
             block_sizes != self._init_block_sizes
             or kernel_block_sizes != self._init_kernel_block_sizes
+            or requires_slot_mapping != self._init_requires_slot_mapping
         ):
             self._init_block_sizes = block_sizes
             self._init_kernel_block_sizes = kernel_block_sizes
+            self._init_requires_slot_mapping = requires_slot_mapping
             self.input_batch = InputBatch(
                 max_num_reqs=self.max_num_reqs,
                 max_model_len=max_model_len,
@@ -6940,6 +6947,7 @@ class GPUModelRunner(
                 logitsprocs_need_output_token_ids=self.input_batch.logitsprocs_need_output_token_ids,
                 is_pooling_model=self.is_pooling_model,
                 reasoning_config=self.vllm_config.reasoning_config,
+                requires_slot_mapping=requires_slot_mapping,
             )
 
         assert self._init_block_sizes == block_sizes, (
@@ -6949,6 +6957,11 @@ class GPUModelRunner(
         assert self._init_kernel_block_sizes == kernel_block_sizes, (
             f"InputBatch kernel_block_sizes {self._init_kernel_block_sizes} "
             f"!= kv_cache kernel_block_sizes {kernel_block_sizes}"
+        )
+        assert self._init_requires_slot_mapping == requires_slot_mapping, (
+            "InputBatch requires_slot_mapping "
+            f"{self._init_requires_slot_mapping} != "
+            f"kv_cache requires_slot_mapping {requires_slot_mapping}"
         )
 
     def _allocate_kv_cache_tensors(


### PR DESCRIPTION

## Purpose

Skip token-level slot mapping work for KV cache groups that do not consume it.

Mamba-style state caches address per-request state instead of per-token KV slots, so computing a `slot_mapping` for those groups is unnecessary. This change adds a `requires_slot_mapping` property to KV cache specs, marks `MambaSpec` as not requiring slot mappings, propagates that flag into `InputBatch`/`MultiGroupBlockTable`, and skips `compute_slot_mapping` for those groups.

This avoids launching unnecessary per-step slot mapping kernels for state-cache groups while preserving the default behavior for attention KV cache groups.

## Test Plan

Serving command:

```bash
vllm serve Qwen/Qwen3.6-35B-A3B -tp 2
```

Benchmark command:

```bash
vllm bench serve Qwen/Qwen3.6-35B-A3B \
  --dataset-name random \
  --num-prompt 10 \
  --max-concurrency 1 \
  --random-input-len 1024 \
  --random-output-len 100
```

## Test Result

Low-concurrency benchmark result, `max-concurrency=1`, random input length 1024, random output length 100:

| Version | Output token throughput | TTFT | TPOT |
| --- | ---: | ---: | ---: |
| Before | 103.29 tok/s | 389.81 ms | 5.84 ms |
| After | 127.52 tok/s | 266.56 ms | 5.22 ms |

Observed change:

- Output token throughput improved from 103.29 tok/s to 127.52 tok/s, about +23.4%.
- TTFT improved from 389.81 ms to 266.56 ms, about -31.6%.
- TPOT improved from 5.84 ms to 5.22 ms, about -10.6%.

Profile before optimization:

<img width="2620" height="676" alt="before" src="https://github.com/user-attachments/assets/5443c1cb-e498-4c62-9040-bcd92a7d4d40" />

Profile after optimization:

<img width="2610" height="678" alt="after" src="https://github.com/user-attachments/assets/5f57e08d-9378-4670-bbb1-b875f790177f" />