### PR TITLE
[KV Connector][Mooncake] Add cache_prefix to namespace store keys

### DIFF
--- a/docs/features/mooncake_store_connector_usage.md
+++ b/docs/features/mooncake_store_connector_usage.md
@@ -205,6 +205,7 @@ the vLLM JSON config.
 - `load_async` (bool): Enable asynchronous loading for better compute-I/O overlap. Default: `true`.
 - `enable_cross_layers_blocks` (bool): Enable cross-layer block packing for reduced store operations. Default: `false`.
 - `lookup_rpc_port` (int): Custom port for the ZMQ lookup RPC socket. Default: `0`.
+- `cache_prefix` (str): Namespace prepended to every store key. Lets separate deployments share one Mooncake master without polluting each other — instances configured with different prefixes never see each other's cached blocks, even for identical prompts. All instances that should share a prefix cache must use the same value. Default: `""` (no prefix; keys are byte-identical to the unprefixed format).
 
 ## Notes
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -26,6 +26,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     ChunkedTokenDatabase,
     KeyMetadata,
     LoadSpec,
+    PoolKey,
     ReqMeta,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.metrics import (
@@ -238,6 +239,31 @@ def _patch_worker_runtime(monkeypatch, *, local_ip: str = "10.0.0.7") -> None:
     monkeypatch.setattr(worker, "get_pcp_group", lambda: single_rank_group)
     monkeypatch.setattr(worker, "get_dcp_group", lambda: single_rank_group)
     monkeypatch.setattr(worker, "get_ip", lambda: local_ip)
+
+
+def test_pool_key_to_string_without_prefix_is_unchanged():
+    """Default (empty) cache_prefix keeps keys byte-identical to the
+    historical unprefixed format so existing deployments keep their hits."""
+    key = PoolKey(KeyMetadata("test-model", 0, 0, 0, 0), "deadbeef")
+    assert (
+        key.to_string() == "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@deadbeef"
+    )
+
+
+def test_pool_key_cache_prefix_namespaces_and_disambiguates():
+    """A non-empty cache_prefix is prepended, and two instances with
+    different prefixes never collide on identical block hashes."""
+    md_a = KeyMetadata("test-model", 0, 0, 0, 0, cache_prefix="depA")
+    md_b = KeyMetadata("test-model", 0, 0, 0, 0, cache_prefix="depB")
+
+    key_a = PoolKey(md_a, "deadbeef")
+    key_b = PoolKey(md_b, "deadbeef")
+
+    assert key_a.to_string() == (
+        "depA@test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@deadbeef"
+    )
+    assert key_a.to_string() != key_b.to_string()
+    assert hash(key_a) != hash(key_b)
 
 
 def test_default_local_buffer_size_matches_pr40900():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -33,6 +33,10 @@ class KeyMetadata:
     dcp_rank: int
     pp_rank: int
     group_id: int = 0
+    # Optional namespace prepended to every key. Lets separate deployments
+    # share one Mooncake master without colliding on identical block hashes.
+    # Empty (the default) keeps keys byte-identical to the unprefixed format.
+    cache_prefix: str = ""
 
 
 @dataclass(order=True)
@@ -45,6 +49,7 @@ class PoolKey:
     def __hash__(self):
         return hash(
             (
+                self.key_metadata.cache_prefix,
                 self.key_metadata.model_name,
                 self.key_metadata.tp_rank,
                 self.key_metadata.pcp_rank,
@@ -56,7 +61,13 @@ class PoolKey:
         )
 
     def to_string(self) -> str:
+        prefix = (
+            f"{self.key_metadata.cache_prefix}@"
+            if self.key_metadata.cache_prefix
+            else ""
+        )
         return (
+            f"{prefix}"
             f"{self.key_metadata.model_name}"
             f"@tp_rank:{self.key_metadata.tp_rank}"
             f"@pcp{self.key_metadata.pcp_rank}"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -982,6 +982,11 @@ class MooncakeStoreWorker:
             pcp_rank=self.pcp_rank,
             dcp_rank=self.dcp_rank,
             pp_rank=self.pp_rank,
+            cache_prefix=str(
+                vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+                    "cache_prefix", ""
+                )
+            ),
         )
 
         # Initialize MooncakeDistributedStore with its own TransferEngine


### PR DESCRIPTION
## Purpose

`MooncakeStoreConnector` keys are derived from the model name, parallel ranks, KV cache group, and block hash. Multiple deployments pointed at the **same** Mooncake master therefore collide on identical block hashes — one deployment can serve another's cached KV, and a `reset_prefix_cache` in one wipes the shared pool for all of them.

The motivating case is a **rollout where two deployments of the same model have incompatible KV caches but share one master** — for example, migrating the KV cache dtype (bf16 → fp8) while both the old and new versions run concurrently. The store key encodes the model name and ranks but **not** the KV cache dtype/layout, so identical prompts produce identical keys on both versions. Without isolation, the new deployment would read the old deployment's byte-incompatible KV blocks (and vice versa), silently corrupting outputs. Tearing down and rebuilding a dedicated master per rollout is wasteful; a per-deployment namespace is enough.

This PR adds an opt-in `cache_prefix` entry to the connector's `kv_connector_extra_config`. When set, the value is prepended to every store key, giving each deployment its own namespace within a shared master:

```json
{
  "kv_connector_extra_config": { "cache_prefix": "llama3-fp8-v2" }
}
```

- Default is `""` (no prefix), so keys are **byte-identical** to today's format — existing deployments are unaffected and keep their cache hits.
- The prefix is threaded through `KeyMetadata`, so it applies uniformly to puts, gets, **and** the rank-0 prefix lookup (`lookup`). All instances meant to share a prefix cache must use the same value.

### Modifications

- `data.py`: add `cache_prefix: str = ""` to `KeyMetadata`; include it in `PoolKey.__hash__` and prepend it in `PoolKey.to_string()` (`f"{cache_prefix}@..."` when non-empty).
- `worker.py`: read `cache_prefix` from `kv_connector_extra_config` when constructing `KeyMetadata`.
- `docs/features/mooncake_store_connector_usage.md`: document the new key under `kv_connector_extra_config`.
- Unit tests for the empty-prefix (backward-compatible) and non-empty-prefix key layouts.

### Duplicate-work check

This is not duplicating an existing vLLM PR. I checked open PRs with:

```bash
gh pr list --repo vllm-project/vllm --state open --search "mooncake cache prefix"
gh pr list --repo vllm-project/vllm --state open --search "mooncake store key prefix in:title,body"
```

The closest open PR, #44956 ("[KV Connector][Mooncake] Add store group semantics"), is orthogonal: it uses Mooncake's `ReplicateConfig.group_ids` to group physical objects *within a single logical KV entry* for lease/eviction routing. It does not namespace keys to isolate *separate deployments* sharing a master, which is what this PR does. No other open PR adds a key/cache prefix.

### AI assistance

This PR includes AI-assisted code, test, and doc changes. I reviewed every changed line and validated the behavior with the tests below.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake_store_worker.py --timeout=60 -q
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake_store_connector.py tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py --timeout=60 -q
pre-commit run --files \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py \
  tests/v1/kv_connector/unit/test_mooncake_store_worker.py \
  docs/features/mooncake_store_connector_usage.md
```

New tests added:

- `test_pool_key_to_string_without_prefix_is_unchanged` — empty prefix yields the historical key format.
- `test_pool_key_cache_prefix_namespaces_and_disambiguates` — a non-empty prefix is prepended, and two instances with different prefixes never collide on identical block hashes (distinct `to_string()` and `__hash__`).

## Test Result

```text
tests/.../test_mooncake_store_worker.py ............ 56 passed
tests/.../test_mooncake_store_connector.py + ..._scheduler.py ... 36 passed
pre-commit: ruff-check / ruff-format / mypy / markdownlint / SPDX ... Passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
