### PR TITLE
[BugFix] Restore calibrated FP8-KV scales on wake from sleep

### DIFF
--- a/tests/v1/worker/test_fp8_kv_scale_wake.py
+++ b/tests/v1/worker/test_fp8_kv_scale_wake.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for FP8 KV-cache scale preservation across sleep/wake.
+
+Background
+----------
+``GPUModelRunner.init_fp8_kv_scales`` is invoked on every wake from sleep
+(``post_kv_cache_wake_up``). The KV-cache memory pool is re-allocated on wake,
+which zeroes the device-resident ``_k_scale`` / ``_v_scale`` tensors. The
+method must restore those tensors so the cache doesn't read as all-zeros.
+
+The bug this guards against: the method used to *unconditionally* fill the
+scales with ``1.0``. For models whose checkpoint carries calibrated per-tensor
+FP8-KV scales (e.g. produced by llm-compressor), that discarded the calibrated
+values on every wake — silently degrading accuracy after the first sleep/wake
+cycle. The calibrated values live on the host in ``_k_scale_float`` /
+``_v_scale_float`` (set once at weight-load time, never freed by the sleep
+allocator), so the wake path must restore from them.
+
+These tests exercise the real ``GPUModelRunner.init_fp8_kv_scales`` logic
+against a lightweight stub ``self`` — no GPU, no full runner construction.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+
+class _StubAttention(torch.nn.Module):
+    """Minimal stand-in for an Attention layer carrying FP8-KV scales.
+
+    Mirrors the real layer's relevant surface: device-resident ``_k_scale`` /
+    ``_v_scale`` tensors plus the host-side ``_k_scale_float`` /
+    ``_v_scale_float`` floats that survive sleep/wake.
+    """
+
+    def __init__(self, k_calib: float, v_calib: float):
+        super().__init__()
+        # Host-side calibrated values, set at weight-load time. These persist
+        # across sleep/wake (plain Python floats, not freed by the allocator).
+        self._k_scale_float = k_calib
+        self._v_scale_float = v_calib
+        # Device tensors. After wake_up the re-allocated pool leaves these at
+        # 0.0; simulate that post-wake state.
+        self._k_scale = torch.zeros(1, dtype=torch.float32)
+        self._v_scale = torch.zeros(1, dtype=torch.float32)
+
+
+def _make_runner_stub(layers: dict, cache_dtype: str = "fp8"):
+    """Build a stub object carrying only what init_fp8_kv_scales reads."""
+    return SimpleNamespace(
+        cache_config=SimpleNamespace(cache_dtype=cache_dtype),
+        kv_caches=[],  # no real cache tensors needed for the scale path
+        compilation_config=SimpleNamespace(static_forward_context=layers),
+    )
+
+
+def _run_wake(runner_stub):
+    """Invoke the real production wake-init logic on the stub."""
+    GPUModelRunner.init_fp8_kv_scales(runner_stub)
+
+
+def test_calibrated_scales_preserved_across_wake(monkeypatch):
+    """A model WITH calibrated scales != 1.0 must keep them after wake.
+
+    Pre-fix this FAILS: scales come back as 1.0 (calibration discarded).
+    Post-fix this PASSES: scales restored to the calibrated host floats.
+    """
+    # Make our stub pass the real isinstance(module, (Attention, MLAAttention))
+    # check inside init_fp8_kv_scales.
+    monkeypatch.setattr(gpu_model_runner_module, "Attention", _StubAttention)
+    monkeypatch.setattr(gpu_model_runner_module, "MLAAttention", _StubAttention)
+
+    k_calib, v_calib = 0.0625, 0.125
+    layer = _StubAttention(k_calib=k_calib, v_calib=v_calib)
+    runner = _make_runner_stub({"layer.0.attn": layer})
+
+    # Sanity: post-wake device tensors are zeroed (the dangerous state).
+    assert layer._k_scale.item() == 0.0
+    assert layer._v_scale.item() == 0.0
+
+    _run_wake(runner)
+
+    # The calibrated scales must be restored onto the device tensors — NOT 1.0.
+    assert layer._k_scale.item() == k_calib, (
+        f"calibrated k_scale clobbered: got {layer._k_scale.item()}, "
+        f"expected {k_calib}"
+    )
+    assert layer._v_scale.item() == v_calib, (
+        f"calibrated v_scale clobbered: got {layer._v_scale.item()}, "
+        f"expected {v_calib}"
+    )
+
+
+def test_uncalibrated_scales_default_to_one(monkeypatch):
+    """A model WITHOUT calibration (host float == 1.0) still wakes to 1.0.
+
+    Guards backward compatibility: the on-the-fly fp8 quant path is unchanged.
+    """
+    monkeypatch.setattr(gpu_model_runner_module, "Attention", _StubAttention)
+    monkeypatch.setattr(gpu_model_runner_module, "MLAAttention", _StubAttention)
+
+    layer = _StubAttention(k_calib=1.0, v_calib=1.0)
+    runner = _make_runner_stub({"layer.0.attn": layer})
+
+    _run_wake(runner)
+
+    assert layer._k_scale.item() == 1.0
+    assert layer._v_scale.item() == 1.0
+
+
+def test_non_quantized_cache_is_noop(monkeypatch):
+    """When the KV cache isn't quantized, the scale path is skipped entirely."""
+    monkeypatch.setattr(gpu_model_runner_module, "Attention", _StubAttention)
+    monkeypatch.setattr(gpu_model_runner_module, "MLAAttention", _StubAttention)
+
+    layer = _StubAttention(k_calib=0.5, v_calib=0.5)
+    runner = _make_runner_stub({"layer.0.attn": layer}, cache_dtype="auto")
+
+    _run_wake(runner)
+
+    # Untouched: still the zeroed post-wake state, because we returned early.
+    assert layer._k_scale.item() == 0.0
+    assert layer._v_scale.item() == 0.0

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -939,9 +939,19 @@ class GPUModelRunner(
         """
         Re-initialize the KV cache and FP8 scales after waking from sleep.
         1. Zero out the KV cache tensors to remove garbage data from re-allocation.
-        2. Reset Attention layer scaling factors (_k_scale, _v_scale) to 1.0.
-          If these are left at 0.0 (default after wake_up), all KV cache values
+        2. Restore Attention layer scaling factors (_k_scale, _v_scale) to the
+          values they held before sleep.
+          The device-resident scale tensors are zeroed when the KV-cache memory
+          pool is re-allocated on wake_up; if left at 0.0, all KV cache values
           become effectively zero, causing gibberish output.
+
+          For on-the-fly fp8 KV quant the calibrated scale is simply 1.0, but
+          compression frameworks like llm-compressor bake tuned per-tensor
+          scales into the checkpoint. Those calibrated values are preserved on
+          the host in ``_k_scale_float`` / ``_v_scale_float`` (set once at weight
+          load time and never freed by the sleep allocator), so we restore from
+          them rather than hard-coding 1.0. For models with no calibrated scales
+          these host floats are already 1.0, so behaviour is unchanged.
         """
         if not is_quantized_kv_cache(self.cache_config.cache_dtype):
             return
@@ -951,32 +961,26 @@ class GPUModelRunner(
             if cache_tensor is not None:
                 cache_tensor.zero_()
 
-        k_attr_names = ("_k_scale", "k_scale")
-        v_attr_names = ("_v_scale", "v_scale")
+        # (device-tensor attr, host-float attr, default) tuples. The host float
+        # holds the calibrated value across sleep/wake; the device tensor was
+        # zeroed by the re-allocated memory pool and must be restored from it.
+        scale_specs = (
+            (("_k_scale", "k_scale"), "_k_scale_float"),
+            (("_v_scale", "v_scale"), "_v_scale_float"),
+        )
 
         attn_layers = self.compilation_config.static_forward_context
         for name, module in attn_layers.items():
             if isinstance(module, (Attention, MLAAttention)):
-                # TODO: Generally, scale is 1.0 if user uses on-the-fly fp8
-                # kvcache quant. However, to get better accuracy, compression
-                # frameworks like llm-compressors allow users to tune the
-                # scale. We may need to restore the specific calibrated scales
-                # here in the future.
-                k_scale_val, v_scale_val = 1.0, 1.0
-
-                # Processing K Scale
-                for attr in k_attr_names:
-                    if hasattr(module, attr):
-                        param = getattr(module, attr)
-                        if isinstance(param, torch.Tensor):
-                            param.fill_(k_scale_val)
-
-                # Processing V Scale
-                for attr in v_attr_names:
-                    if hasattr(module, attr):
-                        param = getattr(module, attr)
-                        if isinstance(param, torch.Tensor):
-                            param.fill_(v_scale_val)
+                for tensor_attrs, host_attr in scale_specs:
+                    # Calibrated scale preserved on the host across wake; falls
+                    # back to 1.0 for uncalibrated / on-the-fly fp8 quant.
+                    scale_val = float(getattr(module, host_attr, 1.0))
+                    for attr in tensor_attrs:
+                        if hasattr(module, attr):
+                            param = getattr(module, attr)
+                            if isinstance(param, torch.Tensor):
+                                param.fill_(scale_val)
 
     def _get_positions(self, num_tokens: Any):
         if isinstance(num_tokens, int):


### PR DESCRIPTION
## Summary

`GPUModelRunner.init_fp8_kv_scales()` runs on every wake from sleep mode (via `post_kv_cache_wake_up`). It was **unconditionally resetting** every `Attention` / `MLAAttention` layer's `_k_scale` and `_v_scale` to `1.0`.

The device-resident scale tensors *are* legitimately zeroed when the KV-cache memory pool is re-allocated on wake, so they must be re-initialized. But hard-coding `1.0` silently discards the **calibrated per-tensor FP8-KV scales** baked into checkpoints (e.g. produced by llm-compressor). After the first sleep/wake cycle, a calibrated model serves with the wrong KV scales — an accuracy regression that's invisible (no crash, no warning). The existing code acknowledged this gap in a `TODO`:

```python
# TODO: ... compression frameworks like llm-compressors allow users to tune
# the scale. We may need to restore the specific calibrated scales here ...
k_scale_val, v_scale_val = 1.0, 1.0
```

## Fix

The calibrated values are already preserved on the **host** in `_k_scale_float` / `_v_scale_float`. These are plain Python floats set once at weight-load time (`BaseKVCacheMethod.process_weights_after_loading`, compressed-tensors loader) and are never freed by the sleep allocator — they survive sleep/wake untouched.

Restore the device tensors from those host floats instead of hard-coding `1.0`. For uncalibrated / on-the-fly fp8 quant the host floats are already `1.0`, so behaviour is unchanged. Applies uniformly to both `Attention` and `MLAAttention` (both initialize the host floats via `set_default_quant_scales`).

## Test

Adds a **CPU-only** regression test (`tests/v1/worker/test_fp8_kv_scale_wake.py`) that exercises the real `init_fp8_kv_scales` logic against a lightweight stub runner — no GPU, no full runner construction:

- `test_calibrated_scales_preserved_across_wake` — a layer with calibrated scales `!= 1.0` keeps them after wake. **Fails on `main`** (scales come back `1.0`), passes with this change.
- `test_uncalibrated_scales_default_to_one` — backward-compat: uncalibrated layer still wakes to `1.0`.
- `test_non_quantized_cache_is_noop` — non-quantized cache skips the scale path entirely.

Verified against the current release wheel: pre-fix the calibration test fails (`1.0 != 0.0625`), post-fix all 3 pass.


---
*Contribution note (AGENTS.md): AI-assisted with Claude Code, maintained under @terafin. Not a duplicate — no open PR addresses calibrated FP8-KV scale loss across sleep/wake. Test command: `pytest tests/v1/worker/test_fp8_kv_scale_wake.py` (CPU-only); the calibration test fails on current `main` (scales return `1.0`) and passes with this change.*
