### PR TITLE
[kv_offload] Use Hugepages for kv_offload tiering setup

### DIFF
--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -62,12 +62,71 @@ vllm serve <model> \
   }'
 ```
 
+## Hugepage CPU Primary Tier
+
+Hugepage-backed CPU memory is opt-in and applies only to the
+`TieringOffloadingSpec` CPU primary tier. With no hugepage keys, vLLM preserves
+the existing defaults: single-tier `CPUOffloadingSpec` uses torch CPU tensors,
+and `TieringOffloadingSpec` uses a shared mmap file under `/dev/shm`.
+
+Before starting vLLM, reserve enough hugepages and mount a hugetlbfs directory
+on the host. vLLM validates and maps an existing hugetlbfs path; it does not
+reserve hugepages or create the mount for you.
+
+```bash
+sudo mkdir -p /dev/hugepages
+sudo mount -t hugetlbfs -o pagesize=2M none /dev/hugepages
+sudo mkdir -p /dev/hugepages/vllm
+```
+
+Then set `cpu_memory_backend` to `"hugetlbfs"` and point `cpu_memory_path` at
+the hugetlbfs directory:
+
+```bash
+vllm serve <model> \
+  --kv-transfer-config '{
+    "kv_connector": "OffloadingConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "spec_name": "TieringOffloadingSpec",
+      "cpu_memory_backend": "hugetlbfs",
+      "cpu_memory_path": "/dev/hugepages/vllm",
+      "cpu_hugepage_block_size": "2MB",
+      "cpu_bytes_to_use": 10737418240,
+      "block_size": 16,
+      "eviction_policy": "lru",
+      "secondary_tiers": []
+    }
+  }'
+```
+
+Invalid or unavailable hugepage mappings fail startup with an actionable error.
+Examples include a missing or unwritable `cpu_memory_path`, using `/dev/shm` for
+`hugetlbfs`, a detectable non-hugetlbfs filesystem, a detected mount page size
+that does not match `cpu_hugepage_block_size`, or insufficient reserved
+hugepages when sizing the mmap file.
+
+To verify that the offload region is backed by hugepages, inspect the vLLM
+process mappings and look for the offload file under `cpu_memory_path`:
+
+```bash
+PID=<vllm-worker-pid>
+grep -A20 '/dev/hugepages/vllm/vllm_offload_' /proc/${PID}/smaps
+```
+
+The matching mapping should report the hugetlbfs file path and hugepage
+properties such as `KernelPageSize` matching the configured page size or
+`VmFlags` containing `ht`.
+
 ## `kv_connector_extra_config` Reference
 
 | Key | Required | Default | Scope | Notes |
 | --- | --- | --- | --- | --- |
 | `spec_name` | no | `CPUOffloadingSpec` | both | Set to `TieringOffloadingSpec` for multi-tier. |
 | `cpu_bytes_to_use` | yes | — | both | Total bytes of host memory reserved for the CPU tier across all workers (not per-worker). |
+| `cpu_memory_backend` | no | `default` | both | `default`, `shm`, or `hugetlbfs`. `default` preserves current behavior. Explicit `shm` and `hugetlbfs` are supported only by `TieringOffloadingSpec`. |
+| `cpu_memory_path` | no | `/dev/shm` for shared mmap | multi-tier | Directory for shared mmap files. Required for `cpu_memory_backend="hugetlbfs"`; optional for `shm`. |
+| `cpu_hugepage_block_size` | no | `2MB` | multi-tier | Expected hugetlbfs page size, either `2MB` or `1GB`. vLLM aligns the mapped file size to this value and validates the mount page size when it can detect it. |
 | `block_size` | no | GPU block size | both | Offloaded block size in tokens; must be a multiple of the GPU block size. |
 | `eviction_policy` | no | `lru` | both | Primary tier policy: `lru` or `arc`. |
 | `store_threshold` | no | `0` | single-tier | Min lookups before a block is offloaded. Values ≥ 2 are rejected by `TieringOffloadingSpec`. |
@@ -120,9 +179,30 @@ To enable KV cache sharing between multiple vLLM instances using the same `root_
 PYTHONHASHSEED=0 vllm serve ...
 ```
 
+### Object Store (OBJ)
+
+The OBJ tier (`type: "obj"`) transfers blocks between the CPU primary tier and
+an object backend through NIXL. The CPU primary tier can be backed by hugetlbfs
+without changing the OBJ tier configuration. See
+`examples/features/kv_offloading/doca_memos/kv_transfer_config.doca_memos_hugepages.json`
+for a DOCA MEMOS example that sets `cpu_memory_backend="hugetlbfs"` and keeps
+the object secondary tier unchanged.
+
+When several vLLM processes share the same object tier prefix, set
+`PYTHONHASHSEED` to the same fixed value on every process so identical token
+content maps to identical object keys.
+
 ## Tuning Tips
 
 - `cpu_bytes_to_use`: a bigger CPU tier means fewer trips to slower secondary tiers and a higher hit rate. The value is total across all workers, not per-worker. Leave headroom for the rest of the host workload.
+- Hugepages: reserve enough hugepages for the aligned mmap size before starting
+  vLLM. Keep additional host-memory headroom for model runtime, request state,
+  networking, and secondary-tier clients; `cpu_bytes_to_use` is only the logical
+  KV capacity and does not include general process memory.
+- Containers: mount the hugetlbfs directory into the container and, on
+  Kubernetes, request the corresponding hugepage resources. vLLM must see the
+  same `cpu_memory_path` inside the container that you configure in
+  `kv_connector_extra_config`.
 - For single-tier (CPU-only) setups, set `cpu_bytes_to_use` larger than the aggregate GPU KV cache. Because offloading is immediate, a smaller CPU tier just mirrors what the GPU already holds and adds no hit rate.
 - `block_size`: larger offloaded blocks reduce per-block bookkeeping overhead but increase the granularity of lookups. Must be a multiple of the GPU block size.
 - FS thread counts: tune `n_read_threads` and `n_write_threads` to the parallelism your storage can sustain. Reads are latency-sensitive on the prefill path, so prefer more read threads when prefill hit rates are high.

--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -183,10 +183,7 @@ PYTHONHASHSEED=0 vllm serve ...
 
 The OBJ tier (`type: "obj"`) transfers blocks between the CPU primary tier and
 an object backend through NIXL. The CPU primary tier can be backed by hugetlbfs
-without changing the OBJ tier configuration. See
-`examples/features/kv_offloading/doca_memos/kv_transfer_config.doca_memos_hugepages.json`
-for a DOCA MEMOS example that sets `cpu_memory_backend="hugetlbfs"` and keeps
-the object secondary tier unchanged.
+without changing the OBJ tier configuration. 
 
 When several vLLM processes share the same object tier prefix, set
 `PYTHONHASHSEED` to the same fixed value on every process so identical token

--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -62,12 +62,71 @@ vllm serve <model> \
   }'
 ```
 
+## Hugepage CPU Primary Tier
+
+Hugepage-backed CPU memory is opt-in and applies only to the
+`TieringOffloadingSpec` CPU primary tier. With no hugepage keys, vLLM preserves
+the existing defaults: single-tier `CPUOffloadingSpec` uses torch CPU tensors,
+and `TieringOffloadingSpec` uses a shared mmap file under `/dev/shm`.
+
+Before starting vLLM, reserve enough hugepages and mount a hugetlbfs directory
+on the host. vLLM validates and maps an existing hugetlbfs path; it does not
+reserve hugepages or create the mount for you.
+
+```bash
+sudo mkdir -p /dev/hugepages
+sudo mount -t hugetlbfs -o pagesize=2M none /dev/hugepages
+sudo mkdir -p /dev/hugepages/vllm
+```
+
+Then set `cpu_memory_backend` to `"hugetlbfs"` and point `cpu_memory_path` at
+the hugetlbfs directory:
+
+```bash
+vllm serve <model> \
+  --kv-transfer-config '{
+    "kv_connector": "OffloadingConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "spec_name": "TieringOffloadingSpec",
+      "cpu_memory_backend": "hugetlbfs",
+      "cpu_memory_path": "/dev/hugepages/vllm",
+      "cpu_hugepage_block_size": "2MB",
+      "cpu_bytes_to_use": 10737418240,
+      "block_size": 16,
+      "eviction_policy": "lru",
+      "secondary_tiers": []
+    }
+  }'
+```
+
+Invalid or unavailable hugepage mappings fail startup with an actionable error.
+Examples include a missing or unwritable `cpu_memory_path`, using `/dev/shm` for
+`hugetlbfs`, a detectable non-hugetlbfs filesystem, a detected mount page size
+that does not match `cpu_hugepage_block_size`, or insufficient reserved
+hugepages when sizing the mmap file.
+
+To verify that the offload region is backed by hugepages, inspect the vLLM
+process mappings and look for the offload file under `cpu_memory_path`:
+
+```bash
+PID=<vllm-worker-pid>
+grep -A20 '/dev/hugepages/vllm/vllm_offload_' /proc/${PID}/smaps
+```
+
+The matching mapping should report the hugetlbfs file path and hugepage
+properties such as `KernelPageSize` matching the configured page size or
+`VmFlags` containing `ht`.
+
 ## `kv_connector_extra_config` Reference
 
 | Key | Required | Default | Scope | Notes |
 | --- | --- | --- | --- | --- |
 | `spec_name` | no | `CPUOffloadingSpec` | both | Set to `TieringOffloadingSpec` for multi-tier. |
 | `cpu_bytes_to_use` | yes | — | both | Total bytes of host memory reserved for the CPU tier across all workers (not per-worker). |
+| `cpu_memory_backend` | no | `default` | both | `default`, `shm`, or `hugetlbfs`. `default` preserves current behavior. Explicit `shm` and `hugetlbfs` are supported only by `TieringOffloadingSpec`. |
+| `cpu_memory_path` | no | `/dev/shm` for shared mmap | multi-tier | Directory for shared mmap files. Required for `cpu_memory_backend="hugetlbfs"`; optional for `shm`. |
+| `cpu_hugepage_block_size` | no | `2MB` | multi-tier | Expected hugetlbfs page size, either `2MB` or `1GB`. vLLM aligns the mapped file size to this value and validates the mount page size when it can detect it. |
 | `block_size` | no | GPU block size | both | Offloaded block size in tokens; must be a multiple of the GPU block size. Mutually exclusive with `blocks_per_chunk`. |
 | `blocks_per_chunk` | no | `1` | both | Offloaded chunk size in GPU blocks; must be > 0. Alternative to `block_size` for models whose KV cache groups have different block sizes. |
 | `eviction_policy` | no | `lru` | both | Primary tier policy: built-in `lru`/`arc`, or a custom `CachePolicy` name (see [Custom Eviction Policies](#custom-eviction-policies)). |
@@ -297,6 +356,14 @@ Implement `SecondaryTierManager` (`vllm/v1/kv_offload/tiering/base.py`) in your 
 ## Tuning Tips
 
 - `cpu_bytes_to_use`: a bigger CPU tier means fewer trips to slower secondary tiers and a higher hit rate. The value is total across all workers, not per-worker. Leave headroom for the rest of the host workload.
+- Hugepages: reserve enough hugepages for the aligned mmap size before starting
+  vLLM. Keep additional host-memory headroom for model runtime, request state,
+  networking, and secondary-tier clients; `cpu_bytes_to_use` is only the logical
+  KV capacity and does not include general process memory.
+- Containers: mount the hugetlbfs directory into the container and, on
+  Kubernetes, request the corresponding hugepage resources. vLLM must see the
+  same `cpu_memory_path` inside the container that you configure in
+  `kv_connector_extra_config`.
 - For single-tier (CPU-only) setups, set `cpu_bytes_to_use` larger than the aggregate GPU KV cache. Because offloading is immediate, a smaller CPU tier just mirrors what the GPU already holds and adds no hit rate.
 - `block_size` / `blocks_per_chunk`: larger offloaded chunks reduce per-block bookkeeping overhead but increase the granularity of lookups.
 - FS thread counts: tune `n_read_threads` and `n_write_threads` to the parallelism your storage can sustain. Reads are latency-sensitive on the prefill path, so prefer more read threads when prefill hit rates are high.

--- a/tests/v1/kv_connector/unit/test_config.py
+++ b/tests/v1/kv_connector/unit/test_config.py
@@ -5,8 +5,15 @@
 
 import pytest
 
-from vllm.config import CacheConfig, KVTransferConfig, ParallelConfig, VllmConfig
+from vllm.config import (
+    CacheConfig,
+    DeviceConfig,
+    KVTransferConfig,
+    ParallelConfig,
+    VllmConfig,
+)
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+from vllm.v1.kv_offload.cpu.memory import CPUOffloadMemoryConfig
 
 pytestmark = pytest.mark.cpu_test
 
@@ -33,11 +40,21 @@ def stub_lmcache_mp_connector(monkeypatch):
     )
 
 
+def _parallel_config(tp: int, pp: int) -> ParallelConfig:
+    # These unit tests only exercise config translation. Set the backend
+    # explicitly so synthetic multi-rank cases do not depend on local GPU count.
+    return ParallelConfig(
+        tensor_parallel_size=tp,
+        pipeline_parallel_size=pp,
+        distributed_executor_backend="mp",
+    )
+
+
 @pytest.mark.parametrize(
     "kv_offloading_backend,kv_offloading_size,tp,pp,expected_backend,expected_bytes",
     [
         ("native", 4.0, 1, 1, "OffloadingConnector", 4.0 * (1 << 30)),
-        # bytes per rank: 8.0 GiB / (2 * 2) = 2.0 GiB
+        # cpu_bytes_to_use remains server-wide at this config layer.
         ("native", 8.0, 2, 2, "OffloadingConnector", 8.0 * (1 << 30)),
         # ``lmcache`` backend now defaults to LMCacheMPConnector. The KV
         # storage capacity is owned by the standalone LMCache server, so
@@ -68,10 +85,9 @@ def test_kv_connector(
             kv_offloading_backend=kv_offloading_backend,
             kv_offloading_size=kv_offloading_size,
         ),
+        device_config=DeviceConfig(device="cpu"),
         kv_transfer_config=kv_transfer_config,
-        parallel_config=ParallelConfig(
-            tensor_parallel_size=tp, pipeline_parallel_size=pp
-        ),
+        parallel_config=_parallel_config(tp, pp),
     )
 
     # No KV transfer config expected
@@ -174,6 +190,7 @@ def test_kv_offloading_size_only_uses_native_default():
             kv_offloading_size=4.0,
             # kv_offloading_backend not set, should default to "native"
         ),
+        device_config=DeviceConfig(device="cpu"),
     )
 
     kv_transfer_config = vllm_config.kv_transfer_config
