### PR TITLE
Fix docs build on `main`

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
@@ -351,8 +351,7 @@ def prepare_int4_moe_layer_for_cpu(
                   If None, synthetic zeros are created for symmetric quant.
 
     Returns:
-        (blocked_w13, blocked_w2, blocked_s13, blocked_s2,
-         blocked_z13, blocked_z2)
+        (blocked_w13, blocked_w2, blocked_s13, blocked_s2, blocked_z13, blocked_z2)
     """
     E = w13_packed.size(0)
 


### PR DESCRIPTION
We will have to do this periodically now that we've stopped building docs on every PR