### PR TITLE
[Bugfix] Use a large HTTP stream buffer in aiohttp to avoid ContentLengthError

### DIFF
--- a/vllm/connections.py
+++ b/vllm/connections.py
@@ -218,7 +218,12 @@ class HTTPConnection:
     # required, so that the client is only accessible inside async event loop
     async def get_async_client(self) -> aiohttp.ClientSession:
         if self._async_client is None or not self.reuse_client:
-            self._async_client = aiohttp.ClientSession(trust_env=True)
+            # Use a large HTTP stream buffer in aiohttp to avoid
+            # ContentLengthError when downloading image/video.
+            self._async_client = aiohttp.ClientSession(
+                trust_env=True,
+                read_bufsize=64 * 1024 * 1024,  # 64MB
+            )
 
         return self._async_client
 


### PR DESCRIPTION
### Problem                                                                                                                                                                                                                     

  When serving multimodal models with video/image inputs, vLLM's aiohttp client downloads
  media files from remote URLs. The default aiohttp `read_bufsize` is 64KB, which is
  insufficient under high concurrency with fast network speeds. This triggers a bug in
  aiohttp that results in:

  ContentLengthError: 400, message: "Not enough data to satisfy content length header"

  In stress testing with 100 concurrent requests downloading video files, **96 out of 100
  requests failed** with this error, causing a 96% failure rate.

  ### Root Cause

  aiohttp has a bug where, with a small `read_bufsize` and fast network speed, the
  stream buffer cannot keep up with incoming data, resulting in incomplete reads that
  fail the content-length validation.

  ### Fix

  Increase aiohttp `ClientSession` `read_bufsize` from the default 64KB to **64MB**.

  The minimum safe buffer size determined by experiment was 2MB, so 64MB provides
  ample headroom while keeping memory usage reasonable (shared across all requests
  using the global `HTTPConnection` instance).

  | Config | Concurrency | Success Rate |
  |---|---|---|
  | Default `read_bufsize` (64KB) | 100 | 4/100 (4%) |
  | `read_bufsize=64MB` | 100 | 100/100 (100%) |

  ## Test Plan

  1. Send 100 concurrent multimodal requests with video URLs:
  ```bash
  for i in {1..100}; do
      curl -s --location 'http://127.0.0.1:8000/v1/chat/completions' \
        -H 'Content-Type: application/json' \
        -d '{
          "model": "<model>",
          "messages": [{
            "role": "user",
            "content": [
              {"type": "video_url", "video_url": {"url": "<video_url>"}},
              {"type": "text", "text": "Summarize this video"}
            ]
          }],
          "stream": false
        }' &
  done
  wait

  2. Verify no ContentLengthError or Not enough data to satisfy content length header
  appears in the logs.
  3. Verify all 100 responses return successfully.

  Test Result

  With read_bufsize=64MB applied:

  - 100 concurrent requests with video input: 100/100 succeeded
  - No ContentLengthError observed
  - Memory overhead of 64MB buffer is acceptable as it is shared via the global
  HTTPConnection singleton
