### PR TITLE
[Feature][Frontend] Report multimodal token counts in usage.prompt_tokens_details

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -23,7 +23,11 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
 )
-from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.chat_completion.serving import (
+    OpenAIServingChat,
+    _get_mm_token_counts,
+    _make_prompt_tokens_details,
+)
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
     RequestResponseMetadata,
@@ -37,6 +41,7 @@ from vllm.entrypoints.openai.parser.harmony_utils import get_encoding
 from vllm.entrypoints.serve.render.serving import OpenAIServingRender
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs import TokensPrompt
+from vllm.multimodal.inputs import PlaceholderRange
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.parser import HarmonyParser
 from vllm.renderers.hf import HfRenderer
@@ -633,6 +638,39 @@ async def _async_serving_chat_init():
 def test_async_serving_chat_init():
     serving_completion = asyncio.run(_async_serving_chat_init())
     assert serving_completion.chat_template == CHAT_TEMPLATE
+
+
+def test_mm_prompt_tokens_details():
+    # Text-only input has no multimodal placeholders.
+    assert _get_mm_token_counts({"type": "tokens"}) is None
+
+    # Per-modality counts sum each modality's placeholder ranges.
+    counts = _get_mm_token_counts(
+        {
+            "mm_placeholders": {
+                "image": [
+                    PlaceholderRange(offset=0, length=576),
+                    PlaceholderRange(offset=600, length=24),
+                ],
+                "video": [PlaceholderRange(offset=700, length=1200)],
+            }
+        }
+    )
+    assert counts == {"image": 600, "video": 1200}
+
+    # Gated off, or nothing to report -> no details.
+    assert _make_prompt_tokens_details(False, 5, counts) is None
+    assert _make_prompt_tokens_details(True, None, None) is None
+
+    # Zero cached_tokens is still reported (not None), matching the cached-only
+    # behavior; multimodal counts ride alongside even when cached_tokens is None.
+    assert _make_prompt_tokens_details(True, 0, None).cached_tokens == 0
+    details = _make_prompt_tokens_details(True, None, counts)
+    assert details.cached_tokens is None
+    assert details.image_tokens == 600
+    assert details.video_tokens == 1200
+    assert details.audio_tokens is None
+    assert _make_prompt_tokens_details(True, 3, counts).cached_tokens == 3
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -667,9 +667,7 @@ def test_mm_prompt_tokens_details():
     assert _make_prompt_tokens_details(True, 0, None).cached_tokens == 0
     details = _make_prompt_tokens_details(True, None, counts)
     assert details.cached_tokens is None
-    assert details.image_tokens == 600
-    assert details.video_tokens == 1200
-    assert details.audio_tokens is None
+    assert details.multimodal_tokens == {"image": 600, "video": 1200}
     assert _make_prompt_tokens_details(True, 3, counts).cached_tokens == 3
 
 

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -642,7 +642,7 @@ def test_async_serving_chat_init():
 
 def test_mm_prompt_tokens_details():
     # Text-only input has no multimodal placeholders.
