### PR TITLE
[Bugfix] DiffusionGemma: only pop a request's logprobs when it commits (#45689)

### DIFF
--- a/tests/models/test_diffusion_gemma_logprobs.py
+++ b/tests/models/test_diffusion_gemma_logprobs.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for DiffusionSampler logprobs assembly (issue #45689)."""
+
+import numpy as np
+import torch
+
+from vllm.model_executor.models.diffusion_gemma import DiffusionSampler
+from vllm.v1.outputs import LogprobsTensors
+
+
+def _make_stash(n_rows: int, n_lp: int, fill: int) -> LogprobsTensors:
+    return LogprobsTensors(
+        logprob_token_ids=torch.full((n_rows, n_lp), fill, dtype=torch.int32),
+        logprobs=torch.full((n_rows, n_lp), float(fill)),
+        selected_token_ranks=torch.full((n_rows,), fill, dtype=torch.int32),
+    )
+
+
+def test_only_committing_request_pops_its_logprobs():
+    """Regression for #45689.
+
+    In a mixed batch where request A (slot 0) commits while request B (slot 1)
+    merely converged this step, only A's stash may be popped. B's stash must
+    survive until B's own commit; popping it early makes the committed
+    response return fewer logprob rows than tokens (IndexError downstream).
+    """
+    slots_np = np.array([0, 1], dtype=np.int64)
+    is_decode_np = np.array([True, True])
+    pending = {0: _make_stash(3, 2, 0), 1: _make_stash(4, 2, 1)}
+
+    out = DiffusionSampler._assemble_committed_logprobs(
+        num_reqs=2,
+        slots_np=slots_np,
+        is_decode_np=is_decode_np,
+        committing_slots={0},  # only slot 0 commits this step
+        pending_logprobs=pending,
+    )
+
+    assert out is not None
+    assert out.logprobs.shape[0] == 3  # only A emitted
+    assert 0 not in pending  # A's stash consumed
+    assert 1 in pending and pending[1].logprobs.shape[0] == 4  # B untouched
+
+
+def test_both_committing_emit_in_request_order():
+    slots_np = np.array([0, 1], dtype=np.int64)
+    is_decode_np = np.array([True, True])
+    pending = {0: _make_stash(3, 2, 0), 1: _make_stash(4, 2, 1)}
+
+    out = DiffusionSampler._assemble_committed_logprobs(
+        num_reqs=2,
+        slots_np=slots_np,
+        is_decode_np=is_decode_np,
+        committing_slots={0, 1},
+        pending_logprobs=pending,
+    )
+
+    assert out is not None
+    assert out.logprobs.shape[0] == 7  # 3 + 4
+    # One cumulative offset per request, in request order.
+    assert out.cu_num_generated_tokens == [0, 3]
+    assert pending == {}
+
+
+def test_no_committing_request_returns_none():
+    slots_np = np.array([0, 1], dtype=np.int64)
+    is_decode_np = np.array([True, True])
+    pending = {0: _make_stash(3, 2, 0)}
+
+    out = DiffusionSampler._assemble_committed_logprobs(
+        num_reqs=2,
+        slots_np=slots_np,
+        is_decode_np=is_decode_np,
+        committing_slots=set(),  # nobody commits this step
+        pending_logprobs=pending,
+    )
+
+    assert out is None
+    assert 0 in pending  # stash preserved
+
+
+def test_non_decode_request_is_skipped():
+    """A committing slot that is not a decode request must not be popped."""
+    slots_np = np.array([0, 1], dtype=np.int64)
+    is_decode_np = np.array([False, True])  # req 0 is a prefill
+    pending = {0: _make_stash(3, 2, 0), 1: _make_stash(4, 2, 1)}
+
+    out = DiffusionSampler._assemble_committed_logprobs(
+        num_reqs=2,
+        slots_np=slots_np,
+        is_decode_np=is_decode_np,
+        committing_slots={0, 1},
+        pending_logprobs=pending,
+    )
+
+    assert out is not None
+    assert out.logprobs.shape[0] == 4  # only the decode request (slot 1)
+    assert 0 in pending  # prefill slot's stash untouched
+    assert 1 not in pending

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -1215,6 +1215,58 @@ class DiffusionSampler:
             num_rejected=num_rejected,
         )
 
+    @staticmethod
+    def _assemble_committed_logprobs(
+        num_reqs: int,
+        slots_np: np.ndarray,
+        is_decode_np: np.ndarray,
+        committing_slots: set[int],
+        pending_logprobs: dict[int, LogprobsTensors],
+    ) -> LogprobsTensors | None:
+        """Pop and concatenate the stashed logprobs of committing requests.
+
+        A request's stashed logprobs are emitted (and removed from
+        ``pending_logprobs``) only when that request itself commits this step
+        (``slot in committing_slots``). A co-batched request that merely
+        converged this step is left untouched, so its stash survives until its
+        own commit. See #45689.
+
+        Args:
+            num_reqs: Number of requests in the batch.
+            slots_np: Per-request slot ids, shape ``[num_reqs]``.
+            is_decode_np: Per-request decode mask, shape ``[num_reqs]``.
+            committing_slots: Slot ids committing this step.
+            pending_logprobs: Slot -> stashed logprobs; mutated in place.
+
+        Returns:
+            The concatenated logprobs for the committing requests, or ``None``
+            if no committing request had a stash.
+        """
+        parts_ids, parts_lp, parts_ranks = [], [], []
+        cu_gen: list[int] = []
+        flat_offset = 0
+        for i in range(num_reqs):
+            cu_gen.append(flat_offset)
+            slot = int(slots_np[i])
+            if (
+                is_decode_np[i]
+                and slot in committing_slots
+                and slot in pending_logprobs
+            ):
+                lp = pending_logprobs.pop(slot)
+                parts_ids.append(lp.logprob_token_ids)
+                parts_lp.append(lp.logprobs)
+                parts_ranks.append(lp.selected_token_ranks)
+                flat_offset += lp.logprobs.shape[0]
+        if not parts_ids:
+            return None
+        return LogprobsTensors(
+            logprob_token_ids=torch.cat(parts_ids),
+            logprobs=torch.cat(parts_lp),
+            selected_token_ranks=torch.cat(parts_ranks),
+            cu_num_generated_tokens=cu_gen,
+        )
+
     # ------------------------------------------------------------------
     # Main entry point
     # ------------------------------------------------------------------
