### PR TITLE
[Feature][ROCm] Add flydsl_intranode MoE expert-parallel backend

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -45,6 +45,7 @@ All2AllBackend = Literal[
     "deepep_v2",
     "mori_high_throughput",
     "mori_low_latency",
+    "flydsl_intranode",
     "nixl_ep",
     "allgather_reducescatter",
     "flashinfer_all2allv",  # temporary alias for flashinfer_nvlink_two_sided
@@ -192,7 +193,8 @@ class ParallelConfig:
     - "mori_low_latency": MoRI EP with InterNodeV1LL for multi-node
     - "nixl_ep": Use nixl-ep kernels
     - "flashinfer_nvlink_two_sided": Use flashinfer two-sided kernels for mnnvl
-    - "flashinfer_nvlink_one_sided": Use flashinfer high-throughput a2a kernels"""
+    - "flashinfer_nvlink_one_sided": Use flashinfer high-throughput a2a kernels
+    - "flydsl_intranode": FlyDSL intranode EP dispatch/combine (PR #522)"""
 
     max_parallel_loading_workers: int | None = Field(default=None, ge=1)
     """Maximum number of parallel loading workers when loading model

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -154,6 +154,10 @@ class CudaCommunicator(DeviceCommunicatorBase):
                     tcp_store_group,
                     device_group=self.device_group,
                 )
+            elif self.all2all_backend == "flydsl_intranode":
+                from .flydsl_all2all import FlydslAll2AllManager
+
+                self.all2all_manager = FlydslAll2AllManager(self.cpu_group)
             elif self.all2all_backend == "nixl_ep":
                 from .all2all import NixlEPAll2AllManager
 

--- a/vllm/distributed/device_communicators/flydsl_all2all.py
+++ b/vllm/distributed/device_communicators/flydsl_all2all.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import os
+import sys
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.utils.import_utils import has_flydsl_ep
+
+from .base_device_communicator import All2AllManagerBase, Cache
+
+logger = init_logger(__name__)
+
+
+class FlydslAll2AllManager(All2AllManagerBase):
+    """FlyDSL intranode EP dispatch/combine all2all manager."""
+
+    def __init__(self, cpu_group):
+        assert has_flydsl_ep(), (
+            "FlyDSL EP requires mori >= 1.2 with mori.ir.flydsl and FlyDSL kernels. "
+            "Set FLYDSL_REPO to the FlyDSL repo root or pip install flydsl."
+        )
+        import mori
+
+        super().__init__(cpu_group)
+        self.handle_cache = Cache()
+        torch._C._distributed_c10d._register_process_group("mori", cpu_group)
+        mori.shmem.shmem_torch_process_group_init("mori")
+
+    def _make_flydsl_kwargs(
+        self,
+        rank: int,
+        num_ep_ranks: int,
+        input_dtype: torch.dtype,
+        quant_dtype: torch.dtype,
+        token_hidden_size: int,
+        scale_dim: int,
+        scale_type_size: int,
+        max_num_tokens_per_dp_rank: int,
+        num_local_experts: int,
+        num_experts_per_token: int,
+    ):
+        return dict(
+            rank=rank,
+            world_size=num_ep_ranks,
+            hidden_dim=token_hidden_size,
+            max_num_inp_token_per_rank=max_num_tokens_per_dp_rank,
+            num_experts_per_rank=num_local_experts,
+            num_experts_per_token=num_experts_per_token,
+            data_type=quant_dtype,
+            use_external_inp_buf=False,
+            scale_dim=scale_dim,
+            scale_type_size=scale_type_size,
+            max_token_type_size=max(input_dtype.itemsize, torch.bfloat16.itemsize),
+        )
+
+    def _make_handle(self, **kwargs):
+        repo = os.environ.get("FLYDSL_REPO", "")
+        if repo and repo not in sys.path:
+            sys.path.insert(0, repo)
+        from kernels.dispatch_combine_intranode_op import (
+            FlyDSLDispatchCombineConfig,
+            FlyDSLDispatchCombineIntraNodeOp,
+        )
+
+        cfg = FlyDSLDispatchCombineConfig(**kwargs)
+        return FlyDSLDispatchCombineIntraNodeOp(cfg)
+
+    def get_handle(self, kwargs):
+        fly_kwargs = self._make_flydsl_kwargs(**kwargs)
+        logger.debug("FlyDSL all2all args %s", fly_kwargs)
+        return self.handle_cache.get_or_create(fly_kwargs, self._make_handle)

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -32,6 +32,7 @@ from vllm.platforms import current_platform
 from vllm.utils.import_utils import (
     has_deep_ep,
     has_deep_ep_v2,
+    has_flydsl_ep,
     has_mori,
     has_nixl_ep,
 )
@@ -49,6 +50,8 @@ if current_platform.is_cuda_alike():
         from .prepare_finalize.deepep_v2 import DeepEPV2PrepareAndFinalize
     if has_mori():
         from .prepare_finalize.mori import MoriPrepareAndFinalize
+    if has_flydsl_ep():
+        from .prepare_finalize.flydsl_ep import FlydslEpPrepareAndFinalize
     if has_nixl_ep():
         from .prepare_finalize.nixl_ep import (
             NIXL_EP_QUANT_BLOCK_SHAPE,
@@ -235,22 +238,17 @@ def maybe_make_prepare_finalize(
             use_cudagraph=use_cudagraph,
         )
 
-    elif moe.use_mori_kernels:
+    elif moe.use_mori_kernels or moe.use_flydsl_ep_kernels:
         assert quant_config is not None
 
-        # Note: We may want to use FP8 dispatch just to reduce
-        # data movement.
+        # Note: We may want to use FP8 dispatch just to reduce data movement.
         use_fp8_dispatch = (
             quant_config.is_per_act_token or quant_config.is_block_quantized
         )
         if use_fp8_dispatch:
-            # For PTPC (per token per channel) quant, scale dim is 1
-            # For 1x128 quant, scale dim is hidden_dim // 128
             quant_dtype = quant_config.quant_dtype
             scale_dim = 1 if quant_config.is_per_act_token else moe.hidden_dim // 128
         else:
-            # Unquantized dispatch (e.g. AITER with defer_input_quant):
-            # dispatch raw BF16/FP16 data, no scales needed.
             quant_dtype = moe.in_dtype
             scale_dim = 0
         all_to_all_args = dict(
@@ -267,12 +265,20 @@ def maybe_make_prepare_finalize(
         )
         handle = all2all_manager.get_handle(all_to_all_args)
 
-        prepare_finalize = MoriPrepareAndFinalize(
-            handle,
-            max_tokens_per_rank=moe.max_num_tokens,
-            num_dispatchers=all2all_manager.world_size,
-            use_fp8_dispatch=use_fp8_dispatch,
-        )
+        if moe.use_mori_kernels:
+            prepare_finalize = MoriPrepareAndFinalize(
+                handle,
+                max_tokens_per_rank=moe.max_num_tokens,
+                num_dispatchers=all2all_manager.world_size,
+                use_fp8_dispatch=use_fp8_dispatch,
+            )
+        else:
+            prepare_finalize = FlydslEpPrepareAndFinalize(
+                handle,
+                max_tokens_per_rank=moe.max_num_tokens,
+                num_dispatchers=all2all_manager.world_size,
+                use_fp8_dispatch=use_fp8_dispatch,
+            )
 
     elif moe.use_fi_nvl_two_sided_kernels:
         assert quant_config is not None

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1067,6 +1067,13 @@ class FusedMoEParallelConfig:
         )
 
     @property
+    def use_flydsl_ep_kernels(self):
+        return (
+            self.use_all2all_kernels
+            and self.all2all_backend == "flydsl_intranode"
+        )
+
+    @property
     def use_nixl_ep_kernels(self):
         return self.use_all2all_kernels and self.all2all_backend == "nixl_ep"
 
@@ -1306,12 +1313,12 @@ class FusedMoEConfig:
                 rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
             )
 
-        if self.use_mori_kernels:
+        if self.use_mori_kernels or self.use_flydsl_ep_kernels:
             assert self.rocm_aiter_fmoe_enabled, (
-                "Mori needs to be used with aiter fused_moe for now."
+                "Mori/FlyDSL EP needs to be used with aiter fused_moe for now."
             )
             assert not self.aiter_fmoe_shared_expert_enabled, (
-                "Mori does not support fusion shared expert now. "
+                "Mori/FlyDSL EP does not support fusion shared expert now. "
                 "Turn it off by setting VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0"
             )
 
@@ -1381,6 +1388,10 @@ class FusedMoEConfig:
     @property
     def use_mori_kernels(self):
         return self.moe_parallel_config.use_mori_kernels
+
+    @property
+    def use_flydsl_ep_kernels(self):
+        return self.moe_parallel_config.use_flydsl_ep_kernels
 
     @property
     def use_fi_nvl_two_sided_kernels(self):

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -399,7 +399,10 @@ class AiterExperts(mk.FusedMoEExpertsModular):
         # so we should not defer input quantization.
         # Otherwise, AITER fused MoE kernels handle input quantization
         # internally via a single fused kernel.
-        return not self.moe_config.use_mori_kernels
+        return not (
+            self.moe_config.use_mori_kernels
+            or self.moe_config.use_flydsl_ep_kernels
+        )
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/flydsl_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/flydsl_ep.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+from vllm.platforms import current_platform
+
+
+def _stage_combine_input(op, expert_out: torch.Tensor, combine_dtype: torch.dtype):
+    if expert_out.dtype != combine_dtype:
+        src = expert_out.to(combine_dtype)
+    else:
+        src = expert_out
+    if getattr(getattr(op, "cfg", None), "zero_copy", False):
+        cb = op.get_registered_combine_input_buffer(combine_dtype)
+        n = src.shape[0]
+        if n > 0:
+            cb[:n].copy_(src)
+        return cb
+    return src if src.is_contiguous() else src.contiguous()
+
+
+class FlydslEpPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
+    """Prepare/Finalize using FlyDSL intranode EP dispatch/combine."""
+
+    def __init__(
+        self,
+        fly_op,
+        max_tokens_per_rank: int,
+        num_dispatchers: int,
+        use_fp8_dispatch: bool = False,
+    ):
+        super().__init__()
+        self.fly_op = fly_op
+        self.num_dispatchers_ = num_dispatchers
+        self.max_tokens_per_rank = max_tokens_per_rank
+        self.use_fp8_dispatch = use_fp8_dispatch
+        self._dispatch_indices: torch.Tensor | None = None
+        self._cur_tok: int = 0
+        self.combine_dtype = torch.bfloat16
+
+    @property
+    def activation_format(self) -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    def output_is_reduced(self) -> bool:
+        return True
+
+    def num_dispatchers(self):
+        return self.num_dispatchers_
+
+    def max_num_tokens_per_rank(self) -> int | None:
+        return self.max_tokens_per_rank
+
+    def topk_indices_dtype(self) -> torch.dtype | None:
+        return torch.int32
+
+    def supports_async(self) -> bool:
+        return False
+
+    def prepare(
+        self,
+        a1: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        num_experts: int,
+        expert_map: torch.Tensor | None,
+        apply_router_weight_on_input: bool,
+        quant_config: FusedMoEQuantConfig,
+        defer_input_quant: bool = False,
+    ) -> mk.PrepareResultType:
+        assert not apply_router_weight_on_input, (
+            "flydsl_ep does not support apply_router_weight_on_input=True now."
+        )
+        scale = None
+        if self.use_fp8_dispatch and not defer_input_quant:
+            from aiter import QuantType, get_hip_quant
+
+            if quant_config.is_block_quantized:
+                quant_func = get_hip_quant(QuantType.per_1x128)
+                a1, scale = quant_func(a1, quant_dtype=current_platform.fp8_dtype())
+            elif quant_config.is_per_act_token:
+                quant_func = get_hip_quant(QuantType.per_Token)
+                a1, scale = quant_func(a1, quant_dtype=current_platform.fp8_dtype())
+
+        (
+            dispatch_a1,
+            dispatch_weights,
+            dispatch_scale,
+            dispatch_ids,
+            dispatch_recv_token_num,
+        ) = self.fly_op.dispatch(a1, topk_weights, scale, topk_ids)
+
+        self._dispatch_indices = dispatch_ids
+        self._cur_tok = a1.shape[0]
+
+        expert_tokens_meta = mk.ExpertTokensMetadata(
+            expert_num_tokens=dispatch_recv_token_num, expert_num_tokens_cpu=None
+        )
+
+        return (
+            dispatch_a1,
+            dispatch_scale,
+            expert_tokens_meta,
+            dispatch_ids,
+            dispatch_weights,
+        )
+
+    def finalize(
+        self,
+        output: torch.Tensor,
+        fused_expert_output: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        apply_router_weight_on_input: bool,
+        weight_and_reduce_impl: mk.TopKWeightAndReduce,
+    ) -> None:
+        num_token = output.shape[0]
+        assert self._dispatch_indices is not None
+        comb_inp = _stage_combine_input(
+            self.fly_op, fused_expert_output, self.combine_dtype
+        )
+        out_tok, _ = self.fly_op.combine(
+            comb_inp,
+            None,
+            self._dispatch_indices,
+            cur_tok=self._cur_tok,
+        )
+        output.copy_(out_tok[:num_token])

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -534,6 +534,23 @@ def has_mori() -> bool:
     return _has_module("mori")
 
 
+def has_flydsl_ep() -> bool:
+    """Whether FlyDSL intranode EP dispatch/combine kernels are available."""
+    if not has_mori():
+        return False
+    try:
+        import mori.ir.flydsl  # noqa: F401
+    except ImportError:
+        return False
+    import importlib.util
+
+    if importlib.util.find_spec("flydsl") is None and not os.environ.get(
+        "FLYDSL_REPO"
+    ):
+        return False
+    return True
+
+
 def has_fbgemm_gpu() -> bool:
     """Whether the optional `fbgemm_gpu` package is available."""
     return _has_module("fbgemm_gpu")


### PR DESCRIPTION
Wire FlyDSL intranode dispatch/combine as an all2all backend alongside MoRI, reusing the existing aiter fused_moe expert GEMM path. Requires mori (shmem), flydsl/mori.ir.flydsl, and FlyDSL dispatch kernels via pip or FLYDSL_REPO.




## Purpose

Wire FlyDSL intranode dispatch/combine as a new `--all2all-backend flydsl_intranode` option alongside MoRI, reusing the existing aiter `fused_moe` expert GEMM path (same as the MoRI EP integration). This adds FlyDSL PR#522-style intranode EP communication without changing the MoE compute backend.

**Requirements:** mori (shmem, ≥1.2 with `mori.ir.flydsl`), FlyDSL dispatch kernels (`pip install flydsl` or `FLYDSL_REPO` pointing at the FlyDSL repo root).

**Note:** This is distinct from the existing `moe_backend=flydsl` / `fused_flydsl_moe.py` path (W4A16 GEMM). This PR only replaces EP dispatch/combine; expert GEMM stays on aiter.

## Test Plan

- [x] Build FlyDSL from source + mori 1.2 on 8× MI355X (gfx950), integrate vLLM FlyDSL EP backend
- [x] MoE layer microbench: comm-only and full-layer E2E (`bench_dsv4_moe_e2e.py`, fp8 dispatch, EP8, DSv4-Pro shapes)
- [x] Full-model vLLM serve + bench serve: MORI EP vs FlyDSL EP, same aiter fused_moe, `--no-enable-prefix-caching`, `--num-warmups 5`, isolated docker runs per backend
- [ ] Upstream CI (gfx950 EP tests) — pending maintainer review

**Serve command (FlyDSL EP):**

```bash
export FLYDSL_REPO=/path/to/FlyDSL   # if flydsl not pip-installed
export MORI_SHMEM_HEAP_SIZE=32G
vllm serve /models/deepseek-v4-pro \
  --enable-expert-parallel \
  --all2all-backend flydsl_intranode \
  --moe-backend aiter \
  --tensor-parallel-size 8 \
  --kv-cache-dtype fp8 \
  --no-enable-prefix-caching
```

**Baseline:** same flags with `--all2all-backend mori_high_throughput`.

## Test Result

Platform: 8× MI355X (gfx950), DSv4-Pro MoE (hidden=7168, topk=6, 384 experts, EP8).

### 1) Comm-only (fp4→bf16, zero-copy=false, eager / no CudaGraph)

| tokens | fly comm (µs) | mori comm (µs) | speedup | PR speedup | PR fly (µs) | PR mori (µs) |
|--------|---------------|----------------|---------|------------|-------------|--------------|
| 4 | 156 | 157 | 1.01x | 1.37x | 27 | 37 |
| 8 | 142 | 214 | 1.51x | 1.46x | 26 | 38 |
| 16 | — | — | failed | 1.48x | 27 | 39 |
| 32 | 249 | 257 | 1.03x | 1.34x | 31 | 42 |
| 64 | 254 | 267 | 1.05x | 1.05x | 45 | 47 |
| 128 | 294 | 324 | 1.10x | 1.11x | 73 | 82 |
| 256 | 309 | 378 | 1.22x | 1.17x | 116 | 135 |
| 4096 | 3842 | 4244 | 1.10x | 1.19x | 1530 | 1819 |
| 8192 | 7622 | 8414 | 1.10x | 1.19x | 3050 | 3640 |

Speedup trend at large tokens is close to the PR reference (~1.10x vs ~1.19x), but absolute latency is still ~2–2.5× higher than PR numbers (likely due to eager vs CudaGraph and `zero_copy=false` in this bench setup).

### 2) Full MoE layer E2E (flydsl/mori dispatch + aiter fused_moe, fp8 dispatch)

| tokens | mori total (µs) | flydsl total (µs) | E2E speedup |
|--------|-----------------|-------------------|-------------|
| 4 | 496 | 263 | 1.89x |
| 8 | 648 | 500 | 1.29x |
| 16 | 745 | 666 | 1.12x |
| 32 | 895 | 852 | 1.05x |
| 64 | 1259 | 1152 | 1.09x |
| 128 | 1199 | 1126 | 1.07x |
| 256 | 1390 | 1266 | 1.10x |
| 4096 | 6398 | 5949 | **1.08x** |
| 8192 | 12495 | 11593 | **1.08x** |

### 3) Full-model vLLM prefill TTFT (EP8, bs=4, output=1, num-warmups=5, no prefix cache)

| input tokens | MORI TTFT (ms) | FlyDSL TTFT (ms) | speedup (mori/flydsl) |
|--------------|----------------|------------------|------------------------|
| 4096 | 794.5 | 777.8 | **1.021x** |
| 8000 | 1739.4 | 1720.4 | **1.011x** |

End-to-end full-model speedup is **~1–2% (~1.02x at 4096)**, consistent with microbench comm savings (~1.08x at 4096/8192 tokens) being a small fraction of total prefill time (attention + dense layers + 58× MoE layers).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR: add `flydsl_intranode` all2all backend for MoE EP dispatch/combine on ROCm, reusing aiter fused_moe GEMM.
- [x] The test plan: microbench (comm + layer E2E) and vLLM serve TTFT A/B on DSv4-Pro EP8.
- [x] The test results: comm ~1.08–1.10x, layer E2E ~1.08x, full-model TTFT ~1.02x vs MoRI baseline.
- [ ] Documentation update: optional follow-up for ROCm EP docs / `--all2all-backend` help text.

</details>

