### PR TITLE
[TieredOffloading] Bound Secondary Tier lookup times

### DIFF
--- a/tests/v1/kv_offload/tiering/test_async_lookup.py
+++ b/tests/v1/kv_offload/tiering/test_async_lookup.py
@@ -20,8 +20,12 @@ def _ctx(req_id: str = "r1") -> ReqContext:
 class InMemoryLookupManager(AsyncLookupManager):
     """Test subclass backed by an in-memory set."""
 
-    def __init__(self, existing_keys: set[OffloadKey] | None = None):
-        super().__init__(tier_type="test")
+    def __init__(
+        self,
+        existing_keys: set[OffloadKey] | None = None,
+        lookup_timeout_s: float | None = None,
+    ):
+        super().__init__(tier_type="test", lookup_timeout_s=lookup_timeout_s)
         self._existing = existing_keys or set()
         self._results_ready = threading.Event()
 
@@ -156,3 +160,41 @@ class TestAsyncLookupManager:
         mgr = InMemoryLookupManager()
         mgr.shutdown()
         assert not mgr._thread.is_alive()
+
+
+def test_lookup_timeout():
+    """
+    Three timeout scenarios tested sequentially:
+    1. Timeout exceeded while result pending: lookup returns False (treated as miss).
+    2. Result arrives before timeout: actual result returned, not timeout-induced False.
+    3. Result arrives after timeout fired: real result is still returned on subsequent
+       lookups; the timeout does not permanently mask the actual result.
+    """
+    # Case 1: timeout exceeded while result is still pending → False.
+    mgr = InMemoryLookupManager(existing_keys={_key(1)}, lookup_timeout_s=10.0)
+    assert mgr.lookup(_key(1), _ctx()) is None  # not yet expired
+    mgr._lookup_state[_key(1)].submit_time -= 11.0  # simulate elapsed time
+    assert mgr.lookup(_key(1), _ctx()) is False  # timeout fires
+    mgr.shutdown()
+
+    # Case 2: result arrives before timeout — actual result returned, not timeout False.
+    mgr = InMemoryLookupManager(existing_keys={_key(1)}, lookup_timeout_s=10.0)
+    mgr.lookup(_key(1), _ctx())
+    mgr.flush()
+    mgr._results_ready.wait()
+    mgr._results_ready.clear()
+    assert mgr.lookup(_key(1), _ctx()) is True  # actual result, not timeout sentinel
+    mgr.shutdown()
+
+    # Case 3: result arrives *after* timeout fired — real result is still returned
+    # on subsequent lookups; the timeout does not permanently mask the result.
+    mgr = InMemoryLookupManager(existing_keys={_key(1)}, lookup_timeout_s=10.0)
+    mgr.lookup(_key(1), _ctx())
+    assert mgr.lookup(_key(1), _ctx()) is None  # pending, timeout not yet expired
+    mgr._lookup_state[_key(1)].submit_time -= 11.0  # simulate timeout expiry
+    assert mgr.lookup(_key(1), _ctx()) is False  # timeout fires
+    mgr.flush()
+    mgr._results_ready.wait()
+    mgr._results_ready.clear()
+    assert mgr.lookup(_key(1), _ctx()) is True  # real result now visible
+    mgr.shutdown()

--- a/vllm/v1/kv_offload/tiering/async_lookup.py
+++ b/vllm/v1/kv_offload/tiering/async_lookup.py
@@ -158,6 +158,10 @@ class AsyncLookupManager(ABC):
         ):
             # Cannot determine lookup within the timeout. It is better to let
             # the request continue processing on the GPU.
+            logger.warning(
+                "Cannot determine lookup reliably within %.2f timeout seconds",
+                self._lookup_timeout_s,
+            )
             return False
 
         return state.result

--- a/vllm/v1/kv_offload/tiering/async_lookup.py
+++ b/vllm/v1/kv_offload/tiering/async_lookup.py
@@ -33,6 +33,7 @@ lookup() is a pure OrderedDict operation.
 
 import queue
 import threading
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -47,6 +48,11 @@ logger = init_logger(__name__)
 class LookupState:
     result: bool | None = None  # True (found), False (not found), None
     request_ids: set[str] = field(default_factory=set)  # requests asking for the lookup
+    submit_time: float = field(default_factory=time.monotonic)
+
+    @property
+    def elapsed_time(self):
+        return time.monotonic() - self.submit_time
 
 
 class AsyncLookupManager(ABC):
@@ -71,8 +77,10 @@ class AsyncLookupManager(ABC):
     def __init__(
         self,
         tier_type: str,
+        lookup_timeout_s: float | None = None,
     ) -> None:
         self._tier_type = tier_type
+        self._lookup_timeout_s = lookup_timeout_s
 
         # key → LookupState; scheduler-owned, no lock needed.
         self._lookup_state: dict[OffloadKey, LookupState] = {}
@@ -142,6 +150,16 @@ class AsyncLookupManager(ABC):
             self._lookup_batch.append((key, req_context))
         state.request_ids.add(req_id)
         self._req_keys.setdefault(req_id, set()).add(key)
+
+        if (
+            state.result is None
+            and self._lookup_timeout_s is not None
+            and state.elapsed_time >= self._lookup_timeout_s
+        ):
+            # Cannot determine lookup within the timeout. It is better to let
+            # the request continue processing on the GPU.
+            return False
+
         return state.result
 
     def flush(self) -> None:
@@ -210,7 +228,6 @@ class AsyncLookupManager(ABC):
             if not batches:
                 continue
 
