### PR TITLE
[Bugfix][KV Cache] Fix hybrid block size alignment across heterogeneous TP

### DIFF
--- a/tests/platforms/test_hybrid_block_size.py
+++ b/tests/platforms/test_hybrid_block_size.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.config import CacheConfig
+from vllm.model_executor.models import ModelRegistry
+from vllm.platforms.interface import Platform
+from vllm.v1.attention.backend import MultipleOf
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_align_hybrid_block_size_is_stable_across_tp(monkeypatch):
+    class _FakeBackend:
+        @staticmethod
+        def get_supported_kernel_block_sizes():
+            return [MultipleOf(32)]
+
+    class _FakeModelCls:
+        global_mamba_page_size = 32776
+
+        @staticmethod
+        def get_mamba_state_shape_from_config(vllm_config):
+            tp_size = vllm_config.parallel_config.tensor_parallel_size
+            return ((
+                _FakeModelCls.global_mamba_page_size // 2 // tp_size,
+            ),)
+
+        @staticmethod
+        def get_mamba_state_dtype_from_config(vllm_config):
+            return (torch.float16,)
+
+    class _FakeModelConfig:
+        architecture = "FakeHybridForCausalLM"
+        dtype = torch.float16
+        is_hybrid = True
+        use_mla = False
+
+        def get_head_size(self):
+            return 64
+
+        def get_total_num_kv_heads(self):
+            return 2
+
+        def get_num_kv_heads(self, parallel_config):
+            return max(
+                1,
+                self.get_total_num_kv_heads()
+                // parallel_config.tensor_parallel_size,
+            )
+
+        def get_mamba_chunk_size(self):
+            return 16
+
+    def _aligned_block_size(tp_size: int) -> int:
+        cache_config = CacheConfig(
+            block_size=32,
+            cache_dtype="float16",
+            mamba_cache_mode="none",
+        )
+        vllm_config = SimpleNamespace(
+            cache_config=cache_config,
+            model_config=_FakeModelConfig(),
+            parallel_config=SimpleNamespace(tensor_parallel_size=tp_size),
+        )
+        Platform._align_hybrid_block_size(vllm_config, _FakeBackend)
+        return cache_config.block_size
+
+    monkeypatch.setattr(
+        ModelRegistry,
+        "resolve_model_cls",
+        lambda *args, **kwargs: (_FakeModelCls, None),
+    )
+
+    aligned_by_tp = {tp_size: _aligned_block_size(tp_size) for tp_size in (1, 2, 4)}
+
+    assert aligned_by_tp == {
+        1: 96,
+        2: 96,
+        4: 96,
+    }

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -561,11 +561,18 @@ class Platform:
 
         kv_quant_mode = get_kv_quant_mode(cache_config.cache_dtype)
 
