### PR TITLE
[Bugfix] Return the tokenizer from maybe_make_thread_pool so it survives pickling

### DIFF
--- a/tests/tokenizers_/test_hf.py
+++ b/tests/tokenizers_/test_hf.py
@@ -7,7 +7,11 @@ import pytest
 from transformers import AutoTokenizer
 
 from vllm.tokenizers import TokenizerLike
-from vllm.tokenizers.hf import get_cached_tokenizer
+from vllm.tokenizers.hf import (
+    ThreadSafeHFTokenizerMixin,
+    get_cached_tokenizer,
+    maybe_make_thread_pool,
+)
 
 
 @pytest.mark.parametrize("model_id", ["gpt2", "zai-org/chatglm3-6b"])
@@ -41,3 +45,23 @@ def _check_consistency(target: TokenizerLike, expected: TokenizerLike):
     )
 
     assert target.encode("prompt") == expected.encode("prompt")
+
+
+@pytest.mark.parametrize("model_id", ["gpt2"])
+def test_thread_pool_tokenizer_pickle(model_id: str):
+    """Regression test for issue #45433: the thread-pool tokenizer wrapper
+    reconstructs through maybe_make_thread_pool on unpickling, which used to
+    fall off the end and return None."""
+    reference_tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+    pooled_tokenizer = maybe_make_thread_pool(deepcopy(reference_tokenizer))
+    assert pooled_tokenizer is not None
+    assert isinstance(pooled_tokenizer, ThreadSafeHFTokenizerMixin)
+
+    unpickled_tokenizer = pickle.loads(pickle.dumps(pooled_tokenizer))
+    assert unpickled_tokenizer is not None
+    assert isinstance(unpickled_tokenizer, ThreadSafeHFTokenizerMixin)
+    assert unpickled_tokenizer.encode("prompt") == reference_tokenizer.encode("prompt")
+
+    # Idempotence: wrapping an already-pooled tokenizer returns it unchanged.
+    assert maybe_make_thread_pool(pooled_tokenizer) is pooled_tokenizer

--- a/vllm/tokenizers/hf.py
+++ b/vllm/tokenizers/hf.py
@@ -99,6 +99,9 @@ def maybe_make_thread_pool(tokenizer: _T, copies: int = 1):
     TokenizerPool.__name__ = f"TokenizerPool{og_tokenizer.__class__.__name__}"
 
     tokenizer.__class__ = TokenizerPool
+    # Return the tokenizer: TokenizerPool.__reduce__ reconstructs through this
+    # function, so falling off the end would unpickle to None (issue #45433).
+    return tokenizer
 
 
 def get_cached_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:


### PR DESCRIPTION
## Purpose

Fix #45433: tokenizers wrapped by `maybe_make_thread_pool` (every fast tokenizer returned by `LLM.get_tokenizer()` / `AsyncLLM.get_tokenizer()` since the thread-pool wrapper landed) **unpickle to `None`**, breaking tokenizer retrieval across Ray actors, multiprocessing, and any cloudpickle path.

Mechanism: `TokenizerPool.__reduce__` reconstructs via `maybe_make_thread_pool(og_tokenizer, copies)`, but the `PreTrainedTokenizerFast` branch mutates `tokenizer.__class__` in place and **falls off the end of the function** — the early-exit branch returns the tokenizer, the main branch returns `None`. Unpickling therefore evaluates to `None`. One-line fix: return the tokenizer. (The in-repo caller in `renderers/hf.py` ignores the return value and is unaffected; the reduce path and external callers now get the tokenizer.)

## Test Plan

New `test_thread_pool_tokenizer_pickle` in `tests/tokenizers_/test_hf.py`: wrap → assert non-None + mixin type → pickle round-trip → assert non-None, type, and `encode()` equivalence with the reference tokenizer → idempotent re-wrap.

```
# without fix
pytest tests/tokenizers_/test_hf.py -k thread_pool → 1 failed (unpickled is None)

# with fix
pytest tests/tokenizers_/test_hf.py → 3 passed
```

pre-commit (ruff, mypy) passes on both files.

## Test Result

`3 passed` (full file); fail→pass verified against main.

## Duplicate check

Issue has 0 comments; searched open PRs for `45433`, `maybe_make_thread_pool`, `tokenizer pickle` — none address this. File history on `vllm/tokenizers/hf.py` shows no fix.

---

AI assistance disclosure: prepared with AI assistance (Claude); reviewed and tested locally by the submitter.
