### PR TITLE
[Core] Add soft thinking token budget with progressive logit bias

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_thinking_token_budget_prompt_hint.py
+++ b/tests/entrypoints/openai/chat_completion/test_thinking_token_budget_prompt_hint.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.serve.render import serving as render_serving
+
+
+def test_thinking_budget_prompt_hint_prepends_system_message():
+    messages = [{"role": "user", "content": "Solve 2+2."}]
+
+    result = render_serving._with_thinking_budget_system_prompt(messages, 50)
+
+    assert result == [
+        {
+            "role": "system",
+            "content": (
+                "Think step by step and use fewer than 50 reasoning tokens "
+                "before the final answer."
+            ),
+        },
+        {"role": "user", "content": "Solve 2+2."},
+    ]
+    assert messages == [{"role": "user", "content": "Solve 2+2."}]
+
+
+def test_thinking_budget_prompt_hint_extends_leading_system_message():
+    messages = [
+        {"role": "system", "content": "You are concise."},
+        {"role": "user", "content": "Solve 2+2."},
+    ]
+
+    result = render_serving._with_thinking_budget_system_prompt(messages, 100)
+
+    assert result[0]["role"] == "system"
+    assert result[0]["content"] == (
+        "You are concise.\n\n"
+        "Think step by step and use fewer than 100 reasoning tokens "
+        "before the final answer."
+    )
+    assert result[1] == {"role": "user", "content": "Solve 2+2."}
+
+
+@pytest.mark.asyncio
+async def test_render_chat_injects_thinking_budget_prompt_hint():
+    captured_messages = []
+
+    async def preprocess_chat(_request, messages, **_kwargs):
+        captured_messages.append(messages)
+        return messages, []
+
+    serving = SimpleNamespace(
+        renderer=SimpleNamespace(tokenizer=None),
+        parser=None,
+        use_harmony=False,
+        enable_auto_tools=False,
+        exclude_tools_when_tool_choice_none=False,
+        chat_template=None,
+        chat_template_content_format="auto",
+        default_chat_template_kwargs={},
+        trust_request_chat_template=False,
+        validate_chat_template=lambda **_kwargs: None,
+        preprocess_chat=preprocess_chat,
+    )
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Solve 2+2."}],
+        thinking_token_budget=50,
+    )
+
+    await render_serving.OpenAIServingRender.render_chat(serving, request)
+
+    assert captured_messages == [
+        [
+            {
+                "role": "system",
+                "content": (
+                    "Think step by step and use fewer than 50 reasoning tokens "
+                    "before the final answer."
+                ),
+            },
+            {"role": "user", "content": "Solve 2+2."},
+        ]
+    ]

--- a/tests/v1/logits_processors/test_correctness.py
+++ b/tests/v1/logits_processors/test_correctness.py
@@ -107,6 +107,14 @@ class MockReasoningConfig:
     enabled = True
 
 
+class MockReasoningMultiTokenEndConfig:
+    """Reasoning config with a multi-token end marker."""
+
+    reasoning_start_token_ids = [THINK_START_TOKEN_ID]
+    reasoning_end_token_ids = [997, THINK_END_TOKEN_ID]
+    enabled = True
+
+
 def _generate_fake_sampling_metadata(
     num_output_tokens: int,
     batch_size: int,
@@ -1194,6 +1202,73 @@ def test_thinking_budget_enforced_without_penalties():
         "Budget exceeded: in_end should be True so that apply_to_logits "
         "forces the end token"
     )
