### PR TITLE
[Core] Priority-based preemption at max_num_seqs

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5318,6 +5318,139 @@ def test_priority_preemption_at_max_num_seqs_no_preempt_when_not_higher():
     assert scheduler.requests["lo"].status == RequestStatus.WAITING
 
 
+def test_priority_preemption_at_max_num_seqs_equal_priority_no_preempt():
+    """Preemption at max_num_seqs must NOT fire when priorities are equal,
+    even if the waiting request arrived earlier.
+
+    Using __lt__ would trigger preemption because the tiebreaker falls
+    back to arrival_time / request_id.  A preempted request keeps its
+    earlier arrival time, so it would immediately reclaim the slot on the
+    next step — causing ping-pong.
+
+    The fix compares only `.priority`, not `__lt__`.
+    """
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,
+    )
+
+    # Two priority-5 requests fill the running queue.
+    running_reqs = create_requests_with_priority(
+        num_requests=2,
+        priorities=[5, 5],
+        arrival_times=[2.0, 3.0],
+        num_tokens=10,
+        req_ids=["r1", "r2"],
+    )
+    for req in running_reqs:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+
+    # Decode.
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["r1", "r2"],
+            req_id_to_index={"r1": 0, "r2": 1},
+            sampled_token_ids=[[99], [98]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    # A waiting request with the SAME priority (5) but an EARLIER
+    # arrival time (1.0 < 2.0).  It must NOT preempt — equal priority
+    # means no preemption.
+    waiting_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[1.0],
+        num_tokens=10,
+        req_ids=["w1"],
+    )[0]
+    scheduler.add_request(waiting_req)
+
+    output = scheduler.schedule()
+
+    w1_scheduled = any(
+        req.req_id == "w1" for req in output.scheduled_new_reqs
+    )
+    assert not w1_scheduled, (
+        "Equal-priority waiting request 'w1' must NOT preempt "
+        "(same priority = no preemption)"
+    )
+    assert len(scheduler.running) == 2
+    assert scheduler.requests["w1"].status == RequestStatus.WAITING
+
+
+def test_priority_preemption_at_max_num_seqs_blocked_skipped():
+    """A blocked waiting request (WAITING_FOR_REMOTE_KVS) must NOT
+    trigger preemption at max_num_seqs — we don't evict a runner for a
+    request that can't be admitted this step anyway."""
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=1,
+        max_num_batched_tokens=200,
+        num_blocks=100,
+        use_kv_connector=True,
+    )
+
+    # Fill the single running slot with a low-priority request.
+    [runner] = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[1.0],
+        num_tokens=10,
+        req_ids=["runner"],
+    )
+    scheduler.add_request(runner)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 1
+    assert len(scheduler.running) == 1
+
+    # Decode.
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["runner"],
+            req_id_to_index={"runner": 0},
+            sampled_token_ids=[[99]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    # Artificially set a high-priority request as WAITING_FOR_REMOTE_KVS
+    # and add it to the skipped queue directly (mimicking what happens
+    # after an async KV load is initiated).
+    blocked_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],  # Higher priority than runner (0 < 5)
+        arrival_times=[2.0],
+        num_tokens=10,
+        req_ids=["blocked_hi"],
+    )[0]
+    blocked_req.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+    scheduler.add_request(blocked_req)
+    # Move to skipped queue simulating a previously skipped request.
+    scheduler.skipped_waiting.add_request(blocked_req)
+    scheduler.waiting.pop_request()
+
+    # Schedule — should NOT preempt because blocked_hi can't be
+    # admitted yet.
+    output = scheduler.schedule()
+
+    assert scheduler.requests["runner"].status == RequestStatus.RUNNING, (
+        "Runner must NOT be preempted for a blocked waiting request"
+    )
+    assert len(scheduler.running) == 1
+
+
 def test_async_load_reservation_prevents_wedge_e2e():
     """Same wedge scenario as PR #40968's lateral-preemption e2e test, but
     resolved by reservation-based admission control instead of preemption.

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5451,6 +5451,86 @@ def test_priority_preemption_at_max_num_seqs_blocked_skipped():
     assert len(scheduler.running) == 1
 
 
+def test_priority_preemption_at_kv_cache_pressure_e2e():
+    """Test that under KV cache pressure, a higher-priority waiting request
+    preempts a lower-priority running request to free blocks.
+
+    Scenario:
+    - block_size = 16, num_blocks = 5 (4 usable after null block).
+    - lo1 (priority 5, 32 tokens) runs first → 2 blocks used. Decode → 33
+      tokens (needs 3rd block on next schedule).
+    - hi (priority 0, 32 tokens) arrives in the waiting queue.
+    - lo1's 3rd block is allocated (3 used), hi can't fit (needs 2 blocks,
+      only 1 free) → hi preempts lo1 and takes the slot.
+    """
+    block_size = 16
+    num_blocks = 5  # 1 null → 4 usable
+    num_tokens = block_size * 2  # 32 tokens = 2 blocks
+
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=3,
+        max_num_batched_tokens=200,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
+
+    # --- Phase 1: low-priority request starts running ---
+    lo1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[1.0],
+        num_tokens=num_tokens,
+        req_ids=["lo1"],
+    )[0]
+    scheduler.add_request(lo1)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 1
+    assert lo1 in scheduler.running
+
+    # Decode: lo1 now has 33 tokens (needs 3rd block next time).
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["lo1"],
+            req_id_to_index={"lo1": 0},
+            sampled_token_ids=[[100]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    # --- Phase 2: high-priority waiting request arrives ---
+    hi = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],
+        arrival_times=[2.0],
+        num_tokens=num_tokens,
+        req_ids=["hi"],
+    )[0]
+    scheduler.add_request(hi)
+
+    # schedule(): lo1 gets its 3rd block (3 used, 1 free).  hi needs
+    # 2 blocks but only 1 is free → block allocation fails for hi.
+    # With the new KV-cache preemption, hi (priority 0) preempts
+    # lo1 (priority 5) to free blocks.
+    output = scheduler.schedule()
+
+    # lo1 should be preempted.
+    lo1_req = scheduler.requests["lo1"]
+    assert lo1_req.status == RequestStatus.PREEMPTED, (
+        f"Expected lo1 to be preempted, got {lo1_req.status}"
+    )
+
+    # hi should be in the running queue.
+    hi_req = scheduler.requests["hi"]
+    assert hi_req.status == RequestStatus.RUNNING, (
+        f"Expected hi to be running, got {hi_req.status}"
+    )
+    assert hi_req in scheduler.running
+
+
 def test_async_load_reservation_prevents_wedge_e2e():
     """Same wedge scenario as PR #40968's lateral-preemption e2e test, but
     resolved by reservation-based admission control instead of preemption.

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5170,6 +5170,154 @@ def test_ec_connector_pending_prefetch_only_checks_future_mm_features():
     )
 
 
