### PR TITLE
[Core] Offload CUDA graph + NCCL communicator memory in sleep mode

### DIFF
--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -104,6 +104,7 @@ class CuMemAllocator:
 
     instance: "CuMemAllocator | None" = None
     default_tag: str = "default"
+    graphs_tag: str = "graphs"
 
     @staticmethod
     def get_instance() -> "CuMemAllocator":
@@ -188,6 +189,16 @@ class CuMemAllocator:
 
         for ptr, data in self.pointer_to_data.items():
             handle = data.handle
+            # CUDA graphs that are not selected for offload must stay resident.
+            # Their memory lives in the cumem pool, but discarding it (unmap
+            # without a CPU backup) would leave the captured graph pointing at
+            # undefined pages after wake-up -> garbage output, since graphs are
+            # restored in place rather than re-captured. Skipping the unmap
+            # keeps level-1 sleep byte-identical to the pre-graph-offload
+            # behavior; level 2 puts the graphs tag in offload_tags so the
+            # pool is backed up to CPU and released.
+            if data.tag == CuMemAllocator.graphs_tag and data.tag not in offload_tags:
+                continue
             total_bytes += handle[1]
             if data.tag in offload_tags:
                 backup_bytes += handle[1]
@@ -213,7 +224,13 @@ class CuMemAllocator:
         )
 
         gc.collect()
