### PR TITLE
[Docs] clarify NIXL KV transfer stats semantics

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -21,7 +21,9 @@ class KVConnectorStats:
     Base class for KV Connector Stats, a container for transfer performance
     metrics or otherwise important telemetry from the connector.
     All sub-classes need to be serializable as stats are sent from worker to
-    logger process.
+    logger process. The logger observes serialized stats, aggregates them over
+    the logging interval, reduces the aggregate to summary values, and logs the
+    resulting metrics.
     """
 
     data: dict[str, Any] = field(default_factory=dict)
@@ -32,7 +34,8 @@ class KVConnectorStats:
 
     def aggregate(self, other: "KVConnectorStats") -> "KVConnectorStats":
         """
-        Aggregate stats with another `KVConnectorStats` object.
+        Aggregate stats with another `KVConnectorStats` object from the same
+        logging interval.
         """
         raise NotImplementedError
 
@@ -67,8 +70,9 @@ class KVConnectorLogging:
         assert self.connector_cls is not None
         # Called periodically when connector syncs with the scheduler.
         # Note that this is not the same as the logging interval.
-        # We expect transfer_stats_data to be aggregated across all workers and
-        # consist of observations from a single connector or a MultiConnector.
+        # transfer_stats_data has already been collected from workers and may
+        # contain observations aggregated across workers or ranks for a single
+        # connector or a MultiConnector.
         transfer_stats = self.connector_cls.build_kv_connector_stats(
             transfer_stats_data
         )
@@ -91,13 +95,13 @@ class KVConnectorLogging:
             )
 
     def log(self, log_fn=logger.info):
-        """Log transfer metrics periodically, similar to throughput logging"""
+        """Reduce accumulated transfer stats and log them periodically."""
         if (
             self.transfer_stats_accumulator
             and not self.transfer_stats_accumulator.is_empty()
         ):
-            # Produce a single cumulative stats object for the last time
-            # interval from the recorded observations.
+            # reduce() summarizes the observations accumulated by observe()
+            # during the last logging interval.
             xfer_metrics = self.transfer_stats_accumulator.reduce()
             xfer_metrics_str = ", ".join(f"{k}={v}" for k, v in xfer_metrics.items())
             log_fn("KV Transfer metrics: %s", xfer_metrics_str)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -23,7 +23,12 @@ if TYPE_CHECKING:
 
 @dataclass
 class NixlKVConnectorStats(KVConnectorStats):
-    """Container for transfer performance metrics"""
+    """Container for NIXL transfer performance metrics.
+
+    In multi-rank deployments, each TP rank records its own per-transfer
+    telemetry. The logger process aggregates those rank-local observations
+    into this container before reducing them to the CLI log summary.
+    """
 
     def __post_init__(self):
         if not self.data:
@@ -84,7 +89,9 @@ class NixlKVConnectorStats(KVConnectorStats):
         return self
 
     def reduce(self) -> dict[str, int | float]:
-        # Compute compact representative stats suitable for CLI logging
+        # Compute compact representative stats suitable for CLI logging. In
+        # multi-rank deployments, these are reduced from the combined pool of
+        # rank-local observations accumulated by aggregate().
         if self.num_successful_transfers == 0:
             # CLI logging only reports successful transfers stats. If all requests in
             # the interval were unsuccessful, Prom will report failures stats instead.
@@ -107,10 +114,18 @@ class NixlKVConnectorStats(KVConnectorStats):
         n = len(descs)
         assert n == self.num_successful_transfers
 
+        # n is the total number of rank-local transfer observations, not the
+        # number of engine-level KV transfer operations.
         total_mb = mb.sum()
+        # Average bytes per rank-local transfer over the combined observation
+        # pool. This is not the total bytes moved by one logical KV transfer
+        # across all ranks.
         avg_mb = total_mb / n
 
         total_time_seconds = xfer_time.sum()
+        # Throughput is total MB divided by total rank-local transfer time,
+        # which represents average per-rank throughput across the observation
+        # pool rather than aggregate system throughput.
         throughput_mb_s = total_mb / total_time_seconds
 
         return {


### PR DESCRIPTION
## Summary
- Clarify how NIXL KV connector transfer stats flow through observe -> aggregate -> reduce -> log.
- Document that multi-rank deployments reduce over the combined pool of rank-local transfer observations.
- Clarify the semantics of successful transfer counts, average MB per transfer, percentiles, and throughput in the source comments.

Closes #41230 for the remaining source-level documentation scope called out in the issue discussion.

## Testing
- git diff --check
- D:\anaconda3\python.exe -m ruff check vllm\distributed\kv_transfer\kv_connector\v1\nixl\stats.py vllm\distributed\kv_transfer\kv_connector\v1\metrics.py
- D:\anaconda3\python.exe -m ruff format --check vllm\distributed\kv_transfer\kv_connector\v1\nixl\stats.py vllm\distributed\kv_transfer\kv_connector\v1\metrics.py