### PR TITLE
Admit MTP/EAGLE spec-decode steps and sliding-window layers into the Triton 3D flash-decoding path (B300, NVFP4)

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -78,6 +78,11 @@ class TritonAttentionMetadata:
     softmax_segm_output: torch.Tensor
     softmax_segm_max: torch.Tensor
     softmax_segm_expsum: torch.Tensor
+    # Per-(spec-)decode-step query length (1 for pure decode, 1 + num_spec for
+    # MTP/EAGLE).  Gates the 3D flash-decoding path for spec-decode in the
+    # ``unified_attention`` launcher.  Set by the builder from the speculative
+    # config (1 when spec-decode is inactive).
+    decode_query_len: int
 
     causal: bool | torch.Tensor
 
@@ -147,11 +152,32 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
                 key=lambda x: abs(x - self.seq_threshold_3D),
             )
 
+        # Per-(spec-)decode-step query length: 1 for pure decode, or
+        # ``1 + num_speculative_tokens`` when MTP/EAGLE speculative decode is
+        # active (e.g. 5 for num_speculative_tokens=4).  Under spec-decode a
+        # uniform decode step packs up to ``decode_query_len`` query tokens per
+        # sequence, so the 3D segment buffers — which are indexed by the
+        # absolute within-batch query-token position (``query_offset_0`` in
+        # ``kernel_unified_attention``), not by sequence index — must size their
+        # first dim by ``seq_threshold_3D * decode_query_len`` to admit a full
+        # spec-verify batch (num_seqs <= seq_threshold_3D, each with up to
+        # decode_query_len tokens).  With ``decode_query_len == 1`` (non-spec)
+        # this reduces to the original ``seq_threshold_3D`` first dim — no
+        # behavior or memory change for non-spec deployments.
+        spec_config = self.vllm_config.speculative_config
+        self.decode_query_len = 1 + (
+            spec_config.num_speculative_tokens
+            if spec_config is not None
+            and spec_config.num_speculative_tokens is not None
+            else 0
+        )
+        segm_first_dim = self.seq_threshold_3D * self.decode_query_len
+
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
         headdim_padded = next_power_of_2(self.headdim)
         self.softmax_segm_output = torch.empty(
             (
-                self.seq_threshold_3D,
+                segm_first_dim,
                 self.num_heads_q,
                 self.num_par_softmax_segments,
                 headdim_padded,
@@ -160,14 +186,35 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             device=device,
         )
         self.softmax_segm_max = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
+            (segm_first_dim, self.num_heads_q, self.num_par_softmax_segments),
             dtype=torch.float32,
             device=device,
         )
         self.softmax_segm_expsum = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
+            (segm_first_dim, self.num_heads_q, self.num_par_softmax_segments),
             dtype=torch.float32,
             device=device,
+        )
+        # Buffer-safety invariant (applies to BOTH the global and sliding
+        # builder instances since this __init__ is shared).  The 3D epilogue in
+        # ``kernel_unified_attention`` indexes all three segment buffers by the
+        # absolute within-batch query-token position, whose max over a
+        # 3D-admitted batch is (num_actual_tokens - 1) <= seq_threshold_3D *
+        # decode_query_len - 1.  All three buffers must therefore share the
+        # first dim ``seq_threshold_3D * decode_query_len``; assert the actual
+        # allocated shapes to fail fast on a half-applied resize.
+        expected_first_dim = self.seq_threshold_3D * self.decode_query_len
+        assert (
+            self.softmax_segm_output.shape[0] == expected_first_dim
+            and self.softmax_segm_max.shape[0] == expected_first_dim
+            and self.softmax_segm_expsum.shape[0] == expected_first_dim
+        ), (
+            "3D softmax segment buffers must all have first dim "
+            f"seq_threshold_3D({self.seq_threshold_3D}) * "
+            f"decode_query_len({self.decode_query_len}) = {expected_first_dim}; "
+            f"got output={self.softmax_segm_output.shape[0]}, "
+            f"max={self.softmax_segm_max.shape[0]}, "
+            f"expsum={self.softmax_segm_expsum.shape[0]}."
         )
 
     def build_for_cudagraph_capture(
@@ -233,6 +280,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             softmax_segm_output=self.softmax_segm_output,
             softmax_segm_max=self.softmax_segm_max,
             softmax_segm_expsum=self.softmax_segm_expsum,
+            decode_query_len=self.decode_query_len,
         )
 
         mm_ranges = common_attn_metadata.mm_req_doc_ranges
