### PR TITLE
[Bugfix][Frontend] Emit response.incomplete for truncated Responses streams

### DIFF
--- a/tests/entrypoints/openai/responses/conftest.py
+++ b/tests/entrypoints/openai/responses/conftest.py
@@ -33,6 +33,7 @@ def pairs_of_event_types() -> dict[str, str]:
     # fmt: off
     event_pairs = {
         "response.completed": "response.created",
+        "response.incomplete": "response.created",
         "response.output_item.done": "response.output_item.added",
         "response.content_part.done": "response.content_part.added",
         "response.output_text.done": "response.output_text.delta",
@@ -150,9 +151,10 @@ def _validate_event_ordering(events: list) -> None:
     assert events[0].type == "response.created", (
         f"First event must be response.created, got {events[0].type}"
     )
-    # Last event must be response.completed
-    assert events[-1].type == "response.completed", (
-        f"Last event must be response.completed, got {events[-1].type}"
+    # Last event must be a terminal response event.
+    terminal_types = ("response.completed", "response.incomplete")
+    assert events[-1].type in terminal_types, (
+        f"Last event must be one of {terminal_types}, got {events[-1].type}"
     )
 
     # response.in_progress, if present, must be the second event
@@ -165,14 +167,14 @@ def _validate_event_ordering(events: list) -> None:
             f"found at indices {in_progress_indices}"
         )
 
-    # Exactly one created and one completed
+    # Exactly one created and one terminal event.
     created_count = sum(1 for e in events if e.type == "response.created")
-    completed_count = sum(1 for e in events if e.type == "response.completed")
+    terminal_count = sum(1 for e in events if e.type in terminal_types)
     assert created_count == 1, (
         f"Expected exactly 1 response.created, got {created_count}"
     )
-    assert completed_count == 1, (
-        f"Expected exactly 1 response.completed, got {completed_count}"
+    assert terminal_count == 1, (
+        f"Expected exactly 1 terminal event, got {terminal_count}"
     )
 
 
@@ -187,6 +189,7 @@ def _validate_field_consistency(events: list) -> None:
         "response.created",
         "response.in_progress",
         "response.completed",
+        "response.incomplete",
     }
 
     active_item_id: str | None = None

--- a/tests/entrypoints/openai/responses/test_simple.py
+++ b/tests/entrypoints/openai/responses/test_simple.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
+
 import pytest
 import pytest_asyncio
 from openai import OpenAI
@@ -250,6 +252,72 @@ async def test_max_tokens(client: OpenAI, model_name: str):
     assert response is not None
     assert response.status == "incomplete"
     assert response.incomplete_details.reason == "max_output_tokens"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_streaming_max_tokens_terminal_event(
+    pairs_of_event_types: dict[str, str], client: OpenAI, model_name: str
+):
+    stream = await client.responses.create(
+        model=model_name,
+        input="What is the first paragraph of Moby Dick?",
+        reasoning={"effort": "low"},
+        max_output_tokens=30,
+        temperature=0.0,
+        stream=True,
+    )
+    events = [event async for event in stream]
+
+    validate_streaming_event_stack(events, pairs_of_event_types)
+
+    terminal_event = events[-1]
+    assert terminal_event.type == "response.incomplete"
+    assert terminal_event.response.status == "incomplete"
+    assert terminal_event.response.incomplete_details.reason == "max_output_tokens"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_background_streaming_max_tokens_terminal_event(
+    pairs_of_event_types: dict[str, str], client: OpenAI, model_name: str
+):
+    stream = await client.responses.create(
+        model=model_name,
+        input="What is the first paragraph of Moby Dick?",
+        reasoning={"effort": "low"},
+        max_output_tokens=30,
+        temperature=0.0,
+        stream=True,
+        background=True,
+    )
+    events = [event async for event in stream]
+
+    validate_streaming_event_stack(events, pairs_of_event_types)
+
+    terminal_event = events[-1]
+    assert terminal_event.type == "response.incomplete"
+    assert terminal_event.response.status == "incomplete"
+    assert terminal_event.response.incomplete_details.reason == "max_output_tokens"
+
+    response_id = events[0].response.id
+
+    async def collect_replay_events():
+        async with await client.responses.retrieve(
+            response_id=response_id,
+            stream=True,
+        ) as replay_stream:
+            return [event async for event in replay_stream]
+
+    replay_events = await asyncio.wait_for(collect_replay_events(), timeout=30)
+
+    assert replay_events == events
+    replay_terminal_event = replay_events[-1]
+    assert replay_terminal_event.type == "response.incomplete"
+    assert replay_terminal_event.response.status == "incomplete"
+    assert (
+        replay_terminal_event.response.incomplete_details.reason == "max_output_tokens"
+    )
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -39,6 +39,9 @@ from openai.types.responses import (
 )
 from openai.types.responses import ResponseCreatedEvent as OpenAIResponseCreatedEvent
 from openai.types.responses import (
+    ResponseIncompleteEvent as OpenAIResponseIncompleteEvent,
+)
+from openai.types.responses import (
     ResponseInProgressEvent as OpenAIResponseInProgressEvent,
 )
 from openai.types.responses.response import IncompleteDetails, ToolChoice
@@ -786,6 +789,10 @@ class ResponseCompletedEvent(OpenAIResponseCompletedEvent):
     response: ResponsesResponse  # type: ignore[override]
 
 
+class ResponseIncompleteEvent(OpenAIResponseIncompleteEvent):
+    response: ResponsesResponse  # type: ignore[override]
+
+
 class ResponseCreatedEvent(OpenAIResponseCreatedEvent):
     response: ResponsesResponse  # type: ignore[override]
 
@@ -798,6 +805,7 @@ StreamingResponsesResponse: TypeAlias = (
     ResponseCreatedEvent
     | ResponseInProgressEvent
     | ResponseCompletedEvent
+    | ResponseIncompleteEvent
     | ResponseOutputItemAddedEvent
     | ResponseOutputItemDoneEvent
     | ResponseContentPartAddedEvent

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -68,6 +68,7 @@ from vllm.entrypoints.openai.responses.protocol import (
     OutputTokensDetails,
     ResponseCompletedEvent,
     ResponseCreatedEvent,
+    ResponseIncompleteEvent,
     ResponseInProgressEvent,
     ResponseInputOutputItem,
     ResponseInputOutputMessage,
@@ -1271,7 +1272,10 @@ class OpenAIServingResponses(OpenAIServing):
             while current_index < len(event_deque):
                 event = event_deque[current_index]
                 yield event
-                if getattr(event, "type", "unknown") == "response.completed":
+                if getattr(event, "type", "unknown") in (
+                    "response.completed",
+                    "response.incomplete",
+                ):
                     return
                 current_index += 1
 
@@ -1552,10 +1556,20 @@ class OpenAIServingResponses(OpenAIServing):
                 request_metadata,
                 created_time=created_time,
             )
-            yield _increment_sequence_number_and_return(
-                ResponseCompletedEvent(
-                    type="response.completed",
-                    sequence_number=-1,
-                    response=final_response,
+            assert isinstance(final_response, ResponsesResponse)
+            if final_response.status == "incomplete":
+                yield _increment_sequence_number_and_return(
+                    ResponseIncompleteEvent(
+                        type="response.incomplete",
+                        sequence_number=-1,
+                        response=final_response,
+                    )
                 )
-            )
+            else:
+                yield _increment_sequence_number_and_return(
+                    ResponseCompletedEvent(
+                        type="response.completed",
+                        sequence_number=-1,
+                        response=final_response,
+                    )
+                )


### PR DESCRIPTION

## Purpose

OpenAI's Responses streaming reference defines `response.completed` as the event emitted when the model response is complete, and `response.incomplete` as the event emitted when a response finishes as incomplete. vLLM already builds the final Responses payload with `response.status == "incomplete"` and `incomplete_details.reason == "max_output_tokens"` when generation stops on the output-token limit, but the streaming path still wraps that payload in a `response.completed` terminal event.

This PR makes the terminal event match the final response status: `incomplete` emits `response.incomplete`, and other successful responses keep emitting `response.completed`. It also adds the vLLM `ResponseIncompleteEvent` wrapper, updates the streaming event-stack helper so both completed and incomplete are valid terminal response events, and treats `response.incomplete` as terminal when replaying stored background stream events.

Scope: this only handles max-token truncation after the final payload is already `status="incomplete"`. It does not change generation-error streaming; #40418 and #38190 cover `response.failed` paths.

## Test Plan

- Run a real Responses streaming truncation E2E with Qwen3-8B and `max_output_tokens=30`.
- Run the same truncation path with `background=True`, then replay it with `retrieve(..., stream=True)`.
- Revert only the source change while keeping the new E2E assertion.
- Run the full Responses simple E2E file.
- Run related Responses protocol, serving, and error tests.
- Run changed-file pre-commit.

## Test Result

| Check | Result |
|---|---|
| Real truncation E2E with fix | Terminal event is `response.incomplete`; payload status is `incomplete`; reason is `max_output_tokens` |
| Background truncation replay E2E with fix | Direct stream and stored replay both end with `response.incomplete` |
| Same E2E after source-only revert | Failed with `AssertionError: assert 'response.completed' == 'response.incomplete'` |
| Full `tests/entrypoints/openai/responses/test_simple.py` | 12 passed |
| Related Responses protocol, serving, and error tests | 26 passed |
| Changed-file pre-commit | Passed |

<details><summary>Real server E2E details</summary>

Environment:

- GPU: NVIDIA A800-SXM4-80GB, single GPU
- Model: `Qwen/Qwen3-8B`
- Server harness: `RemoteOpenAIServer`
- Server args: `--reasoning-parser qwen3 --max_model_len 5000`
- Server env: `VLLM_SYSTEM_START_DATE=2023-09-12`, `VLLM_ENABLE_RESPONSES_API_STORE=1`
- Hardware workaround for this A800 setup: `VLLM_USE_FLASHINFER_SAMPLER=0`

The committed E2E starts a real OpenAI-compatible server and sends a streaming Responses request that is intentionally truncated:

```python
stream = await client.responses.create(
    model="Qwen/Qwen3-8B",
    input="What is the first paragraph of Moby Dick?",
    reasoning={"effort": "low"},
    max_output_tokens=30,
    temperature=0.0,
    stream=True,
)
events = [event async for event in stream]

terminal_event = events[-1]
assert terminal_event.type == "response.incomplete"
assert terminal_event.response.status == "incomplete"
assert terminal_event.response.incomplete_details.reason == "max_output_tokens"
```

The background replay E2E uses the same truncation trigger with `background=True`, then replays the stored stream:

```python
stream = await client.responses.create(
    model="Qwen/Qwen3-8B",
    input="What is the first paragraph of Moby Dick?",
    reasoning={"effort": "low"},
    max_output_tokens=30,
    temperature=0.0,
    stream=True,
    background=True,
)
events = [event async for event in stream]

async with await client.responses.retrieve(
    response_id=events[0].response.id,
    stream=True,
) as replay_stream:
    replay_events = [event async for event in replay_stream]

assert replay_events == events
assert replay_events[-1].type == "response.incomplete"
```

With the fix:

```text
tests/entrypoints/openai/responses/test_simple.py::test_streaming_max_tokens_terminal_event
tests/entrypoints/openai/responses/test_simple.py::test_background_streaming_max_tokens_terminal_event
2 passed, 16 warnings in 73.61s
```

After reverting only the source change and keeping the same test:

```text
AssertionError: assert 'response.completed' == 'response.incomplete'
```

</details>

<details><summary>Additional checks</summary>

Commands:

```bash
PYTHONPATH=$PWD VLLM_USE_FLASHINFER_SAMPLER=0 python -m pytest tests/entrypoints/openai/responses/test_simple.py::test_streaming_max_tokens_terminal_event tests/entrypoints/openai/responses/test_simple.py::test_background_streaming_max_tokens_terminal_event -q --tb=short --disable-warnings
PYTHONPATH=$PWD VLLM_USE_FLASHINFER_SAMPLER=0 python -m pytest tests/entrypoints/openai/responses/test_simple.py -q --tb=short --disable-warnings
CUDA_VISIBLE_DEVICES="" PYTHONPATH=$PWD python -m pytest tests/entrypoints/openai/responses/test_protocol.py tests/entrypoints/openai/responses/test_serving_responses.py tests/entrypoints/openai/responses/test_errors.py -q --tb=short --disable-warnings
pre-commit run --files tests/entrypoints/openai/responses/conftest.py tests/entrypoints/openai/responses/test_simple.py vllm/entrypoints/openai/responses/protocol.py vllm/entrypoints/openai/responses/serving.py
```

Results:

```text
tests/entrypoints/openai/responses/test_simple.py
12 passed, 16 warnings in 169.64s

tests/entrypoints/openai/responses/test_protocol.py
tests/entrypoints/openai/responses/test_serving_responses.py
tests/entrypoints/openai/responses/test_errors.py
26 passed, 16 warnings in 4.27s

pre-commit run --files <changed files>
Passed
```

</details>

AI assistance was used to prepare this PR.

cc @sfeng33 @chaunceyjiang
