### PR TITLE
[ROCm] Fix online-quant CI test failures on AMD

### DIFF
--- a/tests/models/quantization/test_gpt_oss.py
+++ b/tests/models/quantization/test_gpt_oss.py
@@ -99,6 +99,16 @@ def test_gpt_oss_attention_quantization(
     if tp_size > current_platform.device_count():
         pytest.skip("Not enough GPUs to run this test case")
 
+    if (
+        "amd/gpt-oss-20b-MoE-Quant-W-MXFP4-A-FP8-KV-FP8" in model_name
+        and current_platform.is_rocm()
+        and not on_gfx950()
+    ):
+        pytest.skip(
+            "MXFP4 MoE + FP8 attention accuracy is not supported on ROCm "
+            "non-gfx950 (emulation backend) yet."
+        )
+
     if "amd/gpt-oss-20b-MoE-Quant-W-MXFP4-A-FP8-KV-FP8" in model_name and on_gfx950():
         monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
 

--- a/tests/models/quantization/test_gpt_oss.py
+++ b/tests/models/quantization/test_gpt_oss.py
@@ -99,16 +99,6 @@ def test_gpt_oss_attention_quantization(
     if tp_size > current_platform.device_count():
         pytest.skip("Not enough GPUs to run this test case")
 
-    if (
-        "amd/gpt-oss-20b-MoE-Quant-W-MXFP4-A-FP8-KV-FP8" in model_name
-        and current_platform.is_rocm()
-        and not on_gfx950()
-    ):
-        pytest.skip(
-            "MXFP4 MoE + FP8 attention accuracy is not supported on ROCm "
-            "non-gfx950 (emulation backend) yet."
-        )
-
     if "amd/gpt-oss-20b-MoE-Quant-W-MXFP4-A-FP8-KV-FP8" in model_name and on_gfx950():
         monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
 

--- a/tests/models/quantization/test_mxfp8.py
+++ b/tests/models/quantization/test_mxfp8.py
@@ -19,6 +19,7 @@ diverse prompts from ``tests/prompts/example.txt``.
 import pytest
 
 from tests.quantization.utils import is_quant_method_supported
+from vllm.platforms import current_platform
 
 from ..utils import check_logprobs_close
 
@@ -31,13 +32,24 @@ MAX_MODEL_LEN = 1024
 MAX_TOKENS = 4
 NUM_LOG_PROBS = 8
 
+_MODELS = [
+    DENSE_MODEL,
+    pytest.param(
+        MOE_MODEL,
+        marks=pytest.mark.skipif(
+            current_platform.is_rocm(),
+            reason="Online MXFP8 MoE has no ROCm backend yet.",
+        ),
+    ),
+]
+
 
 @pytest.mark.skipif(
     not is_quant_method_supported("mxfp8"),
     reason="mxfp8 is not supported on this GPU type (requires sm_100+).",
 )
 @pytest.mark.quant_model
-@pytest.mark.parametrize("model", [DENSE_MODEL, MOE_MODEL], ids=["dense", "moe"])
+@pytest.mark.parametrize("model", _MODELS, ids=["dense", "moe"])
 def test_mxfp8_logprobs(
     vllm_runner,
     example_prompts,
@@ -86,7 +98,7 @@ def test_mxfp8_logprobs(
     reason="mxfp8 is not supported on this GPU type (requires sm_100+).",
 )
 @pytest.mark.quant_model
-@pytest.mark.parametrize("model", [DENSE_MODEL, MOE_MODEL], ids=["dense", "moe"])
+@pytest.mark.parametrize("model", _MODELS, ids=["dense", "moe"])
 def test_mxfp8_generation(vllm_runner, model: str) -> None:
     """Smoke test: verify online MXFP8 model generates coherent text."""
     prompt = "1 2 3 4 5"


### PR DESCRIPTION
## Purpose

Three independent fixes for AMD CI failures in
tests/models/quantization:

- platforms/rocm.py: add "fp8_per_channel" to supported_quantization. The online shorthand was missing (fp8_per_tensor/fp8_per_block were present), so verify_quantization rejected it at config time, failing both test_fp8_per_channel_logprobs[dense] and [moe]. PTPC rowwise is supported on ROCm.

- moe_wna16.py: read the TP world size via get_tensor_model_parallel_world_size() instead of layer.tp_size. RoutedExperts has no tp_size attribute, so the GPTQ/AWQ WNA16 fallback (taken on ROCm where Marlin is unavailable) raised AttributeError, failing test_awq_load[gemma4-moe-standard-awq-dot-suffix].

- test_mxfp8.py: skip the MoE cases on ROCm. The MXFP8 MoE oracle only selects FlashInfer/Marlin/XPU experts and AITER does not implement MXFP8 MoE, so there is no AMD backend; the dense path still runs.

## Test Plan

run failed tests

Current issue:
```
(EngineCore) ERROR core.py:1195   self.fp8_backend, self.experts_cls = select_mxfp8_moe_backend(config=self.moe)
(EngineCore) ERROR core.py:1195   File ".../vllm/model_executor/layers/fused_moe/oracle/mxfp8.py", line 91, in select_mxfp8_moe_backend
(EngineCore) ERROR core.py:1195     raise ValueError("No MXFP8 MoE backends available.")
(EngineCore) ERROR core.py:1195 ValueError: No MXFP8 MoE backends available.
...
RuntimeError: Engine core initialization failed. See root cause above.
```

## Test Result
================= PHASE: 2-PATCHED-verify (patched=yes) on GPU 0 =================
vllm 0.22.1rc1.dev447+g6fbfdd183
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python
rootdir: /dev
configfile: null
plugins: asyncio-1.4.0, anyio-4.13.0
../dev::test_fp8_per_channel_logprobs[dense] PASSED                      [ 14%]
../dev::test_fp8_per_channel_logprobs[moe]   PASSED                      [ 28%]
../dev::test_mxfp8_logprobs[dense]           PASSED                      [ 42%]
../dev::test_mxfp8_logprobs[moe]             SKIPPED (Online MXFP8 MoE has no RO...) [ 57%]
../dev::test_mxfp8_generation[dense]         PASSED                      [ 71%]
../dev::test_mxfp8_generation[moe]           SKIPPED (Online MXFP8 MoE has no ...) [ 85%]
../dev::test_awq_load[gemma4-moe-standard-awq-dot-suffix] PASSED         [100%]
=========================== short test summary info ============================
PASSED  ../dev::test_fp8_per_channel_logprobs[dense]
PASSED  ../dev::test_fp8_per_channel_logprobs[moe]
PASSED  ../dev::test_mxfp8_logprobs[dense]
PASSED  ../dev::test_mxfp8_generation[dense]
PASSED  ../dev::test_awq_load[gemma4-moe-standard-awq-dot-suffix]
SKIPPED [1] ../work/tests/models/quantization/test_mxfp8.py:51:  Online MXFP8 MoE has no ROCm backend yet.
SKIPPED [1] ../work/tests/models/quantization/test_mxfp8.py:100: Online MXFP8 MoE has no ROCm backend yet.
============ 5 passed, 2 skipped, 22 warnings in 239.59s (0:03:59) =============

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

