### PR TITLE
[Model][Quant] compressed-tensors WNA16 input embeddings + tied embedding (lm_head) support

### DIFF
--- a/tests/quantization/test_quantized_embedding.py
+++ b/tests/quantization/test_quantized_embedding.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests that a compressed-tensors WNA16-INT quantized input embedding is
+dispatched to ``CompressedTensorsEmbeddingWNA16Int`` and loads/runs.
+
+This guards the model-side plumbing: an input ``VocabParallelEmbedding`` is only
+quantized if the model passes ``quant_config`` (and ``prefix``) to it. Without
+that, a checkpoint with a quantized ``embed_in``/``embed_tokens`` silently falls
+back to an unquantized embedding and fails to load.
+
+Run `pytest tests/quantization/test_quantized_embedding.py`.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_embedding import (  # noqa: E501
+    CompressedTensorsEmbeddingWNA16Int,
+)
+
+# Tiny GPTNeoX checkpoint with `embed_in` quantized to WNA16-INT (W4 group64,
+# class-based "Embedding" target), produced with llm-compressor.
+MODEL_ID = "kkothuri/pythia-70m-emb-w4g64-ct"
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="quantized embedding kernel requires CUDA"
+)
+def test_quantized_embedding_dispatch(vllm_runner, monkeypatch) -> None:
+    # `LLM.apply_model` requires pickling a function.
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+    with vllm_runner(
+        MODEL_ID, dtype=torch.float16, max_model_len=2048, enforce_eager=True
+    ) as vllm_model:
+
+        def check_model(model):
+            embed = model.gpt_neox.embed_in
+            assert isinstance(embed.quant_method, CompressedTensorsEmbeddingWNA16Int)
+
+        vllm_model.apply_model(check_model)
+
+        # Smoke test: the dequant-gather embedding path runs end-to-end.
+        print(vllm_model.generate_greedy(["Hello my name is"], max_tokens=4)[0][1])

--- a/tests/quantization/test_quantized_embedding.py
+++ b/tests/quantization/test_quantized_embedding.py
@@ -22,6 +22,11 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
 # class-based "Embedding" target), produced with llm-compressor.
 MODEL_ID = "kkothuri/pythia-70m-emb-w4g64-ct"
 
+# Same, but with tied embeddings: the single packed table is reused as the
+# `embed_out` head, so the logits matmul runs through the quantized embedding's
+# `apply` and the tie must survive a packed (weight-less) embedding.
+TIED_MODEL_ID = "kkothuri/pythia-70m-tied-W4g64-ct"
+
 
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="quantized embedding kernel requires CUDA"
@@ -40,4 +45,27 @@ def test_quantized_embedding_dispatch(vllm_runner, monkeypatch) -> None:
         vllm_model.apply_model(check_model)
 
         # Smoke test: the dequant-gather embedding path runs end-to-end.
+        print(vllm_model.generate_greedy(["Hello my name is"], max_tokens=4)[0][1])
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="quantized embedding kernel requires CUDA"
+)
+def test_tied_quantized_embedding(vllm_runner, monkeypatch) -> None:
+    # `LLM.apply_model` requires pickling a function.
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+    with vllm_runner(
+        TIED_MODEL_ID, dtype=torch.float16, max_model_len=2048, enforce_eager=True
+    ) as vllm_model:
+
+        def check_model(model):
+            embed = model.gpt_neox.embed_in
+            assert isinstance(embed.quant_method, CompressedTensorsEmbeddingWNA16Int)
+            # Tied: the head reuses the quantized embedding module, so its
+            # `apply` (logits matmul) is exercised on the packed table.
+            assert model.embed_out is embed
+
+        vllm_model.apply_model(check_model)
+
+        # Smoke test: load + tie + the apply (logits) path run without error.
         print(vllm_model.generate_greedy(["Hello my name is"], max_tokens=4)[0][1])

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_embedding.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_embedding.py
@@ -164,7 +164,27 @@ class CompressedTensorsEmbeddingWNA16Int(QuantizeMethodBase):
         )
         return deq.reshape(*input_.shape, hidden)
 
