### PR TITLE
[ROCm][Spec Decode] Fix probabilistic draft probs test attention backend

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -21,6 +21,12 @@ steps:
     - export VLLM_WORKER_MULTIPROC_METHOD=spawn
     # TODO: create another `optional` test group for slow tests
     - pytest -v -s -m 'not slow_test' v1/spec_decode
+  mirror:
+    amd:
+      device: mi300_1
+      timeout_in_minutes: 65
+      depends_on:
+      - image-build-amd
 
 - label: V1 Sample + Logits
   key: v1-sample-logits

--- a/.buildkite/test_areas/spec_decode.yaml
+++ b/.buildkite/test_areas/spec_decode.yaml
@@ -12,20 +12,6 @@ steps:
     - tests/v1/e2e/spec_decode/
   commands:
     - pytest -v -s v1/e2e/spec_decode -k "eagle_correctness"
-  mirror:
-    amd:
-      device: mi300_1
-      timeout_in_minutes: 65
-      depends_on:
-      - image-build-amd
-      source_file_dependencies:
-      - vllm/v1/spec_decode/
-      - vllm/v1/worker/gpu/spec_decode/
-      - vllm/model_executor/model_loader/
-      - vllm/v1/sample/
-      - vllm/model_executor/layers/
-      - tests/v1/e2e/spec_decode/
-      - vllm/platforms/rocm.py
 
 - label: Spec Decode Eagle Nightly B200
   key: spec-decode-eagle-nightly-b200

--- a/.buildkite/test_areas/spec_decode.yaml
+++ b/.buildkite/test_areas/spec_decode.yaml
@@ -12,6 +12,20 @@ steps:
     - tests/v1/e2e/spec_decode/
   commands:
     - pytest -v -s v1/e2e/spec_decode -k "eagle_correctness"
+  mirror:
+    amd:
+      device: mi300_1
+      timeout_in_minutes: 65
+      depends_on:
+      - image-build-amd
+      source_file_dependencies:
+      - vllm/v1/spec_decode/
+      - vllm/v1/worker/gpu/spec_decode/
+      - vllm/model_executor/model_loader/
+      - vllm/v1/sample/
+      - vllm/model_executor/layers/
+      - tests/v1/e2e/spec_decode/
+      - vllm/platforms/rocm.py
 
 - label: Spec Decode Eagle Nightly B200
   key: spec-decode-eagle-nightly-b200

--- a/tests/v1/spec_decode/test_eagle.py
+++ b/tests/v1/spec_decode/test_eagle.py
@@ -1052,9 +1052,12 @@ def test_propose_stores_probabilistic_draft_probs(monkeypatch):
         device=device,
     )
 
-    attn_metadata_builder_cls, _ = try_get_attention_backend(
-        AttentionBackendEnum.FLASH_ATTN
+    attn_backend = (
+        AttentionBackendEnum.TRITON_ATTN
+        if current_platform.is_rocm()
+        else AttentionBackendEnum.FLASH_ATTN
     )
+    attn_metadata_builder_cls, _ = try_get_attention_backend(attn_backend)
     attn_metadata_builder = attn_metadata_builder_cls(
         kv_cache_spec=create_standard_kv_cache_spec(proposer.vllm_config),
         layer_names=proposer._draft_attn_layer_names,

--- a/tests/v1/spec_decode/test_eagle.py
+++ b/tests/v1/spec_decode/test_eagle.py
@@ -1002,7 +1002,11 @@ def test_propose(method, attn_backend, num_speculative_tokens, monkeypatch):
     assert torch.equal(result, expected_tokens)
 
 
-def test_propose_stores_probabilistic_draft_probs(monkeypatch):
+@pytest.mark.parametrize(
+    "attn_backend",
+    ["ROCM_ATTN", "TRITON_ATTN"] if current_platform.is_rocm() else ["FLASH_ATTN"],
+)
+def test_propose_stores_probabilistic_draft_probs(attn_backend, monkeypatch):
     device = torch.device(DEVICE_TYPE)
     batch_size = 2
     seq_lens = [5, 3]
@@ -1052,12 +1056,9 @@ def test_propose_stores_probabilistic_draft_probs(monkeypatch):
         device=device,
     )
 
-    attn_backend = (
-        AttentionBackendEnum.TRITON_ATTN
-        if current_platform.is_rocm()
-        else AttentionBackendEnum.FLASH_ATTN
+    attn_metadata_builder_cls, _ = try_get_attention_backend(
+        AttentionBackendEnum[attn_backend]
     )
-    attn_metadata_builder_cls, _ = try_get_attention_backend(attn_backend)
     attn_metadata_builder = attn_metadata_builder_cls(
         kv_cache_spec=create_standard_kv_cache_spec(proposer.vllm_config),
         layer_names=proposer._draft_attn_layer_names,


### PR DESCRIPTION
## Purpose

`test_propose_stores_probabilistic_draft_probs` hardcodes the `FLASH_ATTN`
attention backend, which builds `FlashAttentionMetadata`. On ROCm, the
speculative-decoding proposer only accepts Triton/Rocm/AITER metadata
(`allowed_attn_types` is built under `current_platform.is_rocm()` in
`vllm/v1/spec_decode/llm_base_proposer.py`), so the test fails on AMD MI
architectures (gfx942 / MI325, gfx950 / MI355) with:

```
ValueError: Unsupported attention metadata type for speculative decoding
with num_speculative_tokens > 1: FlashAttentionMetadata. Supported types
are: (TritonAttentionMetadata, RocmAttentionMetadata, ...,
AiterFlashAttentionMetadata, ...)
```

The fix selects `TRITON_ATTN` on ROCm and keeps `FLASH_ATTN` on CUDA,
matching the per-backend pattern already used by `test_propose` in the
same file. No behavior change on CUDA.

## Test Plan

```
pytest -x -v tests/v1/spec_decode/test_eagle.py::test_propose_stores_probabilistic_draft_probs
```

Run on ROCm (gfx950 / MI355).

## Test Result

**Before (ROCm, gfx950 / MI355):**
```
FAILED tests/v1/spec_decode/test_eagle.py::test_propose_stores_probabilistic_draft_probs
ValueError: Unsupported attention metadata type for speculative decoding ... FlashAttentionMetadata
vllm/v1/spec_decode/llm_base_proposer.py:568: ValueError
```

**After (ROCm, gfx950 / MI355):**
```
tests/v1/spec_decode/test_eagle.py::test_propose_stores_probabilistic_draft_probs PASSED
1 passed in 8.81s
```

This is the only failing test in the `tests/v1/spec_decode/` group on ROCm
(141 passed, 1 failed before the fix), so the change turns the V1 Spec
Decode group green on AMD. The same failure was also confirmed on
gfx942 / MI325. CUDA is unaffected (still uses `FLASH_ATTN`).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
