### PR TITLE
[Bugfix][DCP] Fix illegal memory access in DCP a2a decode under full CUDA graphs

### DIFF
--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -26,10 +26,6 @@ import torch
 import torch.distributed as dist
 
 from vllm.triton_utils import tl, triton
-from vllm.v1.worker.workspace import (
-    current_workspace_manager,
-    is_workspace_manager_initialized,
-)
 
 if TYPE_CHECKING:
     from vllm.distributed.parallel_state import GroupCoordinator
@@ -117,13 +113,16 @@ def _dcp_a2a_send_recv_buffers(
     device: torch.device,
     dtype: torch.dtype,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if is_workspace_manager_initialized():
-        send_buffer, recv_buffer = current_workspace_manager().get_simultaneous(
-            (shape, dtype),
-            (shape, dtype),
-        )
-        return send_buffer, recv_buffer
-
+    # Don't use the shared WorkspaceManager here. A FULL cudagraph bakes in the
+    # buffer address at capture, but the workspace is growable and sized only to
+    # the largest *captured* batch (the cudagraph capture cap). Any eager a2a
+    # with a bigger batch regrows it, freeing that address and poisoning every
+    # captured graph -> illegal memory access on replay. This bites the very
+    # first request: the post-capture warmup runs an eager decode at
+    # max_num_seqs (> the cap), so the graphs are already dangling before the
+    # server is ready. torch.empty buffers instead live in the graph's private
+    # pool and stay valid for its lifetime (as _dcp_a2a_unpack_combine and the
+    # AG+RS combine path already rely on).
     return (
         torch.empty(shape, device=device, dtype=dtype),
         torch.empty(shape, device=device, dtype=dtype),


### PR DESCRIPTION
## Summary

`--dcp-comm-backend a2a` crashes every worker with a CUDA illegal memory access on the first request when full CUDA graphs are enabled (cudagraph_mode=FULL_AND_PIECEWISE) for DCP4 when running model `nvidia/Kimi-K2.5-NVFP4`. The DCP a2a combine drew its all-to-all send/recv buffers from the shared, growable WorkspaceManager. A full CUDA graph bakes in those buffer addresses at capture; vLLM's post-capture warmup then regrows the workspace
(freeing the captured block), so every captured decode graph is left dereferencing freed memory and faults on replay.

Fix: allocate the a2a send/recv buffers with torch.empty so they live in the CUDA graph's private memory pool (stable for the graph's lifetime), instead of the shared workspace. This matches what
`_dcp_a2a_unpack_combine` and the AG+RS combine path already do.

## Symptom
```
vllm serve nvidia/Kimi-K2.5-NVFP4 -tp 4 -ep --decode-context-parallel-size 4 \
  --kv-cache-dtype fp8 --dcp-comm-backend a2a \
  --all2all-backend flashinfer_nvlink_one_sided --enable-ep-weight-filter \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}' ...
First /v1/completions request → all workers die. The error first surfaces deferred, in the async output-copy thread:
WorkerAsyncOutputCopy ... self.copy_event.synchronize()
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
With CUDA_LAUNCH_BLOCKING=1 it moves to its true site — a full-graph replay:
File ".../vllm/v1/worker/gpu/model_runner.py", line 1260, in execute_model
    model_output = self.cudagraph_manager.run_fullgraph(batch_desc)
File ".../vllm/v1/worker/gpu/cudagraph_utils.py", line 315, in run_fullgraph
    self.graphs[desc].replay()
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```

## Root cause (instrumentation)

The a2a send/recv buffers came from `WorkspaceManager.get_simultaneous(...)`, which returns views into one growable buffer. A FULL decode graph records that buffer's address at capture. The workspace
size at capture is only the high-water mark of the largest captured batch — and the capture range is itself capped: `max_cudagraph_capture_size = min(max_num_seqs*2, 512)` (so with max_num_seqs=1024,
the largest captured decode batch is 512).

Decode batches above that cap run eagerly (no graph). vLLM's post-capture warmup runs an eager decode at `max_num_seqs`, which calls this op with a batch larger than any captured size. That eager a2a
asks the workspace for a bigger buffer; `_ensure_workspace_size empty_cache()`s + reallocates at a new address, freeing the block every captured graph still points at — all before the server is ready. The first request then replays a poisoned graph.

Important: the only caller that reallocates the workspace here is the a2a itself (via its eager large-batch path) — not the MoE/EP all-to-all. (flashinfer_nvlink_one_sided uses its own buffers; it never appears as a workspace resizer.)

With current codebase and instrumented (1) workspace reallocations, (2) the buffer pointer per batch size at capture, (3) the live workspace pointer at replay. The crashing config produced this timeline (rank 0):

```
14:46:28  Graph capturing finished                 # 51 FULL graphs (B=1..512), all @ 0xffb704400000
14:46:34  WS-DBG RESIZE 0xffb704400000 -> 0xffd424000000 (64.25 -> 128.50 MB)
          caller=dcp_alltoall.py, capturing=False  # post-capture warmup eager B=1024; frees old block
14:46:48  Application startup complete
14:49:14  <B=1 request>  -> illegal memory access
And at replay of the failing decode:
desc: num_tokens=1
live_ws_base    = 0xffd424000000
captured (B=1)  = 0xffb704400000          # baked into the graph, now freed
```

So: all decode graphs captured at `0xffb704400000`; the warmup's eager B=1024 call moved the workspace to `0xffd424000000` and freed `0xffb704400000`; the first request's B=1 graph still dereferences `0xffb704400000` → IMA. (Only two resizes ever occur, both before "ready"; nothing resizes during the request — which is why even a B=1 first request crashes.)

## Debugging roadmap

1. Reproduced with the exact model under `CUDA_LAUNCH_BLOCKING=1` → traceback pins it to `cudagraph_manager.run_fullgraph` → `graph.replay()` (a full-graph replay, not eager prefill, not the async output-copy path where it originally surfaced).
2. Discriminating experiment — changed only `--dcp-comm-backend a2a` → `ag_rs` (same model/flags): no crash. `ag_rs` uses `torch.empty` intermediate buffers; a2a used the shared workspace → isolates the difference to the a2a buffer source.
3. Model-dependence check — a small MLA model (DeepSeek-V2-Lite) with identical flags never crashed; only the large model did → established it's a runtime-state/size effect, not categorically broken a2a.
4. Direct confirmation — instrumented workspace reallocations + buffer pointers at capture and replay; observed the captured pointer freed and relocated by the post-capture warmup, before any request (addresses/timeline above). All instrumentation removed afterward.

## The fix

`_dcp_a2a_send_recv_buffers` now always returns `torch.empty `buffers instead of views into the shared `WorkspaceManager`.

## Memory impact

Negligible, and independent of sequence length / context (the a2a scratch sizes with decode-batch × heads-per-rank × kv_lora_rank, not ISL/OSL):
- Live working set per decode step is one send+recv pair (e.g. ~128 KB at B=1), reused across layers/steps by the caching allocator.
- The graph pool reserves for the largest captured decode batch — e.g. ~64 MB/GPU at B=512 with these dims. Previously this overlapped the shared workspace; now it's a dedicated graph-pool allocation. Net ceiling ≈ +64 MB/GPU worst case.

## Test plan / results

- Repro before fix → IMA on first request (above).
- Control: `--dcp-comm-backend ag_rs`, same flags → works (no crash).
- After fix: `--dcp-comm-backend a2a` + full cudagraphs → no IMA. (Validated with --load-format dummy)
- Existing unit coverage: `tests/distributed/test_dcp_a2a.py` exercises `dcp_a2a_lse_reduce`; this change only affects where the send/recv scratch is allocated, not the packing/exchange/combine semantics.

## Why this is not a duplicate
Fixes a buffer-lifetime crash specific to the DCP-a2a + full-decode-compile path; no open PR addresses the a2a workspace-vs-cudagraph-pool issue.

## AI assistance
Developed with AI assistance (Claude Code). A human author has reviewed every line, reproduced the crash and the fix, and is accountable for the change.