+def test_priority_preemption_at_max_num_seqs_e2e():
+    """Test that a higher-priority waiting request preempts a lower-priority
+    running request when max_num_seqs is reached.
+
+    Scenario:
+    - max_num_seqs = 2
+    - Two low-priority requests (priority 5) fill the running queue.
+    - A high-priority request (priority 0) arrives.
+    - The scheduler preempts one low-priority runner to admit the
+      high-priority one.
+    """
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,  # Plenty of blocks — no KV pressure
+    )
+
+    # --- Phase 1: two low-priority requests fill the running queue ---
+    lo_requests = create_requests_with_priority(
+        num_requests=2,
+        priorities=[5, 5],
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["lo1", "lo2"],
+    )
+    for req in lo_requests:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+    assert len(scheduler.running) == 2
+    assert {req.req_id for req in output.scheduled_new_reqs} == {"lo1", "lo2"}
+
+    # Simulate model execution: both requests produce a token.
+    model_output = ModelRunnerOutput(
+        req_ids=["lo1", "lo2"],
+        req_id_to_index={"lo1": 0, "lo2": 1},
+        sampled_token_ids=[[99], [98]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # --- Phase 2: high-priority request arrives ---
+    hi_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],
+        arrival_times=[3.0],
+        num_tokens=10,
+        req_ids=["hi"],
+    )[0]
+    scheduler.add_request(hi_req)
+
+    # Both low-priority requests are running (max_num_seqs=2 is full).
+    # The high-priority request should preempt the lowest-priority runner.
+    # In this case both runners have priority 5 so arrival_time
+    # is the tiebreaker: lo2 (arrival 2.0) should be preempted
+    # before lo1 (arrival 1.0).
+    output = scheduler.schedule()
+
+    hi_scheduled = any(
+        req.req_id == "hi" for req in output.scheduled_new_reqs
+    )
+    assert hi_scheduled, (
+        "High-priority request 'hi' should have been scheduled "
+        "after preempting a low-priority runner"
+    )
+
+    # Verify the preempted request is lo2 (both priority 5, lo2 arrived later).
+    lo2_req = scheduler.requests["lo2"]
+    assert lo2_req.status == RequestStatus.PREEMPTED, (
+        f"Expected lo2 to be preempted, got {lo2_req.status}"
+    )
+
+    # lo1 should still be running and was scheduled in this step.
+    lo1_req = scheduler.requests["lo1"]
+    assert lo1_req.status == RequestStatus.RUNNING
+
+    # The running queue has max_num_seqs=2:
+    # lo1 (running) + hi (running) = 2.
+    assert len(scheduler.running) == 2
+    running_ids = {req.request_id for req in scheduler.running}
+    assert running_ids == {"lo1", "hi"}
+
+    # The preempted request should be back in the waiting queue.
+    assert lo2_req in scheduler.waiting
+
+
+def test_priority_preemption_at_max_num_seqs_no_preempt_when_not_higher():
+    """Test that preemption at max_num_seqs does NOT happen when the waiting
+    request has lower priority than all running requests."""
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,
+    )
+
+    # Two high-priority requests fill the running queue.
+    hi_requests = create_requests_with_priority(
+        num_requests=2,
+        priorities=[0, 1],  # High priority (lower = higher)
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["hi1", "hi2"],
+    )
+    for req in hi_requests:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+    assert len(scheduler.running) == 2
+
+    # Decode: both running requests produce a token.
+    model_output = ModelRunnerOutput(
+        req_ids=["hi1", "hi2"],
+        req_id_to_index={"hi1": 0, "hi2": 1},
+        sampled_token_ids=[[99], [98]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # A lower-priority request arrives.
+    lo_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],  # Lower priority than running (5 > 1)
+        arrival_times=[3.0],
+        num_tokens=10,
+        req_ids=["lo"],
+    )[0]
+    scheduler.add_request(lo_req)
+
+    # Schedule — should NOT preempt since lo has lower priority.
+    output = scheduler.schedule()
+
+    lo_scheduled = any(
+        req.req_id == "lo" for req in output.scheduled_new_reqs
+    )
+    assert not lo_scheduled, (
+        "Low-priority 'lo' should NOT have been scheduled "
+        "— all running requests have higher priority"
+    )
+    assert len(scheduler.running) == 2
+    assert scheduler.requests["lo"].status == RequestStatus.WAITING
+
+
 def test_async_load_reservation_prevents_wedge_e2e():
     """Same wedge scenario as PR #40968's lateral-preemption e2e test, but
     resolved by reservation-based admission control instead of preemption.

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5864,6 +5864,139 @@ def test_priority_preemption_at_max_num_seqs_no_preempt_when_not_higher():
     assert scheduler.requests["lo"].status == RequestStatus.WAITING
 
 
+def test_priority_preemption_at_max_num_seqs_equal_priority_no_preempt():
+    """Preemption at max_num_seqs must NOT fire when priorities are equal,
+    even if the waiting request arrived earlier.
+
+    Using __lt__ would trigger preemption because the tiebreaker falls
+    back to arrival_time / request_id.  A preempted request keeps its
+    earlier arrival time, so it would immediately reclaim the slot on the
+    next step — causing ping-pong.
+
+    The fix compares only `.priority`, not `__lt__`.
+    """
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,
+    )
+
+    # Two priority-5 requests fill the running queue.
+    running_reqs = create_requests_with_priority(
+        num_requests=2,
+        priorities=[5, 5],
+        arrival_times=[2.0, 3.0],
+        num_tokens=10,
+        req_ids=["r1", "r2"],
+    )
+    for req in running_reqs:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+
+    # Decode.
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["r1", "r2"],
+            req_id_to_index={"r1": 0, "r2": 1},
+            sampled_token_ids=[[99], [98]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    # A waiting request with the SAME priority (5) but an EARLIER
+    # arrival time (1.0 < 2.0).  It must NOT preempt — equal priority
+    # means no preemption.
+    waiting_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[1.0],
+        num_tokens=10,
+        req_ids=["w1"],
+    )[0]
+    scheduler.add_request(waiting_req)
+
+    output = scheduler.schedule()
+
+    w1_scheduled = any(
+        req.req_id == "w1" for req in output.scheduled_new_reqs
+    )
+    assert not w1_scheduled, (
+        "Equal-priority waiting request 'w1' must NOT preempt "
+        "(same priority = no preemption)"
+    )
+    assert len(scheduler.running) == 2
+    assert scheduler.requests["w1"].status == RequestStatus.WAITING
+
+
+def test_priority_preemption_at_max_num_seqs_blocked_skipped():
+    """A blocked waiting request (WAITING_FOR_REMOTE_KVS) must NOT
+    trigger preemption at max_num_seqs — we don't evict a runner for a
+    request that can't be admitted this step anyway."""
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=1,
+        max_num_batched_tokens=200,
+        num_blocks=100,
+        use_kv_connector=True,
+    )
+
+    # Fill the single running slot with a low-priority request.
+    [runner] = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[1.0],
+        num_tokens=10,
+        req_ids=["runner"],
+    )
+    scheduler.add_request(runner)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 1
+    assert len(scheduler.running) == 1
+
+    # Decode.
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["runner"],
+            req_id_to_index={"runner": 0},
+            sampled_token_ids=[[99]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    # Artificially set a high-priority request as WAITING_FOR_REMOTE_KVS
+    # and add it to the skipped queue directly (mimicking what happens
+    # after an async KV load is initiated).
+    blocked_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],  # Higher priority than runner (0 < 5)
+        arrival_times=[2.0],
+        num_tokens=10,
+        req_ids=["blocked_hi"],
+    )[0]
+    blocked_req.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+    scheduler.add_request(blocked_req)
+    # Move to skipped queue simulating a previously skipped request.
+    scheduler.skipped_waiting.add_request(blocked_req)
+    scheduler.waiting.pop_request()
+
+    # Schedule — should NOT preempt because blocked_hi can't be
+    # admitted yet.
+    output = scheduler.schedule()
+
+    assert scheduler.requests["runner"].status == RequestStatus.RUNNING, (
+        "Runner must NOT be preempted for a blocked waiting request"
+    )
+    assert len(scheduler.running) == 1
+
+
 def test_async_load_reservation_prevents_wedge_e2e():
     """Same wedge scenario as PR #40968's lateral-preemption e2e test, but
     resolved by reservation-based admission control instead of preemption.

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5997,6 +5997,86 @@ def test_priority_preemption_at_max_num_seqs_blocked_skipped():
     assert len(scheduler.running) == 1
 
 
+def test_priority_preemption_at_kv_cache_pressure_e2e():
+    """Test that under KV cache pressure, a higher-priority waiting request
+    preempts a lower-priority running request to free blocks.
+
+    Scenario:
+    - block_size = 16, num_blocks = 5 (4 usable after null block).
+    - lo1 (priority 5, 32 tokens) runs first → 2 blocks used. Decode → 33
+      tokens (needs 3rd block on next schedule).
+    - hi (priority 0, 32 tokens) arrives in the waiting queue.
+    - lo1's 3rd block is allocated (3 used), hi can't fit (needs 2 blocks,
+      only 1 free) → hi preempts lo1 and takes the slot.
+    """
+    block_size = 16
+    num_blocks = 5  # 1 null → 4 usable
+    num_tokens = block_size * 2  # 32 tokens = 2 blocks
+
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=3,
+        max_num_batched_tokens=200,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
+
+    # --- Phase 1: low-priority request starts running ---
+    lo1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[1.0],
+        num_tokens=num_tokens,
+        req_ids=["lo1"],
+    )[0]
+    scheduler.add_request(lo1)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 1
+    assert lo1 in scheduler.running
+
+    # Decode: lo1 now has 33 tokens (needs 3rd block next time).
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["lo1"],
+            req_id_to_index={"lo1": 0},
+            sampled_token_ids=[[100]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    # --- Phase 2: high-priority waiting request arrives ---
+    hi = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],
+        arrival_times=[2.0],
+        num_tokens=num_tokens,
+        req_ids=["hi"],
+    )[0]
+    scheduler.add_request(hi)
+
+    # schedule(): lo1 gets its 3rd block (3 used, 1 free).  hi needs
+    # 2 blocks but only 1 is free → block allocation fails for hi.
+    # With the new KV-cache preemption, hi (priority 0) preempts
+    # lo1 (priority 5) to free blocks.
+    output = scheduler.schedule()
+
+    # lo1 should be preempted.
+    lo1_req = scheduler.requests["lo1"]
+    assert lo1_req.status == RequestStatus.PREEMPTED, (
+        f"Expected lo1 to be preempted, got {lo1_req.status}"
+    )
+
+    # hi should be in the running queue.
+    hi_req = scheduler.requests["hi"]
+    assert hi_req.status == RequestStatus.RUNNING, (
+        f"Expected hi to be running, got {hi_req.status}"
+    )
+    assert hi_req in scheduler.running
+
+
 def test_async_load_reservation_prevents_wedge_e2e():
     """Same wedge scenario as PR #40968's lateral-preemption e2e test, but
     resolved by reservation-based admission control instead of preemption.

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5716,6 +5716,154 @@ def test_ec_connector_pending_prefetch_only_checks_future_mm_features():
     )
 
 
