### PR TITLE
vLLM plumbing for cuteDSL hd512 FP8 kv cache kernel integration.

### DIFF
--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -650,7 +650,14 @@ class FlashAttentionImpl(AttentionImpl):
                 "heads in the layer"
             )
 
-        self.supports_quant_query_input = flash_attn_supports_quant_query_input()
+        # FA4's SM90 fp8-KV path consumes fp16 Q (q_descale=None) and dequants fp8 K/V
+        # in-kernel. So for FA4 impls we report False here: the layer then skips
+        # creating/applying query_quant, leaving Q in its native (bf16) dtype, which the
+        # flash_attn_interface FA4 branch casts to fp16. 
+        self.supports_quant_query_input = (
+            flash_attn_supports_quant_query_input()
+            and self.vllm_flash_attn_version != 4
+        )
 
         vllm_config = get_current_vllm_config_or_none()
         dcp_a2a = (

--- a/vllm/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm/vllm_flash_attn/flash_attn_interface.py
@@ -369,6 +369,52 @@ def flash_attn_varlen_func(
 
         from vllm.vllm_flash_attn.cute.interface import _flash_attn_fwd
 
+        # The new SM90 FA4 kernel shares the bf16 code path but adds in-kernel dequant:
+        # it consumes fp16 Q + fp8 e4m3 paged K/V, dequantizes K/V to fp16, and computes
+        # attention in fp16. 
+        # As a temp WAR, for the fp8-KV path we cast Q bf16->fp16, pass q_descale=None 
+        # (the cute interface materializes an identity descale for fp16 Q), and forward the 
+        # (batch, num_kv_heads) float32 k/v descales.
+        fa4_fp8_kv_dequant = (
+            k.dtype == torch.float8_e4m3fn
+            and torch.cuda.get_device_capability()[0] == 9
+        )
+        # TODO(qixiangl): improve this WAR to avoid DRAM round-trip for Q.
+        if fa4_fp8_kv_dequant:
+            if q.dtype != torch.float16:
+                q = q.to(torch.float16)
+            fa4_q_descale = None
+            
+            # vLLM .expand()s the scalar descales into stride-0 broadcasts, but the
+            # cute interface needs stride-1 on num_kv_heads. A (1, 1) descale (TP>1:
+            # 1 KV head/rank + batch=1 decode) counts as "contiguous", so .contiguous()
+            # no-ops; clone() forces a real stride-1 copy (also fixes the derived q_descale).
+            fa4_k_descale = (
+                k_descale.clone(memory_format=torch.contiguous_format)
+                if k_descale is not None
+                else None
+            )
+            fa4_v_descale = (
+                v_descale.clone(memory_format=torch.contiguous_format)
+                if v_descale is not None
+                else None
+            )
+            # The dequant kernel computes in fp16 and writes an fp16 O, and the cute
+            # interface requires out.dtype == q.dtype (fp16). vLLM's `out` buffer is bf16
+            # (the model's dataflow dtype), so let the interface allocate its native fp16
+            # output, then copy it back into vLLM's bf16 buffer after the call.
+            # TODO(qixiangl): fuse the fp16->bf16 downcast into the kernel store
+            # epilogue (write bf16 straight into vLLM's `out`) to drop this extra
+            # buffer + DRAM round-trip.
+            fa4_out_buf = out
+            fa4_out = None
+        else:
+            fa4_q_descale = None
+            fa4_k_descale = None
+            fa4_v_descale = None
+            fa4_out_buf = None
+            fa4_out = out
+
         out, softmax_lse = _flash_attn_fwd(
             q,
             k,
@@ -386,9 +432,18 @@ def flash_attn_varlen_func(
             window_size_right=real_window_size[1] if real_window_size[1] >= 0 else None,
             num_splits=num_splits,
             return_lse=return_softmax_lse,
-            out=out,
+            out=fa4_out,
             learnable_sink=s_aux,
+            q_descale=fa4_q_descale,
+            k_descale=fa4_k_descale,
+            v_descale=fa4_v_descale,
+            fp8_kv_dequant=fa4_fp8_kv_dequant,
         )
+        # TODO(qixiangl): same as above, fuse the fp16->bf16 downcast into the kernel store
+        if fa4_out_buf is not None:
+            # fp16 kernel output -> vLLM's preallocated bf16 out buffer (model dataflow).
+            fa4_out_buf.copy_(out)
+            out = fa4_out_buf
     else:
         raise ValueError(f"Unsupported FA version: {fa_version}")
     return (out, softmax_lse) if return_softmax_lse else out


### PR DESCRIPTION





## Purpose

Depends on: [vllm-project/flash-attention#147](https://github.com/vllm-project/flash-attention/pull/147)

This PR adds the vLLM-side plumbing needed to test the FA4 SM90 FP8 KV dequantization path introduced in the FlashAttention PR. The kernel implementation lives in FlashAttention; this PR only routes the eligible vLLM FA4 path to it.

The new path keeps attention compute in FP16 while storing the KV cache in FP8, reducing KV cache memory footprint without moving the compute path fully to FP8.

Changes included:
- Treat FA4 as not supporting quantized query input, so vLLM keeps Q in the model dtype instead of quantizing it to FP8.
- Detect the SM90 FP8-KV FA4 path in `flash_attn_interface.py`.
- Forward K/V descales and `fp8_kv_dequant=True` to the FA4 CuTe interface.


Changes will be removed (by changing kernel side):
- Cast Q to FP16 for the current kernel contract.
- Copy the temporary FP16 FA4 output back into vLLM's BF16 output buffer.

## Test Plan

- vLLM with `VLLM_FLASH_ATTN_SRC_DIR` pointing to the FlashAttention PR branch.
- Run targeted routing validation to confirm Gemma4 hd512 layers use FA4 with FP8 KV, while hd256 sliding-window layers remain on FA3.
- Compare FA4 FP8-KV output against the existing Triton FP8-KV path.

## Test Result

With `VLLM_FLASH_ATTN_SRC_DIR` pointing to the FlashAttention PR branch, we test the gemma-4-31B-it with FP8 KV cache on (TP4):

Backend | GSM8K Accuracy | Δ vs bf16 | Invalid Rate
-- | -- | -- | --
triton-16bit (bf16 KV) | 62.93% | — | 0.027
triton-fp8 (fp8 KV) | 64.82% | +1.9 pt | 0.025
**fa4-fp8 (new kernel)** | 62.70% | −0.23 pt | 0.021

## TODO

- Remove the temporary BF16 Q -> FP16 cast once the kernel supports the desired input contract directly.
- Add BF16 input / BF16 output support to avoid the extra FP16 output buffer and copy-back.
- Add accuracy test numbers with checkpoint that contains FP8 KV scale factors
- Add performance numbers against the existing Triton FP8-KV path.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

