### PR TITLE
[Bugfix][Core] Fix Mamba prefix cache EAGLE hit

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -985,6 +985,34 @@ def test_prefill_hybrid_model_combinations_eagle(
     manager.free(req1)
 
 
+def test_hybrid_mamba_eagle_does_not_reuse_lookahead_state():
+    block_size = 16
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, 100, ["full", "mamba"]),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+
+    token_ids = [i for i in range(4) for _ in range(block_size)] + [4] * 7
+
+    req0 = make_request("0", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    blocks = manager.allocate_slots(
+        req0, len(token_ids), num_computed_tokens, computed_blocks
+    )
+    assert blocks is not None
+    manager.free(req0)
+
+    req1 = make_request("1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+
+    assert num_computed_tokens == 3 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 3]
+
+
 def test_prefill_hybrid_model_mamba_align():
     """Test that MambaManager.cache_blocks() handles null blocks in align mode.
 

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -664,7 +664,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 elif _new_hit_length < curr_hit_length:
                     # length shrunk; invalidate previous eagle verifications
                     eagle_verified.clear()
-                curr_hit_length = _new_hit_length
+                curr_hit_length = min(curr_hit_length, _new_hit_length)
                 for group_id, blocks in zip(group_ids, hit_blocks):
                     hit_blocks_by_group[group_id] = blocks
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -991,6 +991,8 @@ class MambaManager(SingleTypeKVCacheManager):
 
         block_size = kv_cache_spec.block_size
         max_num_blocks = max_length // block_size
+        if drop_eagle_block and max_num_blocks > 0:
+            max_num_blocks -= 1
         # Search from right to left and early stop when a match is found.
         for i in range(max_num_blocks - 1, -1, -1):
             if cached_block := block_pool.get_cached_block(


### PR DESCRIPTION
## Purpose

Fix an unsafe prefix-cache hit for hybrid full-attention + Mamba/GDN models when
EAGLE/MTP speculative decoding is enabled.

Prefix caching should be behavior-preserving, but with Qwen3.5-style multi-turn
agent prompts we observed prefix-cache-on can diverge from prefix-cache-off.
This is related to the hybrid prefix-caching work tracked in #26201, and to
Mamba/GDN prefix-caching + speculative-decoding reports such as #38182, #39809,
#39273, and #34361. This PR fixes the concrete cache-hit boundary bug shown
below; it does not claim to resolve all startup/kernel/rollback issues discussed
in those reports.

### Root Cause

The hybrid coordinator computes a common reusable prefix across KV cache groups,
but the current code can let a later/sparse group increase that common prefix.

Also, dense KV cache can safely match one EAGLE/MTP lookahead block and then drop
the final block. Mamba/GDN stores recurrent boundary states, so it cannot safely
match a lookahead boundary and then rewind to an earlier state.

Current `main` minimal repro:

| version | `num_computed_tokens` | per-group block lengths | result |
| --- | ---: | --- | --- |
| current `main` | 64 | `[3, 4]` | unsafe: Mamba reuses one extra lookahead state |
| this PR | 48 | `[3, 3]` | safe common prefix |

### Fix

- Clamp the hybrid common hit length with
  `min(curr_hit_length, _new_hit_length)`.
- For `MambaManager` with EAGLE/MTP lookahead dropping, search directly at the
  post-drop boundary.

AI assistance: GPT-5.5 was used to help investigate and draft this change.

## Test Plan

- Add a CPU regression test for hybrid full-attention + Mamba prefix caching
  with EAGLE enabled.
- Run prefix-cache unit tests and pre-commit on changed files.
- Run Qwen3.5-27B multi-turn agent-style replay with prefix caching on/off.
- Compare generated token sequences and cache-hit rate.

## Test Result

Minimal repro on clean current `main`:

```text
num_computed_tokens 64
block_lengths [3, 4]
block_ids [[1, 2, 3], [0, 0, 0, 9]]
```

With this PR:

```text
num_computed_tokens 48
block_lengths [3, 3]
block_ids [[1, 2, 3], [0, 0, 8]]
```

Unit tests:

```bash
python3 -m pytest -q tests/v1/core/test_prefix_caching.py
# 77 passed
```

Focused subset:

```bash
python3 -m pytest -q \
  tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations_eagle \
  tests/v1/core/test_prefix_caching.py::test_hybrid_mamba_eagle_does_not_reuse_lookahead_state \
  tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_mamba_align \
  tests/v1/core/test_prefix_caching.py::test_hybrid_cache_mamba_align_shared_prefix_detection \
  tests/v1/core/test_prefix_caching.py::test_hybrid_model_mamba_align_with_dynamic_draft_tokens \
  tests/v1/core/test_prefix_caching.py::test_eagle_swa_alignment_caches_extra_block \
  tests/v1/core/test_prefix_caching.py::test_eagle_with_partial_blocks \
  tests/v1/core/test_prefix_caching.py::test_eagle_enabled_removes_last_block \
  tests/v1/core/test_single_type_kv_cache_manager.py
# 16 passed
```

Pre-commit on changed files:

```bash
pre-commit run --files \
  vllm/v1/core/kv_cache_coordinator.py \
  vllm/v1/core/single_type_kv_cache_manager.py \
  tests/v1/core/test_prefix_caching.py
# passed
```

E2E replay, Qwen3.5-27B, TP=4, bf16, MTP3, async scheduling:

| run | records | cache hit rate | cached / prompt tokens | output correctness |
| --- | ---: | ---: | ---: | --- |
| prefix cache ON, `max_tokens=1` | 100 | 0.898738 | 1,286,400 / 1,431,340 | cache hit-rate probe |
| prefix cache ON, `max_tokens=32` | 30 | 0.675388 | 85,600 / 126,742 | exact match vs OFF |
| prefix cache OFF, `max_tokens=32` | 30 | 0.0 | 0 / 126,742 | exact match vs ON |

For the `max_tokens=32` ON/OFF comparison:

| check | mismatches |
| --- | ---: |
| prompt tokens | 0 |
| response tokens | 0 |
| response length | 0 |
| stop reason | 0 |
