### PR TITLE
docs: clarify NIXL KV connector metrics aggregation semantics

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -51,6 +51,15 @@ class KVConnectorStats:
 
 
 class KVConnectorLogging:
+    """
+    Handles logging of KV connector metrics.
+    
+    The logging pipeline follows this flow:
+    1. observe(): Receives transfer stats that arrive pre-aggregated across all workers (ranks).
+    2. aggregate(): Accumulates these observations over the logging interval.
+    3. reduce(): Computes representative summary statistics (averages, percentiles) from the accumulated pool.
+    4. log(): Logs the reduced metrics and resets the accumulator for the next interval.
+    """
     def __init__(self, kv_transfer_config: KVTransferConfig | None):
         # Instantiate the connector's stats class.
         if kv_transfer_config and kv_transfer_config.kv_connector:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -23,7 +23,17 @@ if TYPE_CHECKING:
 
 @dataclass
 class NixlKVConnectorStats(KVConnectorStats):
-    """Container for transfer performance metrics"""
+    """
+    Container for transfer performance metrics.
+    
+    Note: In multi-rank (TP > 1) deployments, these stats are aggregated 
+    across all TP ranks. Consequently:
+    - Counts (e.g., 'Num successful transfers') represent the total sum 
+      across all ranks.
+    - Averages and throughputs represent per-rank averages computed over 
+      the combined pool of observations from all ranks.
+    - Percentiles are computed over the combined distribution of all ranks.
+    """
 
     def __post_init__(self):
         if not self.data:
@@ -84,7 +94,10 @@ class NixlKVConnectorStats(KVConnectorStats):
         return self
 
     def reduce(self) -> dict[str, int | float]:
-        # Compute compact representative stats suitable for CLI logging
+        # Compute compact representative stats suitable for CLI logging.
+        # Note: In multi-rank deployments, the metrics here are computed over 
+        # the combined observation pool from all TP ranks. Therefore, throughput 
+        # and averages reflect per-rank metrics rather than aggregate system totals.
         if self.num_successful_transfers == 0:
             # CLI logging only reports successful transfers stats. If all requests in
             # the interval were unsuccessful, Prom will report failures stats instead.


### PR DESCRIPTION
Fixes #41230

**Purpose**
This PR clarifies the NIXL KV connector metrics aggregation semantics by adding docstrings to `KVConnectorLogging` and `NixlKVConnectorStats`. It addresses the confusion regarding `Num successful transfers` being reported as >1 for a single request when TP>1, by explicitly documenting that stats are aggregated across all TP ranks.

**Test Plan**
No new tests needed as this is a documentation-only change (docstrings).

**Test Result**
N/A