### PR TITLE
docs: clarify Gemma 4 MTP assistant quantization

### DIFF
--- a/docs/features/speculative_decoding/mtp.md
+++ b/docs/features/speculative_decoding/mtp.md
@@ -30,6 +30,12 @@ Gemma 4 Unified variant (12B) uses `model_type: gemma4_unified_assistant`.
 vLLM maps both to `Gemma4MTPModel` internally and wires the assistant layers
 to share KV cache with the target model.
 
+When the target model is quantized, only set `quantization` inside
+`speculative_config` if the assistant checkpoint is quantized in the same way.
+For example, a compressed-tensors target can still use an unquantized assistant;
+in that case, leave the speculative `quantization` field unset so the assistant
+weights are loaded according to their own checkpoint metadata.
+
 If an older vLLM release logs `SpeculativeConfig(method='draft_model', ...)`
 for a Gemma 4 assistant checkpoint, that release is treating the assistant as a
 generic draft model and may fail during initialization for multimodal Gemma 4


### PR DESCRIPTION
## Summary
- Clarify that Gemma 4 assistant checkpoints should use the Gemma 4 MTP path.
- Document that speculative `quantization` should only be set when the assistant checkpoint is quantized in the same way as the target.
- Mention the common quantized-target + unquantized-assistant case, where the speculative quantization field should be left unset.

## Why this is not duplicating an existing PR
- Checked open PRs with:
  - `gh pr list --repo vllm-project/vllm --state open --search 'Gemma 4 assistant MTP quantization docs'`
  - `gh pr list --repo vllm-project/vllm --state open --search 'gemma4_unified_assistant mtp docs'`
- Found related Gemma 4 implementation work, but no open PR specifically documenting this assistant quantization pitfall in the MTP guide.

## Test Plan
- `git diff --check`
- `.venv/bin/pre-commit run --files docs/features/speculative_decoding/mtp.md`

## Notes
- AI assistance was used to draft this documentation change. The changed lines were reviewed before submission.
