### PR TITLE
[Bugfix] Reject structured outputs for diffusion decoders with a clear error

### DIFF
--- a/tests/v1/structured_output/test_validation.py
+++ b/tests/v1/structured_output/test_validation.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Request-time validation of structured output requests."""
+
+import pytest
+
+from vllm.config import StructuredOutputsConfig
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+
+pytestmark = pytest.mark.cpu_test
+
+JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "invoice_id": {"type": "string"},
+        "customer": {"type": "string"},
+    },
+    "required": ["invoice_id", "customer"],
+    "additionalProperties": False,
+}
+
+
+class _StubModelConfig:
+    def __init__(self, is_diffusion: bool):
+        self.is_diffusion = is_diffusion
+
+
+def test_structured_outputs_rejected_for_diffusion_models():
+    """Diffusion LLMs denoise the canvas in parallel, which is incompatible
+    with the token-by-token grammar FSM. The request must fail with a clear
+    validation error instead of an FSM rejection mid-generation (#45436)."""
+    params = SamplingParams(
+        structured_outputs=StructuredOutputsParams(json=JSON_SCHEMA)
+    )
+    with pytest.raises(ValueError, match="not yet supported for diffusion"):
+        params._validate_structured_outputs(
+            _StubModelConfig(is_diffusion=True),
+            StructuredOutputsConfig(),
+            tokenizer=None,
+        )
+
+
+def test_plain_request_allowed_for_diffusion_models():
+    """Requests without structured outputs are unaffected by the guard."""
+    params = SamplingParams()
+    params._validate_structured_outputs(
+        _StubModelConfig(is_diffusion=True),
+        StructuredOutputsConfig(),
+        tokenizer=None,
+    )

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -720,7 +720,9 @@ class SamplingParams(
         self._validate_logits_processors(model_config)
         self._validate_allowed_token_ids(tokenizer)
         self._validate_spec_decode(speculative_config)
-        self._validate_structured_outputs(structured_outputs_config, tokenizer)
+        self._validate_structured_outputs(
+            model_config, structured_outputs_config, tokenizer
+        )
 
     def _validate_logprobs(self, model_config: ModelConfig) -> None:
         max_logprobs = model_config.max_logprobs
@@ -853,11 +855,24 @@ class SamplingParams(
 
     def _validate_structured_outputs(
         self,
+        model_config: ModelConfig,
         structured_outputs_config: StructuredOutputsConfig | None,
         tokenizer: TokenizerLike | None,
     ) -> None:
         if structured_outputs_config is None or self.structured_outputs is None:
             return
+
+        if model_config.is_diffusion:
+            # Diffusion LLMs denoise a whole canvas of tokens in parallel
+            # rather than sampling left-to-right, which the grammar FSM
+            # requires. Without this check, requests fail mid-generation
+            # with an FSM rejection (HTTP 500). See issue #45436.
+            raise ValueError(
+                "Structured outputs are not yet supported for diffusion "
+                "language models. Remove the structured output constraint "
+                "(e.g. `response_format`, `structured_outputs`) from the "
+                "request."
+            )
 
         if tokenizer is None:
             raise ValueError(


### PR DESCRIPTION
## Purpose

Fixes #45436.

`nvidia/diffusiongemma-26B-A4B-it-NVFP4` (DiffusionGemma, added in #45163) fails with an
HTTP 500 when a structured output constraint is supplied (`response_format: json_schema`
or top-level `structured_outputs`): the request starts generating and is then terminated
mid-flight by an xgrammar FSM rejection deep in the scheduler.

This PR rejects structured output requests against diffusion language models at request
validation time with an actionable HTTP 400, instead of a 500 from inside the engine.

## Root cause

Diffusion LLMs denoise a fixed-length canvas in parallel (confidence-ordered unmasking,
randomly initialized canvas, whole blocks committed at once) reusing the
speculative-decoding data path. The structured-output stack assumes strictly
autoregressive, left-to-right, token-at-a-time FSM advancement. Reproduced on the
reporter's exact GPU (RTX PRO 6000 Blackwell Max-Q, SM 12.0, CUDA 13.0) at e3e31e54b0
with the issue's serve flags — server-side log is token-for-token identical to the issue:

```
ERROR [backend_xgrammar.py:158] Failed to advance FSM for request chatcmpl-a64f...-b1e9c809 for tokens 106. Please file an issue.
ERROR [scheduler.py:1531] Unexpected: grammar rejected tokens [236782, 107, 138, 236775, 53209, 236779, 547, 1083, 623, 1357, 236772, 236778, 236771, 236778, 236825, 236772, 236771, 236770, 236812, 236778, 827, 107, 138, 236775, 25016, 1083, 623, 236776, 55220, 16502, 236775, 107, 236783, 106] for request chatcmpl-a64f...-b1e9c809. Terminating request.
ERROR [serving.py:195] Request chatcmpl-a64f... failed with an internal error during generation
POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
```

Decoding the rejected block shows why this can't be papered over (also noted in
[my triage comment on the issue](https://github.com/vllm-project/vllm/issues/45436#issuecomment-4695786023)):

- Repro 1's committed block decodes to `{\n  "invoice_id": "RE-2026-0142",\n  "customer": "Aigner Transport"\n}<turn|>` —
  **perfectly schema-valid JSON**. `Scheduler.update_from_output` hands the *entire*
  committed block to `grammar.accept_tokens()` at once; the matcher terminates at the
  closing `}` and then rejects token 106 (`<turn|>`, not an xgrammar stop token). In
  autoregressive decoding the bitmask would force a valid stop token at the next
  single-token step; with whole-block handoff that cannot happen.
- Repro 2's block decodes to `` {json\n{\n ... }\n```<turn|> `` (token 3723 = `json`
  rejected right after `{`), showing the denoising steps were not actually constrained by
  the grammar bitmask at all.

There are two further latent contact points with the same autoregressive assumption:
`StructuredOutputManager.grammar_bitmask` advances the FSM sequentially through the
scheduled canvas tokens with `assert accepted` (vllm/v1/structured_output/__init__.py:290),
and `Scheduler.update_draft_token_ids` trims drafts to the grammar-valid prefix —
which would corrupt the diffusion canvas. Constrained decoding for diffusion needs
canvas-aware semantics; that is real feature work and is out of scope here (follow-up).

## Fix

`SamplingParams._validate_structured_outputs` (vllm/sampling_params.py) now receives
`model_config` (already available in `verify()`) and raises a `ValueError` when
`model_config.is_diffusion` and a structured output constraint is present. This is the
same layer as the existing `skip_tokenizer_init`/empty-grammar/backend checks, so it
covers all entry points (OpenAI `response_format`, top-level `structured_outputs`,
deprecated `guided_*` aliases, offline `LLM`) and maps to HTTP 400 via the standard
validation-error path.

## Not duplicating existing work

- Issue comments: only my own triage comment claiming this with the proposed approach.
- `gh pr list --state open --search "45436 in:body"` → none.
- `gh pr list --state open --search "diffusion structured"` / `"xgrammar diffusion"` →
  only unrelated PRs (#44297 spec-decode reasoning-boundary bitmask, #45413 streaming
  parser engine, #35732 diffusion-transformer LoRA).
- `vllm/v1/structured_output/` history: last touched by #45163 itself; no diffusion
  guard in flight on main.

## Test Plan

Unit (CPU):

```bash
.venv/bin/python -m pytest tests/v1/structured_output/test_validation.py tests/v1/structured_output/test_utils.py -q
```

E2E on RTX PRO 6000 (SM 12.0): served `nvidia/diffusiongemma-26B-A4B-it-NVFP4` with the
issue's flags (`--tool-call-parser gemma4 --reasoning-parser gemma4
--default-chat-template-kwargs '{"enable_thinking":false}' --max-num-batched-tokens 2048`)
and replayed the issue's two curl reproductions plus an unconstrained control request,
before and after this change.

```bash
pre-commit run --files vllm/sampling_params.py tests/v1/structured_output/test_validation.py
```

## Test Result

- Unit: `8 passed` (2 new + 6 existing).
- E2E before (e3e31e54b0): both structured requests → HTTP 500 with the exact FSM
  rejection above; control → 200.
- E2E after: both structured requests → HTTP 400
  `{"error":{"message":"Structured outputs are not yet supported for diffusion language models. Remove the structured output constraint (e.g. \`response_format\`, \`structured_outputs\`) from the request.","type":"BadRequestError",...,"code":400}}`;
  control → 200 ("Hello there!"); no FSM errors in the server log.
- pre-commit: all hooks passed (ruff, ruff-format, typos, mypy, SPDX).

## AI disclosure

This PR was developed with AI assistance (Claude Code). I reviewed every changed line,
ran the tests and the end-to-end reproduction on my own hardware, and can defend the
change end-to-end.

 Generated with [Claude Code](https://claude.com/claude-code)
