### PR TITLE
[Bugfix] Avoid scheduler crash on stale KV transfer completion for already-freed requests

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3952,6 +3952,63 @@ def test_abort_request_finished_recving():
     assert not scheduler.finished_recving_kv_req_ids
 
 
+def test_kv_xfer_finished_recving_for_unknown_request_does_not_crash():
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    # No request was ever added, so "unknown-req" is not in scheduler.requests.
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(finished_recving={"unknown-req"}),
+    )
+
+    scheduler.update_from_output(SchedulerOutput.make_empty(), model_runner_output)
+
+    assert "unknown-req" not in scheduler.requests
+    assert "unknown-req" not in scheduler.finished_recving_kv_req_ids
+
+
+def test_kv_xfer_finished_sending_for_unknown_request_does_not_crash():
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    # No request was ever added, so "unknown-req" is not in scheduler.requests.
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(finished_sending={"unknown-req"}),
+    )
+
+    # Should not raise even though the request is not tracked.
+    scheduler.update_from_output(SchedulerOutput.make_empty(), model_runner_output)
+
+    assert "unknown-req" not in scheduler.requests
+
+
+def test_kv_xfer_finished_after_abort_frees_request_without_crash():
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    # add a single request and abort it before its KV transfer completes.
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+    scheduler.finish_requests((request.request_id,), RequestStatus.FINISHED_ABORTED)
+    assert request.request_id not in scheduler.requests
+
+    # The async connector now reports completion for the already-freed request.
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(
+            finished_recving={request.request_id},
+            finished_sending={request.request_id},
+        ),
+    )
+
+    scheduler.update_from_output(SchedulerOutput.make_empty(), model_runner_output)
+
+    assert request.request_id not in scheduler.requests
+    assert not scheduler.finished_recving_kv_req_ids
+
+
 def test_delayed_kv_connector_free_keeps_scheduler_active():
     scheduler = create_scheduler(use_kv_connector=True)
     queued_request, request = create_requests(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2344,17 +2344,26 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
+            req = self.requests.get(req_id)
+            if req is None:
+                # The request was aborted/freed while its KV transfer was
+                # still in flight, so the connector is reporting completion
+                # for a request the scheduler no longer tracks. Its blocks
+                # were already freed on abort, so drop the stale signal.
+                continue
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
             else:
                 assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                self._free_blocks(req)
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            req = self.requests.get(req_id)
+            if req is None:
+                # Same as above: a late send completion for an
+                # aborted/freed request is benign.
+                continue
+            self._free_blocks(req)
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Summary

Fixes #43226

`Scheduler._update_from_kv_xfer_finished` asserted that every `req_id` reported
in `KVConnectorOutput.finished_recving`/`finished_sending` is still present in
`self.requests`. With an **async** KV connector, completion is reported some
steps after the transfer actually starts, leaving a window where the request
can be aborted/freed before the completion signal arrives. When that happens,
the assert fails and crashes the entire EngineCore process, taking down every
other in-flight request on that instance, not just the aborted one.

## Fix

Replace the `assert req_id in self.requests` + direct indexing with
`self.requests.get(req_id)` and `continue` if the request is no longer tracked,
in both the `finished_recving` and `finished_sending` loops. This mirrors the
pattern already used elsewhere in `update_from_output` (see #33377).

```python
req = self.requests.get(req_id)
if req is None:
    # The request was aborted/freed while its KV transfer was still in
    # flight, so the connector is reporting completion for a request the
    # scheduler no longer tracks. Drop the stale signal.
    continue
```

## Test Plan

Added 3 regression tests to `tests/v1/core/test_scheduler.py`:
- `test_kv_xfer_finished_recving_for_unknown_request_does_not_crash`
- `test_kv_xfer_finished_sending_for_unknown_request_does_not_crash`
- `test_kv_xfer_finished_after_abort_frees_request_without_crash`

```bash
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -v
# 110 passed
pre-commit run ruff-check --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
pre-commit run ruff-format --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
# both clean
```

## Duplicate-work check

Searched open issues/PRs (`gh issue view 43226 --comments`, `gh pr list --search "43226 in:body"`,
and KV-connector/scheduler keyword searches), no open PR currently addresses this fix.

## AI assistance

This PR was developed with AI assistance (Claude Code). I reviewed every changed
line, understand the underlying concepts (the async KV connector race, the
`delay_free_blocks` mechanism from #32255, and the `RequestStatus` state
machine involved), ran the full test suite (110 tests in
`tests/v1/core/test_scheduler.py`, including the 3 new regression tests) and
ruff checks locally, and can defend the change end-to-end.