### PR TITLE
[v1] Initialize InputBatch in initialize_kv_cache instead of __init__

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -36,7 +36,6 @@ from vllm.config import (
     set_current_vllm_config,
     update_config,
 )
-from vllm.config.cache import CacheConfig
 from vllm.distributed.ec_transfer import get_ec_transfer, has_ec_transfer
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
@@ -643,51 +642,26 @@ class GPUModelRunner(
         self.num_prompt_logprobs: dict[str, int] = {}
 
         # Input Batch
-        # NOTE(Chen): Ideally, we should initialize the input batch inside
-        # `initialize_kv_cache` based on the kv cache config. However, as in
-        # https://github.com/vllm-project/vllm/pull/18298, due to some unknown
-        # reasons, we have to initialize the input batch before `load_model`,
-        # quantization + weight offloading will fail otherwise. As a temporary
-        # solution, we initialize the input batch here, and re-initialize it
-        # in `initialize_kv_cache` if the block_sizes here is different from
-        # the block_sizes in the kv cache config.
         logits_processors = model_config.logits_processors
         custom_logitsprocs: Sequence[str | type[LogitsProcessor]] = (
             tuple(logits_processors) if logits_processors is not None else ()
         )
-        placeholder_block_size = (
-            self.cache_config.block_size or CacheConfig.DEFAULT_BLOCK_SIZE
+        self._logitsprocs = build_logitsprocs(
+            self.vllm_config,
+            self.device,
+            PIN_MEMORY,
+            self.is_pooling_model,
+            custom_logitsprocs,
         )
-        self._init_block_sizes = [placeholder_block_size]
-        self._init_kernel_block_sizes = [placeholder_block_size]
-        self.input_batch = InputBatch(
-            max_num_reqs=self.max_num_reqs,
-            # We need to use the encoder length for encoder-decoder
-            # because of KV cache for cross-attention.
-            max_model_len=max(self.max_model_len, self.max_encoder_len),
-            max_num_batched_tokens=self.max_num_tokens,
-            device=self.device,
-            vocab_size=self.model_config.get_vocab_size(),
-            block_sizes=[placeholder_block_size],
-            kernel_block_sizes=[placeholder_block_size],
-            num_spec_tokens=self.num_spec_tokens,
-            logitsprocs=build_logitsprocs(
-                self.vllm_config,
-                self.device,
-                PIN_MEMORY,
-                self.is_pooling_model,
-                custom_logitsprocs,
-            ),
-            # We currently don't know whether a particular custom logits processor
-            # uses output token ids so we set this conservatively.
-            # ThinkingTokenBudgetLogitsProcessor also needs output token ids to
-            # correctly track think start/end token sequences in async scheduling.
-            logitsprocs_need_output_token_ids=bool(custom_logitsprocs)
-            or self.vllm_config.reasoning_config is not None,
-            is_pooling_model=self.is_pooling_model,
-            cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
-            reasoning_config=self.vllm_config.reasoning_config,
+        # We currently don't know whether a particular custom logits processor
+        # uses output token ids so we set this conservatively.
+        # ThinkingTokenBudgetLogitsProcessor also needs output token ids to
+        # correctly track think start/end token sequences in async scheduling.
+        self._logitsprocs_need_output_token_ids = (
+            bool(custom_logitsprocs) or self.vllm_config.reasoning_config is not None
         )
+        # Initialized in initialize_kv_cache.
+        self.input_batch: InputBatch
 
         # Separate cuda stream for overlapping transfer of sampled token ids from
         # GPU to CPU when async scheduling is enabled.
@@ -6945,20 +6919,10 @@ class GPUModelRunner(
             return
         self.reorder_batch_threshold = reduce(min_none_high, reorder_batch_thresholds)  # type: ignore[assignment]
 
-    def may_reinitialize_input_batch(
+    def initialize_input_batch(
         self, kv_cache_config: KVCacheConfig, kernel_block_sizes: list[int]
     ) -> None:
-        """
-        Re-initialize the input batch if the block sizes are different from
-        what it was originally created with. This happens when the final
-        block size (determined after model loading) differs from the
-        placeholder used during __init__, or when there are multiple
-        KV cache groups.
-
-        Args:
-            kv_cache_config: The KV cache configuration.
-            kernel_block_sizes: The kernel block sizes for each KV cache group.
-        """
+        """Initialize the input batch based on the final KV cache configuration."""
         block_sizes = []
         max_num_blocks = []
         max_model_len = max(self.max_model_len, self.max_encoder_len)
@@ -6978,35 +6942,21 @@ class GPUModelRunner(
                 ) + kv_cache_group.kv_cache_spec.num_speculative_blocks
             max_num_blocks.append(max_num_blocks_per_req)
 
-        if (
-            block_sizes != self._init_block_sizes
-            or kernel_block_sizes != self._init_kernel_block_sizes
-        ):
-            self._init_block_sizes = block_sizes
-            self._init_kernel_block_sizes = kernel_block_sizes
-            self.input_batch = InputBatch(
-                max_num_reqs=self.max_num_reqs,
-                max_model_len=max_model_len,
-                max_num_batched_tokens=self.max_num_tokens,
-                device=self.device,
-                vocab_size=self.model_config.get_vocab_size(),
-                block_sizes=block_sizes,
-                kernel_block_sizes=kernel_block_sizes,
-                max_num_blocks_per_req=max_num_blocks,
-                num_spec_tokens=self.num_spec_tokens,
-                logitsprocs=self.input_batch.logitsprocs,
-                logitsprocs_need_output_token_ids=self.input_batch.logitsprocs_need_output_token_ids,
-                is_pooling_model=self.is_pooling_model,
-                reasoning_config=self.vllm_config.reasoning_config,
-            )
-
-        assert self._init_block_sizes == block_sizes, (
-            f"InputBatch block_sizes {self._init_block_sizes} != "
-            f"kv_cache block_sizes {block_sizes}"
-        )
-        assert self._init_kernel_block_sizes == kernel_block_sizes, (
-            f"InputBatch kernel_block_sizes {self._init_kernel_block_sizes} "
-            f"!= kv_cache kernel_block_sizes {kernel_block_sizes}"
+        self.input_batch = InputBatch(
+            max_num_reqs=self.max_num_reqs,
+            max_model_len=max_model_len,
+            max_num_batched_tokens=self.max_num_tokens,
+            device=self.device,
+            vocab_size=self.model_config.get_vocab_size(),
+            block_sizes=block_sizes,
+            kernel_block_sizes=kernel_block_sizes,
+            max_num_blocks_per_req=max_num_blocks,
+            num_spec_tokens=self.num_spec_tokens,
+            logitsprocs=self._logitsprocs,
+            logitsprocs_need_output_token_ids=self._logitsprocs_need_output_token_ids,
+            is_pooling_model=self.is_pooling_model,
+            cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
+            reasoning_config=self.vllm_config.reasoning_config,
         )
 
     def _allocate_kv_cache_tensors(
@@ -7322,8 +7272,7 @@ class GPUModelRunner(
         # create metadata builders
         self.initialize_metadata_builders(kv_cache_config, kernel_block_sizes)
 
-        # Reinitialize need to after initialize_attn_backend
-        self.may_reinitialize_input_batch(kv_cache_config, kernel_block_sizes)
+        self.initialize_input_batch(kv_cache_config, kernel_block_sizes)
         kv_caches = self.initialize_kv_cache_tensors(
             kv_cache_config, kernel_block_sizes
         )


### PR DESCRIPTION
## Summary

- Moves `InputBatch` creation from `GPUModelRunner.__init__` to `initialize_kv_cache`.
  `may_reinitialize_input_batch` (which conditionally re-created the batch if block sizes differed from the placeholder) is renamed to `initialize_input_batch` and becomes the sole initialization point, using the final block sizes from `kv_cache_config` directly.
- Removes the now-unnecessary `_init_block_sizes` / `_init_kernel_block_sizes` tracking fields and the conditional re-init logic.
- Fixes a latent bug where `cp_kv_cache_interleave_size` was omitted from the re-init path in `may_reinitialize_input_batch`.

## Background

The early initialization in `__init__` was a workaround for a UVA pinned-memory aliasing bug (#18298).

The old CPU offloading implementation stored `cpu_data` only as a Python attribute on the parameter object. The UVA CUDA view was created with a no-op C++ deleter that did not hold a reference to `cpu_data`. When `process_weights_after_loading` (GPTQ, Marlin, FP8, ...) replaced parameter objects (e.g. `layer.qweight = Parameter(layer.qweight.data)`), the old `PackedvLLMParameter` was GC'd. This released `_vllm_offloaded_cpu_data` — and thus `cpu_data` — back to `CachingHostAllocator`, while `.data` (the UVA CUDA view) survived as it was now held by the new `Parameter`. Any `InputBatch` created after `load_model` could then receive that freed memory for its pinned buffers (e.g. `block_table_cpu`), aliasing live GPTQ weight CUDA views:

```
Old implementation:

  PackedvLLMParameter
  ├── _vllm_offloaded_cpu_data ──► [pinned @ 0xABCD]
  └── .data (UVA CUDA view) ──────► [CUDA ptr → 0xABCD]  (no-op deleter)

  After GPTQ process_weights_after_loading replaces PackedvLLMParameter → GC:
  _vllm_offloaded_cpu_data released → 0xABCD returned to CachingHostAllocator

  InputBatch.block_table_cpu ─────► [0xABCD]  ← aliases the CUDA view!
```

The workaround was to create `InputBatch` before `load_model` with a placeholder block size (#17945 / #18298), then conditionally re-create it in `initialize_kv_cache` if block sizes differed (#18593 / #18654). The root cause was described at the time as "unknown reasons".

## Why it is now safe

The C++ lambda fix in `csrc/cuda_view.cu` (landed after #18298) captures `cpu_tensor` by value in the deleter, keeping it alive for the full lifetime of the UVA CUDA view. The new offloading implementation no longer stores `cpu_data` on the parameter at all — its lifetime is entirely managed by the C++ lambda:

```
New implementation:

  Parameter
  └── .data (UVA CUDA view) ──────► [CUDA ptr → 0xABCD]
                                     deleter: [cpu_tensor]{}
                                                   |
                                                   ▼
                                     [pinned @ 0xABCD]  ← kept alive by deleter

  After GPTQ replaces Parameter: CUDA view still alive → cpu_tensor not released → no alias
```

PR #36461 confirmed the fix is complete by removing the `offload + quantization` reinit guard added in #18654.

## Change history

- #17945 first moved `InputBatch` init into `initialize_kv_cache`, but was reverted (#18459) due to the then-unknown root cause.
- #18593 re-did the multi-KV-cache-group work, keeping the placeholder init in `__init__`.
- #18654 introduced `may_reinitialize_input_batch` to handle the case where block sizes differ from the placeholder.
- #36461 removed the offload+quantization guard but did not remove the placeholder init.
- No open PR removes the placeholder init entirely.

## Test commands

```bash
# Linters (all passed locally)
pre-commit run --files vllm/v1/worker/gpu_model_runner.py

# Unit tests
.venv/bin/python -m pytest tests/v1/worker/ -v
.venv/bin/python -m pytest tests/quantization/test_cpu_offload.py::test_cpu_offload_gptq -v
```

> AI assistance was used (Claude) to identify the root cause and draft this change. Every changed line has been reviewed by the human submitter.