### PR TITLE
[Kernel] Opt-in fused shared-expert gate + GDN in-proj fusion + prefill scan-output copy elision for Qwen3.5-122B-A10B-NVFP4 (Blackwell SM103)

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -111,6 +111,9 @@ if TYPE_CHECKING:
     VLLM_SKIP_P2P_CHECK: bool = False
     VLLM_DISABLED_KERNELS: list[str] = []
     VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE: bool = True
+    VLLM_GDN_FUSE_IN_PROJ: bool = False
+    VLLM_FUSE_EXPERT_GATE: bool = False
+    VLLM_GDN_DIRECT_SCAN_OUTPUT: bool = False
     VLLM_DISABLE_PYNCCL: bool = False
     VLLM_USE_OINK_OPS: bool = False
     VLLM_ROCM_USE_AITER: bool = False
@@ -1080,6 +1083,38 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE": lambda: bool(
         int(os.getenv("VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE", "1"))
+    ),
+    # Horizontally fuse the GatedDeltaNet in_proj_qkvz (N=20480) and
+    # in_proj_ba (N=128) projections into a single cuBLAS F.linear on a
+    # concatenated [20608, K] weight (built once post-load), then slice the
+    # output back into qkvz/ba. Eliminates the underfilled N=128 ba GEMM and
+    # its split-K reduction. Default off; set 1 to enable.
+    "VLLM_GDN_FUSE_IN_PROJ": lambda: bool(
+        int(os.getenv("VLLM_GDN_FUSE_IN_PROJ", "0"))
+    ),
+    # Fuse the Qwen MoE shared-expert gate chain
+    # (gemv2N N=1 + ATen sigmoid + ATen broadcast-mul) inside the opaque
+    # vllm::moe_forward_shared op. Decode/small-M (M <=
+    # VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD): one Triton kernel does
+    # per-row dot+sigmoid+in-place scale (3 kernels -> 1). Prefill/large-M:
+    # keep the library GEMV, fuse sigmoid+broadcast-mul (2 kernels -> 1,
+    # vectorized). Lossless (fp32 accum, bf16 in/out). Default off; set 1 to
+    # enable.
+    "VLLM_FUSE_EXPERT_GATE": lambda: bool(
+        int(os.getenv("VLLM_FUSE_EXPERT_GATE", "0"))
+    ),
+    # Eliminate the per-GDN-layer scan-output bridge D2D copy in
+    # Qwen3.5 prefill. In the no-spec prefill branch, thread the pre-allocated
+    # core_attn_out buffer (sliced to num_actual_tokens) into the FLA chunk
+    # gated-delta-rule scan so chunk_fwd_o direct-writes the scan output into
+    # the caller buffer (chunk_o.py:166), then skip the now-redundant
+    # core_attn_out[:n] = out.squeeze(0) self-copy. Removes a 268MB/layer
+    # cudaMemcpyAsync on the serial prefill stream. Lossless (same kernel, same
+    # math, different destination buffer). Gated to spec_sequence_masks is None
+    # and num_prefills > 0; spec/merged branches keep their copies. Default off;
+    # set 1 to enable.
+    "VLLM_GDN_DIRECT_SCAN_OUTPUT": lambda: bool(
+        int(os.getenv("VLLM_GDN_DIRECT_SCAN_OUTPUT", "0"))
     ),
     # Disable pynccl (using torch.distributed instead)
     "VLLM_DISABLE_PYNCCL": lambda: (

--- a/vllm/model_executor/layers/fused_moe/fused_expert_gate.py
+++ b/vllm/model_executor/layers/fused_moe/fused_expert_gate.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused shared-expert-gate sigmoid-mul.
+
+Target chain (``Qwen2MoeMLP.forward``, ``qwen2_moe.py:119-120``), executed inside
+the opaque custom op ``vllm::moe_forward_shared`` (so Inductor never sees it):
+
+    if self.expert_gate is not None:
+        out = F.sigmoid(self.expert_gate(x)[0]) * out
+
+where ``expert_gate`` is ``ReplicatedLinear(hidden, 1, bias=False)`` (unquantized,
+plain ``[1, hidden]`` bf16 ``.weight``). The production chain is three kernels:
+
+    cuBLASLt ``gemv2N_kernel`` (N=1 GEMV)  ->  ATen ``vectorized_elementwise`` sigmoid
+    ->  ATen ``elementwise_kernel`` broadcast-mul (UNVECTORIZED iterator)
+
+This module replaces that chain with authored Triton kernels, gated behind
+``VLLM_FUSE_EXPERT_GATE`` (default off):
+
+  * decode / small-M (M <= VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD): ONE kernel
+    ``fused_expert_gate_mul_kernel`` -- per-row ``gate = sigmoid(dot(x_row, w))``
+    in fp32, then in-place ``out_row *= gate``. Replaces 3 kernels -> 1. At N=1 the
+    "GEMV" is a per-row dot; there is no tensor-core tile to preserve, and the
+    cuBLASLt kernel being replaced is a single latency-bound CTA.
+
+  * prefill / large-M: keep the library GEMV for ``expert_gate(x)`` (native vendor
+    tile preserved), fuse only ``sigmoid + broadcast-mul`` into ONE vectorized
+    kernel ``fused_sigmoid_bcast_mul_kernel``. Replaces 2 kernels -> 1 and fixes
+    the unvectorized ATen broadcast iterator.
+
+Precision: LOSSLESS. Inputs bf16, output bf16, fp32 accumulation on both sides --
+identical to the baseline (cuBLASLt accumulates fp32; ATen sigmoid/MulFunctor
+compute in fp32). The fused output is allclose to the baseline, not bit-exact
+(it differs only within the bf16-rounding band).
+
+Derived from a standalone CUDA-graph-captured microbenchmark of the fused
+sigmoid-mul chain.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+# Decode kernel reduction block over K. K (=hidden_size, 3072 for Qwen3.5-122B) is
+# a multiple of 1024 so masking is unnecessary on the common path; we mask anyway
+# to stay correct for any K. num_warps=4 was the best-measured config for this shape.
+_DECODE_BLOCK = 1024
+_PREFILL_BLOCK = 1024
+_NUM_WARPS = 4
+
+
+@triton.jit
+def fused_expert_gate_mul_kernel(
+    out_ptr,
+    x_ptr,
+    w_ptr,
+    M: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """One program per row: ``gate = sigmoid(dot(x_row, w)); out_row *= gate``.
+
+    fp32 accumulation; bf16 load/store. ``w`` is the ``[1, K]`` gate weight row.
+    Mutates ``out`` in place (safe: ``out`` is a local intermediate of the opaque
+    ``moe_forward_shared`` op body, not an op input -- verified dispatch trace).
+    """
+    row = tl.program_id(0)
+    if row >= M:
+        return
+    acc = tl.zeros((BLOCK,), dtype=tl.float32)
+    for k in range(0, K, BLOCK):
+        offs = k + tl.arange(0, BLOCK)
+        mask = offs < K
+        xv = tl.load(x_ptr + row * K + offs, mask=mask, other=0.0).to(tl.float32)
+        wv = tl.load(w_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+        acc += xv * wv
+    gate = tl.sigmoid(tl.sum(acc, axis=0))
+    for k in range(0, K, BLOCK):
+        offs = k + tl.arange(0, BLOCK)
+        mask = offs < K
+        ov = tl.load(out_ptr + row * K + offs, mask=mask, other=0.0).to(tl.float32)
+        tl.store(out_ptr + row * K + offs, (ov * gate).to(tl.bfloat16), mask=mask)
+
+
+@triton.jit
+def fused_sigmoid_bcast_mul_kernel(
+    out_ptr,
+    gate_ptr,
+    K: tl.constexpr,
+    CBLOCKS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """grid = (M * K/BLOCK). ``out[row, cb] *= sigmoid(gate[row])``. Vectorized.
+
+    ``gate`` is the ``[M, 1]`` (or ``[M]``) pre-computed GEMV logits. Mutates
+    ``out`` in place.
+    """
+    pid = tl.program_id(0)
+    row = pid // CBLOCKS
+    cb = pid % CBLOCKS
+    # K % BLOCK == 0 (asserted by caller) and grid is exactly M*CBLOCKS, so
+    # offsets never cross a row boundary -- no mask needed.
+    g = tl.sigmoid(tl.load(gate_ptr + row).to(tl.float32))
+    offs = row * K + cb * BLOCK + tl.arange(0, BLOCK)
+    ov = tl.load(out_ptr + offs).to(tl.float32)
+    tl.store(out_ptr + offs, (ov * g).to(tl.bfloat16))
+
+
+def _decode_supported(out: torch.Tensor, x: torch.Tensor, weight: torch.Tensor) -> bool:
+    """Cheap shape/dtype/contiguity guard for the decode fused path."""
+    if not (out.is_cuda and x.is_cuda and weight.is_cuda):
+        return False
+    if out.dtype != torch.bfloat16 or x.dtype != torch.bfloat16:
+        return False
+    if out.dim() != 2 or x.dim() != 2:
+        return False
+    # weight is [1, K] (ReplicatedLinear(hidden, 1)). Squeeze to [K].
+    if weight.numel() != x.shape[1]:
+        return False
+    K = x.shape[1]
+    if out.shape[0] != x.shape[0] or out.shape[1] != K:
+        return False
+    if not (out.is_contiguous() and x.is_contiguous()):
+        return False
+    return True
+
+
+def fused_expert_gate_decode(
+    out: torch.Tensor, x: torch.Tensor, weight: torch.Tensor
+) -> torch.Tensor:
+    """Decode/small-M path: one kernel does dot + sigmoid + in-place scale.
+
+    ``out``  : [M, K] bf16 (down_proj output) -- mutated in place and returned.
+    ``x``    : [M, K] bf16 (MLP input).
+    ``weight``: [1, K] or [K] bf16 (expert_gate.weight).
+    """
+    M, K = x.shape
+    w = weight.reshape(-1)
+    fused_expert_gate_mul_kernel[(M,)](
+        out, x, w, M=M, K=K, BLOCK=_DECODE_BLOCK, num_warps=_NUM_WARPS
+    )
+    return out
+
+
+def fused_sigmoid_bcast_mul(out: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+    """Prefill/large-M path: vectorized sigmoid(gate) broadcast-mul into ``out``.
+
+    ``out`` : [M, K] bf16 -- mutated in place and returned.
+    ``gate``: [M, 1] or [M] -- pre-computed library GEMV logits.
+    """
+    M, K = out.shape
+    assert K % _PREFILL_BLOCK == 0, (
+        f"prefill fused path requires K % {_PREFILL_BLOCK} == 0, got K={K}"
+    )
+    cblocks = K // _PREFILL_BLOCK
+    g = gate.reshape(-1)
+    fused_sigmoid_bcast_mul_kernel[(M * cblocks,)](
+        out, g, K=K, CBLOCKS=cblocks, BLOCK=_PREFILL_BLOCK, num_warps=_NUM_WARPS
+    )
+    return out

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -496,6 +496,20 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         )
         self.disable_tp_for_ba_proj = self.maybe_disable_tp(self.quant_config)
 
+        # Horizontal in_proj fusion state (built post-load).
+        # in_proj_qkvz (N=key_dim*2 + value_dim*2) and in_proj_ba (N=2*num_v_heads)
+        # both read the SAME hidden_states with no mutual dependency. When enabled
+        # (CUDA + VLLM_GDN_FUSE_IN_PROJ), their weights are concatenated into a
+        # single [N_qkvz + N_ba, K] tensor so one cuBLAS F.linear (+ output slice)
+        # replaces two separate launches, eliminating the underfilled N_ba GEMM and
+        # its split-K reduction. The fused weight is built once in
+        # fuse_weights_after_loading() (post weight-load, pre cudagraph-capture), so
+        # the forward path is fully CUDA-graph capturable. Layout-agnostic: the slice
+        # boundary is the qkvz output width regardless of gqa_interleaved_layout.
+        self.fuse_in_proj = False
+        self.in_proj_fused_weight: torch.Tensor | None = None
+        self._fused_qkvz_size = 0
+
         query_key_settings = (self.key_dim, 0, False)
         value_settings = (self.value_dim, 0, False)
 
@@ -562,6 +576,63 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
+
+    def fuse_weights_after_loading(self) -> None:
+        """Build the concatenated in_proj weight after weights load.
+
+        Called once by the model loader's post-load pass, AFTER all weights are
+        loaded and BEFORE the profiling forward / CUDA-graph capture. Concatenates
+        the loaded in_proj_qkvz and in_proj_ba weights into one [N_qkvz + N_ba, K]
+        tensor and re-points the two original module weights to be views into it,
+        so total weight memory is unchanged (the two separate launches still work
+        in eager / non-CUDA paths, while forward_cuda uses the single fused GEMM).
+
+        Guards (all must hold to enable the fast path):
+          * VLLM_GDN_FUSE_IN_PROJ env (default off) — opt-in enable.
+          * CUDA platform — the win and the cuBLAS launch behavior are
+            CUDA-specific; ROCm/XPU/CPU keep their own forward paths untouched.
+          * Both projections are plain (unquantized) BF16/FP16 2-D weights with
+            matching dtype/device and the same K (input dim). GDN in_proj layers
+            are in the NVFP4 ignore list, so this holds for the target model; if
+            any precondition fails we leave fusion disabled (fail-safe).
+        """
+        if not envs.VLLM_GDN_FUSE_IN_PROJ:
+            return
+        if not current_platform.is_cuda():
+            return
+        # LoRA on Qwen3.5 splits in_proj_qkvz into in_proj_qkv + in_proj_z; if that
+        # path is active these attributes won't both exist as single merged GEMMs.
+        if not (hasattr(self, "in_proj_qkvz") and hasattr(self, "in_proj_ba")):
+            return
+
+        w_qkvz = getattr(self.in_proj_qkvz, "weight", None)
+        w_ba = getattr(self.in_proj_ba, "weight", None)
+        if w_qkvz is None or w_ba is None:
+            return
+        # Only fuse plain unquantized 2-D weights with matching dtype/device/K.
+        if w_qkvz.ndim != 2 or w_ba.ndim != 2:
+            return
+        if w_qkvz.dtype != w_ba.dtype or w_qkvz.device != w_ba.device:
+            return
+        if w_qkvz.shape[1] != w_ba.shape[1]:
+            return
+        # Fail-safe under CPU offloading: the fused F.linear runs on CUDA in
+        # forward_cuda, so both weights must be CUDA-resident here. If they are
+        # offloaded to CPU at load time, skip fusion (the two-launch path works).
+        if not (w_qkvz.is_cuda and w_ba.is_cuda):
+            return
+
+        n_qkvz = w_qkvz.shape[0]
+        # Build the concatenated weight [N_qkvz + N_ba, K] once.
+        fused = torch.cat([w_qkvz.data, w_ba.data], dim=0).contiguous()
+        # Re-point the original parameters at views into the fused buffer so the
+        # eager two-launch path stays bit-exact and no memory is duplicated.
+        self.in_proj_qkvz.weight.data = fused[:n_qkvz]
+        self.in_proj_ba.weight.data = fused[n_qkvz:]
+
+        self.in_proj_fused_weight = fused
+        self._fused_qkvz_size = n_qkvz
+        self.fuse_in_proj = True
 
     def create_qkvz_proj(
         self,
@@ -920,8 +991,28 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
+        if self.fuse_in_proj:
+            # One cuBLAS GEMM on the concatenated [N_qkvz + N_ba, K]
+            # weight replaces the two separate in_proj launches; slice the
+            # output back into qkvz/ba along the qkvz output width. The fused
+            # weight is a constant tensor built post-load, so this is fully
+            # CUDA-graph capturable.
+            fused_out = torch.nn.functional.linear(
+                hidden_states, self.in_proj_fused_weight
+            )
+            mixed_qkvz = fused_out[..., : self._fused_qkvz_size]
+            ba = fused_out[..., self._fused_qkvz_size :]
+            if self.gqa_interleaved_layout:
+                # fix_query_key_value_ordering() below uses .view(), which
+                # requires contiguous inputs (baseline supplies contiguous
+                # F.linear outputs here). The non-interleaved path consumes the
+                # slices via .split()/.reshape()/explicit .contiguous(), which
+                # tolerate the strided views, so it keeps zero-copy slices.
+                mixed_qkvz = mixed_qkvz.contiguous()
+                ba = ba.contiguous()
+        else:
+            mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            ba, _ = self.in_proj_ba(hidden_states)
 
         if self.gqa_interleaved_layout:
             # Qwen3-Next: unpack the interleaved GQA layout
@@ -1500,6 +1591,35 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         else:
             core_attn_out_decode = None
 
+        # In the no-spec prefill branch, thread the pre-allocated
+        # core_attn_out buffer (sliced to num_actual_tokens) into the FLA scan so
+        # chunk_fwd_o direct-writes the scan output into the caller buffer
+        # (chunk_o.py:166) instead of allocating a fresh empty_like(v). This makes
+        # the scan-output bridge copy below redundant, so it is skipped. Gated to
+        # the no-spec prefill branch: spec/merged branches build separate output
+        # buffers and still need their copies; decode does not thread this buffer.
+        # The SLICE is mandatory (not the full padded buffer): chunk_o.py does
+        # o = core_attn_out[:v.numel()].view(*v.shape), which requires numel to
+        # match v exactly; core_attn_out[:num_actual_tokens] has numel == v.numel()
+        # in the no-spec, non-split branch. When decodes are peeled off
+        # (split_non_spec), the scan covers only the prefill tail and its output is
+        # later stitched in front with the decode outputs via torch.cat, so the
+        # direct-write target would not match the final buffer -- that branch keeps
+        # its copy (direct_scan_output stays False). Mirrors the decode
+        # direct-write idiom used elsewhere in this file.
+        direct_scan_output = (
+            envs.VLLM_GDN_DIRECT_SCAN_OUTPUT
+            and spec_sequence_masks is None
+            and attn_metadata.num_prefills > 0
+            and not split_non_spec
+        )
+        if direct_scan_output:
+            # Activation marker (info_once -> logged once when the fast path is
+            # first actually taken; not at init/import).
+            logger.info_once(
+                "GDN direct-scan-output enabled: bridge copy elided"
+            )
+
         # 2.3: Process the remaining part (prefill chunk, or non-spec decode-only)
         if attn_metadata.num_prefills > 0:
             # State indices, initial-state mask and cu_seqlens for the chunk
@@ -1527,6 +1647,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 chunk_indices=attn_metadata.chunk_indices,
                 chunk_offsets=attn_metadata.chunk_offsets,
                 use_qk_l2norm_in_kernel=False,
+                core_attn_out=(
+                    core_attn_out[:num_actual_tokens] if direct_scan_output else None
+                ),
             )
             # Init cache
             ssm_state[prefill_state_indices] = last_recurrent_state.to(ssm_state.dtype)
@@ -1572,7 +1695,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)
         elif spec_sequence_masks is not None:
             core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
-        else:
+        elif not direct_scan_output:
+            # When direct_scan_output is on, the FLA scan above already
+            # wrote core_attn_out_non_spec directly into core_attn_out[:n] (it is a
+            # view of that buffer), so this self-assignment is redundant and skipped.
             core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)
 
     def _forward_core_decode_aiter(

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -125,6 +125,21 @@ def process_weights_after_loading(
             with device_loading_context(module, target_device):
                 module.process_weights_after_loading(model_config.dtype)
 
+    # Build the fused GatedDeltaNet in_proj weight after all weights are
+    # loaded (and before the profiling forward / CUDA-graph capture). Scoped by an
+    # isinstance check so it is a no-op for every other model. Lazy import avoids a
+    # circular dependency (the mamba gdn module imports from model_executor.layers).
+    from vllm.model_executor.layers.mamba.gdn.base import (
+        GatedDeltaNetAttention,
+    )
+
+    for _, module in model.named_modules():
+        if isinstance(module, GatedDeltaNetAttention) and hasattr(
+            module, "fuse_weights_after_loading"
+        ):
+            with device_loading_context(module, target_device):
+                module.fuse_weights_after_loading()
+
     # Needed for torchao model reloading via model.reload_weights
     # @kylesayrs @jerryzh168 this can be removed if callers move to `reload_weights`
     if model_config.quantization == "torchao":

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -111,13 +111,62 @@ class Qwen2MoeMLP(nn.Module):
         self.act_fn = SiluAndMul()
         self.expert_gate = expert_gate
 
+    def _try_fused_expert_gate(self, x: torch.Tensor, out: torch.Tensor) -> bool:
+        """Env-gated fused shared-expert-gate sigmoid-mul.
+
+        Returns True if ``out`` was scaled in place by the fused Triton path
+        (caller must NOT run the baseline chain), False to fall through to the
+        eager ``F.sigmoid(self.expert_gate(x)[0]) * out`` baseline.
+
+        This runs inside the opaque ``vllm::moe_forward_shared`` custom op, so
+        the Python ``if M <= threshold`` branch and the in-place mutation of the
+        local intermediate ``out`` are both invisible to torch.compile/Inductor.
+        """
+        import vllm.envs as envs
+
+        if not envs.VLLM_FUSE_EXPERT_GATE:
+            return False
+
+        from vllm.model_executor.layers.fused_moe.fused_expert_gate import (
+            _decode_supported,
+            fused_expert_gate_decode,
+            fused_sigmoid_bcast_mul,
+        )
+
+        weight = getattr(self.expert_gate, "weight", None)
+        if weight is None:
+            return False
+
+        M = x.shape[0]
+        threshold = envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD
+        if M <= threshold:
+            # decode / small-M: one kernel does dot + sigmoid + in-place scale.
+            if not _decode_supported(out, x, weight):
+                return False
+            fused_expert_gate_decode(out, x, weight)
+            return True
+
+        # prefill / large-M: keep the library GEMV (native vendor tile), fuse
+        # only sigmoid + broadcast-mul. Fall through if K is not a clean
+        # multiple of the vectorized block (kernel precondition).
+        if out.dtype != torch.bfloat16 or out.dim() != 2:
+            return False
+        if not out.is_contiguous():
+            return False
+        if out.shape[1] % 1024 != 0:
+            return False
+        gate = self.expert_gate(x)[0]
+        fused_sigmoid_bcast_mul(out, gate)
+        return True
+
     def forward(self, x):
         gate_up, _ = self.gate_up_proj(x)
         out = self.act_fn(gate_up)
         out, _ = self.down_proj(out)
 
         if self.expert_gate is not None:
-            out = F.sigmoid(self.expert_gate(x)[0]) * out
+            if not self._try_fused_expert_gate(x, out):
+                out = F.sigmoid(self.expert_gate(x)[0]) * out
 
         return out
 


### PR DESCRIPTION
## Summary

This PR adds three **opt-in, default-off** kernel optimizations for serving `nvidia/Qwen3.5-122B-A10B-NVFP4` on NVIDIA Blackwell (B300 SXM6, SM103 / compute capability 10.3, `sm_103`). They target the GatedDeltaNet (GDN) linear-attention and MoE decode/prefill hot paths and are lossless (same math, fp32 accumulation, bf16 in/out). Each is guarded behind its own environment variable; **with all three flags unset the code path is byte-for-byte identical to the base** (current `vllm-project/vllm` main, commit `fa63bb9db`). The change is pure Python/Triton — no C++/CUDA sources are touched, so no recompile is required.

These optimizations were developed on an earlier base (vLLM 0.21.0) and rebased onto current `vllm-project/vllm` main (`fa63bb9db`). The fixed-batch latency sweep below was re-measured on the rebased main tree; the per-optimization GSM8K correctness numbers were measured on the earlier base and not re-run after the rebase (the code is logically equivalent on the rebased tree).

The fixed-batch latency sweep below was measured on B300 SXM6 (SM103) at TP=1, NVFP4, under production-parity settings (full CUDA graphs + `torch.compile`, never `--enforce-eager`). The per-optimization correctness (GSM8K) and isolated kernel-speedup figures were measured separately during earlier development — the shared-expert-gate and scan-output-copy optimizations on B300 SXM6 (SM103), and the GDN in-projection fusion on B200 (SM100) before testing moved to B300 (so the in-projection fusion was not re-validated on SM103). Hardware is noted per item in the Correctness section. All figures are TP=1, NVFP4, and scoped to Blackwell SM10x; no claim is made for other architectures.

## Optimizations

- **Fuse the GatedDeltaNet in-projection GEMMs** — env flag `VLLM_GDN_FUSE_IN_PROJ` (default off), **lossless**. In each GDN linear-attention layer, `in_proj_qkvz` (`[20480, 3072]`) and `in_proj_ba` (`[128, 3072]`) read the same `hidden_states` with no mutual dependency but launch as two separate cuBLAS GEMMs — the `N=128` `ba` projection is badly underfilled (grid 12/148 SMs at BS1) and pays for a separate split-K reduction. After weight load (before the profiling forward / CUDA-graph capture) the two weights are concatenated into a single `[20608, 3072]` tensor; `forward_cuda` then runs one `F.linear` and slices the output back into `qkvz`/`ba` at column 20480. The fused weight is a constant tensor built post-load and the original module weights are re-pointed as zero-copy views into it, so it is fully CUDA-graph capturable, memory-neutral, and the eager two-launch path stays bit-exact. Gated by the env flag plus CUDA-platform / plain-BF16-2D / matching-dtype-device-K / CUDA-resident checks; any miss leaves fusion disabled (fail-safe).
  - *Effect:* one fused GEMM per layer (× 36 layers) replaces the two launches; the separate `ba` GEMM and its split-K reduction are eliminated. Isolated chain-vs-fused speedup 1.20–1.24× warm. qkvz output bit-exact (max abs err 0.0), `ba` ≤ 1 ULP.

- **Fuse the Qwen MoE shared-expert gate chain** — env flag `VLLM_FUSE_EXPERT_GATE` (default off), **lossless**. The shared-expert gate (`sigmoid(gate(x)) * out`) runs inside the opaque `vllm::moe_forward_shared` custom op, so `torch.compile`/Inductor cannot fuse it. Two Triton kernels replace the chain: at decode / small token counts (`M <= VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD`) one kernel does per-row dot + sigmoid + in-place scale, collapsing 3 kernels (GEMV + sigmoid + broadcast-mul) into 1; at prefill / large `M` the vendor GEMV is kept and only sigmoid + broadcast-mul are fused (2 kernels into 1, vectorized).
  - *Isolated kernel speedup (CUDA-graph capture/replay):* decode **5.36× / 4.32× / 4.24×** at M=1/8/32; prefill (cold, L2-busted) **~3.3–3.4×** at M=10616/16384.

- **Elide the redundant GDN scan-output copy in prefill** — env flag `VLLM_GDN_DIRECT_SCAN_OUTPUT` (default off), **lossless**. In the no-spec prefill branch of the GDN linear-attention layer, the pre-allocated `core_attn_out[:num_actual_tokens]` buffer is threaded directly into the FLA `chunk_gated_delta_rule` scan so the scan writes its output straight into the caller's buffer, making the subsequent `core_attn_out[:n] = out.squeeze(0)` self-copy redundant (skipped). Same kernel, same math, different destination buffer. Gated to `spec_sequence_masks is None and num_prefills > 0 and not split_non_spec`; the spec/merged/decode branches keep their copies unchanged. The `not split_non_spec` guard is required on current main: when a mixed batch peels its decode tokens off and the scan covers only the prefill tail (later stitched in front of the decode outputs via `torch.cat`), the direct-write target would not match the final buffer, so that branch keeps its copy.
  - *Effect:* removes a per-layer device-to-device `cudaMemcpyAsync` on the serial prefill stream (the per-layer 268 MB and 173 MB GDN scan-output bridge copies, 36 each = 72 copies → 0); the baseline >100 MB D2D copy bucket measured 16.03 GB / 4959.8 µs across 73 copies, of which only the 100 MB / 65 MB / sub-MB copies (byte-identical in both arms) remain.

## Fixed-batch latency

`vllm bench latency` — `nvidia/Qwen3.5-122B-A10B-NVFP4`, B300 SXM6 (SM103), TP=1, NVFP4 weights + FP8 (e4m3) KV cache, `--max-model-len 131072 --max-num-seqs 32 --no-enable-prefix-caching --trust-remote-code`, `--num-iters 10`, full CUDA graphs + `torch.compile`. Measured on current `vllm-project/vllm` main (`fa63bb9db`); the native FlashInfer GDN prefill kernel was confirmed active on both arms (no Triton fallback). A = base (all three flags unset); B = all three flags enabled. Each (shape, arm) ran as its own fresh process; every cell was recomputed from the raw per-run JSON. OTPS = output tokens/s = batch ÷ TPOT (time per output token). Of the three optimizations, only the scan-output-copy one emits a runtime marker (`GDN direct-scan-output enabled: bridge copy elided`); it appears in all six B-arm logs and none of the A-arm logs, and the B-arm launch command carries all three flags. The other two have no runtime log and are confirmed by their enabled flags.

| ISL | OSL | Batch | A E2E (s) | B E2E (s) | Speedup | E2E Δ | OTPS A→B | OTPS Δ |
|------:|----:|------:|----------:|----------:|--------:|------:|:--------:|-------:|
| 27000  | 150 | 1 | 1.2012 | 1.1601 | 1.035× | −3.42% | 201.6→212.3 | +5.31% |
| 27000  | 150 | 8 | 4.6643 | 4.5843 | 1.017× | −1.72% | 494.0→503.0 | +1.83% |
| 27000  | 512 | 1 | 2.9826 | 2.8522 | 1.046× | −4.37% | 202.7→213.3 | +5.24% |
| 120000 | 150 | 1 | 3.7000 | 3.6378 | 1.017× | −1.68% | 195.5→205.1 | +4.95% |
| 1024   | 512 | 1 | 2.5684 | 2.4306 | 1.057× | −5.36% | 208.9→220.5 | +5.53% |
| 128    | 128 | 1 | 0.7233 | 0.6912 | 1.046× | −4.44% | 209.4→221.0 | +5.54% |

Across the six shapes the combined gain is −1.68% to −5.36% E2E (+1.83% to +5.54% OTPS). The 128/128 row is a no-regression control (tiny context); it improves rather than regressing. No shape regresses.

## Correctness

GSM8K, greedy decode, full 1319-question test split. A change is accepted if accuracy stays within 1.0 pp of baseline. All three optimizations are **lossless** (bf16 in/out, fp32 accumulation), validated per-optimization against the base build:

- **Fuse GDN in-projection (`VLLM_GDN_FUSE_IN_PROJ`):** measured on B200 (SM100). GSM8K **96.06%** vs base 96.21%, Δ **−0.15pp** — within tolerance. Kernel correctness: fused-GEMM output bit-exact for `qkvz` (max abs err 0.0) and ≤ 1 ULP for `ba`; CUDA-graph replay-vs-eager error 0.
- **Fuse shared-expert gate (`VLLM_FUSE_EXPERT_GATE`):** measured on B300 SXM6 (SM103). GSM8K **96.66% (1275/1319)** vs base 96.29% (1270/1319), **+0.38pp** — within tolerance. Independent allclose check (rtol=2e-2, atol=2e-3) across 8 token counts, max abs diff 0.008–0.031 (bf16-rounding band), no NaN/Inf.
- **Elide GDN scan-output copy (`VLLM_GDN_DIRECT_SCAN_OUTPUT`):** measured on B300 SXM6 (SM103). **bit-exact** — flag-on output byte-identical to flag-off (max abs diff 0.0, nan_frac 0.0 at T=2048 and T=16384); GSM8K **96.13% (1268/1319)**.

## Changes

**5 files, +391 / −4, Python/Triton only (no recompile needed)** — diff against current `vllm-project/vllm` main (`fa63bb9db`).

- Env-flag registration (all default off): `vllm/envs.py`
- New Triton fused shared-expert gate kernels + dispatch wrappers: `vllm/model_executor/layers/fused_moe/fused_expert_gate.py`
- GDN in-projection weight-concat fusion (`fuse_weights_after_loading()` + `forward_cuda` fused-GEMM branch) and prefill scan-output buffer threading + copy skip: `vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py`
- Post-load pass that builds the fused GDN in-projection weight (isinstance-scoped; no-op for other models): `vllm/model_executor/model_loader/utils.py`
- Qwen MoE wiring (flag-gated branch into the fused gate): `vllm/model_executor/models/qwen2_moe.py`

## AI-assisted contribution

These optimizations were produced by an automated process driving Claude (Anthropic) with human review at each step. Every change was checked for correctness (bit-exact comparison or allclose for the lossless paths, plus a GSM8K before/after) and benchmarked before/after for latency before being accepted; all numbers were measured on real Blackwell hardware (the combined latency sweep and two of the three correctness checks on B300/SM103, the GDN in-projection fusion on B200/SM100 — see Correctness) under production-parity CUDA graphs + `torch.compile`. The optimizations were developed and measured on an earlier base and rebased onto current main without re-measurement; the rebased code is logically equivalent. All three optimizations are behind default-off environment flags, so the default serving path is unchanged when the flags are unset.
