### PR TITLE
fix: cache bad_words tokenization to avoid 'Already borrowed' errors under concurrency

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -676,17 +676,32 @@ class SamplingParams(
     def update_from_tokenizer(self, tokenizer: TokenizerLike) -> None:
         if not self.bad_words:
             return
+        # Cache tokenized bad_words on the tokenizer to avoid redundant
+        # tokenizer.encode() calls.  When many concurrent requests share the
+        # same bad_words list (a common RL workload pattern) the repeated
+        # encode calls race with prompt tokenization on the same HF fast
+        # tokenizer pool and can cause "RuntimeError: Already borrowed"
+        # despite the thread-safe pool wrapper (#41181, #45445).
+        cache = getattr(tokenizer, '_bad_words_token_cache', None)
+        if cache is None:
+            cache = {}
+            tokenizer._bad_words_token_cache = cache
         self._bad_words_token_ids = []
         for bad_word in self.bad_words:
             # To prohibit words both at the beginning
             # and in the middle of text
             # (related to add_prefix_space tokenizer parameter)
             for add_prefix_space in [False, True]:
-                prefix = " " if add_prefix_space else ""
-                prompt = prefix + bad_word.lstrip()
-                prompt_token_ids = tokenizer.encode(
-                    text=prompt, add_special_tokens=False
-                )
+                cache_key = (bad_word, add_prefix_space)
+                if cache_key in cache:
+                    prompt_token_ids = cache[cache_key]
+                else:
+                    prefix = " " if add_prefix_space else ""
+                    prompt = prefix + bad_word.lstrip()
+                    prompt_token_ids = tokenizer.encode(
+                        text=prompt, add_special_tokens=False
+                    )
+                    cache[cache_key] = prompt_token_ids
 
                 # If no space at the beginning
                 # or if prefix space produces a new word token


### PR DESCRIPTION
## Summary

Fixes #45445 — `RuntimeError: Already borrowed` when using `bad_words` with concurrent OpenAI serving requests.

### Root Cause

`SamplingParams.update_from_tokenizer()` calls `tokenizer.encode()` for each bad_word on every request. When many concurrent requests share the same `bad_words` list (a common workload pattern, e.g. RL), these redundant encode calls race with prompt tokenization on the same HF fast tokenizer pool. This can still trigger "Already borrowed" even after the thread-safe tokenizer wrapper in #41181 was merged.

### Fix

Cache tokenized bad_word results on the tokenizer object (lifetime-bound to the tokenizer). When a bad_word has been tokenized before, the cached result is reused, avoiding the redundant `tokenizer.encode()` call entirely.

- Cache key: `(bad_word, add_prefix_space)` tuple
- Cache storage: `tokenizer._bad_words_token_cache` dict (created lazily)
- Thread-safety: Python dict operations under GIL are safe for this read-heavy workload pattern

### Validation

The reporter [confirmed](#45445) that locally caching bad_words IDs inside `update_from_tokenizer()` eliminated all "Already borrowed" failures across their A/B hammer test:
- Without cache: intermittent HTTP 500s with `RuntimeError: Already borrowed`
- With cache: 0 HTTP 500s across the same hammer rounds

## Test Plan

- [x] No functional change to tokenization logic — same result, just cached
- [x] Cache lifetime is bound to the tokenizer (cleaned up when tokenizer is replaced)
- [x] Backward compatible — `_bad_words_token_cache` attribute is lazily created if absent