### PR TITLE
[Bugfix][CPU] Don't build triton-cpu on arm64 release image

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -168,6 +168,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ######################### TRITON-CPU BUILD IMAGE #########################
 FROM base AS vllm-triton-cpu-build
 
+# Support for cross-compilation with x86 ISA including AVX2 and AVX512: docker build --build-arg VLLM_CPU_X86="true" ...
+# Re-declared here because this stage is `FROM base` (not `vllm-build`), so it
+# does not inherit the ARG/ENV defined there. Without it, the guard below would
+# see an empty value and build triton-cpu on non-x86 targets (e.g. arm64).
+ARG VLLM_CPU_X86=0
+
 WORKDIR /vllm-workspace
 
 RUN mkdir dist
@@ -268,6 +274,11 @@ ENV HF_HUB_DOWNLOAD_TIMEOUT 60
 
 ######################### RELEASE IMAGE #########################
 FROM base AS vllm-openai
+
+# Re-declared here because this stage is `FROM base` (not `vllm-build`), so the
+# RUN below that gates the triton-cpu wheel install on $VLLM_CPU_X86 would
+# otherwise see an empty value and try to install it on non-x86 targets.
+ARG VLLM_CPU_X86=0
 
 WORKDIR /vllm-workspace
 


### PR DESCRIPTION
## Summary

The arm64 CPU release image build fails while compiling `triton-cpu`:

```
triton-cpu/third_party/cpu/runtime/cpu_runtime.cpp:33:3:
  error: '_Float16' does not name a type; did you mean '_FLOAT16'?
ninja: build stopped: subcommand failed.
ERROR: failed to solve: ... exit code: 2
```

(seen in the v0.23.0 release pipeline: `release-v2` build 2626, job "Build release image - arm64 - CPU")

`triton-cpu` is an x86/CPU-only component and should not be built on arm64 at all. It is gated by:

```dockerfile
if [ "$TARGETARCH" = "amd64" ] || [ "$VLLM_CPU_X86" != "0" ]; then ... fi
```

### Root cause

`VLLM_CPU_X86` is declared (`ARG`/`ENV`, default `0`) **only in the `vllm-build` stage**. The `vllm-triton-cpu-build` and `vllm-openai` stages are `FROM base` (not `FROM vllm-build`), so they never inherit it and never re-declare it. `$VLLM_CPU_X86` therefore expands to an **empty string**, and on arm64 the guard becomes:

```
[ "arm64" = "amd64" ] || [ "" != "0" ]   →   false || true   →   true
```

So the x86-only `triton-cpu` wheel gets compiled on aarch64, where `g++-12` rejects `_Float16`.

This stage was introduced in #43977.

### Fix

Re-declare `ARG VLLM_CPU_X86=0` in the `vllm-triton-cpu-build` and `vllm-openai` stages so the guard resolves correctly. On arm64 it now evaluates to `false` and skips triton-cpu; on amd64 it still builds; and explicit x86 cross-compilation via `--build-arg VLLM_CPU_X86=true` is preserved.

## Not a duplicate

No open PR addresses this. Checked:
- `gh pr list --search "triton-cpu arm64"` → none relevant
- `gh pr list --search "VLLM_CPU_X86"` → none
- `gh pr list --search "Dockerfile.cpu in:title"` → none

## Testing

A full arm64 CPU image build isn't reproducible in this environment (no arm64 emulation), so I verified the guard logic directly, simulating the in-stage value of `$VLLM_CPU_X86` before vs. after the fix:

| TARGETARCH | VLLM_CPU_X86 | Result |
|---|---|---|
| arm64 | `""` (before fix) | **BUILD triton-cpu** ← the bug |
| arm64 | `0` (after fix) | SKIP triton-cpu ✅ |
| amd64 | `0` (after fix) | BUILD triton-cpu ✅ |
| arm64 | `true` (cross-compile) | BUILD triton-cpu ✅ (preserved) |
| amd64 | `true` | BUILD triton-cpu ✅ |

`pre-commit` ran on commit (Dockerfile graph + version-validation hooks passed; no Dockerfile.cpu-specific lint hooks exist).

## Note

AI assistance (Claude Code) was used to diagnose the CI failure and prepare this change.