### PR TITLE
fix: disable FlashInfer allreduce fusion for multi-node TP

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -21,6 +21,7 @@ from vllm.config.utils import Range
 from vllm.distributed import get_tp_group, tensor_model_parallel_all_reduce
 from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
 from vllm.distributed.parallel_state import (
+    get_node_count,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
@@ -917,6 +918,16 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
         self.tp_size = get_tensor_model_parallel_world_size()
         if self.tp_size <= 1:
             logger.warning_once("AllReduce fusion pass is disabled for tp_size <= 1.")
+            return
+        # Multi-node requires the MNNVL backend (trtllm is single-node only).
+        # MNNVL fused allreduce has known correctness issues when the TP group
+        # spans multiple NVLink domains (e.g. GB200 NVL72 node boundaries).
+        # Fall back to NCCL allreduce + separate RMSNorm which is safe.
+        if get_node_count() > 1:
+            logger.warning_once(
+                "AllReduce fusion pass is disabled for multi-node setups "
+                "due to known MNNVL fused allreduce correctness issues."
+            )
             return
         self.patterns: PatternMatcherPass = PatternMatcherPass(
             pass_name="all_reduce_fusion_pass"


### PR DESCRIPTION
## Summary

- Disable `AllReduceFusionPass` when `get_node_count() > 1` — falls back to NCCL allreduce + separate RMSNorm (numerically identical)
- Multi-node requires MNNVL backend (trtllm is single-node only), and MNNVL fused allreduce has correctness issues when the TP group spans multiple NVLink domains

## Motivation

On GB200 NVL72, MiniMax-M3 (427B MoE) with TP8+EP8 spanning 2 NVL72 nodes evaluates to gsm8k=0.0000 (completely wrong), while TP1 DEP configs on the same hardware evaluate correctly (gsm8k ≥ 0.90). The fused allreduce+RMSNorm through MNNVL is the **only** code path that differs between the working and broken configs:

| Config | TP | fused AR path | gsm8k |
|--------|---:|---------------|------:|
| DEP8 (1 node per worker) | 1 | skipped (`tp_size==1`) | ≥ 0.90 |
| TEP8 (2 nodes per worker) | 8 | **MNNVL fused** | 0.0000 |

Known MNNVL issues:
- cudagraph interactions: #35772
- IPC on GB200 NVL72: flashinfer/flashinfer#2006

The `_resolve_fi_ar_backend()` already documents that MNNVL has cudagraph issues and avoids it for single-node by defaulting to trtllm. For multi-node, trtllm is not an option, so the only safe path is to skip the fused kernel entirely.

## Test plan

- [ ] Existing `test_fused_allreduce_gemma_rms_norm` still passes (single-node `spawn`, `get_node_count()=1`, fused path exercised)
- [ ] Multi-node TP>1 workloads now fall back to NCCL allreduce + separate RMSNorm (verified by log message)
- [ ] Re-run MiniMax-M3 TP8+EP8 2-node disagg eval → gsm8k should recover to ≥ 0.90

🤖 Generated with [Claude Code](https://claude.com/claude-code)