### PR TITLE
[Bugfix][Reasoning] Mistral: fix [THINK]/[/THINK] leaking into content when emitted as plain text in streaming

### DIFF
--- a/tests/reasoning/test_mistral_reasoning_parser.py
+++ b/tests/reasoning/test_mistral_reasoning_parser.py
@@ -346,3 +346,59 @@ def test_mistral_reasoning(
     else:
         content = parser.extract_content_ids(output_tokens)
         assert content == []
+
+
+LITERAL_THINK_CASES = [
+    pytest.param(
+        "The count is 3.[THINK]Wait, the name is capitalised.[/THINK]Final: 3.",
+        "Wait, the name is capitalised.",
+        "The count is 3.Final: 3.",
+        id="second_block_after_content",
+    ),
+    pytest.param(
+        "[THINK]Reason about it.[/THINK]The answer.",
+        "Reason about it.",
+        "The answer.",
+        id="leading_block",
+    ),
+    pytest.param(
+        "Before[THINK]a[/THINK]mid[THINK]b[/THINK]after",
+        "ab",
+        "Beforemidafter",
+        id="two_blocks",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "output, expected_reasoning, expected_content", LITERAL_THINK_CASES
+)
+def test_mistral_reasoning_literal_think_text_streaming(
+    output: str,
+    expected_reasoning: str,
+    expected_content: str,
+    mistral_tokenizer: MistralTokenizer,
+):
+    """`[THINK]`/`[/THINK]` emitted as ordinary *text* (not the special tokens).
+
+    This is the production leak: when the model writes the delimiters as
+    bracket text — e.g. a second reasoning block after a tool call — the
+    id-based base parser misclassified the whole block as content. Encoding the
+    output purely as text leaves no BEGIN_THINK/END_THINK ids in the stream, so
+    the parser must rely on the literal delimiter strings.
+    """
+    output_tokens = mistral_tokenizer.tokenizer.encode(output, bos=False, eos=False)
+    # Sanity-check the delimiters really are plain text, not the special tokens.
+    assert mistral_tokenizer.instruct.BEGIN_THINK not in output_tokens
+    assert mistral_tokenizer.instruct.END_THINK not in output_tokens
+
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        mistral_tokenizer
+    )
+
+    reasoning, content = run_reasoning_extraction_mistral(
+        parser, output_tokens, streaming=True
+    )
+
+    assert reasoning == expected_reasoning
+    assert content == expected_content

--- a/vllm/reasoning/mistral_reasoning_parser.py
+++ b/vllm/reasoning/mistral_reasoning_parser.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning import ReasoningParser
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
 from vllm.tokenizers.mistral import MistralTokenizer
@@ -12,6 +13,23 @@ from vllm.tokenizers.mistral import MistralTokenizer
 if TYPE_CHECKING:
     from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
     from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+
+def _partial_delimiter_len(text: str, *delimiters: str) -> int:
+    """Length of the longest suffix of ``text`` that is a proper prefix of any
+    of ``delimiters``.
+
+    Used while streaming to hold back a trailing fragment that might still grow
+    into a ``[THINK]`` / ``[/THINK]`` marker (e.g. ``"...[/TH"``), so we never
+    emit half a delimiter as content.
+    """
+    best = 0
+    for delim in delimiters:
+        for k in range(min(len(text), len(delim) - 1), best, -1):
+            if text[-k:] == delim[:k]:
+                best = k
+                break
+    return best
 
 
 class MistralReasoningParser(BaseThinkingReasoningParser):
@@ -116,6 +134,83 @@ class MistralReasoningParser(BaseThinkingReasoningParser):
         #    well prompted and trained.
         else:
             return input_ids[:eot_token_index] + input_ids[eot_token_index + 1 :]
+
+    def _split_reasoning_content(self, text: str) -> tuple[str, str]:
+        """Split ``text`` into ``(reasoning, content)`` on the literal
+        ``[THINK]`` / ``[/THINK]`` delimiter strings.
+
+        The delimiters are dropped. A stray ``[/THINK]`` outside a reasoning
+        block is dropped too (matching :meth:`extract_reasoning`). A trailing
+        partial delimiter is held back so streaming never emits half a marker.
+        """
+        start, end = self.start_token, self.end_token
+        reasoning: list[str] = []
+        content: list[str] = []
+        in_think = False
+        i = 0
+        n = len(text)
+        while i < n:
+            if in_think:
+                j = text.find(end, i)
+                if j == -1:
+                    rest = text[i:]
+                    hold = _partial_delimiter_len(rest, end)
+                    reasoning.append(rest[: len(rest) - hold] if hold else rest)
+                    break
+                reasoning.append(text[i:j])
+                i = j + len(end)
+                in_think = False
+            else:
+                start_idx = text.find(start, i)
+                end_idx = text.find(end, i)
+                if start_idx != -1 and (end_idx == -1 or start_idx < end_idx):
+                    content.append(text[i:start_idx])
+                    i = start_idx + len(start)
+                    in_think = True
+                elif end_idx != -1:
+                    # Stray end-of-think with no matching begin — drop it.
+                    content.append(text[i:end_idx])
+                    i = end_idx + len(end)
+                else:
+                    rest = text[i:]
+                    hold = _partial_delimiter_len(rest, start, end)
+                    content.append(rest[: len(rest) - hold] if hold else rest)
+                    break
+        return "".join(reasoning), "".join(content)
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> DeltaMessage | None:
+        """Split reasoning from content by the literal ``[THINK]`` /
+        ``[/THINK]`` strings rather than the special-token ids.
+
+        The base implementation keys off the ``[THINK]`` / ``[/THINK]``
+        special-token ids. Mistral models sometimes emit those delimiters as
+        ordinary bracket *text* rather than the special tokens — most often a
+        second reasoning block after a tool call, which is out-of-distribution
+        for the prefilled opening ``[THINK]``. In that case the id-based path
+        misses them and the raw ``[THINK]...[/THINK]`` leaks into the visible
+        content. vLLM renders the special tokens as those same strings in the
+        detokenized text, so scanning the text handles both the special-token
+        and the literal-text forms uniformly — and keeps streaming consistent
+        with the (already string-based) :meth:`extract_reasoning`.
+        """
+        prev_reasoning, prev_content = self._split_reasoning_content(previous_text)
+        cur_reasoning, cur_content = self._split_reasoning_content(current_text)
+        delta_reasoning = cur_reasoning[len(prev_reasoning) :]
+        delta_content = cur_content[len(prev_content) :]
+        if not delta_reasoning and not delta_content:
+            return None
+        return DeltaMessage(
+            reasoning=delta_reasoning or None,
+            content=delta_content or None,
+        )
 
     def extract_reasoning(
         self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"


### PR DESCRIPTION
## Purpose

`MistralReasoningParser` inherits `extract_reasoning_streaming` from
`BaseThinkingReasoningParser`, which separates reasoning from content in
streaming mode purely by the `[THINK]` / `[/THINK]` **special-token ids**. When a
model emits those delimiters as ordinary bracket **text** rather than the special
tokens — e.g. a second reasoning block after a tool call, which is
out-of-distribution for a prefilled opening `[THINK]` — the id-based path misses
them and the final branch (`return DeltaMessage(content=delta_text)`) leaks the
raw `[THINK]...[/THINK]` into the user-visible content.

The non-streaming `extract_reasoning` is already string-based (it `partition()`s
on the literal `[THINK]` / `[/THINK]`) and does **not** have this problem, so
streaming and non-streaming currently disagree for the same output.

This PR overrides `MistralReasoningParser.extract_reasoning_streaming` to split on
the literal `[THINK]` / `[/THINK]` strings — vLLM renders the special tokens as
those same strings in detokenized text, so a single string scanner handles both
the special-token and the literal-text forms uniformly. A trailing partial
delimiter is held back so streaming never emits half a marker. This makes
streaming consistent with `extract_reasoning`, including dropping a stray
`[/THINK]`. It follows the existing precedent of `DeepSeekR1ReasoningParser`,
which already overrides `extract_reasoning_streaming` to cover a token-id gap.

## Test Plan

Added `test_mistral_reasoning_literal_think_text_streaming` to
`tests/reasoning/test_mistral_reasoning_parser.py`. It encodes the output
(including the `[THINK]` / `[/THINK]` markers) as **plain text**, asserts no
`BEGIN_THINK` / `END_THINK` ids are present in the stream, then checks the
streamed reasoning/content split for three cases: a second block after content, a
leading block, and two blocks. The existing parametrized cases (special-token
form) are unchanged.

## Test Result

On `main`, the new plain-text cases fail (the inherited streaming path classifies
the literal `[THINK]...[/THINK]` as content); with this change they pass while the
existing special-token cases continue to pass.
