### PR TITLE
Build vllm-flash-attn extensions with C++20

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -57,6 +57,15 @@ install(CODE "set(CMAKE_INSTALL_PREFIX \"\${CMAKE_INSTALL_PREFIX}/vllm/\")" ALL_
 FetchContent_MakeAvailable(vllm-flash-attn)
 message(STATUS "vllm-flash-attn is available at ${vllm-flash-attn_SOURCE_DIR}")
 
+# FA pins CMAKE_CXX_STANDARD to 17; force C++20 to match vLLM and Torch headers.
+foreach(_FA_COMPONENT _vllm_fa2_C _vllm_fa3_C)
+  if(TARGET ${_FA_COMPONENT})
+    set_target_properties(${_FA_COMPONENT} PROPERTIES
+      CXX_STANDARD 20
+      CXX_STANDARD_REQUIRED ON)
+  endif()
+endforeach()
+
 # Restore the install prefix after FA's install rules
 install(CODE "set(CMAKE_INSTALL_PREFIX \"\${OLD_CMAKE_INSTALL_PREFIX}\")" ALL_COMPONENTS)
 install(CODE "set(CMAKE_INSTALL_LOCAL_ONLY TRUE)" ALL_COMPONENTS)


### PR DESCRIPTION
## Purpose

`vllm-flash-attn` (fetched via `FetchContent`) sets `set(CMAKE_CXX_STANDARD 17)` in its own `CMakeLists.txt`, which overrides vLLM's top-level `CMAKE_CXX_STANDARD 20` for the FA extension targets. Their `.cpp` sources (`flash_api*.cpp`) include `<torch/...>` headers, so when PyTorch's public headers use C++20-only syntax the FA build fails under `-std=c++17`.

This forces `_vllm_fa2_C` / `_vllm_fa3_C` to build with C++20, matching the rest of vLLM, so they can compile against current Torch headers. The override is applied after `FetchContent_MakeAvailable` so it wins over FA's directory-scoped default; `if(TARGET ...)` guards FA3, which only exists on some arch configs.

## Test Plan

```bash
pip install -e . --no-build-isolation
```

Inspect the FA targets' compile flags (e.g. via `compile_commands.json`) and confirm `_vllm_fa2_C` / `_vllm_fa3_C` objects compile with `-std=c++20` instead of `-std=c++17`.

## Test Result

The `_vllm_fa2_C` / `_vllm_fa3_C` `.cpp` sources compile with `-std=c++20`; the previous C++17 build failure against C++20-using Torch headers no longer reproduces. Full validation deferred to CI build jobs.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
