### PR TITLE
[Tokenizer] Add batch_split_message tokenizer mode for lossless segmented encoding

### DIFF
--- a/benchmarks/benchmark_batch_split_tokenizer.py
+++ b/benchmarks/benchmark_batch_split_tokenizer.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark: plain encode vs batch_split_message (no cache / with cache).
+
+Compares the end-to-end ``encode`` latency of three tokenizers on synthetic
+multi-segment prompts:
+
+  1. plain      -- vLLM's normal HF tokenizer (CachedHfTokenizer.encode)
+  2. seg        -- batch_split_message, segment cache OFF
+  3. seg_cache  -- batch_split_message, segment cache ON
+
+Synthetic data: for each total-token target we build prompts of N segments
+whose lengths are random (sum == target, with jitter). Each segment is, with
+probability reuse_prob, an already-seen segment (so the cache can hit) and
+otherwise freshly generated -- giving a realistic ~50% hit rate that the script
+also measures for real.
+
+This measures ONLY the tokenizer (pure CPU); it does not start the vLLM engine.
+It does import vllm to exercise the *real* code paths
+(CachedHfTokenizer.encode and BatchSplitMessageTokenizerImpl.encode).
+
+Run on the target machine (same code as the repo):
+    python benchmarks/benchmark_batch_split_tokenizer.py
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import statistics
+import time
+
+from transformers import AutoConfig, AutoTokenizer
+
+from vllm.tokenizers.batch_split_message import (
+    _segment_digest,
+    make_batch_split_message_tokenizer,
+)
+from vllm.tokenizers.hf import get_cached_tokenizer
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+MODEL = os.environ.get("MODEL_PATH")
+if not MODEL:
+    raise SystemExit(
+        "Set MODEL_PATH to the tokenizer/model path (or HF/ModelScope id)."
+    )
+DELIM = "<|im_end|>"
+TOTAL_TOKENS = [5000, 10000, 30000, 50000, 100000, 150000, 200000]
+
+
+def n_segments_for(total: int) -> int:
+    # small prompts -> 5 segments, large prompts -> 10 segments
+    return 5 if total <= 30000 else 10
+
+
+WARMUP = 10  # warmup encodes (fixed query, identical across runs)
+ITERS = 100  # measured prompts per (total, n_seg) cell
+REUSE_PROBS = [0.25, 0.5, 0.75]  # P(reuse existing segment) -> ~hit rates tested
+MIN_SEG_TOKENS = 16  # floor per segment so lengths stay sane
+SEG_LEN_RATIO = 3.0  # longest/shortest segment length ratio (jitter)
+SEED = 1234
+ADD_SPECIAL = False  # chat path / genuinely-segmented path
+TRUST_REMOTE_CODE = True
+
+# Big enough that eviction never interferes (we measure hits, not eviction).
+CACHE_MAX_ENTRIES = 10_000_000
+CACHE_MAX_TOKENS = 100_000_000_000
+
+# A fixed warmup prompt reused by every run (warms the Rust thread pool etc.).
+WARMUP_QUERY = ("warmup " * 256).strip()
+
+
+# --------------------------------------------------------------------------- #
+# Tokenizer construction (bypass get_tokenizer's lru_cache so seg_cache can be
+# a fresh instance per scale; encode logic is identical to the registered mode)
+# --------------------------------------------------------------------------- #
+def load_base():
+    tok = AutoTokenizer.from_pretrained(MODEL, trust_remote_code=TRUST_REMOTE_CODE)
+    return get_cached_tokenizer(tok)
+
+
+def make_seg(segment_cache: bool):
+    return make_batch_split_message_tokenizer(
+        load_base(),
+        split_delimiter=DELIM,
+        segment_cache=segment_cache,
+        cache_max_entries=CACHE_MAX_ENTRIES,
+        cache_max_tokens=CACHE_MAX_TOKENS,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic data
+# --------------------------------------------------------------------------- #
+def split_lengths(total: int, n: int, rng: random.Random) -> list[int]:
+    """Split ``total`` into ``n`` parts whose longest/shortest ratio ~= SEG_LEN_RATIO.
+
+    Lengths are proportional to weights drawn from [1, SEG_LEN_RATIO]; the two
+    extremes are forced in so max/min lands near the target ratio.
+    """
+    if n == 1:
+        return [total]
+    weights = [rng.uniform(1.0, SEG_LEN_RATIO) for _ in range(n)]
+    weights[0], weights[1] = 1.0, SEG_LEN_RATIO  # pin the extremes
+    rng.shuffle(weights)
+    s = sum(weights)
+    lens = [max(MIN_SEG_TOKENS, int(total * w / s)) for w in weights]
+    # push the rounding remainder onto the longest segment (keeps the min intact)
+    lens[lens.index(max(lens))] += total - sum(lens)
+    return lens
+
+
+def make_random_segment(
+    base_tok, target_len: int, rng: random.Random, special_ids: set[int]
+) -> str:
+    """Build a text segment whose *real* token count is ~target_len.
+
+    Random token ids do not form a natural BPE sequence: the text they decode to
+    can re-encode to far MORE tokens than were sampled (BPE re-splits the
+    fragments). So after decoding we re-encode, trim to target_len, and decode
+    back to a stable string -- this keeps each segment near target_len and stops
+    the prompt from inflating past the model's max sequence length.
+    """
+    vocab_size = base_tok.vocab_size
+    ids: list[int] = []
+    guard = 0
+    while len(ids) < target_len and guard < target_len * 4:
+        guard += 1
+        tid = rng.randrange(vocab_size)
+        if tid not in special_ids:
+            ids.append(tid)
+    text = base_tok.decode(ids).replace(DELIM, " ")
+    # re-encode (natural BPE) and trim so the segment can't inflate past target
+    reids = base_tok.encode(text, add_special_tokens=False)
+    if len(reids) > target_len:
+        text = base_tok.decode(reids[:target_len]).replace(DELIM, " ")
+    return text
+
+
+class SegmentFactory:
+    """Builds fixed-structure prompts with one segment pool per slot.
+
+    All prompts share the same per-slot lengths (``seg_lens``); slot ``i`` only
+    ever holds segments of length ``seg_lens[i]``. A reused segment therefore
+    always matches the slot's length, so reuse keeps the prompt's total length
+    and length distribution intact (only the *content* varies with the hit
+    rate). Each slot reuses an already-seen segment with prob ``reuse_prob``.
+    """
+
+    def __init__(
+        self, base_tok, rng: random.Random, reuse_prob: float, seg_lens: list[int]
+    ):
+        self._base = base_tok
+        self._rng = rng
+        self._reuse_prob = reuse_prob
+        self._special = set(base_tok.all_special_ids)
+        self._seg_lens = seg_lens
+        self._pools: list[list[str]] = [[] for _ in seg_lens]
+
+    def make_prompt(self) -> list[str]:
+        segs = []
+        for i, length in enumerate(self._seg_lens):
+            pool = self._pools[i]
+            if pool and self._rng.random() < self._reuse_prob:
+                segs.append(self._rng.choice(pool))  # reuse: same slot length
+            else:
+                seg = make_random_segment(self._base, length, self._rng, self._special)
+                pool.append(seg)
+                segs.append(seg)
+        return segs
+
+
+def build_prompts(base_tok, total: int, n: int, rng: random.Random, reuse_prob: float):
+    seg_lens = split_lengths(total, n, rng)  # fixed structure shared by all prompts
+    factory = SegmentFactory(base_tok, rng, reuse_prob, seg_lens)
+    prompts, seg_lists = [], []
+    for _ in range(ITERS):
+        segs = factory.make_prompt()
+        seg_lists.append(segs)
+        prompts.append(DELIM.join(segs))
+    return prompts, seg_lists
+
+
+def measured_hit_rate(seg_lists) -> float:
+    """Replay the prompts in order and compute the real per-segment hit rate
+    (a segment hits if its digest was seen in an earlier-encoded prompt)."""
+    seen: set[bytes] = set()
+    hits = total = 0
+    for segs in seg_lists:
+        for s in segs:
+            d = _segment_digest(s)
+            total += 1
+            if d in seen:
+                hits += 1
+            seen.add(d)
+    return hits / total if total else 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Timing
+# --------------------------------------------------------------------------- #
+def bench(encode_fn, prompts) -> dict:
+    for _ in range(WARMUP):
+        encode_fn(WARMUP_QUERY)
+    times = []
+    for p in prompts:
+        t0 = time.perf_counter()
+        encode_fn(p)
+        times.append((time.perf_counter() - t0) * 1000.0)  # ms
+    times.sort()
+    return {
+        "p50": statistics.median(times),
+        "p99": times[min(len(times) - 1, int(len(times) * 0.99))],
+        "mean": statistics.fmean(times),
+    }
+
+
+def main():
+    print("=== batch_split_message tokenizer benchmark ===")
+    print(f"model           : {MODEL}")
+    print(f"cpu_count       : {os.cpu_count()}")
+    rayon = os.environ.get("RAYON_NUM_THREADS", "(default)")
+    toks_par = os.environ.get("TOKENIZERS_PARALLELISM", "(default)")
+    print(f"RAYON_NUM_THREADS      : {rayon}")
+    print(f"TOKENIZERS_PARALLELISM : {toks_par}")
+    print(
+        f"warmup={WARMUP} iters={ITERS} reuse_probs={REUSE_PROBS} "
+        f"add_special_tokens={ADD_SPECIAL}"
+    )
+
+    plain = load_base()
+    seg = make_seg(segment_cache=False)
+    # Confirm seg really runs the segmented impl (the lossless assert below would
+    # pass even if seg were plain, so check the class explicitly).
+    print(f"plain class: {type(plain).__name__}")
+    print(f"seg   class: {type(seg).__name__}")
+    assert "BatchSplitMessage" in type(seg).__name__, (
+        "seg is NOT the segmented tokenizer -- make_batch_split_message_tokenizer "
+        "did not take effect; benchmark would be meaningless."
+    )
+
+    def enc_plain(x):
+        return plain.encode(x, add_special_tokens=ADD_SPECIAL)
+
+    def enc_seg(x):
+        return seg.encode(x, add_special_tokens=ADD_SPECIAL)
+
+    # Cap test sizes at the model's maximum sequence length: prompts longer than
+    # that are never used in practice (and trip HF's "sequence length is longer
+    # than the specified maximum" warning).
+    max_len = getattr(plain, "model_max_length", None)
+    if not (isinstance(max_len, int) and 0 < max_len < 10**8):
+        # model_max_length unset (huge sentinel) -> fall back to model config
+        try:
+            cfg = AutoConfig.from_pretrained(MODEL, trust_remote_code=TRUST_REMOTE_CODE)
+            max_len = getattr(cfg, "max_position_embeddings", None)
+        except Exception:
+            max_len = None
+    if isinstance(max_len, int) and max_len > 0:
+        totals = [t for t in TOTAL_TOKENS if t <= max_len]
+        skipped = [t for t in TOTAL_TOKENS if t > max_len]
+        print(
+            f"model max seq len = {max_len}; testing {totals}"
+            + (f"; skipped {skipped} (> max)" if skipped else "")
+        )
+    else:
+        totals = list(TOTAL_TOKENS)
+        print("model max seq len unknown; testing all sizes")
+
+    rows = []
+    total_cells = len(totals) * len(REUSE_PROBS)
+    idx = 0
+    for total in totals:
+        n = n_segments_for(total)
+        for reuse in REUSE_PROBS:
+            idx += 1
+            print(
+                f"[{idx}/{total_cells}] total={total} n={n} reuse={reuse:.0%}:",
+                end="",
+                flush=True,
+            )
+
+            rng = random.Random(SEED)  # same prompts for all three tokenizers
+            print(" build", end="", flush=True)
+            prompts, seg_lists = build_prompts(plain, total, n, rng, reuse)
+
+            # real total token count (decode->re-encode is not identity)
+            real_tok = statistics.median(
+                len(plain.encode(p, add_special_tokens=ADD_SPECIAL))
+                for p in prompts[:5]
+            )
+
+            # correctness: segmented must equal a single encode, token-for-token
+            for p in prompts[:5]:
+                assert list(enc_seg(p)) == list(enc_plain(p)), (
+                    f"LOSSLESS VIOLATION at total={total}"
+                )
+
+            hit = measured_hit_rate(seg_lists)
+
+            seg_cache = make_seg(segment_cache=True)  # fresh cache per cell
+
+            def enc_cache(x, _tok=seg_cache):
+                return _tok.encode(x, add_special_tokens=ADD_SPECIAL)
+
+            print(" plain", end="", flush=True)
+            sp = bench(enc_plain, prompts)
+            print(" seg", end="", flush=True)
+            ss = bench(enc_seg, prompts)
+            print(" cache", end="", flush=True)
+            sc = bench(enc_cache, prompts)
+            print(
+                f" done (p50 ms: plain={sp['p50']:.1f} seg={ss['p50']:.1f} "
+                f"cache={sc['p50']:.1f}, hit={hit:.0%})",
+                flush=True,
+            )
+            rows.append((total, n, reuse, int(real_tok), hit, sp, ss, sc))
+
+    def print_table(stat: str) -> None:
+        header = (
+            f"\n[{stat}] {'total':>8} {'segs':>4} {'reuse':>6} {'real_tok':>9} "
+            f"{'hit%':>5} {'plain(ms)':>10} {'seg(ms)':>10} {'cache(ms)':>10} "
+            f"{'seg/plain':>10} {'cache/seg':>10}"
+        )
+        print(header)
+        print("-" * (len(header) - 1))
+        for total, n, reuse, real_tok, hit, sp, ss, sc in rows:
+            print(
+                f"      {total:>8} {n:>4} {reuse * 100:>5.0f}% {real_tok:>9} "
+                f"{hit * 100:>4.0f}% "
+                f"{sp[stat]:>10.2f} {ss[stat]:>10.2f} {sc[stat]:>10.2f} "
+                f"{sp[stat] / ss[stat]:>9.2f}x {ss[stat] / sc[stat]:>9.2f}x"
+            )
+
+    print_table("p50")
+    print_table("p99")
+    print(
+        "\n(per-encode latency in ms. seg/plain = plain/seg speedup (parallel "
+        "gain); cache/seg = seg/cache speedup (cache gain on top of segmenting); "
+        "higher = faster, e.g. 1.50x = 50% faster. hit% = measured hit rate.)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tokenizers_/test_batch_split_message.py
+++ b/tests/tokenizers_/test_batch_split_message.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for tokenizer_mode='batch_split_message'.
+
+Covers losslessness (segmented encode is byte-for-byte identical to a single
+encode), the optional segment-id cache (hit/eviction bounds), the
+split_delimiter override, and thread-safety under concurrent encode.
+
+Uses a small Qwen tokenizer whose eos `<|im_end|>` is a registered special
+token (hence a valid lossless split delimiter); its repo id is identical on
+HF and ModelScope so the suite runs on either.
+"""
+
+import array
+import copy
+import threading
+
+import pytest
+
+from vllm.tokenizers import get_tokenizer
+from vllm.tokenizers.batch_split_message import (
+    _segment_digest,
+    _SegmentIdsCache,
+    make_batch_split_message_tokenizer,
+)
+
+# A small open-source Qwen tokenizer. Its repo id is identical on HF and
+# ModelScope, so upstream CI uses HF while an offline box can set
+# VLLM_USE_MODELSCOPE=1 -- same test, no test-only env vars. Qwen uses ChatML,
+# so eos (`<|im_end|>`) is the natural message delimiter and it adds no
+# specials on encode (num_special_tokens_to_add == 0).
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+EOS = "<|im_end|>"
+
+# A mix of: no delimiter, leading/trailing delimiter, consecutive delimiters,
+# multi-turn-like text, and empty string.
+LOSSLESS_SAMPLES = [
+    "",
+    "hello world",
+    f"a{EOS}b",
+    f"{EOS}leading",
+    f"trailing{EOS}",
+    f"a{EOS}{EOS}b",
+    f"system prompt here{EOS}user: hi there{EOS}assistant: hello!{EOS}",
+    "no special tokens, just a longer plain sentence to encode in one shot.",
+]
+
+
+@pytest.fixture(scope="module")
+def baseline():
+    return get_tokenizer(MODEL, tokenizer_mode="hf", use_fast=True)
+
+
+@pytest.fixture(scope="module")
+def split_tok():
+    return get_tokenizer(MODEL, tokenizer_mode="batch_split_message")
+
+
+@pytest.fixture(scope="module")
+def split_tok_cached():
+    return get_tokenizer(
+        MODEL, tokenizer_mode="batch_split_message", segment_cache=True
+    )
+
+
+@pytest.mark.parametrize("text", LOSSLESS_SAMPLES)
+def test_lossless_matches_baseline(baseline, split_tok, text):
+    assert list(split_tok.encode(text)) == list(baseline.encode(text))
+
+
+@pytest.mark.parametrize("text", LOSSLESS_SAMPLES)
+def test_lossless_with_cache(baseline, split_tok_cached, text):
+    # Encode twice: first populates the cache, second hits it; both must match.
+    assert list(split_tok_cached.encode(text)) == list(baseline.encode(text))
+    assert list(split_tok_cached.encode(text)) == list(baseline.encode(text))
+
+
+def test_add_special_tokens_false_matches_baseline(baseline, split_tok):
+    text = f"a{EOS}b{EOS}c"
+    assert list(split_tok.encode(text, add_special_tokens=False)) == list(
+        baseline.encode(text, add_special_tokens=False)
+    )
+
+
+def test_truncation_left_keeps_tail(baseline):
+    tok = get_tokenizer(MODEL, tokenizer_mode="batch_split_message")
+    text = f"one{EOS}two{EOS}three{EOS}four"
+    full = list(baseline.encode(text))
+    got = tok.encode(text, truncation=True, max_length=3)
+    assert got == full[-3:]  # generate runner -> truncation_side="left"
+
+
+def test_completion_path_falls_back_when_tokenizer_adds_specials(baseline, monkeypatch):
+    # Qwen adds no specials (n_special == 0). Force a tokenizer that *does* add
+    # specials, so the completion path (add_special_tokens=True) must fall back
+    # to a single encode instead of repeating them on every segment. monkeypatch
+    # avoids depending on a real BOS-adding model being downloadable.
+    base = copy.copy(baseline)  # independent instance; make_ swaps its __class__
+    monkeypatch.setattr(base, "num_special_tokens_to_add", lambda *a, **k: 1)
+    tok = make_batch_split_message_tokenizer(base, segment_cache=False)
+
+    text = f"a{EOS}b{EOS}c"  # multi-segment
+    # completion path (True): falls back to a single encode (not per-segment)
+    assert list(tok.encode(text, add_special_tokens=True)) == list(
+        baseline.encode(text, add_special_tokens=True)
+    )
+    # chat path (False): still segmented and lossless
+    assert list(tok.encode(text, add_special_tokens=False)) == list(
+        baseline.encode(text, add_special_tokens=False)
+    )
+
+
+def test_split_delimiter_override(baseline):
+    # Override the delimiter; result must still equal a single encode().
+    tok = get_tokenizer(
+        MODEL, tokenizer_mode="batch_split_message", split_delimiter=EOS
+    )
+    text = f"x{EOS}y"
+    assert list(tok.encode(text)) == list(baseline.encode(text))
+
+
+def test_is_fast_and_decode_delegated(split_tok):
+    # Non-encode methods are inherited from the underlying HF tokenizer.
+    assert split_tok.is_fast
+    ids = split_tok.encode("round trip test")
+    assert isinstance(split_tok.decode(ids), str)
+
+
+def test_concurrent_encode_consistent(baseline):
+    tok = get_tokenizer(MODEL, tokenizer_mode="batch_split_message", segment_cache=True)
+    texts = [f"thread {i} says hi{EOS}and bye{EOS}" for i in range(32)]
+    expected = {t: list(baseline.encode(t)) for t in set(texts)}
+    results: dict[int, list[int]] = {}
+    errors: list[Exception] = []
+
+    def worker(idx: int):
+        try:
+            results[idx] = list(tok.encode(texts[idx]))
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(len(texts))]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    for i, text in enumerate(texts):
+        assert results[i] == expected[text]
+
+
+# ---------------------------------------------------------------------------
+# _SegmentIdsCache unit tests
+# ---------------------------------------------------------------------------
+
+
+def _ids(n: int) -> "array.array":
+    return array.array("i", range(n))
+
+
+def test_cache_hit_refreshes_recency():
+    c = _SegmentIdsCache(max_entries=2, max_total_tokens=1000)
+    ka, kb = _segment_digest("a"), _segment_digest("b")
+    c.put(ka, _ids(1))
+    c.put(kb, _ids(1))
+    # Touch "a" so "b" becomes LRU.
+    assert c.get(ka) is not None
+    c.put(_segment_digest("c"), _ids(1))  # evicts LRU == "b"
+    assert c.get(ka) is not None
+    assert c.get(kb) is None
+
+
+def test_cache_evicts_on_entry_bound():
+    c = _SegmentIdsCache(max_entries=2, max_total_tokens=1000)
+    for s in ("a", "b", "c"):
+        c.put(_segment_digest(s), _ids(1))
+    assert len(c._data) == 2
+    assert c.get(_segment_digest("a")) is None  # oldest evicted
+
+
+def test_cache_evicts_on_token_bound():
+    c = _SegmentIdsCache(max_entries=100, max_total_tokens=10)
+    c.put(_segment_digest("a"), _ids(6))
+    c.put(_segment_digest("b"), _ids(6))  # 12 > 10 -> evict "a"
+    assert c.get(_segment_digest("a")) is None
+    assert c.get(_segment_digest("b")) is not None
+    assert c._total_tokens == 6
+
+
+def test_cache_rejects_oversized_segment():
+    c = _SegmentIdsCache(max_entries=100, max_total_tokens=10)
+    c.put(_segment_digest("big"), _ids(20))  # larger than whole budget
+    assert c.get(_segment_digest("big")) is None
+    assert c._total_tokens == 0
+
+
+def test_cache_concurrent_put_get_keeps_invariant():
+    c = _SegmentIdsCache(max_entries=64, max_total_tokens=10_000)
+    errors: list[Exception] = []
+
+    def worker(base: int):
+        try:
+            for i in range(200):
+                k = _segment_digest(f"{base}-{i % 80}")
+                if c.get(k) is None:
+                    c.put(k, _ids((i % 5) + 1))
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(b,)) for b in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    # Invariant: tracked total equals the sum of cached segment lengths.
+    assert c._total_tokens == sum(len(v) for v in c._data.values())
+    assert c._total_tokens <= 10_000
+    assert len(c._data) <= 64

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -77,7 +77,15 @@ logger = init_logger(__name__)
 RunnerOption = Literal["auto", RunnerType]
 ConvertType = Literal["none", "embed", "classify"]
 ConvertOption = Literal["auto", ConvertType]
-TokenizerMode = Literal["auto", "hf", "slow", "mistral", "deepseek_v32", "deepseek_v4"]
+TokenizerMode = Literal[
+    "auto",
+    "hf",
+    "slow",
+    "mistral",
+    "deepseek_v32",
+    "deepseek_v4",
+    "batch_split_message",
+]
 ModelDType = Literal["auto", "half", "float16", "bfloat16", "float", "float32"]
 LogprobsMode = Literal[
     "raw_logits", "raw_logprobs", "processed_logits", "processed_logprobs"
@@ -129,6 +137,11 @@ class ModelConfig:
     - "mistral" will always use the tokenizer from `mistral_common`.
     - "deepseek_v32" will always use the tokenizer from `deepseek_v32`.
     - "deepseek_v4" will always use the tokenizer from `deepseek_v4`.
+    - "batch_split_message" wraps a fast HF tokenizer to encode text by
+      splitting on a special-token delimiter (default: eos) and batch-encoding
+      the segments in parallel; lossless when the delimiter is a special token.
+      Configure via `--tokenizer-mode-config` (split_delimiter, segment_cache,
+      cache_max_entries, cache_max_tokens).
     - Other custom values can be supported via plugins.
 
     To swap the Rust BPE backend that powers HF fast tokenizers for the
@@ -274,6 +287,11 @@ class ModelConfig:
     hf_overrides: HfOverrides = field(default_factory=dict)
     """If a dictionary, contains arguments to be forwarded to the Hugging Face
     config. If a callable, it is called to update the HuggingFace config."""
+    tokenizer_mode_config: dict[str, Any] = field(default_factory=dict)
+    """Extra keyword arguments forwarded to the tokenizer's `from_pretrained`,
+    to configure custom tokenizer modes. Values must be hashable. E.g.
+    `tokenizer_mode="batch_split_message"` reads `split_delimiter`,
+    `segment_cache`, `cache_max_entries`, and `cache_max_tokens` from here."""
     generation_config: str = "auto"
     """The folder path to the generation config. Defaults to `"auto"`, the
     generation config will be loaded from model path. If set to `"vllm"`, no
@@ -383,6 +401,7 @@ class ModelConfig:
             "config_format",
             "hf_token",
             "hf_overrides",
+            "tokenizer_mode_config",
             "override_attention_dtype",
             "logits_processors",
             "io_processor_plugin",

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -534,6 +534,9 @@ class EngineArgs:
     code_revision: str | None = ModelConfig.code_revision
     hf_token: bool | str | None = ModelConfig.hf_token
     hf_overrides: HfOverrides = get_field(ModelConfig, "hf_overrides")
+    tokenizer_mode_config: dict[str, Any] = get_field(
+        ModelConfig, "tokenizer_mode_config"
+    )
     tokenizer_revision: str | None = ModelConfig.tokenizer_revision
     quantization: QuantizationMethods | str | None = ModelConfig.quantization
     quantization_config: "dict[str, Any] | QuantizationConfigArgs | None" = None
@@ -847,6 +850,9 @@ class EngineArgs:
         model_group.add_argument("--config-format", **model_kwargs["config_format"])
         model_group.add_argument("--hf-token", **model_kwargs["hf_token"])
         model_group.add_argument("--hf-overrides", **model_kwargs["hf_overrides"])
+        model_group.add_argument(
+            "--tokenizer-mode-config", **model_kwargs["tokenizer_mode_config"]
+        )
         model_group.add_argument("--pooler-config", **model_kwargs["pooler_config"])
         model_group.add_argument(
             "--generation-config", **model_kwargs["generation_config"]
@@ -1596,6 +1602,7 @@ class EngineArgs:
             code_revision=self.code_revision,
             hf_token=self.hf_token,
             hf_overrides=self.hf_overrides,
+            tokenizer_mode_config=self.tokenizer_mode_config,
             tokenizer_revision=self.tokenizer_revision,
             max_model_len=self.max_model_len,
             quantization=self.quantization,

--- a/vllm/renderers/registry.py
+++ b/vllm/renderers/registry.py
@@ -20,6 +20,7 @@ logger = init_logger(__name__)
 
 
 _VLLM_RENDERERS = {
+    "batch_split_message": ("hf", "HfRenderer"),
     "deepseek_v32": ("deepseek_v32", "DeepseekV32Renderer"),
     "deepseek_v4": ("deepseek_v4", "DeepseekV4Renderer"),
     "grok2": ("grok2", "Grok2Renderer"),

--- a/vllm/tokenizers/batch_split_message.py
+++ b/vllm/tokenizers/batch_split_message.py
@@ -1,0 +1,352 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Batch-split-message tokenizer: lossless segmented batch encoding.
+
+``encode(text)`` is split on a special-token delimiter (default: the
+tokenizer's ``eos_token``), the resulting segments are encoded in a single
+``encode_batch`` call -- which the underlying fast (Rust) tokenizer
+parallelizes across segments -- and the segment ids are concatenated back with
+the delimiter ids in between.
+
+This is lossless **iff** the delimiter is a hard BPE boundary, i.e. a
+registered special token. Special tokens never merge with adjacent text, so
+
+    encode(a + DELIM + b) == encode(a) + encode(DELIM) + encode(b)
+
+and the produced id sequence is byte-for-byte identical to a single
+``encode(text)``. Because the token ids are unchanged, downstream prefix
+KV-cache hashing is unaffected -- the win here is purely in the tokenization
+stage, and it applies to every request independently (segments encode in
+parallel; see also the optional segment cache below).
+
+An optional segment-id LRU cache memoizes per-segment ids keyed by a content
+digest, so repeated segments (shared system prompts, prior conversation turns,
+repeated RAG documents) skip re-encoding. This reuse is at the tokenizer layer
+and is independent of vLLM's KV prefix cache.
+
+Note on ``add_special_tokens`` (completion vs chat). Per-segment encoding only
+stays lossless when no special token is injected *per call*: otherwise a model
+that adds a BOS/EOS on ``encode`` would get that BOS/EOS repeated on **every**
+segment. vLLM passes ``add_special_tokens=False`` for chat (the chat template
+already wrote the special tokens into the text) and ``True`` for completion. So
+for a tokenizer that adds specials (``num_special_tokens_to_add() > 0``), the
+``add_special_tokens=True`` (completion) path falls back to a single,
+non-segmented ``encode`` -- still correct, just without the speedup. Tokenizers
+that add nothing (e.g. Qwen/ChatML, where eos is a plain delimiter,
+``num_special_tokens_to_add() == 0``) keep the segmented fast path in both
+modes. Net effect: the chat path is always lossless and fast; the only
+no-speedup case is completion on a BOS/EOS-adding model. Note also that
+completion text rarely contains the delimiter at all, so it usually has nothing
+to segment regardless.
+
+Enable via ``--tokenizer-mode batch_split_message``. Configure through
+``--tokenizer-mode-config`` (forwarded to :meth:`from_pretrained`)::
+
+    --tokenizer-mode-config '{"split_delimiter": "<|im_end|>",
+                         "segment_cache": true,
+                         "cache_max_entries": 100000,
+                         "cache_max_tokens": 8000000}'
+
+All keys are optional; ``split_delimiter`` defaults to the tokenizer's
+``eos_token`` and the cache is off by default, so the default behavior is a
+lossless, parallel re-implementation of ``encode``.
+"""
+
+from __future__ import annotations
+
+import array
+import hashlib
+import threading
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+from transformers import AutoTokenizer, PreTrainedTokenizerFast
+
+from vllm.logger import init_logger
+from vllm.tokenizers.hf import get_cached_tokenizer
+from vllm.tokenizers.protocol import TokenizerLike
+
+logger = init_logger(__name__)
+
+# Defaults for the optional segment cache. The cache is only built when
+# ``segment_cache=True`` is passed; these bound it when it is.
+_DEFAULT_CACHE_MAX_ENTRIES = 100_000
+_DEFAULT_CACHE_MAX_TOKENS = 8_000_000
+
+
+def _segment_digest(text: str) -> bytes:
+    return hashlib.blake2b(text.encode("utf-8"), digest_size=16).digest()
+
+
+class _SegmentIdsCache:
+    """Thread-safe LRU cache of per-segment token ids.
+
+    Bounded by both entry count and total cached tokens; the least-recently
+    used segment is evicted when either bound is exceeded. Keyed by a content
+    digest of the segment text.
+    """
+
+    def __init__(self, max_entries: int, max_total_tokens: int) -> None:
+        self._max_entries = max_entries
+        self._max_total_tokens = max_total_tokens
+        self._data: OrderedDict[bytes, array.array] = OrderedDict()
+        self._total_tokens = 0
+        self._lock = threading.Lock()
+
+    def get(self, key: bytes) -> array.array | None:
+        with self._lock:
+            ids = self._data.get(key)
+            if ids is not None:
+                self._data.move_to_end(key)
+            return ids
+
+    def put(self, key: bytes, ids: array.array) -> None:
+        with self._lock:
+            old = self._data.pop(key, None)
+            if old is not None:
+                self._total_tokens -= len(old)
+            # A single segment larger than the whole budget is never cached.
+            if len(ids) > self._max_total_tokens:
+                return
+            self._data[key] = ids
+            self._total_tokens += len(ids)
+            while (
+                len(self._data) > self._max_entries
+                or self._total_tokens > self._max_total_tokens
+            ):
+                _, evicted = self._data.popitem(last=False)
+                self._total_tokens -= len(evicted)
+
+
+def _encode_segments(
+    tokenizer: PreTrainedTokenizerFast,
+    items: list[str],
+    cache: _SegmentIdsCache | None,
+    add_special_tokens: bool,
+) -> list[Any]:
+    # backend_tokenizer is the underlying ``tokenizers.Tokenizer`` whose
+    # ``encode_batch`` parallelizes across segments. Using ``self``'s backend
+    # (rather than a captured one) keeps each thread-pool copy on its own Rust
+    # tokenizer, so this stays thread-safe under HfRenderer's tokenizer pool.
+    backend = tokenizer.backend_tokenizer
+    if cache is None:
+        encs = backend.encode_batch(items, add_special_tokens=add_special_tokens)
+        return [enc.ids for enc in encs]
+
+    digests = [_segment_digest(s) for s in items]
+    seg_ids: list[Any] = [cache.get(d) for d in digests]
+    miss = [i for i, ids in enumerate(seg_ids) if ids is None]
+    if miss:
+        encs = backend.encode_batch(
+            [items[i] for i in miss], add_special_tokens=add_special_tokens
+        )
+        for j, enc in zip(miss, encs):
+            ids = array.array("i", enc.ids)
+            seg_ids[j] = ids
+            cache.put(digests[j], ids)
+    return seg_ids
+
+
+def _warn_if_not_lossless(
+    tokenizer: PreTrainedTokenizerFast, base_cls: type, delim: str
+) -> None:
+    """Sanity-check that segmented encoding matches a single ``encode``.
+
+    Compares our overridden ``encode`` against the unmodified base-class
+    ``encode`` on a couple of samples. A mismatch means the chosen delimiter is
+    not a clean boundary for this tokenizer, so segmentation would not be
+    lossless -- warn loudly rather than silently produce a different id
+    sequence.
+
+    Checks ``add_special_tokens=False``. That covers both segmented paths: the
+    ``False`` path directly, and the ``True`` path when ``n_special == 0``
+    (there ``add_special_tokens`` has no effect, so it encodes identically to
+    ``False``). The only other case, ``True`` with ``n_special > 0``, falls back
+    to a single ``encode`` and is lossless by construction, so it needs no check.
+    """
+    samples = [f"foo{delim}bar baz", "hello world"]
+    for sample in samples:
+        segmented = tokenizer.encode(sample, add_special_tokens=False)
+        # unbound: bypass override
+        baseline = base_cls.encode(  # type: ignore[attr-defined]
+            tokenizer, sample, add_special_tokens=False
+        )
+        if list(segmented) != list(baseline):
+            logger.warning(
+                "batch_split_message: segmented encode differs from baseline "
+                "for sample %r (%d vs %d ids). The delimiter %r may not be a "
+                "lossless boundary for this tokenizer; results will diverge "
+                "from a single encode().",
+                sample,
+                len(segmented),
+                len(baseline),
+                delim,
+            )
+            return
+
+
+def make_batch_split_message_tokenizer(
+    tokenizer: PreTrainedTokenizerFast,
+    *,
+    split_delimiter: str | None = None,
+    segment_cache: bool = False,
+    cache_max_entries: int = _DEFAULT_CACHE_MAX_ENTRIES,
+    cache_max_tokens: int = _DEFAULT_CACHE_MAX_TOKENS,
+) -> PreTrainedTokenizerFast:
+    """Wrap ``tokenizer`` in-place so ``encode`` uses segmented batch encoding.
+
+    Follows vLLM's ``get_cached_tokenizer`` pattern: a dynamic subclass is
+    installed as ``tokenizer.__class__`` and only ``encode`` is overridden, so
+    every other ``TokenizerLike`` method is inherited from the real tokenizer.
+    The delimiter ids and segment cache live in this function's closure, so
+    they are shared across the deep-copied tokenizer pool that
+    ``HfRenderer`` builds for thread safety (the cache is not copied per pool
+    entry).
+    """
+    if not isinstance(tokenizer, PreTrainedTokenizerFast):
+        raise ValueError(
+            "tokenizer_mode='batch_split_message' requires a fast tokenizer, "
+            f"got {type(tokenizer).__name__}."
+        )
+
+    delim = split_delimiter if split_delimiter is not None else tokenizer.eos_token
+    if not delim:
+        raise ValueError(
+            "batch_split_message: no split delimiter. The tokenizer has no "
+            "eos_token; pass split_delimiter via --tokenizer-mode-config."
+        )
+    delim_ids = list(tokenizer.encode(delim, add_special_tokens=False))
+
+    # Losslessness requires the delimiter to be a hard BPE boundary; a
+    # registered special token always is.
+    if delim not in set(tokenizer.all_special_tokens) and len(delim_ids) != 1:
+        logger.warning(
+            "batch_split_message: delimiter %r is not a registered special "
+            "token and encodes to %d ids; segmented encoding may not match "
+            "encode(text). Prefer a special token such as eos.",
+            delim,
+            len(delim_ids),
+        )
+
+    # add_special_tokens=True injects BOS/EOS on *every* segment for tokenizers
+    # that add them, which breaks losslessness. Probe how many specials this
+    # tokenizer adds so encode() can fall back to a single encode in that case.
+    n_special = tokenizer.num_special_tokens_to_add()
+
+    cache = (
+        _SegmentIdsCache(cache_max_entries, cache_max_tokens) if segment_cache else None
+    )
+
+    base_cls = tokenizer.__class__
+
+    class BatchSplitMessageTokenizerImpl(base_cls):  # type: ignore[valid-type, misc]
+        def encode(  # type: ignore[override]
+            self,
+            text: str,
+            truncation: bool | None = None,
+            max_length: int | None = None,
+            add_special_tokens: bool = True,
+        ) -> list[int]:
+            if not isinstance(text, str):
+                return super().encode(
+                    text,
+                    truncation=truncation,
+                    max_length=max_length,
+                    add_special_tokens=add_special_tokens,
+                )
+
+            # Per-segment encoding repeats any per-call special tokens. If this
+            # tokenizer adds BOS/EOS and the caller wants them (completion), fall
+            # back to a single encode to stay lossless. No-op for the chat path
+            # (add_special_tokens=False) and for Qwen/ChatML (n_special == 0).
+            if add_special_tokens and n_special > 0:
+                return super().encode(
+                    text,
+                    truncation=truncation,
+                    max_length=max_length,
+                    add_special_tokens=True,
+                )
+
+            items = text.split(delim)
+            ends_with_delim = text.endswith(delim)
+            if items and items[-1] == "":
+                items.pop()
+            if not items:
+                return []
+
+            seg_ids = _encode_segments(self, items, cache, add_special_tokens)
+
+            result: list[int] = []
+            last = len(items) - 1
+            for i, ids in enumerate(seg_ids):
+                result.extend(ids)
+                if i < last or ends_with_delim:
+                    result.extend(delim_ids)
+
+            if max_length is not None and truncation and len(result) > max_length:
+                if self.truncation_side == "left":
+                    result = result[-max_length:]
+                else:
+                    result = result[:max_length]
+            return result
+
+    BatchSplitMessageTokenizerImpl.__name__ = f"BatchSplitMessage{base_cls.__name__}"
+    tokenizer.__class__ = BatchSplitMessageTokenizerImpl
+    _warn_if_not_lossless(tokenizer, base_cls, delim)
+    logger.info_once(
+        "batch_split_message tokenizer active: delimiter=%r, segment_cache=%s, "
+        "cache_max_entries=%d, cache_max_tokens=%d, specials_added_per_encode=%d",
+        delim,
+        segment_cache,
+        cache_max_entries,
+        cache_max_tokens,
+        n_special,
+    )
+    return tokenizer
+
+
+class BatchSplitMessageTokenizer(TokenizerLike):
+    """Registry entry for ``tokenizer_mode='batch_split_message'``.
+
+    ``from_pretrained`` loads a fast HF tokenizer and wraps it via
+    :func:`make_batch_split_message_tokenizer`. Configuration is forwarded
+    through ``--tokenizer-mode-config``.
+    """
+
+    @classmethod
+    def from_pretrained(  # type: ignore[override]
+        cls,
+        path_or_repo_id: str | Path,
+        *args,
+        trust_remote_code: bool = False,
+        revision: str | None = None,
+        download_dir: str | None = None,
+        **kwargs,
+    ) -> PreTrainedTokenizerFast:
+        # Pop our config out of kwargs so the rest can flow to AutoTokenizer.
+        split_delimiter = kwargs.pop("split_delimiter", None)
+        segment_cache = bool(kwargs.pop("segment_cache", False))
+        cache_max_entries = int(
+            kwargs.pop("cache_max_entries", _DEFAULT_CACHE_MAX_ENTRIES)
+        )
+        cache_max_tokens = int(
+            kwargs.pop("cache_max_tokens", _DEFAULT_CACHE_MAX_TOKENS)
+        )
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            path_or_repo_id,
+            *args,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            cache_dir=download_dir,
+            **kwargs,
+        )
+        tokenizer = get_cached_tokenizer(tokenizer)  # type: ignore[assignment]
+        return make_batch_split_message_tokenizer(
+            tokenizer,  # type: ignore[arg-type]
+            split_delimiter=split_delimiter,
+            segment_cache=segment_cache,
+            cache_max_entries=cache_max_entries,
+            cache_max_tokens=cache_max_tokens,
+        )

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -34,6 +34,7 @@ logger = init_logger(__name__)
 _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS: set[str] = {"step3_vl", "step3p7"}
 
 _VLLM_TOKENIZERS = {
+    "batch_split_message": ("batch_split_message", "BatchSplitMessageTokenizer"),
     "deepseek_v32": ("deepseek_v32", "DeepseekV32Tokenizer"),
     "deepseek_v4": ("deepseek_v4", "DeepseekV4Tokenizer"),
     "grok2": ("grok2", "Grok2Tokenizer"),
@@ -247,6 +248,12 @@ def cached_tokenizer_from_config(model_config: "ModelConfig", **kwargs):
         return None
 
     _maybe_register_hf_config(getattr(model_config, "hf_config", None))
+
+    # Forward --tokenizer-mode-config to the tokenizer's from_pretrained.
+    # Values must be hashable (these flow through lru_cache); explicit
+    # kwargs win.
+    if model_config.tokenizer_mode_config:
+        kwargs = {**model_config.tokenizer_mode_config, **kwargs}
 
     return cached_get_tokenizer(
         model_config.tokenizer,


### PR DESCRIPTION
## Motivation

In multi-turn / long-conversation serving, the tokenization stage takes a non-trivial slice of TTFT: the prompt grows long, the HF fast tokenizer encodes a single long sequence on one thread, and tokenization cost grows linearly with prompt length. This PR introduces a lossless segmented parallel-encoding scheme, plus a cache for long, highly-reusable segments, substantially cutting the tokenization latency in multi-turn / long-sequence serving.

`batch_split_message` cuts tokenization latency in two independent ways:

- **Parallelism:** split the text on a special-token delimiter (default: eos) and encode the segments in a single `encode_batch`, which the underlying Rust tokenizer parallelizes across segments — so the tokenization cost drops from encoding the whole prompt to encoding the longest single segment.
- **Segment reuse (optional cache):** in many deployments the system prompt and tool definitions are a large, fixed share of the prompt and are fully reusable across requests, while the user message is far smaller than these segments. With those long segments cached, the tokenizer only needs to encode the user segment.

It is lossless: when the delimiter is a registered special token (a hard BPE boundary), the produced token ids are byte-for-byte identical to a single `encode()`.

## What it does

- `encode(text)` → split on delimiter → `encode_batch(segments)` (parallel) → concat with the delimiter ids in between.
- **Lossless guard:** for tokenizers that inject specials on encode (`num_special_tokens_to_add() > 0`), the completion path (`add_special_tokens=True`) falls back to a single `encode` so BOS/EOS isn't repeated per segment. The chat path (`add_special_tokens=False`) always segments. Tokenizers that add nothing (e.g. Qwen/ChatML) segment in both paths.
- **Optional `segment_cache`:** a thread-safe LRU (keyed by a content digest, bounded by both entry count and total tokens) memoizing segment→token-ids. It lives at the tokenizer layer and is orthogonal to the KV prefix cache — it saves re-tokenization regardless of whether the prefix cache hits.
- Follows the existing `get_cached_tokenizer` pattern — a dynamic subclass swaps `__class__` and only `encode` is overridden, so every other `TokenizerLike` method is inherited unchanged. Registered in both the tokenizer and renderer registries (the renderer reuses `HfRenderer`).

## Design / API note (feedback welcome)

Configuration is passed through a new `--tokenizer-mode-config` (a dict, `ModelConfig.tokenizer_mode_config`), forwarded to the tokenizer's `from_pretrained`:

```
--tokenizer-mode batch_split_message \
--tokenizer-mode-config '{"segment_cache": true, "cache_max_entries": 100000}'
```

Keys (all optional): `split_delimiter` (default: eos), `segment_cache` (default: false), `cache_max_entries` (default: 100000), `cache_max_tokens` (default: 8000000).

This adds a general config entry for custom tokenizer modes. Alternatives considered: reusing `hf_overrides` (rejected — it targets the HF *config*, different semantics) or a mode-specific flag (rejected — pollutes the global args and doesn't generalize). Happy to adjust the name/shape if a more constrained or differently-named entry is preferred.

## Changes

- `vllm/tokenizers/batch_split_message.py` (new): core implementation + `_SegmentIdsCache`.
- `vllm/tokenizers/registry.py`, `vllm/renderers/registry.py`: register the mode (renderer reuses `HfRenderer`).
- `vllm/config/model.py`: `TokenizerMode` literal + `tokenizer_mode_config` field.
- `vllm/engine/arg_utils.py`: expose `--tokenizer-mode-config`.
- `tests/tokenizers_/test_batch_split_message.py`, `benchmarks/benchmark_batch_split_tokenizer.py` (new).

Default behavior is unchanged: the mode is opt-in and the cache is off by default.

## Tests

`tests/tokenizers_/test_batch_split_message.py` (small Qwen tokenizer): lossless equivalence vs a single `encode` across edge cases (empty, leading/trailing/ consecutive delimiters, multi-turn), `add_special_tokens=False` equivalence, completion-path fallback, truncation, segment-cache hit/eviction (entry + token bounds, oversized rejection), and concurrent-encode consistency.

## Performance

Standalone tokenizer benchmark (`benchmarks/benchmark_batch_split_tokenizer.py`) — measures the tokenizer only (no engine, no GPU).

**Setup**
- Host: 31-core CPU.
- Tokenizer: Qwen3.5-35B-A3B-FP8; delimiter `<|im_end|>` (eos); `add_special_tokens=False` (chat path).
- Prompt sizes (`total`): 5000 / 10000 / 30000 / 50000 / 100000 / 150000 / 200000 tokens, capped at the model's max sequence length.
- Segments per prompt (`segs`): 5 for `total <= 30000`, else 10. Per-segment lengths are jittered (longest/shortest ratio ~= 3) and sum to `total`.
- Cache hit rate (`reuse`): 0.25 / 0.50 / 0.75 — each segment reuses an already-seen segment with this probability.
- 10 warmup + 100 measured encodes per cell; report p50 and p99.

**Configs compared (identical prompts across all three)**
- `plain` — normal HF tokenizer (`tokenizer_mode=hf`).
- `seg` — `batch_split_message`, segment cache **off** (parallelism only).
- `cache` — `batch_split_message`, segment cache **on**.

**Column meanings**
- `total` — target prompt size (tokens); `real_tok` — actual encoded length (median; differs slightly because random-token text re-encodes non-identically).
- `segs` — segments per prompt; `reuse` — configured reuse probability; `hit%` — measured **segment-level** hit rate (cached segments / total segments). The cache is keyed per segment: when a whole segment is already cached, its token ids are returned directly and re-encoding is skipped.
- `plain(ms)` / `seg(ms)` / `cache(ms)` — per-encode latency of each config.
- `seg/plain` — parallel speedup = `plain / seg` (×, higher is faster).
- `cache/seg` — incremental cache speedup = `seg / cache` (×).

**Results — p50**

```
[p50]    total segs  reuse  real_tok  hit%  plain(ms)    seg(ms)  cache(ms)  seg/plain  cache/seg
-------------------------------------------------------------------------------------------------
          5000    5    25%      5004   25%       8.47       2.99       3.08      2.83x      0.97x
          5000    5    50%      5004   52%       8.20       3.53       2.94      2.33x      1.20x
          5000    5    75%      5004   74%       7.51       3.04       2.56      2.47x      1.19x
         10000    5    25%     10004   27%      16.89       5.96       6.17      2.83x      0.97x
         10000    5    50%     10004   51%      16.96       5.85       5.80      2.90x      1.01x
         10000    5    75%     10004   75%      17.26       6.07       5.33      2.84x      1.14x
         30000    5    25%     30004   23%      54.78      17.80      18.35      3.08x      0.97x
         30000    5    50%     30004   50%      55.52      17.97      16.92      3.09x      1.06x
         30000    5    75%     30004   75%      55.62      20.63      15.11      2.70x      1.37x
         50000   10    25%     50009   27%      94.82      19.74      20.34      4.80x      0.97x
         50000   10    50%     50009   50%      94.16      19.82      17.11      4.75x      1.16x
         50000   10    75%     50009   70%      94.39      19.72      15.37      4.79x      1.28x
        100000   10    25%    100009   23%     196.92      41.77      40.17      4.71x      1.04x
        100000   10    50%    100009   51%     195.53      42.18      34.75      4.64x      1.21x
        100000   10    75%    100009   73%     195.55      41.64      30.64      4.70x      1.36x
        150000   10    25%    150009   24%     313.21      65.78      63.79      4.76x      1.03x
        150000   10    50%    150009   48%     308.52      62.51      57.83      4.94x      1.08x
        150000   10    75%    150009   74%     307.70      64.15      48.98      4.80x      1.31x
        200000   10    25%    200009   23%     418.40      82.55      79.73      5.07x      1.04x
        200000   10    50%    200009   49%     412.52      82.72      72.41      4.99x      1.14x
        200000   10    75%    200009   74%     412.04      81.62      61.05      5.05x      1.34x
```

**Results — p99**

```
[p99]    total segs  reuse  real_tok  hit%  plain(ms)    seg(ms)  cache(ms)  seg/plain  cache/seg
-------------------------------------------------------------------------------------------------
          5000    5    25%      5004   25%       9.31       4.10       4.39      2.27x      0.93x
          5000    5    50%      5004   52%      10.17       4.56       4.38      2.23x      1.04x
          5000    5    75%      5004   74%       9.01       3.83       4.00      2.35x      0.96x
         10000    5    25%     10004   27%      20.23       6.72       8.24      3.01x      0.82x
         10000    5    50%     10004   51%      22.55       7.36       7.82      3.06x      0.94x
         10000    5    75%     10004   75%      21.31       7.99       7.77      2.67x      1.03x
         30000    5    25%     30004   23%      61.43      25.36      24.61      2.42x      1.03x
         30000    5    50%     30004   50%      61.30      22.98      24.37      2.67x      0.94x
         30000    5    75%     30004   75%      66.56      27.00      21.90      2.47x      1.23x
         50000   10    25%     50009   27%     101.77      23.78      25.97      4.28x      0.92x
         50000   10    50%     50009   50%     101.66      24.60      24.77      4.13x      0.99x
         50000   10    75%     50009   70%     105.09      25.55      25.68      4.11x      0.99x
        100000   10    25%    100009   23%     209.40      49.69      51.44      4.21x      0.97x
        100000   10    50%    100009   51%     208.73      51.44      44.48      4.06x      1.16x
        100000   10    75%    100009   73%     217.50      51.43      47.54      4.23x      1.08x
        150000   10    25%    150009   24%     362.27      73.34      76.79      4.94x      0.96x
        150000   10    50%    150009   48%     318.06      74.36      71.38      4.28x      1.04x
        150000   10    75%    150009   74%     327.07      77.24      74.47      4.23x      1.04x
        200000   10    25%    200009   23%     444.89      97.98      98.23      4.54x      1.00x
        200000   10    50%    200009   49%     480.93      95.00      97.34      5.06x      0.98x
        200000   10    75%    200009   74%     437.81      95.31      92.46      4.59x      1.03x
```

The parallel speedup (`seg/plain`) is measured with a single request owning all cores, so it is an optimistic upper bound: under high concurrency vLLM's async micro-batch tokenizer already batches encodes across requests and saturates the cores, leaving less headroom for per-request segment parallelism. The cache speedup (`cache/seg`) is unaffected — it skips work rather than relying on spare cores.

## Correctness

Verified end-to-end on a Qwen3.5-35B-A3B-FP8 deployment: with greedy decoding, `--tokenizer-mode batch_split_message` produces byte-identical output to `--tokenizer-mode hf`, confirming the lossless property on the full inference path.
