### PR TITLE
[Core] shm_broadcast: honor shutdown in acquire_write to avoid dead-worker writer hang

### DIFF
--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -392,3 +392,77 @@ def test_warning_logs(caplog_vllm):
         # Clean up when done
         writer.shutdown()
         reader.shutdown()
+
+
+def test_writer_acquire_write_honors_shutdown():
+    """Writer-starvation regression test.
+
+    Reproduces the cumem hot-wake worker-death wedge: a worker process aborts
+    before setting its shm read flag, so the dead rank's flag stays 0 forever.
+    The engine-side writer's next acquire_write(timeout=None) then blocks
+    indefinitely because the block never becomes writable. The
+    MultiprocWorkerMonitor fires shutdown() (sets shutting_down + cancels the
+    spin-condition, which only wakes *readers*), so before the fix the writer
+    ignored shutting_down and stayed wedged forever.
+
+    Pre-fix: acquire_write has no shutting_down escape -> the writer thread
+    hangs and this test times out / never completes.
+    Post-fix: acquire_write raises RuntimeError("cancelled") promptly after
+    shutdown() is called.
+    """
+    n_reader = 2
+    max_chunks = 4
+    writer = MessageQueue(
+        n_reader=n_reader,
+        n_local_reader=n_reader,
+        max_chunk_bytes=1024,
+        max_chunks=max_chunks,
+    )
+
+    # Fill every block in the ring so the writer's next acquire_write has no
+    # writable block. No reader ever reads, so the read flags stay 0 and the
+    # blocks never become reusable -- exactly the dead-worker scenario.
+    for _ in range(max_chunks):
+        with writer.acquire_write(timeout=1) as buf:
+            buf[0] = 0
+
+    # The ring is now full. acquire_write(timeout=None) must block...
+    error_box: list[BaseException] = []
+    started = threading.Event()
+    finished = threading.Event()
+
+    def blocked_writer():
+        started.set()
+        try:
+            with writer.acquire_write(timeout=None) as buf:
+                buf[0] = 0
+        except BaseException as e:  # noqa: BLE001 - record whatever is raised
+            error_box.append(e)
+        finally:
+            finished.set()
+
+    t = threading.Thread(target=blocked_writer, daemon=True)
+    t.start()
+    started.wait(timeout=1)
+
+    # Give the writer a moment to actually be wedged in the wait loop, and
+    # confirm it has NOT returned on its own (the ring really is full).
+    assert not finished.wait(timeout=0.2), (
+        "acquire_write returned unexpectedly; ring was not full"
+    )
+
+    # Simulate the MultiprocWorkerMonitor reacting to the worker death.
+    writer.shutdown()
+
+    # Post-fix: the writer must unwedge promptly (well under the old
+    # 60s "No available block" loop). Pre-fix this never fires -> times out.
+    assert finished.wait(timeout=0.5), (
+        "acquire_write did not honor shutdown() within 500ms -- still wedged"
+    )
+
+    assert len(error_box) == 1
+    assert isinstance(error_box[0], RuntimeError)
+    assert "cancelled" in str(error_box[0])
+    assert writer.shutting_down
+
+    writer.shutdown()

