### PR TITLE
Preserve tensor dtypes when loading quantized tensorizer models

### DIFF
--- a/tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py
+++ b/tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py
@@ -20,6 +20,7 @@ from vllm.engine.arg_utils import EngineArgs
 from vllm.model_executor.model_loader.tensorizer import (
     TensorizerConfig,
     TensorSerializer,
+    _get_deserialization_kwargs,
     is_vllm_tensorized,
     open_stream,
     tensorize_vllm_model,
@@ -103,6 +104,28 @@ def write_keyfile(keyfile_path: str):
     pathlib.Path(keyfile_path).parent.mkdir(parents=True, exist_ok=True)
     with open(keyfile_path, "wb") as f:
         f.write(encryption_params.key)
+
+
+def test_deserialization_kwargs_include_dtype_for_unquantized_model():
+    config = TensorizerConfig(tensorizer_uri="vllm")
+    config.dtype = torch.float16
+    config.hf_config = type("HFConfig", (), {"quantization_config": None})()
+
+    kwargs = _get_deserialization_kwargs(config, config._construct_tensorizer_args())
+
+    assert kwargs["dtype"] is torch.float16
+
+
+def test_deserialization_kwargs_preserve_dtype_for_quantized_model():
+    config = TensorizerConfig(tensorizer_uri="vllm")
+    config.dtype = torch.float16
+    config.hf_config = type(
+        "HFConfig", (), {"quantization_config": {"quant_method": "awq"}}
+    )()
+
+    kwargs = _get_deserialization_kwargs(config, config._construct_tensorizer_args())
+
+    assert "dtype" not in kwargs
 
 
 @pytest.mark.skipif(not is_curl_installed(), reason="cURL is not installed")

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -541,15 +541,17 @@ def deserialize_tensorizer_model(
     start = time.perf_counter()
     device_index = torch.accelerator.current_device_index()
     device_type = current_platform.device_type
+    deserialization_kwargs = _get_deserialization_kwargs(
+        tensorizer_config, tensorizer_args
+    )
     with (
         open_stream(
             tensorizer_config.tensorizer_uri, mode="rb", **tensorizer_args.stream_kwargs
         ) as stream,
         TensorDeserializer(
             stream,
-            dtype=tensorizer_config.dtype,
             device=f"{device_type}:{device_index}",
-            **tensorizer_args.deserialization_kwargs,
+            **deserialization_kwargs,
         ) as deserializer,
     ):
         deserializer.load_into_module(model)
@@ -569,6 +571,27 @@ def deserialize_tensorizer_model(
     _check_tensors_on_meta_device(model)
     _resize_lora_embeddings(model)
     del model.vllm_tensorized_marker
+
+
+def _should_preserve_serialized_tensor_dtypes(
+    tensorizer_config: TensorizerConfig,
+) -> bool:
+    hf_config = tensorizer_config.hf_config
+    if hf_config is None:
+        return False
+    return getattr(hf_config, "quantization_config", None) is not None
+
+
+def _get_deserialization_kwargs(
+    tensorizer_config: TensorizerConfig,
+    tensorizer_args: "TensorizerArgs",
+) -> dict[str, Any]:
+    deserialization_kwargs = tensorizer_args.deserialization_kwargs.copy()
+    # Quantized checkpoints can contain non-floating tensors, such as packed
+    # int32 weights, that must keep their serialized dtype.
+    if not _should_preserve_serialized_tensor_dtypes(tensorizer_config):
+        deserialization_kwargs["dtype"] = tensorizer_config.dtype
+    return deserialization_kwargs
 
 
 def tensorizer_weights_iterator(


### PR DESCRIPTION
## Summary
- Preserve serialized tensor dtypes when deserializing vLLM tensorized quantized checkpoints.
- Keep the existing dtype override for non-quantized tensorized models.
- Add unit coverage for TensorDeserializer kwargs with and without quantization config.

## Motivation
Tensorizer deserialization currently passes `dtype=tensorizer_config.dtype` for vLLM-tensorized models. This is unsafe for quantized checkpoints because they can contain non-floating tensors. For example, AWQ stores packed `qweight` and `qzeros` tensors as int32, while `scales` remains floating point.

With a tensorized Qwen3-32B-AWQ checkpoint loaded using `--load-format tensorizer --quantization awq`, the model failed during warmup because AWQ packed tensors were deserialized as fp16:

```text
RuntimeError: mutable_data_ptr<int>, /opt/venv/lib/python3.12/site-packages/torch/include/torch/csrc/stable/tensor_inl.h:69, expected scalar type Int but found Half
  File "vllm/model_executor/layers/quantization/awq.py", line 280, in apply
    out = ops.awq_dequantize(qweight, scales, qzeros, 0, 0, 0)
```

Removing the dtype override for quantized tensorizer loads allowed the same tensorized AWQ checkpoint to start successfully, because tensorizer preserved the serialized int32 packed weights.

## Duplicate-work check
I searched open PRs and issues for:
- `tensorizer quantization dtype`
- `AWQ tensorizer`
- `tensorizer dtype`
- `awq_dequantize tensorizer`
- `expected scalar type Int but found Half`
- `TensorDeserializer dtype`

No existing open PR or issue appeared to address preserving serialized tensor dtypes for quantized tensorizer models.

## Tests
- Not run locally: this machine does not have a GPU or the vLLM test environment needed for tensorizer model-loading tests.

## AI assistance
AI assistance was used to help investigate the failure and draft this change.