### PR TITLE
[Kernel] Resurrect rotted gather-cache OOB test + defensive block-table bound-checks

### DIFF
--- a/csrc/libtorch_stable/cache_kernels.cu
+++ b/csrc/libtorch_stable/cache_kernels.cu
@@ -997,9 +997,9 @@ __global__ void gather_and_maybe_dequant_cache(
     const int32_t* __restrict__ cu_seq_lens,   // [BATCH+1]
     const int32_t* __restrict__ token_to_seq,  // [MAX_TOKEN_ACROSS_CHUNK]
     const int32_t num_tokens, const int32_t block_size,
-    const int64_t block_table_stride, const int64_t cache_block_stride,
-    const int64_t cache_entry_stride, const int64_t dst_entry_stride,
-    const float* __restrict__ scale,
+    const int32_t num_block_indices, const int64_t block_table_stride,
+    const int64_t cache_block_stride, const int64_t cache_entry_stride,
+    const int64_t dst_entry_stride, const float* __restrict__ scale,
     const int32_t* __restrict__ seq_starts) {  // Optional: starting offsets per
                                                // batch
   constexpr int vec_size = sizeof(float4) / sizeof(scalar_t);
@@ -1024,6 +1024,9 @@ __global__ void gather_and_maybe_dequant_cache(
     }
     batch_offset += offset;
     int32_t block_table_id = batch_offset / block_size;
+    // Guard against reading past the block table row: seq_starts combined
+    // with the in-batch offset can index beyond BLOCK_INDICES (issue #45380).
+    if (block_table_id >= num_block_indices) continue;
     int32_t slot_id = batch_offset % block_size;
     int32_t block_table_offset = batch_id * block_table_stride + block_table_id;
     int32_t block_id = block_table[block_table_offset];
@@ -1080,9 +1083,9 @@ __global__ void gather_and_maybe_dequant_cache(
           block_table.const_data_ptr<int32_t>(),                              \
           cu_seq_lens.const_data_ptr<int32_t>(),                              \
           token_to_seq.const_data_ptr<int32_t>(), num_tokens, block_size,     \
-          block_table_stride, cache_block_stride, cache_entry_stride,         \
-          dst_entry_stride, reinterpret_cast<const float*>(scale.data_ptr()), \
-          seq_starts_ptr);
+          num_block_indices, block_table_stride, cache_block_stride,          \
+          cache_entry_stride, dst_entry_stride,                               \
+          reinterpret_cast<const float*>(scale.data_ptr()), seq_starts_ptr);
 
 #define CALL_GATHER_CACHE_576(SCALAR_T, CACHE_T, KV_DTYPE) \
   CALL_GATHER_CACHE(SCALAR_T, CACHE_T, KV_DTYPE, 576)
@@ -1140,6 +1143,7 @@ void gather_and_maybe_dequant_cache(
                     "src_cache and seq_starts must be on the same device");
   }
 
+  int32_t num_block_indices = block_table.size(1);
   int64_t block_table_stride = block_table.stride(0);
   int64_t cache_block_stride = src_cache.stride(0);
   int64_t cache_entry_stride = src_cache.stride(1);
@@ -1195,6 +1199,10 @@ __global__ void cp_gather_and_upconvert_fp8_kv_cache(
   const int out_token_id = flat_warp_id;
   int token_offset = out_token_id - workspace_starts[req_id];
   if (seq_starts != nullptr) token_offset += seq_starts[req_id];
+  // Guard against workspace_starts whose first entry is nonzero: the binary
+  // search clamps req_id to 0, so token_offset can go negative and underflow
+  // the block table read below (issue #45377).
+  if (token_offset < 0) return;
   const int cache_block_idx = token_offset / block_size;
   const int offset_in_block = token_offset % block_size;
   const int physical_block =

--- a/tests/kernels/test_cache_kernels.py
+++ b/tests/kernels/test_cache_kernels.py
@@ -16,24 +16,24 @@ except ImportError:
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="Need CUDA device")
 def test_gather_cache_oob():
     """
-    Tests for OOB read in gather_and_maybe_dequant_cache (Issue #27909).
-    This test constructs a boundary case identified in the issue where
-    seq_starts causes the block_table offset to read out of bounds.
+    Tests for OOB read in gather_and_maybe_dequant_cache (issues #27909 and
+    #45380). Constructs the boundary case where seq_starts pushes the
+    block-table index past the table width (block_table_id == 2 for a 2-wide
+    table). Run under compute-sanitizer to catch the OOB read; without the
+    in-kernel bound the read is silently absorbed by allocator slack.
     """
 
