### PR TITLE
[Bugfix][Spec Decode] Fix drafter slot mapping type mismatch when DBO is enabled

### DIFF
--- a/tests/v1/spec_decode/test_utils.py
+++ b/tests/v1/spec_decode/test_utils.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.v1.spec_decode.utils import first_slot_mapping_if_ubatched
+
+
+def test_first_slot_mapping_if_ubatched_passthrough_dict():
+    slot_mapping = {"layer.0": torch.zeros(4, dtype=torch.int64)}
+    assert first_slot_mapping_if_ubatched(slot_mapping) is slot_mapping
+
+
+def test_first_slot_mapping_if_ubatched_passthrough_none():
+    assert first_slot_mapping_if_ubatched(None) is None
+
+
+def test_first_slot_mapping_if_ubatched_takes_first_ubatch():
+    # When the target model runs with DBO ubatching, the model runner
+    # provides one slot-mapping dict per ubatch.
+    ubatch0 = {"layer.0": torch.zeros(4, dtype=torch.int64)}
+    ubatch1 = {"layer.0": torch.ones(4, dtype=torch.int64)}
+    assert first_slot_mapping_if_ubatched([ubatch0, ubatch1]) is ubatch0
+
+
+def test_first_slot_mapping_if_ubatched_empty_list():
+    assert first_slot_mapping_if_ubatched([]) is None

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -13,7 +13,7 @@ from vllm.logger import init_logger
 from vllm.triton_utils import triton
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
-from vllm.v1.spec_decode.utils import copy_and_expand_dflash_inputs_kernel
+from vllm.v1.spec_decode.utils import copy_and_expand_dflash_inputs_kernel, first_slot_mapping_if_ubatched
 
 logger = init_logger(__name__)
 
@@ -203,7 +203,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
         num_tokens: int,
         use_cudagraphs: bool = True,
         is_graph_capturing: bool = False,
-        slot_mappings: dict[str, torch.Tensor] | None = None,
+        slot_mappings: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None = None,
     ) -> None:
         """
         Key differences to default dummy_run:
@@ -213,6 +213,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
         - max_query_tokens is quite small, DFlash only sees spec tokens as queries
         - Multimodal inputs are not currently supported
         """
+        slot_mappings = first_slot_mapping_if_ubatched(slot_mappings)
         num_query_tokens = min(num_tokens, self.max_query_tokens)
         cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
             self._determine_batch_execution_and_padding(

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -18,6 +18,7 @@ from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
+from vllm.v1.spec_decode.utils import first_slot_mapping_if_ubatched
 
 if TYPE_CHECKING:
     from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -249,9 +250,10 @@ class ExtractHiddenStatesProposer:
         num_tokens: int,
         use_cudagraphs: bool = True,
         is_graph_capturing: bool = False,
-        slot_mappings: dict[str, torch.Tensor] | None = None,
+        slot_mappings: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None = None,
     ) -> None:
         assert self.model is not None, "Model must be initialized before dummy_run"
+        slot_mappings = first_slot_mapping_if_ubatched(slot_mappings)
         cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
             self._determine_batch_execution_and_padding(
                 num_tokens, use_cudagraphs=use_cudagraphs

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -47,6 +47,7 @@ from vllm.v1.spec_decode.utils import (
     eagle_step_update_slot_mapping_and_metadata,
     extend_all_queries_by_N,
     next_power_of_2,
+    first_slot_mapping_if_ubatched
 )
 from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
@@ -1475,8 +1476,9 @@ class SpecDecodeBaseProposer:
         num_tokens: int,
         use_cudagraphs: bool = True,
         is_graph_capturing: bool = False,
-        slot_mappings: dict[str, torch.Tensor] | None = None,
+        slot_mappings: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None = None,
     ) -> None:
+        slot_mappings = first_slot_mapping_if_ubatched(slot_mappings)
         # FIXME: when using tree-based specdec, adjust number of forward-passes
         # according to the depth of the tree.
         only_one_forward_pass = is_graph_capturing or self.parallel_drafting

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -600,3 +600,18 @@ def unconditional_to_conditional_rates(rates: list[float]) -> list[float]:
     """Convert per-position unconditional rates to per-position conditional
     rates for the early-terminating rejection loop (c_i = p_i / p_{i-1})."""
     return [p / q if q > 0.0 else 0.0 for p, q in zip(rates, [1.0, *rates[:-1]])]
+
+
+def first_slot_mapping_if_ubatched(
+    slot_mappings: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None,
+) -> dict[str, torch.Tensor] | None:
+    """Normalize the runner-provided per-layer slot mappings to a single dict.
+
+    When the target model runs with DBO ubatching, the model runner passes
+    slot mappings as a per-ubatch list of dicts. Drafters that run
+    non-ubatched only need a dict (e.g. for layer-membership checks), so
+    return the first ubatch's dict in that case.
+    """
+    if isinstance(slot_mappings, list):
+        return slot_mappings[0] if slot_mappings else None
+    return slot_mappings


### PR DESCRIPTION
## Purpose

This commit fixes a DBO + speculative decoding startup crash for MTP/EAGLE-style drafters. When DBO is enabled, the target runner may pass slot_mappings as a per-ubatch list[dict], while drafter dummy_run paths expected a single dict. The fix normalizes that input to the first ubatch mapping before the drafter builds its forward context, avoiding the type mismatch.

This is only a compatibility fix. A proper follow-up would be to implement real MTP drafter-side ubatching so the drafter can process ubatched metadata directly instead of collapsing it to one mapping. I can continue with that implementation next.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

