### PR TITLE
[Bugfix][Rust Frontend] Validate out-of-vocab token ids in the generate route

### DIFF
--- a/rust/src/server/src/routes/inference/generate.rs
+++ b/rust/src/server/src/routes/inference/generate.rs
@@ -44,6 +44,14 @@ pub async fn generate(
 ) -> Response {
     let request_context = resolve_request_context(&headers, body.request_id.as_deref());
     let lora_resolution = state.resolve_model_with_loras(body.model.as_deref()).await;
+
+    if let Err(err) = validate::validate_token_id_ranges(
+        &body,
+        state.tokenizer_vocab_size(),
+        state.model_vocab_size(),
+    ) {
+        return err.into_response();
+    }
     let prepared = match prepare_generate_request(body, &lora_resolution, request_context) {
         Ok(prepared) => prepared,
         Err(error) => return error.into_response(),

--- a/rust/src/server/src/routes/inference/generate/validate.rs
+++ b/rust/src/server/src/routes/inference/generate/validate.rs
@@ -1,5 +1,8 @@
 use super::types::GenerateRequest;
 use crate::error::{ApiError, bail_invalid_request};
+use crate::routes::openai::utils::token_ids::{
+    validate_allowed_token_ids, validate_logit_bias_token_ids, validate_token_ids,
+};
 
 /// Enforce the minimal compatibility contract for the Rust token generate
 /// route.
@@ -47,11 +50,31 @@ pub(super) fn validate_request_compat(
     Ok(())
 }
 
+/// Reject out-of-vocab token ids, mirroring the OpenAI routes' `validate_token_id_ranges`.
+pub(super) fn validate_token_id_ranges(
+    request: &GenerateRequest,
+    tokenizer_vocab_size: usize,
+    model_vocab_size: Option<usize>,
+) -> Result<(), ApiError> {
+    let prompt_bound = tokenizer_vocab_size.max(model_vocab_size.unwrap_or(0));
+    validate_token_ids(&request.token_ids, prompt_bound)?;
+    validate_allowed_token_ids(
+        request.sampling_params.allowed_token_ids.as_deref(),
+        tokenizer_vocab_size,
+    )?;
+    validate_logit_bias_token_ids(
+        request.sampling_params.logit_bias.as_ref(),
+        model_vocab_size.unwrap_or(usize::MAX),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
-    use super::validate_request_compat;
+    use std::collections::HashMap;
+
+    use super::{validate_request_compat, validate_token_id_ranges};
     use crate::routes::inference::generate::types::GenerateRequest;
 
     fn base_request() -> GenerateRequest {
@@ -96,5 +119,30 @@ mod tests {
             ..base_request()
         };
         assert!(validate_request_compat(&request, &served(&["Qwen/Qwen1.5-0.5B-Chat"])).is_err());
+    }
+
+    #[test]
+    fn validate_token_id_ranges_rejects_oob_token_ids_and_params() {
+        let mut request = base_request();
+        request.token_ids = vec![5, 150];
+        assert!(validate_token_id_ranges(&request, 100, Some(200)).is_ok());
+        request.token_ids = vec![5, 200];
+        assert!(validate_token_id_ranges(&request, 100, Some(200)).is_err());
+        // prompt bound is max(tokenizer, model): an id in [model, tokenizer) is accepted
+        request.token_ids = vec![150];
+        assert!(validate_token_id_ranges(&request, 200, Some(100)).is_ok());
+
+        // allowed_token_ids is bounded by the tokenizer vocab, logit_bias by the model vocab
+        let mut request = base_request();
+        request.sampling_params.allowed_token_ids = Some(vec![150]);
+        assert!(validate_token_id_ranges(&request, 100, Some(200)).is_err());
+        request.sampling_params.allowed_token_ids = None;
+        request.sampling_params.logit_bias = Some(HashMap::from([(150, 1.0)]));
+        assert!(validate_token_id_ranges(&request, 200, Some(100)).is_err());
+
+        // unknown vocab sizes skip the check
+        request = base_request();
+        request.token_ids = vec![1_000_000];
+        assert!(validate_token_id_ranges(&request, usize::MAX, None).is_ok());
     }
 }

--- a/rust/src/server/src/routes/inference/generate/validate.rs
+++ b/rust/src/server/src/routes/inference/generate/validate.rs
@@ -1,7 +1,8 @@
 use super::types::GenerateRequest;
 use crate::error::{ApiError, bail_invalid_request};
 use crate::routes::openai::utils::token_ids::{
-    validate_allowed_token_ids, validate_logit_bias_token_ids, validate_token_ids,
+    validate_allowed_token_ids, validate_logit_bias_token_ids, validate_logprob_token_ids,
+    validate_token_ids,
 };
 
 /// Enforce the minimal compatibility contract for the Rust token generate
@@ -64,6 +65,14 @@ pub(super) fn validate_token_id_ranges(
     )?;
     validate_logit_bias_token_ids(
         request.sampling_params.logit_bias.as_ref(),
+        model_vocab_size.unwrap_or(usize::MAX),
+    )?;
+    // The engine gathers `logprob_token_ids` straight from the model's logits
+    // tensor, so an id beyond the model vocab indexes out of bounds and aborts
+    // EngineCore; Python's `SamplingParams._validate_logprobs` bounds it by the
+    // model vocab too.
+    validate_logprob_token_ids(
+        request.sampling_params.logprob_token_ids.as_deref(),
         model_vocab_size.unwrap_or(usize::MAX),
     )
 }
@@ -139,6 +148,13 @@ mod tests {
         request.sampling_params.allowed_token_ids = None;
         request.sampling_params.logit_bias = Some(HashMap::from([(150, 1.0)]));
         assert!(validate_token_id_ranges(&request, 200, Some(100)).is_err());
+
+        // logprob_token_ids is bounded by the model vocab (the engine gathers from the logits tensor)
+        let mut request = base_request();
+        request.sampling_params.logprob_token_ids = Some(vec![150]);
+        assert!(validate_token_id_ranges(&request, 200, Some(100)).is_err());
+        request.sampling_params.logprob_token_ids = Some(vec![150]);
+        assert!(validate_token_id_ranges(&request, 100, Some(200)).is_ok());
 
         // unknown vocab sizes skip the check
         request = base_request();

--- a/rust/src/server/src/routes/openai/utils/token_ids.rs
+++ b/rust/src/server/src/routes/openai/utils/token_ids.rs
@@ -18,6 +18,17 @@ pub(crate) fn validate_prompt_token_ids(prompt: &Prompt, bound: usize) -> Result
     Ok(())
 }
 
+/// Reject `token_ids` prompt entries at or above `bound` (the `generate` route's bare id list).
+pub(crate) fn validate_token_ids(token_ids: &[u32], bound: usize) -> Result<(), ApiError> {
+    if let Some(&bad) = token_ids.iter().find(|&&id| id as usize >= bound) {
+        bail_invalid_request!(
+            param = "token_ids",
+            "token_ids contains out-of-vocab token id {bad}; vocabulary size is {bound}."
+        );
+    }
+    Ok(())
+}
+
 /// Reject `allowed_token_ids` entries at or above `bound`.
 pub(crate) fn validate_allowed_token_ids(
     allowed_token_ids: Option<&[u32]>,
@@ -50,6 +61,22 @@ pub(crate) fn validate_logit_bias(
                 );
             }
         }
+    }
+    Ok(())
+}
+
+/// Reject `logit_bias` keys at or above `bound` (the `generate` route's `u32`-keyed map).
+pub(crate) fn validate_logit_bias_token_ids(
+    logit_bias: Option<&HashMap<u32, f32>>,
+    bound: usize,
+) -> Result<(), ApiError> {
+    if let Some(bias) = logit_bias
+        && let Some(&bad) = bias.keys().find(|&&id| id as usize >= bound)
+    {
+        bail_invalid_request!(
+            param = "logit_bias",
+            "logit_bias contains out-of-vocab token id {bad}; vocabulary size is {bound}."
+        );
     }
     Ok(())
 }