-        torch.cuda.empty_cache()
+        # Flush torch's caching layer so freed blocks are returned to the
+        # driver. This can raise if a pluggable mem-pool context is active (the
+        # persistent CUDA-graph pool); guard so sleep still succeeds.
+        try:
+            torch.cuda.empty_cache()
+        except Exception as e:
+            logger.debug("torch.cuda.empty_cache() skipped during sleep: %s", e)
 
     def wake_up(self, tags: list[str] | None = None) -> None:
         """
@@ -309,3 +326,47 @@ class CuMemAllocator:
             handle = data.handle
             sum_bytes += handle[1]
         return sum_bytes
+
+    def get_graph_pool_handle(self) -> tuple[int, int]:
+        """Return a CUDA graph memory pool id backed by this allocator.
+
+        CUDA graphs captured against this pool are tagged ``graphs`` and thus
+        participate in the same sleep/wake offload mechanism as weights and the
+        KV cache. The pool context is entered once and kept open for the
+        lifetime of the process, so every subsequent graph capture allocates
+        into it.
+
+        Returns:
+            The mempool id tuple ``(int, int)`` to pass as the ``pool``
+            argument of ``torch.cuda.graph`` (matches the return type of
+            ``torch.cuda.graph_pool_handle``). The owning ``MemPool`` object is
+            kept alive via ``allocator_and_pools`` / ``_custom_graph_pool_obj``.
+        """
+        if not hasattr(self, "_custom_graph_pool_id"):
+            logger.info(
+                "CuMemAllocator: creating CUDA graph pool with tag '%s'",
+                CuMemAllocator.graphs_tag,
+            )
+            # Create a MemPool backed by the cumem pluggable allocator, but do
+            # NOT enter a ``use_mem_pool`` context: ``torch.cuda.graph(pool=id)``
+            # runs its own ``beginAllocateToPool`` for the same pool during
+            # capture, and an outer ``use_mem_pool`` on the same id would make
+            # that fail with "already recording to mempool_id".
+            #
+            # The ``graphs`` tag is applied by the capture caller holding
+            # ``current_tag = graphs_tag`` across ``capture_model`` (see
+            # ``GPUWorker._pin_sleep_mode_graph_pool``), so graph allocations are
+            # tagged correctly even when other pool contexts run in between.
+            new_alloc = get_pluggable_allocator(
+                self.python_malloc_callback, self.python_free_callback
+            )
+            mem_pool = torch.cuda.memory.MemPool(new_alloc._allocator)
+            self.allocator_and_pools[CuMemAllocator.graphs_tag] = (
+                mem_pool,
+                new_alloc,
+            )
+            # Keep a strong ref so the pool is not destroyed, and hand callers
+            # the mempool id tuple that torch.cuda.graph(pool=...) expects.
+            self._custom_graph_pool_obj = mem_pool
+            self._custom_graph_pool_id = mem_pool.id
+        return self._custom_graph_pool_id

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -54,6 +54,35 @@ class CudaCommunicator(DeviceCommunicatorBase):
             use_torch_symm_mem = envs.VLLM_ALLREDUCE_USE_SYMM_MEM
             use_flashinfer_allreduce = envs.VLLM_ALLREDUCE_USE_FLASHINFER
 
+            # Sleep-mode CUDA-graph offload routes the graph pool through the
+            # cumem VMM allocator. CustomAllreduce registers captured graph
+            # buffers for IPC via cudaIpcGetMemHandle, which fails on VMM memory
+            # (cudaErrorInvalidValue; VMM needs cuMemExportToShareableHandle) and
+            # crashes FULL-cudagraph capture. Disable it while graph offload is
+            # active; the symm-mem / pynccl backends remain available.
+            if use_custom_allreduce:
+                try:
+                    from vllm.config import get_current_vllm_config
+
+                    mc = get_current_vllm_config().model_config
+                    graph_offload_active = (
+                        mc is not None
+                        and getattr(mc, "enable_cumem_allocator", False)
+                        and not getattr(mc, "enforce_eager", False)
+                    )
+                except Exception:
+                    graph_offload_active = False
+                if graph_offload_active:
+                    use_custom_allreduce = False
+                    logger.warning(
+                        "Disabling custom all-reduce: sleep-mode CUDA-graph "
+                        "offload routes the graph pool through the cumem VMM "
+                        "allocator, which is incompatible with custom "
+                        "all-reduce's IPC graph-buffer registration "
+                        "(cudaIpcGetMemHandle fails on VMM memory). Falling back "
+                        "to symm-mem / pynccl all-reduce."
+                    )
+
         self.use_custom_allreduce = use_custom_allreduce
         self.use_torch_symm_mem = use_torch_symm_mem
         self.use_flashinfer_allreduce = use_flashinfer_allreduce

--- a/vllm/distributed/device_communicators/nccl_suspend.py
+++ b/vllm/distributed/device_communicators/nccl_suspend.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NCCL communicator suspend/resume for sleep mode (NCCL >= 2.29.7).
+
+Releases the GPU memory held by idle NCCL communicators while vLLM is asleep,
+using NCCL's native ``ncclCommSuspend`` / ``ncclCommResume`` (memory manager).
+Topology and connection state are preserved, so resume is cheap (no re-init /
+no bootstrap rendezvous). On NCCL < 2.29.7 the API is absent and every entry
+point is a graceful no-op (``is_supported()`` returns False).
+
+This is a ctypes shim over the ``libnccl.so`` that torch already loaded, so the
+``ncclComm_t`` handles (raw pointers owned by vLLM's ``PyNcclCommunicator``)
+refer to the same library state.
+"""
+
+from __future__ import annotations
+
+import ctypes
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# Bitmask for ncclCommSuspend: release dynamic GPU memory allocations while
+# keeping topology / connection state.
+NCCL_SUSPEND_MEM = 0x01
+NCCL_SUCCESS = 0
+
+_nccl_lib: ctypes.CDLL | None = None
+_load_attempted = False
+
+
+def _get_nccl_lib() -> ctypes.CDLL | None:
+    """Resolve the ``libnccl.so`` torch already loaded and bind the API.
+
+    Returns None if NCCL is not loaded or is older than 2.29.7 (no suspend
+    symbols).
+    """
+    global _nccl_lib, _load_attempted
+    if _load_attempted:
+        return _nccl_lib
+    _load_attempted = True
+
+    try:
+        import psutil
+
+        nccl_path = next(
+            (
+                m.path
+                for m in psutil.Process().memory_maps()
+                if "libnccl.so" in m.path.lower()
+            ),
+            None,
+        )
+    except Exception:
+        nccl_path = None
+
+    if nccl_path is None:
+        logger.warning(
+            "libnccl not found in process memory maps; NCCL suspend/resume disabled."
+        )
+        return None
+
+    try:
+        lib = ctypes.CDLL(nccl_path)
+    except OSError as e:
+        logger.warning("Failed to load %s: %s; NCCL suspend disabled.", nccl_path, e)
+        return None
+
+    if not hasattr(lib, "ncclCommSuspend") or not hasattr(lib, "ncclCommResume"):
+        logger.warning(
+            "NCCL at %s lacks ncclCommSuspend/Resume (needs >= 2.29.7); NCCL "
+            "memory offload disabled.",
+            nccl_path,
+        )
+        return None
+
+    lib.ncclCommSuspend.argtypes = [ctypes.c_void_p, ctypes.c_int]
+    lib.ncclCommSuspend.restype = ctypes.c_int
+    lib.ncclCommResume.argtypes = [ctypes.c_void_p]
+    lib.ncclCommResume.restype = ctypes.c_int
+    logger.info("NCCL suspend/resume enabled via %s", nccl_path)
+    _nccl_lib = lib
+    return lib
+
+
+def is_supported() -> bool:
+    """Whether the loaded NCCL supports ncclCommSuspend/Resume (>= 2.29.7)."""
+    return _get_nccl_lib() is not None
+
+
+def _collect_pynccl_comm_handles() -> list[tuple[str, int]]:
+    """Enumerate ``(name, ncclComm_t)`` for every active PyNcclCommunicator.
+
+    Walks the well-known process-group coordinators (TP / PP / DP / EP / ... /
+    world) and reads the raw ``ncclComm_t`` from each one's device
+    communicator. Handles are de-duplicated by pointer value because a single
+    communicator can be shared across coordinators.
+    """
+    from vllm.distributed import parallel_state as ps
+
+    handles: list[tuple[str, int]] = []
+    seen: set[int] = set()
+
+    group_getters = {
+        "world": "_WORLD",
+        "tp": "_TP",
+        "dcp": "_DCP",
+        "pp": "_PP",
+        "dp": "_DP",
+        "ep": "_EP",
+        "eplb": "_EPLB",
+        "pcp": "_PCP",
+    }
+    for name, attr in group_getters.items():
+        group = getattr(ps, attr, None)
+        if group is None:
+            continue
+        device_comm = getattr(group, "device_communicator", None)
+        if device_comm is None:
+            continue
+        pynccl = getattr(device_comm, "pynccl_comm", None)
+        if pynccl is None or getattr(pynccl, "disabled", True):
+            continue
+        comm = getattr(pynccl, "comm", None)
+        if comm is None:
+            continue
+        # ncclComm_t is a ctypes.c_void_p; .value is the raw pointer int.
+        ptr = comm.value if isinstance(comm, ctypes.c_void_p) else int(comm)
+        if not ptr or ptr in seen:
+            continue
+        seen.add(ptr)
+        handles.append((name, ptr))
+    return handles
+
+
+def _gpu_used_bytes() -> int:
+    free, total = torch.cuda.mem_get_info()
+    return total - free
+
+
+def suspend_nccl_comms() -> dict:
+    """Suspend (release the memory of) all active PyNccl communicators.
+
+    Must be called collectively on every rank with the communicators idle;
+    ``ncclCommSuspend`` performs an internal cross-rank barrier. Returns a
+    small telemetry dict. No-op (and reports ``skipped``) if NCCL is too old
+    or there are no warm communicators.
+    """
+    lib = _get_nccl_lib()
+    if lib is None:
+        return {"skipped": "nccl_suspend_unsupported", "freed_bytes": 0, "n": 0}
+
+    handles = _collect_pynccl_comm_handles()
+    if not handles:
+        return {"skipped": "no_pynccl_comms", "freed_bytes": 0, "n": 0}
+
+    before = _gpu_used_bytes()
+    n_ok = 0
+    for name, ptr in handles:
+        rc = lib.ncclCommSuspend(ctypes.c_void_p(ptr), NCCL_SUSPEND_MEM)
+        if rc != NCCL_SUCCESS:
+            logger.warning("ncclCommSuspend(%s) failed rc=%d", name, rc)
+        else:
+            n_ok += 1
+    freed = before - _gpu_used_bytes()
+    logger.info(
+        "NCCL suspend: %d/%d comms, freed %.1f MiB",
+        n_ok,
+        len(handles),
+        freed / 1024**2,
+    )
+    return {"freed_bytes": freed, "n": n_ok, "total": len(handles)}
+
+
+def resume_nccl_comms() -> dict:
+    """Resume all previously suspended PyNccl communicators.
+
+    Must be called collectively on every rank before any collective op uses the
+    communicators again. No-op if NCCL is too old or there are no comms.
+    """
+    lib = _get_nccl_lib()
+    if lib is None:
+        return {"skipped": "nccl_suspend_unsupported", "reclaimed_bytes": 0, "n": 0}
+
+    handles = _collect_pynccl_comm_handles()
+    if not handles:
+        return {"skipped": "no_pynccl_comms", "reclaimed_bytes": 0, "n": 0}
+
+    before = _gpu_used_bytes()
+    n_ok = 0
+    for name, ptr in handles:
+        rc = lib.ncclCommResume(ctypes.c_void_p(ptr))
+        if rc != NCCL_SUCCESS:
+            logger.warning("ncclCommResume(%s) failed rc=%d", name, rc)
+        else:
+            n_ok += 1
+    torch.accelerator.synchronize()
+    reclaimed = _gpu_used_bytes() - before
+    logger.info(
+        "NCCL resume: %d/%d comms, reclaimed %.1f MiB",
+        n_ok,
+        len(handles),
+        reclaimed / 1024**2,
+    )
+    return {"reclaimed_bytes": reclaimed, "n": n_ok, "total": len(handles)}

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -501,6 +501,32 @@ class CudaPlatformBase(Platform):
         return _cuda_device_count_stateless(envs.CUDA_VISIBLE_DEVICES)
 
     @classmethod
