### PR TITLE
[WIP][not verified yet] [ROCm][M3] Enable AITER AR + Gemma-RMS fusion for MiniMax-M3 (stacked on m3_release)

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -1439,6 +1439,51 @@ class AiterAllreduceFusedAddRMSNormGroupQuantWithIndexerPattern(
         return _replacement
 
 
+class AiterAllreduceFusedAddRMSNormWithCopyPattern(BasePattern, VllmPatternReplacement):
+    """Non-quant AR+RMS fusion for all_reduce with 2 users (copy_).
+
+    In GemmaRMSNorm models, the post-attention all_reduce has a copy_
+    node for cross-chunk residual state, giving it 2 users and preventing
+    the standard pattern from matching. This pattern returns ar_out as
+    an explicit output so the pattern matcher rewires external users
+    (the copy_) to the fused kernel's residual output.
+    """
+
+    def __init__(self, epsilon, dtype, device):
+        super().__init__(dtype, device)
+        self.epsilon = epsilon
+        self.FUSED_OP = rocm_aiter_ops.get_fused_allreduce_rmsnorm_op()
+
+    def get_inputs(self):
+        return [self.empty(5, 16), self.empty(5, 16), self.empty(16)]
+
+    @property
+    def pattern(self):
+        eps = self.epsilon
+
+        def _pattern(residual, input_, weight):
+            ar_out = tensor_model_parallel_all_reduce(input_)
+            rms, res_out = vllm.ir.ops.fused_add_rms_norm(ar_out, residual, weight, eps)
+            return rms, res_out, ar_out
+
+        return _pattern
+
+    @property
+    def replacement(self):
+        eps = self.epsilon
+
+        def _replacement(residual, input_, weight):
+            fused = self.FUSED_OP(
+                input_=input_,
+                residual=residual,
+                weight=weight.to(input_.dtype),
+                epsilon=eps,
+            )
+            return fused[0], fused[1], fused[1]
+
+        return _replacement
+
+
 class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
     def __init__(self, config: VllmConfig) -> None:
         super().__init__(config, "rocm_aiter_allreduce_fusion_pass")
@@ -1503,9 +1548,13 @@ class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
             return
 
         max_token_num = max_size // (hidden_dim * element_size)
+        # Cap at max_cudagraph_capture_size so fusion only fires
+        # for decode. Prefill uses quickreduce + triton rmsnorm.
+        max_cg = config.compilation_config.max_cudagraph_capture_size or 512
         self.max_token_num = min(
             max_token_num,
             config.scheduler_config.max_num_batched_tokens,
+            max_cg,
         )
 
         # Only register the AR+RMS+per-group-FP8-quant patterns when the
@@ -1523,6 +1572,15 @@ class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
                 "aiter past PR #2823 to enable the trailing per-group "
                 "FP8 quant fusion."
             )
+
+        # Non-quant copy-aware pattern for post-attention allreduce
+        for epsilon in [1e-5, 1e-6]:
+            self.register(
+                AiterAllreduceFusedAddRMSNormWithCopyPattern(
+                    epsilon, self.model_dtype, self.device
+                )
+            )
+            torch._inductor.pattern_matcher._seen_patterns.clear()
 
         for epsilon in [1e-5, 1e-6]:
             # Quant-fused variants must register first so the pattern matcher

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -1633,20 +1633,42 @@ class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
 
         self.disabled = False
 
+        # Profiling aid (#45639): surface activation at INFO so a run's logs
+        # show the pass registered and the decode cap it fuses under, without
+        # needing VLLM_LOGGING_LEVEL=DEBUG. Downgrade to debug before merge.
+        logger.info_once(
+            "%s active: patterns registered; fuses only compile ranges with "
+            "end <= max_token_num=%d (decode). If compile_ranges_endpoints "
+            "doesn't split a decode range at/below this, the pass never runs.",
+            self.__class__.__name__,
+            self.max_token_num,
+        )
+
         self.dump_patterns(config, self.pm_pass)
 
     def is_applicable_for_range(self, compile_range: Range) -> bool:
         if self.disabled:
             logger.warning_once("AllReduce fusion pass is disabled.")
             return False