-            results: list[tuple[OffloadKey, bool]] = []
             for req_context, keys in batches.values():
                 try:
                     hits = self.batch_lookup(keys, req_context)
@@ -223,9 +240,8 @@ class AsyncLookupManager(ABC):
                     )
                     hits = (False for _ in keys)
 
-                for key, hit in zip(keys, hits):
-                    results.append((key, hit))
-
-            # Post the entire batch as one item — no lock needed.
-            if results:
-                self._pending_results.put(results)
+                results = list(zip(keys, hits))
+                if results:
+                    # Post results as soon as possible. we dont want a request
+                    # to wait for other requests.
+                    self._pending_results.put(results)

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -49,8 +49,9 @@ class FsAsyncLookupManager(AsyncLookupManager):
         self,
         tier: "FileSystemTierManager",
         tier_type: str,
+        lookup_timeout_s: float | None = None,
     ) -> None:
-        super().__init__(tier_type=tier_type)
+        super().__init__(tier_type=tier_type, lookup_timeout_s=lookup_timeout_s)
         self._tier = tier
 
     def batch_lookup(
@@ -88,6 +89,7 @@ class FileSystemTierManager(SecondaryTierManager):
         root_dir: str,
         n_read_threads: int = 16,
         n_write_threads: int = 16,
+        lookup_timeout_s: float | None = None,
     ):
         """
         Args:
@@ -98,6 +100,7 @@ class FileSystemTierManager(SecondaryTierManager):
             root_dir: Root directory for block files.
             n_read_threads: Number of read-priority I/O threads.
             n_write_threads: Number of write-priority I/O threads.
+            lookup_timeout_s: Timeout for lookup operations.
         """
         super().__init__(offloading_spec, primary_kv_view, tier_type)
 
@@ -130,7 +133,9 @@ class FileSystemTierManager(SecondaryTierManager):
             thread_name_prefix="vllm_kv_py_fs",
         )
 
-        self._lookup_manager = FsAsyncLookupManager(tier=self, tier_type=self.tier_type)
+        self._lookup_manager = FsAsyncLookupManager(
+            tier=self, tier_type=self.tier_type, lookup_timeout_s=lookup_timeout_s
+        )
 
     @override
     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:


### PR DESCRIPTION
## Purpose
When the SecondaryTier is under heavy load, lookups can be expensive. At the moment, the AsyncLookupManager returns None when the lookup is in progress. This effectively asks the Scheduler to retry the request in the next scheduling step. This can put the requests in a long retry loop, even when the GPU is underutilized and the request is better of running on the GPU. A pathological case is when brand new requests have to retry only to find out the keys dont exist. 

PR: 
 - The AsyncLookupManager, buffers the results for all the request before draining it. This PR makes the change to return lookup results eagerly.  
 - Add an opt-in lookup_timeout_s. This is applied per-key and when the lookups can't complete, we simply return False so we dont block the request. Note that the lookup process is not interrupted and when the lookup eventually completes we return the true results. 
 
## Comparison with main
Legend: 
 "deferred" - requests waiting on lookup
  "capacity" - requests waiting due to `max_num_batched_tokens` or `max_num_seqs`
`main - no offload`
```
Requesting API: 100%|███████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [02:10<00:00, 10.08it/s]
2026-06-17:04:38:28 INFO     [loggers.evaluation_tracker:316] Output path not provided, skipping saving results aggregated
local-completions ({'base_url': 'http://localhost:8000/v1/completions', 'model': 'google/gemma-4-31B', 'tokenized_requests': False, 'num_concurrent': 1000}), gen_kwargs: ({'temperature': 0.0}), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8423|±  |  0.01|
|     |       |strict-match    |     5|exact_match|↑  |0.8423|±  |  0.01|
```
<img width="1300" height="295" alt="gpu-only" src="https://github.com/user-attachments/assets/8642cc54-00a8-4659-b761-6b2ea41e203a" />

`main - with FS offloading + CPU bytes 400GB`
```
lm-eval does not finish
```
<img width="1300" height="295" alt="main-offload" src="https://github.com/user-attachments/assets/ba86410c-96d5-488e-9a5a-54f571a7a551" />

`This PR - with FS offloading + CPU byes 400GB + lookup timeout 20s`
```
lm-eval does not finish
```
<img width="1300" height="295" alt="lookup-pr" src="https://github.com/user-attachments/assets/f45dc54e-9ff8-4c4c-a4fe-83763b761635" />
Still too slow - needs fix https://github.com/vllm-project/vllm/pull/45757 
But here you can see the that the requests no longer wait indefinitely for the lookups and it times out.

`This PR + #45757 + lookup timeout 20s`
```
Requesting API: 100%|███████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [02:47<00:00,  7.88it/s]
2026-06-17:02:32:05 INFO     [loggers.evaluation_tracker:316] Output path not provided, skipping saving results aggregated
local-completions ({'base_url': 'http://localhost:8000/v1/completions', 'model': 'google/gemma-4-31B', 'tokenized_requests': False, 'num_concurrent': 1000}), gen_kwargs: ({'temperature': 0.0}), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8423|±  |  0.01|
|     |       |strict-match    |     5|exact_match|↑  |0.8431|±  |  0.01|
```
<img width="1300" height="295" alt="lookup + eviction" src="https://github.com/user-attachments/assets/c9ac0177-5277-48a1-9172-08e68ebd968b" />

Note: Not as fast as just GPU - can be explained by the +20s of lookup time. but there is still some overhead to explore.


## Test Plan
Add unit tests.

## Test Result
Unit tests pass.