### PR TITLE
(security) Enforce allowed_tools at execution time for Responses API

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -524,6 +524,196 @@ class TestExtractAllowedToolsFromMcpRequests:
         }
 
 
+class TestAllowedSubtoolsEnforcement:
+    """Regression tests for CVE: allowed_tools enforcement at execution time.
+
+    Verifies that HarmonyContext and ParsableContext reject sub-tool calls
+    that are not in the request's allowed_tools, even when the coarse
+    namespace gate passes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_harmony_context_blocks_disallowed_browser_subtool(self):
+        """browser.open must be blocked when only 'search' is allowed."""
+        from unittest.mock import MagicMock
+
+        from vllm.entrypoints.openai.responses.context import HarmonyContext
+
+        ctx = HarmonyContext(
+            messages=[],
+            available_tools=["browser"],
+            allowed_subtools={"browser": ["search"]},
+        )
+        ctx._tool_sessions = {"browser": MagicMock()}
+
+        last_msg = MagicMock()
+        last_msg.recipient = "browser.open"
+        last_msg.channel = "commentary"
+        last_msg.content = [MagicMock(text='{"url": "http://evil.com"}')]
+
+        result = await ctx.call_search_tool(ctx._tool_sessions["browser"], last_msg)
+
+        assert len(result) == 1
+        assert "not in allowed_tools" in result[0].content[0].text
+
+    @pytest.mark.asyncio
+    async def test_harmony_context_allows_permitted_browser_subtool(self):
+        """browser.search must be allowed when 'search' is in allowed_tools."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from vllm.entrypoints.openai.responses.context import HarmonyContext
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.content = [MagicMock(text="search results")]
+        mock_session.call_tool.return_value = mock_result
+
+        ctx = HarmonyContext(
+            messages=[],
+            available_tools=["browser"],
+            allowed_subtools={"browser": ["search"]},
+        )
+        ctx._tool_sessions = {"browser": mock_session}
+
+        last_msg = MagicMock()
+        last_msg.recipient = "browser.search"
+        last_msg.channel = "commentary"
+        last_msg.content = [MagicMock(text='{"query": "test"}')]
+
+        result = await ctx.call_search_tool(mock_session, last_msg)
+
+        assert len(result) == 1
+        assert "search results" in result[0].content[0].text
+        mock_session.call_tool.assert_called_once_with("search", {"query": "test"})
+
+    @pytest.mark.asyncio
+    async def test_harmony_context_allows_all_when_no_restriction(self):
+        """All sub-tools allowed when allowed_subtools is None for namespace."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from vllm.entrypoints.openai.responses.context import HarmonyContext
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.content = [MagicMock(text="open result")]
+        mock_session.call_tool.return_value = mock_result
+
+        ctx = HarmonyContext(
+            messages=[],
+            available_tools=["browser"],
+            allowed_subtools={},
+        )
+        ctx._tool_sessions = {"browser": mock_session}
+
+        last_msg = MagicMock()
+        last_msg.recipient = "browser.open"
+        last_msg.channel = "commentary"
+        last_msg.content = [MagicMock(text='{"url": "http://example.com"}')]
+
+        result = await ctx.call_search_tool(mock_session, last_msg)
+
+        assert len(result) == 1
+        assert "open result" in result[0].content[0].text
+        mock_session.call_tool.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_harmony_context_blocks_disallowed_container_subtool(self):
+        """container.list must be blocked when only 'exec' is allowed."""
+        from unittest.mock import MagicMock
+
+        from vllm.entrypoints.openai.responses.context import HarmonyContext
+
+        ctx = HarmonyContext(
+            messages=[],
+            available_tools=["container"],
+            allowed_subtools={"container": ["exec"]},
+        )
+        ctx._tool_sessions = {"container": MagicMock()}
+
+        last_msg = MagicMock()
+        last_msg.recipient = "container.list"
+        last_msg.channel = "commentary"
+        last_msg.content = [MagicMock(text="{}")]
+
+        result = await ctx.call_container_tool(
+            ctx._tool_sessions["container"], last_msg
+        )
+
+        assert len(result) == 1
+        assert "not in allowed_tools" in result[0].content[0].text
+
+    def test_harmony_context_need_builtin_tool_call_unaffected(self):
+        """need_builtin_tool_call still gates on namespace availability."""
+        from unittest.mock import MagicMock
+
+        from vllm.entrypoints.openai.responses.context import HarmonyContext
+
+        ctx = HarmonyContext(
+            messages=[],
+            available_tools=["browser"],
+            allowed_subtools={"browser": ["search"]},
+        )
+
+        msg_open = MagicMock()
+        msg_open.recipient = "browser.open"
+        ctx._messages = [msg_open]
+        assert ctx.need_builtin_tool_call() is True
+
+        msg_python = MagicMock()
+        msg_python.recipient = "python"
+        ctx._messages = [msg_python]
+        assert ctx.need_builtin_tool_call() is False
+
+    def test_demo_tool_server_filters_browser_tools(self):
+        """DemoToolServer.get_tool_description respects allowed_tools."""
+        from vllm.entrypoints.mcp.tool_server import DemoToolServer
+
+        server = DemoToolServer()
+        server.tools = {"browser": MagicMock()}
+
+        cfg_all = server.get_tool_description("browser", allowed_tools=None)
+        assert cfg_all is not None
+        all_tool_names = {t.name for t in cfg_all.tools}
+        assert "search" in all_tool_names
+
+        cfg_search = server.get_tool_description("browser", allowed_tools=["search"])
+        assert cfg_search is not None
+        assert all(t.name == "search" for t in cfg_search.tools)
+
+        cfg_none = server.get_tool_description("browser", allowed_tools=["nonexistent"])
+        assert cfg_none is None
+
+    def test_build_allowed_subtools_map(self):
+        """_build_allowed_subtools_map correctly maps tool types to namespaces."""
+        from unittest.mock import MagicMock
+
+        from vllm.entrypoints.openai.responses.serving import (
+            OpenAIServingResponses,
+        )
+
+        request = MagicMock()
+        request.tools = [
+            Mcp(
+                type="mcp",
+                server_label="web_search_preview",
+                allowed_tools=["search"],
+            ),
+            Mcp(
+                type="mcp",
+                server_label="code_interpreter",
+                allowed_tools=None,
+            ),
+        ]
+
+        serving = MagicMock(spec=OpenAIServingResponses)
+        result = OpenAIServingResponses._build_allowed_subtools_map(serving, request)
+
+        assert result == {
+            "browser": ["search"],
+            "python": None,
+        }
+
+
 class TestHarmonyPreambleStreaming:
     """Tests for preamble (commentary with no recipient) streaming events."""
 

--- a/vllm/entrypoints/mcp/tool_server.py
+++ b/vllm/entrypoints/mcp/tool_server.py
@@ -219,11 +219,24 @@ class DemoToolServer(ToolServer):
         if tool_name not in self.tools:
             return None
         if tool_name == "browser":
-            return ToolNamespaceConfig.browser()
+            cfg = ToolNamespaceConfig.browser()
         elif tool_name == "python":
-            return ToolNamespaceConfig.python()
+            cfg = ToolNamespaceConfig.python()
         else:
             raise ValueError(f"Unknown tool {tool_name}")
+
+        if allowed_tools is None:
+            return cfg
+
+        filtered = [t for t in cfg.tools if t.name in allowed_tools]
+        if not filtered:
+            return None
+
+        return ToolNamespaceConfig(
+            name=cfg.name,
+            description=cfg.description,
+            tools=filtered,
+        )
 
     @asynccontextmanager
     async def new_session(

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -278,6 +278,7 @@ class ParsableContext(ConversationContext):
         parser_cls: type[Parser] | None,
         request: ResponsesRequest,
         available_tools: list[str] | None,
+        allowed_subtools: dict[str, list[str] | None] | None = None,
         chat_template: str | None,
         chat_template_content_format: ChatTemplateContentFormatOption,
         enable_auto_tools: bool = False,
@@ -312,6 +313,7 @@ class ParsableContext(ConversationContext):
         self.request = request
 
         self.available_tools = available_tools or []
+        self.allowed_subtools = allowed_subtools or {}
         self._tool_sessions: dict[str, ClientSession | Tool] = {}
         self.called_tools: set[str] = set()
 
@@ -432,12 +434,32 @@ class ParsableContext(ConversationContext):
 
         return [message]
 
+    def _is_subtool_allowed(self, namespace: str, subtool: str) -> bool:
+        """Check if a sub-tool is permitted by the request's allowed_tools."""
+        allowed = self.allowed_subtools.get(namespace)
+        if allowed is None:
+            return True
+        return subtool in allowed
+
     async def call_search_tool(
         self, tool_session: Union["ClientSession", Tool], last_msg: FunctionCall
     ) -> list[ResponseInputOutputItem]:
         self.called_tools.add("browser")
         if isinstance(tool_session, Tool):
             return await tool_session.get_result_parsable_context(self)
