### PR TITLE
[Bugfix] Fix HF-format Mistral3 crash with --tokenizer-mode mistral

### DIFF
--- a/tests/models/multimodal/processing/test_mistral3.py
+++ b/tests/models/multimodal/processing/test_mistral3.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Mistral3's multimodal preprocessing."""
+
+import pytest
+
+from vllm.config import ModelConfig
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.cache import MultiModalProcessorOnlyCache
+
+from ...registry import HF_EXAMPLE_MODELS
+
+
+@pytest.mark.parametrize("model_id", ["mistralai/Mistral-Small-3.1-24B-Instruct-2503"])
+@pytest.mark.parametrize("use_cache", [True, False])
+def test_dummy_mm_inputs_with_mistral_tokenizer(model_id: str, use_cache: bool):
+    """
+    The HF-format Mistral3 architecture should be usable with
+    `--tokenizer-mode mistral`.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/45289
+    where building the dummy multi-modal inputs (run at API server startup
+    to compute the encoder budget) crashed because the tokenizer handed to
+    `PixtralProcessor` did not encode the `[IMG]` placeholder to its
+    special token id.
+    """
+    model_info = HF_EXAMPLE_MODELS.find_hf_info(model_id)
+    model_info.check_available_online(on_fail="skip")
+
+    results = {}
+    for tokenizer_mode in ("auto", "mistral"):
+        model_config = ModelConfig(
+            model_id,
+            tokenizer=model_id,
+            tokenizer_mode=tokenizer_mode,
+            # The HF repo also contains the consolidated (mistral-format)
+            # checkpoint; force the HF format to test the Mistral3
+            # architecture instead of Pixtral
+            config_format="hf",
+            max_model_len=8192,
+        )
+
+        cache = MultiModalProcessorOnlyCache(model_config) if use_cache else None
+        processor = MULTIMODAL_REGISTRY.create_processor(model_config, cache=cache)
+        mm_inputs = MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
+            model_config,
+            mm_counts={"image": 1},
+            processor=processor,
+        )
+
+        results[tokenizer_mode] = (
+            mm_inputs["prompt_token_ids"],
+            [
+                (placeholder.offset, placeholder.length)
+                for placeholder in mm_inputs["mm_placeholders"]["image"]
+            ],
+        )
+
+    # Both tokenizer modes use the Tekken vocab,
+    # so they should produce identical outputs
+    assert results["mistral"] == results["auto"]

--- a/tests/models/multimodal/processing/test_mistral3.py
+++ b/tests/models/multimodal/processing/test_mistral3.py
@@ -1,18 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for Mistral3's multimodal preprocessing kwargs."""
+"""Tests for Mistral3's multimodal preprocessing."""
 
 import pytest
 import torch
 from PIL import Image
 from transformers import BatchFeature
 
+from vllm.config import ModelConfig
 from vllm.model_executor.models.lightonocr import LightOnOCRProcessingInfo
 from vllm.model_executor.models.mistral3 import Mistral3HFEncoderInfo
 from vllm.model_executor.models.pixtral import PixtralHFEncoderInfo
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.cache import MultiModalProcessorOnlyCache
 from vllm.multimodal.inputs import MultiModalKwargsItems
 
+from ...registry import HF_EXAMPLE_MODELS
 from ...utils import build_model_context
 
 # This repo ships both params.json (Mistral) and config.json (HF). Auto config
@@ -141,3 +144,53 @@ def test_lightonocr_keeps_vision_config_image_size():
     assert encoder_info.get_image_size() == (
         processor.info.get_hf_config().vision_config.image_size
     )
