### PR TITLE
[Ray] Default DP workers to mp-style device placement for symmetric memory

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -945,6 +945,19 @@ class ParallelConfig:
             and getattr(self.distributed_executor_backend, "uses_ray", False)
         )
 
+    @property
+    def ray_no_device_isolation(self) -> bool:
+        """Ray DP workers use the mp-style device layout: all GPUs visible and
+        each rank bound to cuda:{dp_rank}, instead of per-worker
+        CUDA_VISIBLE_DEVICES masking. Applies only when a DP replica fits a node
+        and DP is not ray-backed (which has its own device handling)."""
+        return (
+            self.use_ray
+            and envs.VLLM_RAY_NO_DEVICE_ISOLATION
+            and self.data_parallel_backend != "ray"
+            and self.nnodes_within_dp == 1
+        )
+
     @model_validator(mode="after")
     def _verify_args(self) -> Self:
         # Lazy import to avoid circular import

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -147,6 +147,7 @@ if TYPE_CHECKING:
     VLLM_MLA_DISABLE: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
     VLLM_RAY_BUNDLE_INDICES: str = ""
+    VLLM_RAY_NO_DEVICE_ISOLATION: bool = True
     VLLM_CUDART_SO_PATH: str | None = None
     VLLM_DP_RANK: int = 0
     VLLM_DP_RANK_LOCAL: int = -1
@@ -1278,6 +1279,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # which indices are used for the Ray bundle, for every worker.
     # Format: comma-separated list of integers, e.g. "0,1,2,3"
     "VLLM_RAY_BUNDLE_INDICES": lambda: os.getenv("VLLM_RAY_BUNDLE_INDICES", ""),
+    # When a DP replica fits a node, leave all GPUs visible to each Ray worker
+    # and bind cuda:{dp_rank} like the multiprocessing backend, so
+    # symmetric-memory collectives see distinct devices. Set to 0 to restore
+    # per-worker CUDA_VISIBLE_DEVICES masking (multi-instance GPU isolation).
+    "VLLM_RAY_NO_DEVICE_ISOLATION": lambda: bool(
+        int(os.getenv("VLLM_RAY_NO_DEVICE_ISOLATION", "1"))
+    ),
     # In some system, find_loaded_library() may not work. So we allow users to
     # specify the path through environment variable VLLM_CUDART_SO_PATH.
     "VLLM_CUDART_SO_PATH": lambda: os.getenv("VLLM_CUDART_SO_PATH", None),

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -185,8 +185,20 @@ class CoreEngineProcManager:
                 needs_device_env_isolation = not (
                     current_platform.is_cuda_alike() or current_platform.is_xpu()
                 )
