### PR TITLE
Treat null completion max_tokens like the default

### DIFF
--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -348,6 +348,14 @@ class CompletionRequest(OpenAIBaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def normalize_null_max_tokens(cls, data):
+        if isinstance(data, dict) and data.get("max_tokens") is None:
+            data = data.copy()
+            data["max_tokens"] = cls.model_fields["max_tokens"].default
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def validate_response_format(cls, data):
         response_format = data.get("response_format")
         if response_format is None:


### PR DESCRIPTION
This fixes a Schemathesis failure in the OpenAI API server job: 

```text
AMD: Entrypoints Integration (API Server OpenAI - Part 1) (mi325_1)
tests/entrypoints/openai/test_openai_schema.py::test_openapi_stateless[POST /v1/completions]
```

Buildkite:
https://buildkite.com/vllm/ci/builds/71260/canvas?jid=019eb357-065d-479d-9ab2-ddb06152cac9&tab=output

The generated request was:

```json
{"max_tokens": null, "prompt": [0]}
```

For that exact request, the pre-fix failure is deterministic. The CI job only looks flaky because this is a schema-fuzzing test: Schemathesis does not generate that exact `max_tokens: null` completion body on every run. The serving code later asserts that `CompletionRequest.max_tokens` is not `None`. That assert is useful: response construction needs a normalized integer so echo handling can distinguish normal generation from the special `max_tokens == 0` prompt-only case. The bug was that explicit JSON `null` made it through request parsing as `None`. Omitted `max_tokens` already uses the field default, but explicit `null` did not. This PR normalizes `max_tokens: null` to the existing completions default during `CompletionRequest` validation. The serving asserts stay in place, and no sampling or response construction code changes.