--- a/rust/src/server/src/routes/openai/utils/token_ids.rs
+++ b/rust/src/server/src/routes/openai/utils/token_ids.rs
@@ -80,3 +80,20 @@ pub(crate) fn validate_logit_bias_token_ids(
     }
     Ok(())
 }
+
+/// Reject `logprob_token_ids` entries at or above `bound` (the `generate` route's
+/// per-position logprob ids, gathered from the engine's logits tensor).
+pub(crate) fn validate_logprob_token_ids(
+    logprob_token_ids: Option<&[u32]>,
+    bound: usize,
+) -> Result<(), ApiError> {
+    if let Some(ids) = logprob_token_ids
+        && let Some(&bad) = ids.iter().find(|&&id| id as usize >= bound)
+    {
+        bail_invalid_request!(
+            param = "logprob_token_ids",
+            "logprob_token_ids contains out-of-vocab token id {bad}; vocabulary size is {bound}."
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION

## Purpose

Follow-up to #44680, which added out-of-vocab token-id validation to the Rust frontend's `/v1/completions` and `/v1/chat/completions` routes. The native token-in/token-out route `POST /inference/v1/generate` feeds the same token-id fields to the engine but was left unvalidated.

A `/inference/v1/generate` request whose `token_ids` prompt holds an id `>=` the vocab size reaches the engine, indexes the embedding table out of bounds, and aborts EngineCore, taking the whole server down (single-request DoS). The Python serving stack rejects this with a 400 before it reaches the engine; the Rust frontend bypasses the Python `Processor`, so the check is missing.

This extends the shared `utils::token_ids` validators to the generate route, with the same bounds the OpenAI routes use and the Python input processor follows (`max(tokenizer.max_token_id, model_vocab_size - 1)`): the `token_ids` prompt by `max(tokenizer, model)` vocab (the engine embeds ids beyond either alone, e.g. added LM tokens or multimodal placeholders), `allowed_token_ids` by the tokenizer vocab, and `logit_bias` keys by the model vocab. `allowed_token_ids` reuses the existing validator directly; the generate route's bare `Vec<u32>` prompt and `u32`-keyed `logit_bias` get two thin sibling validators next to the existing ones.

This is complementary to #45286 (which maps lowering-stage `PromptTooLong` / `EmptyPromptTokenIds` submit errors to 400): out-of-vocab token ids pass lowering and abort the engine instead, so they have to be rejected before submit, which this PR does.

## Test Plan

Build the Rust frontend from this branch and serve any model through it, then send a `/inference/v1/generate` request with an out-of-vocab `token_ids` prompt, with and without this change, and check whether the server survives.

## Test Result

`cargo test -p vllm-server` (217 passed), `cargo fmt --check`, and `cargo clippy -p vllm-server` are clean.

Differential on the real `/inference/v1/generate` route (Rust frontend serving `Qwen/Qwen3-0.6B`, vocab 151936), same source with and without the fix:

| OOB `token_ids: [9000000]` | server afterwards |
|---|---|
| without fix: HTTP 500 `engine core reported fatal failure` | DEAD, later requests refused |
| with fix: HTTP 400 `token_ids contains out-of-vocab token id 9000000; vocabulary size is 151936.` | healthy, keeps serving |

<details>
<summary>repro (serve command + client + full before/after output)</summary>

```bash
# build the Rust frontend from this branch
cd rust && cargo build --release --bin vllm-rs

# serve any model through the Rust frontend
VLLM_USE_RUST_FRONTEND=1 \
VLLM_RUST_FRONTEND_PATH=$PWD/target/release/vllm-rs \
vllm serve Qwen/Qwen3-0.6B --port 8744 --enforce-eager

# send an out-of-vocab token-id prompt, then check the server is still up
curl -s -X POST http://127.0.0.1:8744/inference/v1/generate \
  -H 'Content-Type: application/json' \
  -d '{"token_ids":[9000000],"sampling_params":{"max_tokens":4}}'
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8744/health
```

Without this change:

```
HTTP 500
{"error":{"message":"failed to collect raw generate response: engine core reported fatal failure","type":"server_error","code":"server_error"}}
# server log: EngineCore encountered a fatal error
#   (run_busy_loop -> _process_engine_step -> step_with_batch_queue -> execute_model)
/health -> 000   # connection refused, server is down
```

With this change:

```
HTTP 400
{"error":{"message":"token_ids contains out-of-vocab token id 9000000; vocabulary size is 151936.","type":"invalid_request_error","param":"token_ids","code":"invalid_request_error"}}
/health -> 200   # server still serving
```

The same holds for `allowed_token_ids` and `logit_bias`: with the fix they return 400 at the correct bound (tokenizer vocab 151669 and model vocab 151936 respectively). On `Qwen/Qwen3-0.6B` the engine tolerated those two fields out of range without aborting; they are validated for parity with the Python serving layer, which rejects them regardless.

</details>

AI assistance was used to investigate, reproduce, and draft this change; the author reviewed the diff and validation output.

cc @BugenZhao