+                # DeepGEMM mega-MoE symmetric memory needs every rank to see all
+                # node GPUs and bind a distinct physical device, like the mp
+                # backend. Skip the per-DP-rank CUDA_VISIBLE_DEVICES masking Ray
+                # would otherwise apply so the engine core keeps full visibility;
+                # the worker binds cuda:{dp_rank} in gpu_worker.init_device.
+                kernel_config = vllm_config.kernel_config
+                megamoe = (
+                    kernel_config is not None
+                    and getattr(kernel_config, "moe_backend", None)
+                    == "deep_gemm_mega_moe"
+                )
                 if is_dp and (
-                    needs_device_env_isolation or vllm_config.parallel_config.use_ray
+                    needs_device_env_isolation
+                    or (vllm_config.parallel_config.use_ray and not megamoe)
                 ):
                     device_control_context = set_device_control_env_var(
                         vllm_config, local_dp_rank

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -185,20 +185,15 @@ class CoreEngineProcManager:
                 needs_device_env_isolation = not (
                     current_platform.is_cuda_alike() or current_platform.is_xpu()
                 )
-                # DeepGEMM mega-MoE symmetric memory needs every rank to see all
-                # node GPUs and bind a distinct physical device, like the mp
-                # backend. Skip the per-DP-rank CUDA_VISIBLE_DEVICES masking Ray
-                # would otherwise apply so the engine core keeps full visibility;
-                # the worker binds cuda:{dp_rank} in gpu_worker.init_device.
-                kernel_config = vllm_config.kernel_config
-                megamoe = (
-                    kernel_config is not None
-                    and getattr(kernel_config, "moe_backend", None)
-                    == "deep_gemm_mega_moe"
-                )
+                # Skip per-DP-rank CUDA_VISIBLE_DEVICES masking when Ray DP uses
+                # the mp-style device layout, so gpu_worker can bind distinct
+                # cuda:{dp_rank} for symmetric memory (see ray_no_device_isolation).
                 if is_dp and (
                     needs_device_env_isolation
-                    or (vllm_config.parallel_config.use_ray and not megamoe)
+                    or (
+                        vllm_config.parallel_config.use_ray
+                        and not vllm_config.parallel_config.ray_no_device_isolation
+                    )
                 ):
                     device_control_context = set_device_control_env_var(
                         vllm_config, local_dp_rank

--- a/vllm/v1/executor/ray_executor_v2.py
+++ b/vllm/v1/executor/ray_executor_v2.py
@@ -381,14 +381,10 @@ class RayExecutorV2(MultiprocExecutor):
         # Step 7: Initialize workers with correct local_rank and
         # CUDA_VISIBLE_DEVICES. Each worker sees all GPUs assigned to
         # this executor on its node; local_rank indexes into that set.
-        #
-        # With the DeepGEMM mega-MoE backend, each data-parallel worker is
-        # masked to one GPU and reports it as cuda:0, so the symmetric-memory
-        # rendezvous across the EP group sees every rank on the same device
-        # and aborts. The ranks are on distinct physical GPUs, so allow the
-        # overlap. The variable is set here rather than in the launcher
-        # environment because CUDA_VISIBLE_DEVICES-class vars are not carried
-        # over to actors (WORKER_SPECIFIC_ENV_VARS).
+        # DeepGEMM mega-MoE: leave CUDA_VISIBLE_DEVICES wide (inherited from the
+        # unmasked engine core) so every worker sees all node GPUs and binds a
+        # distinct cuda:{dp_rank} in gpu_worker, matching the mp backend. This is
+        # required for the symmetric-memory rendezvous to see distinct devices.
         # See https://github.com/vllm-project/vllm/issues/44556.
         megamoe = (
             self.vllm_config.kernel_config is not None
@@ -398,13 +394,14 @@ class RayExecutorV2(MultiprocExecutor):
         init_worker_refs = []
         for i, (node_id, _) in enumerate(worker_node_and_gpu_ids):
             local_rank = node_workers[node_id].index(i)
-            worker_env_vars = {
-                current_platform.device_control_env_var: ",".join(
-                    map(str, node_gpus[node_id])
-                ),
-            }
             if megamoe:
-                worker_env_vars["TORCH_SYMM_MEM_ALLOW_OVERLAPPING_DEVICES"] = "1"
+                worker_env_vars = {}
+            else:
+                worker_env_vars = {
+                    current_platform.device_control_env_var: ",".join(
+                        map(str, node_gpus[node_id])
+                    ),
+                }
             self.ray_worker_handles[i].local_rank = local_rank
             init_worker_refs.append(
                 self.ray_worker_handles[i].actor.initialize_worker.remote(

--- a/vllm/v1/executor/ray_executor_v2.py
+++ b/vllm/v1/executor/ray_executor_v2.py
@@ -381,20 +381,15 @@ class RayExecutorV2(MultiprocExecutor):
         # Step 7: Initialize workers with correct local_rank and
         # CUDA_VISIBLE_DEVICES. Each worker sees all GPUs assigned to
         # this executor on its node; local_rank indexes into that set.
-        # DeepGEMM mega-MoE: leave CUDA_VISIBLE_DEVICES wide (inherited from the
-        # unmasked engine core) so every worker sees all node GPUs and binds a
-        # distinct cuda:{dp_rank} in gpu_worker, matching the mp backend. This is
-        # required for the symmetric-memory rendezvous to see distinct devices.
+        # With the mp-style device layout, leave CUDA_VISIBLE_DEVICES wide so
+        # each worker binds a distinct cuda:{dp_rank} in gpu_worker, which the
+        # symmetric-memory rendezvous needs (see ray_no_device_isolation).
         # See https://github.com/vllm-project/vllm/issues/44556.
-        megamoe = (
-            self.vllm_config.kernel_config is not None
-            and getattr(self.vllm_config.kernel_config, "moe_backend", None)
-            == "deep_gemm_mega_moe"
-        )
+        mp_device_layout = self.vllm_config.parallel_config.ray_no_device_isolation
         init_worker_refs = []
         for i, (node_id, _) in enumerate(worker_node_and_gpu_ids):
             local_rank = node_workers[node_id].index(i)
-            if megamoe:
+            if mp_device_layout:
                 worker_env_vars = {}
             else:
                 worker_env_vars = {

--- a/vllm/v1/executor/ray_executor_v2.py
+++ b/vllm/v1/executor/ray_executor_v2.py
@@ -381,6 +381,20 @@ class RayExecutorV2(MultiprocExecutor):
         # Step 7: Initialize workers with correct local_rank and
         # CUDA_VISIBLE_DEVICES. Each worker sees all GPUs assigned to
         # this executor on its node; local_rank indexes into that set.
+        #
+        # With the DeepGEMM mega-MoE backend, each data-parallel worker is
+        # masked to one GPU and reports it as cuda:0, so the symmetric-memory
+        # rendezvous across the EP group sees every rank on the same device
+        # and aborts. The ranks are on distinct physical GPUs, so allow the
+        # overlap. The variable is set here rather than in the launcher
+        # environment because CUDA_VISIBLE_DEVICES-class vars are not carried
+        # over to actors (WORKER_SPECIFIC_ENV_VARS).
+        # See https://github.com/vllm-project/vllm/issues/44556.
+        megamoe = (
+            self.vllm_config.kernel_config is not None
+            and getattr(self.vllm_config.kernel_config, "moe_backend", None)
+            == "deep_gemm_mega_moe"
+        )
         init_worker_refs = []
         for i, (node_id, _) in enumerate(worker_node_and_gpu_ids):
             local_rank = node_workers[node_id].index(i)
@@ -389,6 +403,8 @@ class RayExecutorV2(MultiprocExecutor):
                     map(str, node_gpus[node_id])
                 ),
             }
+            if megamoe:
+                worker_env_vars["TORCH_SYMM_MEM_ALLOW_OVERLAPPING_DEVICES"] = "1"
             self.ray_worker_handles[i].local_rank = local_rank
             init_worker_refs.append(
                 self.ray_worker_handles[i].actor.initialize_worker.remote(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -252,25 +252,16 @@ class Worker(WorkerBase):
             # This env var set by Ray causes exceptions with graph building.
             os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
             parallel_config = self.parallel_config
-            # DeepGEMM mega-MoE binds each DP rank to a distinct physical GPU
-            # (cuda:{dp_rank}) with all GPUs visible, like the mp backend, so the
-            # symmetric-memory rendezvous sees distinct devices. The executor
-            # leaves CUDA_VISIBLE_DEVICES wide for this backend, so run the DP
-            # device remap even under ray.
+            # Bind each DP rank to a distinct cuda:{dp_rank} with all GPUs
+            # visible when a replica fits a node: always for the mp backend, and
+            # for Ray when ray_no_device_isolation is set. Lets symmetric-memory
+            # collectives see distinct devices instead of every rank as cuda:0.
             # See https://github.com/vllm-project/vllm/issues/44556.
-            kernel_config = self.vllm_config.kernel_config
-            megamoe = (
-                kernel_config is not None
-                and getattr(kernel_config, "moe_backend", None)
-                == "deep_gemm_mega_moe"
-            )
-            if parallel_config.nnodes_within_dp == 1 and (
-                megamoe
-                or (
-                    parallel_config.distributed_executor_backend
-                    not in ("ray", "external_launcher")
-                    and parallel_config.data_parallel_backend != "ray"
-                )
+            if parallel_config.ray_no_device_isolation or (
+                parallel_config.nnodes_within_dp == 1
+                and parallel_config.data_parallel_backend != "ray"
+                and parallel_config.distributed_executor_backend
+                not in ("ray", "external_launcher")
             ):
                 # Use local DP rank if available, otherwise use global DP rank.
                 dp_local_rank = self.parallel_config.data_parallel_rank_local

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -252,11 +252,25 @@ class Worker(WorkerBase):
             # This env var set by Ray causes exceptions with graph building.
             os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
             parallel_config = self.parallel_config
-            if (
-                parallel_config.distributed_executor_backend
-                not in ("ray", "external_launcher")
-                and parallel_config.data_parallel_backend != "ray"
-                and parallel_config.nnodes_within_dp == 1
+            # DeepGEMM mega-MoE binds each DP rank to a distinct physical GPU
+            # (cuda:{dp_rank}) with all GPUs visible, like the mp backend, so the
+            # symmetric-memory rendezvous sees distinct devices. The executor
+            # leaves CUDA_VISIBLE_DEVICES wide for this backend, so run the DP
+            # device remap even under ray.
+            # See https://github.com/vllm-project/vllm/issues/44556.
+            kernel_config = self.vllm_config.kernel_config
+            megamoe = (
+                kernel_config is not None
+                and getattr(kernel_config, "moe_backend", None)
+                == "deep_gemm_mega_moe"
+            )
+            if parallel_config.nnodes_within_dp == 1 and (
+                megamoe
+                or (
+                    parallel_config.distributed_executor_backend
+                    not in ("ray", "external_launcher")
+                    and parallel_config.data_parallel_backend != "ray"
+                )
             ):
                 # Use local DP rank if available, otherwise use global DP rank.
                 dp_local_rank = self.parallel_config.data_parallel_rank_local


### PR DESCRIPTION
## Summary

Ray data parallelism masks each worker to one GPU through `CUDA_VISIBLE_DEVICES`, so every rank reports its device as `cuda:0`. The DeepGEMM mega-MoE symmetric-memory rendezvous spans the EP group and aborts when ranks collide on the same device:

```
RuntimeError: CUDASymmetricMemoryAllocator::rendezvous: detected allocations from overlapping devices from different ranks.
```

The mp backend does not hit this. It leaves all GPUs visible and binds each rank to a distinct `cuda:{dp_rank}`.

## Fix

Default the Ray backend to the same device placement as mp, controlled by a new env var `VLLM_RAY_NO_DEVICE_ISOLATION` that defaults to on. When a DP replica fits a node, leave `CUDA_VISIBLE_DEVICES` wide and bind each rank to `cuda:{dp_rank}`, so symmetric-memory collectives see distinct devices. Set `VLLM_RAY_NO_DEVICE_ISOLATION=0` to restore per-worker masking.

The condition is `ParallelConfig.ray_no_device_isolation`, read in three places:
- `engine/utils.py`: skip the per-DP-rank `CUDA_VISIBLE_DEVICES` masking so the engine core keeps full visibility.
- `ray_executor_v2.py`: leave the worker `CUDA_VISIBLE_DEVICES` wide.
- `gpu_worker.py`: run the DP device remap so each rank binds `cuda:{dp_rank}`.

It is gated to `nnodes_within_dp == 1` and `data_parallel_backend != ray`, the configurations where the per-rank remap is valid and the engine core is unmasked.

## Relationship to existing work

This extends #44555, which fixes the `MultiprocExecutor` path, to the Ray executor. Fixes the Ray-backend case of #44556. Earlier commits on this branch took narrower approaches and are superseded by this one.

## Testing

Device assignment on 4x A10G with `--data-parallel-size 4 --distributed-executor-backend ray`:
- Default on: every worker sees all 4 GPUs and binds a distinct device from `cuda:0` to `cuda:3`, with no `invalid device ordinal`.
- `VLLM_RAY_NO_DEVICE_ISOLATION=0`: every worker is masked to one GPU and binds `cuda:0`, restoring the previous isolation.

End-to-end on Blackwell with `deep_gemm_mega_moe` and `--data-parallel-size 8 --distributed-executor-backend ray --enable-expert-parallel --enable-eplb`.

Before the fix, all 8 DP engine cores abort during worker init:

```
(EngineCore_DP0) RuntimeError: Worker failed with error 'CUDASymmetricMemoryAllocator::rendezvous: detected allocations from overlapping devices from different ranks.', please check the stack trace above for the root cause
(EngineCore_DP1) RuntimeError: Worker failed with error 'CUDASymmetricMemoryAllocator::rendezvous: detected allocations from overlapping devices from different ranks.', ...
... DP2 through DP7 fail identically ...
```

Full failure log: https://gist.github.com/spencer-p/3f0d30db3e1031278dbc9c5e4761918c

With the fix, the overlap no longer occurs and all 8 DP engine cores complete initialization through profile, KV cache, and warmup:

```
init engine (profile, create kv cache, warmup model):
  EngineCore_DP0 took 780.97 s
  EngineCore_DP1 took 781.09 s
  EngineCore_DP2 took 780.98 s
  EngineCore_DP3 took 781.04 s
  EngineCore_DP4 took 780.94 s
  EngineCore_DP5 took 780.92 s
  EngineCore_DP6 took 780.63 s
  EngineCore_DP7 took 781.19 s
```

All 8 ApiServer processes then logged `Application startup complete`. Full pass log: https://gist.github.com/spencer-p/a8fb0ef8b474f3e78c94e6fcaf61e449

## Limitations

Leaving `CUDA_VISIBLE_DEVICES` wide gives up the per-worker GPU isolation that lets multiple instances share a node. Set `VLLM_RAY_NO_DEVICE_ISOLATION=0` to restore it. A replica that spans nodes keeps masking, since the per-rank remap and NVLink symmetric memory are both intra-node.

AI assistance was used on this change, per AGENTS.md.