+
+        tool_name = "search"
+        if not self._is_subtool_allowed("browser", tool_name):
+            message = ResponseFunctionToolCallOutputItem(
+                id=f"fco_{random_uuid()}",
+                type="function_call_output",
+                call_id=f"call_{random_uuid()}",
+                output=f"Error: tool '{tool_name}' is not in allowed_tools"
+                " for this request.",
+                status="completed",
+            )
+            return [message]
+
         if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
                 args = json.loads(last_msg.arguments)
@@ -445,7 +467,7 @@ class ParsableContext(ConversationContext):
                 return _create_json_parse_error_messages(last_msg, e)
         else:
             args = json.loads(last_msg.arguments)
-        result = await tool_session.call_tool("search", args)
+        result = await tool_session.call_tool(tool_name, args)
         result_str = result.content[0].text
 
         message = ResponseFunctionToolCallOutputItem(
@@ -480,7 +502,19 @@ class ParsableContext(ConversationContext):
         self.called_tools.add("container")
         if isinstance(tool_session, Tool):
             return await tool_session.get_result_parsable_context(self)
-        # tool_name = last_msg.recipient.split(".")[1].split(" ")[0]
+
+        tool_name = "exec"
+        if not self._is_subtool_allowed("container", tool_name):
+            message = ResponseFunctionToolCallOutputItem(
+                id=f"fco_{random_uuid()}",
+                type="function_call_output",
+                call_id=f"call_{random_uuid()}",
+                output=f"Error: tool '{tool_name}' is not in allowed_tools"
+                " for this request.",
+                status="completed",
+            )
+            return [message]
+
         if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
                 args = json.loads(last_msg.arguments)
@@ -488,7 +522,7 @@ class ParsableContext(ConversationContext):
                 return _create_json_parse_error_messages(last_msg, e)
         else:
             args = json.loads(last_msg.arguments)
-        result = await tool_session.call_tool("exec", args)
+        result = await tool_session.call_tool(tool_name, args)
         result_str = result.content[0].text
 
         message = ResponseFunctionToolCallOutputItem(
@@ -591,10 +625,12 @@ class HarmonyContext(ConversationContext):
         messages: list,
         available_tools: list[str],
         function_tool_names: frozenset[str] | None = None,
+        allowed_subtools: dict[str, list[str] | None] | None = None,
     ):
         self._messages = messages
         self.finish_reason: str | None = None
         self.available_tools = available_tools
+        self.allowed_subtools = allowed_subtools or {}
         self.function_tool_names = function_tool_names
         self._tool_sessions: dict[str, ClientSession | Tool] = {}
         self.called_tools: set[str] = set()
@@ -780,6 +816,13 @@ class HarmonyContext(ConversationContext):
     def render_for_completion(self) -> list[int]:
         return render_for_completion(self.messages)
 
+    def _is_subtool_allowed(self, namespace: str, subtool: str) -> bool:
+        """Check if a sub-tool is permitted by the request's allowed_tools."""
+        allowed = self.allowed_subtools.get(namespace)
+        if allowed is None:
+            return True
+        return subtool in allowed
+
     async def call_search_tool(
         self, tool_session: Union["ClientSession", Tool], last_msg: Message
     ) -> list[Message]:
@@ -787,6 +830,22 @@ class HarmonyContext(ConversationContext):
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
         tool_name = last_msg.recipient.split(".")[1]
+
+        if not self._is_subtool_allowed("browser", tool_name):
+            error_text = (
+                f"Error: tool '{tool_name}' is not in allowed_tools for this request."
+            )
+            content = TextContent(text=error_text)
+            author = Author(role=Role.TOOL, name=last_msg.recipient)
+            return [
+                Message(
+                    author=author,
+                    content=[content],
+                    recipient=Role.ASSISTANT,
+                    channel=last_msg.channel,
+                )
+            ]
+
         if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
                 args = json.loads(last_msg.content[0].text)
@@ -874,6 +933,22 @@ class HarmonyContext(ConversationContext):
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
         tool_name = last_msg.recipient.split(".")[1].split(" ")[0]
+
+        if not self._is_subtool_allowed("container", tool_name):
+            error_text = (
+                f"Error: tool '{tool_name}' is not in allowed_tools for this request."
+            )
+            content = TextContent(text=error_text)
+            author = Author(role=Role.TOOL, name=last_msg.recipient)
+            return [
+                Message(
+                    author=author,
+                    content=[content],
+                    recipient=Role.ASSISTANT,
+                    channel=last_msg.channel,
+                )
+            ]
+
         if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
                 args = json.loads(last_msg.content[0].text)

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -415,6 +415,8 @@ class OpenAIServingResponses(OpenAIServing):
         else:
             assert len(builtin_tool_list) == 0
             available_tools = []
+
+        allowed_subtools = self._build_allowed_subtools_map(request)
         tokenizer = self.renderer.get_tokenizer()
 
         for engine_input in engine_inputs:
@@ -448,22 +450,27 @@ class OpenAIServingResponses(OpenAIServing):
             if self.use_harmony:
                 if request.stream:
                     context = StreamingHarmonyContext(
-                        messages, available_tools, function_tool_names
+                        messages,
+                        available_tools,
+                        function_tool_names,
+                        allowed_subtools=allowed_subtools,
                     )
                 else:
                     context = HarmonyContext(
-                        messages, available_tools, function_tool_names
+                        messages,
+                        available_tools,
+                        function_tool_names,
+                        allowed_subtools=allowed_subtools,
                     )
             else:
                 if envs.VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT:
-                    # This is a feature in development for parsing
-                    # tokens during generation instead of at the end
                     context = ParsableContext(
                         response_messages=messages,
                         tokenizer=tokenizer,
                         parser_cls=self.parser,
                         request=request,
                         available_tools=available_tools,
+                        allowed_subtools=allowed_subtools,
                         chat_template=self.chat_template,
                         chat_template_content_format=self.chat_template_content_format,
                         enable_auto_tools=self.enable_auto_tools,
@@ -1121,6 +1128,30 @@ class OpenAIServingResponses(OpenAIServing):
             "python_description": python_description,
             "container_description": container_description,
         }
+
+    def _build_allowed_subtools_map(
+        self, request: ResponsesRequest
+    ) -> dict[str, list[str] | None]:
+        """Build a mapping from tool namespace to allowed sub-tools.
+
+        Translates the request-level allowed_tools (keyed by server_label /
+        tool type) into a map keyed by the internal namespace name used by
+        the execution contexts (e.g. "browser", "python", "container").
+        A value of None means all sub-tools are allowed for that namespace.
+        """
+        allowed_tools_map = _extract_allowed_tools_from_mcp_requests(request.tools)
+
+        _TYPE_TO_NAMESPACE = {
+            "web_search_preview": "browser",
+            "code_interpreter": "python",
+            "container": "container",
+        }
+
+        allowed_subtools: dict[str, list[str] | None] = {}
+        for tool_type, namespace in _TYPE_TO_NAMESPACE.items():
+            if tool_type in allowed_tools_map:
+                allowed_subtools[namespace] = allowed_tools_map[tool_type]
+        return allowed_subtools
 
     def _construct_input_messages_with_harmony(
         self,


### PR DESCRIPTION
### Summary

Fixes a security vulnerability where the Responses API allowed_tools parameter was only applied when building tool descriptions for the model prompt, but not enforced during actual tool execution. This allowed a model to emit tool calls targeting sub-tools (e.g. browser.open, browser.find) that the request explicitly excluded via allowed_tools=["search"], bypassing the caller's declared tool policy.
Adds execution-time sub-tool allowlist enforcement in both HarmonyContext and ParsableContext, and fixes DemoToolServer.get_tool_description() to respect the allowed_tools filter.
Adds regression tests proving allowed_tools=["search"] permits browser.search but rejects browser.open and browser.find.

### Changes

- vllm/entrypoints/openai/responses/serving.py: Adds _build_allowed_subtools_map() to translate request-level allowed_tools (keyed by server label) into a namespace-keyed map, and passes it to context constructors.
- vllm/entrypoints/openai/responses/context.py: Adds allowed_subtools parameter and _is_subtool_allowed() check to HarmonyContext and ParsableContext. Enforces the allowlist before every call_tool() invocation, returning a structured error for disallowed sub-tools.
- vllm/entrypoints/mcp/tool_server.py: Fixes DemoToolServer.get_tool_description() to filter tool descriptions based on allowed_tools (previously ignored for browser/python namespaces).
- tests/entrypoints/openai/responses/test_serving_responses.py: Adds TestAllowedSubtoolsEnforcement with 7 regression tests covering allowed, blocked, and unrestricted scenarios.

### Test plan

-  pytest tests/entrypoints/openai/responses/test_serving_responses.py — 28 tests pass
-  pytest tests/entrypoints/openai/responses/test_mcp_tools.py::TestMCPToolServerUnit — 2 tests pass
-  All pre-commit hooks pass (ruff, mypy, typos, format)