### PR TITLE
[Misc] benchmark_moe: support Gemma4 architectures

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -792,7 +792,11 @@ def get_model_params(config):
         topk = text_config.num_experts_per_tok
         intermediate_size = text_config.moe_intermediate_size
         hidden_size = text_config.hidden_size
-    elif architecture == "DiffusionGemmaForBlockDiffusion":
+    elif architecture in (
+        "DiffusionGemmaForBlockDiffusion",
+        "Gemma4ForConditionalGeneration",
+        "Gemma4ForCausalLM",
+    ):
         text_config = config.get_text_config()
         E = text_config.num_experts
         topk = text_config.top_k_experts


### PR DESCRIPTION



## Purpose

`get_model_params` in `benchmarks/kernels/benchmark_moe.py` has no branch for the
Gemma4 architectures. `Gemma4ForConditionalGeneration` and `Gemma4ForCausalLM` fall
through to the Mixtral-style default branch, which reads `num_local_experts` /
`num_experts_per_tok` / `intermediate_size` and raises:

```
AttributeError: 'Gemma4TextConfig' object has no attribute 'num_local_experts'
```

This makes it impossible to tune fused-MoE kernel configs for Gemma4 MoE models such
as `google/gemma-4-26B-A4B-it`, which therefore fall back to the default (sub-optimal)
MoE config at serving time.

Gemma4 exposes its MoE shape on the text config under `num_experts`, `top_k_experts`
and `moe_intermediate_size` — the same fields the existing
`DiffusionGemmaForBlockDiffusion` branch already reads — so this adds the Gemma4
architectures to that branch rather than duplicating the body.

## Test Plan

```
python benchmarks/kernels/benchmark_moe.py \
    --model google/gemma-4-26B-A4B-it \
    --tp-size 2 --dtype fp8_w8a8 --trust-remote-code --tune \
    --save-dir /tmp/moe-configs
```

## Test Result

**Before:** crashes in `get_model_params` with the `AttributeError` above.

**After:** detection resolves `E=128`, `N=352`; tuning completes and writes
`E=128,N=352,device_name=NVIDIA_H100_PCIe,dtype=fp8_w8a8.json`.

With output ending:
```
Writing best config to /tmp/moe-configs/E=128,N=352,device_name=NVIDIA_H100_PCIe,dtype=fp8_w8a8.json...
Tuning took 5750.48 seconds
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

