### PR TITLE
[Core] Validate engine with a forward pass after wake_up so /health can't lie

### DIFF
--- a/tests/v1/engine/test_engine_core_wake_validate.py
+++ b/tests/v1/engine/test_engine_core_wake_validate.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for failed-wake state propagation in EngineCore.wake_up().
+
+When the worker-level post-wake validation forward pass raises (a corrupt
+wake), EngineCore.wake_up() must (a) mark the engine as fatally errored via the
+_on_fatal_error hook so /health reports the truth, and (b) re-raise so the wake
+call itself reports failure. A clean wake must do neither.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.v1.engine.core import EngineCore
+
+
+def _make_core(*, wake_side_effect=None):
+    core = object.__new__(EngineCore)
+
+    model_executor = MagicMock()
+    if wake_side_effect is not None:
+        model_executor.wake_up.side_effect = wake_side_effect
+    core.model_executor = model_executor
+
+    flags = {"resume_scheduler": 0, "on_fatal_error": 0}
+    core.resume_scheduler = lambda: flags.__setitem__(
+        "resume_scheduler", flags["resume_scheduler"] + 1
+    )
+    core._on_fatal_error = lambda: flags.__setitem__(
+        "on_fatal_error", flags["on_fatal_error"] + 1
+    )
+    return core, model_executor, flags
+
+
+def test_clean_wake_does_not_mark_dead():
+    core, model_executor, flags = _make_core()
+
+    EngineCore.wake_up(core, tags=None)
+
+    model_executor.wake_up.assert_called_once_with(None)
+    assert flags["on_fatal_error"] == 0
+    assert flags["resume_scheduler"] == 1
+
+
+def test_failed_wake_marks_engine_dead_and_reraises():
+    """Pre-fix the exception escaped without marking the engine dead, so
+    /health kept returning ready. Post-fix _on_fatal_error must fire AND the
+    exception must propagate."""
+    boom = RuntimeError("CUDA error: an illegal memory access was encountered")
+    core, model_executor, flags = _make_core(wake_side_effect=boom)
+
+    with pytest.raises(RuntimeError, match="illegal memory access"):
+        EngineCore.wake_up(core, tags=None)
+
+    assert flags["on_fatal_error"] == 1
+    # Scheduling must NOT resume on a dead engine.
+    assert flags["resume_scheduler"] == 0
+
+
+def test_scheduling_only_wake_skips_executor():
+    core, model_executor, flags = _make_core()
+
+    EngineCore.wake_up(core, tags=["scheduling"])
+
+    model_executor.wake_up.assert_not_called()
+    assert flags["on_fatal_error"] == 0
+    assert flags["resume_scheduler"] == 1
+
+
+def test_base_on_fatal_error_is_noop():
+    core = object.__new__(EngineCore)
+    # Base hook must be a safe no-op (overridden by the multiproc core).
+    assert EngineCore._on_fatal_error(core) is None

