### PR TITLE
[AMD][CI] Fix Language Models Test (Extended Generation) failures

### DIFF
--- a/tests/models/language/generation/test_common.py
+++ b/tests/models/language/generation/test_common.py
@@ -130,8 +130,11 @@ def test_models(
         monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
         if model == "TitanML/tiny-mixtral":
             # Untrained model: near-uniform logits make argmax sensitive to
-            # AITER's bfloat16 rounding error in plain rms_norm.
+            # AITER's bfloat16 rounding error. Route the plain rms_norm and the
+            # fused MoE (whose near-uniform router logits flip expert selection
+            # under ~1 ULP drift) through the native kernels for this model.
             monkeypatch.setenv("VLLM_ROCM_USE_AITER_RMSNORM", "0")
+            monkeypatch.setenv("VLLM_ROCM_USE_AITER_MOE", "0")
     elif use_rocm_aiter and model not in AITER_MODEL_LIST:
         # Skip model that are not using AITER tests.
         # When more AITER kernels are added, this list will not be

--- a/tests/models/language/generation/test_common.py
+++ b/tests/models/language/generation/test_common.py
@@ -133,6 +133,7 @@ def test_models(
             # AITER's bfloat16 rounding error. Route the plain rms_norm and the
             # fused MoE (whose near-uniform router logits flip expert selection
             # under ~1 ULP drift) through the native kernels for this model.
+            # See ROCm/aiter#3806 for the tracking issue and minimal repro.
             monkeypatch.setenv("VLLM_ROCM_USE_AITER_RMSNORM", "0")
             monkeypatch.setenv("VLLM_ROCM_USE_AITER_MOE", "0")
     elif use_rocm_aiter and model not in AITER_MODEL_LIST:


### PR DESCRIPTION
## Purpose

Two unrelated failures in
tests/models/language/generation/test_common.py::test_models:

- openbmb/MiniCPM4.1-8B: its remote modeling_minicpm.py imports `is_torch_fx_available` from `transformers.utils.import_utils`, which was removed in Transformers v5, so the HF reference run fails to load with an ImportError. Cap the HF run at transformers 4.57 via max_transformers_version so the comparison is skipped on v5 (vLLM's native impl is unaffected).

- TitanML/tiny-mixtral (AITER): the untrained MoE has near-uniform router logits, so the AITER fused-MoE bf16 rounding flips expert selection and the final token diverges from HF even with AITER rms_norm already disabled. Also route the fused MoE through the native kernel for this model.

## Test Plan
Run failed tests

## Test Result
=========================== short test summary info ============================
PASSED tests/models/language/generation/test_common.py::test_models[True-True-5-32-TitanML/tiny-mixtral]
PASSED tests/models/language/generation/test_common.py::test_models[True-False-5-32-TitanML/tiny-mixtral]
PASSED tests/models/language/generation/test_common.py::test_models[False-True-5-32-TitanML/tiny-mixtral]
PASSED tests/models/language/generation/test_common.py::test_models[False-False-5-32-TitanML/tiny-mixtral]
SKIPPED [4] tests/models/registry.py:173: `transformers==5.11.0` installed, but `transformers<=4.57` is required to run this model. Reason(hf): Remote modeling_minicpm.py imports `is_torch_fx_available` from `transformers.utils.import_utils`, which was removed in Transformers v5.
===== 4 passed, 4 skipped, 72 deselected, 46 warnings in 197.56s (0:03:17) =====
EXIT=0

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

