### PR TITLE
[Misc] Support exporting torch profiler table as CSV or JSON

### DIFF
--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -61,10 +61,9 @@ class ProfilerConfig:
     """If `True`, dumps total CUDA time in torch profiler traces. Enabled by default."""
 
     torch_profiler_table_format: ProfilerTableFormat = "txt"
-    """Format used to save the profiler key-averages table. Defaults to 'txt'
-    (the human-readable torch table). Set to 'csv' or 'json' to instead export
-    a structured file with per-event metrics. Only applicable when profiler is
-    'torch'."""
+    """Format used to save the profiler key-averages table. Defaults to 'txt'. 
+    Set to 'csv' or 'json' to instead export a structured file with per-event metrics. 
+    Only applicable when profiler is'torch'."""
 
     torch_profiler_record_shapes: bool = False
     """If `True`, records tensor shapes in the torch profiler. Disabled by default."""

--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -14,6 +14,7 @@ from vllm.utils.hashing import safe_hash
 logger = init_logger(__name__)
 
 ProfilerKind = Literal["torch", "cuda"]
+ProfilerTableFormat = Literal["csv", "json"]
 
 
 def _is_uri_path(path: str) -> bool:
@@ -58,6 +59,12 @@ class ProfilerConfig:
 
     torch_profiler_dump_cuda_time_total: bool = True
     """If `True`, dumps total CUDA time in torch profiler traces. Enabled by default."""
+
+    torch_profiler_export_format: ProfilerTableFormat | None = None
+    """If set, additionally exports the profiler key-averages table as a
+    structured file ('csv' or 'json') alongside the default .txt table.
+    Defaults to None (no structured export). Only applicable when profiler is
+    'torch'."""
 
     torch_profiler_record_shapes: bool = False
     """If `True`, records tensor shapes in the torch profiler. Disabled by default."""
@@ -149,6 +156,12 @@ class ProfilerConfig:
             )
         if self.profiler == "torch" and not profiler_dir:
             raise ValueError("torch_profiler_dir must be set when profiler is 'torch'")
+
+        if self.torch_profiler_export_format and self.profiler != "torch":
+            raise ValueError(
+                "torch_profiler_export_format is only applicable when profiler "
+                "is set to 'torch'"
+            )
 
         # Support any URI scheme (gs://, s3://, hdfs://, etc.)
         # These paths should not be converted to absolute paths

--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -14,7 +14,7 @@ from vllm.utils.hashing import safe_hash
 logger = init_logger(__name__)
 
 ProfilerKind = Literal["torch", "cuda"]
-ProfilerTableFormat = Literal["csv", "json"]
+ProfilerTableFormat = Literal["txt", "csv", "json"]
 
 
 def _is_uri_path(path: str) -> bool:
@@ -60,10 +60,10 @@ class ProfilerConfig:
     torch_profiler_dump_cuda_time_total: bool = True
     """If `True`, dumps total CUDA time in torch profiler traces. Enabled by default."""
 