--- a/tests/v1/worker/test_gpu_worker_wake_validate.py
+++ b/tests/v1/worker/test_gpu_worker_wake_validate.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the post-wake validation forward pass in Worker.wake_up().
+
+These tests assert that a silently-corrupted wake (where the first real forward
+pass raises, e.g. cudaErrorIllegalAddress after a cumem remap) surfaces as a
+failure from wake_up() itself, instead of wake_up() blindly returning success
+and letting the engine report ready over a poisoned state.
+
+They run on CPU with the allocator and model runner mocked; no GPU required.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.v1.worker.gpu_worker import Worker
+
+
+def _make_worker(monkeypatch, *, dummy_run_side_effect=None):
+    """Build a bare Worker with only the attributes wake_up() touches.
+
+    Returns (worker, calls) where calls records which validation/runner methods
+    fired so tests can assert ordering.
+    """
+    calls = {"dummy_run": 0, "post_kv_cache_wake_up": 0, "allocator_wake_up": 0}
+
+    allocator = MagicMock()
+
+    def _allocator_wake_up(tags):
+        calls["allocator_wake_up"] += 1
+
+    allocator.wake_up.side_effect = _allocator_wake_up
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu_worker.get_mem_allocator_instance",
+        lambda: allocator,
+    )
+    # Avoid a real torch.cuda.synchronize() in the CPU test environment.
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu_worker.current_platform.is_cuda_alike",
+        lambda: False,
+    )
+
+    def _dummy_run(num_tokens, uniform_decode=False, **kwargs):
+        calls["dummy_run"] += 1
+        if dummy_run_side_effect is not None:
+            raise dummy_run_side_effect
+
+    def _post_kv_cache_wake_up():
+        calls["post_kv_cache_wake_up"] += 1
+
+    worker = object.__new__(Worker)
+    worker._sleep_saved_buffers = {}
+    worker.model_runner = SimpleNamespace(
+        uniform_decode_query_len=1,
+        _dummy_run=_dummy_run,
+        post_kv_cache_wake_up=_post_kv_cache_wake_up,
+    )
+    return worker, calls
+
+
+def test_wake_runs_validation_forward_pass_on_clean_wake(monkeypatch):
+    monkeypatch.setenv("VLLM_WAKE_VALIDATE", "1")
+    worker, calls = _make_worker(monkeypatch)
+
+    Worker.wake_up(worker, tags=None)
+
+    assert calls["allocator_wake_up"] == 1
+    assert calls["post_kv_cache_wake_up"] == 1
+    # A clean wake still runs the validation forward pass exactly once.
+    assert calls["dummy_run"] == 1
+
+
+def test_wake_raises_on_corrupt_wake(monkeypatch):
+    """Pre-fix this would silently return success; post-fix it must raise."""
+    monkeypatch.setenv("VLLM_WAKE_VALIDATE", "1")
+    boom = RuntimeError("CUDA error: an illegal memory access was encountered")
+    worker, calls = _make_worker(monkeypatch, dummy_run_side_effect=boom)
+
+    with pytest.raises(RuntimeError, match="illegal memory access"):
+        Worker.wake_up(worker, tags=None)
+
+    # Validation ran and failed loud — wake_up does NOT report success.
+    assert calls["dummy_run"] == 1
+
+
+def test_wake_validation_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("VLLM_WAKE_VALIDATE", "0")
+    boom = RuntimeError("CUDA error: an illegal memory access was encountered")
+    worker, calls = _make_worker(monkeypatch, dummy_run_side_effect=boom)
+
+    # With the flag off, wake_up must NOT run the validation pass and therefore
+    # must not raise (preserving the legacy opt-out behavior).
+    Worker.wake_up(worker, tags=None)
+    assert calls["dummy_run"] == 0
+
+
+def test_weights_only_wake_skips_validation(monkeypatch):
+    """A weights-only wake does not re-enable real forward passes, so the
+    validation pass (which needs KV cache) must be skipped."""
+    monkeypatch.setenv("VLLM_WAKE_VALIDATE", "1")
+    worker, calls = _make_worker(monkeypatch)
+
+    Worker.wake_up(worker, tags=["weights"])
+
+    assert calls["allocator_wake_up"] == 1
+    assert calls["post_kv_cache_wake_up"] == 0
+    assert calls["dummy_run"] == 0

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -143,6 +143,7 @@ if TYPE_CHECKING:
     VLLM_USE_RUST_FRONTEND: bool = False
     VLLM_RUST_FRONTEND_PATH: str | None = "auto"
     VLLM_SERVER_DEV_MODE: bool = False
+    VLLM_WAKE_VALIDATE: bool = True
     VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
     VLLM_MLA_DISABLE: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
@@ -1256,6 +1257,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # some additional endpoints for developing and debugging,
     # e.g. `/reset_prefix_cache`
     "VLLM_SERVER_DEV_MODE": lambda: bool(int(os.getenv("VLLM_SERVER_DEV_MODE", "0"))),
