### PR TITLE
[Bugfix] Unset HF's default max_new_tokens for DiffusionGemma

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -158,6 +158,20 @@ class DiffusionGemmaModelForBlockDiffusionConfig(VerifyAndUpdateConfig):
         if sc is not None and sc.max_num_seqs >= SchedulerConfig.DEFAULT_MAX_NUM_SEQS:
             sc.max_num_seqs = 8
 
+        # Remove the model's generation_config.json cap on max_new_tokens
+        # (256) so DiffusionGemma behaves like every other model: no
+        # server-wide limit, each request controls its own output length
+        # via max_tokens.  Setting to None causes get_diff_sampling_param
+        # to skip this key entirely.
+        model_config = vllm_config.model_config
+        if "max_new_tokens" not in model_config.override_generation_config:
+            model_config.override_generation_config["max_new_tokens"] = None
+            logger.info(
+                "DiffusionGemma: removing server-wide max_new_tokens cap "
+                "from generation_config.json (use "
+                "--override-generation-config to set a custom limit).",
+            )
+
 
 class DeepseekV4ForCausalLMConfig(VerifyAndUpdateConfig):
     @staticmethod


### PR DESCRIPTION


## Purpose
DiffusionGemma model's [generation_config.json](https://huggingface.co/google/diffusiongemma-26B-A4B-it/blob/main/generation_config.json) sets default max_new_tokens to 256. The rationale being that the HuggingFace users should never hit OOMs when running the model. For vLLM implementation, we don't need to limit the max length by default in order to limit OOMs.

## Test Plan
Run the model without specifying max len, and generate more than one canvas.

## Test Result
Generates more than one canvas 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ x] The test plan, such as providing test command.
- [ x] The test results, such as pasting the results comparison before and after, or e2e results
- [ x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
