### PR TITLE
[Core] Expose engine pause/resume state as prometheus metrics

### DIFF
--- a/tests/entrypoints/serve/dev/test_pause.py
+++ b/tests/entrypoints/serve/dev/test_pause.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import requests
+from prometheus_client.parser import text_string_to_metric_families
+
+from tests.utils import RemoteOpenAIServer
+
+MODEL_NAME = "meta-llama/Llama-3.2-1B"
+
+
+def test_pause_state_metric():
+    # dtype, max-len etc set so that this can run in CI
+    args = [
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "8192",
+        "--max-num-seqs",
+        "128",
+    ]
+
+    with RemoteOpenAIServer(
+        MODEL_NAME,
+        args,
+        env_dict={"VLLM_SERVER_DEV_MODE": "1", "CUDA_VISIBLE_DEVICES": "0"},
+    ) as remote_server:
+        # "keep" mode freezes all requests -> paused_all.
+        response = requests.post(
+            remote_server.url_for("pause"), params={"mode": "keep"}
+        )
+        assert response.status_code == 200
+        response = requests.get(remote_server.url_for("is_paused"))
+        assert response.status_code == 200
+        assert response.json().get("is_paused") is True
+
+        response = requests.get(remote_server.url_for("metrics"))
+        assert response.status_code == 200
+        unpaused, paused_new, paused_all = _get_pause_metrics_from_api(response)
+        assert unpaused == 0
+        assert paused_new == 0
+        assert paused_all == 1
+
+        response = requests.post(remote_server.url_for("resume"))
+        assert response.status_code == 200
+        response = requests.get(remote_server.url_for("is_paused"))
+        assert response.status_code == 200
+        assert response.json().get("is_paused") is False
+
+        response = requests.get(remote_server.url_for("metrics"))
+        assert response.status_code == 200
+        unpaused, paused_new, paused_all = _get_pause_metrics_from_api(response)
+        assert unpaused == 1
+        assert paused_new == 0
+        assert paused_all == 0
+
+        # "abort" mode only blocks new requests -> paused_new.
+        response = requests.post(
+            remote_server.url_for("pause"), params={"mode": "abort"}
+        )
+        assert response.status_code == 200
+
+        response = requests.get(remote_server.url_for("metrics"))
+        assert response.status_code == 200
+        unpaused, paused_new, paused_all = _get_pause_metrics_from_api(response)
+        assert unpaused == 0
+        assert paused_new == 1
+        assert paused_all == 0
+
+
+def _get_pause_metrics_from_api(response: requests.Response):
+    """Return (unpaused, paused_new, paused_all)"""
+
+    unpaused, paused_new, paused_all = None, None, None
+
+    for family in text_string_to_metric_families(response.text):
+        if family.name == "vllm:engine_pause_state":
+            for sample in family.samples:
+                if sample.name == "vllm:engine_pause_state":
+                    for label_name, label_value in sample.labels.items():
+                        if label_value == "unpaused":
+                            unpaused = sample.value
+                        elif label_value == "paused_new":
+                            paused_new = sample.value
+                        elif label_value == "paused_all":
+                            paused_all = sample.value
+
+    assert unpaused is not None
+    assert paused_new is not None
+    assert paused_all is not None
+
+    return unpaused, paused_new, paused_all

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -784,6 +784,8 @@ class AsyncLLM(EngineClient):
         if clear_cache:
             await self.renderer.clear_mm_cache_async()
         await self.engine_core.pause_scheduler_async(mode=mode, clear_cache=clear_cache)
+        if self.logger_manager is not None:
+            self.logger_manager.record_pause_state(True, mode)
         # Small sleep to help ensure that final outputs from any in-flight requests are
         # returned prior to this method returning. These outputs come out of the engine
         # prior to the wait-for-idle completion event, but involve additional async
@@ -795,6 +797,8 @@ class AsyncLLM(EngineClient):
     async def resume_generation(self) -> None:
         """Resume generation after :meth:`pause_generation`."""
         await self.engine_core.resume_scheduler_async()
