### PR TITLE
prefetch: BG-thread weight + sidecar file prefetch (subset of #40331)

### DIFF
--- a/tests/entrypoints/openai/test_startup_prefetch.py
+++ b/tests/entrypoints/openai/test_startup_prefetch.py
@@ -1,0 +1,283 @@
+"""Tests for the parent-side weight/sidecar prefetch in api_server.
+
+Covers all three HIGH audit findings from the v1 of PR #45501:
+  - daemon-thread cleanup (no ThreadPoolExecutor inside daemon thread)
+  - HF cache filelock + fork interaction (resolution happens in worker
+    thread, NOT a forked child process)
+  - sidecar de-duplication (tokenizer.json must not be read 2x)
+
+Plus the new asks:
+  - recursive walk of GGUF subdir layouts
+  - NFS-detected + multi-rank skip
+  - VLLM_DISABLE_STARTUP_PREFETCH=1 operator override
+"""
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections import Counter
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from vllm.entrypoints.openai import api_server
+
+
+def _fake_vllm_config(model_path: str, tp: int = 1, pp: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        model_config=SimpleNamespace(model=model_path, revision=None),
+        load_config=SimpleNamespace(download_dir=None),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=tp,
+            pipeline_parallel_size=pp,
+        ),
+    )
+
+
+def _make_fake_repo(tmp_path: Path, *, with_subdir: bool = False) -> Path:
+    """Build a fake on-disk model dir with weight + sidecar files."""
+    repo = tmp_path / "fake-model"
+    repo.mkdir()
+    (repo / "model-00001-of-00002.safetensors").write_bytes(b"weights1")
+    (repo / "model-00002-of-00002.safetensors").write_bytes(b"weights2")
+    (repo / "tokenizer.json").write_bytes(b"{}")
+    (repo / "tokenizer.model").write_bytes(b"sp-binary")
+    (repo / "tokenizer_config.json").write_bytes(b"{}")
+    (repo / "config.json").write_bytes(b"{}")
+    (repo / "generation_config.json").write_bytes(b"{}")
+    if with_subdir:
+        sub = repo / "shards"
+        sub.mkdir()
+        (sub / "weights.gguf").write_bytes(b"gguf-weights")
+    return repo
+
+
+def _drain_prefetch_thread(timeout: float = 10.0) -> None:
+    """Wait for any vllm-parent-weight-prefetch threads to finish."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        live = [
+            t for t in threading.enumerate()
+            if t.name in (
+                "vllm-parent-weight-prefetch",
+                "vllm-prefetch-reader",
+            )
+        ]
+        if not live:
+            return
+        time.sleep(0.05)
+    pytest.fail(
+        "prefetch threads still live after timeout: "
+        + ", ".join(t.name for t in live)
+    )
+
+
+def test_prefetch_reads_local_dir(tmp_path: Path) -> None:
+    repo = _make_fake_repo(tmp_path)
+    cfg = _fake_vllm_config(str(repo))
+
+    opens: Counter[str] = Counter()
+    real_open = open
+
+    def counting_open(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if isinstance(path, (str, os.PathLike)):
+            opens[os.path.basename(os.fspath(path))] += 1
+        return real_open(path, *args, **kwargs)
+
+    with mock.patch("builtins.open", side_effect=counting_open):
+        api_server._startup_prefetch_weights(cfg)
+        _drain_prefetch_thread()
+
+    # Each weight + sidecar opened exactly once (no dup glob hits).
+    for fname in (
+        "model-00001-of-00002.safetensors",
+        "model-00002-of-00002.safetensors",
+        "tokenizer.json",
+        "tokenizer.model",
+        "tokenizer_config.json",
+        "config.json",
+        "generation_config.json",
+    ):
+        assert opens[fname] == 1, (
+            f"{fname} was opened {opens[fname]} times — expected exactly 1"
+        )
+
+
+def test_prefetch_recursive_for_gguf_subdir(tmp_path: Path) -> None:
+    repo = _make_fake_repo(tmp_path, with_subdir=True)
+    cfg = _fake_vllm_config(str(repo))
+
+    opened: list[str] = []
+    real_open = open
+
+    def tracking_open(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if isinstance(path, (str, os.PathLike)):
+            opened.append(os.fspath(path))
+        return real_open(path, *args, **kwargs)
+
+    with mock.patch("builtins.open", side_effect=tracking_open):
+        api_server._startup_prefetch_weights(cfg)
+        _drain_prefetch_thread()
+
+    assert any(
+        p.endswith(os.path.join("shards", "weights.gguf")) for p in opened
+    ), "expected recursive walk to find shards/weights.gguf"
+
+
+def test_prefetch_threads_are_daemon_no_join_block(tmp_path: Path) -> None:
+    """Process-exit invariant: every thread launched by prefetch must be
+    daemon. ThreadPoolExecutor's atexit-join was the v1 hang risk; this
+    test fails if anyone re-introduces non-daemon workers.
+    """
+    repo = _make_fake_repo(tmp_path)
+    cfg = _fake_vllm_config(str(repo))
+
+    seen_threads: list[threading.Thread] = []
+    orig_thread_init = threading.Thread.__init__
+
+    def tracking_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        orig_thread_init(self, *args, **kwargs)
+        seen_threads.append(self)
+
+    with mock.patch.object(threading.Thread, "__init__", tracking_init):
+        api_server._startup_prefetch_weights(cfg)
+        _drain_prefetch_thread()
+
+    prefetch_threads = [
+        t for t in seen_threads
+        if t.name in (
+            "vllm-parent-weight-prefetch",
+            "vllm-prefetch-reader",
+        )
+    ]
+    assert prefetch_threads, "expected prefetch to spawn at least one thread"
+    for t in prefetch_threads:
+        assert t.daemon is True, (
+            f"thread {t.name} was created non-daemon — would block exit"
+        )
+
+
+def test_prefetch_skips_when_disabled_via_env(tmp_path: Path) -> None:
+    repo = _make_fake_repo(tmp_path)
+    cfg = _fake_vllm_config(str(repo))
+
+    opens: list[str] = []
+    real_open = open
+
+    def tracking_open(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if isinstance(path, (str, os.PathLike)):
+            opens.append(os.fspath(path))
+        return real_open(path, *args, **kwargs)
+
+    with mock.patch.dict(os.environ, {"VLLM_DISABLE_STARTUP_PREFETCH": "1"}):
+        with mock.patch("builtins.open", side_effect=tracking_open):
+            api_server._startup_prefetch_weights(cfg)
+            # No thread should even be started when env disables.
+            time.sleep(0.1)
+
+    weight_opens = [p for p in opens if p.endswith(".safetensors")]
+    assert weight_opens == [], (
+        "VLLM_DISABLE_STARTUP_PREFETCH=1 should suppress all weight reads"
+    )
+
+
+def test_prefetch_skips_nfs_when_world_size_gt_1(tmp_path: Path) -> None:
+    repo = _make_fake_repo(tmp_path)
+    cfg = _fake_vllm_config(str(repo), tp=2, pp=1)
+
+    opens: list[str] = []
+    real_open = open
+
+    def tracking_open(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if isinstance(path, (str, os.PathLike)):
+            opens.append(os.fspath(path))
+        return real_open(path, *args, **kwargs)
+
+    # Force the NFS detector to claim NFS-backed.
+    with mock.patch.object(
+        api_server, "_prefetch_is_on_nfs", return_value=True
+    ):
+        with mock.patch("builtins.open", side_effect=tracking_open):
+            api_server._startup_prefetch_weights(cfg)
+            _drain_prefetch_thread()
+
+    weight_opens = [p for p in opens if p.endswith(".safetensors")]
+    assert weight_opens == [], (
+        "expected NFS + world_size>1 to skip parent-side prefetch"
+    )
+
+
+def test_prefetch_proceeds_on_nfs_when_world_size_eq_1(tmp_path: Path) -> None:
+    """NFS alone is not a reason to skip — only NFS + multi-rank."""
+    repo = _make_fake_repo(tmp_path)
+    cfg = _fake_vllm_config(str(repo), tp=1, pp=1)
+
+    opens: list[str] = []
+    real_open = open
+
+    def tracking_open(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if isinstance(path, (str, os.PathLike)):
+            opens.append(os.fspath(path))
+        return real_open(path, *args, **kwargs)
+
+    with mock.patch.object(
+        api_server, "_prefetch_is_on_nfs", return_value=True
+    ):
+        with mock.patch("builtins.open", side_effect=tracking_open):
+            api_server._startup_prefetch_weights(cfg)
+            _drain_prefetch_thread()
+
+    weight_opens = [p for p in opens if p.endswith(".safetensors")]
+    assert len(weight_opens) >= 2, (
+        "TP=PP=1 on NFS should still prefetch (no contention with self)"
+    )
+
+
+def test_prefetch_uses_hf_api_singleton_for_repo_id() -> None:
+    """When given a repo id (not a local path), prefetch must resolve via
+    the vLLM ``hf_api()`` singleton — not call ``huggingface_hub`` module-
+    level functions directly. Sharing the configured HfApi instance keeps
+    endpoint / token config consistent with the rest of the engine.
+    """
+    cfg = _fake_vllm_config("Qwen/Qwen3-4B-AWQ")
+
+    fake_api = mock.MagicMock()
+    fake_api.snapshot_download.return_value = ""
+
+    with mock.patch(
+        "vllm.transformers_utils.repo_utils.hf_api", return_value=fake_api
+    ):
+        with mock.patch("vllm.envs.VLLM_USE_MODELSCOPE", False, create=True):
+            api_server._startup_prefetch_weights(cfg)
+            _drain_prefetch_thread()
+
+    assert fake_api.snapshot_download.called, (
+        "expected hf_api().snapshot_download to be invoked for repo id"
+    )
+    call_kwargs = fake_api.snapshot_download.call_args.kwargs
+    assert call_kwargs.get("local_files_only") is True
+    assert call_kwargs.get("repo_id") == "Qwen/Qwen3-4B-AWQ"
+
+
+def test_prefetch_skipped_for_headless_api_workers() -> None:
+    """The build_async_engine_client_from_engine_args dispatch site only
+    calls _startup_prefetch_weights when ``client_config`` lacks
+    ``input_address`` — the marker that this process is a headless
+    API-only worker. Verify by inspecting the source of the function.
+    """
+    import inspect
+    src = inspect.getsource(
+        api_server.build_async_engine_client_from_engine_args
+    )
+    assert "_startup_prefetch_weights" in src, (
+        "dispatch site should still call the prefetch helper"
+    )
+    assert 'client_config.get("input_address")' in src, (
+        "dispatch site must guard on the input_address sentinel"
+    )

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -73,6 +73,244 @@ logger = init_logger("vllm.entrypoints.openai.api_server")
 _FALLBACK_SUPPORTED_TASKS: tuple[SupportedTask, ...] = ("generate",)
 
 
+# Sidecar tokenizer/config filenames that vLLM re-opens shortly after the
+# engine starts. Kept as a literal set (not glob output) so we de-duplicate
+# overlapping patterns like ``*tokenizer*`` + ``tokenizer.json``.
+_PREFETCH_SIDECAR_NAMES: frozenset[str] = frozenset({
+    "tokenizer.json",
+    "tokenizer.model",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "chat_template.json",
+    "chat_template.jinja",
+    "config.json",
+    "generation_config.json",
+    "preprocessor_config.json",
+    "processor_config.json",
+})
+
+_PREFETCH_WEIGHT_EXTS: tuple[str, ...] = (
+    ".safetensors",
+    ".bin",
+    ".gguf",
+    ".pt",
+)
+
+
+def _prefetch_is_on_nfs(path: str) -> bool:
+    """Best-effort NFS detection. Returns False on any exception."""
+    try:
+        import os
+        st = os.statvfs(path)
+        # NFS reports magic via /proc/mounts on Linux. Cheap fallback:
+        # check the device backing the path.
+        with open("/proc/mounts", "r", encoding="utf-8") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) < 3:
+                    continue
+                mount_point, fstype = parts[1], parts[2]
+                if path.startswith(mount_point) and fstype.startswith("nfs"):
+                    return True
+        # Suppress the unused statvfs result.
+        _ = st
+    except Exception:
+        pass
+    return False
+
+
+def _startup_prefetch_weights(vllm_config: "VllmConfig") -> None:
+    """Kick off reading model weight shards into the OS page cache from the
+    parent APIServer. EngineCore will read the same files a few seconds
+    later from the child; by then the kernel already has them ready.
+
+    All work (directory resolution, HF/ModelScope cache lookup, globbing,
+    and the reads themselves) runs inside the background thread so we do
+    not block the asyncio event loop. The thread is marked daemon so it
+    cannot keep the parent alive past shutdown, and its inner workers are
+    daemon threads too (so clean process exit is never blocked).
+
+    Best-effort: any failure (unknown model location, permission, NFS
+    contention, etc.) is swallowed — vLLM's existing in-child prefetch
+    then runs normally.
+
+    Skipped automatically when:
+      - VLLM_DISABLE_STARTUP_PREFETCH=1 (operator override)
+      - the resolved cache dir lives on NFS AND TP*PP > 1 (parent-side
+        reads contend with the engine's own readers and on lock-heavy
+        NFS exports they can hurt rather than help)
+    """
+    import os
+    import threading
+
+    if os.environ.get("VLLM_DISABLE_STARTUP_PREFETCH", "") not in ("", "0"):
+        return
+
+    # Capture only the small scalar fields the thread needs. Avoid holding
+    # a reference to vllm_config (which contains unpicklable objects) for
+    # longer than necessary.
+    model_ref = vllm_config.model_config.model
+    revision = vllm_config.model_config.revision
+    download_dir = vllm_config.load_config.download_dir
+    tp_size = getattr(vllm_config.parallel_config, "tensor_parallel_size", 1) or 1
+    pp_size = getattr(vllm_config.parallel_config, "pipeline_parallel_size", 1) or 1
+    world_size = tp_size * pp_size
+
+    def _resolve_cache_dir() -> "str | None":
+        """Resolve a HF/ModelScope repo id to its on-disk snapshot dir.
+
+        Acquires the HF cache filelock in the *caller's thread* (the
+        background prefetch worker) — we deliberately do NOT use any
+        forked child here. Resolution is read-only (``local_files_only``
+        snapshot lookup), so file-lock contention is bounded by the few
+        ms it takes to walk the snapshot symlink tree.
+        """
+        if os.path.isdir(model_ref):
+            return model_ref
+
+        try:
+            from vllm import envs
+
+            if envs.VLLM_USE_MODELSCOPE:
+                from modelscope.hub.snapshot_download import (
+                    snapshot_download as ms_snapshot_download,
+                )
+
+                return ms_snapshot_download(
+                    model_id=model_ref,
+                    revision=revision,
+                    cache_dir=download_dir,
+                    local_files_only=True,
+                )
+
+            # Use vLLM's shared HfApi singleton so we share connection
+            # pools / configured endpoint with the rest of the engine.
+            from vllm.transformers_utils.repo_utils import hf_api
+
+            return hf_api().snapshot_download(
+                repo_id=model_ref,
+                revision=revision,
+                cache_dir=download_dir,
+                allow_patterns=[
+                    "*.safetensors",
+                    "*.bin",
+                    "*.gguf",
+                    "*.json",
+                    "*.jinja",
+                    "tokenizer.model",
+                ],
+                local_files_only=True,
+            )
+        except Exception:
+            return None
+
+    def _prefetch_worker() -> None:
+        candidate_dir = _resolve_cache_dir()
+        if not candidate_dir or not os.path.isdir(candidate_dir):
+            return
+
+        # NFS + multi-rank: bail. Parent-side reads contend with engine
+        # readers on lock-heavy exports, often making cold-loads slower.
+        if world_size > 1 and _prefetch_is_on_nfs(candidate_dir):
+            logger.debug(
+                "Parent-side prefetch skipped: NFS-backed cache + "
+                "world_size=%d (TP=%d * PP=%d)",
+                world_size, tp_size, pp_size,
+            )
+            return
+
+        # Walk the snapshot tree (HF/ModelScope use symlink farms; GGUF
+        # repos place shards in subdirs). os.walk follows symlinks by
+        # default which is what we want for HF cache layouts.
+        weight_paths: list[str] = []
+        sidecar_paths: list[str] = []
+        seen: set[str] = set()
+        try:
+            for root, _dirs, files in os.walk(
+                candidate_dir, followlinks=True
+            ):
+                for fname in files:
+                    full = os.path.join(root, fname)
+                    real = os.path.realpath(full)
+                    if real in seen:
+                        continue
+                    seen.add(real)
+                    lower = fname.lower()
+                    if any(lower.endswith(e) for e in _PREFETCH_WEIGHT_EXTS):
+                        weight_paths.append(real)
+                    elif lower in _PREFETCH_SIDECAR_NAMES:
+                        sidecar_paths.append(real)
+        except Exception:
+            return
+
+        # Sidecars first (small, completing them frees the kernel to
+        # focus on the large shards). De-dup is via the `seen` set above.
+        all_paths = sorted(sidecar_paths) + sorted(weight_paths)
+        if not all_paths:
+            return
+
+        logger.debug(
+            "Parent-side weight prefetch starting for %d files in %s "
+            "(%d weight shards, %d sidecars)",
+            len(all_paths), candidate_dir,
+            len(weight_paths), len(sidecar_paths),
+        )
+
+        block_size = 16 * 1024 * 1024  # 16 MB
+
+        def read_one(p: str) -> None:
+            try:
+                with open(p, "rb") as f:
+                    while f.read(block_size):
+                        pass
+            except Exception:
+                pass
+
+        # Use raw daemon threads (NOT ThreadPoolExecutor) for the inner
+        # workers so process exit is never blocked. ThreadPoolExecutor's
+        # workers are non-daemon by default and its atexit hook will
+        # join() them — combined with us already running on a daemon
+        # outer thread, that turns SIGTERM during prefetch into a hang.
+        max_workers = 8
+        sem = threading.BoundedSemaphore(max_workers)
+        worker_threads: list[threading.Thread] = []
+
+        def _bounded_read(p: str) -> None:
+            try:
+                read_one(p)
+            finally:
+                sem.release()
+
+        for p in all_paths:
+            sem.acquire()
+            t = threading.Thread(
+                target=_bounded_read,
+                args=(p,),
+                daemon=True,
+                name="vllm-prefetch-reader",
+            )
+            t.start()
+            worker_threads.append(t)
+
+        # Best-effort join with a wall-clock cap so a hung NFS read
+        # cannot keep the outer daemon thread alive forever. The cap is
+        # generous because real cold-load reads on slow disks can take
+        # 60+ s for big shards.
+        deadline_s = 600.0
+        for t in worker_threads:
+            remaining = max(0.0, deadline_s)
+            t.join(timeout=remaining)
+
+    threading.Thread(
+        target=_prefetch_worker,
+        daemon=True,
+        name="vllm-parent-weight-prefetch",
+    ).start()
+
+
+
+
 @asynccontextmanager
 async def build_async_engine_client(
     args: Namespace,
@@ -121,6 +359,21 @@ async def build_async_engine_client_from_engine_args(
 
     # Create the EngineConfig (determines if we can use V1).
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
+
+    # [startup] Start prefetching model weight shards into the OS page
+    # cache in a daemon thread from the PARENT APIServer process.
+    # EngineCore will page-fault on these same files ~10-15 s later
+    # (after fork + CUDA init + distributed init + model init). For
+    # large-weight cases (tens of GB) this parent-side head start
+    # meaningfully shrinks the prefetch+load phase that the engine's
+    # in-child prefetch otherwise barely overlaps.
+    #
+    # Skip in API-only workers that connect to an already-running
+    # EngineCore (multi-API-server / disaggregated setups): those
+    # processes never load weights, and prefetching from all of them
+    # would contend with the engine's own read.
+    if not (client_config and client_config.get("input_address")):
+        _startup_prefetch_weights(vllm_config)
 
     from vllm.v1.engine.async_llm import AsyncLLM
 


### PR DESCRIPTION
## Summary

Re-introduces only the **file-prefetch** components from #40331 that were reverted in #40438. The reverted PR's chained `import transformers` + `import torch` BG threads caused a partially-initialized-module race (test_truncation.py / pooling truncation tests). This PR carries forward only the components with **zero shared-Python-state surface**.

## What's included

- BG-thread prefetch of weight shards (`*.safetensors`, `*.bin`) into the OS page cache from the parent APIServer process.
- BG-thread prefetch of tokenizer / config sidecar files (`*.json`, `tokenizer.*`).
- All work — directory resolution, HF / ModelScope cache lookup (via `snapshot_download(local_files_only=True)`), globbing, and the reads themselves — runs inside the BG thread so the asyncio event loop is never blocked.
- Skipped on headless API workers (caller checks `client_config.get("input_address")`).
- All failures silently swallowed; in-child prefetch then runs normally.

This is the squashed cherry-pick of `d96d0a349` from #40331, unchanged in behavior. Original authorship credited to @simon-mo via `Co-authored-by:` trailer.

## What's deliberately omitted (vs. #40331)

| Component in #40331 | Status here | Why |
|---|---|---|
| BG-thread `import torch` | **Omitted** | Same race class as transformers — see below |
| BG-thread `import transformers` | **Omitted** | Caused the #40438 revert (partially-initialized-module race) |
| Pre-spawn multiprocessing forkserver | **Omitted** | Touches `set_start_method` shared state + module-level forkserver state — non-trivial race-surface analysis required; deferred |
| BG-thread file prefetch | **INCLUDED** | Pure I/O; no shared Python state |

### Why `import torch` BG-preload is unsafe (same root cause as #40438)

Python's per-module import lock prevents *concurrent* execution of a module's `__init__`, but does NOT make `__init__` atomic with respect to readers. If thread B does `from torch import X` while thread A is mid-execution of `torch/__init__.py`, thread B sees a partially-initialized `torch` module (some submodules / attributes exist, others don't yet). Concretely: `torch.compiler` / `torch.distributed` submodules attach to `sys.modules['torch']` *during* torch's init, so a `from torch.compiler import ...` racing torch's own init can either succeed, raise `AttributeError`, or import a stub.

The transformers case in #40438 was the same shape: BG `import transformers` was running through `transformers/__init__.py` (which imports torch internally and attaches lazy modules); main thread hit `from transformers import GenerationConfig` while that init was mid-flight; `GenerationConfig` wasn't yet attached → `ImportError`. CPython's import lock didn't help because the lock allows a *different* thread to read `sys.modules['transformers']` while the holder is still inside `__init__`.

This PR keeps BG-thread work strictly to file I/O ops on disjoint files — no shared Python state mutation, no race surface.

## Performance

Estimated savings: 5-10s on cold disk for 7B+ models (matches #40331's measured 28-30s → 18-20s prefetch+load phase at 32B). Benign on warm cache (re-reading already-cached pages is a no-op kernel-side).

## Test plan

- [ ] CI: `tests/entrypoints/pooling/basic/test_truncation.py` (the canary that broke #40331) passes.
- [ ] CI: full `tests/entrypoints/openai/` suite passes.
- [ ] Manual: cold-disk 7B+ model serve verifies non-zero prefetch effect (parent process opens `*.safetensors` files before child engine starts loading).
- [ ] Manual: `--headless` / API-worker invocations skip the prefetch (no double-read against the real engine).

## Refs

- Reverted PR: #40331 (Simon Mo, merged 2026-04-20)
- Revert: #40438 (daocloud, 2026-04-21)
