### PR TITLE
[BugFix] Wake the still-asleep tag subset on mixed wake_up()

### DIFF
--- a/tests/v1/executor/test_executor.py
+++ b/tests/v1/executor/test_executor.py
@@ -202,3 +202,87 @@ def test_custom_executor_async(distributed_executor_backend, tmp_path):
         assert os.path.exists(".marker")
     finally:
         os.chdir(cwd)
+
+
+class _RecordingExecutor(Executor):
+    """Minimal concrete Executor that records collective_rpc calls.
+
+    Constructed via __new__ to bypass __init__ (which needs a VllmConfig);
+    sleep/wake_up state is set directly. This keeps the test pure-CPU and
+    exercises the inherited Executor.wake_up tag-handling logic in isolation.
+    """
+
+    def _init_executor(self) -> None: ...
+
+    def collective_rpc(
+        self, method, timeout=None, args=(), kwargs=None, non_block=False
+    ):
+        self.rpc_calls.append((method, (kwargs or {}).get("tags")))
+        return []
+
+    def check_health(self) -> None: ...
+
+
+def _make_sleeping_executor() -> _RecordingExecutor:
+    executor = _RecordingExecutor.__new__(_RecordingExecutor)
+    executor.rpc_calls = []
+    # Mirror Executor.sleep() state: both tags asleep.
+    executor.sleeping_tags = {"weights", "kv_cache"}
+    executor.is_sleeping = True
+    return executor
+
+
+def test_wake_up_mixed_tags_wakes_still_sleeping_subset():
+    # Regression for the mixed-tag partial-wake silent no-op: when wake_up is
+    # called with one already-awake tag and one still-asleep tag, the asleep
+    # tag must still be woken (an RPC is issued for the sleeping subset),
+    # instead of early-returning and leaving it unmapped.
+    executor = _make_sleeping_executor()
+
+    # Wake only "weights" first -> "kv_cache" remains asleep.
+    executor.wake_up(tags=["weights"])
+    assert executor.sleeping_tags == {"kv_cache"}
+    assert executor.is_sleeping is True
+
+    executor.rpc_calls.clear()
+
+    # Mixed request: "weights" already awake, "kv_cache" still asleep.
+    executor.wake_up(tags=["weights", "kv_cache"])
+
+    # An RPC must be issued, and it must include the still-sleeping tag.
+    assert len(executor.rpc_calls) == 1, executor.rpc_calls
+    method, rpc_tags = executor.rpc_calls[0]
+    assert method == "wake_up"
+    assert "kv_cache" in (rpc_tags or [])
+    # The already-awake tag is filtered out of the RPC.
+    assert "weights" not in (rpc_tags or [])
+    # State fully reconciled: everything awake.
+    assert executor.sleeping_tags == set()
+    assert executor.is_sleeping is False
+
+
+def test_wake_up_all_already_awake_is_clean_no_op():
+    # When every requested tag is already awake, wake_up is a clean no-op:
+    # no RPC is issued and state is unchanged.
+    executor = _make_sleeping_executor()
+    executor.wake_up(tags=["weights"])
+    assert executor.sleeping_tags == {"kv_cache"}
+
+    executor.rpc_calls.clear()
+    executor.wake_up(tags=["weights"])  # already awake
+
+    assert executor.rpc_calls == []
+    assert executor.sleeping_tags == {"kv_cache"}
+    assert executor.is_sleeping is True
+
+
+def test_wake_up_no_tags_wakes_everything():
+    # tags=None wakes all sleeping tags and clears the sleeping state.
+    executor = _make_sleeping_executor()
+    executor.wake_up()
+    assert len(executor.rpc_calls) == 1
+    method, rpc_tags = executor.rpc_calls[0]
+    assert method == "wake_up"
+    assert rpc_tags is None
+    assert executor.sleeping_tags == set()
+    assert executor.is_sleeping is False

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -332,13 +332,18 @@ class Executor(ABC):
         if not self.is_sleeping:
             logger.warning("Executor is not sleeping.")
             return
-        if tags:
-            for tag in tags:
-                if tag not in self.sleeping_tags:
-                    logger.warning(
-                        "Tag %s is not in sleeping tags %s", tag, self.sleeping_tags
-                    )
-                    return
+        if tags is not None:
+            # Wake only the requested tags that are still asleep. A tag that is
+            # already awake is silently skipped instead of aborting the whole
+            # call: a mixed request such as ["weights", "kv_cache"] where one
+            # tag is already awake must still wake the remaining asleep tag(s).
+            # The previous early-return left those tags unmapped while the
+            # engine believed the wake-up succeeded, wedging it (e.g. KV
+            # unmapped with /health still reporting healthy).
+            tags = [tag for tag in tags if tag in self.sleeping_tags]
+            if not tags:
+                # Every requested tag is already awake -> clean no-op.
+                return
         time_before_wakeup = time.perf_counter()
         self.collective_rpc("wake_up", kwargs=dict(tags=tags))
         time_after_wakeup = time.perf_counter()
@@ -347,7 +352,7 @@ class Executor(ABC):
             time_after_wakeup - time_before_wakeup,
             tags if tags is not None else self.sleeping_tags,
         )
-        if tags:
+        if tags is not None:
             for tag in tags:
                 self.sleeping_tags.remove(tag)
         else:


### PR DESCRIPTION
## Summary

`Executor.wake_up(tags=...)` aborts the entire call on the **first** requested tag that is already awake, instead of waking the tags that are still asleep.

```python
if tags:
    for tag in tags:
        if tag not in self.sleeping_tags:
            logger.warning("Tag %s is not in sleeping tags %s", tag, self.sleeping_tags)
            return   # <-- returns before any collective_rpc is issued
```

So a mixed request such as `wake_up(["weights", "kv_cache"])` where `"weights"` has already been woken hits this branch on `"weights"` and returns **before issuing any `collective_rpc`** — the still-asleep `"kv_cache"` is never woken. No exception is raised, so the engine proceeds believing the wake-up succeeded while that memory pool stays unmapped. The failure surfaces later (e.g. KV cache unmapped) while `/health` continues to report healthy, which makes it hard to diagnose.

This is reachable any time tags are woken in more than one step and a later call re-lists an already-woken tag alongside a still-sleeping one.

## Fix

Filter the requested tags down to the subset that is still asleep and wake only those, instead of early-returning:

```python
if tags is not None:
    tags = [tag for tag in tags if tag in self.sleeping_tags]
    if not tags:
        return   # every requested tag already awake -> clean no-op
```

- A mixed already-awake/still-asleep request now wakes the asleep subset.
- The all-already-awake case stays a clean idempotent no-op (no RPC issued) — unchanged behavior.
- `tags=None` still wakes everything.

## Tests

Added CPU-only regression tests in `tests/v1/executor/test_executor.py` (no GPU required — they construct a minimal recording `Executor` subclass and exercise the inherited tag-handling directly):

- `test_wake_up_mixed_tags_wakes_still_sleeping_subset` — **fails before this change** (no RPC issued, `kv_cache` left asleep), passes after.
- `test_wake_up_all_already_awake_is_clean_no_op` — RPC-free no-op preserved.
- `test_wake_up_no_tags_wakes_everything` — full wake unchanged.
