### PR TITLE
[Bugfix][Mamba] Fix DS conv state copy in fused postprocess kernel

### DIFF
--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -494,8 +494,15 @@ def apply_patch(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(mamba_utils, "do_mamba_copy_block", fake_copy_fn)
 
 
+@pytest.mark.parametrize("conv_layout", ["SD", "DS"])
 @create_new_process_for_each_test()
-def test_mamba_prefix_cache(monkeypatch: pytest.MonkeyPatch):
+def test_mamba_prefix_cache(monkeypatch: pytest.MonkeyPatch, conv_layout: str):
+    # Set the env before spawning the ref-state subprocess so both processes
+    # use the same conv state layout (issue #38898).
+    monkeypatch.setenv("VLLM_SSM_CONV_STATE_LAYOUT", conv_layout)
+    from vllm.model_executor.layers.mamba import mamba_utils as model_mamba_utils
+
+    model_mamba_utils.get_conv_state_layout.cache_clear()
     run_ref_mamba_state_in_subprocess()
     apply_patch(monkeypatch)
     prompt_dataset = datasets.load_dataset("heheda/a_long_article")

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -2132,3 +2132,139 @@ class TestPostprocessMambaFusedKernel:
             expected_accepted,
             msg="num_accepted_tokens mismatch at accept_token_bias=2",
         )