+def test_priority_preemption_at_max_num_seqs_e2e():
+    """Test that a higher-priority waiting request preempts a lower-priority
+    running request when max_num_seqs is reached.
+
+    Scenario:
+    - max_num_seqs = 2
+    - Two low-priority requests (priority 5) fill the running queue.
+    - A high-priority request (priority 0) arrives.
+    - The scheduler preempts one low-priority runner to admit the
+      high-priority one.
+    """
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,  # Plenty of blocks — no KV pressure
+    )
+
+    # --- Phase 1: two low-priority requests fill the running queue ---
+    lo_requests = create_requests_with_priority(
+        num_requests=2,
+        priorities=[5, 5],
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["lo1", "lo2"],
+    )
+    for req in lo_requests:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+    assert len(scheduler.running) == 2
+    assert {req.req_id for req in output.scheduled_new_reqs} == {"lo1", "lo2"}
+
+    # Simulate model execution: both requests produce a token.
+    model_output = ModelRunnerOutput(
+        req_ids=["lo1", "lo2"],
+        req_id_to_index={"lo1": 0, "lo2": 1},
+        sampled_token_ids=[[99], [98]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # --- Phase 2: high-priority request arrives ---
+    hi_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],
+        arrival_times=[3.0],
+        num_tokens=10,
+        req_ids=["hi"],
+    )[0]
+    scheduler.add_request(hi_req)
+
+    # Both low-priority requests are running (max_num_seqs=2 is full).
+    # The high-priority request should preempt the lowest-priority runner.
+    # In this case both runners have priority 5 so arrival_time
+    # is the tiebreaker: lo2 (arrival 2.0) should be preempted
+    # before lo1 (arrival 1.0).
+    output = scheduler.schedule()
+
+    hi_scheduled = any(
+        req.req_id == "hi" for req in output.scheduled_new_reqs
+    )
+    assert hi_scheduled, (
+        "High-priority request 'hi' should have been scheduled "
+        "after preempting a low-priority runner"
+    )
+
+    # Verify the preempted request is lo2 (both priority 5, lo2 arrived later).
+    lo2_req = scheduler.requests["lo2"]
+    assert lo2_req.status == RequestStatus.PREEMPTED, (
+        f"Expected lo2 to be preempted, got {lo2_req.status}"
+    )
+
+    # lo1 should still be running and was scheduled in this step.
+    lo1_req = scheduler.requests["lo1"]
+    assert lo1_req.status == RequestStatus.RUNNING
+
+    # The running queue has max_num_seqs=2:
+    # lo1 (running) + hi (running) = 2.
+    assert len(scheduler.running) == 2
+    running_ids = {req.request_id for req in scheduler.running}
+    assert running_ids == {"lo1", "hi"}
+
+    # The preempted request should be back in the waiting queue.
+    assert lo2_req in scheduler.waiting
+
+
+def test_priority_preemption_at_max_num_seqs_no_preempt_when_not_higher():
+    """Test that preemption at max_num_seqs does NOT happen when the waiting
+    request has lower priority than all running requests."""
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,
+    )
+
+    # Two high-priority requests fill the running queue.
+    hi_requests = create_requests_with_priority(
+        num_requests=2,
+        priorities=[0, 1],  # High priority (lower = higher)
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["hi1", "hi2"],
+    )
+    for req in hi_requests:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+    assert len(scheduler.running) == 2
+
+    # Decode: both running requests produce a token.
+    model_output = ModelRunnerOutput(
+        req_ids=["hi1", "hi2"],
+        req_id_to_index={"hi1": 0, "hi2": 1},
+        sampled_token_ids=[[99], [98]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # A lower-priority request arrives.
+    lo_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],  # Lower priority than running (5 > 1)
+        arrival_times=[3.0],
+        num_tokens=10,
+        req_ids=["lo"],
+    )[0]
+    scheduler.add_request(lo_req)
+
+    # Schedule — should NOT preempt since lo has lower priority.
+    output = scheduler.schedule()
+
+    lo_scheduled = any(
+        req.req_id == "lo" for req in output.scheduled_new_reqs
+    )
+    assert not lo_scheduled, (
+        "Low-priority 'lo' should NOT have been scheduled "
+        "— all running requests have higher priority"
+    )
+    assert len(scheduler.running) == 2
+    assert scheduler.requests["lo"].status == RequestStatus.WAITING
+
+
 def test_async_load_reservation_prevents_wedge_e2e():
     """Same wedge scenario as PR #40968's lateral-preemption e2e test, but
     resolved by reservation-based admission control instead of preemption.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -633,6 +633,40 @@ class Scheduler(SchedulerInterface):
             )
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
+        # Helper: evict a running request to make room for a
+        # higher-priority waiting request.  Undoes any scheduling
+        # already done for the victim in this step.
+        def _evict_runner(victim: Request) -> None:
+            self.running.remove(victim)
+            if victim in scheduled_running_reqs:
+                scheduled_running_reqs.remove(victim)
+                victim_id = victim.request_id
+                nonlocal token_budget
+                token_budget += num_scheduled_tokens.pop(victim_id)
+                req_to_new_blocks.pop(victim_id)
+                scheduled_spec_decode_tokens.pop(victim_id, None)
+                victim_encoder = scheduled_encoder_inputs.pop(
+                    victim_id, None
+                )
+                if victim_encoder:
+                    nonlocal encoder_compute_budget
+                    encoder_compute_budget += sum(
+                        victim.get_num_encoder_embeds(i)
+                        for i in victim_encoder
+                    )
+                # Discard the victim's LoRA only when no remaining
+                # scheduled request still uses it.
+                if self.lora_config and victim.lora_request:
+                    lora_id = victim.lora_request.lora_int_id
+                    if lora_id > 0 and not any(
+                        req.lora_request
+                        and req.lora_request.lora_int_id == lora_id
+                        for req in scheduled_running_reqs
+                    ):
+                        scheduled_loras.discard(lora_id)
+            self._preempt_request(victim, scheduled_timestamp)
+            preempted_reqs.append(victim)
+
         # Next, schedule the WAITING requests.
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
             step_skipped_waiting = create_request_queue(self.policy)
@@ -708,63 +742,9 @@ class Scheduler(SchedulerInterface):
                         ):
                             break
 
-                        # Remove the victim from the running queue and
-                        # undo any scheduling already done for it in
-                        # this step.
-                        self.running.remove(lowest_priority_req)
-                        if lowest_priority_req in scheduled_running_reqs:
-                            scheduled_running_reqs.remove(
-                                lowest_priority_req
-                            )
-                            preempted_req_id = (
-                                lowest_priority_req.request_id
-                            )
-                            token_budget += num_scheduled_tokens.pop(
-                                preempted_req_id
-                            )
-                            req_to_new_blocks.pop(preempted_req_id)
-                            scheduled_spec_decode_tokens.pop(
-                                preempted_req_id, None
-                            )
-                            preempted_encoder_inputs = (
-                                scheduled_encoder_inputs.pop(
-                                    preempted_req_id, None
-                                )
-                            )
-                            if preempted_encoder_inputs:
-                                encoder_compute_budget += sum(
-                                    lowest_priority_req.get_num_encoder_embeds(
-                                        i
-                                    )
-                                    for i in preempted_encoder_inputs
-                                )
-
-                            # Discard only the victim's LoRA when no
-                            # remaining scheduled request uses it.
-                            # This preserves LoRA IDs from waiting
-                            # requests already admitted earlier in
-                            # this scheduling pass.
-                            if (
-                                self.lora_config
-                                and lowest_priority_req.lora_request
-                            ):
-                                victim_lora_id = (
-                                    lowest_priority_req.lora_request.lora_int_id
-                                )
-                                if victim_lora_id > 0 and not any(
-                                    req.lora_request
-                                    and req.lora_request.lora_int_id
-                                    == victim_lora_id
-                                    for req in scheduled_running_reqs
-                                ):
-                                    scheduled_loras.discard(
-                                        victim_lora_id
-                                    )
-
-                        self._preempt_request(
-                            lowest_priority_req, scheduled_timestamp
-                        )
-                        preempted_reqs.append(lowest_priority_req)
+                        # Evict the lowest-priority runner to make
+                        # room for the higher-priority waiter.
+                        _evict_runner(lowest_priority_req)
                         # Loop back to schedule the waiting request
                         # (len(self.running) is now < max_num_running_reqs).
                         continue
@@ -1066,70 +1046,7 @@ class Scheduler(SchedulerInterface):
                             request.priority
                             < lowest_priority_req.priority
                         ):
-                            self.running.remove(lowest_priority_req)
-                            if (
-                                lowest_priority_req
-                                in scheduled_running_reqs
-                            ):
-                                scheduled_running_reqs.remove(
-                                    lowest_priority_req
-                                )
-                                preempted_req_id = (
-                                    lowest_priority_req.request_id
-                                )
-                                token_budget += (
-                                    num_scheduled_tokens.pop(
-                                        preempted_req_id
-                                    )
-                                )
-                                req_to_new_blocks.pop(
-                                    preempted_req_id
-                                )
-                                scheduled_spec_decode_tokens.pop(
-                                    preempted_req_id, None
-                                )
-                                preempted_encoder_inputs = (
-                                    scheduled_encoder_inputs.pop(
-                                        preempted_req_id, None
-                                    )
-                                )
-                                if preempted_encoder_inputs:
-                                    encoder_compute_budget += sum(
-                                        lowest_priority_req.get_num_encoder_embeds(
-                                            i
-                                        )
-                                        for i in preempted_encoder_inputs
-                                    )
-
-                                # Discard only the victim's LoRA
-                                # when no remaining scheduled
-                                # request still uses it.
-                                if (
-                                    self.lora_config
-                                    and lowest_priority_req.lora_request
-                                ):
-                                    victim_lora_id = (
-                                        lowest_priority_req.lora_request.lora_int_id
-                                    )
-                                    if (
-                                        victim_lora_id > 0
-                                        and not any(
-                                            req.lora_request
-                                            and req.lora_request.lora_int_id
-                                            == victim_lora_id
-                                            for req in scheduled_running_reqs
-                                        )
-                                    ):
-                                        scheduled_loras.discard(
-                                            victim_lora_id
-                                        )
-
-                            self._preempt_request(
-                                lowest_priority_req, scheduled_timestamp
-                            )
-                            preempted_reqs.append(
-                                lowest_priority_req
-                            )
+                            _evict_runner(lowest_priority_req)
                             # Retry allocation for this waiting
                             # request with the freed blocks.
                             continue

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1050,6 +1050,90 @@ class Scheduler(SchedulerInterface):
                     # manager
                     if request.has_encoder_inputs:
                         self.encoder_cache_manager.free(request)
+
+                    # Priority-based preemption for KV cache pressure:
+                    # free blocks by preempting the lowest-priority runner
+                    # so this higher-priority waiting request can fit.
+                    if (
+                        self.policy == SchedulingPolicy.PRIORITY
+                        and self.running
+                    ):
+                        lowest_priority_req = max(
+                            self.running,
+                            key=lambda r: (r.priority, r.arrival_time),
+                        )
+                        if (
+                            request.priority
+                            < lowest_priority_req.priority
+                        ):
+                            self.running.remove(lowest_priority_req)
+                            if (
+                                lowest_priority_req
+                                in scheduled_running_reqs
+                            ):
+                                scheduled_running_reqs.remove(
+                                    lowest_priority_req
+                                )
+                                preempted_req_id = (
+                                    lowest_priority_req.request_id
+                                )
+                                token_budget += (
+                                    num_scheduled_tokens.pop(
+                                        preempted_req_id
+                                    )
+                                )
+                                req_to_new_blocks.pop(
+                                    preempted_req_id
+                                )
+                                scheduled_spec_decode_tokens.pop(
+                                    preempted_req_id, None
+                                )
+                                preempted_encoder_inputs = (
+                                    scheduled_encoder_inputs.pop(
+                                        preempted_req_id, None
+                                    )
+                                )
+                                if preempted_encoder_inputs:
+                                    encoder_compute_budget += sum(
+                                        lowest_priority_req.get_num_encoder_embeds(
+                                            i
+                                        )
+                                        for i in preempted_encoder_inputs
+                                    )
+
+                                # Discard only the victim's LoRA
+                                # when no remaining scheduled
+                                # request still uses it.
+                                if (
+                                    self.lora_config
+                                    and lowest_priority_req.lora_request
+                                ):
+                                    victim_lora_id = (
+                                        lowest_priority_req.lora_request.lora_int_id
+                                    )
+                                    if (
+                                        victim_lora_id > 0
+                                        and not any(
+                                            req.lora_request
+                                            and req.lora_request.lora_int_id
+                                            == victim_lora_id
+                                            for req in scheduled_running_reqs
+                                        )
+                                    ):
+                                        scheduled_loras.discard(
+                                            victim_lora_id
+                                        )
+
+                            self._preempt_request(
+                                lowest_priority_req, scheduled_timestamp
+                            )
+                            preempted_reqs.append(
+                                lowest_priority_req
+                            )
+                            # Retry allocation for this waiting
+                            # request with the freed blocks.
+                            continue
+
                     break
 
                 # KVTransfer: the connector uses this info to determine

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -642,7 +642,77 @@ class Scheduler(SchedulerInterface):
                 # in `running` but still hold a model-runner request slot.
                 num_running = len(self.running) + self.num_waiting_for_streaming_input
                 if num_running >= self.max_num_running_reqs:
-                    break
+                    if self.policy == SchedulingPolicy.PRIORITY:
+                        # Priority-based preemption at max_num_seqs:
+                        # Allow a higher-priority waiting request to preempt
+                        # a lower-priority running request.
+                        request_queue = self._select_waiting_queue_for_scheduling()
+                        if request_queue is None:
+                            break
+                        waiting_req = request_queue.peek_request()
+
+                        # Find the lowest-priority running request.
+                        lowest_priority_req = max(
+                            self.running,
+                            key=lambda r: (r.priority, r.arrival_time),
+                        )
+
+                        # If the waiting request has higher priority
+                        # (lower numerical value), preempt the runner.
+                        if waiting_req < lowest_priority_req:
+                            self.running.remove(lowest_priority_req)
+                            if lowest_priority_req in scheduled_running_reqs:
+                                scheduled_running_reqs.remove(
+                                    lowest_priority_req
+                                )
+                                preempted_req_id = (
+                                    lowest_priority_req.request_id
+                                )
+                                token_budget += (
+                                    num_scheduled_tokens.pop(
+                                        preempted_req_id
+                                    )
+                                )
+                                req_to_new_blocks.pop(preempted_req_id)
+                                scheduled_spec_decode_tokens.pop(
+                                    preempted_req_id, None
+                                )
+                                preempted_encoder_inputs = (
+                                    scheduled_encoder_inputs.pop(
+                                        preempted_req_id, None
+                                    )
+                                )
+                                if preempted_encoder_inputs:
+                                    num_embeds_to_restore = sum(
+                                        lowest_priority_req.get_num_encoder_embeds(i)
+                                        for i in preempted_encoder_inputs
+                                    )
+                                    encoder_compute_budget += (
+                                        num_embeds_to_restore
+                                    )
+
+                                # Recalculate scheduled_loras since
+                                # scheduled_running_reqs changed.
+                                if self.lora_config:
+                                    scheduled_loras = set(
+                                        req.lora_request.lora_int_id
+                                        for req in scheduled_running_reqs
+                                        if (
+                                            req.lora_request
+                                            and req.lora_request.lora_int_id > 0
+                                        )
+                                    )
+
+                            self._preempt_request(
+                                lowest_priority_req, scheduled_timestamp
+                            )
+                            preempted_reqs.append(lowest_priority_req)
+                            # Loop back to schedule the waiting request.
+                            continue
+                        else:
+                            break
+                    else:
+                        break
 
                 request_queue = self._select_waiting_queue_for_scheduling()
                 assert request_queue is not None

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -644,12 +644,52 @@ class Scheduler(SchedulerInterface):
                 if num_running >= self.max_num_running_reqs:
                     if self.policy == SchedulingPolicy.PRIORITY:
                         # Priority-based preemption at max_num_seqs:
-                        # Allow a higher-priority waiting request to preempt
-                        # a lower-priority running request.
+                        # A higher-priority waiting request can preempt a
+                        # lower-priority running request.  Run the blocked-
+                        # status and max_loras admission checks first so we
+                        # don't evict a runner for a request that can't be
+                        # admitted this step.
                         request_queue = self._select_waiting_queue_for_scheduling()
                         if request_queue is None:
                             break
-                        waiting_req = request_queue.peek_request()
+                        request = request_queue.peek_request()
+                        request_id = request.request_id
+
+                        # Blocked-status check: don't preempt for a request
+                        # that is still waiting on async deps.
+                        if self._is_blocked_waiting_status(
+                            request.status
+                        ) and not self._try_promote_blocked_waiting_request(
+                            request
+                        ):
+                            if (
+                                request.status
+                                == RequestStatus.WAITING_FOR_REMOTE_KVS
+                            ):
+                                logger.debug(
+                                    "%s is still in "
+                                    "WAITING_FOR_REMOTE_KVS state.",
+                                    request_id,
+                                )
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
+                            continue
+
+                        # Max_loras check: don't preempt if the waiting
+                        # request would exceed the LoRA limit.
+                        if (
+                            self.lora_config
+                            and request.lora_request
+                            and (
+                                len(scheduled_loras)
+                                == self.lora_config.max_loras
+                                and request.lora_request.lora_int_id
+                                not in scheduled_loras
+                            )
+                        ):
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
+                            continue
 
                         # Find the lowest-priority running request.
                         lowest_priority_req = max(
@@ -657,60 +697,77 @@ class Scheduler(SchedulerInterface):
                             key=lambda r: (r.priority, r.arrival_time),
                         )
 
-                        # If the waiting request has higher priority
-                        # (lower numerical value), preempt the runner.
-                        if waiting_req < lowest_priority_req:
-                            self.running.remove(lowest_priority_req)
-                            if lowest_priority_req in scheduled_running_reqs:
-                                scheduled_running_reqs.remove(
-                                    lowest_priority_req
-                                )
-                                preempted_req_id = (
-                                    lowest_priority_req.request_id
-                                )
-                                token_budget += (
-                                    num_scheduled_tokens.pop(
-                                        preempted_req_id
-                                    )
-                                )
-                                req_to_new_blocks.pop(preempted_req_id)
-                                scheduled_spec_decode_tokens.pop(
+                        # Preempt only for strictly higher priority
+                        # (lower numerical value).  Equal priority must
+                        # not preempt — it causes ping-pong since the
+                        # preempted request keeps its earlier arrival
+                        # time and would immediately reclaim the slot.
+                        if (
+                            request.priority
+                            >= lowest_priority_req.priority
+                        ):
+                            break
+
+                        # Remove the victim from the running queue and
+                        # undo any scheduling already done for it in
+                        # this step.
+                        self.running.remove(lowest_priority_req)
+                        if lowest_priority_req in scheduled_running_reqs:
+                            scheduled_running_reqs.remove(
+                                lowest_priority_req
+                            )
+                            preempted_req_id = (
+                                lowest_priority_req.request_id
+                            )
+                            token_budget += num_scheduled_tokens.pop(
+                                preempted_req_id
+                            )
+                            req_to_new_blocks.pop(preempted_req_id)
+                            scheduled_spec_decode_tokens.pop(
+                                preempted_req_id, None
+                            )
+                            preempted_encoder_inputs = (
+                                scheduled_encoder_inputs.pop(
                                     preempted_req_id, None
                                 )
-                                preempted_encoder_inputs = (
-                                    scheduled_encoder_inputs.pop(
-                                        preempted_req_id, None
-                                    )
-                                )
-                                if preempted_encoder_inputs:
-                                    num_embeds_to_restore = sum(
-                                        lowest_priority_req.get_num_encoder_embeds(i)
-                                        for i in preempted_encoder_inputs
-                                    )
-                                    encoder_compute_budget += (
-                                        num_embeds_to_restore
-                                    )
-
-                                # Recalculate scheduled_loras since
-                                # scheduled_running_reqs changed.
-                                if self.lora_config:
-                                    scheduled_loras = set(
-                                        req.lora_request.lora_int_id
-                                        for req in scheduled_running_reqs
-                                        if (
-                                            req.lora_request
-                                            and req.lora_request.lora_int_id > 0
-                                        )
-                                    )
-
-                            self._preempt_request(
-                                lowest_priority_req, scheduled_timestamp
                             )
-                            preempted_reqs.append(lowest_priority_req)
-                            # Loop back to schedule the waiting request.
-                            continue
-                        else:
-                            break
+                            if preempted_encoder_inputs:
+                                encoder_compute_budget += sum(
+                                    lowest_priority_req.get_num_encoder_embeds(
+                                        i
+                                    )
+                                    for i in preempted_encoder_inputs
+                                )
+
+                            # Discard only the victim's LoRA when no
+                            # remaining scheduled request uses it.
+                            # This preserves LoRA IDs from waiting
+                            # requests already admitted earlier in
+                            # this scheduling pass.
+                            if (
+                                self.lora_config
+                                and lowest_priority_req.lora_request
+                            ):
+                                victim_lora_id = (
+                                    lowest_priority_req.lora_request.lora_int_id
+                                )
+                                if victim_lora_id > 0 and not any(
+                                    req.lora_request
+                                    and req.lora_request.lora_int_id
+                                    == victim_lora_id
+                                    for req in scheduled_running_reqs
+                                ):
+                                    scheduled_loras.discard(
+                                        victim_lora_id
+                                    )
+
+                        self._preempt_request(
+                            lowest_priority_req, scheduled_timestamp
+                        )
+                        preempted_reqs.append(lowest_priority_req)
+                        # Loop back to schedule the waiting request
+                        # (len(self.running) is now < max_num_running_reqs).
+                        continue
                     else:
                         break
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -752,6 +752,40 @@ class Scheduler(SchedulerInterface):
             )
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
+        # Helper: evict a running request to make room for a
+        # higher-priority waiting request.  Undoes any scheduling
+        # already done for the victim in this step.
+        def _evict_runner(victim: Request) -> None:
+            self.running.remove(victim)
+            if victim in scheduled_running_reqs:
+                scheduled_running_reqs.remove(victim)
+                victim_id = victim.request_id
+                nonlocal token_budget
+                token_budget += num_scheduled_tokens.pop(victim_id)
+                req_to_new_blocks.pop(victim_id)
+                scheduled_spec_decode_tokens.pop(victim_id, None)
+                victim_encoder = scheduled_encoder_inputs.pop(
+                    victim_id, None
+                )
+                if victim_encoder:
+                    nonlocal encoder_compute_budget
+                    encoder_compute_budget += sum(
+                        victim.get_num_encoder_embeds(i)
+                        for i in victim_encoder
+                    )
+                # Discard the victim's LoRA only when no remaining
+                # scheduled request still uses it.
+                if self.lora_config and victim.lora_request:
+                    lora_id = victim.lora_request.lora_int_id
+                    if lora_id > 0 and not any(
+                        req.lora_request
+                        and req.lora_request.lora_int_id == lora_id
+                        for req in scheduled_running_reqs
+                    ):
+                        scheduled_loras.discard(lora_id)
+            self._preempt_request(victim, scheduled_timestamp)
+            preempted_reqs.append(victim)
+
         # Next, schedule the WAITING requests.
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
             step_skipped_waiting = create_request_queue(self.policy)
@@ -829,63 +863,9 @@ class Scheduler(SchedulerInterface):
                         ):
                             break
 
-                        # Remove the victim from the running queue and
-                        # undo any scheduling already done for it in
-                        # this step.
-                        self.running.remove(lowest_priority_req)
-                        if lowest_priority_req in scheduled_running_reqs:
-                            scheduled_running_reqs.remove(
-                                lowest_priority_req
-                            )
-                            preempted_req_id = (
-                                lowest_priority_req.request_id
-                            )
-                            token_budget += num_scheduled_tokens.pop(
-                                preempted_req_id
-                            )
-                            req_to_new_blocks.pop(preempted_req_id)
-                            scheduled_spec_decode_tokens.pop(
-                                preempted_req_id, None
-                            )
-                            preempted_encoder_inputs = (
-                                scheduled_encoder_inputs.pop(
-                                    preempted_req_id, None
-                                )
-                            )
-                            if preempted_encoder_inputs:
-                                encoder_compute_budget += sum(
-                                    lowest_priority_req.get_num_encoder_embeds(
-                                        i
-                                    )
-                                    for i in preempted_encoder_inputs
-                                )
-
-                            # Discard only the victim's LoRA when no
-                            # remaining scheduled request uses it.
-                            # This preserves LoRA IDs from waiting
-                            # requests already admitted earlier in
-                            # this scheduling pass.
-                            if (
-                                self.lora_config
-                                and lowest_priority_req.lora_request
-                            ):
-                                victim_lora_id = (
-                                    lowest_priority_req.lora_request.lora_int_id
-                                )
-                                if victim_lora_id > 0 and not any(
-                                    req.lora_request
-                                    and req.lora_request.lora_int_id
-                                    == victim_lora_id
-                                    for req in scheduled_running_reqs
-                                ):
-                                    scheduled_loras.discard(
-                                        victim_lora_id
-                                    )
-
-                        self._preempt_request(
-                            lowest_priority_req, scheduled_timestamp
-                        )
-                        preempted_reqs.append(lowest_priority_req)
+                        # Evict the lowest-priority runner to make
+                        # room for the higher-priority waiter.
+                        _evict_runner(lowest_priority_req)
                         # Loop back to schedule the waiting request
                         # (len(self.running) is now < max_num_running_reqs).
                         continue
@@ -1202,70 +1182,7 @@ class Scheduler(SchedulerInterface):
                             request.priority
                             < lowest_priority_req.priority
                         ):
-                            self.running.remove(lowest_priority_req)
-                            if (
-                                lowest_priority_req
-                                in scheduled_running_reqs
-                            ):
-                                scheduled_running_reqs.remove(
-                                    lowest_priority_req
-                                )
-                                preempted_req_id = (
-                                    lowest_priority_req.request_id
-                                )
-                                token_budget += (
-                                    num_scheduled_tokens.pop(
-                                        preempted_req_id
-                                    )
-                                )
-                                req_to_new_blocks.pop(
-                                    preempted_req_id
-                                )
-                                scheduled_spec_decode_tokens.pop(
-                                    preempted_req_id, None
-                                )
-                                preempted_encoder_inputs = (
-                                    scheduled_encoder_inputs.pop(
-                                        preempted_req_id, None
-                                    )
-                                )
-                                if preempted_encoder_inputs:
-                                    encoder_compute_budget += sum(
-                                        lowest_priority_req.get_num_encoder_embeds(
-                                            i
-                                        )
-                                        for i in preempted_encoder_inputs
-                                    )
-
-                                # Discard only the victim's LoRA
-                                # when no remaining scheduled
-                                # request still uses it.
-                                if (
-                                    self.lora_config
-                                    and lowest_priority_req.lora_request
-                                ):
-                                    victim_lora_id = (
-                                        lowest_priority_req.lora_request.lora_int_id
-                                    )
-                                    if (
-                                        victim_lora_id > 0
-                                        and not any(
-                                            req.lora_request
-                                            and req.lora_request.lora_int_id
-                                            == victim_lora_id
-                                            for req in scheduled_running_reqs
-                                        )
-                                    ):
-                                        scheduled_loras.discard(
-                                            victim_lora_id
-                                        )
-
-                            self._preempt_request(
-                                lowest_priority_req, scheduled_timestamp
-                            )
-                            preempted_reqs.append(
-                                lowest_priority_req
-                            )
+                            _evict_runner(lowest_priority_req)
                             # Retry allocation for this waiting
                             # request with the freed blocks.
                             continue

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -763,7 +763,77 @@ class Scheduler(SchedulerInterface):
                 # in `running` but still hold a model-runner request slot.
                 num_running = len(self.running) + self.num_waiting_for_streaming_input
                 if num_running >= self.max_num_running_reqs:
-                    break
+                    if self.policy == SchedulingPolicy.PRIORITY:
+                        # Priority-based preemption at max_num_seqs:
+                        # Allow a higher-priority waiting request to preempt
+                        # a lower-priority running request.
+                        request_queue = self._select_waiting_queue_for_scheduling()
+                        if request_queue is None:
+                            break
+                        waiting_req = request_queue.peek_request()
+
+                        # Find the lowest-priority running request.
+                        lowest_priority_req = max(
+                            self.running,
+                            key=lambda r: (r.priority, r.arrival_time),
+                        )
+
+                        # If the waiting request has higher priority
+                        # (lower numerical value), preempt the runner.
+                        if waiting_req < lowest_priority_req:
+                            self.running.remove(lowest_priority_req)
+                            if lowest_priority_req in scheduled_running_reqs:
+                                scheduled_running_reqs.remove(
+                                    lowest_priority_req
+                                )
+                                preempted_req_id = (
+                                    lowest_priority_req.request_id
+                                )
+                                token_budget += (
+                                    num_scheduled_tokens.pop(
+                                        preempted_req_id
+                                    )
+                                )
+                                req_to_new_blocks.pop(preempted_req_id)
+                                scheduled_spec_decode_tokens.pop(
+                                    preempted_req_id, None
+                                )
+                                preempted_encoder_inputs = (
+                                    scheduled_encoder_inputs.pop(
+                                        preempted_req_id, None
+                                    )
+                                )
+                                if preempted_encoder_inputs:
+                                    num_embeds_to_restore = sum(
+                                        lowest_priority_req.get_num_encoder_embeds(i)
+                                        for i in preempted_encoder_inputs
+                                    )
+                                    encoder_compute_budget += (
+                                        num_embeds_to_restore
+                                    )
+
+                                # Recalculate scheduled_loras since
+                                # scheduled_running_reqs changed.
+                                if self.lora_config:
+                                    scheduled_loras = set(
+                                        req.lora_request.lora_int_id
+                                        for req in scheduled_running_reqs
+                                        if (
+                                            req.lora_request
+                                            and req.lora_request.lora_int_id > 0
+                                        )
+                                    )
+
+                            self._preempt_request(
+                                lowest_priority_req, scheduled_timestamp
+                            )
+                            preempted_reqs.append(lowest_priority_req)
+                            # Loop back to schedule the waiting request.
+                            continue
+                        else:
+                            break
+                    else:
+                        break
 
                 request_queue = self._select_waiting_queue_for_scheduling()
                 assert request_queue is not None

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1186,6 +1186,90 @@ class Scheduler(SchedulerInterface):
                     # manager
                     if request.has_encoder_inputs:
                         self.encoder_cache_manager.free(request)
+
+                    # Priority-based preemption for KV cache pressure:
+                    # free blocks by preempting the lowest-priority runner
+                    # so this higher-priority waiting request can fit.
+                    if (
+                        self.policy == SchedulingPolicy.PRIORITY
+                        and self.running
+                    ):
+                        lowest_priority_req = max(
+                            self.running,
+                            key=lambda r: (r.priority, r.arrival_time),
+                        )
+                        if (
+                            request.priority
+                            < lowest_priority_req.priority
+                        ):
+                            self.running.remove(lowest_priority_req)
+                            if (
+                                lowest_priority_req
+                                in scheduled_running_reqs
+                            ):
+                                scheduled_running_reqs.remove(
+                                    lowest_priority_req
+                                )
+                                preempted_req_id = (
+                                    lowest_priority_req.request_id
+                                )
+                                token_budget += (
+                                    num_scheduled_tokens.pop(
+                                        preempted_req_id
+                                    )
+                                )
+                                req_to_new_blocks.pop(
+                                    preempted_req_id
+                                )
+                                scheduled_spec_decode_tokens.pop(
+                                    preempted_req_id, None
+                                )
+                                preempted_encoder_inputs = (
+                                    scheduled_encoder_inputs.pop(
+                                        preempted_req_id, None
+                                    )
+                                )
+                                if preempted_encoder_inputs:
+                                    encoder_compute_budget += sum(
+                                        lowest_priority_req.get_num_encoder_embeds(
+                                            i
+                                        )
+                                        for i in preempted_encoder_inputs
+                                    )
+
+                                # Discard only the victim's LoRA
+                                # when no remaining scheduled
+                                # request still uses it.
+                                if (
+                                    self.lora_config
+                                    and lowest_priority_req.lora_request
+                                ):
+                                    victim_lora_id = (
+                                        lowest_priority_req.lora_request.lora_int_id
+                                    )
+                                    if (
+                                        victim_lora_id > 0
+                                        and not any(
+                                            req.lora_request
+                                            and req.lora_request.lora_int_id
+                                            == victim_lora_id
+                                            for req in scheduled_running_reqs
+                                        )
+                                    ):
+                                        scheduled_loras.discard(
+                                            victim_lora_id
+                                        )
+
+                            self._preempt_request(
+                                lowest_priority_req, scheduled_timestamp
+                            )
+                            preempted_reqs.append(
+                                lowest_priority_req
+                            )
+                            # Retry allocation for this waiting
+                            # request with the freed blocks.
+                            continue
+
                     break
 
                 # KVTransfer: the connector uses this info to determine

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -765,12 +765,52 @@ class Scheduler(SchedulerInterface):
                 if num_running >= self.max_num_running_reqs:
                     if self.policy == SchedulingPolicy.PRIORITY:
                         # Priority-based preemption at max_num_seqs:
-                        # Allow a higher-priority waiting request to preempt
-                        # a lower-priority running request.
+                        # A higher-priority waiting request can preempt a
+                        # lower-priority running request.  Run the blocked-
+                        # status and max_loras admission checks first so we
+                        # don't evict a runner for a request that can't be
+                        # admitted this step.
                         request_queue = self._select_waiting_queue_for_scheduling()
                         if request_queue is None:
                             break
-                        waiting_req = request_queue.peek_request()
+                        request = request_queue.peek_request()
+                        request_id = request.request_id
+
+                        # Blocked-status check: don't preempt for a request
+                        # that is still waiting on async deps.
+                        if self._is_blocked_waiting_status(
+                            request.status
+                        ) and not self._try_promote_blocked_waiting_request(
+                            request
+                        ):
+                            if (
+                                request.status
+                                == RequestStatus.WAITING_FOR_REMOTE_KVS
+                            ):
+                                logger.debug(
+                                    "%s is still in "
+                                    "WAITING_FOR_REMOTE_KVS state.",
+                                    request_id,
+                                )
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
+                            continue
+
+                        # Max_loras check: don't preempt if the waiting
+                        # request would exceed the LoRA limit.
+                        if (
+                            self.lora_config
+                            and request.lora_request
+                            and (
+                                len(scheduled_loras)
+                                == self.lora_config.max_loras
+                                and request.lora_request.lora_int_id
+                                not in scheduled_loras
+                            )
+                        ):
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
+                            continue
 
                         # Find the lowest-priority running request.
                         lowest_priority_req = max(
@@ -778,60 +818,77 @@ class Scheduler(SchedulerInterface):
                             key=lambda r: (r.priority, r.arrival_time),
                         )
 
-                        # If the waiting request has higher priority
-                        # (lower numerical value), preempt the runner.
-                        if waiting_req < lowest_priority_req:
-                            self.running.remove(lowest_priority_req)
-                            if lowest_priority_req in scheduled_running_reqs:
-                                scheduled_running_reqs.remove(
-                                    lowest_priority_req
-                                )
-                                preempted_req_id = (
-                                    lowest_priority_req.request_id
-                                )
-                                token_budget += (
-                                    num_scheduled_tokens.pop(
-                                        preempted_req_id
-                                    )
-                                )
-                                req_to_new_blocks.pop(preempted_req_id)
-                                scheduled_spec_decode_tokens.pop(
+                        # Preempt only for strictly higher priority
+                        # (lower numerical value).  Equal priority must
+                        # not preempt — it causes ping-pong since the
+                        # preempted request keeps its earlier arrival
+                        # time and would immediately reclaim the slot.
+                        if (
+                            request.priority
+                            >= lowest_priority_req.priority
+                        ):
+                            break
+
+                        # Remove the victim from the running queue and
+                        # undo any scheduling already done for it in
+                        # this step.
+                        self.running.remove(lowest_priority_req)
+                        if lowest_priority_req in scheduled_running_reqs:
+                            scheduled_running_reqs.remove(
+                                lowest_priority_req
+                            )
+                            preempted_req_id = (
+                                lowest_priority_req.request_id
+                            )
+                            token_budget += num_scheduled_tokens.pop(
+                                preempted_req_id
+                            )
+                            req_to_new_blocks.pop(preempted_req_id)
+                            scheduled_spec_decode_tokens.pop(
+                                preempted_req_id, None
+                            )
+                            preempted_encoder_inputs = (
+                                scheduled_encoder_inputs.pop(
                                     preempted_req_id, None
                                 )
-                                preempted_encoder_inputs = (
-                                    scheduled_encoder_inputs.pop(
-                                        preempted_req_id, None
-                                    )
-                                )
-                                if preempted_encoder_inputs:
-                                    num_embeds_to_restore = sum(
-                                        lowest_priority_req.get_num_encoder_embeds(i)
-                                        for i in preempted_encoder_inputs
-                                    )
-                                    encoder_compute_budget += (
-                                        num_embeds_to_restore
-                                    )
-
-                                # Recalculate scheduled_loras since
-                                # scheduled_running_reqs changed.
-                                if self.lora_config:
-                                    scheduled_loras = set(
-                                        req.lora_request.lora_int_id
-                                        for req in scheduled_running_reqs
-                                        if (
-                                            req.lora_request
-                                            and req.lora_request.lora_int_id > 0
-                                        )
-                                    )
-
-                            self._preempt_request(
-                                lowest_priority_req, scheduled_timestamp
                             )
-                            preempted_reqs.append(lowest_priority_req)
-                            # Loop back to schedule the waiting request.
-                            continue
-                        else:
-                            break
+                            if preempted_encoder_inputs:
+                                encoder_compute_budget += sum(
+                                    lowest_priority_req.get_num_encoder_embeds(
+                                        i
+                                    )
+                                    for i in preempted_encoder_inputs
+                                )
+
+                            # Discard only the victim's LoRA when no
+                            # remaining scheduled request uses it.
+                            # This preserves LoRA IDs from waiting
+                            # requests already admitted earlier in
+                            # this scheduling pass.
+                            if (
+                                self.lora_config
+                                and lowest_priority_req.lora_request
+                            ):
+                                victim_lora_id = (
+                                    lowest_priority_req.lora_request.lora_int_id
+                                )
+                                if victim_lora_id > 0 and not any(
+                                    req.lora_request
+                                    and req.lora_request.lora_int_id
+                                    == victim_lora_id
+                                    for req in scheduled_running_reqs
+                                ):
+                                    scheduled_loras.discard(
+                                        victim_lora_id
+                                    )
+
+                        self._preempt_request(
+                            lowest_priority_req, scheduled_timestamp
+                        )
+                        preempted_reqs.append(lowest_priority_req)
+                        # Loop back to schedule the waiting request
+                        # (len(self.running) is now < max_num_running_reqs).
+                        continue
                     else:
                         break
 


### PR DESCRIPTION
When the running queue hits max_num_seqs, the scheduler previously stopped processing the waiting queue entirely — even if a higher-priority request was waiting behind lower-priority runners. KV-block preemption already handled resource pressure, but admission control had no priority-aware preemption.

This change allows a higher-priority waiting request to preempt the lowest-priority running request when max_num_seqs is reached and the policy is PRIORITY. FCFS behavior is unchanged.




Fixes #40004

  ## Purpose

  Currently, priority scheduling only preempts low-priority requests when a
  running request can't allocate KV cache blocks. There's no priority-aware
  preemption for admission control — when `max_num_seqs` is reached, the
  scheduler simply stops processing the waiting queue, regardless of priority.

  This PR adds priority-based preemption at the `max_num_seqs` boundary:
  - A higher-priority request in the waiting queue can displace the
    lowest-priority running request when the running queue is full.
  - The preempted request is moved back to the waiting queue for rescheduling.
  - All associated state (token budget, encoder budget, LoRA tracking,
    spec decode tokens) is properly cleaned up.

  ## Test Plan

  Existing and new scheduler unit tests:

  ```bash
  # New tests for this feature
  pytest tests/v1/core/test_scheduler.py \
    -k "test_priority_preemption_at_max_num_seqs" -v

  # All priority scheduler tests
  pytest tests/v1/core/test_scheduler.py -k "priority" -v

  Test Result


  Existing and new scheduler unit tests:

  ```bash
  # New tests for this feature
  pytest tests/v1/core/test_scheduler.py \
    -k "test_priority_preemption_at_max_num_seqs" -v

  # All priority scheduler tests
  pytest tests/v1/core/test_scheduler.py -k "priority" -v

  Test Result

  All priority scheduler tests pass. Two new tests added:

  - test_priority_preemption_at_max_num_seqs_e2e: Two low-priority
  requests fill the running queue (max_num_seqs=2) → a high-priority
  request arrives → the lowest-priority runner is preempted, and the
  high-priority request is scheduled.
  - test_priority_preemption_at_max_num_seqs_no_preempt_when_not_higher:
  Two high-priority requests fill the running queue → a low-priority
  request arrives → no preemption occurs (correctly).
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

