### PR TITLE
[Bugfix][KVConnector][Mooncake] Wire LookupKeyServer/Client close into store teardown

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -659,7 +659,7 @@ def test_del_invokes_shutdown_and_closes_store():
     worker.close.assert_called_once_with()
 
 
-def test_shutdown_scheduler_role_is_noop():
+def test_shutdown_scheduler_role_closes_lookup_client():
     vllm_config = _make_vllm_config()
     kv_cache_config = _make_kv_cache_config()
 
@@ -668,12 +668,41 @@ def test_shutdown_scheduler_role_is_noop():
         patch(
             "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
             "connector.MooncakeStoreScheduler"
-        ),
+        ) as mock_scheduler_cls,
     ):
         connector = mooncake_store_connector.MooncakeStoreConnector(
             vllm_config, KVConnectorRole.SCHEDULER, kv_cache_config
         )
 
-    # Scheduler role holds no store handle, so shutdown must be a safe no-op.
     assert connector.connector_worker is None
+    scheduler = mock_scheduler_cls.return_value
+    mock_client = MagicMock()
+    scheduler.client = mock_client
+
+    connector.shutdown()
+
+    mock_client.close.assert_called_once_with()
+
+
+def test_shutdown_scheduler_role_swallows_client_errors():
+    vllm_config = _make_vllm_config()
+    kv_cache_config = _make_kv_cache_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+            "connector.MooncakeStoreScheduler"
+        ) as mock_scheduler_cls,
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER, kv_cache_config
+        )
+
+    scheduler = mock_scheduler_cls.return_value
+    mock_client = MagicMock()
+    mock_client.close.side_effect = RuntimeError("boom")
+    scheduler.client = mock_client
+
+    # Must not propagate.
     connector.shutdown()

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -1570,14 +1570,26 @@ def test_store_worker_close_releases_store():
     assert worker.store is None
 
 
+def test_store_worker_close_releases_lookup_server():
+    worker = _make_bare_worker()
+    mock_server = MagicMock()
+    worker.lookup_server = mock_server
+
+    worker.close()
+
+    assert worker.lookup_server is None
+    mock_server.close.assert_called_once_with()
+
+
 def test_store_worker_close_is_idempotent():
     worker = _make_bare_worker()
     store = worker.store
+    worker.lookup_server = MagicMock()
 
     worker.close()
     worker.close()
 
-    # Second call short-circuits because store was already released.
+    # Second call short-circuits because both resources were already released.
     store.close.assert_called_once_with()
 
 
@@ -1589,3 +1601,14 @@ def test_store_worker_close_swallows_store_errors():
     worker.close()
 
     assert worker.store is None
+
+
+def test_store_worker_close_swallows_lookup_server_errors():
+    worker = _make_bare_worker()
+    mock_server = MagicMock()
+    mock_server.close.side_effect = RuntimeError("boom")
+    worker.lookup_server = mock_server
+
+    worker.close()
+
+    assert worker.lookup_server is None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -156,14 +156,26 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
     def shutdown(self):
         """Release connector resources on teardown.
 
-        Closes the worker's MooncakeDistributedStore handle so its
-        TransferEngine and RDMA registrations are released. Invoked from the
-        engine's explicit shutdown path and as a backstop from ``__del__``;
-        a no-op on the scheduler role, which holds no store handle.
+        Worker role: closes the MooncakeDistributedStore (TransferEngine,
+        RDMA buffers, master-server connection) and the LookupKeyServer
+        (ZMQ socket, IPC file).
+        Scheduler role: closes the LookupKeyClient (ZMQ socket).
+
+        Invoked from the engine's explicit shutdown path and as a backstop
+        from ``__del__``.
         """
         worker = getattr(self, "connector_worker", None)
         if worker is not None:
             worker.close()
+
+        scheduler = getattr(self, "connector_scheduler", None)
+        if scheduler is not None:
+            client = getattr(scheduler, "client", None)
+            if client is not None:
+                try:
+                    client.close()
+                except Exception as e:
+                    logger.warning("Error closing LookupKeyClient: %s", e)
 
     def __del__(self):
         self.shutdown()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -1427,20 +1427,28 @@ class MooncakeStoreWorker:
         return []
 
     def close(self) -> None:
-        """Release the MooncakeDistributedStore handle on teardown.
+        """Release worker resources on teardown.
 
