### PR TITLE
[MSA] Tune Triton indexer score decode for spec-decode

### DIFF
--- a/tests/kernels/attention/test_minimax_m3.py
+++ b/tests/kernels/attention/test_minimax_m3.py
@@ -90,7 +90,6 @@ def _reference_index_topk(
     topk: int,
     init_blocks: int,
     local_blocks: int,
-    sm_scale: float,
 ) -> torch.Tensor:
     total_q, num_idx_heads, _ = idx_q.shape
     out = torch.full(
@@ -106,7 +105,7 @@ def _reference_index_topk(
         num_blocks = (seq_len + BLOCK_SIZE - 1) // BLOCK_SIZE
         pages = block_table[req_id, :num_blocks]
         k = index_kv_cache[pages].reshape(num_blocks * BLOCK_SIZE, -1)
-        score = torch.einsum("qhd,kd->hqk", q.float(), k.float()) * sm_scale
+        score = torch.einsum("qhd,kd->hqk", q.float(), k.float())
 
         q_pos = prefix_len + torch.arange(q_len, device=idx_q.device)
         k_pos = torch.arange(k.shape[0], device=idx_q.device)
@@ -177,7 +176,6 @@ def test_prefill_index_topk_correctness():
         max_query_len=q_lens.max().item(),
         max_seq_len=max_seq_len,
         num_kv_heads=num_idx_heads,
-        sm_scale=head_dim**-0.5,
     )
     actual = minimax_m3_index_topk(
         score,
@@ -198,15 +196,22 @@ def test_prefill_index_topk_correctness():
         topk,
         init_blocks,
         local_blocks,
-        head_dim**-0.5,
     )
     _assert_topk_indices_equal_unordered(actual, expected)
 
 
-@pytest.mark.parametrize("decode_query_len", [1, 4])
+@pytest.mark.parametrize(
+    ("decode_query_len", "max_decode_query_len"),
+    [
+        (1, 1),
+        (1, 4),
+        (4, 4),
+    ],
+)
 @pytest.mark.parametrize("num_padded_reqs", [0, 2])
 def test_decode_index_topk_correctness(
     decode_query_len: int,
+    max_decode_query_len: int,
     num_padded_reqs: int,
 ):
     topk = 6
@@ -249,8 +254,8 @@ def test_decode_index_topk_correctness(
         init_blocks=init_blocks,
         local_blocks=local_blocks,
         num_kv_heads=num_idx_heads,
-        sm_scale=head_dim**-0.5,
         decode_query_len=decode_query_len,
+        max_decode_query_len=max_decode_query_len,
     )
     expected = torch.full_like(actual, -1)
     active_tokens = active_batch * decode_query_len
@@ -264,7 +269,6 @@ def test_decode_index_topk_correctness(
         topk,
         init_blocks,
         local_blocks,
-        head_dim**-0.5,
     )
     _assert_topk_indices_equal_unordered(actual, expected)
 

--- a/vllm/models/minimax_m3/common/indexer.py
+++ b/vllm/models/minimax_m3/common/indexer.py
@@ -175,6 +175,7 @@ class MiniMaxM3IndexerDecodeMetadata:
     block_table: torch.Tensor
     max_seq_len: int
     decode_query_len: int
+    max_decode_query_len: int
 
 
 @dataclass
@@ -229,6 +230,8 @@ class MiniMaxM3IndexerMetadataBuilder(
             assert tp_size % total_index_heads == 0
         self.num_index_heads = max(1, total_index_heads // tp_size)
         self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
+        assert self.reorder_batch_threshold is not None
+        self.max_decode_query_len = self.reorder_batch_threshold
 
         # Stable context-length buffer for decode cudagraph replays.
         self.context_len_buffer = torch.empty(
@@ -297,6 +300,7 @@ class MiniMaxM3IndexerTritonMetadataBuilder(MiniMaxM3IndexerMetadataBuilder):
                 block_table=block_table[:num_decodes],
                 max_seq_len=common_attn_metadata.max_seq_len,
                 decode_query_len=decode_query_len,
+                max_decode_query_len=self.max_decode_query_len,
             )
 
         return MiniMaxM3IndexerMetadata(
@@ -403,8 +407,8 @@ class MiniMaxM3IndexerTritonImpl(MiniMaxM3IndexerImpl):
                 self.init_blocks,
                 self.local_blocks,
                 self.num_kv_heads,
-                self.scale,
                 d.decode_query_len,
+                d.max_decode_query_len,
             )
         if index_md.num_prefills > 0:
             p = index_md.prefill
@@ -419,7 +423,6 @@ class MiniMaxM3IndexerTritonImpl(MiniMaxM3IndexerImpl):
                 p.max_query_len,
                 p.max_seq_len,
                 self.num_kv_heads,
-                self.scale,
             )
             prefill_topk = minimax_m3_index_topk(
                 score,

--- a/vllm/models/minimax_m3/common/ops/index_topk.py
+++ b/vllm/models/minimax_m3/common/ops/index_topk.py
@@ -794,7 +794,7 @@ def minimax_m3_index_decode(
     )
     # split-K over seq blocks; chunk count depends only on shape constants so
     # the grid is fixed within a cuda graph.
-    TARGET_GRID = 4096
+    TARGET_GRID = 512
     MAX_NUM_KV_CHUNKS = 256
     # Use the configured max decode length to avoid Triton recompiles when
     # switching between qlen=1 and spec-decode verification batches.

--- a/vllm/models/minimax_m3/common/ops/index_topk.py
+++ b/vllm/models/minimax_m3/common/ops/index_topk.py
@@ -89,7 +89,6 @@ def _index_block_score_kernel(
     prefix_lens,  # [batch] context length before this chunk's queries
     num_idx_heads,
     head_dim: tl.constexpr,
-    sm_scale,
     stride_q_n,
     stride_q_h,
     stride_q_d,
@@ -103,7 +102,6 @@ def _index_block_score_kernel(
     BLOCK_SIZE_Q: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,  # == SPARSE_BLOCK_SIZE (128)
 ):
-    sm_scale_log2e = sm_scale * 1.4426950409
     pid_q = tl.program_id(0)
     pid_bh = tl.program_id(1)
     pid_b = pid_bh // num_idx_heads
@@ -148,7 +146,7 @@ def _index_block_score_kernel(
             + off_k[None, :] * stride_ik_pos
             + off_d[:, None] * stride_ik_d,
         )
-        qk = tl.dot(q, k) * sm_scale_log2e
+        qk = tl.dot(q, k)
         # apply causal mask as needed
         if q_start < i + BLOCK_SIZE_K:
             qk = tl.where(off_q[:, None] >= pos[None, :], qk, float("-inf"))
@@ -290,8 +288,8 @@ def _topk_index_kernel(
 # Decode index-score kernel (split-K over seq blocks). Decode batches are
 # flattened request-major, with a runtime query length used to map each query
 # token back to its request metadata. Chunk counts depend only on shape
-# constants so the grid is fixed within a cuda graph. Base-2 (exp2/log2)
-# softmax matches prefill.
+# constants so the grid is fixed within a cuda graph. The score scale is omitted
+# because decode only consumes block ordering.
 # ---------------------------------------------------------------------------
 @triton.jit(do_not_specialize=["num_kv_chunks", "decode_query_len"])
 def _decode_index_score_kernel(
@@ -304,7 +302,6 @@ def _decode_index_score_kernel(
     head_dim: tl.constexpr,
     init_blocks,
     local_blocks,
-    sm_scale,
     decode_query_len,
     stride_q_n,
     stride_q_h,
@@ -317,25 +314,31 @@ def _decode_index_score_kernel(
     stride_s_k,
     stride_bt_b,
     BLOCK_SIZE_K: tl.constexpr,  # == SPARSE_BLOCK_SIZE (128)
+    BLOCK_SIZE_Q: tl.constexpr,
     num_kv_chunks,
     USE_PDL: tl.constexpr,
 ):
-    sm_scale_log2e = sm_scale * 1.4426950409
-    pid_b = tl.program_id(0)  # flattened query-token id
+    BLOCK_SIZE_HQ: tl.constexpr = num_idx_heads * BLOCK_SIZE_Q
+    pid_r = tl.program_id(0)
     pid_c = tl.program_id(1)
-    req_id = pid_b // decode_query_len
-    q_offset = pid_b - req_id * decode_query_len
+    hq_offsets = tl.arange(0, BLOCK_SIZE_HQ)
+    h_offsets = hq_offsets // BLOCK_SIZE_Q
+    q_offsets = hq_offsets % BLOCK_SIZE_Q
+    q_mask = q_offsets < decode_query_len
+    q_ids = pid_r * decode_query_len + q_offsets
 
     if USE_PDL:
         tl.extra.cuda.gdc_wait()
         tl.extra.cuda.gdc_launch_dependents()
 
-    seq_len = tl.load(seq_lens + req_id)
-    query_pos = seq_len - decode_query_len + q_offset
+    seq_len = tl.load(seq_lens + pid_r)
+    query_pos = seq_len - decode_query_len + q_offsets
     # Full-CG padding uses zero-length request rows. Clamp to an empty
     # attention range instead of letting padded rows produce negative lengths.
     kv_len = tl.maximum(query_pos + 1, 0)
-    num_blocks = (kv_len + BLOCK_SIZE_K - 1) // BLOCK_SIZE_K
+    num_blocks_q = (kv_len + BLOCK_SIZE_K - 1) // BLOCK_SIZE_K
+    kv_len_max = tl.max(tl.where(q_mask, kv_len, 0), axis=0)
+    num_blocks = (kv_len_max + BLOCK_SIZE_K - 1) // BLOCK_SIZE_K
 
     # block-aligned fixed-count split: grid independent of seq_len (cuda graph).
     chunk_size_blocks = (num_blocks + num_kv_chunks - 1) // num_kv_chunks
@@ -345,20 +348,22 @@ def _decode_index_score_kernel(
         return
     off_k = tl.arange(0, BLOCK_SIZE_K)  # positions within a 128-block
     off_d = tl.arange(0, head_dim)
-    bt_row = block_table_ptr + req_id * stride_bt_b
+    bt_row = block_table_ptr + pid_r * stride_bt_b
     # Force-select init (1e30) and local (1e29, higher priority) blocks.
-    local_start = tl.maximum(0, num_blocks - local_blocks)
-    # query vectors across all heads
+    local_start = tl.maximum(0, num_blocks_q - local_blocks)
+    # Query vectors for all index heads in a small spec-decode block.
     q = tl.load(
         q_ptr
-        + pid_b * stride_q_n
-        + tl.arange(0, num_idx_heads) * stride_q_h
+        + q_ids[None, :] * stride_q_n
+        + h_offsets[None, :] * stride_q_h
         + off_d[:, None] * stride_q_d,
-    )  # [D,H]
+        mask=q_mask[None, :],
+        other=0.0,
+    )  # [D,HQ]
     for blk in tl.range(chunk_start_block, chunk_end_block):
         page = tl.load(bt_row + blk).to(tl.int64)
         pos = blk * BLOCK_SIZE_K + off_k
-        pos_mask = pos < kv_len
+        pos_mask = pos[:, None] < kv_len[None, :]
         # we don't need masked load for K, because KV cache ensures
         # allocation is multiple of BLOCK_SIZE_K.
         # for tokens beyond seqlen, they will be masked in qk later.
@@ -368,18 +373,17 @@ def _decode_index_score_kernel(
             + off_k[:, None] * stride_ik_pos
             + off_d * stride_ik_d,
         )  # [N,D]
-        kq = tl.dot(k, q) * sm_scale_log2e  # [N,H]
-        kq = tl.where(pos_mask[:, None], kq, float("-inf"))
-        score = tl.max(kq, axis=0)  # [H]
-        is_init = blk < init_blocks
-        is_local = (blk >= local_start) & (blk < num_blocks)
+        kq = tl.dot(k, q)  # [N,HQ]
+        kq = tl.where(pos_mask & q_mask[None, :], kq, float("-inf"))
+        score = tl.max(kq, axis=0)  # [HQ]
+        is_visible_block = blk < num_blocks_q
+        is_init = (blk < init_blocks) & is_visible_block
+        is_local = (blk >= local_start) & is_visible_block
         score = tl.where(is_local, 1e29, tl.where(is_init, 1e30, score))
         tl.store(
-            score_ptr
-            + tl.arange(0, num_idx_heads) * stride_s_h
-            + pid_b * stride_s_n
-            + blk * stride_s_k,
+            score_ptr + h_offsets * stride_s_h + q_ids * stride_s_n + blk * stride_s_k,
             score,
+            mask=q_mask,
         )
 
 
@@ -648,7 +652,6 @@ def minimax_m3_index_score(
     max_query_len: int,
     max_seq_len: int,
     num_kv_heads: int,
-    sm_scale: float,
 ) -> torch.Tensor:
     """Compute per-token index scores for each visible sparse block.
 
@@ -681,7 +684,6 @@ def minimax_m3_index_score(
         prefix_lens,
         num_idx_heads,
         head_dim,
-        sm_scale,
         idx_q.stride(0),
         idx_q.stride(1),
         idx_q.stride(2),
@@ -753,8 +755,8 @@ def minimax_m3_index_decode(
     init_blocks: int,
     local_blocks: int,
     num_kv_heads: int,
-    sm_scale: float,
     decode_query_len: int,
+    max_decode_query_len: int,
 ) -> torch.Tensor:
     """Decode index block-score + top-k, both split-K (cudagraph-safe).
 
@@ -764,6 +766,7 @@ def minimax_m3_index_decode(
     assert num_idx_heads == num_kv_heads, (
         "M3 expects num_idx_heads == num_kv_heads (no topk index reduce)"
     )
+    assert decode_query_len <= max_decode_query_len
     assert total_q == seq_lens.shape[0] * decode_query_len
     batch = total_q
     max_block = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
@@ -772,7 +775,15 @@ def minimax_m3_index_decode(
     # SM9+); this ROCm Triton rejects it even when False ("Keyword argument
     # launch_pdl was specified but unrecognised"). Only pass it when PDL is
     # actually supported -- on ROCm use_pdl is always False, so it's omitted.
-    pdl_launch = {"launch_pdl": True} if use_pdl else {}
+    pdl_kwargs: dict[str, bool | int] = {}
+    if use_pdl:
+        pdl_kwargs.update({"launch_pdl": True})
+    # TP=1 spec decode scores a wide 4-head x 4-position query tile per K block;
+    # reduce stages to ease memory/register pressure. Keep no-spec and TP=4
+    # single-head codegen unchanged.
+    score_kwargs = pdl_kwargs.copy()
+    if num_idx_heads > 1 and max_decode_query_len > 1:
+        score_kwargs.update({"num_warps": 4, "num_stages": 2})
 
     # Keep score strides 16-divisible to avoid Triton recompiles.
     score_block_stride = round_up(max_block, 16)
@@ -785,11 +796,16 @@ def minimax_m3_index_decode(
     # the grid is fixed within a cuda graph.
     TARGET_GRID = 4096
     MAX_NUM_KV_CHUNKS = 256
+    # Use the configured max decode length to avoid Triton recompiles when
+    # switching between qlen=1 and spec-decode verification batches.
+    BLOCK_SIZE_Q = triton.next_power_of_2(max_decode_query_len)
+    score_ctas_per_chunk = seq_lens.shape[0]
     target = max(
-        1, min(MAX_NUM_KV_CHUNKS, TARGET_GRID // max(1, batch * num_idx_heads))
+        1,
+        min(MAX_NUM_KV_CHUNKS, TARGET_GRID // max(1, score_ctas_per_chunk)),
     )
     num_kv_chunks = 1 << (target.bit_length() - 1)
-    grid_score = (batch, num_kv_chunks)
+    grid_score = (seq_lens.shape[0], num_kv_chunks)
     _decode_index_score_kernel[grid_score](
         idx_q,
         index_kv_cache,
@@ -800,7 +816,6 @@ def minimax_m3_index_decode(
         head_dim,
         init_blocks,
         local_blocks,
-        sm_scale,
         decode_query_len,
         idx_q.stride(0),
         idx_q.stride(1),
@@ -813,9 +828,10 @@ def minimax_m3_index_decode(
         score.stride(2),
         block_table.stride(0),
         BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
+        BLOCK_SIZE_Q=BLOCK_SIZE_Q,
         num_kv_chunks=num_kv_chunks,
         USE_PDL=use_pdl,
-        **pdl_launch,
+        **score_kwargs,
     )
 
     topk_idx = torch.empty(
@@ -870,7 +886,7 @@ def minimax_m3_index_decode(
         topk_idx_partial.stride(2),
         topk_idx_partial.stride(3),
         USE_PDL=use_pdl,
-        **pdl_launch,
+        **pdl_kwargs,
     )
     _topk_index_merge_kernel[(batch, num_idx_heads)](
         topk_score_partial,
@@ -893,6 +909,6 @@ def minimax_m3_index_decode(
         topk_idx.stride(2),
         num_topk_chunks=num_topk_chunks,
         USE_PDL=use_pdl,
-        **pdl_launch,
+        **pdl_kwargs,
     )
     return topk_idx


### PR DESCRIPTION
## Purpose

Currently, to support spec-decode case, we simply launch extra CTAs for each decode token. This is simple, because the kernel remains mostly unchanged. However, it is not good because we could have batched multiple Query tokens together for QK MMA to improve efficiency. This PR does exactly just that.
- Before: launch 1 CTA per **token** across all heads. Each CTA loads `num_idx_heads` Query tokens. For TP=4, this is just 1 token
- After: launch 1 CTA per **request** across all heads. Each CTA loads `decode_query_len x num_idx_heads` Query tokens. For TP=4 and spec-decode=3, this is 4 tokens. Crucially, when there is no spec-decode, this kernel should behave exactly like the old kernel.

Other design considerations:
- In spec-decode, the max number of decode tokens per request is `1 + num_spec_tokens`. But the scheduler can pass fewer tokens too. To avoid recompilation, we use an extra metadata `max_decode_query_len`, which stays constant throughout the lifetime of a vLLM worker, as the constexpr for the kernel.
- To keep the kernel simple, we don't introduce extra tiling over `num_idx_heads` nor `decode_query_len`. This is because at the worst case, TP=1 and 3 spec-tokens, we only have `num_idx_heads x decode_query_len = 16` Query tokens. This is still a small number that the kernel works just fine. I did some extra `num_warps` and `num_stages` tuning for this case though.
- Also reduce `TARGET_GRID` to 512 since 4096 was too much
- Also remove `sm_scale` since it doesn't affect the subsequent topk

## Microbenchmark

### TP=1, no spec-dec

bs | context | latency before | latency after | bandwidth before | bandwidth after
-- | -- | -- | -- | -- | --
1 | 8191 | 4.800 us | 4.704 us (-2.0%) | 437 GB/s | 446 GB/s (+2.0%)
1 | 32767 | 5.920 us | 5.856 us (-1.1%) | 1418 GB/s | 1433 GB/s (+1.1%)
1 | 131071 | 11.744 us | 11.648 us (-0.8%) | 2859 GB/s | 2882 GB/s (+0.8%)
4 | 8191 | 6.304 us | 6.176 us (-2.0%) | 1332 GB/s | 1360 GB/s (+2.1%)
4 | 32767 | 10.912 us | 10.976 us (+0.6%) | 3077 GB/s | 3059 GB/s (-0.6%)
4 | 131071 | 32.032 us | 29.920 us (-6.6%) | 4192 GB/s | 4488 GB/s (+7.1%)
16 | 8191 | 11.008 us | 10.816 us (-1.7%) | 3051 GB/s | 3105 GB/s (+1.8%)
16 | 32767 | 32.192 us | 29.856 us (-7.3%) | 4172 GB/s | 4498 GB/s (+7.8%)
16 | 131071 | 106.433 us | 92.672 us (-12.9%) | 5047 GB/s | 5796 GB/s (+14.8%)

### TP=1, w/ spec-dec (decode_query_len=4)

bs | context | latency before | latency after | bandwidth before | bandwidth after
-- | -- | -- | -- | -- | --
1 | 8191 | 4.960 us | 5.344 us (+7.7%) | 431 GB/s | 400 GB/s (-7.2%)
1 | 32767 | 8.736 us | 7.616 us (-12.8%) | 966 GB/s | 1108 GB/s (+14.7%)
1 | 131071 | 16.416 us | 12.704 us (-22.6%) | 2050 GB/s | 2649 GB/s (+29.2%)
4 | 8191 | 8.448 us | 7.008 us (-17.0%) | 1012 GB/s | 1220 GB/s (+20.5%)
4 | 32767 | 16.288 us | 11.360 us (-30.3%) | 2073 GB/s | 2973 GB/s (+43.4%)
4 | 131071 | 60.384 us | 30.848 us (-48.9%) | 2230 GB/s | 4364 GB/s (+95.7%)
16 | 8191 | 16.768 us | 11.616 us (-30.7%) | 2040 GB/s | 2945 GB/s (+44.4%)
16 | 32767 | 61.600 us | 32.512 us (-47.2%) | 2193 GB/s | 4154 GB/s (+89.5%)
16 | 131071 | 225.873 us | 115.776 us (-48.7%) | 2384 GB/s | 4651 GB/s (+95.1%)

### TP=4, w/ spec-dec (decode_query_len=4)

bs | context | latency before | latency after | bandwidth before | bandwidth after
-- | -- | -- | -- | -- | --
1 | 8191 | 4.800 us | 4.736 us (-1.3%) | 444 GB/s | 450 GB/s (+1.4%)
1 | 32767 | 8.416 us | 6.752 us (-19.8%) | 1001 GB/s | 1248 GB/s (+24.6%)
1 | 131071 | 15.968 us | 12.736 us (-20.2%) | 2104 GB/s | 2639 GB/s (+25.4%)
4 | 8191 | 9.824 us | 6.144 us (-37.5%) | 868 GB/s | 1388 GB/s (+59.9%)
4 | 32767 | 18.592 us | 10.880 us (-41.5%) | 1813 GB/s | 3098 GB/s (+70.9%)
4 | 131071 | 48.352 us | 30.560 us (-36.8%) | 2780 GB/s | 4399 GB/s (+58.2%)
16 | 8191 | 18.752 us | 10.816 us (-42.3%) | 1819 GB/s | 3154 GB/s (+73.4%)
16 | 32767 | 48.672 us | 30.529 us (-37.3%) | 2770 GB/s | 4416 GB/s (+59.4%)
16 | 131071 | 164.320 us | 92.544 us (-43.7%) | 3272 GB/s | 5810 GB/s (+77.6%)

It's good that we are nearer to SOL as context increases

## Accuracy

GSM8K: 0.9136. m3_release is 0.913

## E2E benchmark

Decode-only, Minimax-M3 MXFP8 on 4xGB200, TEP4. Decode 1024 tokens at various prefix lengths. Eagle3 with synthetic acceptance rate `[0.7,0.45,0.3]`

Prefix length | Concurrency | TPOT before | TPOT after
---|---|---|---
10k | 1 | 8.18 ms | 8.13 ms (-0.6%)
10k | 4 | 9.69 ms | 9.67 ms (-0.2%)
10k | 16 | 13.17 ms | 12.77 ms (-3%)
100k | 1 | 8.74 ms | 8.67 ms (-0.8%)
100k | 4 | 10.59 ms | 10.24 ms (3.3%)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

