### PR TITLE
fix: reset KV load recompute placeholders

### DIFF
--- a/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
+++ b/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
@@ -105,6 +105,9 @@ def test_sync_recompute_blocks_not_freed_for_running_requests(
 
     # store original num_computed_tokens for comparison
     original_num_computed_tokens = request.num_computed_tokens
+    # A KV load failure can arrive after async scheduling has reserved an
+    # output placeholder. Recompute must restart from prefill state.
+    request.num_output_placeholders = 1
 
     model_runner_output = create_model_runner_output(
         [request],
@@ -132,6 +135,8 @@ def test_sync_recompute_blocks_not_freed_for_running_requests(
     assert request.num_computed_tokens < original_num_computed_tokens, (
         "num_computed_tokens should be reduced after invalid block detection"
     )
+    assert request.num_output_placeholders == 0
+    assert request.async_tokens_to_discard == 0
 
     # 3. no output should be generated (request is still running)
     # the request should be skipped in the output loop

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2423,6 +2423,19 @@ class Scheduler(SchedulerInterface):
                     blocks_to_evict.update(req_block_ids[idx:])
 
             if is_affected:
+                if request.num_output_placeholders > 0:
+                    # The scheduled output for this step is skipped below when
+                    # the request is returned in failed_kv_load_req_ids. Any
+                    # older in-flight async outputs still need to be ignored.
+                    skipped_current_output = req_id in num_scheduled_tokens
+                    request.async_tokens_to_discard += max(
+                        request.num_output_placeholders - int(skipped_current_output),
+                        0,
+                    )
+                    request.num_output_placeholders = 0
+                    if request.spec_token_ids:
+                        request.spec_token_ids = []
+
                 if not marked_invalid_block:
                     # All invalid blocks of this request are shared with
                     # previous requests and will be recomputed by them.


### PR DESCRIPTION
## Purpose

Fixes #45138.

When a KV load failure is handled with `kv_load_failure_policy="recompute"`, the scheduler truncates `num_computed_tokens` so the request can recompute from the first invalid block. If the request already had output placeholders reserved by async scheduling, those placeholders were left in place.

That leaves the retried request in a mixed prefill/decode state: `num_output_placeholders` keeps contributing to `num_new_tokens` and to the max-token guard even though the request is being sent back to prefill work. This can keep a load-failure retry from making normal progress.

This PR clears stale output placeholders when a request is affected by invalid KV blocks. If there are older async outputs still in flight, they are counted in `async_tokens_to_discard`; the current scheduled output is already skipped by `failed_kv_load_req_ids`, so it is not double-counted.

## Test Plan

To verify:

```bash
python -m pytest tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py::test_sync_recompute_blocks_not_freed_for_running_requests -q
python -m ruff check vllm/v1/core/sched/scheduler.py tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
python -m ruff format --check vllm/v1/core/sched/scheduler.py tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
python -m py_compile vllm/v1/core/sched/scheduler.py tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
git diff --check
```

## Test Result

Passed locally:

```text
python -m ruff check vllm\v1\core\sched\scheduler.py tests\v1\kv_connector\unit\test_invalid_blocks_correctness.py
All checks passed!

python -m ruff format --check vllm\v1\core\sched\scheduler.py tests\v1\kv_connector\unit\test_invalid_blocks_correctness.py
2 files already formatted

python -m py_compile vllm\v1\core\sched\scheduler.py tests\v1\kv_connector\unit\test_invalid_blocks_correctness.py
# no output

git diff --check
# no output
```

Local pytest did not reach the test body in this Windows base environment because the installed `transformers==5.8.1` / `kernels==0.15.2` combination fails during import of `tests/conftest.py`:

```text
ValueError: Either a revision or a version must be specified.
```
