### PR TITLE
[Bugfix][V1] Split V2 model-runner attention groups on num_heads_q

### DIFF
--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -85,8 +85,8 @@ def init_attn_backend(
         layer_type = cast(type[Any], AttentionLayerBase)
         attn_layers = get_layers_from_vllm_config(vllm_config, layer_type, layer_names)
 
-        group_map: dict[tuple[tuple[str, str], KVCacheSpec], AttentionGroup] = {}
-        group_order: list[tuple[tuple[str, str], KVCacheSpec]] = []
+        group_map: dict[tuple[str, KVCacheSpec, int], AttentionGroup] = {}
+        group_order: list[tuple[str, KVCacheSpec, int]] = []
 
         for layer_name in layer_names:
             attn_backend = attn_layers[layer_name].get_attn_backend()
@@ -95,7 +95,12 @@ def init_attn_backend(
             if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
                 layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
 
-            key = (attn_backend.full_cls_name(), layer_kv_cache_spec)
+            # Also split on per-rank num_heads_q so layers with different Q-head
+            # counts (e.g. a spec-decode draft head and its target) get separate
+            # metadata builders, matching the V1 runner. Non-attention layers
+            # (e.g. Mamba) lack num_heads; fall back to 0.
+            num_heads_q = getattr(attn_layers[layer_name], "num_heads", 0)
+            key = (attn_backend.full_cls_name(), layer_kv_cache_spec, num_heads_q)
             if key not in group_map:
                 group_map[key] = AttentionGroup(
                     attn_backend, [layer_name], layer_kv_cache_spec, kv_cache_group_id

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -95,10 +95,9 @@ def init_attn_backend(
             if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
                 layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
 
-            # Also split on per-rank num_heads_q so layers with different Q-head
+            # Split on per-rank num_heads_q so layers with different Q-head
             # counts (e.g. a spec-decode draft head and its target) get separate
-            # metadata builders, matching the V1 runner. Non-attention layers
-            # (e.g. Mamba) lack num_heads; fall back to 0.
+            # metadata builders.
             num_heads_q = getattr(attn_layers[layer_name], "num_heads", 0)
             key = (attn_backend.full_cls_name(), layer_kv_cache_spec, num_heads_q)
             if key not in group_map:

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -85,8 +85,8 @@ def init_attn_backend(
         layer_type = cast(type[Any], AttentionLayerBase)
         attn_layers = get_layers_from_vllm_config(vllm_config, layer_type, layer_names)
 
-        group_map: dict[tuple[str, KVCacheSpec, int], AttentionGroup] = {}
-        group_order: list[tuple[str, KVCacheSpec, int]] = []
+        group_map: dict[tuple[tuple[str, str], KVCacheSpec, int], AttentionGroup] = {}
+        group_order: list[tuple[tuple[str, str], KVCacheSpec, int]] = []
 
         for layer_name in layer_names:
             attn_backend = attn_layers[layer_name].get_attn_backend()


### PR DESCRIPTION
## Purpose

The V2 model runner's `init_attn_backend` (`vllm/v1/worker/gpu/attn_utils.py`) keys
attention metadata-builder groups on `(backend, kv_cache_spec)` only. The V1 runner
(`gpu_model_runner.initialize_attn_backend`) additionally keys on per-rank
`num_heads_q`, with a comment explaining why: layers with different Q-head counts
(e.g. a spec-decode draft head vs its target) must get **separate** metadata builders
because a builder's scratch (e.g. `num_qo_heads` in FlashInfer) is sized from its
layers and assumes uniformity within the group.

Because V2 dropped that split, layers that share a backend + kv-cache spec but differ
in Q-head count get **merged** into one builder. Besides the uniformity violation,
this can flip a group's effective `num_qo_heads // num_kv_heads` ratio (GQA vs MHA).

### Concrete failure

Serving **MiniMax-M3 + EAGLE3** with `--block-size 128` under the V2 model runner
(`VLLM_USE_V2_MODEL_RUNNER=1`) crashes at engine init:

```
NotImplementedError: FlashInfer page size 128 is only supported by the trtllm-gen
dynamic kernel, which requires GQA/MQA (num_qo_heads // num_kv_heads > 1), not MHA.
```

The draft head and target attention get merged into one FlashInfer builder whose
ratio reads as MHA, tripping the `page_size >= 128` GQA/MQA-only guard in
`FlashInferMetadataBuilder.__init__`. The V1 runner serves the identical config fine
because its `num_heads_q` split keeps each FlashInfer builder uniform (GQA).

## Changes

Mirror the V1 grouping key by adding `num_heads_q` to the V2 group key so both runners
bucket attention layers identically. Non-attention layers (e.g. Mamba) lack
`num_heads` and fall back to `0`, matching V1.

## Test Plan / Result

- Root-caused against the exact build that fails (`MiniMax-M3-MXFP8` + `MiniMax-M3-EAGLE3`,
  TP=4, `--block-size 128`): V1 runner healthy; V2 runner raises the guard above at init.
- The fix makes V2's keying identical to V1's (which serves this config), so V2 should
  reach the same per-builder head config.
- Would appreciate a maintainer running CI; I can add a focused unit test for
  `init_attn_backend` group splitting if desired.
