### PR TITLE
[Misc] Add pure decode throughput to `vllm bench serve` results

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1153,6 +1153,11 @@ async def benchmark(
         )
         actual_output_lens = 0
 
+    if diffusion_stats is not None and isinstance(metrics, BenchmarkMetrics):
+        # Committed decode-only throughput (excludes the first canvas, which
+        # lands in TTFT). See BenchmarkMetrics.decode_throughput.
+        diffusion_stats["decode_throughput"] = metrics.decode_throughput
+
     print("{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=50, c="="))
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
     print("{:<40} {:<10}".format("Failed requests:", metrics.failed))
@@ -1183,10 +1188,10 @@ async def benchmark(
                     metrics.output_throughput,
                 )
             )
-            if metrics.decode_throughput > 0:
+            if metrics.decode_throughput > 0 and diffusion_stats is None:
                 print(
                     "{:<40} {:<10.2f}".format(
-                        "Output throughput (decode only) (tok/s):",
+                        "Output throughput (excl. prefill) (tok/s):",
                         metrics.decode_throughput,
                     )
                 )
@@ -1268,6 +1273,7 @@ async def benchmark(
         result["diffusion_committed_throughput"] = diffusion_stats[
             "committed_throughput"
         ]
+        result["diffusion_decode_throughput"] = diffusion_stats["decode_throughput"]
         result["diffusion_steps_per_canvas"] = diffusion_stats["steps_per_canvas"]
         result["diffusion_committed_per_step"] = diffusion_stats["committed_per_step"]
         result["diffusion_committed_tokens"] = int(diffusion_stats["committed_tokens"])
@@ -1322,7 +1328,16 @@ async def benchmark(
     if diffusion_stats is not None:
         print("{s:{c}^{n}}".format(s="Diffusion Decoding", n=50, c="-"))
         for label, key, value_fmt in (
-            ("Committed throughput (tok/s):", "committed_throughput", "{:<10.2f}"),
+            (
+                "Committed throughput (e2e, incl. prefill) (tok/s):",
+                "committed_throughput",
+                "{:<10.2f}",
+            ),
+            (
+                "Committed throughput (excl. prefill) (tok/s):",
+                "decode_throughput",
+                "{:<10.2f}",
+            ),
             ("Denoising steps per canvas:", "steps_per_canvas", "{:<10.2f}"),
             ("Committed per denoising step:", "committed_per_step", "{:<10.2f}"),
             ("Committed tokens:", "committed_tokens", "{:<10d}"),

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1128,7 +1128,6 @@ async def benchmark(
                 "denoising_steps": denoising_steps,
                 "canvas_positions": delta_positions,
                 "committed_tokens": delta_committed,
-                "committed_throughput": delta_committed / benchmark_duration,
                 "steps_per_canvas": denoising_steps / num_canvases,
                 "committed_per_step": delta_committed / denoising_steps,
             }
@@ -1152,11 +1151,6 @@ async def benchmark(
             selected_percentiles=selected_percentiles,
         )
         actual_output_lens = 0
-
-    if diffusion_stats is not None and isinstance(metrics, BenchmarkMetrics):
-        # Committed decode-only throughput (excludes the first canvas, which
-        # lands in TTFT). See BenchmarkMetrics.decode_throughput.
-        diffusion_stats["decode_throughput"] = metrics.decode_throughput
 
     print("{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=50, c="="))
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
@@ -1184,14 +1178,14 @@ async def benchmark(
         if tokenizer:
             print(
                 "{:<40} {:<10.2f}".format(
-                    "Output throughput (e2e, incl. prefill) (tok/s):",
+                    "Output throughput (incl. TTFT) (tok/s):",
                     metrics.output_throughput,
                 )
             )
-            if metrics.decode_throughput > 0 and diffusion_stats is None:
+            if metrics.decode_throughput > 0:
                 print(
                     "{:<40} {:<10.2f}".format(
-                        "Output throughput (excl. prefill) (tok/s):",
+                        "Output throughput (excl. TTFT) (tok/s):",
                         metrics.decode_throughput,
                     )
                 )
@@ -1270,10 +1264,6 @@ async def benchmark(
         )
 
     if diffusion_stats is not None:
-        result["diffusion_committed_throughput"] = diffusion_stats[
-            "committed_throughput"
-        ]
-        result["diffusion_decode_throughput"] = diffusion_stats["decode_throughput"]
         result["diffusion_steps_per_canvas"] = diffusion_stats["steps_per_canvas"]
         result["diffusion_committed_per_step"] = diffusion_stats["committed_per_step"]
         result["diffusion_committed_tokens"] = int(diffusion_stats["committed_tokens"])
@@ -1328,16 +1318,6 @@ async def benchmark(
     if diffusion_stats is not None:
         print("{s:{c}^{n}}".format(s="Diffusion Decoding", n=50, c="-"))
         for label, key, value_fmt in (
-            (
-                "Committed throughput (e2e, incl. prefill) (tok/s):",
-                "committed_throughput",
-                "{:<10.2f}",
-            ),
-            (
-                "Committed throughput (excl. prefill) (tok/s):",
-                "decode_throughput",
-                "{:<10.2f}",
-            ),
             ("Denoising steps per canvas:", "steps_per_canvas", "{:<10.2f}"),
             ("Committed per denoising step:", "committed_per_step", "{:<10.2f}"),
             ("Committed tokens:", "committed_tokens", "{:<10d}"),

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -325,7 +325,11 @@ class BenchmarkMetrics:
     total_output: int
     request_throughput: float
     request_goodput: float
+    # Total output tokens / wall-clock; the window includes prefill (TTFT).
     output_throughput: float
+    # Per-request median of (output_len - first_chunk) / sum(itls); excludes
+    # prefill. 0.0 if uncomputable (e.g. no itls when streaming is disabled).
+    decode_throughput: float
     total_token_throughput: float
     mean_ttft_ms: float
     median_ttft_ms: float
@@ -560,6 +564,7 @@ def calculate_metrics(
     tokenizer: TokenizerLike,
     selected_percentiles: list[float],
     goodput_config_dict: dict[str, float],
+    decode_first_chunk: float = 1.0,
 ) -> tuple[BenchmarkMetrics, list[int]]:
     """Calculate the metrics for the benchmark.
 
@@ -570,6 +575,9 @@ def calculate_metrics(
         tokenizer: The tokenizer to use.
         selected_percentiles: The percentiles to select.
         goodput_config_dict: The goodput configuration.
+        decode_first_chunk: Output tokens produced during TTFT, excluded from
+            decode throughput. 1 for autoregressive models, the canvas length
+            for diffusion.
 
     Returns:
         A tuple of the benchmark metrics and the actual output lengths.
@@ -581,6 +589,7 @@ def calculate_metrics(
     itls: list[float] = []
     tpots: list[float] = []
     all_tpots: list[float] = []
+    decode_tputs: list[float] = []
     ttfts: list[float] = []
     e2els: list[float] = []
     input_audio_duration = 0.0
@@ -612,6 +621,10 @@ def calculate_metrics(
             # Note: if output_len <= 1, we regard tpot as 0 for goodput
             all_tpots.append(tpot)
             itls += outputs[i].itl
+            # Per-request decode-only throughput (see decode_throughput field).
+            sum_itl = sum(outputs[i].itl)
+            if output_len > decode_first_chunk and sum_itl > 0:
+                decode_tputs.append((output_len - decode_first_chunk) / sum_itl)
             ttfts.append(outputs[i].ttft)
             e2els.append(outputs[i].latency)
             input_audio_duration += outputs[i].input_audio_duration
@@ -731,6 +744,7 @@ def calculate_metrics(
         request_throughput=completed / dur_s,
         request_goodput=good_completed / dur_s,
         output_throughput=sum(actual_output_lens) / dur_s,
+        decode_throughput=float(np.median(decode_tputs)) if decode_tputs else 0.0,
         total_token_throughput=(total_input + sum(actual_output_lens)) / dur_s,
         mean_ttft_ms=np.mean(ttfts or 0)
         * 1000,  # ttfts is empty if streaming is not supported by the endpoint
@@ -1091,6 +1105,7 @@ async def benchmark(
 
     diffusion_metrics_after = await fetch_diffusion_metrics(base_url, session)
     diffusion_stats: dict[str, Any] | None = None
+    decode_first_chunk: float = 1.0  # AR: first token; diffusion: set below
     if diffusion_metrics_before is not None and diffusion_metrics_after is not None:
         delta_steps = (
             diffusion_metrics_after.num_denoising_steps
@@ -1106,6 +1121,7 @@ async def benchmark(
         )
         if delta_steps > 0 and delta_committed > 0:
             block_size = delta_positions / delta_steps  # canvas length (CL)
+            decode_first_chunk = round(block_size)  # first canvas lands in TTFT
             num_canvases = delta_committed / block_size  # = number of commit steps
             denoising_steps = delta_steps - num_canvases  # exclude commit steps
             diffusion_stats = {
@@ -1127,6 +1143,7 @@ async def benchmark(
             tokenizer=tokenizer,
             selected_percentiles=selected_percentiles,
             goodput_config_dict=goodput_config_dict,
+            decode_first_chunk=decode_first_chunk,
         )
     else:
         metrics = calculate_metrics_for_embeddings(
@@ -1162,9 +1179,17 @@ async def benchmark(
         if tokenizer:
             print(
                 "{:<40} {:<10.2f}".format(
-                    "Output token throughput (tok/s):", metrics.output_throughput
+                    "Output throughput (e2e, incl. prefill) (tok/s):",
+                    metrics.output_throughput,
                 )
             )
+            if metrics.decode_throughput > 0:
+                print(
+                    "{:<40} {:<10.2f}".format(
+                        "Output throughput (decode only) (tok/s):",
+                        metrics.decode_throughput,
+                    )
+                )
             print(
                 "{:<40} {:<10.2f}".format(
                     "Peak output token throughput (tok/s):",
@@ -1200,6 +1225,7 @@ async def benchmark(
             "request_throughput": metrics.request_throughput,
             "request_goodput": metrics.request_goodput if goodput_config_dict else None,
             "output_throughput": metrics.output_throughput,
+            "decode_throughput": metrics.decode_throughput,
             "total_token_throughput": metrics.total_token_throughput,
             "input_lens": [output.prompt_len for output in outputs],
             "output_lens": actual_output_lens,


### PR DESCRIPTION
## Purpose
The throughput reported in `vllm bench serve` includes prefill time in the denominator, which gives a good sense of overall throughput but is misleading to those looking to benchmark pure decode performance. This PR adds such a measurement to the `vllm bench serve` results.

## Test Plan

```
vllm bench serve \
    --backend vllm \
    --base-url http://localhost:8000 \
    --model "RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic" \
    --dataset-name random \
    --random-input-len 4096 \
    --random-output-len 512 \
    --ignore-eos \
    --num-prompts 100 \
    --max-concurrency 1
```

## Test Result

main
```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Maximum request concurrency:             1
Benchmark duration (s):                  58.56
Total input tokens:                      409600
Total generated tokens:                  51200
Request throughput (req/s):              1.71
Output token throughput (tok/s):         874.25
Peak output token throughput (tok/s):    5.00
Peak concurrent requests:                3.00
Total token throughput (tok/s):          7868.28
---------------Time to First Token----------------
Mean TTFT (ms):                          389.48
Median TTFT (ms):                        341.80
P99 TTFT (ms):                           646.89
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.38
Median TPOT (ms):                        0.45
P99 TPOT (ms):                           0.64
---------------Inter-token Latency----------------
Mean ITL (ms):                           195.93
Median ITL (ms):                         230.56
P99 ITL (ms):                            325.61
----------------Diffusion Decoding----------------
Committed throughput (tok/s):            874.25
Denoising steps per canvas:              15.99
Committed per denoising step:            16.01
Committed tokens:                        51200
Denoising steps:                         3199
Canvas positions evaluated:              870144
==================================================
```

PR
```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Maximum request concurrency:             1
Benchmark duration (s):                  58.88
Total input tokens:                      409600
Total generated tokens:                  51200
Request throughput (req/s):              1.70
Output throughput (incl. TTFT) (tok/s):  869.61
Output throughput (excl. TTFT) (tok/s):  1103.24
Peak output token throughput (tok/s):    4.00
Peak concurrent requests:                3.00
Total token throughput (tok/s):          7826.49
---------------Time to First Token----------------
Mean TTFT (ms):                          395.43
Median TTFT (ms):                        340.79
P99 TTFT (ms):                           639.61
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.38
Median TPOT (ms):                        0.45
P99 TPOT (ms):                           0.63
---------------Inter-token Latency----------------
Mean ITL (ms):                           193.12
Median ITL (ms):                         232.05
P99 ITL (ms):                            320.53
----------------Diffusion Decoding----------------
Denoising steps per canvas:              15.99
Committed per denoising step:            16.01
Committed tokens:                        51200
Denoising steps:                         3199
Canvas positions evaluated:              870144
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
