### PR TITLE
  [BugFix] Fix MXFP8 checkpoint loading when quant_method collides with online shorthand

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -289,6 +289,45 @@ def get_quant_config(
         ):
             pass  # fall through to file-based loading below
         else:
+            # Bug fix for issue #45568: Some pre-quantized checkpoints use
+            # quant_method names that collide with online quantization shorthands
+            # (e.g., "mxfp8"). Detect this case and reroute to the appropriate
+            # checkpoint-capable config class.
+            from vllm.model_executor.layers.quantization.online.base import (
+                OnlineQuantizationConfig,
+            )
+
+            if (
+                quant_cls is OnlineQuantizationConfig
+                and isinstance(hf_quant_config, dict)
+            ):
+                # Check if this looks like a pre-quantized checkpoint rather than
+                # an online quantization request. Pre-quantized MXFP8 checkpoints
+                # contain weight_block_size.
+                if "weight_block_size" in hf_quant_config:
+                    # This is a pre-quantized MXFP8 checkpoint. Reroute to
+                    # ModelOptMxFp8Config which can load from checkpoints.
+                    # Transform the config format to match what ModelOpt expects.
+                    quant_method_str = hf_quant_config.get("quant_method", "")
+                    if quant_method_str.lower() == "mxfp8":
+                        from vllm.model_executor.layers.quantization.modelopt import (
+                            ModelOptMxFp8Config,
+                        )
+
+                        # Transform MiniMax format to ModelOpt format
+                        modelopt_config = {
+                            "quantization": {
+                                "quant_algo": "MXFP8",
+                                "kv_cache_quant_algo": hf_quant_config.get(
+                                    "kv_cache_quant_algo"
+                                ),
+                                "exclude_modules": hf_quant_config.get(
+                                    "ignored_layers", []
+                                ),
+                            }
+                        }
+                        return ModelOptMxFp8Config.from_config(modelopt_config)
+
             return quant_cls.from_config(hf_quant_config)
 
     # if hf_quant_config is None, we will try to get config from


### PR DESCRIPTION

  ## What does this PR do?

  Fixes #45568

  This PR fixes a bug where pre-quantized MXFP8 checkpoints (e.g., `MiniMaxAI/MiniMax-M3-MXFP8`)
  fail to load because their `quant_method="mxfp8"` collides with the online quantization
  shorthand.

  ## Problem

  When loading checkpoints like `MiniMaxAI/MiniMax-M3-MXFP8`:
  - Checkpoint's `config.json` contains `quant_method="mxfp8"` with `weight_block_size` field
  - `"mxfp8"` is also registered as an online quantization shorthand in `_ONLINE_SHORTHANDS`
  - `get_quantization_config("mxfp8")` returns `OnlineQuantizationConfig`
  - `OnlineQuantizationConfig.from_config()` raises `NotImplementedError` for checkpoint configs
  - Server fails to start with: `NotImplementedError: OnlineQuantizationConfig does not support
  loading from a checkpoint config`

  ## Solution

  Detect pre-quantized checkpoints by checking for the `weight_block_size` field (present in
  pre-quantized MXFP8 checkpoints, absent in online quantization configs). When detected:
  1. Reroute from `OnlineQuantizationConfig` to `ModelOptMxFp8Config`
  2. Transform config format from MiniMax format to ModelOpt format
  3. Successfully load the checkpoint

  ## Changes

  Modified `vllm/model_executor/model_loader/weight_utils.py`:
  - Added detection logic in `get_quant_config()` before calling `from_config()`
  - Checks for `weight_block_size` field to distinguish pre-quantized checkpoints
  - Transforms config format: `ignored_layers` → `exclude_modules`, `quant_method` →
  `quant_algo`
  - Routes to `ModelOptMxFp8Config` which supports checkpoint loading

  ## Testing

  - ✅ Simulated `MiniMaxAI/MiniMax-M3-MXFP8` checkpoint config successfully routes to
  `ModelOptMxFp8Config`
  - ✅ Config format transformation works correctly (handles missing `kv_cache_quant_algo`)
  - ✅ No impact on online quantization functionality (different code path)

  ## AI Assistance Disclosure

  This PR was developed with assistance from Claude Opus 4.8. All code has been thoroughly
  reviewed and tested. The AI helped with:
  - Understanding the bug's root cause
  - Designing the detection and routing logic
  - Format transformation implementation