### PR TITLE
fix: remove extraneous 'messages' argument in DeepseekV4Renderer chat template call (closes #44949)

### DIFF
--- a/vllm/renderers/deepseek_v4.py
+++ b/vllm/renderers/deepseek_v4.py
@@ -50,7 +50,6 @@ class DeepseekV4Renderer(BaseRenderer[DeepseekV4Tokenizer]):
 
         prompt_raw = self._apply_chat_template(
             conversation=conversation,
-            messages=messages,
             **params.get_apply_chat_template_kwargs(),
         )
 


### PR DESCRIPTION
## What
The DeepseekV4Renderer's `render_messages` and `render_messages_async` methods call `self._apply_chat_template` with both `conversation` and `messages` arguments, but the underlying `apply_chat_template` method expects only `conversation` and additional kwargs. This causes a TypeError: `mlir_global_dtors() missing 1 required positional argument: 'data'` because the extra `messages` argument is misinterpreted.

## Fix
Remove the `messages` argument from the `_apply_chat_template` call, as only `conversation` (the pre-processed message list) should be passed. This aligns with the expected signature and resolves the error.

Closes #44949