### PR TITLE
[Feat] Add request arrival and completed log

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/api_router.py
+++ b/vllm/entrypoints/openai/chat_completion/api_router.py
@@ -17,6 +17,7 @@ from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.serve.utils.api_utils import (
     load_aware_call,
+    track_request_exit,
     validate_json_request,
     with_cancellation,
 )
@@ -50,6 +51,7 @@ def batch_chat(request: Request) -> OpenAIServingChatBatch | None:
 )
 @with_cancellation
 @load_aware_call
+@track_request_exit
 async def create_chat_completion(request: ChatCompletionRequest, raw_request: Request):
     metrics_header_format = raw_request.headers.get(
         ENDPOINT_LOAD_METRICS_FORMAT_HEADER_LABEL, ""

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -253,6 +253,15 @@ class OpenAIServingChat(OpenAIServing):
         request: ChatCompletionRequest,
         raw_request: Request | None = None,
     ) -> AsyncGenerator[str, None] | ChatCompletionResponse | ErrorResponse:
+        request_id = (
+            f"chatcmpl-{self._base_request_id(raw_request, request.request_id)}"
+        )
+        request.request_id = request_id
+        self._log_arrival(request_id)
+        request_metadata = RequestResponseMetadata(request_id=request_id)
+        if raw_request:
+            raw_request.state.request_metadata = request_metadata
+
         # Streaming response
         tokenizer = self.renderer.tokenizer
         assert tokenizer is not None
@@ -270,15 +279,13 @@ class OpenAIServingChat(OpenAIServing):
 
         conversation, engine_inputs = result
 
-        request_id = (
-            f"chatcmpl-{self._base_request_id(raw_request, request.request_id)}"
-        )
-
-        request_metadata = RequestResponseMetadata(request_id=request_id)
-        if raw_request:
-            raw_request.state.request_metadata = request_metadata
-
-        lora_request = self._maybe_get_adapters(request, supports_default_mm_loras=True)
+        try:
+            lora_request = self._maybe_get_adapters(
+                request, supports_default_mm_loras=True
+            )
+        except (ValueError, TypeError, RuntimeError) as e:
+            logger.exception("Error preparing request components")
+            return self.create_error_response(e)
 
         model_name = self.models.model_name(lora_request)
 

--- a/vllm/entrypoints/openai/completion/api_router.py
+++ b/vllm/entrypoints/openai/completion/api_router.py
@@ -15,6 +15,7 @@ from vllm.entrypoints.openai.completion.serving import OpenAIServingCompletion
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.serve.utils.api_utils import (
     load_aware_call,
+    track_request_exit,
     validate_json_request,
     with_cancellation,
 )
@@ -43,6 +44,7 @@ def completion(request: Request) -> OpenAIServingCompletion | None:
 )
 @with_cancellation
 @load_aware_call
+@track_request_exit
 async def create_completion(request: CompletionRequest, raw_request: Request):
     metrics_header_format = raw_request.headers.get(
         ENDPOINT_LOAD_METRICS_FORMAT_HEADER_LABEL, ""

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -136,20 +136,26 @@ class OpenAIServingCompletion(OpenAIServing):
                 "Streaming is not currently supported with beam search"
             )
 
-        result = await self.render_completion_request(request)
-        if isinstance(result, ErrorResponse):
-            return result
-
-        engine_inputs = result
-
         request_id = f"cmpl-{self._base_request_id(raw_request, request.request_id)}"
+        request.request_id = request_id
+        self._log_arrival(request_id)
         created_time = int(time.time())
 
         request_metadata = RequestResponseMetadata(request_id=request_id)
         if raw_request:
             raw_request.state.request_metadata = request_metadata
 
-        lora_request = self._maybe_get_adapters(request)
+        result = await self.render_completion_request(request)
+        if isinstance(result, ErrorResponse):
+            return result
+
+        engine_inputs = result
+
+        try:
+            lora_request = self._maybe_get_adapters(request)
+        except (ValueError, TypeError, RuntimeError) as e:
+            logger.exception("Error preparing request components")
+            return self.create_error_response(e)
 
         # Extract data_parallel_rank from header (router can inject it)
         data_parallel_rank = self._get_data_parallel_rank(raw_request)

