### PR TITLE
[ROCm][DSv4] Add AITER MXFP4-MXFP8 W4A8 MoE backend

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import functools
+
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
@@ -20,6 +22,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 
 __all__ = [
     "AiterW4A8ExpertsMonolithic",
+    "AiterMxfp4Mxfp8ExpertsMonolithic",
     "aiter_triton_kernel_w4a8_moe_forward",
 ]
 
@@ -292,4 +295,291 @@ class AiterW4A8ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
             unpadded_K_w1=self.moe_config.hidden_dim_unpadded,
             unpadded_N_w2=self.moe_config.hidden_dim_unpadded,
             unpadded_K_w2=self.moe_config.intermediate_size_per_partition_unpadded,
+        )
+
+
+@functools.cache
+def _aiter_mxfp4_mxfp8_supported() -> bool:
+    """Whether the installed aiter exposes the routing APIs this backend needs."""
+    import inspect
+
+    try:
+        from aiter.ops.triton.moe.moe_routing.routing import (  # noqa: F401
+            routing,
+            routing_from_hash,
+        )
+
+        return "use_grouped_topk" in inspect.signature(routing).parameters
+    except Exception:
+        return False
+
+
+def _aiter_mxfp4_mxfp8_fused_experts(
+    hidden_states: torch.Tensor,
+    w1,  # Tensor or triton_kernels.Tensor
+    w2,  # Tensor or triton_kernels.Tensor
+    routing_data,  # RoutingData
+    gather_indx,  # GatherIndx
+    scatter_indx,  # ScatterIndx
+    quant_config: FusedMoEQuantConfig,
+    swiglu_alpha: float = 1.0,
+    swiglu_limit: float = 1e30,
+    apply_router_weight_on_input: bool = False,
+    a1q_scale: torch.Tensor | None = None,
+    unpadded_N_w1=None,
+    unpadded_K_w1=None,
+    unpadded_N_w2=None,
+    unpadded_K_w2=None,
+    fold_inter_stage_requant: bool = False,
+) -> torch.Tensor:
+    """MXFP4 weights + dynamic per-1x32 MXFP8 activations, two-stage moe_gemm_a8w4."""
+    assert quant_config is not None
+    assert quant_config.w1_bias is None or quant_config.w1_bias.dtype == torch.float32
+    assert quant_config.w2_bias is None or quant_config.w2_bias.dtype == torch.float32
+    assert hidden_states.shape[-1] == w1.shape[-2]
+    assert w2.shape[-1] == w1.shape[1]
+    assert quant_config.w1_precision is not None, (
+        "w1_precision in quant config can't be None"
+    )
+    assert quant_config.w2_precision is not None, (
+        "w2_precision in quant config can't be None"
+    )
+
+    gammas = routing_data.gate_scal if routing_data else None
+
+    from aiter.ops.triton.moe.moe_op_gemm_a8w4 import moe_gemm_a8w4
+    from aiter.ops.triton.moe.quant_moe import downcast_to_mxfp
+
+    from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
+        should_use_cdna4_mx_scale_swizzle,
+    )
+
+    # Load-time scale swizzle (_swizzle_mxfp4) and this kernel arg must agree;
+    # both gate on the same predicate (gfx950 AND TP<=2).
+    swizzle = "CDNA4_SCALE" if should_use_cdna4_mx_scale_swizzle() else None
+
+    # Dual-mode input: a pre-quantized fp8 activation (+a1q_scale, e.g. from the
+    # prepare step) is used as-is; otherwise quantize the bf16 input here.
+    if hidden_states.dtype == torch.float8_e4m3fn:
+        assert a1q_scale is not None, "pre-quantized fp8 activations require a1q_scale"
+        x_q, x_sc = hidden_states, a1q_scale
+    else:
+        x_q, x_sc = downcast_to_mxfp(hidden_states, torch.float8_e4m3fn, axis=-1)
+
+    stage1 = moe_gemm_a8w4(
+        x_q,
+        w1.storage.data,
+        x_sc,
+        quant_config.w1_precision.weight_scale.storage.data,
+        None,
+        None,
+        quant_config.w1_bias,
+        routing_data,
+        gather_indx=gather_indx,
+        gammas=gammas if apply_router_weight_on_input else None,
+        swizzle_mx_scale=swizzle,
+        out_dtype=torch.bfloat16,
+        apply_swiglu=True,
+        alpha=swiglu_alpha,
+        limit=swiglu_limit,
+        swiglu_add_residual=False,
+        out_mx_quant=fold_inter_stage_requant,
+        unpadded_N=unpadded_N_w1,
+        unpadded_K=unpadded_K_w1,
+    )
+    if fold_inter_stage_requant:
+        inter_q, inter_sc = stage1
+    else:
+        inter_q, inter_sc = downcast_to_mxfp(stage1, torch.float8_e4m3fn, axis=-1)
+
+    return moe_gemm_a8w4(
+        inter_q,
+        w2.storage.data,
+        inter_sc,
+        quant_config.w2_precision.weight_scale.storage.data,
+        None,
+        None,
+        quant_config.w2_bias,
+        routing_data,
+        scatter_indx=scatter_indx,
+        gammas=None if apply_router_weight_on_input else gammas,
+        swizzle_mx_scale=swizzle,
+        out_dtype=torch.bfloat16,
+        unpadded_N=unpadded_N_w2,
+        unpadded_K=unpadded_K_w2,
+    )
+
+
+class AiterMxfp4Mxfp8ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
+    """
+    Monolithic MXFP4 W4A8 expert using AITER triton kernels, for DeepSeek-V4.
+
+    This backend uses:
+    - aiter.ops.triton.moe.moe_routing.routing for routing (DeepSeek-V4 noaux_tc)
+    - aiter.ops.triton.moe.moe_op_gemm_a8w4.moe_gemm_a8w4 for computation
+
+    Weight format: MXFP4 weights with GFX950 swizzle
+    Activation: Dynamic per-1x32 MXFP8 quantization
+    """
+
+    # Fold the inter-stage mxfp8 requant into stage1's out_mx_quant epilogue.
+    # That epilogue requires split_k == 1, which holds at decode (NK <= this);
+    # prefill (NK > this) uses the explicit 2-kernel requant instead.
+    _FOLD_REQUANT_MAX_NK = 4096
+
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+    ):
+        super().__init__(moe_config, quant_config)
+        self.topk = moe_config.experts_per_token
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        if not rocm_aiter_ops.is_enabled():
+            return False
+        from vllm.platforms.rocm import on_gfx950
+
+        return on_gfx950() and _aiter_mxfp4_mxfp8_supported()
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        return False
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        # MXFP4 weights; FP8 activation is quantized dynamically in-class.
+        return (weight_key, activation_key) == (kMxfp4Static, None)
+
+    @staticmethod
+    def _supports_activation(activation: MoEActivation) -> bool:
+        return activation == MoEActivation.SILU
+
+    @staticmethod
+    def _supports_parallel_config(
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> bool:
+        # aiter routing() has no expert_map argument -> TP only (no EP/DP).
+        return (
+            not moe_parallel_config.use_all2all_kernels
+            and not moe_parallel_config.enable_eplb
+            and moe_parallel_config.dp_size <= 1
+        )
+
+    @staticmethod
+    def _supports_routing_method(
+        routing_method: RoutingMethodType,
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return routing_method == RoutingMethodType.DeepseekV4
+
+    @staticmethod
+    def _supports_router_logits_dtype(
+        router_logits_dtype: torch.dtype | None,
+        routing_method: RoutingMethodType,
+    ) -> bool:
+        return True
+
+    @property
+    def expects_unquantized_inputs(self) -> bool:
+        # Take bf16 and self-quantize to per-1x32 mxfp8
+        return True
+
+    def apply(
+        self,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        router_logits: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        apply_router_weight_on_input: bool,
+        # grouped topk + fused topk bias parameters
+        num_expert_group: int | None = None,
+        e_score_correction_bias: torch.Tensor | None = None,
+        routed_scaling_factor: float | None = None,
+        topk_group: int | None = None,
+        # DeepSeek-V4 hash-layer routing
+        input_ids: torch.Tensor | None = None,
+        hash_indices_table: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        import triton
+        from aiter.ops.triton.moe.moe_routing.routing import routing
+
+        qc = self.quant_config
+        assert qc is not None and qc.use_mxfp4_w4a8 and rocm_aiter_ops.is_enabled()
+        assert self.moe_config.intermediate_size_per_partition_unpadded is not None
+        assert self.moe_config.hidden_dim_unpadded is not None
+
+        rsf = routed_scaling_factor or 1.0
+        if hash_indices_table is not None:
+            # DSv4 hash layer: experts come from the tid2eid table (by token id),
+            # not logits top-k
+            assert input_ids is not None, "DSv4 hash MoE routing requires input_ids"
+            from aiter.ops.triton.moe.moe_routing.routing import routing_from_hash
+
+            E = global_num_experts if global_num_experts > 0 else w1.shape[0]
+            M = router_logits.shape[0]
+            block_m = max(
+                16, min(triton.next_power_of_2(max(M * self.topk // E, 1)), 128)
+            )
+            routing_data, gather_idx, scatter_idx = routing_from_hash(
+                router_logits,
+                hash_indices_table,
+                input_ids,
+                self.topk,
+                block_m,
+                score_mode="sqrtsoftplus",
+                renorm=True,
+                routed_scaling_factor=rsf,
+            )
+        else:
+            use_grouped = num_expert_group is not None and num_expert_group > 1
+            routing_data, gather_idx, scatter_idx = routing(
+                router_logits,
+                self.topk,
+                score_mode="sqrtsoftplus",
+                bias=e_score_correction_bias,
+                renorm=True,
+                routed_scaling_factor=rsf,
+                use_grouped_topk=use_grouped,
+                num_expert_group=num_expert_group,
+                topk_group=topk_group,
+            )
+
+        unpadded_i = self.moe_config.intermediate_size_per_partition_unpadded
+        unpadded_h = self.moe_config.hidden_dim_unpadded
+        nk = router_logits.shape[0] * self.topk
+        fold = nk <= self._FOLD_REQUANT_MAX_NK
+        swiglu_limit = (
+            qc.gemm1_clamp_limit if qc.gemm1_clamp_limit is not None else 1e30
+        )
+        return _aiter_mxfp4_mxfp8_fused_experts(
+            hidden_states,
+            w1,
+            w2,
+            routing_data,
+            gather_idx,
+            scatter_idx,
+            quant_config=qc,
+            swiglu_alpha=1.0,
+            swiglu_limit=swiglu_limit,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            a1q_scale=a1q_scale,
+            unpadded_N_w1=unpadded_i * 2,
+            unpadded_K_w1=unpadded_h,
+            unpadded_N_w2=unpadded_h,
+            unpadded_K_w2=unpadded_i,
+            fold_inter_stage_requant=fold,
         )

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -199,6 +199,7 @@ class FusedMoEMethodBase(QuantizeMethodBase):
         x: torch.Tensor,
         router_logits: torch.Tensor,
         input_ids: torch.Tensor | None = None,
+        hash_indices_table: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         Apply the MoE operation using monolithic kernels.

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import inspect
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -1452,6 +1453,9 @@ class FusedMoEKernelMonolithicImpl:
         e_score_correction_bias: torch.Tensor | None = None,
         routed_scaling_factor: float | None = None,
         topk_group: int | None = None,
+        # DeepSeek-V4 hash-layer routing
+        input_ids: torch.Tensor | None = None,
+        hash_indices_table: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         Same as forward(), except uses router_logits as opposed
@@ -1465,6 +1469,14 @@ class FusedMoEKernelMonolithicImpl:
             quant_config=self.fused_experts.quant_config,
             defer_input_quant=self.fused_experts.expects_unquantized_inputs,
         )
+
+        # Only pass hash-routing inputs to backends that declare them.
+        extra_kwargs: dict = {}
+        _apply_params = inspect.signature(self.fused_experts.apply).parameters
+        if "input_ids" in _apply_params:
+            extra_kwargs["input_ids"] = input_ids
+        if "hash_indices_table" in _apply_params:
+            extra_kwargs["hash_indices_table"] = hash_indices_table
 
         fused_out = self.fused_experts.apply(
             hidden_states=a1q,
@@ -1481,6 +1493,7 @@ class FusedMoEKernelMonolithicImpl:
             e_score_correction_bias=e_score_correction_bias,
             routed_scaling_factor=routed_scaling_factor,
             topk_group=topk_group,
+            **extra_kwargs,
         )
 
         output = self.prepare_finalize.finalize(fused_out)
@@ -1583,6 +1596,9 @@ class FusedMoEKernel:
         e_score_correction_bias: torch.Tensor | None = None,
         routed_scaling_factor: float | None = None,
         topk_group: int | None = None,
+        # DeepSeek-V4 hash-layer routing
+        input_ids: torch.Tensor | None = None,
+        hash_indices_table: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert isinstance(self.impl, FusedMoEKernelMonolithicImpl)
         return self.impl.apply(
@@ -1598,6 +1614,8 @@ class FusedMoEKernel:
             e_score_correction_bias=e_score_correction_bias,
             routed_scaling_factor=routed_scaling_factor,
             topk_group=topk_group,
+            input_ids=input_ids,
+            hash_indices_table=hash_indices_table,
         )
 
     def apply(

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -76,6 +76,7 @@ class Mxfp4MoeBackend(Enum):
     AITER = "AITER_MXFP4_BF16"
     AITER_MXFP4_FP8 = "AITER_MXFP4_FP8"  # W4A8: triton kernel
     AITER_MXFP4_MXFP4 = "AITER_MXFP4_MXFP4"  # W4A4: CK kernel
+    AITER_MXFP4_MXFP8 = "AITER_MXFP4_MXFP8"  # W4A8: triton kernel
     # Triton
     TRITON = "TRITON"
     TRITON_UNFUSED = "TRITON_UNFUSED"
@@ -94,6 +95,7 @@ AITER_BACKENDS = (
     Mxfp4MoeBackend.AITER_MXFP4_BF16,
     Mxfp4MoeBackend.AITER_MXFP4_FP8,
     Mxfp4MoeBackend.AITER_MXFP4_MXFP4,
+    Mxfp4MoeBackend.AITER_MXFP4_MXFP8,
 )
 
 
@@ -205,6 +207,13 @@ def backend_to_kernel_cls(
 
         return [AiterExperts]
 
+    elif backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP8:
+        from vllm.model_executor.layers.fused_moe.experts.aiter_mxfp4_w4a8_moe import (
+            AiterMxfp4Mxfp8ExpertsMonolithic,
+        )
+
+        return [AiterMxfp4Mxfp8ExpertsMonolithic]
+
     elif backend == Mxfp4MoeBackend.XPU:
         from vllm.model_executor.layers.fused_moe.experts.xpu_moe import XPUExpertsMxFp4
 
@@ -255,6 +264,7 @@ def map_mxfp4_backend(runner_backend: MoEBackend) -> list[Mxfp4MoeBackend]:
         ],
         "aiter_mxfp4_fp8": [Mxfp4MoeBackend.AITER_MXFP4_FP8],
         "aiter_mxfp4_mxfp4": [Mxfp4MoeBackend.AITER_MXFP4_MXFP4],
+        "aiter_mxfp4_mxfp8": [Mxfp4MoeBackend.AITER_MXFP4_MXFP8],
         "xpu": [Mxfp4MoeBackend.XPU],
         "cpu": [Mxfp4MoeBackend.CPU],
         "emulation": [Mxfp4MoeBackend.EMULATION],
@@ -554,13 +564,14 @@ def select_deepseek_v4_mxfp4_moe_backend(
         assert last_error is not None
         raise last_error
 
-    # DeepSeek-V4 on ROCm: prefer AITER FlyDSL MoE (better perf + accuracy
-    # after shuffle/TP-offset fixes), with Triton-unfused as fallback.
+    # DeepSeek-V4 on ROCm: try the AITER W4A8 path (gfx950 + aiter, self-gated)
+    # first, then BF16-activation AITER, then Triton-unfused.
     if (
         current_platform.is_rocm()
         and config.routing_method == RoutingMethodType.DeepseekV4
     ):
         priority_backends = [
+            Mxfp4MoeBackend.AITER_MXFP4_MXFP8,
             Mxfp4MoeBackend.AITER_MXFP4_BF16,
             Mxfp4MoeBackend.TRITON_UNFUSED,
         ]
@@ -1395,6 +1406,47 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w2_bias,
         )
 
+    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP8:
+        from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
+
+        if w13_bias is not None:
+            w13_bias = w13_bias.to(torch.float32)
+        if w2_bias is not None:
+            w2_bias = w2_bias.to(torch.float32)
+
+        e, n, k = w13_weight.shape
+        w13_weight = (
+            w13_weight.view(e, 2, n // 2, k)
+            .permute(0, 2, 1, 3)
+            .reshape(e, n, k)
+            .contiguous()
+        )
+        w13_weight_scale = (
+            w13_weight_scale.view(e, 2, n // 2, -1)
+            .permute(0, 2, 1, 3)
+            .reshape(e, n, -1)
+            .contiguous()
+        )
+
+        w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(w13_weight, w13_weight_scale)
+        w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(w2_weight, w2_weight_scale)
+        w13_precision_config = PrecisionConfig(
+            weight_scale=w13_scale, flex_ctx=FlexCtx(rhs_data=w13_flex)
+        )
+        w2_precision_config = PrecisionConfig(
+            weight_scale=w2_scale, flex_ctx=FlexCtx(rhs_data=w2_flex)
+        )
+        del layer.w13_weight
+        del layer.w2_weight
+        return (
+            w13_weight,
+            w2_weight,
+            w13_precision_config,
+            w2_precision_config,
+            w13_bias,
+            w2_bias,
+        )
+
     elif mxfp4_backend in TRITON_BACKENDS:
         from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
 
@@ -1521,8 +1573,12 @@ def make_mxfp4_moe_quant_config(
             gemm1_clamp_limit=swiglu_limit,
             is_scale_swizzled=True,
         )
-    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_FP8:
-        # W4A8: MXFP4 weights + static FP8 activations
+    elif mxfp4_backend in (
+        Mxfp4MoeBackend.AITER_MXFP4_FP8,
+        Mxfp4MoeBackend.AITER_MXFP4_MXFP8,
+    ):
+        # W4A8: MXFP4 weights + FP8 activations (static for AITER_MXFP4_FP8;
+        # dynamic per-1x32 mxfp8, quantized in-kernel, for AITER_MXFP4_MXFP8).
         return mxfp4_w4a8_moe_quant_config(
             w1_scale=w1_scale,
             w2_scale=w2_scale,

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -1088,6 +1088,7 @@ class RoutedExperts(PluggableLayer):
         x: torch.Tensor,
         router_logits: torch.Tensor | None = None,
         input_ids: torch.Tensor | None = None,
+        hash_indices_table: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         Execute routed experts using the quantization method's apply function.
@@ -1113,6 +1114,7 @@ class RoutedExperts(PluggableLayer):
             x=x,
             router_logits=router_logits,
             input_ids=input_ids,
+            hash_indices_table=hash_indices_table,
         )
 
     def forward(

--- a/vllm/model_executor/layers/fused_moe/router/fused_moe_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_moe_router.py
@@ -19,6 +19,15 @@ class FusedMoERouter(ABC):
         self._routing_replay_out: torch.Tensor | None = None
         self.eplb_state = eplb_state
 
+    @property
+    def hash_indices_table(self) -> torch.Tensor | None:
+        """DeepSeek-V4 hash-layer tid2eid table, or None.
+
+        Monolithic kernels read this to do the hash lookup themselves, since the
+        runner skips select_experts for them.
+        """
+        return getattr(self, "_hash_indices_table", None)
+
     @abstractmethod
     def set_capture_fn(
         self,

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -547,11 +547,13 @@ class MoERunner(MoERunnerInterface):
         )
 
         if self.routed_experts.quant_method.is_monolithic:
-            # Monolithic kernels: pass router_logits to routed_experts
+            # Monolithic kernels route internally (select_experts is skipped),
+            # so forward the router's hash table for DSv4 hash-layer routing.
             fused_out = self.routed_experts.forward_monolithic(
                 x=hidden_states,
                 router_logits=router_logits,
                 input_ids=input_ids,
+                hash_indices_table=self.router.hash_indices_table,
             )
         else:
             # Modular kernels: select experts first, then call routed_experts

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -36,6 +36,8 @@ from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
 logger = init_logger(__name__)
 
+_PRECISION_CONFIG_BACKENDS = (*TRITON_BACKENDS, Mxfp4MoeBackend.AITER_MXFP4_MXFP8)
+
 
 class Mxfp4Config(QuantizationConfig):
     """Canonical base config for MXFP4 quantization.
@@ -343,7 +345,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
 
         # For TRITON backends, weights are wrapped tensors from triton_kernels
         # that don't support .detach(). Manually assign parameters.
-        if self.mxfp4_backend not in TRITON_BACKENDS:
+        if self.mxfp4_backend not in _PRECISION_CONFIG_BACKENDS:
             replace_parameter(layer, "w13_weight", w13)
             replace_parameter(layer, "w2_weight", w2)
             replace_parameter(layer, "w13_weight_scale", w13_scale)
@@ -398,7 +400,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
         w1_bias = getattr(layer, "w13_bias", None)
         w2_bias = getattr(layer, "w2_bias", None)
 
-        if self.mxfp4_backend in TRITON_BACKENDS:
+        if self.mxfp4_backend in _PRECISION_CONFIG_BACKENDS:
             assert self.w13_precision_config is not None
             assert self.w2_precision_config is not None
             w1_scale = self.w13_precision_config
@@ -457,6 +459,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
         x: torch.Tensor,
         router_logits: torch.Tensor,
         input_ids: torch.Tensor | None = None,
+        hash_indices_table: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert self.is_monolithic
         assert self.moe_kernel is not None
@@ -469,6 +472,8 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
             global_num_experts=layer.global_num_experts,
             expert_map=layer.expert_map,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            input_ids=input_ids,
+            hash_indices_table=hash_indices_table,
         )
 
 
@@ -687,7 +692,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         # For TRITON backends, weights are wrapped tensors from triton_kernels
         # that don't support .detach(). Manually assign parameters.
-        if self.mxfp4_backend not in TRITON_BACKENDS:
+        if self.mxfp4_backend not in _PRECISION_CONFIG_BACKENDS:
             replace_parameter(layer, "w13_weight", w13)
             replace_parameter(layer, "w2_weight", w2)
             replace_parameter(layer, "w13_weight_scale", w13_scale)
@@ -744,7 +749,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         w2_bias = getattr(layer, "w2_bias", None)
         swiglu_limit = getattr(layer, "swiglu_limit", None)
 
-        if self.mxfp4_backend in TRITON_BACKENDS:
+        if self.mxfp4_backend in _PRECISION_CONFIG_BACKENDS:
             assert self.w13_precision_config is not None
             assert self.w2_precision_config is not None
             w1_scale = self.w13_precision_config
@@ -801,6 +806,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         x: torch.Tensor,
         router_logits: torch.Tensor,
         input_ids: torch.Tensor | None = None,
+        hash_indices_table: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert self.is_monolithic
         assert self.moe_kernel is not None
@@ -813,4 +819,12 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             global_num_experts=layer.global_num_experts,
             expert_map=layer.expert_map,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            # Monolithic routes internally, so pass the routing config the router
+            # would use (routed_scaling_factor is already output-scale-adjusted).
+            num_expert_group=layer.num_expert_group,
+            e_score_correction_bias=layer.e_score_correction_bias,
+            routed_scaling_factor=layer.routed_scaling_factor,
+            topk_group=layer.topk_group,
+            input_ids=input_ids,
+            hash_indices_table=hash_indices_table,
         )


### PR DESCRIPTION
## Purpose

Adds a W4A8 fused-MoE backend for DeepSeek-V4 on ROCm/gfx950, MXFP4 weights with dynamic per-1x32 MXFP8 activations.

 It's a monolithic MoE backend but the hash table is threaded through multiple calls, which increased the number of touched files. This was needed to bring the routing tensors to the monolithic backend for DSV4.

On gfx950 + DeepSeek-V4 the MXFP4 oracle now prefers this path. If aiter that lacks them the oracle falls back cleanly.

TODO:

- [ ] Do a concurrency sweep

## Test Plan

DeepSeek-V4-Pro, TP=8 on MI355X (gfx950)

Accuracy (lm-eval, gsm8k 5-shot, 64 concurrent):
```
lm_eval --model local-completions \
  --model_args model=$MODEL,base_url=http://localhost:8000/v1/completions,num_concurrent=64 \
  --tasks gsm8k --num_fewshot 5 --limit 2000
```

Throughput (`vllm bench serve`, random ISL/OSL 1024/1024, 64 concurrent, 640 prompts):
```
vllm bench serve --backend vllm --model $MODEL --dataset-name random \
  --random-input-len 1024 --random-output-len 1024 --max-concurrency 64 \
  --num-prompts 640 --ignore-eos
```

Both run with `--moe-backend auto` (selects `AITER_MXFP4_MXFP8`) and, as a
baseline, `--moe-backend triton_unfused`.

## Test Result

Backend selected by `auto`: `AITER_MXFP4_MXFP8` (confirmed in the server log).

| Metric | `AITER_MXFP4_MXFP8` (this PR, `auto`) | `AITER_MXFP4_BF16` (a16w4) | `TRITON_UNFUSED` (baseline) |
| --- | --- | --- | --- |
| gsm8k exact_match (flex / strict) | 0.9522 / 0.9522 | 0.9454 / 0.9454 | 0.9507 / 0.9515 |
| Output throughput (tok/s) | **1572.8** | 1445.6 | 1217.9 |
| Request throughput (req/s) | **1.54** | 1.41 | 1.19 |
| Median TPOT (ms) | **39.2** | 42.7 | 51.0 |
| Median ITL (ms) | **36.8** | 40.0 | 48.2 |
| Median TTFT (ms) | **1406.3** | 1449.0 | 1594.7 |


Notes:
-  `AITER_MXFP4_BF16` was run on ToT vLLM + the pinned aiter, was having issues running it with ToT aiter.