### PR TITLE
[Draft][Rust Frontend] Route top-N tool-call families through the Dynamo parser

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -32,6 +32,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,12 +145,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -146,6 +181,15 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "async-io"
@@ -302,6 +346,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,10 +503,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
 
 [[package]]
 name = "blake3"
@@ -454,6 +556,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
@@ -534,6 +642,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1077,6 +1202,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dynamo-parsers-v2"
+version = "0.1.22"
+source = "git+https://github.com/ai-dynamo/frontend-crates.git?rev=a948ebc8ab08a808681b9cf5ebf781871a4f783b#a948ebc8ab08a808681b9cf5ebf781871a4f783b"
+dependencies = [
+ "anyhow",
+ "num-traits",
+ "openai-harmony",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "easy-ext"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1312,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,7 +1363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
 dependencies = [
  "futures-core",
- "nom",
+ "nom 7.1.3",
  "pin-project-lite",
 ]
 
@@ -1214,6 +1375,23 @@ checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
 dependencies = [
  "dissimilar",
  "once_cell",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "num-complex",
+ "pulp",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -1509,8 +1687,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1534,10 +1714,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1748,6 +1931,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1954,11 +2138,16 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
+ "exr",
  "gif",
  "image-webp",
  "moxcms",
  "num-traits",
  "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
  "tiff",
  "zune-core",
  "zune-jpeg",
@@ -1973,6 +2162,12 @@ dependencies = [
  "byteorder-lite",
  "quick-error",
 ]
+
+[[package]]
+name = "imgref"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
@@ -2017,6 +2212,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2160,10 +2366,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -2265,6 +2487,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "macro_rules_attribute"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,6 +2598,16 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -2536,6 +2783,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,6 +2806,21 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2555,11 +2832,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -2570,11 +2858,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2645,6 +2955,30 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openai-harmony"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77e82af451fc95deeb728a40b84db8ee82d341e136c268de415123a560b9b72"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bstr",
+ "clap",
+ "fancy-regex 0.13.0",
+ "futures",
+ "image",
+ "regex",
+ "reqwest 0.12.28",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha1",
+ "sha2",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "openai-protocol"
@@ -2776,6 +3110,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pcre2"
@@ -3049,6 +3389,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3145,6 +3504,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,10 +3602,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "quote"
@@ -3268,6 +3715,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,6 +3761,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -3350,6 +3882,12 @@ checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
 dependencies = [
  "rustfft",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -3435,6 +3973,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -3452,6 +3991,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3459,6 +4000,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3468,6 +4010,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3516,11 +4059,17 @@ dependencies = [
  "futures-core",
  "futures-timer",
  "mime",
- "nom",
+ "nom 7.1.3",
  "pin-project-lite",
  "reqwest 0.12.28",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -3651,6 +4200,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4057,6 +4607,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4081,6 +4644,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -4124,6 +4698,15 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "siphasher"
@@ -4182,7 +4765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
 dependencies = [
  "base64 0.13.1",
- "nom",
+ "nom 7.1.3",
  "serde",
  "unicode-segmentation",
 ]
@@ -4736,6 +5319,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls-listener"
@@ -5297,6 +5895,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5388,6 +5992,18 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -5620,7 +6236,9 @@ dependencies = [
 name = "vllm-parser"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "criterion",
+ "dynamo-parsers-v2",
  "easy-ext",
  "expect-test",
  "futures",
@@ -6279,6 +6897,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6445,6 +7069,15 @@ name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-jpeg"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,6 +34,7 @@ byteorder = "1.5.0"
 bytes = "1.12.0"
 clap = { version = "4.5.38", features = ["derive", "env"] }
 criterion = "0.5.1"
+dynamo-parsers-v2 = { git = "https://github.com/ai-dynamo/frontend-crates.git", rev = "a948ebc8ab08a808681b9cf5ebf781871a4f783b", version = "=0.1.22" }
 easy-ext = "1.0.3"
 educe = "0.6.0"
 enum-as-inner = "0.7.0"

--- a/rust/src/chat/src/parser/tool/mod.rs
+++ b/rust/src/chat/src/parser/tool/mod.rs
@@ -7,14 +7,19 @@ use std::sync::{Arc, LazyLock};
 
 pub use vllm_parser::tool::{
     DeepSeekV3ToolParser, DeepSeekV4ToolParser, DeepSeekV31ToolParser, DeepSeekV32ToolParser,
-    Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser, HermesToolParser, HyV3ToolParser,
-    Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser, MinimaxM2ToolParser,
-    MinimaxM3ToolParser, MistralToolParser, Phi4MiniJsonToolParser, Qwen3CoderToolParser,
-    Qwen3XmlToolParser, SeedOssToolParser, ToolParser, ToolParserError,
+    DynamoDeepSeekV4ToolParser, DynamoGemma4ToolParser, DynamoGlm47ToolParser,
+    DynamoKimiK2ToolParser, DynamoMiniMaxM2ToolParser, DynamoMiniMaxM3ToolParser,
+    DynamoQwen3CoderToolParser, Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser,
+    HermesToolParser, HyV3ToolParser, Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser,
+    MinimaxM2ToolParser, MinimaxM3ToolParser, MistralToolParser, Phi4MiniJsonToolParser,
+    Qwen3CoderToolParser, Qwen3XmlToolParser, SeedOssToolParser, ToolParser, ToolParserError,
 };
 
 use crate::parser::ParserFactory;
 use crate::request::ChatTool;
+
+pub const USE_EXPERIMENTAL_DYNAMO_RUST_PARSER_ENV: &str =
+    "VLLM_USE_EXPERIMENTAL_DYNAMO_RUST_PARSER";
 
 /// Canonical public names for registered tool parsers.
 pub mod names {
@@ -62,6 +67,10 @@ impl ToolParserFactory {
     /// Create the default registry with built-in parser names and model
     /// mappings.
     pub fn new() -> Self {
+        Self::new_with_options(use_experimental_dynamo_rust_parser())
+    }
+
+    fn new_with_options(use_dynamo: bool) -> Self {
         let mut factory = Self::default();
 
         factory
@@ -87,6 +96,20 @@ impl ToolParserFactory {
             .register_parser::<Qwen3XmlToolParser>(names::QWEN3_XML)
             .register_parser::<Qwen3CoderToolParser>(names::QWEN3_CODER)
             .register_parser::<SeedOssToolParser>(names::SEED_OSS);
+
+        // Experimental: override every family the Dynamo v2 crate implements so
+        // its parser runs instead of the native one. Registration is by name, so
+        // re-registering overwrites; gemma4's unified-dummy becomes a real parser.
+        if use_dynamo {
+            factory
+                .register_parser::<DynamoDeepSeekV4ToolParser>(names::DEEPSEEK_V4)
+                .register_parser::<DynamoQwen3CoderToolParser>(names::QWEN3_CODER)
+                .register_parser::<DynamoGlm47ToolParser>(names::GLM47)
+                .register_parser::<DynamoKimiK2ToolParser>(names::KIMI_K2)
+                .register_parser::<DynamoMiniMaxM2ToolParser>(names::MINIMAX_M2)
+                .register_parser::<DynamoMiniMaxM3ToolParser>(names::MINIMAX_M3)
+                .register_parser::<DynamoGemma4ToolParser>(names::GEMMA4);
+        }
 
         factory
             .register_pattern("mistral-", names::MISTRAL)
@@ -178,6 +201,11 @@ impl ToolParserFactory {
         })?;
         self.create(name, tools)
     }
+}
+
+fn use_experimental_dynamo_rust_parser() -> bool {
+    std::env::var(USE_EXPERIMENTAL_DYNAMO_RUST_PARSER_ENV)
+        .is_ok_and(|value| matches!(value.as_str(), "1" | "true" | "True" | "TRUE"))
 }
 
 #[cfg(test)]

--- a/rust/src/chat/src/parser/tool/tests.rs
+++ b/rust/src/chat/src/parser/tool/tests.rs
@@ -34,6 +34,13 @@ impl ToolParser for FakeToolParser {
     }
 }
 
+fn parse_complete(parser: &mut dyn ToolParser, text: &str) -> Result<ToolParserOutput> {
+    let mut output = ToolParserOutput::default();
+    parser.parse_into(text, &mut output)?;
+    output.append(parser.finish()?);
+    Ok(output.coalesce())
+}
+
 #[test]
 fn default_factory_starts_empty() {
     let factory = ToolParserFactory::default();
@@ -220,4 +227,105 @@ fn factory_new_registers_phi4_mini_json_by_name() {
 
     assert!(factory.contains(names::PHI4_MINI_JSON));
     factory.create(names::PHI4_MINI_JSON, &[]).unwrap();
+}
+
+#[test]
+fn factory_uses_native_deepseek_v4_by_default() {
+    let factory = ToolParserFactory::new_with_options(false);
+    let mut parser = factory.create(names::DEEPSEEK_V4, &[]).unwrap();
+
+    let error = parse_complete(&mut *parser, DEEPSEEK_V4_MISSING_OUTER_CLOSE).unwrap_err();
+
+    assert!(error.to_string().contains("incomplete DeepSeek DSML tool call"));
+}
+
+#[test]
+fn factory_uses_dynamo_deepseek_v4_when_enabled() {
+    let factory = ToolParserFactory::new_with_options(true);
+    let mut parser = factory.create(names::DEEPSEEK_V4, &[]).unwrap();
+
+    let result = parse_complete(&mut *parser, DEEPSEEK_V4_MISSING_OUTER_CLOSE).unwrap();
+
+    assert_eq!(result.normal_text(), "");
+    assert_eq!(result.calls().len(), 1);
+    assert_eq!(result.calls()[0].name.as_deref(), Some("get_datetime"));
+    assert_eq!(
+        result.calls()[0].arguments,
+        r#"{"timezone":"Asia/Shanghai"}"#
+    );
+}
+
+const DEEPSEEK_V4_MISSING_OUTER_CLOSE: &str = "<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"get_datetime\">\n\
+<｜DSML｜parameter name=\"timezone\" string=\"true\">Asia/Shanghai</｜DSML｜parameter>\n\
+</｜DSML｜invoke>";
+
+#[test]
+fn factory_uses_native_qwen3_coder_by_default() {
+    let factory = ToolParserFactory::new_with_options(false);
+    let mut parser = factory.create(names::QWEN3_CODER, &qwen3_coder_weather_tools()).unwrap();
+
+    let result = parse_complete(&mut *parser, QWEN3_CODER_BARE_FUNCTION).unwrap();
+
+    // Native Qwen3-Coder requires the <tool_call> wrapper; a bare <function=...>
+    // back-off form is not recovered, so no tool call is emitted.
+    assert!(result.calls().is_empty());
+}
+
+#[test]
+fn factory_uses_dynamo_qwen3_coder_when_enabled() {
+    let factory = ToolParserFactory::new_with_options(true);
+    let mut parser = factory.create(names::QWEN3_CODER, &qwen3_coder_weather_tools()).unwrap();
+
+    let result = parse_complete(&mut *parser, QWEN3_CODER_BARE_FUNCTION).unwrap();
+
+    // Dynamo recovers the bare <function=...> back-off form as a tool call.
+    assert_eq!(result.normal_text(), "");
+    assert_eq!(result.calls().len(), 1);
+    assert_eq!(result.calls()[0].name.as_deref(), Some("get_weather"));
+    assert_eq!(result.calls()[0].arguments, r#"{"location":"NYC"}"#);
+}
+
+fn qwen3_coder_weather_tools() -> Vec<ChatTool> {
+    vec![ChatTool {
+        name: "get_weather".to_string(),
+        description: None,
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": { "location": { "type": "string" } }
+        }),
+        strict: None,
+    }]
+}
+
+const QWEN3_CODER_BARE_FUNCTION: &str =
+    "<function=get_weather> <parameter=location>NYC</parameter> </function>";
+
+#[test]
+fn factory_routes_all_dynamo_families_when_enabled() {
+    // Every family the Dynamo v2 crate implements must construct through the
+    // Dynamo adapter when the experimental env is on.
+    let factory = ToolParserFactory::new_with_options(true);
+    for name in [
+        names::DEEPSEEK_V4,
+        names::QWEN3_CODER,
+        names::GLM47,
+        names::KIMI_K2,
+        names::MINIMAX_M2,
+        names::MINIMAX_M3,
+        names::GEMMA4,
+    ] {
+        assert!(
+            factory.create(name, &[]).is_ok(),
+            "dynamo parser for {name} should construct when enabled"
+        );
+    }
+}
+
+#[test]
+fn factory_gemma4_is_dummy_until_dynamo_enabled() {
+    // Native gemma4 is a unified-only dummy that errors on direct tool-parser
+    // creation; enabling Dynamo overrides it with a real parser.
+    assert!(ToolParserFactory::new_with_options(false).create(names::GEMMA4, &[]).is_err());
+    assert!(ToolParserFactory::new_with_options(true).create(names::GEMMA4, &[]).is_ok());
 }

--- a/rust/src/parser/Cargo.toml
+++ b/rust/src/parser/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 test-util = []
 
 [dependencies]
+anyhow.workspace = true
+dynamo-parsers-v2.workspace = true
 easy-ext.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/rust/src/parser/python/src/lib.rs
+++ b/rust/src/parser/python/src/lib.rs
@@ -46,6 +46,14 @@ tool_parser_factory! {
     // Below are the parsers just for testing purposes on Python side.
     DeepSeekV4ToolParser,
     KimiK2ToolParser,
+    Qwen3CoderToolParser,
+    DynamoDeepSeekV4ToolParser,
+    DynamoQwen3CoderToolParser,
+    DynamoGlm47ToolParser,
+    DynamoKimiK2ToolParser,
+    DynamoMiniMaxM2ToolParser,
+    DynamoMiniMaxM3ToolParser,
+    DynamoGemma4ToolParser,
 }
 
 #[pyclass(name = "Tool", module = "vllm._rust_tool_parser", skip_from_py_object)]

--- a/rust/src/parser/src/tool/dynamo_adapter.rs
+++ b/rust/src/parser/src/tool/dynamo_adapter.rs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use dynamo_parsers_v2::{
+    Tool as DynamoTool, ToolCallDelta as DynamoToolCallDelta,
+    ToolParseResult as DynamoToolParseResult, ToolParser as DynamoToolParser,
+    create_tool_parser_for_family,
+};
+
+use crate::tool::{Result, Tool, ToolCallDelta, ToolParser, ToolParserOutput};
+
+/// Shared adapter around any Dynamo-owned `dynamo-parsers-v2` stream parser.
+///
+/// The only per-family difference is the family name passed to the Dynamo
+/// crate's `create_tool_parser_for_family` dispatch, so every family routes
+/// through this one core instead of a copy-pasted adapter per parser.
+struct DynamoStreamAdapter {
+    family: &'static str,
+    tools: Vec<DynamoTool>,
+    inner: Box<dyn DynamoToolParser>,
+}
+
+impl DynamoStreamAdapter {
+    fn new(family: &'static str, tools: &[Tool]) -> Result<Self> {
+        let tools = tools.iter().map(to_dynamo_tool).collect::<Vec<_>>();
+        let inner = create_tool_parser_for_family(family, &tools).map_err(dynamo_error)?;
+        Ok(Self {
+            family,
+            tools,
+            inner,
+        })
+    }
+
+    fn preserve_special_tokens(&self) -> bool {
+        self.inner.preserve_special_tokens()
+    }
+
+    fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+        output.append(self.inner.push(chunk).map(to_vllm_output).map_err(dynamo_error)?);
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<ToolParserOutput> {
+        self.inner.finish().map(to_vllm_output).map_err(dynamo_error)
+    }
+
+    fn reset(&mut self) -> String {
+        // Rebuild from the same family + tools so per-family state (e.g. the
+        // Qwen3-Coder tool-schema typing) is restored. The family already
+        // constructed successfully once, so this cannot fail on these tools.
+        self.inner = create_tool_parser_for_family(self.family, &self.tools)
+            .expect("Dynamo parser recreate on reset");
+        String::new()
+    }
+}
+
+/// Define a vLLM `ToolParser` that delegates to a Dynamo v2 family parser.
+///
+/// The family string is the only thing that varies between parsers, so it is
+/// passed as data rather than duplicating the adapter body.
+macro_rules! dynamo_family_parser {
+    ($(#[$meta:meta])* $name:ident, $family:literal) => {
+        $(#[$meta])*
+        pub struct $name(DynamoStreamAdapter);
+
+        impl $name {
+            fn new(tools: &[Tool]) -> Result<Self> {
+                Ok(Self(DynamoStreamAdapter::new($family, tools)?))
+            }
+        }
+
+        impl ToolParser for $name {
+            fn create(tools: &[Tool]) -> Result<Box<dyn ToolParser>>
+            where
+                Self: Sized + 'static,
+            {
+                Ok(Box::new(Self::new(tools)?))
+            }
+
+            fn preserve_special_tokens(&self) -> bool {
+                self.0.preserve_special_tokens()
+            }
+
+            fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+                self.0.parse_into(chunk, output)
+            }
+
+            fn finish(&mut self) -> Result<ToolParserOutput> {
+                self.0.finish()
+            }
+
+            fn reset(&mut self) -> String {
+                self.0.reset()
+            }
+        }
+    };
+}
+
+dynamo_family_parser!(
+    /// Adapter for the Dynamo-owned DeepSeek V4 parser.
+    DynamoDeepSeekV4ToolParser,
+    "deepseek_v4"
+);
+
+dynamo_family_parser!(
+    /// Adapter for the Dynamo-owned Qwen3-Coder parser.
+    DynamoQwen3CoderToolParser,
+    "qwen3_coder"
+);
+
+dynamo_family_parser!(
+    /// Adapter for the Dynamo-owned GLM-4.7 parser.
+    DynamoGlm47ToolParser,
+    "glm47"
+);
+
+dynamo_family_parser!(
+    /// Adapter for the Dynamo-owned Kimi K2 parser.
+    DynamoKimiK2ToolParser,
+    "kimi_k2"
+);
+
+dynamo_family_parser!(
+    /// Adapter for the Dynamo-owned MiniMax M2 parser.
+    DynamoMiniMaxM2ToolParser,
+    "minimax_m2"
+);
+
+dynamo_family_parser!(
+    /// Adapter for the Dynamo-owned MiniMax M3 parser.
+    DynamoMiniMaxM3ToolParser,
+    "minimax_m3"
+);
+
+dynamo_family_parser!(
+    /// Adapter for the Dynamo-owned Gemma 4 parser.
+    DynamoGemma4ToolParser,
+    "gemma4"
+);
+
+fn to_dynamo_tool(tool: &Tool) -> DynamoTool {
+    DynamoTool {
+        name: tool.name.clone(),
+        description: tool.description.clone(),
+        parameters: tool.parameters.clone(),
+        strict: tool.strict,
+    }
+}
+
+fn to_vllm_output(result: DynamoToolParseResult) -> ToolParserOutput {
+    // vLLM's ToolParserOutput is event-ordered; the Dynamo result already
+    // separates text from calls, so emit the text first, then each call.
+    let mut output = ToolParserOutput::default();
+    output.push_text(result.normal_text);
+    for call in result.calls {
+        output.push_call(to_vllm_delta(call));
+    }
+    output
+}
+
+fn to_vllm_delta(delta: DynamoToolCallDelta) -> ToolCallDelta {
+    ToolCallDelta {
+        tool_index: delta.tool_index,
+        name: delta.name,
+        arguments: delta.arguments,
+    }
+}
+
+fn dynamo_error(error: anyhow::Error) -> crate::tool::ToolParserError {
+    parsing_failed!("Dynamo parser failed: {}", error)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use crate::tool::Tool;
+    use crate::tool::ToolParserTestExt as _;
+
+    use super::{DynamoDeepSeekV4ToolParser, DynamoGemma4ToolParser, DynamoQwen3CoderToolParser};
+
+    #[test]
+    fn parse_complete_uses_dynamo_stream_parser() {
+        let mut parser = DynamoDeepSeekV4ToolParser::new(&[]).unwrap();
+        let result = parser
+            .parse_complete(
+                "<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"get_weather\">\n\
+<｜DSML｜parameter name=\"location\" string=\"true\">SF</｜DSML｜parameter>\n\
+</｜DSML｜invoke>\n\
+</｜DSML｜tool_calls>",
+            )
+            .unwrap();
+
+        assert_eq!(result.normal_text(), "");
+        assert_eq!(result.calls().len(), 1);
+        assert_eq!(result.calls()[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(
+            serde_json::from_str::<Value>(&result.calls()[0].arguments).unwrap(),
+            json!({ "location": "SF" })
+        );
+    }
+
+    #[test]
+    fn parse_complete_recovers_complete_invoke_without_outer_close() {
+        let mut parser = DynamoDeepSeekV4ToolParser::new(&[]).unwrap();
+        let result = parser
+            .parse_complete(
+                "<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"get_datetime\">\n\
+<｜DSML｜parameter name=\"timezone\" string=\"true\">Asia/Shanghai</｜DSML｜parameter>\n\
+</｜DSML｜invoke>",
+            )
+            .unwrap();
+
+        assert_eq!(result.normal_text(), "");
+        assert_eq!(result.calls().len(), 1);
+        assert_eq!(result.calls()[0].name.as_deref(), Some("get_datetime"));
+        assert_eq!(
+            serde_json::from_str::<Value>(&result.calls()[0].arguments).unwrap(),
+            json!({ "timezone": "Asia/Shanghai" })
+        );
+    }
+
+    fn weather_tool() -> Tool {
+        Tool {
+            name: "get_weather".to_string(),
+            description: None,
+            parameters: json!({
+                "type": "object",
+                "properties": { "location": { "type": "string" } }
+            }),
+            strict: None,
+        }
+    }
+
+    #[test]
+    fn qwen3_coder_parse_complete_uses_dynamo_stream_parser() {
+        let mut parser = DynamoQwen3CoderToolParser::new(&[weather_tool()]).unwrap();
+        let result = parser
+            .parse_complete(
+                "<tool_call> <function=get_weather> \
+<parameter=location> NYC </parameter> </function> </tool_call>",
+            )
+            .unwrap();
+
+        assert_eq!(result.normal_text(), "");
+        assert_eq!(result.calls().len(), 1);
+        assert_eq!(result.calls()[0].name.as_deref(), Some("get_weather"));
+        // Value is schema-typed (string) and trimmed, matching the v1 batch parser.
+        assert_eq!(
+            serde_json::from_str::<Value>(&result.calls()[0].arguments).unwrap(),
+            json!({ "location": "NYC" })
+        );
+    }
+
+    #[test]
+    fn qwen3_coder_preserves_prefix_text_before_block() {
+        let mut parser = DynamoQwen3CoderToolParser::new(&[weather_tool()]).unwrap();
+        let result = parser
+            .parse_complete(
+                "I will check the weather. <tool_call> <function=get_weather> \
+<parameter=location>NYC</parameter> </function> </tool_call>",
+            )
+            .unwrap();
+
+        assert_eq!(result.normal_text(), "I will check the weather. ");
+        assert_eq!(result.calls().len(), 1);
+        assert_eq!(result.calls()[0].name.as_deref(), Some("get_weather"));
+    }
+
+    // gemma4 has no native vLLM tool parser (unified-only), so verify the
+    // Dynamo parser directly on gemma4's custom `<|tool_call>...` grammar.
+    #[test]
+    fn gemma4_dynamo_parser_extracts_call() {
+        let tools = vec![Tool {
+            name: "get_weather".to_string(),
+            description: None,
+            parameters: json!({
+                "type": "object",
+                "properties": { "location": { "type": "string" } }
+            }),
+            strict: None,
+        }];
+        let mut parser = DynamoGemma4ToolParser::new(&tools).unwrap();
+        let result = parser
+            .parse_complete("<|tool_call>call:get_weather{location:<|\"|>NYC<|\"|>}<tool_call|>")
+            .unwrap();
+
+        assert_eq!(result.calls().len(), 1);
+        assert_eq!(result.calls()[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(
+            serde_json::from_str::<Value>(&result.calls()[0].arguments).unwrap(),
+            json!({ "location": "NYC" })
+        );
+    }
+}

--- a/rust/src/parser/src/tool/glm_xml/glm47_moe.rs
+++ b/rust/src/parser/src/tool/glm_xml/glm47_moe.rs
@@ -144,4 +144,22 @@ mod tests {
             json!({})
         );
     }
+    #[test]
+    fn glm47_dynamo_parser_matches_native() {
+        let tools = test_tools();
+        let input = glm47_tool_call("get_weather", &[("city", "Beijing")]);
+
+        let mut native = Glm47MoeToolParser::new(&tools);
+        let native =
+            crate::tool::test_utils::semantic_calls(native.parse_complete(&input).unwrap());
+
+        let mut dynamo =
+            <crate::tool::DynamoGlm47ToolParser as crate::tool::ToolParser>::create(&tools)
+                .unwrap();
+        let dynamo =
+            crate::tool::test_utils::semantic_calls(dynamo.parse_complete(&input).unwrap());
+
+        assert_eq!(native.len(), 1);
+        assert_eq!(native, dynamo);
+    }
 }

--- a/rust/src/parser/src/tool/kimi_k2.rs
+++ b/rust/src/parser/src/tool/kimi_k2.rs
@@ -602,4 +602,23 @@ mod tests {
         ]]
         .assert_eq(&error.to_report_string());
     }
+    #[test]
+    fn kimi_k2_dynamo_parser_matches_native() {
+        let tools = test_tools();
+        let input =
+            build_tool_section(&[build_tool_call("get_weather", 0, r#"{"location":"NYC"}"#)]);
+
+        let mut native = KimiK2ToolParser::new(&tools);
+        let native =
+            crate::tool::test_utils::semantic_calls(native.parse_complete(&input).unwrap());
+
+        let mut dynamo =
+            <crate::tool::DynamoKimiK2ToolParser as crate::tool::ToolParser>::create(&tools)
+                .unwrap();
+        let dynamo =
+            crate::tool::test_utils::semantic_calls(dynamo.parse_complete(&input).unwrap());
+
+        assert_eq!(native.len(), 1);
+        assert_eq!(native, dynamo);
+    }
 }

--- a/rust/src/parser/src/tool/minimax_m2.rs
+++ b/rust/src/parser/src/tool/minimax_m2.rs
@@ -599,4 +599,22 @@ mod tests {
         expect![[r#"tool parser parsing failed: near "<bad></minimax:tool_call>": "#]]
             .assert_eq(&error.to_report_string());
     }
+    #[test]
+    fn minimax_m2_dynamo_parser_matches_native() {
+        let tools = test_tools();
+        let input = build_tool_block(&[("get_weather", vec![("city", "Seattle"), ("days", "5")])]);
+
+        let mut native = MinimaxM2ToolParser::new(&tools);
+        let native =
+            crate::tool::test_utils::semantic_calls(native.parse_complete(&input).unwrap());
+
+        let mut dynamo =
+            <crate::tool::DynamoMiniMaxM2ToolParser as crate::tool::ToolParser>::create(&tools)
+                .unwrap();
+        let dynamo =
+            crate::tool::test_utils::semantic_calls(dynamo.parse_complete(&input).unwrap());
+
+        assert_eq!(native.len(), 1);
+        assert_eq!(native, dynamo);
+    }
 }

--- a/rust/src/parser/src/tool/minimax_m3.rs
+++ b/rust/src/parser/src/tool/minimax_m3.rs
@@ -931,4 +931,25 @@ mod tests {
             })
         );
     }
+    #[test]
+    fn minimax_m3_dynamo_parser_matches_native() {
+        let tools = m3_test_tools();
+        let input = build_tool_block(&[(
+            "get_weather",
+            format!("{}{}", element("city", "Seattle"), element("days", "5")),
+        )]);
+
+        let mut native = MinimaxM3ToolParser::new(&tools);
+        let native =
+            crate::tool::test_utils::semantic_calls(native.parse_complete(&input).unwrap());
+
+        let mut dynamo =
+            <crate::tool::DynamoMiniMaxM3ToolParser as crate::tool::ToolParser>::create(&tools)
+                .unwrap();
+        let dynamo =
+            crate::tool::test_utils::semantic_calls(dynamo.parse_complete(&input).unwrap());
+
+        assert_eq!(native.len(), 1);
+        assert_eq!(native, dynamo);
+    }
 }

--- a/rust/src/parser/src/tool/mod.rs
+++ b/rust/src/parser/src/tool/mod.rs
@@ -7,6 +7,7 @@
 pub(crate) mod error;
 mod deepseek_dsml;
 pub(crate) mod deepseek_json;
+mod dynamo_adapter;
 mod glm_xml;
 mod hy_v3;
 pub(crate) mod json;
@@ -22,6 +23,11 @@ use std::collections::{BTreeMap, btree_map};
 
 pub use deepseek_dsml::{DeepSeekV4ToolParser, DeepSeekV32ToolParser};
 pub use deepseek_json::{DeepSeekV3ToolParser, DeepSeekV31ToolParser};
+pub use dynamo_adapter::{
+    DynamoDeepSeekV4ToolParser, DynamoGemma4ToolParser, DynamoGlm47ToolParser,
+    DynamoKimiK2ToolParser, DynamoMiniMaxM2ToolParser, DynamoMiniMaxM3ToolParser,
+    DynamoQwen3CoderToolParser,
+};
 pub use error::{Result, ToolParserError};
 pub use glm_xml::{Glm45MoeToolParser, Glm47MoeToolParser};
 pub use hy_v3::HyV3ToolParser;

--- a/rust/src/parser/src/tool/test_utils.rs
+++ b/rust/src/parser/src/tool/test_utils.rs
@@ -118,3 +118,18 @@ pub fn split_by_chars(text: &str, chunk_chars: usize) -> Vec<&str> {
 
     chunks
 }
+
+/// Extract `(function name, semantically-parsed arguments)` for each coalesced
+/// tool call. Lets a native parser be compared against its Dynamo counterpart
+/// without depending on argument-string formatting (raw vs re-serialized JSON).
+pub fn semantic_calls(output: ToolParserOutput) -> Vec<(Option<String>, serde_json::Value)> {
+    output
+        .coalesce()
+        .calls()
+        .into_iter()
+        .map(|call| {
+            let args = serde_json::from_str(&call.arguments).unwrap_or(serde_json::Value::Null);
+            (call.name.clone(), args)
+        })
+        .collect()
+}

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -154,6 +154,7 @@ if TYPE_CHECKING:
     V_SCALE_CONSTANT: int = 100
     VLLM_USE_RUST_FRONTEND: bool = False
     VLLM_RUST_FRONTEND_PATH: str | None = "auto"
+    VLLM_USE_EXPERIMENTAL_DYNAMO_RUST_PARSER: bool = False
     VLLM_SERVER_DEV_MODE: bool = False
     VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
     VLLM_MLA_DISABLE: bool = False
@@ -1343,6 +1344,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # the binary installed with the vllm package. Only used when
     # VLLM_USE_RUST_FRONTEND=1.
     "VLLM_RUST_FRONTEND_PATH": lambda: _resolve_rust_frontend_path(),
+    # Experimental: use Dynamo's Rust parser crate for supported Rust frontend
+    # tool parsers.
+    "VLLM_USE_EXPERIMENTAL_DYNAMO_RUST_PARSER": lambda: bool(
+        int(os.getenv("VLLM_USE_EXPERIMENTAL_DYNAMO_RUST_PARSER", "0"))
+    ),
     # If set, vllm will run in development mode, which will enable
     # some additional endpoints for developing and debugging,
     # e.g. `/reset_prefix_cache`


### PR DESCRIPTION
# Route top-N tool-call families through the Dynamo parser

Experimental, opt-in path to route tool-call parsing through the Dynamo-owned `dynamo-parsers-v2` crate instead of vLLM's native Rust parsers, for every family the crate implements.

Linear: https://linear.app/nvidia/issue/DIS-2218

## What changed

- `rust/src/parser/src/tool/dynamo_adapter.rs`: one shared adapter over the Dynamo crate's `create_tool_parser_for_family` dispatch. The family name is passed as data, so all families route through the same code (no per-family copy).
- Under `VLLM_USE_EXPERIMENTAL_DYNAMO_RUST_PARSER=1`, the factory overrides every native parser the Dynamo v2 crate implements: `deepseek_v4`, `qwen3_coder`, `glm47`, `kimi_k2`, `minimax_m2`, `minimax_m3`, `gemma4`. Registration is by name, so the flag re-registers each name in place; without it, behavior is unchanged.
- `gemma4` is a unified-only dummy in the native factory (errors on direct tool-parser creation); the flag turns it into a real parser.
- Exposes the Dynamo parsers through the PyO3 test binding (`vllm_parser::tool`) so the path is reachable from Python.
- Pins `dynamo-parsers-v2 = "=0.1.22"` at `ai-dynamo/frontend-crates` rev `a948ebc`.

## How to use

```bash
VLLM_USE_RUST_FRONTEND=1 \
VLLM_USE_EXPERIMENTAL_DYNAMO_RUST_PARSER=1 \
vllm serve <model> \
  --enable-auto-tool-choice \
  --tool-call-parser <deepseek_v4|qwen3_coder|glm47|kimi_k2|minimax_m2|minimax_m3|gemma4>
```

## Validation

Run from `rust/`:

- `cargo fmt --check`: passed
- `cargo test --locked -p vllm-parser`: 361 passed (adapter tests included)
- `cargo test --locked -p vllm-chat`: 234 passed — includes `factory_routes_all_dynamo_families_when_enabled` (all 7 families construct through the Dynamo adapter), `factory_gemma4_is_dummy_until_dynamo_enabled` (dummy without the flag, real parser with it), and the native-vs-Dynamo behavioral gates for `deepseek_v4` and `qwen3_coder`
- `cargo build --locked -p vllm-tool-parser-py`: clean (PyO3 binding compiles with the Dynamo parsers registered)

## Duplicate-work check

Searched open vLLM PRs for `dynamo-parsers-v2`, `VLLM_USE_EXPERIMENTAL_DYNAMO_RUST_PARSER`, and Dynamo Rust parser integration; no overlapping open PR.

## Disclosure

Prepared with AI assistance. A human must review every line and run the tests before this is marked ready for review.