-        return bool(compile_range.end <= self.max_token_num)
+        applicable = bool(compile_range.end <= self.max_token_num)
+        # Profiling aid (#45639): the False case is otherwise silent.
+        logger.info_once(
+            "%s applicable for compile range end=%s (max_token_num=%d): %s",
+            self.__class__.__name__,
+            compile_range.end,
+            self.max_token_num,
+            applicable,
+        )
+        return applicable
 
     @VllmInductorPass.time_and_log
     def __call__(self, graph: fx.Graph) -> None:
         self.matched_count = self.pm_pass.apply(graph)
         VllmPatternMatcherPass.match_table[self.pass_name] += self.matched_count
-        logger.debug(
-            "%s Replaced %s patterns", self.__class__.__name__, self.matched_count
+        # Profiling aid (#45639): info (was debug) so the verdict is visible at
+        # default log level. Downgrade to debug before merge.
+        logger.info(
+            "%s replaced %s patterns", self.__class__.__name__, self.matched_count
         )
 
     def __del__(self) -> None:

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -159,7 +159,7 @@ class GemmaRMSNorm(CustomOp):
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """PyTorch-native implementation equivalent to forward()."""
-        weight = self.weight.float() + 1.0
+        weight = self.weight.data.to(x.dtype) + 1.0
         if residual is None:
             return ir.ops.rms_norm(x, weight, self.variance_epsilon)
         return ir.ops.fused_add_rms_norm(x, residual, weight, self.variance_epsilon)

--- a/vllm/models/minimax_m3/amd/model.py
+++ b/vllm/models/minimax_m3/amd/model.py
@@ -23,7 +23,7 @@ import torch
 from torch import nn
 from transformers import PretrainedConfig
 
-from vllm import _custom_ops as ops
+from vllm import _custom_ops as ops, ir
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import (
     CacheConfig,
@@ -32,6 +32,7 @@ from vllm.config import (
 )
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
+from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.fused_allreduce_gemma_rms_norm import (
@@ -160,17 +161,24 @@ def _build_rotary_emb(config: PretrainedConfig, head_dim: int):
     )
 
 
-class MiniMAXGemmaRMSNorm(nn.Module):
-    """Gemma-style RMS normalization (native ROCm implementation).
+@CustomOp.register("minimax_gemma_rms_norm")
+class MiniMAXGemmaRMSNorm(CustomOp):
+    """Gemma-style RMS normalization for the M3 ROCm path.
 
-    Normalizes in fp32 and scales by ``(1 + weight)`` — numerically equivalent
-    to the FlashInfer ``gemma_rmsnorm`` / ``gemma_fused_add_rmsnorm`` kernels
-    used in the NVIDIA path, which are unavailable on ROCm. When ``residual`` is
-    given, the fused add + norm returns the updated ``(normed, residual)`` pair.
+    Default (custom op enabled, ``forward_hip``): an fp32 Triton pass
+    (``amd.ops.gemma_rmsnorm`` / ``gemma_fused_add_rmsnorm``) — numerically
+    equivalent to the FlashInfer ``gemma_rmsnorm`` kernels used in the NVIDIA
+    path, which are unavailable on ROCm. This is the unchanged M3 default.
 
-    The fp32 normalize + scale + (optional) residual-add run in a single fused
-    Triton pass (``amd.ops.gemma_rmsnorm`` / ``gemma_fused_add_rmsnorm``) instead
-    of a chain of elementwise PyTorch kernels.
+    When the custom op is disabled (``--compilation-config
+    '{"custom_ops":["-minimax_gemma_rms_norm"]}'``), ``forward_native`` instead
+    emits the plain ``ir.ops.rms_norm`` / ``ir.ops.fused_add_rms_norm`` IR ops,
+    with the Gemma ``1 + weight`` offset folded into the weight. That exposes the
+    post-attention ``all_reduce -> fused_add_rms_norm`` sequence to the AITER
+    AR+RMS fusion pass (``RocmAiterAllReduceFusionPass``), letting it fuse the
+    decode-time allreduce + residual-add + rmsnorm into a single AITER kernel at
+    TP>1. Opt-in because it swaps M3's accuracy-tuned fp32 norm path for the IR
+    lowering: validate gsm8k parity before enabling by default.
     """
 
     def __init__(
@@ -182,11 +190,24 @@ class MiniMAXGemmaRMSNorm(nn.Module):
         self.weight = nn.Parameter(torch.zeros(hidden_size))
         self.variance_epsilon = eps
 
-    def forward(
+    def forward_native(
         self,
         x: torch.Tensor,
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        # Fusable IR path, matched by the AITER AR+RMS fusion pass. Fold the
+        # Gemma ``1 + weight`` offset into the weight in x's dtype.
+        weight = self.weight.data.to(x.dtype) + 1.0
+        if residual is None:
+            return ir.ops.rms_norm(x, weight, self.variance_epsilon)
+        return ir.ops.fused_add_rms_norm(x, residual, weight, self.variance_epsilon)
+
+    def forward_hip(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        # Default ROCm path: fp32 Triton gemma kernels (unchanged M3 behavior).
         if residual is None:
             return gemma_rmsnorm(x, self.weight, self.variance_epsilon)
         return gemma_fused_add_rmsnorm(x, residual, self.weight, self.variance_epsilon)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -976,9 +976,13 @@ class RocmPlatform(Platform):
         using_inductor = cc.backend == "inductor" and cc.mode != CompilationMode.NONE
         default = ["native"] if using_inductor else ["vllm_c", "native"]
 
-        #  Aiter rms norm perform best when CUDA Graph capture is enabled.
-        # TODO(luka/TJ) remove env vars completely
-        if (
+        #  When allreduce+rmsnorm fusion is enabled (default on ROCm TP>1),
+        # use native priority so triton can fuse rmsnorm with adjacent ops.
+        # The aiter CK rmsnorm is opaque to triton and blocks fusion.
+        fuse_ar_rms = cc.pass_config.fuse_allreduce_rms
+        if using_inductor and fuse_ar_rms is not False:
+            rms_norm = default  # ["native"]
+        elif (
             cc.cudagraph_mode != CUDAGraphMode.NONE
             and envs.VLLM_ROCM_USE_AITER
             and envs.VLLM_ROCM_USE_AITER_RMSNORM


### PR DESCRIPTION
> **Draft / WIP.** Stacks on `m3_release` and **targets `m3_release`** (not `main`). Ports the AR+RMS fusion from #43953 and wires it to M3's Gemma RMSNorm. Needs MI355X validation before it should land.

cc @hongxiayang @andyluo7 @chunfangamd

## What this does

M3 uses Gemma-style RMSNorm, so it should benefit from the ROCm/AITER **all_reduce + residual_add + rmsnorm** fusion. Two pieces:

1. **Cherry-pick #43953** (`[ROCm][Compile] Enable AR+RMS fusion for GemmaRMSNorm models`, by @nholmber) — the copy-aware `AiterAllreduceFusedAddRMSNormWithCopyPattern`, the decode-only `max_token_num` cap (`max_cudagraph_capture_size`), and the ROCm `ir_op_priority -> ["native"]` auto-set. Applies cleanly on `m3_release`.
2. **Wire M3's `MiniMAXGemmaRMSNorm`** (`vllm/models/minimax_m3/amd/model.py`) — it's now a `CustomOp`:
   - `forward_hip` → the existing fp32 Triton kernels (`amd/ops/gemma_rmsnorm.py`). **This is the default; M3 behavior is unchanged unless you opt in.**
   - `forward_native` → emits `ir.ops.rms_norm` / `ir.ops.fused_add_rms_norm` (Gemma `1 + weight` offset folded into the weight), which the fusion pattern matcher can see.

## Why the M3 wiring is needed

#43953 patches the *shared* `GemmaRMSNorm`, but M3 has its own `MiniMAXGemmaRMSNorm` calling opaque Triton kernels — invisible to the pattern matcher, so nothing fuses. Separately, M3's existing `fused_allreduce_gemma_rms_norm` helper is **NVIDIA-only** in practice: its FlashInfer/NVSwitch fast path (`_can_use_flashinfer`) is unavailable on ROCm, so MI355 currently falls back to **unfused** `all_reduce + MiniMAXGemmaRMSNorm`. That fallback is exactly the `all_reduce -> fused_add_rms_norm` sequence the ported pass matches — once the norm emits IR ops.

## How to turn on **only** the AITER AR+Gemma-RMS fusion

The fusion is **opt-in** via `custom_ops`. On MI355X (gfx950), TP>1:

```bash
VLLM_ROCM_USE_AITER=1 \
vllm serve MiniMaxAI/MiniMax-M3-MXFP8 \
  --tensor-parallel-size 8 \
  --trust-remote-code \
  --tool-call-parser minimax_m3 --reasoning-parser minimax_m3 --enable-auto-tool-choice \
  --compilation-config '{
    "cudagraph_mode": "FULL_AND_PIECEWISE",
    "compile_ranges_endpoints": [512],
    "custom_ops": ["-minimax_gemma_rms_norm"],
    "pass_config": {
      "fuse_allreduce_rms": true,
      "fuse_norm_quant": false,
      "fuse_act_quant": false
    }
  }'
```

What each knob does (and why this isolates *just* this fusion):

| Knob | Purpose |
|---|---|
| `VLLM_ROCM_USE_AITER=1` | the fused AR+RMS kernel lives in AITER |
| `custom_ops: ["-minimax_gemma_rms_norm"]` | **the M3-specific switch** — disables M3's gemma-rmsnorm custom op so `forward_native` emits the fusable `ir.ops.*`. Without it, M3's norms stay opaque Triton kernels and nothing fuses. |
| `pass_config.fuse_allreduce_rms: true` | the AR+RMS fusion pass (default-on for ROCm TP>1; set explicitly) |
| `fuse_norm_quant: false`, `fuse_act_quant: false` | turn the *other* default-on fusion passes **off** so AR+RMS is the only one active |
| `cudagraph_mode: FULL_AND_PIECEWISE` + `compile_ranges_endpoints: [512]` | the fusion is **decode-only** (capped at `max_cudagraph_capture_size`); prefill (>512) keeps quickreduce + triton rmsnorm |

**A/B baseline (fusion OFF):** drop `-minimax_gemma_rms_norm` from `custom_ops` (or set `pass_config.fuse_allreduce_rms: false`) — everything else identical.

**Verify it fired:** the AR+RMS pass logs matched-pattern counts at startup; with the op disabled and TP>1 you should see the AITER fused-allreduce-rmsnorm op in the compiled decode graph.

## Validation needed (why it's a draft)

- This is **opt-in** and changes M3's accuracy-tuned fp32 norm path to the IR lowering when enabled. Please run **GSM8K (5-shot, full 1319)** at TP=8 on MI355X with the op disabled (fusion on) vs. enabled (fusion off) and confirm parity (#43953 saw no regression for Qwen3-Next: flex ~86%, strict ~82%).
- Throughput A/B at low concurrency (decode-bound) is where the win shows.
- Note: when the op is disabled globally, **all** M3 gemma norms (incl. `q_norm`/`k_norm`/index norms, which are *not* allreduce-adjacent and get no fusion benefit) switch to the IR `rms_norm` lowering. If GSM8K regresses, the next step is to scope IR emission to only the layer-boundary norms (`input_layernorm` / `post_attention_layernorm` / final `norm`).

## Notes

- Scope is the **AMD/ROCm** path only; the NVIDIA `MiniMAXGemmaRMSNorm` (FlashInfer kernels + the existing manual fused helper) is untouched.
- Based on #43953 (cherry-picked, original author preserved). Targets `m3_release`; should be re-based / dropped once #43953 and `m3_release` land on `main`.

---
This PR was authored with assistance from Claude Code (AI-assisted). Commits carry a `Co-Authored-By: Claude` trailer; the cherry-picked commit keeps its original `nholmber` authorship.
