### PR TITLE
[Bugfix][NVFP4] Support swigluoai_uninterleave on FlashInfer-CUTLASS MoE

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -811,6 +811,8 @@ def nvfp4_moe_quant_config(
     w2_bias: torch.Tensor | None = None,
     is_scale_swizzled: bool = True,
     gemm1_clamp_limit: float | None = None,
+    gemm1_alpha: float | None = None,
+    gemm1_beta: float | None = None,
 ) -> FusedMoEQuantConfig:
     """
     Construct a quant config for mxfp4 activations and nvp4 weights.
@@ -830,6 +832,8 @@ def nvfp4_moe_quant_config(
         block_shape=None,
         is_scale_swizzled=is_scale_swizzled,
         gemm1_clamp_limit=gemm1_clamp_limit,
+        gemm1_alpha=gemm1_alpha,
+        gemm1_beta=gemm1_beta,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -102,15 +102,35 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
                 device=self.device,
             )
 
+        # Per-expert SwiGLU alpha/beta from the quant config (e.g. MiniMax-M3
+        # clamped swigluoai_uninterleave). The mxfp4 (gpt-oss) branch below
+        # fills in its hard-coded defaults only when these are still unset.
+        self.gemm1_alpha: torch.Tensor | None = None
+        self.gemm1_beta: torch.Tensor | None = None
+        if quant_config.gemm1_alpha is not None:
+            self.gemm1_alpha = torch.tensor(
+                [quant_config.gemm1_alpha] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
+        if quant_config.gemm1_beta is not None:
+            self.gemm1_beta = torch.tensor(
+                [quant_config.gemm1_beta] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
+
         if quant_config.weight_quant_dtype == "mxfp4":
             # This value is used specifically for gpt-oss,
             # Need to revisit this for other models
-            self.gemm1_alpha = torch.tensor(
-                [1.702] * self.num_experts, dtype=torch.float32, device=self.device
-            )
-            self.gemm1_beta = torch.tensor(
-                [1.0] * self.num_experts, dtype=torch.float32, device=self.device
-            )
+            if self.gemm1_alpha is None:
+                self.gemm1_alpha = torch.tensor(
+                    [1.702] * self.num_experts, dtype=torch.float32, device=self.device
+                )
+            if self.gemm1_beta is None:
+                self.gemm1_beta = torch.tensor(
+                    [1.0] * self.num_experts, dtype=torch.float32, device=self.device
+                )
             if self.gemm1_clamp_limit is None:
                 self.gemm1_clamp_limit = torch.tensor(
                     [7.0] * self.num_experts,
@@ -191,6 +211,9 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             MoEActivation.GELU_TANH,
             MoEActivation.RELU2_NO_MUL,
             MoEActivation.SWIGLUOAI,
+            # Packed gate_up clamped SwiGLU (e.g. MiniMax-M3). Same kernel as
+            # SWIGLUOAI; weights are already packed [w3,w1] for this path.
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
         ]
 
     @staticmethod
@@ -270,6 +293,9 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             MoEActivation.SILU: ActivationType.Swiglu,  # This is the default
             MoEActivation.GELU_TANH: ActivationType.Geglu,
             MoEActivation.SWIGLUOAI: ActivationType.Swiglu,  # gpt-oss alias
+            # MiniMax-M3: packed gate_up clamped swiglu; kernel applies
+            # alpha/beta/limit forwarded below.
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE: ActivationType.Swiglu,
             MoEActivation.RELU2_NO_MUL: ActivationType.Relu2,
         }
         assert activation in activation_str_to_value_map, (
@@ -322,6 +348,12 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             # FlashInfer API requires weight to be long for nvfp4
             fc1_expert_weights = w1.view(torch.long)
             fc2_expert_weights = w2.view(torch.long)
+            # Clamped SwiGLU (MiniMax-M3): forward alpha/beta/limit so the
+            # cutlass kernel computes silu(clamp(gate))*clamp(up).
+            if activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:
+                swiglu_alpha = self.gemm1_alpha
+                swiglu_beta = self.gemm1_beta
+                swiglu_limit = self.gemm1_clamp_limit
         elif self.weight_quant_dtype == "mxfp4":
             assert self.w1_scale is not None and self.w2_scale is not None
             assert w1.is_contiguous() and w2.is_contiguous()

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -174,6 +174,9 @@ def select_nvfp4_moe_backend(
 
     NVFP4_BACKENDS_WITH_CLAMP = {
         NvFp4MoeBackend.FLASHINFER_TRTLLM,
+        # flashinfer cutlass_fused_moe applies swiglu_alpha/beta/limit, so it can
+        # serve clamped-swiglu models (e.g. MiniMax-M3 swigluoai_uninterleave).
+        NvFp4MoeBackend.FLASHINFER_CUTLASS,
     }
 
     if config.swiglu_limit is not None:
@@ -416,6 +419,8 @@ def make_nvfp4_moe_quant_config(
     a13_scale: torch.Tensor,
     a2_scale: torch.Tensor,
     swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
 ) -> FusedMoEQuantConfig:
     if backend == NvFp4MoeBackend.MARLIN:
         return nvfp4_w4a16_moe_quant_config(
@@ -433,6 +438,8 @@ def make_nvfp4_moe_quant_config(
             w1_scale=w13_scale,
             w2_scale=w2_scale,
             gemm1_clamp_limit=swiglu_limit,
+            gemm1_alpha=swiglu_alpha,
+            gemm1_beta=swiglu_beta,
         )
 
     # Pass w13_scale_2 / w2_scale_2 directly as g1/g2_alphas.
@@ -457,6 +464,8 @@ def make_nvfp4_moe_quant_config(
             )
         ),
         gemm1_clamp_limit=swiglu_limit,
+        gemm1_alpha=swiglu_alpha,
+        gemm1_beta=swiglu_beta,
     )
 
 

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1616,6 +1616,8 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             a13_scale=layer.w13_input_scale,
             a2_scale=layer.w2_input_scale,
             swiglu_limit=getattr(layer, "swiglu_limit", None),
+            swiglu_alpha=getattr(layer, "swiglu_alpha", None),
+            swiglu_beta=getattr(layer, "swiglu_beta", None),
         )
 
     @property


### PR DESCRIPTION
## Purpose

Serving **MiniMax-M3-NVFP4** (ModelOpt NVFP4) fails at engine init: the NVFP4 MoE
oracle (`select_nvfp4_moe_backend`) rejects every backend with
`No NvFp4 MoE backend supports the deployment configuration`. M3's MoE uses the
clamped **`swigluoai_uninterleave`** activation (`swiglu_limit=7.0`,
`swiglu_alpha=1.702`, `swiglu_beta=1.0`; packed `[all gates; all ups]` gate_up).

- The FlashInfer **trtllm** FP4 kernel ignores the clamp/alpha params (vLLM's
  trtllm wrapper passes `gemm1_alpha=None`), so it can't serve this model.
- FlashInfer **`cutlass_fused_moe`** *does* apply `swiglu_alpha/beta/limit`
  (`activation_type=ActivationType.Swiglu`), so the CUTLASS backend can.

This wires the FlashInfer-CUTLASS NVFP4 backend for `swigluoai_uninterleave`.

## Changes

- `oracle/nvfp4.py`: add `FLASHINFER_CUTLASS` to `NVFP4_BACKENDS_WITH_CLAMP` so the
  oracle keeps it for clamped-swiglu models; forward `swiglu_alpha/beta` through
  `make_nvfp4_moe_quant_config`.
- `config.py`: `nvfp4_moe_quant_config` forwards `gemm1_alpha/gemm1_beta`.
- `quantization/modelopt.py`: `ModelOptNvFp4FusedMoE.get_fused_moe_quant_config`
  forwards `swiglu_alpha/beta` (mirrors the MXFP8 method).
- `experts/flashinfer_cutlass_moe.py`: accept `SWIGLUOAI_UNINTERLEAVE`; build
  per-expert `gemm1_alpha/beta` tensors generically; map it to
  `ActivationType.Swiglu`; forward clamp/alpha/beta on the nvfp4 path.

`trtllm` is intentionally left unsupported for this activation, so auto-selection
skips it (activation reject) and lands on cutlass. No weight-prep change — M3's
packed gate_up already matches the existing `reorder_w1w3_to_w3w1` layout.

## Test Plan / Status

- **Backend selection verified** end-to-end against MiniMax-M3-NVFP4 (TP=4): the
  oracle now logs
  `Using 'FLASHINFER_CUTLASS' NvFp4 MoE backend out of potential backends:
  ['FLASHINFER_TRTLLM', 'FLASHINFER_CUTLASS']` and proceeds past MoE init
  (previously it raised at this point).
- **Numerical/accuracy validation (gsm8k) is still pending** in my environment due
  to two *unrelated* blockers: the only NVFP4 checkpoint I had on disk
  (`lukealonso/MiniMax-M3-NVFP4`) uses transformers-5.x weight naming that
  `m3_release` can't load (`Mapika/MiniMax-M3-NVFP4` has compatible naming), and
  serving from source currently crash-loops the API server with
  `_IncludedRouter has no attribute 'path'`. Appreciate a maintainer running a
  gsm8k check on a compatible NVFP4 checkpoint to confirm output correctness.

Targets `m3_release` (the activation enum value `SWIGLUOAI_UNINTERLEAVE` and the
MiniMax-M3 model live there, not `main`).
