### PR TITLE
[BugFix] Fix MergedColumnParallelLinearWithLoRA apply for non-sharded LoRA.

### DIFF
--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -335,7 +335,13 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
             and type(self.base_layer).forward is not merged_cls.forward
         ):
             return self._apply_base_forward(x)
-        return _mcp_apply(x, bias, self)
+        # _mcp_apply always all-gathers the shrink buffer, which is only
+        # correct when lora_a is TP-sharded (S-LoRA). For the default path
+        # lora_a is replicated on every rank, so all_gather would inflate
+        # the buffer rank dim and break add_expand against lora_b_stacked.
+        if self.lora_config.fully_sharded_loras:
+            return _mcp_apply(x, bias, self)
+        return self._apply_sync(x, bias)
 
     @classmethod
     def can_replace_layer(


### PR DESCRIPTION
## Fix issue: https://github.com/vllm-project/vllm/issues/45691

## Pull Request

**Title:** `Fix MergedColumnParallelLinearWithLoRA apply for non-sharded LoRA under TP`

---

### Purpose

Fix a bug where `MergedColumnParallelLinearWithLoRA.apply()` incorrectly always used `_mcp_apply()`, which unconditionally all-gathers the shrink buffer. That path is only valid for S-LoRA (`fully_sharded_loras=True`). For the default replicated-`lora_a` path, all_gather inflates the buffer rank dimension and breaks `add_expand` against `lora_b_stacked` when `tensor_parallel_size > 1`.

Restore v0.18.0 behavior for the default case:
- `fully_sharded_loras=True` → `_mcp_apply()` (with all_gather)
- `fully_sharded_loras=False` → `_apply_sync()` (no all_gather)
- Custom unsharded subclass with tp_size=1 → `_apply_base_forward()` (unchanged)

Fixes: <!-- link your issue once filed, e.g. #XXXXX -->

---

### Test Plan

1. **Unit test — merged column parallel LoRA layers (primary):**
   ```bash
   pytest tests/lora/test_layers.py::test_column_parallel_packed \
     -k "repeats-2 and fully_shard-False" -v
   ```
   Covers `MergedColumnParallelLinearWithLoRA` with TP and non-sharded LoRA.

2. **Unit test — S-LoRA path still works:**
   ```bash
   pytest tests/lora/test_layers.py::test_column_parallel_packed \
     -k "repeats-2 and fully_shard-True" -v
   ```
   Ensures `_mcp_apply()` is still used for `MergedColumnParallelLinearWithShardedLoRA`.

3. **Broader LoRA layer regression:**
   ```bash
   pytest tests/lora/test_layers.py -k "fully_shard" -v
   ```

4. **Optional e2e (if available):** Serve a model with `gate_up_proj` LoRA under TP=2:
   ```bash
   vllm serve <model> --enable-lora --tensor-parallel-size 2 \
     --lora-modules '{"name": "test-lora", "path": "<path>", "base_model_name": "<model>"}'
   ```

---

### Test Result

| Test | Before fix | After fix |
|------|------------|-----------|
| `test_column_parallel_packed` (`repeats=2`, `fully_shard=False`, TP>1) | Fails — buffer rank dim inflated by all_gather, `add_expand` shape mismatch | Pass — uses `_apply_sync()`, no all_gather |
| `test_column_parallel_packed` (`repeats=2`, `fully_shard=True`) | Pass | Pass — still uses `_mcp_apply()` |
| Custom-forward subclass (`tp_size=1`) | Pass | Pass — `_apply_base_forward()` unchanged |

**Change summary:**

```diff
- return _mcp_apply(x, bias, self)
+ if self.lora_config.fully_sharded_loras:
+     return _mcp_apply(x, bias, self)
+ return self._apply_sync(x, bias)
```

---

**Checklist:**
- [x] Purpose describes the bug and fix
- [x] Test plan provides commands
- [x] Test results explain before/after behavior
- [ ] Documentation update not required (internal LoRA path fix)

