### PR TITLE
[CI] Wait for SSL cert refresher events in the test

### DIFF
--- a/tests/entrypoints/serve/utils/test_ssl_cert_refresher.py
+++ b/tests/entrypoints/serve/utils/test_ssl_cert_refresher.py
@@ -41,6 +41,28 @@ def touch_file(path: str) -> None:
     Path(path).touch()
 
 
+async def wait_for_counts(
+    ssl_context: MockSSLContext,
+    *,
+    cert_chain_count: int,
+    ca_count: int,
+    timeout: float = 5.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        if (
+            ssl_context.load_cert_chain_count >= cert_chain_count
+            and ssl_context.load_ca_count >= ca_count
+        ):
+            return
+
+        if asyncio.get_running_loop().time() >= deadline:
+            assert ssl_context.load_cert_chain_count >= cert_chain_count
+            assert ssl_context.load_ca_count >= ca_count
+
+        await asyncio.sleep(0.05)
+
+
 @pytest.mark.asyncio
 async def test_ssl_refresher():
     ssl_context = MockSSLContext()
@@ -53,20 +75,28 @@ async def test_ssl_refresher():
     assert ssl_context.load_ca_count == 0
 
     touch_file(key_path)
-    await asyncio.sleep(1)
-    assert ssl_context.load_cert_chain_count == 1
+    await wait_for_counts(
+        ssl_context,
+        cert_chain_count=1,
+        ca_count=0,
+    )
     assert ssl_context.load_ca_count == 0
 
     touch_file(cert_path)
     touch_file(ca_path)
-    await asyncio.sleep(1)
-    assert ssl_context.load_cert_chain_count == 2
-    assert ssl_context.load_ca_count == 1
+    await wait_for_counts(
+        ssl_context,
+        cert_chain_count=2,
+        ca_count=1,
+    )
 
     ssl_refresher.stop()
+    await asyncio.sleep(0)
+    cert_chain_count = ssl_context.load_cert_chain_count
+    ca_count = ssl_context.load_ca_count
 
     touch_file(cert_path)
     touch_file(ca_path)
     await asyncio.sleep(1)
-    assert ssl_context.load_cert_chain_count == 2
-    assert ssl_context.load_ca_count == 1
+    assert ssl_context.load_cert_chain_count == cert_chain_count
+    assert ssl_context.load_ca_count == ca_count


### PR DESCRIPTION
This PR fixes a rare failure in the AMD API server job:

```text
AMD: Entrypoints Integration (API Server) (mi325_1)
tests/entrypoints/serve/utils/test_ssl_cert_refresher.py::test_ssl_refresher
```

Buildkite:
https://buildkite.com/vllm/ci/builds/71260/canvas?sid=019eb357-0345-44d5-a052-89ed36249172&tab=output

The test was touching the watched cert files, sleeping for one second, and then asserting that the mock SSL context had reloaded. That is a little too hopeful for an async file watcher on a busy CI machine. In the failing run, the cert file change was observed, but the CA reload had not happened before the fixed sleep expired. This one is a real timing flake. If the watcher callback runs within the fixed sleep window, the test passes. If CI scheduling delays the callback slightly, the same test fails even though the production watcher still works.

The change keeps the test behavior the same, but waits for the observed reload counts instead of waiting for a fixed amount of time. The wait is bounded, so a real failure still fails quickly and with the same counter assertions. 