+
+
+def _make_holder_in_soft_zone(reasoning_config):
+    h = ThinkingBudgetStateHolder(
+        reasoning_config,
+        1,
+        0,
+        torch.device("cpu"),
+        False,
+    )
+    output_token_ids = [THINK_START_TOKEN_ID]
+    h.sync_batch(
+        BatchUpdate(
+            batch_size=1,
+            removed=(),
+            added=[
+                (
+                    0,
+                    SamplingParams(thinking_token_budget=10),
+                    None,
+                    output_token_ids,
+                )
+            ],
+            moved=(),
+        )
+    )
+
+    for token_id in range(8):
+        output_token_ids.append(token_id)
+        h.update_state([output_token_ids], None, None)
+
+    return h, output_token_ids
+
+
+def test_thinking_budget_soft_zone_biases_before_hard_force():
+    h, _ = _make_holder_in_soft_zone(MockReasoningConfig())
+    state = h._state[0]
+    assert state["in_think"]
+    assert not state["in_end"]
+    assert state["soft_progress"] > 0.0
+
+    logits = torch.zeros((1, VOCAB_SIZE), dtype=torch.float32)
+    logits[0, 7] = 10.0
+    logits[0, THINK_END_TOKEN_ID] = 2.0
+    h.apply_to_logits(logits, predict_bonus_token=False, spec_token_ids=None)
+
+    assert 2.0 < logits[0, THINK_END_TOKEN_ID] < 1.0e8
+    assert logits[0, 7] == 10.0
+
+
+def test_thinking_budget_soft_zone_biases_only_next_close_token():
+    h, output_token_ids = _make_holder_in_soft_zone(
+        MockReasoningMultiTokenEndConfig()
+    )
+    logits = torch.zeros((1, VOCAB_SIZE), dtype=torch.float32)
+    logits[0, 7] = 10.0
+    h.apply_to_logits(logits, predict_bonus_token=False, spec_token_ids=None)
+    assert logits[0, 997] > 0.0
+    assert logits[0, THINK_END_TOKEN_ID] == 0.0
+
+    output_token_ids.append(997)
+    h.update_state([output_token_ids], None, None)
+    logits = torch.zeros((1, VOCAB_SIZE), dtype=torch.float32)
+    logits[0, 7] = 10.0
+    h.apply_to_logits(logits, predict_bonus_token=False, spec_token_ids=None)
+    assert logits[0, 997] == 0.0
+    assert logits[0, THINK_END_TOKEN_ID] > 0.0
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/logits_processors/test_correctness.py
+++ b/tests/v1/logits_processors/test_correctness.py
@@ -1248,8 +1248,22 @@ def test_thinking_budget_soft_zone_biases_before_hard_force():
     logits[0, THINK_END_TOKEN_ID] = 2.0
     h.apply_to_logits(logits, predict_bonus_token=False, spec_token_ids=None)
 
-    assert 2.0 < logits[0, THINK_END_TOKEN_ID] < 1.0e8
+    expected = 2.0 + state["soft_progress"] * (10.0 - 0.25 - 2.0)
+    assert logits[0, THINK_END_TOKEN_ID] == pytest.approx(expected)
     assert logits[0, 7] == 10.0
+
+
+def test_thinking_budget_soft_zone_does_not_overtake_top_logit():
+    h, _ = _make_holder_in_soft_zone(MockReasoningConfig())
+    h._state[0]["soft_progress"] = 1.0
+
+    logits = torch.zeros((1, VOCAB_SIZE), dtype=torch.float32)
+    logits[0, 7] = 10.0
+    logits[0, THINK_END_TOKEN_ID] = -20.0
+    h.apply_to_logits(logits, predict_bonus_token=False, spec_token_ids=None)
+
+    assert logits[0, THINK_END_TOKEN_ID] == pytest.approx(9.75)
+    assert logits[0, THINK_END_TOKEN_ID] < logits[0, 7]
 
 
 def test_thinking_budget_soft_zone_biases_only_next_close_token():

--- a/tests/v1/logits_processors/test_correctness.py
+++ b/tests/v1/logits_processors/test_correctness.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import random
+import math
 from collections.abc import Callable
 from typing import NamedTuple, TypeAlias
 
@@ -1236,12 +1237,27 @@ def _make_holder_in_soft_zone(reasoning_config):
     return h, output_token_ids
 
 
+def _expected_soft_sigmoid_ramp(progress: float) -> float:
+    center = 0.8
+    sharpness = 10.0
+
+    def sigmoid(x: float) -> float:
+        return 1.0 / (1.0 + math.exp(-sharpness * x))
+
+    start = sigmoid(0.0 - center)
+    finish = sigmoid(1.0 - center)
+    value = sigmoid(progress - center)
+    return min(max((value - start) / (finish - start), 0.0), 1.0)
+
+
 def test_thinking_budget_soft_zone_biases_before_hard_force():
     h, _ = _make_holder_in_soft_zone(MockReasoningConfig())
     state = h._state[0]
     assert state["in_think"]
     assert not state["in_end"]
