### PR TITLE
[CI test] Validate dedicated pre-commit pipeline step (ci-infra#378)

### DIFF
--- a/tests/entrypoints/unit_tests/test_context.py
+++ b/tests/entrypoints/unit_tests/test_context.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+# No-op change to trigger CI for testing the dedicated pre-commit pipeline step.
+
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
**Do not merge / do not review — CI infrastructure test only. Will be closed.**

This draft PR is a no-op change used to validate [vllm-project/ci-infra#378](https://github.com/vllm-project/ci-infra/pull/378), which splits `pre-commit` out of the bootstrap step into a dedicated Buildkite step that runs **in parallel** with the image build, and makes image-build-dependent jobs also depend on the pre-commit step.

A Buildkite build is triggered manually with `VLLM_CI_BRANCH` pointing at the ci-infra branch to confirm:
1. `pre-commit` shows up as its own Buildkite step.
2. `pre-commit` and `image-build` run in parallel.
3. Test steps wait on both `image-build` and `pre-commit`.