### PR TITLE
[KVConnector] Remove `VLLM_DISABLE_REQUEST_ID_RANDOMIZATION` and auto-set it for PD

### DIFF
--- a/tests/v1/engine/test_assign_request_id.py
+++ b/tests/v1/engine/test_assign_request_id.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine.input_processor import InputProcessor
+
+
+def _make_request(request_id: str = "test-req-42") -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id=request_id,
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=SamplingParams(),
+        pooling_params=None,
+        arrival_time=time.time(),
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+    )
+
+
+def _make_processor(*, disable_randomization: bool) -> InputProcessor:
+    proc = MagicMock(spec=InputProcessor)
+    proc._disable_request_id_randomization = disable_randomization
+    proc.assign_request_id = lambda req: InputProcessor.assign_request_id(proc, req)
+    return proc
+
+
+class TestAssignRequestId:
+    def test_randomization_enabled_by_default(self):
+        proc = _make_processor(disable_randomization=False)
+        req = _make_request("my-req")
+        proc.assign_request_id(req)
+
+        assert req.external_req_id == "my-req"
+        assert req.request_id.startswith("my-req-")
+        assert len(req.request_id) > len("my-req-")
+
+    def test_randomization_disabled_for_kv_transfer(self):
+        proc = _make_processor(disable_randomization=True)
+        req = _make_request("my-req")
+        proc.assign_request_id(req)
+
+        assert req.external_req_id == "my-req"
+        assert req.request_id == "my-req"
+
+    def test_raises_if_external_req_id_already_set(self):
+        proc = _make_processor(disable_randomization=False)
+        req = _make_request("my-req")
+        req.external_req_id = "already-set"
+
+        with pytest.raises(ValueError, match="external_req_id"):
+            proc.assign_request_id(req)
+
+    def test_randomized_ids_are_unique(self):
+        proc = _make_processor(disable_randomization=False)
+        ids = set()
+        for _ in range(100):
+            req = _make_request("same-id")
+            proc.assign_request_id(req)
+            ids.add(req.request_id)
+
+        assert len(ids) == 100

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -37,9 +37,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
     NixlPushConnectorWorker,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import (
-    get_base_request_id,
-)
 from vllm.v1.outputs import KVConnectorOutput
 
 from .utils import make_nixl_push_scheduler
@@ -408,29 +405,6 @@ class TestPushWriterMatching:
         assert len(w.start_push_calls) == 0
         assert "req-B" in w._pending_d_registrations
 
-    def test_handle_push_reg_matches_after_stripping_random_suffix(self):
-        """P and D assign the same logical request the same
-        ``cmpl-<uuid>-<index>`` but different per-engine random suffixes;
-        the writer should still match P's finished blocks via the
-        suffix-stripping fallback in ``_pop_matching_finished_blocks``.
-        """
-        w = _StubWriterWorker.fresh()
-        # Same base id + completion index; differ only in the trailing
-        # ``-<8 hex>`` randomization suffix.
-        p_id = "cmpl-12345678-aaaa-bbbb-cccc-1234567890ab-0-aaaaaaaa"
-        d_id = "cmpl-12345678-aaaa-bbbb-cccc-1234567890ab-0-bbbbbbbb"
-        # Sanity: same base id under the helper used by the connector.
-        assert get_base_request_id(p_id) == get_base_request_id(d_id)
-
-        w._push_finished_blocks[p_id] = ([1, 2, 3],)
-        notif = PUSH_REG_NOTIF_PREFIX + msgspec.msgpack.encode(_registration_data(d_id))
-        w._handle_push_reg_notif(notif)
-
-        # Suffix-stripped fallback matched and fired.
-        assert len(w.start_push_calls) == 1
-        assert w.start_push_calls[0][0] == p_id
-        assert p_id not in w._push_finished_blocks
-
     def test_handle_push_reg_drops_malformed(self, caplog):
         # The writer logs WARNING/ERROR when it sees these bad payloads;
         # that's the desired behavior, so suppress the noise from test
@@ -656,21 +630,13 @@ class TestPushWriterNegative:
         w = _StubWriterWorker.fresh()
         assert w._pop_matching_finished_blocks("nope") is None
 
