### PR TITLE
[Bugfix] Set type/role explicitly in streaming message_start event

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -996,3 +996,39 @@ class TestMessageStreamConverterToolUseContentBuffering:
         assert "text" in block_starts
 
         assert events[-1][0] == "message_stop"
+
+
+class TestMessageStartIncludesTypeAndRole:
+    """Regression test for issue #45367: the streaming message_start event is
+    serialized with exclude_unset=True, which silently dropped the
+    default-valued ``type``/``role`` fields of the nested message object.
+    Strict Anthropic SDK clients (e.g. Claude Code) validate
+    ``message_start.message.type``/``role`` and reject the whole stream when
+    they are missing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_message_start_contains_message_type_and_role(self):
+        async def sse_input():
+            yield _make_stream_chunk(
+                delta=DeltaMessage(content="Hello"),
+                usage=UsageInfo(
+                    prompt_tokens=20,
+                    total_tokens=20,
+                    completion_tokens=0,
+                ),
+            )
+            yield _make_stream_chunk(finish_reason="stop")
+            yield "data: [DONE]"
+
+        converter = _make_stream_converter()
+        output = []
+        async for event in converter.message_stream_converter(sse_input()):
+            output.append(event)
+
+        events = _parse_sse_events(output)
+
+        assert events[0][0] == "message_start"
+        message = events[0][1]["message"]
+        assert message["type"] == "message"
+        assert message["role"] == "assistant"

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -678,6 +678,13 @@ class AnthropicServingMessages(OpenAIServingChat):
                                 type="message_start",
                                 message=AnthropicMessagesResponse(
                                     id=origin_chunk.id,
+                                    # Set explicitly: this event is serialized
+                                    # with exclude_unset=True, which drops
+                                    # default-valued fields, while strict
+                                    # Anthropic SDK clients require
+                                    # message.type/role (issue #45367).
+                                    type="message",
+                                    role="assistant",
                                     content=[],
                                     model=origin_chunk.model,
                                     stop_reason=None,


### PR DESCRIPTION
## Purpose

Fix #45367: the `/v1/messages` streaming path builds the `message_start` event without explicitly setting the nested message's `type`/`role`, then serializes it with `model_dump_json(exclude_unset=True)`. Since `AnthropicMessagesResponse` declares `type: Literal["message"] = "message"` and `role: Literal["assistant"] = "assistant"` as defaults, `exclude_unset=True` drops both from the wire. Strict Anthropic SDK clients (e.g. Claude Code) validate `message_start.message.type`/`role` and reject every stream — while the server logs `200 OK`. Non-streaming responses use a different serialization path and are unaffected.

Fix: set both fields explicitly in the streaming constructor (same approach the reporter verified end-to-end with Claude Code; see the before/after SSE captures in the issue).

## Test Plan

New regression test asserting the parsed `message_start` SSE event contains `message.type == "message"` and `message.role == "assistant"`, using the existing `message_stream_converter` test harness. Verified fail→pass:

```
# without fix
.venv/bin/python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py::TestMessageStartIncludesTypeAndRole -q
1 failed

# with fix
.venv/bin/python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -q
34 passed
```

pre-commit (ruff check/format, mypy) passes on both changed files.

## Test Result

`34 passed` on the full `test_anthropic_messages_conversion.py` file (CPU-only test, no GPU required).

## Duplicate check

No open PR addresses this: searched `is:pr is:open 45367`, `message_start type role`, and open PRs touching `vllm/entrypoints/anthropic/serving.py` (#45083 maps `cache_read_input_tokens` — different bug; #40912 cache usage — unrelated). Recent file history (#45287 tool_use args, #45163 usage nesting) does not touch this. Issue was opened at @bbrowning's request as a follow-up from #45163; reporter @markbdean01 offered to retest a candidate fix.

## (Optional) Documentation Update

None.

---

AI assistance disclosure: this PR was prepared with AI assistance (Claude); the change and test were reviewed and run locally by the submitter.
