### PR TITLE
[Model] Enable LoRA support for tower and connector in Voxtral

### DIFF
--- a/tests/models/multimodal/test_voxtral.py
+++ b/tests/models/multimodal/test_voxtral.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from vllm.model_executor.models.voxtral import VoxtralForConditionalGeneration
+
+
+def _make_voxtral_model(downsample_factor: int) -> VoxtralForConditionalGeneration:
+    model = VoxtralForConditionalGeneration.__new__(VoxtralForConditionalGeneration)
+    model.downsample_factor = downsample_factor
+    return model
+
+
+@pytest.mark.parametrize(
+    ("downsample_factor", "num_audio_tokens"),
+    [(2, 1), (2, 50), (4, 1), (4, 375)],
+)
+def test_voxtral_mm_lora_token_counts(
+    downsample_factor: int, num_audio_tokens: int
+) -> None:
+    # The whisper encoder runs on `downsample_factor` tokens per language-model
+    # audio token; the adapter (connector) maps them back down. The tower and
+    # connector LoRA mappings rely on this round-trip (see gpu_model_runner).
+    model = _make_voxtral_model(downsample_factor)
+
+    num_encoder_tokens = num_audio_tokens * downsample_factor
+    assert model.get_num_mm_encoder_tokens(num_audio_tokens) == num_encoder_tokens
+    assert model.get_num_mm_connector_tokens(num_encoder_tokens) == num_audio_tokens

--- a/vllm/model_executor/models/voxtral.py
+++ b/vllm/model_executor/models/voxtral.py
@@ -361,6 +361,17 @@ class VoxtralForConditionalGeneration(
             tower_model=["whisper_encoder"],
         )
 
+    def get_num_mm_encoder_tokens(self, num_image_tokens: int) -> int:
+        # The whisper encoder runs before the `downsample_factor` packing that
+        # produces the audio tokens seen by the language model (see
+        # `embed_multimodal`), so it processes that many more tokens.
+        return num_image_tokens * self.downsample_factor
+
+    def get_num_mm_connector_tokens(self, num_vision_tokens: int) -> int:
+        # The audio-language adapter consumes the packed encoder output, i.e.
+        # `downsample_factor` encoder tokens per language-model audio token.
+        return num_vision_tokens // self.downsample_factor
+
     def forward(
         self,
         input_ids: torch.Tensor | None,


### PR DESCRIPTION
## Purpose

Part of #31479. Enables tower/connector LoRA for **Voxtral** (audio multimodal model).

`VoxtralForConditionalGeneration` already declares `SupportsLoRA` and `get_mm_mapping` (connector=`audio_language_adapter`, tower=`whisper_encoder`) but was missing the token-count helpers, so adapter LoRA on the encoder/connector used the wrong sequence length — the consumers in `gpu_model_runner.py` and `lora/model_manager.py` mis-map (or skip the connector) without them.

This adds `get_num_mm_encoder_tokens` / `get_num_mm_connector_tokens` using the audio `downsample_factor`, the audio analog of the vision `spatial_merge_size**2` pattern used by the already-merged sibling PRs (GLM4-V #31652, LLaVA #31513). The factor matches the packing in `embed_multimodal`: the whisper-encoder output is padded and packed by `downsample_factor` into the adapter tokens the language model sees.

## Not a duplicate

Voxtral is not on #31479's done list. The in-flight Mistral-family PR #42228 touches `mistral3.py` only; the earlier Voxtral+Mistral3 bundle #31812 was closed. The other open Voxtral PRs (#44364/#44461/#39229/#45022) are all `Voxtral Realtime` perf/bugfixes — unrelated to the LoRA token helpers. No open PR addresses this.

## Test

Added `tests/models/multimodal/test_voxtral.py` (token-count round-trip, mirroring the Mistral3 test pattern). It is self-contained — constructs the model via `__new__` and checks the helpers, no fixtures/GPU needed.

Built and run on an A100 80GB (`VLLM_USE_PRECOMPILED=1 pip install -e .`):

```
$ pytest --noconftest tests/models/multimodal/test_voxtral.py -v
tests/models/multimodal/test_voxtral.py::test_voxtral_mm_lora_token_counts[2-1]   PASSED
tests/models/multimodal/test_voxtral.py::test_voxtral_mm_lora_token_counts[2-50]  PASSED
tests/models/multimodal/test_voxtral.py::test_voxtral_mm_lora_token_counts[4-1]   PASSED
tests/models/multimodal/test_voxtral.py::test_voxtral_mm_lora_token_counts[4-375] PASSED
4 passed in 7.60s
```
(`--noconftest` only because the full test-harness deps weren't installed locally; the test uses no conftest fixtures, so it runs identically under the normal CI invocation.)

## AI assistance

This PR was written with AI assistance (Claude). I reviewed every changed line and validated the build + tests on my own A100.
