### PR TITLE
[Core] Release CUDA graphs before sleep() unmap, re-capture on wake

### DIFF
--- a/tests/v1/cudagraph/test_cudagraph_release_on_sleep.py
+++ b/tests/v1/cudagraph/test_cudagraph_release_on_sleep.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for releasing CUDA graphs before a cumem sleep() unmap and
+re-capturing them after wake_up().
+
+Background: with CUDA-graph capture pools resident, per-allocation cumem VMM
+unmap/remap operations slow dramatically (field-measured ~6-9s for a 32B model
+vs ~2s without graphs). Releasing the captured graphs *before* the cumem unmap
+restores the fast unmap path; the graphs are re-captured on the next full wake.
+
+These tests assert the ordering contract -- graphs are released *before* the
+allocator unmap and re-captured *after* the allocator remap -- and the NONE-mode
+no-op behavior. The ordering tests run on CPU (allocator + model interactions
+are mocked); the real-graph release test is GPU-gated.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm.compilation.cuda_graph import CUDAGraphWrapper
+from vllm.config import CompilationConfig, CUDAGraphMode
+from vllm.forward_context import BatchDescriptor, set_forward_context
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu_worker import Worker
+
+from .test_cudagraph_dispatch import SimpleMLP, _create_vllm_config
+
+DEVICE_TYPE = current_platform.device_type
+
+
+# ---------------------------------------------------------------------------
+# Worker sleep/wake ordering contract (CPU; allocator + runner mocked)
+# ---------------------------------------------------------------------------
+
+
+def _make_worker_stub(cudagraph_mode: CUDAGraphMode = CUDAGraphMode.PIECEWISE):
+    """A bare object onto which we can bind the unbound Worker.sleep/wake_up
+    methods without standing up a real Worker (which needs a GPU + a model)."""
+    stub = MagicMock()
+    stub._sleep_saved_buffers = {}
+    stub._cudagraphs_released = False
+    # Wake-path tests assume a prior sleep() has run, which leaves both the
+    # weights and the KV cache suspended until a wake restores them. Tests that
+    # exercise sleep() itself reset these as needed.
+    stub._weights_suspended = True
+    stub._kv_cache_suspended = True
+
+    # model_runner.release_cudagraphs returns True iff graphs were present.
+    released = cudagraph_mode != CUDAGraphMode.NONE
+    stub.model_runner.release_cudagraphs.return_value = released
+    return stub
+
+
+def test_release_happens_before_unmap_on_sleep():
+    """sleep() must release CUDA graphs BEFORE the allocator unmaps the VA
+    space -- that is the whole point of the optimization."""
+    stub = _make_worker_stub(CUDAGraphMode.PIECEWISE)
+
+    order = []
+    stub.model_runner.release_cudagraphs.side_effect = lambda: (
+        order.append("release"),
+        True,
+    )[1]
+
+    allocator = MagicMock()
+    allocator.sleep.side_effect = lambda *a, **k: order.append("unmap")
+
+    with (
+        patch(
+            "vllm.v1.worker.gpu_worker.get_mem_allocator_instance",
+            return_value=allocator,
+        ),
+        patch("torch.cuda.mem_get_info", return_value=(10, 100)),
+    ):
+        Worker.sleep(stub, level=1)
+
+    assert order == ["release", "unmap"], (
+        "graphs must be released before the cumem unmap"
+    )
+    assert stub._cudagraphs_released is True
+    # sleep() unmaps both the weights and the KV cache, so both are suspended.
+    assert stub._weights_suspended is True
+    assert stub._kv_cache_suspended is True
+
+
+def test_recapture_happens_after_remap_on_wake():
+    """wake_up() must re-capture graphs AFTER the allocator remaps the VA
+    space (weights + KV cache must be back before capture)."""
+    stub = _make_worker_stub(CUDAGraphMode.PIECEWISE)
+    stub._cudagraphs_released = True  # as if a prior sleep() released them
+
+    order = []
+    allocator = MagicMock()
+    allocator.wake_up.side_effect = lambda *a, **k: order.append("remap")
+    stub.model_runner.recapture_cudagraphs.side_effect = lambda: order.append(
+        "recapture"
+    )
+
+    with patch(
+        "vllm.v1.worker.gpu_worker.get_mem_allocator_instance",
+        return_value=allocator,
+    ):
+        Worker.wake_up(stub, tags=None)
+
+    assert order == ["remap", "recapture"], (
+        "graphs must be re-captured after the cumem remap"
+    )
+    assert stub._cudagraphs_released is False
+
+
+def test_weights_only_wake_does_not_recapture():
+    """A weights-only wake leaves the KV cache unmapped, so graph capture must
+    wait for a full (kv_cache) wake."""
+    stub = _make_worker_stub(CUDAGraphMode.PIECEWISE)
+    stub._cudagraphs_released = True
+
+    allocator = MagicMock()
+    with patch(
+        "vllm.v1.worker.gpu_worker.get_mem_allocator_instance",
+        return_value=allocator,
+    ):
+        Worker.wake_up(stub, tags=["weights"])
+
+    stub.model_runner.recapture_cudagraphs.assert_not_called()
+    # Still pending: must re-capture on the eventual full wake.
+    assert stub._cudagraphs_released is True
+
+    # Now the KV cache comes back -> recapture fires.
+    with patch(
+        "vllm.v1.worker.gpu_worker.get_mem_allocator_instance",
+        return_value=allocator,
+    ):
+        Worker.wake_up(stub, tags=["kv_cache"])
+    stub.model_runner.recapture_cudagraphs.assert_called_once()
+    assert stub._cudagraphs_released is False
+
+
+def test_kv_cache_only_wake_defers_recapture_while_weights_asleep():
+    """The RLHF partial-wake pattern: sleep() -> wake_up(tags=["kv_cache"])
+    WITHOUT a prior weights wake. The weights are still cumem-unmapped, so a
+    recapture (which runs a forward pass through the weights) would fault with
+    CUDA_ERROR_ILLEGAL_ADDRESS. recapture_cudagraphs() must therefore be
+    deferred until the weights are subsequently woken.
+
+    Pre-fix this faulted: the recapture was gated only on the KV cache being
+    awake, so a kv_cache-only wake called capture_model() on unmapped weights.
+    """
+    stub = _make_worker_stub(CUDAGraphMode.PIECEWISE)
+    stub._cudagraphs_released = True
+    # Both segments start suspended (post-sleep); no wake has happened yet.
+    stub._weights_suspended = True
+    stub._kv_cache_suspended = True
+
+    allocator = MagicMock()
+
+    # kv_cache-only wake while weights are still asleep -> must NOT recapture.
+    with patch(
+        "vllm.v1.worker.gpu_worker.get_mem_allocator_instance",
+        return_value=allocator,
+    ):
+        Worker.wake_up(stub, tags=["kv_cache"])
+
+    stub.model_runner.recapture_cudagraphs.assert_not_called()
+    # Still pending: must fire once the weights come back. KV cache is now
+    # mapped, but the weights remain unmapped.
+    assert stub._cudagraphs_released is True
+    assert stub._weights_suspended is True
+    assert stub._kv_cache_suspended is False
+
+    # Now the weights are woken -> recapture fires (KV cache already mapped).
+    with patch(
+        "vllm.v1.worker.gpu_worker.get_mem_allocator_instance",
+        return_value=allocator,
+    ):
+        Worker.wake_up(stub, tags=["weights"])
+
+    stub.model_runner.recapture_cudagraphs.assert_called_once()
+    assert stub._cudagraphs_released is False
+    assert stub._weights_suspended is False
+
+
+def test_no_recapture_when_nothing_was_released():
+    """If sleep() never released graphs (e.g. cudagraph_mode NONE), wake_up()
+    must not attempt a re-capture."""
+    stub = _make_worker_stub(CUDAGraphMode.NONE)
+    stub._cudagraphs_released = False
+
+    allocator = MagicMock()
+    with patch(
+        "vllm.v1.worker.gpu_worker.get_mem_allocator_instance",
+        return_value=allocator,
+    ):
+        Worker.wake_up(stub, tags=None)
+
+    stub.model_runner.recapture_cudagraphs.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# GPUModelRunner.release_cudagraphs / recapture_cudagraphs unit behavior
+# ---------------------------------------------------------------------------
+
+
+class _RunnerStub:
+    """Minimal stand-in exposing just the attributes the two methods touch,
+    so we can exercise the real GPUModelRunner methods unbound without a GPU
+    model load."""
+
+    def __init__(self, cudagraph_mode: CUDAGraphMode):
+        self.compilation_config = MagicMock()
+        self.compilation_config.cudagraph_mode = cudagraph_mode
+        self.encoder_cudagraph_manager = None
+
+
+def test_release_cudagraphs_noop_for_none_mode():
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    stub = _RunnerStub(CUDAGraphMode.NONE)
+    assert GPUModelRunner.release_cudagraphs(stub) is False
+
+
+def test_recapture_cudagraphs_noop_for_none_mode():
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    stub = _RunnerStub(CUDAGraphMode.NONE)
+    # Should return without calling capture_model.
+    stub.capture_model = MagicMock()
+    GPUModelRunner.recapture_cudagraphs(stub)
+    stub.capture_model.assert_not_called()
+
+
+def test_release_cudagraphs_clears_wrappers_for_active_mode():
+    """For an active cudagraph_mode, release_cudagraphs must clear all
+    CUDAGraphWrapper instances and report that re-capture is required."""
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    stub = _RunnerStub(CUDAGraphMode.PIECEWISE)
+    stub.encoder_cudagraph_manager = MagicMock()
+
+    with (
+        patch.object(CUDAGraphWrapper, "clear_all_graphs") as clear_cg,
+        patch("vllm.v1.worker.gpu_model_runner.BreakableCUDAGraphWrapper") as breakable,
+        patch("torch.accelerator.synchronize"),
+        patch("torch.accelerator.empty_cache"),
+        patch("gc.collect"),
+    ):
+        result = GPUModelRunner.release_cudagraphs(stub)
+
+    assert result is True
+    clear_cg.assert_called_once()
+    breakable.clear_all_graphs.assert_called_once()
+    # Encoder graph manager dropped so its capture pool is freed too.
+    assert stub.encoder_cudagraph_manager is None
+
+
+# ---------------------------------------------------------------------------
+# Real captured-graph release (GPU only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="CUDA graph capture requires a CUDA-like device",
+)
+def test_clear_all_graphs_releases_captured_entries():
+    """End-to-end: capture a real CUDA graph, then assert clear_all_graphs()
+    (the primitive release_cudagraphs() relies on) drops the captured entry so
+    its capture pool can be reclaimed before a cumem unmap."""
+    vllm_config = _create_vllm_config(CompilationConfig())
+    model = SimpleMLP().to(DEVICE_TYPE)
+    wrapper = CUDAGraphWrapper(model, vllm_config, runtime_mode=CUDAGraphMode.FULL)
+    inp = torch.randn(1, 10, device=DEVICE_TYPE)
+    batch_descriptor = BatchDescriptor(num_tokens=10)
+
+    # Warmup (NONE mode), then capture (FULL mode).
+    with set_forward_context(
+        attn_metadata=None,
+        vllm_config=vllm_config,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+        batch_descriptor=None,
+    ):
+        wrapper(inp)
+    with set_forward_context(
+        attn_metadata=None,
+        vllm_config=vllm_config,
+        cudagraph_runtime_mode=CUDAGraphMode.FULL,
+        batch_descriptor=batch_descriptor,
+    ):
+        wrapper(inp)
+
+    assert batch_descriptor in wrapper.concrete_cudagraph_entries
+    assert wrapper.concrete_cudagraph_entries[batch_descriptor].cudagraph is not None
+
+    # The release primitive used by release_cudagraphs().
+    CUDAGraphWrapper.clear_all_graphs()
+
+    assert not wrapper.concrete_cudagraph_entries, (
+        "captured graphs must be dropped so the capture pool is reclaimable "
+        "before the cumem unmap"
+    )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6644,6 +6644,62 @@ class GPUModelRunner(
         )
         return cuda_graph_size
 
