### PR TITLE
[Bugfix] Cap fastapi < 0.137 to avoid prometheus-fastapi-in strumentator crash on serve startup

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -11,7 +11,7 @@ transformers >= 5.5.3
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 safetensors >= 0.6.2  # MXFP4/MXFP6 dtype support (F8_E8M0, F4) added in 0.6.0: https://github.com/huggingface/safetensors/pull/611
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
-fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.
+fastapi[standard] >= 0.115.0, < 0.137 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint; <0.137 due to prometheus-fastapi-instrumentator#370.
 aiohttp >= 3.13.3
 openai >= 2.0.0  # For Responses API with reasoning content
 pydantic >= 2.12.0


### PR DESCRIPTION
A fresh pip install pulls fastapi 0.137, whose new _IncludedRouter route type (a BaseRoute with no .path) breaks prometheus-fastapi-instrumentator's route iteration -> 'vllm serve' dies at startup with:
  AttributeError: '_IncludedRouter' object has no attribute 'path'

requirements/common.txt pinned fastapi[standard]>=0.115.0 with no upper bound. Cap to <0.137; lift once the instrumentator handles _IncludedRouter (https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370).

fix #45596 #45597 
