### PR TITLE
[BugFix] Don't strand parked async-KV-load requests behind an unschedulable queue head

### DIFF
--- a/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
@@ -736,3 +736,83 @@ def test_async_loads_both_admitted_when_pool_fits():
 
     for req in reqs:
         assert req.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+
+
+def test_parked_async_load_not_stranded_by_unschedulable_head():
+    """A request whose async KV load already finished must not be stranded
+    behind an unschedulable queue head when nothing is running (#45388).
+
+    Setup (priority policy):
+    - req_a (low priority) is admitted as an async KV load and parks in
+      WAITING_FOR_REMOTE_KVS holding its blocks.
+    - req_b (high priority) arrives; its full sequence does not fit in the
+      remaining free blocks, so it blocks the head of the waiting queue.
+    - req_a's load finishes, but it is only promoted when the waiting-queue
+      traversal reaches it. With nothing running, stopping the traversal at
+      req_b would deadlock the scheduler permanently: req_a holds the very
+      blocks req_b needs.
+
+    The scheduler must keep scanning past req_b, promote req_a, run it to
+    completion, and then schedule req_b.
+    """
+    vllm_config = create_vllm_config()
+    vllm_config.scheduler_config.policy = "priority"
+    BLOCK_SIZE = vllm_config.cache_config.block_size
+    NUM_BLOCKS = 12
+    scheduler = create_scheduler(vllm_config, num_blocks=NUM_BLOCKS)
+
+    # req_a: 4 full blocks, fully remote -> parks holding 4 blocks.
+    req_a = create_request(
+        request_id=1,
+        block_size=BLOCK_SIZE,
+        num_tokens=BLOCK_SIZE * 4,
+        do_remote_prefill=True,
+        max_tokens=1,
+    )
+    req_a.priority = 1
+    scheduler.add_request(req_a)
+    scheduler_output = scheduler.schedule()
+    assert req_a.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+    assert len(scheduler.running) == 0
+    scheduler.update_from_output(scheduler_output, EMPTY_MODEL_RUNNER_OUTPUT)
+
+    # req_b: higher priority, full sequence cannot fit while req_a's
+    # blocks are held.
+    free_blocks = scheduler.kv_cache_manager.block_pool.get_num_free_blocks()
+    num_b_blocks = free_blocks + 1
+    req_b = create_request(
+        request_id=2,
+        block_size=BLOCK_SIZE,
+        num_tokens=BLOCK_SIZE * num_b_blocks,
+        max_tokens=1,
+    )
+    assert req_b.priority == 0
+    scheduler.add_request(req_b)
+
+    # req_b blocks the head; nothing schedulable yet.
+    scheduler_output = scheduler.schedule()
+    assert scheduler_output.total_num_scheduled_tokens == 0
+    assert len(scheduler.running) == 0
+
+    # req_a finishes receiving its KV.
+    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
+    model_runner_output.kv_connector_output = KVConnectorOutput(
+        finished_recving={req_a.request_id}
+    )
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert req_a.request_id in scheduler.finished_recving_kv_req_ids
+
+    # The scheduler must promote and schedule req_a even though req_b
+    # (unschedulable) is ahead of it in the queue.
+    scheduler_output = scheduler.schedule()
+    assert req_a.status == RequestStatus.RUNNING
+    assert scheduler_output.num_scheduled_tokens[req_a.request_id] == 1
+
+    # req_a finishes, freeing its blocks.
+    model_runner_output = create_model_runner_output([req_a], use_eos=True)
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    # req_b now fits and gets scheduled.
+    scheduler_output = scheduler.schedule()
+    assert req_b.status == RequestStatus.RUNNING
+    assert scheduler_output.num_scheduled_tokens[req_b.request_id] > 0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -844,7 +844,22 @@ class Scheduler(SchedulerInterface):
                     # manager
                     if request.has_encoder_inputs:
                         self.encoder_cache_manager.free(request)
-                    break
+                    if self.running:
+                        # Running requests will free blocks when they
+                        # complete; stop here to preserve queue-order
+                        # admission.
+                        break
+                    # Nothing is running, so no future event frees blocks and
+                    # stopping at this request would freeze this state
+                    # permanently. Requests behind this one may hold blocks
+                    # while parked (async KV loads in WAITING_FOR_REMOTE_KVS)
+                    # and are only promoted when this traversal reaches them.
+                    # Keep scanning so they can be promoted, scheduled, and
+                    # eventually free the blocks this request needs.
+                    # See https://github.com/vllm-project/vllm/issues/45388
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
 
                 # KVTransfer: the connector uses this info to determine
                 # if a load is needed. Note that