-    assert _get_mm_token_counts({"type": "tokens"}) is None
+    assert _get_mm_token_counts({"type": "tokens"}) == {}
 
     # Per-modality counts sum each modality's placeholder ranges.
     counts = _get_mm_token_counts(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import numpy as np
 import pybase64 as base64
@@ -53,7 +53,7 @@ from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.entrypoints.serve.utils.tool_calls_utils import (
     maybe_filter_parallel_tool_calls,
 )
-from vllm.inputs import EngineInput
+from vllm.inputs import EngineInput, MultiModalPlaceholders
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
 from vllm.outputs import RequestOutput
@@ -70,6 +70,47 @@ if TYPE_CHECKING:
     from vllm.entrypoints.serve.render.serving import OpenAIServingRender
 
 logger = init_logger(__name__)
+
+# Multimodal modalities surfaced in ``usage.prompt_tokens_details``.
+_MM_USAGE_MODALITIES = ("image", "audio", "video")
+
+
+def _get_mm_token_counts(engine_input: EngineInput) -> dict[str, int] | None:
+    """Sum per-modality placeholder tokens from ``mm_placeholders``.
+
+    ``PlaceholderRange.length`` is the placeholder's prompt token span, so the
+    sum matches the placeholder tokens already in ``usage.prompt_tokens``.
+    """
+    mm_placeholders = cast(
+        "MultiModalPlaceholders | None", engine_input.get("mm_placeholders")
+    )
+    if not mm_placeholders:
+        return None
+    counts: dict[str, int] = {}
+    for modality in _MM_USAGE_MODALITIES:
+        ranges = mm_placeholders.get(modality)
+        if ranges:
+            counts[modality] = sum(p.length for p in ranges)
+    return counts or None
+
+
+def _make_prompt_tokens_details(
+    enable_prompt_tokens_details: bool,
+    num_cached_tokens: int | None,
+    mm_token_counts: dict[str, int] | None,
+) -> PromptTokenUsageInfo | None:
+    """Build ``prompt_tokens_details`` from cached + multimodal token counts."""
+    if not enable_prompt_tokens_details:
+        return None
+    if num_cached_tokens is None and not mm_token_counts:
+        return None
+    counts = mm_token_counts or {}
+    return PromptTokenUsageInfo(
+        cached_tokens=num_cached_tokens,
+        image_tokens=counts.get("image"),
+        audio_tokens=counts.get("audio"),
+        video_tokens=counts.get("video"),
+    )
 
 
 class OpenAIServingChat(OpenAIServing):
@@ -263,8 +304,10 @@ class OpenAIServingChat(OpenAIServing):
         # Schedule the request and get the result generator.
         max_model_len = self.model_config.max_model_len
         generators: list[AsyncGenerator[RequestOutput, None]] = []
+        mm_token_counts: dict[str, int] | None = None
         for i, engine_input in enumerate(engine_inputs):
             prompt_token_ids = self._extract_prompt_components(engine_input).token_ids
+            mm_token_counts = _get_mm_token_counts(engine_input)
 
             # If we are creating sub requests for multiple prompts, ensure that they
             # have unique request ids.
@@ -361,6 +404,7 @@ class OpenAIServingChat(OpenAIServing):
                 tokenizer,
                 request_metadata,
                 chat_template_kwargs=chat_template_kwargs,
+                mm_token_counts=mm_token_counts,
             )
 
         return await self.chat_completion_full_generator(
@@ -372,6 +416,7 @@ class OpenAIServingChat(OpenAIServing):
             tokenizer,
             request_metadata,
             chat_template_kwargs=chat_template_kwargs,
+            mm_token_counts=mm_token_counts,
         )
 
     def get_chat_request_role(self, request: ChatCompletionRequest) -> str:
@@ -389,6 +434,7 @@ class OpenAIServingChat(OpenAIServing):
         tokenizer: TokenizerLike,
         request_metadata: RequestResponseMetadata,
         chat_template_kwargs: dict[str, Any] | None = None,
+        mm_token_counts: dict[str, int] | None = None,
     ) -> AsyncGenerator[str, None]:
         created_time = int(time.time())
         chunk_object_type: Final = "chat.completion.chunk"
@@ -732,10 +778,11 @@ class OpenAIServingChat(OpenAIServing):
                     completion_tokens=completion_tokens,
                     total_tokens=num_prompt_tokens + completion_tokens,
                 )
-                if self.enable_prompt_tokens_details and num_cached_tokens is not None:
-                    final_usage.prompt_tokens_details = PromptTokenUsageInfo(
-                        cached_tokens=num_cached_tokens
-                    )
+                final_usage.prompt_tokens_details = _make_prompt_tokens_details(
+                    self.enable_prompt_tokens_details,
+                    num_cached_tokens,
+                    mm_token_counts,
+                )
 
                 final_usage_chunk = ChatCompletionStreamResponse(
                     id=request_id,
@@ -796,6 +843,7 @@ class OpenAIServingChat(OpenAIServing):
         tokenizer: TokenizerLike,
         request_metadata: RequestResponseMetadata,
         chat_template_kwargs: dict[str, Any] | None = None,
+        mm_token_counts: dict[str, int] | None = None,
     ) -> ErrorResponse | ChatCompletionResponse:
         created_time = int(time.time())
         final_res: RequestOutput | None = None
@@ -1023,13 +1071,11 @@ class OpenAIServingChat(OpenAIServing):
             completion_tokens=num_generated_tokens,
             total_tokens=num_prompt_tokens + num_generated_tokens,
         )