+    def release_cudagraphs(self) -> bool:
+        """Drop all captured CUDA graphs so their capture-pool memory is freed
+        before a cumem ``sleep()`` unmaps the virtual-address space.
+
+        With CUDA-graph capture pools resident, per-allocation cumem VMM
+        unmap/remap operations slow dramatically (field-measured ~6-9s for a
+        32B model vs ~2s without graphs), because every block the graph pool
+        touches forces an individual VMM op. Releasing the graphs first lets
+        the unmap take the fast path; ``recapture_cudagraphs()`` rebuilds them
+        after wake.
+
+        Returns ``True`` if there were graphs to release (i.e. the caller
+        should re-capture on wake), ``False`` otherwise (no-op when
+        ``cudagraph_mode`` is ``NONE``).
+        """
+        if self.compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
+            return False
+
+        # Ensure no captured graph is mid-replay before we drop references.
+        torch.accelerator.synchronize()
+
+        CUDAGraphWrapper.clear_all_graphs()
+        BreakableCUDAGraphWrapper.clear_all_graphs()
+        if self.encoder_cudagraph_manager is not None:
+            self.encoder_cudagraph_manager = None
+
+        # Force the dropped torch.cuda.CUDAGraph objects to finalize now so the
+        # backing capture pool is actually returned to the driver before the
+        # cumem unmap walks the address space. All three calls are required and
+        # ordered: gc.collect() runs the CUDAGraph finalizers that release the
+        # underlying graph exec + capture pool (clearing references alone is not
+        # enough -- the C++ objects free only on __del__); synchronize() then
+        # waits for any in-flight stream work referencing those pools to drain
+        # so the free is safe; and empty_cache() returns the now-unused caching
+        # allocator blocks (including the capture pool) to the driver, which is
+        # what lets the subsequent cumem unmap take the fast path instead of
+        # walking per-block VMM ops. Dropping any one leaves the pool resident
+        # and reintroduces the slow ~6-9s unmap.
+        gc.collect()
+        torch.accelerator.synchronize()
+        torch.accelerator.empty_cache()
+        logger.info("Released CUDA graphs ahead of sleep.")
+        return True
+
+    def recapture_cudagraphs(self) -> None:
+        """Re-capture CUDA graphs after a cumem ``wake_up()`` has remapped the
+        weights and KV cache. Counterpart to :meth:`release_cudagraphs`.
+
+        No-op when ``cudagraph_mode`` is ``NONE``. Safe to call even if no
+        graphs were previously captured -- ``capture_model`` simply rebuilds
+        the dispatch set.
+        """
+        if self.compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
+            return
+        self.capture_model()
+
     def _warmup_and_capture(
         self,
         desc: BatchDescriptor,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -142,6 +142,22 @@ class Worker(WorkerBase):
         # Buffers saved before sleep
         self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
 
+        # Whether CUDA graphs were released in the most recent sleep() and
+        # therefore need to be re-captured once the model is fully awake again.
+        self._cudagraphs_released: bool = False
+
+        # Whether the model weights / KV cache are currently offloaded or
+        # unmapped by a sleep(). Re-capturing CUDA graphs runs a forward pass
+        # through the weights AND uses the KV cache, so recapture MUST be
+        # deferred until a wake_up() has restored BOTH -- otherwise (e.g. the
+        # RLHF sleep() -> wake_up(["kv_cache"]) partial-wake sequence, which
+        # leaves the weights unmapped) the capture forward pass would read
+        # unmapped memory and fault with CUDA_ERROR_ILLEGAL_ADDRESS. These are
+        # tracked independently because weights and kv_cache can be woken in
+        # either order across separate wake_up() calls.
+        self._weights_suspended: bool = False
+        self._kv_cache_suspended: bool = False
+
         # Weight transfer engine is created in `load_model` once the model
         # is available, since the engine needs a reference to the model.
         self.weight_transfer_engine: WeightTransferEngine | None = None
@@ -172,6 +188,22 @@ class Worker(WorkerBase):
                 name: buffer.cpu().clone() for name, buffer in model.named_buffers()
             }
 
