### PR TITLE
Pre-Commit CI Speedup

### DIFF
--- a/.github/actions/setup-pre-commit/action.yml
+++ b/.github/actions/setup-pre-commit/action.yml
@@ -1,0 +1,27 @@
+name: Setup pre-commit
+description: Restore pre-commit hook environments and install pre-commit.
+
+inputs:
+  python-version:
+    description: Python version used to run pre-commit.
+    default: "3.12"
+    required: false
+
+runs:
+  using: composite
+  steps:
+  - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+    with:
+      python-version: ${{ inputs.python-version }}
+
+  - name: Restore pre-commit environments
+    uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+    with:
+      path: ~/.cache/pre-commit
+      key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      restore-keys: |
+        pre-commit-3|${{ env.pythonLocation }}|
+
+  - name: Install pre-commit
+    shell: bash
+    run: python -m pip install "pre-commit>=4.5.1"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -43,18 +43,67 @@ jobs:
             core.setFailed(`PR must have the 'verified' or 'ready' (which also triggers tests) label or the author must have at least 4 merged PRs (found ${mergedCount}).`);
           }
 
-  pre-commit:
+  pre-commit-hooks:
+    name: pre-commit hooks
     needs: pre-run-check
     if: always() && (needs.pre-run-check.result == 'success' || needs.pre-run-check.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-      with:
-        python-version: "3.12"
+    - uses: ./.github/actions/setup-pre-commit
     - run: echo "::add-matcher::.github/workflows/matchers/actionlint.json"
     - run: echo "::add-matcher::.github/workflows/matchers/markdownlint.json"
     - run: echo "::add-matcher::.github/workflows/matchers/mypy.json"
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-      with:
-        extra_args: --all-files --hook-stage manual
+    - name: Run non-mypy hooks
+      env:
+        SKIP: mypy-3.10,mypy-3.11,mypy-3.12,mypy-3.13
+      run: pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage manual
+
+  mypy:
+    name: ${{ matrix.hook }}
+    needs: pre-run-check
+    if: always() && (needs.pre-run-check.result == 'success' || needs.pre-run-check.result == 'skipped')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        hook:
+        - mypy-3.10
+        - mypy-3.11
+        - mypy-3.12
+        - mypy-3.13
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: ./.github/actions/setup-pre-commit
+    - run: echo "::add-matcher::.github/workflows/matchers/mypy.json"
+    - name: Run ${{ matrix.hook }}
+      run: pre-commit run ${{ matrix.hook }} --show-diff-on-failure --color=always --all-files --hook-stage manual
+
+  pre-commit:
+    name: pre-commit
+    needs:
+    - pre-run-check
+    - pre-commit-hooks
+    - mypy
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check pre-commit result
+      env:
+        PRE_RUN_RESULT: ${{ needs.pre-run-check.result }}
+        HOOKS_RESULT: ${{ needs.pre-commit-hooks.result }}
+        MYPY_RESULT: ${{ needs.mypy.result }}
+      run: |
+        echo "pre-run-check: ${PRE_RUN_RESULT}"
+        echo "pre-commit hooks: ${HOOKS_RESULT}"
+        echo "mypy: ${MYPY_RESULT}"
+
+        if [[ "${PRE_RUN_RESULT}" == "failure" || "${PRE_RUN_RESULT}" == "cancelled" ]]; then
+          exit 1
+        fi
+        if [[ "${HOOKS_RESULT}" != "success" ]]; then
+          exit 1
+        fi
+        if [[ "${MYPY_RESULT}" != "success" ]]; then
+          exit 1
+        fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -203,6 +203,8 @@ repos:
     entry: python tools/pre_commit/check_init_lazy_imports.py
     language: python
     types: [python]
+    files: ^(vllm/__init__\.py|tools/pre_commit/check_init_lazy_imports\.py)$
+    pass_filenames: false
   - id: check-filenames
     name: Check for spaces in all filenames
     entry: bash
@@ -216,6 +218,7 @@ repos:
     name: Update Dockerfile dependency graph
     entry: tools/pre_commit/update-dockerfile-graph.sh
     language: script
+    files: ^docker/Dockerfile$
   - id: test-nonroot-entrypoint
     name: Test non-root entrypoint wrapper
     entry: bash docker/entrypoints/test_vllm_nonroot_entrypoint.sh
@@ -239,6 +242,7 @@ repos:
     name: Validate configuration has default values and that each field has a docstring
     entry: python tools/pre_commit/validate_config.py
     language: python
+    files: ^(vllm|tests)/.*\.py$
     additional_dependencies: [regex]
   - id: validate-docker-versions
     name: Validate docker/versions.json matches Dockerfile
@@ -251,6 +255,7 @@ repos:
     name: Check attention backend documentation is up to date
     entry: python tools/pre_commit/generate_attention_backend_docs.py --check
     language: python
+    files: ^(vllm/v1/attention/backends/.*\.py|vllm/models/minimax_m3/common/sparse_attention\.py|vllm/model_executor/layers/attention/mla_attention\.py|vllm/platforms/cuda\.py|tools/pre_commit/generate_attention_backend_docs\.py|docs/design/attention_backends\.md)$
   - id: check-boolean-context-manager
     name: Check for boolean ops in with-statements
     entry: python tools/pre_commit/check_boolean_context_manager.py


### PR DESCRIPTION
This PR aims to reduce GitHub pre-commit wall time by splitting the slow mypy hooks out of the single pre-commit job and running them in parallel.

* `.github/workflows/pre-commit.yml`

- Replaces the single `pre-commit/action` invocation with explicit jobs.
- Runs all non-mypy hooks in one job.
- Runs `mypy-3.10`, `mypy-3.11`, `mypy-3.12`, and `mypy-3.13` as parallel matrix jobs.
- Adds a final `pre-commit` aggregate job so branch protection can still use one
  familiar check name.

Effect:

- The four mypy hooks no longer run sequentially.
- Expected warm-cache runtime drops from about 4.5 minutes to about 1.5-2 minutes.

* `.github/actions/setup-pre-commit/action.yml`

- Adds a reusable local action for pre-commit setup.
- Installs Python 3.12.
- Restores `~/.cache/pre-commit` using `actions/cache@v5`.
- Keeps the existing `pre-commit-3|<pythonLocation>|<configHash>` key format.
- Adds a restore-key prefix so config changes can reuse previous hook env caches.
- Installs `pre-commit>=4.5.1`.

Effect:

- Avoids fully cold hook setup when `.pre-commit-config.yaml` changes.
- Keeps compatibility with the cache already produced by the old `pre-commit/action`.

* `.pre-commit-config.yaml`

- Narrows `check-root-lazy-imports` to only run for `vllm/__init__.py` or its hook script.
- Narrows `update-dockerfile-graph` to only run for `docker/Dockerfile`.
- Narrows `validate-config` to only run for Python files under `vllm/` or `tests/`.
- Narrows `attention-backend-docs` to only run for files that affect the generated docs.

Effect:

- Avoids starting broad local hooks for unrelated changed files.
- Keeps the same checks active when relevant files change.



Generated with: Codex GPT 5.5