### PR TITLE
[Feature] Support Anthropic search_result content blocks

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -344,6 +344,73 @@ class TestToolResultContent:
         ]
         assert len(user_follow_ups) == 0
 
+    def test_tool_result_search_result_blocks(self):
+        request = self._make_tool_result_request(
+            [
+                {
+                    "type": "search_result",
+                    "source": "https://example.com/ref",
+                    "title": "Reference",
+                    "content": [
+                        {"type": "text", "text": "first result"},
+                        {"type": "text", "text": "second result"},
+                    ],
+                    "citations": {"enabled": True},
+                }
+            ]
+        )
+        result = _convert(request)
+
+        tool_msg = [m for m in result.messages if m["role"] == "tool"]
+        assert len(tool_msg) == 1
+        assert tool_msg[0]["content"] == "first result\nsecond result"
+
+
+# ======================================================================
+# search_result content handling
+# ======================================================================
+
+
+class TestSearchResultContent:
+    def test_user_search_result_blocks_become_text_content(self):
+        request = _make_request(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "search_result",
+                            "source": "https://example.com/api",
+                            "title": "API docs",
+                            "content": [
+                                {"type": "text", "text": "Use an API key."},
+                                {"type": "text", "text": "Limit: 1000 requests."},
+                            ],
+                            "citations": {"enabled": True},
+                        },
+                        {
+                            "type": "text",
+                            "text": "How do I authenticate?",
+                        },
+                    ],
+                }
+            ]
+        )
+        result = _convert(request)
+
+        assert result.messages == [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Use an API key.\nLimit: 1000 requests.",
+                    },
+                    {"type": "text", "text": "How do I authenticate?"},
+                ],
+            }
+        ]
+
 
 # ======================================================================
 # Attribution header stripping

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -40,12 +40,13 @@ class AnthropicContentBlock(BaseModel):
         "tool_use",
         "tool_result",
         "tool_reference",
+        "search_result",
         "thinking",
         "redacted_thinking",
     ]
     text: str | None = None
-    # For image content
-    source: dict[str, Any] | None = None
+    # For image content and search results
+    source: dict[str, Any] | str | None = None
     # For tool use/result
     id: str | None = None
     tool_use_id: str | None = None
@@ -60,6 +61,16 @@ class AnthropicContentBlock(BaseModel):
     signature: str | None = None
     # For redacted thinking content (safety-filtered by the API)
     data: str | None = None
+
+    @model_validator(mode="after")
+    def validate_source(self):
+        if (
+            self.type == "image"
+            and self.source is not None
+            and not isinstance(self.source, dict)
+        ):
+            raise ValueError("image source must be a dictionary")
+        return self
 
 
 class AnthropicMessage(BaseModel):

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -121,6 +121,29 @@ class AnthropicServingMessages(OpenAIServingChat):
         data = source.get("data", "")
         return f"data:{media_type};base64,{data}"
 
+    @staticmethod
+    def _convert_search_result_to_text(
+        block: AnthropicContentBlock | dict[str, Any],
+    ) -> str:
+        if isinstance(block, AnthropicContentBlock):
+            content = block.content
+        else:
+            content = block.get("content")
+
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            return ""
+
+        text_parts: list[str] = []
+        for item in content:
+            if not isinstance(item, dict) or item.get("type") != "text":
+                continue
+            text = item.get("text")
+            if isinstance(text, str):
+                text_parts.append(text)
+        return "\n".join(text_parts)
+
     @classmethod
     def _convert_anthropic_to_openai_request(
         cls, anthropic_request: AnthropicMessagesRequest | AnthropicCountTokensRequest
@@ -243,9 +266,13 @@ class AnthropicServingMessages(OpenAIServingChat):
         """Convert individual content block"""
         if block.type == "text" and block.text:
             content_parts.append({"type": "text", "text": block.text})
-        elif block.type == "image" and block.source:
+        elif block.type == "image" and isinstance(block.source, dict):
             image_url = cls._convert_image_source_to_url(block.source)
             content_parts.append({"type": "image_url", "image_url": {"url": image_url}})
+        elif block.type == "search_result":
+            text = cls._convert_search_result_to_text(block)
+            if text:
+                content_parts.append({"type": "text", "text": text})
         elif block.type == "thinking" and block.thinking is not None:
             reasoning_parts.append(block.thinking)
         elif block.type == "redacted_thinking":
@@ -312,6 +339,10 @@ class AnthropicServingMessages(OpenAIServingChat):
                 item_type = item.get("type")
                 if item_type == "text":
                     text_parts.append(item.get("text", ""))
+                elif item_type == "search_result":
+                    search_text = cls._convert_search_result_to_text(item)
+                    if search_text:
+                        text_parts.append(search_text)
                 elif item_type == "image":
                     source = item.get("source", {})
                     url = cls._convert_image_source_to_url(source)


### PR DESCRIPTION
## Purpose

Fixes #45593.

This adds support for Anthropic `search_result` content blocks in the Messages API conversion path. The block text content is converted into normal OpenAI-compatible text content, and citation metadata is intentionally ignored because the OpenAI chat message format used here does not carry Anthropic citation fields.

## Test Plan

- Add conversion coverage for top-level user `search_result` content blocks.
- Add conversion coverage for nested `search_result` blocks inside `tool_result` content.
- Run Anthropic messages conversion unit tests.
- Run ruff check and format check on changed files.

## Test Result

- `python -m pytest --confcutdir=tests/entrypoints/anthropic tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -q`
  - `36 passed, 1 warning in 11.54s`
- `python -m ruff check vllm/entrypoints/anthropic/protocol.py vllm/entrypoints/anthropic/serving.py tests/entrypoints/anthropic/test_anthropic_messages_conversion.py`
  - `All checks passed!`
- `python -m ruff format --check vllm/entrypoints/anthropic/protocol.py vllm/entrypoints/anthropic/serving.py tests/entrypoints/anthropic/test_anthropic_messages_conversion.py`
  - `3 files already formatted`
- `git diff --check`
  - passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

