### PR TITLE
[Bugfix][Frontend] Warn on silent GPT-OSS Harmony non-terminal parse drops

### DIFF
--- a/tests/parser/test_harmony.py
+++ b/tests/parser/test_harmony.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+import logging
 from collections.abc import Sequence
 
 import pytest
@@ -362,6 +363,35 @@ class TestParse:
         assert reasoning == "I'm thinking."
         assert content == "I'm in the middle of answering"
         assert tool_calls is None
+
+    def test_malformed_final_missing_message_delimiter(
+        self, harmony_parser, chat_request, caplog_vllm
+    ):
+        # gpt-oss occasionally omits the <|message|> delimiter after
+        # <|channel|>final, trapping the answer body in the header and leaving
+        # the parser in a non-terminal state. vLLM must surface this instead of
+        # silently returning content=None with finish_reason="stop".
+        caplog_vllm.set_level(logging.WARNING, logger="vllm.parser.harmony")
+
+        reasoning, content, tool_calls = harmony_parser.parse(
+            "",
+            chat_request,
+            model_output_token_ids=encode_output(
+                "<|channel|>analysis<|message|>thinking<|end|>"
+                "<|start|>assistant<|channel|>final "
+                '{"answer": "hi"}<|return|>'
+            ),
+        )
+
+        assert reasoning == "thinking"
+        # Recovering the trapped body is out of scope for Option A; it is still
+        # dropped, but the parser must no longer stay silent about it.
+        assert content is None
+        assert tool_calls is None
+        assert any(
+            "non-terminal state" in record.getMessage()
+            for record in caplog_vllm.records
+        )
 
     @pytest.mark.parametrize(
         ("harmony_str", "expected_content"),

--- a/vllm/parser/harmony.py
+++ b/vllm/parser/harmony.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import TYPE_CHECKING, NamedTuple
 
+from openai_harmony import StreamState
+
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.engine.protocol import (
@@ -23,13 +25,16 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     is_function_recipient,
 )
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.logger import init_logger
 from vllm.parser.abstract_parser import DelegatingParser
 from vllm.reasoning.gptoss_reasoning_parser import GptOssReasoningParser
 from vllm.tool_parsers.gptoss_tool_parser import GptOssToolParser
 
 if TYPE_CHECKING:
     from openai_harmony import Message, Role
-    from openai_harmony import StreamState as HarmonyStreamState
+
+
+logger = init_logger(__name__)
 
 
 class _SegmentType(Enum):
@@ -87,7 +92,7 @@ class HarmonyParser(DelegatingParser):
         self._num_processed_messages = 0
 
     @property
-    def state(self) -> HarmonyStreamState:
+    def state(self) -> StreamState:
         return self._harmony_parser.state
 
     @property
@@ -183,6 +188,28 @@ class HarmonyParser(DelegatingParser):
 
         reasoning = "\n".join(reasoning_parts) or None
         content = "\n".join(content_parts) or None
+
+        # Detect a malformed assistant turn that produced no deliverable output
+        # and left the parser in a non-terminal state (e.g. a 'final' channel
+        # missing the <|message|> delimiter, which traps the body in the header).
+        # ``not self.current_content`` excludes legitimate mid-content
+        # truncation, where the partial body is recovered above.
+        if (
+            content is None
+            and not tool_calls
+            and not self.current_content
+            and self.state != StreamState.EXPECT_START
+        ):
+            logger.warning(
+                "Harmony parser ended in a non-terminal state (%s) with no "
+                "content or tool calls; %d generated token(s) produced no "
+                "deliverable output. This usually indicates a malformed "
+                "assistant turn, e.g. a 'final' channel missing the "
+                "<|message|> delimiter.",
+                self.state,
+                len(model_output_token_ids),
+            )
+
         return reasoning, content, tool_calls or None
 
     def parse_delta(


### PR DESCRIPTION
## Purpose

Fixes #45736.

In some cases gpt-oss emits a malformed final turn that skips the `<|message|>`
delimiter (`…<|channel|>final {body}<|return|>`). In that case the Harmony
`StreamableParser` never leaves the header state, never commits the `final`
message, and treats the body as header tokens instead.

`HarmonyParser.parse()` then returns `content=None`, and vLLM surfaces this as
`finish_reason="stop"` with `content: null` and non-zero completion tokens. The
answer is effectively dropped, with no error and no log.

This change doesn’t change the HTTP response yet; it just makes this situation
visible in server logs.

## What changed

- In `HarmonyParser.parse()`, after generation finishes, log a warning when:
  - no content or tool calls were produced,
  - the in-progress buffer is empty, and
  - the parser did not return to `StreamState.EXPECT_START`.

  The empty-buffer check avoids flagging cases where we intentionally truncate
  mid-content and still have a recoverable partial body.

- Added `test_malformed_final_missing_message_delimiter` to cover the malformed
  final stream from the issue.

## Scope

This PR is intentionally narrow:

- It **does not** change the response shape: clients still see
  `content: null` and `finish_reason="stop"` in this edge case.
- It **does** add a clear warning so this stop-without-content scenario is no
  longer silent.

Changing the client-visible contract (e.g. different `finish_reason`, or trying
to recover the trapped body) seems worth a separate discussion and follow-up PR.

## Why this isn’t a duplicate

#43408 (“Tolerate malformed Harmony streams”) targeted streams where the
Harmony parser raises `HarmonyError` and worked through
`parse_output_into_messages`, which was removed in the later Harmony
refactors (#45171 / #45104).

This bug is different: the parser does **not** raise, it just ends in a
non-terminal state and drops content. The code paths and failure modes don’t
overlap with #43408.

## Test plan

```bash
.venv/bin/python -m pytest tests/parser/test_harmony.py -v
pre-commit run --files vllm/parser/harmony.py tests/parser/test_harmony.py

cc @aarnphm @chaunceyjiang @sfeng33 @bbrowning 