### PR TITLE
[DRAFT] OPT: MergeAttention shared memory for LSE loading

### DIFF
--- a/csrc/libtorch_stable/attention/merge_attn_states.cu
+++ b/csrc/libtorch_stable/attention/merge_attn_states.cu
@@ -36,14 +36,33 @@ __global__ void merge_attn_states_kernel(
   const uint global_idx = blockIdx.x * NUM_THREADS + threadIdx.x;
   const uint token_head_threads = num_tokens * num_heads * threads_per_head;
 
-  if (global_idx >= token_head_threads) return;
-
-  // global_idx -> token_idx + head_idx + pack_idx
+  // Compute indices before __syncthreads so all threads enter the barrier.
   const uint token_head_idx = global_idx / threads_per_head;
   const uint pack_idx = global_idx % threads_per_head;
-
   const uint token_idx = token_head_idx / num_heads;
   const uint head_idx = token_head_idx % num_heads;
+
+  // Cache LSE in smem: only pack_idx==0 loads from global, rest read smem.
+  // Falls back to direct global reads when groups can span block boundaries
+  // (i.e., NUM_THREADS % threads_per_head != 0, e.g. head_size=96 w/ bf16).
+  __shared__ float smem_p_lse[NUM_THREADS];
+  __shared__ float smem_s_lse[NUM_THREADS];
+  const bool group_fits_in_block = (NUM_THREADS % threads_per_head == 0);
+
+  const bool is_valid = (global_idx < token_head_threads);
+  const uint group_idx = threadIdx.x / threads_per_head;
+
+  if (group_fits_in_block) {
+    // Only merge-path tokens need smem; copy-path tokens skip this.
+    if (is_valid && pack_idx == 0 && token_idx < prefix_num_tokens) {
+      smem_p_lse[group_idx] = prefix_lse[head_idx * num_tokens + token_idx];
+      smem_s_lse[group_idx] = suffix_lse[head_idx * num_tokens + token_idx];
+    }
+    __syncthreads();
+    if (!is_valid) return;  // OOB threads exit only after the barrier.
+  } else {
+    if (!is_valid) return;
+  }
 
   const uint pack_offset = pack_idx * pack_size;  // (0~15)*8, etc.
   const uint src_head_offset = token_idx * num_heads * prefix_head_stride +
@@ -83,16 +102,23 @@ __global__ void merge_attn_states_kernel(
             output_head_ptr)[pack_offset / pack_size] = s_out_pack;
       }
     }
+    // Copy path only reads lse once, no smem needed.
     if (output_lse != nullptr && pack_idx == 0) {
-      float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
-      output_lse[head_idx * num_tokens + token_idx] = s_lse;
+      output_lse[head_idx * num_tokens + token_idx] =
+          suffix_lse[head_idx * num_tokens + token_idx];
     }
     return;
   }
 
-  // For tokens within prefix range, merge prefix and suffix
-  float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
-  float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
+  // Merge path: read lse from smem if it's safe, otherwise from global.
+  float p_lse, s_lse;
+  if (group_fits_in_block) {
+    p_lse = smem_p_lse[group_idx];
+    s_lse = smem_s_lse[group_idx];
+  } else {
+    p_lse = prefix_lse[head_idx * num_tokens + token_idx];
+    s_lse = suffix_lse[head_idx * num_tokens + token_idx];
+  }
   p_lse = std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
   s_lse = std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
 

--- a/tests/kernels/attention/test_merge_attn_states.py
+++ b/tests/kernels/attention/test_merge_attn_states.py
@@ -390,3 +390,155 @@ def test_merge_attn_states(
         len(NUM_BATCH_TOKENS) * len(HEAD_SIZES) * len(NUM_QUERY_HEADS) * len(DTYPES)
     ):
         generate_markdown_table()
