### PR TITLE
docs: mention RTX Blackwell CUDA requirement

### DIFF
--- a/docs/getting_started/installation/gpu.cuda.inc.md
+++ b/docs/getting_started/installation/gpu.cuda.inc.md
@@ -34,7 +34,7 @@ uv pip install vllm --torch-backend=auto
 We recommend leveraging `uv` to [automatically select the appropriate PyTorch index at runtime](https://docs.astral.sh/uv/guides/integration/pytorch/#automatic-backend-selection) by inspecting the installed CUDA driver version via `--torch-backend=auto` (or `UV_TORCH_BACKEND=auto`). To select a specific backend (e.g., `cu130`), set `--torch-backend=cu130` (or `UV_TORCH_BACKEND=cu130`). If this doesn't work, try running `uv self update` to update `uv` first.
 
 !!! note
-    NVIDIA Blackwell GPUs (B200, GB200) require a minimum of CUDA 12.8, so make sure you are installing PyTorch wheels with at least that version. PyTorch itself offers a [dedicated interface](https://pytorch.org/get-started/locally/) to determine the appropriate pip command to run for a given target configuration.
+    NVIDIA Blackwell GPUs (for example B200, GB200, RTX 50-series, and RTX PRO Blackwell) require a minimum of CUDA 12.8, so make sure you are installing PyTorch wheels with at least that version. PyTorch itself offers a [dedicated interface](https://pytorch.org/get-started/locally/) to determine the appropriate pip command to run for a given target configuration.
 
 As of now, vLLM's binaries are compiled with CUDA 12.9 and public PyTorch release versions by default. We also provide vLLM binaries compiled with CUDA 12.8, 13.0, and public PyTorch release versions:
 


### PR DESCRIPTION
## Summary
- Expand the CUDA installation note for NVIDIA Blackwell GPUs to explicitly include RTX 50-series and RTX PRO Blackwell cards.
- Keep the guidance aligned with the existing CUDA 12.8+ requirement and PyTorch wheel selection advice.

## Why this is not duplicating an existing PR
- Checked open PRs with:
  - `gh pr list --repo vllm-project/vllm --state open --search 'Blackwell FlashInfer CUDA 13 installation docs'`
  - `gh pr list --repo vllm-project/vllm --state open --search 'SM120 FlashInfer CUDA arch docs'`
- Found related Blackwell implementation PRs, but no open PR specifically clarifying the CUDA install note for RTX Blackwell users.

## Test Plan
- `git diff --check`
- `.venv/bin/pre-commit run --files docs/getting_started/installation/gpu.cuda.inc.md`

## Notes
- AI assistance was used to draft this documentation change. The changed lines were reviewed before submission.