+        # Drop captured CUDA graphs before the cumem unmap. With graph capture
+        # pools resident, per-allocation VMM unmap/remap ops slow to ~6-9s for a
+        # 32B model (vs ~2s without graphs); releasing graphs first restores the
+        # fast unmap path. Re-captured lazily on wake_up(). No-op when
+        # cudagraph_mode is NONE.
+        self._cudagraphs_released = self.model_runner.release_cudagraphs()
+
+        # The cumem unmap below drops the weights and KV cache from GPU virtual
+        # memory (weights are offloaded to CPU on level-1 sleep, discarded on
+        # level-2; the KV cache is always discarded). Mark both suspended so a
+        # subsequent partial wake does NOT trigger a CUDA graph recapture (which
+        # would run a forward pass through unmapped weights). Recapture is
+        # deferred until BOTH are restored.
+        self._weights_suspended = True
+        self._kv_cache_suspended = True
+
         allocator = get_mem_allocator_instance()
         allocator.sleep(offload_tags=("weights",) if level == 1 else tuple())
         free_bytes_after_sleep, total = torch.cuda.mem_get_info()
@@ -188,6 +220,17 @@ class Worker(WorkerBase):
         allocator = get_mem_allocator_instance()
         allocator.wake_up(tags)
 
+        # Track whether this wake has restored the weights / KV cache to GPU
+        # memory. A wake with no tags restores everything; an explicit tag list
+        # restores only the named segments. This must happen BEFORE the
+        # recapture gate below, since recapture needs both mapped. The flags are
+        # sticky across wake_up() calls so weights and kv_cache may be woken in
+        # either order (e.g. weights-only then kv_cache-only, or vice versa).
+        if tags is None or "weights" in tags:
+            self._weights_suspended = False
+        if tags is None or "kv_cache" in tags:
+            self._kv_cache_suspended = False
+
         # Restore the buffers after level 2 sleep
         if len(self._sleep_saved_buffers):
             model = self.model_runner.model