-        if (
-            self.enable_prompt_tokens_details
-            and final_res.num_cached_tokens is not None
-        ):
-            usage.prompt_tokens_details = PromptTokenUsageInfo(
-                cached_tokens=final_res.num_cached_tokens
-            )
+        usage.prompt_tokens_details = _make_prompt_tokens_details(
+            self.enable_prompt_tokens_details,
+            final_res.num_cached_tokens,
+            mm_token_counts,
+        )
 
         request_metadata.final_usage_info = usage
 

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -71,26 +71,24 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-# Multimodal modalities surfaced in ``usage.prompt_tokens_details``.
-_MM_USAGE_MODALITIES = ("image", "audio", "video")
-
 
 def _get_mm_token_counts(engine_input: EngineInput) -> dict[str, int] | None:
     """Sum per-modality placeholder tokens from ``mm_placeholders``.
 
-    ``PlaceholderRange.length`` is the placeholder's prompt token span, so the
-    sum matches the placeholder tokens already in ``usage.prompt_tokens``.
+    Keyed by modality name; ``PlaceholderRange.length`` is the placeholder's
+    prompt token span, so each sum matches the placeholder tokens already
+    counted in ``usage.prompt_tokens``.
     """
     mm_placeholders = cast(
         "MultiModalPlaceholders | None", engine_input.get("mm_placeholders")
     )
     if not mm_placeholders:
         return None
-    counts: dict[str, int] = {}
-    for modality in _MM_USAGE_MODALITIES:
-        ranges = mm_placeholders.get(modality)
-        if ranges:
-            counts[modality] = sum(p.length for p in ranges)
+    counts = {
+        modality: sum(p.length for p in ranges)
+        for modality, ranges in mm_placeholders.items()
+        if ranges
+    }
     return counts or None
 
 
