### PR TITLE
[Spec Decode] Avoid materializing target probabilities in rejection sampling

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -14,6 +14,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (
     PLACEHOLDER_TOKEN_ID,
     RejectionSampler,
+    compute_target_normalization,
     sample_recovered_tokens,
 )
 from vllm.v1.sample.sampler import Sampler, SamplerOutput
@@ -930,7 +931,8 @@ def test_sample_recovered_tokens(
         spec_decode_metadata.cu_num_draft_tokens,
         draft_token_ids,
         None if no_draft_probs else draft_probs,
-        target_probs,
+        target_logits,
+        *compute_target_normalization(target_logits, vocab_size, block_size=8192),
         sampling_metadata,
         device=DEVICE_TYPE,
     )
@@ -971,6 +973,7 @@ def test_sample_recovered_tokens_uses_fp64_exponential_race_when_requested():
         draft_token_ids.reshape(batch_size, max_spec_len).tolist(),
         target_probs.log(),
     )
+    target_logits = target_probs.log()
 
     expected = native_sample_recovered_tokens(
         max_spec_len,
@@ -989,7 +992,8 @@ def test_sample_recovered_tokens_uses_fp64_exponential_race_when_requested():
         spec_decode_metadata.cu_num_draft_tokens,
         draft_token_ids,
         draft_probs,
-        target_probs,
+        target_logits,
+        *compute_target_normalization(target_logits, vocab_size, block_size=8192),
         sampling_metadata,
         device=torch.device(DEVICE_TYPE),
         use_fp64_gumbel=True,
@@ -1076,7 +1080,8 @@ def test_sample_recovered_tokens_vocab_boundary(vocab_size: int, no_draft_probs:
         spec_decode_metadata.cu_num_draft_tokens,
         draft_token_ids.squeeze(-1),
         None if no_draft_probs else draft_probs,
-        target_probs,
+        target_probs.log(),
+        *compute_target_normalization(target_probs.log(), vocab_size, block_size=8192),
         sampling_metadata,
         device=DEVICE_TYPE,
     )
@@ -1089,6 +1094,75 @@ def test_sample_recovered_tokens_vocab_boundary(vocab_size: int, no_draft_probs:
         f"Recovered token IDs >= vocab_size ({vocab_size}): "
         f"{recovered[recovered >= vocab_size].tolist()}"
     )
+
+
+def test_compute_target_normalization_enforces_dense_row_stride_contract():
+    logits = torch.randn(4, 8, dtype=torch.float32)
+
+    with pytest.raises(AssertionError):
+        compute_target_normalization(logits, vocab_size=7, block_size=4)
+
+    with pytest.raises(AssertionError):
+        compute_target_normalization(logits[:, ::2], vocab_size=4, block_size=4)
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fused_target_normalization_matches_fp64_lse_reference():
+    """Fused normalization state should match an fp64 logsumexp oracle closely.
+
+    The production kernel consumes row max and inverse normalized sum to
+    reconstruct target probabilities. Compare the implied LSE against fp64
+    rather than torch's fp32 logsumexp so the test bounds numerical error
+    against a stronger reference.
+    """
+    torch.manual_seed(0)
+    num_tokens = 64
+    vocab_size = 8193
+    logits = torch.randn(
+        num_tokens, vocab_size, dtype=torch.float32, device="cuda"
+    )
+
+    # Simulate top-k/top-p masks. Keep at least one finite value per row.
+    mask = torch.rand(num_tokens, vocab_size, device="cuda") < 0.2
+    logits = logits.masked_fill(mask, float("-inf"))
+    logits[:, 0] = torch.maximum(logits[:, 0], torch.zeros_like(logits[:, 0]))
+
+    target_max, target_inv_sum = compute_target_normalization(
+        logits, vocab_size, block_size=4096
+    )
+    fused_lse = target_max - torch.log(target_inv_sum)
+    fp64_lse = torch.logsumexp(logits.double(), dim=-1).float()
+
+    assert torch.max(torch.abs(fused_lse - fp64_lse)).item() < 2e-6
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fused_target_normalization_handles_full_negative_infinity_tiles():
+    """Rows with entire masked tiles must not poison online state with NaNs.
+
+    Top-k/top-p can mask complete vocab tiles to -inf. The online update must
+    skip those tiles instead of evaluating -inf - -inf into a persistent NaN.
+    """
+    block_size = 4096
+    vocab_size = block_size * 3 + 17
+    logits = torch.full((2, vocab_size), float("-inf"), device="cuda")
+
+    # First two full tiles are -inf; all finite values are in the final tile.
+    logits[0, block_size * 2 + 3] = 0.25
+    logits[0, block_size * 2 + 11] = -1.0
+    logits[1, block_size * 3 + 7] = 2.0
+
+    target_max, target_inv_sum = compute_target_normalization(
+        logits, vocab_size, block_size=block_size
+    )
+    fused_lse = target_max - torch.log(target_inv_sum)
+    fp64_lse = torch.logsumexp(logits.double(), dim=-1).float()
+
+    assert torch.isfinite(target_max).all()
+    assert torch.isfinite(target_inv_sum).all()
+    torch.testing.assert_close(fused_lse, fp64_lse, atol=2e-6, rtol=0)
 
 
 ########################### Tests for Synthetic Rejection Sampling #########

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 
 from vllm.logger import init_logger
-from vllm.triton_utils import tl, triton
+from vllm.triton_utils import HAS_TRITON, tl, triton
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
 from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -32,6 +32,7 @@ GREEDY_TEMPERATURE: tl.constexpr = 0
 # Maximum number of speculative draft tokens allowed per request in a single
 # step. This value is chosen to be large enough to handle typical use cases.
 MAX_SPEC_LEN = 128
+TARGET_NORMALIZATION_BLOCK_SIZE = 8192
 
 
 class RejectionSampler(nn.Module):
@@ -470,9 +471,14 @@ def rejection_sample(
         if sampling_metadata.all_greedy:
             return output_token_ids
 
-    # Compute probability distribution from target logits.
-    target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
-    assert target_probs.is_contiguous()
+    # Compute the online-softmax state without materializing the full
+    # [num_tokens, vocab_size] target_probs tensor. Kernels consume the state
+    # directly as exp2((logit - target_max) * log2(e)) * target_inv_sum
+    # instead of reconstructing probabilities through logsumexp.
+    assert target_logits.is_contiguous()
+    target_max, target_inv_sum = compute_target_normalization(
+        target_logits, vocab_size, TARGET_NORMALIZATION_BLOCK_SIZE
+    )
 
     # Sample recovered tokens for each position.
     # [num_tokens]
@@ -482,7 +488,9 @@ def rejection_sample(
         cu_num_draft_tokens,
         draft_token_ids,
         draft_probs,
-        target_probs,
+        target_logits,
+        target_max,
+        target_inv_sum,
         sampling_metadata,
         device,
         use_fp64_gumbel,
@@ -495,7 +503,9 @@ def rejection_sample(
         cu_num_draft_tokens,
         draft_token_ids,
         draft_probs,
-        target_probs,
+        target_logits,
+        target_max,
+        target_inv_sum,
         bonus_token_ids,
         recovered_token_ids,
         uniform_probs,
@@ -672,14 +682,18 @@ def sample_recovered_tokens(
     # [num_tokens, vocab_size]
     draft_probs: torch.Tensor | None,
     # [num_tokens, vocab_size]
-    target_probs: torch.Tensor,
+    target_logits: torch.Tensor,
+    # [num_tokens]
+    target_max: torch.Tensor,
+    # [num_tokens]
+    target_inv_sum: torch.Tensor,
     sampling_metadata: SamplingMetadata,
     device: torch.device,
     use_fp64_gumbel: bool = False,
 ) -> torch.Tensor:
     # NOTE(woosuk): Create only one distribution for each request.
     batch_size = len(num_draft_tokens)
-    vocab_size = target_probs.shape[-1]
+    vocab_size = target_logits.shape[-1]
     q_dtype = torch.float64 if use_fp64_gumbel else torch.float32
     q = torch.empty(
         (batch_size, vocab_size),
@@ -702,7 +716,9 @@ def sample_recovered_tokens(
         cu_num_draft_tokens,
         draft_token_ids,
         draft_probs,
-        target_probs,
+        target_logits,
+        target_max,
+        target_inv_sum,
         inv_q,
         vocab_size,
         BLOCK_SIZE,
@@ -710,6 +726,96 @@ def sample_recovered_tokens(
         USE_FP64_GUMBEL=use_fp64_gumbel,
     )
     return recovered_token_ids
+
+
+def compute_target_normalization(
+    target_logits: torch.Tensor,
+    vocab_size: int,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute per-row online-softmax state for target probabilities.
+
+    Returns ``(row_max, inverse_normalized_sum)`` so consumers can reconstruct
+    probabilities as ``exp(logit - row_max) * inverse_normalized_sum`` without
+    first collapsing the state into logsumexp.
+
+    ``vocab_size`` is both the valid-column bound and the row stride used by
+    the Triton kernels, so it must match the logits' trailing dimension.
+    """
+    assert target_logits.is_contiguous()
+    assert vocab_size == target_logits.shape[-1]
+    if target_logits.is_cuda and HAS_TRITON:
+        target_max = torch.empty(
+            (target_logits.shape[0],),
+            dtype=torch.float32,
+            device=target_logits.device,
+        )
+        target_inv_sum = torch.empty_like(target_max)
+        target_normalization_kernel[(target_logits.shape[0],)](
+            target_logits,
+            target_max,
+            target_inv_sum,
+            vocab_size,
+            BLOCK_SIZE=block_size,
+            num_warps=8,
+        )
+        return target_max, target_inv_sum
+
+    target_max = torch.max(target_logits, dim=-1).values
+    finite_target_max = torch.where(
+        torch.isfinite(target_max), target_max, torch.zeros_like(target_max)
+    )
+    normalized_sum = torch.exp(target_logits - finite_target_max.unsqueeze(-1)).sum(
+        dim=-1
+    )
+    return target_max, normalized_sum.reciprocal()
+
+
+@triton.jit
+def target_normalization_kernel(
+    target_logits_ptr,  # [num_tokens, vocab_size]
+    target_max_ptr,  # [num_tokens]
+    target_inv_sum_ptr,  # [num_tokens]
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Online softmax state over target logits.
+
+    Sampling constraints keep at least one finite logit per row. An all--inf
+    row is undefined here, as in the previous materialized-softmax path.
+    """
+    row = tl.program_id(0)
+
+    m = tl.full((), float("-inf"), tl.float32)
+    s = tl.full((), 0.0, tl.float32)
+    for v in range(0, vocab_size, BLOCK_SIZE):
+        vocab_offset = v + tl.arange(0, BLOCK_SIZE)
+        vocab_mask = vocab_offset < vocab_size
+        logits = tl.load(
+            target_logits_ptr + row * vocab_size + vocab_offset,
+            mask=vocab_mask,
+            other=float("-inf"),
+        ).to(tl.float32)
+        tile_max = tl.max(logits, axis=0)
+        new_m = tl.maximum(m, tile_max)
+        # If all visited tiles are -inf so far, new_m is -inf. Avoid forming
+        # -inf - -inf in either branch; masked contributions should be zero.
+        finite_new_m = tl.where(new_m > float("-inf"), new_m, 0.0)
+        old_scale = tl.where(
+            m > float("-inf"),
+            tl.exp2((m - finite_new_m) * 1.4426950408889634),
+            0.0,
+        )
+        tile_contrib = tl.where(
+            logits > float("-inf"),
+            tl.exp2((logits - finite_new_m) * 1.4426950408889634),
+            0.0,
+        )
+        s = s * old_scale + tl.sum(tile_contrib, axis=0)
+        m = new_m
+
+    tl.store(target_max_ptr + row, m)
+    tl.store(target_inv_sum_ptr + row, 1.0 / s)
 
 
 # NOTE(woosuk): Avoid specialization to prevent unnecessary recompilation.
@@ -778,7 +884,9 @@ def rejection_random_sample_kernel(
     cu_num_draft_tokens_ptr,  # [batch_size]
     draft_token_ids_ptr,  # [num_tokens]
     draft_probs_ptr,  # [num_tokens, vocab_size] or None
-    target_probs_ptr,  # [num_tokens, vocab_size]
+    target_logits_ptr,  # [num_tokens, vocab_size]
+    target_max_ptr,  # [num_tokens]
+    target_inv_sum_ptr,  # [num_tokens]
     bonus_token_ids_ptr,  # [batch_size]
     recovered_token_ids_ptr,  # [num_tokens]
     uniform_probs_ptr,  # [num_tokens]
@@ -823,12 +931,18 @@ def rejection_random_sample_kernel(
                         + (start_idx + pos) * vocab_size
                         + draft_token_id
                     )
-                target_prob = tl.load(
-                    target_probs_ptr + (start_idx + pos) * vocab_size + draft_token_id
+                target_logit = tl.load(
+                    target_logits_ptr + (start_idx + pos) * vocab_size + draft_token_id
+                )
+                target_max = tl.load(target_max_ptr + start_idx + pos)
+                target_inv_sum = tl.load(target_inv_sum_ptr + start_idx + pos)
+                target_prob = (
+                    tl.exp2((target_logit - target_max) * 1.4426950408889634)
+                    * target_inv_sum
                 )
                 # NOTE(woosuk): While the draft probability should never be 0,
                 # we check it to avoid NaNs. If it happens to be 0, we reject.
-                accepted = draft_prob > 0 and target_prob / draft_prob >= uniform_prob
+                accepted = draft_prob > 0 and target_prob >= uniform_prob * draft_prob
             if accepted:
                 token_id = draft_token_id
             else:
@@ -877,7 +991,9 @@ def sample_recovered_tokens_kernel(
     cu_num_draft_tokens_ptr,  # [batch_size]
     draft_token_ids_ptr,  # [num_tokens]
     draft_probs_ptr,  # [num_tokens, vocab_size] or None
-    target_probs_ptr,  # [num_tokens, vocab_size]
+    target_logits_ptr,  # [num_tokens, vocab_size]
+    target_max_ptr,  # [num_tokens]
+    target_inv_sum_ptr,  # [num_tokens]
     inv_q_ptr,  # [batch_size, vocab_size]
     vocab_size,
     BLOCK_SIZE: tl.constexpr,
@@ -903,6 +1019,8 @@ def sample_recovered_tokens_kernel(
     if NO_DRAFT_PROBS:
         draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
 
+    target_max = tl.load(target_max_ptr + token_idx)
+    target_inv_sum = tl.load(target_inv_sum_ptr + token_idx)
     if USE_FP64_GUMBEL:
         max_val = tl.full((), float("-inf"), tl.float64)
     else:
@@ -913,10 +1031,14 @@ def sample_recovered_tokens_kernel(
         vocab_mask = vocab_offset < vocab_size
 
         if NO_DRAFT_PROBS:
-            prob = tl.load(
-                target_probs_ptr + token_idx * vocab_size + vocab_offset,
+            target_logit = tl.load(
+                target_logits_ptr + token_idx * vocab_size + vocab_offset,
                 mask=(vocab_mask & (vocab_offset != draft_token_id)),
-                other=0.0,
+                other=float("-inf"),
+            )
+            prob = (
+                tl.exp2((target_logit - target_max) * 1.4426950408889634)
+                * target_inv_sum
             )
         else:
             draft_prob = tl.load(
@@ -924,10 +1046,14 @@ def sample_recovered_tokens_kernel(
                 mask=vocab_mask,
                 other=0.0,
             )
-            target_prob = tl.load(
-                target_probs_ptr + token_idx * vocab_size + vocab_offset,
+            target_logit = tl.load(
+                target_logits_ptr + token_idx * vocab_size + vocab_offset,
                 mask=vocab_mask,
-                other=0.0,
+                other=float("-inf"),
+            )
+            target_prob = (
+                tl.exp2((target_logit - target_max) * 1.4426950408889634)
+                * target_inv_sum
             )
             prob = tl.maximum(target_prob - draft_prob, 0.0)
             # NOTE(woosuk): We don't need `prob = prob / tl.sum(prob)` here because


### PR DESCRIPTION
## Summary

This removes the materialized `target_probs = softmax(target_logits)` tensor from the non-greedy speculative rejection sampler.

The sampler still uses the same softmax probabilities. Instead of writing the full probability tensor, it computes one logsumexp value per row and reconstructs probabilities where they are used:

```python
prob = exp(logit - logsumexp(row))
```

## Why

The old path allocates and reads a full fp32 probability tensor:

```text
num_draft_tokens_total x vocab_size x 4 bytes
```

At batch 64, k=16, that transient tensor is:

| vocab | removed transient tensor |
|---:|---:|
| 50,272 | 205.9 MB |
| 128,256 | 525.3 MB |
| 151,936 | 622.3 MB |

This reduces transient GPU memory pressure and HBM traffic in the speculative rejection path.

This is independent of #41258: #41258 removes eager recovery buffers, while this PR removes the materialized target probability tensor. Both touch the rejection sampler, so whichever lands first, the other will rebase. Together, the two changes remove two separate full-vocab tensors from this path.

## Changes

- Added a one-pass Triton logsumexp producer for target logits.
- Passed `target_logits` and per-row LSE into the rejection kernels instead of `target_probs`.
- Reconstructed target probabilities at point of use with `exp(logit - lse)`.
- Kept the same acceptance and recovery sampling algorithms.
- Added coverage for LSE parity, fp64-reference accuracy, and fully masked `-inf` vocab tiles.

## Correctness

The probability identity is exact in real arithmetic:

```text
softmax(logits)[i] == exp(logits[i] - logsumexp(logits))
```

Floating point reduction order can differ from materialized softmax by a few ULPs. The tests check acceptance parity outside threshold-edge cases and compare the fused LSE producer against an fp64 reference.

## Performance

A100 mechanism benchmark, paired against latest main, 200 trials per row:

| vocab | draft probs | reject pos | main median | this PR median | delta |
|---:|---|---:|---:|---:|---:|
| 50,272 | false | none | 0.9099 ms | 0.6457 ms | -29.03% |
| 50,272 | false | 0 | 0.9484 ms | 0.6351 ms | -33.04% |
| 50,272 | true | 0 | 0.9157 ms | 0.8422 ms | -8.02% |
| 128,256 | false | none | 2.1401 ms | 1.4180 ms | -33.74% |
| 128,256 | false | 15 | 2.1218 ms | 1.2975 ms | -38.85% |
| 128,256 | true | 0 | 2.1406 ms | 1.9066 ms | -10.93% |

Full sweep: faster in all 20 probed rows, with median mechanism latency reduced by 6.97% to 38.85%. The equivalent mechanism throughput gain is 7.49% to 63.53%.

No end-to-end throughput claim is made in this PR.

## Duplicate-work check

I searched open vLLM PRs for `target_probs rejection_sampler`, `compute_target_lse`, `logsumexp rejection sampler`, and `target probabilities rejection sampling`. I did not find another PR removing `target_probs` from this path.

Related open work is different in scope: #41258 makes recovery sampling lazy, #45060 fixes an out-of-vocab recovered-token bug, and #45229 changes relaxed acceptance behavior.

## Test plan

Local checks:

```bash
uv run --no-project python -m py_compile vllm/v1/sample/rejection_sampler.py tests/v1/sample/test_rejection_sampler.py
uvx ruff check vllm/v1/sample/rejection_sampler.py tests/v1/sample/test_rejection_sampler.py
```

A100 validation:

```text
vllm-lse-clean-validate-20260612t200123z
NVIDIA A100-SXM4-80GB, driver 550.54.14
ruff passed
focused full -inf tile LSE test passed
focused LSE acceptance parity test passed
focused fp64 oracle test passed
tests/v1/sample/test_rejection_sampler.py: 77 passed
```

A100 mechanism benchmark:

```text
vllm-lse-clean-validate-20260612t200123z
NVIDIA A100-SXM4-80GB, driver 550.54.14
20/20 rows faster than main, 200 trials per row
```

## AI assistance disclosure

AI assistance was used. I reviewed the changed code, tests, duplicate-work check, and benchmark results before submitting.
