### PR TITLE
[Bugfix][Gemma4] Fix offline parser truncation, adjust_request token leak, and chat template sync

### DIFF
--- a/examples/tool_chat_template_gemma4.jinja
+++ b/examples/tool_chat_template_gemma4.jinja
@@ -116,7 +116,9 @@
     }
 {%- endmacro -%}
 {%- macro format_argument(argument, escape_keys=True) -%}
-    {%- if argument is string -%}
+    {%- if argument is none -%}
+        {{- 'null' -}}
+    {%- elif argument is string -%}
         {{- '<|"|>' + argument + '<|"|>' -}}
     {%- elif argument is boolean -%}
         {{- 'true' if argument else 'false' -}}
@@ -172,18 +174,21 @@
     {{- '<tool_response|>' -}}
 {%- endmacro -%}
 
-{%- set ns = namespace(prev_message_type=None) -%}
+{#- ===== SETUP ===== -#}
+{%- set ns = namespace(prev_message_type=None, prev_non_tool_role=None) -%}
 {%- set loop_messages = messages -%}
+{%- set enable_thinking = enable_thinking | default(false) -%}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
 {{- bos_token -}}
 {#- Handle System/Tool Definitions Block -#}
-{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+{%- if enable_thinking or tools or (messages and messages[0]['role'] in ['system', 'developer']) -%}
     {{- '<|turn>system\n' -}}
     {#- Inject Thinking token at the very top of the FIRST system turn -#}
-    {%- if enable_thinking is defined and enable_thinking -%}
+    {%- if enable_thinking -%}
         {{- '<|think|>\n' -}}
         {%- set ns.prev_message_type = 'think' -%}
     {%- endif -%}
-    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+    {%- if messages and messages[0]['role'] in ['system', 'developer'] -%}
         {%- if messages[0]['content'] is string -%}
             {{- messages[0]['content'] | trim -}}
         {%- elif messages[0]['content'] is sequence -%}
@@ -217,31 +222,24 @@
     {%- if message['role'] != 'tool' -%}
     {%- set ns.prev_message_type = None -%}
     {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
-    {#- Detect continuation: suppress duplicate <|turn>model when previous non-tool message was also assistant -#}
-    {%- set prev_nt = namespace(role=None, found=false) -%}
-    {%- if loop.index0 > 0 -%}
-        {%- for j in range(loop.index0 - 1, -1, -1) -%}
-            {%- if not prev_nt.found -%}
-                {%- if loop_messages[j]['role'] != 'tool' -%}
-                    {%- set prev_nt.role = loop_messages[j]['role'] -%}
-                    {%- set prev_nt.found = true -%}
-                {%- endif -%}
-            {%- endif -%}
-        {%- endfor -%}
-    {%- endif -%}
-    {%- set continue_same_model_turn = (role == 'model' and prev_nt.role == 'assistant') -%}
+    {#- Detect continuation using tracked state — O(1) instead of O(n) backward scan -#}
+    {%- set continue_same_model_turn = (role == 'model' and ns.prev_non_tool_role == 'assistant') -%}
     {%- if not continue_same_model_turn -%}
         {{- '<|turn>' + role + '\n' }}
+        {%- if role == 'model' and not enable_thinking and not (message.get('reasoning') or message.get('reasoning_content')) -%}
+            {{- '<|channel>thought\n<channel|>' -}}
+        {%- endif -%}
     {%- endif -%}
 
-    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {#- Render reasoning/reasoning_content as thinking channel (tool-call turns only) -#}
     {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
-    {%- if thinking_text and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+    {%- set thinking_gate = (loop.index0 > ns_turn.last_user_idx) or preserve_thinking -%}
+    {%- if thinking_text and thinking_gate and message.get('tool_calls') -%}
         {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
     {%- endif -%}
 
-            {%- if message['tool_calls'] -%}
-                {%- for tool_call in message['tool_calls'] -%}
+            {%- if message.get('tool_calls') -%}
+                {%- for tool_call in message.get('tool_calls') -%}
                     {%- set function = tool_call['function'] -%}
                     {{- '<|tool_call>call:' + function['name'] + '{' -}}
                     {%- if function['arguments'] is mapping -%}
@@ -251,8 +249,13 @@
                             {%- set ns_args.found_first = true -%}
                             {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
                         {%- endfor -%}
-                    {%- elif function['arguments'] is string -%}
-                        {{- function['arguments'] -}}
+                    {%- elif function['arguments'] is none -%}
+                    {%- else -%}
+                        {{- raise_exception(
+                            "chat_template: tool_calls[].function.arguments must be a "
+                            "JSON object (mapping), not a string. Deserialize arguments "
+                            "before passing to the template."
+                        ) -}}
                     {%- endif -%}
                     {{- '}<tool_call|>' -}}
                 {%- endfor -%}
@@ -262,7 +265,7 @@
             {%- set ns_tr_out = namespace(flag=false) -%}
             {%- if message.get('tool_responses') -%}
                 {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
-                {%- for tool_response in message['tool_responses'] -%}
+                {%- for tool_response in message.get('tool_responses') -%}
                     {{- format_tool_response_block(tool_response['name'] | default('unknown', true), tool_response['response']) -}}
                     {%- set ns_tr_out.flag = true -%}
                     {%- set ns.prev_message_type = 'tool_response' -%}
@@ -277,8 +280,8 @@
                     {%- else -%}
                         {%- set follow = loop_messages[k] -%}
                         {#- Resolve tool_call_id to function name -#}
-                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown', true)) -%}
-                        {%- for tc in message['tool_calls'] -%}
+                        {%- set ns_tname = namespace(name=follow.get('name') or 'unknown') -%}
+                        {%- for tc in message.get('tool_calls') -%}
                             {%- if tc.get('id') == follow.get('tool_call_id') -%}
                                 {%- set ns_tname.name = tc['function']['name'] -%}
                             {%- endif -%}
@@ -296,9 +299,9 @@
                             {%- endfor -%}
                             {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
                             {%- for part in tool_body -%}
-                                {%- if part.get('type') == 'image' -%}
+                                {%- if part.get('type') in ['image', 'image_url'] -%}
                                     {{- '<|image|>' -}}
-                                {%- elif part.get('type') == 'audio' -%}
+                                {%- elif part.get('type') in ['audio', 'input_audio'] -%}
                                     {{- '<|audio|>' -}}
                                 {%- elif part.get('type') == 'video' -%}
                                     {{- '<|video|>' -}}
@@ -314,29 +317,26 @@
             {%- endif -%}
 
             {%- set captured_content -%}
-            {%- if message['content'] is string -%}
+            {%- if message.get('content') is string -%}
                 {%- if role == 'model' -%}
                     {{- strip_thinking(message['content']) -}}
                 {%- else -%}
                     {{- message['content'] | trim -}}
                 {%- endif -%}
-            {%- elif message['content'] is sequence -%}
+            {%- elif message.get('content') is sequence -%}
                 {%- for item in message['content'] -%}
-                    {%- if item['type'] == 'text' -%}
+                    {%- if item.get('type') == 'text' -%}
                         {%- if role == 'model' -%}
                             {{- strip_thinking(item['text']) -}}
                         {%- else -%}
                             {{- item['text'] | trim -}}
                         {%- endif -%}
-                    {%- elif item['type'] == 'image' -%}
+                    {%- elif item.get('type') in ['image', 'image_url'] -%}
                         {{- '<|image|>' -}}
-                        {%- set ns.prev_message_type = 'image' -%}
-                    {%- elif item['type'] == 'audio' -%}
+                    {%- elif item.get('type') in ['audio', 'input_audio'] -%}
                         {{- '<|audio|>' -}}
-                        {%- set ns.prev_message_type = 'audio' -%}
-                    {%- elif item['type'] == 'video' -%}
+                    {%- elif item.get('type') == 'video' -%}
                         {{- '<|video|>' -}}
-                        {%- set ns.prev_message_type = 'video' -%}
                     {%- endif -%}
                 {%- endfor -%}
             {%- endif -%}
@@ -345,19 +345,43 @@
             {{- captured_content -}}
             {%- set has_content = captured_content | trim | length > 0 -%}
 
+        {#- Forward-scan: find next non-tool message role for continuation detection -#}
+        {%- set next_nt = namespace(role=None, found=false) -%}
+        {%- for j in range(loop.index0 + 1, loop_messages | length) -%}
+            {%- if not next_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set next_nt.role = loop_messages[j]['role'] -%}
+                    {%- set next_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {%- set continues_into_next = (
+            role == 'model'
+            and next_nt.role == 'assistant'
+            and (not message.get('tool_calls') or ns_tr_out.flag)
+        ) -%}
+
         {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
             {{- '<|tool_response>' -}}
+        {%- elif continues_into_next -%}
+            {{- '\n' -}}
         {%- elif not (ns_tr_out.flag and not has_content) -%}
             {{- '<turn|>\n' -}}
         {%- endif -%}
+
+    {#- Track previous non-tool role for next iteration (avoids O(n) backward scan) -#}
+    {%- set ns.prev_non_tool_role = message['role'] -%}
     {%- endif -%}
 {%- endfor -%}
 
 {%- if add_generation_prompt -%}
     {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
         {{- '<|turn>model\n' -}}
-        {%- if not enable_thinking | default(false) -%}
+        {%- if not enable_thinking -%}
             {{- '<|channel>thought\n<channel|>' -}}
         {%- endif -%}
+    {%- elif ns.prev_message_type == 'tool_response' and enable_thinking -%}
+        {{- '<|channel>thought\n' -}}
     {%- endif -%}
 {%- endif -%}

--- a/tests/reasoning/test_gemma4_reasoning_parser.py
+++ b/tests/reasoning/test_gemma4_reasoning_parser.py
@@ -54,7 +54,7 @@ NO_REASONING = {
     "output": "This is content",
     "reasoning": None,
     "content": "This is content",
-    "is_reasoning_end": False,
+    "is_reasoning_end": True,
 }
 REASONING_WITH_CHANNEL = {
     "output": "<|channel>This is a reasoning section<channel|>This is the rest",

--- a/tests/renderers/test_gemma4_chat_template.py
+++ b/tests/renderers/test_gemma4_chat_template.py
@@ -358,7 +358,7 @@ class TestGemma4ChatTemplate:
                         "type": "function",
                         "function": {
                             "name": "download_image",
-                            "arguments": '{"url": "https://example.com/x.png"}',
+                            "arguments": {"url": "https://example.com/x.png"},
                         },
                     },
                 ],
@@ -392,7 +392,7 @@ class TestGemma4ChatTemplate:
                         "type": "function",
                         "function": {
                             "name": "process",
-                            "arguments": "{}",
+                            "arguments": {},
                         },
                     },
                 ],

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -423,6 +423,8 @@ class Gemma4Parser(ParserEngine):
         tools: list[Tool] | None = None,
         **kwargs,
     ) -> None:
+        chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
+        self._thinking_enabled = chat_kwargs.get("enable_thinking", True)
         super().__init__(
             tokenizer,
             tools,
@@ -509,12 +511,12 @@ class Gemma4Parser(ParserEngine):
             if tool_call_id is not None and tid == tool_call_id:
                 return True
             if new_turn_id is not None and tid == new_turn_id:
-                return False
+                return not self._thinking_enabled
             if tool_response_id is not None and tid == tool_response_id:
-                return False
+                return not self._thinking_enabled
             if end_id is not None and tid == end_id:
                 return True
-        return self._reasoning_ended
+        return True
 
     def _events_to_delta(
         self,

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -437,6 +437,21 @@ class Gemma4Parser(ParserEngine):
         self._prefix_stripped: bool = False
         self._is_first_feed: bool = True
 
+    def adjust_request(
+        self,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        """Skip ``skip_special_tokens=False`` when thinking is disabled.
+
+        When there are no reasoning channel tokens to preserve,
+        keeping the default prevents tool-call delimiter tokens
+        from leaking into content (e.g. with ``tool_choice="none"``).
+        """
+        chat_template_kwargs = getattr(request, "chat_template_kwargs", None) or {}
+        if not chat_template_kwargs.get("enable_thinking", True):
+            return request
+        return super().adjust_request(request)
+
     def _reset(self, initial_state=None) -> None:
         super()._reset(initial_state=initial_state)
         self._reasoning_text = ""

--- a/vllm/tool_parsers/gemma4_utils.py
+++ b/vllm/tool_parsers/gemma4_utils.py
@@ -35,8 +35,6 @@ Ported from ``transformers.models.gemma4.utils_gemma4`` so that vLLM users
 do not need a transformers dependency for output parsing.
 """
 
-import json
-
 import regex as re
 
 # Tool call delimiter tokens as they appear in decoded text.
@@ -52,42 +50,23 @@ _ESCAPE_TOKEN = '<|"|>'
 def _parse_tool_arguments(args_str: str) -> dict[str, str]:
     """Parse tool call arguments from the Gemma4 compact format.
 
-    Handles the ``key:<|"|>value<|"|>`` format used by Gemma4, with fallback
-    to heuristic key-value extraction. Also tolerates the slightly different
-    ``key: "value"`` format (space + plain quotes) that some chat templates
-    produce.
+    Delegates to the native ``<|"|>``-aware parser from
+    ``vllm.parser.gemma4``, which handles internal quotes, nested
+    objects, arrays, and all Gemma4 value types correctly.
 
     Args:
         args_str: Raw argument string from inside ``call:name{...}``.
 
     Returns:
-        Dictionary of argument name → value.
+        Dictionary of argument name → string value.
     """
     if not args_str or not args_str.strip():
         return {}
 
-    # Replace Gemma4 escape tokens with standard quotes.
-    cleaned = args_str.replace(_ESCAPE_TOKEN, '"')
+    from vllm.parser.gemma4 import _parse_gemma4_args
 
-    # Try JSON parsing first (handles nested values, arrays, etc.).
-    try:
-        parsed = json.loads("{" + cleaned + "}")
-        # Ensure all values are strings for consistency.
-        return {k: str(v) if not isinstance(v, str) else v for k, v in parsed.items()}
-    except (json.JSONDecodeError, ValueError):
-        pass
-
-    # Fallback: extract key:"value" pairs (allow optional space after colon).
-    arguments = {}
-    for key, value in re.findall(r'(\w+):\s*"([^"]*)"', cleaned):
-        arguments[key] = value
-
-    if not arguments:
-        # Last resort: extract key:value pairs (unquoted).
-        for key, value in re.findall(r"(\w+):\s*([^,}]+)", args_str):
-            arguments[key] = value.strip().strip('"').replace(_ESCAPE_TOKEN, "")
-
-    return arguments
+    parsed = _parse_gemma4_args(args_str)
+    return {k: str(v) if not isinstance(v, str) else v for k, v in parsed.items()}
 
 
 def parse_tool_calls(text: str, *, strict: bool = False) -> list[dict]:


### PR DESCRIPTION
## Purpose

Fixes remaining Gemma4 tool calling bugs not addressed by #45588 (ParserEngine rewrite): offline parser truncation, reasoning token leak when thinking is disabled, and chat template sync with upstream HuggingFace model PRs.

Fixes #39069
Fixes #39130

### Bugs fixed

- **#39069** — Offline `_parse_tool_arguments` in `gemma4_utils.py` truncates string values containing internal double quotes. The function replaced `<|"|>` with `"` then used regex `[^"]*` which stopped at the first internal quote. Fix: delegate to the native `_parse_gemma4_args` parser.
- **#39130** — `is_reasoning_end()` returns `False` when no reasoning markers exist in `input_ids`, silently bypassing xgrammar structured output when `enable_thinking=false`. Fix: change fallthrough to `return True` (reasoning never started = ended); return `not self._thinking_enabled` on `<|turn>` and `<|tool_response>` so structured output is applied when thinking is disabled. Ref: [#45588 comment](https://github.com/vllm-project/vllm/pull/45588#issuecomment-4711324461).
- **#39588** — `ParserEngine.adjust_request()` unconditionally sets `skip_special_tokens=False`. When `enable_thinking=false`, tool-call delimiter tokens leak into content (especially with `tool_choice="none"`). Fix: `Gemma4Parser` overrides `adjust_request` to skip the override when thinking is disabled.

### Chat template changes

The vLLM example template (`examples/tool_chat_template_gemma4.jinja`) is synced with upstream HuggingFace model chat template PRs:

- [google/gemma-4-E2B-it#35](https://huggingface.co/google/gemma-4-E2B-it/discussions/35)
- [google/gemma-4-E4B-it#36](https://huggingface.co/google/gemma-4-E4B-it/discussions/36)
- [google/gemma-4-12B-it#35](https://huggingface.co/google/gemma-4-12B-it/discussions/35)
- [google/gemma-4-26B-A4B-it#47](https://huggingface.co/google/gemma-4-26B-A4B-it/discussions/47)
- [google/gemma-4-31B-it#118](https://huggingface.co/google/gemma-4-31B-it/discussions/118)

Template fixes:
- `None` → `null` rendering in `format_argument`
- Reject string-typed `function.arguments` with `raise_exception`
- Empty `<|channel>thought\n<channel|>` primer on historical assistant turns for APC consistency (12B/26B/31B)
- `preserve_thinking` default changed to `false` per [Gemma4 docs](https://ai.google.dev/gemma/docs/core/prompt-formatting-gemma4#managing-thought-context)
- Restored `add_generation_prompt` guard: suppress `<|turn>model` when `prev_message_type` is `tool_response` or `tool_call` (a multi-step tool chain is one model turn)
- `continues_into_next` fix: no extra `<turn|>` in content+tool_calls+continuation sequences (reported in #42776)
- `.get()` safe access, `image_url`/`input_audio` content type aliases, O(1) continuation detection

### Previously fixed by #45588

The original version of this PR addressed 11 bugs. After rebase, 7 were already resolved by the ParserEngine rewrite in #45588: #44522 (token decode mismatch), #44715 (dict key delimiter), #42875 (streaming state reset), #42300 (`<|tool_response>` leak). #39130 was partially fixed by #45588 (empty `input_ids` case) but the non-empty fallthrough remained broken — fully fixed in this PR.

## Test Plan

```bash
python -m pytest tests/tool_parsers/test_gemma4_tool_parser.py \
                 tests/reasoning/test_gemma4_reasoning_parser.py \
                 tests/renderers/test_gemma4_chat_template.py -v
```

## Test Result

```
121 passed, 0 failed

ruff check   — Passed
ruff format  — Passed
```