-        Closing the store frees its TransferEngine, the registered RDMA
-        buffers, and the connection to the master server. Idempotent so it is
-        safe to call from both the explicit shutdown path and ``__del__``.
+        Closes the MooncakeDistributedStore (TransferEngine, RDMA buffers,
+        master-server connection) and the LookupKeyServer (ZMQ socket, IPC
+        file). Idempotent so it is safe to call from both the explicit
+        shutdown path and ``__del__``.
         """
         store = getattr(self, "store", None)
-        if store is None:
-            return
-        self.store = None
-        try:
-            store.close()
-        except Exception as e:
-            logger.warning("Error closing MooncakeDistributedStore: %s", e)
+        if store is not None:
+            self.store = None
+            try:
+                store.close()
+            except Exception as e:
+                logger.warning("Error closing MooncakeDistributedStore: %s", e)
+
+        lookup_server = getattr(self, "lookup_server", None)
+        if lookup_server is not None:
+            self.lookup_server = None
+            try:
+                lookup_server.close()
+            except Exception as e:
+                logger.warning("Error closing LookupKeyServer: %s", e)
 
 
 # ============================================================
@@ -1518,6 +1526,7 @@ class LookupKeyServer:
         self.thread.start()
 
     def close(self):
+        self.running = False
         self.socket.close(linger=0)
         if os.path.exists(self._ipc_path):
             os.unlink(self._ipc_path)


### PR DESCRIPTION
## Purpose

Follow-up to #45206: the worker's `LookupKeyServer` and the scheduler's `LookupKeyClient` hold ZMQ sockets and an IPC file that were never closed on connector shutdown. This wires their `close()` methods into the existing teardown path.

From PR #45206's scope note:
> "the worker's `LookupKeyServer` and the scheduler's `LookupKeyClient` also expose `close()` methods that hold ZMQ sockets / an IPC file. I kept this PR focused on the store handle (the heavyweight leak); wiring those into the same path is a reasonable follow-up."

### Changes

**Worker side** (`MooncakeStoreWorker.close()`):
- Now also closes `self.lookup_server` (ZMQ REP socket + IPC file unlink)
- Restructured to close both resources independently (store can be None but lookup_server may still need cleanup, and vice versa)

**Connector side** (`MooncakeStoreConnector.shutdown()`):
- Now also closes the scheduler's `LookupKeyClient` (ZMQ REQ socket)
- Previously was "a no-op on the scheduler role" — now properly releases the client socket

**LookupKeyServer.close()**:
- Sets `self.running = False` before closing the socket so the daemon thread's `while self.running` loop exits cleanly when `recv_multipart` raises on socket closure

All teardown paths are idempotent and swallow exceptions, matching the pattern established by #45206.

## Not a duplicate

```
gh pr list --repo vllm-project/vllm --state open --search "LookupKeyServer close"
gh pr list --repo vllm-project/vllm --state open --search "mooncake teardown"
gh pr list --repo vllm-project/vllm --state open --search "mooncake ZMQ close"
```

No matching open PRs.

## Test Plan

- [x] `pre-commit run --files ...` — all hooks pass (ruff check, ruff format, typos, mypy-3.10, SPDX headers)
- [x] Added unit tests mirroring the pattern from #45206:
  - `test_store_worker_close_releases_lookup_server` — verifies close is called and handle nulled
  - `test_store_worker_close_is_idempotent` — updated to include lookup_server
  - `test_store_worker_close_swallows_lookup_server_errors` — exception doesn't propagate
  - `test_shutdown_scheduler_role_closes_lookup_client` — verifies client.close() called
  - `test_shutdown_scheduler_role_swallows_client_errors` — exception doesn't propagate

I do **not** have a multi-node Mooncake cluster (RDMA + master server) available locally, so the end-to-end store lifecycle was not exercised on hardware; that verification is left to CI.

## Test Result

```
pre-commit run --files <all changed files>
ruff check........Passed
ruff format.......Passed
typos.............Passed
mypy-3.10.........Passed
SPDX headers......Passed
```

---

> **Disclosure:** AI assistance (Claude) was used for drafting this change. I reviewed every changed line, traced the teardown path through the codebase, and verified correctness against the existing shutdown lifecycle. This is not duplicating an existing PR — it implements the explicit follow-up scoped out in #45206.


Made with [Cursor](https://cursor.com)