### PR TITLE
[v2 of #45506] EngineArgs CLI plumbing for --sleep-mode-backend

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -853,3 +853,62 @@ class TestDpDeviceIdSharding:
             get_physical_gpu_ids_for_local_dp_rank(
                 evar, local_dp_rank=2, world_size=2, user_assigned_gpu_ids=[4, 5, 6, 7]
             )
+
+def test_sleep_mode_backend_cli_plumbing():
+    """Regression test for the --sleep-mode-backend / --sleep-mode-backend-options
+    CLI plumbing through EngineArgs.add_cli_args() and EngineArgs.create_model_config().
+
+    Catches the original landmine: closed PR #45506 review noted that operators
+    setting --sleep-mode-backend on the CLI saw their value silently dropped
+    because EngineArgs never declared the field, so from_cli_args() never copied
+    it into the EngineArgs instance and create_model_config() never forwarded it
+    to ModelConfig. The default cumem-backend path masked the bug because every
+    in-tree codepath read the ModelConfig default ("cumem") rather than the
+    operator override.
+    """
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+
+    # default — no flags passed: backend defaults to ModelConfig default
+    args = parser.parse_args([])
+    engine_args = EngineArgs.from_cli_args(args)
+    assert engine_args.sleep_mode_backend == ModelConfig.sleep_mode_backend
+    assert engine_args.sleep_mode_backend_options == {}
+
+    # operator override: --sleep-mode-backend=cumem_tag must reach EngineArgs
+    args = parser.parse_args(["--sleep-mode-backend", "cumem_tag"])
+    engine_args = EngineArgs.from_cli_args(args)
+    assert engine_args.sleep_mode_backend == "cumem_tag"
+
+    # ModelConfig forwarding: create_model_config() must pass the override
+    # through. Round-trip the field via the EngineArgs constructor; we only
+    # assert that the dataclass exposes the field and accepts overrides
+    # (full create_model_config() needs a real model dir, out of scope here).
+    engine_args = EngineArgs(
+        model="facebook/opt-125m",
+        sleep_mode_backend="cumem_tag",
+        sleep_mode_backend_options={"suspend_tags": ["weights"]},
+    )
+    assert engine_args.sleep_mode_backend == "cumem_tag"
+    assert engine_args.sleep_mode_backend_options == {"suspend_tags": ["weights"]}
+
+
+def test_model_config_declares_sleep_mode_backend_fields():
+    """ModelConfig must declare the sleep_mode_backend and
+    sleep_mode_backend_options dataclass fields with their documented defaults.
+
+    The CLI plumbing in EngineArgs reads ``ModelConfig.sleep_mode_backend`` at
+    class-body import time as the default for the corresponding EngineArgs
+    field; if the ModelConfig field is missing, importing arg_utils raises
+    AttributeError. This test pins the surface so a future refactor that
+    accidentally drops or renames the field fails fast at unit-test time.
+    """
+    from dataclasses import fields
+
+    field_map = {f.name: f for f in fields(ModelConfig)}
+    assert "sleep_mode_backend" in field_map
+    assert "sleep_mode_backend_options" in field_map
+    # Documented defaults: backend is "cumem", options is an empty dict.
+    assert ModelConfig.sleep_mode_backend == "cumem"
+    # default_factory=dict means each instance gets a fresh empty dict.
+    cfg = ModelConfig.__dataclass_fields__["sleep_mode_backend_options"]
+    assert cfg.default_factory is dict

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -289,6 +289,19 @@ class ModelConfig:
     enable_sleep_mode: bool = False
     """Enable sleep mode for the engine (only cuda and
     hip platforms are supported)."""
+    sleep_mode_backend: str = "cumem"
+    """Mechanism used to free and restore GPU state for sleep mode. ``"cumem"``
+    (default) uses the built-in ``CuMemAllocator`` and is behavior-compatible
+    with prior releases. Additional backends (CUDA checkpoint, CRIU, durable
+    snapshot) may be registered in-tree or by plugins (RFC #34303)."""
+    sleep_mode_backend_options: dict[str, Any] = field(default_factory=dict)
+    """Backend-specific options forwarded to the selected
+    ``sleep_mode_backend``'s constructor. The factory ``**``-unpacks this dict
+    into the backend class, so the accepted keys are defined by each backend
+    (e.g. ``cumem_tag`` accepts ``suspend_tags``). Validation lives in the
+    concrete backend's ``__init__``; ``ModelConfig`` does not enforce a schema.
+    Defaults to an empty dict, which preserves prior behavior for every
+    registered backend."""
     enable_cumem_allocator: bool = False
     """Enable the custom cumem allocator to leverage advanced GPU memory
     allocation features such as multi-node NVLink support.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -670,6 +670,10 @@ class EngineArgs:
 
     generation_config: str = ModelConfig.generation_config
     enable_sleep_mode: bool = ModelConfig.enable_sleep_mode
+    sleep_mode_backend: str = ModelConfig.sleep_mode_backend
+    sleep_mode_backend_options: dict[str, Any] = get_field(
+        ModelConfig, "sleep_mode_backend_options"
+    )
     enable_cumem_allocator: bool = ModelConfig.enable_cumem_allocator
     override_generation_config: dict[str, Any] = get_field(
         ModelConfig, "override_generation_config"
@@ -859,6 +863,13 @@ class EngineArgs:
         )
         model_group.add_argument(
             "--enable-sleep-mode", **model_kwargs["enable_sleep_mode"]
+        )
+        model_group.add_argument(
+            "--sleep-mode-backend", **model_kwargs["sleep_mode_backend"]
+        )
+        model_group.add_argument(
+            "--sleep-mode-backend-options",
+            **model_kwargs["sleep_mode_backend_options"],
         )
         model_group.add_argument(
             "--enable-cumem-allocator", **model_kwargs["enable_cumem_allocator"]
@@ -1654,6 +1665,8 @@ class EngineArgs:
             generation_config=self.generation_config,
             override_generation_config=self.override_generation_config,
             enable_sleep_mode=self.enable_sleep_mode,
+            sleep_mode_backend=self.sleep_mode_backend,
+            sleep_mode_backend_options=self.sleep_mode_backend_options,
             enable_cumem_allocator=self.enable_cumem_allocator,
             model_impl=self.model_impl,
             override_attention_dtype=self.override_attention_dtype,


### PR DESCRIPTION
## Summary

Re-files closed #45506 narrowed to **only** the EngineArgs CLI plumbing layer + the ModelConfig field surface it depends on:

- ModelConfig declares `sleep_mode_backend` (default `"cumem"`) and `sleep_mode_backend_options` (default `{}`) so configuration consumers have a stable schema to read.
- EngineArgs.add_cli_args() declares `--sleep-mode-backend` and `--sleep-mode-backend-options`.
- EngineArgs.create_model_config() forwards both fields to ModelConfig so operator overrides actually reach the engine instead of being silently dropped at parse time.

**Self-contained.** This PR can be imported, tested, and merged independently of any other RFC #34303 work. The default `cumem`-backend path is unchanged — every in-tree caller continues to read the `"cumem"` default — so existing users see no behavior change.

The original #45506 was closed because it bundled too much (workflow YAML, docker, docs, multiple unrelated tests). This v2 is the minimum-surface CLI-layer slice — 3 files, 87 lines.

## Relationship to #45398

`#45398` ([Core][RFC #34303] Add CuMemTagBackend) provides the concrete `cumem_tag` backend implementation that consumes the `sleep_mode_backend = "cumem_tag"` setting wired through here. Dependency direction inverted from the original filing: **#45398 now depends on this PR**, not the other way around. The public API surface lands first, the implementation lands second — the natural order for a public API change.

## Test plan

- [x] `python -m py_compile vllm/config/model.py vllm/engine/arg_utils.py tests/engine/test_arg_utils.py`
- [x] `test_sleep_mode_backend_cli_plumbing` exercises default round-trip plus operator override (`--sleep-mode-backend=cumem_tag`) reaching the EngineArgs instance via `add_cli_args` → `parse_args` → `from_cli_args`.
- [x] `test_model_config_declares_sleep_mode_backend_fields` asserts both ModelConfig fields exist with their documented defaults (`"cumem"` and an empty dict via `default_factory`) so a future refactor that drops or renames the fields fails fast at unit-test time.
- [x] Full `pytest tests/engine/test_arg_utils.py` — runs cleanly without any other RFC #34303 work landed first.
