### PR TITLE
[CI Bug] Fix `ValueError: There is no module or parameter named 'model.vision_tower.vision_model'`

### DIFF
--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -303,17 +303,13 @@ class Base(
         - Any quantization config specific mappings
         """
         self.hf_to_vllm_mapper = WeightsMapper()
+        orig_to_new_renamings = self.hf_to_vllm_mapper.orig_to_new_renamings
         orig_to_new_regex = self.hf_to_vllm_mapper.orig_to_new_regex
 
         for mapping in get_model_conversion_mapping(self.model):
             # Handle weights which have been renamed in Transformers
             if isinstance(mapping, WeightRenaming):
-                # Recompile using regex (Transformers used re)
-                compiled_sources = re.compile(
-                    mapping.compiled_sources.pattern, mapping.compiled_sources.flags
-                )
-                target_pattern = mapping.target_patterns[0]
-                orig_to_new_regex[compiled_sources] = target_pattern
+                orig_to_new_renamings.append(mapping)
             # TODO: Handle WeightConverter to enable layer merging
 
         # Handle unexpected weights which should be ignored

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -44,6 +44,7 @@ class WeightsMapper:
 
     If a key maps to a value of `None`, the corresponding weight is ignored."""
 
+    orig_to_new_renamings: list[Any] = field(default_factory=list)
     orig_to_new_regex: Mapping[re.Pattern, str | None] = field(default_factory=dict)
     orig_to_new_substr: Mapping[str, str | None] = field(default_factory=dict)
     orig_to_new_prefix: Mapping[str, str | None] = field(default_factory=dict)
@@ -52,6 +53,10 @@ class WeightsMapper:
     def __or__(self, other: "WeightsMapper") -> "WeightsMapper":
         """Combine two `WeightsMapper`s by merging their mappings."""
         return WeightsMapper(
+            orig_to_new_renamings=[
+                *self.orig_to_new_renamings,
+                *other.orig_to_new_renamings,
+            ],
             orig_to_new_regex={**self.orig_to_new_regex, **other.orig_to_new_regex},
             orig_to_new_substr={**self.orig_to_new_substr, **other.orig_to_new_substr},
             orig_to_new_prefix={**self.orig_to_new_prefix, **other.orig_to_new_prefix},
@@ -59,6 +64,9 @@ class WeightsMapper:
         )
 
     def _map_name(self, key: str) -> str | None:
+        for renaming in self.orig_to_new_renamings:
+            key, _ = renaming.rename_source_key(key)
+
         for pattern, new_key in self.orig_to_new_regex.items():
             if pattern.search(key):
                 if new_key is None:


### PR DESCRIPTION
## Purpose

Fixes https://buildkite.com/vllm/ci/builds/71235#019ebd0b-5a0c-44e8-9f0c-7a7965833cc8

```bash
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=3055546)     return func(*args, **kwargs)
(EngineCore pid=3055546)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/v1/executor/abstract.py", line 109, in __init__
(EngineCore pid=3055546)     self._init_executor()
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/v1/executor/uniproc_executor.py", line 68, in _init_executor
(EngineCore pid=3055546)     self.driver_worker.load_model()
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu_worker.py", line 356, in load_model
(EngineCore pid=3055546)     self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=3055546)     return func(*args, **kwargs)
(EngineCore pid=3055546)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu_model_runner.py", line 5103, in load_model
(EngineCore pid=3055546)     self.model = model_loader.load_model(
(EngineCore pid=3055546)                  ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=3055546)     return func(*args, **kwargs)
(EngineCore pid=3055546)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/model_executor/model_loader/base_loader.py", line 64, in load_model
(EngineCore pid=3055546)     self.load_weights(model, model_config)
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=3055546)     return func(*args, **kwargs)
(EngineCore pid=3055546)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/model_executor/model_loader/default_loader.py", line 394, in load_weights
(EngineCore pid=3055546)     loaded_weights = model.load_weights(self.get_all_weights(model_config, model))
(EngineCore pid=3055546)                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/model_executor/models/transformers/base.py", line 661, in load_weights
(EngineCore pid=3055546)     return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
(EngineCore pid=3055546)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/model_executor/model_loader/reload/torchao_decorator.py", line 50, in patched_model_load_weights
(EngineCore pid=3055546)     return original_load_weights(self, weights, *args, **kwargs)
(EngineCore pid=3055546)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/model_executor/models/utils.py", line 368, in load_weights
(EngineCore pid=3055546)     autoloaded_weights = set(self._load_module("", self.module, weights))
(EngineCore pid=3055546)                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/model_executor/models/utils.py", line 301, in _load_module
(EngineCore pid=3055546)     yield from self._load_module(
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/model_executor/models/utils.py", line 301, in _load_module
(EngineCore pid=3055546)     yield from self._load_module(
(EngineCore pid=3055546)   File "/home/yewentao256/vllm-source/vllm/model_executor/models/utils.py", line 338, in _load_module
(EngineCore pid=3055546)     raise ValueError(msg)
(EngineCore pid=3055546) ValueError: There is no module or parameter named 'model.vision_tower.vision_model' in TransformersMultiModalForCausalLM.
```

We reuse the renaming logic from huggingface.

Now

```bash
================= 1 passed, 23 warnings in 174.57s (0:02:54) ==================
```
