### PR TITLE
[Core] Priority scheduling: preempt running requests for higher-priority waiting requests at max_num_seqs

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -10,12 +10,14 @@ from vllm.config import (
     CacheConfig,
     ECTransferConfig,
     KVTransferConfig,
+    LoRAConfig,
     ModelConfig,
     SchedulerConfig,
     SpeculativeConfig,
     VllmConfig,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
     MultiModalKwargsItem,
@@ -1819,6 +1821,7 @@ def create_scheduler_with_priority(
     num_speculative_tokens: int | None = None,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    lora_config: LoRAConfig | None = None,
 ) -> Scheduler:
     """Create scheduler with priority policy enabled.
 
@@ -1893,6 +1896,7 @@ def create_scheduler_with_priority(
         kv_transfer_config=kv_transfer_config,
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
+        lora_config=lora_config,
     )
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,  # A large number of blocks to hold all requests
@@ -2384,6 +2388,131 @@ def test_priority_scheduling_waiting_queue_order():
     # Should be ordered by priority: req_1 (1), req_2 (2), req_0 (3)
     assert waiting_req_ids == ["1", "2", "0"]
     assert waiting_priorities == [1, 2, 3]
+
+
+def test_priority_waiting_request_preempts_at_max_num_seqs():
+    """Test waiting-queue priority preemption when max_num_seqs is full."""
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=512,
+        num_blocks=10000,
+    )
+
+    lo1, lo2 = create_requests_with_priority(
+        num_requests=2,
+        priorities=[5, 5],
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["lo1", "lo2"],
+    )
+    scheduler.add_request(lo1)
+    scheduler.add_request(lo2)
+
+    output = scheduler.schedule()
+    assert len(scheduler.running) == 2
+
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["lo1", "lo2"],
+            req_id_to_index={"lo1": 0, "lo2": 1},
+            sampled_token_ids=[[100], [100]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    hi1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],
+        arrival_times=[3.0],
+        num_tokens=10,
+        req_ids=["hi1"],
+    )[0]
+    scheduler.add_request(hi1)
+
+    output = scheduler.schedule()
+
+    assert [req.req_id for req in output.scheduled_new_reqs] == ["hi1"]
+    assert "hi1" in {req.request_id for req in scheduler.running}
+    assert output.preempted_req_ids is not None
+    assert len(output.preempted_req_ids) == 1
+
+    preempted = [
+        req
+        for req in (scheduler.requests["lo1"], scheduler.requests["lo2"])
+        if req.status == RequestStatus.PREEMPTED
+    ]
+    assert len(preempted) == 1
+    assert len(scheduler.running) == 2
+
+
+def test_priority_waiting_preemption_preserves_scheduled_loras():
+    """Test priority preemption keeps LoRA accounting for admitted waiters."""
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=3,
+        max_num_batched_tokens=512,
+        num_blocks=10000,
+        lora_config=LoRAConfig(max_loras=2, max_cpu_loras=2),
+    )
+
+    lora1 = LoRARequest("lora-1", 1, "/tmp/lora-1")
+    lora2 = LoRARequest("lora-2", 2, "/tmp/lora-2")
+    lora3 = LoRARequest("lora-3", 3, "/tmp/lora-3")
+
+    lo1, lo2 = create_requests_with_priority(
+        num_requests=2,
+        priorities=[9, 8],
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["lo1", "lo2"],
+    )
+    lo1.lora_request = lora1
+    scheduler.add_request(lo1)
+    scheduler.add_request(lo2)
+
+    output = scheduler.schedule()
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["lo1", "lo2"],
+            req_id_to_index={"lo1": 0, "lo2": 1},
+            sampled_token_ids=[[100], [100]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    w1, w2, w3 = create_requests_with_priority(
+        num_requests=3,
+        priorities=[0, 1, 2],
+        arrival_times=[3.0, 4.0, 5.0],
+        num_tokens=10,
+        req_ids=["w1", "w2", "w3"],
+    )
+    w1.lora_request = lora2
+    w2.lora_request = lora1
+    w3.lora_request = lora3
+    for request in (w1, w2, w3):
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert [req.req_id for req in output.scheduled_new_reqs] == ["w1", "w2"]
+    assert output.preempted_req_ids == {"lo1"}
+    queued_req_ids = {
+        req.request_id
+        for req in list(scheduler.waiting) + list(scheduler.skipped_waiting)
+    }
+    assert "w3" in queued_req_ids
+    scheduled_lora_ids = {
+        req.lora_request.lora_int_id
+        for req in output.scheduled_new_reqs
+        if req.lora_request
+    }
+    assert scheduled_lora_ids == {1, 2}
 
 
 def test_priority_scheduling_fcfs_fallback():

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -579,12 +579,61 @@ class Scheduler(SchedulerInterface):
             )
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
+        def _preempt_lowest_priority_running(request: Request) -> bool:
+            """Preempt a lower-priority running request for request admission."""
+            nonlocal token_budget, encoder_compute_budget, scheduled_loras
+
+            if self.policy != SchedulingPolicy.PRIORITY or not self.running:
+                return False
+
+            preempted_req = max(
+                self.running,
+                key=lambda r: (r.priority, r.arrival_time),
+            )
+            # Lower numeric values indicate higher priority. Equal-priority
+            # waiting requests should not displace running requests.
+            if request.priority >= preempted_req.priority:
+                return False
+
+            self.running.remove(preempted_req)
+            if preempted_req in scheduled_running_reqs:
+                preempted_req_id = preempted_req.request_id
+                scheduled_running_reqs.remove(preempted_req)
+                if self.lora_config:
+                    lora_request = preempted_req.lora_request
+                    if lora_request and lora_request.lora_int_id > 0:
+                        lora_id = lora_request.lora_int_id
+                        if not any(
+                            req.lora_request and req.lora_request.lora_int_id == lora_id
+                            for req in self.running
+                        ):
+                            scheduled_loras.discard(lora_id)
+                token_budget += num_scheduled_tokens.pop(preempted_req_id)
+                req_to_new_blocks.pop(preempted_req_id)
+                scheduled_spec_decode_tokens.pop(preempted_req_id, None)
+                preempted_encoder_inputs = scheduled_encoder_inputs.pop(
+                    preempted_req_id, None
+                )
+                if preempted_encoder_inputs:
+                    num_embeds_to_restore = sum(
+                        preempted_req.get_num_encoder_embeds(i)
+                        for i in preempted_encoder_inputs
+                    )
+                    encoder_compute_budget += num_embeds_to_restore
+
+            self._preempt_request(preempted_req, scheduled_timestamp)
+            preempted_reqs.append(preempted_req)
+            return True
+
         # Next, schedule the WAITING requests.
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
             step_skipped_waiting = create_request_queue(self.policy)
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
-                if len(self.running) == self.max_num_running_reqs:
+                if (
+                    self.policy != SchedulingPolicy.PRIORITY
+                    and len(self.running) == self.max_num_running_reqs
+                ):
                     break
 
                 request_queue = self._select_waiting_queue_for_scheduling()
@@ -620,6 +669,12 @@ class Scheduler(SchedulerInterface):
                     request_queue.pop_request()
                     step_skipped_waiting.prepend_request(request)
                     continue
+
+                # If max_num_seqs is the only blocker, a higher-priority
+                # waiting request can make room by preempting a running one.
+                at_capacity = len(self.running) == self.max_num_running_reqs
+                if at_capacity and not _preempt_lowest_priority_running(request):
+                    break
 
                 num_external_computed_tokens = 0
                 load_kv_async = False


### PR DESCRIPTION


## Purpose

Fixes #40004.

Priority scheduling currently only preempts running requests under resource pressure encountered while scheduling the running queue (e.g. when KV-cache blocks can't be allocated for already-running requests). When the bottleneck is **`max_num_seqs`** (the running queue is full), the waiting-request loop exits unconditionally, so a higher-priority request waits behind lower-priority running requests until one of them finishes and frees a slot, causing a priority inversion.

This PR makes the V1 scheduler, in `PRIORITY` policy, preempt the lowest-priority running request for a strictly-higher-priority waiting request when `max_num_seqs` is the bottleneck:

- Adds a helper that selects the victim via `max(running, key=(priority, arrival_time))`, preempts only if the waiting request is **strictly** higher priority, and unwinds any scheduling state the victim accumulated this step (token budget, allocated blocks, spec-decode tokens, encoder budget, LoRA accounting).
- `FCFS` behavior is unchanged (early-out preserved for the non-priority path).

**Scope:** intentionally limited to the `max_num_seqs` case described in the issue. Extending waiting-queue preemption to KV-block pressure (via an allocation retry loop) is a natural follow-up and is left out to keep this PR small and reviewable.

## Test Plan

```bash
# Unit tests
pytest tests/v1/core/test_scheduler.py -k priority -q

# Lint (matches CI: ruff 0.14.0)
ruff check vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
ruff format --check vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
```

New tests in `tests/v1/core/test_scheduler.py`:
- `test_priority_waiting_request_preempts_at_max_num_seqs`: high-priority waiting request preempts a lower-priority running one when `max_num_seqs` is full (no KV pressure).
- `test_priority_waiting_preemption_preserves_scheduled_loras`: preemption keeps `max_loras` accounting correct for already-admitted waiters (guards against over-admitting a 3rd LoRA).

## Test Result

Unit tests (priority subset):

```
21 passed, 88 deselected
```

Lint: `ruff check` reports "All checks passed!" and `ruff format --check` reports the files are already formatted.

End-to-end with a real engine (`facebook/opt-125m`, `scheduling_policy="priority"`, `max_num_seqs=2`):

**Before (bug):**
```
After adding high-priority request
  running: [(lo1, prio=5, RUNNING), (lo2, prio=5, RUNNING)]
  waiting: [(hi1, prio=0, WAITING)]
After second engine step
  running: [(lo1, prio=5, RUNNING), (lo2, prio=5, RUNNING)]
  waiting: [(hi1, prio=0, WAITING)]   # hi1 never admitted
```

**After (fix):**
```
After second engine step
  running: [(lo1, prio=5, RUNNING), (hi1, prio=0, RUNNING)]
  waiting: [(lo2, prio=5, PREEMPTED)]   # hi1 admitted by preempting lowest-priority runner
```

> Note: `tests/v1/core/test_scheduler.py::test_async_scheduling_pp_allows_rescheduling_with_output_placeholders` fails locally only because it requires 2 GPUs (`pipeline_parallel_size=2`); it is unrelated to this change and passes in multi-GPU CI.