### PR TITLE
serving: dispatch renderer warmup on a background thread

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import io
+import threading
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
@@ -161,13 +162,25 @@ class OpenAIServingChat(OpenAIServing):
         self.python_tool = None
 
     def warmup(self) -> None:
-        self.renderer.warmup(
-            ChatParams(
-                chat_template=self.chat_template,
-                chat_template_content_format=self.chat_template_content_format,
-                chat_template_kwargs=self.default_chat_template_kwargs,
-            )
+        # Run renderer warmup off the startup critical path. HF preprocessor
+        # priming is CPU-bound and overlaps with concurrent GPU-side cudagraph
+        # capture / torch.compile work in the engine. We do NOT join on this
+        # thread — first MM request blocks on `_process_multimodal_async`
+        # (already executor-offloaded) which serializes naturally against the
+        # renderer's thread pool, and the existing try/except inside
+        # BaseRenderer.warmup treats failures as best-effort.
+        chat_params = ChatParams(
+            chat_template=self.chat_template,
+            chat_template_content_format=self.chat_template_content_format,
+            chat_template_kwargs=self.default_chat_template_kwargs,
         )
+        self._warmup_thread = threading.Thread(
+            target=self.renderer.warmup,
+            args=(chat_params,),
+            name="renderer-warmup",
+            daemon=True,
+        )
+        self._warmup_thread.start()
 
     def _effective_chat_template_kwargs(
         self, request: ChatCompletionRequest


### PR DESCRIPTION
## Summary
Convert `OpenAIServingChat.warmup()` to dispatch `BaseRenderer.warmup()` on a daemon thread so HF preprocessor priming overlaps with concurrent GPU-side cudagraph capture / KV cache init, instead of blocking startup serially.

## Why
Profiling a Qwen3.6-27B AWQ deployment showed the multi-modal renderer warmup adds ~42s of CPU-bound work serially after engine init (`[base.py:227] Multi-modal warmup completed in 42.677s`). Meanwhile the longer GPU-side stages (cudagraph capture, KV cache profiling) run after warmup completes, even though they could run concurrently — the warmup work is pure CPU/Python state priming with no GPU dependency.

## Why this is safe
- The renderer warmup body is unchanged — same HF state still primes.
- Existing `try/except` inside `BaseRenderer.warmup` already treats warmup as best-effort (PR #36482 + #40797 design intent).
- First multi-modal request goes through `_process_multimodal_async` on the same renderer thread-pool executor, which serializes against the warmup thread via Python's GIL + executor queue. A request arriving before warmup completes pays its HF lazy init cost on request 1 instead of on startup — strictly the same total wall-time, just shifted off the cold-load critical path.
- Daemon thread — process exit doesn't wait on it.

## Estimated savings
~40s per cold-load on multi-modal services. On services running large mm-capable models with TP/PP cudagraph capture in the multi-tens-of-seconds range, the overlap pulls warmup entirely under that umbrella.

## Test plan
- [ ] `tests/entrypoints/openai/test_chat.py` multi-modal cases pass (existing coverage).
- [ ] First MM request after warmup-still-running completes correctly (no race, no exception leak).
- [ ] First MM request TTFT not regressed vs synchronous warmup baseline.
- [ ] Steady-state TTFT (request 10+) identical to baseline.
- [ ] Issue #40365's language-only-mode case unaffected (renderer.warmup short-circuits when no MM processor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)