-    def test_pop_matching_registration_no_match_when_base_ids_differ(self):
-        """A registration whose base id (after stripping the random suffix)
-        does NOT match the lookup request_id must not be popped."""
+    def test_pop_matching_registration_no_match_for_different_ids(self):
+        """A registration with a different request_id must not be popped."""
         w = _StubWriterWorker.fresh()
-        # Two unrelated requests: different base UUIDs, so stripping the
-        # trailing ``-<8 hex>`` suffix still yields different base ids.
-        unrelated_d = "cmpl-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa-0-11111111"
-        lookup = "cmpl-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb-0-22222222"
-        assert get_base_request_id(unrelated_d) != get_base_request_id(lookup)
-
-        w._pending_d_registrations[unrelated_d] = _registration_data(unrelated_d)
-        result = w._pop_matching_registration(lookup)
+        w._pending_d_registrations["req-A"] = _registration_data("req-A")
+        result = w._pop_matching_registration("req-B")
         assert result is None
-        # Original entry untouched.
-        assert unrelated_d in w._pending_d_registrations
+        assert "req-A" in w._pending_d_registrations
 
     def test_handle_push_reg_with_non_dict_payload_is_dropped(self, caplog):
         """msgpack-encoded non-dict payload (e.g. a list) should be

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -51,7 +51,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     TransferHandle,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import ReadSpec
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import get_base_request_id
 from vllm.logger import init_logger
 
 if TYPE_CHECKING:
@@ -335,35 +334,16 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
     # --- Matching helpers --------------------------------------------- #
 
     def _pop_matching_registration(self, request_id: str) -> dict[str, Any] | None:
-        """Pop the D-side registration matching *request_id*.
-
-        Exact key first, then a match after stripping the random suffix from
-        both sides. No match leaves the request unmatched (push not started).
-        """
-        data = self._pending_d_registrations.pop(request_id, None)
-        if data is not None:
-            return data
-        base_id = get_base_request_id(request_id)
-        for reg_id in list(self._pending_d_registrations):
-            if get_base_request_id(reg_id) == base_id:
-                return self._pending_d_registrations.pop(reg_id)
-        return None
+        """Pop the D-side registration matching *request_id*."""
+        return self._pending_d_registrations.pop(request_id, None)
 
     def _pop_matching_finished_blocks(
         self, request_id: str
     ) -> tuple[str, BlockIds] | None:
-        """Pop the P-side finished blocks matching *request_id*.
-
-        Same lookup as ``_pop_matching_registration``: exact key, then a
-        match after stripping the random suffix from both sides.
-        """
+        """Pop the P-side finished blocks matching *request_id*."""
         blocks = self._push_finished_blocks.pop(request_id, None)
         if blocks is not None:
             return request_id, blocks
-        base_id = get_base_request_id(request_id)
-        for fin_id in list(self._push_finished_blocks):
-            if get_base_request_id(fin_id) == base_id:
-                return fin_id, self._push_finished_blocks.pop(fin_id)
         return None
 
     # --- WRITE transfer logic (writer thread) ------------------------- #

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/utils.py
@@ -6,7 +6,6 @@ import contextlib
 from collections.abc import Iterator
 from typing import Any
 
-import regex as re
 import zmq
 
 from vllm.platforms import current_platform
@@ -56,13 +55,3 @@ def get_representative_spec_type(spec: KVCacheSpec) -> type[KVCacheSpec]:
         inner = next(iter(spec.kv_cache_specs.values()))
         return type(inner)
     return type(spec)
-
-
-# Trailing 8-hex randomization suffix appended by
-# ``input_processor.assign_request_id`` as ``-{random_uuid():.8}``.
-_RANDOM_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$", re.IGNORECASE)
-
-
-def get_base_request_id(request_id: str) -> str:
-    """Strip the per-request ``-<8 hex>`` randomization suffix, if present."""
-    return _RANDOM_SUFFIX_RE.sub("", request_id)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -191,7 +191,7 @@ if TYPE_CHECKING:
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
     VLLM_ALLOW_INSECURE_SERIALIZATION: bool = False
-    VLLM_DISABLE_REQUEST_ID_RANDOMIZATION: bool = False
+
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5600
     VLLM_MOONCAKE_BOOTSTRAP_PORT: int = 8998
@@ -1470,11 +1470,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # insecure method and it is needed for some reason.
     "VLLM_ALLOW_INSECURE_SERIALIZATION": lambda: bool(
         int(os.getenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "0"))
-    ),
-    # Temporary: skip adding random suffix to internal request IDs. May be
-    # needed for KV connectors that match request IDs across instances.
-    "VLLM_DISABLE_REQUEST_ID_RANDOMIZATION": lambda: bool(
-        int(os.getenv("VLLM_DISABLE_REQUEST_ID_RANDOMIZATION", "0"))
     ),
     # IP address used for NIXL handshake between remote agents.
     "VLLM_NIXL_SIDE_CHANNEL_HOST": lambda: os.getenv(

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 import time
 from collections.abc import Mapping
 from typing import Any, Literal
 
-import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.inputs import (
     EngineInput,
@@ -71,6 +71,17 @@ class InputProcessor:
             renderer=renderer,
             mm_registry=mm_registry,
         )
+
+        kv_cfg = vllm_config.kv_transfer_config
+        self._disable_request_id_randomization = (
+            kv_cfg is not None and kv_cfg.is_kv_transfer_instance
+        )
+        if os.environ.get("VLLM_DISABLE_REQUEST_ID_RANDOMIZATION"):
+            logger.warning_once(
+                "VLLM_DISABLE_REQUEST_ID_RANDOMIZATION has been removed. "
+                "Request ID randomization is now automatically disabled "
+                "for KV transfer (P/D disaggregated) instances."
+            )
 
     @property
     def tokenizer(self) -> TokenizerLike | None:
@@ -219,10 +230,13 @@ class InputProcessor:
                 exc_info=True,
             )
 
-    @staticmethod
-    def assign_request_id(request: EngineCoreRequest):
+    def assign_request_id(self, request: EngineCoreRequest):
         """Replace the externally supplied request ID with an internal request ID
         that adds 8 random characters in order to ensure uniqueness.