+    def graph_pool_handle(cls):
+        """Return the CUDA graph memory pool.
+
+        When the cumem allocator is active (sleep mode), route CUDA graph
+        captures through the allocator's ``graphs``-tagged pool so the graph
+        memory can be offloaded and restored on sleep/wake. Otherwise fall back
+        to the native ``torch.cuda.graph_pool_handle()``.
+
+        The "is sleep mode on" signal is the existence of the ``CuMemAllocator``
+        singleton: it is created the first time a cumem memory pool is entered
+        (weight loading under sleep mode), which always precedes CUDA graph
+        capture. We deliberately do NOT use ``get_current_vllm_config()`` here
+        because graph_pool_handle() is also called during ``torch.compile``,
+        where the current-config context is not set and the lookup raises.
+        """
+        try:
+            from vllm.device_allocator.cumem import CuMemAllocator
+
+            if CuMemAllocator.instance is not None:
+                logger.debug("Routing CUDA graph pool through CuMemAllocator")
+                return CuMemAllocator.instance.get_graph_pool_handle()
+        except Exception as e:
+            logger.warning("Falling back to native CUDA graph pool (%s)", str(e))
+        return torch.cuda.graph_pool_handle()
+
+    @classmethod
     def check_if_supports_dtype(cls, dtype: torch.dtype):
         if dtype == torch.bfloat16:  # noqa: SIM102
             if not cls.has_device_capability(80):

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -322,7 +322,7 @@ class Executor(ABC):
         time_before_sleep = time.perf_counter()
         self.collective_rpc("sleep", kwargs=dict(level=level))
         time_after_sleep = time.perf_counter()