-    batch_size = 1
     block_size = 64
-    entry_size = 128
+    entry_size = 576
 
     block_table = torch.tensor([[1, 2]], dtype=torch.int32, device="cuda")
 
-    # This will result in offset = 128 / block_size = 128 / 64 = 2
-    # This will cause the kernel to try to read from
-    # block_table[0, 2], but its size is only 2.
+    # offset = 128 / block_size = 128 / 64 = 2 -> one past the table width.
     seq_starts = torch.tensor([128], dtype=torch.int32, device="cuda")
 
     seq_len = 65
     cu_seq_lens = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+    token_to_seq = torch.zeros(seq_len, dtype=torch.int32, device="cuda")
 
     # src_cache: [num_blocks, block_size, entry_size]
     num_blocks = 5
@@ -45,20 +45,52 @@ def test_gather_cache_oob():
 
     scale = torch.tensor([1.0], dtype=torch.float32, device="cuda")
 
-    # Calling the C++ function gather_and_maybe_dequant_cache
     ops.gather_and_maybe_dequant_cache(
         src_cache,
         dst,
         block_table,
         cu_seq_lens,
-        batch_size,
+        token_to_seq,
+        seq_len,
         "auto",  # kv_cache_dtype
         scale,
         seq_starts,
     )
 
     torch.accelerator.synchronize()
-    assert True
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="Need CUDA device")
+def test_cp_gather_upconvert_negative_offset():
+    """
+    Tests for OOB read in cp_gather_and_upconvert_fp8_kv_cache (issue #45377).
+    When workspace_starts[0] != 0, the binary search clamps req_id to 0 and
+    token_offset goes negative, underflowing the block-table read
+    (block_table[-1]). Run under compute-sanitizer to catch the OOB read.
+    """
+
+    num_blocks = 4
+    num_reqs = 1
+    total_tokens = 8
+
+    # FP8 KV cache layout expected by the kernel: [num_blocks, block_size, 656]
+    src_cache = torch.zeros((num_blocks, 64, 656), dtype=torch.uint8, device="cuda")
+    dst = torch.empty((total_tokens, 576), dtype=torch.bfloat16, device="cuda")
+    block_table = torch.tensor([[1, 2]], dtype=torch.int32, device="cuda")
+    seq_lens = torch.tensor([total_tokens], dtype=torch.int32, device="cuda")
+    # Nonzero first entry: tokens 0..3 get token_offset < 0.
+    workspace_starts = torch.tensor([4], dtype=torch.int32, device="cuda")
+
+    ops.cp_gather_and_upconvert_fp8_kv_cache(
+        src_cache,
+        dst,
+        block_table,
+        seq_lens,
+        workspace_starts,
+        num_reqs,
+    )
+
+    torch.accelerator.synchronize()
 
 
 if __name__ == "__main__":

--- a/tests/kernels/test_cache_kernels.py
+++ b/tests/kernels/test_cache_kernels.py
@@ -78,8 +78,13 @@ def test_cp_gather_upconvert_negative_offset():
     dst = torch.empty((total_tokens, 576), dtype=torch.bfloat16, device="cuda")
     block_table = torch.tensor([[1, 2]], dtype=torch.int32, device="cuda")
     seq_lens = torch.tensor([total_tokens], dtype=torch.int32, device="cuda")