+
+
+@pytest.mark.parametrize("model_id", [_MODEL_ID])
+@pytest.mark.parametrize("use_cache", [True, False])
+def test_dummy_mm_inputs_with_mistral_tokenizer(model_id: str, use_cache: bool):
+    """
+    The HF-format Mistral3 architecture should be usable with
+    `--tokenizer-mode mistral`.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/45289
+    where building the dummy multi-modal inputs (run at API server startup
+    to compute the encoder budget) crashed because the tokenizer handed to
+    `PixtralProcessor` did not encode the `[IMG]` placeholder to its
+    special token id.
+    """
+    model_info = HF_EXAMPLE_MODELS.find_hf_info(model_id)
+    model_info.check_available_online(on_fail="skip")
+
+    results = {}
+    for tokenizer_mode in ("auto", "mistral"):
+        model_config = ModelConfig(
+            model_id,
+            tokenizer=model_id,
+            tokenizer_mode=tokenizer_mode,
+            # The HF repo also contains the consolidated (mistral-format)
+            # checkpoint; force the HF format to test the Mistral3
+            # architecture instead of Pixtral
+            config_format="hf",
+            max_model_len=8192,
+        )
+
+        cache = MultiModalProcessorOnlyCache(model_config) if use_cache else None
+        processor = MULTIMODAL_REGISTRY.create_processor(model_config, cache=cache)
+        mm_inputs = MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
+            model_config,
+            mm_counts={"image": 1},
+            processor=processor,
+        )
+
+        results[tokenizer_mode] = (
+            mm_inputs["prompt_token_ids"],
+            [
+                (placeholder.offset, placeholder.length)
+                for placeholder in mm_inputs["mm_placeholders"]["image"]
+            ],
+        )
+
+    # Both tokenizer modes use the Tekken vocab,
+    # so they should produce identical outputs
+    assert results["mistral"] == results["auto"]

--- a/tests/tokenizers_/test_mistral.py
+++ b/tests/tokenizers_/test_mistral.py
@@ -188,6 +188,40 @@ class TestMistralTokenizer:
         ):
             mistral_tokenizer("Hello world !", "invalid pair")
 