-        self.sleeping_tags = {"weights", "kv_cache"}
+        self.sleeping_tags = {"weights", "kv_cache", "graphs"}
         self.is_sleeping = True
         logger.info(
             "It took %.6f seconds to fall asleep.", time_after_sleep - time_before_sleep

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -78,6 +78,7 @@ from .utils import request_memory
 logger = init_logger(__name__)
 
 if TYPE_CHECKING:
+    from vllm.device_allocator.cumem import CuMemAllocator
     from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
@@ -173,7 +174,23 @@ class Worker(WorkerBase):
             }
 
         allocator = get_mem_allocator_instance()
-        allocator.sleep(offload_tags=("weights",) if level == 1 else tuple())
+        # CUDA graphs live in the "graphs"-tagged cumem pool and are offloaded
+        # to CPU (not discarded) at both levels so they can be restored in
+        # place on wake without re-capture (their captured pointers stay valid
+        # because cumem preserves virtual addresses).
+        #   Level 1: offload weights + graphs to CPU; discard KV.
+        #   Level 2: offload graphs to CPU; discard weights + KV.
+        allocator.sleep(
+            offload_tags=("weights", "graphs") if level == 1 else ("graphs",)
+        )
+
+        # Release idle NCCL communicator memory (NCCL >= 2.29.7). Collective
+        # across ranks; no-op at world_size 1 or on older NCCL. Done after the
+        # cumem unmap so the reported freed bytes include the NCCL release.
+        from vllm.distributed.device_communicators import nccl_suspend
+
+        nccl_suspend.suspend_nccl_comms()
+
         free_bytes_after_sleep, total = torch.cuda.mem_get_info()
         freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
         used_bytes = total - free_bytes_after_sleep