+        local_num_kv_heads = model_config.get_num_kv_heads(parallel_config)
+        alignment_num_kv_heads = (
+            local_num_kv_heads
+            if model_config.use_mla
+            else max(1, model_config.get_total_num_kv_heads())
+        )
+
         # Compute attention page size for 1 token
         if model_config.use_mla:
             attn_page_size_1_token = MLAAttentionSpec(
                 block_size=1,
-                num_kv_heads=model_config.get_num_kv_heads(parallel_config),
+                num_kv_heads=local_num_kv_heads,
                 head_size=model_config.get_head_size(),
                 dtype=kv_cache_dtype,
                 kv_quant_mode=kv_quant_mode,
@@ -586,7 +593,7 @@ class Platform:
             )
             tq_page = TQFullAttentionSpec(
                 block_size=1,
-                num_kv_heads=model_config.get_num_kv_heads(parallel_config),
+                num_kv_heads=local_num_kv_heads,
                 head_size=model_config.get_head_size(),
                 head_size_v=model_config.get_head_size(),
                 dtype=kv_cache_dtype,
@@ -596,7 +603,7 @@ class Platform:
             if cache_config.kv_cache_dtype_skip_layers:
                 skip_page = FullAttentionSpec(
                     block_size=1,
-                    num_kv_heads=model_config.get_num_kv_heads(parallel_config),
+                    num_kv_heads=local_num_kv_heads,
                     head_size=model_config.get_head_size(),
                     dtype=model_config.dtype,
                 ).page_size_bytes
@@ -609,11 +616,20 @@ class Platform:
         else:
             attn_page_size_1_token = FullAttentionSpec(
                 block_size=1,
-                num_kv_heads=model_config.get_num_kv_heads(parallel_config),
+                num_kv_heads=local_num_kv_heads,
                 head_size=model_config.get_head_size(),
                 dtype=kv_cache_dtype,
                 kv_quant_mode=kv_quant_mode,
             ).page_size_bytes
+
+        if model_config.use_mla:
+            alignment_attn_page_size_1_token = attn_page_size_1_token
+        else:
+            alignment_attn_page_size_1_token = (
+                attn_page_size_1_token
+                * alignment_num_kv_heads
+                // local_num_kv_heads
+            )
 
         # Compute mamba page size
         model_cls, _ = ModelRegistry.resolve_model_cls(
@@ -628,6 +644,13 @@ class Platform:
 
         if mamba_page_size == 0:
             return
+
+        # Use the global Mamba/attention ratio so heterogeneous TP P/D
+        # deployments choose the same logical token block size. The local page
+        # size check below still enforces the per-rank memory invariant.
+        alignment_mamba_page_size = (
+            mamba_page_size * parallel_config.tensor_parallel_size
+        )
 
         # mamba_block_size here should either be user specified value or None
         mamba_block_size = (
@@ -653,16 +676,18 @@ class Platform:
             # mamba2 kernels.
             base_chunk_size = mamba_block_size or model_config.get_mamba_chunk_size()
             assert base_chunk_size is not None
-            attn_tokens_per_mamba_state = cdiv(mamba_page_size, attn_page_size_1_token)
+            attn_tokens_per_mamba_state = cdiv(
+                alignment_mamba_page_size, alignment_attn_page_size_1_token
+            )
             chunk_size = lcm(base_chunk_size, kernel_block_alignment_size)
             attn_block_size = chunk_size * cdiv(attn_tokens_per_mamba_state, chunk_size)
             cache_config.mamba_block_size = attn_block_size
         else:
             # Without prefix caching, use minimum block size that satisfies
-            # both backend alignment and mamba page size compatibility
+            # both backend alignment and TP-stable mamba page size compatibility.
             attn_block_size = kernel_block_alignment_size * cdiv(
-                mamba_page_size,
-                kernel_block_alignment_size * attn_page_size_1_token,
+                alignment_mamba_page_size,
+                kernel_block_alignment_size * alignment_attn_page_size_1_token,
             )
 
         if cache_config.block_size < attn_block_size:


### PR DESCRIPTION
## Purpose

Related to #41037: #49612 closed that issue by making the NIXL connector
tolerate heterogeneous block sizes (`block_size_ratio != 1`) between prefill
and decode. This PR fixes the root cause. `_align_hybrid_block_size`
computes the Mamba-to-attention page-size ratio from per-rank page sizes,
so for hybrid attention/Mamba models the aligned block size depends on TP
size. That's still true after #49612; heterogeneous P/D just no longer
crashes on it.

This computes the ratio from TP-stable page sizes while keeping the final
padding check against the local per-rank page size, so:
- prefill/decode TP configs agree on block size in the common case
- prefix-cache granularity stops shifting with TP for a fixed model/config

I checked for duplicate open PRs for #41037 and did not find one addressing
the root cause (#49612 works around it in the connector layer). I used AI
assistance while developing and validating this change, and reviewed the
resulting diff before submitting.

## Test Plan

- `python -m pytest tests/platforms/test_hybrid_block_size.py -q`
- `python -m pytest --confcutdir=tests/v1/kv_connector/unit tests/v1/kv_connector/unit/test_nixl_connector_hma.py -q`
- `python -m pytest "tests/models/language/generation/test_hybrid.py::test_apc_single_prompt[1-5-2-64-ai21labs/Jamba-tiny-dev]" -q -s`

## Test Result

Re-ran all three against current `main` (post rebase) to confirm nothing drifted:

`tests/platforms/test_hybrid_block_size.py`

```
1 passed, 3 warnings in 0.25s
```

`tests/v1/kv_connector/unit/test_nixl_connector_hma.py`

```
92 passed, 8 warnings in 149.56s
```

`tests/models/language/generation/test_hybrid.py::test_apc_single_prompt[1-5-2-64-ai21labs/Jamba-tiny-dev]`

```
1 passed, 5 warnings in 109.28s
```

All warnings across all three runs are pre-existing/environmental
(PyTorch/SWIG deprecations, a zmq-context teardown `ResourceWarning`, the
comparison test's own diagnostic `UserWarning`). None originate in this
diff. Confirmed the aligned block size is TP-stable in the running engine
too: `kv cache group sizes [144, 144, 144, 144, 144, 144, 144, 144]`, uniform
across all groups.

The exact heterogeneous P/D repro with `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8` (prefill TP=8 / decode TP=1) was not run locally because it requires a larger multi-GPU setup than the available RTX 3080. Already asked in the team Slack for a run on multi-GPU hardware to confirm this case directly.
