### PR TITLE
[Metrics][LoRA] Expose loaded LoRA adapters in metrics

### DIFF
--- a/rust/src/engine-core-client/src/client/imp.rs
+++ b/rust/src/engine-core-client/src/client/imp.rs
@@ -468,6 +468,14 @@ pub(crate) async fn run_output_dispatcher_loop(
                                         event,
                                     );
                                 }
+                                EngineNotification::Custom(custom) => {
+                                    // Plugin-defined payload; this frontend
+                                    // has no consumer for it, so ignore.
+                                    trace!(
+                                        key = %custom.key,
+                                        "ignoring custom engine notification"
+                                    );
+                                }
                             }
                         }
                     }

--- a/rust/src/engine-core-client/src/client/imp.rs
+++ b/rust/src/engine-core-client/src/client/imp.rs
@@ -469,8 +469,7 @@ pub(crate) async fn run_output_dispatcher_loop(
                                     );
                                 }
                                 EngineNotification::Custom(custom) => {
-                                    // Plugin-defined payload; this frontend
-                                    // has no consumer for it, so ignore.
+                                    // Plugin payload, nothing consumes it here.
                                     trace!(
                                         key = %custom.key,
                                         "ignoring custom engine notification"

--- a/rust/src/engine-core-client/src/client/imp.rs
+++ b/rust/src/engine-core-client/src/client/imp.rs
@@ -19,8 +19,9 @@ use crate::client::state::{OutputReceiver, RequestRegistry, UtilityReceiver, Uti
 use crate::client::stream::EngineCoreStreamOutput;
 use crate::client::{AbortCause, AbortRequest};
 use crate::error::{client_closed, dispatcher_closed, unexpected_dispatcher_output};
-use crate::metrics::{LoraInfoExporter, SchedulerStatsRecorder};
+use crate::metrics::{LoraInfoExporter, LoraLoadedExporter, SchedulerStatsRecorder};
 use crate::protocol::encode_msgpack;
+use crate::protocol::notifications::EngineNotification;
 use crate::protocol::output::{EngineCoreOutput, EngineCoreOutputs};
 use crate::protocol::request::{EngineCoreRequest, EngineCoreRequestType};
 use crate::protocol::stats::SchedulerStats;
@@ -398,6 +399,7 @@ pub(crate) async fn run_output_dispatcher_loop(
     mut output_rx: mpsc::Receiver<Result<EngineCoreOutputs>>,
 ) {
     let mut lora_info = LoraInfoExporter::default();
+    let mut lora_loaded = LoraLoadedExporter::default();
 
     let result: Result<()> = async {
         loop {
@@ -454,6 +456,21 @@ pub(crate) async fn run_output_dispatcher_loop(
                     // request tracking instead.
                     let (running, waiting) = inner.lora_adapter_states();
                     lora_info.update(&METRICS.scheduler, running, waiting);
+
+                    if let Some(engine_notifications) = batch.engine_notifications.as_ref() {
+                        for event in engine_notifications {
+                            match event {
+                                EngineNotification::LoraLoadEvent(event) => {
+                                    lora_loaded.update(
+                                        &METRICS.scheduler,
+                                        inner.model_name(),
+                                        batch.engine_index,
+                                        event,
+                                    );
+                                }
+                            }
+                        }
+                    }
                 }
                 EngineCoreOutputs::Utility(utility) => {
                     let call_id = utility.output.call_id;

--- a/rust/src/engine-core-client/src/metrics.rs
+++ b/rust/src/engine-core-client/src/metrics.rs
@@ -3,14 +3,16 @@
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use vllm_metrics::{
     EngineLabels, EnginePositionLabels, F64Gauge, Family, HistogramMetric, LoraAdapterNames,
-    LoraInfoLabels, SchedulerLogStatsAccumulator, SchedulerMetrics, U64Counter, U64Gauge,
-    WaitingReasonLabels,
+    LoraInfoLabels, LoraLoadedLabels, LoraLoadedLevel, SchedulerLogStatsAccumulator,
+    SchedulerMetrics, U64Counter, U64Gauge, WaitingReasonLabels,
 };
 
+use crate::protocol::notifications::LoraLoadEvent;
 use crate::protocol::stats::SchedulerStats;
 use crate::transport::ConnectedEngine;
 
@@ -277,6 +279,69 @@ impl LoraInfoExporter {
     }
 }
 
+/// Exports the loaded-LoRA-adapter gauges from
+/// `EngineNotification::LoraLoadEvent` events.
+///
+/// Each event carries the complete current state for one engine, so the
+/// exporter diffs against the previously emitted series to drop adapters
+/// that were evicted since the last event.
+#[derive(Default)]
+pub(crate) struct LoraLoadedExporter {
+    current: HashMap<u32, BTreeSet<LoraLoadedLabels>>,
+}
+
+impl LoraLoadedExporter {
+    pub(crate) fn update(
+        &mut self,
+        metrics: &SchedulerMetrics,
+        model_name: impl Into<String>,
+        engine: u32,
+        event: &LoraLoadEvent,
+    ) {
+        let model_name = model_name.into();
+
+        let engine_labels = EngineLabels {
+            model_name: model_name.clone(),
+            engine,
+        };
+        metrics
+            .lora_gpu_adapters
+            .get_or_create(&engine_labels)
+            .set(event.gpu_adapters.len() as u64);
+        metrics
+            .lora_cpu_adapters
+            .get_or_create(&engine_labels)
+            .set(event.cpu_adapters.len() as u64);
+
+        let gpu: BTreeSet<&str> = event.gpu_adapters.iter().map(String::as_str).collect();
+        let pinned: BTreeSet<&str> = event.pinned_adapters.iter().map(String::as_str).collect();
+        let next: BTreeSet<LoraLoadedLabels> = event
+            .cpu_adapters
+            .iter()
+            .map(|adapter_name| LoraLoadedLabels {
+                model_name: model_name.clone(),
+                engine,
+                adapter_name: adapter_name.clone(),
+                level: if gpu.contains(adapter_name.as_str()) {
+                    LoraLoadedLevel::Gpu
+                } else {
+                    LoraLoadedLevel::Cpu
+                },
+                pinned: pinned.contains(adapter_name.as_str()),
+            })
+            .collect();
+
+        let prev = self.current.entry(engine).or_default();
+        for stale in prev.difference(&next) {
+            metrics.lora_adapter_loaded.remove(stale);
+        }
+        for labels in &next {
+            metrics.lora_adapter_loaded.get_or_create(labels).set(1);
+        }
+        *prev = next;
+    }
+}
+
 fn now_unix_secs() -> f64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -309,6 +374,75 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn lora_loaded_emits_levels_and_clears_stale() {
+        use crate::metrics::LoraLoadedExporter;
+        use crate::protocol::notifications::LoraLoadEvent;
+
+        let metrics = Metrics::new();
+        let mut exporter = LoraLoadedExporter::default();
+
+        // Family iteration order is not deterministic; sort for snapshots.
+        let loaded_series = |rendered: &str| {
+            let mut lines = rendered
+                .lines()
+                .filter(|l| l.starts_with("vllm:lora_adapter_loaded{"))
+                .collect::<Vec<_>>();
+            lines.sort_unstable();
+            lines.join("\n")
+        };
+
+        // "a" active on GPU and pinned, "b" only in the CPU cache.
+        exporter.update(
+            &metrics.scheduler,
+            "model",
+            0,
+            &LoraLoadEvent {
+                gpu_adapters: vec!["a".to_string()],
+                cpu_adapters: vec!["a".to_string(), "b".to_string()],
+                pinned_adapters: vec!["a".to_string()],
+            },
+        );
+        let rendered = metrics.render().unwrap();
+        expect![[r#"
+            vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="a",level="gpu",pinned="true"} 1
+            vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="b",level="cpu",pinned="false"} 1"#]]
+        .assert_eq(&loaded_series(&rendered));
+        assert!(
+            rendered
+                .contains(r#"vllm:num_gpu_loaded_lora_adapters{model_name="model",engine="0"} 1"#)
+        );
+        assert!(
+            rendered
+                .contains(r#"vllm:num_cpu_loaded_lora_adapters{model_name="model",engine="0"} 2"#)
+        );
+
+        // "a" evicted from GPU to CPU (and unpinned), "b" evicted entirely:
+        // the stale series must disappear.
+        exporter.update(
+            &metrics.scheduler,
+            "model",
+            0,
+            &LoraLoadEvent {
+                gpu_adapters: vec![],
+                cpu_adapters: vec!["a".to_string()],
+                pinned_adapters: vec![],
+            },
+        );
+        let rendered = metrics.render().unwrap();
+        expect![[r#"
+            vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="a",level="cpu",pinned="false"} 1"#]]
+        .assert_eq(&loaded_series(&rendered));
+        assert!(
+            rendered
+                .contains(r#"vllm:num_gpu_loaded_lora_adapters{model_name="model",engine="0"} 0"#)
+        );
+        assert!(
+            rendered
+                .contains(r#"vllm:num_cpu_loaded_lora_adapters{model_name="model",engine="0"} 1"#)
+        );
     }
 
     #[test]

--- a/rust/src/engine-core-client/src/protocol/mod.rs
+++ b/rust/src/engine-core-client/src/protocol/mod.rs
@@ -27,6 +27,7 @@ pub mod handshake;
 pub mod logprobs;
 pub mod lora;
 pub mod multimodal;
+pub mod notifications;
 pub mod output;
 pub mod request;
 pub mod sampling;

--- a/rust/src/engine-core-client/src/protocol/notifications.rs
+++ b/rust/src/engine-core-client/src/protocol/notifications.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 /// The set of loaded LoRA adapters changed.
@@ -28,6 +30,28 @@ pub struct LoraLoadEvent {
     pub pinned_adapters: Vec<String>,
 }
 
+/// An open-schema notification reserved for out-of-tree producers (plugins).
+///
+/// The union fails fast on unknown tags, so a plugin can't add its own struct
+/// type without forking the protocol. This reserved `custom` tag is the
+/// escape hatch: the producer namespaces its event under `key` and carries an
+/// arbitrary msgpack `payload`. Frontends that don't recognize `key` ignore
+/// the event (the channel is additive, so an unapplied delta is a no-op).
+///
+/// Python models `payload` as `dict[str, Any]` with `omit_defaults=True`, so
+/// it needs `#[serde(default)]`.
+///
+/// Original Python definition:
+/// <https://github.com/vllm-project/vllm/blob/main/vllm/v1/notifications.py>
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CustomNotification {
+    /// Producer-chosen namespace (e.g. the plugin name).
+    pub key: String,
+    /// Arbitrary msgpack-encodable event data, opaque to this frontend.
+    #[serde(default)]
+    pub payload: BTreeMap<String, rmpv::Value>,
+}
+
 /// Rare engine-level event notifications carried on
 /// `EngineCoreOutputs::engine_notifications`.
 ///
@@ -44,6 +68,7 @@ pub struct LoraLoadEvent {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EngineNotification {
     LoraLoadEvent(LoraLoadEvent),
+    Custom(CustomNotification),
 }
 
 #[cfg(test)]
@@ -95,6 +120,39 @@ mod tests {
         assert_eq!(
             event,
             EngineNotification::LoraLoadEvent(LoraLoadEvent::default())
+        );
+    }
+
+    /// Captured from Python:
+    /// `msgspec.msgpack.encode(CustomNotification(key="my_plugin",
+    /// payload={"count": 5, "name": "foo"}))`
+    const PYTHON_CUSTOM: &str = "83a474797065a6637573746f6da36b6579a96d795f706c7567696ea77061796c6f616482a5636f756e7405a46e616d65a3666f6f";
+
+    /// Captured from Python:
+    /// `msgspec.msgpack.encode(CustomNotification(key="my_plugin"))`,
+    /// where `omit_defaults=True` strips the empty payload.
+    const PYTHON_CUSTOM_EMPTY: &str = "82a474797065a6637573746f6da36b6579a96d795f706c7567696e";
+
+    #[test]
+    fn engine_event_decodes_python_custom_notification() {
+        let event: EngineNotification = decode_msgpack(&hex_bytes(PYTHON_CUSTOM)).unwrap();
+        let EngineNotification::Custom(custom) = event else {
+            panic!("expected custom notification, got {event:?}");
+        };
+        assert_eq!(custom.key, "my_plugin");
+        assert_eq!(custom.payload["count"], rmpv::Value::from(5));
+        assert_eq!(custom.payload["name"], rmpv::Value::from("foo"));
+    }
+
+    #[test]
+    fn engine_event_decodes_custom_omitted_payload() {
+        let event: EngineNotification = decode_msgpack(&hex_bytes(PYTHON_CUSTOM_EMPTY)).unwrap();
+        assert_eq!(
+            event,
+            EngineNotification::Custom(CustomNotification {
+                key: "my_plugin".to_string(),
+                payload: BTreeMap::new(),
+            })
         );
     }
 

--- a/rust/src/engine-core-client/src/protocol/notifications.rs
+++ b/rust/src/engine-core-client/src/protocol/notifications.rs
@@ -30,24 +30,20 @@ pub struct LoraLoadEvent {
     pub pinned_adapters: Vec<String>,
 }
 
-/// An open-schema notification reserved for out-of-tree producers (plugins).
+/// Open escape hatch for out-of-tree producers (plugins).
 ///
-/// The union fails fast on unknown tags, so a plugin can't add its own struct
-/// type without forking the protocol. This reserved `custom` tag is the
-/// escape hatch: the producer namespaces its event under `key` and carries an
-/// arbitrary msgpack `payload`. Frontends that don't recognize `key` ignore
-/// the event (the channel is additive, so an unapplied delta is a no-op).
-///
-/// Python models `payload` as `dict[str, Any]` with `omit_defaults=True`, so
-/// it needs `#[serde(default)]`.
+/// The union fails fast on unknown tags, so plugins can't add their own struct
+/// type. They emit this instead: namespace under `key`, arbitrary `payload`.
+/// Frontends that don't know the `key` ignore it. `payload` is Python's
+/// `dict[str, Any]` with `omit_defaults=True`, hence `#[serde(default)]`.
 ///
 /// Original Python definition:
 /// <https://github.com/vllm-project/vllm/blob/main/vllm/v1/notifications.py>
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct CustomNotification {
-    /// Producer-chosen namespace (e.g. the plugin name).
+    /// Producer-chosen namespace, e.g. the plugin name.
     pub key: String,
-    /// Arbitrary msgpack-encodable event data, opaque to this frontend.
+    /// Arbitrary msgpack data, opaque to this frontend.
     #[serde(default)]
     pub payload: BTreeMap<String, rmpv::Value>,
 }

--- a/rust/src/engine-core-client/src/protocol/notifications.rs
+++ b/rust/src/engine-core-client/src/protocol/notifications.rs
@@ -73,10 +73,7 @@ mod tests {
     use crate::protocol::decode_msgpack;
 
     fn hex_bytes(hex: &str) -> Vec<u8> {
-        (0..hex.len())
-            .step_by(2)
-            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
-            .collect()
+        hex::decode(hex).unwrap()
     }
 
     /// Captured from Python:
@@ -132,12 +129,28 @@ mod tests {
     #[test]
     fn engine_event_decodes_python_custom_notification() {
         let event: EngineNotification = decode_msgpack(&hex_bytes(PYTHON_CUSTOM)).unwrap();
-        let EngineNotification::Custom(custom) = event else {
-            panic!("expected custom notification, got {event:?}");
-        };
-        assert_eq!(custom.key, "my_plugin");
-        assert_eq!(custom.payload["count"], rmpv::Value::from(5));
-        assert_eq!(custom.payload["name"], rmpv::Value::from("foo"));
+        expect_test::expect![[r#"
+            Custom(
+                CustomNotification {
+                    key: "my_plugin",
+                    payload: {
+                        "count": Integer(
+                            PosInt(
+                                5,
+                            ),
+                        ),
+                        "name": String(
+                            Utf8String {
+                                s: Ok(
+                                    "foo",
+                                ),
+                            },
+                        ),
+                    },
+                },
+            )
+        "#]]
+        .assert_debug_eq(&event);
     }
 
     #[test]

--- a/rust/src/engine-core-client/src/protocol/notifications.rs
+++ b/rust/src/engine-core-client/src/protocol/notifications.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use serde::{Deserialize, Serialize};
+
+/// The set of loaded LoRA adapters changed.
+///
+/// Emitted by the worker only when the loaded set changed. Each event
+/// carries the complete current state, so consumers should replace (not
+/// merge with) the previously observed snapshot.
+///
+/// Python models this as a plain (non-`array_like`) tagged `msgspec.Struct`
+/// with `omit_defaults=True`, so every field needs `#[serde(default)]`.
+///
+/// Original Python definition:
+/// <https://github.com/vllm-project/vllm/blob/main/vllm/v1/notifications.py>
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct LoraLoadEvent {
+    /// Names of adapters currently activated into GPU slots (sorted).
+    #[serde(default)]
+    pub gpu_adapters: Vec<String>,
+    /// Names of adapters resident in the CPU cache (sorted). This is a
+    /// superset of `gpu_adapters`.
+    #[serde(default)]
+    pub cpu_adapters: Vec<String>,
+    /// Names of adapters pinned in the caches (sorted).
+    #[serde(default)]
+    pub pinned_adapters: Vec<String>,
+}
+
+/// Rare engine-level event notifications carried on
+/// `EngineCoreOutputs::engine_notifications`.
+///
+/// These are engine-scoped state transitions (as opposed to the per-request
+/// lifecycle events in `EngineCoreOutput::events` and the per-step sampling
+/// in `SchedulerStats`). The union is map-encoded with a `"type"`
+/// discriminator field; msgspec dispatches on each struct's tag. Like the
+/// rest of `EngineCoreOutputs`, the union is version-lockstep with the
+/// engine: an unknown tag is a deployment error and fails the decode.
+///
+/// Original Python definition:
+/// <https://github.com/vllm-project/vllm/blob/main/vllm/v1/notifications.py>
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EngineNotification {
+    LoraLoadEvent(LoraLoadEvent),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::decode_msgpack;
+
+    fn hex_bytes(hex: &str) -> Vec<u8> {
+        (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+            .collect()
+    }
+
+    /// Captured from Python:
+    /// `msgspec.msgpack.encode(LoRALoadEvent(gpu_adapters=["alpha"],
+    /// cpu_adapters=["alpha", "beta"], pinned_adapters=["alpha"]))`
+    const PYTHON_FULL_EVENT: &str = "84a474797065af6c6f72615f6c6f61645f6576656e74ac6770755f616461707465727391a5616c706861ac6370755f616461707465727392a5616c706861a462657461af70696e6e65645f616461707465727391a5616c706861";
+
+    /// Captured from Python: `msgspec.msgpack.encode(LoRALoadEvent())`,
+    /// where `omit_defaults=True` strips everything but the tag.
+    const PYTHON_EMPTY_EVENT: &str = "81a474797065af6c6f72615f6c6f61645f6576656e74";
+
+    #[test]
+    fn engine_event_decodes_python_lora_load_event() {
+        let event: EngineNotification = decode_msgpack(&hex_bytes(PYTHON_FULL_EVENT)).unwrap();
+        expect_test::expect![[r#"
+            LoraLoadEvent(
+                LoraLoadEvent {
+                    gpu_adapters: [
+                        "alpha",
+                    ],
+                    cpu_adapters: [
+                        "alpha",
+                        "beta",
+                    ],
+                    pinned_adapters: [
+                        "alpha",
+                    ],
+                },
+            )
+        "#]]
+        .assert_debug_eq(&event);
+    }
+
+    #[test]
+    fn engine_event_decodes_omitted_defaults() {
+        let event: EngineNotification = decode_msgpack(&hex_bytes(PYTHON_EMPTY_EVENT)).unwrap();
+        assert_eq!(
+            event,
+            EngineNotification::LoraLoadEvent(LoraLoadEvent::default())
+        );
+    }
+
+    #[test]
+    fn engine_event_unknown_tag_fails_fast() {
+        // The union is version-lockstep with the engine; an event type this
+        // frontend does not know about must fail the decode, not be skipped.
+        let value = rmpv::Value::Map(vec![
+            (
+                rmpv::Value::from("type"),
+                rmpv::Value::from("graceful_shutdown_started"),
+            ),
+            (rmpv::Value::from("deadline_seconds"), rmpv::Value::from(30)),
+        ]);
+        let mut bytes = Vec::new();
+        rmpv::encode::write_value(&mut bytes, &value).unwrap();
+
+        let result: Result<EngineNotification, _> = decode_msgpack(&bytes);
+        assert!(result.is_err());
+    }
+}

--- a/rust/src/engine-core-client/src/protocol/output.rs
+++ b/rust/src/engine-core-client/src/protocol/output.rs
@@ -12,6 +12,7 @@ use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use super::utility::UtilityOutput;
 use crate::error::{Error, Result, ext_value_decode};
 use crate::protocol::logprobs::MaybeWireLogprobs;
+use crate::protocol::notifications::EngineNotification;
 use crate::protocol::stats::{PrefillStats, SchedulerStats};
 use crate::protocol::{OpaqueValue, decode_msgpack};
 
@@ -163,6 +164,9 @@ struct WireEngineCoreOutputs {
     /// wave needs to start in other engines.
     #[serde(default)]
     start_wave: Option<u32>,
+    /// Rare engine-level event notifications (see `notifications.rs`).
+    #[serde(default)]
+    engine_notifications: Option<Vec<EngineNotification>>,
 }
 
 /// Data-parallel control notifications multiplexed through `EngineCoreOutputs`.
@@ -179,6 +183,7 @@ pub struct RequestBatchOutputs {
     pub scheduler_stats: Option<Box<SchedulerStats>>,
     pub timestamp: f64,
     pub finished_requests: Option<BTreeSet<String>>,
+    pub engine_notifications: Option<Vec<EngineNotification>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -248,7 +253,8 @@ impl TryFrom<WireEngineCoreOutputs> for EngineCoreOutputs {
     fn try_from(value: WireEngineCoreOutputs) -> Result<Self> {
         let has_request_payload = !value.outputs.is_empty()
             || value.scheduler_stats.is_some()
-            || value.finished_requests.is_some();
+            || value.finished_requests.is_some()
+            || value.engine_notifications.is_some();
 
         match (
             has_request_payload,
@@ -262,6 +268,7 @@ impl TryFrom<WireEngineCoreOutputs> for EngineCoreOutputs {
                 scheduler_stats: value.scheduler_stats,
                 timestamp: value.timestamp,
                 finished_requests: value.finished_requests,
+                engine_notifications: value.engine_notifications,
             }
             .into()),
             (false, Some(_), None, None) => Ok(UtilityCallOutput {
@@ -300,6 +307,7 @@ impl From<EngineCoreOutputs> for WireEngineCoreOutputs {
                 scheduler_stats: batch.scheduler_stats,
                 timestamp: batch.timestamp,
                 finished_requests: batch.finished_requests,
+                engine_notifications: batch.engine_notifications,
                 ..Default::default()
             },
             EngineCoreOutputs::Utility(utility) => Self {
@@ -363,6 +371,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     use super::*;
+    use crate::protocol::notifications::LoraLoadEvent;
     use crate::protocol::output::EngineCoreOutput;
     use crate::protocol::{decode_msgpack, encode_msgpack};
 
@@ -445,6 +454,41 @@ mod tests {
                         {
                             "req-1",
                         },
+                    ),
+                    engine_notifications: None,
+                },
+            )
+        "#]]
+        .assert_debug_eq(&EngineCoreOutputs::try_from(outputs).unwrap());
+    }
+
+    #[test]
+    fn engine_core_outputs_classify_event_only_as_request_batch() {
+        let outputs = WireEngineCoreOutputs {
+            engine_notifications: Some(vec![EngineNotification::LoraLoadEvent(
+                LoraLoadEvent::default(),
+            )]),
+            ..Default::default()
+        };
+
+        expect_test::expect![[r#"
+            RequestBatch(
+                RequestBatchOutputs {
+                    engine_index: 0,
+                    outputs: [],
+                    scheduler_stats: None,
+                    timestamp: 0.0,
+                    finished_requests: None,
+                    engine_notifications: Some(
+                        [
+                            LoraLoadEvent(
+                                LoraLoadEvent {
+                                    gpu_adapters: [],
+                                    cpu_adapters: [],
+                                    pinned_adapters: [],
+                                },
+                            ),
+                        ],
                     ),
                 },
             )

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2616,6 +2616,24 @@ fn python_msgpack_fixtures_match_rust_encoding() {
                         "req-1",
                     },
                 ),
+                engine_notifications: Some(
+                    [
+                        LoraLoadEvent(
+                            LoraLoadEvent {
+                                gpu_adapters: [
+                                    "alpha",
+                                ],
+                                cpu_adapters: [
+                                    "alpha",
+                                    "beta",
+                                ],
+                                pinned_adapters: [
+                                    "alpha",
+                                ],
+                            },
+                        ),
+                    ],
+                ),
             },
         )
     "#]]

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -99,6 +99,20 @@ class EngineCoreOutput(
     num_nans_in_logits: int = 0
 
 
+class LoRALoadEvent(
+    msgspec.Struct,
+    tag="lora_load_event",
+    omit_defaults=True,
+):
+    gpu_adapters: list[str] = []
+    cpu_adapters: list[str] = []
+    pinned_adapters: list[str] = []
+
+
+# Union of engine-level event types; mirrors vllm/v1/notifications.py.
+EngineNotification = LoRALoadEvent
+
+
 class EngineCoreOutputs(
     msgspec.Struct,
     array_like=True,
@@ -112,6 +126,7 @@ class EngineCoreOutputs(
     finished_requests: set[str] | None = None
     wave_complete: int | None = None
     start_wave: int | None = None
+    engine_notifications: list[EngineNotification] | None = None
 
 
 request = EngineCoreRequest(
@@ -199,6 +214,13 @@ outputs = EngineCoreOutputs(
         )
     ],
     finished_requests={"req-1"},
+    engine_notifications=[
+        LoRALoadEvent(
+            gpu_adapters=["alpha"],
+            cpu_adapters=["alpha", "beta"],
+            pinned_adapters=["alpha"],
+        )
+    ],
 )
 
 

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -109,8 +109,17 @@ class LoRALoadEvent(
     pinned_adapters: list[str] = []
 
 
+class CustomNotification(
+    msgspec.Struct,
+    tag="custom",
+    omit_defaults=True,
+):
+    key: str
+    payload: dict[str, object] = {}
+
+
 # Union of engine-level event types; mirrors vllm/v1/notifications.py.
-EngineNotification = LoRALoadEvent
+EngineNotification = LoRALoadEvent | CustomNotification
 
 
 class EngineCoreOutputs(

--- a/rust/src/metrics/src/scheduler.rs
+++ b/rust/src/metrics/src/scheduler.rs
@@ -150,6 +150,38 @@ impl SchedulerLogStatsAccumulator {
     }
 }
 
+/// Where a LoRA adapter is resident, encoded as the `level` label value.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LoraLoadedLevel {
+    /// Active in a GPU slot.
+    Gpu,
+    /// Only resident in the host cache.
+    Cpu,
+}
+
+impl EncodeLabelValue for LoraLoadedLevel {
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(
+            &match self {
+                Self::Gpu => "gpu",
+                Self::Cpu => "cpu",
+            },
+            encoder,
+        )
+    }
+}
+
+/// Labels for `vllm:lora_adapter_loaded`, one series per resident adapter.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet)]
+pub struct LoraLoadedLabels {
+    pub model_name: String,
+    pub engine: u32,
+    pub adapter_name: String,
+    pub level: LoraLoadedLevel,
+    /// Whether the adapter is pinned in the caches.
+    pub pinned: bool,
+}
+
 /// Scheduler/batch-scoped Prometheus families exported from `SchedulerStats`.
 pub struct SchedulerMetrics {
     // Scheduler state gauges.
@@ -161,6 +193,12 @@ pub struct SchedulerMetrics {
     /// `vllm:lora_requests_info`. Value is the emit-time unix timestamp in
     /// seconds.
     pub lora_info: Family<LoraInfoLabels, F64Gauge>,
+
+    // Worker-side LoRA adapter cache residency, driven by
+    // `EngineNotification::LoraLoadEvent` events.
+    pub lora_gpu_adapters: Family<EngineLabels, U64Gauge>,
+    pub lora_cpu_adapters: Family<EngineLabels, U64Gauge>,
+    pub lora_adapter_loaded: Family<LoraLoadedLabels, U64Gauge>,
 
     // Prefix-cache counters, including the connector-backed external cache path.
     pub prefix_cache_queries: Family<EngineLabels, U64Counter>,
@@ -227,8 +265,29 @@ impl SchedulerMetrics {
         let lora_info = Family::default();
         registry.register(
             "vllm:lora_requests_info",
-            "Running stats on lora requests.",
+            "Running stats on lora requests. DEPRECATED: encodes adapter names into comma-separated label values; superseded by vllm:lora_adapter_loaded, vllm:num_gpu_loaded_lora_adapters and vllm:num_cpu_loaded_lora_adapters.",
             lora_info.clone(),
+        );
+
+        let lora_gpu_adapters = Family::default();
+        registry.register(
+            "vllm:num_gpu_loaded_lora_adapters",
+            "Number of LoRA adapters currently loaded into GPU slots.",
+            lora_gpu_adapters.clone(),
+        );
+
+        let lora_cpu_adapters = Family::default();
+        registry.register(
+            "vllm:num_cpu_loaded_lora_adapters",
+            "Number of LoRA adapters currently resident in the worker's CPU cache (superset of the GPU-loaded set).",
+            lora_cpu_adapters.clone(),
+        );
+
+        let lora_adapter_loaded = Family::default();
+        registry.register(
+            "vllm:lora_adapter_loaded",
+            "Residency of individual LoRA adapters in the worker's adapter caches. The series exists (value 1) while the adapter is resident; 'level' is 'gpu' when the adapter is active in a GPU slot and 'cpu' when it is only in the host cache.",
+            lora_adapter_loaded.clone(),
         );
 
         // Prefix-cache counters, including the connector-backed external cache path.
@@ -342,6 +401,9 @@ impl SchedulerMetrics {
             scheduler_waiting_by_reason,
             kv_cache_usage,
             lora_info,
+            lora_gpu_adapters,
+            lora_cpu_adapters,
+            lora_adapter_loaded,
             prefix_cache_queries,
             prefix_cache_hits,
             external_prefix_cache_queries,

--- a/tests/plugins/vllm_add_dummy_stat_logger/dummy_stat_logger/dummy_stat_logger.py
+++ b/tests/plugins/vllm_add_dummy_stat_logger/dummy_stat_logger/dummy_stat_logger.py
@@ -18,7 +18,12 @@ class DummyStatLogger(StatLoggerBase):
         self.engine_initialized = False
 
     def record(
-        self, scheduler_stats, iteration_stats, mm_cache_stats=None, engine_idx=0
+        self,
+        scheduler_stats,
+        iteration_stats,
+        mm_cache_stats=None,
+        engine_notifications=None,
+        engine_idx=0,
     ):
         self.recorded.append(
             (scheduler_stats, iteration_stats, mm_cache_stats, engine_idx)

--- a/tests/v1/distributed/test_async_llm_dp.py
+++ b/tests/v1/distributed/test_async_llm_dp.py
@@ -22,6 +22,7 @@ from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.engine.core_client import DPLBAsyncMPClient
 from vllm.v1.metrics.loggers import StatLoggerBase
 from vllm.v1.metrics.stats import IterationStats, MultiModalCacheStats, SchedulerStats
+from vllm.v1.notifications import EngineNotification
 
 DP_SIZE = int(os.getenv("DP_SIZE", 2))
 
@@ -108,6 +109,7 @@ async def test_load(
             scheduler_stats: SchedulerStats | None,
             iteration_stats: IterationStats | None,
             mm_cache_stats: MultiModalCacheStats | None = None,
+            engine_notifications: list[EngineNotification] | None = None,
             engine_idx: int = 0,
         ):
             if iteration_stats:

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -7,15 +7,23 @@ model: the buffer only touches `self._pending_notifications`, so a bare
 instance is enough to assert the additive delivery contract.
 """
 
+from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import EngineCoreOutputs
 from vllm.v1.engine.core import EngineCore
-from vllm.v1.notifications import LoRALoadEvent
+from vllm.v1.notifications import CustomNotification, LoRALoadEvent
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
 
 
 def _bare_engine_core() -> EngineCore:
     engine_core = EngineCore.__new__(EngineCore)
     engine_core._pending_notifications = []
     return engine_core
+
+
+def _bare_scheduler() -> Scheduler:
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._pending_notifications = []
+    return scheduler
 
 
 def test_notifications_accumulate_additively():
@@ -78,3 +86,38 @@ def test_flush_noop_when_empty():
     outputs: dict[int, EngineCoreOutputs] = {}
     engine_core._flush_notifications(outputs)
     assert outputs == {}
+
+
+def test_scheduler_publish_take_roundtrip():
+    """publish_notification queues; take_notifications drains exactly once."""
+    scheduler = _bare_scheduler()
+
+    lora = LoRALoadEvent(gpu_adapters=["a"])
+    custom = CustomNotification(key="my_plugin", payload={"count": 1})
+    scheduler.publish_notification(lora)
+    scheduler.publish_notification(custom)
+
+    assert scheduler.take_notifications() == [lora, custom]
+    # Drained: a second take returns nothing.
+    assert scheduler.take_notifications() == []
+
+
+def test_collect_drains_scheduler_notifications():
+    """_collect_step_notifications forwards scheduler-sourced events.
+
+    Worker and scheduler producers share the same additive channel; this
+    pins the review ask (maxdebayser) that scheduler notifications flow
+    through EngineCore alongside worker_notifications.
+    """
+    engine_core = _bare_engine_core()
+    engine_core.scheduler = _bare_scheduler()
+
+    event = CustomNotification(key="my_plugin", payload={"n": 1})
+    engine_core.scheduler.publish_notification(event)
+
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._collect_step_notifications(EMPTY_MODEL_RUNNER_OUTPUT, outputs)
+
+    assert outputs[0].engine_notifications == [event]
+    # Scheduler buffer was drained as a side effect.
+    assert engine_core.scheduler.take_notifications() == []

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -2,9 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for the in-process engine-notification buffer.
 
-These exercise the real `EngineCore` buffering helpers without loading a
-model: the buffer only touches `self._pending_notifications`, so a bare
-instance is enough to assert the additive delivery contract.
+Hits the real `EngineCore`/`Scheduler` buffer helpers without a model: they
+only touch `_pending_notifications`, so a bare instance is enough.
 """
 
 from vllm.v1.core.sched.scheduler import Scheduler
@@ -27,10 +26,10 @@ def _bare_scheduler() -> Scheduler:
 
 
 def test_notifications_accumulate_additively():
-    """Multiple events queued before a flush are all delivered, in order.
+    """Everything queued before a flush comes out, in order.
 
-    This is the additive contract: the buffer must not coalesce (e.g. keep
-    only the latest per type), or counter-style increments would be lost.
+    The additive contract: no coalescing (e.g. latest-per-type), or counter
+    increments would get lost.
     """
     engine_core = _bare_engine_core()
 
@@ -98,16 +97,15 @@ def test_scheduler_publish_take_roundtrip():
     scheduler.publish_notification(custom)
 
     assert scheduler.take_notifications() == [lora, custom]
-    # Drained: a second take returns nothing.
+    # Second take is empty, it drained.
     assert scheduler.take_notifications() == []
 
 
 def test_collect_drains_scheduler_notifications():
-    """_collect_step_notifications forwards scheduler-sourced events.
+    """Scheduler-sourced events flow out through EngineCore too.
 
-    Worker and scheduler producers share the same additive channel; this
-    pins the review ask (maxdebayser) that scheduler notifications flow
-    through EngineCore alongside worker_notifications.
+    Worker and scheduler notifications share the same channel: scheduler events
+    ride alongside worker_notifications.
     """
     engine_core = _bare_engine_core()
     engine_core.scheduler = _bare_scheduler()
@@ -119,5 +117,5 @@ def test_collect_drains_scheduler_notifications():
     engine_core._collect_step_notifications(EMPTY_MODEL_RUNNER_OUTPUT, outputs)
 
     assert outputs[0].engine_notifications == [event]
-    # Scheduler buffer was drained as a side effect.
+    # Draining it was a side effect of the collect.
     assert engine_core.scheduler.take_notifications() == []

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the in-process engine-notification buffer.
+
+These exercise the real `EngineCore` buffering helpers without loading a
+model: the buffer only touches `self._pending_notifications`, so a bare
+instance is enough to assert the additive delivery contract.
+"""
+
+from vllm.v1.engine import EngineCoreOutputs
+from vllm.v1.engine.core import EngineCore
+from vllm.v1.notifications import LoRALoadEvent
+
+
+def _bare_engine_core() -> EngineCore:
+    engine_core = EngineCore.__new__(EngineCore)
+    engine_core._pending_notifications = []
+    return engine_core
+
+
+def test_notifications_accumulate_additively():
+    """Multiple events queued before a flush are all delivered, in order.
+
+    This is the additive contract: the buffer must not coalesce (e.g. keep
+    only the latest per type), or counter-style increments would be lost.
+    """
+    engine_core = _bare_engine_core()
+
+    first = LoRALoadEvent(gpu_adapters=["a"], cpu_adapters=["a"])
+    second = LoRALoadEvent(gpu_adapters=["a", "b"], cpu_adapters=["a", "b"])
+    engine_core._publish_notifications([first])
+    engine_core._publish_notifications([second])
+
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(outputs)
+
+    assert outputs[0].engine_notifications == [first, second]
+
+
+def test_flush_clears_buffer_between_steps():
+    """A flush drains the buffer; later events are independent."""
+    engine_core = _bare_engine_core()
+
+    engine_core._publish_notifications([LoRALoadEvent(gpu_adapters=["a"])])
+    first_outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(first_outputs)
+
+    second_outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(second_outputs)
+    assert second_outputs == {}
+
+    later = LoRALoadEvent(gpu_adapters=["b"])
+    engine_core._publish_notifications([later])
+    third_outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(third_outputs)
+    assert third_outputs[0].engine_notifications == [later]
+
+
+def test_flush_reuses_existing_outputs():
+    """Notifications attach to an existing per-engine outputs entry."""
+    engine_core = _bare_engine_core()
+
+    event = LoRALoadEvent(gpu_adapters=["a"])
+    engine_core._publish_notifications([event])
+
+    existing = EngineCoreOutputs(engine_index=2)
+    outputs = {2: existing}
+    engine_core._flush_notifications(outputs)
+
+    assert outputs == {2: existing}
+    assert existing.engine_notifications == [event]
+
+
+def test_flush_noop_when_empty():
+    """Nothing is added to outputs when the buffer is empty."""
+    engine_core = _bare_engine_core()
+
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(outputs)
+    assert outputs == {}

--- a/tests/v1/test_serial_utils.py
+++ b/tests/v1/test_serial_utils.py
@@ -559,3 +559,49 @@ def test_zero_copy_frames_survive_without_caller_side_references():
         assert torch.equal(decoded.prompt_embeds, expected)
         push.close(linger=0)
         pull.close(linger=0)
+
+
+def test_engine_notifications_round_trip():
+    """LoRA residency events survive the EngineCoreOutputs wire format.
+
+    The Rust frontend decodes the exact same bytes (see
+    rust/src/engine-core-client/src/protocol/notifications.rs), so this
+    also pins the map-with-"type"-tag encoding produced by msgspec.
+    """
+    from vllm.v1.engine import EngineCoreOutputs
+    from vllm.v1.notifications import LoRALoadEvent
+
+    event = LoRALoadEvent(
+        gpu_adapters=["alpha"],
+        cpu_adapters=["alpha", "beta"],
+        pinned_adapters=["alpha"],
+    )
+    outputs = EngineCoreOutputs(engine_index=3, engine_notifications=[event])
+
+    encoder = MsgpackEncoder()
+    decoder = MsgpackDecoder(EngineCoreOutputs)
+    decoded = decoder.decode(encoder.encode(outputs))
+
+    assert decoded.engine_index == 3
+    assert decoded.engine_notifications == [event]
+
+    # tag check
+    raw = msgspec.msgpack.decode(msgspec.msgpack.encode(event))
+    assert raw["type"] == "lora_load_event"
+
+    # events are rare, ensure not transmitted when unset
+    no_events = decoder.decode(encoder.encode(EngineCoreOutputs(engine_index=3)))
+    assert no_events.engine_notifications is None
+
+
+def test_engine_notifications_unknown_tag_fails_fast():
+    """The notification union is version-lockstep, like the rest of
+    EngineCoreOutputs: an unknown tag is a deployment error and must fail
+    the decode, not be skipped."""
+    from vllm.v1.notifications import EngineNotification
+
+    future_event = msgspec.msgpack.encode(
+        {"type": "graceful_shutdown_started", "step": 1}
+    )
+    with pytest.raises(msgspec.ValidationError):
+        msgspec.msgpack.decode(future_event, type=EngineNotification)

--- a/tests/v1/test_serial_utils.py
+++ b/tests/v1/test_serial_utils.py
@@ -594,6 +594,32 @@ def test_engine_notifications_round_trip():
     assert no_events.engine_notifications is None
 
 
+def test_custom_notification_round_trip():
+    """The open `custom` tag survives the wire and namespaces its payload.
+
+    Plugins emit this when they can't add a struct type to the lockstep
+    union; the Rust frontend decodes the same bytes (see
+    rust/src/engine-core-client/src/protocol/notifications.rs).
+    """
+    from vllm.v1.engine import EngineCoreOutputs
+    from vllm.v1.notifications import CustomNotification
+
+    event = CustomNotification(key="my_plugin", payload={"count": 5, "name": "foo"})
+    outputs = EngineCoreOutputs(engine_index=1, engine_notifications=[event])
+
+    encoder = MsgpackEncoder()
+    decoder = MsgpackDecoder(EngineCoreOutputs)
+    decoded = decoder.decode(encoder.encode(outputs))
+
+    assert decoded.engine_notifications == [event]
+
+    raw = msgspec.msgpack.decode(msgspec.msgpack.encode(event))
+    assert raw["type"] == "custom"
+    # omit_defaults strips the payload when empty.
+    empty = msgspec.msgpack.decode(msgspec.msgpack.encode(CustomNotification(key="p")))
+    assert "payload" not in empty
+
+
 def test_engine_notifications_unknown_tag_fails_fast():
     """The notification union is version-lockstep, like the rest of
     EngineCoreOutputs: an unknown tag is a deployment error and must fail

--- a/tests/v1/test_serial_utils.py
+++ b/tests/v1/test_serial_utils.py
@@ -595,11 +595,10 @@ def test_engine_notifications_round_trip():
 
 
 def test_custom_notification_round_trip():
-    """The open `custom` tag survives the wire and namespaces its payload.
+    """The open `custom` tag survives the wire with its payload intact.
 
-    Plugins emit this when they can't add a struct type to the lockstep
-    union; the Rust frontend decodes the same bytes (see
-    rust/src/engine-core-client/src/protocol/notifications.rs).
+    What plugins emit when they can't add a struct to the lockstep union; Rust
+    decodes the same bytes (see notifications.rs).
     """
     from vllm.v1.engine import EngineCoreOutputs
     from vllm.v1.notifications import CustomNotification

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -3,6 +3,7 @@
 
 import math
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TypeVar
 
 import torch
@@ -55,6 +56,20 @@ class SupportsLoRAModel(nn.Module, SupportsLoRA): ...
 
 
 class SupportsLoRAMultiModalModel(SupportsLoRAModel, SupportsMultiModal): ...
+
+
+@dataclass
+class LoRALoadedState:
+    """Adapter int ids resident in each tier of a LoRA manager's caches."""
+
+    active_ids: set[int]
+    """Adapters activated into GPU slots."""
+
+    registered_ids: set[int]
+    """Adapters resident in the CPU cache (superset of `active_ids`)."""
+
+    pinned_ids: set[int]
+    """Adapters pinned in the caches."""
 
 
 class AdapterLRUCache(LRUCache[int, T]):
@@ -356,6 +371,13 @@ class LoRAModelManager:
             "Pinning is not supported in LoRAModelManager. "
             "Use LRUCacheLoRAModelManager for pinning"
         )  # type: ignore
+
+    def get_loaded_state(self) -> LoRALoadedState:
+        return LoRALoadedState(
+            active_ids=set(self._active_adapters),
+            registered_ids=set(self._registered_adapters),
+            pinned_ids=set(),
+        )
 
     def _set_adapter_mapping(self, mapping: LoRAMapping) -> None:
         # Default to the main language model wrapper
@@ -1228,6 +1250,15 @@ class LRUCacheLoRAModelManager(LoRAModelManager):
             self.activate_adapter(lora_id)
 
         self._active_adapters.pin(lora_id)
+
+    def get_loaded_state(self) -> LoRALoadedState:
+        # Iterate the LRU caches directly: the .cache property copies the
+        # whole backing dict per access, and this runs on every step.
+        return LoRALoadedState(
+            active_ids=set(self._active_adapters),
+            registered_ids=set(self._registered_adapters),
+            pinned_ids=set(self._registered_adapters.pinned_items),
+        )
 
 
 def create_lora_manager(

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -12,6 +12,7 @@ from vllm.exceptions import LoRAAdapterNotFoundError
 from vllm.logger import init_logger
 from vllm.lora.lora_model import LoRAModel
 from vllm.lora.model_manager import (
+    LoRALoadedState,
     LoRAModelManager,
     LRUCacheLoRAModelManager,
     create_lora_manager,
@@ -67,6 +68,9 @@ class WorkerLoRAManager:
                 text_config, "max_position_embeddings", None
             )
         self.device = device
+        # Adapter int id -> adapter name, for load-event reporting. Entries
+        # for evicted adapters are pruned on each get_loaded_names() call.
+        self._adapter_names: dict[int, str] = {}
         # Lazily initialized by create_lora_manager.
         self._adapter_manager: LoRAModelManager
 
@@ -169,6 +173,7 @@ class WorkerLoRAManager:
         except Exception as e:
             raise e
 
+        self._adapter_names[lora_request.lora_int_id] = lora_request.lora_name
         return lora
 
     def add_dummy_lora(self, lora_request: LoRARequest, rank: int) -> bool:
@@ -236,6 +241,45 @@ class WorkerLoRAManager:
 
     def list_adapters(self) -> set[int]:
         return set(self._adapter_manager.list_adapters())
+
+    def get_loaded_state(self) -> LoRALoadedState:
+        return self._adapter_manager.get_loaded_state()
+
+    def get_loaded_names(
+        self, state: LoRALoadedState
+    ) -> tuple[list[str], list[str], list[str]]:
+        """Resolve a loaded-adapter state into adapter names, for the
+        loaded-adapter metrics.
+
+        Names are deduplicated: if the same adapter name is briefly
+        registered under more than one int id (e.g. an unload racing a
+        reload of the same name), it is reported once per tier it occupies.
+
+        Args:
+            state: The id-level loaded-adapter snapshot to resolve.
+
+        Returns:
+            A `(gpu_adapters, cpu_adapters, pinned_adapters)` tuple of
+            sorted adapter name lists.
+        """
+        # Drop name entries for adapters that have been evicted/removed so
+        # the map stays bounded by the CPU cache capacity.
+        self._adapter_names = {
+            lora_id: name
+            for lora_id, name in self._adapter_names.items()
+            if lora_id in state.registered_ids
+        }
+
+        def names(ids: set[int]) -> list[str]:
+            # Dummy/warmup adapters never go through _load_adapter; fall
+            # back to the int id so they are still visible.
+            return sorted({self._adapter_names.get(i, str(i)) for i in ids})
+
+        return (
+            names(state.active_ids),
+            names(state.registered_ids),
+            names(state.pinned_ids),
+        )
 
 
 class LRUCacheWorkerLoRAManager(WorkerLoRAManager):

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from vllm.v1.engine import EngineCoreOutputs
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.metrics.stats import SchedulerStats
+    from vllm.v1.notifications import EngineNotification
     from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
     from vllm.v1.request import Request, RequestStatus
     from vllm.v1.structured_output import StructuredOutputManager
@@ -246,6 +247,16 @@ class SchedulerInterface(ABC):
         The SchedulerStats object is created for every scheduling step.
         """
         raise NotImplementedError
+
+    def take_notifications(self) -> list["EngineNotification"]:
+        """Drain engine notifications the scheduler produced this step.
+
+        EngineCore calls this each step and forwards the result on
+        `EngineCoreOutputs.engine_notifications` (the same additive channel
+        the worker uses). The base scheduler produces none; override to emit
+        engine-scoped events (e.g. plugin metrics) from the scheduler.
+        """
+        return []
 
     @abstractmethod
     def shutdown(self) -> None:

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -249,12 +249,12 @@ class SchedulerInterface(ABC):
         raise NotImplementedError
 
     def take_notifications(self) -> list["EngineNotification"]:
-        """Drain engine notifications the scheduler produced this step.
+        """Drain notifications the scheduler emitted this step.
 
-        EngineCore calls this each step and forwards the result on
-        `EngineCoreOutputs.engine_notifications` (the same additive channel
-        the worker uses). The base scheduler produces none; override to emit
-        engine-scoped events (e.g. plugin metrics) from the scheduler.
+        EngineCore calls this each step and forwards them on
+        `EngineCoreOutputs.engine_notifications`, same channel the worker uses.
+        Base scheduler emits none; override to push events (e.g. plugin
+        metrics) from the scheduler.
         """
         return []
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -106,10 +106,8 @@ class Scheduler(SchedulerInterface):
         # Track requests scheduled in prior step (MRV1-only).
         self.prev_step_scheduled_req_ids: set[str] = set()
 
-        # Engine notifications the scheduler emits this step. Drained by
-        # EngineCore via take_notifications() and forwarded on the additive
-        # EngineCoreOutputs.engine_notifications channel. Empty in the base
-        # scheduler; plugins call publish_notification() to populate it.
+        # Notifications the scheduler emits this step, drained by EngineCore.
+        # Empty unless a plugin calls publish_notification().
         self._pending_notifications: list[EngineNotification] = []
 
         # Scheduling constraints.
@@ -2538,12 +2536,10 @@ class Scheduler(SchedulerInterface):
         )
 
     def publish_notification(self, notification: EngineNotification) -> None:
-        """Queue an engine notification to forward on the next step.
+        """Queue a notification to forward on the next step.
 
-        Producer side of the scheduler notification hook: a plugin holding a
-        reference to the scheduler appends here, and EngineCore drains the
-        buffer via take_notifications(). Events accumulate additively, so a
-        producer may emit more than one per step.
+        Producer side: a plugin holding the scheduler appends here, EngineCore
+        drains via take_notifications(). Additive, so emit as many as you want.
         """
         self._pending_notifications.append(notification)
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -56,6 +56,7 @@ from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutp
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
+from vllm.v1.notifications import EngineNotification
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
 from vllm.v1.spec_decode.dynamic.utils import build_dynamic_sd_schedule_lookup
@@ -104,6 +105,12 @@ class Scheduler(SchedulerInterface):
         )
         # Track requests scheduled in prior step (MRV1-only).
         self.prev_step_scheduled_req_ids: set[str] = set()
+
+        # Engine notifications the scheduler emits this step. Drained by
+        # EngineCore via take_notifications() and forwarded on the additive
+        # EngineCoreOutputs.engine_notifications channel. Empty in the base
+        # scheduler; plugins call publish_notification() to populate it.
+        self._pending_notifications: list[EngineNotification] = []
 
         # Scheduling constraints.
         self.max_num_running_reqs = self.scheduler_config.max_num_seqs
@@ -2529,6 +2536,21 @@ class Scheduler(SchedulerInterface):
             cudagraph_stats=cudagraph_stats,
             perf_stats=perf_stats,
         )
+
+    def publish_notification(self, notification: EngineNotification) -> None:
+        """Queue an engine notification to forward on the next step.
+
+        Producer side of the scheduler notification hook: a plugin holding a
+        reference to the scheduler appends here, and EngineCore drains the
+        buffer via take_notifications(). Events accumulate additively, so a
+        producer may emit more than one per step.
+        """
+        self._pending_notifications.append(notification)
+
+    def take_notifications(self) -> list[EngineNotification]:
+        notifications = self._pending_notifications
+        self._pending_notifications = []
+        return notifications
 
     def make_spec_decoding_stats(
         self,

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -17,6 +17,7 @@ from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.v1.metrics.stats import PrefillStats, SchedulerStats
+from vllm.v1.notifications import EngineNotification
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors
 from vllm.v1.serial_utils import UtilityResult
 
@@ -254,6 +255,11 @@ class EngineCoreOutputs(
     # In DP case, used to signal that a request was received for an
     # "old" wave, so the next wave needs to be started in other engines.
     start_wave: int | None = None
+
+    # Rare engine-level event notifications (see vllm/v1/notifications.py).
+    # This struct is array_like, so field order is load-bearing for
+    # non-Python frontends; new fields must be appended.
+    engine_notifications: list[EngineNotification] | None = None
 
     def __post_init__(self):
         if self.timestamp == 0.0:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -727,6 +727,7 @@ class AsyncLLM(EngineClient):
                             scheduler_stats=outputs.scheduler_stats,
                             iteration_stats=iteration_stats,
                             mm_cache_stats=renderer.stat_mm_cache(),
+                            engine_notifications=outputs.engine_notifications,
                         )
             except Exception as e:
                 logger.exception("AsyncLLM output_handler failed.")

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -240,10 +240,11 @@ class EngineCore:
 
         # Engine notifications awaiting delivery to the in-process frontend
         # (EngineCoreProc overrides _publish_notifications to broadcast
-        # immediately instead). Keyed by notification type: each
-        # notification is a complete snapshot, so the latest one supersedes
-        # earlier ones and the queue stays bounded while the engine is idle.
-        self._pending_notifications: dict[type, EngineNotification] = {}
+        # immediately instead). Accumulated additively in emission order,
+        # like scheduler_stats: every queued event is delivered, nothing is
+        # dropped. Producers throttle their own emission (e.g. LoRA only
+        # emits on a change), so the buffer stays bounded while idle.
+        self._pending_notifications: list[EngineNotification] = []
 
         # Mark the startup heap as static so that it's ignored by GC.
         # Reduces pause times of oldest generation collections.
@@ -751,14 +752,13 @@ class EngineCore:
     def _publish_notifications(self, notifications: list[EngineNotification]) -> None:
         """Queue engine notifications for delivery to the frontend.
 
-        Notifications are one-shot deltas (unlike scheduler_stats they are
-        not regenerated every step), so delivery must not silently drop
-        them. The in-process engine holds the latest snapshot per type
-        until the next step's outputs; EngineCoreProc overrides this to
-        broadcast to every connected frontend immediately.
+        Notifications accumulate additively (like scheduler_stats), so
+        delivery must not silently drop them: every queued event is sent in
+        emission order. The in-process engine buffers them until the next
+        step's outputs; EngineCoreProc overrides this to broadcast to every
+        connected frontend immediately.
         """
-        for notification in notifications:
-            self._pending_notifications[type(notification)] = notification
+        self._pending_notifications.extend(notifications)
 
     def _flush_notifications(
         self, engine_core_outputs: dict[int, EngineCoreOutputs]
@@ -768,8 +768,8 @@ class EngineCore:
             return
         if (eco := next(iter(engine_core_outputs.values()), None)) is None:
             engine_core_outputs[0] = eco = EngineCoreOutputs()
-        eco.engine_notifications = list(self._pending_notifications.values())
-        self._pending_notifications.clear()
+        eco.engine_notifications = self._pending_notifications
+        self._pending_notifications = []
 
     def _collect_step_notifications(
         self,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -778,6 +778,8 @@ class EngineCore:
     ) -> None:
         if model_output.worker_notifications:
             self._publish_notifications(model_output.worker_notifications)
+        if scheduler_notifications := self.scheduler.take_notifications():
+            self._publish_notifications(scheduler_notifications)
         self._flush_notifications(engine_core_outputs)
 
     def _process_aborts_queue(self):

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -238,12 +238,10 @@ class EngineCore:
 
         self._idle_state_callbacks: list[Callable] = []
 
-        # Engine notifications awaiting delivery to the in-process frontend
-        # (EngineCoreProc overrides _publish_notifications to broadcast
-        # immediately instead). Accumulated additively in emission order,
-        # like scheduler_stats: every queued event is delivered, nothing is
-        # dropped. Producers throttle their own emission (e.g. LoRA only
-        # emits on a change), so the buffer stays bounded while idle.
+        # Notifications waiting on the in-process frontend (EngineCoreProc
+        # overrides _publish_notifications to broadcast instead). Additive in
+        # emission order, like scheduler_stats: nothing dropped. Producers
+        # throttle themselves, so this stays bounded while idle.
         self._pending_notifications: list[EngineNotification] = []
 
         # Mark the startup heap as static so that it's ignored by GC.
@@ -750,13 +748,11 @@ class EngineCore:
         return engine_core_outputs, model_executed
 
     def _publish_notifications(self, notifications: list[EngineNotification]) -> None:
-        """Queue engine notifications for delivery to the frontend.
+        """Queue notifications for the frontend.
 
-        Notifications accumulate additively (like scheduler_stats), so
-        delivery must not silently drop them: every queued event is sent in
-        emission order. The in-process engine buffers them until the next
-        step's outputs; EngineCoreProc overrides this to broadcast to every
-        connected frontend immediately.
+        Additive (like scheduler_stats): nothing gets dropped. The in-process
+        engine buffers until the next step's outputs; EngineCoreProc overrides
+        this to broadcast to every frontend right away.
         """
         self._pending_notifications.extend(notifications)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -85,6 +85,7 @@ from vllm.v1.fault_tolerance.engine_core_sentinel import (
 )
 from vllm.v1.kv_cache_interface import KVCacheConfig, get_kv_cache_spec_kind
 from vllm.v1.metrics.stats import SchedulerIterationDetails, SchedulerStats
+from vllm.v1.notifications import EngineNotification
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder, bytestr
@@ -236,6 +237,13 @@ class EngineCore:
         self.aborts_queue = queue.Queue[list[str]]()
 
         self._idle_state_callbacks: list[Callable] = []
+
+        # Engine notifications awaiting delivery to the in-process frontend
+        # (EngineCoreProc overrides _publish_notifications to broadcast
+        # immediately instead). Keyed by notification type: each
+        # notification is a complete snapshot, so the latest one supersedes
+        # earlier ones and the queue stays bounded while the engine is idle.
+        self._pending_notifications: dict[type, EngineNotification] = {}
 
         # Mark the startup heap as static so that it's ignored by GC.
         # Reduces pause times of oldest generation collections.
@@ -610,6 +618,7 @@ class EngineCore:
             scheduler_output, model_output
         )
         self._attach_iteration_details(engine_core_outputs, iteration_details)
+        self._collect_step_notifications(model_output, engine_core_outputs)
 
         return engine_core_outputs, scheduler_output.total_num_scheduled_tokens > 0
 
@@ -712,6 +721,7 @@ class EngineCore:
             scheduler_output, model_output
         )
         self._attach_iteration_details(engine_core_outputs, iteration_details)
+        self._collect_step_notifications(model_output, engine_core_outputs)
 
         # NOTE(nick): We can either handle the deferred tasks here or save
         # in a field and do it immediately once step_with_batch_queue is
@@ -737,6 +747,38 @@ class EngineCore:
             batch_queue.appendleft((future, deferred_scheduler_output, exec_future))
 
         return engine_core_outputs, model_executed
+
+    def _publish_notifications(self, notifications: list[EngineNotification]) -> None:
+        """Queue engine notifications for delivery to the frontend.
+
+        Notifications are one-shot deltas (unlike scheduler_stats they are
+        not regenerated every step), so delivery must not silently drop
+        them. The in-process engine holds the latest snapshot per type
+        until the next step's outputs; EngineCoreProc overrides this to
+        broadcast to every connected frontend immediately.
+        """
+        for notification in notifications:
+            self._pending_notifications[type(notification)] = notification
+
+    def _flush_notifications(
+        self, engine_core_outputs: dict[int, EngineCoreOutputs]
+    ) -> None:
+        """Attach pending notifications to the in-process frontend's outputs."""
+        if not self._pending_notifications:
+            return
+        if (eco := next(iter(engine_core_outputs.values()), None)) is None:
+            engine_core_outputs[0] = eco = EngineCoreOutputs()
+        eco.engine_notifications = list(self._pending_notifications.values())
+        self._pending_notifications.clear()
+
+    def _collect_step_notifications(
+        self,
+        model_output: ModelRunnerOutput,
+        engine_core_outputs: dict[int, EngineCoreOutputs],
+    ) -> None:
+        if model_output.worker_notifications:
+            self._publish_notifications(model_output.worker_notifications)
+        self._flush_notifications(engine_core_outputs)
 
     def _process_aborts_queue(self):
         if not self.aborts_queue.empty():
@@ -929,16 +971,43 @@ class EngineCore:
         self.model_executor.execute_dummy_batch()
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
-        return self.model_executor.add_lora(lora_request)
+        added = self.model_executor.add_lora(lora_request)
+        self._publish_lora_load_event()
+        return added
 
     def remove_lora(self, lora_id: int) -> bool:
-        return self.model_executor.remove_lora(lora_id)
+        removed = self.model_executor.remove_lora(lora_id)
+        self._publish_lora_load_event()
+        return removed
 
     def list_loras(self) -> set[int]:
         return self.model_executor.list_loras()
 
     def pin_lora(self, lora_id: int) -> bool:
-        return self.model_executor.pin_lora(lora_id)
+        pinned = self.model_executor.pin_lora(lora_id)
+        self._publish_lora_load_event()
+        return pinned
+
+    def _publish_lora_load_event(self) -> None:
+        """Emit a load event for dynamic adapter changes.
+
+        Without this, an idle engine (e.g. a replica with statically
+        configured adapters and no traffic yet) would not report its loaded
+        adapters until its first step, which defeats cold routing.
+        """
+        try:
+            deltas = self.model_executor.collective_rpc("take_lora_load_event")
+        except Exception:
+            # Metrics must never fail the adapter operation itself (the
+            # executor mutation has already happened). Workers without the
+            # snapshot method (e.g. out-of-tree platforms) land here.
+            logger.warning_once(
+                "Could not collect a LoRA load event; loaded-adapter "
+                "metrics will not reflect this adapter change."
+            )
+            return
+        if deltas and deltas[0] is not None:
+            self._publish_notifications([deltas[0]])
 
     def save_sharded_state(
         self,
@@ -1825,6 +1894,19 @@ class EngineCoreProc(EngineCore):
         if more_flag:
             socket.send_multipart(buffers[1:], copy=False)
         return tracker
+
+    def _publish_notifications(self, notifications: list[EngineNotification]) -> None:
+        """Broadcast notifications to every connected frontend.
+
+        One-shot deltas must reach all clients: attaching to a single
+        client's step outputs (as scheduler_stats does) would leave every
+        other frontend permanently stale, and an idle engine has no step
+        outputs at all.
+        """
+        for client_index in range(len(self.addresses.outputs)):
+            self.output_queue.put_nowait(
+                (client_index, EngineCoreOutputs(engine_notifications=notifications))
+            )
 
     def _handle_request_preproc_error(self, request: EngineCoreRequest) -> None:
         """Log and return a request-scoped error response for exceptions raised

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1079,7 +1079,11 @@ class AsyncMPClient(MPClient):
                             return
                         await output_handler(_self, outputs)
 
-                    if outputs.outputs or outputs.scheduler_stats:
+                    if (
+                        outputs.outputs
+                        or outputs.scheduler_stats
+                        or outputs.engine_notifications
+                    ):
                         outputs_queue.put_nowait(outputs)
             except Exception as e:
                 outputs_queue.put_nowait(e)

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -321,15 +321,19 @@ class LLMEngine:
 
         # 4) Record stats
         with record_function_or_nullcontext("llm_engine step: record_stats"):
-            if (
-                self.logger_manager is not None
-                and outputs.scheduler_stats is not None
-                and len(outputs.outputs) > 0
+            record_stats = (
+                outputs.scheduler_stats is not None and len(outputs.outputs) > 0
+            )
+            engine_notifications = outputs.engine_notifications
+            if self.logger_manager is not None and (
+                record_stats or engine_notifications
             ):
                 self.logger_manager.record(
-                    scheduler_stats=outputs.scheduler_stats,
-                    iteration_stats=iteration_stats,
+                    scheduler_stats=outputs.scheduler_stats if record_stats else None,
+                    iteration_stats=iteration_stats if record_stats else None,
                     mm_cache_stats=self.renderer.stat_mm_cache(),
+                    engine_notifications=engine_notifications,
+                    engine_idx=outputs.engine_index,
                 )
                 self.do_log_stats_with_interval()
 

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -328,12 +328,15 @@ class LLMEngine:
             if self.logger_manager is not None and (
                 record_stats or engine_notifications
             ):
+                # The manager is always single-engine here (engine_idxs=[0]),
+                # so don't forward outputs.engine_index: in offline DP it
+                # carries the DP rank, which is not a key in the per-engine
+                # metrics.
                 self.logger_manager.record(
                     scheduler_stats=outputs.scheduler_stats if record_stats else None,
                     iteration_stats=iteration_stats if record_stats else None,
                     mm_cache_stats=self.renderer.stat_mm_cache(),
                     engine_notifications=engine_notifications,
-                    engine_idx=outputs.engine_index,
                 )
                 self.do_log_stats_with_interval()
 

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -27,7 +27,8 @@ from vllm.v1.metrics.stats import (
     PromptTokenStats,
     SchedulerStats,
 )
-from vllm.v1.metrics.utils import create_metric_per_engine
+from vllm.v1.metrics.utils import PromMetric, create_metric_per_engine
+from vllm.v1.notifications import EngineNotification, LoRALoadEvent
 from vllm.v1.spec_decode.metrics import SpecDecodingLogging, SpecDecodingProm
 
 logger = init_logger(__name__)
@@ -58,6 +59,7 @@ class StatLoggerBase(ABC):
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        engine_notifications: list[EngineNotification] | None = None,
         engine_idx: int = 0,
     ): ...
 
@@ -201,6 +203,7 @@ class LoggingStatLogger(StatLoggerBase):
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        engine_notifications: list[EngineNotification] | None = None,
         engine_idx: int = 0,
     ):
         """Log Stats to standard output."""
@@ -355,6 +358,7 @@ class AggregatedLoggingStatLogger(LoggingStatLogger, AggregateStatLoggerBase):
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        engine_notifications: list[EngineNotification] | None = None,
         engine_idx: int = 0,
     ):
         if engine_idx not in self.engine_indexes:
@@ -365,6 +369,7 @@ class AggregatedLoggingStatLogger(LoggingStatLogger, AggregateStatLoggerBase):
             scheduler_stats,
             iteration_stats,
             mm_cache_stats=mm_cache_stats,
+            engine_notifications=engine_notifications,
             engine_idx=engine_idx,
         )
         if scheduler_stats is not None:
@@ -419,6 +424,7 @@ class PerEngineStatLoggerAdapter(AggregateStatLoggerBase):
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        engine_notifications: list[EngineNotification] | None = None,
         engine_idx: int = 0,
     ):
         if engine_idx not in self.per_engine_stat_loggers:
@@ -428,6 +434,7 @@ class PerEngineStatLoggerAdapter(AggregateStatLoggerBase):
             scheduler_stats,
             iteration_stats,
             mm_cache_stats=mm_cache_stats,
+            engine_notifications=engine_notifications,
             engine_idx=engine_idx,
         )
 
@@ -1052,6 +1059,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         # TODO: This metric might be incorrect in case of using multiple
         # api_server counts which uses prometheus mp.
         self.gauge_lora_info: Gauge | None = None
+        self.gauge_lora_adapter_loaded: Gauge | None = None
+        self.gauge_lora_gpu_adapters: dict[int, PromMetric] = {}
+        self.gauge_lora_cpu_adapters: dict[int, PromMetric] = {}
         if vllm_config.lora_config is not None:
             if len(self.engine_indexes) > 1:
                 logger.warning(
@@ -1064,7 +1074,13 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             self.max_lora = vllm_config.lora_config.max_loras
             self.gauge_lora_info = self._gauge_cls(
                 name="vllm:lora_requests_info",
-                documentation="Running stats on lora requests.",
+                documentation=(
+                    "Running stats on lora requests. "
+                    "DEPRECATED: encodes adapter names into comma-separated "
+                    "label values; superseded by vllm:lora_adapter_loaded, "
+                    "vllm:num_gpu_loaded_lora_adapters and "
+                    "vllm:num_cpu_loaded_lora_adapters."
+                ),
                 multiprocess_mode="sum",
                 labelnames=[
                     self.labelname_max_lora,
@@ -1072,6 +1088,83 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     self.labelname_running_lora_adapters,
                 ],
             )
+
+            gauge_lora_gpu_adapters = self._gauge_cls(
+                name="vllm:num_gpu_loaded_lora_adapters",
+                documentation=(
+                    "Number of LoRA adapters currently loaded into GPU slots."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            self.gauge_lora_gpu_adapters = create_metric_per_engine(
+                gauge_lora_gpu_adapters, per_engine_labelvalues
+            )
+
+            gauge_lora_cpu_adapters = self._gauge_cls(
+                name="vllm:num_cpu_loaded_lora_adapters",
+                documentation=(
+                    "Number of LoRA adapters currently resident in the "
+                    "worker's CPU cache (superset of the GPU-loaded set)."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            self.gauge_lora_cpu_adapters = create_metric_per_engine(
+                gauge_lora_cpu_adapters, per_engine_labelvalues
+            )
+
+            self.gauge_lora_adapter_loaded = self._gauge_cls(
+                name="vllm:lora_adapter_loaded",
+                documentation=(
+                    "Whether an individual LoRA adapter is loaded in the worker's "
+                    "adapter caches. The series exists (value 1) while the "
+                    "adapter is resident; 'level' is 'gpu' when the adapter "
+                    "is active in a GPU slot and 'cpu' when it is only in "
+                    "the host cache."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames + ["adapter_name", "level", "pinned"],
+            )
+            # Label tuples emitted for the last load event, per engine,
+            # so stale series can be removed when the loaded set changes.
+            self._lora_loaded_series: dict[
+                int, set[tuple[str, str, str, str, str]]
+            ] = {}
+
+    def _record_lora_load_event(self, event: LoRALoadEvent, engine_idx: int):
+        if self.gauge_lora_adapter_loaded is None:
+            return
+        self.gauge_lora_gpu_adapters[engine_idx].set(len(event.gpu_adapters))
+        self.gauge_lora_cpu_adapters[engine_idx].set(len(event.cpu_adapters))
+
+        # Each event carries the complete state: emit one series per
+        # resident adapter and drop series for evicted ones.
+        model_name, engine_label = self.per_engine_labelvalues[engine_idx]
+        gpu_adapters = set(event.gpu_adapters)
+        pinned_adapters = set(event.pinned_adapters)
+        new_series = {
+            (
+                str(model_name),
+                str(engine_label),
+                adapter_name,
+                "gpu" if adapter_name in gpu_adapters else "cpu",
+                str(adapter_name in pinned_adapters).lower(),
+            )
+            for adapter_name in event.cpu_adapters
+        }
+        prev_series = self._lora_loaded_series.get(engine_idx, set())
+        for labels in prev_series - new_series:
+            # Zero before removing: under prometheus multiprocess mode
+            # remove() only deletes the in-process child while the
+            # mmap-backed sample keeps its last value, and the Ray backend
+            # cannot delete series at all. The explicit 0 ensures evicted
+            # adapters never keep reading as resident.
+            self.gauge_lora_adapter_loaded.labels(*labels).set(0)
+            self.gauge_lora_adapter_loaded.remove(*labels)
+        for labels in new_series:
+            self.gauge_lora_adapter_loaded.labels(*labels).set(1)
+        self._lora_loaded_series[engine_idx] = new_series
 
     def log_metrics_info(self, type: str, config_obj: SupportsMetricsInfo):
         metrics_info = config_obj.metrics_info()
@@ -1102,9 +1195,14 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        engine_notifications: list[EngineNotification] | None = None,
         engine_idx: int = 0,
     ):
         """Log to prometheus."""
+        for notification in engine_notifications or ():
+            if isinstance(notification, LoRALoadEvent):
+                self._record_lora_load_event(notification, engine_idx)
+
         if scheduler_stats is not None:
             self.gauge_scheduler_running[engine_idx].set(
                 scheduler_stats.num_running_reqs
@@ -1377,6 +1475,7 @@ class StatLoggerManager:
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        engine_notifications: list[EngineNotification] | None = None,
         engine_idx: int | None = None,
     ):
         if engine_idx is None:
@@ -1386,6 +1485,7 @@ class StatLoggerManager:
                 scheduler_stats,
                 iteration_stats,
                 mm_cache_stats=mm_cache_stats,
+                engine_notifications=engine_notifications,
                 engine_idx=engine_idx,
             )
 

--- a/vllm/v1/metrics/ray_wrappers.py
+++ b/vllm/v1/metrics/ray_wrappers.py
@@ -115,6 +115,11 @@ class RayGaugeWrapper(RayPrometheusMetric):
         # ray metrics doesn't have set_to_current time, https://docs.ray.io/en/latest/_modules/ray/util/metrics.html
         return self.set(time.time())
 
+    def remove(self, *labels):
+        # Ray metrics cannot delete series, so removal is a no-op; callers
+        # zero the series first so a stale one never reads as live.
+        pass
+
 
 class RayCounterWrapper(RayPrometheusMetric):
     """Wraps around ray.util.metrics.Counter to provide same API as

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Engine-level event notifications.
+
+These are rare, engine-scoped state transitions (as opposed to the
+per-request lifecycle events in `EngineCoreEvent` and the per-step sampling
+in `SchedulerStats`). Events originate in the worker or engine core and are
+forwarded to frontends on `EngineCoreOutputs.engine_notifications`.
+
+Each event is a msgspec Struct with an explicit `tag`, so the union is
+encoded as a map with a `"type"` discriminator field. Like the rest of
+`EngineCoreOutputs`, the union is version-lockstep between engine and
+frontend: an unknown tag is a deployment error and fails the decode loudly
+rather than being skipped. The Rust frontend
+(`rust/src/engine-core-client/src/protocol/notifications.rs`) mirrors the
+union and the same fail-fast behavior.
+
+Channel contract: every notification type must be a complete, self-contained
+snapshot. The engine may coalesce queued notifications by keeping only the
+latest one per type, and consumers replace (never merge with) previously
+observed state.
+"""
+
+import msgspec
+
+
+class LoRALoadEvent(
+    msgspec.Struct,
+    tag="lora_load_event",
+    omit_defaults=True,  # type: ignore[call-arg]
+    gc=False,
+):  # type: ignore[call-arg]
+    """The set of loaded LoRA adapters changed.
+
+    Emitted only when the loaded set changed (on a step, or directly on
+    dynamic adapter load/unload). Each event carries the complete current
+    state, so consumers should replace (not merge with) the previously
+    observed snapshot.
+
+    Adapters are identified by name. If an adapter id is reused for a
+    different adapter (which `LoRARequest` forbids but does not enforce),
+    the change detector may miss the swap until the next load event.
+    """
+
+    gpu_adapters: list[str] = []
+    """Names of adapters currently activated into GPU slots (sorted)."""
+
+    cpu_adapters: list[str] = []
+    """Names of adapters resident in the CPU cache (sorted). This is a
+    superset of `gpu_adapters`."""
+
+    pinned_adapters: list[str] = []
+    """Names of adapters pinned in the caches (sorted)."""
+
+
+# Union of all engine-level event types. Grows as new event types are added
+# (e.g. graceful shutdown progress); msgspec dispatches on each struct's tag.
+EngineNotification = LoRALoadEvent

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -2,10 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Engine-level event notifications.
 
-These are rare, engine-scoped state transitions (as opposed to the
-per-request lifecycle events in `EngineCoreEvent` and the per-step sampling
-in `SchedulerStats`). Events originate in the worker or engine core and are
-forwarded to frontends on `EngineCoreOutputs.engine_notifications`.
+These are engine-scoped state transitions (as opposed to the per-request
+lifecycle events in `EngineCoreEvent` and the per-step sampling in
+`SchedulerStats`). Events originate in the worker or engine core and are
+forwarded to frontends on `EngineCoreOutputs.engine_notifications`. They are
+typically infrequent (LoRA load/unload), but the channel does not assume so:
+a producer may emit on every step.
 
 Each event is a msgspec Struct with an explicit `tag`, so the union is
 encoded as a map with a `"type"` discriminator field. Like the rest of
@@ -15,10 +17,12 @@ rather than being skipped. The Rust frontend
 (`rust/src/engine-core-client/src/protocol/notifications.rs`) mirrors the
 union and the same fail-fast behavior.
 
-Channel contract: every notification type must be a complete, self-contained
-snapshot. The engine may coalesce queued notifications by keeping only the
-latest one per type, and consumers replace (never merge with) previously
-observed state.
+Channel contract: notifications accumulate additively (like `SchedulerStats`).
+The engine delivers every queued event in emission order and never drops one,
+so a notification may carry an absolute snapshot (consumers replace prior
+state, as `LoRALoadEvent` does) or an incremental delta (consumers apply each
+event, e.g. a counter increment). Throttling redundant events is the
+producer's job: `LoRALoadEvent` only emits when the loaded set changed.
 """
 
 import msgspec

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -2,33 +2,20 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Engine-level event notifications.
 
-These are engine-scoped state transitions (as opposed to the per-request
-lifecycle events in `EngineCoreEvent` and the per-step sampling in
-`SchedulerStats`). Events originate in the worker or engine core and are
-forwarded to frontends on `EngineCoreOutputs.engine_notifications`. They are
-typically infrequent (LoRA load/unload), but the channel does not assume so:
-a producer may emit on every step.
+Engine-scoped state transitions (unlike per-request `EngineCoreEvent` or
+per-step `SchedulerStats`), forwarded to frontends on
+`EngineCoreOutputs.engine_notifications`. A producer fires one whenever its
+state changes, e.g. `LoRALoadEvent` on a LoRA load/unload.
 
-Each event is a msgspec Struct with an explicit `tag`, so the union is
-encoded as a map with a `"type"` discriminator field. Like the rest of
-`EngineCoreOutputs`, the union is version-lockstep between engine and
-frontend: an unknown tag is a deployment error and fails the decode loudly
-rather than being skipped. The Rust frontend
-(`rust/src/engine-core-client/src/protocol/notifications.rs`) mirrors the
-union and the same fail-fast behavior.
+Each event is a tagged msgspec Struct, map-encoded with a `"type"` field. The
+union is version-lockstep with the engine like the rest of `EngineCoreOutputs`:
+an unknown tag fails the decode loudly instead of getting skipped. The Rust
+frontend mirrors it. Plugins that can't add a tag use the open `custom` one.
 
-Out-of-tree producers (plugins) can't add their own tags without forking the
-protocol, so the union reserves a single open `CustomNotification` tag: a
-plugin namespaces its event under `key` and carries an arbitrary payload.
-The tag is known to every frontend (so it never trips fail-fast), but an
-unrecognized `key` is ignored rather than fatal.
-
-Channel contract: notifications accumulate additively (like `SchedulerStats`).
-The engine delivers every queued event in emission order and never drops one,
-so a notification may carry an absolute snapshot (consumers replace prior
-state, as `LoRALoadEvent` does) or an incremental delta (consumers apply each
-event, e.g. a counter increment). Throttling redundant events is the
-producer's job: `LoRALoadEvent` only emits when the loaded set changed.
+Events are additive (like `SchedulerStats`): everything queued gets delivered
+in order, nothing dropped. So an event can be a full snapshot (consumer
+replaces its state) or a delta (consumer applies each one). Producers throttle
+themselves; `LoRALoadEvent` only fires when the loaded set actually changes.
 """
 
 from typing import Any
@@ -44,25 +31,20 @@ class LoRALoadEvent(
 ):  # type: ignore[call-arg]
     """The set of loaded LoRA adapters changed.
 
-    Emitted only when the loaded set changed (on a step, or directly on
-    dynamic adapter load/unload). Each event carries the complete current
-    state, so consumers should replace (not merge with) the previously
-    observed snapshot.
-
-    Adapters are identified by name. If an adapter id is reused for a
-    different adapter (which `LoRARequest` forbids but does not enforce),
-    the change detector may miss the swap until the next load event.
+    Carries the full current state, so consumers replace their snapshot rather
+    than merge. Adapters are keyed by name; if an id gets reused for a
+    different adapter (which `LoRARequest` forbids but doesn't enforce), the
+    differ can miss the swap until the next event.
     """
 
     gpu_adapters: list[str] = []
-    """Names of adapters currently activated into GPU slots (sorted)."""
+    """Adapters activated into GPU slots (sorted)."""
 
     cpu_adapters: list[str] = []
-    """Names of adapters resident in the CPU cache (sorted). This is a
-    superset of `gpu_adapters`."""
+    """Adapters resident in the CPU cache, a superset of `gpu_adapters`."""
 
     pinned_adapters: list[str] = []
-    """Names of adapters pinned in the caches (sorted)."""
+    """Adapters pinned in the caches (sorted)."""
 
 
 class CustomNotification(
@@ -71,25 +53,20 @@ class CustomNotification(
     omit_defaults=True,  # type: ignore[call-arg]
     gc=False,
 ):  # type: ignore[call-arg]
-    """An open-schema notification for out-of-tree producers (plugins).
+    """Open escape hatch for out-of-tree producers (plugins).
 
-    The in-tree union fails fast on unknown tags, so a plugin can't add its
-    own struct type without forking the protocol. This reserved tag is the
-    escape hatch: emit a `CustomNotification`, namespace it under `key`, and
-    carry whatever the consumer needs in `payload`. Frontends that don't
-    recognize `key` ignore the event (per the channel's additive contract,
-    deltas a consumer doesn't apply are simply no-ops).
+    The union fails fast on unknown tags, so plugins can't add their own struct
+    type. Instead they emit this: namespace under `key`, and place event data
+    in `payload`. Frontends that don't know the `key` just ignore it.
     """
 
     key: str
-    """Producer-chosen namespace (e.g. the plugin name). Consumers match on
-    this to decide whether and how to interpret `payload`."""
+    """Producer-chosen namespace, e.g. the plugin name."""
 
     payload: dict[str, Any] = {}
-    """Arbitrary msgpack-encodable event data, opaque to the engine and to
-    consumers that don't recognize `key`."""
+    """Arbitrary msgpack-encodable event data, opaque to anyone who doesn't
+    know `key`."""
 
 
-# Union of all engine-level event types. Grows as new event types are added
-# (e.g. graceful shutdown progress); msgspec dispatches on each struct's tag.
+# All engine-level event types; msgspec dispatches on each struct's tag.
 EngineNotification = LoRALoadEvent | CustomNotification

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -17,6 +17,12 @@ rather than being skipped. The Rust frontend
 (`rust/src/engine-core-client/src/protocol/notifications.rs`) mirrors the
 union and the same fail-fast behavior.
 
+Out-of-tree producers (plugins) can't add their own tags without forking the
+protocol, so the union reserves a single open `CustomNotification` tag: a
+plugin namespaces its event under `key` and carries an arbitrary payload.
+The tag is known to every frontend (so it never trips fail-fast), but an
+unrecognized `key` is ignored rather than fatal.
+
 Channel contract: notifications accumulate additively (like `SchedulerStats`).
 The engine delivers every queued event in emission order and never drops one,
 so a notification may carry an absolute snapshot (consumers replace prior
@@ -24,6 +30,8 @@ state, as `LoRALoadEvent` does) or an incremental delta (consumers apply each
 event, e.g. a counter increment). Throttling redundant events is the
 producer's job: `LoRALoadEvent` only emits when the loaded set changed.
 """
+
+from typing import Any
 
 import msgspec
 
@@ -57,6 +65,31 @@ class LoRALoadEvent(
     """Names of adapters pinned in the caches (sorted)."""
 
 
+class CustomNotification(
+    msgspec.Struct,
+    tag="custom",
+    omit_defaults=True,  # type: ignore[call-arg]
+    gc=False,
+):  # type: ignore[call-arg]
+    """An open-schema notification for out-of-tree producers (plugins).
+
+    The in-tree union fails fast on unknown tags, so a plugin can't add its
+    own struct type without forking the protocol. This reserved tag is the
+    escape hatch: emit a `CustomNotification`, namespace it under `key`, and
+    carry whatever the consumer needs in `payload`. Frontends that don't
+    recognize `key` ignore the event (per the channel's additive contract,
+    deltas a consumer doesn't apply are simply no-ops).
+    """
+
+    key: str
+    """Producer-chosen namespace (e.g. the plugin name). Consumers match on
+    this to decide whether and how to interpret `payload`."""
+
+    payload: dict[str, Any] = {}
+    """Arbitrary msgpack-encodable event data, opaque to the engine and to
+    consumers that don't recognize `key`."""
+
+
 # Union of all engine-level event types. Grows as new event types are added
 # (e.g. graceful shutdown progress); msgspec dispatches on each struct's tag.
-EngineNotification = LoRALoadEvent
+EngineNotification = LoRALoadEvent | CustomNotification

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -12,6 +12,7 @@ import torch
 
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.notifications import EngineNotification
 
 if TYPE_CHECKING:
     from vllm.distributed.kv_events import KVConnectorKVEvents
@@ -295,6 +296,11 @@ class ModelRunnerOutput:
 
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
+
+    # Rare worker-originated engine events (e.g. LoRA load events),
+    # forwarded by the engine core to frontends on
+    # EngineCoreOutputs.engine_notifications. None on the vast majority of steps.
+    worker_notifications: list[EngineNotification] | None = None
 
     # Per-step routed experts data captured by the worker.
     # ``routing_data`` shape: (num_scheduled_tokens, num_layers,

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -297,9 +297,8 @@ class ModelRunnerOutput:
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
 
-    # Rare worker-originated engine events (e.g. LoRA load events),
-    # forwarded by the engine core to frontends on
-    # EngineCoreOutputs.engine_notifications. None on the vast majority of steps.
+    # Worker-originated engine events (e.g. LoRA load events), forwarded by the
+    # engine core to frontends on EngineCoreOutputs.engine_notifications.
     worker_notifications: list[EngineNotification] | None = None
 
     # Per-step routed experts data captured by the worker.

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1623,6 +1623,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         kv_connector_output = self.kv_connector.post_forward(finished_req_ids)
         model_runner_output.kv_connector_output = kv_connector_output
 
+        if lora_load_event := self.take_lora_load_event(self.lora_config):
+            model_runner_output.worker_notifications = [lora_load_event]
+
         return async_output
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:
@@ -1653,10 +1656,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
 
         # Build the model runner output.
+        lora_load_event = self.take_lora_load_event(self.lora_config)
         model_runner_output = ModelRunnerOutput(
             req_ids=input_batch.req_ids,
             req_id_to_index={req_id: i for i, req_id in enumerate(input_batch.req_ids)},
             kv_connector_output=kv_connector_output,
+            worker_notifications=[lora_load_event] if lora_load_event else None,
         )
         async_output = AsyncPoolingOutput(
             model_runner_output=model_runner_output,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3495,10 +3495,12 @@ class GPUModelRunner(
             finished_mask=finished_mask,
         )
 
+        lora_load_event = self.take_lora_load_event(self.lora_config)
         model_runner_output = ModelRunnerOutput(
             req_ids=self.input_batch.req_ids.copy(),
             req_id_to_index=self.input_batch.req_id_to_index.copy(),
             kv_connector_output=kv_connector_output,
+            worker_notifications=[lora_load_event] if lora_load_event else None,
         )
 
         if raw_pooler_output is None or not any(finished_mask):
@@ -4751,6 +4753,8 @@ class GPUModelRunner(
         kv_connector_output = self.kv_connector_output
         self.kv_connector_output = None
 
+        lora_load_event = self.take_lora_load_event(self.lora_config)
+
         with record_function_or_nullcontext("gpu_model_runner: ModelRunnerOutput"):
             output = ModelRunnerOutput(
                 req_ids=req_ids_output_copy,
@@ -4764,6 +4768,7 @@ class GPUModelRunner(
                 else None,
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
+                worker_notifications=[lora_load_event] if lora_load_event else None,
                 routed_experts=None,
             )
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -90,6 +90,7 @@ logger = init_logger(__name__)
 if TYPE_CHECKING:
     from vllm.device_allocator.sleep_mode_backend import SleepModeBackend
     from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
+    from vllm.v1.notifications import LoRALoadEvent
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
@@ -1177,6 +1178,9 @@ class Worker(WorkerBase):
 
     def pin_lora(self, lora_id: int) -> bool:
         return self.model_runner.pin_lora(lora_id)
+
+    def take_lora_load_event(self) -> "LoRALoadEvent | None":
+        return self.model_runner.take_lora_load_event(self.vllm_config.lora_config)
 
     def check_health(self) -> None:
         # worker will always be healthy as long as it's running.

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -15,9 +15,11 @@ from vllm.config import VllmConfig
 from vllm.config.lora import LoRAConfig
 from vllm.logger import init_logger
 from vllm.lora.layers import LoRAMapping, LoRAMappingType
+from vllm.lora.model_manager import LoRALoadedState
 from vllm.lora.request import LoRARequest
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.model_executor.models import supports_lora
+from vllm.v1.notifications import LoRALoadEvent
 from vllm.v1.worker.gpu_input_batch import InputBatch as GPUInputBatch
 from vllm.v1.worker.tpu_input_batch import InputBatch as TPUInputBatch
 
@@ -28,6 +30,8 @@ logger = init_logger(__name__)
 
 # Defined as a mixin for GPUModelRunner
 class LoRAModelRunnerMixin:
+    _last_lora_loaded_state: LoRALoadedState | None = None
+
     def load_lora_model(
         self,
         model: nn.Module,
@@ -286,3 +290,25 @@ class LoRAModelRunnerMixin:
     def list_loras(self) -> set[int]:
         self._ensure_lora_enabled()
         return self.lora_manager.list_adapters()
+
+    def take_lora_load_event(
+        self, lora_config: LoRAConfig | None
+    ) -> LoRALoadEvent | None:
+        """Return a load event if the set of loaded adapters changed since
+        the last call, else None. The loaded set churns far slower than
+        engine .step(), so unchanged does not notify; the unchanged path
+        costs three small set copies and an equality check."""
+        if lora_config is None or not hasattr(self, "lora_manager"):
+            return None
+        state = self.lora_manager.get_loaded_state()
+        if state == self._last_lora_loaded_state:
+            return None
+        self._last_lora_loaded_state = state
+        gpu_adapters, cpu_adapters, pinned_adapters = (
+            self.lora_manager.get_loaded_names(state)
+        )
+        return LoRALoadEvent(
+            gpu_adapters=gpu_adapters,
+            cpu_adapters=cpu_adapters,
+            pinned_adapters=pinned_adapters,
+        )

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -19,6 +19,7 @@ from vllm.v1.kv_cache_interface import KVCacheSpec
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
+    from vllm.v1.notifications import LoRALoadEvent
     from vllm.v1.outputs import AsyncModelRunnerOutput, ModelRunnerOutput
 else:
     SchedulerOutput = object
@@ -173,6 +174,12 @@ class WorkerBase:
 
     def list_loras(self) -> set[int]:
         raise NotImplementedError
+
+    def take_lora_load_event(self) -> "LoRALoadEvent | None":
+        """Return a load event if the set of loaded adapters changed since
+        the last call. Workers without LoRA load reporting (e.g. TPU)
+        return None."""
+        return None
 
     @property
     def vocab_size(self) -> int:


### PR DESCRIPTION
Closes #45325
Related: llm-d/llm-d-router#1500, llm-d/llm-d-router#709, llm-d/llm-d-router#926

## Problem

The only LoRA metric today is `vllm:lora_requests_info`, and it only shows adapters with requests in flight. When an adapter goes idle it disappears from metrics, even though it's still loaded. Routers that want to send requests to a replica that already has the adapter (llm-d, gateway-api-inference-extension) have to make an educated guess from request recency. They also lose the ability to determine a replica that has the adapter is in warm or cold storage, which is important to avoiding TTFT spikes for adapter loads (more common in lower concurrency regimes).

## Additional Metrics

- `vllm:lora_adapter_loaded{adapter_name, level="gpu"|"cpu", pinned}` — one series per loaded adapter, present while it's loaded, gone when it's evicted.
- `vllm:num_gpu_loaded_lora_adapters` and `vllm:num_cpu_loaded_lora_adapters`.
- `vllm:lora_requests_info` is marked deprecated in its help text (hiding it comes next release, per the metrics policy; we'll coordinate with downstream users first).

The worker reports a snapshot whenever the set of loaded adapters changes, including when an adapter is loaded or unloaded on an idle engine. So a replica with statically configured adapters advertises what it has before any traffic arrives, which is the case routers care about most. For example, after loading 8 adapters with `--max-loras 4 --max-cpu-loras 6` and sending zero requests:

```
vllm:lora_adapter_loaded{adapter_name="ad-3",level="cpu",pinned="false"} 1
vllm:lora_adapter_loaded{adapter_name="ad-4",level="cpu",pinned="false"} 1
vllm:lora_adapter_loaded{adapter_name="ad-5",level="gpu",pinned="false"} 1
vllm:lora_adapter_loaded{adapter_name="ad-6",level="gpu",pinned="false"} 1
vllm:lora_adapter_loaded{adapter_name="ad-7",level="gpu",pinned="false"} 1
vllm:lora_adapter_loaded{adapter_name="ad-8",level="gpu",pinned="false"} 1
vllm:num_cpu_loaded_lora_adapters 6
vllm:num_gpu_loaded_lora_adapters 4
```

(ad-1 and ad-2 were LRU-evicted and correctly have no series.)

## Design notes

- Load events passed via a small new `engine_notifications` field on the existing engine→frontend output
- Events are broadcast to every API server, so all `/metrics` endpoints agree
- Checking for changes costs a few set copies per step when nothing changed, which is the common case
- The notification channel is additive (every queued event is delivered in emission order, no coalescing) and reserves an open `custom` tag so out-of-tree producers can emit through it without breaking the fail-fast-on-unknown-tag wire contract (see review discussion with @maxdebayser, related to #45864)
- `SchedulerInterface.take_notifications()` (default empty) gives scheduler-side producers a path onto the same channel

## Changes since the draft

- Rebased over the engine-core DTO refactors (#47265, #47283)
- Notifications made additive and extensible per review feedback
- Fixed a queue condition in `core_client.py` that dropped notification-only broadcasts
- Fixed `LLMEngine` stat recording to stay on engine index 0 (offline DP ranks stamp `outputs.engine_index` with the DP rank, which isn't a key in the single-engine logger)

## Validation

Ran on a single-GPU cluster pod (zephyr-7b-beta + a rank-64 adapter loaded under several names), with both the Python frontend and our Rust frontend, re-run in full on the rebased branch (2026-07-02):

- Loading an adapter with no traffic makes its series appear; unloading while idle removes it (Rust frontend; see the note below for the Python frontend)
- Filling the GPU slots and CPU cache past capacity shows the right adapters at the right level, and evicted adapters' series disappear
- Running requests promotes a CPU-cached adapter to gpu and demotes the one it displaced
- With `--api-server-count 2`, both API server processes report the same loaded adapters before any traffic (12/12 identical `/metrics` samples; static `--lora-modules`, since runtime LoRA updating is rejected with `api_server_count > 1`)

> [!NOTE]
> One behavior this metric makes visible: the Python OpenAI frontend's `/v1/unload_lora_adapter` only removes the frontend alias and never calls `engine.remove_lora` (#42633), so an "unloaded" adapter genuinely stays resident in the engine caches and `vllm:lora_adapter_loaded` keeps truthfully reporting it until LRU eviction. #42634 fixes the unload path separately; once it lands, the series disappears on unload with no changes needed here (that's exactly the behavior the Rust frontend, which does call `remove_lora`, already shows).

Tests run locally on the rebased branch:

- `pytest tests/v1/engine/test_notifications.py tests/v1/test_serial_utils.py` — 25 passed
- `cargo test -p vllm-engine-core-client -p vllm-metrics -p vllm-server -p vllm-llm` — all green (one pre-existing flaky TLS-handshake-timeout test in vllm-server, fails intermittently on upstream/main too)
- `cargo clippy --all --benches --tests --examples --all-features` and `cargo fmt` — clean
- `pre-commit run` on all changed Python files — clean

The wire-format tests include fixtures that run real Python msgspec encoding through the Rust decoder.

## Duplicate-work check

No open PR addresses #45325 (searched open PRs for `lora metrics`, `lora residency`, `lora_requests_info`).

## AI assistance disclosure

Developed code and the test harness with AI assistance (Claude Code). All changes were reviewed line-by-line by myself, who ran the tests and reviewed output.
