### PR TITLE
fix(v1/engine): report pid + exit signal when a core proc dies during init

### DIFF
--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import os
+import signal
 import threading
 import weakref
 from collections.abc import Callable, Iterator
@@ -1199,6 +1200,26 @@ def launch_core_engines(
         )
 
 
+def describe_proc_exit(proc: BaseProcess) -> str:
+    """Human-readable exit status (pid + exit code or signal) for a proc.
+
+    A process' sentinel becomes ready the instant it dies, but ``exitcode`` is
+    only populated once the process has been reaped. Callers that want a useful
+    diagnostic should ``join`` the dead process briefly before calling this.
+    """
+    exitcode = proc.exitcode
+    if exitcode is None:
+        return f"pid={proc.pid} (still terminating, exit code unavailable)"
+    if exitcode < 0:
+        try:
+            sig = signal.Signals(-exitcode)
+            reason = f"killed by signal {sig.value} ({sig.name})"
+        except ValueError:
+            reason = f"killed by signal {-exitcode}"
+        return f"pid={proc.pid} {reason}"
+    return f"pid={proc.pid} exit code {exitcode}"
+
+
 def wait_for_engine_startup(
     handshake_socket: zmq.Socket,
     addresses: EngineZmqAddresses,
@@ -1243,13 +1264,27 @@ def wait_for_engine_startup(
             continue
         if len(events) > 1 or events[0][0] != handshake_socket:
             # One of the local core processes exited.
-            finished = proc_manager.finished_procs() if proc_manager else {}
-            if coord_process is not None and coord_process.exitcode is not None:
-                finished[coord_process.name] = coord_process.exitcode
+            candidate_procs: list[BaseProcess] = (
+                list(proc_manager.processes) if proc_manager else []
+            )
+            if coord_process is not None:
+                candidate_procs.append(coord_process)
+            # A sentinel becomes ready the instant the process dies, but its
+            # exitcode may not be populated until the process has been reaped,
+            # which is why the diagnostic could otherwise be an empty mapping.
+            # Briefly join any dead process so we can report a real exit
+            # code/signal (e.g. SIGKILL from an OOM during JIT compilation).
+            finished = {}
+            for proc in candidate_procs:
+                if proc.is_alive():
+                    continue
+                if proc.exitcode is None:
+                    proc.join(timeout=1)
+                finished[proc.name] = describe_proc_exit(proc)
             raise RuntimeError(
                 "Engine core initialization failed. "
                 "See root cause above. "
-                f"Failed core proc(s): {finished}"
+                f"Failed core proc(s): {finished or '{}'}"
             )
 
         # Receive HELLO and READY messages from the input socket.


### PR DESCRIPTION
## Purpose

Fixes #45626.

When a V1 `EngineCore` subprocess exits abnormally during startup (in the reporter's case, OOM-killed by the kernel while FlashInfer JIT-compiled CUTLASS FP4 kernels on the first forward), the only error surfaced was:

```
Engine core initialization failed. See root cause above. Failed core proc(s): {}
```

The mapping is **empty** — no PID, no exit code, no signal — so from the parent the failure is indistinguishable from any other init error.

## Root cause

In `wait_for_engine_startup` (`vllm/v1/engine/utils.py`), when the poller wakes on a process sentinel the diagnostic is built from `proc_manager.finished_procs()`, which only includes procs whose `proc.exitcode is not None`. A sentinel becomes ready the *instant* the process dies, but `exitcode` is only populated once the process has been reaped — so at the raise site `finished_procs()` is frequently still empty, producing `{}`.

## Fix

At the raise site, iterate the candidate procs (engine cores + coordinator), briefly `join()` any that are no longer alive so their exit status is reaped, and report each with a new `describe_proc_exit()` helper that surfaces the PID and decodes the exit code — negative codes become signal names. An OOM kill now reads:

```
Failed core proc(s): {'EngineCore': 'pid=12345 killed by signal 9 (SIGKILL)'}
```

which points straight at the cause.

## Test Plan

- No behavioral change on the success path (only the abnormal-exit diagnostic branch is touched).
- `describe_proc_exit` decodes: `None` → "still terminating", negative → `signal.Signals` name (falls back to the raw number for unknown signals), non-negative → "exit code N".
- Existing engine-startup tests continue to exercise the success path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