+
+        Randomization is automatically skipped for KV transfer (P/D
+        disaggregated) instances, where connectors and external proxies
+        rely on predictable request IDs across nodes.
         """
         if request.external_req_id is not None:
             raise ValueError(
@@ -230,13 +244,7 @@ class InputProcessor:
                 " passed to vLLM; use the request_id field."
             )
         request.external_req_id = request.request_id
-        if envs.VLLM_DISABLE_REQUEST_ID_RANDOMIZATION:
-            logger.warning_once(
-                "VLLM_DISABLE_REQUEST_ID_RANDOMIZATION is set and will be "
-                "removed in a future release. Duplicate externally-provided "
-                "request IDs may cause failures and/or subtle correctness errors."
-            )
-        else:
+        if not self._disable_request_id_randomization:
             request.request_id = f"{request.external_req_id}-{random_uuid():.8}"
 
     def process_inputs(


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/34415 introduced `VLLM_DISABLE_REQUEST_ID_RANDOMIZATION` to disable vllm-internal id randomization.
In a PD setup, we're shipping a _system_ not a vllm instance, and that system includes a router/proxy which is by design the component which should retain responsability on setting params like request-ids, as the identifier is the basis on which we can build logic on top for optimized routing. 

Furthermore, `VLLM_DISABLE_REQUEST_ID_RANDOMIZATION` was introduced as a "temporary workaround" to patch the breaking change, yet it's been there for 4+ months now, and code working around the randomization behavior has started to appear in PD  
https://github.com/vllm-project/vllm/blob/6c5872efc5fca7a53f5f3aa589e8cb7896d98618/vllm/distributed/kv_transfer/kv_connector/v1/nixl/utils.py#L66-L68

This PR proposes to remove the "temporary" `VLLM_DISABLE_REQUEST_ID_RANDOMIZATION` and auto-set its behavior for detected PD deployments, in an effort to reduce knobs to tune/be aware of when running PD.

cc @markmc @njhill as you worked on various nasty issues re id duplication, @eicherseiji who fixed the bug back in February