### PR TITLE
Deterministic MoE combine (reduce_scatterv) under `VLLM_BATCH_INVARIANT`

### DIFF
--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -362,7 +362,10 @@ class CudaCommunicator(DeviceCommunicatorBase):
             output_shape, dtype=input_tensor.dtype, device=input_tensor.device
         )
 
-        if sizes is not None and sizes.count(sizes[0]) != len(sizes):
+        if sizes is not None and (
+            sizes.count(sizes[0]) != len(sizes) or envs.VLLM_BATCH_INVARIANT
+        ):
+            # Note: force to use `reduce_scatterv` under BATCH_INVARIANT mode.
             pynccl_comm.reduce_scatterv(output, input_tensor, sizes=sizes)
         else:
             pynccl_comm.reduce_scatter(output, input_tensor)

--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -302,6 +302,33 @@ class PyNcclCommunicator:
         if stream is None:
             stream = current_stream()
 
+        # Batch-invariant deterministic path.
+        #
+        # The default implementation below issues one ncclReduce per chunk with
+        # a different `root` per chunk (so a token is reduced to `root == its
+        # rank`). Different roots use different NCCL reduction trees, so the
+        # cross-rank floating-point summation order changes with how tokens are
+        # routed into the buffer -> ULP-level nondeterminism. This breaks
+        # batch-invariance (the same request must produce bit-identical results
+        # regardless of which rank it lands on).
+        #
+        # `world_size > 2` is required because at world_size == 2 the cross-rank
+        # sum is a single `a + b`, which is commutative and therefore already
+        # bit-identical regardless of root.
+        #
+        # Instead we reduce the *entire* buffer with a single ncclReduce to a
+        # fixed root (0) so every element is summed with the same reduction
+        # tree, then scatter each rank's own chunk back from root. The scatter
+        # is pure data movement (no arithmetic), so determinism is preserved.
+        # We scatter (not broadcast) because each rank only needs its own
+        # `sizes[rank]` rows. This is effectively a deterministic reduce-scatter,
+        # at the cost of relying on NCCL using a single tree for one ncclReduce.
+        if envs.VLLM_BATCH_INVARIANT and self.world_size > 2:
+            reduced = torch.empty_like(input_tensor)
+            self.reduce(reduced, input_tensor, root=0, op=op, stream=stream)
+            self.scatter(output_tensor, reduced, sizes, root=0, stream=stream)
+            return
+
         split_offset = 0
         self.nccl.ncclGroupStart()
         for root, split_size in enumerate(sizes):
@@ -318,6 +345,64 @@ class PyNcclCommunicator:
             )
             split_offset += split_size
         self.nccl.ncclGroupEnd()
+
+    def reduce(
+        self,
+        output_tensor: torch.Tensor,
+        input_tensor: torch.Tensor,
+        root: int,
+        op: ReduceOp = ReduceOp.SUM,
+        stream=None,
+    ):
+        if self.disabled:
+            return
+        assert input_tensor.device == self.device, (
+            f"this nccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {input_tensor.device}"
+        )
+        if stream is None:
+            stream = current_stream()
+        self.nccl.ncclReduce(
+            buffer_type(input_tensor.data_ptr()),
+            buffer_type(output_tensor.data_ptr()),
+            input_tensor.numel(),
+            ncclDataTypeEnum.from_torch(input_tensor.dtype),
+            ncclRedOpTypeEnum.from_torch(op),
+            root,
+            self.comm,
+            cudaStream_t(stream.cuda_stream),
+        )
+
+    def scatter(
+        self,
+        output_tensor: torch.Tensor,
+        input_tensor: torch.Tensor,
+        sizes: list[int],
+        root: int = 0,
+        stream=None,
+    ):
+        if self.disabled:
+            return
+        assert output_tensor.device == self.device, (
+            f"this nccl communicator is created to work on {self.device}, "
+            f"but the output tensor is on {output_tensor.device}"
+        )
+        if stream is None:
+            stream = current_stream()
+        if self.rank == root:
+            split_offset = 0
+            for dst, split_size in enumerate(sizes):
+                if split_size == 0:
+                    continue
+
+                chunk = input_tensor[split_offset : split_offset + split_size, ...]
+                if dst == root:
+                    output_tensor.copy_(chunk)
+                else:
+                    self.send(chunk, dst, stream)
+                split_offset += split_size
+        elif sizes[self.rank] > 0:
+            self.recv(output_tensor, root, stream)
 
     def send(self, tensor: torch.Tensor, dst: int, stream=None):
         if self.disabled:


### PR DESCRIPTION


## Purpose
Under batch-invariant / deterministic mode (`VLLM_BATCH_INVARIANT=1`), the
cross-rank summation order in the MoE *combine* step is not stable, which breaks
bit-for-bit reproducibility when running with Data Parallel (DP) + Expert
Parallel (EP). This PR makes the combine reduction deterministic with two
coordinated changes:

1. **`cuda_communicator.py` (dispatch fix)**: under `VLLM_BATCH_INVARIANT`,
   always route the MoE combine through the deterministic `reduce_scatterv`
   path, even when the per-rank `sizes` are uniform. Previously uniform `sizes`
   (e.g. `[1, 1, 1, 1]` in the decode phase) fell through to the plain,
   routing-dependent `reduce_scatter`, so the deterministic path was never
   exercised during decode.
2. **`pynccl.py` (deterministic kernel)**: implement the deterministic
   `reduce_scatterv` as a single fixed-root `reduce` + `scatter`, so every
   element is reduced with the same NCCL reduction tree regardless of where a
   token is routed.

This only changes behavior when `VLLM_BATCH_INVARIANT` is enabled and DP world
size `> 2`; the default (non-deterministic, performance-first) path is
untouched.

## Motivation

vLLM's batch-invariant mode is meant to guarantee that the logits/logprobs of a
request are **bit-for-bit identical** regardless of batch composition and of
which DP worker the request lands on. For MoE/EP models this guarantee currently
does not hold in the combine step. This issue was first observed in [[Feature]: 
Batch Invariant Feature in DP+EP](https://github.com/vllm-project/vllm/issues/30321#issue-3709833975).

We observed the divergence by sending the same request to different DP ranks.
This issue can be reproduced using an MoE model with DP world size > 2.

Brief Env:

vLLM version: 0.23.0
Model: Qwen/Qwen3-30B-A3B-Instruct-2507
GPU: NVIDIA H200 141GB x 4
OS: Linux
CUDA: 13.0
PyTorch: 2.11.0

First launch the vLLM server with DP world size 4:
```bash
VLLM_BATCH_INVARIANT=1 vllm serve --model Qwen/Qwen3-30B-A3B-Instruct-2507 --data-parallel-size 4
```

Then send the same request to different DP ranks with the script [repro_for_issue.py](https://github.com/user-attachments/files/28948987/repro_for_issue.py):

`repro_for_issue.py` sends the same prompt to both workers and compares the results.

Observed output:
```
[INFO] Comparing Worker 0 vs Worker 1 ...
  [FAIL] Different tokens sampled.
         BS=1 tokens: [' the', ' long', ',', ' warm', ' days', ' that', ' stretch', ' out']
         BS=N tokens: [' the', ' long', ',', ' warm', ' days', ' with', ' the', ' sun']
```

## Root cause

The MoE combine is implemented on top of `CudaCommunicator.reduce_scatterv`,
which picks **one of two** PyNCCL primitives depending on the per-rank `sizes`:

```python
# vllm/distributed/device_communicators/cuda_communicator.py (before)
if sizes is not None and sizes.count(sizes[0]) != len(sizes):
    pynccl_comm.reduce_scatterv(output, input_tensor, sizes=sizes)  # variable sizes
else:
    pynccl_comm.reduce_scatter(output, input_tensor)                # uniform sizes
```

Both branches are routing/order-dependent and therefore non-deterministic across
DP ranks:

1. **`reduce_scatter` (uniform-`sizes` branch)** maps to `ncclReduceScatter`,
   whose internal ring/tree reduction order depends on rank position. This is
   the branch that actually breaks decode (see below).
2. **`reduce_scatterv` (variable-`sizes` branch)** issues **one `ncclReduce`
   per chunk, each with a different `root`** (chunk `i` is reduced to
   `root == i`):

   ```python
   for root, split_size in enumerate(sizes):
       chunk = input_tensor[split_offset : split_offset + split_size, ...]
       self.nccl.ncclReduce(..., root, ...)
   ```

   Different `root`s use different NCCL reduction trees, so the summation order
   depends on which chunk/root a token belongs to.

**Why decode was the failing case:** in the decode phase every DP rank contributes
exactly one token, so `sizes` is uniform (e.g. `[1, 1, 1, 1]`). With uniform
`sizes`, `sizes.count(sizes[0]) != len(sizes)` is `False`, so the dispatcher took
the **`reduce_scatter`** branch and never entered `reduce_scatterv` at all. A
deterministic implementation living *inside* `reduce_scatterv` therefore had no
effect on decode — the combine still went through the non-deterministic
`ncclReduceScatter`.

Floating-point addition is not associative: `(a + b) + c` ≠ `a + (c + b)` at the
ULP level. Because the reduction order is rank/routing dependent in both
branches, the rounded combine result changes with the DP rank a request lands
on. This is the source of the DP-rank-dependent, ULP-level nondeterminism.

Note this only matters for DP world size `> 2`: with exactly two ranks the
cross-rank reduction is a single `a + b`, which is commutative and bit-exact
regardless of the tree, so no fix is needed there.

## Changes

1. **`cuda_communicator.py`: force the deterministic path under
   `VLLM_BATCH_INVARIANT`.** The dispatch condition in
   `CudaCommunicator.reduce_scatterv` is extended so that batch-invariant mode
   always routes to `pynccl_comm.reduce_scatterv` (the deterministic primitive),
   regardless of whether `sizes` is uniform:

   ```python
   if sizes is not None and (
       sizes.count(sizes[0]) != len(sizes) or envs.VLLM_BATCH_INVARIANT):
       # Note: force to use `reduce_scatterv` under BATCH_INVARIANT mode.
       pynccl_comm.reduce_scatterv(output, input_tensor, sizes=sizes)
   else:
       pynccl_comm.reduce_scatter(output, input_tensor)
   ```

   This is what fixes the decode phase, where uniform `sizes` (e.g.
   `[1, 1, 1, 1]`) previously bypassed the deterministic path.

2. **`pynccl.py`: add a `PyNcclCommunicator.reduce(...)` method.**
   It reduces the *entire* `input_tensor` to a single `root` with one
   `ncclReduce` call (binding already exists in `pynccl_wrapper.py`), so every
   element is summed with the **same** reduction tree irrespective of its
   position in the buffer.

3. **`pynccl.py`: add a `PyNcclCommunicator.scatter(...)` method.**
   It splits the buffer on `root` into per-rank chunks (`sizes`) and delivers
   chunk `i` to rank `i`, implemented as a single `self.send`/`self.recv`
   (root keeps its own chunk via a local copy). This is pure data movement.

4. **`pynccl.py`: deterministic branch inside `reduce_scatterv`.**
   The deterministic combine is implemented in
   `PyNcclCommunicator.reduce_scatterv`. When `envs.VLLM_BATCH_INVARIANT` is set
   and `self.world_size > 2`, instead of the per-chunk `ncclReduce` loop it:
   - reduces the whole buffer to a fixed `root=0` with the new single-tree
     `reduce`,
   - `scatter`s each rank's own chunk back from `root=0`.

   This is effectively a *deterministic reduce-scatter*: a single reduce tree
   (independent of token routing) followed by pure data movement. Otherwise it
   falls back to the original per-chunk loop, so the default path is unchanged.

```text
vllm/distributed/device_communicators/cuda_communicator.py | force reduce_scatterv under VLLM_BATCH_INVARIANT
vllm/distributed/device_communicators/pynccl.py            | + reduce(), + scatter(), deterministic branch in reduce_scatterv()
```

## Why this approach

Alternatives considered:

- **all_gather + local sum in a fixed order**: also deterministic, but requires
  gathering `world_size` full copies of the buffer and summing them locally —
  more memory traffic and a local reduction on top.
- **single `reduce` (fixed root) + `broadcast`**: one reduce + one broadcast.
  Correct and deterministic, but `broadcast` delivers the *whole* buffer to
  every rank while each rank only needs its own `chunk_size` rows — roughly
  `world_size`x redundant ingest per rank. Even with NCCL multicast (NVLS/SHARP)
  optimizing the broadcast, each receiver still has to pull the full buffer over
  its inbound link, so the redundant data can't be avoided.
- **single `reduce` (fixed root) + `scatter`** (this PR): the reduced result
  already lives on `root`, so we scatter only the `sizes[rank]` rows each rank
  needs. On a fully-connected intra-node fabric (NVLink/NVSwitch) the root fans
  out the distinct chunks over independent links in parallel, moving far less
  data per rank than broadcast. Determinism is identical (scatter does no
  arithmetic). The only assumption is that a single `ncclReduce` call uses one
  consistent reduction tree for the whole buffer (fixed root / communicator).

## Limitations / future work

- Active only for DP world size `> 2`; DP ≤ 2 is already bit-exact.
- CUDA / NCCL path only (`CudaCommunicator`); other backends (e.g. XPU) are not
  changed. Note the dispatch fix lives in `CudaCommunicator.reduce_scatterv`, so
  non-CUDA communicators still take their original combine path.
- Relies on NCCL using a single reduction tree per `ncclReduce` call for a fixed
  root and communicator.

## Test plan

Batch Invariance Test [test.py](https://github.com/user-attachments/files/28949020/test.py):
1. Start the server.
2. Send 32 requests with batch size 1 one-by-one.
3. Send 32 requests with batch size 32 all at once.
4. Compare the results.

```bash
python3 test.py
```

## Test results

Pass.

```
============================================================
Batch Invariance Test
============================================================
  Server URL : http://0.0.0.0:8000/v1
  Model      : Qwen/Qwen3-30B-A3B-Instruct-2507
  Num prompts: 32
  Max tokens : 8
  Seed       : 42
  Temperature: 0.6
  Top-p      : 1.0
  Logprobs   : 5
============================================================
[INFO] Server reachable. Available models: ['Qwen/Qwen3-30B-A3B-Instruct-2507']
[INFO] Starting BS=1 requests for 32 prompts ...
  BS=1 progress: 8/32
  BS=1 progress: 16/32
  BS=1 progress: 24/32
  BS=1 progress: 32/32
[INFO] Starting BS=N (batch of 32) request ...
  BS=N done.
[INFO] Comparing BS=1 vs BS=N ...
  [PASS] Prompt 0: tokens and logprobs match exactly.
  [PASS] Prompt 1: tokens and logprobs match exactly.
  [PASS] Prompt 2: tokens and logprobs match exactly.
  [PASS] Prompt 3: tokens and logprobs match exactly.
  [PASS] Prompt 4: tokens and logprobs match exactly.
  [PASS] Prompt 5: tokens and logprobs match exactly.
  [PASS] Prompt 6: tokens and logprobs match exactly.
  [PASS] Prompt 7: tokens and logprobs match exactly.
  [PASS] Prompt 8: tokens and logprobs match exactly.
  [PASS] Prompt 9: tokens and logprobs match exactly.
  [PASS] Prompt 10: tokens and logprobs match exactly.
  [PASS] Prompt 11: tokens and logprobs match exactly.
  [PASS] Prompt 12: tokens and logprobs match exactly.
  [PASS] Prompt 13: tokens and logprobs match exactly.
  [PASS] Prompt 14: tokens and logprobs match exactly.
  [PASS] Prompt 15: tokens and logprobs match exactly.
  [PASS] Prompt 16: tokens and logprobs match exactly.
  [PASS] Prompt 17: tokens and logprobs match exactly.
  [PASS] Prompt 18: tokens and logprobs match exactly.
  [PASS] Prompt 19: tokens and logprobs match exactly.
  [PASS] Prompt 20: tokens and logprobs match exactly.
  [PASS] Prompt 21: tokens and logprobs match exactly.
  [PASS] Prompt 22: tokens and logprobs match exactly.
  [PASS] Prompt 23: tokens and logprobs match exactly.
  [PASS] Prompt 24: tokens and logprobs match exactly.
  [PASS] Prompt 25: tokens and logprobs match exactly.
  [PASS] Prompt 26: tokens and logprobs match exactly.
  [PASS] Prompt 27: tokens and logprobs match exactly.
  [PASS] Prompt 28: tokens and logprobs match exactly.
  [PASS] Prompt 29: tokens and logprobs match exactly.
  [PASS] Prompt 30: tokens and logprobs match exactly.
  [PASS] Prompt 31: tokens and logprobs match exactly.
============================================================
[RESULT] ALL 32 prompts PASSED — BS=1 and BS=N produce bitwise-identical results.
```

Without this, 19 of the 32 runs will diverge from the batch-size 1 version. Otherwise, it will pass.

```
============================================================
Batch Invariance Test
============================================================
  Server URL : http://0.0.0.0:8000/v1
  Model      : Qwen/Qwen3-30B-A3B-Instruct-2507
  Num prompts: 32
  Max tokens : 8
  Seed       : 42
  Temperature: 0.6
  Top-p      : 1.0
  Logprobs   : 5
============================================================
[INFO] Server reachable. Available models: ['Qwen/Qwen3-30B-A3B-Instruct-2507']
[INFO] Starting BS=1 requests for 32 prompts ...
  BS=1 progress: 8/32
  BS=1 progress: 16/32
  BS=1 progress: 24/32
  BS=1 progress: 32/32
[INFO] Starting BS=N (batch of 32) request ...
  BS=N done.
[INFO] Comparing BS=1 vs BS=N ...
  [PASS] Prompt 0: tokens and logprobs match exactly.
  [PASS] Prompt 1: tokens and logprobs match exactly.
  [FAIL] Prompt 2 Step 0: Bitwise mismatch (abs diff=5.671501e-02).
         BS=1 tokens: [' ', '3', '0', '0', ' pieces', ' of', ' candy', '.']
         BS=N tokens: [' ', '3', '0', '0', ' pieces', ' of', ' candy', '.']
  [FAIL] Prompt 3 Step 0: Bitwise mismatch (abs diff=1.016247e-02).
         BS=1 tokens: [' the', ' long', ',', ' warm', ' days', ' that', ' stretch', ' out']
         BS=N tokens: [' the', ' long', ',', ' warm', ' days', ' that', ' stretch', ' out']
  [PASS] Prompt 4: tokens and logprobs match exactly.
  [PASS] Prompt 5: tokens and logprobs match exactly.
  [FAIL] Prompt 6 Step 0: Bitwise mismatch (abs diff=2.738833e-02).
         BS=1 tokens: [' the', ' long', '-lo', 'st', ' planet', ' of', ' Earth', ',']
         BS=N tokens: [' the', ' long', '-lo', 'st', ' planet', ' of', ' Earth', ',']
  [FAIL] Prompt 7 Step 0: Bitwise mismatch (abs diff=4.982090e-02).
         BS=1 tokens: [' ', '3', '0', '0', ' pieces', ' of', ' candy', '.']
         BS=N tokens: [' ', '3', '0', '0', ' pieces', ' of', ' candy', '.']
  [PASS] Prompt 8: tokens and logprobs match exactly.
  [FAIL] Prompt 9 Step 0: Bitwise mismatch (abs diff=7.431746e-03).
         BS=1 tokens: [' natural', ' and', ' human', ' activities', '.', ' What', ' are', ' some']
         BS=N tokens: [' natural', ' and', ' human', ' activities', '.', ' What', ' are', ' some']
  [FAIL] Prompt 10 Step 0: Bitwise mismatch (abs diff=1.092851e-02).
         BS=1 tokens: [' span', 'ned', ' from', ' the', ' ', '1', '4', 'th']
         BS=N tokens: [' span', 'ned', ' from', ' the', ' ', '1', '4', 'th']
  [FAIL] Prompt 11 Step 0: Bitwise mismatch (abs diff=1.361342e-04).
         BS=1 tokens: [' a', ' fundamental', ' theory', ' in', ' physics', ' that', ' provides', ' a']
         BS=N tokens: [' a', ' fundamental', ' theory', ' in', ' physics', ' that', ' provides', ' a']
  [PASS] Prompt 12: tokens and logprobs match exactly.
  [PASS] Prompt 13: tokens and logprobs match exactly.
  [FAIL] Prompt 14 Step 0: Bitwise mismatch (abs diff=1.092851e-02).
         BS=1 tokens: [' span', 'ned', ' from', ' the', ' ', '1', '4', 'th']
         BS=N tokens: [' span', 'ned', ' from', ' the', ' ', '1', '4', 'th']
  [FAIL] Prompt 15 Step 0: Bitwise mismatch (abs diff=5.140714e-05).
         BS=1 tokens: [' a', ' fundamental', ' theory', ' in', ' physics', ' that', ' provides', ' a']
         BS=N tokens: [' a', ' fundamental', ' theory', ' in', ' physics', ' that', ' provides', ' a']
  [PASS] Prompt 16: tokens and logprobs match exactly.
  [FAIL] Prompt 17 Step 0: Bitwise mismatch (abs diff=8.551445e-03).
         BS=1 tokens: [' a', ' curious', ' little', ' robot', ' named', ' R', 'oly', '.']
         BS=N tokens: [' a', ' curious', ' little', ' robot', ' named', ' R', 'oly', '.']
  [FAIL] Prompt 18 Step 0: Bitwise mismatch (abs diff=2.738833e-02).
         BS=1 tokens: [' the', ' long', '-lo', 'st', ' planet', ' of', ' Earth', ',']
         BS=N tokens: [' the', ' long', '-lo', 'st', ' planet', ' of', ' Earth', ',']
  [FAIL] Prompt 19 Step 0: Bitwise mismatch (abs diff=1.113994e-01).
         BS=1 tokens: [' for', ' each', ' element', ',', ' it', ' compares', ' the', ' current']
         BS=N tokens: [' for', ' each', ' element', ',', ' it', ' compares', ' the', ' current']
  [PASS] Prompt 20: tokens and logprobs match exactly.
  [PASS] Prompt 21: tokens and logprobs match exactly.
  [FAIL] Prompt 22 Step 0: Bitwise mismatch (abs diff=6.803842e-04).
         BS=1 tokens: [' Paris', '.\n\n', 'Question', ':', ' What', ' is', ' the', ' capital']
         BS=N tokens: [' Paris', '.\n\n', 'Question', ':', ' What', ' is', ' the', ' capital']
  [FAIL] Prompt 23 Step 0: Bitwise mismatch (abs diff=5.350661e-02).
         BS=1 tokens: [' natural', ' and', ' human', ' activities', '.', ' What', ' are', ' some']
         BS=N tokens: [' natural', ' and', ' human', ' activities', '.', ' What', ' are', ' some']
  [PASS] Prompt 24: tokens and logprobs match exactly.
  [PASS] Prompt 25: tokens and logprobs match exactly.
  [FAIL] Prompt 26 Step 0: Bitwise mismatch (abs diff=5.025234e-03).
         BS=1 tokens: [' green', ' plants', ',', ' algae', ',', ' and', ' some', ' bacteria']
         BS=N tokens: [' green', ' plants', ',', ' algae', ',', ' and', ' some', ' bacteria']
  [FAIL] Prompt 27 Step 0: Bitwise mismatch (abs diff=5.155802e-06).
         BS=1 tokens: [' green', ' plants', ',', ' algae', ',', ' and', ' some', ' bacteria']
         BS=N tokens: [' green', ' plants', ',', ' algae', ',', ' and', ' some', ' bacteria']
  [PASS] Prompt 28: tokens and logprobs match exactly.
  [FAIL] Prompt 29 Step 0: Bitwise mismatch (abs diff=8.551445e-03).
         BS=1 tokens: [' a', ' curious', ' little', ' robot', ' named', ' R', 'oly', '.']
         BS=N tokens: [' a', ' curious', ' little', ' robot', ' named', ' R', 'oly', '.']
  [FAIL] Prompt 30 Step 0: Bitwise mismatch (abs diff=1.092851e-02).
         BS=1 tokens: [' span', 'ned', ' from', ' the', ' ', '1', '4', 'th']
         BS=N tokens: [' span', 'ned', ' from', ' the', ' ', '1', '4', 'th']
  [FAIL] Prompt 31 Step 0: Bitwise mismatch (abs diff=4.395278e-02).
         BS=1 tokens: [' my', ' current', ' one', ' is', ' over', ' ', '5', ' years']
         BS=N tokens: [' my', ' current', ' one', ' is', ' over', ' ', '5', ' years']
============================================================
[RESULT] 19/32 prompts FAILED — batch invariance is NOT satisfied.
```

## Notes

AI assistance was used to help analyze the root cause and draft this change.
The submitter has reviewed every changed line and is responsible for the change
end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