@@ -181,3 +198,47 @@ def test_kv_offloading_size_only_uses_native_default():
     assert kv_transfer_config.kv_connector == "OffloadingConnector"
     assert kv_transfer_config.kv_role == "kv_both"
     assert kv_connector_extra_config["cpu_bytes_to_use"] == 4.0 * (1 << 30)
+
+
+def test_kv_offloading_preserves_cpu_memory_backend_extra_config():
+    kv_transfer_config = KVTransferConfig(
+        kv_connector_extra_config={
+            "spec_name": "TieringOffloadingSpec",
+            "cpu_memory_backend": "hugetlbfs",
+            "cpu_memory_path": "/dev/hugepages/vllm",
+            "cpu_hugepage_block_size": "1GB",
+        }
+    )
+
+    vllm_config = VllmConfig(
+        cache_config=CacheConfig(kv_offloading_size=4.0),
+        device_config=DeviceConfig(device="cpu"),
+        kv_transfer_config=kv_transfer_config,
+    )
+
+    extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
+    assert vllm_config.kv_transfer_config.kv_connector == "OffloadingConnector"
+    assert vllm_config.kv_transfer_config.kv_role == "kv_both"
+    assert extra_config["cpu_bytes_to_use"] == 4.0 * (1 << 30)
+    assert extra_config["spec_name"] == "TieringOffloadingSpec"
+    assert extra_config["cpu_memory_backend"] == "hugetlbfs"
+    assert extra_config["cpu_memory_path"] == "/dev/hugepages/vllm"
+    assert extra_config["cpu_hugepage_block_size"] == "1GB"
+
+
+@pytest.mark.parametrize(
+    ("extra_config", "match"),
+    [
+        (
+            {"cpu_memory_backend": "invalid"},
+            "Invalid cpu_memory_backend",
+        ),
+        (
+            {"cpu_memory_backend": "hugetlbfs"},
+            "cpu_memory_path is required",
+        ),
+    ],
+)
+def test_cpu_memory_backend_config_errors_are_clear(extra_config, match):
+    with pytest.raises(ValueError, match=match):
+        CPUOffloadMemoryConfig.from_extra_config(extra_config)

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import mmap
 import random
 import time
 import uuid
+from typing import Any
 
 import pytest
 import torch
@@ -16,8 +18,10 @@ from vllm.v1.kv_offload.base import (
     CanonicalKVCacheTensor,
     GPULoadStoreSpec,
 )
+from vllm.v1.kv_offload.cpu import gpu_worker as gpu_worker_module
 from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
 from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
+from vllm.v1.kv_offload.cpu.memory import CPUOffloadMemoryConfig
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 
 NUM_GPU_BLOCKS = [64]
@@ -30,6 +34,98 @@ DEVICE_TYPE = current_platform.device_type
 DEVICES = [f"{DEVICE_TYPE}:0"]
 NUM_MAPPINGS = [3]
 NUM_MAPPINGS_PER_GROUP = [2]