@@ -198,6 +241,24 @@ class Worker(WorkerBase):
 
         if tags is None or "kv_cache" in tags:
             self.model_runner.post_kv_cache_wake_up()
+
+        # Re-capture CUDA graphs that were released in sleep(), now that the
+        # model is fully awake. Recapture runs a forward pass through the
+        # weights AND uses the KV cache, so BOTH must be mapped before it can
+        # run. We gate on the sticky suspension flags rather than this wake's
+        # tags so that the deferred recapture fires on whichever wake completes
+        # the pair -- handling the RLHF partial-wake pattern (kv_cache woken
+        # first, weights later) as well as the weights-first ordering. Until
+        # both are awake `_cudagraphs_released` stays True so a later wake still
+        # triggers it. No-op when cudagraph_mode is NONE (release_cudagraphs()
+        # returned False, so _cudagraphs_released is False).
+        if (
+            self._cudagraphs_released
+            and not self._weights_suspended
+            and not self._kv_cache_suspended
+        ):
+            self.model_runner.recapture_cudagraphs()
+            self._cudagraphs_released = False
 
     def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:
         if (


### PR DESCRIPTION
## What

With CUDA-graph capture pools resident, per-allocation cumem VMM unmap/remap operations slow dramatically during `sleep()`/`wake_up()` — **field-measured ~6-9s for a 32B model versus ~2s without graphs** — because every block the graph capture pool touches forces an individual VMM op.

This PR releases the captured graphs **before** the cumem unmap so the unmap takes the fast path, then re-captures them on the next full wake once weights and the KV cache have been remapped.

- `GPUModelRunner.release_cudagraphs()` — drops all captured graph entries (`CUDAGraphWrapper` / `BreakableCUDAGraphWrapper` instances + the encoder cudagraph manager), forces finalization (`gc.collect()` + `empty_cache()`) so the capture pool returns to the driver before the unmap, and reports whether re-capture is needed.
- `GPUModelRunner.recapture_cudagraphs()` — rebuilds graphs via `capture_model()`.
- `Worker.sleep()` — releases graphs before `allocator.sleep()` (the unmap).
- `Worker.wake_up()` — re-captures after `allocator.wake_up()` (the remap), **only on a full wake** (no tags / `kv_cache`); a weights-only wake defers re-capture until the KV cache is back.

All paths are **no-ops when `cudagraph_mode` is `NONE`**.

## Why this is complementary to #45623 (not a duplicate)

#45623 routes the graph pool through cumem and restores it **in place** on wake (a capacity optimization — frees graph memory while asleep, no re-capture). This PR takes the opposite, complementary tack for **wake latency**: it releases the graphs so the slow VMM unmap/remap path is avoided entirely, then re-captures. The release/recapture strategy is the workaround field-confirmed by @AlanFokCo on #45398 (no clean allocator-level fix was found for the in-place case).

## Tests

`tests/v1/cudagraph/test_cudagraph_release_on_sleep.py` asserts the ordering contract:
- graphs are released **before** the allocator unmap in `sleep()` (the core assertion — fails pre-fix, passes post-fix),
- graphs are re-captured **after** the allocator remap in `wake_up()`,
- a weights-only wake defers re-capture until a `kv_cache` wake,
- `release_cudagraphs()` clears all wrapper instances + drops the encoder manager,
- `cudagraph_mode == NONE` is a no-op on both paths.

The ordering/no-op tests run on CPU (allocator + model interactions mocked); the real captured-graph release test is GPU-gated via `current_platform.is_cuda_alike()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)