@@ -1366,28 +1418,21 @@ class DiffusionSampler:
                         )
 
         # Commit steps: is_committing was True at entry. Reassemble previously
-        # stashed logprobs and attach to SamplerOutput.
+        # stashed logprobs and attach to SamplerOutput. Only a committing
+        # request may pop its own stash: a co-batched request that merely
+        # converged this step keeps its stash until its own commit, otherwise
+        # a peer's commit would consume it one step early and the response
+        # would return fewer logprob rows than tokens (#45689).
         logprobs_tensors = None
         if max_num_logprobs >= 0 and is_committing.any() and self._pending_logprobs:
-            parts_ids, parts_lp, parts_ranks = [], [], []
-            cu_gen: list[int] = []
-            flat_offset = 0
-            for i in range(num_reqs):
-                cu_gen.append(flat_offset)
-                slot = int(slots_np[i])
-                if is_decode_np[i] and slot in self._pending_logprobs:
-                    lp = self._pending_logprobs.pop(slot)
-                    parts_ids.append(lp.logprob_token_ids)
-                    parts_lp.append(lp.logprobs)
-                    parts_ranks.append(lp.selected_token_ranks)
-                    flat_offset += lp.logprobs.shape[0]
-            if parts_ids:
-                logprobs_tensors = LogprobsTensors(
-                    logprob_token_ids=torch.cat(parts_ids),
-                    logprobs=torch.cat(parts_lp),
-                    selected_token_ranks=torch.cat(parts_ranks),
-                    cu_num_generated_tokens=cu_gen,
-                )
+            committing_slots = set(decode_slots[is_committing].tolist())
+            logprobs_tensors = self._assemble_committed_logprobs(
+                num_reqs,
+                slots_np,
+                is_decode_np,
+                committing_slots,
+                self._pending_logprobs,
+            )
 
         return self._build_output(
             input_batch,


### PR DESCRIPTION
## Purpose

Fixes #45689.

In a mixed decode batch, `DiffusionSampler.__call__` gated logprobs
reassembly on the batch-wide `is_committing.any()`, then popped
`self._pending_logprobs[slot]` for **every** decode request that had a stashed
entry — without checking whether *that* request was itself committing this
step:

```python
if is_committing.any() and self._pending_logprobs:
    for i in range(num_reqs):
        ...
        if is_decode_np[i] and slot in self._pending_logprobs:   # no per-request committing check
            lp = self._pending_logprobs.pop(slot)
```

So when request A commits while a co-batched request B merely *converged* this
step (its logprobs stashed via `just_converged`, but `is_committing[B]` is
False), B's stash is consumed one step early. B's eventual committed response
then returns fewer logprob rows than tokens, crashing the OpenAI chat formatter
with `IndexError: list index out of range` (in `_create_chat_logprobs`).

Credit to @masterFoad for the root-cause analysis and the suggested fix in the
issue.

## Fix

Pop a request's stash **only when that request commits**: build the set of
committing slots from the pre-step `is_committing` snapshot and require
`slot in committing_slots`. A converged-but-not-committing request keeps its
stash until its own commit. The commit-loop assembly is extracted into a
`_assemble_committed_logprobs` static helper so the interleaving is unit-testable
without a GPU. No behavior change for the single-request / aligned cases.

## Not a duplicate

- `gh issue view 45689 --comments` → unassigned, no prior PR.
- `gh pr list --state open --search "45689"` → none.
- The reporter's other open PRs are all in spec-decode (a different subsystem); no competing PR for this fix.

## Test plan / results

New `tests/models/test_diffusion_gemma_logprobs.py` (pure CPU, no GPU):

```
$ python -m pytest tests/models/test_diffusion_gemma_logprobs.py -q
4 passed
```

Covers: only-committing-pops, both-committing-emit-in-order (incl.
`cu_num_generated_tokens`), no-committing-returns-None, non-decode-skipped.
Verified the test catches the bug: removing the `slot in committing_slots`
guard makes `test_only_committing_request_pops_its_logprobs` and
`test_no_committing_request_returns_none` fail (the early/erroneous pop).

`pre-commit run --files vllm/model_executor/models/diffusion_gemma.py tests/models/test_diffusion_gemma_logprobs.py` → all hooks pass (ruff check + format, mypy-3.10, SPDX, …).

## Notes

AI-assisted: this change was developed with AI assistance (Claude) and reviewed
end-to-end by the submitter.