--- a/vllm/entrypoints/serve/engine/serving.py
+++ b/vllm/entrypoints/serve/engine/serving.py
@@ -90,6 +90,11 @@ class BaseServing:
     def _extract_prompt_len(self, prompt: EngineInput):
         return extract_prompt_len(self.model_config, prompt)
 
+    def _log_arrival(self, request_id: str) -> None:
+        if self.request_logger is None:
+            return
+        self.request_logger.log_arrival(request_id)
+
     def _log_inputs(
         self,
         request_id: str,

--- a/vllm/entrypoints/serve/utils/api_utils.py
+++ b/vllm/entrypoints/serve/utils/api_utils.py
@@ -6,12 +6,13 @@ import dataclasses
 import functools
 import os
 from argparse import Namespace
+from http import HTTPStatus
 from logging import Logger
 from string import Template
 from typing import Any
 
 import regex as re
-from fastapi import Request
+from fastapi import Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.background import BackgroundTask, BackgroundTasks
@@ -141,6 +142,58 @@ def load_aware_call(func):
         else:
             raw_request.app.state.server_load_metrics -= 1
 
+        return response
+
+    return wrapper
+
+
+def log_request_exit(
+    request: Request,
+    response: Response | Exception,
+):
+    request_id = request.state.request_metadata.request_id
+    if isinstance(response, Exception):
+        logger.error("Failed request %s (exception: %s)", request_id, str(response))
+    else:
+        status_code = response.status_code
+        if status_code == HTTPStatus.OK.value:
+            logger.info("Completed request %s", request_id)
+        else:
+            logger.error(
+                "Failed request %s (status_code: %s, response body: %s)",
+                request_id,
+                status_code,
+                response.body,
+            )
+
+
+def track_request_exit(func):
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        raw_request = kwargs.get("raw_request", args[1] if len(args) > 1 else None)
+        if raw_request is None:
+            raise ValueError("raw_request required when request exited")
+        try:
+            response = await func(*args, **kwargs)
+        except Exception as e:
+            log_request_exit(raw_request, e)
+            raise
+        if isinstance(response, (JSONResponse, StreamingResponse)):
+            if response.background is None:
+                response.background = BackgroundTask(
+                    log_request_exit, raw_request, response
+                )
+            elif isinstance(response.background, BackgroundTasks):
+                response.background.add_task(log_request_exit, raw_request, response)
+            elif isinstance(response.background, BackgroundTask):
+                tasks = BackgroundTasks()
+                tasks.add_task(
+                    response.background.func,
+                    *response.background.args,
+                    **response.background.kwargs,
+                )
+                tasks.add_task(log_request_exit, raw_request, response)
+                response.background = tasks
         return response
 
     return wrapper

--- a/vllm/entrypoints/serve/utils/request_logger.py
+++ b/vllm/entrypoints/serve/utils/request_logger.py
@@ -32,6 +32,9 @@ class RequestLogger:
                 "To view more details, set `VLLM_LOGGING_LEVEL=DEBUG`."
             )
 
+    def log_arrival(self, request_id: str) -> None:
+        logger.info("Arrived request %s", request_id)
+
     def log_inputs(
         self,
         request_id: str,


### PR DESCRIPTION




## Purpose
  Add request arrival and completion logging for Chat Completion and Completion API endpoints to improve request lifecycle observability and debugging.                                  
                                                                                                                                                                                         
  Changes:
  - Add `log_arrival` method to `RequestLogger` — logs `INFO` level when a request arrives
  - Add `log_request_exit` function and `track_request_exit` decorator — logs request completion or failure via FastAPI background tasks after response is sent
  - Add `_log_arrival` helper to `OpenAIServing` base class
  - Apply `@track_request_exit` decorator to `create_chat_completion` and `create_completion` endpoints
  - Restructure serving code to generate `request_id` and log arrival earlier, before prompt rendering
  - Wrap `_maybe_get_adapters()` in try/except for graceful error handling on LoRA adapter resolution failures
## Test Plan
  ```bash
  # Start server
  python -m vllm.entrypoints.openai.api_server --model <model> --enable-log-requests

  # Send a normal request and verify arrival + completion logs
  curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{"model": "<model>", "messages": [{"role": "user", "content": "hello"}]}'

  # Expected log output:
  # INFO: Arrived request chatcmpl-xxx
  # INFO: Completed request chatcmpl-xxx
```
## Test Result
Verified locally.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

