### PR TITLE
Relax routed_experts capture KV-connector check to a warning for P/D

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -868,18 +868,19 @@ class VllmConfig:
                     "pipeline parallelism (PP > 1)."
                 )
 
-            # Incompatible with any KV connector — covers both PD disaggregation
-            # (kv_producer/kv_consumer: routing captured on P can't reach D) and
-            # single-instance KV offload/sharing (kv_both: slot_mapping semantics
-            # change when KV blocks live outside local GPU memory, breaking the
-            # slot-indexed routed_experts buffer).
+            # KV connectors for P/D disaggregation are allowed: the decode
+            # replica pulls the prompt KV and never forwards the prompt, so its
+            # prompt-region routing is invalid, but a P/D-aware router/proxy can
+            # splice the prefill replica's routing back in. kv_role cannot tell
+            # P/D transfer from single-instance KV offload (NixlConnector P/D
+            # runs as kv_both), so this is a warning rather than an error.
             if (
                 self.kv_transfer_config is not None
                 and self.kv_transfer_config.is_kv_transfer_instance
             ):
-                raise ValueError(
-                    "--enable-return-routed-experts is incompatible with KV "
-                    "connectors (PD disaggregation, KV cache offload)."
+                logger.warning(
+                    "You are using P/D disaggregation with routed_experts capture, "
+                    "for this to work your router/proxy needs to support it"
                 )
 
         if self.lora_config is not None:


### PR DESCRIPTION
## Relax `routed_experts` capture KV-connector check to a warning for P/D

### Background
`--enable-return-routed-experts` records, per token, which MoE experts it routed
to. Today `VllmConfig.__post_init__` hard-rejects it whenever a KV connector is
configured:

```python
if self.kv_transfer_config is not None and self.kv_transfer_config.is_kv_transfer_instance:
    raise ValueError("--enable-return-routed-experts is incompatible with KV "
                     "connectors (PD disaggregation, KV cache offload).")
```

### Why relax it
For **P/D disaggregation** this is not fundamentally incompatible. The decode
replica pulls the prompt KV from prefill and never forwards the prompt, so its
prompt-region routing rows are invalid — but the prefill replica returns the
correct prompt-region routing, and a P/D-aware router/proxy can splice it back in:

```
merged = concat( prefill_rows[:Lp], decode_rows[Lp:] )
```

So whether routed-experts capture works under disaggregation is a property of the
router/proxy, not something vLLM can decide at config time.

### Change
Replace the `ValueError` for KV-transfer instances with a warning:

> You are using P/D disaggregation with routed_experts capture, for this to work
> your router/proxy needs to support it

The PP>1 incompatibility is unchanged.

Note: `kv_role` alone cannot distinguish P/D transfer from single-instance KV
offload — `NixlConnector` P/D itself runs as `kv_both` (see
`docs/features/disagg_prefill.md`, `docs/serving/expert_parallel_deployment.md`) —
which is why this is a warning rather than a role-gated error.

### Router/proxy support
Companion PRs add the prefill→decode `routed_experts` merge to two routers, each
verified end-to-end against this change on a 2-node Qwen3-30B-A3B P/D deployment
(NIXL + Mooncake), checked against a non-disaggregated oracle under greedy
decoding:
- vllm-project/router
- llm-d/llm-d-router

**Router PRs:** vllm-project/router#184 · llm-d/llm-d-router#1627