@@ -188,6 +205,12 @@ class Worker(WorkerBase):
         allocator = get_mem_allocator_instance()
         allocator.wake_up(tags)
 
+        # Restore NCCL communicator memory before any collective runs again.
+        # Collective across ranks; no-op at world_size 1 or on older NCCL.
+        from vllm.distributed.device_communicators import nccl_suspend
+
+        nccl_suspend.resume_nccl_comms()
+
         # Restore the buffers after level 2 sleep
         if len(self._sleep_saved_buffers):
             model = self.model_runner.model
@@ -198,6 +221,39 @@ class Worker(WorkerBase):
 
         if tags is None or "kv_cache" in tags:
             self.model_runner.post_kv_cache_wake_up()
+
+    def _pin_sleep_mode_graph_pool(self) -> "CuMemAllocator | None":
+        """Pin the cumem-backed CUDA graph pool before graph capture.
+
+        Returns the allocator when graph offload is active so the caller can
+        hold the ``graphs`` tag across capture and restore it afterwards, else
+        None.
+
+        The cumem graph pool must be the pool every CUDA-graph capture allocates
+        into, so it has to be wired up *before* ``capture_model``:
+        ``CudaPlatform._global_graph_pool`` is cached process-wide on the first
+        ``get_global_graph_pool()`` call, which can precede the cumem instance
+        and cache the native pool; and ``CUDAGraphWrapper`` instances cache
+        ``graph_pool`` at construction. We therefore overwrite the global pool
+        and re-point every live wrapper at the cumem pool. Without this, capture
+        routes to the native allocator and the graph memory is never offloaded.
+        """
+        if not self.vllm_config.model_config.enable_cumem_allocator:
+            return None
+        if not current_platform.is_cuda_alike():
+            return None
+        from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphWrapper
+        from vllm.compilation.cuda_graph import CUDAGraphWrapper
+        from vllm.device_allocator.cumem import CuMemAllocator
+
+        allocator = CuMemAllocator.get_instance()
+        pool_id = allocator.get_graph_pool_handle()
+        type(current_platform)._global_graph_pool = pool_id
+        for inst in list(CUDAGraphWrapper._all_instances) + list(
+            BreakableCUDAGraphWrapper._all_instances
+        ):
+            inst.graph_pool = pool_id
+        return allocator
 
     def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:
         if (
@@ -627,7 +683,17 @@ class Worker(WorkerBase):
 
         cuda_graph_memory_bytes = 0
         if not self.model_config.enforce_eager:
-            cuda_graph_memory_bytes = self.model_runner.capture_model()
+            # Wire the cumem graph pool before capture so the captured graph
+            # memory is tagged "graphs" and participates in sleep/wake offload.
+            graph_allocator = self._pin_sleep_mode_graph_pool()
+            if graph_allocator is not None:
+                old_tag = graph_allocator.current_tag
+                graph_allocator.current_tag = graph_allocator.graphs_tag
+            try:
+                cuda_graph_memory_bytes = self.model_runner.capture_model()
+            finally:
+                if graph_allocator is not None:
+                    graph_allocator.current_tag = old_tag
 
         # Compare actual vs estimated CUDA graph memory (if we did profiling)
         if (


### PR DESCRIPTION
## What
Extends vLLM sleep/wake (`CuMemAllocator`) to release two GPU-memory classes
that currently stay resident while an engine sleeps, restoring them on wake —
beyond the existing weights/KV-cache offload:

1. **CUDA graphs** — route the CUDA-graph capture pool through the cumem
   allocator under a new `graphs` tag. The graph memory is offloaded to CPU and
   restored **in place** on wake (no re-capture; cumem preserves virtual
   addresses).
2. **NCCL communicators** — release idle PyNccl communicator memory via native
   `ncclCommSuspend(NCCL_SUSPEND_MEM)` / `ncclCommResume` (NCCL ≥ 2.29.7), a
   ctypes shim over torch's loaded `libnccl`. Graceful no-op on older NCCL or
   single-GPU.

To make graph capture actually land in the cumem pool, the pool is pinned
**before** capture: `gpu_worker._pin_sleep_mode_graph_pool()` overwrites
`CudaPlatform._global_graph_pool` and re-points every live `CUDAGraphWrapper` /
`BreakableCUDAGraphWrapper`, and the `graphs` tag is held across
`capture_model()`. (Without this, on the v1 runner the global graph pool is
cached before the cumem instance exists and capture lands in the native
allocator.) `sleep()` also always attempts a guarded `torch.cuda.empty_cache()`
so freed blocks return to the driver.

It also disables **custom all-reduce** while graph offload is active: captured
graph buffers become VMM-backed, and custom all-reduce registers them for IPC
via `cudaIpcGetMemHandle`, which fails on VMM memory (needs
`cuMemExportToShareableHandle`) and aborts FULL-cudagraph capture. The engine
falls back to symm-mem / pynccl (a microbenchmark shows these are
equal-or-faster at 8-GPU NVLink anyway).

## Scope / honesty about coverage
Graph offload only catches allocations that route through the cumem graph
`MemPool`. Measured on **Qwen3-235B-A22B, TP=8 + EP, H200**:
- **NCCL communicator release: 958 MiB/GPU** (2 comms/rank: TP + EP) — the
  dominant, reliable saving.
- **CUDA-graph offload: ~90 MiB/GPU on this MoE+EP config.** A large share of
  capture-time memory (attention / expert / EP workspace) is allocated **outside
  torch's pool routing**, so `pool=` does not capture it. On dense models nearly
  all captured graph memory routes in (Qwen3-4B: ~99%).
- Net effect at level-2 sleep: post-fix frees an **extra ~1 GiB/GPU vs baseline**
  (NCCL 958 MiB + graphs). The pre-fix version was actually net-negative on the
  v1 runner (graph capture bypassed the pool and `empty_cache` was skipped); both
  are fixed here.

Full graph-memory coverage on MoE+EP needs global allocation interception
(torch_memory_saver style, as SGLang does) rather than torch `MemPool` routing —
left as a **follow-up**.

## Why this is not a duplicate
- **#25628** (“Enable offloading of cuda graphs in sleep mode”) is **closed**
  (auto-closed for inactivity). This revives the graph-tag approach and ports it
  to current code.
- **#35934** (suspend/resume for CRIU) *destroys and rebuilds* NCCL; this keeps
  the comm alive and only releases its buffers (`ncclCommSuspend`).
- **#44994** *splits* NCCL comms for elastic EP; it does not free comm memory.
- **#45398 / #44074** add the tag-offload/backend framework but define no
  `graphs`/`nccl` tags and implement no graph/NCCL offload.
- NCCL communicator **memory offload** is otherwise unclaimed upstream.

## Tests (H200; container `vllm/vllm-openai:v0.23.0`, NCCL upgraded to 2.30.7)
Correctness uses a variant-set / `VLLM_BATCH_INVARIANT=1` bit-exact criterion
(greedy decode is otherwise nondeterministic on near-tie tokens, independent of
sleep).
- **1-GPU Qwen3-4B**, default cudagraph (FULL+PIECEWISE), `VLLM_BATCH_INVARIANT=1`:
  sleep→wake bit-exact across cycles at level 1 and level 2; graph pool routed
  through cumem (graphs tag isolated).
- **2/8-GPU TP** Qwen3-4B/8B + **8-GPU MoE+EP** Qwen3-30B-A3B: graph + NCCL
  offload; NCCL releases ~0.5–1 GiB/rank; no hang; outputs within no-sleep
  variance.
- **2-node (16 GPU)**: `ncclCommSuspend`/`resume` over inter-node transport,
  correct all-reduce before and after.
- **8-GPU Qwen3-235B-A22B (TP8+EP)**: per-phase HBM/timing profiled; numbers
  above. Sleep wall ~2.1 s, wake ~3.3 s (NCCL suspend/resume dominates).
- **All-reduce kernel microbench** (8 & 16 GPU): disabling custom all-reduce is
  ~free.
- `pre-commit run` ruff/ruff-format/typos/SPDX/torch.cuda policy pass.

## AI assistance
Developed with AI assistance (Claude). The human submitter has reviewed every
changed line and run the tests above.
