### PR TITLE
[Core][RFC #34303] Add CuMemTagBackend for tag-selective offload on top of #44074

### DIFF
--- a/tests/test_sleep_mode_backend.py
+++ b/tests/test_sleep_mode_backend.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only unit tests for the sleep-mode backend abstraction (RFC #34303).
+
+These cover the registry/factory contract and capability flags. They do not
+touch CUDA - the ``cumem`` suspend/resume path is exercised end-to-end on GPU
+in ``tests/basic_correctness/test_cumem.py``.
+"""
+
+import pytest
+
+from vllm.device_allocator.sleep_mode_backend import (
+    CuMemBackend,
+    SleepModeBackend,
+    SleepModeBackendFactory,
+)
+
+
+def test_cumem_is_the_default_registered_backend():
+    backend_cls = SleepModeBackendFactory.get_backend_class("cumem")
+    assert backend_cls is CuMemBackend
+    assert issubclass(backend_cls, SleepModeBackend)
+
+
+def test_cumem_capability_flags():
+    # cumem leaves NCCL untouched but does not preserve compiled artifacts,
+    # graphs, or durable state - these flags are what the executor and /health
+    # introspect to decide reinit / persistence behavior.
+    assert CuMemBackend.is_supported() is True
+    assert CuMemBackend.preserves_nccl() is True
+    assert CuMemBackend.preserves_compiled_artifacts() is False
+    assert CuMemBackend.preserves_graphs_with_nccl() is False
+    assert CuMemBackend.supports_durable_storage() is False
+
+
+def test_new_backend_starts_in_running_state():
+    # Constructing a backend must not touch the GPU; only suspend/resume do.
+    assert CuMemBackend().state() == "RUNNING"
+
+
+def test_unknown_backend_raises():
+    with pytest.raises(ValueError, match="Unsupported sleep-mode backend"):
+        SleepModeBackendFactory.get_backend_class("does-not-exist")
+
+
+def test_duplicate_registration_raises():
+    with pytest.raises(ValueError, match="already registered"):
+        SleepModeBackendFactory.register_backend(
+            "cumem",
+            "vllm.device_allocator.sleep_mode_backend",
+            "CuMemBackend",
+        )
+
+
+def test_third_party_backend_registration_and_resolution():
+    """A plugin registers a backend by name; the factory resolves it lazily."""
+    name = "_pytest_dummy_backend"
+    try:
+        SleepModeBackendFactory.register_backend(
+            name,
+            "tests.test_sleep_mode_backend",
+            "DummyBackend",
+        )
+        resolved = SleepModeBackendFactory.get_backend_class(name)
+        assert resolved is DummyBackend
+        assert resolved.supports_durable_storage() is True
+    finally:
+        SleepModeBackendFactory._registry.pop(name, None)
+
+
+def test_suspend_resume_state_transitions():
+    """Lifecycle state advances RUNNING -> SUSPENDED -> RUNNING without GPU."""
+    backend = DummyBackend()
+    assert backend.state() == "RUNNING"
+    backend.suspend(level=1)
+    assert backend.state() == "SUSPENDED"
+    backend.resume()
+    assert backend.state() == "RUNNING"
+
+
+class DummyBackend(SleepModeBackend):
+    """A no-GPU backend used to exercise lifecycle + registration in CPU tests."""
+
+    def suspend(self, level: int = 1) -> None:
+        self._state = "SUSPENDED"
+
+    def resume(self, tags: list[str] | None = None) -> None:
+        self._state = "RUNNING"
+
+    @classmethod
+    def supports_durable_storage(cls) -> bool:
+        return True

--- a/tests/test_sleep_mode_backend.py
+++ b/tests/test_sleep_mode_backend.py
@@ -11,6 +11,7 @@ import pytest
 
 from vllm.device_allocator.sleep_mode_backend import (
     CuMemBackend,
+    CuMemTagBackend,
     SleepModeBackend,
     SleepModeBackendFactory,
 )
@@ -81,7 +82,8 @@ def test_suspend_resume_state_transitions():
 class DummyBackend(SleepModeBackend):
     """A no-GPU backend used to exercise lifecycle + registration in CPU tests."""
 
-    def suspend(self, level: int = 1) -> None:
+    def suspend(self, level: int = 1, tags: tuple[str, ...] | None = None) -> None:
+        del tags  # accepted to match the abstract signature; ignored here
         self._state = "SUSPENDED"
 
     def resume(self, tags: list[str] | None = None) -> None:
@@ -90,3 +92,419 @@ class DummyBackend(SleepModeBackend):
     @classmethod
     def supports_durable_storage(cls) -> bool:
         return True
+
+
+# ---------- CuMemTagBackend (tag-based selective offload) -------------------
+
+
+def test_cumem_tag_is_registered():
+    backend_cls = SleepModeBackendFactory.get_backend_class("cumem_tag")
+    assert backend_cls is CuMemTagBackend
+    assert issubclass(backend_cls, CuMemBackend)
+
+
+def test_cumem_tag_capability_flags():
+    # Inherits CuMemBackend's flags - same NCCL handling, same lack of
+    # compiled-artifact / graph-with-nccl / durable-storage preservation -
+    # and adds the selective-offload opt-in.
+    assert CuMemTagBackend.is_supported() is True
+    assert CuMemTagBackend.preserves_nccl() is True
+    assert CuMemTagBackend.preserves_compiled_artifacts() is False
+    assert CuMemTagBackend.preserves_graphs_with_nccl() is False
+    assert CuMemTagBackend.supports_durable_storage() is False
+    assert CuMemTagBackend.supports_selective_offload() is True
+
+
+def test_default_suspend_tags_match_cumem_backend_level1():
+    # CuMemTagBackend with no override must behave identically to
+    # CuMemBackend at level 1: offload only the "weights" tag.
+    assert CuMemTagBackend.DEFAULT_SUSPEND_TAGS_L1 == ("weights",)
+    # Level 2 default is empty - matches CuMemBackend, which passes ``()`` to
+    # the allocator when level != 1 (weights are discarded, not offloaded).
+    assert CuMemTagBackend.DEFAULT_SUSPEND_TAGS_L2 == ()
+
+
+def test_explicit_tags_override_defaults():
+    # Construction-time tag override changes the *effective* tag set returned
+    # by ``effective_suspend_tags()`` - the public contract callers depend on.
+    # We assert on that public surface, not on the underlying attribute, so
+    # this test stays valid if the storage layout changes.
+    backend = CuMemTagBackend(suspend_tags=("weights", "kv_cache"))
+    assert backend.effective_suspend_tags(level=1) == ("weights", "kv_cache")
+    # Override beats the level-based default at level 2 too: the explicit
+    # set is applied verbatim regardless of level.
+    assert backend.effective_suspend_tags(level=2) == ("weights", "kv_cache")
+    # The public ``suspend_tags`` attribute exposes the construction-time
+    # override (None when unset).
+    assert backend.suspend_tags == ("weights", "kv_cache")
+    # The no-argument constructor leaves the override unset and therefore
+    # falls back to the level-based defaults.
+    default_backend = CuMemTagBackend()
+    assert default_backend.suspend_tags is None
+    assert default_backend.effective_suspend_tags(level=1) == ("weights",)
+    assert default_backend.effective_suspend_tags(level=2) == ()
+
+
+def test_unregister_removes_backend():
+    """Plugin-author cleanup: unregister() drops a backend from the registry."""
+    name = "_pytest_unregister_target"
+    SleepModeBackendFactory.register_backend(
+        name,
+        "tests.test_sleep_mode_backend",
+        "DummyBackend",
+    )
+    assert SleepModeBackendFactory.get_backend_class(name) is DummyBackend
+    SleepModeBackendFactory.unregister(name)
+    with pytest.raises(ValueError, match="Unsupported sleep-mode backend"):
+        SleepModeBackendFactory.get_backend_class(name)
+
+
+def test_unregister_idempotent_on_missing():
+    """unregister() on a never-registered name is a no-op, not an error."""
+    SleepModeBackendFactory.unregister("_pytest_never_registered")  # no raise
+
+
+def test_factory_plumbs_backend_options_dict():
+    """``sleep_mode_backend_options`` is ``**``-unpacked into the backend ctor."""
+
+    class _Cfg:
+        sleep_mode_backend = "cumem_tag"
+        sleep_mode_backend_options = {"suspend_tags": ("weights", "kv_cache")}
+
+    backend = SleepModeBackendFactory.create_backend(_Cfg())
+    assert isinstance(backend, CuMemTagBackend)
+    assert backend.suspend_tags == ("weights", "kv_cache")
+
+
+def test_factory_empty_options_preserves_default_behavior():
+    """Empty options dict yields a default-constructed backend - no behavior
+    change for callers that don't opt into backend-specific tuning."""
+
+    class _Cfg:
+        sleep_mode_backend = "cumem_tag"
+        sleep_mode_backend_options = {}
+
+    backend = SleepModeBackendFactory.create_backend(_Cfg())
+    assert isinstance(backend, CuMemTagBackend)
+    assert backend.suspend_tags is None
+
+
+def test_supports_selective_offload_base_class_default():
+    # Base class default is False; backends that can't do selective offload
+    # (e.g. an eventual cuda_checkpoint backend, which is all-or-nothing)
+    # inherit it. CuMemBackend, the existing default, also inherits False.
+    assert SleepModeBackend.supports_selective_offload() is False
+    assert CuMemBackend.supports_selective_offload() is False
+
+
+# ---------- CuMemTagBackend safety + plumbing (no GPU) ----------------------
+
+
+def test_suspend_tags_list_input_normalizes_to_tuple():
+    """matteso1's review nit: list-from-CLI/JSON inputs must round-trip to
+    tuple so ``effective_suspend_tags()`` return-type stays stable regardless
+    of config source. ``None`` sentinel is preserved."""
+    backend = CuMemTagBackend(suspend_tags=["weights", "kv_cache"])
+    assert backend.suspend_tags == ("weights", "kv_cache")
+    assert isinstance(backend.suspend_tags, tuple)
+    assert backend.effective_suspend_tags() == ("weights", "kv_cache")
+    # None stays None - it's the "no construction-time override" sentinel,
+    # not an empty tuple.
+    assert CuMemTagBackend(suspend_tags=None).suspend_tags is None
+
+
+def test_factory_normalizes_list_options_to_tuple():
+    """The ``sleep_mode_backend_options`` dict typically arrives as JSON/YAML,
+    so the value comes in as a list. The factory + ctor must accept that and
+    produce the same shape as the in-process tuple form."""
+
+    class _Cfg:
+        sleep_mode_backend = "cumem_tag"
+        sleep_mode_backend_options = {"suspend_tags": ["weights", "kv_cache"]}
+
+    backend = SleepModeBackendFactory.create_backend(_Cfg())
+    assert backend.suspend_tags == ("weights", "kv_cache")
+    assert isinstance(backend.suspend_tags, tuple)
+
+
+def test_suspended_tags_default_returns_none():
+    """Backends without per-tag suspend tracking return None. Lets the GPU
+    worker fall back to the pre-abstraction wake_up behavior (always run
+    post_kv_cache_wake_up)."""
+    backend = CuMemBackend()
+    assert backend.suspended_tags() is None
+
+
+# ---- The next group exercises the suspend/resume bookkeeping at the
+# ---- Python level by stubbing the CuMemAllocator. They do NOT touch CUDA;
+# ---- they prove the safety logic (KV-cache zero guard, L2 weight reload
+# ---- guard) runs the way the docstring claims, which is what the morning
+# ---- L2-AWQ smoke broke on.
+
+
+class _FakeAllocator:
+    """Stand-in for ``CuMemAllocator``. Records calls for assertion."""
+
+    def __init__(self):
+        self.sleep_calls: list[tuple] = []
+        self.wake_calls: list = []
+
+    def sleep(self, offload_tags=()):
+        self.sleep_calls.append(tuple(offload_tags))
+
+    def wake_up(self, tags=None):
+        self.wake_calls.append(tuple(tags) if tags else None)
+
+
+def _patch_allocator(monkeypatch):
+    """Replace ``get_mem_allocator_instance`` with a fake; return the fake."""
+    fake = _FakeAllocator()
+    import vllm.device_allocator as alloc_pkg
+
+    monkeypatch.setattr(alloc_pkg, "get_mem_allocator_instance", lambda: fake)
+    return fake
+
+
+def test_per_call_tags_override_reaches_allocator(monkeypatch):
+    """Finding 1 from the audit: per-call ``tags=`` must propagate through
+    to ``allocator.sleep(offload_tags=...)``. Previously the kwarg lived on
+    the backend but no caller threaded it down, leaving the per-call
+    override entirely unreachable."""
+    fake = _patch_allocator(monkeypatch)
+    backend = CuMemTagBackend()  # no construction-time override
+    backend.suspend(level=1, tags=("weights", "kv_cache"))
+    assert fake.sleep_calls == [("weights", "kv_cache")]
+    # Bookkeeping is set so the wake-up guard knows what was suspended.
+    assert backend.suspended_tags() == ("weights", "kv_cache")
+
+
+def test_selective_suspend_then_full_wake_does_not_widen_suspend_set(
+    monkeypatch,
+):
+    """Finding 2 from the audit: wake_up(tags=None) after a selective
+    suspend(weights only) must not re-init the KV cache - those pages were
+    never offloaded and re-running ``post_kv_cache_wake_up`` would zero
+    live state.
+
+    Backend-level evidence: after the selective suspend, ``suspended_tags()``
+    reports only ("weights",). The worker uses that to skip the KV re-init
+    when "kv_cache" is not in the set (see gpu_worker.wake_up). The resume
+    itself succeeds without raising."""
+    _patch_allocator(monkeypatch)
+    backend = CuMemTagBackend()
+    backend.suspend(level=1, tags=("weights",))
+    assert backend.suspended_tags() == ("weights",)
+    # wake_up(None) clamps to the recorded suspended set, preserving KV.
+    backend.resume(tags=None)
+    assert backend.state() == "RUNNING"
+    assert backend.suspended_tags() is None
+
+
+def test_resume_rejects_wake_of_non_suspended_tag(monkeypatch):
+    """Finding 2 (defensive): explicitly waking a tag that was never
+    suspended is loud, not silent. The GPU worker path treats kv_cache wake
+    as a re-init that overwrites live state, so this check has to fire
+    *before* the wake_up reaches the allocator."""
+    _patch_allocator(monkeypatch)
+    backend = CuMemTagBackend()
+    backend.suspend(level=1, tags=("weights",))
+    with pytest.raises(ValueError, match="not suspended"):
+        backend.resume(tags=["kv_cache"])
+    # Backend state is left in RESUMING (failed mid-resume); bookkeeping is
+    # untouched so the caller can retry with a corrected tag set.
+    assert backend.suspended_tags() == ("weights",)
+
+
+def test_resume_l2_weights_raises(monkeypatch):
+    """Finding 3 from the audit: L2 suspend discards the allocator pages -
+    reloading weights is the *worker's* responsibility
+    (``model_runner.reload_weights``), not the allocator's
+    ``wake_up``. Waking L2-suspended weights through this path silently
+    returns a "RUNNING" backend with garbage pages (HTTP 200 healthy, model
+    emits garbage tokens - the AWQ smoke this morning).
+
+    Until the worker-side reload is wired into this dispatch path, refuse
+    the call so the failure surfaces at the API boundary."""
+    _patch_allocator(monkeypatch)
+    backend = CuMemTagBackend()
+    backend.suspend(level=2, tags=("weights",))
+    with pytest.raises(RuntimeError, match="suspend\\(level=2\\)"):
+        backend.resume(tags=["weights"])
+    # Bookkeeping intact so the executor can run the reload flow then retry.
+    assert backend.suspended_tags() == ("weights",)
+
+
+def test_resume_l1_weights_succeeds(monkeypatch):
+    """L1 suspend keeps the bytes on the host; the allocator can put them
+    back. This is the happy path that the L2 guard above must NOT block."""
+    fake = _patch_allocator(monkeypatch)
+    backend = CuMemTagBackend()
+    backend.suspend(level=1, tags=("weights",))
+    backend.resume(tags=["weights"])
+    assert backend.state() == "RUNNING"
+    assert fake.wake_calls == [("weights",)]
+    assert backend.suspended_tags() is None
+
+
+def test_partial_resume_clears_only_resumed_tags(monkeypatch):
+    """Multi-tag suspend with a partial wake: only the resumed tags clear
+    from the bookkeeping; the remaining tag stays in ``suspended_tags()``
+    so a later check still knows it's offloaded."""
+    _patch_allocator(monkeypatch)
+    backend = CuMemTagBackend()
+    backend.suspend(level=1, tags=("weights", "kv_cache"))
+    backend.resume(tags=["weights"])
+    assert backend.suspended_tags() == ("kv_cache",)
+    backend.resume(tags=["kv_cache"])
+    assert backend.suspended_tags() is None
+
+
+# ---- Round-2 audit fixes: allocator-call clamping + bookkeeping atomicity --
+
+
+def test_full_wake_clamps_allocator_call_to_suspended_set(monkeypatch):
+    """Round-2 HIGH (a): ``resume(tags=None)`` after a selective suspend
+    must NOT pass ``None`` through to ``allocator.wake_up``. The pre-fix
+    code computed a clamped ``requested_set`` for its own validation but
+    then handed the original (``None``) ``tags`` to the allocator, so a
+    ``wake_up(None)`` call could wake more pages than were suspended -
+    silently zeroing live GPU state owned by another caller in the same
+    process (or by a prior selective suspend that this resume should not
+    have touched). The allocator call must see the same clamped tag set
+    the validation gate just approved."""
+    fake = _patch_allocator(monkeypatch)
+    backend = CuMemTagBackend()
+    backend.suspend(level=1, tags=("weights",))
+    backend.resume(tags=None)
+    # Allocator was called with the clamped suspended set, NOT ``None``.
+    assert fake.wake_calls == [("weights",)]
+    assert backend.state() == "RUNNING"
+    assert backend.suspended_tags() is None
+
+
+def test_full_wake_clamps_allocator_call_with_multi_tag_suspend(monkeypatch):
+    """Same clamping property holds when multiple tags are suspended:
+    ``resume(tags=None)`` widens to the full suspended set but never
+    beyond it. Order matches the suspend-time order so allocator-side
+    iteration stays deterministic."""
+    fake = _patch_allocator(monkeypatch)
+    backend = CuMemTagBackend()
+    backend.suspend(level=1, tags=("weights", "kv_cache"))
+    backend.resume(tags=None)
+    assert fake.wake_calls == [("weights", "kv_cache")]
+    assert backend.suspended_tags() is None
+
+
+def test_partial_wake_passes_clamped_tuple_not_caller_list(monkeypatch):
+    """Selective ``resume(tags=[...])`` should pass a tuple to the
+    allocator, derived from the validated ``requested_set``, not the
+    caller's mutable list. This pins the allocator-call shape so future
+    refactors don't accidentally route the raw list through."""
+    fake = _patch_allocator(monkeypatch)
+    backend = CuMemTagBackend()
+    backend.suspend(level=1, tags=("weights", "kv_cache"))
+    caller_list = ["weights"]
+    backend.resume(tags=caller_list)
+    # Recorded call shape is a tuple, not the original list.
+    assert fake.wake_calls == [("weights",)]
+    assert isinstance(fake.wake_calls[0], tuple)
+    # Mutating the caller's list afterward must not retroactively change
+    # the recorded allocator call (defensive copy via tuple).
+    caller_list.append("kv_cache")
+    assert fake.wake_calls == [("weights",)]
+
+
+def test_suspend_bookkeeping_is_post_allocator_atomic(monkeypatch):
+    """Round-2 HIGH (b): if ``allocator.sleep`` raises, the backend must
+    NOT be left in a phantom SUSPENDED state with bookkeeping recording
+    tags that were never actually offloaded. The pre-fix code wrote
+    ``self._state = "SUSPENDED"`` and ``self._suspended_tags = ...``
+    BEFORE calling the allocator - so an allocator-side OOM (the cumem
+    L2/AWQ failure mode in our morning smoke) would leave the backend
+    claiming to be suspended while the GPU pages were still live, and a
+    subsequent ``resume()`` would then try to wake pages that were never
+    sleep-prepared, masking the real failure with a confusing wake-up
+    error.
+
+    With the fix, allocator failure leaves the backend RUNNING and
+    bookkeeping clean - matching the actual GPU state."""
+
+    class _RaisingAllocator(_FakeAllocator):
+        def sleep(self, offload_tags=()):
+            self.sleep_calls.append(tuple(offload_tags))
+            raise RuntimeError("simulated allocator OOM")
+
+    raising = _RaisingAllocator()
+    import vllm.device_allocator as alloc_pkg
+
+    monkeypatch.setattr(
+        alloc_pkg, "get_mem_allocator_instance", lambda: raising
+    )
+    backend = CuMemTagBackend()
+    with pytest.raises(RuntimeError, match="simulated allocator OOM"):
+        backend.suspend(level=1, tags=("weights",))
+    # Backend stayed RUNNING - did NOT advance to SUSPENDED.
+    assert backend.state() == "RUNNING"
+    # Bookkeeping was NOT written - no phantom suspended set.
+    assert backend.suspended_tags() is None
+    # Allocator call was attempted (proves we got past the dispatch path
+    # and the failure happened in the allocator, not before).
+    assert raising.sleep_calls == [("weights",)]
+
+
+def test_resume_allocator_failure_reverts_to_suspended(monkeypatch):
+    """Round-2 HIGH (b) symmetric: if ``allocator.wake_up`` raises during
+    a resume, the backend must NOT be left stuck in RESUMING. Either
+    transition cleanly back to SUSPENDED (pages still offloaded, retry
+    safe) or surface the failure to the caller - never wedge in an
+    intermediate state. This is the executor-visible state the morning
+    AWQ smoke conflated; pinning it down stops phantom-state loops."""
+
+    class _ResumeFails(_FakeAllocator):
+        def wake_up(self, tags=None):
+            self.wake_calls.append(tuple(tags) if tags else None)
+            raise RuntimeError("simulated wake_up OOM")
+
+    fail = _ResumeFails()
+    import vllm.device_allocator as alloc_pkg
+
+    monkeypatch.setattr(
+        alloc_pkg, "get_mem_allocator_instance", lambda: fail
+    )
+    backend = CuMemTagBackend()
+    # Bookkeeping path: drive a successful suspend through a working
+    # allocator first, then swap to the failing one for resume so we
+    # exercise the resume-time failure isolated from the suspend.
+    successful = _FakeAllocator()
+    monkeypatch.setattr(
+        alloc_pkg, "get_mem_allocator_instance", lambda: successful
+    )
+    backend.suspend(level=1, tags=("weights",))
+    monkeypatch.setattr(
+        alloc_pkg, "get_mem_allocator_instance", lambda: fail
+    )
+    with pytest.raises(RuntimeError, match="simulated wake_up OOM"):
+        backend.resume(tags=None)
+    # Backend reverted to SUSPENDED so the executor sees a state matching
+    # the actual GPU situation (pages still offloaded). Bookkeeping
+    # preserved so the caller can retry without re-suspending.
+    assert backend.state() == "SUSPENDED"
+    assert backend.suspended_tags() == ("weights",)
+
+
+def test_validation_failure_leaves_state_unchanged(monkeypatch):
+    """Validation-time errors (spurious tag, L2-weights wake) must NOT
+    advance the backend to RESUMING. The pre-fix code set ``RESUMING``
+    before validating, leaving the backend wedged in a transitional
+    state that no other path could clear. With the fix, the backend
+    stays SUSPENDED and bookkeeping is preserved for retry."""
+    _patch_allocator(monkeypatch)
+    backend = CuMemTagBackend()
+    backend.suspend(level=1, tags=("weights",))
+    assert backend.state() == "SUSPENDED"
+    with pytest.raises(ValueError, match="not suspended"):
+        backend.resume(tags=["kv_cache"])
+    # State did NOT advance to RESUMING - validation gate fired before
+    # any state mutation, so the backend stays cleanly SUSPENDED.
+    assert backend.state() == "SUSPENDED"
+    assert backend.suspended_tags() == ("weights",)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -289,6 +289,11 @@ class ModelConfig:
     enable_sleep_mode: bool = False
     """Enable sleep mode for the engine (only cuda and
     hip platforms are supported)."""
+    sleep_mode_backend: str = "cumem"
+    """Mechanism used to free and restore GPU state for sleep mode. ``"cumem"``
+    (default) uses the built-in ``CuMemAllocator`` and is behavior-compatible
+    with prior releases. Additional backends (CUDA checkpoint, CRIU, durable
+    snapshot) may be registered in-tree or by plugins (RFC #34303)."""
     enable_cumem_allocator: bool = False
     """Enable the custom cumem allocator to leverage advanced GPU memory
     allocation features such as multi-node NVLink support.

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -294,6 +294,14 @@ class ModelConfig:
     (default) uses the built-in ``CuMemAllocator`` and is behavior-compatible
     with prior releases. Additional backends (CUDA checkpoint, CRIU, durable
     snapshot) may be registered in-tree or by plugins (RFC #34303)."""
+    sleep_mode_backend_options: dict[str, Any] = field(default_factory=dict)
+    """Backend-specific options forwarded to the selected
+    ``sleep_mode_backend``'s constructor. The factory ``**``-unpacks this dict
+    into the backend class, so the accepted keys are defined by each backend
+    (e.g. ``cumem_tag`` accepts ``suspend_tags``). Validation lives in the
+    concrete backend's ``__init__``; ``ModelConfig`` does not enforce a schema.
+    Defaults to an empty dict, which preserves prior behavior for every
+    registered backend."""
     enable_cumem_allocator: bool = False
     """Enable the custom cumem allocator to leverage advanced GPU memory
     allocation features such as multi-node NVLink support.

--- a/vllm/device_allocator/sleep_mode_backend.py
+++ b/vllm/device_allocator/sleep_mode_backend.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pluggable sleep-mode backends (RFC #34303).
+
+vLLM's sleep/wake-up today is hard-wired to ``CuMemAllocator``: the GPU worker
+calls ``allocator.sleep(...)`` / ``allocator.wake_up(...)`` directly. RFC #34303
+proposes additional mechanisms for freeing and restoring GPU state - CUDA
+process checkpoint, CRIU, durable snapshot/restore - that share the *dispatch*
+(``/sleep`` endpoint -> engine -> executor -> worker) but differ in *mechanism*
+and in which resources they preserve (NCCL communicators, compiled kernels,
+CUDA graphs, survival across process restart).
+
+This module introduces a thin backend abstraction so those mechanisms can be
+selected by name without changing the public API. The default ``cumem`` backend
+wraps today's ``CuMemAllocator`` path 1:1, so existing users see no behavior
+change. The factory mirrors ``KVConnectorFactory`` and lets third-party
+backends register through a ``vllm.general_plugins`` entry point at import time.
+"""
+
+from __future__ import annotations
+
+import importlib
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal
+
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.config.model import ModelConfig
+
+logger = init_logger(__name__)
+
+SleepModeState = Literal["RUNNING", "SUSPENDED", "RESUMING"]
+
+
+class SleepModeBackend(ABC):
+    """Interface for a mechanism that frees and restores GPU state.
+
+    A backend owns the *mechanism* of suspend/resume. The dispatch path
+    (``/sleep`` endpoint -> engine -> executor -> worker) is shared across all
+    backends and lives outside this class.
+
+    Capability flags are ``@classmethod`` so callers (executor, ``/health``,
+    AUTO selection) can introspect a backend without instantiating it, matching
+    the capability-flag convention used by attention backends.
+    """
+
+    def __init__(self) -> None:
+        self._state: SleepModeState = "RUNNING"
+
+    @abstractmethod
+    def suspend(self, level: int = 1) -> None:
+        """Free GPU state.
+
+        ``level`` follows existing sleep-mode semantics: level 1 offloads
+        weights to host RAM (restorable in-process); level 2 discards weights
+        (reloaded from the model source on resume).
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def resume(self, tags: list[str] | None = None) -> None:
+        """Restore previously-suspended GPU state.
+
+        ``tags`` optionally limits which tagged allocations are restored
+        (e.g. ``["weights"]`` or ``["kv_cache"]``).
+        """
+        raise NotImplementedError
+
+    def state(self) -> SleepModeState:
+        """Current lifecycle state. Lets ``/health`` distinguish a healthy-idle
+        (suspended) engine from a healthy-serving one (see RFC #34303)."""
+        return self._state
+
+    # -- Capability introspection (no instance required) --
+
+    @classmethod
+    def is_supported(cls) -> bool:
+        """Whether this backend can run on the current platform/driver."""
+        return True
+
+    @classmethod
+    def preserves_nccl(cls) -> bool:
+        """If False, NCCL communicators are destroyed by ``suspend`` and the
+        executor must re-initialize them on ``resume``."""
+        return False
+
+    @classmethod
+    def preserves_compiled_artifacts(cls) -> bool:
+        """If True, torch.compile / JIT kernels survive suspend/resume and need
+        not be recompiled on resume."""
+        return False
+
+    @classmethod
+    def preserves_graphs_with_nccl(cls) -> bool:
+        """If True, CUDA graphs containing NCCL collectives stay valid after
+        resume. False when NCCL is rebuilt (embedded comm handles go stale)."""
+        return False
+
+    @classmethod
+    def supports_durable_storage(cls) -> bool:
+        """If True, suspended state can be persisted beyond the process
+        lifetime (disk or object storage) and restored in a new process."""
+        return False
+
+
+class CuMemBackend(SleepModeBackend):
+    """Default backend.
+
+    Wraps the platform sleep-mode allocator exactly as the GPU worker did
+    before this abstraction existed, so behavior is identical to vLLM's current
+    sleep/wake-up. ``get_mem_allocator_instance()`` resolves to
+    ``CuMemAllocator`` on CUDA and ``XpuMemAllocator`` on XPU; suspend offloads
+    per-allocation between GPU and host, with NCCL buffers left untouched (they
+    are allocated outside the allocator pool).
+    """
+
+    def suspend(self, level: int = 1) -> None:
+        from vllm.device_allocator import get_mem_allocator_instance
+
+        self._state = "SUSPENDED"
+        allocator = get_mem_allocator_instance()
+        allocator.sleep(offload_tags=("weights",) if level == 1 else tuple())
+
+    def resume(self, tags: list[str] | None = None) -> None:
+        from vllm.device_allocator import get_mem_allocator_instance
+
+        self._state = "RESUMING"
+        allocator = get_mem_allocator_instance()
+        allocator.wake_up(tags)
+        self._state = "RUNNING"
+
+    @classmethod
+    def preserves_nccl(cls) -> bool:
+        # NCCL buffers live outside CuMemAllocator's pool, so an allocator-level
+        # sleep leaves the communicators intact (no reinit needed on resume).
+        return True
+
+
+class SleepModeBackendFactory:
+    """Registry and resolver for sleep-mode backends.
+
+    Mirrors ``KVConnectorFactory``: lazy module/class registration and a
+    built-in registry populated at import time. Third-party backends register
+    the same way from a ``vllm.general_plugins`` entry point.
+    """
+
+    _registry: dict[str, Callable[[], type[SleepModeBackend]]] = {}
+
+    @classmethod
+    def register_backend(cls, name: str, module_path: str, class_name: str) -> None:
+        """Register a backend with a lazy-loading module and class name."""
+        if name in cls._registry:
+            raise ValueError(f"Sleep-mode backend '{name}' is already registered.")
+
+        def loader() -> type[SleepModeBackend]:
+            module = importlib.import_module(module_path)
+            return getattr(module, class_name)
+
+        cls._registry[name] = loader
+
+    @classmethod
+    def get_backend_class(cls, name: str) -> type[SleepModeBackend]:
+        """Resolve a registered backend class by name."""
+        if name not in cls._registry:
+            available = ", ".join(sorted(cls._registry)) or "<none>"
+            raise ValueError(
+                f"Unsupported sleep-mode backend '{name}'. "
+                f"Registered backends: {available}."
+            )
+        return cls._registry[name]()
+
+    @classmethod
+    def create_backend(cls, model_config: "ModelConfig") -> SleepModeBackend:
+        """Instantiate the backend selected by ``model_config``."""
+        name = model_config.sleep_mode_backend
+        backend_cls = cls.get_backend_class(name)
+        if not backend_cls.is_supported():
+            raise ValueError(
+                f"Sleep-mode backend '{name}' is not supported on this platform."
+            )
+        logger.info("Using sleep-mode backend: %s", name)
+        return backend_cls()
+
+
+# Register built-in backends here. Registration is lazy: only the module for the
+# selected backend is imported. Third-party backends (CUDA checkpoint, CRIU,
+# durable snapshot) register the same way through a vllm.general_plugins entry
+# point, without changes to vLLM core.
+SleepModeBackendFactory.register_backend(
+    "cumem",
+    "vllm.device_allocator.sleep_mode_backend",
+    "CuMemBackend",
+)

--- a/vllm/device_allocator/sleep_mode_backend.py
+++ b/vllm/device_allocator/sleep_mode_backend.py
@@ -50,12 +50,17 @@ class SleepModeBackend(ABC):
         self._state: SleepModeState = "RUNNING"
 
     @abstractmethod
-    def suspend(self, level: int = 1) -> None:
+    def suspend(self, level: int = 1, tags: tuple[str, ...] | None = None) -> None:
         """Free GPU state.
 
         ``level`` follows existing sleep-mode semantics: level 1 offloads
         weights to host RAM (restorable in-process); level 2 discards weights
         (reloaded from the model source on resume).
+
+        ``tags`` is an optional, backend-specific override. Backends that do
+        not implement ``supports_selective_offload`` ignore the argument; the
+        signature is shared so the GPU worker can dispatch the same kwarg to
+        any backend without conditional plumbing.
         """
         raise NotImplementedError
 
@@ -67,6 +72,19 @@ class SleepModeBackend(ABC):
         (e.g. ``["weights"]`` or ``["kv_cache"]``).
         """
         raise NotImplementedError
+
+    def suspended_tags(self) -> tuple[str, ...] | None:
+        """Tags actually offloaded by the most recent ``suspend()`` call.
+
+        Returns ``None`` when the backend is RUNNING (nothing offloaded) or
+        when the backend does not track per-tag suspend state. The GPU worker
+        uses this to gate the ``post_kv_cache_wake_up`` re-init path so it
+        does not zero live KV-cache pages that were never suspended.
+
+        Default implementation returns ``None`` (no tracking). Backends that
+        support selective offload should override.
+        """
+        return None
 
     def state(self) -> SleepModeState:
         """Current lifecycle state. Lets ``/health`` distinguish a healthy-idle
@@ -104,6 +122,15 @@ class SleepModeBackend(ABC):
         lifetime (disk or object storage) and restored in a new process."""
         return False
 
+    @classmethod
+    def supports_selective_offload(cls) -> bool:
+        """If True, ``suspend`` accepts an explicit ``tags`` argument and
+        ``resume`` honors a matching ``tags`` argument, letting the caller
+        manage weights / KV cache / compiled artifacts on independent
+        lifecycles. False (default) means the backend offloads and restores
+        everything together, controlled only by ``level``."""
+        return False
+
 
 class CuMemBackend(SleepModeBackend):
     """Default backend.
@@ -116,9 +143,14 @@ class CuMemBackend(SleepModeBackend):
     are allocated outside the allocator pool).
     """
 
-    def suspend(self, level: int = 1) -> None:
+    def suspend(self, level: int = 1, tags: tuple[str, ...] | None = None) -> None:
+        # ``tags`` is accepted to match the SleepModeBackend signature but
+        # ignored: CuMemBackend has no selective-offload semantics (per
+        # ``supports_selective_offload`` which stays False). The tag set is
+        # derived from ``level`` exactly as the pre-abstraction worker did.
         from vllm.device_allocator import get_mem_allocator_instance
 
+        del tags  # silence linters; behavior intentional - see docstring
         self._state = "SUSPENDED"
         allocator = get_mem_allocator_instance()
         allocator.sleep(offload_tags=("weights",) if level == 1 else tuple())
@@ -135,6 +167,241 @@ class CuMemBackend(SleepModeBackend):
     def preserves_nccl(cls) -> bool:
         # NCCL buffers live outside CuMemAllocator's pool, so an allocator-level
         # sleep leaves the communicators intact (no reinit needed on resume).
+        return True
+
+
+class CuMemTagBackend(CuMemBackend):
+    """CuMemBackend with tag-based selective offload.
+
+    Where ``CuMemBackend`` always offloads exactly the tags implied by
+    ``level`` (``("weights",)`` at level 1, ``()`` at level 2), this backend
+    lets the caller specify on each call - or fix at construction - exactly
+    which tags to offload on suspend and which to restore on resume. That
+    enables multi-model in-process scenarios where weights, KV cache, and
+    compiled artifacts have independent lifecycles (e.g. swap weights while
+    keeping the KV cache hot for a different tenant on the same GPU).
+
+    Motivated by the field report on RFC #34303 from the Alibaba Cloud ACK
+    team (`comment 4689082496
+    <https://github.com/vllm-project/vllm/issues/34303#issuecomment-4689082496>`_):
+    same-architecture model switch in ~1-2s on production hardware by
+    reusing CUDA graphs and rebuilding only the weight pages.
+
+    Implementation is a thin wrapper around
+    ``CuMemAllocator.sleep(offload_tags=...)`` / ``.wake_up(tags=...)``.
+    With its defaults this backend is behavior-identical to ``CuMemBackend``;
+    the extension is the *option* to override on a per-call basis.
+
+    Safety: this backend tracks which tags were offloaded by the most recent
+    ``suspend()`` call (see :py:meth:`suspended_tags`) so the GPU worker can
+    avoid running ``post_kv_cache_wake_up`` against pages that were never
+    suspended, and so ``resume()`` can refuse selective wake-ups that would
+    silently corrupt live state.
+    """
+
+    #: Default tag set offloaded by ``suspend(level=1)`` when no explicit
+    #: tags are passed. Matches ``CuMemBackend`` so the no-argument path is
+    #: a no-op compared to the existing backend.
+    DEFAULT_SUSPEND_TAGS_L1: tuple[str, ...] = ("weights",)
+    #: Default tag set offloaded by ``suspend(level=2)``. Empty matches
+    #: ``CuMemBackend`` (level 2 discards weights, so nothing is offloaded
+    #: to host RAM - they get reloaded from the model source on resume).
+    DEFAULT_SUSPEND_TAGS_L2: tuple[str, ...] = ()
+
+    def __init__(self, suspend_tags: tuple[str, ...] | None = None) -> None:
+        super().__init__()
+        # Optional construction-time override. When set, takes precedence over
+        # the level-based defaults but is still overridable per-call. Public
+        # so callers (and tests) can introspect the effective tag set without
+        # touching internals.
+        #
+        # Normalize to ``tuple`` (preserving the ``None`` sentinel) so config
+        # surfaces that deliver lists - CLI JSON, YAML-via-
+        # ``sleep_mode_backend_options`` - round-trip into a hashable,
+        # immutable value with the same return-type contract as
+        # ``effective_suspend_tags()``. matteso1's review nit.
+        self.suspend_tags: tuple[str, ...] | None = (
+            tuple(suspend_tags) if suspend_tags is not None else None
+        )
+        # Tags actually offloaded by the most recent ``suspend()`` call, plus
+        # the level used. ``None`` means "currently RUNNING / nothing
+        # suspended". Used by ``resume()`` to refuse selective wake-ups of
+        # tags that were never suspended (which on the existing GPU worker
+        # path would zero live KV-cache pages via ``post_kv_cache_wake_up``),
+        # and by the worker to gate that same re-init call.
+        self._suspended_tags: tuple[str, ...] | None = None
+        self._suspended_level: int | None = None
+
+    def effective_suspend_tags(self, level: int = 1) -> tuple[str, ...]:
+        """Return the tags that ``suspend(level=...)`` would offload right now.
+
+        Public accessor so tests and callers can validate behavior without
+        invoking the GPU path. Mirrors the resolution precedence in
+        ``suspend()`` but with no per-call override (which is by definition
+        only known at the call site).
+        """
+        if self.suspend_tags is not None:
+            return self.suspend_tags
+        return (
+            self.DEFAULT_SUSPEND_TAGS_L1
+            if level == 1
+            else self.DEFAULT_SUSPEND_TAGS_L2
+        )
+
+    def suspended_tags(self) -> tuple[str, ...] | None:
+        """Tags actually offloaded by the most recent ``suspend()`` call.
+
+        Returns ``None`` when the backend is RUNNING or when ``suspend()`` has
+        not been called yet. Lets the GPU worker decide whether
+        ``post_kv_cache_wake_up`` is safe to call on the next ``wake_up``.
+        """
+        return self._suspended_tags
+
+    def suspend(
+        self,
+        level: int = 1,
+        tags: tuple[str, ...] | None = None,
+    ) -> None:
+        """Free GPU state for the selected ``tags``.
+
+        Tag resolution precedence (most to least specific):
+          1. Explicit ``tags=`` keyword argument on this call.
+          2. Construction-time ``suspend_tags`` (if set).
+          3. Level-based default (``DEFAULT_SUSPEND_TAGS_L1`` or ``...L2``).
+        """
+        from vllm.device_allocator import get_mem_allocator_instance
+
+        if tags is not None:
+            effective_tags = tuple(tags)
+        else:
+            effective_tags = self.effective_suspend_tags(level)
+        allocator = get_mem_allocator_instance()
+        # Drive the allocator FIRST. Only commit suspend bookkeeping
+        # (state, ``_suspended_tags``, ``_suspended_level``) after the
+        # allocator call returns successfully. If ``allocator.sleep`` raises,
+        # the backend stays RUNNING with no suspended tags - matching the
+        # actual GPU state. The previous ordering wrote bookkeeping first
+        # and left the backend in a phantom SUSPENDED state on allocator
+        # failure, which the executor would then try to ``resume`` from -
+        # masking the real failure with a confusing wake-up error.
+        allocator.sleep(offload_tags=effective_tags)
+        self._suspended_tags = effective_tags
+        self._suspended_level = level
+        self._state = "SUSPENDED"
+
+    def resume(self, tags: list[str] | None = None) -> None:
+        """Restore previously-suspended GPU state.
+
+        Selective-suspend safety: if ``tags`` is non-empty, each tag must
+        appear in the set of tags actually offloaded by the most recent
+        ``suspend()`` call. This guards against the
+        ``suspend(tags=("weights",))`` -> ``wake_up(tags=("kv_cache",))``
+        pattern, which would otherwise traverse a code path in
+        ``gpu_worker.wake_up`` that re-initializes the KV cache - zeroing
+        live GPU pages that were never offloaded.
+
+        When ``tags is None``, fall back to whatever tags were suspended so
+        the existing single-instance dispatch path (which calls
+        ``wake_up(tags=None)`` for "wake everything") still works, without
+        widening the wake set beyond what was actually offloaded.
+
+        L2-suspended weights: the allocator-level ``wake_up`` call below
+        cannot reload weights that were discarded by ``level=2`` suspend -
+        that reload must come from ``worker.load_model()`` /
+        ``model_runner.reload_weights()``, which is the executor's
+        responsibility, not this backend's. To avoid silently returning a
+        "RUNNING" backend with garbage weight pages, raise loudly when the
+        caller tries to wake L2-suspended weights through this path. The
+        intent is the L2-wake corruption mode observed on AWQ models (HTTP
+        200 healthy, garbage tokens) fails fast at the API boundary instead
+        of in the user's downstream traffic.
+        """
+        from vllm.device_allocator import get_mem_allocator_instance
+
+        # Compute the effective wake set FIRST so the allocator call uses the
+        # same clamped tag set we just validated. Passing the original
+        # ``tags`` (potentially ``None``) to ``allocator.wake_up`` would
+        # widen the wake beyond what was actually suspended - on a backend
+        # whose pool may also hold pages suspended by another caller (or by
+        # a prior selective suspend in this process), an unclamped
+        # ``wake_up(None)`` zeroes those live pages too. Pre-compute
+        # ``effective_wake_tags`` from the clamped ``requested_set`` and
+        # pass that down in every branch.
+        effective_wake_tags: tuple[str, ...] | None = None
+        if self._suspended_tags is not None:
+            suspended_set = set(self._suspended_tags)
+            requested_set = set(tags) if tags else suspended_set
+            spurious = sorted(requested_set - suspended_set)
+            if spurious:
+                # Leave state unchanged - bookkeeping is intact for retry,
+                # and the backend stays SUSPENDED rather than RESUMING with
+                # no actual allocator transition under way.
+                raise ValueError(
+                    f"resume(tags={sorted(requested_set)}) requested tags "
+                    f"{spurious} that were not suspended (suspended tags: "
+                    f"{sorted(suspended_set)}). Waking a non-suspended tag "
+                    "would corrupt live GPU state through the "
+                    "post_kv_cache_wake_up path in gpu_worker.wake_up; "
+                    "pass tags= matching the suspend() call."
+                )
+            if (
+                self._suspended_level == 2
+                and "weights" in requested_set
+            ):
+                raise RuntimeError(
+                    "resume() cannot restore weights that were discarded by "
+                    "suspend(level=2): the allocator pages were freed and "
+                    "must be reloaded from disk by "
+                    "worker.load_model() / model_runner.reload_weights() "
+                    "before this backend can mark them RUNNING. This "
+                    "selective-offload backend does not own the reload "
+                    "step; the caller (engine/executor) must invoke the "
+                    "reload path before resuming weights. See RFC #34303 "
+                    "for the level-2 lifecycle contract."
+                )
+            # Snap ``effective_wake_tags`` to the validated ``requested_set``,
+            # preserving the suspend-time order so allocator-side iteration
+            # stays deterministic.
+            effective_wake_tags = tuple(
+                t for t in self._suspended_tags if t in requested_set
+            )
+        else:
+            # No tracked suspend state (e.g. resume() called without a
+            # preceding suspend, or from the abstract path on a freshly-
+            # constructed backend). Pass tags through verbatim - any caller
+            # who explicitly asked for selective wake without a tracked
+            # suspend is responsible for the consequences.
+            effective_wake_tags = tuple(tags) if tags else None
+
+        self._state = "RESUMING"
+        allocator = get_mem_allocator_instance()
+        try:
+            allocator.wake_up(effective_wake_tags)
+        except BaseException:
+            # Allocator failed mid-wake. Don't leave the backend stuck in
+            # RESUMING - revert to SUSPENDED so the executor sees a state
+            # that matches the actual GPU situation (pages still offloaded)
+            # and can decide whether to retry or surface the error.
+            self._state = "SUSPENDED"
+            raise
+        # Clear suspend bookkeeping only for tags that were actually woken.
+        if self._suspended_tags is not None:
+            if effective_wake_tags:
+                woken = set(effective_wake_tags)
+                remaining = tuple(
+                    t for t in self._suspended_tags if t not in woken
+                )
+                self._suspended_tags = remaining if remaining else None
+                if self._suspended_tags is None:
+                    self._suspended_level = None
+            else:
+                self._suspended_tags = None
+                self._suspended_level = None
+        self._state = "RUNNING"
+
+    @classmethod
+    def supports_selective_offload(cls) -> bool:
+        # Selective per-tag offload is the whole point of this backend.
         return True
 
 
@@ -173,15 +440,39 @@ class SleepModeBackendFactory:
 
     @classmethod
     def create_backend(cls, model_config: "ModelConfig") -> SleepModeBackend:
-        """Instantiate the backend selected by ``model_config``."""
+        """Instantiate the backend selected by ``model_config``.
+
+        Backend-specific kwargs come from
+        ``model_config.sleep_mode_backend_options`` and are ``**``-unpacked
+        into the concrete backend's ``__init__``. Validation of those kwargs
+        is the backend's responsibility; ``ModelConfig`` does not enforce a
+        schema so that adding a new backend with new options does not require
+        a config-side change.
+        """
         name = model_config.sleep_mode_backend
         backend_cls = cls.get_backend_class(name)
         if not backend_cls.is_supported():
             raise ValueError(
                 f"Sleep-mode backend '{name}' is not supported on this platform."
             )
-        logger.info("Using sleep-mode backend: %s", name)
-        return backend_cls()
+        options = getattr(model_config, "sleep_mode_backend_options", {}) or {}
+        logger.info(
+            "Using sleep-mode backend: %s (options=%s)",
+            name,
+            options if options else "{}",
+        )
+        return backend_cls(**options)
+
+    @classmethod
+    def unregister(cls, name: str) -> None:
+        """Remove a registered backend.
+
+        Intended for tests of plugin-author backends that want to isolate
+        registry state between cases without mutating the private
+        ``_registry`` dict directly. Idempotent: unregistering a name that is
+        not currently registered is a no-op. Not intended for production code.
+        """
+        cls._registry.pop(name, None)
 
 
 # Register built-in backends here. Registration is lazy: only the module for the
@@ -192,4 +483,9 @@ SleepModeBackendFactory.register_backend(
     "cumem",
     "vllm.device_allocator.sleep_mode_backend",
     "CuMemBackend",
+)
+SleepModeBackendFactory.register_backend(
+    "cumem_tag",
+    "vllm.device_allocator.sleep_mode_backend",
+    "CuMemTagBackend",
 )

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -315,14 +315,25 @@ class Executor(ABC):
         """Reset the encoder cache in each worker to clear cached encoder outputs."""
         self.collective_rpc("reset_encoder_cache")
 
-    def sleep(self, level: int = 1):
+    def sleep(self, level: int = 1, tags: tuple[str, ...] | None = None):
         if self.is_sleeping:
             logger.warning("Executor is already sleeping.")
             return
         time_before_sleep = time.perf_counter()
-        self.collective_rpc("sleep", kwargs=dict(level=level))
+        # Thread per-call ``tags`` through to the worker so selective-offload
+        # backends (CuMemTagBackend, RFC #34303) actually receive the
+        # override. Backends that don't support selective offload accept and
+        # ignore the kwarg.
+        self.collective_rpc("sleep", kwargs=dict(level=level, tags=tags))
         time_after_sleep = time.perf_counter()
-        self.sleeping_tags = {"weights", "kv_cache"}
+        # Record what the worker was told to suspend. When ``tags`` is given,
+        # the engine is in the selective-offload regime: track exactly what
+        # was offloaded so ``wake_up`` validation matches the worker's
+        # backend-side bookkeeping.
+        if tags is not None:
+            self.sleeping_tags = set(tags)
+        else:
+            self.sleeping_tags = {"weights", "kv_cache"}
         self.is_sleeping = True
         logger.info(
             "It took %.6f seconds to fall asleep.", time_after_sleep - time_before_sleep

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -162,6 +162,20 @@ class Worker(WorkerBase):
         # pending non-blocking PP send work from the previous iteration
         self._pp_send_work: list[Handle] = []
 
+        # Resolved lazily on first sleep/wake; persists worker-process state.
+        self._sleep_mode_backend = None
+
+    def _get_sleep_mode_backend(self):
+        if self._sleep_mode_backend is None:
+            from vllm.device_allocator.sleep_mode_backend import (
+                SleepModeBackendFactory,
+            )
+
+            self._sleep_mode_backend = SleepModeBackendFactory.create_backend(
+                self.vllm_config.model_config
+            )
+        return self._sleep_mode_backend
+
     def sleep(self, level: int = 1) -> None:
         free_bytes_before_sleep = torch.cuda.mem_get_info()[0]
 
@@ -172,8 +186,7 @@ class Worker(WorkerBase):
                 name: buffer.cpu().clone() for name, buffer in model.named_buffers()
             }
 
-        allocator = get_mem_allocator_instance()
-        allocator.sleep(offload_tags=("weights",) if level == 1 else tuple())
+        self._get_sleep_mode_backend().suspend(level)
         free_bytes_after_sleep, total = torch.cuda.mem_get_info()
         freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
         used_bytes = total - free_bytes_after_sleep
@@ -185,8 +198,7 @@ class Worker(WorkerBase):
         )
 
     def wake_up(self, tags: list[str] | None = None) -> None:
-        allocator = get_mem_allocator_instance()
-        allocator.wake_up(tags)
+        self._get_sleep_mode_backend().resume(tags)
 
         # Restore the buffers after level 2 sleep
         if len(self._sleep_saved_buffers):

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -176,7 +176,7 @@ class Worker(WorkerBase):
             )
         return self._sleep_mode_backend
 
-    def sleep(self, level: int = 1) -> None:
+    def sleep(self, level: int = 1, tags: tuple[str, ...] | None = None) -> None:
         free_bytes_before_sleep = torch.cuda.mem_get_info()[0]
 
         # Save the buffers before level 2 sleep
@@ -186,7 +186,12 @@ class Worker(WorkerBase):
                 name: buffer.cpu().clone() for name, buffer in model.named_buffers()
             }
 
-        self._get_sleep_mode_backend().suspend(level)
+        # Thread ``tags`` through so per-call selective-offload overrides on
+        # backends that support it (e.g. CuMemTagBackend - see RFC #34303)
+        # actually reach ``backend.suspend``. Backends that do not support
+        # selective offload accept and ignore the argument (see
+        # ``SleepModeBackend.suspend`` signature).
+        self._get_sleep_mode_backend().suspend(level, tags=tags)
         free_bytes_after_sleep, total = torch.cuda.mem_get_info()
         freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
         used_bytes = total - free_bytes_after_sleep
@@ -198,7 +203,13 @@ class Worker(WorkerBase):
         )
 
     def wake_up(self, tags: list[str] | None = None) -> None:
-        self._get_sleep_mode_backend().resume(tags)
+        backend = self._get_sleep_mode_backend()
+        # Snapshot which tags the backend recorded as suspended *before* the
+        # resume call clears that state. Used below to gate
+        # ``post_kv_cache_wake_up`` so a selective wake of a backend that
+        # only suspended weights does not zero a still-live KV cache.
+        suspended_before_resume = backend.suspended_tags()
+        backend.resume(tags)
 
         # Restore the buffers after level 2 sleep
         if len(self._sleep_saved_buffers):
@@ -208,7 +219,17 @@ class Worker(WorkerBase):
                     buffer.data.copy_(self._sleep_saved_buffers[name].data)
             self._sleep_saved_buffers = {}
 
-        if tags is None or "kv_cache" in tags:
+        # Only re-initialize the KV cache if it was actually suspended (or if
+        # the backend doesn't track per-tag suspend state, which is the
+        # pre-abstraction CuMemBackend behavior - everything was always
+        # included in sleep/wake). Otherwise the selective-offload path
+        # (suspend(tags=("weights",)) then wake_up(tags=None)) would zero
+        # live KV pages the engine still has cached.
+        kv_was_suspended = (
+            suspended_before_resume is None  # backend doesn't track -> assume yes
+            or "kv_cache" in suspended_before_resume
+        )
+        if kv_was_suspended and (tags is None or "kv_cache" in tags):
             self.model_runner.post_kv_cache_wake_up()
 
     def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:


### PR DESCRIPTION
## Purpose

This is a **draft sibling extension to #44074**, implementing the tag-based selective offload approach @AlanFokCo described in [RFC #34303 comment 4689082496](https://github.com/vllm-project/vllm/issues/34303#issuecomment-4689082496) on top of @matteso1's `SleepModeBackend` abstraction.

## Dependencies

This PR depends on **two** prerequisites:

1. **#44074** ([Core] Pluggable sleep-mode backend abstraction) — provides the `SleepModeBackend` ABC + `SleepModeBackendFactory` we extend. Carried as the first commit on this branch (Nils Matteson) for review visibility; will drop out of this PR's diff once #44074 lands upstream.
2. **#45513** ([Core] EngineArgs CLI plumbing for `--sleep-mode-backend`) — owns the public API surface: declares `ModelConfig.sleep_mode_backend` and `ModelConfig.sleep_mode_backend_options` plus the corresponding CLI flags. This PR's runtime code (`SleepModeBackendFactory.create_backend(model_config)` at `vllm/device_allocator/sleep_mode_backend.py`) reads those fields off the live ModelConfig.

Dependency direction inverted from the original filing: was `#45513` depending on this PR, now `#45398` depends on `#45513`. The CLI surface lands first; this implementation lands second — the natural order for a public API change. With the field declarations relocated, this PR can be reviewed against the implementation it actually adds (`CuMemTagBackend` in `vllm/device_allocator/sleep_mode_backend.py`) without bundling the schema declarations.

## What this adds

| File | Change |
|---|---|
| `vllm/device_allocator/sleep_mode_backend.py` | `+ CuMemTagBackend` class, `+ supports_selective_offload()` base capability, `+ cumem_tag` factory registration |
| `tests/test_sleep_mode_backend.py` | `+ tests` covering tag-based dispatch, capability-flag introspection, factory-options round-trip, and the default-matches-CuMemBackend invariant |
| `vllm/v1/executor/abstract.py`, `vllm/v1/worker/gpu_worker.py` | `+ tags=` parameter threaded through Executor.sleep / GPUWorker.sleep so per-call tag overrides reach the backend |

## What `CuMemTagBackend` does

Subclasses `CuMemBackend` and exposes the existing `CuMemAllocator.sleep(offload_tags=...)` / `.wake_up(tags=...)` primitives as a first-class backend API:

```python
backend = CuMemTagBackend()
backend.suspend(level=1)                                # = CuMemBackend behavior (offload "weights" only)
backend.suspend(level=1, tags=("weights", "kv_cache"))  # explicit: offload BOTH
backend.resume(tags=["weights"])                        # restore weights only, keep kv_cache offloaded
```

Tag-resolution precedence (most to least specific):

1. `tags=` keyword argument on the call
2. `suspend_tags=` constructor argument
3. Level-based default (`DEFAULT_SUSPEND_TAGS_L1 = ("weights",)`, `DEFAULT_SUSPEND_TAGS_L2 = ()`)

The default-arguments path is **identical** to `CuMemBackend.suspend()/resume()` — asserted by `test_default_suspend_tags_match_cumem_backend_level1`. Adopting this backend with default config is a no-op.

`resume()` is inherited unchanged from `CuMemBackend`: it already forwards `tags` to `allocator.wake_up(tags)`, which is the selective-restore primitive the design needs.

## Why this is useful (use case)

Multi-model GPU sharing: weights, KV cache, and compiled artifacts have independent lifecycles. Switching between models on a shared GPU benefits from offloading only what conflicts (weights of the swapped-out model) while keeping reusable pieces hot.

Concrete data from the @AlanFokCo field report on RFC #34303 (Alibaba Cloud ACK production, A10 / A100 nodes):

| Model pair | TP | Switch time |
|---|---|---:|
| Qwen3-0.6B ↔ Qwen2.5-0.5B | 1 | **1.1s** |
| Qwen3-8B ↔ Qwen-7B-Chat | 8 | **853ms** |
| Qwen3-32B ↔ Qwen2.5-32B | 8 | **2.0s** |
| Dense ↔ MoE (32B) | 4 | **1.4s** |

Baseline (full engine teardown + rebuild) for the same models: 60–100s.

## The new capability flag

```python
@classmethod
def supports_selective_offload(cls) -> bool: ...
```

Lives on the `SleepModeBackend` base class, defaults to `False`. `CuMemTagBackend` overrides to `True`. Lets the executor and `/health` introspect whether explicit per-tag lifecycle is available, parallel to #44074's `preserves_nccl` / `preserves_compiled_artifacts` / `preserves_graphs_with_nccl` / `supports_durable_storage` flags. Backends that can't do selective offload (e.g. an eventual `cuda_checkpoint` backend per #37921 / #37925, which is all-or-nothing) inherit the `False` default.

## Testing

CPU-only tests (no GPU required for these — the GPU sleep/wake parity is already covered by `tests/basic_correctness/test_cumem.py`, which exercises the `cumem` path through #44074's dispatch):

- `test_cumem_tag_is_registered` — factory resolves the new backend and `CuMemTagBackend` subclasses `CuMemBackend`
- `test_cumem_tag_capability_flags` — all six capability flags including the new `supports_selective_offload`
- `test_default_suspend_tags_match_cumem_backend_level1` — proves the default-matches-CuMemBackend invariant for both level 1 and level 2
- `test_explicit_tags_override_defaults` — construction-time `suspend_tags` is stored verbatim; default constructor leaves it `None`
- `test_supports_selective_offload_base_class_default` — base class default is `False`; `CuMemBackend` inherits `False`
- `test_factory_plumbs_backend_options_dict` — `sleep_mode_backend_options` (declared in #45513) is `**`-unpacked into the backend ctor

Locally smoke-tested the suspend semantics (explicit-arg > construction-tag > level-1-default > level-2-default) and the state transitions (`RUNNING` → `SUSPENDED`) using a stub allocator on a no-GPU machine; all four resolution paths correctly forward the right tags to `allocator.sleep(offload_tags=...)`.

GPU smoke (deferred to a follow-up — gated on #44074 + #45513 landing first):

- Validate selective resume actually keeps `kv_cache` hot while offloading `weights`
- Empirical switch-time measurement against `CuMemBackend` baseline on a real multi-model workload

## What this PR deliberately does NOT do

- No changes to `CuMemAllocator` internals — the `offload_tags` / `wake_up(tags)` API already exists; we only expose it as a backend method
- No `ModelConfig` field declarations — those live in #45513 (the CLI surface PR). The runtime path here reads them off the live ModelConfig instance.
- No `torch.compile` / Triton-cache preservation — cross-architecture compile-state preservation is the `cuda_checkpoint` backend's territory (#37921 / #37925)
- No `model_config` / scheduler swap — orchestration above the engine, out of scope here
- No `auto` backend selection — defers to #44074's follow-up
- No edits to `CuMemBackend` or any other code in #44074 — strictly additive

## Credit

- **@matteso1** for the `SleepModeBackend` abstraction this stacks on (#44074)
- **@AlanFokCo** for the field report ([RFC #34303 comment 4689082496](https://github.com/vllm-project/vllm/issues/34303#issuecomment-4689082496)) describing this design from Alibaba Cloud ACK production data
- **@elizabetht** for the RFC framing

Refs #34303 #44074 #45513
