### PR TITLE
[Bugfix] Fix int32 overflow in concat_mla_q flat warp index

### DIFF
--- a/csrc/libtorch_stable/cache_kernels.cu
+++ b/csrc/libtorch_stable/cache_kernels.cu
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cfloat>
+#include <limits>
 
 #ifdef USE_ROCM
   #include <hip/hip_bf16.h>
@@ -1576,8 +1577,13 @@ void concat_mla_q(
   if (num_tokens == 0) return;
 
   constexpr int warps_per_block = 8;
-  const int total_warps = num_tokens * num_heads;
-  const int grid_size = (total_warps + warps_per_block - 1) / warps_per_block;
+  // 64-bit: num_tokens * num_heads overflows int past 2^31 token-heads.
+  const int64_t total_warps = static_cast<int64_t>(num_tokens) * num_heads;
+  const int64_t grid_size_64 =
+      (total_warps + warps_per_block - 1) / warps_per_block;
+  STD_TORCH_CHECK(grid_size_64 <= std::numeric_limits<int>::max(),
+                  "concat_mla_q grid size exceeds CUDA limits: ", grid_size_64);
+  const int grid_size = static_cast<int>(grid_size_64);
   const int block_size = warps_per_block * 32;
 
   const torch::stable::accelerator::DeviceGuard device_guard(

--- a/csrc/libtorch_stable/cache_kernels.cu
+++ b/csrc/libtorch_stable/cache_kernels.cu
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <cfloat>
 #include <cstdlib>
+#include <limits>
 
 #ifdef USE_ROCM
   #include <hip/hip_bf16.h>
@@ -1790,8 +1791,13 @@ void concat_mla_q(
   if (num_tokens == 0) return;
 
   constexpr int warps_per_block = 8;
-  const int total_warps = num_tokens * num_heads;
-  const int grid_size = (total_warps + warps_per_block - 1) / warps_per_block;
+  // 64-bit: num_tokens * num_heads overflows int past 2^31 token-heads.
+  const int64_t total_warps = static_cast<int64_t>(num_tokens) * num_heads;
+  const int64_t grid_size_64 =
+      (total_warps + warps_per_block - 1) / warps_per_block;
+  STD_TORCH_CHECK(grid_size_64 <= std::numeric_limits<int>::max(),
+                  "concat_mla_q grid size exceeds CUDA limits: ", grid_size_64);
+  const int grid_size = static_cast<int>(grid_size_64);
   const int block_size = warps_per_block * 32;
 
   const torch::stable::accelerator::DeviceGuard device_guard(

--- a/csrc/libtorch_stable/concat_mla_q.cuh
+++ b/csrc/libtorch_stable/concat_mla_q.cuh
@@ -17,8 +17,11 @@ __global__ void ConcatMLAQKernel(
     const int64_t out_stride_0, const int64_t out_stride_1,
     const int64_t nope_stride_0, const int64_t nope_stride_1,
     const int64_t pe_stride_0, const int64_t pe_stride_1) {
-  const int flat_warp_id = (blockIdx.x * blockDim.x + threadIdx.x) >> 5;
-  if (flat_warp_id >= num_tokens * num_heads) return;
+  // 64-bit: blockIdx.x * blockDim.x wraps past 2^32 threads (i.e. more than
+  // 2^27 token-heads), aliasing later warps onto earlier tokens/heads.
+  const int64_t flat_warp_id =
+      (static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x) >> 5;
+  if (flat_warp_id >= static_cast<int64_t>(num_tokens) * num_heads) return;
 
   const int token_id = flat_warp_id / num_heads;
   const int head_id = flat_warp_id % num_heads;


### PR DESCRIPTION
## Purpose

Fix #45373: `ConcatMLAQKernel` computes `blockIdx.x * blockDim.x` in 32-bit arithmetic. Once the launch exceeds 2^32 threads (> 2^27 token-heads — e.g. the reporter's 128 heads × 140×7491 tokens = 134.2M token-heads → 4.296e9 threads), the product wraps and later warps alias earlier token/head slots: they redundantly rewrite early `q_out` rows while their own rows are never written → incorrect `q_out`.

Changes (both sites):
- Kernel (`concat_mla_q.cuh`): compute `flat_warp_id` in 64-bit; compare against the 64-bit token-head count. `token_id`/`head_id` stay `int` (each individually bounded by `num_tokens`/`num_heads`).
- Launcher (`cache_kernels.cu`): `total_warps = num_tokens * num_heads` was `int × int` — a second, latent overflow past 2^31 token-heads. Widened to `int64_t` with a `STD_TORCH_CHECK` on the final grid size.

## Test Plan

The trigger requires a ~154 GB `q_out` (134M token-heads × 576 × fp16), which exceeds any single GPU, so validation is a standalone nvcc harness (sm_120, CUDA 13.0) compiling the **fixed header from this tree** plus an index-math probe replicating the old arithmetic:

- **Leg A — wrap demonstration at the reporter's exact scale** (no giant allocation needed): probe blocks of the real launch geometry (grid=16,779,840 × 256 threads):
```
block          0: old_flat=           7 new_flat=           7 expected=           7
block   16777215: old_flat=   134217727 new_flat=   134217727 expected=   134217727
block   16777216: old_flat=           7 new_flat=   134217735 expected=   134217735 <-- OLD WRAPS
block   16779839: old_flat=       20991 new_flat=   134238719 expected=   134238719 <-- OLD WRAPS
```
The old math wraps exactly at block 2^32/256 = 16,777,216, aliasing onto flat id 7 — the mechanism in the issue. The fixed math is correct at all probed blocks.

- **Leg B — no-regression at feasible scale**: the fixed `ConcatMLAQKernel<__half, 512>` run on 8192×128 = 1,048,576 token-heads (~1.2 GB, below the wrap threshold), compared element-wise against a CPU reference: **0/603,979,776 mismatches (byte-identical)**. On sm_120 + CUDA 13 this exercises the 256-bit PTX path (`VLLM_256B_PTX_ENABLED=1`).

- clang-format pre-commit hook passes on both files.

## Test Result

Leg A: old arithmetic wraps at trigger scale, fixed arithmetic correct. Leg B: byte-identical output at non-overflow scale. (Honest framing: the >150 GB end-to-end trigger cannot be run on a single GPU; correctness at trigger scale is established by the device-level index-math probe + the unchanged data path.)

## Duplicate check

No open PR addresses this: searched `45373`, `concat_mla_q in:title`, and the file history (`git log origin/main -- csrc/libtorch_stable/concat_mla_q.cuh` — last touched by the libtorch_stable migration, no overflow fix). #36743 optimizes the same kernel for ROCm (perf, not a fix) — flagging for conflict awareness.

## (Optional) Documentation Update

None.

---

AI assistance disclosure: prepared with AI assistance (Claude); the change was reviewed, compiled, and validated locally by the submitter.
