### PR TITLE
[Bugfix] Fix token splitting caused by stop string truncation in the incremental detokenizer

### DIFF
--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -87,6 +87,8 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
             self.stop_buffer_length = max(len(s) for s in self.stop) - 1
         else:
             self.stop_buffer_length = 0
+        # TODO(wengang.cwg): hardcode stop_buffer_length to 0 for now and need a more perfect solution
+        self.stop_buffer_length = 0
         self._last_output_text_offset: int = 0
 
         # Generation data


### PR DESCRIPTION
### Problem                                                                                                                                                                            
                                                                                                                                                                                         
  When `include_stop_str_in_output=false` (default), vLLM's detokenizer truncates the last
  `stop_buffer_length` characters from streamed output to exclude matched stop strings.
  This truncation operates at the character level and can **split individual tokens**,
  breaking downstream systems that parse token boundaries.

  For example, with a Qwen-style model, the `</think>` marker can be incorrectly split into
  `"<thin"` and `"k"` across two streaming chunks instead of appearing as the complete token
  `"<think>"`. This causes middleware to fail to correctly separate `reasoning_content`
  from `content`.

  | Scenario | Stop string `"b,c"` | Output behavior |
  |---|---|---|
  | `include_stop_str_in_output=true` | | Outputs `"a,b,c"` — includes stop string |
  | `include_stop_str_in_output=false` (before fix) | | Outputs `"a"` — **token split** (`",b,c"` truncated) |
  | `include_stop_str_in_output=false` (after fix) | | Outputs `"a,b"` — token-level, partial stop string |

  ### Fix

  Hardcode `stop_buffer_length=0` in `BaseIncrementalDetokenizer.__init__`,
  disabling the character-level truncation. This ensures tokens are always output
  as complete units.

  This is a short-term fix. The long-term solution should simultaneously:
  - Handle stop strings per the OpenAI protocol (exclude matched stop from output)
  - Output tokens as whole units without splitting

  ## Test Plan

  1. Send a streaming chat completion request with a stop string:
  ```bash
  curl -X POST http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
      "model": "<model>",
      "messages": [{"role": "user", "content": "repeat this: a,b,c,d,e"}],
      "max_tokens": 30,
      "temperature": 0,
      "stop": "b,c",
      "stream": true
    }'

  2. Verify that in the streaming response, the token containing ",b" is output
  as a complete delta (not split at the character level).
  3. Verify that finish_reason: "stop" and stop_reason: "b,c" are still correctly reported.

  Test Result

  With the fix applied:

  - include_stop_str_in_output=false + stop "b,c": output "a,b" — token ",b" is preserved intact
  - finish_reason and stop_reason are correctly set on the last chunk
  - No token splitting observed for </think> boundary markers
