### PR TITLE
[Core][KV Connector] Avoid hybrid KV load failure crash

### DIFF
--- a/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
+++ b/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
@@ -478,3 +478,29 @@ def test_async_recompute_blocks_not_cached_when_invalid(
 
     # request should be in the running queue
     assert request in recompute_scheduler.running
+
+
+# TODO: Remove or update this fallback test once hybrid KV supports precise,
+# group-aware invalid block recovery.
+def test_hybrid_invalid_blocks_fallback_recomputes_from_beginning(
+    recompute_scheduler: Scheduler,
+):
+    """Hybrid KV recovery should not assume a single KV cache group."""
+    request = create_request(num_tokens=4 * recompute_scheduler.block_size)
+    request.num_computed_tokens = request.num_tokens
+    request.num_output_placeholders = 1
+    recompute_scheduler.kv_cache_manager.get_block_ids = Mock(
+        return_value=([1, 2], [3, 4])
+    )
+
+    affected_req_ids, total_affected_tokens, blocks_to_evict = (
+        recompute_scheduler._update_requests_with_invalid_blocks(
+            [request], {3}, {}, evict_blocks=True
+        )
+    )
+
+    assert affected_req_ids == {request.request_id}
+    assert request.num_computed_tokens == 0
+    assert request.num_output_placeholders == 0
+    assert total_affected_tokens == request.num_tokens
+    assert blocks_to_evict == {1, 2, 3, 4}

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2378,13 +2378,32 @@ class Scheduler(SchedulerInterface):
             marked_invalid_block = False
             req_id = request.request_id
             # TODO (davidb): add support for hybrid memory allocator
-            (req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)
+            req_block_ids_by_group = self.kv_cache_manager.get_block_ids(req_id)
             # We iterate only over blocks that may contain externally computed
             # tokens
             req_num_computed_tokens = (
                 request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
             )
 
+            if len(req_block_ids_by_group) > 1:
+                # TODO: Replace this conservative fallback with precise,
+                # group-aware recovery once invalid blocks can be mapped to
+                # safe token prefixes across hybrid KV groups.
+                req_block_ids_set = {
+                    block_id
+                    for group_block_ids in req_block_ids_by_group
+                    for block_id in group_block_ids
+                }
+                if req_block_ids_set & invalid_block_ids:
+                    affected_req_ids.add(req_id)
+                    total_affected_tokens += req_num_computed_tokens
+                    request.num_computed_tokens = 0
+                    request.num_output_placeholders = 0
+                    if evict_blocks:
+                        blocks_to_evict.update(req_block_ids_set)
+                continue
+
+            (req_block_ids,) = req_block_ids_by_group
             req_num_computed_blocks = (
                 req_num_computed_tokens + self.block_size - 1
             ) // self.block_size
@@ -2413,6 +2432,7 @@ class Scheduler(SchedulerInterface):
                 marked_invalid_block = True
                 # Truncate the computed tokens at the first failed block
                 request.num_computed_tokens = idx * self.block_size
+                request.num_output_placeholders = 0
                 num_affected_tokens = (
                     req_num_computed_tokens - request.num_computed_tokens
                 )
@@ -2433,6 +2453,7 @@ class Scheduler(SchedulerInterface):
                         request.num_computed_tokens - req_num_computed_tokens
                     )
                     request.num_computed_tokens = req_num_computed_tokens
+                    request.num_output_placeholders = 0
 
                 affected_req_ids.add(request.request_id)
 


### PR DESCRIPTION
## Purpose

Fix #45474. 
Fix a scheduler crash in KV load failure recovery for hybrid KV cache models. The existing path assumed `get_block_ids()` returned a single KV cache group, but hybrid models return one block-id list per group.

This PR keeps the existing precise recovery behavior for single-group requests and adds a conservative fallback for multi-group requests: if any invalid block belongs to the request, reset its computed KV prefix and reschedule it for recomputation.

This is a tradeoff for the failure path. Precise recovery for hybrid KV would need group-aware invalid-block metadata and a way to map failed blocks back to the earliest safe token prefix across all KV cache groups, which is a larger change. This PR instead prioritizes correctness and keeping the engine alive over minimizing recomputation.  Since KV load failures are expected to be uncommon, the extra recomputation only applies on the error path.

Happy to work on precise recovery for hybrid KV if maintainers think it is necessary.

## Test Plan

Run the focused invalid-block recovery tests and ruff on the modified files.

## Test Result

```bash
pytest tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py::test_hybrid_invalid_blocks_fallback_recomputes_from_beginning -q
pytest tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py::test_sync_recompute_blocks_not_freed_for_running_requests tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py::test_sync_fail_invalid_blocks_evicted tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py::test_hybrid_invalid_blocks_fallback_recomputes_from_beginning -q
ruff check vllm/v1/core/sched/scheduler.py tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
```

All passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