### PR DESCRIPTION
## Purpose

Closes the residual scheduler-deadlock window behind #45388 (symptom family of #42371): requests parked in `WAITING_FOR_REMOTE_KVS` hold their allocated blocks and are only promoted (i.e. their `finished_recving` signal only *consumed*) when the waiting-queue traversal reaches them. An unschedulable queue head `break`s that traversal — and when nothing is running, no future event can free blocks: the head keeps failing `allocate_slots`, the parked requests behind it are never promoted, and `schedule()` returns an empty step forever (`Running: 0 reqs, Waiting: N`, GPU KV 0%).

**Status of the original report:** the issue's exact FCFS repro is already fixed on main by #44560 (the reporter's `0.22.1.dev2+g175a57ed9` build predates it) — verified empirically by running the issue's harness on main (completes). However #44560's admission gate only protects an FCFS admission-time invariant. The same permanent freeze is still reachable on today's main, deterministically, under priority scheduling (a later high-priority unfittable head strands a parked low-priority async load that holds the blocks it needs) — and more generally whenever the fit invariant is invalidated after admission. This PR is defense-in-depth that recovers the otherwise-frozen state regardless of which event created it.

**Independently confirmed (2nd trigger, plain FCFS):** @howarlii reproduced and fixed a distinct instance on plain **FCFS** with #44560 in place — `OffloadingConnector`'s `get_num_new_matched_tokens → None` deferral (in-flight hit block; the `_blocks_being_loaded` branch) re-queues an already-admitted async load via `skipped_waiting`, bypassing #44560's admission fit-check. Four shared-prefix parked loads then strand behind a full-ISL-reservation FCFS head (`Running: 0`, single core pinned, hung 10h+); pulling this branch drains and recovers the engine. Same terminal freeze as the priority repro, reached by a different post-admission invariant bypass — confirming the fix is connector- and policy-agnostic. (Config: hybrid Mamba+full-attn, `block_size=416`, `num_gpu_blocks=630`, `scheduler_reserve_full_isl=True`.)

**Fix (+17/−1):** in the waiting-loop allocation-failure path, keep the bare `break` whenever anything is running (running requests will free blocks; preserves strict queue-order admission — byte-identical semantics to today in all healthy states). Only when `self.running` is empty — i.e. when the alternative is scheduling nothing forever — pop the unschedulable request into the existing `step_skipped_waiting` mechanism and keep scanning, so parked requests can be promoted, scheduled, and eventually free the blocks the head needs. No starvation: as soon as anything is admitted, strict ordering resumes. Terminates: each skip pops one request.

## Test Plan

- New regression test `test_parked_async_load_not_stranded_by_unschedulable_head` (in `tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py`): reconstructs the priority-policy scenario; **fails on pristine main** (request stuck in `WAITING_FOR_REMOTE_KVS` with its recv finished — the exact #45388 symptom) → **passes with the fix** (parked request promoted, runs, frees blocks, head then schedules).
- Existing suites:
```
pytest tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py \
       tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py \
       tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
→ 25 passed

pytest tests/v1/core/test_scheduler.py
→ 101 passed, 1 failed — test_async_scheduling_pp_allows_rescheduling_with_output_placeholders
  fails identically on pristine-scheduler code on this box (single-GPU env limitation,
  unrelated to this change)
```
- The issue's deterministic e2e harness completes both on pristine main and with this fix.
- pre-commit (ruff/ruff-format) clean.

## Duplicate check

Issue has 0 comments and no linked PR; searched `45388`, `finished_recving`, `WAITING_FOR_REMOTE_KVS`, `scheduler deadlock` in open PRs — none touch the waiting-loop allocation-failure path. Closest, all different: #44560 (merged admission gate — complementary, see above), #45363 (sleep/unmap transfer drain — different files/mechanism), #42568 (request-count limit), #36014 (mooncake leak cleanup), #33522 (skip ordering).

## (Optional) Documentation Update

None.

---

AI assistance disclosure: investigated and drafted with AI assistance (Claude); the submitter reviewed every changed line and ran the tests locally.

