### PR TITLE
[Benchmark] Add --strict-request-rate flag to serve benchmark

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -790,7 +790,7 @@ async def benchmark(
     ready_check_timeout_sec: int = 600,
     ssl_context: ssl.SSLContext | bool | None = None,
     self_timed: bool = False,
-    rate_gate_sends: bool = False,
+    strict_request_rate: bool = False,
 ):
     try:
         request_func = ASYNC_REQUEST_FUNCS[endpoint_type]
@@ -961,14 +961,14 @@ async def benchmark(
     )
 
     # Optionally space the actual sends after the concurrency semaphore so
-    # batched slot releases don't burst above request_rate (see --rate-gate-sends).
+    # batched slot releases don't burst above request_rate (see --strict-request-rate).
     # send_next_ts holds the next allowed send time, advanced per reserved slot.
     send_next_ts = 0.0
 
     async def limited_request_func(request_func_input, session, pbar, send_rate):
         nonlocal send_next_ts
         async with semaphore:
-            if rate_gate_sends and 0.0 < send_rate < float("inf"):
+            if strict_request_rate and 0.0 < send_rate < float("inf"):
                 now = time.perf_counter()
                 # No await between reading and writing send_next_ts.
                 slot = max(send_next_ts, now)
@@ -1610,14 +1610,15 @@ def add_cli_args(parser: argparse.ArgumentParser):
         "results in a more uniform arrival of requests.",
     )
     parser.add_argument(
-        "--rate-gate-sends",
+        "--strict-request-rate",
         action="store_true",
-        help="Space the actual request sends to at most --request-rate, applied "
-        "after the --max-concurrency semaphore is acquired. Without this, requests "
-        "pace into the semaphore wait but exit it in lumps (synchronized "
-        "completions free many slots at once), bursting the engine above the "
-        "target rate. Off by default; only takes effect when request_rate is "
-        "finite. Note: it evens out arrivals and so overrides --burstiness.",
+        help="Enforce --request-rate on the actual sends, not just on task "
+        "creation. After the --max-concurrency semaphore is acquired, space each "
+        "send so the engine arrival rate stays at --request-rate. Without this, "
+        "requests that queued on the semaphore exit in lumps when a batch of "
+        "completions frees many slots at once, bursting the engine above the "
+        "target rate. Off by default. Only takes effect when --request-rate is "
+        "finite, and it evens out arrivals so it overrides --burstiness.",
     )
     parser.add_argument(
         "--disable-tqdm",
@@ -2135,7 +2136,7 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         ready_check_timeout_sec=args.ready_check_timeout_sec,
         ssl_context=ssl_context,
         self_timed=args.self_timed,
-        rate_gate_sends=args.rate_gate_sends,
+        strict_request_rate=args.strict_request_rate,
     )
 
     # Save config and results to json

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -790,6 +790,7 @@ async def benchmark(
     ready_check_timeout_sec: int = 600,
     ssl_context: ssl.SSLContext | bool | None = None,
     self_timed: bool = False,
+    rate_gate_sends: bool = False,
 ):
     try:
         request_func = ASYNC_REQUEST_FUNCS[endpoint_type]
@@ -959,8 +960,26 @@ async def benchmark(
         else contextlib.nullcontext()
     )
 
-    async def limited_request_func(request_func_input, session, pbar):
+    # Optional rate-gating of the actual sends, applied AFTER the concurrency
+    # semaphore is acquired. Pacing only task creation (get_request) is not enough
+    # when max_concurrency is set: requests queue on the semaphore and exit it in
+    # lumps, since a batch of synchronized completions frees many slots at once,
+    # so the freed sends all fire together and burst the engine above the target
+    # rate. Reserving an evenly spaced slot per send caps instantaneous arrivals
+    # at the target rate. Off by default so it does not alter arrival patterns
+    # (or override burstiness) unless explicitly requested; a send_rate of 0
+    # (self-timed traces) or inf is never gated.
+    send_next_ts = [0.0]  # next allowed send time (perf_counter); mutable cell
+
+    async def limited_request_func(request_func_input, session, pbar, send_rate):
         async with semaphore:
+            if rate_gate_sends and 0.0 < send_rate < float("inf"):
+                now = time.perf_counter()
+                # Reserve this slot atomically: no await between read and write.
+                slot = max(send_next_ts[0], now)
+                send_next_ts[0] = slot + 1.0 / send_rate
+                if slot > now:
+                    await asyncio.sleep(slot - now)
             return await request_func(
                 request_func_input=request_func_input, session=session, pbar=pbar
             )
@@ -1026,7 +1045,10 @@ async def benchmark(
         tasks.append(
             asyncio.create_task(
                 limited_request_func(
-                    request_func_input=request_func_input, session=session, pbar=pbar
+                    request_func_input=request_func_input,
+                    session=session,
+                    pbar=pbar,
+                    send_rate=current_request_rate,
                 )
             )
         )
@@ -1593,6 +1615,16 @@ def add_cli_args(parser: argparse.ArgumentParser):
         "results in a more uniform arrival of requests.",
     )
     parser.add_argument(
+        "--rate-gate-sends",
+        action="store_true",
+        help="Space the actual request sends to at most --request-rate, applied "
+        "after the --max-concurrency semaphore is acquired. Without this, requests "
+        "pace into the semaphore wait but exit it in lumps (synchronized "
+        "completions free many slots at once), bursting the engine above the "
+        "target rate. Off by default; only takes effect when request_rate is "
+        "finite. Note: it evens out arrivals and so overrides --burstiness.",
+    )
+    parser.add_argument(
         "--disable-tqdm",
         action="store_true",
         help="Specify to disable tqdm progress bar.",
@@ -2108,6 +2140,7 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         ready_check_timeout_sec=args.ready_check_timeout_sec,
         ssl_context=ssl_context,
         self_timed=args.self_timed,
+        rate_gate_sends=args.rate_gate_sends,
     )
 
     # Save config and results to json

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -960,24 +960,19 @@ async def benchmark(
         else contextlib.nullcontext()
     )
 
