### PR TITLE
[Bugfix][Frontend] Handle constrained Harmony output without recipient

### DIFF
--- a/tests/entrypoints/openai/responses/test_harmony_utils.py
+++ b/tests/entrypoints/openai/responses/test_harmony_utils.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit tests for vllm.entrypoints.openai.responses.harmony."""
 
+from types import SimpleNamespace
+
 from openai.types.responses import (
     ResponseFunctionToolCall,
     ResponseOutputMessage,
@@ -10,10 +12,19 @@ from openai.types.responses import (
 from openai.types.responses.response_output_item import McpCall
 from openai_harmony import Author, Message, Role, TextContent
 
+from vllm.entrypoints.openai.parser.harmony_utils import (
+    get_encoding,
+    get_streamable_parser_for_assistant,
+)
 from vllm.entrypoints.openai.responses.harmony import (
     harmony_to_response_output,
     parser_state_to_response_output,
     response_previous_input_to_harmony,
+)
+from vllm.entrypoints.openai.responses.streaming_events import (
+    StreamingState,
+    emit_content_delta_events,
+    emit_previous_item_done_events,
 )
 
 
@@ -631,3 +642,49 @@ def test_parser_state_to_response_output_analysis_channel() -> None:
     assert len(builtin_items) == 1
     assert not isinstance(builtin_items[0], McpCall)
     assert builtin_items[0].type == "reasoning"
+
+
+class TestConstrainedOutputWithoutRecipient:
+    @staticmethod
+    def _parse(text: str):
+        parser = get_streamable_parser_for_assistant()
+        for token in get_encoding().encode(text, allowed_special="all"):
+            parser.process(token)
+        return parser
+
+    def test_completed_output(self) -> None:
+        parser = self._parse(
+            '<|channel|>final <|constrain|>json<|message|>{"result":true}<|return|>',
+        )
+
+        message = parser.messages[0]
+        output_items = harmony_to_response_output(message)
+        assert len(output_items) == 1
+        assert isinstance(output_items[0], ResponseOutputMessage)
+        assert output_items[0].content[0].text == '{"result":true}'
+
+        state = StreamingState(
+            current_content_index=0,
+            current_item_id="msg_test",
+        )
+        events = emit_previous_item_done_events(message, state)
+        assert "response.output_text.done" in [event.type for event in events]
+
+    def test_in_progress_output(self) -> None:
+        parser = self._parse(
+            '<|channel|>final <|constrain|>json<|message|>{"result":true}',
+        )
+
+        output_items = parser_state_to_response_output(parser)
+        assert len(output_items) == 1
+        assert isinstance(output_items[0], ResponseOutputMessage)
+        assert output_items[0].content[0].text == '{"result":true}'
+
+        context = SimpleNamespace(
+            last_content_delta=parser.current_content,
+            parser=parser,
+            function_tool_names=None,
+        )
+        events = emit_content_delta_events(context, StreamingState())
+        event_types = [event.type for event in events]
+        assert "response.output_text.delta" in event_types

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -424,6 +424,13 @@ def _parse_message_no_recipient(
 # ---------------------------------------------------------------------------
 
 
+def get_response_output_recipient(recipient: str | None) -> str | None:
+    """Exclude constrained formats misparsed as recipients by older Harmony."""
+    if recipient and recipient.startswith("<|constrain|>"):
+        return None
+    return recipient
+
+
 def harmony_to_response_output(
     message: Message,
     function_tool_names: frozenset[str] | None = None,
@@ -439,7 +446,7 @@ def harmony_to_response_output(
         return []
 
     output_items: list[ResponseOutputItem] = []
-    recipient = message.recipient
+    recipient = get_response_output_recipient(message.recipient)
 
     if recipient is not None:
         # Browser tool calls (browser.search, browser.open, browser.find)
@@ -478,7 +485,7 @@ def parser_state_to_response_output(
         return []
     if parser.current_role != Role.ASSISTANT:
         return []
-    current_recipient = parser.current_recipient
+    current_recipient = get_response_output_recipient(parser.current_recipient)
     if current_recipient is not None and current_recipient.startswith("browser."):
         return []
 

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -67,6 +67,7 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     is_function_recipient,
 )
 from vllm.entrypoints.openai.responses.context import StreamingHarmonyContext
+from vllm.entrypoints.openai.responses.harmony import get_response_output_recipient
 from vllm.entrypoints.openai.responses.protocol import (
     ResponseReasoningPartAddedEvent,
     ResponseReasoningPartDoneEvent,
@@ -571,7 +572,7 @@ def emit_content_delta_events(
         return []
 
     channel = ctx.parser.current_channel
-    recipient = ctx.parser.current_recipient
+    recipient = get_response_output_recipient(ctx.parser.current_recipient)
 
     if channel in ("final", "commentary") and recipient is None:
         # Preambles (commentary with no recipient) and final messages
@@ -605,7 +606,7 @@ def emit_previous_item_done_events(
     Harmony parser's message object and delegates to shared leaf helpers.
     """
     text = previous_item.content[0].text