+        if self.logger_manager is not None:
+            self.logger_manager.record_pause_state(False)
 
     async def is_paused(self) -> bool:
         """Return whether the engine is currently paused."""

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -70,6 +70,9 @@ class StatLoggerBase(ABC):
     def record_sleep_state(self, is_awake: int, level: int):  # noqa
         pass
 
+    def record_pause_state(self, paused: bool, mode: str):  # noqa
+        pass
+
 
 def load_stat_logger_plugin_factories() -> list[StatLoggerFactory]:
     factories: list[StatLoggerFactory] = []
@@ -520,6 +523,32 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
 
         # Setting default values
         self.record_sleep_state()
+
+        gauge_engine_pause_state = self._gauge_cls(
+            name="vllm:engine_pause_state",
+            documentation=(
+                "Engine pause state; unpaused = 1 means the engine is "
+                "scheduling requests; paused_new = 1 means new requests are "
+                "blocked while in-flight requests continue; paused_all = 1 "
+                "means all requests are blocked."
+            ),
+            labelnames=labelnames + ["pause_state"],
+            multiprocess_mode="mostrecent",
+        )
+
+        self.gauge_engine_pause_state = {}
+        pause_state = ["unpaused", "paused_new", "paused_all"]
+
+        for s in pause_state:
+            self.gauge_engine_pause_state[s] = {
+                idx: gauge_engine_pause_state.labels(
+                    engine=idx, model_name=model_name, pause_state=s
+                )
+                for idx in engine_indexes
+            }
+
+        # Setting default values
+        self.record_pause_state()
 
         gauge_kv_cache_usage = self._gauge_cls(
             name="vllm:kv_cache_usage_perc",
@@ -1240,6 +1269,23 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             )
             self.gauge_engine_sleep_state["awake"][engine_idx].set(awake)
 
+    def record_pause_state(self, paused: bool = False, mode: str = ""):
+        unpaused = 0 if paused else 1
+        paused_new = 0
+        paused_all = 0
+
+        if paused:
+            # "keep" freezes all requests; "abort"/"wait" only block new ones.
+            if mode == "keep":
+                paused_all = 1
+            else:
+                paused_new = 1
+
+        for engine_idx in self.engine_indexes:
+            self.gauge_engine_pause_state["unpaused"][engine_idx].set(unpaused)
+            self.gauge_engine_pause_state["paused_new"][engine_idx].set(paused_new)
+            self.gauge_engine_pause_state["paused_all"][engine_idx].set(paused_all)
+
     def log_engine_initialized(self):
         self.log_metrics_info("cache_config", self.vllm_config.cache_config)
 
@@ -1355,6 +1401,10 @@ class StatLoggerManager:
     def record_sleep_state(self, sleep: int = 0, level: int = 0):
         for logger in self.stat_loggers:
             logger.record_sleep_state(sleep, level)
+
+    def record_pause_state(self, paused: bool = False, mode: str = ""):
+        for logger in self.stat_loggers:
+            logger.record_pause_state(paused, mode)
 
     def log(self):
         for logger in self.stat_loggers:


### PR DESCRIPTION
## Purpose

The engine can be paused/resumed via `AsyncLLM.pause_generation` / `resume_generation` (exposed over the dev RLHF `/pause`, `/resume`, `/is_paused` endpoints), which RL and online weight-update workflows rely on.

Today this state is only observable through the `is_paused()` API. There is no metric, so operators cannot graph pause state on dashboards or alert on an engine that has been paused for too long.

This PR adds a `vllm:engine_pause_state` Prometheus gauge, completing the engine-lifecycle metric family alongside the existing `vllm:engine_sleep_state` gauge (#24176). 
No behavior change to pause/resume and the metric is additive.

## Test Plan
- `tests/entrypoints/serve/dev/test_pause.py`

## Test Result


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