-    # Nonzero first entry: tokens 0..3 get token_offset < 0.
-    workspace_starts = torch.tensor([4], dtype=torch.int32, device="cuda")
+    # Nonzero first entry: the binary search clamps req_id to 0, so
+    # token_offset = flat_warp_id - workspace_starts[0] goes negative. CUDA
+    # integer division truncates toward zero, so a small offset like -4 gives
+    # cache_block_idx = -4 / 64 = 0 (still in bounds) and does NOT reproduce
+    # the bug. Use >= block_size (64) so flat_warp_id 0 -> token_offset -64 ->
+    # cache_block_idx -1 -> block_table[-1] OOB read on the unfixed kernel.
+    workspace_starts = torch.tensor([64], dtype=torch.int32, device="cuda")
 
     ops.cp_gather_and_upconvert_fp8_kv_cache(
         src_cache,

--- a/tests/kernels/test_cache_kernels.py
+++ b/tests/kernels/test_cache_kernels.py
@@ -77,7 +77,6 @@ def test_cp_gather_upconvert_negative_offset():
     src_cache = torch.zeros((num_blocks, 64, 656), dtype=torch.uint8, device="cuda")
     dst = torch.empty((total_tokens, 576), dtype=torch.bfloat16, device="cuda")
     block_table = torch.tensor([[1, 2]], dtype=torch.int32, device="cuda")
-    seq_lens = torch.tensor([total_tokens], dtype=torch.int32, device="cuda")
     # Nonzero first entry: the binary search clamps req_id to 0, so
     # token_offset = flat_warp_id - workspace_starts[0] goes negative. CUDA
     # integer division truncates toward zero, so a small offset like -4 gives
@@ -90,7 +89,6 @@ def test_cp_gather_upconvert_negative_offset():
         src_cache,
         dst,
         block_table,
-        seq_lens,
         workspace_starts,
         num_reqs,
     )


### PR DESCRIPTION
## Purpose

Restore a dead regression test and add two defensive bound-checks in the CP gather cache kernels (`csrc/libtorch_stable/cache_kernels.cu`).

1. **Resurrect a dead regression test (the substantive fix).** `tests/kernels/test_cache_kernels.py::test_gather_cache_oob` (the #27909 sanitizer-mode regression test) still called the op without the since-added `token_to_seq` argument and **fails with a binding error on current `main`** (`Expected a value of type 'Tensor' for argument 'token_to_seq' but instead found type 'int'`). The only sanitizer-mode coverage for this kernel family has been dead since the signature changed; updated to the current signature.

2. **Defensive bound-checks for two malformed-index paths (#45380, #45377).** Both kernels index `block_table[...]` with a computed offset that isn't range-checked:
   - `gather_and_maybe_dequant_cache`: `block_table_id` can exceed the table width if `seq_starts` pushes a token past the block table's coverage (#45380). The kernel now receives `block_table.size(1)` and `continue`s past out-of-range indices.
   - `cp_gather_and_upconvert_fp8_kv_cache`: the ownership binary search floors `req_id` at 0, so a nonzero `workspace_starts[0]` would drive `token_offset` negative and underflow the read (#45377). Early-return on a negative offset (warp-uniform).

   **Reachability (honest):** I could not establish that either input occurs in production. For **#45377** I traced the callers — `flashmla_sparse.py` builds `workspace_starts` as `zeros()` then `cumsum()` into `[1:]`, with the per-chunk adjustment zeroing each chunk slice's first entry, so `workspace_starts[0] == 0` always and `token_offset >= 0` by construction. For **#45380** the chunked-context caller (`mla_attention.py`) sizes the block table to the full sequence, so a well-formed config keeps `block_table_id` in range. The sanitizer evidence below is from feeding the issues' constructed inputs directly. So these are defensive guards against malformed indices into `block_table`, not fixes for demonstrated production failures — happy to drop either if you'd prefer not to guard a currently-unreachable path.

## Test Plan / Result

- `tests/kernels/test_cache_kernels.py` — `2 passed` (previously `1 failed` on `main` from the signature rot). Against the prebuilt binary these exercise the op bindings; CI's source build + sanitizer covers the guards.
- Standalone compute-sanitizer (`--tool memcheck`, sm_120, CUDA 13.0) on a replica of the kernels' indexing logic (payload simplified to plain copies; the indexing under test preserved verbatim), fed the issues' constructed trigger inputs:

| build | constructed trigger inputs | valid inputs |
|---|---|---|
| pre-fix logic | 4161 invalid global reads | 0 errors |
| with guards | 0 errors | 0 errors |

The guards are pure bound checks, so behavior on well-formed input is unchanged.

## Duplicate check

No open PR addresses either issue: searched `45380`, `45377`, `gather_and_maybe_dequant`, `cp_gather_and_upconvert`; both issues have zero comments; reporter has no authored PRs; file history on `main` shows no fix since the libtorch_stable migration. Related but distinct: #45384 fixes an int32 overflow in `concat_mla_q` in the same file (different function; no textual overlap).

## AI assistance disclosure

Prepared with AI assistance (Claude); reviewed, compiled, and sanitizer-validated by the submitter.