+    # After waking from sleep mode (e.g. cumem-backed sleep/wake), run a minimal
+    # validation forward pass inside wake_up() before reporting success. This
+    # catches engines that were silently corrupted by the wake (e.g. stale CUDA
+    # graphs or remapped memory producing cudaErrorIllegalAddress on the first
+    # real forward pass) so the failure surfaces at wake time and /health
+    # reflects the truth, instead of routing traffic into a poisoned engine.
+    # Default on; set to 0 to opt out.
+    "VLLM_WAKE_VALIDATE": lambda: bool(int(os.getenv("VLLM_WAKE_VALIDATE", "1"))),
     # Controls the maximum number of requests to handle in a
     # single asyncio task when processing per-token outputs in the
     # V1 AsyncLLM interface. It is applicable when handling a high
@@ -1981,6 +1990,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_CACHE_ROOT",
         "LD_LIBRARY_PATH",
         "VLLM_SERVER_DEV_MODE",
+        "VLLM_WAKE_VALIDATE",
         "VLLM_DP_MASTER_IP",
         "VLLM_DP_MASTER_PORT",
         "VLLM_NIXL_SIDE_CHANNEL_HOST",

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -780,10 +780,30 @@ class EngineCore:
             tags = [t for t in tags if t != "scheduling"]
 
         if tags is None or tags:
-            self.model_executor.wake_up(tags)
+            try:
+                self.model_executor.wake_up(tags)
+            except Exception:
+                # A wake failure (e.g. the post-wake validation forward pass
+                # raising on a silently-corrupted engine) means this engine can
+                # no longer serve traffic. Mark it dead so /health reports the
+                # truth instead of returning ready over a poisoned engine, then
+                # re-raise so the wake call itself reports failure.
+                logger.exception(
+                    "Engine wake_up failed; marking engine as dead. The engine "
+                    "must be restarted to recover."
+                )
+                self._on_fatal_error()
+                raise
 
         # Resume scheduling (applies to all levels)
         self.resume_scheduler()
+
+    def _on_fatal_error(self) -> None:
+        """Hook invoked when an unrecoverable engine error occurs (e.g. a
+        corrupt wake). Base implementation is a no-op; the multiprocess engine
+        core overrides this to signal the client that the engine is dead so
+        readiness/health checks fail."""
+        return None
 
     def is_sleeping(self) -> bool:
         """Check if engine is sleeping at any level."""
@@ -1443,7 +1463,6 @@ class EngineCoreProc(EngineCore):
 
         # Put ENGINE_CORE_DEAD in the queue.
         self.output_queue.put_nowait(EngineCoreProc.ENGINE_CORE_DEAD)
-
         # Wait until msg sent by the daemon before shutdown.
         self.output_thread.join(timeout=5.0)
         if self.output_thread.is_alive():
@@ -1451,6 +1470,11 @@ class EngineCoreProc(EngineCore):
                 "vLLM shutdown signal from EngineCore failed "
                 "to send. Please report this issue."
             )
