### PR TITLE
[Bugfix][V1] Warm up all top-k/top-p Triton sampler kernel specializations

### DIFF
--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -958,3 +958,105 @@ class TestFlashInferDistributionMatch:
             f"{label}: distribution differs from theoretical: "
             f"chi2={chi2:.2f} p_value={p_value:.2e} alpha={self.ALPHA}"
         )
+
+
+@pytest.mark.skipif(
+    not (current_platform.is_cuda() and HAS_TRITON),
+    reason="Requires CUDA GPU and Triton",
+)
+class TestTritonTopkToppWarmupSpecializations:
+    """``_topk_topp_kernel`` warmup must cover every specialization reached
+    at runtime, so no JIT compilation happens during inference.
+
+    The kernel specializes on two axes:
+
+    1. The ``TOPK_ENABLED`` / ``TOPP_ENABLED`` ``tl.constexpr`` flags, derived
+       from whether ``k`` / ``p`` are passed. This yields three runtime
+       combinations (both, top-k only, top-p only).
+    2. Triton's implicit integer specialization of the non-constexpr
+       ``BATCH_SIZE`` argument (``== 1`` / divisible-by-16 / other), which is
+       neutralized via ``do_not_specialize=["BATCH_SIZE"]`` because the value
+       is only the grid-stride loop bound.
+
+    A miss on either axis triggers a JIT compile during inference, which the
+    ``jit_monitor`` flags as a latency spike.
+    """
+
+    def _num_cached_specializations(self) -> int:
+        """Number of compiled ``_topk_topp_kernel`` variants currently cached.
+
+        Counts entries in the Triton ``JITFunction.device_caches`` rather than
+        hooking ``jit_post_compile_hook``: a kernel served from Triton's
+        on-disk cache populates ``device_caches`` but does *not* fire the
+        post-compile hook, so a hook-based count would be unreliable across
+        runs. The relative growth of this count is what matters here.
+        """
+        from vllm.v1.sample.ops.topk_topp_triton import _topk_topp_kernel
+
+        return sum(len(dc[0]) for dc in _topk_topp_kernel.device_caches.values())
+
+    def _make_inputs(self, batch_size: int, vocab: int):
+        torch.set_default_device(DEVICE_TYPE)
+        logits = torch.randn(batch_size, vocab, dtype=torch.float32)
+        k = torch.full((batch_size,), 32, dtype=torch.int32)
+        p = torch.full((batch_size,), 0.9, dtype=torch.float32)
+        return logits, k, p
+
+    def test_warmup_covers_all_runtime_specializations(self):
+        """Warming the three k/p combinations must cover every variant reached
+        at inference, so post-warmup requests add no new kernel compilation.
+
+        Uses a dedicated vocab size (a ``VOCAB_SIZE`` constexpr) so the count
+        below is unaffected by other tests sharing the process-wide cache.
+        """
+        from vllm.v1.sample.ops.topk_topp_triton import apply_top_k_top_p_triton
+
+        vocab = 4099
+
+        # Warmup: exercise all three (TOPK_ENABLED, TOPP_ENABLED) combinations,
+        # mirroring what ``_dummy_sampler_run`` now does at engine startup.
+        for k_arg, p_arg in (("k", "p"), ("k", None), (None, "p")):
+            logits, k, p = self._make_inputs(16, vocab=vocab)
+            apply_top_k_top_p_triton(
+                logits.clone(),
+                k if k_arg else None,
+                p if p_arg else None,
+            )
+
+        after_warmup = self._num_cached_specializations()
+
+        # Inference: every combination again at a different batch-size class
+        # (15 is neither 1 nor divisible by 16). None may add a new variant.
+        for batch_size in (16, 15):
+            logits, k, p = self._make_inputs(batch_size, vocab=vocab)
+            apply_top_k_top_p_triton(logits.clone(), k, p)
+            apply_top_k_top_p_triton(logits.clone(), k, None)
+            apply_top_k_top_p_triton(logits.clone(), None, p)
+
+        assert self._num_cached_specializations() == after_warmup, (
+            "Inference must not compile new _topk_topp_kernel variants after "
+            "warmup covered all (k, p) combinations"
+        )
+
+    def test_batch_size_is_not_specialized(self):
+        """``do_not_specialize=["BATCH_SIZE"]`` means a batch-size class change
+        reuses the cached kernel instead of recompiling."""
+        from vllm.v1.sample.ops.topk_topp_triton import apply_top_k_top_p_triton
+
+        vocab = 6151  # distinct vocab to isolate from the other test
+
+        # Warm a divisible-by-16 batch so the variant is cached.
+        logits, k, p = self._make_inputs(16, vocab=vocab)
+        apply_top_k_top_p_triton(logits.clone(), k, p)
+        after_warmup = self._num_cached_specializations()
+
+        # Other batch-size classes (none == 1, none divisible by 16) must not
+        # add new variants now that BATCH_SIZE is excluded from the key.
+        for batch_size in (15, 8, 24):
+            logits, k, p = self._make_inputs(batch_size, vocab=vocab)
+            apply_top_k_top_p_triton(logits.clone(), k, p)
+
+        assert self._num_cached_specializations() == after_warmup, (
+            "BATCH_SIZE must not trigger recompilation across batch-size "
+            "classes once do_not_specialize is set"
+        )

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -90,7 +90,11 @@ def _update_min_larger_stats(data, above_mask, min_larger, num_min_larger, senti
     return min_larger, num_min_larger
 
 
-@triton.jit
+# BATCH_SIZE is only the grid-stride loop bound, so value specialization
+# (==1 / divisible-by-16) buys nothing but forces a recompile when the
+# running batch size changes class (e.g. warmup at max_num_seqs=16 vs a
+# real decode step at 15), causing a JIT latency spike mid-inference.
+@triton.jit(do_not_specialize=["BATCH_SIZE"])
 def _topk_topp_kernel(
     LOGITS,
     LOGITS_STRIDE_0,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6026,15 +6026,24 @@ class GPUModelRunner(
                 "processed_logits",
                 "processed_logprobs",
             ):
-                self.sampler(
-                    logits=logits,
-                    sampling_metadata=replace(
-                        dummy_metadata,
-                        generators={
-                            0: torch.Generator(device=self.device).manual_seed(0)
-                        },
-                    ),
-                )
+                # The Triton top-k/top-p kernel specializes on which of k/p
+                # are present (TOPK_ENABLED/TOPP_ENABLED constexprs), so warm
+                # all three combinations reached at runtime: both set,
+                # top-k only (top_p=None), and top-p only (top_k=None).
+                generators = {0: torch.Generator(device=self.device).manual_seed(0)}
+                for overrides in (
+                    {},
+                    {"top_p": None},
+                    {"top_k": None},
+                ):
+                    self.sampler(
+                        logits=logits,
+                        sampling_metadata=replace(
+                            dummy_metadata,
+                            generators=generators,
+                            **overrides,
+                        ),
+                    )
         except RuntimeError as e:
             if "out of memory" in str(e):
                 raise RuntimeError(


### PR DESCRIPTION
## Summary

The Triton `_topk_topp_kernel` (native top-k/top-p sampling path) is
JIT-compiled **during inference** rather than at warmup, producing a
latency spike that `jit_monitor` flags with:

```
Triton kernel JIT compilation during inference: _topk_topp_kernel.
This causes a latency spike; consider extending warmup to cover this shape/config.
```

The kernel specializes on two axes, and warmup covered neither fully:

1. **`TOPK_ENABLED` / `TOPP_ENABLED` constexprs** — derived from whether
   `k` / `p` are passed, yielding three runtime combinations
   (both / top-k only / top-p only). `_dummy_sampler_run` only exercised the
   **both-set** combination, so the first real *top-k-only* or *top-p-only*
   request (with batch ≥ 8, where `apply_top_k_top_p` takes the Triton path)
   compiled mid-inference.

2. **Implicit integer specialization of the non-constexpr `BATCH_SIZE`**
   (`== 1` / divisible-by-16 / other). Warmup runs at
   `batch == max_num_seqs`; under continuous batching a real step can land in
   a different class (e.g. 16 → 15), forcing a recompile even for an
   already-warmed `(k, p)` combination.

## Fix

- `_dummy_sampler_run`: warm all three `(k, p)` combinations instead of only
  both-set.
- `_topk_topp_kernel`: add `do_not_specialize=["BATCH_SIZE"]`. `BATCH_SIZE`
  is only the grid-stride loop bound, so value specialization has no benefit
  and just causes recompiles across batch-size classes — the same approach
  #42165 takes for `num_tokens`.

Both changes are needed: warming the combinations alone still recompiles on a
batch-size class change; `do_not_specialize` alone leaves the top-k-only /
top-p-only variants uncompiled at warmup.

## Not a duplicate

- **#41375** (merged) added the `forward_native` sampler warmup but uses a
  both-set `dummy_metadata`, so it only covers the `(True, True)` variant.
  This PR completes it for the top-k-only / top-p-only variants and the
  batch-size axis.
- **#42165** (open) warms `_compute_slot_mapping_kernel` (a different kernel);
  this PR reuses its `do_not_specialize` pattern for `_topk_topp_kernel`.
- No open PR/issue touches `_topk_topp_kernel` warmup or its specialization
  (`#42684` was a contiguity bug, closed; `#25824` introduced the kernel).
- Related to the warmup-coverage tracking issue #43009 (which lists other
  uncovered kernels but not this one).

## Test

Adds `tests/v1/sample/test_topk_topp_sampler.py::TestTritonTopkToppWarmupSpecializations`
(GPU + Triton), which counts compiled `_topk_topp_kernel` variants via the
Triton `JITFunction.device_caches` (robust to on-disk cache hits, which a
`jit_post_compile_hook` count would miss):

- `test_warmup_covers_all_runtime_specializations` — after warming the three
  `(k, p)` combinations, inference across combinations **and** batch sizes
  (16, 15) adds **no** new compiled variant.
- `test_batch_size_is_not_specialized` — batch-size class changes
  (15 / 8 / 24) reuse the cached kernel.

Both fail if either half of the fix is reverted (verified locally).

```bash
pytest tests/v1/sample/test_topk_topp_sampler.py::TestTritonTopkToppWarmupSpecializations -v
# 2 passed
```

Also verified end-to-end: with `VLLM_USE_FLASHINFER_SAMPLER=0`, a scan over
greedy / top-k / top-p / top-k+top-p / min-p / penalty / batch-16 sampling no
longer reports `_topk_topp_kernel` from `jit_monitor` (was reported before the
fix). Tested on RTX 4060 (SM89), CUDA 13.3, Triton 3.6.

## Scope

V1 model runner. The V2 `SamplingParams.for_sampler_warmup` helper has the
same both-set-only gap (left as a follow-up); the kernel-side
`do_not_specialize` change already benefits V2 as well. The
`processed_logits` / `processed_logprobs` logprobs modes keep the existing
single warmup call (their `forward` is bound to `forward_native` at init, so
the extra calls would only inflate profile-run peak memory).

## AI assistance

AI assistance (Claude) was used during investigation and drafting. I reviewed
every changed line, ran the tests above, and can defend the change end to end.
