### PR TITLE
[Bugfix] Invalidate CPU metadata shadows after query extension

### DIFF
--- a/tests/v1/spec_decode/test_eagle.py
+++ b/tests/v1/spec_decode/test_eagle.py
@@ -27,11 +27,13 @@ from vllm.config import (
 from vllm.config.load import LoadConfig
 from vllm.model_executor.models.llama import LlamaForCausalLM
 from vllm.platforms import current_platform
+from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.spec_decode.dflash import DFlashProposer
 from vllm.v1.spec_decode.draft_model import DraftModelProposer
 from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
+from vllm.v1.spec_decode.utils import extend_all_queries_by_N
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
 model_dir = "meta-llama/Llama-3.1-8B-Instruct"
@@ -43,6 +45,52 @@ dflash_dir = "z-lab/Qwen3-8B-DFlash-b16"
 
 BLOCK_SIZE = 16
 DEVICE_TYPE = current_platform.device_type
+
+
+def _make_common_attn_metadata() -> CommonAttentionMetadata:
+    device = torch.device("cpu")
+    query_start_loc = torch.tensor([0, 51], dtype=torch.int32, device=device)
+    seq_lens = torch.tensor([51], dtype=torch.int32, device=device)
+
+    return CommonAttentionMetadata(
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc.cpu(),
+        seq_lens=seq_lens,
+        seq_lens_cpu_upper_bound=seq_lens.cpu(),
+        _seq_lens_cpu=seq_lens.cpu(),
+        _num_computed_tokens_cpu=torch.tensor([0], dtype=torch.int32),
+        num_reqs=1,
+        num_actual_tokens=51,
+        max_query_len=51,
+        max_seq_len=51,
+        block_table_tensor=torch.zeros((1, 4), dtype=torch.int32, device=device),
+        slot_mapping=torch.arange(51, dtype=torch.int64, device=device),
+    )
+
+
+def test_extend_all_queries_by_n_invalidates_stale_cpu_shadows():
+    common_attn_metadata = _make_common_attn_metadata()
+    updated_metadata = extend_all_queries_by_N(
+        common_attn_metadata,
+        N=1,
+        arange=torch.arange(2, dtype=torch.int32),
+        new_slot_mapping=torch.arange(52, dtype=torch.int64),
+    )
+
+    assert torch.equal(
+        updated_metadata.query_start_loc, torch.tensor([0, 52], dtype=torch.int32)
+    )
+    assert torch.equal(updated_metadata.seq_lens, torch.tensor([52], dtype=torch.int32))
+
+    assert updated_metadata._seq_lens_cpu is None
+    assert updated_metadata._num_computed_tokens_cpu is None
+
+    assert torch.equal(
+        updated_metadata.seq_lens_cpu, torch.tensor([52], dtype=torch.int32)
+    )
+    assert torch.equal(
+        updated_metadata.num_computed_tokens_cpu, torch.tensor([0], dtype=torch.int32)
+    )
 
 
 def _create_proposer(

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -300,6 +300,10 @@ def extend_all_queries_by_N(
         max_query_len=cad.max_query_len + N,
         max_seq_len=cad.max_seq_len + N,
         slot_mapping=new_slot_mapping,
+        # Invalidate the derived CPU shadows so they are lazily recomputed from
+        # the already-updated GPU seq_lens, avoiding a stale CPU/GPU mismatch.
+        _seq_lens_cpu=None,
+        _num_computed_tokens_cpu=None,
     )
     return new_cad
 


### PR DESCRIPTION
## Purpose

This PR invalidates derived CPU metadata shadows after `extend_all_queries_by_N` updates query starts and sequence lengths during speculative decoding.

Previously, the new `CommonAttentionMetadata` preserved cached CPU shadow fields from the old metadata. This could leave `_seq_lens_cpu` and `_num_computed_tokens_cpu` stale even though the device-side `seq_lens` and CPU-side `query_start_loc_cpu` had already been updated.

### Why

`seq_lens_cpu` and `num_computed_tokens_cpu` are deprecated, but they are still available and may still be used by existing code paths before removal. If their cached backing fields are carried over after query extension, later access can observe CPU metadata that is inconsistent with the updated metadata.

This change clears the derived CPU shadows so they are recomputed lazily from the updated metadata when accessed.

### When this triggers

In the current upstream code, this path is hard to hit: other code paths already invalidate the CPU shadows (e.g. after dropping rejected tokens), and the in-tree drafting builders read GPU-side `seq_lens` directly rather than the deprecated CPU shadows. So upstream this is mostly a latent inconsistency.

It becomes a real bug for downstream code that reads the still-public but deprecated `seq_lens_cpu` / `num_computed_tokens_cpu` after `extend_all_queries_by_N`. For example, an external project that hooks / monkey-patches vLLM (a custom proposer or attention-metadata builder) and relies on these CPU shadows will observe stale values: the device-side `seq_lens` is already incremented by `N`, while the carried-over CPU shadows still hold the pre-extension lengths. This off-by-`N` CPU/GPU mismatch can then propagate into derived quantities such as context lengths or scheduling/backend metadata.

Clearing the shadows here forces a lazy recompute from the updated metadata, matching the invalidation convention already used elsewhere in this file.

## Changes

- Clear `_seq_lens_cpu` and `_num_computed_tokens_cpu` in `extend_all_queries_by_N`.
- Add a regression test covering stale CPU shadow metadata after query extension.

## Duplicate Work Check

I checked open PRs for related terms such as:

- `spec decode seq_lens_cpu`
- `extend_all_queries_by_N`
- `CPU shadow`

I did not find an open PR addressing this same fix.

## Test Plan and Result

```bash
.venv/bin/python -m pytest tests/v1/spec_decode/test_eagle.py::test_extend_all_queries_by_n_invalidates_stale_cpu_shadows -q
.venv/bin/pre-commit run --files vllm/v1/spec_decode/utils.py tests/v1/spec_decode/test_eagle.py
```

<img width="1201" height="805" alt="图片" src="https://github.com/user-attachments/assets/2e067754-db6d-44ae-8611-11d91f0a730d" />

## AI Assistance

AI assistance (Baidu Comate) was used to help inspect the bug, place the regression test, and validate the fix. I reviewed and verified the final changes.

## Related Previous Issue

This is related to #29134 in that it touches the lazy/deprecated CPU metadata shadows used by `CommonAttentionMetadata`, but it does not attempt to solve the full async spec-decoding performance work described there. It only fixes a correctness issue where those shadows could remain stale after query extension.