+
+    def test_ds_conv_layout_bias_gt_0_byte_equal_to_sd(
+        self, device, test_config, monkeypatch
+    ):
+        """
+        Regression test for issue #38898.
+
+        With ``VLLM_SSM_CONV_STATE_LAYOUT=DS`` the conv state is laid out
+        ``(num_blocks, dim, state_len)``. Slicing along the last (state_len)
+        dim with ``offset > 0`` is non-contiguous, so the fused postprocess
+        kernel must split the copy into per-row contiguous regions instead of
+        the single-region copy used for SD.
+
+        Strategy: run the SD path (current behaviour) on tensor ``S`` of
+        shape ``(B, state_len, dim)``, then run only the DS GPU kernel on a
+        twin tensor ``D`` permuted/contiguous-ified from ``S``. After both,
+        ``D.permute(0, 2, 1).contiguous()`` must equal ``S`` byte-for-byte.
+
+        Scenario mirrors
+        ``test_same_block_idx_with_offset_copies_then_sets_accepted_to_1``
+        which exercises ``accept_token_bias = 1`` with ``src == dst``.
+        """
+        from vllm.model_executor.layers.mamba import mamba_utils as model_mamba_utils
+
+        cfg = test_config
+        torch.manual_seed(38898)
+
+        req_ids = ["req_0"]
+        num_computed_tokens = [30]
+        num_scheduled_tokens = {"req_0": 1}
+        num_draft_tokens: dict[str, int] = {}
+        num_accepted_tokens = [2]  # Results in accept_token_bias = 1
+        mamba_state_idx = [1]  # src_block_idx = 1 = dest_block_idx
+        block_ids_per_req = [list(range(8))]
+
+        layer_names = ["layer_0"]
+        kv_cache_config = _make_kv_cache_config(cfg, layer_names)
+
+        num_reqs = len(req_ids)
+        block_table_gpu = torch.zeros(num_reqs, 8, dtype=torch.int32, device=device)
+        block_table_gpu[0, :8] = torch.tensor(block_ids_per_req[0], dtype=torch.int32)
+
+        # --- Source bytes: SD-shaped (B, state_len, dim) and DS-shaped twin.
+        # ds_source = sd_source.permute(0, 2, 1).contiguous() ensures the two
+        # tensors hold the SAME logical state in different memory layouts.
+        sd_source_conv = torch.randn(
+            cfg.num_blocks,
+            cfg.conv_width,
+            cfg.conv_inner_dim,
+            dtype=cfg.dtype,
+            device=device,
+        )
+        ds_source_conv = sd_source_conv.permute(0, 2, 1).contiguous()
+        sd_source_temporal = torch.randn(
+            cfg.num_blocks, cfg.temporal_state_dim, dtype=cfg.dtype, device=device
+        )
+
+        # --- 1. SD GPU path: this is the golden. Default layout is SD.
+        model_mamba_utils.get_conv_state_layout.cache_clear()
+        sd_conv = sd_source_conv.clone()
+        sd_temporal = sd_source_temporal.clone()
+        forward_context_sd = {
+            "layer_0": _make_mock_attention(sd_conv, sd_temporal),
+        }
+        gpu_ctx_sd = _make_gpu_ctx(cfg, kv_cache_config, device)
+        _run_gpu_postprocess(
+            gpu_ctx_sd,
+            kv_cache_config=kv_cache_config,
+            forward_context=forward_context_sd,
+            copy_funcs=_COPY_FUNCS,
+            block_table=block_table_gpu,
+            req_ids=req_ids,
+            num_accepted_tokens=num_accepted_tokens,
+            mamba_state_idx=mamba_state_idx,
+            num_scheduled_tokens=num_scheduled_tokens,
+            num_computed_tokens=num_computed_tokens,
+            num_draft_tokens=num_draft_tokens,
+            device=device,
+        )
+        torch.accelerator.synchronize()
+
+        # Sanity: SD path actually modified the state (copy was performed).
+        assert not torch.equal(sd_conv, sd_source_conv), (
+            "SD baseline did not modify conv state — test setup is wrong"
+        )
+
+        # --- 2. DS GPU path on the DS twin under VLLM_SSM_CONV_STATE_LAYOUT=DS.
+        monkeypatch.setenv("VLLM_SSM_CONV_STATE_LAYOUT", "DS")
+        model_mamba_utils.get_conv_state_layout.cache_clear()
+        try:
+            ds_conv = ds_source_conv.clone()
+            ds_temporal = sd_source_temporal.clone()
+            forward_context_ds = {
+                "layer_0": _make_mock_attention(ds_conv, ds_temporal),
+            }
+            gpu_ctx_ds = _make_gpu_ctx(cfg, kv_cache_config, device)
+            _run_gpu_postprocess(
+                gpu_ctx_ds,
+                kv_cache_config=kv_cache_config,
+                forward_context=forward_context_ds,
+                copy_funcs=_COPY_FUNCS,
+                block_table=block_table_gpu,
+                req_ids=req_ids,
+                num_accepted_tokens=num_accepted_tokens,
+                mamba_state_idx=mamba_state_idx,
+                num_scheduled_tokens=num_scheduled_tokens,
+                num_computed_tokens=num_computed_tokens,
+                num_draft_tokens=num_draft_tokens,
+                device=device,
+            )
+            torch.accelerator.synchronize()
+        finally:
+            # Reset the lru cache so other tests see the default layout again.
+            model_mamba_utils.get_conv_state_layout.cache_clear()
+
+        # --- 3. Byte-equality check: DS post-kernel bytes, un-permuted, must
+        # match the SD post-kernel golden. Temporal layout is unchanged
+        # under DS, so it must match directly.
+        torch.testing.assert_close(
+            ds_conv.permute(0, 2, 1).contiguous(),
+            sd_conv,
+            msg=(
+                "DS conv post-kernel does not match SD baseline; the DS "
+                "row-loop in postprocess_mamba_fused_kernel is wrong."
+            ),
+        )
+        torch.testing.assert_close(
+            ds_temporal,
+            sd_temporal,
+            msg="DS temporal state diverged from SD",
+        )
+        torch.testing.assert_close(
+            gpu_ctx_ds.num_accepted_tokens_out[:num_reqs],
+            gpu_ctx_sd.num_accepted_tokens_out[:num_reqs],
+            msg="DS num_accepted_tokens diverged from SD",
+        )

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -303,15 +303,13 @@ def get_conv_copy_spec(
     src_block_id = block_ids[cur_block_idx]
     offset = num_accepted_tokens - 1
     if is_conv_state_dim_first():
-        # DS layout: (num_blocks, dim, state_len) — state_len is last.
-        if offset > 0:
-            # Slicing along the last dim yields a non-contiguous view
-            # because features (dim) are strided by state_len.
-            raise NotImplementedError(
-                "DS conv state layout does not yet support speculative "
-                "decoding with mamba_cache_mode='align' "
-                "(num_accepted_tokens > 1)."
-            )
+        # DS layout: (num_blocks, dim, state_len). offset > 0 is handled
+        # by the fused postprocess kernel under spec decode + align mode;
+        # this path only ever sees offset == 0.
+        assert offset == 0, (
+            "DS conv state with num_accepted_tokens > 1 must be handled by "
+            "the fused postprocess kernel, not get_conv_copy_spec"
+        )
         src_state = state[src_block_id]
     else:
         # SD layout: (num_blocks, state_len, dim) — dim contiguous.

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -12,6 +12,7 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateCopyFunc,
     get_conv_copy_spec,
     get_temporal_copy_spec,
+    is_conv_state_dim_first,
 )
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
@@ -43,6 +44,9 @@ def postprocess_mamba_fused_kernel(
     state_inner_sizes_ptr,  # number of elements in inner dimensions
     state_conv_widths_ptr,  # conv width for conv states (0 for temporal)
     state_group_indices_ptr,  # maps state_idx to group index in block table
+    # DS conv state metadata (zero for SD-conv and temporal states):
+    state_dim_row_count_ptr,  # int32: per-block dim row count for DS conv
+    state_dim_row_stride_ptr,  # int64: bytes between rows for DS conv
     # Output: num_accepted_tokens update (for src==dst case)
     num_accepted_tokens_out_ptr,
     # Runtime parameter (varies per batch - NOT constexpr to avoid recompilation)
@@ -121,8 +125,46 @@ def postprocess_mamba_fused_kernel(
     # conv_width == 0 means this is a temporal state (get_temporal_copy_spec logic)
     is_conv_state = conv_width > 0
 
+    # Mirror postprocess_mamba's trailing
+    #     if src_block_idx == dest_block_idx: num_accepted_tokens_cpu[i] = 1
+    # This runs whether or not the copy below is skipped (it's per-request, so
+    # only state_idx == 0 writes).
+    if src_block_idx == dest_block_idx and state_idx == 0:
+        tl.store(num_accepted_tokens_out_ptr + req_idx, 1)
+
+    # Mirror collect_mamba_copy_meta's early return: src==dst with no token
+    # bias means source and destination ranges coincide, so the copy is a
+    # no-op.
+    if src_block_idx == dest_block_idx and accept_token_bias == 0:
+        return
+
+    # DS conv state (shape (num_blocks, dim, state_len)): the slice along
+    # state_len is non-contiguous, so the copy is split into `dim_rows`
+    # contiguous row copies. dim_rows is 0 for SD-conv and temporal states,
+    # signalling the single-region path below.
+    dim_rows = tl.load(state_dim_row_count_ptr + state_idx)
+    is_ds_conv = is_conv_state and dim_rows > 0
+
+    if is_ds_conv:
+        row_stride = tl.load(state_dim_row_stride_ptr + state_idx)
+        per_row_bytes = (conv_width - accept_token_bias).to(tl.int64) * state_elem_size
+        bias_bytes = accept_token_bias.to(tl.int64) * state_elem_size
+        src_block_addr = state_base_addr + src_block_id * state_block_stride
+        dst_block_addr = state_base_addr + dest_block_id * state_block_stride
+        offsets = tl.arange(0, COPY_BLOCK_SIZE)
+        for d in range(0, dim_rows):
+            row_src = src_block_addr + d * row_stride + bias_bytes
+            row_dst = dst_block_addr + d * row_stride
+            for i in range(0, per_row_bytes, COPY_BLOCK_SIZE):
+                mask = (i + offsets) < per_row_bytes
+                curr_src = (row_src + i + offsets).to(tl.pointer_type(tl.uint8))
+                curr_dst = (row_dst + i + offsets).to(tl.pointer_type(tl.uint8))
+                data = tl.load(curr_src, mask=mask)
+                tl.store(curr_dst, data, mask=mask)
+        return
+
     if is_conv_state:
-        # Conv state: copy
+        # SD conv: copy
         #   state[block_table[req_idx, src_block_idx],  accept_token_bias:]
         # to
         #   state[block_table[req_idx, dest_block_idx], :conv_width - accept_token_bias]
@@ -150,19 +192,6 @@ def postprocess_mamba_fused_kernel(
         # state_block_stride which is the page stride and can exceed the
         # actual data when the state tensor uses as_strided page padding.
         copy_size = state_inner_size * state_elem_size
-
-    # Mirror postprocess_mamba's trailing
-    #     if src_block_idx == dest_block_idx: num_accepted_tokens_cpu[i] = 1
-    # This runs whether or not the copy below is skipped (it's per-request, so
-    # only state_idx == 0 writes).
-    if src_block_idx == dest_block_idx and state_idx == 0:
-        tl.store(num_accepted_tokens_out_ptr + req_idx, 1)
-
-    # Mirror collect_mamba_copy_meta's early return: src==dst with no token
-    # bias means source and destination ranges coincide, so the copy is a
-    # no-op.
-    if src_block_idx == dest_block_idx and accept_token_bias == 0:
-        return
 
     offsets = tl.arange(0, COPY_BLOCK_SIZE)
     for i in range(0, copy_size, COPY_BLOCK_SIZE):
@@ -271,6 +300,11 @@ class MambaSpecDecodeGPUContext:
     state_inner_sizes: torch.Tensor  # int64: elements in inner dimensions
     state_conv_widths: torch.Tensor  # int32: conv width (0 for temporal states)
     state_group_indices: torch.Tensor  # int32: maps state_idx to group index
+    # DS conv state metadata. Zero for SD-conv and temporal states (the
+    # single-region copy path is used for those). For DS conv states, the
+    # kernel performs `dim_row_count` independent contiguous row copies.
+    state_dim_row_count: torch.Tensor  # int32: per-block dim row count
+    state_dim_row_stride: torch.Tensor  # int64: bytes between rows
 
     # Configuration
     block_size: int
@@ -337,6 +371,12 @@ class MambaSpecDecodeGPUContext:
             ),
             state_group_indices=torch.zeros(
                 total_states, dtype=torch.int32, device=device
+            ),
+            state_dim_row_count=torch.zeros(
+                total_states, dtype=torch.int32, device=device
+            ),
+            state_dim_row_stride=torch.zeros(
+                total_states, dtype=torch.int64, device=device
             ),
             block_size=mamba_spec.block_size,
             num_layers=num_layers,
@@ -430,17 +470,24 @@ class MambaSpecDecodeGPUContext:
                         or copy_func is get_temporal_copy_spec
                     ), f"unexpected copy func: {copy_func}"
                     if copy_func is get_conv_copy_spec:
-                        # Conv state: conv_width is state.size(1)
-                        # inner_size is stride(1) = elements per conv position,
-                        # used to compute byte offset for state[block, offset:]
-                        conv_w = state.size(1) if state.dim() > 1 else 0
-                        self.state_conv_widths[idx] = conv_w
-                        if state.dim() > 2:
-                            # stride(1) = product of dims[2:] for contiguous tensor
-                            self.state_inner_sizes[idx] = state.stride(1)
-                        else:
-                            # 2D tensor: [num_blocks, conv_dim], no inner dims
+                        if is_conv_state_dim_first() and state.dim() > 2:
+                            # DS layout (num_blocks, dim, state_len): the
+                            # kernel uses conv_width as the slide axis
+                            # (state_len) and copies `dim_row_count` rows.
+                            self.state_conv_widths[idx] = state.size(2)
                             self.state_inner_sizes[idx] = 1
+                            self.state_dim_row_count[idx] = state.size(1)
+                            self.state_dim_row_stride[idx] = (
+                                state.stride(1) * state.element_size()
+                            )
+                        else:
+                            # SD layout (num_blocks, state_len, dim) or 2D.
+                            conv_w = state.size(1) if state.dim() > 1 else 0
+                            self.state_conv_widths[idx] = conv_w
+                            if state.dim() > 2:
+                                self.state_inner_sizes[idx] = state.stride(1)
+                            else:
+                                self.state_inner_sizes[idx] = 1
                     else:
                         # Temporal state: inner_size = natural elements per
                         # block (prod of inner dims).  The kernel uses this
@@ -521,6 +568,8 @@ class MambaSpecDecodeGPUContext:
             self.state_inner_sizes,
             self.state_conv_widths,
             self.state_group_indices,
+            self.state_dim_row_count,
+            self.state_dim_row_stride,
             self.num_accepted_tokens_out,
             num_reqs,
             block_size=self.block_size,


### PR DESCRIPTION
Under VLLM_SSM_CONV_STATE_LAYOUT=DS the conv state is laid out (num_blocks, dim, state_len). The fused postprocess kernel hard-coded the SD assumption (conv_width = state.size(1), inner_size = stride(1)), producing a non-contiguous source slice and silently corrupting state whenever speculative decoding accepted >1 token. Path A's NotImplementedError in get_conv_copy_spec is unreachable in this configuration because the fused kernel rewrites num_accepted_tokens=1 back to the CPU buffer before the next preprocess reads it.

Split the kernel's conv branch on a new state_dim_row_count metadata field: SD (and 2D) keep the single-region copy; DS performs dim_row_count contiguous row copies of (state_len - bias) elements each. Temporal states are unaffected.

Closes #38898.

AI assistance was used for this change.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

