### PR TITLE
[Rust Frontend] Add ERNIE 4.5 reasoning parser

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -297,6 +297,6 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, kimi, kimi_k2, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, ernie45, gemma4, glm45, kimi, kimi_k2, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
     }
 }

--- a/rust/src/chat/src/parser/reasoning/mod.rs
+++ b/rust/src/chat/src/parser/reasoning/mod.rs
@@ -4,10 +4,10 @@ use std::sync::{Arc, LazyLock};
 
 pub use vllm_parser::reasoning::{
     CohereCmdReasoningParser, DeepSeekR1ReasoningParser, DeepSeekV3ReasoningParser,
-    DeepSeekV4ReasoningParser, Glm45ReasoningParser, KimiK2ReasoningParser, KimiReasoningParser,
-    MiniMaxM2ReasoningParser, MiniMaxM3ReasoningParser, NemotronV3ReasoningParser,
-    Qwen3ReasoningParser, ReasoningDelta, ReasoningError, ReasoningParser, SeedOssReasoningParser,
-    Step3ReasoningParser, Step3p5ReasoningParser,
+    DeepSeekV4ReasoningParser, Ernie45ReasoningParser, Glm45ReasoningParser, KimiK2ReasoningParser,
+    KimiReasoningParser, MiniMaxM2ReasoningParser, MiniMaxM3ReasoningParser,
+    NemotronV3ReasoningParser, Qwen3ReasoningParser, ReasoningDelta, ReasoningError,
+    ReasoningParser, SeedOssReasoningParser, Step3ReasoningParser, Step3p5ReasoningParser,
 };
 use vllm_tokenizer::DynTokenizer;
 