+
+
+# Tests for the smem LSE caching optimization in merge_attn_states.cu.
+# Covers two edge cases: partial last block (OOB threads must still hit barrier)
+# and non-aligned head size (groups span block boundaries, falls back to global).
+
+# Cases hitting partial-block and/or non-aligned fallback paths (bf16/fp16: threads_per_head = head_size/8, NUM_THREADS=128).
+_SMEM_BOUNDARY_CASES = [
+    # aligned (smem path): partial last block
+    (4, 128, 3),   # total=192=128+64, last block has 64 OOB threads
+    (4, 128, 1),   # total=64<128, single partial block
+    (4, 64, 5),    # total=160=128+32
+    (8, 256, 1),   # total=256=2×128, full blocks
+    # non-aligned (fallback): 128 % threads_per_head != 0
+    (4, 96, 3),    # threads_per_head=12, 128%12=8≠0
+    (4, 48, 5),    # threads_per_head=6, 128%6=2≠0
+]
+
+
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@pytest.mark.parametrize("num_heads,head_size,num_tokens", _SMEM_BOUNDARY_CASES)
+@torch.inference_mode()
+def test_smem_block_boundary(
+    dtype: torch.dtype,
+    num_heads: int,
+    head_size: int,
+    num_tokens: int,
+):
+    """CUDA output must match Triton for smem optimization boundary cases."""
+    if not current_platform.is_cuda():
+        pytest.skip("CUDA kernel only available on CUDA")
+
+    element_size = torch.empty([], dtype=dtype).element_size()
+    pack_size = 16 // element_size
+    if head_size % pack_size != 0:
+        pytest.skip(
+            f"head_size={head_size} not divisible by pack_size={pack_size} "
+            f"for dtype={dtype}"
+        )
+
+    prefix_output = torch.randn(
+        num_tokens, num_heads, head_size, dtype=dtype, device="cuda"
+    )
+    suffix_output = torch.randn(
+        num_tokens, num_heads, head_size, dtype=dtype, device="cuda"
+    )
+    prefix_lse = torch.randn(
+        num_heads, num_tokens, dtype=torch.float32, device="cuda"
+    )
+    suffix_lse = torch.randn(
+        num_heads, num_tokens, dtype=torch.float32, device="cuda"
+    )
+    output_cuda = torch.zeros(
+        num_tokens, num_heads, head_size, dtype=dtype, device="cuda"
+    )
+    output_ref = torch.zeros(
+        num_tokens, num_heads, head_size, dtype=dtype, device="cuda"
+    )
+    output_lse_cuda = torch.zeros(
+        num_heads, num_tokens, dtype=torch.float32, device="cuda"
+    )
+    output_lse_ref = torch.zeros(
+        num_heads, num_tokens, dtype=torch.float32, device="cuda"
+    )
+
+    merge_attn_states_cuda(
+        output_cuda, prefix_output, prefix_lse,
+        suffix_output, suffix_lse, output_lse_cuda,
+    )
+    merge_attn_states_triton(
+        output_ref, prefix_output, prefix_lse,
+        suffix_output, suffix_lse, output_lse_ref,
+    )
+
+    atol, rtol = (1e-3, 1e-2) if dtype == torch.bfloat16 else (1e-3, 1e-3)
+    torch.testing.assert_close(
+        output_cuda.float(), output_ref.float(), atol=atol, rtol=rtol
+    )
+    torch.testing.assert_close(
+        output_lse_cuda, output_lse_ref, atol=atol, rtol=rtol
+    )
+
+
+@pytest.mark.parametrize("use_output_lse", [True, False])
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@pytest.mark.parametrize(
+    "num_heads,head_size,num_tokens",
+    [
+        (8, 128, 256),   # aligned, group_fits_in_block=True
+        (4, 64, 512),    # aligned, group_fits_in_block=True
+        (16, 96, 256),   # non-aligned, group_fits_in_block=False (fallback)
+        (4, 128, 3),     # aligned + partial last block
+    ],
+)
+@torch.inference_mode()
+def test_smem_no_context_tokens(
+    dtype: torch.dtype,
+    num_heads: int,
+    num_tokens: int,
+    head_size: int,
+    use_output_lse: bool,
+):
+    """prefill_tokens_with_context=0 means all tokens are copy-path; output must equal suffix."""
+    if not current_platform.is_cuda():
+        pytest.skip("CUDA kernel only available on CUDA")
+
+    element_size = torch.empty([], dtype=dtype).element_size()
+    pack_size = 16 // element_size
+    if head_size % pack_size != 0:
+        pytest.skip(
+            f"head_size={head_size} not divisible by pack_size={pack_size}"
+        )
+
+    prefix_output = torch.randn(
+        num_tokens, num_heads, head_size, dtype=dtype, device="cuda"
+    )
+    suffix_output = torch.randn(
+        num_tokens, num_heads, head_size, dtype=dtype, device="cuda"
+    )
+    prefix_lse = torch.randn(
+        num_heads, num_tokens, dtype=torch.float32, device="cuda"
+    )
+    suffix_lse = torch.randn(
+        num_heads, num_tokens, dtype=torch.float32, device="cuda"
+    )
+    output_cuda = torch.zeros(
+        num_tokens, num_heads, head_size, dtype=dtype, device="cuda"
+    )
+    output_lse_cuda = (
+        torch.zeros(num_heads, num_tokens, dtype=torch.float32, device="cuda")
+        if use_output_lse
+        else None
+    )
+
+    merge_attn_states_cuda(
+        output_cuda, prefix_output, prefix_lse,
+        suffix_output, suffix_lse, output_lse_cuda,
+        prefill_tokens_with_context=0,
+    )
+
+    atol, rtol = (1e-3, 1e-2) if dtype == torch.bfloat16 else (1e-3, 1e-3)
+
+    # With no context tokens the copy path fires for every token:
+    # output must equal suffix_output exactly.
+    torch.testing.assert_close(
+        output_cuda.float(), suffix_output.float(), atol=atol, rtol=rtol
+    )
+    if use_output_lse:
+        assert output_lse_cuda is not None
+        torch.testing.assert_close(
+            output_lse_cuda, suffix_lse, atol=atol, rtol=rtol
+        )


### PR DESCRIPTION
## Purpose

Load prefix/suffix LSE into shared memory once per warp group to reduce 
redundant global memory reads. Pack threads can share the value efficiently.

Falls back to global reads when head_size causes groups to span block boundaries
(e.g., head_size=96 with bf16).

- Fix OOB thread barrier synchronization

## Test Plan

- Add tests for smem boundary cases and fallback paths

## Test Result

TODO

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

