### PR TITLE
[V1][PP] Reach cudagraph-mode consensus across PP ranks (fix #45094 split-brain wedge)

### DIFF
--- a/tests/v1/cudagraph/test_pp_cudagraph_consensus.py
+++ b/tests/v1/cudagraph/test_pp_cudagraph_consensus.py
@@ -1,0 +1,819 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for the pipeline-parallel cudagraph-mode consensus that
+guards against the #45094 PP cudagraph-vs-eager split-brain wedge.
+
+Root cause (vllm-project/vllm#45094): under pipeline parallelism each PP rank
+runs ``CudagraphDispatcher.dispatch`` independently. Per-rank-local state
+(calculate_kv_scales, cascade-attention detection, LoRA bookkeeping, a
+partially-failed capture) can make one stage pick PIECEWISE (replay a graph with
+baked-in inter-stage P2P send/recv shapes) while another stage picks NONE
+(eager). The stages then disagree on the cross-stage P2P schedule, the
+send/recv never rendezvous, and the engine wedges
+(``shm_broadcast`` 60s timeout -> RPC timeout -> EngineCore crash).
+
+``coordinate_cudagraph_mode_across_pp`` reaches consensus by taking the MIN of
+the per-rank mode across the PP group (NONE=0 < PIECEWISE=1 < FULL=2), mirroring
+the data-parallel consensus already in ``dp_utils._post_process_cudagraph_mode``.
+
+These tests reproduce the divergence at the unit level (two simulated PP ranks)
+and verify the consensus collapses them to a single agreed mode. The first test
+fails against pre-fix code (no such function / no consensus -> ranks stay
+divergent). A multi-GPU integration repro is described in the module docstring
+of ``tests/v1/cudagraph/test_pp_cudagraph_consensus.py`` (this file) below.
+
+Integration repro (requires >=2 GPUs, TP>=1 PP=2):
+
+    vllm serve <model> -tp 1 -pp 2 \
+        --compilation-config '{"cudagraph_mode":"PIECEWISE"}'
+    # then drive concurrent long-reasoning requests whose admitted batch-token
+    # count crosses a captured cudagraph bucket boundary on some steps but not
+    # others. Pre-fix: one PP stage replays the graph while the other runs
+    # eager -> shm_broadcast "No available shared memory broadcast block found
+    # in 60 seconds" -> RPC timeout -> EngineCore crash. Post-fix: both stages
+    # agree (MIN) -> no wedge.
+"""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from vllm.config import CUDAGraphMode
+
+
+def _patch_pp_group(world_size: int, peer_modes: list[int] | None = None):
+    """Return a mock get_pp_group() whose all_reduce(MIN) simulates peers.
+
+    peer_modes: the cudagraph-mode ints contributed by the *other* PP ranks.
+    The mocked all_reduce computes min(local, *peer_modes) in place, exactly as
+    a real MIN all-reduce over the PP group would.
+    """
+    peer_modes = peer_modes or []
+
+    mock_group = mock.MagicMock()
+    mock_group.world_size = world_size
+    mock_group.cpu_group = mock.MagicMock()
+
+    def fake_all_reduce(tensor, op, group):
+        # Emulate torch.distributed.all_reduce(MIN) over the PP cpu_group.
+        local = int(tensor.item())
+        tensor.fill_(min([local, *peer_modes]))
+
+    return mock_group, fake_all_reduce
+
+
+@pytest.mark.parametrize(
+    "rank_a_mode, rank_b_mode, expected_consensus",
+    [
+        # The #45094 split-brain: one stage PIECEWISE (graph replay), the other
+        # NONE (eager). MIN -> NONE so both run eager and the P2P schedule
+        # stays consistent.
+        (CUDAGraphMode.PIECEWISE, CUDAGraphMode.NONE, CUDAGraphMode.NONE),
+        (CUDAGraphMode.NONE, CUDAGraphMode.PIECEWISE, CUDAGraphMode.NONE),
+        # FULL vs PIECEWISE -> PIECEWISE (still a divergence that would
+        # mismatch graph capture across stages).
+        (CUDAGraphMode.FULL, CUDAGraphMode.PIECEWISE, CUDAGraphMode.PIECEWISE),
+        # Already in agreement -> unchanged.
+        (CUDAGraphMode.PIECEWISE, CUDAGraphMode.PIECEWISE, CUDAGraphMode.PIECEWISE),
+        (CUDAGraphMode.NONE, CUDAGraphMode.NONE, CUDAGraphMode.NONE),
+    ],
+)
+def test_pp_consensus_collapses_divergent_modes(
+    rank_a_mode, rank_b_mode, expected_consensus
+):
+    """Two PP ranks that dispatched divergent cudagraph modes must converge to
+    the MIN after consensus — the guard against the #45094 split-brain wedge."""
+    from vllm.v1.worker.pp_utils import coordinate_cudagraph_mode_across_pp
+
+    # Rank A's view: its peer (rank B) contributed rank_b_mode.
+    mock_group_a, fake_ar_a = _patch_pp_group(
+        world_size=2, peer_modes=[rank_b_mode.value]
+    )
+    with (
+        mock.patch(
+            "vllm.v1.worker.pp_utils.get_pp_group", return_value=mock_group_a
+        ),
+        mock.patch(
+            "vllm.v1.worker.pp_utils.torch.distributed.all_reduce",
+            side_effect=fake_ar_a,
+        ),
+    ):
+        result_a = coordinate_cudagraph_mode_across_pp(rank_a_mode.value)
+
+    # Rank B's view: its peer (rank A) contributed rank_a_mode.
+    mock_group_b, fake_ar_b = _patch_pp_group(
+        world_size=2, peer_modes=[rank_a_mode.value]
+    )
+    with (
+        mock.patch(
+            "vllm.v1.worker.pp_utils.get_pp_group", return_value=mock_group_b
+        ),
+        mock.patch(
+            "vllm.v1.worker.pp_utils.torch.distributed.all_reduce",
+            side_effect=fake_ar_b,
+        ),
+    ):
+        result_b = coordinate_cudagraph_mode_across_pp(rank_b_mode.value)
+
+    # The core invariant: after consensus BOTH ranks agree (no split-brain).
+    assert result_a == result_b, (
+        f"PP ranks disagree post-consensus: {result_a} != {result_b}; "
+        "this is the #45094 split-brain that wedges the pipeline."
+    )
+    assert result_a == expected_consensus.value
+    assert result_b == expected_consensus.value
+
+
+def test_pp_consensus_noop_on_single_stage():
+    """With PP world_size == 1 there are no peers; the mode is returned
+    unchanged and no collective is issued (cannot wedge a 1-stage pipeline)."""
+    from vllm.v1.worker.pp_utils import coordinate_cudagraph_mode_across_pp
+
+    mock_group, fake_ar = _patch_pp_group(world_size=1)
+    with (
+        mock.patch(
+            "vllm.v1.worker.pp_utils.get_pp_group", return_value=mock_group
+        ),
+        mock.patch(
+            "vllm.v1.worker.pp_utils.torch.distributed.all_reduce",
+            side_effect=fake_ar,
+        ) as mock_ar,
+    ):
+        result = coordinate_cudagraph_mode_across_pp(CUDAGraphMode.PIECEWISE.value)
+
+    assert result == CUDAGraphMode.PIECEWISE.value
+    mock_ar.assert_not_called()
+
+
+def test_demonstrates_dispatcher_divergence_without_consensus():
+    """Show the determinism gap the consensus closes: the dispatcher decision
+    flips on per-rank-local state for an identical batch shape.
+
+    Here we model the real #45094 trigger — one PP rank still owes a KV-scale
+    calculation (forces NONE in the model runner) while its peer does not (gets
+    PIECEWISE). Without consensus these two diverge for the same step; WITH
+    consensus they collapse to NONE.
+    """
+    from vllm.v1.worker.pp_utils import coordinate_cudagraph_mode_across_pp
+
+    # Same logical step / batch shape on both ranks would dispatch PIECEWISE...
+    rank_with_graph = CUDAGraphMode.PIECEWISE.value
+    # ...but the peer is forced eager by local calculate_kv_scales (model runner
+    # line: `if self.calculate_kv_scales: cudagraph_mode = CUDAGraphMode.NONE`).
+    rank_forced_eager = CUDAGraphMode.NONE.value
+
+    # Pre-consensus: divergent (this is the wedge condition).
+    assert rank_with_graph != rank_forced_eager
+
+    # Post-consensus on the rank that wanted a graph: peer forced eager -> NONE.
+    mock_group, fake_ar = _patch_pp_group(
+        world_size=2, peer_modes=[rank_forced_eager]
+    )
+    with (
+        mock.patch(
+            "vllm.v1.worker.pp_utils.get_pp_group", return_value=mock_group
+        ),
+        mock.patch(
+            "vllm.v1.worker.pp_utils.torch.distributed.all_reduce",
+            side_effect=fake_ar,
+        ),
+    ):
+        synced = coordinate_cudagraph_mode_across_pp(rank_with_graph)
+
+    assert synced == CUDAGraphMode.NONE.value, (
+        "PP rank that captured a graph must defer to its eager peer; "
+        "otherwise it replays a graph while the peer runs eager -> #45094 wedge."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration test: the execute_model re-dispatch ORDERING, not just the leaf
+# helper. Reproduces the real #45094 trigger end-to-end — calculate_kv_scales
+# forcing eager on ONE PP rank — and proves that consensus is only correct when
+# that force is folded in BEFORE the PP all-reduce (post-revision), and that the
+# pre-revision ordering (force AFTER consensus) re-introduces the split-brain.
+# ---------------------------------------------------------------------------
+
+
+class _FakeDispatcher:
+    """Faithful stand-in for CudagraphDispatcher.dispatch w.r.t. the contract
+    this fix depends on:
+
+    * ``valid_modes`` is an allow-list; ``NONE`` is the universal fallback.
+    * If the agreed (synced) mode has no captured key on this rank, dispatch
+      falls back to ``NONE`` — but ONLY if ``NONE`` is in ``valid_modes``;
+      otherwise the real dispatcher asserts (``assert NONE in allowed_modes``).
+      We raise AssertionError to mirror that crash (covers MED-2).
+
+    ``captured_modes`` is the set of modes for which THIS rank actually holds a
+    capture key for the step's batch shape.
+    """
+
+    def __init__(self, captured_modes: set[CUDAGraphMode]):
+        self.captured_modes = captured_modes
+
+    def dispatch(self, valid_modes: set[CUDAGraphMode] | None):
+        allowed = valid_modes or {
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.PIECEWISE,
+            CUDAGraphMode.FULL,
+        }
+        # Prefer the richest captured mode that is allowed (FULL > PIECEWISE).
+        for mode in (CUDAGraphMode.FULL, CUDAGraphMode.PIECEWISE):
+            if mode in allowed and mode in self.captured_modes:
+                return mode
+        # No captured key for an allowed graph mode -> must fall back to NONE.
+        assert CUDAGraphMode.NONE in allowed, (
+            "dispatcher would assert: NONE not in allowed_modes "
+            f"({allowed}); this is the MED-2 re-dispatch crash."
+        )
+        return CUDAGraphMode.NONE
+
+
+def _run_one_rank(
+    *,
+    dispatcher: "_FakeDispatcher",
+    peer_modes: list[int],
+    calculate_kv_scales: bool,
+    thread_kv_scales_before_consensus: bool,
+) -> CUDAGraphMode:
+    """Mirror gpu_model_runner's execute_model cudagraph-mode resolution for a
+    single PP rank, using the REAL coordinate_cudagraph_mode_across_pp.
+
+    thread_kv_scales_before_consensus:
+        True  -> POST-revision ordering: kv_scales force folded into the
+                 dispatch BEFORE the PP all-reduce (force eager up front).
+        False -> PRE-revision ordering: dispatch + PP consensus first, THEN
+                 force NONE for kv_scales (the #45094 bug).
+    """
+    from vllm.v1.worker.pp_utils import coordinate_cudagraph_mode_across_pp
+
+    # --- initial dispatch (optionally already forced eager, post-revision) ---
+    if thread_kv_scales_before_consensus and calculate_kv_scales:
+        initial_valid = {CUDAGraphMode.NONE}
+    else:
+        initial_valid = None
+    cudagraph_mode = dispatcher.dispatch(valid_modes=initial_valid)
+
+    # --- PP consensus all-reduce (real helper, mocked peers) ---
+    mock_group, fake_ar = _patch_pp_group(world_size=2, peer_modes=peer_modes)
+    with (
+        mock.patch(
+            "vllm.v1.worker.pp_utils.get_pp_group", return_value=mock_group
+        ),
+        mock.patch(
+            "vllm.v1.worker.pp_utils.torch.distributed.all_reduce",
+            side_effect=fake_ar,
+        ),
+    ):
+        synced = coordinate_cudagraph_mode_across_pp(cudagraph_mode.value)
+    if synced != cudagraph_mode.value:
+        # Re-dispatch at the agreed mode. MED-2: keep NONE so a rank lacking
+        # the agreed mode's capture key falls back instead of asserting.
+        cudagraph_mode = dispatcher.dispatch(
+            valid_modes={CUDAGraphMode.NONE, CUDAGraphMode(synced)}
+        )
+
+    # --- pre-revision: local kv_scales force applied AFTER consensus (BUG) ---
+    if not thread_kv_scales_before_consensus and calculate_kv_scales:
+        cudagraph_mode = CUDAGraphMode.NONE
+
+    return cudagraph_mode
+
+
+def test_integration_kv_scales_before_consensus_keeps_pp_consistent():
+    """POST-revision: rank A owes a KV-scale calc (forces eager), rank B does
+    not. Both hold a PIECEWISE key for the step. With the force threaded BEFORE
+    the all-reduce, rank A contributes NONE to the consensus, so rank B is
+    pulled down to NONE too -> both ranks run eager, no split-brain."""
+    rank_a = _run_one_rank(
+        dispatcher=_FakeDispatcher({CUDAGraphMode.PIECEWISE}),
+        peer_modes=[CUDAGraphMode.PIECEWISE.value],  # B before consensus
+        calculate_kv_scales=True,
+        thread_kv_scales_before_consensus=True,
+    )
+    rank_b = _run_one_rank(
+        dispatcher=_FakeDispatcher({CUDAGraphMode.PIECEWISE}),
+        peer_modes=[CUDAGraphMode.NONE.value],  # A already forced eager
+        calculate_kv_scales=False,
+        thread_kv_scales_before_consensus=True,
+    )
+    assert rank_a == rank_b == CUDAGraphMode.NONE, (
+        f"PP ranks diverged post-revision: A={rank_a}, B={rank_b}. The "
+        "kv_scales eager-force must propagate through PP consensus."
+    )
+
+
+def test_integration_pre_revision_ordering_reproduces_split_brain():
+    """PRE-revision: the SAME scenario but with the kv_scales force applied
+    AFTER the PP consensus. Rank A contributes PIECEWISE to the all-reduce
+    (its force hasn't happened yet), so neither rank is pulled to NONE; then
+    rank A forces itself to NONE locally while rank B replays its PIECEWISE
+    graph. Ranks diverge -> exactly the #45094 wedge. This test documents the
+    bug the revision fixes; it asserts the divergence EXISTS pre-revision."""
+    rank_a = _run_one_rank(
+        dispatcher=_FakeDispatcher({CUDAGraphMode.PIECEWISE}),
+        peer_modes=[CUDAGraphMode.PIECEWISE.value],
+        calculate_kv_scales=True,
+        thread_kv_scales_before_consensus=False,
+    )
+    rank_b = _run_one_rank(
+        dispatcher=_FakeDispatcher({CUDAGraphMode.PIECEWISE}),
+        peer_modes=[CUDAGraphMode.PIECEWISE.value],
+        calculate_kv_scales=False,
+        thread_kv_scales_before_consensus=False,
+    )
+    assert rank_a == CUDAGraphMode.NONE
+    assert rank_b == CUDAGraphMode.PIECEWISE
+    assert rank_a != rank_b, (
+        "Pre-revision ordering should reproduce the #45094 split-brain; if "
+        "this no longer diverges the test no longer guards the regression."
+    )
+
+
+def test_integration_redispatch_falls_back_when_no_capture_key():
+    """MED-2: a rank is pulled to PIECEWISE by consensus but holds NO PIECEWISE
+    capture key (e.g. FULL_DECODE_ONLY build). The re-dispatch must fall back to
+    NONE rather than assert-crash. With valid_modes={NONE, PIECEWISE} it falls
+    back; with {PIECEWISE} alone it would raise (the pre-fix MED-2 crash)."""
+    # Peer agreed PIECEWISE (lower than this rank's FULL), forcing re-dispatch.
+    rank = _run_one_rank(
+        dispatcher=_FakeDispatcher({CUDAGraphMode.FULL}),  # no PIECEWISE key
+        peer_modes=[CUDAGraphMode.PIECEWISE.value],
+        calculate_kv_scales=False,
+        thread_kv_scales_before_consensus=True,
+    )
+    assert rank == CUDAGraphMode.NONE, (
+        "re-dispatch must fall back to NONE when the agreed mode has no "
+        "capture key on this rank (MED-2)."
+    )
+
+    # And prove the bug it guards: pinning to {synced} alone asserts.
+    bad = _FakeDispatcher({CUDAGraphMode.FULL})
+    with pytest.raises(AssertionError):
+        bad.dispatch(valid_modes={CUDAGraphMode.PIECEWISE})
+
+
+# ---------------------------------------------------------------------------
+# Source-level guard: tie the regression test to the ACTUAL gpu_model_runner
+# code so a future revert of the threading fails CI here even though the unit
+# helpers still pass. Asserts (a) execute_model threads force_eager_kv_scales
+# into _determine_batch_execution_and_padding, and (b) there is no
+# `cudagraph_mode = CUDAGraphMode.NONE` reassignment positioned AFTER the PP
+# consensus block (which was the #45094 ordering bug).
+# ---------------------------------------------------------------------------
+
+
+def _gpu_model_runner_source() -> str:
+    # Read the file directly (not via import) so this guard does not drag in the
+    # full model_runner import chain (multimodal, lora, prometheus, ...). Locate
+    # it relative to this test file: <repo>/vllm/v1/worker/gpu_model_runner.py.
+    repo_root = Path(__file__).resolve().parents[3]
+    return (repo_root / "vllm" / "v1" / "worker" / "gpu_model_runner.py").read_text()
+
+
+def _gpu_worker_source() -> str:
+    repo_root = Path(__file__).resolve().parents[3]
+    return (repo_root / "vllm" / "v1" / "worker" / "gpu_worker.py").read_text()
+
+
+def test_source_threads_kv_scales_force_into_dispatch():
+    src = _gpu_model_runner_source()
+    assert "force_eager_kv_scales=self.calculate_kv_scales" in src, (
+        "execute_model must thread calculate_kv_scales into "
+        "_determine_batch_execution_and_padding so the eager force happens "
+        "BEFORE the PP/DP consensus all-reduce (#45094)."
+    )
+    assert "force_eager = force_eager or force_eager_kv_scales" in src, (
+        "_determine_batch_execution_and_padding must fold the kv_scales force "
+        "into the dispatch decision ahead of the consensus reductions."
+    )
+
+
+def test_source_has_no_kv_scales_force_after_pp_consensus():
+    """The pre-revision bug was `cudagraph_mode = CUDAGraphMode.NONE` for
+    calculate_kv_scales executed AFTER the PP consensus. The consensus all-reduce
+    now lives in Worker.execute_model (hoisted above the inter-stage recv,
+    #45610), and the runner consumes the agreed value via
+    `pp_synced_cudagraph_mode`. Ensure no calculate_kv_scales-driven NONE force
+    reappears downstream of that consumption point in the runner."""
+    src = _gpu_model_runner_source()
+    anchor = "pp_synced_cudagraph_mode is not None"
+    idx = src.find(anchor)
+    assert idx != -1, (
+        "pp_synced_cudagraph_mode consumption site not found in "
+        "gpu_model_runner; the runner must consume the worker-agreed PP mode."
+    )
+    after = src[idx:]
+    # The kv_scales fold must happen BEFORE this point (via force_eager_kv_scales,
+    # folded inside _determine_batch_execution_and_padding). The old buggy pair
+    # (a bare calculate_kv_scales force re-deciding the mode) must not reappear
+    # after consensus consumption.
+    assert not (
+        "if self.calculate_kv_scales:" in after
+        and "cudagraph_mode = CUDAGraphMode.NONE" in after
+    ), (
+        "Found a calculate_kv_scales-driven `cudagraph_mode = NONE` AFTER the "
+        "PP consensus consumption — this is the #45094 split-brain ordering. "
+        "Thread the force into _determine_batch_execution_and_padding instead."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ordering guard (#45610): the PP consensus all-reduce MUST run BEFORE the
+# inter-stage recv.
+#
+# Root cause (root-caused live via py-spy): the group-wide PP all-reduce
+# `coordinate_cudagraph_mode_across_pp` used to be issued INSIDE the model
+# runner's execute_model -> _determine_batch_execution_and_padding, which
+# Worker.execute_model (vllm/v1/worker/gpu_worker.py) invokes AFTER the stage-1
+# `irecv_tensor_dict`. Stage 0's activation SEND happens only after its runner
+# returns. That forms a structural deadlock cycle on the very first real decode
+# step:
+#   stage0.all_reduce  waits-for  stage1.all_reduce
+#   stage1.recv        waits-for  stage0.activation_send (after stage0.all_reduce)
+# so PP0 parks in coordinate_cudagraph_mode_across_pp -> all_reduce while PP1
+# parks in irecv_tensor_dict gloo waitRecv, forever. Triton-JIT only affects
+# timing; the inversion is unconditional.
+#
+# The fix hoists the consensus into Worker.execute_model, ahead of the recv, and
+# threads the agreed mode down to the runner (which no longer self-issues the
+# all-reduce). These tests pin that ordering: a behavioral fake of
+# Worker.execute_model on a stage-1 (not is_first_rank) PP rank records the order
+# of the all-reduce vs. the recv, and an AST guard pins the source placement.
+# Both FAIL against the pre-fix tree (where the all-reduce trailed the recv).
+# ---------------------------------------------------------------------------
+
+
+def test_pp_all_reduce_precedes_irecv_in_worker_execute_model():
+    """Layer A (ordering): drive a real Worker.execute_model on a stage-1
+    (not is_first_rank) PP rank, world_size=2, with all_reduce + irecv recorded
+    as fakes, and assert the PP all-reduce is issued BEFORE irecv_tensor_dict.
+
+    Pre-fix the all-reduce lived inside the runner (after the worker's recv) so
+    the recorded order was [irecv, ...] with the all-reduce never reached on a
+    real pipeline (deadlock); here the runner is a stub, so pre-fix would record
+    irecv first (or no all-reduce at all from the worker). Post-fix the worker
+    issues the all-reduce first."""
+    import vllm.v1.worker.gpu_worker as gw
+
+    events: list[str] = []
+
+    # --- fake PP group: world_size 2, this rank is NOT the first stage (so it
+    #     performs the inter-stage recv), and IS not the last (so it would send).
+    pp_group = mock.MagicMock()
+    pp_group.world_size = 2
+    pp_group.is_first_rank = False
+    pp_group.is_last_rank = False
+    pp_group.cpu_group = mock.MagicMock()
+
+    def fake_irecv(*args, **kwargs):
+        events.append("irecv_tensor_dict")
+        # (tensor_dict, comm_handles, comm_postprocess)
+        return {"hidden_states": object()}, None, None
+
+    pp_group.irecv_tensor_dict.side_effect = fake_irecv
+
+    def fake_all_reduce(tensor, op, group):
+        events.append("pp_all_reduce")
+        # min over a single simulated peer that agrees (no-op on value)
+        tensor.fill_(int(tensor.item()))
+
+    # --- minimal worker stand-in: only the attributes Worker.execute_model
+    #     touches up to and including the runner call. The runner is a stub that
+    #     returns a ModelRunnerOutput-like sentinel so the worker returns early.
+    worker = mock.MagicMock()
+    worker._pp_send_work = []
+    worker.use_v2_model_runner = False
+    worker.vllm_config.compilation_config.pass_config.enable_sp = False
+    worker.vllm_config.parallel_config.pipeline_parallel_size = 2
+
+    # predispatch returns this rank's local mode; execute_model records nothing
+    # about ordering but must be a real ModelRunnerOutput-typed object so the
+    # worker returns it. We use NoneType (a valid early-return type).
+    worker.model_runner.predispatch_cudagraph_mode.return_value = (
+        CUDAGraphMode.PIECEWISE.value
+    )
+    worker.model_runner.execute_model.return_value = None  # NoneType -> early return
+
+    scheduler_output = mock.MagicMock()
+    scheduler_output.total_num_scheduled_tokens = 8
+
+    with (
+        mock.patch.object(gw, "get_pp_group", return_value=pp_group),
+        mock.patch.object(gw, "get_tp_group", return_value=mock.MagicMock()),
+        mock.patch.object(
+            gw,
+            "coordinate_cudagraph_mode_across_pp",
+            wraps=lambda v: v,
+        ) as wrapped_consensus,
+    ):
+        # Record the consensus call as the all-reduce event (it wraps the real
+        # all-reduce; recording at the helper boundary is equivalent for ordering
+        # and avoids needing a live gloo group).
+        def record_consensus(v):
+            events.append("pp_all_reduce")
+            return v
+
+        wrapped_consensus.side_effect = record_consensus
+
+        gw.Worker.execute_model(worker, scheduler_output)
+
+    assert "pp_all_reduce" in events, (
+        "Worker.execute_model must issue the PP cudagraph-mode consensus "
+        "all-reduce; it was never called."
+    )
+    assert "irecv_tensor_dict" in events, (
+        "test setup error: the stage-1 recv was not exercised."
+    )
+    assert events.index("pp_all_reduce") < events.index("irecv_tensor_dict"), (
+        f"PP all-reduce must precede the inter-stage recv; got order {events}. "
+        "If the all-reduce trails the recv the pipeline deadlocks on the first "
+        "real decode step (#45094/#45610)."
+    )
+
+
+def _call_lineno_in_function(
+    src: str, func_name: str, callee_name: str
+) -> int | None:
+    """Return the source line of the FIRST *call* to ``callee_name`` inside the
+    function ``func_name`` (matching either ``callee_name(...)`` or
+    ``obj.callee_name(...)``), or ``None`` if there is no such call.
+
+    Unlike a bare ``str.find(callee_name)`` this ignores import lines, comments,
+    and docstrings — so it pins the real CALL-SITE ORDERING, not the position of
+    a module-level ``import`` (which always sorts to the top of the file and
+    makes a naive find-based ordering check pass even if the call is misplaced).
+    """
+    import ast
+
+    tree = ast.parse(src)
+    fn = next(
+        (
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == func_name
+        ),
+        None,
+    )
+    if fn is None:
+        return None
+    best: int | None = None
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        name = getattr(node.func, "attr", getattr(node.func, "id", None))
+        if name == callee_name:
+            ln = node.lineno
+            if best is None or ln < best:
+                best = ln
+    return best
+
+
+def test_source_worker_issues_pp_consensus_before_irecv():
+    """Layer B (AST/source guard): in Worker.execute_model the PP consensus CALL
+    (coordinate_cudagraph_mode_across_pp) must execute BEFORE the
+    irecv_tensor_dict CALL, and the runner's
+    _determine_batch_execution_and_padding must NO LONGER self-issue the
+    all-reduce.
+
+    HARDENED (was previously a naive ``wsrc.find(...)`` over the whole file,
+    which matched the module-level ``from ... import
+    coordinate_cudagraph_mode_across_pp`` at the TOP of the file — so it passed
+    even if the actual CALL were moved BELOW the recv, the exact #45610 deadlock
+    this guards). We now resolve the line of each *call* inside the
+    Worker.execute_model function body via the AST and compare CALL-SITE lines."""
+    wsrc = _gpu_worker_source()
+    consensus_call_ln = _call_lineno_in_function(
+        wsrc, "execute_model", "coordinate_cudagraph_mode_across_pp"
+    )
+    irecv_call_ln = _call_lineno_in_function(
+        wsrc, "execute_model", "irecv_tensor_dict"
+    )
+    assert consensus_call_ln is not None, (
+        "Worker.execute_model must CALL coordinate_cudagraph_mode_across_pp "
+        "(not merely import it); the PP consensus was hoisted into the worker "
+        "(#45610). No call found in the function body."
+    )
+    assert irecv_call_ln is not None, (
+        "Worker.execute_model must call irecv_tensor_dict (the inter-stage recv)."
+    )
+    assert consensus_call_ln < irecv_call_ln, (
+        "The PP consensus all-reduce CALL "
+        f"(line {consensus_call_ln}) must execute BEFORE the irecv_tensor_dict "
+        f"CALL (line {irecv_call_ln}) in Worker.execute_model; otherwise the "
+        "collective and the recv deadlock (#45094/#45610). NOTE: this asserts "
+        "the *call* order, not the import position."
+    )
+
+    # Belt-and-braces: the import must NOT be the only occurrence (i.e. a real
+    # call exists), and the textual import precedes every call — proving the old
+    # naive find() would have matched the import and could not have detected a
+    # misplaced call.
+    import_idx = wsrc.find(
+        "from vllm.v1.worker.pp_utils import coordinate_cudagraph_mode_across_pp"
+    )
+    assert import_idx != -1, "expected the helper to be imported."
+
+    # The runner must consume the agreed value, NOT issue the all-reduce itself.
+    rsrc = _gpu_model_runner_source()
+    assert _call_lineno_in_function(
+        rsrc, "_determine_batch_execution_and_padding",
+        "coordinate_cudagraph_mode_across_pp",
+    ) is None, (
+        "gpu_model_runner._determine_batch_execution_and_padding must not CALL "
+        "coordinate_cudagraph_mode_across_pp anymore (the all-reduce moved to "
+        "the worker, ahead of the recv)."
+    )
+    assert "pp_synced_cudagraph_mode" in rsrc, (
+        "_determine_batch_execution_and_padding must accept and consume the "
+        "worker-agreed pp_synced_cudagraph_mode."
+    )
+
+
+def test_predispatch_cudagraph_mode_issues_no_collective():
+    """predispatch_cudagraph_mode (called pre-recv in the worker) must compute a
+    LOCAL mode without any collective — the all-reduce is the worker's job,
+    separately, right after. AST: predispatch's body must not reference
+    coordinate_cudagraph_mode_across_pp or torch.distributed.all_reduce."""
+    import ast
+
+    src = _gpu_model_runner_source()
+    tree = ast.parse(src)
+    fn = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "predispatch_cudagraph_mode"
+    )
+    # Exclude the docstring (which legitimately *mentions* the helper) and check
+    # only the executable statements.
+    body = list(fn.body)
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    body_src = "\n".join(ast.get_source_segment(src, stmt) or "" for stmt in body)
+    assert "coordinate_cudagraph_mode_across_pp" not in body_src, (
+        "predispatch_cudagraph_mode must NOT issue the PP consensus; it only "
+        "computes this rank's local mode. The worker issues the all-reduce."
+    )
+    assert "all_reduce" not in body_src, (
+        "predispatch_cudagraph_mode must issue no collective (no all_reduce)."
+    )
+
+
+def test_dummy_run_path_does_not_call_predispatch_or_consensus():
+    """The dummy/capture path (_dummy_run) must never trigger the PP consensus.
+    It calls _determine_batch_execution_and_padding with pp_synced_cudagraph_mode
+    left as the None default (so no reconciliation), and never calls
+    predispatch_cudagraph_mode (only the worker pre-recv path does)."""
+    import ast
+
+    src = _gpu_model_runner_source()
+    tree = ast.parse(src)
+    dummy = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_dummy_run"
+    )
+    for node in ast.walk(dummy):
+        if not isinstance(node, ast.Call):
+            continue
+        name = getattr(node.func, "attr", getattr(node.func, "id", None))
+        assert name != "predispatch_cudagraph_mode", (
+            "_dummy_run must not call predispatch_cudagraph_mode; the PP "
+            "consensus must never be tied to the per-stage-asynchronous capture "
+            "path or PP>1 deadlocks at startup (#45610)."
+        )
+        if name == "_determine_batch_execution_and_padding":
+            for kw in node.keywords:
+                assert kw.arg != "pp_synced_cudagraph_mode", (
+                    "_dummy_run must leave pp_synced_cudagraph_mode at its None "
+                    "default (no PP reconciliation on the capture path)."
+                )
+
+
+def test_worker_threads_pp_synced_mode_into_runner_execute_model():
+    """Positive call-site test (work-item 2d): on the real execute_model path the
+    worker not only RUNS the consensus before the recv, it THREADS the agreed
+    value into model_runner.execute_model via the pp_synced_cudagraph_mode kwarg.
+
+    Behavioral: drive Worker.execute_model on a stage-1 (not is_first_rank) PP
+    rank; the consensus stub returns a sentinel agreed mode (NONE); assert the
+    runner's execute_model received exactly that value as
+    pp_synced_cudagraph_mode. Pre-fix the worker did not compute or pass it at
+    all -> kwarg absent / None."""
+    import vllm.v1.worker.gpu_worker as gw
+
+    pp_group = mock.MagicMock()
+    pp_group.world_size = 2
+    pp_group.is_first_rank = False
+    pp_group.is_last_rank = False
+    pp_group.cpu_group = mock.MagicMock()
+    pp_group.irecv_tensor_dict.return_value = ({"hidden_states": object()}, None, None)
+
+    worker = mock.MagicMock()
+    worker._pp_send_work = []
+    worker.use_v2_model_runner = False
+    worker.vllm_config.compilation_config.pass_config.enable_sp = False
+    worker.vllm_config.parallel_config.pipeline_parallel_size = 2
+    # This rank locally wanted PIECEWISE...
+    worker.model_runner.predispatch_cudagraph_mode.return_value = (
+        CUDAGraphMode.PIECEWISE.value
+    )
+    worker.model_runner.execute_model.return_value = None  # early return
+
+    scheduler_output = mock.MagicMock()
+    scheduler_output.total_num_scheduled_tokens = 8
+
+    with (
+        mock.patch.object(gw, "get_pp_group", return_value=pp_group),
+        mock.patch.object(gw, "get_tp_group", return_value=mock.MagicMock()),
+        # ...but the PP consensus agreed NONE (a peer chose eager).
+        mock.patch.object(
+            gw,
+            "coordinate_cudagraph_mode_across_pp",
+            return_value=CUDAGraphMode.NONE.value,
+        ),
+    ):
+        gw.Worker.execute_model(worker, scheduler_output)
+
+    assert worker.model_runner.execute_model.called, "runner execute_model not called"
+    _, kwargs = worker.model_runner.execute_model.call_args
+    assert "pp_synced_cudagraph_mode" in kwargs, (
+        "Worker.execute_model must thread the agreed mode into the runner via "
+        "the pp_synced_cudagraph_mode kwarg; it was not passed."
+    )
+    assert kwargs["pp_synced_cudagraph_mode"] == CUDAGraphMode.NONE.value, (
+        "The worker must pass the CONSENSUS value "
+        f"({CUDAGraphMode.NONE.value}) to the runner, not this rank's local "
+        f"pre-consensus mode; got {kwargs['pp_synced_cudagraph_mode']}."
+    )
+
+
+def test_predispatch_only_kv_scale_inputs_issues_no_collective():
+    """Work-item 2a (behavioral, V1): predispatch_cudagraph_mode is the
+    dispatch-only prefix — given a step whose only eager driver is KV-scale
+    calibration (calculate_kv_scales=True), it must resolve a LOCAL mode (NONE,
+    via the force) and issue NO collective. We stub the dispatcher and assert it
+    is consulted with the eager-forcing valid_modes while NO all_reduce / PP
+    consensus is touched.
+
+    This complements the AST guard (test_predispatch_cudagraph_mode_issues_no_collective)
+    with a runtime check that the function body actually runs collective-free."""
+    import vllm.v1.worker.gpu_model_runner as gmr
+
+    runner = mock.MagicMock()
+    runner.calculate_kv_scales = True  # the canonical #45094 eager trigger
+    runner.model_config.is_encoder_decoder = False
+    runner.input_batch.lora_id_to_lora_request = {}
+    runner.uniform_decode_query_len = 1
+    runner._is_uniform_decode.return_value = True
+    runner._pad_for_sequence_parallelism.side_effect = lambda n: n
+    # Dispatcher returns whatever valid_modes pins; record the call.
+    dispatch_calls: list = []
+
+    def fake_dispatch(**kwargs):
+        dispatch_calls.append(kwargs)
+        return CUDAGraphMode.NONE, mock.MagicMock()
+
+    runner.cudagraph_dispatcher.dispatch.side_effect = fake_dispatch
+
+    scheduler_output = mock.MagicMock()
+    scheduler_output.num_scheduled_tokens = {0: 1, 1: 1}
+    scheduler_output.total_num_scheduled_tokens = 2
+    scheduler_output.scheduled_encoder_inputs = {}
+
+    # NOTE: the AST guard test_predispatch_cudagraph_mode_issues_no_collective is
+    # the AUTHORITATIVE proof that this function body issues no collective (it
+    # inspects the source so it cannot be fooled by a mock that misses the real
+    # call site). This runtime check is complementary. predispatch_cudagraph_mode
+    # never imports/calls coordinate_cudagraph_mode_across_pp, so the only
+    # all_reduce that could fire is gmr's own; we patch that here, and also patch
+    # the pp_utils all_reduce (where the real PP consensus collective lives) so a
+    # future regression that wired the consensus into predispatch would be caught
+    # at runtime too, not only by the AST guard.
+    import vllm.v1.worker.pp_utils as pp_utils
+
+    with (
+        mock.patch.object(gmr.torch.distributed, "all_reduce") as mock_ar,
+        mock.patch.object(pp_utils.torch.distributed, "all_reduce") as mock_pp_ar,
+    ):
+        result = gmr.GPUModelRunner.predispatch_cudagraph_mode(
+            runner, scheduler_output
+        )
+
+    mock_ar.assert_not_called()
+    mock_pp_ar.assert_not_called()
+    assert result == CUDAGraphMode.NONE.value
+    assert dispatch_calls, "dispatcher must be consulted"
+    # KV-scale force must be folded as an eager-only allow-list before consensus.
+    assert dispatch_calls[0].get("valid_modes") == {CUDAGraphMode.NONE}, (
+        "predispatch must fold calculate_kv_scales into valid_modes={NONE} so "
+        "the value contributed to the PP MIN already reflects the eager force "
+        f"(got valid_modes={dispatch_calls[0].get('valid_modes')})."
+    )

--- a/tests/v1/cudagraph/test_pp_cudagraph_consensus_v2.py
+++ b/tests/v1/cudagraph/test_pp_cudagraph_consensus_v2.py
@@ -1,0 +1,705 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""V2-model-runner regression tests for the pipeline-parallel cudagraph-mode
+consensus that guards against the #45094 PP cudagraph-vs-eager split-brain wedge.
+
+This is the V2 analog of ``tests/v1/cudagraph/test_pp_cudagraph_consensus.py``.
+The maintainer (njhill, vllm-project/vllm#45610) noted that vLLM is migrating to
+the V2 model runner and recommends it for pipeline parallelism, and asked whether
+the #45094 split-brain also applies there. It does:
+
+* The V2 dispatch+sync path is ``dispatch_cg_and_sync_dp``
+  (``vllm/v1/worker/gpu/dp_utils.py``). It takes a MIN of ``cg_mode`` across the
+  *DP* group (``sync_cudagraph_and_dp_padding``) but had **no PP-rank consensus**.
+* ``CudaGraphManager.dispatch`` runs independently per PP stage, so the same
+  per-rank-local divergence the V1 fix addresses (calculate_kv_scales force-eager,
+  encoder-decoder skip_compiled, cascade-attn detection, a partially-failed
+  capture, LoRA bookkeeping) produces a PIECEWISE/FULL-vs-NONE split-brain across
+  PP stages on V2 too — the stages disagree on the inter-stage P2P send/recv
+  schedule, the rendezvous never completes, and the engine wedges
+  (``shm_broadcast`` 60s timeout -> RPC timeout -> EngineCore crash).
+
+The fix mirrors V1: a MIN all-reduce of the cudagraph mode across the PP CPU
+(gloo) group, reusing the shared V1 helper ``coordinate_cudagraph_mode_across_pp``
+(``vllm/v1/worker/pp_utils.py``). It is gated to the real (non-dummy, non-profile)
+execute path so the collective is never issued during the per-stage-asynchronous
+capture/profile path (that gating was the #45610 startup-deadlock follow-up).
+
+These are unit tests against ``dp_utils._coordinate_cudagraph_mode_across_pp`` and
+``dispatch_cg_and_sync_dp`` with a mocked PP group, mirroring how the V1 tests
+mock ``get_pp_group``. They FAIL against pre-fix code (the function does not exist
+/ no PP consensus -> the two simulated stages stay divergent).
+
+Integration repro (requires >=2 GPUs, PP=2, V2 runner):
+
+    VLLM_USE_V1_MODEL_RUNNER_V2=1 vllm serve <model> -tp 1 -pp 2 \\
+        --compilation-config '{"cudagraph_mode":"PIECEWISE"}'
+    # then drive concurrent long-reasoning requests whose admitted batch-token
+    # count crosses a captured cudagraph bucket boundary on some steps but not
+    # others. Pre-fix: one PP stage replays the graph while the other runs eager
+    # -> shm_broadcast "No available shared memory broadcast block found in 60
+    # seconds" -> RPC timeout -> EngineCore crash. Post-fix: both stages agree
+    # (MIN) -> no wedge.
+"""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from vllm.config import CUDAGraphMode
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+
+
+def _patch_pp_group(world_size: int, peer_modes: list[int] | None = None):
+    """Return a mock get_pp_group() whose all_reduce(MIN) simulates peers.
+
+    peer_modes: the cudagraph-mode ints contributed by the *other* PP ranks.
+    The mocked all_reduce computes min(local, *peer_modes) in place, exactly as
+    a real MIN all-reduce over the PP group would.
+    """
+    peer_modes = peer_modes or []
+
+    mock_group = mock.MagicMock()
+    mock_group.world_size = world_size
+    mock_group.cpu_group = mock.MagicMock()
+
+    def fake_all_reduce(tensor, op, group):
+        local = int(tensor.item())
+        tensor.fill_(min([local, *peer_modes]))
+
+    return mock_group, fake_all_reduce
+
+
+class _FakeCudaGraphManager:
+    """Minimal stand-in for CudaGraphManager.dispatch.
+
+    ``captured_mode`` is the richest mode this rank holds a capture key for at
+    the step's batch shape. ``dispatch`` returns a descriptor at that mode
+    (FULL/PIECEWISE) or NONE if it holds no graph — matching the real
+    dispatcher's "best matching captured descriptor, else NONE" contract.
+    """
+
+    def __init__(self, captured_mode: CUDAGraphMode):
+        self.captured_mode = captured_mode
+
+    def dispatch(self, num_reqs, num_tokens, uniform_token_count):
+        return BatchExecutionDescriptor(
+            cg_mode=self.captured_mode,
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+        )
+
+
+def _run_pp_consensus_one_rank(
+    *,
+    local_mode: CUDAGraphMode,
+    peer_modes: list[int],
+) -> CUDAGraphMode:
+    """Drive the V2 reconciliation for one PP rank: compute the agreed MIN via
+    the REAL leaf helper ``coordinate_cudagraph_mode_across_pp`` (with mocked PP
+    peers) — exactly as ``Worker.execute_model`` now does *before* the recv —
+    then feed it to ``dp_utils._reconcile_cudagraph_mode_across_pp``. Returns the
+    post-reconciliation cg_mode."""
+    from vllm.v1.worker.gpu import dp_utils
+    from vllm.v1.worker.pp_utils import coordinate_cudagraph_mode_across_pp
+
+    batch_desc = BatchExecutionDescriptor(
+        cg_mode=local_mode, num_tokens=128, num_reqs=4
+    )
+
+    mock_group, fake_ar = _patch_pp_group(world_size=2, peer_modes=peer_modes)
+    with (
+        mock.patch("vllm.v1.worker.gpu.dp_utils.get_pp_group", return_value=mock_group),
+        mock.patch("vllm.v1.worker.pp_utils.get_pp_group", return_value=mock_group),
+        mock.patch(
+            "vllm.v1.worker.pp_utils.torch.distributed.all_reduce",
+            side_effect=fake_ar,
+        ),
+    ):
+        # The worker computes the agreed MIN ahead of the recv...
+        pp_synced = coordinate_cudagraph_mode_across_pp(local_mode.value)
+        # ...and the runner consumes it (no collective issued here).
+        synced = dp_utils._reconcile_cudagraph_mode_across_pp(
+            batch_desc, 4, 128, pp_synced
+        )
+    return synced.cg_mode
+
+
+@pytest.mark.parametrize(
+    "rank_a_mode, rank_b_mode, expected_a, expected_b",
+    [
+        # The #45094 split-brain on V2: one stage on a graph, the other NONE
+        # (eager). Both must end eager so the inter-stage P2P schedule agrees.
+        (
+            CUDAGraphMode.PIECEWISE,
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.NONE,
+        ),
+        (
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.PIECEWISE,
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.NONE,
+        ),
+        (
+            CUDAGraphMode.FULL,
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.NONE,
+        ),
+        # FULL vs PIECEWISE: an UNREACHABLE same-shape graph-vs-graph divergence
+        # (see the NOTE on the test below), pinned only to document the
+        # mechanical behavior. The PP MIN is PIECEWISE; the PIECEWISE rank is
+        # already at the MIN and keeps it, while the FULL rank cannot be
+        # re-dispatched to PIECEWISE (V2 dispatch is shape-deterministic, no
+        # valid_modes allow-list) so it drops to NONE. That is a *split*
+        # (NONE vs PIECEWISE), NOT a convergence — it is safe ONLY because this
+        # input cannot occur (config-global capture keys => all graph-capable
+        # stages dispatch the same graph mode at a given shape; the only
+        # reachable PP divergence is graph-vs-NONE, covered by the rows above,
+        # which DO converge on NONE).
+        (
+            CUDAGraphMode.FULL,
+            CUDAGraphMode.PIECEWISE,
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.PIECEWISE,
+        ),
+        # Already in agreement -> unchanged (no divergence, no drop).
+        (
+            CUDAGraphMode.PIECEWISE,
+            CUDAGraphMode.PIECEWISE,
+            CUDAGraphMode.PIECEWISE,
+            CUDAGraphMode.PIECEWISE,
+        ),
+        (
+            CUDAGraphMode.FULL,
+            CUDAGraphMode.FULL,
+            CUDAGraphMode.FULL,
+            CUDAGraphMode.FULL,
+        ),
+        (
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.NONE,
+            CUDAGraphMode.NONE,
+        ),
+    ],
+)
+def test_v2_pp_consensus_reconciles_divergent_modes(
+    rank_a_mode, rank_b_mode, expected_a, expected_b
+):
+    """Each PP rank that dispatched a mode != the PP MIN drops to eager on the
+    V2 path; a rank already at the MIN keeps it. The guard against #45094.
+
+    NOTE on the FULL-vs-PIECEWISE row: it is an UNREACHABLE input, pinned only to
+    document the mechanical behavior — and that behavior is a *split*
+    (a=NONE, b=PIECEWISE), NOT a convergence. It is safe precisely because the
+    input cannot occur: cudagraph capture sizes are config-global, so all
+    graph-capable PP stages hold identical capture keys and dispatch the SAME
+    graph mode at a given batch shape. The only PP divergence that can actually
+    arise is graph-vs-NONE (one stage forced eager by per-step-local state:
+    calculate_kv_scales, cascade-attn detection, LoRA bookkeeping, a partially
+    failed capture), and for that the MIN is NONE so BOTH stages drop to NONE and
+    converge (the graph-vs-NONE rows above, and
+    test_v2_pp_consensus_graph_vs_eager_always_converges). We assert the split
+    here for the FULL/PIECEWISE row ONLY to lock the mechanical contract; if a
+    future change ever makes same-shape FULL-vs-PIECEWISE reachable, this split
+    becomes a real wedge and the reconcile must be taught to re-dispatch toward
+    the agreed mode (as the V1 path does via valid_modes={NONE, pp_synced})."""
+    result_a = _run_pp_consensus_one_rank(
+        local_mode=rank_a_mode, peer_modes=[rank_b_mode.value]
+    )
+    result_b = _run_pp_consensus_one_rank(
+        local_mode=rank_b_mode, peer_modes=[rank_a_mode.value]
+    )
+
+    assert result_a == expected_a
+    assert result_b == expected_b
+
+    # Honesty guard: for every REACHABLE row both stages must end on the SAME
+    # mode (no split-brain). The single FULL-vs-PIECEWISE row is the documented
+    # UNREACHABLE exception (see the docstring) and is the only place the modes
+    # are allowed to differ.
+    graph_vs_graph_unreachable = {rank_a_mode, rank_b_mode} == {
+        CUDAGraphMode.FULL,
+        CUDAGraphMode.PIECEWISE,
+    }
+    if not graph_vs_graph_unreachable:
+        assert result_a == result_b, (
+            f"reachable PP divergence ({rank_a_mode} vs {rank_b_mode}) must "
+            f"converge, got a={result_a}, b={result_b} — that is the #45094 "
+            "split-brain."
+        )
+
+
+def test_v2_pp_consensus_graph_vs_eager_always_converges():
+    """The load-bearing invariant for the realistic divergence (graph-vs-NONE):
+    BOTH stages end at the SAME mode (NONE), eliminating the split-brain."""
+    for graph_mode in (CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL):
+        a = _run_pp_consensus_one_rank(
+            local_mode=graph_mode, peer_modes=[CUDAGraphMode.NONE.value]
+        )
+        b = _run_pp_consensus_one_rank(
+            local_mode=CUDAGraphMode.NONE, peer_modes=[graph_mode.value]
+        )
+        assert a == b == CUDAGraphMode.NONE, (
+            f"graph({graph_mode}) vs eager PP stages diverged: a={a}, b={b}; "
+            "this is the #45094 split-brain that wedges the pipeline."
+        )
+
+
+def test_v2_pp_consensus_noop_on_single_stage():
+    """With PP world_size == 1 there are no peers; the descriptor is returned
+    unchanged (the reconciliation short-circuits)."""
+    from vllm.v1.worker.gpu import dp_utils
+
+    batch_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.PIECEWISE, num_tokens=128, num_reqs=4
+    )
+    mock_group, _ = _patch_pp_group(world_size=1)
+    with mock.patch(
+        "vllm.v1.worker.gpu.dp_utils.get_pp_group", return_value=mock_group
+    ):
+        # pp_synced is irrelevant on a 1-stage pipeline; pass this rank's own
+        # value to show it is returned unchanged.
+        result = dp_utils._reconcile_cudagraph_mode_across_pp(
+            batch_desc, 4, 128, CUDAGraphMode.PIECEWISE.value
+        )
+
+    assert result is batch_desc  # unchanged, no drop
+
+
+def test_v2_dispatch_cg_and_sync_dp_runs_pp_consensus_when_dp1():
+    """End-to-end through the public entry point: dp_size==1 (pure PP) with the
+    PP-agreed mode supplied (as Worker.execute_model now does, pre-recv), the two
+    stages still reconcile (DP MIN never runs in pure PP, so the PP
+    reconciliation is the only guard)."""
+    from vllm.v1.worker.gpu import dp_utils
+    from vllm.v1.worker.pp_utils import coordinate_cudagraph_mode_across_pp
+
+    def run_rank(local_captured, peer_mode):
+        mgr = _FakeCudaGraphManager(local_captured)
+        mock_group, fake_ar = _patch_pp_group(
+            world_size=2, peer_modes=[peer_mode.value]
+        )
+        with (
+            mock.patch(
+                "vllm.v1.worker.gpu.dp_utils.get_pp_group", return_value=mock_group
+            ),
+            mock.patch("vllm.v1.worker.pp_utils.get_pp_group", return_value=mock_group),
+            mock.patch(
+                "vllm.v1.worker.pp_utils.torch.distributed.all_reduce",
+                side_effect=fake_ar,
+            ),
+        ):
+            # Worker computes the agreed MIN before the recv from this rank's
+            # local captured mode...
+            pp_synced = coordinate_cudagraph_mode_across_pp(local_captured.value)
+            # ...and the runner consumes it.
+            desc, across_dp = dp_utils.dispatch_cg_and_sync_dp(
+                mgr,
+                num_reqs=4,
+                num_tokens=128,
+                uniform_token_count=None,
+                dp_size=1,
+                dp_rank=0,
+                need_eager=False,
+                pp_synced_cudagraph_mode=pp_synced,
+            )
+        assert across_dp is None  # pure PP: no DP padding tensor
+        return desc.cg_mode
+
+    # Stage A dispatched PIECEWISE; stage B was forced eager (NONE).
+    a = run_rank(CUDAGraphMode.PIECEWISE, CUDAGraphMode.NONE)
+    b = run_rank(CUDAGraphMode.NONE, CUDAGraphMode.PIECEWISE)
+    assert a == b == CUDAGraphMode.NONE, (
+        f"pure-PP stages diverged through dispatch_cg_and_sync_dp: A={a}, B={b}"
+    )
+
+
+def test_v2_dispatch_cg_and_sync_dp_pp_consensus_off_by_default():
+    """Default (dummy/profile/capture path): pp_synced_cudagraph_mode is None, so
+    NO PP reconciliation happens — the guard that keeps the
+    per-stage-asynchronous capture path from deadlocking at startup (#45094/#45610
+    follow-up). The descriptor is returned unreconciled."""
+    from vllm.v1.worker.gpu import dp_utils
+
+    mgr = _FakeCudaGraphManager(CUDAGraphMode.PIECEWISE)
+    mock_group, _ = _patch_pp_group(
+        world_size=2, peer_modes=[CUDAGraphMode.NONE.value]
+    )
+    with mock.patch(
+        "vllm.v1.worker.gpu.dp_utils.get_pp_group", return_value=mock_group
+    ):
+        desc, _ = dp_utils.dispatch_cg_and_sync_dp(
+            mgr,
+            num_reqs=4,
+            num_tokens=128,
+            uniform_token_count=None,
+            dp_size=1,
+            dp_rank=0,
+            need_eager=False,
+            # default: pp_synced_cudagraph_mode=None -> no reconciliation
+        )
+
+    assert desc.cg_mode == CUDAGraphMode.PIECEWISE  # unreconciled, as on capture
+
+
+# ---------------------------------------------------------------------------
+# Source-level guards: tie the V2 regression to the ACTUAL call-site gating so
+# a future revert fails CI here even if the unit helpers still pass. Mirrors the
+# V1 test's source guards. Asserts (a) dispatch_cg_and_sync_dp accepts the gate
+# flag defaulting False, and (b) the model_runner execute_model call site only
+# requests PP coordination on the real (non-dummy, non-profile) path.
+# ---------------------------------------------------------------------------
+
+
+def _dp_utils_source() -> str:
+    repo_root = Path(__file__).resolve().parents[3]
+    return (
+        repo_root / "vllm" / "v1" / "worker" / "gpu" / "dp_utils.py"
+    ).read_text()
+
+
+def _v2_model_runner_source() -> str:
+    repo_root = Path(__file__).resolve().parents[3]
+    return (
+        repo_root / "vllm" / "v1" / "worker" / "gpu" / "model_runner.py"
+    ).read_text()
+
+
+def _gpu_worker_source() -> str:
+    repo_root = Path(__file__).resolve().parents[3]
+    return (repo_root / "vllm" / "v1" / "worker" / "gpu_worker.py").read_text()
+
+
+def test_v2_source_dispatch_consumes_presynced_mode():
+    src = _dp_utils_source()
+    assert "pp_synced_cudagraph_mode: int | None = None" in src, (
+        "dispatch_cg_and_sync_dp must accept pp_synced_cudagraph_mode (a "
+        "pre-agreed mode value computed by the worker before the recv), "
+        "defaulting to None (no reconciliation on the dummy/capture path)."
+    )
+    # dp_utils must NOT issue the all-reduce itself anymore — the worker does it
+    # ahead of the recv (#45610). Only doc-comment references are allowed.
+    code_without_docstrings = "\n".join(
+        line for line in src.splitlines() if "``" not in line
+    )
+    assert "coordinate_cudagraph_mode_across_pp(" not in code_without_docstrings, (
+        "dp_utils must NOT call coordinate_cudagraph_mode_across_pp; the PP "
+        "all-reduce moved to Worker.execute_model, ahead of the inter-stage "
+        "recv (#45610)."
+    )
+
+
+def test_v2_source_execute_model_consumes_presynced_mode():
+    src = _v2_model_runner_source()
+    assert "pp_synced_cudagraph_mode=pp_synced_cudagraph_mode" in src, (
+        "V2 execute_model must thread the worker-agreed pp_synced_cudagraph_mode "
+        "into dispatch_cg_and_sync_dp (the consensus all-reduce is issued by "
+        "Worker.execute_model before the recv; the runner only consumes it)."
+    )
+    assert "def predispatch_cudagraph_mode(" in src, (
+        "V2 model runner must expose predispatch_cudagraph_mode so the worker "
+        "can compute this rank's local mode before the recv (#45610)."
+    )
+
+
+def test_v2_worker_hoists_pp_consensus_before_recv():
+    """The shared Worker.execute_model (drives both V1 and V2 runners) must issue
+    the PP consensus all-reduce before the inter-stage recv, and the Ray
+    compiled-graph path (which bypasses Worker.execute_model) must also reach
+    consensus before consuming intermediate tensors (#45610).
+
+    HARDENED: both ordering checks resolve the actual *call* line via the AST
+    (inside the relevant function), not a whole-file ``str.find`` that would
+    match the module-level import at the top and pass even if the call were
+    misplaced below the recv."""
+    import ast
+
+    def _call_lineno(src: str, func_name: str, callee_name: str) -> int | None:
+        tree = ast.parse(src)
+        fn = next(
+            (
+                n
+                for n in ast.walk(tree)
+                if isinstance(n, ast.FunctionDef) and n.name == func_name
+            ),
+            None,
+        )
+        if fn is None:
+            return None
+        best = None
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Call):
+                name = getattr(node.func, "attr", getattr(node.func, "id", None))
+                if name == callee_name and (best is None or node.lineno < best):
+                    best = node.lineno
+        return best
+
+    wsrc = _gpu_worker_source()
+    c_ln = _call_lineno(wsrc, "execute_model", "coordinate_cudagraph_mode_across_pp")
+    r_ln = _call_lineno(wsrc, "execute_model", "irecv_tensor_dict")
+    assert c_ln is not None and r_ln is not None and c_ln < r_ln, (
+        "Worker.execute_model must CALL coordinate_cudagraph_mode_across_pp "
+        f"(line {c_ln}) BEFORE irecv_tensor_dict (line {r_ln}) — drives the V2 "
+        "runner too; #45610. (call-site order, not import position)."
+    )
+
+    repo_root = Path(__file__).resolve().parents[3]
+    ray_src = (
+        repo_root / "vllm" / "v1" / "executor" / "ray_utils.py"
+    ).read_text()
+    # The Ray path must (a) actually CALL the consensus inside execute_model_ray,
+    # and (b) call it BEFORE it consumes intermediate_tensors via the runner's
+    # execute_model. A bare ``in ray_src`` substring would be satisfied by the
+    # import alone — harden to call-site ordering.
+    ray_consensus_ln = _call_lineno(
+        ray_src, "execute_model_ray", "coordinate_cudagraph_mode_across_pp"
+    )
+    assert ray_consensus_ln is not None, (
+        "The Ray compiled-graph executor (execute_model_ray) bypasses "
+        "Worker.execute_model, so it must CALL coordinate_cudagraph_mode_across_pp "
+        "itself before running the model, or PP+cudagraph wedges under Ray "
+        "(#45610). No call found in the function body (an import alone is "
+        "insufficient)."
+    )
+    # The runner execute_model call on the Ray path must come AFTER the consensus.
+    ray_run_ln = _call_lineno(ray_src, "execute_model_ray", "execute_model")
+    # (execute_model matches the runner call; consensus must precede it.)
+    assert ray_run_ln is not None and ray_consensus_ln < ray_run_ln, (
+        "On the Ray path the PP consensus "
+        f"(line {ray_consensus_ln}) must run before the model is executed "
+        f"(line {ray_run_ln}); otherwise the PP stages can split-brain on the "
+        "DAG's P2P edge (#45610)."
+    )
+    # And the Ray path must thread the agreed value into the runner.
+    assert "pp_synced_cudagraph_mode=pp_synced_cudagraph_mode" in ray_src, (
+        "execute_model_ray must thread the agreed pp_synced_cudagraph_mode into "
+        "the runner's execute_model."
+    )
+
+
+def test_v2_dp_and_pp_reconcile_composes_via_dp_min_fold():
+    """Work-item 2b + MED-2 regression (V2): DP>1 AND PP>1.
+
+    Models the (DP replica x PP stage) grid where the PP-agreed mode is folded
+    INTO the DP all-reduce (the MED-2 fix). Pre-fix the PP drop ran *after* the
+    DP collective over an orthogonal MIN slice, so two replicas of the same PP
+    stage could end on different modes (one graph, one NONE) — a DP-lockstep
+    split that re-wedges the pipeline. Post-fix the DP MIN subsumes the PP MIN
+    globally, so every replica of a stage ends identical.
+
+    We drive ``sync_cudagraph_and_dp_padding`` for each DP rank of stage s with a
+    DP all-reduce simulated over the *other* DP rank's CONTRIBUTED value, and
+    feed each rank its replica's pp_synced. We assert: with the fold, both DP
+    replicas of the stage agree; and the FAIL-PRE check shows that without the
+    fold (contributing the bare local mode) they would diverge."""
+    from vllm.v1.worker.gpu import dp_utils
+
+    # Grid (2 replicas x 2 stages); we examine stage s0 across both replicas.
+    #   r0 local @ s0 = PIECEWISE ; r0 pp_synced (MIN over r0's stages) = PIECEWISE
+    #   r1 local @ s0 = PIECEWISE ; r1 pp_synced (MIN over r1's stages) = NONE
+    # Pre-fix DP MIN over {PIECEWISE, PIECEWISE} = PIECEWISE; r1 then drops to
+    # NONE post-collective -> stage-0 split (PIECEWISE vs NONE).
+    # Post-fix contributions are min(local, pp_synced): r0->PIECEWISE, r1->NONE;
+    # DP MIN = NONE -> both replicas agree on NONE.
+    def run_stage_rank(local_mode, pp_synced, peer_contributed, dp_rank, *, fold):
+        mgr = _FakeCudaGraphManager(local_mode)
+        # Simulate the DP all-reduce: each rank contributes either the folded
+        # value (post-fix, done inside sync_cudagraph_and_dp_padding) or the bare
+        # local value (pre-fix). We emulate the SUM all_reduce of the 3xN tensor
+        # by injecting the peer's contribution at its dp_rank slot.
+        peer_rank = 1 - dp_rank
+
+        def fake_dp_all_reduce(tensor, group=None):
+            # tensor rows: [num_tokens, cg_mode, uniform]; fill the peer slot.
+            tensor[0][peer_rank] = 128
+            tensor[1][peer_rank] = peer_contributed
+            tensor[2][peer_rank] = 0
+
+        mock_pp, _ = _patch_pp_group(world_size=2)
+        with (
+            mock.patch(
+                "vllm.v1.worker.gpu.dp_utils.get_dp_group",
+                return_value=mock.MagicMock(),
+            ),
+            mock.patch(
+                "vllm.v1.worker.gpu.dp_utils.get_pp_group", return_value=mock_pp
+            ),
+            mock.patch(
+                "vllm.v1.worker.gpu.dp_utils.dist.all_reduce",
+                side_effect=fake_dp_all_reduce,
+            ),
+        ):
+            desc, _ = dp_utils.dispatch_cg_and_sync_dp(
+                mgr,
+                num_reqs=4,
+                num_tokens=128,
+                uniform_token_count=None,
+                dp_size=2,
+                dp_rank=dp_rank,
+                need_eager=False,
+                pp_synced_cudagraph_mode=(pp_synced if fold else None),
+            )
+        return desc.cg_mode
+
+    # --- POST-FIX (fold ON): contributions are min(local, pp_synced). ---
+    # r0 contributes min(PIECEWISE, PIECEWISE)=PIECEWISE; r1 min(PIECEWISE,NONE)=NONE.
+    r0 = run_stage_rank(
+        local_mode=CUDAGraphMode.PIECEWISE,
+        pp_synced=CUDAGraphMode.PIECEWISE.value,
+        peer_contributed=CUDAGraphMode.NONE.value,  # r1's folded contribution
+        dp_rank=0,
+        fold=True,
+    )
+    r1 = run_stage_rank(
+        local_mode=CUDAGraphMode.PIECEWISE,
+        pp_synced=CUDAGraphMode.NONE.value,
+        peer_contributed=CUDAGraphMode.PIECEWISE.value,  # r0's folded contribution
+        dp_rank=1,
+        fold=True,
+    )
+    assert r0 == r1 == CUDAGraphMode.NONE, (
+        f"DP>1 & PP>1 must compose: both replicas of stage 0 must agree post-"
+        f"fold, got r0={r0}, r1={r1}. The PP MIN (NONE in r1) must be folded "
+        "into the DP MIN so neither replica is left graph-mode (#45094 MED-2)."
+    )
+
+
+def test_v2_med2_pre_fix_ordering_would_split_dp_replicas():
+    """FAIL-PRE companion to the test above: demonstrate that taking the DP MIN
+    over the BARE local modes and applying the PP drop only AFTER the collective
+    (the pre-fix ordering) diverges the two DP replicas of a stage. This pins WHY
+    the fold is required; it asserts the divergence EXISTS in the pre-fix model
+    (computed here directly, not by calling the fixed code)."""
+    # Pre-fix: DP MIN over bare local modes {PIECEWISE(r0,s0), PIECEWISE(r1,s0)}.
+    dp_min_s0 = min(CUDAGraphMode.PIECEWISE.value, CUDAGraphMode.PIECEWISE.value)
+    # Then each replica applies its own PP drop AFTER the collective:
+    pp_synced_r0 = CUDAGraphMode.PIECEWISE.value
+    pp_synced_r1 = CUDAGraphMode.NONE.value
+
+    def post_collective_drop(dp_synced, pp_synced):
+        # _reconcile_cudagraph_mode_across_pp: drop to NONE iff pp_synced != mode.
+        return (
+            CUDAGraphMode.NONE.value if pp_synced != dp_synced else dp_synced
+        )
+
+    r0_final = post_collective_drop(dp_min_s0, pp_synced_r0)  # stays PIECEWISE
+    r1_final = post_collective_drop(dp_min_s0, pp_synced_r1)  # drops to NONE
+    assert r0_final != r1_final, (
+        "Pre-fix ordering (DP MIN over bare locals, PP drop after) must split "
+        "the DP replicas of stage 0; if it no longer does, this test no longer "
+        "guards the #45094 MED-2 regression."
+    )
+    assert r0_final == CUDAGraphMode.PIECEWISE.value
+    assert r1_final == CUDAGraphMode.NONE.value
+
+
+def test_v2_source_sync_dp_folds_pp_synced_into_reduce():
+    """Source guard (MED-2 fix): sync_cudagraph_and_dp_padding must FOLD the
+    PP-agreed mode into the value it contributes to the DP all-reduce, i.e.
+    accept ``pp_synced_cudagraph_mode`` and apply ``min(local, pp_synced)``
+    BEFORE ``dist.all_reduce``. A future revert that drops the fold (and relies
+    only on the post-reduce reconcile) re-introduces the DP-lockstep split."""
+    import ast
+
+    src = _dp_utils_source()
+    assert "pp_synced_cudagraph_mode: int | None = None" in src
+    tree = ast.parse(src)
+    fn = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "sync_cudagraph_and_dp_padding"
+    )
+    # Find the line of the min(...) fold and the line of dist.all_reduce; the
+    # fold must precede the collective.
+    min_ln = None
+    ar_ln = None
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            name = getattr(node.func, "attr", getattr(node.func, "id", None))
+            if name == "min" and min_ln is None:
+                min_ln = node.lineno
+            if name == "all_reduce" and ar_ln is None:
+                ar_ln = node.lineno
+    assert min_ln is not None, (
+        "sync_cudagraph_and_dp_padding must fold the PP-agreed mode via "
+        "min(local, pp_synced) before contributing to the DP all-reduce (MED-2)."
+    )
+    assert ar_ln is not None, "expected a dist.all_reduce call."
+    assert min_ln < ar_ln, (
+        f"the min(local, pp_synced) fold (line {min_ln}) must execute BEFORE "
+        f"the DP all_reduce (line {ar_ln}) so the DP MIN subsumes the PP MIN "
+        "(MED-2)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer A (ordering) for the V2 path. The V2 runner is driven by the SAME
+# Worker.execute_model as V1 (gpu_worker.py dispatches to the V2 runner when
+# self.use_v2_model_runner is True), so the all-reduce-before-recv ordering is
+# enforced in one place. This test pins it with use_v2_model_runner=True so a
+# V2-only regression of the worker ordering is caught here too.
+# ---------------------------------------------------------------------------
+
+
+def test_v2_pp_all_reduce_precedes_irecv_in_worker_execute_model():
+    """Drive Worker.execute_model with a V2 runner stub on a stage-1 (not
+    is_first_rank) PP rank, world_size=2, and assert the PP consensus all-reduce
+    is issued BEFORE irecv_tensor_dict. FAILS pre-fix (the worker did not issue
+    the consensus at all; the V2 runner did, after the recv -> deadlock)."""
+    from unittest import mock
+
+    import vllm.v1.worker.gpu_worker as gw
+
+    events: list[str] = []
+
+    pp_group = mock.MagicMock()
+    pp_group.world_size = 2
+    pp_group.is_first_rank = False
+    pp_group.is_last_rank = False
+    pp_group.cpu_group = mock.MagicMock()
+
+    def fake_irecv(*args, **kwargs):
+        events.append("irecv_tensor_dict")
+        return {"hidden_states": object()}, None, None
+
+    pp_group.irecv_tensor_dict.side_effect = fake_irecv
+
+    worker = mock.MagicMock()
+    worker._pp_send_work = []
+    worker.use_v2_model_runner = True  # V2 path
+    worker.model_runner.is_pooling_model = False  # so None returns early
+    worker.vllm_config.compilation_config.pass_config.enable_sp = False
+    worker.vllm_config.parallel_config.pipeline_parallel_size = 2
+    worker.model_runner.predispatch_cudagraph_mode.return_value = (
+        CUDAGraphMode.PIECEWISE.value
+    )
+    worker.model_runner.execute_model.return_value = None  # NoneType -> early return
+
+    scheduler_output = mock.MagicMock()
+    scheduler_output.total_num_scheduled_tokens = 8
+
+    with (
+        mock.patch.object(gw, "get_pp_group", return_value=pp_group),
+        mock.patch.object(gw, "get_tp_group", return_value=mock.MagicMock()),
+        mock.patch.object(gw, "coordinate_cudagraph_mode_across_pp") as consensus,
+    ):
+        def record_consensus(v):
+            events.append("pp_all_reduce")
+            return v
+
+        consensus.side_effect = record_consensus
+        gw.Worker.execute_model(worker, scheduler_output)
+
+    assert "pp_all_reduce" in events and "irecv_tensor_dict" in events, (
+        f"both the consensus and the recv must run; got {events}"
+    )
+    assert events.index("pp_all_reduce") < events.index("irecv_tensor_dict"), (
+        f"PP all-reduce must precede the inter-stage recv on the V2 path; got "
+        f"{events}. Otherwise the pipeline deadlocks on the first decode step "
+        "(#45094/#45610)."
+    )

--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -19,6 +19,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.utils.network_utils import get_ip
 from vllm.v1.outputs import AsyncModelRunnerOutput
 from vllm.v1.serial_utils import run_method
+from vllm.v1.worker.pp_utils import coordinate_cudagraph_mode_across_pp
 from vllm.v1.worker.worker_base import WorkerWrapperBase
 
 if TYPE_CHECKING:
@@ -142,8 +143,30 @@ try:
                 scheduler_output, grammar_output = execute_model_input
                 intermediate_tensors = None
             assert self.worker.model_runner is not None
+            # PP cudagraph-mode consensus (#45094/#45610). The Ray compiled-graph
+            # executor bypasses Worker.execute_model (where the consensus is
+            # hoisted for the default executor), so issue it here too. Ray passes
+            # the inter-stage activations as a DAG argument rather than via the
+            # worker's gloo recv, so there is no all-reduce-vs-recv deadlock on
+            # this path; we still must reach consensus or PP stages can
+            # split-brain on cudagraph mode and wedge the DAG's P2P edge. The
+            # all-reduce is on the PP CPU (gloo) group, independent of the Ray
+            # DAG channel, and must precede consuming intermediate_tensors.
+            pp_synced_cudagraph_mode: int | None = None
+            forward_pass = scheduler_output.total_num_scheduled_tokens > 0
+            if forward_pass and get_pp_group().world_size > 1:
+                local_cudagraph_mode = (
+                    self.worker.model_runner.predispatch_cudagraph_mode(
+                        scheduler_output
+                    )
+                )
+                pp_synced_cudagraph_mode = coordinate_cudagraph_mode_across_pp(
+                    local_cudagraph_mode
+                )
             output = self.worker.model_runner.execute_model(
-                scheduler_output, intermediate_tensors
+                scheduler_output,
+                intermediate_tensors,
+                pp_synced_cudagraph_mode=pp_synced_cudagraph_mode,
             )
             if self._is_intermediate_tensors(output):
                 if (

--- a/vllm/v1/worker/gpu/dp_utils.py
+++ b/vllm/v1/worker/gpu/dp_utils.py
@@ -6,7 +6,7 @@ import torch
 import torch.distributed as dist
 
 from vllm.config.compilation import CUDAGraphMode
-from vllm.distributed.parallel_state import get_dp_group
+from vllm.distributed.parallel_state import get_dp_group, get_pp_group
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     CudaGraphManager,
@@ -22,17 +22,37 @@ def sync_cudagraph_and_dp_padding(
     dp_size: int,
     dp_rank: int,
     num_active_loras: int = 0,
+    pp_synced_cudagraph_mode: int | None = None,
 ) -> tuple[BatchExecutionDescriptor, torch.Tensor | None]:
     """
     Coordinates the batch descriptor and DP padding across all ranks.
 
     Returns (synced_batch_desc, num_tokens_across_dp).
+
+    ``pp_synced_cudagraph_mode`` (when not ``None``) is the PP-group MIN cudagraph
+    mode for *this* DP replica, already agreed by the worker's pre-recv
+    ``coordinate_cudagraph_mode_across_pp`` all-reduce. It is FOLDED INTO the value
+    this rank contributes to the DP cg_mode all-reduce so the DP MIN subsumes the
+    PP MIN of every replica. Without that fold the DP and PP MINs are taken over
+    *orthogonal* slices of the (DP replica x PP stage) grid, and a graph-vs-eager
+    split present in one replica's PP group but not another's makes the two
+    replicas of the SAME PP stage end on different modes *after* the DP collective
+    — a DP lockstep violation that re-wedges the pipeline (#45094 MED-2). Folding
+    here makes the contributed value ``min(local, pp_synced)``, so the reduced
+    ``synced_cg_mode`` is the global MIN: identical across every replica and
+    stage, and the post-reduce PP reconciliation in ``dispatch_cg_and_sync_dp``
+    becomes a provable no-op.
     """
     assert dp_size > 1, "DP size must be greater than 1"
     group = get_dp_group().cpu_group
+    local_cg_mode = desired_batch_desc.cg_mode.value
+    if pp_synced_cudagraph_mode is not None:
+        # Contribute the PP-agreed value so the DP MIN is the global (DP x PP)
+        # MIN. Keeps every DP replica of a PP stage on one mode post-reduce.
+        local_cg_mode = min(local_cg_mode, pp_synced_cudagraph_mode)
     tensor = torch.zeros(3, dp_size, dtype=torch.int32, device="cpu")
     tensor[0][dp_rank] = num_tokens
-    tensor[1][dp_rank] = desired_batch_desc.cg_mode.value
+    tensor[1][dp_rank] = local_cg_mode
     tensor[2][dp_rank] = uniform_token_count or 0  # (0 means None)
     dist.all_reduce(tensor, group=group)
 
@@ -85,6 +105,61 @@ def sync_cudagraph_and_dp_padding(
     return synced_desc, num_tokens_across_dp
 
 
+def _reconcile_cudagraph_mode_across_pp(
+    batch_desc: BatchExecutionDescriptor,
+    num_reqs: int,
+    num_tokens: int,
+    pp_synced_mode_val: int,
+) -> BatchExecutionDescriptor:
+    """Reconcile this rank's V2 batch descriptor to the PP-agreed cudagraph mode.
+
+    Mirror of the V1 fix (vllm-project/vllm#45094). Each PP rank runs
+    ``CudaGraphManager.dispatch`` independently, and per-rank-local state
+    (calculate_kv_scales / cascade-attention detection / LoRA bookkeeping / a
+    partially-failed capture / encoder-decoder skip_compiled) can make one stage
+    pick PIECEWISE/FULL (replay a graph with baked-in inter-stage P2P send/recv
+    shapes) while another picks NONE (eager). The stages then disagree on the
+    cross-stage P2P schedule, the send/recv never rendezvous, and the engine
+    wedges (``shm_broadcast`` 60s timeout -> RPC timeout -> EngineCore crash).
+
+    ``pp_synced_mode_val`` is the MIN of ``cg_mode`` across the PP group
+    (NONE=0 < PIECEWISE=1 < FULL=2), already agreed via the CPU (gloo) all-reduce
+    in ``coordinate_cudagraph_mode_across_pp``. Crucially that all-reduce is
+    issued by ``Worker.execute_model`` *before* the inter-stage recv — NOT here
+    — because the collective and the point-to-point recv form a deadlock cycle
+    otherwise (#45094/#45610). This function only consumes the agreed value.
+
+    Reconciliation rule: if the synced MIN differs from this rank's local mode,
+    drop this rank to NONE (eager). Unlike the V1 dispatcher, the V2
+    ``CudaGraphManager.dispatch`` is *shape-deterministic* — it returns the one
+    best-matching captured descriptor for ``(num_reqs, num_tokens,
+    uniform_token_count)`` and takes no ``valid_modes`` allow-list — so it cannot
+    be coaxed to an arbitrary intermediate mode. NONE is the only target every
+    rank can always honor. This is provably consistent: whenever any rank goes
+    eager the MIN is NONE, so every graph rank sees ``synced(NONE) !=
+    local(graph)`` and also drops to NONE; and because cudagraph capture sizes
+    are config-global and identical across PP stages, a same-shape
+    FULL-vs-PIECEWISE split between stages cannot arise (the realistic PP
+    divergence is strictly graph-vs-NONE).
+    """
+    if get_pp_group().world_size == 1:
+        # No peers: nothing to coordinate.
+        return batch_desc
+
+    if pp_synced_mode_val == batch_desc.cg_mode.value:
+        return batch_desc
+
+    # A peer stage chose a lower mode and this rank cannot be re-dispatched to an
+    # arbitrary intermediate mode (V2 dispatch is shape-deterministic). Drop to
+    # eager — the universally-honorable mode — to keep the inter-stage P2P
+    # schedule consistent across all stages.
+    return BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.NONE,
+        num_tokens=num_tokens,
+        num_reqs=num_reqs,
+    )
+
+
 def dispatch_cg_and_sync_dp(
     cudagraph_manager: CudaGraphManager | None,
     num_reqs: int,
@@ -94,6 +169,14 @@ def dispatch_cg_and_sync_dp(
     dp_rank: int,
     need_eager: bool = False,
     num_active_loras: int = 0,
+    # Pre-agreed pipeline-parallel cudagraph mode (a CUDAGraphMode ``.value``
+    # int), or ``None`` to skip PP reconciliation. The PP consensus MIN
+    # all-reduce is NO LONGER issued here: it must run in ``Worker.execute_model``
+    # *before* the inter-stage ``irecv_tensor_dict`` (see the V2
+    # ``predispatch_cudagraph_mode`` + the worker call site), or the collective
+    # and the recv deadlock (#45094/#45610). The dummy/profile/capture path
+    # leaves this ``None`` so no reconciliation happens there.
+    pp_synced_cudagraph_mode: int | None = None,
 ) -> tuple[BatchExecutionDescriptor, torch.Tensor | None]:
     if need_eager:
         batch_desc = BatchExecutionDescriptor(
@@ -115,9 +198,19 @@ def dispatch_cg_and_sync_dp(
         )
 
     if dp_size == 1:
+        # No DP consensus, but PP ranks within this replica may still have
+        # diverged (the #45094 split-brain). Reconcile to the PP-agreed mode
+        # (the all-reduce ran earlier, in Worker.execute_model, before the recv).
+        if pp_synced_cudagraph_mode is not None:
+            batch_desc = _reconcile_cudagraph_mode_across_pp(
+                batch_desc,
+                num_reqs,
+                num_tokens,
+                pp_synced_cudagraph_mode,
+            )
         return batch_desc, None
 
-    return sync_cudagraph_and_dp_padding(
+    synced_desc, num_tokens_across_dp = sync_cudagraph_and_dp_padding(
         cudagraph_manager,
         batch_desc,
         num_tokens,
@@ -126,4 +219,46 @@ def dispatch_cg_and_sync_dp(
         dp_size,
         dp_rank,
         num_active_loras=num_active_loras,
+        pp_synced_cudagraph_mode=pp_synced_cudagraph_mode,
     )
+
+    # The PP-agreed mode was already FOLDED INTO the DP cg_mode all-reduce above,
+    # so ``synced_desc.cg_mode`` is the global (DP x PP) MIN and is identical on
+    # every DP replica of this PP stage *provided all replicas of the stage
+    # contributed the same pp_synced value* (homogeneous PP consensus across
+    # replicas). Under that precondition the reconcile below is a no-op for DP>1
+    # (synced == pp_synced whenever pp_synced was the limiting mode). It is NOT a
+    # guaranteed no-op under heterogeneous replicas (e.g. per-replica LoRA /
+    # partial-capture divergence yielding different pp_synced per replica), so it
+    # is kept (not skipped) as a real guard, not merely a defensive one.
+    # Crucially we must NOT skip the fold and rely on this reconcile alone: that
+    # was the #45094 MED-2 bug — the DP and PP MINs are taken over orthogonal
+    # grid slices, so a post-reduce per-replica drop to NONE diverges the DP
+    # ranks of a stage after the collective.
+    if pp_synced_cudagraph_mode is not None:
+        # F2 (known limitation, pre-existing, correctness-safe): when one PP
+        # stage is forced eager by cascade-attention detection (cascade-attn +
+        # PP>=2) while peers hold a PIECEWISE graph, the MIN drives ALL stages to
+        # NONE for that step. That is a throughput cost (the peers run eager when
+        # they could have replayed PIECEWISE) but is correct — every stage agrees
+        # on the inter-stage P2P schedule. We do NOT try to keep the peers on
+        # PIECEWISE here: that is exactly the split the consensus exists to
+        # prevent. No logic change.
+        synced_desc = _reconcile_cudagraph_mode_across_pp(
+            synced_desc,
+            num_reqs,
+            num_tokens,
+            pp_synced_cudagraph_mode,
+        )
+        # F4 (known limitation, defensive): this clobber of the DP padding tensor
+        # to the (possibly lowered) mode's num_tokens is only reachable if the
+        # reconcile above actually lowered the mode — i.e. only under the
+        # heterogeneous-replica DP>1 case described in the comment above the
+        # reconcile (homogeneous replicas make the reconcile a no-op, leaving
+        # num_tokens unchanged). It is kept so the padding stays consistent with
+        # the lowered mode if that case fires. No logic change.
+        # Keep the DP padding tensor consistent with the (possibly lowered) mode.
+        if num_tokens_across_dp is not None:
+            num_tokens_across_dp[:] = synced_desc.num_tokens
+
+    return synced_desc, num_tokens_across_dp

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1107,6 +1107,41 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.model_state.postprocess_state(idx_mapping, num_sampled)
 
     @torch.inference_mode()
+    def predispatch_cudagraph_mode(self, scheduler_output: SchedulerOutput) -> int:
+        """Compute this PP rank's *local* V2 cudagraph mode for the upcoming
+        step, WITHOUT issuing any collective.
+
+        Extracted from the mode-resolution prefix of ``execute_model`` /
+        ``dispatch_cg_and_sync_dp`` so the PP cudagraph-mode consensus all-reduce
+        can be driven from ``Worker.execute_model`` *before* the inter-stage
+        ``irecv_tensor_dict``. Running the consensus before the recv is mandatory:
+        the all-reduce and the point-to-point recv form a deadlock cycle
+        otherwise (vllm-project/vllm#45094 / #45610; root-caused via py-spy).
+
+        The dispatch decision is a pure function of the per-step batch shape
+        (broadcast to every PP rank in lockstep via ``scheduler_output``) plus
+        per-rank-local eager forces (encoder-decoder ``skip_compiled``, a
+        partially-failed capture). Inter-stage activation tensors are NOT an
+        input to it, so it is safe to resolve here, ahead of the recv.
+
+        Returns the ``CUDAGraphMode`` ``.value`` int for this rank.
+        """
+        num_reqs = len(scheduler_output.num_scheduled_tokens)
+        num_toks = scheduler_output.total_num_scheduled_tokens
+        max_query_len = max(scheduler_output.num_scheduled_tokens.values())
+        uniform_tok_count = get_uniform_token_count(num_reqs, num_toks, max_query_len)
+
+        skip_compiled = (
+            self.is_encoder_decoder and bool(scheduler_output.scheduled_encoder_inputs)
+        )
+        if skip_compiled or self.cudagraph_manager is None:
+            return CUDAGraphMode.NONE.value
+        batch_desc = self.cudagraph_manager.dispatch(
+            num_reqs, num_toks, uniform_tok_count
+        )
+        return batch_desc.cg_mode.value
+
+    @torch.inference_mode()
     def execute_model(
         self,
         scheduler_output: SchedulerOutput,
@@ -1114,6 +1149,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         dummy_run: bool = False,
         skip_attn_for_dummy_run: bool = False,
         is_profile: bool = False,
+        pp_synced_cudagraph_mode: int | None = None,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
         if not dummy_run:
             # Update the request states.
@@ -1157,6 +1193,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.dp_rank,
             need_eager=is_profile or skip_compiled,
             num_active_loras=num_active_loras,
+            # PP cudagraph-mode consensus. The MIN all-reduce that produces this
+            # value is issued by Worker.execute_model BEFORE the inter-stage
+            # recv (it must precede the recv or the collective and the recv
+            # deadlock — #45094/#45610). Here we only reconcile to the agreed
+            # value. None (the dummy/profile/capture path default) skips
+            # reconciliation, so no collective is ever tied to that path.
+            pp_synced_cudagraph_mode=pp_synced_cudagraph_mode,
         )
 
         if batch_desc.num_tokens == 0:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3819,6 +3819,80 @@ class GPUModelRunner(
             else force_uniform_decode
         )
 
+    def predispatch_cudagraph_mode(
+        self, scheduler_output: "SchedulerOutput"
+    ) -> int:
+        """Compute this PP rank's *local* cudagraph mode for the upcoming step,
+        WITHOUT issuing any collective.
+
+        This is the dispatch-only prefix of ``_determine_batch_execution_and_padding``
+        (mode resolution + the per-rank-local eager forces), extracted so the PP
+        cudagraph-mode consensus all-reduce can be driven from
+        ``Worker.execute_model`` *before* the inter-stage ``irecv_tensor_dict``.
+        Running the consensus before the recv is mandatory: the all-reduce and
+        the point-to-point recv form a deadlock cycle otherwise — stage 0 parks
+        in the all-reduce waiting for stage 1, while stage 1 parks in the recv
+        waiting for stage 0's activation send, which is gated behind stage 0's
+        all-reduce (vllm-project/vllm#45094 / #45610, root-caused via py-spy:
+        PP0 ranks in ``coordinate_cudagraph_mode_across_pp`` -> ``all_reduce``;
+        PP1 ranks in ``irecv_tensor_dict`` gloo ``waitRecv``).
+
+        The dispatch decision is a pure function of the per-step batch shape
+        (broadcast to every PP rank in lockstep via ``scheduler_output``) plus
+        per-rank-local eager forces (``calculate_kv_scales`` on the first pass, a
+        partially-failed capture). Inter-stage activation tensors are NOT an
+        input to it, so it is safe — and correct — to resolve here, ahead of the
+        recv. Cascade-attention's ``disable_full`` is intentionally NOT applied
+        here (mirrors the SP precedent in ``Worker.execute_model`` which calls
+        ``_determine_batch_execution_and_padding`` pre-recv with
+        ``use_cascade_attn=False``): cascade detection is uniform across PP
+        stages (it reads the scheduler-broadcast ``num_common_prefix_blocks`` and
+        replicated per-request computed-token counts), so any FULL->lower
+        adjustment it would make happens identically on every stage and the
+        agreed MIN stays consistent; ``execute_model``'s own re-dispatch then
+        honors the agreed mode with the real cascade flag.
+
+        Returns the ``CUDAGraphMode`` ``.value`` int for this rank.
+        """
+        num_scheduled_tokens_np = np.array(
+            list(scheduler_output.num_scheduled_tokens.values()),
+            dtype=np.int32,
+        )
+        num_tokens = scheduler_output.total_num_scheduled_tokens
+        num_reqs = len(num_scheduled_tokens_np)
+        max_num_scheduled_tokens = int(num_scheduled_tokens_np.max())
+
+        uniform_decode = self._is_uniform_decode(
+            max_num_scheduled_tokens=max_num_scheduled_tokens,
+            uniform_decode_query_len=self.uniform_decode_query_len,
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+        )
+        has_encoder_output = (
+            self.model_config.is_encoder_decoder
+            and len(scheduler_output.scheduled_encoder_inputs) > 0
+        )
+        num_active_loras = len(self.input_batch.lora_id_to_lora_request)
+        has_lora = num_active_loras > 0
+
+        # Fold the per-rank-local eager force in BEFORE resolving the mode, so
+        # the value contributed to the PP MIN consensus already reflects it
+        # (calculate_kv_scales is the canonical #45094 trigger). This mirrors the
+        # `force_eager = force_eager or force_eager_kv_scales` fold in
+        # _determine_batch_execution_and_padding.
+        force_eager = self.calculate_kv_scales
+
+        num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
+        cudagraph_mode, _ = self.cudagraph_dispatcher.dispatch(
+            num_tokens=num_tokens_padded,
+            has_lora=has_lora,
+            uniform_decode=uniform_decode,
+            num_active_loras=num_active_loras,
+            valid_modes={CUDAGraphMode.NONE} if force_eager else None,
+            invalid_modes={CUDAGraphMode.FULL} if has_encoder_output else None,
+        )
+        return cudagraph_mode.value
+
     def _determine_batch_execution_and_padding(
         self,
         num_tokens: int,
@@ -3828,6 +3902,23 @@ class GPUModelRunner(
         use_cascade_attn: bool,
         allow_microbatching: bool = True,
         force_eager: bool = False,
+        # Per-step local state that independently forces eager on *this* rank
+        # (KV-scale calibration on the first forward pass). It MUST be folded
+        # into the dispatch decision *before* the PP all-reduce below, otherwise
+        # a rank forced eager here would diverge from peers that captured a
+        # graph -> the #45094 split-brain. See execute_model's call site.
+        force_eager_kv_scales: bool = False,
+        # Pre-agreed pipeline-parallel cudagraph mode (a CUDAGraphMode ``.value``
+        # int), or ``None`` to skip PP reconciliation. The PP consensus MIN
+        # all-reduce is NO LONGER issued here: it must run in
+        # ``Worker.execute_model`` *before* the inter-stage ``irecv_tensor_dict``
+        # (see ``predispatch_cudagraph_mode`` + the worker call site), otherwise
+        # the collective deadlocks against the recv (#45094/#45610: stage 0
+        # blocks in the all-reduce waiting for stage 1, while stage 1 is blocked
+        # in the recv waiting for stage 0's activation send, which only happens
+        # after stage 0's all-reduce). Here we simply *consume* the agreed value
+        # and re-dispatch to it when it is lower than this rank's local mode.
+        pp_synced_cudagraph_mode: int | None = None,
         # For cudagraph capture TODO(lucas): Refactor how we capture cudagraphs (will
         # be improved in model runner v2)
         force_uniform_decode: bool | None = None,
@@ -3864,6 +3955,16 @@ class GPUModelRunner(
 
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
 
+        # Fold per-rank-local eager forces into the dispatch decision *before*
+        # the DP/PP consensus reductions so the synced mode is final. KV-scale
+        # calibration (calculate_kv_scales) is the canonical #45094 trigger:
+        # historically it forced cudagraph_mode = NONE in execute_model *after*
+        # this method returned and after the PP all-reduce, so the rank ran
+        # eager while peers replayed a captured graph -> inter-stage P2P
+        # split-brain wedge. Forcing eager here, ahead of the all-reduce, lets
+        # the consensus see (and propagate) the NONE.
+        force_eager = force_eager or force_eager_kv_scales
+
         def dispatch_cudagraph(num_tokens, disable_full=False, valid_modes=None):
             return self.cudagraph_dispatcher.dispatch(
                 num_tokens=num_tokens,
@@ -3892,6 +3993,22 @@ class GPUModelRunner(
         # across ranks
         should_ubatch, num_tokens_across_dp = False, None
         if self.vllm_config.parallel_config.data_parallel_size > 1:
+            # Fold the PP-agreed mode INTO the value contributed to the DP MIN
+            # all-reduce so the DP consensus subsumes the PP consensus globally.
+            # The DP MIN is taken over DP replicas of THIS PP stage; the PP MIN
+            # (pp_synced_cudagraph_mode) is taken over PP stages of THIS replica —
+            # orthogonal slices of the (DP replica x PP stage) grid. If we fed the
+            # DP reduce only the bare local mode and applied the PP drop *after*
+            # it (below), two replicas of the same stage could end on different
+            # modes post-collective (one stayed graph, one dropped to NONE) — a DP
+            # lockstep violation that re-wedges the pipeline (#45094 MED-2).
+            # Contributing min(local, pp_synced) makes synced_cudagraph_mode the
+            # global (DP x PP) MIN: identical on every replica and stage.
+            dp_contributed_mode = cudagraph_mode.value
+            if pp_synced_cudagraph_mode is not None:
+                dp_contributed_mode = min(
+                    dp_contributed_mode, pp_synced_cudagraph_mode
+                )
             should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
                 coordinate_batch_across_dp(
                     num_tokens_unpadded=num_tokens,
@@ -3899,7 +4016,7 @@ class GPUModelRunner(
                     allow_microbatching=allow_microbatching,
                     num_tokens_padded=num_tokens_padded,
                     uniform_decode=uniform_decode,
-                    cudagraph_mode=cudagraph_mode.value,
+                    cudagraph_mode=dp_contributed_mode,
                 )
             )
 
@@ -3915,6 +4032,59 @@ class GPUModelRunner(
                 # Assert to make sure the agreed upon token count is correct otherwise
                 # num_tokens_across_dp will no-longer be valid
                 assert batch_descriptor.num_tokens == num_tokens_padded
+
+        # Pipeline-parallel cudagraph-mode consensus (vllm-project/vllm#45094).
+        # Each PP rank dispatched independently above; per-rank-local state
+        # (calculate_kv_scales, cascade-attn detection, LoRA bookkeeping, a
+        # partially-failed capture) can make one stage pick PIECEWISE/FULL
+        # (replay a graph with baked-in inter-stage P2P send/recv shapes) while
+        # another picks NONE (eager). The stages then disagree on the P2P
+        # schedule and the pipeline wedges. The MIN consensus (NONE wins) is
+        # reached by the cheap CPU all-reduce in
+        # ``coordinate_cudagraph_mode_across_pp`` — but that all-reduce is issued
+        # by ``Worker.execute_model`` *before* the inter-stage recv, NOT here
+        # (#45094/#45610: issuing it here, after the worker's
+        # ``irecv_tensor_dict``, structurally deadlocks the pipeline — the recv
+        # waits on a peer's activation send that is gated behind that peer's own
+        # all-reduce). The agreed value arrives as ``pp_synced_cudagraph_mode``;
+        # we only re-dispatch to honor it when a peer chose a lower mode.
+        #
+        # When data-parallel is also on, the PP-agreed mode was already FOLDED
+        # INTO the DP all-reduce above (dp_contributed_mode = min(local,
+        # pp_synced)), so synced_cudagraph_mode — and hence cudagraph_mode here —
+        # is the global (DP x PP) MIN, identical on every replica of this stage.
+        # This re-dispatch is then a no-op for DP>1 *provided every DP replica of
+        # this stage contributed the same pp_synced value* — i.e. the replicas
+        # are homogeneous in their PP consensus. That holds for the common case
+        # (all replicas run the identical PP topology / compile config), but is
+        # NOT guaranteed under heterogeneous replicas (e.g. per-replica LoRA or
+        # partial-capture divergence that makes one replica's pp_synced lower
+        # than another's): there the post-fold cudagraph_mode can still differ
+        # from pp_synced on some replica and this re-dispatch becomes live. It is
+        # therefore kept (not skipped) for DP>1 as a real correctness guard, not
+        # merely a defensive one. Folding into the DP reduce — rather than
+        # dropping to NONE *after* it — is what prevents the #45094 MED-2
+        # DP-lockstep split (orthogonal MIN slices diverging the replicas of a
+        # stage post-collective).
+        if (
+            pp_synced_cudagraph_mode is not None
+            and pp_synced_cudagraph_mode != cudagraph_mode.value
+        ):
+            # A peer stage chose a lower mode; re-dispatch so the batch
+            # descriptor / padding match the agreed-upon mode. Always keep
+            # NONE in valid_modes: a rank may not hold a capture key for the
+            # agreed mode (e.g. a FULL_DECODE_ONLY compile build has no
+            # PIECEWISE key), and the dispatcher asserts NONE is always an
+            # allowed fallback (`assert CUDAGraphMode.NONE in allowed_modes`)
+            # — pinning to {synced_mode} alone would assert-crash that rank.
+            cudagraph_mode, batch_descriptor = dispatch_cudagraph(
+                num_tokens_padded,
+                valid_modes={
+                    CUDAGraphMode.NONE,
+                    CUDAGraphMode(pp_synced_cudagraph_mode),
+                },
+            )
+            num_tokens_padded = batch_descriptor.num_tokens
 
         cudagraph_stats = None
         if self.vllm_config.observability_config.cudagraph_metrics:
@@ -4057,6 +4227,7 @@ class GPUModelRunner(
         self,
         scheduler_output: "SchedulerOutput",
         intermediate_tensors: IntermediateTensors | None = None,
+        pp_synced_cudagraph_mode: int | None = None,
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors | None:
         if self.execute_model_state is not None:
             raise RuntimeError(
@@ -4165,6 +4336,17 @@ class GPUModelRunner(
                 max_num_scheduled_tokens=max_num_scheduled_tokens,
                 use_cascade_attn=cascade_attn_prefix_lens is not None,
                 num_encoder_reqs=len(scheduler_output.scheduled_encoder_inputs),
+                # KV-scale calibration forces eager on the *first* forward pass.
+                # Thread it in here so it is folded into the PP/DP consensus
+                # *before* the all-reduce (was previously applied after this
+                # returned -> #45094 split-brain). Consumed (cleared) below.
+                force_eager_kv_scales=self.calculate_kv_scales,
+                # PP cudagraph-mode consensus. The MIN all-reduce that produces
+                # this value is issued by Worker.execute_model BEFORE the
+                # inter-stage recv (it must precede the recv or the collective
+                # and the recv deadlock — #45094/#45610). Here we only consume
+                # the agreed value and re-dispatch to it if a peer chose lower.
+                pp_synced_cudagraph_mode=pp_synced_cudagraph_mode,
             )
 
             logger.debug(
@@ -4291,12 +4473,20 @@ class GPUModelRunner(
                 scheduler_output, num_tokens_padded, intermediate_tensors
             )
 
-        # Set cudagraph mode to none if calc_kv_scales is true.
-        # KV scales calculation involves dynamic operations that are incompatible
-        # with CUDA graph capture.
+        # KV-scale calibration involves dynamic ops incompatible with CUDA graph
+        # capture, so it forces eager. That force is now threaded into
+        # _determine_batch_execution_and_padding (via force_eager_kv_scales)
+        # ahead of the PP/DP consensus all-reduce, so cudagraph_mode is already
+        # NONE here and every PP stage agreed on it (fixes #45094: forcing NONE
+        # *after* the consensus made this rank diverge from graph-replaying
+        # peers). All we do now is consume the one-shot flag.
         if self.calculate_kv_scales:
-            cudagraph_mode = CUDAGraphMode.NONE
-            # Mark KV scales as calculated after the first forward pass
+            assert cudagraph_mode == CUDAGraphMode.NONE, (
+                "calculate_kv_scales must have forced eager before PP/DP "
+                f"consensus, but cudagraph_mode={cudagraph_mode}. The "
+                "force_eager_kv_scales threading regressed -> #45094 risk."
+            )
+            # Mark KV scales as calculated after the first forward pass.
             self.calculate_kv_scales = False
 
         # Encoder-decoder models can only compile the pure decode steps where no

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -67,6 +67,7 @@ from vllm.v1.outputs import (
     ModelRunnerOutput,
 )
 from vllm.v1.utils import compute_iteration_details, report_usage_stats
+from vllm.v1.worker.pp_utils import coordinate_cudagraph_mode_across_pp
 from vllm.v1.worker.utils import is_residual_scattered_for_sp
 from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
@@ -877,6 +878,35 @@ class Worker(WorkerBase):
                 )
             }
 
+        # Pipeline-parallel cudagraph-mode consensus MUST happen here, BEFORE the
+        # inter-stage recv below (#45094/#45610). The consensus is a group-wide
+        # MIN all-reduce over the PP CPU (gloo) group; the recv is a
+        # point-to-point gloo recv from the previous stage. If the all-reduce is
+        # issued *after* the recv (as it was when it lived inside the model
+        # runner's execute_model), the two form a structural deadlock cycle:
+        #   stage0.all_reduce  waits-for  stage1.all_reduce
+        #   stage1.recv        waits-for  stage0.activation_send (below, after
+        #                                 stage0's runner -> after stage0's
+        #                                 all_reduce)
+        # so stage 0 parks in the all-reduce while stage 1 parks in the recv,
+        # forever (root-caused via py-spy: PP0 ranks in
+        # coordinate_cudagraph_mode_across_pp -> all_reduce at pp_utils.py;
+        # PP1 ranks in irecv_tensor_dict gloo waitRecv). Hoisting the all-reduce
+        # ahead of the recv makes every PP rank enter the collective
+        # symmetrically at step start, with no point-to-point recv between any
+        # rank and the collective. The dispatch decision is a pure function of
+        # the batch shape (broadcast in lockstep to every PP rank via
+        # scheduler_output) plus per-rank-local eager forces — all available
+        # pre-recv; inter-stage activation tensors are NOT one of its inputs.
+        pp_synced_cudagraph_mode: int | None = None
+        if forward_pass and get_pp_group().world_size > 1:
+            local_cudagraph_mode = self.model_runner.predispatch_cudagraph_mode(
+                scheduler_output
+            )
+            pp_synced_cudagraph_mode = coordinate_cudagraph_mode_across_pp(
+                local_cudagraph_mode
+            )
+
         if forward_pass and not get_pp_group().is_first_rank:
             tensor_dict, comm_handles, comm_postprocess = (
                 get_pp_group().irecv_tensor_dict(
@@ -893,7 +923,9 @@ class Worker(WorkerBase):
 
         with self.annotate_profile(scheduler_output):
             output = self.model_runner.execute_model(
-                scheduler_output, intermediate_tensors
+                scheduler_output,
+                intermediate_tensors,
+                pp_synced_cudagraph_mode=pp_synced_cudagraph_mode,
             )
             if (
                 self.use_v2_model_runner

--- a/vllm/v1/worker/pp_utils.py
+++ b/vllm/v1/worker/pp_utils.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pipeline-parallel (PP) cross-rank coordination helpers.
+
+When pipeline parallelism is enabled, every PP rank independently runs the
+cudagraph dispatcher (``CudagraphDispatcher.dispatch``) for the same logical
+step. The dispatch decision is a pure function of the per-step batch shape, but
+several of its inputs are *per-rank local* state (e.g. ``calculate_kv_scales``,
+cascade-attention prefix detection from a rank's local block table, LoRA
+bookkeeping, or a partially-failed graph capture). If those differ, one PP rank
+can resolve a step to ``PIECEWISE`` (replay a captured graph whose baked-in
+inter-stage P2P send/recv shapes are fixed) while another resolves the same step
+to ``NONE`` (eager). The two stages then disagree on the cross-stage P2P
+schedule, the send/recv never rendezvous, and the engine wedges forever
+(vllm-project/vllm#45094: ``shm_broadcast`` "No available shared memory
+broadcast block found in 60 seconds" -> RPC timeout -> EngineCore crash).
+
+This mirrors the existing data-parallel consensus in ``dp_utils.py``
+(``_post_process_cudagraph_mode`` takes the ``min`` across DP ranks so that if
+any rank picks ``NONE`` they all do). DP already pays this cost; PP did not have
+an equivalent, so a pure-PP (DP=1) deployment had no guard. This module adds the
+PP equivalent: a cheap ``min`` all-reduce over the PP *CPU* process group
+(gloo), which keeps the consensus off the NCCL/GPU P2P channel that is itself
+the thing prone to wedging.
+"""
+
+import torch
+
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def coordinate_cudagraph_mode_across_pp(local_cudagraph_mode: int) -> int:
+    """Reach consensus on the cudagraph runtime mode across all PP ranks.
+
+    Takes the minimum of the per-rank cudagraph mode over the pipeline-parallel
+    group, where ``NONE=0 < PIECEWISE=1 < FULL=2``. If *any* PP rank decided to
+    run a step eager (``NONE``), every rank runs it eager, guaranteeing all
+    stages agree on the inter-stage P2P send/recv schedule for the step.
+
+    The reduction is performed on the PP CPU (gloo) process group so it does not
+    contend with — and cannot itself be wedged by — the GPU P2P channel.
+
+    Args:
+        local_cudagraph_mode: This rank's intended runtime mode as an int
+            (``CUDAGraphMode`` ``.value``: 0=NONE, 1=PIECEWISE, 2=FULL).
+
+    Returns:
+        The agreed-upon runtime mode int (min across all PP ranks). On a
+        single-stage pipeline (``world_size == 1``) the input is returned
+        unchanged with no communication.
+    """
+    pp_group = get_pp_group()
+    if pp_group.world_size == 1:
+        # Early exit: no peers, nothing to coordinate.
+        return local_cudagraph_mode
+
+    # CPU all-reduce keeps this off the GPU P2P channel (matches the
+    # disable_nccl_for_dp_synchronization path in dp_utils).
+    tensor = torch.tensor([local_cudagraph_mode], dtype=torch.int32, device="cpu")
+    torch.distributed.all_reduce(
+        tensor,
+        op=torch.distributed.ReduceOp.MIN,
+        group=pp_group.cpu_group,
+    )
+    synced = int(tensor.item())
+    if synced != local_cudagraph_mode:
+        logger.debug(
+            "PP cudagraph-mode consensus dropped this rank from %d to %d "
+            "(a peer PP stage chose a lower mode); running the step at the "
+            "agreed mode to keep inter-stage P2P consistent.",
+            local_cudagraph_mode,
+            synced,
+        )
+    return synced


### PR DESCRIPTION
## Purpose

Fixes the pipeline-parallel cudagraph-vs-eager split-brain wedge tracked in #45094.

Under pipeline parallelism each PP rank runs `CudagraphDispatcher.dispatch` independently for the same logical step. The dispatch decision is a pure function of the batch shape, but several of its inputs are **per-rank-local** state:

- `calculate_kv_scales` (KV-scale calibration forces eager on the *first* forward pass)
- cascade-attention prefix detection (from a rank's local block table)
- LoRA bookkeeping
- a partially-failed graph capture

When those differ, one stage can resolve a step to `PIECEWISE`/`FULL` (replay a captured graph whose baked-in inter-stage P2P send/recv shapes are fixed) while another resolves the same step to `NONE` (eager). The two stages then disagree on the cross-stage P2P schedule, the send/recv never rendezvous, and the engine wedges:

```
shm_broadcast: No available shared memory broadcast block found in 60 seconds
  -> RPC timeout -> EngineCore crash
```

## Why DP was already safe but PP was not

Data parallelism already guards against exactly this in `dp_utils._post_process_cudagraph_mode`, which takes the **min** across DP ranks (so if any rank picks `NONE`, they all do). A pure-PP deployment (DP=1) had no equivalent guard.

## The fix

Mirror the DP consensus for the PP group:

- **`vllm/v1/worker/pp_utils.py`** — new `coordinate_cudagraph_mode_across_pp()` does a `MIN` all-reduce of the cudagraph mode over the PP **CPU (gloo)** process group (`NONE=0 < PIECEWISE=1 < FULL=2`). It is deliberately on the CPU group, off the NCCL/GPU P2P channel that is itself the thing prone to wedging — matching the `disable_nccl_for_dp_synchronization` rationale in `dp_utils`.

- **`vllm/v1/worker/gpu_model_runner.py`** — after the per-rank dispatch, when `get_pp_group().world_size > 1`, call the helper. If a peer chose a lower mode, re-dispatch at the agreed mode. The re-dispatch **always keeps `NONE` in `valid_modes`** so a rank that holds no capture key for the agreed mode (e.g. a `FULL_DECODE_ONLY` build with no `PIECEWISE` key) falls back to eager instead of tripping the dispatcher's `assert CUDAGraphMode.NONE in allowed_modes`.

- The `calculate_kv_scales` eager-force was previously applied *after* the consensus (and after `_determine_batch_execution_and_padding` returned) — so the forced rank diverged from graph-replaying peers. That is the canonical #45094 trigger. It is now threaded in via a new `force_eager_kv_scales` argument so the force is folded into the dispatch decision **before** the PP/DP all-reduce. The post-consensus block now only consumes the one-shot flag and asserts the ordering held.

## Tradeoff

This adds one small per-step CPU `MIN` all-reduce over the PP gloo group when PP>1. It is off the GPU P2P channel and bounded by PP depth. The alternative is the silent 60s wedge followed by an EngineCore crash, so the per-step collective is a deliberate and cheap price.

## Tests

`tests/v1/cudagraph/test_pp_cudagraph_consensus.py`:

- **Unit** — the `MIN` consensus collapses divergent modes across two simulated PP ranks; no-op on a single-stage pipeline (no collective issued).
- **Integration (ordering)** — reproduces the real `calculate_kv_scales` trigger end-to-end and proves the fix is correct *only* when the force is folded **before** the all-reduce. The pre-revision-ordering test still reproduces the split-brain, guarding against a regression of the ordering.
- **MED-2** — the re-dispatch falls back to `NONE` rather than asserting when a rank lacks the agreed mode's capture key.
- **Source-level guards** — tie the regression test to the actual `gpu_model_runner` threading so a future revert of the fix fails CI here even if the leaf helpers still pass.

A multi-GPU integration repro (TP>=1, PP=2, `cudagraph_mode: PIECEWISE`, concurrent long-reasoning requests crossing a captured-bucket boundary) is documented in the test module docstring.

## Closes

#45094
