### PR TITLE
[BugFix] Auto-disable custom all-reduce when cumem allocator (sleep mode) is active

### DIFF
--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -36,6 +36,9 @@ constexpr int kMaxBlocks = 36;
 #ifndef USE_ROCM
 const int defaultBlockLimit = 36;
 CUpointer_attribute rangeStartAddrAttr = CU_POINTER_ATTRIBUTE_RANGE_START_ADDR;
+// Used to detect VMM (cuMemMap) backed allocations, which cannot be exported
+// via the legacy cudaIpc* API and must not be registered for custom all-reduce.
+CUpointer_attribute memTypeAttr = CU_POINTER_ATTRIBUTE_MEMORY_TYPE;
 #else
 const int defaultBlockLimit = 16;
 hipPointer_attribute rangeStartAddrAttr =
@@ -452,6 +455,28 @@ class CustomAllreduce {
       if (cuPointerGetAttribute(&base_ptr, rangeStartAddrAttr,
                                 (CUdeviceptr)ptr) != CUDA_SUCCESS)
         throw std::runtime_error("failed to get pointer attr");
+#ifndef USE_ROCM
+      // A buffer allocated through the CUDA Virtual Memory Management API
+      // (cuMemCreate + cuMemMap) — as used by PyTorch expandable_segments
+      // and by vLLM's CuMemAllocator sleep-mode pool — cannot be exported
+      // with the legacy cudaIpcGetMemHandle API. Calling it on such a
+      // pointer returns the opaque "invalid argument" error. Detect this
+      // case up front and raise an actionable error instead so the failure
+      // is diagnosable rather than a bare CUDA error at
+      // custom_all_reduce.cuh:cudaIpcGetMemHandle.
+      unsigned int mem_type = 0;
+      CUresult mt = cuPointerGetAttribute(&mem_type, memTypeAttr,
+                                          (CUdeviceptr)base_ptr);
+      if (mt == CUDA_SUCCESS && mem_type == 0) {
+        throw std::runtime_error(
+            "custom all-reduce cannot register a VMM/cuMemMap-backed buffer "
+            "for CUDA-graph IPC. This happens when sleep mode "
+            "(enable_cumem_allocator) or PYTORCH_CUDA_ALLOC_CONF="
+            "expandable_segments:True is active. Pass "
+            "disable_custom_all_reduce=True (sleep mode now does this "
+            "automatically).");
+      }
+#endif
       CUDACHECK(cudaIpcGetMemHandle(
           (cudaIpcMemHandle_t*)&handles[i * handle_sz], base_ptr));
       offsets[i] = ((char*)ptr) - ((char*)base_ptr);

--- a/tests/test_cumem_custom_all_reduce_ipc.py
+++ b/tests/test_cumem_custom_all_reduce_ipc.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for the cumem sleep-mode + custom all-reduce IPC crash.
+
+Background
+----------
+When sleep mode is enabled, vLLM activates the CuMemAllocator, which backs
+model activation tensors with the CUDA Virtual Memory Management API
+(``cuMemCreate`` + ``cuMemMap``). The custom all-reduce kernel tries to
+register the CUDA-graph activation buffers for cross-rank IPC using
+``cudaIpcGetMemHandle`` (``csrc/custom_all_reduce.cuh`` ->
+``get_graph_buffer_ipc_meta``). That legacy IPC API only works on
+``cudaMalloc`` allocations and returns the opaque CUDA error
+``invalid argument`` on VMM-backed pointers. The result on a TP>1 +
+sleep-mode deployment is a hard crash during cudagraph capture
+(``custom_all_reduce.cuh:455 'invalid argument'``) followed by a wedged
+engine while ``/health`` still returns 200.
+
+The fix auto-disables custom all-reduce whenever the cumem allocator is
+active, mirroring the existing auto-disable for ``VLLM_BATCH_INVARIANT`` and
+multi-node deployments.
+
+Pre-fix:  this test FAILS — ``disable_custom_all_reduce`` stays ``False``
+          (its constructed default) so the kernel would later crash at
+          ``cudaIpcGetMemHandle`` during cudagraph capture.
+Post-fix: this test PASSES — ``VllmConfig.__post_init__`` flips
+          ``disable_custom_all_reduce`` to ``True``.
+"""
+
+import pytest
+
+from vllm.config import ModelConfig, ParallelConfig, VllmConfig
+
+
+@pytest.fixture(autouse=True)
+def _force_custom_allreduce_supported(monkeypatch):
+    """Make the platform report custom all-reduce as supported.
+
+    ``ParallelConfig._verify_args`` unconditionally sets
+    ``disable_custom_all_reduce=True`` when
+    ``current_platform.use_custom_allreduce()`` is ``False`` (the CPU / base
+    platform default). That platform gate would otherwise mask whether the
+    cumem auto-disable in ``VllmConfig.__post_init__`` is the thing flipping
+    the flag — and would make the over-broad-guard negative test fail on a
+    CPU-only CI runner. Forcing it ``True`` isolates the assertions to the
+    behavior under test on any host.
+    """
+    monkeypatch.setattr(
+        "vllm.config.parallel.current_platform.use_custom_allreduce",
+        lambda: True,
+    )
+
+
+def _build_config(
+    *,
+    enable_cumem_allocator: bool,
+    tensor_parallel_size: int,
+    disable_custom_all_reduce: bool = False,
+) -> VllmConfig:
+    model_config = ModelConfig("facebook/opt-125m")
+    # Simulate what enable_sleep_mode does on a CUDA box without needing a GPU
+    # in CI: sleep mode forces the cumem allocator on.
+    model_config.enable_cumem_allocator = enable_cumem_allocator
+    parallel_config = ParallelConfig(
+        tensor_parallel_size=tensor_parallel_size,
+        disable_custom_all_reduce=disable_custom_all_reduce,
+    )
+    return VllmConfig(model_config=model_config, parallel_config=parallel_config)
+
+
+def test_cumem_allocator_auto_disables_custom_all_reduce():
+    """cumem (sleep mode) must auto-disable custom all-reduce on TP>1.
+
+    This is the load-bearing assertion. Without the fix, the constructed
+    config leaves ``disable_custom_all_reduce`` at ``False`` and the engine
+    crashes at ``cudaIpcGetMemHandle`` during cudagraph capture.
+    """
+    cfg = _build_config(enable_cumem_allocator=True, tensor_parallel_size=2)
+    assert cfg.parallel_config.disable_custom_all_reduce is True
+
+
+def test_cumem_allocator_auto_disable_is_idempotent():
+    """An explicit disable_custom_all_reduce=True is preserved (no-op path)."""
+    cfg = _build_config(
+        enable_cumem_allocator=True,
+        tensor_parallel_size=2,
+        disable_custom_all_reduce=True,
+    )
+    assert cfg.parallel_config.disable_custom_all_reduce is True
+
+
+def test_no_cumem_leaves_custom_all_reduce_enabled():
+    """Without the cumem allocator the auto-disable must NOT fire.
+
+    Guards against the fix being too broad (it must only trigger for the
+    VMM-backed sleep-mode path, not for ordinary TP deployments).
+    """
+    cfg = _build_config(enable_cumem_allocator=False, tensor_parallel_size=2)
+    assert cfg.parallel_config.disable_custom_all_reduce is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -877,6 +877,30 @@ class VllmConfig:
 
             self.parallel_config.is_moe_model = self.model_config.is_moe
 
+            # The custom all-reduce kernel registers CUDA-graph activation
+            # buffers for cross-rank IPC via cudaIpcGetMemHandle. That API only
+            # supports legacy cudaMalloc allocations; it returns the opaque
+            # "invalid argument" on VMM/cuMemMap-backed memory. The
+            # CuMemAllocator sleep-mode pool (enable_cumem_allocator) routes
+            # activations through exactly such a VMM pool, so custom all-reduce
+            # crashes during cudagraph capture (custom_all_reduce.cuh
+            # get_graph_buffer_ipc_meta -> cudaIpcGetMemHandle) on TP>1.
+            # Auto-disable it so sleep/wake works out of the box. This mirrors
+            # the platform/multi-node auto-disables in
+            # ParallelConfig._verify_args, but lives here because
+            # enable_cumem_allocator is a ModelConfig field not visible during
+            # ParallelConfig validation.
+            if (
+                self.model_config.enable_cumem_allocator
+                and not self.parallel_config.disable_custom_all_reduce
+            ):
+                self.parallel_config.disable_custom_all_reduce = True
+                logger.info(
+                    "Disabled the custom all-reduce kernel because the cumem "
+                    "allocator (sleep mode) uses VMM-backed memory that cannot "
+                    "be IPC-registered for CUDA graphs."
+                )
+
         if (
             self.model_config is not None
             and self.model_config.enable_return_routed_experts


### PR DESCRIPTION
## Summary

The custom all-reduce kernel registers CUDA-graph activation buffers for cross-rank IPC with `cudaIpcGetMemHandle` (`csrc/custom_all_reduce.cuh`, `get_graph_buffer_ipc_meta`). That legacy IPC API only supports `cudaMalloc` allocations; on VMM/`cuMemMap`-backed memory it returns the opaque `invalid argument` CUDA error.

vLLM's `CuMemAllocator` sleep-mode pool (`enable_cumem_allocator`, forced on by `enable_sleep_mode`) routes activations through exactly such a VMM pool. So on **TP>1 + sleep mode** the engine crashes during cudagraph capture (`custom_all_reduce.cuh:455 'invalid argument'`) and then wedges while `/health` still returns 200. The same failure mode arises with `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.

This is the same family as #42609 and #43923 (legacy CUDA IPC vs. VMM-backed memory).

## Fix

- **`VllmConfig.__post_init__`** auto-sets `disable_custom_all_reduce=True` whenever `enable_cumem_allocator` is active (and not already disabled), so sleep/wake works out of the box. This mirrors the existing platform / multi-node / `VLLM_BATCH_INVARIANT` auto-disables in `ParallelConfig._verify_args`. It lives in `VllmConfig` rather than `ParallelConfig` because `enable_cumem_allocator` is a `ModelConfig` field not visible during `ParallelConfig` validation.
- **`csrc/custom_all_reduce.cuh`** gains a defensive probe: if a to-be-registered base pointer is VMM-backed (`CU_POINTER_ATTRIBUTE_MEMORY_TYPE == 0`), it raises an actionable error instead of the bare `cudaIpcGetMemHandle` "invalid argument". This is conservative — legacy `cudaMalloc` pointers report `CU_MEMORYTYPE_DEVICE` and proceed unchanged. (CUDA-only; ROCm path untouched.)

## Test

`tests/test_cumem_custom_all_reduce_ipc.py` asserts the auto-disable:
- **fires** for cumem on TP>1 (load-bearing — FAILs without the config change),
- is **idempotent** when already disabled,
- does **NOT fire** without cumem (guards against over-broad disabling).

The negative test forces `current_platform.use_custom_allreduce() -> True` so the platform gate in `_verify_args` doesn't confound the assertion on CPU-only CI runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
