### PR TITLE
[Rust Frontend] [Metrics]Make metrics respect --served-model-name

### DIFF
--- a/rust/src/server/src/lib.rs
+++ b/rust/src/server/src/lib.rs
@@ -35,9 +35,24 @@ use crate::routes::build_router;
 use crate::server_info::ServerInfoSnapshot;
 use crate::state::AppState;
 
+/// Resolve the public model names accepted by the frontend.
+fn effective_served_model_names(model: &str, served_model_name: &[String]) -> Vec<String> {
+    if served_model_name.is_empty() {
+        vec![model.to_string()]
+    } else {
+        served_model_name.to_vec()
+    }
+}
+
 /// Build the shared application state for one configured model and one engine
 /// client.
 async fn build_state(config: &Config) -> Result<Arc<AppState>> {
+    // If no served names are specified, fall back to the backend model path so
+    // that the API always has at least one valid model ID. Use the same primary
+    // public name for frontend-side metrics labels.
+    let served_model_names = effective_served_model_names(&config.model, &config.served_model_name);
+    let metrics_model_name = served_model_names[0].clone();
+
     // Load both backends from the same model metadata so they stay in sync.
     let loaded = load_model_backends(
         &config.model,
@@ -68,7 +83,7 @@ async fn build_state(config: &Config) -> Result<Arc<AppState>> {
     let client = EngineCoreClient::connect(EngineCoreClientConfig {
         transport_mode: config.transport_mode.clone(),
         coordinator_mode,
-        model_name: config.model.clone(),
+        model_name: metrics_model_name,
         client_index: 0,
     })
     .await
@@ -80,14 +95,6 @@ async fn build_state(config: &Config) -> Result<Arc<AppState>> {
     let chat = ChatLlm::new(text, chat_backend)
         .with_tool_call_parser(config.tool_call_parser.clone())
         .with_reasoning_parser(config.reasoning_parser.clone());
-
-    // If no served names are specified, fall back to the backend model path so
-    // that the API always has at least one valid model ID.
-    let served_model_names = if config.served_model_name.is_empty() {
-        vec![config.model.clone()]
-    } else {
-        config.served_model_name.clone()
-    };
 
     Ok(Arc::new(
         AppState::new(served_model_names, chat)
@@ -257,4 +264,27 @@ where
         .copied()
         .unwrap_or_else(|| Instant::now() + config.shutdown_timeout);
     state.shutdown(shutdown_deadline).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_served_model_names_falls_back_to_backend_model() {
+        assert_eq!(
+            effective_served_model_names("backend-model", &[]),
+            vec!["backend-model"]
+        );
+    }
+
+    #[test]
+    fn effective_served_model_names_preserves_public_names() {
+        let served_names = vec!["public-model".to_string(), "public-alias".to_string()];
+
+        assert_eq!(
+            effective_served_model_names("backend-model", &served_names),
+            served_names
+        );
+    }
 }

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -1679,6 +1679,85 @@ async fn http_metrics_record_list_models_requests() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn request_metrics_use_served_model_name_label() {
+    let ipc = IpcNamespace::new().expect("create ipc namespace");
+    let handshake_address = ipc.handshake_endpoint();
+    let engine_id = b"engine-openai-served-model-metrics".to_vec();
+
+    let engine_task = MockEngineTask::new(spawn_mock_engine_task(
+        handshake_address.clone(),
+        engine_id.clone(),
+        |dealer, push| {
+            boxed_test_future(async move {
+                let add = recv_engine_message(dealer).await;
+                let request: EngineCoreRequest =
+                    rmp_serde::from_slice(&add[1]).expect("decode request");
+                send_outputs(
+                    push,
+                    engine_outputs_for_request(&request.request_id, default_stream_output_specs()),
+                )
+                .await;
+            })
+        },
+    ));
+
+    let client = EngineCoreClient::connect(
+        EngineCoreClientConfig::new_single(handshake_address)
+            .with_model_name("served-model-metrics")
+            .with_local_input_output_addresses(
+                Some(ipc.input_endpoint()),
+                Some(ipc.output_endpoint()),
+            ),
+    )
+    .await
+    .expect("connect client");
+    let chat = ChatLlm::from_shared_backend(test_llm(client), Arc::new(FakeChatBackend::new()));
+    let mut app = build_router(Arc::new(AppState::new(
+        vec![
+            "served-model-metrics".to_string(),
+            "served-model-alias".to_string(),
+        ],
+        chat,
+    )));
+    let before = METRICS.render().unwrap();
+
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "served-model-alias",
+                        "stream": false,
+                        "messages": [{"role": "user", "content": "hello"}]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let _ = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+
+    let after = METRICS.render().unwrap();
+    assert_eq!(
+        metric_delta(
+            &before,
+            &after,
+            "vllm:request_success_total",
+            Some("model_name=\"served-model-metrics\",engine=\"0\",finished_reason=\"stop\""),
+        ),
+        1.0
+    );
+    engine_task.await.expect("mock engine task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn wrong_model_returns_not_found() {
     let mut app = test_app().await;
     let response = app


### PR DESCRIPTION



## Purpose
  The Rust frontend currently accepts `--served-model-name`, but frontend
  Prometheus metrics can still be labeled with the backend model path instead of
  the public served model name.

  For example, serving `Qwen/Qwen3-0.6B` with:

  ```bash
  --served-model-name my-model

  should expose frontend metrics with:

  model_name="my-model"

  instead of:

  model_name="Qwen/Qwen3-0.6B"
```

  This change resolves served model names once in server state setup and uses the
  primary served name for frontend-side metrics labels. If no served model name is
  configured, it preserves the existing fallback to the backend model name.

## Test Plan

## Test Result

```
 cargo test -p vllm-server served_model -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running unittests src/lib.rs (target/debug/deps/vllm_server-0d9e659a05348f62)

running 3 tests
test tests::effective_served_model_names_falls_back_to_backend_model ... ok
test tests::effective_served_model_names_preserves_public_names ... ok
test routes::tests::request_metrics_use_served_model_name_label ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 216 filtered out; finished in 0.03s
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