@@ -19,6 +19,7 @@ pub mod names {
     pub const DEEPSEEK_R1: &str = "deepseek_r1";
     pub const DEEPSEEK_V3: &str = "deepseek_v3";
     pub const DEEPSEEK_V4: &str = "deepseek_v4";
+    pub const ERNIE45: &str = "ernie45";
     pub const GEMMA4: &str = "gemma4";
     pub const GLM45: &str = "glm45";
     pub const KIMI: &str = "kimi";
@@ -59,6 +60,7 @@ impl ReasoningParserFactory {
             .register_parser::<DeepSeekR1ReasoningParser>(names::DEEPSEEK_R1)
             .register_parser::<DeepSeekV3ReasoningParser>(names::DEEPSEEK_V3)
             .register_parser::<DeepSeekV4ReasoningParser>(names::DEEPSEEK_V4)
+            .register_parser::<Ernie45ReasoningParser>(names::ERNIE45)
             .register_unified_dummy(names::GEMMA4)
             .register_parser::<Glm45ReasoningParser>(names::GLM45)
             .register_parser::<KimiReasoningParser>(names::KIMI)
@@ -76,6 +78,16 @@ impl ReasoningParserFactory {
             .register_pattern("deepseek-v4", names::DEEPSEEK_V4)
             .register_pattern("deepseek_v4", names::DEEPSEEK_V4)
             .register_pattern("deepseek-v3", names::DEEPSEEK_V3)
+            // Route ONLY the Baidu ERNIE 4.5 *-Thinking variants. The matching
+            // PT base models (`baidu/ERNIE-4.5-0.3B-PT`, `*-21B-A3B-PT`,
+            // `*-300B-A47B-PT`, and VL-PT counterparts) do not emit `</think>`
+            // and would be silently captured as reasoning if this parser were
+            // routed for them, because the parser defaults to
+            // `in_reasoning = true`. The substring matcher cannot AND-combine
+            // patterns, so list the Thinking model IDs directly; add more here
+            // when Baidu ships additional Thinking sizes.
+            .register_pattern("ernie-4.5-21b-a3b-thinking", names::ERNIE45)
+            .register_pattern("ernie-4.5-vl-28b-a3b-thinking", names::ERNIE45)
             .register_pattern("gemma-4", names::GEMMA4)
             .register_pattern("gemma4", names::GEMMA4)
             .register_pattern("qwen", names::QWEN3)

--- a/rust/src/chat/src/parser/reasoning/tests.rs
+++ b/rust/src/chat/src/parser/reasoning/tests.rs
@@ -106,6 +106,42 @@ fn factory_resolves_minimax_m3_before_generic_minimax() {
 }
 
 #[test]
+fn factory_routes_ernie45_models() {
+    let factory = ReasoningParserFactory::new();
+
+    // Positive: only the *-Thinking variants route to the ERNIE 4.5
+    // reasoning parser.
+    assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-21B-A3B-Thinking"),
+        Some(names::ERNIE45)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-VL-28B-A3B-Thinking"),
+        Some(names::ERNIE45)
+    );
+
+    // Negative: the matching PT base models do NOT emit `</think>` and must
+    // not auto-route here, otherwise their plain content would be silently
+    // captured as reasoning (the parser starts with `in_reasoning = true`).
+    assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-21B-A3B-PT"),
+        None
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-VL-28B-A3B-PT"),
+        None
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-0.3B-PT"),
+        None
+    );
+
+    // Negative: non-4.5 ERNIE model IDs must NOT route here either.
+    assert_eq!(factory.resolve_name_for_model("baidu/ERNIE-Bot-4"), None);
+    assert_eq!(factory.resolve_name_for_model("baidu/ernie-3.5-8k"), None);
+}
+
+#[test]
 fn factory_rejects_unknown_parser_names() {
     let tokenizer = Arc::new(FakeTokenizer);
     let factory = ReasoningParserFactory::new();

--- a/rust/src/parser/src/reasoning/ernie45.rs
+++ b/rust/src/parser/src/reasoning/ernie45.rs
@@ -1,0 +1,327 @@
+use vllm_tokenizer::DynTokenizer;
+
+use super::{DelimitedReasoningParser, ReasoningDelta, ReasoningParser, Result};
+
+const RESPONSE_START: &str = "<response>";
+const RESPONSE_END: &str = "</response>";
+
+/// Reasoning parser for Baidu ERNIE 4.5 thinking models.
+///
+/// The model output format is either of:
+///
+/// ```text
+/// abc\n</think>\n\n<response>\ndef\n</response>\n
+/// abc\n</think>\ndef
+/// ```
+///
+/// Reasoning uses the standard `<think>...</think>` delimiters, with the model
+/// typically starting directly inside a reasoning span and only emitting the
+/// closing `</think>` (like DeepSeek R1), so the no-boundary fallback defaults
+/// to `in_reasoning = true`.
+///
+/// On top of the shared delimited split, ERNIE 4.5 wraps the visible answer in
+/// an optional `<response>...</response>` block. This parser strips those
+/// structural markers from the content stream and trims the newline runs the
+/// chat format inserts after `</think>` and `</response>`, so downstream
+/// consumers see only the answer text. Text between the markers is forwarded
+/// verbatim.
+///
+/// Unlike the Python parser, the `<response>` / `</response>` markers are
+/// matched as plain text rather than by token ID, so they do not need to be
+/// present in the tokenizer vocabulary. Also unlike Python — which truncates
+/// everything after the final `</response>` — any non-newline text following
+/// `</response>` is forwarded as content instead of being dropped.
+///
+/// Original Python implementation:
+/// <https://github.com/vllm-project/vllm/blob/main/vllm/reasoning/ernie45_reasoning_parser.py>
+pub struct Ernie45ReasoningParser {
+    inner: DelimitedReasoningParser,
+    /// Holdback buffer for a partial `<response>` / `</response>` marker at
+    /// the end of the content stream.
+    content_buffer: String,
+    /// Drop the structural newline run from upcoming content. Set after
+    /// `</think>` and `</response>`, cleared at the first non-newline.
+    trim_newlines: bool,
+}
+
+impl Ernie45ReasoningParser {
+    /// Create an ERNIE 4.5 parser backed by the shared delimited state
+    /// machine plus response-marker stripping.
+    pub fn new(tokenizer: DynTokenizer) -> Result<Self> {
+        Ok(Self {
+            inner: DelimitedReasoningParser::new(tokenizer, "<think>", "</think>", true)?,
+            content_buffer: String::new(),
+            trim_newlines: false,
+        })
+    }
+
+    /// Post-process one inner delta: pass reasoning through and strip response
+    /// markers plus structural newlines from the content half.
+    fn postprocess(
+        &mut self,
+        inner_delta: ReasoningDelta,
+        was_in_reasoning: bool,
+    ) -> ReasoningDelta {
+        let mut delta = ReasoningDelta::default();
+
+        if let Some(reasoning) = &inner_delta.reasoning {
+            delta.push_reasoning(reasoning);
+        }
+
+        // A reasoning -> content transition within this push means the content
+        // half directly follows `</think>`: start trimming its newline run.
+        // An explicit `<think>...</think>` round trip inside one push also
+        // counts: the inner emits reasoning while ending in content mode.
+        if !self.inner.in_reasoning() && (was_in_reasoning || inner_delta.reasoning.is_some()) {
+            self.trim_newlines = true;
+        }
+
+        if let Some(content) = &inner_delta.content {
+            let processed = self.process_content(content);
+            delta.push_content(&processed);
+        }
+
+        delta
+    }
+
+    /// Buffer content text and process the prefix that cannot be part of a
+    /// response marker split across deltas.
+    fn process_content(&mut self, new_text: &str) -> String {
+        self.content_buffer.push_str(new_text);
+
+        let holdback = partial_marker_suffix_len(&self.content_buffer);
+        let stable_len = self.content_buffer.len() - holdback;
+        let pending_suffix = self.content_buffer.split_off(stable_len);
+        let stable_text = std::mem::replace(&mut self.content_buffer, pending_suffix);
+
+        self.process_stable_content(&stable_text)
+    }
+
+    /// Strip response markers and structural newline runs from content text
+    /// that is known not to end with a partial marker suffix.
+    fn process_stable_content(&mut self, mut stable: &str) -> String {
+        let mut output = String::new();
+
+        loop {
+            if self.trim_newlines {
+                stable = stable.trim_start_matches('\n');
+                if stable.is_empty() {
+                    break;
+                }
+                self.trim_newlines = false;
+            }
+
+            match find_earliest_marker(stable) {
+                Some((marker_idx, marker)) => {
+                    output.push_str(&stable[..marker_idx]);
+                    stable = &stable[marker_idx + marker.len()..];
+                    if marker == RESPONSE_END {
+                        self.trim_newlines = true;
+                    }
+                }
+                None => {
+                    output.push_str(stable);
+                    break;
+                }
+            }
+        }
+
+        output
+    }
+}
+
+impl ReasoningParser for Ernie45ReasoningParser {
+    fn create(tokenizer: DynTokenizer) -> Result<Box<dyn ReasoningParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tokenizer)?))
+    }
+
+    fn initialize(&mut self, prompt_token_ids: &[u32]) -> Result<()> {
+        self.inner.initialize(prompt_token_ids);
+        self.content_buffer.clear();
+        self.trim_newlines = false;
+        Ok(())
+    }
+
+    fn push(&mut self, delta: &str) -> Result<ReasoningDelta> {
+        let was_in_reasoning = self.inner.in_reasoning();
+        let inner_delta = self.inner.push(delta);
+        Ok(self.postprocess(inner_delta, was_in_reasoning))
+    }
+
+    fn finish(&mut self) -> Result<ReasoningDelta> {
+        let was_in_reasoning = self.inner.in_reasoning();
+        let inner_delta = self.inner.finish();
+        let mut delta = self.postprocess(inner_delta, was_in_reasoning);
+
+        // A held-back partial marker prefix that never completed is real text.
+        let leftover = std::mem::take(&mut self.content_buffer);
+        if !leftover.is_empty() {
+            delta.push_content(&leftover);
+        }
+
+        Ok(delta)
+    }
+}
+
+/// Parse the longest text suffix that could still complete a response marker.
+fn partial_marker_suffix_len(text: &str) -> usize {
+    for (idx, _) in text.char_indices() {
+        let suffix = &text[idx..];
+        if (RESPONSE_START.starts_with(suffix) && suffix != RESPONSE_START)
+            || (RESPONSE_END.starts_with(suffix) && suffix != RESPONSE_END)
+        {
+            return text.len() - idx;
+        }
+    }
+    0
+}
+
+/// Parse the earliest complete response marker in the text, if any.
+fn find_earliest_marker(text: &str) -> Option<(usize, &'static str)> {
+    let start_idx = text.find(RESPONSE_START);
+    let end_idx = text.find(RESPONSE_END);
+
+    match (start_idx, end_idx) {
+        (Some(start), Some(end)) if start < end => Some((start, RESPONSE_START)),
+        (Some(_), Some(end)) => Some((end, RESPONSE_END)),
+        (Some(start), None) => Some((start, RESPONSE_START)),
+        (None, Some(end)) => Some((end, RESPONSE_END)),
+        (None, None) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::Ernie45ReasoningParser;
+    use crate::reasoning::{ReasoningDelta, ReasoningParser, tests::FakeTokenizer};
+
+    fn collect(parser: &mut Ernie45ReasoningParser, chunks: &[&str]) -> ReasoningDelta {
+        let mut total = ReasoningDelta::default();
+        for chunk in chunks {
+            merge(&mut total, parser.push(chunk).unwrap());
+        }
+        merge(&mut total, parser.finish().unwrap());
+        total
+    }
+
+    fn merge(total: &mut ReasoningDelta, delta: ReasoningDelta) {
+        if let Some(reasoning) = &delta.reasoning {
+            total.push_reasoning(reasoning);
+        }
+        if let Some(content) = &delta.content {
+            total.push_content(content);
+        }
+    }
+
+    #[test]
+    fn ernie45_defaults_to_reasoning_without_prompt_boundary() {
+        let tokenizer = Arc::new(FakeTokenizer);
+        let mut parser = Ernie45ReasoningParser::new(tokenizer).unwrap();
+
+        let total = collect(&mut parser, &["abc\n</think>\ndef"]);
+
+        assert_eq!(total.reasoning.as_deref(), Some("abc\n"));
+        assert_eq!(total.content.as_deref(), Some("def"));
+    }
+
+    #[test]
+    fn ernie45_strips_response_wrapper_and_structural_newlines() {
+        let tokenizer = Arc::new(FakeTokenizer);
+        let mut parser = Ernie45ReasoningParser::new(tokenizer).unwrap();
+
+        let total = collect(
+            &mut parser,
+            &["abc\n</think>\n\n<response>\ndef\n</response>\n"],
+        );
+
+        assert_eq!(total.reasoning.as_deref(), Some("abc\n"));
+        assert_eq!(total.content.as_deref(), Some("\ndef\n"));
+    }
+
+    #[test]
+    fn ernie45_streaming_handles_markers_split_across_deltas() {
+        let tokenizer = Arc::new(FakeTokenizer);
+        let mut parser = Ernie45ReasoningParser::new(tokenizer).unwrap();
+
+        let full = "abc\n</think>\n\n<response>\ndef\n</response>\n";
+        let chunks: Vec<String> = full
+            .as_bytes()
+            .chunks(3)
+            .map(|chunk| String::from_utf8(chunk.to_vec()).unwrap())
+            .collect();
+        let chunk_refs: Vec<&str> = chunks.iter().map(String::as_str).collect();
+
+        let total = collect(&mut parser, &chunk_refs);
+
+        assert_eq!(total.reasoning.as_deref(), Some("abc\n"));
+        assert_eq!(total.content.as_deref(), Some("\ndef\n"));
+    }
+
+    #[test]
+    fn ernie45_flushes_partial_response_marker_on_finish() {
+        let tokenizer = Arc::new(FakeTokenizer);
+        let mut parser = Ernie45ReasoningParser::new(tokenizer).unwrap();
+
+        let total = collect(&mut parser, &["</think>x<resp"]);
+
+        assert_eq!(total.reasoning, None);
+        assert_eq!(total.content.as_deref(), Some("x<resp"));
+    }
+
+    #[test]
+    fn ernie45_explicit_think_round_trip_still_trims_after_think_end() {
+        let tokenizer = Arc::new(FakeTokenizer);
+        let mut parser = Ernie45ReasoningParser::new(tokenizer).unwrap();
+        parser.initialize(&[2]).unwrap();
+
+        let total = collect(&mut parser, &["<think>more\n</think>\nanswer"]);
+
+        assert_eq!(total.reasoning.as_deref(), Some("more\n"));
+        assert_eq!(total.content.as_deref(), Some("answer"));
+    }
+
+    #[test]
+    fn ernie45_prompt_end_marker_starts_in_content_without_trimming() {
+        let tokenizer = Arc::new(FakeTokenizer);
+        let mut parser = Ernie45ReasoningParser::new(tokenizer).unwrap();
+        parser.initialize(&[2]).unwrap();
+
+        let total = collect(&mut parser, &["hello"]);
+
+        assert_eq!(total.reasoning, None);
+        assert_eq!(total.content.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn ernie45_forwards_text_after_response_end() {
+        let tokenizer = Arc::new(FakeTokenizer);
+        let mut parser = Ernie45ReasoningParser::new(tokenizer).unwrap();
+
+        let total = collect(
+            &mut parser,
+            &["abc</think><response>def</response>\ntrailing"],
+        );
+
+        assert_eq!(total.reasoning.as_deref(), Some("abc"));
+        assert_eq!(total.content.as_deref(), Some("deftrailing"));
+    }
+
+    #[test]
+    fn ernie45_keeps_response_markers_inside_reasoning() {
+        let tokenizer = Arc::new(FakeTokenizer);
+        let mut parser = Ernie45ReasoningParser::new(tokenizer).unwrap();
+
+        let total = collect(&mut parser, &["plan: emit <response> later</think>ok"]);
+
+        assert_eq!(
+            total.reasoning.as_deref(),
+            Some("plan: emit <response> later")
+        );
+        assert_eq!(total.content.as_deref(), Some("ok"));
+    }
+}

--- a/rust/src/parser/src/reasoning/mod.rs
+++ b/rust/src/parser/src/reasoning/mod.rs
@@ -17,6 +17,7 @@
 mod cohere_cmd;
 mod deepseek_r1;
 mod delimited;
+mod ernie45;
 mod kimi;
 mod minimax_m3;
 mod qwen3;
@@ -29,6 +30,7 @@ use vllm_tokenizer::DynTokenizer;
 pub use self::cohere_cmd::CohereCmdReasoningParser;
 pub use self::deepseek_r1::DeepSeekR1ReasoningParser;
 pub(crate) use self::delimited::{DelimitedReasoningParser, last_reasoning_boundary};
+pub use self::ernie45::Ernie45ReasoningParser;
 pub use self::kimi::KimiReasoningParser;
 pub use self::minimax_m3::MiniMaxM3ReasoningParser;
 pub use self::qwen3::Qwen3ReasoningParser;


### PR DESCRIPTION
## Summary

Port the Python `ernie45_reasoning_parser.py` into Rust as
`Ernie45ReasoningParser` under `rust/src/reasoning-parser/src/ernie45.rs`
(tracking: #44280, claimed in [this comment](https://github.com/vllm-project/vllm/issues/44280#issuecomment-4688685899)).

ERNIE 4.5 thinking models emit either of:

```text
abc\n</think>\n\n<response>\ndef\n</response>\n
abc\n</think>\ndef
```

- Reasoning uses the standard `<think>...</think>` delimiters handled by the
  shared `DelimitedReasoningParser`, with the no-boundary fallback defaulting
  to `in_reasoning = true` — the model starts directly inside a reasoning
  span and only emits the closing `</think>`, like DeepSeek R1.
- On top of the shared split, the parser strips the structural
  `<response>` / `</response>` markers from the content stream and trims the
  newline runs the chat format inserts after `</think>` and `</response>`.
  Text between the markers is forwarded verbatim. Markers split across
  streaming deltas are handled with a holdback buffer mirroring the shared
  delimiter logic; a partial marker prefix that never completes is flushed as
  literal content on `finish()`.
- An explicit `<think>...</think>` round trip inside one push also counts as
  a transition (same predicate as the recently merged Step3p5 parser).

Documented divergences from Python:

- `<response>` / `</response>` are matched as plain text rather than token
  IDs, so they do not need to be present in the tokenizer vocabulary.
- Non-newline text after `</response>` is forwarded as content rather than
  truncated.

Auto-routed for model IDs containing `ernie-4.5` / `ernie4.5`, covering
`baidu/ERNIE-4.5-*-Thinking` and the VL thinking variants. Negative routing
tests pin that non-4.5 ERNIE IDs do not route here.

This pairs with the ERNIE 4.5 tool parser (#44310): that PR intentionally
leaves `</think>` / `<response>` boundaries to the reasoning parser, so the
two together complete end-to-end support for ERNIE 4.5 thinking models.

## Duplicate-work check

```bash
gh pr list --repo vllm-project/vllm --state open --search "ernie reasoning"
```

No existing Rust ERNIE 4.5 reasoning parser PR. The `ernie45` reasoning
entry in the #44280 checklist was unclaimed before
[my claim comment](https://github.com/vllm-project/vllm/issues/44280#issuecomment-4688685899).
The recently merged #44552 covered `seed_oss` / `step3p5` only; the open
#45359 covers `mistral` only.

## Test plan

Commands run locally:

- `cargo nextest run -p vllm-reasoning-parser -p vllm-chat` → 226/226 passing
- `cargo clippy -p vllm-reasoning-parser -p vllm-chat --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean

Tests added:

- `ernie45_defaults_to_reasoning_without_prompt_boundary`
- `ernie45_strips_response_wrapper_and_structural_newlines` (Python golden case: reasoning=`abc\n`, content=`\ndef\n`)
- `ernie45_streaming_handles_markers_split_across_deltas` (3-byte chunked replay of the golden case)
- `ernie45_flushes_partial_response_marker_on_finish`
- `ernie45_explicit_think_round_trip_still_trims_after_think_end`
- `ernie45_prompt_end_marker_starts_in_content_without_trimming`
- `ernie45_forwards_text_after_response_end`
- `ernie45_keeps_response_markers_inside_reasoning`
- Model routing: `baidu/ERNIE-4.5-21B-A3B-Thinking`, `baidu/ERNIE-4.5-VL-28B-A3B-Thinking` → `ernie45`; `baidu/ERNIE-Bot-4`, `baidu/ernie-3.5-8k` → no route
- Registered-name list updated (`ernie45` inserted in the reasoning
  parser-availability error message).

## AI assistance disclosure

This PR was prepared with assistance from Claude (Anthropic) as a code
porting and review aide, plus an automated Codex review pass before
submission (one finding on the transition predicate, fixed and re-verified).
The human submitter reviewed every changed line and ran the test commands
above.

Co-authored-by: Claude <noreply@anthropic.com>