-    # Optional rate-gating of the actual sends, applied AFTER the concurrency
-    # semaphore is acquired. Pacing only task creation (get_request) is not enough
-    # when max_concurrency is set: requests queue on the semaphore and exit it in
-    # lumps, since a batch of synchronized completions frees many slots at once,
-    # so the freed sends all fire together and burst the engine above the target
-    # rate. Reserving an evenly spaced slot per send caps instantaneous arrivals
-    # at the target rate. Off by default so it does not alter arrival patterns
-    # (or override burstiness) unless explicitly requested; a send_rate of 0
-    # (self-timed traces) or inf is never gated.
-    send_next_ts = [0.0]  # next allowed send time (perf_counter); mutable cell
+    # Optionally space the actual sends after the concurrency semaphore so
+    # batched slot releases don't burst above request_rate (see --rate-gate-sends).
+    # send_next_ts holds the next allowed send time, advanced per reserved slot.
+    send_next_ts = 0.0
 
     async def limited_request_func(request_func_input, session, pbar, send_rate):
+        nonlocal send_next_ts
         async with semaphore:
             if rate_gate_sends and 0.0 < send_rate < float("inf"):
                 now = time.perf_counter()
-                # Reserve this slot atomically: no await between read and write.
-                slot = max(send_next_ts[0], now)
-                send_next_ts[0] = slot + 1.0 / send_rate
+                # No await between reading and writing send_next_ts.
+                slot = max(send_next_ts, now)
+                send_next_ts = slot + 1.0 / send_rate
                 if slot > now:
                     await asyncio.sleep(slot - now)
             return await request_func(


### PR DESCRIPTION
## Purpose

The serve benchmark paces task creation but not the actual send. `get_request` schedules when each request is created, then the request blocks on the `--max-concurrency` semaphore before it is sent. When the engine is saturated the semaphore stays full, and a batch of synchronized completions releases many slots at once. All the waiting requests then send together, so the engine sees a burst well above `--request-rate` even though task creation was paced correctly.

This adds an opt-in `--strict-request-rate` flag that enforces `--request-rate` on the sends themselves. After the semaphore is acquired, each send reserves the next evenly spaced slot, so engine arrivals stay at the target rate even when slots free in lumps.

The flag is off by default, so existing runs are unchanged. It only takes effect for a finite `--request-rate`, leaving `inf` (max-throughput) and self-timed trace runs ungated. It keys off the per-request rate, so it composes with `--ramp-up-*`. Because it spaces arrivals evenly it overrides `--burstiness` when enabled, as noted in the flag help.

## Test Plan

Run the serve benchmark against a saturated server with and without the flag, and compare the instantaneous engine-side arrival rate:

```
# baseline, bursts above target
vllm bench serve --request-rate 500 --max-concurrency 256 ...          # ISL approx 8k, OSL 50, 8 engines
# with the flag, capped at target
vllm bench serve --request-rate 500 --max-concurrency 256 --strict-request-rate ...
```

Lint and compile:

```
python -m py_compile vllm/benchmarks/serve.py
ruff check vllm/benchmarks/serve.py
ruff format --check vllm/benchmarks/serve.py
```

## Test Result

8-engine OpenAI-compatible server, ISL approx 8k / OSL 50, `request_rate=500`, `max_concurrency=256`. Instantaneous arrival rate measured from per-step engine logs in 100 ms bins.

| metric | without flag | with `--strict-request-rate` |
|---|---|---|
| peak instantaneous arrival rate | ~1200 req/s (~2.4x target) | ~640 req/s |
| p95 instantaneous arrival rate | ~620 req/s | ~550 req/s (~target) |
| TTFT p99 | 706 ms | 606 ms |
| TTFT mean | 359 ms | 335 ms |
| throughput / TPOT | baseline | unchanged |

Without the flag, offered load spikes to about 2.4x the requested rate whenever a batch of completions frees slots. With it, instantaneous arrivals hold at the target. Smoothing the offered load also trims the TTFT tail, p99 from 706 ms to 606 ms, with no change to throughput or per-token latency, as expected for a change that shapes arrivals rather than engine scheduling. The residual peak above 500 with the flag on is per-step engine-log bucketing. The client sends are spaced at exactly 1/request_rate.

Per-100 ms arrival rate at the engine, without (left) vs with (right) the flag. The dashed line is the 500 req/s target.

<img width="2240" height="864" alt="sendpacer-arrivals-before-after" src="https://github.com/user-attachments/assets/bb6d5e2f-299e-4c27-871c-d1738f39f6a9" />

## Why this isn't a duplicate

Searched open PRs and issues for `benchmark request rate semaphore`, `serve benchmark send rate`, and `benchmark request rate burst semaphore`. None address post-semaphore send bursting in the serve benchmark.

## AI assistance

The submitter wrote the original approach, reviewed every changed line, ran the benchmark above, and is accountable for the change end-to-end. AI (Claude) helped adapt the patch to the current `get_request` API, add the opt-in flag, and draft this description.
