### PR TITLE
[v1] Gate scheduler resume on full executor residency after partial wake_up

### DIFF
--- a/tests/v1/engine/test_wake_up_scheduler_resume.py
+++ b/tests/v1/engine/test_wake_up_scheduler_resume.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit test for the partial-wake scheduler-resume race (issue #44395).
+
+After a partial ``wake_up(tags=["weights"])`` the KV cache is still released,
+yet ``EngineCore.wake_up`` used to resume the scheduler unconditionally. The
+engine could then step (including the DP-lockstep ``execute_dummy_batch`` path
+on idle ranks) against a released KV cache and crash with an illegal memory
+access.
+
+These tests pin the contract that ``EngineCore.wake_up`` only resumes the
+scheduler once the executor is *fully* resident (``is_sleeping == False``).
+They drive the real ``EngineCore.wake_up`` method against a tiny fake that
+faithfully mirrors ``Executor``'s tag bookkeeping, so no GPU / model load is
+needed.
+"""
+
+from unittest.mock import MagicMock
+
+from vllm.v1.engine.core import EngineCore
+
+
+class _FakeExecutor:
+    """Mirrors Executor.sleep/wake_up tag bookkeeping (abstract.py:318-356).
+
+    is_sleeping flips to False only once every sleeping tag is woken, which is
+    exactly the residency signal EngineCore.wake_up must gate the scheduler
+    resume on.
+    """
+
+    def __init__(self):
+        self.is_sleeping = False
+        self.sleeping_tags: set[str] = set()
+
+    def sleep(self, level: int = 1):
+        self.sleeping_tags = {"weights", "kv_cache"}
+        self.is_sleeping = True
+
+    def wake_up(self, tags=None):
+        # Mirror Executor.wake_up's early-exit guard (abstract.py:332): a
+        # wake_up on an already-resident executor is a no-op and must not
+        # disturb the tag bookkeeping.
+        if not self.is_sleeping:
+            return
+        if tags:
+            for tag in tags:
+                self.sleeping_tags.discard(tag)
+        else:
+            self.sleeping_tags.clear()
+        if not self.sleeping_tags:
+            self.is_sleeping = False
+
+
+def _make_engine_core(executor: _FakeExecutor) -> EngineCore:
+    """A bare EngineCore with only the attributes wake_up() touches.
+
+    We avoid EngineCore.__init__ (which builds a real executor + scheduler and
+    needs a GPU) and instead attach a recording resume_scheduler plus the fake
+    executor, then exercise the real bound wake_up method.
+    """
+    core = EngineCore.__new__(EngineCore)
+    core.model_executor = executor
+    core.resume_scheduler = MagicMock(name="resume_scheduler")
+    return core
+
+
+def test_partial_weights_wake_does_not_resume_scheduler():
+    """wake_up(tags=["weights"]) leaves KV asleep -> scheduler must stay paused."""
+    executor = _FakeExecutor()
+    executor.sleep(level=1)
+    core = _make_engine_core(executor)
+
+    core.wake_up(tags=["weights"])
+
+    # KV cache tag still present -> executor not fully resident.
+    assert executor.is_sleeping is True
+    assert executor.sleeping_tags == {"kv_cache"}
+    # The race: resuming here would let a forward run against released KV.
+    core.resume_scheduler.assert_not_called()
+
+
+def test_final_kv_wake_resumes_scheduler():
+    """The completing wake_up(tags=["kv_cache"]) makes us resident -> resume."""
+    executor = _FakeExecutor()
+    executor.sleep(level=1)
+    core = _make_engine_core(executor)
+
+    core.wake_up(tags=["weights"])
+    core.resume_scheduler.assert_not_called()
+
+    core.wake_up(tags=["kv_cache"])
+
+    assert executor.is_sleeping is False
+    assert executor.sleeping_tags == set()
+    core.resume_scheduler.assert_called_once()
+
+
+def test_full_wake_resumes_scheduler():
+    """A plain full wake_up() is fully resident -> resume immediately."""
+    executor = _FakeExecutor()
+    executor.sleep(level=1)
+    core = _make_engine_core(executor)
+
+    core.wake_up()
+
+    assert executor.is_sleeping is False
+    core.resume_scheduler.assert_called_once()
+
+
+def test_level0_scheduling_wake_resumes_scheduler():
+    """Level-0 wake (tags=["scheduling"]) never touched GPU; executor is not
+    sleeping, so scheduling must resume."""
+    executor = _FakeExecutor()  # never slept the executor (level-0 sleep)
+    core = _make_engine_core(executor)
+
+    core.wake_up(tags=["scheduling"])
+
+    # "scheduling" is stripped; executor.wake_up is not called for level 0.
+    assert executor.is_sleeping is False
+    core.resume_scheduler.assert_called_once()
+
+
+def test_reversed_tag_order_resume():
+    """Order-independence: waking kv_cache first leaves weights asleep (no
+    resume), then waking weights empties the tags and resumes exactly once.
+
+    Tags can be woken in either order; residency -- not call order -- gates the
+    resume, so the scheduler must stay paused until the last tag is woken.
+    """
+    executor = _FakeExecutor()
+    executor.sleep(level=1)
+    core = _make_engine_core(executor)
+
+    # kv_cache first: weights tag still pending -> still partially asleep.
+    core.wake_up(tags=["kv_cache"])
+    assert executor.is_sleeping is True
+    assert executor.sleeping_tags == {"weights"}
+    core.resume_scheduler.assert_not_called()
+
+    # weights second: completing wake -> fully resident -> resume once.
+    core.wake_up(tags=["weights"])
+    assert executor.is_sleeping is False
+    assert executor.sleeping_tags == set()
+    core.resume_scheduler.assert_called_once()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -782,8 +782,41 @@ class EngineCore:
         if tags is None or tags:
             self.model_executor.wake_up(tags)
 
-        # Resume scheduling (applies to all levels)
-        self.resume_scheduler()
+        # A partial wake (e.g. wake_up(tags=["weights"])) intentionally keeps
+        # some allocations -- notably the KV cache -- released. The executor
+        # reports is_sleeping == True until every sleeping tag has been woken
+        # (see Executor.wake_up in vllm/v1/executor/abstract.py). Resuming the
+        # scheduler while the executor is still partially asleep lets the engine
+        # step against a released KV cache (including the DP lockstep
+        # execute_dummy_batch path on idle ranks), which writes the KV slot
+        # mapping into freed memory and crashes with an illegal memory access.
+        # Only resume once the executor is fully resident; the final
+        # wake_up(tags=["kv_cache"]) / full wake clears the last tag and resumes.
+        #
+        # DP note: in a data-parallel deployment every wake_up(tags=...) call is
+        # broadcast to all DP ranks and awaited together by the client
+        # (DPLBAsyncMPClient.call_utility_async fans out via asyncio.gather and
+        # waits for all engines). The next wake_up cannot be issued until the
+        # current one has completed on every rank, so all ranks reach the final
+        # wake -- and DPEngineCoreProc.resume_scheduler()'s has_unfinished_dp
+        # all-reduce barrier -- in lockstep. Deferring resume to the final tag
+        # therefore does not desynchronize the DP collective: it fires on the
+        # same wake call on every rank, exactly as the unconditional resume did.
+        if not self.model_executor.is_sleeping:
+            self.resume_scheduler()
+        elif tags:
+            # Protocol guard: a caller that wakes a subset of tags (e.g.
+            # ["weights"]) and never sends the completing wake leaves the
+            # scheduler paused indefinitely. Log the partially-resident state
+            # so the paused-scheduler condition is observable rather than a
+            # silent hang.
+            logger.warning(
+                "wake_up(tags=%s) left the executor partially asleep "
+                "(remaining sleeping tags pending); the scheduler stays "
+                "paused until a completing wake_up (e.g. tags=['kv_cache']) "
+                "or a full wake_up() is issued.",
+                tags,
+            )
 
     def is_sleeping(self) -> bool:
         """Check if engine is sleeping at any level."""


### PR DESCRIPTION
## Summary
Fixes #44395. After a partial `wake_up(tags=["weights"])` the KV cache is still
released, but `EngineCore.wake_up` resumed the scheduler unconditionally. The
engine could then step against the released KV cache — including the
data-parallel lockstep `execute_dummy_batch` path that runs on idle ranks even
with no user request — writing the KV slot mapping into freed memory and
crashing with `CUDA error: an illegal memory access was encountered`.

## Fix
`Executor.wake_up` clears `is_sleeping` only once every sleeping tag has been
woken (`sleeping_tags` empty). Gate the wake-triggered `resume_scheduler()` on
`not self.model_executor.is_sleeping`, so a weights-only wake leaves the
scheduler paused; it resumes only at the final `wake_up(tags=["kv_cache"])` or a
full wake. A `logger.warning` now records when a partial wake leaves the
scheduler paused (observability instead of a silent pause).

## Data-parallel safety
The DP client fans the same `wake_up(tags=...)` to every rank and awaits all of
them before issuing the next, so all ranks process `weights` (no resume) then
the final `kv_cache` (resume) in lockstep — the `has_unfinished_dp` all-reduce
still fires on the same call on every rank. No DP behavior change.

## Test
`tests/v1/engine/test_wake_up_scheduler_resume.py` drives the real
`EngineCore.wake_up` against a fake executor mirroring `Executor` tag
bookkeeping. It fails on pre-fix code (scheduler resumes during the weights-only
window) and passes with the residency gate. Covers partial weights-wake (no
resume), final kv-wake (resume once), full wake, level-0 `scheduling` wake, and
reversed tag order.