-    if previous_item.recipient is not None:
+    if get_response_output_recipient(previous_item.recipient) is not None:
         # Deal with tool call
         if is_function_recipient(previous_item.recipient, function_tool_names):
             function_name = extract_function_from_recipient(previous_item.recipient)


### PR DESCRIPTION
## Purpose

Fixes #45570.

`openai-harmony` currently parses a standalone constrained output header such
as `<|channel|>final <|constrain|>json<|message|>...` with
`recipient="<|constrain|>json"` and `content_type=None`. The Responses API
therefore routes valid final JSON through the MCP path and returns an
`McpCall` instead of a `ResponseOutputMessage`.

This change excludes standalone constrained-format markers from recipient
routing at the Responses output boundary. It covers completed messages,
truncated parser state, streaming deltas, and streaming completion events
without changing the shared Harmony parser.

The underlying parser fix is open as openai/harmony#144.

### Duplicate check

This is intentionally narrower than #35906 and #31677:

- #35906 proposes broad sanitization and parser recovery for malformed or
  leaked Harmony control tokens.
- #31677 sanitizes malformed tool-call recipients.
- This PR only handles a valid standalone constrained-output header that the
  current Harmony dependency misclassifies as a recipient. It does not add a
  parser wrapper or change Chat Completions behavior.

## Test Plan

```bash
CUDA_VISIBLE_DEVICES=1 .venv-codex/bin/python -m pytest \
  tests/entrypoints/openai/responses/test_harmony_utils.py -q
```

Run every pre-commit hook applicable to the changed Python files:

```bash
.venv-codex/bin/pre-commit run <hook> --files \
  vllm/entrypoints/openai/responses/harmony.py \
  vllm/entrypoints/openai/responses/streaming_events.py \
  tests/entrypoints/openai/responses/test_harmony_utils.py
```

## Test Result

- `34 passed, 17 warnings`
- Passed: `ruff-check`, `ruff-format`, `typos`, `mypy-3.10`,
  `check-spdx-header`, `check-root-lazy-imports`, `check-filenames`,
  `check-forbidden-imports`, `check-torch-cuda-call`, `validate-config`,
  `attention-backend-docs`, and `check-boolean-context-manager`.
- The aggregate `pre-commit run` could not initialize the unrelated
  `actionlint` environment because its Go download failed with a proxy TLS EOF.
  `actionlint` does not apply to the changed Python files.

No documentation update is needed because this restores the existing
Responses API message behavior without changing the public API.

AI assistance disclosure: OpenAI Codex assisted with investigation,
implementation, test execution, and drafting this PR. I reviewed every changed
line and validated the behavior and tests.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it resolves.
- [x] The test plan and commands.
- [x] The test results.
- [x] Documentation impact considered.

</details>