@@ -104,12 +102,9 @@ def _make_prompt_tokens_details(
         return None
     if num_cached_tokens is None and not mm_token_counts:
         return None
-    counts = mm_token_counts or {}
     return PromptTokenUsageInfo(
         cached_tokens=num_cached_tokens,
-        image_tokens=counts.get("image"),
-        audio_tokens=counts.get("audio"),
-        video_tokens=counts.get("video"),
+        multimodal_tokens=mm_token_counts or None,
     )
 
 

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-def _get_mm_token_counts(engine_input: EngineInput) -> dict[str, int] | None:
+def _get_mm_token_counts(engine_input: EngineInput) -> dict[str, int]:
     """Sum per-modality placeholder tokens from ``mm_placeholders``.
 
     Keyed by modality name; ``PlaceholderRange.length`` is the placeholder's
@@ -82,14 +82,11 @@ def _get_mm_token_counts(engine_input: EngineInput) -> dict[str, int] | None:
     mm_placeholders = cast(
         "MultiModalPlaceholders | None", engine_input.get("mm_placeholders")
     )
-    if not mm_placeholders:
-        return None
-    counts = {
+    return {
         modality: sum(p.length for p in ranges)
-        for modality, ranges in mm_placeholders.items()
+        for modality, ranges in (mm_placeholders or {}).items()
         if ranges
     }
-    return counts or None
 
 
 def _make_prompt_tokens_details(

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -103,8 +103,8 @@ class PromptTokenUsageInfo(OpenAIBaseModel):
     cached_tokens: int | None = None
     multimodal_tokens: dict[str, int] | None = None
     """Prompt tokens contributed by each input modality, keyed by modality name
-    (e.g. ``image``, ``audio``, ``video``). A breakdown of the multimodal
-    placeholder tokens already counted in ``prompt_tokens``; ``None`` when the
+    (e.g. `image`, `audio`, `video`). A breakdown of the multimodal
+    placeholder tokens already counted in `prompt_tokens`; `None` when the
     request has no multimodal input."""
 
 

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -101,9 +101,7 @@ class ModelList(OpenAIBaseModel):
 
 class PromptTokenUsageInfo(OpenAIBaseModel):
     cached_tokens: int | None = None
-    image_tokens: int | None = None
-    audio_tokens: int | None = None
-    video_tokens: int | None = None
+    multimodal_tokens: dict[str, int] | None = None
 
 
 class UsageInfo(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -101,6 +101,9 @@ class ModelList(OpenAIBaseModel):
 
 class PromptTokenUsageInfo(OpenAIBaseModel):
     cached_tokens: int | None = None
+    image_tokens: int | None = None
+    audio_tokens: int | None = None
+    video_tokens: int | None = None
 
 
 class UsageInfo(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -102,6 +102,10 @@ class ModelList(OpenAIBaseModel):
 class PromptTokenUsageInfo(OpenAIBaseModel):
     cached_tokens: int | None = None
     multimodal_tokens: dict[str, int] | None = None
+    """Prompt tokens contributed by each input modality, keyed by modality name
+    (e.g. ``image``, ``audio``, ``video``). A breakdown of the multimodal
+    placeholder tokens already counted in ``prompt_tokens``; ``None`` when the
+    request has no multimodal input."""
 
 
 class UsageInfo(OpenAIBaseModel):


### PR DESCRIPTION

## Purpose

`usage.prompt_tokens` already includes the image / audio / video placeholder tokens, but clients cannot tell how many tokens each modality contributed. This adds `image_tokens`, `audio_tokens` and `video_tokens` to `usage.prompt_tokens_details`, following sgl-project/sglang#27122. `audio_tokens` mirrors the OpenAI field of the same name; `image_tokens` and `video_tokens` are multimodal extensions beyond the OpenAI schema.

The per-modality counts come from the request's multimodal placeholder ranges (`PlaceholderRange.length`), which matches the placeholder tokens already counted in `usage.prompt_tokens` (not `get_num_embeds()`, the embedding-mask count). Both streaming and non-streaming final usage are covered and gated by `--enable-prompt-tokens-details`. The per-modality counts ride alongside `cached_tokens`, which keeps its existing behavior (0 is still reported), so a multimodal request reports both.

Scope is the Chat Completions endpoint. The legacy Completions endpoint shares `PromptTokenUsageInfo` but is left unchanged, since it does not carry image / audio / video content.

## Test Plan

Real `/v1/chat/completions` before/after on `Qwen2.5-VL-3B-Instruct` (below), plus `pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py`.

## Test Result

Same image sent to a real server with `--enable-prompt-tokens-details`. `prompt_tokens` is 108 on both sides; the PR exposes that 81 of them are the image placeholder. `cached_tokens` (including 0) is unchanged, and text-only requests are unaffected.

| request | current main | this PR |
|---|---|---|
| image, non-stream | `{cached_tokens: 0}` | `{cached_tokens: 0, image_tokens: 81}` |
| image, stream final usage | `{cached_tokens: 96}` | `{cached_tokens: 96, image_tokens: 81}` |
| text-only, non-stream | `{cached_tokens: 0}` | `{cached_tokens: 0}` |

One unit test in `test_serving_chat.py` covers the parts the E2E run cannot: per-modality multi-range summation, the feature gate, and that zero `cached_tokens` is still reported while multimodal counts ride alongside. `ruff check` and `ruff format --check` clean.

<details>
<summary>repro (serve command + client + full output)</summary>

```
# A800-80GB. VLLM_USE_FLASHINFER_SAMPLER=0 + FLASH_ATTN are A800 JIT
# workarounds, unrelated to this feature.
VLLM_USE_FLASHINFER_SAMPLER=0 VLLM_ATTENTION_BACKEND=FLASH_ATTN \
vllm serve Qwen/Qwen2.5-VL-3B-Instruct --served-model-name qwen-vl \
  --enable-prompt-tokens-details --max-model-len 4096 \
  --gpu-memory-utilization 0.80 --enforce-eager
```

Client (image + text; non-stream and streaming):

```python
import base64, io, requests
from PIL import Image

buf = io.BytesIO()
Image.new("RGB", (256, 256), (123, 200, 50)).save(buf, "PNG")
url = "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
messages = [{"role": "user", "content": [
    {"type": "image_url", "image_url": {"url": url}},
    {"type": "text", "text": "What color dominates this image?"}]}]

# non-stream
r = requests.post("http://127.0.0.1:8000/v1/chat/completions", json={
    "model": "qwen-vl", "messages": messages, "max_tokens": 8, "temperature": 0})
print(r.json()["usage"])

# stream
r = requests.post("http://127.0.0.1:8000/v1/chat/completions", json={
    "model": "qwen-vl", "messages": messages, "max_tokens": 8, "temperature": 0,
    "stream": True, "stream_options": {"include_usage": True}}, stream=True)
# ... accumulate the final chunk's "usage"
```

Output, current main vs this PR:

```
# current main, non-stream: no per-modality breakdown
{"prompt_tokens": 108, "total_tokens": 116, "completion_tokens": 8,
 "prompt_tokens_details": {"cached_tokens": 0}}

# this PR, non-stream
{"prompt_tokens": 108, "total_tokens": 116, "completion_tokens": 8,
 "prompt_tokens_details": {"cached_tokens": 0, "image_tokens": 81,
                           "audio_tokens": null, "video_tokens": null}}

# this PR, stream final usage (cached hit + image both reported)
{"prompt_tokens": 108, "total_tokens": 116, "completion_tokens": 8,
 "prompt_tokens_details": {"cached_tokens": 96, "image_tokens": 81}}

# this PR, text-only: cached_tokens unchanged, per-modality counts all null
{"prompt_tokens": 25, "total_tokens": 28, "completion_tokens": 3,
 "prompt_tokens_details": {"cached_tokens": 0, "image_tokens": null,
                           "audio_tokens": null, "video_tokens": null}}
```
</details>

AI assistance was used to investigate, reproduce, and draft this change; the author reviewed the diff and validation output.

cc @DarkLight1337
