### PR TITLE
[Bugfix] Reset per-item content_index in gpt-oss Responses streaming

### DIFF
--- a/tests/entrypoints/openai/responses/test_harmony.py
+++ b/tests/entrypoints/openai/responses/test_harmony.py
@@ -454,18 +454,20 @@ async def test_streaming(client: OpenAI, model_name: str, background: bool):
             if event.type == "response.output_item.added":
                 assert event.item.id != current_item_id
                 current_item_id = event.item.id
+                # content_index is per output item, so it restarts at 0
+                current_content_index = -1
             elif event.type in [
                 "response.output_text.delta",
                 "response.reasoning_text.delta",
             ]:
                 assert event.item_id == current_item_id
 
-            # Verify content indices
+            # Verify content indices: 0-based within each output item
             if event.type in [
                 "response.content_part.added",
                 "response.reasoning_part.added",
             ]:
-                assert event.content_index != current_content_index
+                assert event.content_index == current_content_index + 1
                 current_content_index = event.content_index
             elif event.type in [
                 "response.output_text.delta",

--- a/tests/entrypoints/openai/responses/test_streaming_events.py
+++ b/tests/entrypoints/openai/responses/test_streaming_events.py
@@ -8,7 +8,10 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.entrypoints.openai.responses.streaming_events import (
     SimpleStreamingEventProcessor,
+    StreamingState,
     _StateType,
+    emit_reasoning_delta_events,
+    emit_text_delta_events,
     split_delta,
 )
 
@@ -124,3 +127,30 @@ class TestProcessorCompoundDeltas:
         types = [e.type for e in events]
         assert "response.reasoning_text.delta" in types
         assert "response.output_text.delta" in types
+
+
+def _first_content_index(events: list) -> int:
+    for event in events:
+        content_index = getattr(event, "content_index", None)
+        if content_index is not None:
+            return content_index
+    raise AssertionError("no event carried a content_index")
+
+
+class TestHarmonyContentIndexPerItem:
+    def test_content_index_resets_for_each_output_item(self):
+        """content_index is the part index within an output item, so the first
+        part of every new item must be 0. Regression: reset_for_new_item() did
+        not reset current_content_index, so item N's first part was labeled N,
+        which crashes the OpenAI SDK responses stream accumulator."""
+        state = StreamingState()
+
+        reasoning = emit_reasoning_delta_events("r", state)
+        state.reset_for_new_item()
+        message = emit_text_delta_events("c", state)
+        state.reset_for_new_item()
+        message_2 = emit_text_delta_events("c", state)
+
+        assert _first_content_index(reasoning) == 0
+        assert _first_content_index(message) == 0
+        assert _first_content_index(message_2) == 0

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -110,6 +110,10 @@ class StreamingState:
     def reset_for_new_item(self) -> None:
         """Reset state when expecting a new output item."""
         self.current_output_index += 1
+        # content_index is the part index within an output item, so it must
+        # restart per item. Reset to -1 because it is pre-incremented when the
+        # first content part of the next item opens.
+        self.current_content_index = -1
         self.sent_output_item_added = False
         self.is_first_function_call_delta = False
         self.current_call_id = ""


### PR DESCRIPTION
Fixes #45742.

gpt-oss (Harmony) Responses streaming never reset `content_index` between
output items, so the second item's first content part was labeled `1` instead
of `0`. That crashes the OpenAI SDK `responses.stream()` accumulator with
`IndexError`. See the issue for the repro and details.

Fix: reset `current_content_index` in `StreamingState.reset_for_new_item()`
(to `-1`, since it is pre-incremented when the next item's first part opens).

Tests: added a unit test asserting each output item's first content part is
`content_index=0`, and tightened the existing streaming assertion (it only
checked the index changed from the previous one).