-    def apply(self, layer: torch.nn.Module, *args, **kwargs) -> torch.Tensor:
-        raise NotImplementedError(
-            "CompressedTensorsEmbeddingWNA16Int supports embedding lookup only"
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Linear projection against the packed table (logits matmul).
+
+        Needed when a quantized embedding is reused as a tied ``lm_head``: the
+        logits step requires ``x @ W.T`` rather than a row gather. The full
+        table is dequantized once (reusing the gather kernel over all rows) and
+        passed to ``F.linear``. A fused dequant-GEMM would avoid materializing
+        the dense weight; left as a follow-up optimization.
+        """
+        vocab_size = layer.weight_packed.shape[0]
+        ids = torch.arange(vocab_size, device=layer.weight_packed.device)
+        weight = _dequant_gather_triton(
+            ids,
+            layer.weight_packed,
+            layer.weight_scale,
+            layer.hidden_size,
+            self.num_bits,
         )
+        return torch.nn.functional.linear(x, weight.to(x.dtype), bias)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_embedding.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_embedding.py
@@ -68,9 +68,11 @@ def _dequant_gather_triton(
     weight_scale: torch.Tensor,
     hidden: int,
     num_bits: int,
+    out_dtype: torch.dtype | None = None,
 ) -> torch.Tensor:
     n = ids.numel()
-    out = torch.empty(n, hidden, dtype=weight_scale.dtype, device=weight_packed.device)
+    dtype = out_dtype if out_dtype is not None else weight_scale.dtype
+    out = torch.empty(n, hidden, dtype=dtype, device=weight_packed.device)
     num_groups = weight_scale.shape[1]
     group_size = 0 if num_groups == 1 else hidden // num_groups
     block = min(triton.next_power_of_2(hidden), 1024)
@@ -153,6 +155,13 @@ class CompressedTensorsEmbeddingWNA16Int(QuantizeMethodBase):
         layer.register_parameter("weight_scale", weight_scale)
         layer.register_parameter("weight_shape", weight_shape)
 
+        # Row indices for the full table, used by `apply` (tied lm_head logits)
+        # to gather+dequantize every row. Registered once as a buffer so it moves
+        # with the layer to the device and is not rebuilt on each call.
+        layer.register_buffer(
+            "all_row_ids", torch.arange(vocab_pp, dtype=torch.long), persistent=False
+        )
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         pass
 
@@ -174,17 +183,28 @@ class CompressedTensorsEmbeddingWNA16Int(QuantizeMethodBase):
 
         Needed when a quantized embedding is reused as a tied ``lm_head``: the
         logits step requires ``x @ W.T`` rather than a row gather. The full
-        table is dequantized once (reusing the gather kernel over all rows) and
-        passed to ``F.linear``. A fused dequant-GEMM would avoid materializing
-        the dense weight; left as a follow-up optimization.
+        table is dequantized once (reusing the gather kernel over all rows,
+        directly into ``x``'s dtype) and passed to ``F.linear``. A fused
+        dequant-GEMM would avoid materializing the dense weight; left as a
+        follow-up optimization.
         """
-        vocab_size = layer.weight_packed.shape[0]
-        ids = torch.arange(vocab_size, device=layer.weight_packed.device)
         weight = _dequant_gather_triton(
-            ids,
+            layer.all_row_ids,
             layer.weight_packed,
             layer.weight_scale,
             layer.hidden_size,
             self.num_bits,
+            out_dtype=x.dtype,
         )
-        return torch.nn.functional.linear(x, weight.to(x.dtype), bias)
+        return torch.nn.functional.linear(x, weight, bias)
+
+    def tie_weights(
+        self, layer: torch.nn.Module, embed_tokens: torch.nn.Module
+    ) -> torch.nn.Module:
+        """Reuse the quantized embedding module as the tied ``lm_head``.
+
+        The packed table exposes no plain ``weight`` to share, so instead of
+        aliasing a tensor return the embedding module itself; its ``apply``
+        then serves the ``lm_head`` logits matmul.
+        """
+        return embed_tokens

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -572,13 +572,14 @@ class ParallelLMHead(VocabParallelEmbedding):
         set_weight_attrs(weight=self.bias, weight_attrs=weight_attrs)
 
     def tie_weights(self, embed_tokens: VocabParallelEmbedding):
-        """Tie the weights with word embeddings."""
-        # Packed/quantized embeddings (e.g. compressed-tensors WNA16) expose no
-        # plain ``weight`` to share; reuse the embedding module directly so its
-        # quant method serves the lm_head matmul.
-        if not hasattr(embed_tokens, "weight"):
-            return embed_tokens
-        return self.quant_method.tie_weights(self, embed_tokens)
+        """Tie the weights with word embeddings.
+
+        Dispatch on ``embed_tokens``' quant method (the source of the shared
+        weight), so a packed/quantized embedding can override ``tie_weights`` to
+        reuse itself as the head (e.g. compressed-tensors WNA16) instead of
+        aliasing a plain ``weight`` it does not expose.
+        """
+        return embed_tokens.quant_method.tie_weights(self, embed_tokens)
 
     def forward(self, input_):
         del input_

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -573,6 +573,11 @@ class ParallelLMHead(VocabParallelEmbedding):
 
     def tie_weights(self, embed_tokens: VocabParallelEmbedding):
         """Tie the weights with word embeddings."""
+        # Packed/quantized embeddings (e.g. compressed-tensors WNA16) expose no
+        # plain ``weight`` to share; reuse the embedding module directly so its
+        # quant method serves the lm_head matmul.
+        if not hasattr(embed_tokens, "weight"):
+            return embed_tokens
         return self.quant_method.tie_weights(self, embed_tokens)
 
     def forward(self, input_):

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -579,6 +579,10 @@ class ParallelLMHead(VocabParallelEmbedding):
         reuse itself as the head (e.g. compressed-tensors WNA16) instead of
         aliasing a plain ``weight`` it does not expose.
         """
+        # On a pipeline-parallel rank without the embedding, ``embed_tokens`` is
+        # a ``PPMissingLayer`` placeholder with no quant method; nothing to tie.
+        if not hasattr(embed_tokens, "quant_method"):
+            return embed_tokens
         return embed_tokens.quant_method.tie_weights(self, embed_tokens)
 
     def forward(self, input_):

--- a/vllm/model_executor/models/afmoe.py
+++ b/vllm/model_executor/models/afmoe.py
@@ -387,7 +387,10 @@ class AfmoeModel(nn.Module, EagleModelMixin):
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
-                config.vocab_size, config.hidden_size, prefix=f"{prefix}.embed_tokens"
+                config.vocab_size,
+                config.hidden_size,
+                prefix=f"{prefix}.embed_tokens",
+                quant_config=quant_config,
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/vllm/model_executor/models/arctic.py
+++ b/vllm/model_executor/models/arctic.py
@@ -387,7 +387,11 @@ class ArcticModel(nn.Module):
         self.config = config
         self.vocab_size = config.vocab_size
         self.embed_tokens = VocabParallelEmbedding(
-            self.vocab_size, config.hidden_size, org_num_embeddings=self.vocab_size
+            self.vocab_size,
+            config.hidden_size,
+            org_num_embeddings=self.vocab_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,

--- a/vllm/model_executor/models/bailing_moe_linear.py
+++ b/vllm/model_executor/models/bailing_moe_linear.py
@@ -496,6 +496,8 @@ class BailingMoeV25Model(nn.Module):
                 self.vocab_size,
                 self.embed_dim,
                 org_num_embeddings=self.vocab_size,
+                quant_config=vllm_config.quant_config,
+                prefix=f"{prefix}.word_embeddings",
             )
         else:
             from vllm.model_executor.models.utils import PPMissingLayer

--- a/vllm/model_executor/models/bailing_moe_mtp.py
+++ b/vllm/model_executor/models/bailing_moe_mtp.py
@@ -156,6 +156,7 @@ class BailingMoeV25MultiTokenPredictor(nn.Module):
                 config.hidden_size,
                 org_num_embeddings=config.vocab_size,
                 prefix=maybe_prefix(prefix, "embed_tokens"),
+                quant_config=vllm_config.quant_config,
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/vllm/model_executor/models/bert.py
+++ b/vllm/model_executor/models/bert.py
@@ -47,11 +47,19 @@ from .utils import AutoWeightsLoader, WeightsMapper, maybe_prefix
 
 
 class BertEmbedding(nn.Module):
-    def __init__(self, config: BertConfig):
+    def __init__(
+        self,
+        config: BertConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.size = config.hidden_size
         self.word_embeddings = VocabParallelEmbedding(
-            config.vocab_size, config.hidden_size
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.word_embeddings",
         )
         self.position_embeddings = VocabParallelEmbedding(
             config.max_position_embeddings, config.hidden_size
@@ -393,7 +401,11 @@ class BertModel(nn.Module, SupportsQuant):
         super().__init__()
 
         self.config = vllm_config.model_config.hf_config
-        self.embeddings = embedding_class(self.config)
+        self.embeddings = embedding_class(
+            self.config,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embeddings",
+        )
         self.encoder = BertEncoder(vllm_config=vllm_config, prefix=f"{prefix}.encoder")
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/bert_with_rope.py
+++ b/vllm/model_executor/models/bert_with_rope.py
@@ -46,7 +46,12 @@ from .interfaces_base import default_pooling_type
 
 
 class BertWithRopeEmbedding(nn.Module):
-    def __init__(self, config: PretrainedConfig):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         if config.position_embedding_type not in ["rope", "rotary"]:
             raise ValueError(
@@ -54,7 +59,10 @@ class BertWithRopeEmbedding(nn.Module):
             )
 
         self.word_embeddings = VocabParallelEmbedding(
-            config.vocab_size, config.hidden_size
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.word_embeddings",
         )
         if config.type_vocab_size > 0:
             self.token_type_embeddings = VocabParallelEmbedding(
@@ -457,7 +465,11 @@ class BertWithRope(nn.Module, SupportsQuant):
         self.vllm_config = vllm_config
         self.add_pooling_layer = add_pooling_layer
         self.config = vllm_config.model_config.hf_config
-        self.embeddings = BertWithRopeEmbedding(self.config)
+        self.embeddings = BertWithRopeEmbedding(
+            self.config,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embeddings",
+        )
         self.encoder = BertWithRopeEncoder(
             vllm_config=vllm_config,
             bias=getattr(self.config, "bias", True),

--- a/vllm/model_executor/models/bloom.py
+++ b/vllm/model_executor/models/bloom.py
@@ -249,6 +249,8 @@ class BloomModel(nn.Module):
         self.word_embeddings = VocabParallelEmbedding(
             config.vocab_size,
             self.embed_dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.word_embeddings",
         )
         self.word_embeddings_layernorm = nn.LayerNorm(
             self.embed_dim, eps=config.layer_norm_epsilon

--- a/vllm/model_executor/models/chameleon.py
+++ b/vllm/model_executor/models/chameleon.py
@@ -836,6 +836,8 @@ class ChameleonModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.vocabulary_mapping = ChameleonImageVocabularyMapping(config.vocabulary_map)
         decoder_layer = (

--- a/vllm/model_executor/models/cohere2_moe.py
+++ b/vllm/model_executor/models/cohere2_moe.py
@@ -398,7 +398,10 @@ class Cohere2MoeModel(nn.Module):
         self.vocab_size = config.vocab_size
         self.org_vocab_size = config.vocab_size
         self.embed_tokens = VocabParallelEmbedding(
-            config.vocab_size, config.hidden_size
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         # Decoder layers read per-layer MLP layout from config.mlp_layer_types

--- a/vllm/model_executor/models/cohere_eagle.py
+++ b/vllm/model_executor/models/cohere_eagle.py
@@ -79,6 +79,7 @@ class CohereEagleModel(nn.Module):
             self.config.vocab_size,
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
+            quant_config=vllm_config.quant_config,
         )
 
         self.layers = nn.ModuleList(

--- a/vllm/model_executor/models/commandr.py
+++ b/vllm/model_executor/models/commandr.py
@@ -289,7 +289,10 @@ class CohereModel(nn.Module):
         self.vocab_size = config.vocab_size
 
         self.embed_tokens = VocabParallelEmbedding(
-            config.vocab_size, config.hidden_size
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,

--- a/vllm/model_executor/models/dbrx.py
+++ b/vllm/model_executor/models/dbrx.py
@@ -340,6 +340,8 @@ class DbrxModel(nn.Module):
         self.wte = VocabParallelEmbedding(
             config.vocab_size,
             config.d_model,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wte",
         )
         self.start_layer, self.end_layer, self.blocks = make_layers(
             config.n_layers,

--- a/vllm/model_executor/models/deepseek_eagle3.py
+++ b/vllm/model_executor/models/deepseek_eagle3.py
@@ -180,6 +180,7 @@ class DeepseekV2Eagle3Model(nn.Module):
             self.config.vocab_size,
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
+            quant_config=vllm_config.quant_config,
         )
 
         self.layers = nn.ModuleList(

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -157,6 +157,7 @@ class DeepSeekMultiTokenPredictor(nn.Module):
             config.vocab_size,
             config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
+            quant_config=vllm_config.quant_config,
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)
 

--- a/vllm/model_executor/models/ernie_mtp.py
+++ b/vllm/model_executor/models/ernie_mtp.py
@@ -106,6 +106,8 @@ class ErnieMultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)
 

--- a/vllm/model_executor/models/exaone4_5_mtp.py
+++ b/vllm/model_executor/models/exaone4_5_mtp.py
@@ -68,6 +68,8 @@ class Exaone4_5MultiTokenPredictor(ExaoneMoeMultiTokenPredictor):
             self.vocab_size,
             text_config.hidden_size,
             org_num_embeddings=config.vocab_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         self.fc = ColumnParallelLinear(

--- a/vllm/model_executor/models/exaone_moe_mtp.py
+++ b/vllm/model_executor/models/exaone_moe_mtp.py
@@ -65,6 +65,8 @@ class ExaoneMoeMultiTokenPredictor(nn.Module):
             self.vocab_size,
             config.hidden_size,
             org_num_embeddings=config.vocab_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         self.fc = ColumnParallelLinear(

--- a/vllm/model_executor/models/falcon.py
+++ b/vllm/model_executor/models/falcon.py
@@ -380,6 +380,8 @@ class FalconModel(nn.Module):
         self.word_embeddings = VocabParallelEmbedding(
             config.vocab_size,
             self.embed_dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.word_embeddings",
         )
 
         # Transformer blocks

--- a/vllm/model_executor/models/falcon_h1.py
+++ b/vllm/model_executor/models/falcon_h1.py
@@ -428,6 +428,8 @@ class FalconH1Model(nn.Module):
             self.embed_tokens = VocabParallelEmbedding(
                 self.vocab_size,
                 config.hidden_size,
+                quant_config=quant_config,
+                prefix=f"{prefix}.embed_tokens",
             )
             self.embedding_multiplier = config.embedding_multiplier
         else:

--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -271,6 +271,8 @@ class GemmaModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -259,6 +259,8 @@ class Gemma2Model(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,

--- a/vllm/model_executor/models/gemma4_dspark.py
+++ b/vllm/model_executor/models/gemma4_dspark.py
@@ -153,6 +153,7 @@ class Gemma4DSparkModel(DFlashQwen3Model):
             config.vocab_size,
             config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
+            quant_config=quant_config,
         )
         self.register_buffer(
             "normalizer",

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -432,7 +432,10 @@ class Glm4MoeModel(nn.Module):
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
-                config.vocab_size, config.hidden_size, prefix=f"{prefix}.embed_tokens"
+                config.vocab_size,
+                config.hidden_size,
+                prefix=f"{prefix}.embed_tokens",
+                quant_config=quant_config,
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/vllm/model_executor/models/glm4_moe_lite_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_lite_mtp.py
@@ -162,6 +162,8 @@ class Glm4MoeLiteMultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)
 

--- a/vllm/model_executor/models/glm4_moe_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_mtp.py
@@ -150,6 +150,8 @@ class Glm4MoeMultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)
 

--- a/vllm/model_executor/models/glm_ocr_mtp.py
+++ b/vllm/model_executor/models/glm_ocr_mtp.py
@@ -121,6 +121,8 @@ class GlmOcrMultiTokenPredictor(Glm4MoeLiteMultiTokenPredictor):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)
 

--- a/vllm/model_executor/models/gpt_j.py
+++ b/vllm/model_executor/models/gpt_j.py
@@ -200,6 +200,8 @@ class GPTJModel(nn.Module):
         self.wte = VocabParallelEmbedding(
             config.vocab_size,
             self.embed_dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wte",
         )
         self.start_layer, self.end_layer, self.h = make_layers(
             config.n_layer,

--- a/vllm/model_executor/models/gpt_neox.py
+++ b/vllm/model_executor/models/gpt_neox.py
@@ -208,6 +208,8 @@ class GPTNeoXModel(nn.Module):
         self.embed_in = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_in",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,

--- a/vllm/model_executor/models/gpt_neox.py
+++ b/vllm/model_executor/models/gpt_neox.py
@@ -287,7 +287,7 @@ class GPTNeoXForCausalLM(nn.Module, SupportsPP):
             prefix=maybe_prefix(prefix, "embed_out"),
         )
         if self.config.tie_word_embeddings:
-            self.embed_out.weight = self.gpt_neox.embed_in.weight
+            self.embed_out = self.embed_out.tie_weights(self.gpt_neox.embed_in)
         self.logits_processor = LogitsProcessor(config.vocab_size)
         self.make_empty_intermediate_tensors = (
             self.gpt_neox.make_empty_intermediate_tensors

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -309,6 +309,8 @@ class GptOssModel(nn.Module, EagleModelMixin):
         self.embedding = VocabParallelEmbedding(
             self.config.vocab_size,
             self.config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embedding",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             self.config.num_hidden_layers,

--- a/vllm/model_executor/models/granitemoe.py
+++ b/vllm/model_executor/models/granitemoe.py
@@ -298,6 +298,8 @@ class GraniteMoeModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.embedding_multiplier = config.embedding_multiplier
 

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -343,6 +343,8 @@ class GraniteMoeHybridModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.embedding_multiplier = config.embedding_multiplier
 

--- a/vllm/model_executor/models/hy_v3.py
+++ b/vllm/model_executor/models/hy_v3.py
@@ -452,6 +452,8 @@ class HYV3Model(nn.Module, MixtureOfExperts):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         self.start_layer, self.end_layer, self.layers = make_layers(

--- a/vllm/model_executor/models/hy_v3_mtp.py
+++ b/vllm/model_executor/models/hy_v3_mtp.py
@@ -169,6 +169,8 @@ class HYV3MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         self.logits_processor = LogitsProcessor(config.vocab_size)

--- a/vllm/model_executor/models/internlm2.py
+++ b/vllm/model_executor/models/internlm2.py
@@ -274,6 +274,8 @@ class InternLM2Model(nn.Module):
         self.tok_embeddings = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.tok_embeddings",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,

--- a/vllm/model_executor/models/jamba.py
+++ b/vllm/model_executor/models/jamba.py
@@ -316,6 +316,8 @@ class JambaModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         extra_kwargs = {"is_lora_enabled": bool(vllm_config.lora_config)}

--- a/vllm/model_executor/models/laguna_dflash.py
+++ b/vllm/model_executor/models/laguna_dflash.py
@@ -84,6 +84,7 @@ class DFlashLagunaModel(DFlashQwen3Model, EagleModelMixin):
             self.config.vocab_size,
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
+            quant_config=vllm_config.quant_config,
         )
 
         self.mask_token_id = self.config.dflash_config.get("mask_token_id")

--- a/vllm/model_executor/models/lfm2.py
+++ b/vllm/model_executor/models/lfm2.py
@@ -323,7 +323,11 @@ class Lfm2Model(nn.Module):
         self.vocab_size = config.vocab_size
 
         self.embed_tokens = VocabParallelEmbedding(
-            self.vocab_size, config.hidden_size, org_num_embeddings=config.vocab_size
+            self.vocab_size,
+            config.hidden_size,
+            org_num_embeddings=config.vocab_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         def get_layer(prefix: str):

--- a/vllm/model_executor/models/lfm2_moe.py
+++ b/vllm/model_executor/models/lfm2_moe.py
@@ -432,7 +432,11 @@ class Lfm2MoeModel(nn.Module):
         self.vocab_size = config.vocab_size
 
         self.embed_tokens = VocabParallelEmbedding(
-            self.vocab_size, config.hidden_size, org_num_embeddings=config.vocab_size
+            self.vocab_size,
+            config.hidden_size,
+            org_num_embeddings=config.vocab_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         def get_layer(prefix: str):

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -377,6 +377,7 @@ class LlamaModel(nn.Module, EagleModelMixin):
                 self.vocab_size,
                 config.hidden_size,
                 quant_config=quant_config,
+                prefix=f"{prefix}.embed_tokens",
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/vllm/model_executor/models/llama4_eagle.py
+++ b/vllm/model_executor/models/llama4_eagle.py
@@ -75,6 +75,7 @@ class LlamaModel(nn.Module):
             self.config.vocab_size,
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
+            quant_config=quant_config,
         )
 
         # Temporarily modify vllm_config.quant_config for draft model layers

--- a/vllm/model_executor/models/llama_eagle.py
+++ b/vllm/model_executor/models/llama_eagle.py
@@ -79,6 +79,7 @@ class LlamaModel(nn.Module):
             self.config.vocab_size,
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
+            quant_config=vllm_config.quant_config,
         )
 
         self.layers = nn.ModuleList(

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -159,6 +159,7 @@ class LlamaModel(nn.Module):
             self.config.vocab_size,
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
+            quant_config=vllm_config.quant_config,
         )
 
         self.layers = nn.ModuleList(

--- a/vllm/model_executor/models/longcat_flash.py
+++ b/vllm/model_executor/models/longcat_flash.py
@@ -495,6 +495,7 @@ class FlashModel(nn.Module):
                 config.vocab_size,
                 config.hidden_size,
                 prefix=maybe_prefix(prefix, "embed_tokens"),
+                quant_config=quant_config,
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/vllm/model_executor/models/longcat_flash_mtp.py
+++ b/vllm/model_executor/models/longcat_flash_mtp.py
@@ -101,6 +101,8 @@ class LongCatMultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
     def forward(

--- a/vllm/model_executor/models/mamba.py
+++ b/vllm/model_executor/models/mamba.py
@@ -116,6 +116,8 @@ class MambaModel(nn.Module):
         self.embeddings = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embeddings",
         )
 
         self.start_layer, self.end_layer, self.layers = make_layers(

--- a/vllm/model_executor/models/mamba2.py
+++ b/vllm/model_executor/models/mamba2.py
@@ -112,6 +112,8 @@ class Mamba2Model(nn.Module):
         self.embeddings = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embeddings",
         )
 
         self.start_layer, self.end_layer, self.layers = make_layers(

--- a/vllm/model_executor/models/mimo_mtp.py
+++ b/vllm/model_executor/models/mimo_mtp.py
@@ -99,6 +99,8 @@ class MiMoMultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         self.mtp_layers = torch.nn.ModuleDict(

--- a/vllm/model_executor/models/mimo_v2_mtp.py
+++ b/vllm/model_executor/models/mimo_v2_mtp.py
@@ -177,6 +177,8 @@ class MiMoV2MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         self.mtp = _MiMoV2MTPLayers(

--- a/vllm/model_executor/models/minicpm.py
+++ b/vllm/model_executor/models/minicpm.py
@@ -414,6 +414,8 @@ class MiniCPMModel(nn.Module, EagleModelMixin):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.num_experts = getattr(self.config, "num_experts", 0)
         self._init_layers(prefix, config, cache_config, quant_config)

--- a/vllm/model_executor/models/minicpm_eagle.py
+++ b/vllm/model_executor/models/minicpm_eagle.py
@@ -167,6 +167,8 @@ class EagleMiniCPMModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.num_experts = getattr(self.config, "num_experts", 0)
         self._init_layers(prefix, config, cache_config, quant_config, start_layer)

--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -315,6 +315,8 @@ class MixtralModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         self.enable_eplb = parallel_config.enable_eplb

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -22,6 +22,7 @@ from vllm.model_executor.layers.pooler.seqwise import (
     get_seq_pooling_method,
 )
 from vllm.model_executor.layers.pooler.tokwise import pooler_for_token_classify
+from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
@@ -33,11 +34,19 @@ from .utils import AutoWeightsLoader, WeightsMapper, maybe_prefix
 
 
 class ModernBertEmbeddings(nn.Module):
-    def __init__(self, config: ModernBertConfig):
+    def __init__(
+        self,
+        config: ModernBertConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.config = config
         self.tok_embeddings = VocabParallelEmbedding(
-            config.vocab_size, config.hidden_size
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.tok_embeddings",
         )
         eps = (
             getattr(config, "norm_eps", None)
@@ -252,7 +261,11 @@ class ModernBertModel(nn.Module):
         super().__init__()
         config = vllm_config.model_config.hf_config
         self.config = config
-        self.embeddings = ModernBertEmbeddings(config)
+        self.embeddings = ModernBertEmbeddings(
+            config,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embeddings",
+        )
         self.encoder_layer = ModernBertEncoderLayer(
             vllm_config, prefix=f"{prefix}.encoder_layer"
         )

--- a/vllm/model_executor/models/moondream3.py
+++ b/vllm/model_executor/models/moondream3.py
@@ -809,6 +809,7 @@ class Moondream3TextModel(nn.Module):
             config.vocab_size,
             config.dim,
             prefix=f"{prefix}.wte",
+            quant_config=quant_config,
         )
 
         blocks_prefix = maybe_prefix(prefix, "blocks")

--- a/vllm/model_executor/models/mpt.py
+++ b/vllm/model_executor/models/mpt.py
@@ -230,6 +230,8 @@ class MPTModel(nn.Module):
         self.wte = VocabParallelEmbedding(
             config.vocab_size,
             config.d_model,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wte",
         )
         self.start_layer, self.end_layer, self.blocks = make_layers(
             config.n_layers,

--- a/vllm/model_executor/models/nemotron.py
+++ b/vllm/model_executor/models/nemotron.py
@@ -309,6 +309,8 @@ class NemotronModel(nn.Module):
             self.embed_tokens = VocabParallelEmbedding(
                 self.vocab_size,
                 config.hidden_size,
+                quant_config=quant_config,
+                prefix=f"{prefix}.embed_tokens",
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -567,6 +567,8 @@ class NemotronHModel(nn.Module, EagleModelMixin):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         self.has_moe = "E" in config.hybrid_override_pattern

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -235,6 +235,8 @@ class NemotronHMultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         # Build flat list of layers

--- a/vllm/model_executor/models/olmo3.py
+++ b/vllm/model_executor/models/olmo3.py
@@ -286,6 +286,7 @@ class Olmo3Model(nn.Module):
             self.config.vocab_size,
             self.config.hidden_size,
             prefix=f"{prefix}.embed_tokens",
+            quant_config=vllm_config.quant_config,
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             self.config.num_hidden_layers,

--- a/vllm/model_executor/models/olmo_hybrid.py
+++ b/vllm/model_executor/models/olmo_hybrid.py
@@ -324,6 +324,7 @@ class OlmoHybridModel(nn.Module):
             self.config.vocab_size,
             self.config.hidden_size,
             prefix=f"{prefix}.embed_tokens",
+            quant_config=vllm_config.quant_config,
         )
 
         self.start_layer, self.end_layer, self.layers = make_layers(

--- a/vllm/model_executor/models/openpangu_mtp.py
+++ b/vllm/model_executor/models/openpangu_mtp.py
@@ -88,6 +88,8 @@ class OpenPanguMultiTokenPredictor(DeepSeekMultiTokenPredictor):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)
 

--- a/vllm/model_executor/models/opt.py
+++ b/vllm/model_executor/models/opt.py
@@ -211,6 +211,8 @@ class OPTDecoder(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.word_embed_proj_dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         # Positional embeddings are replicated (not sharded).
         self.embed_positions = OPTLearnedPositionalEmbedding(

--- a/vllm/model_executor/models/orion.py
+++ b/vllm/model_executor/models/orion.py
@@ -231,6 +231,8 @@ class OrionModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,

--- a/vllm/model_executor/models/phi.py
+++ b/vllm/model_executor/models/phi.py
@@ -214,7 +214,10 @@ class PhiModel(nn.Module):
         self.config = config
         self.quant_config = quant_config
         self.embed_tokens = VocabParallelEmbedding(
-            config.vocab_size, config.hidden_size
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,

--- a/vllm/model_executor/models/phimoe.py
+++ b/vllm/model_executor/models/phimoe.py
@@ -458,6 +458,8 @@ class PhiMoEModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,

--- a/vllm/model_executor/models/plamo3.py
+++ b/vllm/model_executor/models/plamo3.py
@@ -326,6 +326,7 @@ class Plamo3Model(nn.Module):
             config.hidden_size,
             org_num_embeddings=config.vocab_size,
             prefix=f"{prefix}.embed_tokens",
+            quant_config=vllm_config.quant_config,
         )
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -243,6 +243,8 @@ class Qwen3_5Model(Qwen3NextModel):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=self.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         def get_layer(prefix: str):

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -82,6 +82,8 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -381,6 +381,7 @@ class DFlashQwen3Model(nn.Module):
             self.config.vocab_size,
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
+            quant_config=vllm_config.quant_config,
         )
 
         # Masked query slots are fed to the draft as `mask_token_id`. Most DFlash

--- a/vllm/model_executor/models/qwen3_eagle3.py
+++ b/vllm/model_executor/models/qwen3_eagle3.py
@@ -183,6 +183,7 @@ class Qwen3Eagle3Model(nn.Module):
             self.config.vocab_size,
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
+            quant_config=vllm_config.quant_config,
         )
 
         self.layers = nn.ModuleList(

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -617,6 +617,8 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         def get_layer(prefix: str):

--- a/vllm/model_executor/models/qwen3_next_mtp.py
+++ b/vllm/model_executor/models/qwen3_next_mtp.py
@@ -61,6 +61,8 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is

--- a/vllm/model_executor/models/roberta.py
+++ b/vllm/model_executor/models/roberta.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.pooler.tokwise import (
     pooler_for_token_classify,
     pooler_for_token_embed,
 )
+from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
@@ -46,11 +47,19 @@ from .interfaces_base import attn_type, default_pooling_type
 
 
 class RobertaEmbedding(nn.Module):
-    def __init__(self, config: RobertaConfig):
+    def __init__(
+        self,
+        config: RobertaConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.size = config.hidden_size
         self.word_embeddings = VocabParallelEmbedding(
-            config.vocab_size, config.hidden_size
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.word_embeddings",
         )
         self.padding_idx = config.pad_token_id
         self.position_embeddings = VocabParallelEmbedding(

--- a/vllm/model_executor/models/solar.py
+++ b/vllm/model_executor/models/solar.py
@@ -266,6 +266,8 @@ class SolarModel(nn.Module):
             self.embed_tokens = VocabParallelEmbedding(
                 self.vocab_size,
                 config.hidden_size,
+                quant_config=quant_config,
+                prefix=f"{prefix}.embed_tokens",
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/vllm/model_executor/models/step3_text.py
+++ b/vllm/model_executor/models/step3_text.py
@@ -325,6 +325,8 @@ class Step3TextModel(nn.Module):
             self.embed_tokens = VocabParallelEmbedding(
                 self.vocab_size,
                 config.hidden_size,
+                quant_config=quant_config,
+                prefix=f"{prefix}.embed_tokens",
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/vllm/model_executor/models/step3p5.py
+++ b/vllm/model_executor/models/step3p5.py
@@ -563,6 +563,8 @@ class Step3p5Model(nn.Module):
             self.embed_tokens = VocabParallelEmbedding(
                 self.vocab_size,
                 config.hidden_size,
+                quant_config=vllm_config.quant_config,
+                prefix=f"{prefix}.embed_tokens",
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/vllm/model_executor/models/step3p5_mtp.py
+++ b/vllm/model_executor/models/step3p5_mtp.py
@@ -97,6 +97,8 @@ class Step3p5AMultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.mtp_start_layer_idx = config.num_hidden_layers
         self.num_mtp_layers = config.num_nextn_predict_layers

--- a/vllm/model_executor/models/zamba2.py
+++ b/vllm/model_executor/models/zamba2.py
@@ -699,6 +699,8 @@ class Zamba2Model(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         # Map hybrid layer indices to block indices

--- a/vllm/models/deepseek_v32/amd/mtp.py
+++ b/vllm/models/deepseek_v32/amd/mtp.py
@@ -116,6 +116,7 @@ class DeepseekV32MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -148,6 +148,7 @@ class DeepseekV32MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)

--- a/vllm/models/deepseek_v4/amd/dspark.py
+++ b/vllm/models/deepseek_v4/amd/dspark.py
@@ -78,6 +78,7 @@ class DSparkDeepseekV4Model(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 

--- a/vllm/models/deepseek_v4/amd/mtp.py
+++ b/vllm/models/deepseek_v4/amd/mtp.py
@@ -210,6 +210,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -82,6 +82,7 @@ class DSparkDeepseekV4Model(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -224,6 +224,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)

--- a/vllm/models/deepseek_v4/xpu/dspark.py
+++ b/vllm/models/deepseek_v4/xpu/dspark.py
@@ -64,6 +64,7 @@ class DSparkDeepseekV4Model(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 

--- a/vllm/models/deepseek_v4/xpu/mtp.py
+++ b/vllm/models/deepseek_v4/xpu/mtp.py
@@ -207,6 +207,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -661,6 +661,7 @@ class KimiLinearModel(nn.Module, EagleModelMixin):
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
                 config.hidden_size,
+                quant_config=vllm_config.quant_config,
                 prefix=f"{prefix}.embed_tokens",
             )
         else:

--- a/vllm/models/kimi_k3/amd/mtp.py
+++ b/vllm/models/kimi_k3/amd/mtp.py
@@ -138,6 +138,7 @@ class KimiK3MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1027,6 +1027,7 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
                 config.hidden_size,
+                quant_config=vllm_config.quant_config,
                 prefix=f"{prefix}.embed_tokens",
             )
         else:

--- a/vllm/models/kimi_k3/nvidia/mtp.py
+++ b/vllm/models/kimi_k3/nvidia/mtp.py
@@ -166,6 +166,7 @@ class KimiK3MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)

--- a/vllm/models/minimax_m3/amd/mtp.py
+++ b/vllm/models/minimax_m3/amd/mtp.py
@@ -134,6 +134,7 @@ class MiniMaxM3MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 

--- a/vllm/models/minimax_m3/nvidia/mtp.py
+++ b/vllm/models/minimax_m3/nvidia/mtp.py
@@ -116,6 +116,7 @@ class MiniMaxM3MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=vllm_config.quant_config,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 


### PR DESCRIPTION
## Purpose

compressed-tensors supports weight-only WNA16-INT quantization of the input embedding (`CompressedTensorsEmbeddingWNA16Int`, added in #44340), but the model-side plumbing was incomplete, so the feature silently failed on real models. This PR makes it work for both **untied** and **tied** embeddings.

### 1. Input-embedding plumbing (untied)

A `VocabParallelEmbedding` is only quantized if the model passes `quant_config` (and, for name-based targets, `prefix`) to it.

- **GPTNeoX** passed neither → quantized `embed_in` silently fell back to unquantized → `KeyError: 'embed_in.weight_packed'`.
- **Llama** passed `quant_config` but not `prefix` → name-based targets (e.g. `re:.*embed_tokens$`) could not match → same fallback: `KeyError: 'embed_tokens.weight_packed'`.
- **LFM2** passed neither → same as GPTNeoX.

Fix: pass `quant_config`/`prefix` to these input embeddings.

### 2. Tied embeddings reused as `lm_head` (new)

For tied models (common in small SOTA models like **Qwen3-0.6B** and **LFM2.5-350M**, where the embedding/`lm_head` dominates size), the shared matrix is used both for the input lookup *and* the output logits. Two things blocked quantizing it once and reusing it:

- `CompressedTensorsEmbeddingWNA16Int.apply()` raised `NotImplementedError`, so a quantized embedding could not serve the logits matmul.
- The tie paths assumed a plain `.weight` tensor, which a packed embedding does not expose (`AttributeError`), affecting the `tie_weights()` idiom (LFM2) and the direct `.weight`-assignment idiom (GPTNeoX).

Working around this by *untying* materializes a full fp16 head and **inflates** the checkpoint instead of shrinking it (e.g. Qwen3-0.6B: a 311 MB shared fp16 table becomes 82 MB packed **+ 303 MB fp16 head**). Instead, this PR quantizes the single shared matrix and reuses it for both paths:

- `compressed_tensors_embedding.py`: implement `apply()` (dequantize the packed table, `F.linear`).
- `vocab_parallel_embedding.tie_weights()`: when the embedding exposes no plain `weight` (packed/quantized), return the embedding module directly, mirroring the existing GGUF path.
- `gpt_neox.py`: route the tie through `tie_weights()`.

### 3. Extending the plumbing across the model zoo

The `quant_config`/`prefix` gap from section 1 was not unique to GPTNeoX/Llama/LFM2 — most models never passed them to their input embedding, so a WNA16-quantized checkpoint silently fell back to an unquantized embedding (or `KeyError` on the packed weight). This PR threads `quant_config`/`prefix` into the remaining input embeddings uniformly (~75 sites): dense and MoE decoders, MTP/eagle/speculator draft models (which source `quant_config` from `vllm_config`), and the BERT/RoBERTa/ModernBERT encoder families (threaded through their embedding helper classes, applied to the word/token embedding only). Position/token-type embeddings, CLIP/SigLIP vision embeddings, and non-token embeddings (gemma3n modality embedder, qwen3_dspark markov head) are intentionally left untouched — quantizing them is not a supported path.

Passing `quant_config` is inert unless the checkpoint actually targets the embedding (as proven by Llama/Qwen2, which already do this across every quant backend), so unquantized model loads are unchanged. Construction across these architectures is covered by `tests/models/test_initialization.py`; the WNA16 dispatch and kernel themselves are exercised by the GPTNeoX fixtures in the test below.

**Not a duplicate:** related embedding-quant PRs exist (#42791 ModelOpt FP8/NVFP4 embedding methods, #41365 opt-in FP8 vocab embedding) but none addresses compressed-tensors WNA16 input-embedding plumbing or tied-embedding reuse as `lm_head` for these models.

## Test Plan

`tests/quantization/test_quantized_embedding.py` loads tiny GPTNeoX checkpoints whose `embed_in` is WNA16-INT quantized (W4 group64), asserts dispatch to `CompressedTensorsEmbeddingWNA16Int`, and smoke-tests generation — one untied (`kkothuri/pythia-70m-emb-w4g64-ct`) and one tied (`kkothuri/pythia-70m-tied-W4g64-ct`, which additionally asserts the head reuses the quantized embedding so `apply()` is exercised).

```
pytest tests/quantization/test_quantized_embedding.py
```

## Test Result

- **Before:** GPTNeoX/Llama WNA16-embedding checkpoints fail to load with the `KeyError` above; tied quantized embeddings fail with `NotImplementedError`/`AttributeError`.
- **After:** both tests pass; all loads/generates work.
- **Accuracy (lm-eval, arc_easy + wikitext):**
  - *Untied input embedding (pythia-1.4b):* ~lossless — W8-channel wikitext ppl 14.733 → 14.732 (arc 0.6048 → 0.6052); W4-group64 ppl → 14.752 (arc → 0.6061).
  - *Tied shared matrix (fp16 → quant), wikitext bits-per-byte ↓:*

    | model | fp16 | **W8 tied** | W4 tied |
    | --- | --- | --- | --- |
    | Qwen3-0.6B | 0.9119 | **0.9119 (−0.0%)** | 0.9228 (+1.2%) |
    | LFM2.5-350M | 1.6525 | **1.6599 (+0.45%)** | 1.7254 (+4.4%) |

    arc_easy flat for both. W8 tied is near-lossless while halving the shared table; W4 is heavier on these compression-sensitive models because it also lowers the logits precision.
- `pre-commit run` on changed files is clean (incl. mypy).

> [!NOTE]
> Test fixtures are currently hosted under a personal HF account (`kkothuri/pythia-70m-emb-w4g64-ct`, `kkothuri/pythia-70m-tied-W4g64-ct`); happy to re-host under `nm-testing` if maintainers prefer.

> [!NOTE]
> The companion llm-compressor change (keep tied models tied when quantizing the embedding, and drop the redundant fp16 head at save) that *produces* tied quantized checkpoints whose on-disk size actually shrinks has landed in [llm-compressor#2835](https://github.com/vllm-project/llm-compressor/pull/2835). Runtime VRAM is already correct here regardless, since vLLM ties the head to the packed table at load.

---

This change was developed with AI assistance (Claude Code). All changed lines were reviewed by the submitter.