+    def test_transformers_tokenizer_with_special_tokens(
+        self, mistral_tokenizer: MistralTokenizer
+    ):
+        backend = mistral_tokenizer.transformers_tokenizer_with_special_tokens
+        plain_backend = mistral_tokenizer.transformers_tokenizer
+
+        hello_ids = plain_backend.encode("Hello world !", add_special_tokens=False)
+
+        # Plain text is tokenized identically
+        assert backend.encode("Hello world !", add_special_tokens=False) == hello_ids
+
+        # Special tokens in text are encoded to their token ids,
+        # which `MistralCommonBackend` deliberately never does
+        assert backend.encode("[INST]", add_special_tokens=False) == [3]
+        assert plain_backend.encode("[INST]", add_special_tokens=False) != [3]
+
+        # Mixed text and special tokens
+        assert backend.encode(
+            "[INST]Hello world ![/INST]", add_special_tokens=False
+        ) == [3, *hello_ids, 4]
+        assert backend.encode("[INST]Hello world ![/INST]") == [1, 3, *hello_ids, 4]
+        assert backend("[INST]Hello world ![/INST]", add_special_tokens=False)[
+            "input_ids"
+        ] == [3, *hello_ids, 4]
+        assert backend.tokenize("[INST]Hello world !") == [
+            "[INST]",
+            *plain_backend.tokenize("Hello world !"),
+        ]
+
+        # The user-facing tokenizer is unaffected
+        assert mistral_tokenizer.encode(
+            "[INST]", add_special_tokens=False
+        ) == plain_backend.encode("[INST]", add_special_tokens=False)
+
     @pytest.mark.parametrize(
         "openai_request,add_generation_prompt,continue_final_message,expected_output,decoded_expected_output",
         [

--- a/tests/tokenizers_/test_mistral.py
+++ b/tests/tokenizers_/test_mistral.py
@@ -190,6 +190,40 @@ class TestMistralTokenizer:
         ):
             mistral_tokenizer("Hello world !", "invalid pair")
 
+    def test_transformers_tokenizer_with_special_tokens(
+        self, mistral_tokenizer: MistralTokenizer
+    ):
+        backend = mistral_tokenizer.transformers_tokenizer_with_special_tokens
+        plain_backend = mistral_tokenizer.transformers_tokenizer
+
+        hello_ids = plain_backend.encode("Hello world !", add_special_tokens=False)
+
+        # Plain text is tokenized identically
+        assert backend.encode("Hello world !", add_special_tokens=False) == hello_ids
+
+        # Special tokens in text are encoded to their token ids,
+        # which `MistralCommonBackend` deliberately never does
+        assert backend.encode("[INST]", add_special_tokens=False) == [3]
+        assert plain_backend.encode("[INST]", add_special_tokens=False) != [3]
+
+        # Mixed text and special tokens
+        assert backend.encode(
+            "[INST]Hello world ![/INST]", add_special_tokens=False
+        ) == [3, *hello_ids, 4]
+        assert backend.encode("[INST]Hello world ![/INST]") == [1, 3, *hello_ids, 4]
+        assert backend("[INST]Hello world ![/INST]", add_special_tokens=False)[
+            "input_ids"
+        ] == [3, *hello_ids, 4]
+        assert backend.tokenize("[INST]Hello world !") == [
+            "[INST]",
+            *plain_backend.tokenize("Hello world !"),
+        ]
+
+        # The user-facing tokenizer is unaffected
+        assert mistral_tokenizer.encode(
+            "[INST]", add_special_tokens=False
+        ) == plain_backend.encode("[INST]", add_special_tokens=False)
+
     @pytest.mark.parametrize(
         "openai_request,add_generation_prompt,continue_final_message,expected_output,decoded_expected_output",
         [

--- a/vllm/multimodal/processing/context.py
+++ b/vllm/multimodal/processing/context.py
@@ -197,7 +197,10 @@ class InputProcessingContext:
 
         tokenizer = self.tokenizer
         if is_mistral_tokenizer(tokenizer):
-            tokenizer = tokenizer.transformers_tokenizer  # type: ignore[union-attr]
+            # HF processors insert special placeholder tokens (e.g. "[IMG]")
+            # into the prompt text and rely on the tokenizer to encode them
+            # back to their token ids, which mistral-common never does.
+            tokenizer = tokenizer.transformers_tokenizer_with_special_tokens  # type: ignore[union-attr]
 
         merged_kwargs = self.get_merged_mm_kwargs(kwargs)
         merged_kwargs.pop("tokenizer", None)

--- a/vllm/multimodal/processing/context.py
+++ b/vllm/multimodal/processing/context.py
@@ -236,7 +236,10 @@ class InputProcessingContext:
 
         tokenizer = self.tokenizer
         if is_mistral_tokenizer(tokenizer):
-            tokenizer = tokenizer.transformers_tokenizer  # type: ignore[union-attr]
+            # HF processors insert special placeholder tokens (e.g. "[IMG]")
+            # into the prompt text and rely on the tokenizer to encode them
+            # back to their token ids, which mistral-common never does.
+            tokenizer = tokenizer.transformers_tokenizer_with_special_tokens  # type: ignore[union-attr]
 
         merged_kwargs = self.get_merged_mm_kwargs(kwargs)
         merged_kwargs.pop("tokenizer", None)

--- a/vllm/multimodal/processing/dummy_inputs.py
+++ b/vllm/multimodal/processing/dummy_inputs.py
@@ -16,6 +16,7 @@ from vllm.config.multimodal import (
 )
 from vllm.inputs import MultiModalDataDict
 from vllm.logger import init_logger
+from vllm.utils.mistral import is_mistral_tokenizer
 
 from .context import BaseProcessingInfo
 from .inputs import ProcessorInputs
@@ -92,6 +93,11 @@ class BaseDummyInputsBuilder(ABC, Generic[_I]):
             dummy_prompt = []
         else:
             from .processor import cached_encode
+
+            if is_mistral_tokenizer(tokenizer):
+                # The dummy text contains special placeholder tokens
+                # (e.g. "[IMG]") which mistral-common never encodes from text.
+                tokenizer = tokenizer.transformers_tokenizer_with_special_tokens  # type: ignore[assignment]
 
             dummy_prompt = cached_encode(tokenizer, dummy_text, truncation=False)
 

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import re
 from collections.abc import Sequence
 from functools import cached_property
 from pathlib import Path
@@ -221,6 +222,52 @@ def tekken_convert_tokens_to_string(
     return "".join(cast(Sequence[str], tokens))
 
 
+class _MistralCommonBackendWithSpecialTokens(MistralCommonBackend):
+    """`MistralCommonBackend` that encodes special tokens found in text.
+
+    mistral-common deliberately never encodes special tokens from text:
+    `encode("[IMG]")` tokenizes the literal string instead of returning the id
+    of the `[IMG]` token. HF processors (such as `PixtralProcessor`) insert
+    special placeholder tokens into the prompt text and rely on the tokenizer
+    to encode them back to their token ids, like HF tokenizers do for added
+    tokens.
+
+    This backend implements that behavior so HF processors can be used with
+    Mistral tokenizers. It must only be used to tokenize trusted text, not
+    user-provided prompts.
+    """
+
+    @cached_property
+    def _special_token_to_id(self) -> dict[str, int]:
+        # `all_special_tokens` is aligned with `all_special_ids`.
+        return dict(zip(self.all_special_tokens, self.all_special_ids))
+
+    @cached_property
+    def _special_token_pattern(self) -> re.Pattern[str]:
+        # Longest match first, so a special token that is a prefix of another
+        # does not shadow it.
+        special_tokens = sorted(self.all_special_tokens, key=len, reverse=True)
+        return re.compile(f"({'|'.join(map(re.escape, special_tokens))})")
+
+    def _text_to_ids(self, text: str, add_special_tokens: bool) -> list[int]:
+        tokenizer = self.tokenizer.instruct_tokenizer.tokenizer
+
+        token_ids = list[int]()
+        # Segments at odd indices are the special tokens the pattern matched.
+        for i, segment in enumerate(self._special_token_pattern.split(text)):
+            if i % 2:
+                token_ids.append(self._special_token_to_id[segment])
+            elif segment:
+                token_ids.extend(tokenizer.encode(segment, bos=False, eos=False))
+
+        if add_special_tokens:
+            token_ids.insert(0, tokenizer.bos_id)
+            if self._mode == ValidationMode.finetuning:
+                token_ids.append(tokenizer.eos_id)
+
+        return token_ids
+
+
 class MistralTokenizer(TokenizerLike):
     IS_MISTRAL_TOKENIZER = True  # used by vllm.utils.mistral
 
@@ -296,6 +343,26 @@ class MistralTokenizer(TokenizerLike):
             self.tokenizer.decode([i], special_token_policy=SpecialTokenPolicy.KEEP)
             for i in all_special_ids
         ]
+
+    @cached_property
+    def transformers_tokenizer_with_special_tokens(self) -> MistralCommonBackend:
+        """Variant of `transformers_tokenizer` that encodes special tokens
+        found in text, which mistral-common never does.
+
+        HF processors insert special placeholder tokens (e.g. `"[IMG]"`) into
+        the prompt text and rely on the tokenizer to encode them back to their
+        ids. Only use it to tokenize trusted text, not user-provided prompts.
+        """
+        backend = self.transformers_tokenizer
+        return _MistralCommonBackendWithSpecialTokens(
+            tokenizer_path=backend._tokenizer_path,
+            mode=backend.mode,
+            model_max_length=backend.model_max_length,
+            padding_side=backend.padding_side,
+            truncation_side=backend.truncation_side,
+            model_input_names=backend.model_input_names,
+            clean_up_tokenization_spaces=backend.clean_up_tokenization_spaces,
+        )
 
     def num_special_tokens_to_add(self) -> int:
         return len(self.encode(""))

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import re
 from collections.abc import Sequence
 from functools import cached_property
 from pathlib import Path
@@ -206,6 +207,52 @@ def tekken_convert_tokens_to_string(
     return "".join(cast(Sequence[str], tokens))
 
 
+class _MistralCommonBackendWithSpecialTokens(MistralCommonBackend):
+    """`MistralCommonBackend` that encodes special tokens found in text.
+
+    mistral-common deliberately never encodes special tokens from text:
+    `encode("[IMG]")` tokenizes the literal string instead of returning the id
+    of the `[IMG]` token. HF processors (such as `PixtralProcessor`) insert
+    special placeholder tokens into the prompt text and rely on the tokenizer
+    to encode them back to their token ids, like HF tokenizers do for added
+    tokens.
+
+    This backend implements that behavior so HF processors can be used with
+    Mistral tokenizers. It must only be used to tokenize trusted text, not
+    user-provided prompts.
+    """
+
+    @cached_property
+    def _special_token_to_id(self) -> dict[str, int]:
+        # `all_special_tokens` is aligned with `all_special_ids`.
+        return dict(zip(self.all_special_tokens, self.all_special_ids))
+
+    @cached_property
+    def _special_token_pattern(self) -> re.Pattern[str]:
+        # Longest match first, so a special token that is a prefix of another
+        # does not shadow it.
+        special_tokens = sorted(self.all_special_tokens, key=len, reverse=True)
+        return re.compile(f"({'|'.join(map(re.escape, special_tokens))})")
+
+    def _text_to_ids(self, text: str, add_special_tokens: bool) -> list[int]:
+        tokenizer = self.tokenizer.instruct_tokenizer.tokenizer
+
+        token_ids = list[int]()
+        # Segments at odd indices are the special tokens the pattern matched.
+        for i, segment in enumerate(self._special_token_pattern.split(text)):
+            if i % 2:
+                token_ids.append(self._special_token_to_id[segment])
+            elif segment:
+                token_ids.extend(tokenizer.encode(segment, bos=False, eos=False))
+
+        if add_special_tokens:
+            token_ids.insert(0, tokenizer.bos_id)
+            if self._mode == ValidationMode.finetuning:
+                token_ids.append(tokenizer.eos_id)
+
+        return token_ids
+
+
 class MistralTokenizer(TokenizerLike):
     IS_MISTRAL_TOKENIZER = True  # used by vllm.utils.mistral
 
@@ -281,6 +328,26 @@ class MistralTokenizer(TokenizerLike):
             self.tokenizer.decode([i], special_token_policy=SpecialTokenPolicy.KEEP)
             for i in all_special_ids
         ]
+
+    @cached_property
+    def transformers_tokenizer_with_special_tokens(self) -> MistralCommonBackend:
+        """Variant of `transformers_tokenizer` that encodes special tokens
+        found in text, which mistral-common never does.
+
+        HF processors insert special placeholder tokens (e.g. `"[IMG]"`) into
+        the prompt text and rely on the tokenizer to encode them back to their
+        ids. Only use it to tokenize trusted text, not user-provided prompts.
+        """
+        backend = self.transformers_tokenizer
+        return _MistralCommonBackendWithSpecialTokens(
+            tokenizer_path=backend._tokenizer_path,
+            mode=backend.mode,
+            model_max_length=backend.model_max_length,
+            padding_side=backend.padding_side,
+            truncation_side=backend.truncation_side,
+            model_input_names=backend.model_input_names,
+            clean_up_tokenization_spaces=backend.clean_up_tokenization_spaces,
+        )
 
     def num_special_tokens_to_add(self) -> int:
         return len(self.encode(""))


### PR DESCRIPTION
## Purpose

Fixes #45289.

The crash is not specific to `--reasoning-parser`: any HF-format `Mistral3ForConditionalGeneration` checkpoint served with `--tokenizer-mode mistral` fails at startup in the `MultiModalBudget` dummy run, and the same failure hits real multimodal requests. `get_hf_processor` hands `MistralTokenizer.transformers_tokenizer` to the HF `PixtralProcessor` (#31817), but mistral-common deliberately never encodes special tokens from text, so the `[IMG]` placeholder the processor inserts tokenizes as a literal string and `_check_special_mm_tokens` raises. The issue was closed via the workaround of using the consolidated checkpoint (which resolves to `PixtralForConditionalGeneration` and bypasses the HF processor), but the HF-format combination remains broken on main.

This PR hands HF processors a `MistralCommonBackend` subclass whose `_text_to_ids` encodes special tokens found in text to their ids (HF added-token semantics), scoped to `InputProcessingContext.get_hf_processor` only — user-facing tokenization is unchanged, and vLLM's own `MistralCommonPixtralProcessor`/`MistralCommonVoxtralProcessor` are untouched.

## Test Plan

`pytest tests/models/multimodal/processing/test_mistral3.py` (new; reproduces the startup failure with `mistralai/Mistral-Small-3.1-24B-Instruct-2503` + `config_format="hf"` and asserts parity with `tokenizer_mode="auto"`, with and without processor cache) and a new unit test in `tests/tokenizers_/test_mistral.py` for the special-token-aware backend (tekken + spm).

## Test Result

New tests fail on main with the exact error from the issue and pass with this change; `tests/tokenizers_/test_mistral.py` (57 passed, 2 pre-existing skips) and `test_common.py -k "Mistral-Small-3.1"` (3 passed) stay green.

---

### AI-assistance disclosure (per AGENTS.md)

- **AI assistance was used.** This change was developed with the assistance of Claude Code; the human submitter (@discobot) has reviewed every changed line and is able to defend the change end-to-end.
- **Not a duplicate.** Per the duplicate-work checks (`gh issue view 45289 --comments`, `gh pr list --search "45289 in:body"`, and an area-keyword search for Mistral tokenizer / `tokenizer-mode mistral` PRs), no open PR addresses this issue. The only related open PR, #45514, adds a `batch_split_message` tokenizer mode for parallel encoding and touches different code paths; it does not fix the HF-processor special-token encoding bug.
- **Tests run:** `pytest tests/models/multimodal/processing/test_mistral3.py`, `tests/tokenizers_/test_mistral.py`, and `tests/models/multimodal/processing/test_common.py -k "Mistral-Small-3.1"`, plus `ruff check`/`ruff format` on the touched files (results above). Validated on a pure-Python (`VLLM_TARGET_DEVICE=empty`) install at the exact failing layer; a full CUDA `vllm serve` e2e was not run on this machine.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