--- a/tests/v1/executor/test_executor.py
+++ b/tests/v1/executor/test_executor.py
@@ -88,6 +88,174 @@ def test_multiproc_executor_worker_termination_timeout(
     assert proc.terminate_called is expected_terminate
 
 
+class _TimingOutExecutor(Executor):
+    """Minimal Executor whose sleep/wake collective RPC always times out.
+
+    Mirrors the MultiprocExecutor contract: ``is_failed`` exists and gates
+    ``collective_rpc`` into the "Executor failed." fast-fail, ``shutdown`` and a
+    one-shot ``failure_callback`` exist exactly like the real worker-death path
+    (``start_worker_monitor``). Used to prove that a bounded sleep/wake RPC
+    timeout tears the executor down (callback fires → EXECUTOR_FAILED enqueued)
+    instead of a silent ``is_sleeping`` split-brain. No GPU/torch.
+    """
+
+    def __init__(self) -> None:
+        # Bypass the heavy base __init__ (workers, RPC mq, etc.).
+        self.is_sleeping = False
+        self.sleeping_tags = set()
+        self.is_failed = False
+        self.failure_callback = None
+        self.shutdown_called = False
+
+    def _init_executor(self) -> None:  # pragma: no cover - not exercised
+        ...
+
+    def check_health(self) -> None:  # pragma: no cover - not exercised
+        ...
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+    def register_failure_callback(self, callback) -> None:
+        if self.is_failed:
+            callback()
+        else:
+            self.failure_callback = callback
+
+    def collective_rpc(
+        self, method, timeout=None, args=(), kwargs=None, non_block=False
+    ):
+        # A non-zero timeout was threaded through: simulate a dead/hung worker
+        # whose reply never arrives, exactly like MultiprocExecutor raises.
+        if self.is_failed:
+            raise RuntimeError("Executor failed.")
+        assert timeout is not None, "expected a bounded timeout to be threaded through"
+        raise TimeoutError(f"RPC call to {method} timed out.")
+
+
+def test_wake_up_timeout_marks_executor_failed_not_silent_sleeping(monkeypatch):
+    """Regression: a timed-out wake must tear the executor down, not silently wedge.
+
+    Pre-fix, ``wake_up`` only set ``is_failed=True`` on the timeout. That is NOT
+    enough to recover: ``wake_up`` re-raises before ``EngineCore.wake_up`` reaches
+    ``resume_scheduler()``, so the scheduler stays paused, ``has_work()`` is false,
+    no engine step ever runs and ``is_failed`` is never consulted — the engine
+    sits alive forever with ``is_sleeping()==True`` and ``/health`` lying 200. The
+    only thing that actually tears the engine down is the registered
+    ``failure_callback`` (it enqueues ``EXECUTOR_FAILED`` →
+    ``RuntimeError("Executor failed.")`` → ``_send_engine_dead``).
+
+    Post-fix, ``_fail_on_sleep_wake_timeout`` mirrors the real worker-death path:
+    ``is_failed=True`` + ``shutdown()`` + ``failure_callback()``. This test
+    asserts the callback fired (engine-dead path triggered) and the executor was
+    shut down — both FAIL pre-fix (callback never invoked, only is_failed set) and
+    PASS post-fix — without falsely flipping ``is_sleeping``.
+    """
+    monkeypatch.setenv("VLLM_SLEEP_WAKE_TIMEOUT_SECONDS", "30")
+
+    executor = _TimingOutExecutor()
+    executor.is_sleeping = True
+    executor.sleeping_tags = {"weights", "kv_cache"}
+
+    # Engine registers a failure callback (here: a stand-in for the lambda that
+    # enqueues EXECUTOR_FAILED on the engine input queue).
+    callback_fired: list[bool] = []
+    executor.register_failure_callback(lambda: callback_fired.append(True))
+
+    with pytest.raises(TimeoutError):
+        executor.wake_up()
+
+    # The engine-dead path MUST have been triggered: the failure callback fired
+    # (EXECUTOR_FAILED would be enqueued) and the executor was shut down. This is
+    # the core of the fix — setting is_failed alone left the engine wedged.
+    assert callback_fired == [True], (
+        "wake_up timeout must invoke the failure callback (EXECUTOR_FAILED "
+        "enqueued → engine teardown), not merely set is_failed"
+    )
+    assert executor.shutdown_called is True
+    # The callback is one-shot (mirrors monitor_workers): cleared after firing.
+    assert executor.failure_callback is None
+    # Still a detectable FAILED state...
+    assert executor.is_failed is True
+    # ...and it must NOT lie that the workers are awake (is_sleeping flipped to
+    # False) — workers may never have woken.
+    assert executor.is_sleeping is True
+    # The failed flag means a subsequent RPC fast-fails (recovery trigger).
+    with pytest.raises(RuntimeError, match="Executor failed."):
+        executor.collective_rpc("noop")
+
+
+def test_sleep_timeout_marks_executor_failed(monkeypatch):
+    """A timed-out sleep also tears the executor down (failure callback fired +
+    shutdown) and re-raises, instead of falsely recording is_sleeping=True for
+    dead workers."""
+    monkeypatch.setenv("VLLM_SLEEP_WAKE_TIMEOUT_SECONDS", "30")
+
+    executor = _TimingOutExecutor()
+    assert executor.is_sleeping is False
+
+    callback_fired: list[bool] = []
+    executor.register_failure_callback(lambda: callback_fired.append(True))
+
+    with pytest.raises(TimeoutError):
+        executor.sleep()
+
+    assert callback_fired == [True], (
+        "sleep timeout must invoke the failure callback, not merely set is_failed"
+    )
+    assert executor.shutdown_called is True
+    assert executor.failure_callback is None
+    assert executor.is_failed is True
+    # Did NOT falsely flip to sleeping — the sleep RPC never completed.
+    assert executor.is_sleeping is False
+    assert executor.sleeping_tags == set()
+
+
+def test_sleep_wake_timeout_without_callback_still_fails_safe(monkeypatch):
+    """Executors that never registered a failure callback (or lack one) must
+    still avoid the lying state update and end up failed + shut down — the
+    teardown degrades gracefully when no callback is present."""
+    monkeypatch.setenv("VLLM_SLEEP_WAKE_TIMEOUT_SECONDS", "30")
+
+    executor = _TimingOutExecutor()  # no register_failure_callback call
+    assert executor.failure_callback is None
+
+    with pytest.raises(TimeoutError):
+        executor.sleep()
+
+    assert executor.is_failed is True
+    assert executor.shutdown_called is True
+    assert executor.is_sleeping is False
+
+
+def test_sleep_wake_default_disabled_threads_none_timeout(monkeypatch):
+    """When VLLM_SLEEP_WAKE_TIMEOUT_SECONDS=0 (default), the RPC timeout is
+    None — i.e. the bounded-timeout behavior is fully dormant and the
+    sleep/wake path is unchanged from upstream (no teardown, no callback)."""
+    monkeypatch.setenv("VLLM_SLEEP_WAKE_TIMEOUT_SECONDS", "0")
+
+    captured: dict[str, object] = {}
+
+    class _CapturingExecutor(_TimingOutExecutor):
+        def collective_rpc(
+            self, method, timeout=None, args=(), kwargs=None, non_block=False
+        ):
+            captured["timeout"] = timeout
+            return []
+
+    executor = _CapturingExecutor()
+    callback_fired: list[bool] = []
+    executor.register_failure_callback(lambda: callback_fired.append(True))
+    executor.sleep()
+    assert captured["timeout"] is None
+    assert executor.is_sleeping is True
+    assert executor.is_failed is False
+    # Dormant path: no teardown, callback untouched.
+    assert callback_fired == []
+    assert executor.shutdown_called is False
+    assert executor.failure_callback is not None
+
+
 class CustomMultiprocExecutor(MultiprocExecutor):
     def collective_rpc(
         self,

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -571,6 +571,15 @@ class MessageQueue:
                     # Release the processor to other threads
                     sched_yield()
 
+                    # If the queue is shutting down (e.g. because a worker
+                    # process died), the dead reader's flag will never be set,
+                    # so `check()` would stay False forever and a `timeout=None`
+                    # writer would wedge here indefinitely. Mirror the reader's
+                    # shutdown escape in acquire_read so a worker death surfaces
+                    # as a clean cancellation instead of an unrecoverable hang.
+                    if self.shutting_down:
+                        raise RuntimeError("cancelled")
+
                     # if we time out, raise an exception
                     elapsed = time.monotonic() - start_time
                     if timeout is not None and elapsed > timeout:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -205,6 +205,7 @@ if TYPE_CHECKING:
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS: int = 5
+    VLLM_SLEEP_WAKE_TIMEOUT_SECONDS: int = 0
     VLLM_KV_CACHE_LAYOUT: Literal["NHD", "HND"] | None = None
     VLLM_SSM_CONV_STATE_LAYOUT: Literal["SD", "DS"] | None = None
     VLLM_COMPUTE_NANS_IN_LOGITS: bool = False
@@ -1565,6 +1566,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS": lambda: int(
         os.getenv("VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS", "5")
     ),
+    # Timeout in seconds for the sleep/wake_up collective RPC calls. These
+    # calls have no timeout by default (0 == disabled), because a legitimate
+    # cold wake (e.g. re-mapping weights/kv_cache that were paged out) can take
+    # minutes. Set this to a generous bound (e.g. 300) when you want a wedged
+    # worker (e.g. a worker that aborted mid-wake) to surface as a TimeoutError
+    # the engine can act on, instead of blocking the engine forever. Must be
+    # larger than the slowest legitimate wake to avoid false positives.
+    "VLLM_SLEEP_WAKE_TIMEOUT_SECONDS": lambda: int(
+        os.getenv("VLLM_SLEEP_WAKE_TIMEOUT_SECONDS", "0")
+    ),
     # KV Cache layout used throughout vllm.
     # Some common values are:
     # - NHD
@@ -2008,6 +2019,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_HTTP_TIMEOUT_KEEP_ALIVE",
         "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS",
         "VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS",
+        "VLLM_SLEEP_WAKE_TIMEOUT_SECONDS",
         "VLLM_KEEP_ALIVE_ON_ENGINE_DEATH",
         "VLLM_IMAGE_FETCH_TIMEOUT",
         "VLLM_VIDEO_FETCH_TIMEOUT",

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -34,6 +34,20 @@ _R = TypeVar("_R")
 FailureCallback = Callable[[], None]
 
 
+def _sleep_wake_timeout() -> float | None:
+    """Optional bounded timeout for the sleep/wake_up collective RPCs.
+
+    Returns ``None`` (no timeout) unless ``VLLM_SLEEP_WAKE_TIMEOUT_SECONDS`` is
+    set to a positive value. When enabled, a worker that aborts mid-wake (e.g.
+    the cumem hot-wake CUDA crash) surfaces as a ``TimeoutError`` the engine can
+    act on, instead of the engine blocking forever on a dead worker's RPC reply.
+    Disabled by default because a legitimate cold wake can take minutes; only
+    enable with a bound generously above the slowest legitimate wake.
+    """
+    secs = envs.VLLM_SLEEP_WAKE_TIMEOUT_SECONDS
+    return float(secs) if secs and secs > 0 else None
+
+
 class Executor(ABC):
     """Abstract base class for vLLM executors."
 
@@ -315,12 +329,89 @@ class Executor(ABC):
         """Reset the encoder cache in each worker to clear cached encoder outputs."""
         self.collective_rpc("reset_encoder_cache")
 
+    def _fail_on_sleep_wake_timeout(self, op: str) -> None:
+        """Tear down the executor after a timed-out sleep/wake RPC.
+
+        A ``TimeoutError`` from the bounded sleep/wake ``collective_rpc`` means a
+        worker is dead or hung — its reply never arrived. We must NOT fall
+        through to the post-RPC state updates (which would leave the executor in
+        a lying half-state, e.g. ``is_sleeping=True`` with dead workers, or
+        ``is_sleeping=False`` while workers never actually woke).
+
+        Setting ``is_failed`` alone is NOT enough to recover. The real
+        worker-death path (``MultiprocExecutor.start_worker_monitor``) does
+        three things: sets ``is_failed=True``, calls ``shutdown()``, AND invokes
+        the registered ``failure_callback``. Only the callback enqueues
+        ``EXECUTOR_FAILED`` on the engine input queue, which is the *only* thing
+        that makes ``EngineCoreProc._handle_client_request`` raise
+        ``RuntimeError("Executor failed.")`` and tear the engine down via
+        ``_send_engine_dead``.
+
+        Relying on the next ``collective_rpc`` to observe ``is_failed`` does not
+        work for a timed-out ``wake_up``: ``wake_up`` re-raises before
+        ``EngineCore.wake_up`` reaches ``resume_scheduler()``, so the scheduler
+        stays paused, ``has_work()`` is false, no engine step ever runs, and
+        ``is_failed`` is never consulted — the engine sits alive forever with
+        ``is_sleeping()==True`` and ``/health`` lying 200 (a new silent wedge).
+        The re-raised ``TimeoutError`` is itself swallowed by the utility-method
+        catch-all, so it never reaches the engine-dead path either.
+
+        We therefore MIRROR the real death path: mark failed, shut the executor
+        down, and invoke the failure callback so ``EXECUTOR_FAILED`` is actually
+        enqueued and the engine tears down. Re-raise (by the caller) so the
+        caller still sees the timeout. Executors that don't track ``is_failed``
+        / lack a failure callback (uni/ray-v1) simply skip the parts they don't
+        have — the lying state update is still avoided.
+        """
+        # ``is_failed`` is defined on MultiprocExecutor / RayExecutorV2 and is
+        # what gates ``collective_rpc`` into the "Executor failed." fast-fail.
+        if hasattr(self, "is_failed"):
+            self.is_failed = True
+        logger.error(
+            "Timed out waiting for %r collective RPC reply; a worker is dead or "
+            "hung. Tearing down the executor instead of updating sleep/wake "
+            "state.",
+            op,
+        )
+        # Mirror the real worker-death path so the engine actually tears down
+        # rather than waiting on a future collective_rpc that a paused scheduler
+        # guarantees will never happen.
+        try:
+            self.shutdown()
+        except Exception:
+            logger.exception("Error shutting down executor after %r timeout", op)
+        # The failure callback (registered by EngineCore via
+        # register_failure_callback) is the ONLY path that enqueues
+        # EXECUTOR_FAILED and triggers _send_engine_dead. Invoke it if present.
+        callback = getattr(self, "failure_callback", None)
+        if callback is not None:
+            # One-shot, mirroring start_worker_monitor's monitor_workers().
+            self.failure_callback = None
+            try:
+                callback()
+            except Exception:
+                logger.exception(
+                    "Error invoking failure callback after %r timeout", op
+                )
+
     def sleep(self, level: int = 1):
         if self.is_sleeping:
             logger.warning("Executor is already sleeping.")
             return
         time_before_sleep = time.perf_counter()
-        self.collective_rpc("sleep", kwargs=dict(level=level))
+        # The except arm is intentionally always present. When
+        # VLLM_SLEEP_WAKE_TIMEOUT_SECONDS is unset/0, _sleep_wake_timeout()
+        # returns None, collective_rpc blocks without a bounded deadline and
+        # cannot raise the bounded TimeoutError, so this arm is inert and
+        # behavior is identical to upstream. It only activates when the bound
+        # is explicitly opted into.
+        try:
+            self.collective_rpc(
+                "sleep", kwargs=dict(level=level), timeout=_sleep_wake_timeout()
+            )
+        except TimeoutError:
+            self._fail_on_sleep_wake_timeout("sleep")
+            raise
         time_after_sleep = time.perf_counter()
         self.sleeping_tags = {"weights", "kv_cache"}
         self.is_sleeping = True
@@ -340,7 +431,16 @@ class Executor(ABC):
                     )
                     return
         time_before_wakeup = time.perf_counter()
-        self.collective_rpc("wake_up", kwargs=dict(tags=tags))
+        # See sleep(): the except arm is inert when the bound is disabled
+        # (timeout=None can't raise the bounded TimeoutError); behavior is
+        # unchanged from upstream unless VLLM_SLEEP_WAKE_TIMEOUT_SECONDS is set.
+        try:
+            self.collective_rpc(
+                "wake_up", kwargs=dict(tags=tags), timeout=_sleep_wake_timeout()
+            )
+        except TimeoutError:
+            self._fail_on_sleep_wake_timeout("wake_up")
+            raise
         time_after_wakeup = time.perf_counter()
         logger.info(
             "It took %.6f seconds to wake up tags %s.",


### PR DESCRIPTION
## Summary

On TP/PP, if a worker process dies or aborts **before setting its shm read flag**, the broadcast ring fills and the engine-side broadcaster's `MessageQueue.acquire_write(timeout=None)` blocks **forever**. The dead rank's read flag is never set, so the block never becomes writable, and `shutdown()` only wakes blocked *readers* — not the writer.

The reader path (`acquire_read`) already has a `shutting_down` escape that raises `RuntimeError("cancelled")`. This PR adds the **mirror escape to the `acquire_write` spin loop**, so a worker death surfaces as a clean, recoverable cancellation instead of an unrecoverable hang.

It also adds an **optional bounded timeout** for the `sleep` / `wake_up` collective RPCs via `VLLM_SLEEP_WAKE_TIMEOUT_SECONDS` (default `0` = disabled, since a legitimate cold wake can take minutes). When set to a generous bound, a worker that aborts mid-wake surfaces as a `TimeoutError` the engine can act on, rather than the engine blocking forever on a dead worker's RPC reply.

## Repro

TP2/PP2 serving wedges on a single request when a worker dies mid-RPC:

1. A worker aborts mid-RPC; the `sample_tokens` collective RPC times out → `EngineDead`.
2. The engine `SIGKILL`s the workers.
3. On restart it wedges again with `No available shared memory broadcast block found in 60 seconds`.

Root cause: the broadcaster (writer) had no `shutting_down` escape, so a dead reader's never-set flag left the writer spinning on a full ring indefinitely.

## The fix

- `vllm/distributed/device_communicators/shm_broadcast.py` — `acquire_write` spin loop gains `if self.shutting_down: raise RuntimeError("cancelled")`, mirroring the reader's existing escape.
- `vllm/v1/executor/abstract.py` — bounded sleep/wake collective RPC via a `_sleep_wake_timeout()` helper.
- `vllm/envs.py` — `VLLM_SLEEP_WAKE_TIMEOUT_SECONDS` (default `0` = disabled).

## Test

Adds `tests/distributed/test_shm_broadcast.py::test_writer_acquire_write_honors_shutdown`: fills the ring, blocks a writer on `acquire_write(timeout=None)`, then calls `shutdown()` and asserts the writer unwedges with `RuntimeError("cancelled")`.

The regression test **FAILs pre-fix** (the writer stays wedged and the test times out) and **PASSes post-fix**.