+requires_accelerator = pytest.mark.skipif(
+    not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
+    reason="GPU offload transfer tests require CUDA/ROCm/XPU",
+)
+
+
+def test_handlers_consume_shared_region_selected_by_memory_config(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(gpu_worker_module, "PIN_MEMORY", False)
+    created_handlers: list[Any] = []
+
+    class FakeSingleDirectionOffloadingHandler:
+        def __init__(
+            self,
+            *,
+            gpu_tensors: list[torch.Tensor],
+            cpu_tensors: list[torch.Tensor],
+            block_size_factor: int,
+            kv_cache_groups_data_refs: list[list[CanonicalKVCacheRef]],
+            gpu_to_cpu: bool,
+            mmap_region: SharedOffloadRegion | None = None,
+            pin_thread: Any = None,
+            manually_pinned_tensors: list[torch.Tensor] | None = None,
+        ) -> None:
+            self.gpu_tensors = gpu_tensors
+            self.cpu_tensors = cpu_tensors
+            self.block_size_factor = block_size_factor
+            self.kv_cache_groups_data_refs = kv_cache_groups_data_refs
+            self.gpu_to_cpu = gpu_to_cpu
+            self.mmap_region = mmap_region
+            created_handlers.append(self)
+
+    monkeypatch.setattr(
+        gpu_worker_module,
+        "SingleDirectionOffloadingHandler",
+        FakeSingleDirectionOffloadingHandler,
+    )
+
+    gpu_page_size_bytes = mmap.PAGESIZE
+    block_size_factor = 2
+    num_cpu_blocks = 3
+    kv_caches = CanonicalKVCaches(
+        tensors=[
+            CanonicalKVCacheTensor(
+                tensor=torch.zeros((4, gpu_page_size_bytes), dtype=torch.int8),
+                page_size_bytes=gpu_page_size_bytes,
+            )
+        ],
+        group_data_refs=[
+            [CanonicalKVCacheRef(tensor_idx=0, page_size_bytes=gpu_page_size_bytes)]
+        ],
+    )
+    memory_config = CPUOffloadMemoryConfig.from_extra_config(
+        {"cpu_memory_backend": "shm", "cpu_memory_path": str(tmp_path)}
+    )
+    mmap_region = SharedOffloadRegion(
+        instance_id=str(uuid.uuid4()),
+        num_blocks=num_cpu_blocks,
+        rank=0,
+        kv_bytes_per_block=gpu_page_size_bytes * block_size_factor,
+        cpu_page_size=gpu_page_size_bytes * block_size_factor,
+        memory_config=memory_config,
+    )
+
+    cpu_tensor: torch.Tensor | None = None
+    try:
+        CPUOffloadingWorker(
+            kv_caches=kv_caches,
+            block_size_factor=block_size_factor,
+            num_cpu_blocks=num_cpu_blocks,
+            mmap_region=mmap_region,
+        )
+
+        assert len(created_handlers) == 2
+        cpu_tensor = created_handlers[0].cpu_tensors[0]
+        assert cpu_tensor is not None
+        assert created_handlers[1].cpu_tensors[0] is cpu_tensor
+        assert created_handlers[0].mmap_region is mmap_region
+        assert created_handlers[1].mmap_region is None
+        assert mmap_region.mmap_path.startswith(str(tmp_path))
+        assert cpu_tensor.shape == (
+            num_cpu_blocks,
+            gpu_page_size_bytes * block_size_factor,
+        )
+        assert cpu_tensor.data_ptr() == mmap_region._base.data_ptr()
+    finally:
+        for handler in created_handlers:
+            handler.cpu_tensors.clear()
+            handler.gpu_tensors.clear()
+        cpu_tensor = None
+        mmap_region.cleanup()
 
 
 @pytest.mark.parametrize("gpu_to_cpu", [True, False])
@@ -42,6 +138,7 @@ NUM_MAPPINGS_PER_GROUP = [2]
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("use_shared_memory", [False, True])
+@requires_accelerator
 @torch.inference_mode()
 def test_transfer(
     default_vllm_config,
@@ -219,6 +316,7 @@ def test_transfer(
 @pytest.mark.parametrize("num_cpu_blocks", NUM_CPU_BLOCKS)
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", DEVICES)
+@requires_accelerator
 @torch.inference_mode()
 def test_transfer_multi_group(
     default_vllm_config,

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import logging
+import mmap
 import random
 import time
 import uuid
 from unittest.mock import MagicMock
+from typing import Any
 
 import pytest
 import torch
@@ -23,6 +25,7 @@ from vllm.v1.kv_offload.base import (
 from vllm.v1.kv_offload.cpu import gpu_worker
 from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
 from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
+from vllm.v1.kv_offload.cpu.memory import CPUOffloadMemoryConfig
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 
 NUM_GPU_BLOCKS = [64]
@@ -35,6 +38,277 @@ DEVICE_TYPE = current_platform.device_type
 DEVICES = [f"{DEVICE_TYPE}:0"]
 NUM_MAPPINGS = [3]
 NUM_MAPPINGS_PER_GROUP = [2]
+requires_accelerator = pytest.mark.skipif(
+    not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
+    reason="GPU offload transfer tests require CUDA/ROCm/XPU",
+)
+
+
+def test_handlers_consume_shared_region_selected_by_memory_config(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(gpu_worker, "PIN_MEMORY", False)
+    created_handlers: list[Any] = []
+
+    class FakeSingleDirectionOffloadingHandler:
+        def __init__(
+            self,
+            gpu_tensors: list[torch.Tensor],
+            cpu_tensors: list[torch.Tensor],
+            blocks_per_chunk: int,
+            layer_refs_per_group: list[list[CanonicalKVCacheRef]],
+            gpu_to_cpu: bool,
+            canonical_layout: bool = False,
+        ) -> None:
+            self.gpu_tensors = gpu_tensors
+            self.cpu_tensors = cpu_tensors
+            self.blocks_per_chunk = blocks_per_chunk
+            self.layer_refs_per_group = layer_refs_per_group
+            self.gpu_to_cpu = gpu_to_cpu
+            created_handlers.append(self)
+
+    monkeypatch.setattr(
+        gpu_worker,
+        "SingleDirectionOffloadingHandler",
+        FakeSingleDirectionOffloadingHandler,
+    )
+
+    gpu_page_size_bytes = mmap.PAGESIZE
+    blocks_per_chunk = 2
+    num_cpu_blocks = 3
+    kv_caches = CanonicalKVCaches(
+        tensors=[
+            CanonicalKVCacheTensor(
+                tensor=torch.zeros((4, gpu_page_size_bytes), dtype=torch.int8),
+                page_size_bytes=gpu_page_size_bytes,
+            )
+        ],
+        group_data_refs=[
+            [CanonicalKVCacheRef(tensor_idx=0, page_size_bytes=gpu_page_size_bytes)]
+        ],
+    )
+    memory_config = CPUOffloadMemoryConfig.from_extra_config(
+        {"cpu_memory_backend": "shm", "cpu_memory_path": str(tmp_path)}
+    )
+    mmap_region = SharedOffloadRegion(
+        engine_id=str(uuid.uuid4()),
+        num_blocks=num_cpu_blocks,
+        rank=0,
+        kv_bytes_per_block=gpu_page_size_bytes * blocks_per_chunk,
+        cpu_page_size=gpu_page_size_bytes * blocks_per_chunk,
+        memory_config=memory_config,
+    )
+
+    cpu_tensor: torch.Tensor | None = None
+    try:
+        worker = CPUOffloadingWorker(
+            kv_caches=kv_caches,
+            blocks_per_chunk=blocks_per_chunk,
+            num_cpu_blocks=num_cpu_blocks,
+            mmap_region=mmap_region,
+        )
+
+        assert worker._mmap_region is mmap_region
+        assert len(created_handlers) == 2
+        cpu_tensor = created_handlers[0].cpu_tensors[0]
+        assert cpu_tensor is not None
+        assert created_handlers[1].cpu_tensors[0] is cpu_tensor
+        assert mmap_region.mmap_path.startswith(str(tmp_path))
+        assert cpu_tensor.shape == (
+            num_cpu_blocks,
+            gpu_page_size_bytes * blocks_per_chunk,
+        )
+        assert cpu_tensor.data_ptr() == mmap_region._base.data_ptr()
+    finally:
+        for handler in created_handlers:
+            handler.cpu_tensors.clear()
+            handler.gpu_tensors.clear()
+        cpu_tensor = None
+        mmap_region.cleanup()
+
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-specific test")
+def test_rocm_cpu_to_gpu_uses_dma(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gpu_worker, "HAS_TRITON", True)
+    monkeypatch.setattr(gpu_worker.current_platform, "is_xpu", lambda: False)
+    monkeypatch.setattr(gpu_worker.current_platform, "is_rocm", lambda: True)
+
+    refs = [[CanonicalKVCacheRef(tensor_idx=0, page_size_bytes=512)]]
+    assert gpu_worker._select_swap_blocks_fn(refs, gpu_to_cpu=False) is (
+        ops.swap_blocks_batch
+    )
+
+
+def test_worker_shutdown_releases_region_and_runs_both_handlers() -> None:
+    """Both directions drain before the worker releases its shared region."""
+    worker = CPUOffloadingWorker.__new__(CPUOffloadingWorker)
+    calls: list[str] = []
+
+    def record_store_shutdown() -> bool:
+        calls.append("store")
+        return True
+
+    def record_load_shutdown() -> bool:
+        calls.append("load")
+        return True
+
+    store_handler = MagicMock()
+    load_handler = MagicMock()
+    store_handler.shutdown.side_effect = record_store_shutdown
+    load_handler.shutdown.side_effect = record_load_shutdown
+
+    def record_region_cleanup(**_: bool) -> bool:
+        calls.append("region")
+        return True
+
+    mmap_region = MagicMock()
+    mmap_region.cleanup.side_effect = record_region_cleanup
+    worker._store_handler = store_handler
+    worker._load_handler = load_handler
+    worker._mmap_region = mmap_region
+
+    worker.shutdown()
+
+    assert calls == ["store", "load", "region"]
+    store_handler.shutdown.assert_called_once_with()
+    load_handler.shutdown.assert_called_once_with()
+    mmap_region.cleanup.assert_called_once_with()
+    assert worker._mmap_region is None
+
+
+@pytest.mark.parametrize("failing_handler", ["store", "load"])
+def test_worker_logs_handler_error_and_cleans_region(
+    caplog_vllm, monkeypatch: pytest.MonkeyPatch, failing_handler
+) -> None:
+    worker = CPUOffloadingWorker.__new__(CPUOffloadingWorker)
+    calls: list[str] = []
+    store_handler = MagicMock()
+    load_handler = MagicMock()
+    if failing_handler == "store":
+
+        def fail_store_shutdown() -> bool:
+            calls.append("store")
+            raise RuntimeError("transfer did not drain")
+
+        store_handler.shutdown.side_effect = fail_store_shutdown
+    else:
+
+        def fail_load_shutdown() -> bool:
+            calls.append("load")
+            raise RuntimeError("transfer did not drain")
+
+        load_handler.shutdown.side_effect = fail_load_shutdown
+
+    def record_other_shutdown() -> bool:
+        calls.append("load" if failing_handler == "store" else "store")
+        return True
+
+    if failing_handler == "store":
+        load_handler.shutdown.side_effect = record_other_shutdown
+    else:
+        store_handler.shutdown.side_effect = record_other_shutdown
+
+    def record_device_sync() -> None:
+        calls.append("sync")
+
+    monkeypatch.setattr(torch.accelerator, "synchronize", record_device_sync)
+
+    def record_region_cleanup() -> None:
+        calls.append("region")
+
+    mmap_region = MagicMock()
+    mmap_region.cleanup.side_effect = record_region_cleanup
+    worker._store_handler = store_handler
+    worker._load_handler = load_handler
+    worker._mmap_region = mmap_region
+
+    with caplog_vllm.at_level(
+        logging.ERROR, logger="vllm.v1.kv_offload.cpu.gpu_worker"
+    ):
+        worker.shutdown()
+
+    other = "load" if failing_handler == "store" else "store"
+    getattr(worker, f"_{other}_handler").shutdown.assert_called_once_with()
+    mmap_region.cleanup.assert_called_once_with()
+    assert worker._mmap_region is None
+    assert (
+        f"Failed to shut down {failing_handler} offloading handler" in caplog_vllm.text
+    )
+    assert calls[-2:] == ["sync", "region"]
+
+
+def test_handler_shutdown_skips_transfers_after_event_sync_failure() -> None:
+    handler = gpu_worker.SingleDirectionOffloadingHandler.__new__(
+        gpu_worker.SingleDirectionOffloadingHandler
+    )
+    failed_event = MagicMock()
+    failed_event.synchronize.side_effect = RuntimeError("device lost")
+    skipped_event = MagicMock()
+    handler._transfers = gpu_worker.deque(
+        [
+            MagicMock(end_event=failed_event),
+            MagicMock(end_event=skipped_event),
+        ]
+    )
+    handler._transfer_events = {1: failed_event, 2: skipped_event}
+    handler._stream_pool = [MagicMock()]
+    handler._event_pool = [MagicMock()]
+    handler._buffer_pool = [(MagicMock(), MagicMock(), MagicMock())]
+    handler.src_tensors = [MagicMock()]
+    handler.dst_tensors = [MagicMock()]
+
+    with pytest.raises(RuntimeError, match="device lost"):
+        handler.shutdown()
+    failed_event.synchronize.assert_called_once_with()
+    skipped_event.synchronize.assert_not_called()
+    assert not handler._transfers
+    assert not handler._transfer_events
+    assert not handler._stream_pool
+    assert not handler._event_pool
+    assert not handler._buffer_pool
+    assert not handler.src_tensors
+    assert not handler.dst_tensors
+
+
+@pytest.mark.parametrize("device_sync_fails", [False, True])
+def test_worker_syncs_before_cleanup_after_handler_failure(
+    caplog_vllm, monkeypatch: pytest.MonkeyPatch, device_sync_fails: bool
+) -> None:
+    worker = CPUOffloadingWorker.__new__(CPUOffloadingWorker)
+    calls: list[str] = []
+    store_handler = MagicMock()
+
+    def fail_store_shutdown() -> None:
+        raise RuntimeError("device lost")
+
+    store_handler.shutdown.side_effect = fail_store_shutdown
+    load_handler = MagicMock()
+
+    def record_device_sync() -> None:
+        calls.append("sync")
+        if device_sync_fails:
+            raise RuntimeError("device lost")
+
+    def record_region_cleanup() -> None:
+        calls.append("region")
+
+    monkeypatch.setattr(torch.accelerator, "synchronize", record_device_sync)
+    mmap_region = MagicMock()
+    mmap_region.cleanup.side_effect = record_region_cleanup
+    worker._store_handler = store_handler
+    worker._load_handler = load_handler
+    worker._mmap_region = mmap_region
+
+    with caplog_vllm.at_level(
+        logging.WARNING, logger="vllm.v1.kv_offload.cpu.gpu_worker"
+    ):
+        worker.shutdown()
+
+    assert calls == ["sync", "region"]
+    mmap_region.cleanup.assert_called_once_with()
+    if device_sync_fails:
+        assert "Device sync before mmap cleanup failed" in caplog_vllm.text
 
 
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-specific test")
@@ -233,6 +507,7 @@ def test_worker_syncs_before_cleanup_after_handler_failure(
     ("use_shared_memory", "replicated_layout"),
     [(False, False), (True, False), (True, True)],
 )
+@requires_accelerator
 @torch.inference_mode()
 def test_transfer(
     default_vllm_config,
@@ -413,6 +688,7 @@ def test_transfer(
 @pytest.mark.parametrize("num_cpu_blocks", NUM_CPU_BLOCKS)
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", DEVICES)
+@requires_accelerator
 @torch.inference_mode()
 def test_transfer_multi_group(
     default_vllm_config,

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -12,6 +12,14 @@ import uuid
 import pytest
 
 from vllm.utils.system_utils import get_mp_context
+from vllm.v1.kv_offload.cpu import memory as memory_module
+from vllm.v1.kv_offload.cpu.memory import (
+    HUGEPAGE_1GB,
+    HUGEPAGE_2MB,
+    CPUOffloadMemoryBackend,
+    CPUOffloadMemoryConfig,
+    MountInfo,
+)
 from vllm.v1.kv_offload.cpu.shared_offload_region import (
     SharedOffloadRegion,
     _wait_for_file_size,
@@ -39,6 +47,7 @@ def _make_region(
     cpu_page_size: int = PAGE_SIZE,
     num_workers: int = 1,
     rank: int = 0,
+    memory_config: CPUOffloadMemoryConfig | None = None,
 ) -> SharedOffloadRegion:
     assert cpu_page_size % PAGE_SIZE == 0
     return SharedOffloadRegion(
@@ -47,6 +56,7 @@ def _make_region(
         rank=rank,
         kv_bytes_per_block=num_workers * cpu_page_size,
         cpu_page_size=cpu_page_size,
+        memory_config=memory_config,
     )
 
 
@@ -161,6 +171,136 @@ def _mp_race_construct_and_write(
 def iid():
     """Fresh instance ID for each test."""
     return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# CPUOffloadMemoryConfig — parsing and path selection
+# ---------------------------------------------------------------------------
+
+
+def test_memory_config_defaults_to_shm_path(iid):
+    """No new keys must preserve the existing /dev/shm mmap path."""
+    config = CPUOffloadMemoryConfig.from_extra_config({})
+
+    assert config.backend == CPUOffloadMemoryBackend.DEFAULT
+    assert config.effective_backend == CPUOffloadMemoryBackend.SHM
+    assert config.mmap_path(iid) == f"/dev/shm/vllm_offload_{iid}.mmap"
+    assert config.mapped_size(PAGE_SIZE) == PAGE_SIZE
+
+
+def test_memory_config_invalid_backend_raises():
+    with pytest.raises(ValueError, match="Invalid cpu_memory_backend"):
+        CPUOffloadMemoryConfig.from_extra_config({"cpu_memory_backend": "invalid"})
+
+
+def test_memory_config_hugetlbfs_requires_path():
+    with pytest.raises(ValueError, match="cpu_memory_path is required"):
+        CPUOffloadMemoryConfig.from_extra_config(
+            {"cpu_memory_backend": "hugetlbfs"}
+        )
+
+
+def test_memory_config_invalid_hugepage_block_size_raises(tmp_path):
+    with pytest.raises(ValueError, match="cpu_hugepage_block_size"):
+        CPUOffloadMemoryConfig.from_extra_config(
+            {
+                "cpu_memory_backend": "hugetlbfs",
+                "cpu_memory_path": str(tmp_path),
+                "cpu_hugepage_block_size": "4MB",
+            }
+        )
+
+
+def test_shm_memory_path_changes_mmap_path(tmp_path, iid):
+    """An explicit shm path should relocate the shared mmap file."""
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {"cpu_memory_backend": "shm", "cpu_memory_path": str(tmp_path)}
+    )
+
+    with _region(iid, memory_config=config) as r:
+        assert r.mmap_path == str(tmp_path / f"vllm_offload_{iid}.mmap")
+        assert os.path.exists(r.mmap_path)
+        assert os.path.getsize(r.mmap_path) == r.total_size_bytes
+
+
+def test_hugetlbfs_rejects_dev_shm(iid):
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {"cpu_memory_backend": "hugetlbfs", "cpu_memory_path": "/dev/shm"}
+    )
+
+    with pytest.raises(ValueError, match="must not be under /dev/shm"):
+        _make_region(iid, memory_config=config)
+
+
+def test_hugetlbfs_rejects_mount_page_size_mismatch(
+    monkeypatch, tmp_path, iid
+):
+    config = CPUOffloadMemoryConfig(
+        backend=CPUOffloadMemoryBackend.HUGETLBFS,
+        path=str(tmp_path),
+        hugepage_block_size=HUGEPAGE_1GB,
+    )
+    monkeypatch.setattr(
+        memory_module,
+        "_get_mount_info",
+        lambda _: MountInfo(
+            mount_point=str(tmp_path), fs_type="hugetlbfs", options=("pagesize=2M",)
+        ),
+    )
+
+    with pytest.raises(ValueError, match="does not match hugetlbfs mount"):
+        _make_region(iid, memory_config=config)
+
+
+def test_hugetlbfs_maps_aligned_size_but_exposes_logical_view(
+    monkeypatch, tmp_path, iid
+):
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {"cpu_memory_backend": "hugetlbfs", "cpu_memory_path": str(tmp_path)}
+    )
+    monkeypatch.setattr(
+        memory_module,
+        "_get_mount_info",
+        lambda _: MountInfo(
+            mount_point=str(tmp_path), fs_type="hugetlbfs", options=("pagesize=2M",)
+        ),
+    )
+
+    with _region(iid, num_blocks=1, memory_config=config) as r:
+        assert r.total_size_bytes == PAGE_SIZE
+        assert r.mapped_size_bytes == HUGEPAGE_2MB
+        assert len(r.mmap_obj) == HUGEPAGE_2MB
+        assert os.path.getsize(r.mmap_path) == HUGEPAGE_2MB
+        assert r._base.numel() == PAGE_SIZE
+
+        view = r.create_kv_memoryview()
+        assert view.nbytes == PAGE_SIZE
+        assert view.shape == (1, PAGE_SIZE)
+        del view
+
+
+def test_hugetlbfs_allocation_with_env_path(iid):
+    hugepage_path = os.environ.get("VLLM_TEST_HUGETLBFS_PATH")
+    if not hugepage_path:
+        pytest.skip("VLLM_TEST_HUGETLBFS_PATH is not set")
+
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {
+            "cpu_memory_backend": "hugetlbfs",
+            "cpu_memory_path": hugepage_path,
+            "cpu_hugepage_block_size": os.environ.get(
+                "VLLM_TEST_HUGETLBFS_BLOCK_SIZE", "2MB"
+            ),
+        }
+    )
+
+    with _region(iid, num_blocks=1, memory_config=config) as r:
+        assert r.mmap_path == os.path.join(
+            hugepage_path, f"vllm_offload_{iid}.mmap"
+        )
+        assert r.total_size_bytes == PAGE_SIZE
+        assert r.mapped_size_bytes == config.hugepage_block_size
+        assert os.path.exists(r.mmap_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -15,10 +15,16 @@ from unittest.mock import MagicMock
 import pytest
 
 from vllm.utils.system_utils import get_mp_context
-from vllm.v1.kv_offload.cpu.shared_offload_region import (
-    SharedOffloadRegion,
+from vllm.v1.kv_offload.cpu import memory as memory_module
+from vllm.v1.kv_offload.cpu.memory import (
+    HUGEPAGE_1GB,
+    HUGEPAGE_2MB,
+    CPUOffloadMemoryBackend,
+    CPUOffloadMemoryConfig,
+    MountInfo,
     _wait_for_file_size,
 )
+from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 
 PAGE_SIZE = mmap.PAGESIZE
 
@@ -42,6 +48,7 @@ def _make_region(
     cpu_page_size: int = PAGE_SIZE,
     num_workers: int = 1,
     rank: int = 0,
+    memory_config: CPUOffloadMemoryConfig | None = None,
 ) -> SharedOffloadRegion:
     assert cpu_page_size % PAGE_SIZE == 0
     return SharedOffloadRegion(
@@ -50,6 +57,7 @@ def _make_region(
         rank=rank,
         kv_bytes_per_block=num_workers * cpu_page_size,
         cpu_page_size=cpu_page_size,
+        memory_config=memory_config,
     )
 
 
@@ -187,6 +195,266 @@ def _mp_race_construct_and_write(
 def iid():
     """Fresh instance ID for each test."""
     return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# CPUOffloadMemoryConfig — parsing and path selection
+# ---------------------------------------------------------------------------
+
+
+def test_memory_config_defaults_to_shm_path(iid):
+    """No new keys must preserve the existing /dev/shm mmap path."""
+    config = CPUOffloadMemoryConfig.from_extra_config({})
+
+    assert config.backend == CPUOffloadMemoryBackend.DEFAULT
+    assert config.effective_backend == CPUOffloadMemoryBackend.SHM
+    assert config.mmap_path(iid) == f"/dev/shm/vllm_offload_{iid}.mmap"
+    assert config.mapped_size(PAGE_SIZE) == PAGE_SIZE
+
+
+def test_memory_config_invalid_backend_raises():
+    with pytest.raises(ValueError, match="Invalid cpu_memory_backend"):
+        CPUOffloadMemoryConfig.from_extra_config({"cpu_memory_backend": "invalid"})
+
+
+def test_memory_config_hugetlbfs_requires_path():
+    with pytest.raises(ValueError, match="cpu_memory_path is required"):
+        CPUOffloadMemoryConfig.from_extra_config(
+            {"cpu_memory_backend": "hugetlbfs"}
+        )
+
+
+def test_memory_config_invalid_hugepage_block_size_raises(tmp_path):
+    with pytest.raises(ValueError, match="cpu_hugepage_block_size"):
+        CPUOffloadMemoryConfig.from_extra_config(
+            {
+                "cpu_memory_backend": "hugetlbfs",
+                "cpu_memory_path": str(tmp_path),
+                "cpu_hugepage_block_size": "4MB",
+            }
+        )
+
+
+def test_shm_memory_path_changes_mmap_path(tmp_path, iid):
+    """An explicit shm path should relocate the shared mmap file."""
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {"cpu_memory_backend": "shm", "cpu_memory_path": str(tmp_path)}
+    )
+
+    with _region(iid, memory_config=config) as r:
+        assert r.mmap_path == str(tmp_path / f"vllm_offload_{iid}.mmap")
+        assert os.path.exists(r.mmap_path)
+        assert os.path.getsize(r.mmap_path) == r.total_size_bytes
+
+
+def test_hugetlbfs_rejects_dev_shm(iid):
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {"cpu_memory_backend": "hugetlbfs", "cpu_memory_path": "/dev/shm"}
+    )
+
+    with pytest.raises(ValueError, match="must not be under /dev/shm"):
+        _make_region(iid, memory_config=config)
+
+
+def test_hugetlbfs_rejects_mount_page_size_mismatch(
+    monkeypatch, tmp_path, iid
+):
+    config = CPUOffloadMemoryConfig(
+        backend=CPUOffloadMemoryBackend.HUGETLBFS,
+        path=str(tmp_path),
+        hugepage_block_size=HUGEPAGE_1GB,
+    )
+    monkeypatch.setattr(
+        memory_module,
+        "_get_mount_info",
+        lambda _: MountInfo(
+            mount_point=str(tmp_path), fs_type="hugetlbfs", options=("pagesize=2M",)
+        ),
+    )
+
+    with pytest.raises(ValueError, match="does not match hugetlbfs mount"):
+        _make_region(iid, memory_config=config)
+
+
+def test_hugetlbfs_maps_aligned_size_but_exposes_logical_view(
+    monkeypatch, tmp_path, iid
+):
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {"cpu_memory_backend": "hugetlbfs", "cpu_memory_path": str(tmp_path)}
+    )
+    monkeypatch.setattr(
+        memory_module,
+        "_get_mount_info",
+        lambda _: MountInfo(
+            mount_point=str(tmp_path), fs_type="hugetlbfs", options=("pagesize=2M",)
+        ),
+    )
+
+    with _region(iid, num_blocks=1, memory_config=config) as r:
+        assert r.total_size_bytes == PAGE_SIZE
+        assert r.mapped_size_bytes == HUGEPAGE_2MB
+        assert len(r.mmap_obj) == HUGEPAGE_2MB
+        assert os.path.getsize(r.mmap_path) == HUGEPAGE_2MB
+        assert r._base.numel() == PAGE_SIZE
+
+        view = r.create_kv_memoryview()
+        assert view.nbytes == PAGE_SIZE
+        assert view.shape == (1, PAGE_SIZE)
+        del view
+
+
+def test_hugetlbfs_allocation_with_env_path(iid):
+    hugepage_path = os.environ.get("VLLM_TEST_HUGETLBFS_PATH")
+    if not hugepage_path:
+        pytest.skip("VLLM_TEST_HUGETLBFS_PATH is not set")
+
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {
+            "cpu_memory_backend": "hugetlbfs",
+            "cpu_memory_path": hugepage_path,
+            "cpu_hugepage_block_size": os.environ.get(
+                "VLLM_TEST_HUGETLBFS_BLOCK_SIZE", "2MB"
+            ),
+        }
+    )
+
+    with _region(iid, num_blocks=1, memory_config=config) as r:
+        assert r.mmap_path == os.path.join(
+            hugepage_path, f"vllm_offload_{iid}.mmap"
+        )
+        assert r.total_size_bytes == PAGE_SIZE
+        assert r.mapped_size_bytes == config.hugepage_block_size
+        assert os.path.exists(r.mmap_path)
+
+
+# ---------------------------------------------------------------------------
+# CPUOffloadMemoryConfig — parsing and path selection
+# ---------------------------------------------------------------------------
+
+
+def test_memory_config_defaults_to_shm_path(iid):
+    """No new keys must preserve the existing /dev/shm mmap path."""
+    config = CPUOffloadMemoryConfig.from_extra_config({})
+
+    assert config.backend == CPUOffloadMemoryBackend.DEFAULT
+    assert config.effective_backend == CPUOffloadMemoryBackend.SHM
+    assert config.mmap_path(iid) == f"/dev/shm/vllm_offload_{iid}.mmap"
+    assert config.mapped_size(PAGE_SIZE) == PAGE_SIZE
+
+
+def test_memory_config_invalid_backend_raises():
+    with pytest.raises(ValueError, match="Invalid cpu_memory_backend"):
+        CPUOffloadMemoryConfig.from_extra_config({"cpu_memory_backend": "invalid"})
+
+
+def test_memory_config_hugetlbfs_requires_path():
+    with pytest.raises(ValueError, match="cpu_memory_path is required"):
+        CPUOffloadMemoryConfig.from_extra_config(
+            {"cpu_memory_backend": "hugetlbfs"}
+        )
+
+
+def test_memory_config_invalid_hugepage_block_size_raises(tmp_path):
+    with pytest.raises(ValueError, match="cpu_hugepage_block_size"):
+        CPUOffloadMemoryConfig.from_extra_config(
+            {
+                "cpu_memory_backend": "hugetlbfs",
+                "cpu_memory_path": str(tmp_path),
+                "cpu_hugepage_block_size": "4MB",
+            }
+        )
+
+
+def test_shm_memory_path_changes_mmap_path(tmp_path, iid):
+    """An explicit shm path should relocate the shared mmap file."""
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {"cpu_memory_backend": "shm", "cpu_memory_path": str(tmp_path)}
+    )
+
+    with _region(iid, memory_config=config) as r:
+        assert r.mmap_path == str(tmp_path / f"vllm_offload_{iid}.mmap")
+        assert os.path.exists(r.mmap_path)
+        assert os.path.getsize(r.mmap_path) == r.total_size_bytes
+
+
+def test_hugetlbfs_rejects_dev_shm(iid):
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {"cpu_memory_backend": "hugetlbfs", "cpu_memory_path": "/dev/shm"}
+    )
+
+    with pytest.raises(ValueError, match="must not be under /dev/shm"):
+        _make_region(iid, memory_config=config)
+
+
+def test_hugetlbfs_rejects_mount_page_size_mismatch(
+    monkeypatch, tmp_path, iid
+):
+    config = CPUOffloadMemoryConfig(
+        backend=CPUOffloadMemoryBackend.HUGETLBFS,
+        path=str(tmp_path),
+        hugepage_block_size=HUGEPAGE_1GB,
+    )
+    monkeypatch.setattr(
+        memory_module,
+        "_get_mount_info",
+        lambda _: MountInfo(
+            mount_point=str(tmp_path), fs_type="hugetlbfs", options=("pagesize=2M",)
+        ),
+    )
+
+    with pytest.raises(ValueError, match="does not match hugetlbfs mount"):
+        _make_region(iid, memory_config=config)
+
+
+def test_hugetlbfs_maps_aligned_size_but_exposes_logical_view(
+    monkeypatch, tmp_path, iid
+):
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {"cpu_memory_backend": "hugetlbfs", "cpu_memory_path": str(tmp_path)}
+    )
+    monkeypatch.setattr(
+        memory_module,
+        "_get_mount_info",
+        lambda _: MountInfo(
+            mount_point=str(tmp_path), fs_type="hugetlbfs", options=("pagesize=2M",)
+        ),
+    )
+
+    with _region(iid, num_blocks=1, memory_config=config) as r:
+        assert r.total_size_bytes == PAGE_SIZE
+        assert r.mapped_size_bytes == HUGEPAGE_2MB
+        assert len(r.mmap_obj) == HUGEPAGE_2MB
+        assert os.path.getsize(r.mmap_path) == HUGEPAGE_2MB
+        assert r._base.numel() == PAGE_SIZE
+
+        view = r.create_kv_memoryview()
+        assert view.nbytes == PAGE_SIZE
+        assert view.shape == (1, PAGE_SIZE)
+        del view
+
+
+def test_hugetlbfs_allocation_with_env_path(iid):
+    hugepage_path = os.environ.get("VLLM_TEST_HUGETLBFS_PATH")
+    if not hugepage_path:
+        pytest.skip("VLLM_TEST_HUGETLBFS_PATH is not set")
+
+    config = CPUOffloadMemoryConfig.from_extra_config(
+        {
+            "cpu_memory_backend": "hugetlbfs",
+            "cpu_memory_path": hugepage_path,
+            "cpu_hugepage_block_size": os.environ.get(
+                "VLLM_TEST_HUGETLBFS_BLOCK_SIZE", "2MB"
+            ),
+        }
+    )
+
+    with _region(iid, num_blocks=1, memory_config=config) as r:
+        assert r.mmap_path == os.path.join(
+            hugepage_path, f"vllm_offload_{iid}.mmap"
+        )
+        assert r.total_size_bytes == PAGE_SIZE
+        assert r.mapped_size_bytes == config.hugepage_block_size
+        assert os.path.exists(r.mmap_path)
 
 
 # ---------------------------------------------------------------------------
@@ -780,25 +1048,23 @@ def test_wait_for_file_size_timeout(tmp_path):
 
 def test_insufficient_space_raises_clear_error(monkeypatch):
     """A failed creator capacity check must clean up and give a clear error."""
-    import vllm.v1.kv_offload.cpu.shared_offload_region as region
-
     engine_id = str(uuid.uuid4())
     mmap_path = f"/dev/shm/vllm_offload_{engine_id}.mmap"
     mock_open = MagicMock(return_value=9999)
     mock_unlink = MagicMock()
     mock_close = MagicMock()
-    monkeypatch.setattr(region.os, "open", mock_open)
-    monkeypatch.setattr(region.os, "unlink", mock_unlink)
-    monkeypatch.setattr(region.os, "close", mock_close)
+    monkeypatch.setattr(memory_module.os, "open", mock_open)
+    monkeypatch.setattr(memory_module.os, "unlink", mock_unlink)
+    monkeypatch.setattr(memory_module.os, "close", mock_close)
     monkeypatch.setattr(
-        region,
+        memory_module,
         "check_shm_free_space",
         lambda *a, **kw: (_ for _ in ()).throw(
             RuntimeError("Insufficient space in /dev/shm: 30 GB required.")
         ),
     )
 
-    with pytest.raises(RuntimeError, match="Insufficient space"):
+    with pytest.raises(OSError, match="Failed to size offload mmap file") as exc_info:
         SharedOffloadRegion(
             engine_id=engine_id,
             num_blocks=4,
@@ -806,6 +1072,8 @@ def test_insufficient_space_raises_clear_error(monkeypatch):
             kv_bytes_per_block=PAGE_SIZE,
             cpu_page_size=PAGE_SIZE,
         )
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "Insufficient space" in str(exc_info.value.__cause__)
 
     mock_unlink.assert_called_once_with(mmap_path)
     mock_close.assert_called_once_with(9999)
@@ -813,23 +1081,21 @@ def test_insufficient_space_raises_clear_error(monkeypatch):
 
 def test_ftruncate_failure_cleans_up_creator(monkeypatch):
     """A failed creator ftruncate must close and unlink before re-raising."""
-    import vllm.v1.kv_offload.cpu.shared_offload_region as region
-
     engine_id = str(uuid.uuid4())
     mmap_path = f"/dev/shm/vllm_offload_{engine_id}.mmap"
     mock_unlink = MagicMock()
     mock_close = MagicMock()
-    monkeypatch.setattr(region.os, "open", MagicMock(return_value=9999))
-    monkeypatch.setattr(region.os, "unlink", mock_unlink)
-    monkeypatch.setattr(region.os, "close", mock_close)
-    monkeypatch.setattr(region, "check_shm_free_space", MagicMock())
+    monkeypatch.setattr(memory_module.os, "open", MagicMock(return_value=9999))
+    monkeypatch.setattr(memory_module.os, "unlink", mock_unlink)
+    monkeypatch.setattr(memory_module.os, "close", mock_close)
+    monkeypatch.setattr(memory_module, "check_shm_free_space", MagicMock())
     monkeypatch.setattr(
-        region.os,
+        memory_module.os,
         "ftruncate",
         MagicMock(side_effect=OSError("ftruncate failed")),
     )
 
-    with pytest.raises(OSError, match="ftruncate failed"):
+    with pytest.raises(OSError, match="Failed to size offload mmap file") as exc_info:
         SharedOffloadRegion(
             engine_id=engine_id,
             num_blocks=4,
@@ -837,6 +1103,8 @@ def test_ftruncate_failure_cleans_up_creator(monkeypatch):
             kv_bytes_per_block=PAGE_SIZE,
             cpu_page_size=PAGE_SIZE,
         )
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert "ftruncate failed" in str(exc_info.value.__cause__)
 
     mock_unlink.assert_called_once_with(mmap_path)
     mock_close.assert_called_once_with(9999)

--- a/tests/v1/kv_offload/cpu/test_spec_memory_config.py
+++ b/tests/v1/kv_offload/cpu/test_spec_memory_config.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for CPU offload memory backend selection in offloading specs."""
+
+import mmap
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+import vllm.v1.kv_offload.tiering.spec as tiering_spec_module
+from vllm.config import KVTransferConfig
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheTensor,
+)
+from vllm.v1.kv_offload.cpu.memory import (
+    HUGEPAGE_2MB,
+    CPUOffloadMemoryBackend,
+)
+from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
+from vllm.v1.kv_offload.tiering.spec import TieringOffloadingSpec
+
+PAGE_SIZE = mmap.PAGESIZE
+BLOCK_SIZE = 16
+
+
+def _make_vllm_config(
+    extra_config: dict[str, Any], *, world_size: int = 1
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="OffloadingConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config=extra_config,
+        ),
+        parallel_config=SimpleNamespace(
+            world_size=world_size,
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+        cache_config=SimpleNamespace(
+            block_size=BLOCK_SIZE,
+            enable_prefix_caching=True,
+            hash_block_size=None,
+        ),
+        kv_events_config=None,
+        instance_id="spec-memory-config-test",
+    )
+
+
+def _make_kv_cache_config(
+    *, num_blocks: int = 1, gpu_bytes_per_block: int = PAGE_SIZE
+) -> KVCacheConfig:
+    layer_names = ["layer"]
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[
+            KVCacheTensor(
+                size=num_blocks * gpu_bytes_per_block,
+                shared_by=layer_names,
+            )
+        ],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                layer_names,
+                FullAttentionSpec(
+                    block_size=BLOCK_SIZE,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            )
+        ],
+    )
+
+
+def _recording_shared_region(created: list[Any]) -> type:
+    class RecordingSharedOffloadRegion:
+        def __init__(
+            self,
+            instance_id: str,
+            num_blocks: int,
+            rank: int | None,
+            kv_bytes_per_block: int,
+            cpu_page_size: int,
+            memory_config: Any = None,
+        ) -> None:
+            self.instance_id = instance_id
+            self.num_blocks = num_blocks
+            self.rank = rank
+            self.kv_bytes_per_block = kv_bytes_per_block
+            self.cpu_page_size = cpu_page_size
+            self.memory_config = memory_config
+            self.mmap_path = memory_config.mmap_path(instance_id)
+            self.kv_view = memoryview(bytearray(num_blocks * kv_bytes_per_block))
+            created.append(self)
+
+        def create_kv_memoryview(self) -> memoryview:
+            return self.kv_view
+
+        def cleanup(self) -> None:
+            self.kv_view.release()
+
+    return RecordingSharedOffloadRegion
+
+
+def test_cpu_offloading_spec_default_keeps_torch_backend() -> None:
+    extra_config = {"cpu_bytes_to_use": 4 * PAGE_SIZE}
+    spec = CPUOffloadingSpec(
+        _make_vllm_config(extra_config),
+        _make_kv_cache_config(),
+    )
+
+    assert spec.cpu_memory_config.backend == CPUOffloadMemoryBackend.DEFAULT
+    assert spec.cpu_memory_config.effective_backend == CPUOffloadMemoryBackend.SHM
+    assert spec.num_blocks == 4
+
+
+@pytest.mark.parametrize("backend", ["shm", "hugetlbfs"])
+def test_cpu_offloading_spec_rejects_explicit_shared_backend(
+    backend: str,
+) -> None:
+    extra_config: dict[str, Any] = {
+        "cpu_bytes_to_use": 4 * PAGE_SIZE,
+        "cpu_memory_backend": backend,
+    }
+
+    with pytest.raises(ValueError, match="only supported by TieringOffloadingSpec"):
+        CPUOffloadingSpec(
+            _make_vllm_config(extra_config),
+            _make_kv_cache_config(),
+        )
+
+
+def test_tiering_offloading_spec_default_keeps_shared_shm_backend() -> None:
+    extra_config = {
+        "cpu_bytes_to_use": 4 * PAGE_SIZE,
+        "spec_name": "TieringOffloadingSpec",
+    }
+    spec = TieringOffloadingSpec(
+        _make_vllm_config(extra_config),
+        _make_kv_cache_config(),
+    )
+
+    assert spec.cpu_memory_config.backend == CPUOffloadMemoryBackend.DEFAULT
+    assert spec.cpu_memory_config.effective_backend == CPUOffloadMemoryBackend.SHM
+    assert spec.num_blocks == 4
+
+
+def test_tiering_spec_threads_memory_config_to_scheduler_and_worker(
+    monkeypatch, tmp_path
+) -> None:
+    created_regions: list[Any] = []
+    secondary_views: list[memoryview] = []
+
+    class FakeWorker:
+        def __init__(self, *args: Any, mmap_region: Any, **kwargs: Any) -> None:
+            self.mmap_region = mmap_region
+
+    class FakeSecondaryTier:
+        tier_type = "fake"
+
+    def create_secondary_tier(
+        tier_config: dict[str, Any],
+        primary_kv_view: memoryview,
+        offloading_spec: TieringOffloadingSpec,
+    ) -> FakeSecondaryTier:
+        secondary_views.append(primary_kv_view)
+        return FakeSecondaryTier()
+
+    monkeypatch.setattr(
+        tiering_spec_module,
+        "SharedOffloadRegion",
+        _recording_shared_region(created_regions),
+    )
+    monkeypatch.setattr(
+        tiering_spec_module,
+        "CPUOffloadingWorker",
+        FakeWorker,
+    )
+    monkeypatch.setattr(
+        tiering_spec_module.SecondaryTierFactory,
+        "create_secondary_tier",
+        staticmethod(create_secondary_tier),
+    )
+    monkeypatch.setattr(
+        tiering_spec_module.torch.accelerator,
+        "current_device_index",
+        lambda: 1,
+    )
+
+    extra_config = {
+        "cpu_bytes_to_use": 8 * PAGE_SIZE,
+        "spec_name": "TieringOffloadingSpec",
+        "cpu_memory_backend": "hugetlbfs",
+        "cpu_memory_path": str(tmp_path),
+        "secondary_tiers": [{"type": "fake"}],
+    }
+    spec = TieringOffloadingSpec(
+        _make_vllm_config(extra_config, world_size=2),
+        _make_kv_cache_config(),
+    )
+
+    spec.get_manager()
+    worker = spec.create_worker(MagicMock())
+
+    scheduler_region = created_regions[0]
+    worker_region = created_regions[1]
+    assert scheduler_region.rank is None
+    assert worker_region.rank == 1
+    assert scheduler_region.memory_config is spec.cpu_memory_config
+    assert worker_region.memory_config is spec.cpu_memory_config
+    assert scheduler_region.mmap_path.startswith(str(tmp_path))
+    assert worker_region.mmap_path.startswith(str(tmp_path))
+    assert worker.mmap_region is worker_region
+    assert secondary_views == [scheduler_region.kv_view]
+
+
+def test_tiering_num_blocks_uses_logical_cpu_bytes_not_hugepage_padding(
+    tmp_path,
+) -> None:
+    extra_config = {
+        "cpu_bytes_to_use": PAGE_SIZE + 1,
+        "spec_name": "TieringOffloadingSpec",
+        "cpu_memory_backend": "hugetlbfs",
+        "cpu_memory_path": str(tmp_path),
+    }
+    spec = TieringOffloadingSpec(
+        _make_vllm_config(extra_config),
+        _make_kv_cache_config(),
+    )
+
+    logical_size = spec.num_blocks * spec.kv_bytes_per_offloaded_block
+    assert spec.num_blocks == 1
+    assert logical_size == PAGE_SIZE
+    assert spec.cpu_memory_config.mapped_size(logical_size) == HUGEPAGE_2MB

--- a/tests/v1/kv_offload/cpu/test_spec_memory_config.py
+++ b/tests/v1/kv_offload/cpu/test_spec_memory_config.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for CPU offload memory backend selection in offloading specs."""
+
+import mmap
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import vllm.v1.kv_offload.tiering.spec as tiering_spec_module
+from vllm.v1.kv_offload.config import (
+    OffloadingCacheConfig,
+    OffloadingConfig,
+    OffloadingGroupConfig,
+    OffloadingModelConfig,
+    OffloadingParallelConfig,
+)
+from vllm.v1.kv_offload.cpu.memory import (
+    HUGEPAGE_2MB,
+    CPUOffloadMemoryBackend,
+)
+from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
+from vllm.v1.kv_offload.tiering.spec import TieringOffloadingSpec
+
+PAGE_SIZE = mmap.PAGESIZE
+BLOCK_SIZE = 16
+
+
+def _make_offloading_config(
+    extra_config: dict[str, Any],
+    *,
+    world_size: int = 1,
+    worker_kv_bytes_per_block: int = PAGE_SIZE,
+) -> OffloadingConfig:
+    return OffloadingConfig(
+        groups=(
+            OffloadingGroupConfig(
+                tokens_per_block=BLOCK_SIZE,
+                layer_names=("layer",),
+            ),
+        ),
+        worker_kv_bytes_per_block=worker_kv_bytes_per_block,
+        enable_kv_cache_events=False,
+        extra_config=extra_config,
+        engine_id="spec-memory-config-test",
+        model=OffloadingModelConfig(name="test-model", dtype="float32"),
+        cache=OffloadingCacheConfig(
+            tokens_per_hash=BLOCK_SIZE,
+            blocks_per_chunk=1,
+        ),
+        parallel=OffloadingParallelConfig(
+            rank=0,
+            world_size=world_size,
+            tp_size=world_size,
+            pp_size=1,
+            pcp_size=1,
+            dcp_size=1,
+            data_parallel_index=0,
+            data_parallel_size=1,
+            data_parallel_rank_local=None,
+            is_parallelism_agnostic=False,
+        ),
+    )
+
+
+def _recording_shared_region(created: list[Any]) -> type:
+    class RecordingSharedOffloadRegion:
+        def __init__(
+            self,
+            engine_id: str,
+            num_blocks: int,
+            rank: int | None,
+            kv_bytes_per_block: int,
+            cpu_page_size: int,
+            memory_config: Any = None,
+        ) -> None:
+            self.engine_id = engine_id
+            self.num_blocks = num_blocks
+            self.rank = rank
+            self.kv_bytes_per_block = kv_bytes_per_block
+            self.cpu_page_size = cpu_page_size
+            self.memory_config = memory_config
+            self.mmap_path = memory_config.mmap_path(engine_id)
+            self.kv_view = memoryview(bytearray(num_blocks * kv_bytes_per_block))
+            created.append(self)
+
+        def create_kv_memoryview(self) -> memoryview:
+            return self.kv_view
+
+        def cleanup(self) -> None:
+            self.kv_view.release()
+
+    return RecordingSharedOffloadRegion
+
+
+def test_cpu_offloading_spec_default_keeps_torch_backend() -> None:
+    extra_config = {"cpu_bytes_to_use": 4 * PAGE_SIZE}
+    spec = CPUOffloadingSpec(_make_offloading_config(extra_config))
+
+    assert spec.cpu_memory_config.backend == CPUOffloadMemoryBackend.DEFAULT
+    assert spec.cpu_memory_config.effective_backend == CPUOffloadMemoryBackend.SHM
+    assert spec.num_blocks == 4
+
+
+@pytest.mark.parametrize("backend", ["shm", "hugetlbfs"])
+def test_cpu_offloading_spec_rejects_explicit_shared_backend(
+    backend: str,
+) -> None:
+    extra_config: dict[str, Any] = {
+        "cpu_bytes_to_use": 4 * PAGE_SIZE,
+        "cpu_memory_backend": backend,
+    }
+
+    with pytest.raises(ValueError, match="only supported by TieringOffloadingSpec"):
+        CPUOffloadingSpec(_make_offloading_config(extra_config))
+
+
+def test_tiering_offloading_spec_default_keeps_shared_shm_backend() -> None:
+    extra_config = {
+        "cpu_bytes_to_use": 4 * PAGE_SIZE,
+        "spec_name": "TieringOffloadingSpec",
+    }
+    spec = TieringOffloadingSpec(_make_offloading_config(extra_config))
+
+    assert spec.cpu_memory_config.backend == CPUOffloadMemoryBackend.DEFAULT
+    assert spec.cpu_memory_config.effective_backend == CPUOffloadMemoryBackend.SHM
+    assert spec.num_blocks == 4
+
+
+def test_tiering_spec_threads_memory_config_to_scheduler_and_worker(
+    monkeypatch, tmp_path
+) -> None:
+    created_regions: list[Any] = []
+    secondary_views: list[memoryview] = []
+
+    class FakeWorker:
+        def __init__(self, *args: Any, mmap_region: Any, **kwargs: Any) -> None:
+            self.mmap_region = mmap_region
+
+    class FakeSecondaryTier:
+        tier_type = "fake"
+
+    def create_secondary_tier(
+        tier_config: dict[str, Any],
+        primary_kv_view: memoryview,
+        offloading_spec: TieringOffloadingSpec,
+    ) -> FakeSecondaryTier:
+        secondary_views.append(primary_kv_view)
+        return FakeSecondaryTier()
+
+    monkeypatch.setattr(
+        tiering_spec_module,
+        "SharedOffloadRegion",
+        _recording_shared_region(created_regions),
+    )
+    monkeypatch.setattr(
+        tiering_spec_module,
+        "CPUOffloadingWorker",
+        FakeWorker,
+    )
+    monkeypatch.setattr(
+        tiering_spec_module.SecondaryTierFactory,
+        "create_secondary_tier",
+        staticmethod(create_secondary_tier),
+    )
+    monkeypatch.setattr(
+        tiering_spec_module.torch.accelerator,
+        "current_device_index",
+        lambda: 1,
+    )
+
+    extra_config = {
+        "cpu_bytes_to_use": 8 * PAGE_SIZE,
+        "spec_name": "TieringOffloadingSpec",
+        "cpu_memory_backend": "hugetlbfs",
+        "cpu_memory_path": str(tmp_path),
+        "secondary_tiers": [{"type": "fake"}],
+    }
+    spec = TieringOffloadingSpec(_make_offloading_config(extra_config, world_size=2))
+
+    spec.get_manager()
+    worker = spec.create_worker(MagicMock())
+
+    scheduler_region = created_regions[0]
+    worker_region = created_regions[1]
+    assert scheduler_region.rank is None
+    assert worker_region.rank == 1
+    assert scheduler_region.memory_config is spec.cpu_memory_config
+    assert worker_region.memory_config is spec.cpu_memory_config
+    assert scheduler_region.mmap_path.startswith(str(tmp_path))
+    assert worker_region.mmap_path.startswith(str(tmp_path))
+    assert worker.mmap_region is worker_region
+    assert secondary_views == [scheduler_region.kv_view]
+
+
+def test_tiering_num_blocks_uses_logical_cpu_bytes_not_hugepage_padding(
+    tmp_path,
+) -> None:
+    extra_config = {
+        "cpu_bytes_to_use": PAGE_SIZE + 1,
+        "spec_name": "TieringOffloadingSpec",
+        "cpu_memory_backend": "hugetlbfs",
+        "cpu_memory_path": str(tmp_path),
+    }
+    spec = TieringOffloadingSpec(_make_offloading_config(extra_config))
+
+    logical_size = spec.num_blocks * spec.kv_bytes_per_chunk
+    assert spec.num_blocks == 1
+    assert logical_size == PAGE_SIZE
+    assert spec.cpu_memory_config.mapped_size(logical_size) == HUGEPAGE_2MB

--- a/vllm/v1/kv_offload/cpu/memory.py
+++ b/vllm/v1/kv_offload/cpu/memory.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from vllm.logger import init_logger
+from vllm.utils.math_utils import round_up
+
+logger = init_logger(__name__)
+
+DEFAULT_SHM_PATH = "/dev/shm"
+HUGEPAGE_2MB = 2 * 1024 * 1024
+HUGEPAGE_1GB = 1024 * 1024 * 1024
+HUGEPAGE_BLOCK_SIZES = {
+    "2M": HUGEPAGE_2MB,
+    "2MB": HUGEPAGE_2MB,
+    "1G": HUGEPAGE_1GB,
+    "1GB": HUGEPAGE_1GB,
+}
+
+
+class CPUOffloadMemoryBackend(str, Enum):
+    DEFAULT = "default"
+    SHM = "shm"
+    HUGETLBFS = "hugetlbfs"
+
+
+@dataclass(frozen=True)
+class MountInfo:
+    mount_point: str
+    fs_type: str
+    options: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SharedMemoryAllocation:
+    path: str
+    fd: int
+    creator: bool
+    logical_size_bytes: int
+    mapped_size_bytes: int
+
+
+@dataclass(frozen=True)
+class CPUOffloadMemoryConfig:
+    backend: CPUOffloadMemoryBackend = CPUOffloadMemoryBackend.DEFAULT
+    path: str | None = None
+    hugepage_block_size: int = HUGEPAGE_2MB
+
+    @classmethod
+    def from_extra_config(
+        cls, extra_config: Mapping[str, Any] | None
+    ) -> "CPUOffloadMemoryConfig":
+        extra_config = extra_config or {}
+        backend = _parse_backend(extra_config.get("cpu_memory_backend", "default"))
+        path = _parse_memory_path(extra_config.get("cpu_memory_path"))
+        hugepage_block_size = _parse_hugepage_block_size(
+            extra_config.get("cpu_hugepage_block_size", "2MB")
+        )
+        if backend == CPUOffloadMemoryBackend.HUGETLBFS and path is None:
+            raise ValueError(
+                "cpu_memory_path is required when "
+                "cpu_memory_backend='hugetlbfs'"
+            )
+        return cls(
+            backend=backend,
+            path=path,
+            hugepage_block_size=hugepage_block_size,
+        )
+
+    @property
+    def effective_backend(self) -> CPUOffloadMemoryBackend:
+        if self.backend == CPUOffloadMemoryBackend.DEFAULT:
+            return CPUOffloadMemoryBackend.SHM
+        return self.backend
+
+    def mmap_path(self, instance_id: str) -> str:
+        directory = self.path or DEFAULT_SHM_PATH
+        return os.path.join(directory, f"vllm_offload_{instance_id}.mmap")
+
+    def mapped_size(self, logical_size_bytes: int) -> int:
+        if self.effective_backend == CPUOffloadMemoryBackend.HUGETLBFS:
+            return round_up(logical_size_bytes, self.hugepage_block_size)
+        return logical_size_bytes
+
+    def validate(self) -> None:
+        directory = self.path or DEFAULT_SHM_PATH
+        _validate_directory(directory)
+        if self.effective_backend == CPUOffloadMemoryBackend.HUGETLBFS:
+            _validate_hugetlbfs_directory(directory, self.hugepage_block_size)
+
+
+def _parse_backend(value: Any) -> CPUOffloadMemoryBackend:
+    if isinstance(value, CPUOffloadMemoryBackend):
+        return value
+    try:
+        return CPUOffloadMemoryBackend(str(value).lower())
+    except ValueError as exc:
+        supported = ", ".join(backend.value for backend in CPUOffloadMemoryBackend)
+        raise ValueError(
+            f"Invalid cpu_memory_backend {value!r}; supported values are: "
+            f"{supported}"
+        ) from exc
+
+
+def _parse_memory_path(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError("cpu_memory_path must be a non-empty string")
+    return value
+
+
+def _parse_hugepage_block_size(value: Any) -> int:
+    if isinstance(value, int):
+        if value in (HUGEPAGE_2MB, HUGEPAGE_1GB):
+            return value
+    else:
+        parsed = HUGEPAGE_BLOCK_SIZES.get(str(value).upper())
+        if parsed is not None:
+            return parsed
+    raise ValueError("cpu_hugepage_block_size must be either '2MB' or '1GB'")
+
+
+def _validate_directory(directory: str) -> None:
+    if not os.path.isdir(directory):
+        raise ValueError(f"cpu_memory_path {directory!r} must be an existing directory")
+    if not os.access(directory, os.W_OK):
+        raise ValueError(f"cpu_memory_path {directory!r} must be writable")
+
+
+def _validate_hugetlbfs_directory(
+    directory: str, expected_page_size: int
+) -> None:
+    real_path = os.path.realpath(directory)
+    if _path_is_under(real_path, DEFAULT_SHM_PATH):
+        raise ValueError(
+            "cpu_memory_path for cpu_memory_backend='hugetlbfs' must not be "
+            f"under {DEFAULT_SHM_PATH}"
+        )
+
+    mount_info = _get_mount_info(real_path)
+    if mount_info is None:
+        logger.warning(
+            "Could not determine filesystem type for cpu_memory_path=%s; "
+            "continuing with hugetlbfs allocation attempt.",
+            directory,
+        )
+        return
+    if mount_info.fs_type != "hugetlbfs":
+        raise ValueError(
+            "cpu_memory_path for cpu_memory_backend='hugetlbfs' must be backed "
+            f"by hugetlbfs; found filesystem type {mount_info.fs_type!r} at "
+            f"{mount_info.mount_point!r}"
+        )
+    mount_page_size = _get_hugetlbfs_page_size(mount_info)
+    if mount_page_size is not None and mount_page_size != expected_page_size:
+        raise ValueError(
+            "cpu_hugepage_block_size does not match hugetlbfs mount page size: "
+            f"expected {expected_page_size} bytes, mount uses "
+            f"{mount_page_size} bytes"
+        )
+
+
+def _path_is_under(path: str, parent: str) -> bool:
+    try:
+        real_parent = os.path.realpath(parent)
+        return os.path.commonpath([os.path.realpath(path), real_parent]) == real_parent
+    except ValueError:
+        return False
+
+
+def _decode_mountinfo_path(value: str) -> str:
+    return (
+        value.replace("\\040", " ")
+        .replace("\\011", "\t")
+        .replace("\\012", "\n")
+        .replace("\\134", "\\")
+    )
+
+
+def _get_mount_info(path: str) -> MountInfo | None:
+    try:
+        with open("/proc/self/mountinfo", encoding="utf-8") as f:
+            mount_lines = f.readlines()
+    except OSError:
+        return None
+
+    best_match: MountInfo | None = None
+    best_match_len = -1
+    real_path = os.path.realpath(path)
+    for line in mount_lines:
+        fields = line.split()
+        try:
+            separator = fields.index("-")
+        except ValueError:
+            continue
+        if separator + 3 >= len(fields) or separator < 6:
+            continue
+
+        mount_point = os.path.realpath(_decode_mountinfo_path(fields[4]))
+        if not _path_is_under(real_path, mount_point):
+            continue
+        if len(mount_point) <= best_match_len:
+            continue
+
+        options: list[str] = []
+        options.extend(fields[5].split(","))
+        options.extend(fields[separator + 3].split(","))
+        best_match = MountInfo(
+            mount_point=mount_point,
+            fs_type=fields[separator + 1],
+            options=tuple(options),
+        )
+        best_match_len = len(mount_point)
+    return best_match
+
+
+def _get_hugetlbfs_page_size(mount_info: MountInfo) -> int | None:
+    for option in mount_info.options:
+        key, separator, value = option.partition("=")
+        if key == "pagesize" and separator:
+            try:
+                return _parse_hugepage_block_size(value)
+            except ValueError:
+                logger.warning(
+                    "Could not parse hugetlbfs pagesize mount option %r",
+                    value,
+                )
+                return None
+    return None
+
+
+def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> None:
+    """Spin-wait until the file reaches expected_size (creator truncated it)."""
+    deadline = time.monotonic() + timeout
+    while True:
+        if os.fstat(fd).st_size >= expected_size:
+            return
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"Timed out waiting for mmap file to reach {expected_size} bytes"
+            )
+        time.sleep(0.005)
+
+
+def create_shared_memory_allocation(
+    instance_id: str,
+    logical_size_bytes: int,
+    memory_config: CPUOffloadMemoryConfig,
+) -> SharedMemoryAllocation:
+    memory_config.validate()
+    path = memory_config.mmap_path(instance_id)
+    mapped_size_bytes = memory_config.mapped_size(logical_size_bytes)
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+    except FileExistsError:
+        fd = os.open(path, os.O_RDWR)
+        _wait_for_file_size(fd, mapped_size_bytes)
+        logger.info("Opened existing mmap file %s", path)
+        return SharedMemoryAllocation(
+            path=path,
+            fd=fd,
+            creator=False,
+            logical_size_bytes=logical_size_bytes,
+            mapped_size_bytes=mapped_size_bytes,
+        )
+    except OSError as exc:
+        raise OSError(
+            f"Failed to open offload mmap file {path!r} for "
+            f"cpu_memory_backend={memory_config.effective_backend.value!r}"
+        ) from exc
+
+    try:
+        os.ftruncate(fd, mapped_size_bytes)
+    except OSError as exc:
+        os.close(fd)
+        try:
+            os.unlink(path)
+        except OSError:
+            logger.warning("Failed to unlink incomplete mmap file %s", path)
+        raise OSError(
+            f"Failed to size offload mmap file {path!r} to "
+            f"{mapped_size_bytes} bytes for "
+            f"cpu_memory_backend={memory_config.effective_backend.value!r}; "
+            "verify cpu_memory_path and available hugepages"
+        ) from exc
+
+    logger.info(
+        "Created mmap file %s (logical %.2f GB, mapped %.2f GB)",
+        path,
+        logical_size_bytes / 1e9,
+        mapped_size_bytes / 1e9,
+    )
+    return SharedMemoryAllocation(
+        path=path,
+        fd=fd,
+        creator=True,
+        logical_size_bytes=logical_size_bytes,
+        mapped_size_bytes=mapped_size_bytes,
+    )

--- a/vllm/v1/kv_offload/cpu/memory.py
+++ b/vllm/v1/kv_offload/cpu/memory.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from vllm.logger import init_logger
+from vllm.utils.math_utils import round_up
+from vllm.distributed.device_communicators.shm_broadcast import (
+    check_shm_free_space,
+)
+
+logger = init_logger(__name__)
+
+DEFAULT_SHM_PATH = "/dev/shm"
+HUGEPAGE_2MB = 2 * 1024 * 1024
+HUGEPAGE_1GB = 1024 * 1024 * 1024
+HUGEPAGE_BLOCK_SIZES = {
+    "2M": HUGEPAGE_2MB,
+    "2MB": HUGEPAGE_2MB,
+    "1G": HUGEPAGE_1GB,
+    "1GB": HUGEPAGE_1GB,
+}
+
+
+class CPUOffloadMemoryBackend(str, Enum):
+    DEFAULT = "default"
+    SHM = "shm"
+    HUGETLBFS = "hugetlbfs"
+
+
+@dataclass(frozen=True)
+class MountInfo:
+    mount_point: str
+    fs_type: str
+    options: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SharedMemoryAllocation:
+    path: str
+    fd: int
+    creator: bool
+    logical_size_bytes: int
+    mapped_size_bytes: int
+
+
+@dataclass(frozen=True)
+class CPUOffloadMemoryConfig:
+    backend: CPUOffloadMemoryBackend = CPUOffloadMemoryBackend.DEFAULT
+    path: str | None = None
+    hugepage_block_size: int = HUGEPAGE_2MB
+
+    @classmethod
+    def from_extra_config(
+        cls, extra_config: Mapping[str, Any] | None
+    ) -> "CPUOffloadMemoryConfig":
+        extra_config = extra_config or {}
+        backend = _parse_backend(extra_config.get("cpu_memory_backend", "default"))
+        path = _parse_memory_path(extra_config.get("cpu_memory_path"))
+        hugepage_block_size = _parse_hugepage_block_size(
+            extra_config.get("cpu_hugepage_block_size", "2MB")
+        )
+        if backend == CPUOffloadMemoryBackend.HUGETLBFS and path is None:
+            raise ValueError(
+                "cpu_memory_path is required when "
+                "cpu_memory_backend='hugetlbfs'"
+            )
+        return cls(
+            backend=backend,
+            path=path,
+            hugepage_block_size=hugepage_block_size,
+        )
+
+    @property
+    def effective_backend(self) -> CPUOffloadMemoryBackend:
+        if self.backend == CPUOffloadMemoryBackend.DEFAULT:
+            return CPUOffloadMemoryBackend.SHM
+        return self.backend
+
+    def mmap_path(self, instance_id: str) -> str:
+        directory = self.path or DEFAULT_SHM_PATH
+        return os.path.join(directory, f"vllm_offload_{instance_id}.mmap")
+
+    def mapped_size(self, logical_size_bytes: int) -> int:
+        if self.effective_backend == CPUOffloadMemoryBackend.HUGETLBFS:
+            return round_up(logical_size_bytes, self.hugepage_block_size)
+        return logical_size_bytes
+
+    def validate(self) -> None:
+        directory = self.path or DEFAULT_SHM_PATH
+        _validate_directory(directory)
+        if self.effective_backend == CPUOffloadMemoryBackend.HUGETLBFS:
+            _validate_hugetlbfs_directory(directory, self.hugepage_block_size)
+
+
+def _parse_backend(value: Any) -> CPUOffloadMemoryBackend:
+    if isinstance(value, CPUOffloadMemoryBackend):
+        return value
+    try:
+        return CPUOffloadMemoryBackend(str(value).lower())
+    except ValueError as exc:
+        supported = ", ".join(backend.value for backend in CPUOffloadMemoryBackend)
+        raise ValueError(
+            f"Invalid cpu_memory_backend {value!r}; supported values are: "
+            f"{supported}"
+        ) from exc
+
+
+def _parse_memory_path(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError("cpu_memory_path must be a non-empty string")
+    return value
+
+
+def _parse_hugepage_block_size(value: Any) -> int:
+    if isinstance(value, int):
+        if value in (HUGEPAGE_2MB, HUGEPAGE_1GB):
+            return value
+    else:
+        parsed = HUGEPAGE_BLOCK_SIZES.get(str(value).upper())
+        if parsed is not None:
+            return parsed
+    raise ValueError("cpu_hugepage_block_size must be either '2MB' or '1GB'")
+
+
+def _validate_directory(directory: str) -> None:
+    if not os.path.isdir(directory):
+        raise ValueError(f"cpu_memory_path {directory!r} must be an existing directory")
+    if not os.access(directory, os.W_OK):
+        raise ValueError(f"cpu_memory_path {directory!r} must be writable")
+
+
+def _validate_hugetlbfs_directory(
+    directory: str, expected_page_size: int
+) -> None:
+    real_path = os.path.realpath(directory)
+    if _path_is_under(real_path, DEFAULT_SHM_PATH):
+        raise ValueError(
+            "cpu_memory_path for cpu_memory_backend='hugetlbfs' must not be "
+            f"under {DEFAULT_SHM_PATH}"
+        )
+
+    mount_info = _get_mount_info(real_path)
+    if mount_info is None:
+        logger.warning(
+            "Could not determine filesystem type for cpu_memory_path=%s; "
+            "continuing with hugetlbfs allocation attempt.",
+            directory,
+        )
+        return
+    if mount_info.fs_type != "hugetlbfs":
+        raise ValueError(
+            "cpu_memory_path for cpu_memory_backend='hugetlbfs' must be backed "
+            f"by hugetlbfs; found filesystem type {mount_info.fs_type!r} at "
+            f"{mount_info.mount_point!r}"
+        )
+    mount_page_size = _get_hugetlbfs_page_size(mount_info)
+    if mount_page_size is not None and mount_page_size != expected_page_size:
+        raise ValueError(
+            "cpu_hugepage_block_size does not match hugetlbfs mount page size: "
+            f"expected {expected_page_size} bytes, mount uses "
+            f"{mount_page_size} bytes"
+        )
+
+
+def _path_is_under(path: str, parent: str) -> bool:
+    try:
+        real_parent = os.path.realpath(parent)
+        return os.path.commonpath([os.path.realpath(path), real_parent]) == real_parent
+    except ValueError:
+        return False
+
+
+def _decode_mountinfo_path(value: str) -> str:
+    return (
+        value.replace("\\040", " ")
+        .replace("\\011", "\t")
+        .replace("\\012", "\n")
+        .replace("\\134", "\\")
+    )
+
+
+def _get_mount_info(path: str) -> MountInfo | None:
+    try:
+        with open("/proc/self/mountinfo", encoding="utf-8") as f:
+            mount_lines = f.readlines()
+    except OSError:
+        return None
+
+    best_match: MountInfo | None = None
+    best_match_len = -1
+    real_path = os.path.realpath(path)
+    for line in mount_lines:
+        fields = line.split()
+        try:
+            separator = fields.index("-")
+        except ValueError:
+            continue
+        if separator + 3 >= len(fields) or separator < 6:
+            continue
+
+        mount_point = os.path.realpath(_decode_mountinfo_path(fields[4]))
+        if not _path_is_under(real_path, mount_point):
+            continue
+        if len(mount_point) <= best_match_len:
+            continue
+
+        options: list[str] = []
+        options.extend(fields[5].split(","))
+        options.extend(fields[separator + 3].split(","))
+        best_match = MountInfo(
+            mount_point=mount_point,
+            fs_type=fields[separator + 1],
+            options=tuple(options),
+        )
+        best_match_len = len(mount_point)
+    return best_match
+
+
+def _get_hugetlbfs_page_size(mount_info: MountInfo) -> int | None:
+    for option in mount_info.options:
+        key, separator, value = option.partition("=")
+        if key == "pagesize" and separator:
+            try:
+                return _parse_hugepage_block_size(value)
+            except ValueError:
+                logger.warning(
+                    "Could not parse hugetlbfs pagesize mount option %r",
+                    value,
+                )
+                return None
+    return None
+
+
+def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> None:
+    """Spin-wait until the file reaches expected_size (creator truncated it)."""
+    deadline = time.monotonic() + timeout
+    while True:
+        if os.fstat(fd).st_size >= expected_size:
+            return
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"Timed out waiting for mmap file to reach {expected_size} bytes"
+            )
+        time.sleep(0.005)
+
+
+def create_shared_memory_allocation(
+    instance_id: str,
+    logical_size_bytes: int,
+    memory_config: CPUOffloadMemoryConfig,
+) -> SharedMemoryAllocation:
+    memory_config.validate()
+    path = memory_config.mmap_path(instance_id)
+    mapped_size_bytes = memory_config.mapped_size(logical_size_bytes)
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+    except FileExistsError:
+        fd = os.open(path, os.O_RDWR)
+        try:
+            _wait_for_file_size(fd, mapped_size_bytes)
+        except TimeoutError:
+            os.close(fd)
+            raise
+        logger.info("Opened existing mmap file %s", path)
+        return SharedMemoryAllocation(
+            path=path,
+            fd=fd,
+            creator=False,
+            logical_size_bytes=logical_size_bytes,
+            mapped_size_bytes=mapped_size_bytes,
+        )
+    except OSError as exc:
+        raise OSError(
+            f"Failed to open offload mmap file {path!r} for "
+            f"cpu_memory_backend={memory_config.effective_backend.value!r}"
+        ) from exc
+
+    try:
+        if memory_config.effective_backend == CPUOffloadMemoryBackend.SHM:
+            check_shm_free_space(
+                mapped_size_bytes, memory_config.path or DEFAULT_SHM_PATH
+            )
+        os.ftruncate(fd, mapped_size_bytes)
+    except (RuntimeError, OSError) as exc:
+        os.unlink(path)
+        os.close(fd)
+        raise OSError(
+            f"Failed to size offload mmap file {path!r} to "
+            f"{mapped_size_bytes} bytes for "
+            f"cpu_memory_backend={memory_config.effective_backend.value!r}; "
+            "verify cpu_memory_path and available hugepages"
+        ) from exc
+
+    logger.info(
+        "Created mmap file %s (logical %.2f GB, mapped %.2f GB)",
+        path,
+        logical_size_bytes / 1e9,
+        mapped_size_bytes / 1e9,
+    )
+    return SharedMemoryAllocation(
+        path=path,
+        fd=fd,
+        creator=True,
+        logical_size_bytes=logical_size_bytes,
+        mapped_size_bytes=mapped_size_bytes,
+    )

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -8,21 +8,16 @@ import torch
 
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.v1.kv_offload.cpu.memory import (
+    CPUOffloadMemoryBackend,
+    CPUOffloadMemoryConfig,
+    _wait_for_file_size,
+    create_shared_memory_allocation,
+)
 
 logger = init_logger(__name__)
 
-
-def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> None:
-    """Spin-wait until the file reaches expected_size (creator truncated it)."""
-    deadline = time.monotonic() + timeout
-    while True:
-        if os.fstat(fd).st_size >= expected_size:
-            return
-        if time.monotonic() > deadline:
-            raise TimeoutError(
-                f"Timed out waiting for mmap file to reach {expected_size} bytes"
-            )
-        time.sleep(0.005)
+__all__ = ["SharedOffloadRegion", "_wait_for_file_size"]
 
 
 class SharedOffloadRegion:
@@ -33,7 +28,7 @@ class SharedOffloadRegion:
     the rest open the existing file and wait until it reaches the expected
     size.  Each worker then mmap()s the full file.
 
-    File path: /dev/shm/vllm_offload_{instance_id}.mmap
+    Default file path: /dev/shm/vllm_offload_{instance_id}.mmap
     """
 
     BLOCK_SIZE_ALIGNMENT: int = mmap.PAGESIZE
@@ -45,45 +40,49 @@ class SharedOffloadRegion:
         rank: int | None,
         kv_bytes_per_block: int,
         cpu_page_size: int,
+        memory_config: CPUOffloadMemoryConfig | None = None,
     ) -> None:
         self.page_size = mmap.PAGESIZE
         assert kv_bytes_per_block % self.page_size == 0
 
+        self.memory_config = memory_config or CPUOffloadMemoryConfig()
         self.num_blocks = num_blocks
         self._row_stride = kv_bytes_per_block
         self.total_size_bytes = self.num_blocks * self._row_stride
+        self.mapped_size_bytes = self.memory_config.mapped_size(self.total_size_bytes)
 
-        self.mmap_path = f"/dev/shm/vllm_offload_{instance_id}.mmap"
+        self.mmap_path = self.memory_config.mmap_path(instance_id)
         self._creator = False  # set True only if this worker creates the file
         self.rank = rank
+        self.fd: int | None = None
+        self.mmap_obj: mmap.mmap | None = None
+        self._base: torch.Tensor | None = None
+        self._views: list[torch.Tensor] = []
+        self.is_pinned: bool = False
         if rank is not None:
             # byte offset to this worker's first slot within each block row
             self._worker_offset = rank * cpu_page_size
             # exclusive upper bound for this worker's area within each row
             self._worker_area_end = (rank + 1) * cpu_page_size
         try:
-            # Exclusive create — only one worker succeeds
-            self.fd: int | None = os.open(
-                self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
+            allocation = create_shared_memory_allocation(
+                instance_id=instance_id,
+                logical_size_bytes=self.total_size_bytes,
+                memory_config=self.memory_config,
             )
-            os.ftruncate(self.fd, self.total_size_bytes)
-            self._creator = True
-            logger.info(
-                "Created mmap file %s (%.2f GB)",
-                self.mmap_path,
-                self.total_size_bytes / 1e9,
-            )
-        except FileExistsError:
-            self.fd = os.open(self.mmap_path, os.O_RDWR)
-            _wait_for_file_size(self.fd, self.total_size_bytes)
-            logger.info("Opened existing mmap file %s", self.mmap_path)
+            self.mmap_path = allocation.path
+            self.fd = allocation.fd
+            self._creator = allocation.creator
 
-        self.mmap_obj: mmap.mmap | None = mmap.mmap(
-            self.fd,
-            self.total_size_bytes,
-            flags=mmap.MAP_SHARED,
-            prot=mmap.PROT_READ | mmap.PROT_WRITE,
-        )
+            self.mmap_obj = mmap.mmap(
+                self.fd,
+                self.mapped_size_bytes,
+                flags=mmap.MAP_SHARED,
+                prot=mmap.PROT_READ | mmap.PROT_WRITE,
+            )
+        except Exception:
+            self.cleanup()
+            raise
 
         # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
         _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
@@ -97,9 +96,10 @@ class SharedOffloadRegion:
                 aligned_offset = (raw_offset // page_size) * page_size
                 end = raw_offset + cpu_page_size
                 aligned_length = end - aligned_offset
-                self.mmap_obj.madvise(
+                if not self._madvise(
                     _MADV_POPULATE_WRITE, aligned_offset, aligned_length
-                )
+                ):
+                    break
             logger.debug(
                 "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
                 num_blocks,
@@ -108,14 +108,33 @@ class SharedOffloadRegion:
         else:
             # No rank — populate the entire shared region in one call.
             _t0 = time.perf_counter()
-            self.mmap_obj.madvise(_MADV_POPULATE_WRITE, 0, self.total_size_bytes)
+            self._madvise(_MADV_POPULATE_WRITE, 0, self.mapped_size_bytes)
             logger.debug(
                 "MADV_POPULATE_WRITE entire region: %.3f s", time.perf_counter() - _t0
             )
 
-        self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
-        self._views: list[torch.Tensor] = []
-        self.is_pinned: bool = False
+        self._base = torch.frombuffer(
+            self.mmap_obj, dtype=torch.int8, count=self.total_size_bytes
+        )
+
+    def _madvise(self, advice: int, offset: int, length: int) -> bool:
+        assert self.mmap_obj is not None
+        try:
+            self.mmap_obj.madvise(advice, offset, length)
+            return True
+        except (AttributeError, OSError, ValueError):
+            if (
+                self.memory_config.effective_backend
+                == CPUOffloadMemoryBackend.HUGETLBFS
+            ):
+                logger.warning(
+                    "MADV_POPULATE_WRITE failed for hugetlbfs mmap %s; "
+                    "continuing without eager population",
+                    self.mmap_path,
+                    exc_info=True,
+                )
+                return False
+            raise
 
     def create_next_view(self, tensor_page_size: int) -> torch.Tensor:
         """Allocate a strided int8 view for this worker, one canonical tensor.
@@ -140,6 +159,7 @@ class SharedOffloadRegion:
             tensor_page_size: Bytes per block for this  tensor.
         """
         assert self.rank is not None
+        assert self._base is not None
         new_offset = self._worker_offset + tensor_page_size
         assert new_offset <= self._worker_area_end, (
             f"Worker offset {new_offset} exceeds worker area end "
@@ -162,6 +182,7 @@ class SharedOffloadRegion:
         Shape: (num_blocks, row_stride_bytes). Secondary tiers address
         block *b* as ``view[b]``.
         """
+        assert self._base is not None
         kv_tensor = self._base.view(self.num_blocks, self._row_stride)
         np_arr = kv_tensor.numpy()
         assert np_arr.ctypes.data == self._base.data_ptr(), (

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -14,29 +14,18 @@ from vllm.distributed.device_communicators.shm_broadcast import (
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.v1.kv_offload.cpu.memory import (
+    CPUOffloadMemoryConfig,
+    create_shared_memory_allocation,
+)
 
 logger = init_logger(__name__)
 
 # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
 _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
 
-
-def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> None:
-    """Spin-wait until the file reaches expected_size (creator truncated it)."""
-    deadline = time.monotonic() + timeout
-    while True:
-        if os.fstat(fd).st_size >= expected_size:
-            return
-        if time.monotonic() > deadline:
-            raise TimeoutError(
-                f"Timed out waiting for mmap file to reach {expected_size} bytes"
-            )
-        time.sleep(0.005)
-
-
 def _madvise_populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
     mmap_obj.madvise(_MADV_POPULATE_WRITE, offset, length)
-
 
 def _fallback_populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
     # Touch one byte per page via a read-modify-write so existing bytes are
@@ -44,7 +33,6 @@ def _fallback_populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> N
     # shared mmap by the time we run on a kernel without MADV_POPULATE_WRITE.
     arr = np.frombuffer(mmap_obj, dtype=np.uint8)
     arr[offset : offset + length : mmap.PAGESIZE] |= 0
-
 
 def _get_populate_write_fn(
     mmap_obj: mmap.mmap,
@@ -62,7 +50,6 @@ def _get_populate_write_fn(
         return _fallback_populate_write
     return _madvise_populate_write
 
-
 class SharedOffloadRegion:
     """
     Single mmap-backed memory region shared across all workers for a
@@ -71,7 +58,7 @@ class SharedOffloadRegion:
     the rest open the existing file and wait until it reaches the expected
     size.  Each worker then mmap()s the full file.
 
-    File path: /dev/shm/vllm_offload_{engine_id}.mmap
+    Default file path: /dev/shm/vllm_offload_{engine_id}.mmap
     """
 
     BLOCK_SIZE_ALIGNMENT: int = mmap.PAGESIZE
@@ -83,64 +70,51 @@ class SharedOffloadRegion:
         rank: int | None,
         kv_bytes_per_block: int,
         cpu_page_size: int,
+        memory_config: CPUOffloadMemoryConfig | None = None,
     ) -> None:
         self.page_size = mmap.PAGESIZE
         assert kv_bytes_per_block % self.page_size == 0
 
+        self.memory_config = memory_config or CPUOffloadMemoryConfig()
         self.num_blocks = num_blocks
         self._row_stride = kv_bytes_per_block
         self.total_size_bytes = self.num_blocks * self._row_stride
+        self.mapped_size_bytes = self.memory_config.mapped_size(self.total_size_bytes)
 
-        self.mmap_path = f"/dev/shm/vllm_offload_{engine_id}.mmap"
+        self.mmap_path = self.memory_config.mmap_path(engine_id)
         self._creator = False  # set True only if this worker creates the file
         self.rank = rank
+        self.fd: int | None = None
+        self.mmap_obj: mmap.mmap | None = None
+        self._base: torch.Tensor | None = None
+        self._views: list[torch.Tensor] = []
+        self.is_pinned: bool = False
         if rank is not None:
             # byte offset to this worker's first slot within each block row
             self._worker_offset = rank * cpu_page_size
             # exclusive upper bound for this worker's area within each row
             self._worker_area_end = (rank + 1) * cpu_page_size
         try:
-            self.fd: int | None = os.open(
-                self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
+            allocation = create_shared_memory_allocation(
+                instance_id=engine_id,
+                logical_size_bytes=self.total_size_bytes,
+                memory_config=self.memory_config,
             )
-        except FileExistsError:
-            # Joiner path — another worker won O_EXCL. Reopen and wait
-            # for the file to reach expected size.
-            self.fd = os.open(self.mmap_path, os.O_RDWR)
-            try:
-                _wait_for_file_size(self.fd, self.total_size_bytes)
-            except (TimeoutError, OSError):
-                os.close(self.fd)
-                raise
-            logger.info("Opened existing mmap file %s", self.mmap_path)
-        else:
-            # Creator path. We won O_EXCL, so we own the file: any
-            # failure here must clean up so concurrent joiners don't
-            # land on a 0-byte stub and spin in _wait_for_file_size
-            # for the full 30 s timeout.
-            try:
-                check_shm_free_space(self.total_size_bytes)
-                os.ftruncate(self.fd, self.total_size_bytes)
-            except (RuntimeError, OSError):
-                os.unlink(self.mmap_path)
-                os.close(self.fd)
-                raise
-            self._creator = True
-            logger.info(
-                "Created mmap file %s (%.2f GB)",
-                self.mmap_path,
-                self.total_size_bytes / 1e9,
-            )
+            self.mmap_path = allocation.path
+            self.fd = allocation.fd
+            self._creator = allocation.creator
 
-        self.mmap_obj: mmap.mmap | None = mmap.mmap(
-            self.fd,
-            self.total_size_bytes,
-            flags=mmap.MAP_SHARED,
-            prot=mmap.PROT_READ | mmap.PROT_WRITE,
-        )
+            self.mmap_obj = mmap.mmap(
+                self.fd,
+                self.mapped_size_bytes,
+                flags=mmap.MAP_SHARED,
+                prot=mmap.PROT_READ | mmap.PROT_WRITE,
+            )
+        except Exception:
+            self.cleanup()
+            raise
 
         populate_write_fn = _get_populate_write_fn(self.mmap_obj)
-
         if rank is not None:
             # Populate only this worker's pages (one slot per block row).
             worker_offset = rank * cpu_page_size
@@ -165,10 +139,11 @@ class SharedOffloadRegion:
                 "MADV_POPULATE_WRITE entire region: %.3f s", time.perf_counter() - _t0
             )
 
-        self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
+        self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8, count=self.total_size_bytes)
         self._views: list[torch.Tensor] = []
         self._canonical_offset = 0
         self.is_pinned: bool = False
+
 
     def create_next_worker_view(self, tensor_page_size: int) -> torch.Tensor:
         """Allocate a strided int8 view for this worker, one canonical tensor.
@@ -193,6 +168,7 @@ class SharedOffloadRegion:
             tensor_page_size: Bytes per block for this  tensor.
         """
         assert self.rank is not None
+        assert self._base is not None
         new_offset = self._worker_offset + tensor_page_size
         assert new_offset <= self._worker_area_end, (
             f"Worker offset {new_offset} exceeds worker area end "
@@ -259,6 +235,7 @@ class SharedOffloadRegion:
         Shape: (num_blocks, row_stride_bytes). Secondary tiers address
         block *b* as ``view[b]``.
         """
+        assert self._base is not None
         kv_tensor = self._base.view(self.num_blocks, self._row_stride)
         np_arr = kv_tensor.numpy()
         assert np_arr.ctypes.data == self._base.data_ptr(), (

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -20,10 +20,15 @@ from vllm.v1.kv_offload.base import (
 from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
 from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
+from vllm.v1.kv_offload.cpu.memory import (
+    CPUOffloadMemoryBackend,
+    CPUOffloadMemoryConfig,
+)
 
 
 class CPUOffloadingSpec(OffloadingSpec):
     BLOCK_SIZE_ALIGNMENT = 1
+    SUPPORTS_SHARED_MEMORY_BACKENDS = False
 
     @classmethod
     def build_metric_definitions(
@@ -53,6 +58,27 @@ class CPUOffloadingSpec(OffloadingSpec):
 
     def __init__(self, vllm_config: VllmConfig, kv_cache_config: KVCacheConfig):
         super().__init__(vllm_config, kv_cache_config)
+
+        raw_memory_backend = self.extra_config.get("cpu_memory_backend")
+        if isinstance(raw_memory_backend, CPUOffloadMemoryBackend):
+            raw_memory_backend = raw_memory_backend.value
+        if (
+            not self.SUPPORTS_SHARED_MEMORY_BACKENDS
+            and str(raw_memory_backend).lower()
+            in (
+                CPUOffloadMemoryBackend.SHM.value,
+                CPUOffloadMemoryBackend.HUGETLBFS.value,
+            )
+        ):
+            raise ValueError(
+                "cpu_memory_backend is only supported by TieringOffloadingSpec; "
+                "CPUOffloadingSpec uses torch CPU tensors for single-tier CPU "
+                "offload. Use spec_name='TieringOffloadingSpec' for shared mmap "
+                "or hugetlbfs CPU primary tiering."
+            )
+        self.cpu_memory_config = CPUOffloadMemoryConfig.from_extra_config(
+            self.extra_config
+        )
 
         cpu_bytes_to_use = self.extra_config.get("cpu_bytes_to_use")
         if not cpu_bytes_to_use:

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -22,10 +22,15 @@ from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
 from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+from vllm.v1.kv_offload.cpu.memory import (
+    CPUOffloadMemoryBackend,
+    CPUOffloadMemoryConfig,
+)
 
 
 class CPUOffloadingSpec(OffloadingSpec):
     BLOCK_SIZE_ALIGNMENT = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    SUPPORTS_SHARED_MEMORY_BACKENDS = False
 
     @classmethod
     def build_metric_definitions(
@@ -76,6 +81,27 @@ class CPUOffloadingSpec(OffloadingSpec):
 
     def __init__(self, config: OffloadingConfig):
         super().__init__(config)
+
+        raw_memory_backend = self.extra_config.get("cpu_memory_backend")
+        if isinstance(raw_memory_backend, CPUOffloadMemoryBackend):
+            raw_memory_backend = raw_memory_backend.value
+        if (
+            not self.SUPPORTS_SHARED_MEMORY_BACKENDS
+            and str(raw_memory_backend).lower()
+            in (
+                CPUOffloadMemoryBackend.SHM.value,
+                CPUOffloadMemoryBackend.HUGETLBFS.value,
+            )
+        ):
+            raise ValueError(
+                "cpu_memory_backend is only supported by TieringOffloadingSpec; "
+                "CPUOffloadingSpec uses torch CPU tensors for single-tier CPU "
+                "offload. Use spec_name='TieringOffloadingSpec' for shared mmap "
+                "or hugetlbfs CPU primary tiering."
+            )
+        self.cpu_memory_config = CPUOffloadMemoryConfig.from_extra_config(
+            self.extra_config
+        )
 
         cpu_bytes_to_use = self.extra_config.get("cpu_bytes_to_use")
         if not cpu_bytes_to_use:

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -70,6 +70,7 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
     """
 
     BLOCK_SIZE_ALIGNMENT = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    SUPPORTS_SHARED_MEMORY_BACKENDS = True
 
     @classmethod
     @override
@@ -129,6 +130,7 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                 rank=None,
                 kv_bytes_per_block=self.kv_bytes_per_offloaded_block,
                 cpu_page_size=self.cpu_page_size_per_worker,
+                memory_config=self.cpu_memory_config,
             )
             self._scheduler_mmap = scheduler_mmap
 
@@ -195,6 +197,7 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
             rank=rank,
             kv_bytes_per_block=self.kv_bytes_per_offloaded_block,
             cpu_page_size=self.cpu_page_size_per_worker,
+            memory_config=self.cpu_memory_config,
         )
         return CPUOffloadingWorker(
             kv_caches=kv_caches,

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -95,6 +95,7 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
     """
 
     BLOCK_SIZE_ALIGNMENT = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    SUPPORTS_SHARED_MEMORY_BACKENDS = True
 
     @classmethod
     @override
@@ -304,6 +305,7 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                     rank=None,
                     kv_bytes_per_block=self.kv_bytes_per_chunk,
                     cpu_page_size=self.cpu_page_size_per_worker,
+                memory_config=self.cpu_memory_config,
                 )
                 self._scheduler_mmap = scheduler_mmap
 
@@ -397,6 +399,7 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
             rank=rank,
             kv_bytes_per_block=self.kv_bytes_per_chunk,
             cpu_page_size=self.cpu_page_size_per_worker,
+            memory_config=self.cpu_memory_config,
         )
         try:
             if self.config.canonical_layout:


### PR DESCRIPTION
## Purpose

Add an opt-in hugepage-backed host-memory backend for the V1 KV offload `TieringOffloadingSpec` CPU primary tier.

Now you can specify to use hugepages instead of the old shared memory in the configuration:

```
{
  "kv_connector": "OffloadingConnector",
  "kv_role": "kv_both",
  "kv_connector_extra_config": {
    "spec_name": "TieringOffloadingSpec",
    "cpu_memory_backend": "hugetlbfs",
    "cpu_memory_path": "/dev/hugepages/vllm",
    "cpu_hugepage_block_size": "2MB",
    "cpu_bytes_to_use": 10737418240,
    "block_size": 256,
    "eviction_policy": "lru",
    "offload_prompt_only": true,
  }
}
```

New `kv_connector_extra_config` keys introduced:
- `cpu_memory_backend`: `default`, `shm`, or `hugetlbfs`
- `cpu_memory_path`: directory for shared mmap files, required for `hugetlbfs`
- `cpu_hugepage_block_size`: `2MB` or `1GB`

The implementation adds shared-memory backend parsing/validation, maps hugetlbfs files with hugepage-aligned size while exposing only logical KV capacity, threads the selected backend through scheduler and worker `SharedOffloadRegion` creation, keeps creator/joiner cleanup semantics, and documents setup/verification guidance.

AI assistance was used in preparing this change.

## Test Plan

- Run focused KV offload unit tests, including config parsing, shared mmap allocation, spec wiring, GPU-worker handler wiring, and tiering manager coverage.
- Run the optional real hugetlbfs smoke test with `VLLM_TEST_HUGETLBFS_PATH=/mnt/huge` (requires hugepages setup)
Set up a hugepages directory: 
```
sudo sysctl -w vm.nr_hugepages=10000

sudo mkdir -p /mnt/huge

sudo mount -t hugetlbfs nodev /mnt/huge

```

Set up permissions so the test user can read write and execute on the /mnt/huge directory

- Run CPU-only hardware-gating coverage for GPU transfer tests.
- Run relevant ruff hooks and documentation/example validation.

## Test Result

Passed:

```bash
VLLM_TEST_HUGETLBFS_PATH=/mnt/huge .venv/bin/python -m pytest \
  tests/v1/kv_offload/cpu/test_shared_offload_region.py \
  tests/v1/kv_connector/unit/test_config.py \
  tests/v1/kv_offload/cpu/test_spec_memory_config.py \
  tests/v1/kv_offload/cpu/test_gpu_worker.py \
  tests/v1/kv_offload/tiering/test_tiering_offloading.py -q
Result: 100 passed on a host with one visible CUDA device and /mnt/huge mounted as hugetlbfs.
Passed:
.venv/bin/python -m pytest tests/v1/kv_offload/cpu/test_gpu_worker.py -q
Result: 1 passed, 24 skipped in a CPU-only environment.
Passed:
pre-commit run ruff-check --files \
  tests/v1/kv_connector/unit/test_config.py \
  tests/v1/kv_offload/cpu/test_shared_offload_region.py \
  tests/v1/kv_offload/cpu/test_gpu_worker.py \
  tests/v1/kv_offload/tiering/test_tiering_offloading.py
Also passed:
.venv/bin/python -m json.tool examples/features/kv_offloading/doca_memos/kv_transfer_config.doca_memos_hugepages.json
git diff --check origin/main...HEAD