+
+    def _on_fatal_error(self) -> None:
+        """Signal the client that the engine is dead so health/readiness checks
+        report the failure (e.g. after a corrupt wake)."""
+        self._send_engine_dead()
 
     def process_input_sockets(
         self,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -196,8 +196,45 @@ class Worker(WorkerBase):
                     buffer.data.copy_(self._sleep_saved_buffers[name].data)
             self._sleep_saved_buffers = {}
 
-        if tags is None or "kv_cache" in tags:
+        woke_kv_cache = tags is None or "kv_cache" in tags
+        if woke_kv_cache:
             self.model_runner.post_kv_cache_wake_up()
+
+        # Validate the woken engine with a minimal forward pass before reporting
+        # success. A cumem-backed wake can leave the engine silently corrupted
+        # (e.g. stale CUDA graphs or remapped device memory that produce
+        # cudaErrorIllegalAddress on the FIRST real forward pass). Without this,
+        # wake_up() returns success and /health reports ready, then traffic is
+        # routed into a poisoned engine and the next decode crashes the worker.
+        # Running a dummy decode here forces any such corruption to raise NOW,
+        # which propagates up through collective_rpc -> engine core and marks the
+        # engine errored so /health returns non-200 (the truth). Only run when KV
+        # cache was woken, since that is the wake that re-enables real forward
+        # passes; weights-only / scheduling wakes do not.
+        if woke_kv_cache and envs.VLLM_WAKE_VALIDATE:
+            self._validate_wake()
+
+    def _validate_wake(self) -> None:
+        """Run a minimal validation forward pass after waking from sleep.
+
+        Raises whatever the forward pass raises (e.g. a CUDA illegal-access
+        error from a corrupt wake), after synchronizing so the error is
+        attributed here rather than surfacing asynchronously on the next real
+        request.
+        """
+        try:
+            num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)
+            self.model_runner._dummy_run(num_tokens, uniform_decode=True)
+            if current_platform.is_cuda_alike():
+                torch.cuda.synchronize()
+        except Exception as e:
+            logger.error(
+                "Post-wake validation forward pass failed; the engine is "
+                "corrupted after wake_up and must not serve traffic. Set "
+                "VLLM_WAKE_VALIDATE=0 to disable this check. Error: %s",
+                e,
+            )
+            raise
 
     def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:
         if (


### PR DESCRIPTION
## Purpose

After a cumem-backed sleep/wake cycle, `wake_up()` can return success and `/health` can report the engine as ready even though the wake silently corrupted the engine (e.g. stale CUDA graphs or remapped device memory). The corruption only surfaces on the **first real forward pass**, which crashes the worker with `cudaErrorIllegalAddress`. By then traffic has already been routed into the poisoned engine and recovery requires a cold restart.

This is a real failure mode for sleep/wake-based model multiplexing: callers poll `/health`, see 200, route a request, and the engine dies on the first decode. `/health` lies.

This PR closes the gap at the source by validating the woken engine before reporting success:

- **`Worker.wake_up()`** runs a minimal validation forward pass (a dummy decode via the existing `_dummy_run` path) after the cumem remap and KV-cache re-init, before returning. If it raises, `wake_up()` raises instead of blindly reporting success. The exception is logged with a clear message. Gated behind `VLLM_WAKE_VALIDATE` (default **on**); only runs when the KV cache is woken, since that is the wake that re-enables real forward passes — weights-only and scheduling-only wakes are skipped.

- **`EngineCore.wake_up()`** catches a wake failure, invokes a new `_on_fatal_error()` hook, then re-raises. The multiprocess `EngineCoreProc` overrides the hook to send `ENGINE_CORE_DEAD`, so the client marks the engine errored and `/health` returns non-200 (the truth) instead of routing into a dead engine. Scheduling is not resumed on a failed wake.

Net effect: a corrupt wake now (a) fails the `wake_up` call loudly and (b) flips `/health` to unhealthy, so operators/orchestrators trigger recovery instead of feeding requests into a poisoned engine.

### Opt-out

`VLLM_WAKE_VALIDATE` (default `1`). Set `VLLM_WAKE_VALIDATE=0` to disable the post-wake validation pass and restore the previous behavior.

## Test Plan

Added unit tests:

- `tests/v1/worker/test_gpu_worker_wake_validate.py`
  - clean wake runs the validation pass exactly once
  - corrupt wake (dummy decode raises) makes `wake_up()` raise instead of returning success
  - `VLLM_WAKE_VALIDATE=0` skips validation and does not raise
  - weights-only wake skips validation (no KV cache woken)
- `tests/v1/engine/test_engine_core_wake_validate.py`
  - clean wake: engine not marked dead, scheduling resumes
  - failed wake: `_on_fatal_error` fires, exception re-raised, scheduling does **not** resume
  - scheduling-only wake skips the executor
  - base `_on_fatal_error` is a no-op

```
pytest tests/v1/worker/test_gpu_worker_wake_validate.py tests/v1/engine/test_engine_core_wake_validate.py
```

Each test asserts the post-fix behavior; the corresponding pre-fix code (no validation pass / no dead-marking) fails these assertions, confirming the tests catch the bug.

## Test Result

Tests pass against this branch. The corrupt-wake tests fail when the validation pass / fatal-error propagation is removed (pre-fix behavior), demonstrating the regression coverage.