-    torch_profiler_export_format: ProfilerTableFormat | None = None
-    """If set, additionally exports the profiler key-averages table as a
-    structured file ('csv' or 'json') alongside the default .txt table.
-    Defaults to None (no structured export). Only applicable when profiler is
+    torch_profiler_table_format: ProfilerTableFormat = "txt"
+    """Format used to save the profiler key-averages table. Defaults to 'txt'
+    (the human-readable torch table). Set to 'csv' or 'json' to instead export
+    a structured file with per-event metrics. Only applicable when profiler is
     'torch'."""
 
     torch_profiler_record_shapes: bool = False
@@ -157,9 +157,9 @@ class ProfilerConfig:
         if self.profiler == "torch" and not profiler_dir:
             raise ValueError("torch_profiler_dir must be set when profiler is 'torch'")
 
-        if self.torch_profiler_export_format and self.profiler != "torch":
+        if self.torch_profiler_table_format != "txt" and self.profiler != "torch":
             raise ValueError(
-                "torch_profiler_export_format is only applicable when profiler "
+                "torch_profiler_table_format is only applicable when profiler "
                 "is set to 'torch'"
             )
 

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import csv
+import json
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import nullcontext
@@ -156,6 +158,29 @@ TorchProfilerActivityMap = {
 }
 
 
+# Per-event fields exported when torch_profiler_export_format is set.
+# Each maps to an attribute on torch's FunctionEventAvg (read defensively
+# with getattr so a missing attribute on a given torch version yields None
+# rather than raising).
+_PROFILER_EXPORT_FIELDS = (
+    "key",
+    "count",
+    "node_id",
+    "cpu_time_total",
+    "self_cpu_time_total",
+    "cpu_time",
+    "cuda_time_total",
+    "self_cuda_time_total",
+    "cuda_time",
+    "cpu_memory_usage",
+    "self_cpu_memory_usage",
+    "cuda_memory_usage",
+    "self_cuda_memory_usage",
+    "flops",
+    "input_shapes",
+)
+
+
 class TorchProfilerWrapper(WorkerProfiler):
     def __init__(
         self,
@@ -258,6 +283,33 @@ class TorchProfilerWrapper(WorkerProfiler):
             with open(profiler_out_file, "w") as f:
                 print(table, file=f)
 
+    def _export_profiler_table(self, rank: int, export_format: str) -> None:
+        profiler_dir = self.profiler_config.torch_profiler_dir
+
+        # Skip file write for URI paths (gs://, s3://, etc.)
+        # as standard file I/O doesn't work with URI schemes
+        if _is_uri_path(profiler_dir):
+            return
+
+        rows = [
+            {field: getattr(event, field, None) for field in _PROFILER_EXPORT_FIELDS}
+            for event in self.profiler.key_averages()
+        ]
+
+        out_file = f"{profiler_dir}/profiler_out_{rank}.{export_format}"
+        if export_format == "json":
+            with open(out_file, "w") as f:
+                json.dump(rows, f, indent=2, default=str)
+        else:  # csv
+            for row in rows:
+                # input_shapes is a nested list; flatten to a string for CSV.
+                if row["input_shapes"] is not None:
+                    row["input_shapes"] = str(row["input_shapes"])
+            with open(out_file, "w", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=list(_PROFILER_EXPORT_FIELDS))
+                writer.writeheader()
+                writer.writerows(rows)
+
     @override
     def _start(self) -> None:
         self.profiler.start()
@@ -285,6 +337,11 @@ class TorchProfilerWrapper(WorkerProfiler):
             # only print profiler results on rank 0
             if rank == 0:
                 print(table)
+
+        if profiler_config.torch_profiler_export_format:
+            self._export_profiler_table(
+                rank, profiler_config.torch_profiler_export_format
+            )
 
     @override
     def _profiler_step(self) -> bool:

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -3,7 +3,6 @@
 
 import csv
 import json
-import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import nullcontext
@@ -159,25 +158,6 @@ TorchProfilerActivityMap = {
 }
 
 
-def _event_to_row(event: object) -> dict[str, object]:
-    """Extract every public, non-callable metric from a FunctionEventAvg."""
-    row: dict[str, object] = {}
-    # Reading every attribute touches deprecated cuda_* aliases; silence them.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        for attr in dir(event):
-            if attr.startswith("_"):
-                continue
-            try:
-                value = getattr(event, attr)
-            except Exception:
-                continue
-            if callable(value):
-                continue
-            row[attr] = value
-    return row
-
-
 class TorchProfilerWrapper(WorkerProfiler):
     def __init__(
         self,
@@ -290,7 +270,21 @@ class TorchProfilerWrapper(WorkerProfiler):
         if _is_uri_path(profiler_dir):
             return
 
-        rows = [_event_to_row(event) for event in self.profiler.key_averages()]
+        # Extract every public, non-callable metric from each event.
+        rows: list[dict[str, object]] = []
+        for event in self.profiler.key_averages():
+            row: dict[str, object] = {}
+            for attr in dir(event):
+                if attr.startswith("_"):
+                    continue
+                try:
+                    value = getattr(event, attr)
+                except Exception:
+                    continue
+                if not callable(value):
+                    row[attr] = value
+            rows.append(row)
+
         # Stable, sorted superset of every metric seen across the events.
         fieldnames = sorted({key for row in rows for key in row})
 

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -265,12 +265,9 @@ class TorchProfilerWrapper(WorkerProfiler):
         export_format = self.profiler_config.torch_profiler_table_format
         profiler_dir = self.profiler_config.torch_profiler_dir
 
-        # Skip file write for URI paths (gs://, s3://, etc.)
-        # as standard file I/O doesn't work with URI schemes
         if _is_uri_path(profiler_dir):
             return
 
-        # Extract every public, non-callable metric from each event.
         rows: list[dict[str, object]] = []
         for event in self.profiler.key_averages():
             row: dict[str, object] = {}
@@ -285,16 +282,14 @@ class TorchProfilerWrapper(WorkerProfiler):
                     row[attr] = value
             rows.append(row)
 
-        # Stable, sorted superset of every metric seen across the events.
         fieldnames = sorted({key for row in rows for key in row})
 
         out_file = f"{profiler_dir}/profiler_out_{rank}.{export_format}"
         if export_format == "json":
             with open(out_file, "w") as f:
                 json.dump(rows, f, indent=2, default=str)
-        else:  # csv
+        elif export_format == "csv":
             for row in rows:
-                # Flatten non-primitive values (lists, tensors, etc.) for CSV.
                 for key, value in row.items():
                     if value is not None and not isinstance(
                         value, (int, float, bool, str)
@@ -304,6 +299,8 @@ class TorchProfilerWrapper(WorkerProfiler):
                 writer = csv.DictWriter(f, fieldnames=fieldnames, restval="")
                 writer.writeheader()
                 writer.writerows(rows)
+        else:
+            raise ValueError(f"Unsupported export format: {export_format}")
 
     @override
     def _start(self) -> None:
@@ -336,7 +333,6 @@ class TorchProfilerWrapper(WorkerProfiler):
             if rank == 0:
                 print(table)
 
-        # Structured formats replace the .txt file and are written once.
         if export_format in ("csv", "json"):
             self._export_profiler_table(rank)
 

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -3,6 +3,7 @@
 
 import csv
 import json
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import nullcontext
@@ -158,27 +159,23 @@ TorchProfilerActivityMap = {
 }
 
 
-# Per-event fields exported when torch_profiler_export_format is set.
-# Each maps to an attribute on torch's FunctionEventAvg (read defensively
-# with getattr so a missing attribute on a given torch version yields None
-# rather than raising).
-_PROFILER_EXPORT_FIELDS = (
-    "key",
-    "count",
-    "node_id",
-    "cpu_time_total",
-    "self_cpu_time_total",
-    "cpu_time",
-    "cuda_time_total",
-    "self_cuda_time_total",
-    "cuda_time",
-    "cpu_memory_usage",
-    "self_cpu_memory_usage",
-    "cuda_memory_usage",
-    "self_cuda_memory_usage",
-    "flops",
-    "input_shapes",
-)
+def _event_to_row(event: object) -> dict[str, object]:
+    """Extract every public, non-callable metric from a FunctionEventAvg."""
+    row: dict[str, object] = {}
+    # Reading every attribute touches deprecated cuda_* aliases; silence them.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for attr in dir(event):
+            if attr.startswith("_"):
+                continue
+            try:
+                value = getattr(event, attr)
+            except Exception:
+                continue
+            if callable(value):
+                continue
+            row[attr] = value
+    return row
 
 
 class TorchProfilerWrapper(WorkerProfiler):
@@ -283,7 +280,9 @@ class TorchProfilerWrapper(WorkerProfiler):
             with open(profiler_out_file, "w") as f:
                 print(table, file=f)
 
-    def _export_profiler_table(self, rank: int, export_format: str) -> None:
+    def _export_profiler_table(self, rank: int) -> None:
+        """Write per-event profiler metrics as a structured 'csv' or 'json' file."""
+        export_format = self.profiler_config.torch_profiler_table_format
         profiler_dir = self.profiler_config.torch_profiler_dir
 
         # Skip file write for URI paths (gs://, s3://, etc.)
@@ -291,10 +290,9 @@ class TorchProfilerWrapper(WorkerProfiler):
         if _is_uri_path(profiler_dir):
             return
 
-        rows = [
-            {field: getattr(event, field, None) for field in _PROFILER_EXPORT_FIELDS}
-            for event in self.profiler.key_averages()
-        ]
+        rows = [_event_to_row(event) for event in self.profiler.key_averages()]
+        # Stable, sorted superset of every metric seen across the events.
+        fieldnames = sorted({key for row in rows for key in row})
 
         out_file = f"{profiler_dir}/profiler_out_{rank}.{export_format}"
         if export_format == "json":
@@ -302,11 +300,14 @@ class TorchProfilerWrapper(WorkerProfiler):
                 json.dump(rows, f, indent=2, default=str)
         else:  # csv
             for row in rows:
-                # input_shapes is a nested list; flatten to a string for CSV.
-                if row["input_shapes"] is not None:
-                    row["input_shapes"] = str(row["input_shapes"])
+                # Flatten non-primitive values (lists, tensors, etc.) for CSV.
+                for key, value in row.items():
+                    if value is not None and not isinstance(
+                        value, (int, float, bool, str)
+                    ):
+                        row[key] = str(value)
             with open(out_file, "w", newline="") as f:
-                writer = csv.DictWriter(f, fieldnames=list(_PROFILER_EXPORT_FIELDS))
+                writer = csv.DictWriter(f, fieldnames=fieldnames, restval="")
                 writer.writeheader()
                 writer.writerows(rows)
 
@@ -320,9 +321,11 @@ class TorchProfilerWrapper(WorkerProfiler):
 
         profiler_config = self.profiler_config
         rank = self.local_rank
+        export_format = profiler_config.torch_profiler_table_format
         if profiler_config.torch_profiler_dump_cuda_time_total:
             table = self._build_profiler_table(sort_key="self_cuda_time_total")
-            self._write_profiler_table(rank, table)
+            if export_format == "txt":
+                self._write_profiler_table(rank, table)
 
             # only print profiler results on rank 0
             if rank == 0:
@@ -332,16 +335,16 @@ class TorchProfilerWrapper(WorkerProfiler):
             table = self._build_profiler_table(
                 sort_key="self_cpu_time_total", row_limit=50
             )
-            self._write_profiler_table(rank, table)
+            if export_format == "txt":
+                self._write_profiler_table(rank, table)
 
             # only print profiler results on rank 0
             if rank == 0:
                 print(table)
 
-        if profiler_config.torch_profiler_export_format:
-            self._export_profiler_table(
-                rank, profiler_config.torch_profiler_export_format
-            )
+        # Structured formats replace the .txt file and are written once.
+        if export_format in ("csv", "json"):
+            self._export_profiler_table(rank)
 
     @override
     def _profiler_step(self) -> bool:


### PR DESCRIPTION


## Purpose

The torch profiler currently only writes its key-averages summary as a
human-readable `.txt` table (`profiler_out_{rank}.txt`), which is hard to
post-process programmatically.

This PR adds a new profiler arg to instead export the per-kernel
profiler metrics as a structured file:

- New `ProfilerConfig` field `torch_profiler_table_format`
  (`Literal["txt", "csv", "json"]`, default `"txt"`), exposed on the CLI as
  `--profiler-config.torch_profiler_table_format=...`.
- users can set the arg to either `"csv"` / `"json"` .

## Test Plan

1. Launch a server with the torch profiler enabled, once per format (`txt`, `csv`, `json`):

```bash
vllm serve <model> \
  --profiler-config.profiler=torch \
  --profiler-config.torch_profiler_dir=/tmp/vllm_prof \
  --profiler-config.torch_profiler_table_format=csv   # repeat with  =json, or don't pass this arg for default txt behaviour
 ```
or
```bash
vllm serve <model> \
  --profiler-config '{"profiler": "torch", "torch_profiler_dir": "/tmp/vllm_prof", "torch_profiler_table_format" : "csv"}' 
 ```

2. Drive a short profiled benchmark against the server:
```bash
vllm bench serve --model <model> --num-prompts 8 --profile
```
3. Confirm the expected file type is produced and is parseable

4. Negative test — non-txt format with a non-torch profiler must raise ValueError:

```bash
vllm serve <model> --profiler-config.profiler=cuda --profiler-config.torch_profiler_table_format=csv
```

## Test Result

Detailed JSON or CSV generated in the profiler directory when setting the "torch_profiler_table_format" arg.

See output below:

[profiler_out_0.csv](https://github.com/user-attachments/files/28961471/profiler_out_0.csv)
[profiler_out_0.json](https://github.com/user-attachments/files/28961473/profiler_out_0.json)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

