### PR TITLE
[V1][Worker] Don't crash sleep() on shared-GPU device-global free drop

### DIFF
--- a/tests/v1/worker/test_gpu_worker_sleep_shared_gpu.py
+++ b/tests/v1/worker/test_gpu_worker_sleep_shared_gpu.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for Worker.sleep() on a shared GPU.
+
+Worker.sleep() must not crash when device-global free memory drops between
+the before/after reads of ``torch.cuda.mem_get_info`` -- for example when a
+sibling PP/TP rank grows its NCCL buffers, or another model resident on the
+same physical device allocates, concurrently with this process releasing its
+own pool. Freed bytes are measured from the allocator's own process-scoped
+pool, and a negative result is logged rather than asserted.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from vllm.v1.worker.gpu_worker import Worker
+
+
+def _make_bare_worker() -> Worker:
+    # Bypass __init__ (which requires a GPU + full VllmConfig); we only exercise
+    # the sleep() accounting path.
+    worker = object.__new__(Worker)
+    worker._sleep_saved_buffers = {}
+    return worker
+
+
+def test_sleep_survives_shared_gpu_free_memory_drop():
+    """device-global free DROPS across sleep (shared GPU) -> no crash.
+
+    Pre-fix this raised ``AssertionError: Memory usage increased after
+    sleeping.`` because freed_bytes was a device-global delta that went
+    negative. Post-fix freed_bytes is the allocator pool delta (process
+    scoped), so a concurrent foreign allocation can never make sleep crash.
+    """
+    worker = _make_bare_worker()
+
+    allocator = MagicMock()
+    # This process genuinely released 4 GiB from its own pool.
+    allocator.get_current_usage.side_effect = [8 * 1024**3, 4 * 1024**3]
+
+    total = 80 * 1024**3
+    # Device-global free DROPS across the sleep call: a sibling rank /
+    # co-located model grabbed memory while we freed ours. mem_get_info is
+    # called twice by the pre-fix code (before + after) and once by the
+    # post-fix code (after only); supply enough values for both. The
+    # pre-fix device-global delta (40 - 45 = -5 GiB) is what triggered the
+    # AssertionError this test guards against.
+    mem_info_returns = iter(
+        [
+            (45 * 1024**3, total),  # pre-fix free_before (post-fix ignores)
+            (40 * 1024**3, total),  # free_after_sleep
+        ]
+    )
+
+    with (
+        patch(
+            "vllm.v1.worker.gpu_worker.get_mem_allocator_instance",
+            return_value=allocator,
+        ),
+        patch(
+            "vllm.v1.worker.gpu_worker.torch.cuda.mem_get_info",
+            side_effect=lambda *a, **k: next(mem_info_returns),
+        ),
+    ):
+        # Must NOT raise (pre-fix: AssertionError).
+        worker.sleep(level=1)
+
+    allocator.sleep.assert_called_once()
+    # freed_bytes is computed from the process-scoped pool, not device-global.
+    assert allocator.get_current_usage.call_count == 2
+
+
+def test_sleep_reports_positive_freed_bytes_from_pool():
+    """Normal case: allocator pool shrinks -> positive freed_bytes, no warning."""
+    worker = _make_bare_worker()
+
+    allocator = MagicMock()
+    allocator.get_current_usage.side_effect = [10 * 1024**3, 2 * 1024**3]
+
+    total = 80 * 1024**3
+    mem_info_returns = iter([(60 * 1024**3, total), (50 * 1024**3, total)])
+
+    with (
+        patch(
+            "vllm.v1.worker.gpu_worker.get_mem_allocator_instance",
+            return_value=allocator,
+        ),
+        patch(
+            "vllm.v1.worker.gpu_worker.torch.cuda.mem_get_info",
+            side_effect=lambda *a, **k: next(mem_info_returns),
+        ),
+        patch("vllm.v1.worker.gpu_worker.logger") as mock_logger,
+    ):
+        worker.sleep(level=1)
+
+    # Freed 8 GiB from the pool; no "increased after sleeping" warning.
+    mock_logger.warning.assert_not_called()
+    mock_logger.info.assert_called_once()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -163,8 +163,6 @@ class Worker(WorkerBase):
         self._pp_send_work: list[Handle] = []
 
     def sleep(self, level: int = 1) -> None:
