### PR TITLE
fix: close qwen3 coder streaming tool args

### DIFF
--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -662,6 +662,45 @@ true
     assert isinstance(args["verbose"], bool)
 
 
+def test_qwen3coder_streaming_closes_function_after_parameter_fragment(qwen3_tokenizer):
+    tools = [
+        ChatCompletionToolsParam(
+            type="function",
+            function={
+                "name": "read_pdf",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "page": {"type": "integer"},
+                    },
+                },
+            },
+        )
+    ]
+    request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
+    parser = Qwen3EngineToolParser(qwen3_tokenizer, tools=tools)
+    model_output = """<tool_call>
+<function=read_pdf>
+<parameter=page>
+1
+</parameter>
+</function>
+</tool_call>"""
+
+    accumulated_args = ""
+
+    for delta in stream_delta_message_generator(
+        parser, qwen3_tokenizer, model_output, request
+    ):
+        if delta and delta.tool_calls:
+            for tool_call in delta.tool_calls:
+                function = tool_call.function
+                if function and function.arguments is not None:
+                    accumulated_args += function.arguments
+
+    assert json.loads(accumulated_args) == {"page": 1}
+
+
 @pytest.mark.parametrize(
     ids=[
         "no_tools",


### PR DESCRIPTION
## Purpose

Fixes #45256.

`Qwen3CoderToolParser.extract_tool_calls_streaming()` already waits to check `</function>` until after parameter fragments are processed. That avoids dropping the last parameter, but it still returns immediately when a delta contains both the final parameter fragment and `</function>`. With batched streaming, the next delta may be EOS/empty text, so the closing `}` is never emitted.

This change closes the current streamed function in the same arguments delta when the parameter-processing pass also sees `</function>`. The existing close path is kept for deltas that contain only the function close.

## Test Plan

- `python -m py_compile vllm\tool_parsers\qwen3coder_tool_parser.py tests\tool_parsers\test_qwen3coder_tool_parser.py`
- `python -m ruff check vllm\tool_parsers\qwen3coder_tool_parser.py tests\tool_parsers\test_qwen3coder_tool_parser.py`
- `python -m ruff format --check vllm\tool_parsers\qwen3coder_tool_parser.py tests\tool_parsers\test_qwen3coder_tool_parser.py`
- `git diff --check`
- direct parser regression script using the same batched chunks from #45256
- attempted `python -m pytest tests\tool_parsers\test_qwen3coder_tool_parser.py::test_qwen3coder_streaming_closes_function_after_parameter_fragment -q --tb=short`

## Test Result

- `py_compile`: passed
- `ruff check`: passed
- `ruff format --check`: passed
- `git diff --check`: passed
- direct parser regression script: passed, accumulated arguments are `{"page": 1}`
- targeted pytest did not reach the test body in my local Windows/base environment. It failed during import because the environment has an incompatible `transformers` / `kernels` integration (`ValueError: Either a revision or a version must be specified.`). After bypassing that for a direct parser script, the local environment also lacks Windows-compatible `uvloop` and `xgrammar`. I did not change the project code to work around those environment issues.