-    assert state["soft_progress"] > 0.0
+    assert state["soft_progress"] == pytest.approx(
+        _expected_soft_sigmoid_ramp(0.5)
+    )
 
     logits = torch.zeros((1, VOCAB_SIZE), dtype=torch.float32)
     logits[0, 7] = 10.0
@@ -1251,6 +1267,17 @@ def test_thinking_budget_soft_zone_biases_before_hard_force():
     expected = 2.0 + state["soft_progress"] * (10.0 - 0.25 - 2.0)
     assert logits[0, THINK_END_TOKEN_ID] == pytest.approx(expected)
     assert logits[0, 7] == 10.0
+
+
+def test_thinking_budget_soft_zone_reaches_full_ramp_before_hard_force():
+    h, output_token_ids = _make_holder_in_soft_zone(MockReasoningConfig())
+    output_token_ids.append(99)
+    h.update_state([output_token_ids], None, None)
+
+    state = h._state[0]
+    assert state["in_think"]
+    assert not state["in_end"]
+    assert state["soft_progress"] == pytest.approx(1.0)
 
 
 def test_thinking_budget_soft_zone_does_not_overtake_top_logit():

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -160,6 +160,36 @@ def _build_chat_choice(
     )
 
 
+def _append_text_content(content: Any, text: str) -> Any:
+    if isinstance(content, str):
+        return f"{content}\n\n{text}" if content else text
+    if content is None:
+        return text
+    if isinstance(content, list):
+        return [*content, {"type": "text", "text": f"\n\n{text}"}]
+    return f"{content}\n\n{text}"
+
+
+def _with_thinking_budget_system_prompt(
+    messages: Sequence[Any], thinking_token_budget: int | None
+) -> list[Any]:
+    """Add prompt guidance for requests with a thinking token budget."""
+    if thinking_token_budget is None or thinking_token_budget <= 0:
+        return list(messages)
+
+    instruction = (
+        "Think step by step and use fewer than "
+        f"{thinking_token_budget} reasoning tokens before the final answer."
+    )
+    updated = [dict(message) for message in messages]
+    if updated and updated[0].get("role") in ("system", "developer"):
+        updated[0]["content"] = _append_text_content(
+            updated[0].get("content"), instruction
+        )
+        return updated
+    return [{"role": "system", "content": instruction}, *updated]
+
+
 class OpenAIServingRender:
     def __init__(
         self,
@@ -332,6 +362,10 @@ class OpenAIServingRender:
         else:
             tool_dicts = [tool.model_dump() for tool in request.tools]
 
+        messages = _with_thinking_budget_system_prompt(
+            request.messages, request.thinking_token_budget
+        )
+
         if not self.use_harmony:
             # Common case.
             error_check_ret = self.validate_chat_template(
@@ -344,7 +378,7 @@ class OpenAIServingRender:
 
             conversation, engine_inputs = await self.preprocess_chat(
                 request,
-                request.messages,
+                messages,
                 default_template=self.chat_template,
                 default_template_content_format=self.chat_template_content_format,
                 default_template_kwargs=self.default_chat_template_kwargs,
@@ -356,7 +390,7 @@ class OpenAIServingRender:
             # For GPT-OSS.
             should_include_tools = tool_dicts is not None
             conversation, engine_inputs = self._make_request_with_harmony(
-                request, should_include_tools
+                request, should_include_tools, chat_messages_override=messages
             )
 
         return conversation, engine_inputs
@@ -492,6 +526,7 @@ class OpenAIServingRender:
         self,
         request: ChatCompletionRequest,
         should_include_tools: bool = True,
+        chat_messages_override: Sequence[Any] | None = None,
     ):
         """Build Harmony (GPT-OSS) messages and engine prompt from a chat request."""
         messages: list[OpenAIMessage] = []
@@ -501,7 +536,13 @@ class OpenAIServingRender:
         # for more info: see comment in `maybe_serialize_tool_calls`
         _mt.maybe_serialize_tool_calls(request)  # type: ignore[arg-type]
 
-        chat_messages = list(request.messages)
+        chat_messages = list(
+            chat_messages_override
+            if chat_messages_override is not None
+            else _with_thinking_budget_system_prompt(
+                request.messages, request.thinking_token_budget
+            )
+        )
         instructions, chat_messages = extract_instructions_from_messages(chat_messages)
 
         # Add system message.

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -32,7 +32,18 @@ def maybe_create_thinking_budget_state_holder(
 
 
 class ThinkingBudgetStateHolder:
-    """Tracks thinking sections and forces end tokens when budget is exceeded."""
+    """Tracks thinking sections and forces end tokens when budget is exceeded.
+
+    Includes a soft budget zone over the last 30% of the token budget.
+    Instead of a single hard cut, the logit for the end-of-thinking token is
+    progressively boosted relative to the model's own logit distribution,
+    encouraging a natural stopping point before the hard force at 100%.
+    The soft bias applies on the standard decoding path only; speculative
+    decoding keeps the existing hard-force behavior.
+    """
+
+    # Fraction of budget where the soft zone begins (0.7 = last 30%).
+    _SOFT_ZONE_START_FRAC = 0.7
 
     think_start_token_ids: list[int]
     think_end_token_ids: list[int]
@@ -65,6 +76,12 @@ class ThinkingBudgetStateHolder:
         self.device = device
         self._state: dict[int, dict[str, Any]] = {}
         self.cu_num_tokens: dict[int, int] = {}
+        # Pre-built tensor for end token IDs (used by the soft bias).
+        self._end_ids = (
+            torch.tensor(self.think_end_token_ids, device=device, dtype=torch.long)
+            if self.think_end_token_ids
+            else None
+        )
 
         if self.num_spec_tokens > 0:
             self._mask_capacity = max_num_reqs * (self.num_spec_tokens + 1)
@@ -216,6 +233,7 @@ class ThinkingBudgetStateHolder:
         return {
             "in_think": in_think,
             "in_end": in_end,
+            "soft_progress": 0.0,  # 0..1 ramp through the soft budget zone
             "check_count_down": countdown,
             "think_count": think_count,
             "end_count": 0,
@@ -273,10 +291,14 @@ class ThinkingBudgetStateHolder:
         )
         predicted_countdown = current_step_countdown - len(state["spec_token_ids"]) - 1
         # We only proceed further if we have counted down the thinking budget
-        # to 0 or less and when we are in the "in think" mode.
+        # into the soft zone (last 30% of the budget) or to 0 or less, and
+        # when we are in the "in think" mode. Taking the early return inside
+        # the soft zone would freeze ``think_count`` and skip the ramp.
+        budget = state["thinking_token_budget"]
+        soft_span = budget - int(budget * self._SOFT_ZONE_START_FRAC)
         if (
             not state.get("in_end", False)
-            and predicted_countdown >= 0
+            and predicted_countdown >= soft_span
             and state["start_thinking"] > -1
         ):
             state["check_count_down"] = current_step_countdown
@@ -378,6 +400,17 @@ class ThinkingBudgetStateHolder:
             else:
                 state["check_count_down"] = state["thinking_token_budget"]
 
+            # Soft zone: ramp progress from 0.0 to 1.0 over the last 30% of
+            # the budget; 0.0 outside the zone or when not thinking.
+            soft_start = int(budget * self._SOFT_ZONE_START_FRAC)
+            if state["in_think"] and state["think_count"] > soft_start:
+                state["soft_progress"] = min(
+                    1.0,
+                    (state["think_count"] - soft_start) / max(1, budget - soft_start),
+                )
+            else:
+                state["soft_progress"] = 0.0
+
             total_thinking_tokens = (
                 state["think_count"] + len(state["spec_token_ids"]) + 1
             )
@@ -394,6 +427,7 @@ class ThinkingBudgetStateHolder:
                 # where budget is exceeded.
                 state["in_think"] = False
                 state["in_end"] = True
+                state["soft_progress"] = 0.0
                 state["end_count"] = 0
                 state["check_count_down"] = state["thinking_token_budget"]
                 remaining_budget = state["thinking_token_budget"] - state["think_count"]
@@ -433,6 +467,7 @@ class ThinkingBudgetStateHolder:
                     {
                         "in_end": False,
                         "end_count": 0,
+                        "soft_progress": 0.0,
                         "check_count_down": state["thinking_token_budget"],
                     }
                 )
@@ -509,6 +544,26 @@ class ThinkingBudgetStateHolder:
                                     state["force_index"] = []
                                 else:
                                     state["bonus_token_forced"] = True
+            elif (
+                not self.in_spec_mode
+                and self._end_ids is not None
+                and state.get("soft_progress", 0.0) > 0.0
+            ):
+                # Adaptive soft bias: boost the end-of-thinking logit
+                # relative to the current gap between the top logit and the
+                # end token.
+                #   progress=0%   -> target = end_logit (no change)
+                #   progress=50%  -> target = top_logit (equal)
+                #   progress=100% -> target = top + gap (dominates)
+                row = self.cu_num_tokens[seq_idx]
+                if row < logits.shape[0]:
+                    top_logit = logits[row].max().item()
+                    end_logit = logits[row, self._end_ids[0]].item()
+                    gap = max(top_logit - end_logit, 1.0)
+                    target = end_logit + 2.0 * gap * state["soft_progress"]
+                    logits[row, self._end_ids] = torch.clamp(
+                        logits[row, self._end_ids], min=target
+                    )
 
         if active_indices_cpu:
             device = logits.device

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -76,12 +76,6 @@ class ThinkingBudgetStateHolder:
         self.device = device
         self._state: dict[int, dict[str, Any]] = {}
         self.cu_num_tokens: dict[int, int] = {}
-        # Pre-built tensor for end token IDs (used by the soft bias).
-        self._end_ids = (
-            torch.tensor(self.think_end_token_ids, device=device, dtype=torch.long)
-            if self.think_end_token_ids
-            else None
-        )
 
         if self.num_spec_tokens > 0:
             self._mask_capacity = max_num_reqs * (self.num_spec_tokens + 1)
@@ -181,6 +175,23 @@ class ThinkingBudgetStateHolder:
             return logits
         spec_lists = spec_token_ids or []
         return self._apply_forcing_to_logits(logits, predict_bonus_token, spec_lists)
+
+    def _next_close_token_id(self, state: dict[str, Any]) -> int:
+        """The only close-marker token that is valid to sample next.
+
+        For a multi-token close marker the ids must be emitted in order; if
+        the tail of already-generated output tokens matches a proper prefix
+        of the marker, the next id of the sequence is the one to encourage.
+        Otherwise (and always for a single-token marker) it is the first id.
+        """
+        ids = self.think_end_token_ids
+        if len(ids) == 1:
+            return ids[0]
+        output = state.get("output_tok_ids") or []
+        for k in range(min(len(output), len(ids) - 1), 0, -1):
+            if output[-k:] == ids[:k]:
+                return ids[k]
+        return ids[0]
 
     @staticmethod
     def _find_last_sequence_index(target_list: list[int], token_ids: list[int]) -> int:
@@ -546,7 +557,7 @@ class ThinkingBudgetStateHolder:
                                     state["bonus_token_forced"] = True
             elif (
                 not self.in_spec_mode
-                and self._end_ids is not None
+                and self.think_end_token_ids
                 and state.get("soft_progress", 0.0) > 0.0
             ):
                 # Adaptive soft bias: boost the end-of-thinking logit
@@ -555,15 +566,21 @@ class ThinkingBudgetStateHolder:
                 #   progress=0%   -> target = end_logit (no change)
                 #   progress=50%  -> target = top_logit (equal)
                 #   progress=100% -> target = top + gap (dominates)
+                #
+                # Kept entirely in torch ops — no ``.item()`` — so the
+                # sampler never syncs device->host on this path. Only the
+                # *next valid* close token is biased: for a multi-token
+                # marker, boosting later ids could let the model sample them
+                # out of order and leak a marker fragment into the thinking
+                # text.
                 row = self.cu_num_tokens[seq_idx]
                 if row < logits.shape[0]:
-                    top_logit = logits[row].max().item()
-                    end_logit = logits[row, self._end_ids[0]].item()
-                    gap = max(top_logit - end_logit, 1.0)
-                    target = end_logit + 2.0 * gap * state["soft_progress"]
-                    logits[row, self._end_ids] = torch.clamp(
-                        logits[row, self._end_ids], min=target
-                    )
+                    next_id = self._next_close_token_id(state)
+                    top = logits[row].max()
+                    end = logits[row, next_id]
+                    gap = torch.clamp(top - end, min=1.0)
+                    target = end + 2.0 * state["soft_progress"] * gap
+                    logits[row, next_id] = torch.maximum(end, target)
 
         if active_indices_cpu:
             device = logits.device

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Per-batch thinking token budget state; applied after penalties at sample time."""
 
+import math
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -44,6 +45,8 @@ class ThinkingBudgetStateHolder:
 
     # Fraction of budget where the soft zone begins (0.7 = last 30%).
     _SOFT_ZONE_START_FRAC = 0.7
+    _SOFT_SIGMOID_CENTER = 0.8
+    _SOFT_SIGMOID_SHARPNESS = 10.0
     # Keep the soft target just below the current best logit so it nudges the
     # model toward a natural close without becoming the argmax at temperature 0.
     _SOFT_TARGET_MARGIN = 0.25
@@ -247,7 +250,7 @@ class ThinkingBudgetStateHolder:
         return {
             "in_think": in_think,
             "in_end": in_end,
-            "soft_progress": 0.0,  # 0..1 ramp through the soft budget zone
+            "soft_progress": 0.0,  # 0..1 sigmoid ramp through the soft zone
             "check_count_down": countdown,
             "think_count": think_count,
             "end_count": 0,
@@ -414,13 +417,15 @@ class ThinkingBudgetStateHolder:
             else:
                 state["check_count_down"] = state["thinking_token_budget"]
 
-            # Soft zone: ramp progress from 0.0 to 1.0 over the last 30% of
-            # the budget; 0.0 outside the zone or when not thinking.
+            # Soft zone: map progress through a late sigmoid over the last
+            # 30% of the budget; 0.0 outside the zone or when not thinking.
             soft_start = int(budget * self._SOFT_ZONE_START_FRAC)
             if state["in_think"] and state["think_count"] > soft_start:
+                progress = (state["think_count"] - soft_start) / max(
+                    1, budget - soft_start - 1
+                )
                 state["soft_progress"] = min(
-                    1.0,
-                    (state["think_count"] - soft_start) / max(1, budget - soft_start),
+                    1.0, self._normalized_soft_ramp(progress)
                 )
             else:
                 state["soft_progress"] = 0.0
@@ -565,9 +570,9 @@ class ThinkingBudgetStateHolder:
             ):
                 # Adaptive soft bias: pull the end-of-thinking logit toward
                 # just below the current top logit.
-                #   progress=0%   -> target = end_logit (no change)
-                #   progress=50%  -> halfway to top_logit - margin
-                #   progress=100% -> target = top_logit - margin
+                #   ramp=0%   -> target = end_logit (no change)
+                #   ramp=50%  -> halfway to top_logit - margin
+                #   ramp=100% -> target = top_logit - margin
                 #
                 # Kept entirely in torch ops — no ``.item()`` — so the
                 # sampler never syncs device->host on this path. Only the
@@ -615,3 +620,16 @@ class ThinkingBudgetStateHolder:
                 logits.index_put_((active_indices, force_tokens), fill)
 
         return logits
+
+    @classmethod
+    def _normalized_soft_ramp(cls, progress: float) -> float:
+        """Map soft-zone progress [0, 1] to a late-rising sigmoid [0, 1]."""
+        progress = min(max(progress, 0.0), 1.0)
+
+        def sigmoid(x: float) -> float:
+            return 1.0 / (1.0 + math.exp(-cls._SOFT_SIGMOID_SHARPNESS * x))
+
+        start = sigmoid(0.0 - cls._SOFT_SIGMOID_CENTER)
+        finish = sigmoid(1.0 - cls._SOFT_SIGMOID_CENTER)
+        value = sigmoid(progress - cls._SOFT_SIGMOID_CENTER)
+        return min(max((value - start) / (finish - start), 0.0), 1.0)

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -44,6 +44,9 @@ class ThinkingBudgetStateHolder:
 
     # Fraction of budget where the soft zone begins (0.7 = last 30%).
     _SOFT_ZONE_START_FRAC = 0.7
+    # Keep the soft target just below the current best logit so it nudges the
+    # model toward a natural close without becoming the argmax at temperature 0.
+    _SOFT_TARGET_MARGIN = 0.25
 
     think_start_token_ids: list[int]
     think_end_token_ids: list[int]
@@ -560,12 +563,11 @@ class ThinkingBudgetStateHolder:
                 and self.think_end_token_ids
                 and state.get("soft_progress", 0.0) > 0.0
             ):
-                # Adaptive soft bias: boost the end-of-thinking logit
-                # relative to the current gap between the top logit and the
-                # end token.
+                # Adaptive soft bias: pull the end-of-thinking logit toward
+                # just below the current top logit.
                 #   progress=0%   -> target = end_logit (no change)
-                #   progress=50%  -> target = top_logit (equal)
-                #   progress=100% -> target = top + gap (dominates)
+                #   progress=50%  -> halfway to top_logit - margin
+                #   progress=100% -> target = top_logit - margin
                 #
                 # Kept entirely in torch ops — no ``.item()`` — so the
                 # sampler never syncs device->host on this path. Only the
@@ -578,8 +580,9 @@ class ThinkingBudgetStateHolder:
                     next_id = self._next_close_token_id(state)
                     top = logits[row].max()
                     end = logits[row, next_id]
-                    gap = torch.clamp(top - end, min=1.0)
-                    target = end + 2.0 * state["soft_progress"] * gap
+                    target = end + state["soft_progress"] * (
+                        (top - self._SOFT_TARGET_MARGIN) - end
+                    )
                     logits[row, next_id] = torch.maximum(end, target)
 
         if active_indices_cpu:


### PR DESCRIPTION
## Summary

Supersedes #38277, which GitHub refuses to reopen (`viewerCanReopen=false`).

This PR keeps `thinking_token_budget` as a hard safety wall, and adds softer guidance before that wall:

- Chat rendering now injects a compact system prompt hint when `thinking_token_budget` is set. It asks the model to keep reasoning under the requested budget, and merges into the leading system/developer message when one exists.
- In the last 30% of the budget, standard decoding applies a late sigmoid `soft_progress` ramp instead of waiting for the hard cut.
- The logits path nudges only the next valid end-of-thinking token, so multi-token close markers are completed in order.
- The soft target stays below the current winner: `target = end + ramp * ((top - 0.25) - end)`, then `max(end, target)`. This can help a natural close, but does not make the close token beat the current top logit at temperature 0.
- The nudge stays in torch tensor ops, with no `.item()` sync in the sampling loop.
- Speculative decoding keeps the existing hard-force behavior.
- At 100% of the budget, the existing hard force remains the safety net.
- 
<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/f8313c68-b96e-4836-b69a-56bcc146d1e6" />


## Why

A pure hard cut can land mid-thought. When that happens, the model may not realize its thinking section was interrupted and can leak reasoning into the visible answer/content. The prompt hint and soft zone give it a chance to close naturally before the hard budget cut, while keeping the hard wall as the final guard.

## Duplicate Check

I checked open PRs for `thinking token budget` and `soft thinking budget`. I did not find another open PR adding this soft close-token bias to `ThinkingBudgetStateHolder`; the closest open PRs cover MRV2 support, enforcement bugs, implicit tool calls, parser detection, or speculative decoding acceptance.

## Validation

- `UV_CACHE_DIR=/private/tmp/uv-cache PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/private/tmp/vllm-test-sitecustomize:/Users/manu/Projects/vllm VLLM_TARGET_DEVICE=cpu uv run --active --no-sync python -m pytest tests/v1/logits_processors/test_correctness.py tests/entrypoints/openai/chat_completion/test_thinking_token_budget_prompt_hint.py -q -k "thinking_budget" -p no:cacheprovider` -> 20 passed, 15 deselected
- `PYTHONPYCACHEPREFIX=/private/tmp/vllm-pycache UV_CACHE_DIR=/private/tmp/uv-cache uv run --active --no-sync python -m compileall -q vllm/v1/sample/thinking_budget_state.py tests/v1/logits_processors/test_correctness.py vllm/entrypoints/serve/render/serving.py tests/entrypoints/openai/chat_completion/test_thinking_token_budget_prompt_hint.py`

The local test run used a temporary `sitecustomize` only to force vLLM's CPU platform on macOS arm64, because no editable/precompiled vLLM wheel is available for this local platform.

## References

- NVIDIA NIM BudgetControlLogitsProcessor: https://docs.nvidia.com/nim/large-language-models/1.13.0/thinking-budget-control.html
- Token-Budget-Aware LLM Reasoning: https://arxiv.org/abs/2412.18547
- Steering LLM Thinking with Budget Guidance: https://arxiv.org/abs/2506.13752
- BudgetThinker: https://arxiv.org/html/2508.17196v1

AI assistance was used; the human author should review the changed lines and validation before marking this PR ready for review.