-        free_bytes_before_sleep = torch.cuda.mem_get_info()[0]
-
         # Save the buffers before level 2 sleep
         if level == 2:
             model = self.model_runner.model
@@ -173,11 +171,26 @@ class Worker(WorkerBase):
             }
 
         allocator = get_mem_allocator_instance()
+        usage_before_sleep = allocator.get_current_usage()
         allocator.sleep(offload_tags=("weights",) if level == 1 else tuple())
         free_bytes_after_sleep, total = torch.cuda.mem_get_info()
-        freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
+        # Measure freed bytes from the allocator's own process-scoped pool
+        # rather than device-global mem_get_info(). On a shared GPU (e.g. a
+        # sibling PP/TP rank growing NCCL buffers, or another model resident on
+        # the same physical device), device-global free memory can drop between
+        # the two reads even though THIS process correctly released its pool,
+        # which would make a device-global delta spuriously negative.
+        freed_bytes = usage_before_sleep - allocator.get_current_usage()
         used_bytes = total - free_bytes_after_sleep
-        assert freed_bytes >= 0, "Memory usage increased after sleeping."
+        if freed_bytes < 0:
+            # Advisory only: the allocator pool should never grow across sleep,
+            # but never crash the worker mid-sleep over a memory accounting
+            # anomaly. Downgraded from an assert for shared-GPU robustness.
+            logger.warning(
+                "Memory usage increased after sleeping (allocator pool delta "
+                "%s GiB); continuing.",
+                format_gib(freed_bytes),
+            )
         logger.info(
             "Sleep mode freed %s GiB memory, %s GiB memory is still in use.",
             format_gib(freed_bytes),


### PR DESCRIPTION
## Purpose

`Worker.sleep()` computes `freed_bytes` as a delta of **device-global** `torch.cuda.mem_get_info()` free memory taken before and after the allocator sleep, then asserts the delta is non-negative:

```python
free_bytes_before_sleep = torch.cuda.mem_get_info()[0]
...
free_bytes_after_sleep, total = torch.cuda.mem_get_info()
freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
assert freed_bytes >= 0, "Memory usage increased after sleeping."
```

On a **shared GPU**, this assert can fire spuriously and crash the worker mid-sleep even though this process correctly released its own memory pool. Between the two `mem_get_info()` reads, device-global free memory can drop because of a *different* consumer on the same physical device:

- a sibling PP/TP rank growing its NCCL communication buffers, or
- another model resident on the same GPU allocating concurrently.

`mem_get_info()` reports device-global free memory, not this process's usage, so the delta goes negative through no fault of this worker. An `AssertionError` is the wrong response to an advisory, cross-process metric — it takes down a worker that did exactly the right thing.

This is reachable in practice by multi-model serving setups that sleep/wake models sharing a physical GPU (e.g. a swap group of vLLM instances colocated on one device).

## Fix

Measure freed bytes from the allocator's **own process-scoped pool** (`get_current_usage()` before/after the sleep) instead of device-global `mem_get_info()`. The allocator pool delta is unaffected by concurrent foreign allocations from other processes/ranks. The useful "Sleep mode freed X GiB" log is preserved, and the never-grow invariant is downgraded from an `assert` to a `logger.warning`, so a memory-accounting anomaly can never crash the worker.

## Test

`tests/v1/worker/test_gpu_worker_sleep_shared_gpu.py` (CPU-only, fully mocked — no GPU required):

- `test_sleep_survives_shared_gpu_free_memory_drop` — mocks the allocator pool to genuinely shrink while `torch.cuda.mem_get_info()` reports **less** device-global free memory after sleep (a concurrent foreign allocation). Asserts `sleep()` completes without raising.
  - **Pre-fix:** fails with `AssertionError: Memory usage increased after sleeping.`
  - **Post-fix:** passes.
- `test_sleep_reports_positive_freed_bytes_from_pool` — normal case: pool shrinks, positive freed bytes, no warning emitted.

```
$ pytest tests/v1/worker/test_gpu_worker_sleep_shared_gpu.py -v
test_sleep_survives_shared_gpu_free_memory_drop PASSED
test_sleep_reports_positive_freed_bytes_from_pool PASSED
```
