### PR TITLE
[Bugfix] Skip torch-compile decoration for DiffusionGemma transformers fallback

### DIFF
--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -168,7 +168,13 @@ class Base(
             dtype=self.model_config.dtype,
             trust_remote_code=self.model_config.trust_remote_code,
         )
-        self._decorate_for_torch_compile(**from_config_kwargs)
+        should_decorate_for_compile = not getattr(
+            self.model_config.hf_config,
+            "model_type",
+            None,
+        ) == "diffusion_gemma"
+        if should_decorate_for_compile:
+            self._decorate_for_torch_compile(**from_config_kwargs)
         # Init on "meta" to delay allocating GPU tensors
         with init_on_device_without_buffers("meta"):
             self.model: PreTrainedModel = AutoModel.from_config(**from_config_kwargs)


### PR DESCRIPTION
## Summary
- skip the generic torch-compile decoration path for `model_type=diffusion_gemma` in the Transformers fallback backend
- avoid decorating `DiffusionGemmaDecoderModel` with a hard-coded `input_ids` / `position_ids` signature assumption that does not match its HF forward
- preserve the existing generic compile decoration behavior for other Transformers backend models

## Why this is not duplicating an existing PR
I checked for overlapping work before opening this PR:
- `gh pr list --repo vllm-project/vllm --state open --search "DiffusionGemma input_ids"` → no results
- `gh pr list --repo vllm-project/vllm --state open --search "DiffusionGemma transformers backend"` → no results
- Open DiffusionGemma PRs such as #45429 and #45417 cover sampling / generation-config behavior, not the startup crash in the Transformers fallback path.

## Root cause
On vLLM 0.23.0, serving `RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic` can resolve to `TransformersMultiModalMoEForCausalLM` and fall back to the Transformers backend. During model initialization, `Base._decorate_for_torch_compile()` unconditionally decorates the decoder class with generic dynamic arg dims:
- `input_ids`
- `inputs_embeds`
- `position_ids`

For DiffusionGemma's HF decoder class (`DiffusionGemmaDecoderModel`), that signature assumption is invalid and raises:

```text
ValueError: Argument input_ids not found in the forward method of <class 'transformers.models.diffusion_gemma.modeling_diffusion_gemma.DiffusionGemmaDecoderModel'>
```

This happens even when users pass `--enforce-eager`, because the decoration path runs before eager-mode compile disablement matters.

## Fix
Guard the generic decoration path in the Transformers backend base class and skip it when `hf_config.model_type == "diffusion_gemma"`.

This is intentionally surgical:
- it does not change the dedicated `vllm/model_executor/models/diffusion_gemma.py` implementation
- it does not alter compile behavior for other Transformers backend models
- it only avoids the incorrect generic decoration for the DiffusionGemma fallback path

## Test Plan
Commands actually run:
- `python3 -m py_compile vllm/model_executor/models/transformers/base.py`

Runtime reproduction performed before patch on a remote GPU host with vLLM 0.23.0:
- installed `vllm==0.23.0`
- downloaded `RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic`
- attempted `vllm serve` with both compiled mode and `--enforce-eager`
- observed the same startup failure in both cases:
  - `ValueError: Argument input_ids not found in the forward method of DiffusionGemmaDecoderModel`

## AI Assistance
AI assistance was used to help diagnose the fallback-path failure and draft this targeted fix. I reviewed the changed line set and the reproduced failure end-to-end before submitting.
