### PR TITLE
[XPU] Fix Triton attn fp8/bf16 check failing

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -464,26 +464,29 @@ class TritonAttentionImpl(AttentionImpl):
         else:
             self.sliding_window = (sliding_window - 1, 0)
         self.kv_cache_dtype = kv_cache_dtype
-        cap = current_platform.get_device_capability()
-        cap_str = cap.as_version_str() if cap is not None else "unknown"
-        dev = current_platform.get_device_name()
-        if self.kv_cache_dtype.startswith("fp8") and not (
-            current_platform.has_device_capability(89)
-        ):
-            suggested = "float16" if (cap is None or cap.to_int() < 80) else "bfloat16"
-            raise ValueError(
-                f"FP8 KV cache is not supported by the Triton attention backend "
-                f"on {dev} (compute capability {cap_str}); native FP8 (fp8e4nv) "
-                f"requires SM89+. Re-run with --kv-cache-dtype {suggested}."
-            )
-        if self.kv_cache_dtype == "bfloat16" and not (
-            current_platform.has_device_capability(80)
-        ):
-            raise ValueError(
-                f"bfloat16 KV cache is not supported on {dev} (compute capability "
-                f"{cap_str}); bfloat16 requires SM80+. Re-run with "
-                f"--kv-cache-dtype float16."
-            )
+        if current_platform.is_cuda():
+            cap = current_platform.get_device_capability()
+            cap_str = cap.as_version_str() if cap is not None else "unknown"
+            dev = current_platform.get_device_name()
+            if self.kv_cache_dtype.startswith("fp8") and not (
+                current_platform.has_device_capability(89)
+            ):
+                suggested = (
+                    "float16" if (cap is None or cap.to_int() < 80) else "bfloat16"
+                )
+                raise ValueError(
+                    f"FP8 KV cache is not supported by the Triton attention backend "
+                    f"on {dev} (compute capability {cap_str}); native FP8 (fp8e4nv) "
+                    f"requires SM89+. Re-run with --kv-cache-dtype {suggested}."
+                )
+            if self.kv_cache_dtype == "bfloat16" and not (
+                current_platform.has_device_capability(80)
+            ):
+                raise ValueError(
+                    f"bfloat16 KV cache is not supported on {dev} (compute capability "
+                    f"{cap_str}); bfloat16 requires SM80+. Re-run with "
+                    f"--kv-cache-dtype float16."
+                )
         if logits_soft_cap is None:
             # In flash-attn, setting logits_soft_cap as 0 means no soft cap.
             logits_soft_cap = 0

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -23,9 +23,9 @@ def _is_supported_kv_cache_dtype(kv_cache_dtype: str) -> bool:
     ):
         return False
     if kv_cache_dtype.startswith("fp8"):
-        return current_platform.has_device_capability(89)
+        return current_platform.has_device_capability(89) or current_platform.is_xpu()
     if kv_cache_dtype == "bfloat16":
-        return current_platform.has_device_capability(80)
+        return current_platform.has_device_capability(80) or current_platform.is_xpu()
     return True
 
 


### PR DESCRIPTION



## Purpose

The compute capability checks added in https://github.com/vllm-project/vllm/pull/43914 are CUDA-specific and incorrectly reject XPU devices. This PR skip these checks on XPU.


## Test Plan
`python3 examples/basic/offline_inference/generate.py --model Qwen/Qwen3-0.6B   --enforce-eager -tp 1 --attention-backend TRITON_ATTN --kv-cache-dtype fp8`

## Test Result
```
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: " Alex. I'm a 22-year-old student. I'm studying in"
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the same as the president of the United States. The president of the United States'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' Paris. The capital of Italy is Rome. The capital of Spain is Madrid.'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' not just a technological marvel but a profound shift in how we live, work,'
--------------------------------------------------

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