@@ -636,6 +684,7 @@ class TritonAttentionImpl(AttentionImpl):
             k_descale=k_descale,
             v_descale=v_descale,
             seq_threshold_3D=seq_threshold_3D,
+            decode_query_len=attn_metadata.decode_query_len,
             num_par_softmax_segments=num_par_softmax_segments,
             softmax_segm_output=softmax_segm_output,
             softmax_segm_max=softmax_segm_max,

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -139,40 +139,40 @@ def init_softmax_M(
 
 
 @triton.jit
-def compute_tile_loop_bounds(
+def compute_window_tile_range(
     context_len,
     seq_len,
     cur_batch_query_len,
     q_block_local_idx,
-    segm_idx_or_0,
-    tiles_per_segment_or_0,
     TILE_SIZE: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_Q: tl.constexpr,
     num_queries_per_kv: tl.constexpr,
     SLIDING_WINDOW: tl.constexpr,
     USE_MM_PREFIX: tl.constexpr,
-    IS_3D: tl.constexpr,
     USE_CAUSAL: tl.constexpr = True,
     USE_PER_SEQ_CAUSAL: tl.constexpr = False,
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
 ):
-    """Compute the tile-loop bounds ``(loop_lo, loop_hi)`` and the
-    derived ``max_seq_prefix_len`` used for per-tile masking.
+    """Single source of truth for the *un-segmented* tile range
+    ``[tile_start, tile_end)`` spanned by one q-block, plus the
+    derived ``max_seq_prefix_len``.
 
-    Combines three concerns into one helper:
+    Factored out of ``compute_tile_loop_bounds`` so that the attention
+    mainloop, ``compute_tile_loop_bounds``, AND ``reduce_segments`` can
+    all derive the IDENTICAL window range from the same q-block
+    geometry.  This is the keystone that prevents the mainloop and the
+    3D reduction from disagreeing on the window-relative segment layout:
+    any drift between the two would silently read stale /
+    mis-masked segment partials.
 
-    1. Longest prefix spanned by any query token in this q-block.
-       Clamped to ``seq_len`` (causal) or extended to it when
-       mm_prefix is active or non-causal sequences need the full
-       sequence.
-    2. Sliding-window pruning: narrows ``[tile_start, tile_end)`` to
-       only tiles that can contain an allowed key under SWA.
-       For non-causal sequences, the window extends in both directions.
-    3. 3D scoping: when ``IS_3D`` is True, further narrows to the
-       segment's slice via ``(segm_idx * tiles_per_segment,
-       (segm_idx + 1) * tiles_per_segment)``.
+    The prefix is clamped to ``seq_len`` (causal) or extended to it
+    when mm_prefix is active or non-causal/per-seq-causal sequences
+    need the full sequence; for non-causal sequences the sliding
+    window extends in both directions.  For ``SLIDING_WINDOW <= 0``
+    (global layers) this returns ``[0, num_tiles)`` — byte-identical
+    to the previous inline logic.
     """
     # compute the length of the longest sequence prefix spanned by any
     # query token in the current q_block (q_block_local_idx)
@@ -226,9 +226,142 @@ def compute_tile_loop_bounds(
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
         tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
 
+    return tile_start, tile_end, max_seq_prefix_len
+
+
+@triton.jit
+def compute_window_segments(
+    context_len,
+    seq_len,
+    cur_batch_query_len,
+    q_block_local_idx,
+    NUM_SEGMENTS: tl.constexpr,
+    TILE_SIZE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_Q: tl.constexpr,
+    num_queries_per_kv: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr,
+    USE_MM_PREFIX: tl.constexpr,
+    USE_CAUSAL: tl.constexpr = True,
+    USE_PER_SEQ_CAUSAL: tl.constexpr = False,
+    CHUNK_LOOKBACK: tl.constexpr = -1,
+    CHUNK_SIZE: tl.constexpr = -1,
+):
+    """Window-relative 3D segmentation for one q-block.
+
+    Returns ``(tile_start, tiles_per_segment, act_num_segments)`` where
+    the ``NUM_SEGMENTS`` parallel-softmax segments tile ONLY the
+    sliding window's tile range ``[tile_start, tile_end)`` rather than
+    the full sequence.  At 27k context with a 1024 window this restores
+    ~11/16 active segments vs the window-blind 1/16 collapse.
+
+    The mainloop (for its early-return + loop bounds) and
+    ``reduce_segments`` (for its segment mask) MUST call this with the
+    SAME q-block geometry so their ``act_num_segments`` agree — the
+    mainloop early-returns (does not overwrite) empty high segments, so
+    the reduction relies on the matching mask to exclude stale data.
+    """
+    tile_start, tile_end, _ = compute_window_tile_range(
+        context_len,
+        seq_len,
+        cur_batch_query_len,
+        q_block_local_idx,
+        TILE_SIZE,
+        BLOCK_M,
+        BLOCK_Q,
+        num_queries_per_kv,
+        SLIDING_WINDOW,
+        USE_MM_PREFIX,
+        USE_CAUSAL,
+        USE_PER_SEQ_CAUSAL,
+        CHUNK_LOOKBACK,
+        CHUNK_SIZE,
+    )
+    window_tiles = tile_end - tile_start
+    # window_tiles >= 1 whenever the q-block has any allowed key (the
+    # caller only reaches here for non-empty q-blocks); guard anyway so
+    # cdiv never divides by zero.
+    window_tiles = tl.maximum(window_tiles, 1)
+    tiles_per_segment = cdiv_fn(window_tiles, NUM_SEGMENTS)
+    act_num_segments = cdiv_fn(window_tiles, tiles_per_segment)
+    return tile_start, tiles_per_segment, act_num_segments
+
+
+@triton.jit
+def compute_tile_loop_bounds(
+    context_len,
+    seq_len,
+    cur_batch_query_len,
+    q_block_local_idx,
+    segm_idx_or_0,
+    tiles_per_segment_or_0,
+    TILE_SIZE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_Q: tl.constexpr,
+    num_queries_per_kv: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr,
+    USE_MM_PREFIX: tl.constexpr,
+    IS_3D: tl.constexpr,
+    USE_CAUSAL: tl.constexpr = True,
+    USE_PER_SEQ_CAUSAL: tl.constexpr = False,
+    CHUNK_LOOKBACK: tl.constexpr = -1,
+    CHUNK_SIZE: tl.constexpr = -1,
+    WINDOW_SEG_3D: tl.constexpr = False,
+):
+    """Compute the tile-loop bounds ``(loop_lo, loop_hi)`` and the
+    derived ``max_seq_prefix_len`` used for per-tile masking.
+
+    Combines three concerns into one helper:
+
+    1. Longest prefix spanned by any query token in this q-block.
+       Clamped to ``seq_len`` (causal) or extended to it when
+       mm_prefix is active (bidirectional ranges can reach past the
+       causal prefix).
+    2. Sliding-window pruning: narrows ``[tile_start, tile_end)`` to
+       only tiles that can contain an allowed key under SWA.
+    3. 3D scoping: when ``IS_3D`` is True, further narrows to the
+       segment's slice.  Two segmentation modes:
+       - ``WINDOW_SEG_3D``: segments tile the WINDOW range
+         ``[tile_start, tile_end)`` — base offset by ``tile_start``.
+       - default: full-sequence segmentation via
+         ``(segm_idx * tiles_per_segment, (segm_idx + 1) *
+         tiles_per_segment)`` (GLOBAL + existing behavior, unchanged).
+    """
+    tile_start, tile_end, max_seq_prefix_len = compute_window_tile_range(
+        context_len,
+        seq_len,
+        cur_batch_query_len,
+        q_block_local_idx,
+        TILE_SIZE,
+        BLOCK_M,
+        BLOCK_Q,
+        num_queries_per_kv,
+        SLIDING_WINDOW,
+        USE_MM_PREFIX,
+        USE_CAUSAL,
+        USE_PER_SEQ_CAUSAL,
+        CHUNK_LOOKBACK,
+        CHUNK_SIZE,
+    )
+
     if IS_3D:
-        loop_lo = max(segm_idx_or_0 * tiles_per_segment_or_0, tile_start)
-        loop_hi = min((segm_idx_or_0 + 1) * tiles_per_segment_or_0, tile_end)
+        if WINDOW_SEG_3D:
+            # Window-relative segmentation: the ``NUM_SEGMENTS`` segments
+            # tile only the window range ``[tile_start, tile_end)``, with
+            # segment ``segm_idx`` covering
+            # ``[tile_start + segm_idx*tps, tile_start + (segm_idx+1)*tps)``.
+            # ``tiles_per_segment_or_0`` is the WINDOW-relative tps the
+            # mainloop computed via ``compute_window_segments`` on the
+            # same q-block geometry; ``tile_start`` is re-derived here from
+            # the shared ``compute_window_tile_range`` — so neither value
+            # can drift from the early-return / reduce_segments view.
+            loop_lo = max(tile_start + segm_idx_or_0 * tiles_per_segment_or_0, tile_start)
+            loop_hi = min(
+                tile_start + (segm_idx_or_0 + 1) * tiles_per_segment_or_0, tile_end
+            )
+        else:
+            loop_lo = max(segm_idx_or_0 * tiles_per_segment_or_0, tile_start)
+            loop_hi = min((segm_idx_or_0 + 1) * tiles_per_segment_or_0, tile_end)
     else:
         loop_lo = tile_start
         loop_hi = tile_end

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -21,6 +21,7 @@ from vllm.v1.attention.ops.triton_attention_helpers import (
     cdiv_fn,
     compute_kv_seq_mask,
     compute_tile_loop_bounds,
+    compute_window_segments,
     find_seq_idx,
     init_softmax_M,
     load_qq_bias_tile,
@@ -274,6 +275,13 @@ def kernel_unified_attention(
     USE_TD: tl.constexpr = False,
     USE_TD_QO: tl.constexpr = False,
     Q_IS_FP8: tl.constexpr = False,
+    # When True (3D + sliding-window + spec-decode regime), the
+    # ``NUM_SEGMENTS_PER_SEQ`` parallel-softmax segments tile only the
+    # sliding window's tile range rather than the full sequence, so
+    # segment parallelism is not collapsed to 1/NSEG at long context.
+    # Default False preserves the full-sequence (global / existing)
+    # segmentation byte-for-byte.
+    WINDOW_SEG_3D: tl.constexpr = False,
 ):
     USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = KV_QUANT_MODE >= 2
     USE_FP8_Q_DESCALE: tl.constexpr = KV_QUANT_MODE == 1 and Q_IS_FP8
@@ -301,10 +309,43 @@ def kernel_unified_attention(
     if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
         return
 
+    # context_len is needed both for window segmentation (3D) and the
+    # tile loop below; compute it once here.
+    context_len = seq_len - cur_batch_query_len
+
     if IS_3D:
-        tiles_per_segment = cdiv_fn(seq_len, NUM_SEGMENTS_PER_SEQ * TILE_SIZE)
-        if segm_idx * tiles_per_segment * TILE_SIZE >= seq_len:
-            return
+        if WINDOW_SEG_3D:
+            # Window-relative segmentation: segments tile only
+            # the sliding window's tile range for THIS q-block.  The
+            # early-return below skips segments past the window's active
+            # count; those segment buffers are left untouched and are
+            # masked out by ``reduce_segments`` (which recomputes the
+            # SAME act_num_segments via compute_window_segments).
+            _ws_tile_start, tiles_per_segment, _ws_act_segments = (
+                compute_window_segments(
+                    context_len,
+                    seq_len,
+                    cur_batch_query_len,
+                    q_block_local_idx,
+                    NUM_SEGMENTS_PER_SEQ,
+                    TILE_SIZE,
+                    BLOCK_M,
+                    BLOCK_Q,
+                    num_queries_per_kv,
+                    SLIDING_WINDOW,
+                    USE_MM_PREFIX,
+                    USE_CAUSAL,
+                    USE_PER_SEQ_CAUSAL,
+                    CHUNK_LOOKBACK,
+                    CHUNK_SIZE,
+                )
+            )
+            if segm_idx >= _ws_act_segments:
+                return
+        else:
+            tiles_per_segment = cdiv_fn(seq_len, NUM_SEGMENTS_PER_SEQ * TILE_SIZE)
+            if segm_idx * tiles_per_segment * TILE_SIZE >= seq_len:
+                return
     else:
         tiles_per_segment = 0
 
@@ -368,8 +409,6 @@ def kernel_unified_attention(
         score_scale = scale * tl.load(q_scale) * tl.load(k_scale)
         value_scale = tl.load(v_scale)
 
-    context_len = seq_len - cur_batch_query_len
-
     if USE_ALIBI_SLOPES:
         alibi_slope = tl.load(
             alibi_slopes_ptr + query_offset_1, mask=query_mask_1, other=0.0
@@ -396,6 +435,7 @@ def kernel_unified_attention(
         USE_PER_SEQ_CAUSAL,
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
+        WINDOW_SEG_3D,
     )
 
     # iterate through tiles (now limited to the sliding window range)
@@ -682,6 +722,21 @@ def reduce_segments(
     USE_FP8: tl.constexpr,  # bool
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
+    # Window-relative segmentation: when WINDOW_SEG_3D is True the
+    # active-segment count is recomputed from the SAME per-q-block window
+    # range the mainloop used (compute_window_segments) instead of the
+    # window-blind full-seq formula.  These constexprs mirror the
+    # mainloop's so the two views CANNOT drift.  Defaults reproduce the
+    # original window-blind behavior byte-for-byte.
+    BLOCK_M: tl.constexpr = 0,
+    num_queries_per_kv: tl.constexpr = 0,
+    SLIDING_WINDOW: tl.constexpr = 0,
+    USE_MM_PREFIX: tl.constexpr = False,
+    USE_CAUSAL: tl.constexpr = True,
+    USE_PER_SEQ_CAUSAL: tl.constexpr = False,
+    CHUNK_LOOKBACK: tl.constexpr = -1,
+    CHUNK_SIZE: tl.constexpr = -1,
+    WINDOW_SEG_3D: tl.constexpr = False,
 ):
     query_token_idx = tl.program_id(0)
     query_head_idx = tl.program_id(1)
@@ -694,11 +749,40 @@ def reduce_segments(
     seq_len = tl.load(seq_lens_ptr + seq_idx)
 
     # number of segments for this particular sequence
-    num_segments = NUM_SEGMENTS_PER_SEQ
-    tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
+    if WINDOW_SEG_3D:
+        # Reconstruct the SAME q-block geometry the mainloop used for this
+        # query token, then derive the identical window-relative active
+        # segment count.  cur_start / cur_batch_query_len mirror
+        # resolve_seq_and_query_len; q_block_local_idx is the token's
+        # q-block within its sequence (all tokens in a q-block share it).
+        cur_start = tl.load(query_start_len_ptr + seq_idx)
+        cur_stop = tl.load(query_start_len_ptr + seq_idx + 1)
+        cur_batch_query_len = cur_stop - cur_start
+        q_block_local_idx = (query_token_idx - cur_start) // BLOCK_Q
+        context_len = seq_len - cur_batch_query_len
+        _ws_tile_start, tiles_per_segment, act_num_segments = compute_window_segments(
+            context_len,
+            seq_len,
+            cur_batch_query_len,
+            q_block_local_idx,
+            NUM_SEGMENTS_PER_SEQ,
+            TILE_SIZE,
+            BLOCK_M,
+            BLOCK_Q,
+            num_queries_per_kv,
+            SLIDING_WINDOW,
+            USE_MM_PREFIX,
+            USE_CAUSAL,
+            USE_PER_SEQ_CAUSAL,
+            CHUNK_LOOKBACK,
+            CHUNK_SIZE,
+        )
+    else:
+        num_segments = NUM_SEGMENTS_PER_SEQ
+        tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
+        # create masks for subsequent loads
+        act_num_segments = cdiv_fn(seq_len, tiles_per_segment * TILE_SIZE)
 
-    # create masks for subsequent loads
-    act_num_segments = cdiv_fn(seq_len, tiles_per_segment * TILE_SIZE)
     segm_mask = tl.arange(0, NUM_SEGMENTS_PER_SEQ) < tl.full(
         [NUM_SEGMENTS_PER_SEQ], act_num_segments, dtype=tl.int32
     )
@@ -795,6 +879,13 @@ def unified_attention(
     k_descale,
     v_descale,
     seq_threshold_3D=None,
+    # Max per-sequence query length admitted to the 3D flash-decoding path.
+    # Defaults to 1 (today's pure-decode behavior).  Under MTP/EAGLE
+    # speculative decode this is ``1 + num_speculative_tokens`` so that the
+    # uniform spec-verify decode step (query_len == 1 + num_spec) is still
+    # routed to 3D instead of falling back to the under-occupied 2D split-KV
+    # path.  See ``TritonAttentionMetadataBuilder`` for how it is derived.
+    decode_query_len: int = 1,
     num_par_softmax_segments=None,
     softmax_segm_output=None,
     softmax_segm_max=None,
@@ -963,18 +1054,49 @@ def unified_attention(
 
     # Launch the 2D kernel if
     # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
-    # 2. The batch includes at least one prefill request, or
+    # 2. The batch includes a query longer than the (spec-)decode query length, i.e.
+    #    a real prefill/chunked-prefill request (``max_seqlen_q > decode_query_len``).
+    #    Under MTP spec-decode ``decode_query_len = 1 + num_spec`` (e.g. 5), so a
+    #    uniform spec-verify decode step (max_seqlen_q == 5) is admitted to 3D rather
+    #    than falling to the under-occupied 2D split-KV path.  With the default
+    #    ``decode_query_len == 1`` this disjunct is byte-for-byte the old
+    #    ``max_seqlen_q > 1`` test (backward-safe no-op for non-spec callers), or
     # 3. The number of sequences exceeds the configured threshold, or
     # 4. Batch invariance is enabled
+    #
+    # Sliding-window layers under spec-decode (``decode_query_len > 1`` and
+    # ``window_size[0] >= 0``) ARE admitted to 3D: the
+    # window-relative segmentation (``WINDOW_SEG_3D`` below) tiles the
+    # segments over the sliding window's tile range instead of the full
+    # sequence, so segment parallelism is not collapsed.  Without
+    # WINDOW_SEG_3D the window-blind segmentation would mis-segment sliding
+    # layers; the flag and the matched ``reduce_segments`` recompute keep
+    # the mainloop and reduction consistent.  ``mm_prefix`` (bidirectional)
+    # sliding layers are NOT window-segmented (the window pruning is
+    # disabled for them in the helpers), so they fall back to full-seq 3D.
     use_3d = not (
         seq_threshold_3D is None
         or num_par_softmax_segments is None
         or softmax_segm_output is None
         or softmax_segm_max is None
         or softmax_segm_expsum is None
-        or max_seqlen_q > 1
+        or max_seqlen_q > decode_query_len
         or num_seqs > seq_threshold_3D
         or is_batch_invariant
+    )
+
+    # Window-relative 3D segmentation applies only to sliding-window
+    # layers in the spec-decode regime.  Global layers (window_size[0] < 0)
+    # and pure-decode callers (decode_query_len == 1) keep the original
+    # full-sequence segmentation byte-for-byte.  mm_prefix sliding layers are
+    # excluded (window tile-pruning is a no-op under USE_MM_PREFIX, so the
+    # window range would equal the full sequence and segmentation must stay
+    # full-seq to match).
+    window_seg_3d = (
+        use_3d
+        and decode_query_len > 1
+        and window_size[0] >= 0
+        and not use_mm_prefix
     )
 
     # The kernel signature is the same for 2D and 3D — only the launch
@@ -1088,6 +1210,7 @@ def unified_attention(
         CHUNK_SIZE=chunk_size,
         USE_TD=use_td,
         USE_TD_QO=use_td_qo,
+        WINDOW_SEG_3D=window_seg_3d,
         **launch_kwargs,
     )
 
@@ -1111,4 +1234,15 @@ def unified_attention(
             BLOCK_Q=BLOCK_Q,
             NUM_SEGMENTS_PER_SEQ=num_par_softmax_segments,
             USE_FP8=output_scale is not None,
+            # Mirror the mainloop's window-segmentation inputs so
+            # reduce_segments recomputes the IDENTICAL active-segment count.
+            BLOCK_M=BLOCK_M,
+            num_queries_per_kv=num_queries_per_kv,
+            SLIDING_WINDOW=(1 + window_size[0]),
+            USE_MM_PREFIX=use_mm_prefix,
+            USE_CAUSAL=use_causal,
+            USE_PER_SEQ_CAUSAL=use_per_seq_causal,
+            CHUNK_LOOKBACK=chunk_lookback,
+            CHUNK_SIZE=chunk_size,
+            WINDOW_SEG_3D=window_seg_3d,
         )


### PR DESCRIPTION
## Summary

This PR makes the Triton unified-attention 3D flash-decoding (split-KV) path usable for two cases that currently fall back to the slower 2D path: (1) speculative-decode verify steps, where each forward pass carries `query_len = 1 + num_speculative_tokens` (e.g. 5) instead of 1, and (2) sliding-window attention layers at long context. It was developed and measured on **NVIDIA B300 SXM6 (Blackwell, `sm_103`)**, TP=1, running `nvidia/gemma-4-31B-it-NVFP4` with MTP speculative decoding (`num_speculative_tokens=4`). Base is **vLLM v0.22.1** (commit `0decac0d96c42b49572498019f0a0e3600f50398`).

The change is **structurally guarded, not flag-gated**: it reduces to byte-for-byte the original code for every non-speculative caller (`query_len == 1`) on global/non-sliding layers, so the default decode path on every other model and arch is unchanged. There is no new env var to set.

This branch is rebased onto current `main`. The optimization commit was developed and measured on v0.22.1; rebasing onto `main` required threading the `USE_CAUSAL` / `USE_PER_SEQ_CAUSAL` constexprs added by #45163 through the new shared window-segmentation helpers (`compute_window_tile_range` / `compute_window_segments`) so the non-causal sliding-window path and the window-relative 3D segmentation stay consistent. The numbers below were measured on v0.22.1 and have not been re-validated on `main`.

## Optimizations

- **Admit speculative-decode verify steps into 3D flash-decoding** — always-on, guarded no-op; bit-exact. The launcher's 3D-admission test was hardcoded to `max_seqlen_q > 1`, which forced every spec-decode verify step (uniform `query_len = 1 + num_spec`, e.g. 5) onto the 2D path. It is replaced with `max_seqlen_q > decode_query_len`, where `decode_query_len` is derived from `speculative_config` (None-guarded to 1 when there is no spec). The three 3D softmax-segment buffers' first dim is resized from `seq_threshold_3D` to `seq_threshold_3D * decode_query_len`, with a fail-fast shape assert. When `decode_query_len == 1` the admission test is identical to the original `max_seqlen_q > 1`, so non-spec callers are untouched.
- **Window-relative 3D segmentation for sliding-window layers** — always-on, guarded no-op; bit-exact. With a window-blind 3D segmentation, a sliding-window layer at long context with a 1024-token window keeps only ~1/16 of its parallel-softmax segments active (the rest tile masked-out history). This adds a window-relative segmentation (`WINDOW_SEG_3D`) so the `NUM_SEGMENTS_PER_SEQ` segments tile only the window's live tile range. A shared `@triton.jit` helper (`compute_window_tile_range` / `compute_window_segments`) is used by both the mainloop early-return and the `reduce_segments` mask so the two kernels cannot drift apart. Sliding-window layers are admitted to 3D **only** under spec-decode (`decode_query_len > 1 and window_size[0] >= 0`); global layers (`window_size[0] < 0`) and the `mm_prefix` path are excluded.

## Fixed-batch latency

`vllm bench latency` — `nvidia/gemma-4-31B-it-NVFP4`, B300 SXM6, TP=1, NVFP4, `--max-num-seqs 32`, MTP spec-decode (`num_speculative_tokens=4`), output_len=150, CUDA graphs (FULL_AND_PIECEWISE) + torch.compile inductor, 5 iters per shape. A = base (vLLM v0.22.1, unpatched); B = this PR. Both arms run the same base commit `0decac0d9` with an identical workload; the only difference is the patched files. The grid sweeps input length × batch size in a single model load per arm. OTPS = output tokens/sec; TPOT = time per output token (both decode-path, from per-request metrics).

| Input len | Batch | A E2E (s) | B E2E (s) | E2E Δ | A OTPS | B OTPS | A TPOT (ms) | B TPOT (ms) |
|----------:|------:|----------:|----------:|------:|-------:|-------:|------------:|------------|
| 2048  | 1 | 0.810  | 0.739  | −8.7%  | 254   | 290   | 3.93   | 3.44   |
| 2048  | 8 | 1.642  | 1.443  | −12.1% | 1790  | 2051  | 4.47   | 3.90   |
| 8192  | 1 | 1.887  | 1.218  | −35.4% | 123   | 269   | 8.11   | 3.72   |
| 8192  | 8 | 7.353  | 6.763  | −8.0%  | 406   | 494   | 19.71  | 16.18  |
| 27000 | 1 | 6.309  | 4.734  | −25.0% | 74.5  | 320.6 | 13.42  | 3.12   |
| 27000 | 8 | 37.962 | 35.596 | −6.2%  | 71.1  | 76.9  | 112.60 | 103.99 | 

The decode-path metrics (OTPS, TPOT) are derived from per-request timing and improve at every shape, scaling with context length — largest at input_len=27000, batch=1, where the unpatched path falls back to the 2D kernel for the entire spec-verify decode (decode time 1.999 s → 0.465 s). On end-to-end latency, only the two 27000-token shapes have a delta that clears twice the baseline's per-iteration standard deviation; the shorter-context E2E deltas sit inside that ±2σ band and are not distinguishable from run-to-run variance (at 8192/bs1, for example, the baseline per-iteration standard deviation is ~0.57 s, so the ±2σ band of ~1.14 s spans the 0.67 s mean delta). Prefill latency is identical between arms at every shape (e.g. 4.263 s vs 4.261 s at 27000/bs1), consistent with the change touching only the decode path. No shape regresses on any metric.

## Correctness

GSM8K (greedy, full 1319-question split), B300, vLLM v0.22.1, same config as above:

- Base 56.41% (744/1319); this PR 55.95% (738/1319); delta −0.46pp (within the 1.0pp gate).

Both changes are structurally guarded no-ops on the default path and bit-exact on the admitted spec-decode/sliding-window paths; the GSM8K delta is consistent with FP-associativity churn from the segmented-softmax reduction order rather than an algorithmic change.

After rebasing onto `main`, the rebased kernel was re-checked with a differential numerics test (`unified_attention` vs a dense PyTorch reference) over a 74-case matrix: 2D vs 3D flash-decoding, global vs sliding-window (64/128/256/1024), pure-decode vs spec-decode-verify (query_len 3/5), causal vs per-seq-causal (the `USE_PER_SEQ_CAUSAL` path from #45163), MHA/GQA/MQA, head_size 128/256, and softcap on the window-relative 3D path. All 74 matched the reference (max abs error consistent with bf16 rounding). The window-relative 3D segmentation branch was confirmed to actually engage on the spec-decode + sliding-window cases (verified via the `reduce_segments` launch). **Scope of this re-check:** L40S (`sm_89`), bf16, kernel-level vs reference only — it is not a B300/NVFP4 run and not an end-to-end GSM8K. The B300/NVFP4 GSM8K numbers above are from the pre-rebase v0.22.1 tree and have not been re-run on `main`.

## Changes

**3 files, +351/−35 (rebased onto `main`), Python/Triton only — no `csrc/` or C++/CUDA changes, so no recompilation is required.** (The +20-line delta over the original v0.22.1 commit is the `USE_CAUSAL` / `USE_PER_SEQ_CAUSAL` threading needed to integrate with #45163.)

- Attention launcher / kernels (`vllm/v1/attention/ops/triton_unified_attention.py`): `decode_query_len` kwarg + rewritten 3D-admission gate; window-relative segmentation (`WINDOW_SEG_3D`) in the mainloop and `reduce_segments`.
- Shared Triton helpers (`vllm/v1/attention/ops/triton_attention_helpers.py`): `compute_window_tile_range` / `compute_window_segments` used by both kernels to keep segmentation layout bit-identical.
- Attention backend builder (`vllm/v1/attention/backends/triton_attn.py`): derive `decode_query_len` from `speculative_config` (defaults to 1), resize the three 3D segment buffers to `seq_threshold_3D * decode_query_len`, plus a buffer-shape invariant assert.

## AI-assisted contribution

This change was produced by an automated process driving AMMO under human review. Each change was checked for correctness (a bit-exact comparison against the 2D reference, plus a GSM8K before/after) and benchmarked before/after for latency; all numbers above were measured on real B300 hardware under CUDA graphs and torch.compile. With the optimization reducing to a structural no-op for non-speculative, non-sliding callers, the default decode path is byte-for-byte identical to base.
