### PR TITLE
[XPU][MiniMax-M3] Tune gemma_rmsnorm Triton num_warps for BMG

### DIFF
--- a/vllm/models/minimax_m3/xpu/ops/gemma_rmsnorm.py
+++ b/vllm/models/minimax_m3/xpu/ops/gemma_rmsnorm.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused Gemma-style RMSNorm for Intel XPU via Triton.
+
+Gemma RMSNorm = ``normalize(x) * (1 + weight)``, computed in fp32. FlashInfer's
+``gemma_rmsnorm`` / ``gemma_fused_add_rmsnorm`` CUDA kernels are unavailable on
+XPU, so this single-pass Triton implementation is used instead (no dependency on
+vllm-xpu-kernels). Mirrors the ROCm Triton path.
+
+Two entry points:
+  * ``gemma_rmsnorm(x, w, eps)``                 -> normalized tensor
+  * ``gemma_fused_add_rmsnorm(x, res, w, eps)``  -> (normalized, x + res)
+
+Both normalize over the last dim and broadcast ``weight`` (shape [N]) over it,
+so they serve both the full-hidden norms (input/post-attn/final) and the
+per-head q_norm/k_norm (N == head_dim). Inputs may be non-contiguous views
+(e.g. ``qkv.split`` slices); strides are passed through and outputs are written
+contiguous.
+"""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _gemma_rmsnorm_kernel(
+    x_ptr,
+    w_ptr,
+    out_ptr,
+    n_cols,
+    stride_row,
+    stride_col,
+    eps,
+    BLOCK_N: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_N)
+    mask = cols < n_cols
+    x = tl.load(x_ptr + row * stride_row + cols * stride_col, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    var = tl.sum(x * x, axis=0) / n_cols
+    rstd = 1.0 / tl.sqrt(var + eps)
+    w = tl.load(w_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+    out = x * rstd * (1.0 + w)
+    tl.store(
+        out_ptr + row * n_cols + cols,
+        out.to(out_ptr.dtype.element_ty),
+        mask=mask,
+    )
+
+
+@triton.jit
+def _gemma_fused_add_rmsnorm_kernel(
+    x_ptr,
+    res_ptr,
+    w_ptr,
+    out_ptr,
+    res_out_ptr,
+    n_cols,
+    stride_xrow,
+    stride_xcol,
+    stride_rrow,
+    stride_rcol,
+    eps,
+    BLOCK_N: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_N)
+    mask = cols < n_cols
+    x = tl.load(
+        x_ptr + row * stride_xrow + cols * stride_xcol, mask=mask, other=0.0
+    ).to(tl.float32)
+    r = tl.load(
+        res_ptr + row * stride_rrow + cols * stride_rcol, mask=mask, other=0.0
+    ).to(tl.float32)
+    s = x + r
+    # residual_out is the pre-norm sum (consumed by the next layer's add).
+    tl.store(
+        res_out_ptr + row * n_cols + cols,
+        s.to(res_out_ptr.dtype.element_ty),
+        mask=mask,
+    )
+    var = tl.sum(s * s, axis=0) / n_cols
+    rstd = 1.0 / tl.sqrt(var + eps)
+    w = tl.load(w_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+    out = s * rstd * (1.0 + w)
+    tl.store(
+        out_ptr + row * n_cols + cols,
+        out.to(out_ptr.dtype.element_ty),
+        mask=mask,
+    )
+
+
+def _num_warps(block_n: int) -> int:
+    # Tuned on BMG/Xe2: for the M3 hidden sizes (block_n up to 4096) 16 warps
+    # over-subscribes a single row and regresses vs 8; only the very widest
+    # rows benefit from 16.
+    if block_n >= 8192:
+        return 16
+    if block_n >= 2048:
+        return 8
+    if block_n >= 512:
+        return 4
+    return 2
+
+
+def gemma_rmsnorm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """Return ``x * rsqrt(mean(x^2)+eps) * (1+weight)`` (normalized over -1)."""
+    orig_shape = x.shape
+    n = orig_shape[-1]
+    x2 = x.reshape(-1, n)
+    m = x2.shape[0]
+    out = torch.empty((m, n), dtype=x.dtype, device=x.device)
+    block_n = triton.next_power_of_2(n)
+    _gemma_rmsnorm_kernel[(m,)](
+        x2,
+        weight,
+        out,
+        n,
+        x2.stride(0),
+        x2.stride(1),
+        eps,
+        BLOCK_N=block_n,
+        num_warps=_num_warps(block_n),
+    )
+    return out.reshape(orig_shape)
+
+
+def gemma_fused_add_rmsnorm(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused add + Gemma RMSNorm.
+
+    Returns ``(gemma_rmsnorm(x + residual), x + residual)``, matching the
+    FlashInfer ``gemma_fused_add_rmsnorm`` contract used by the NVIDIA model.
+    """
+    orig_shape = x.shape
+    n = orig_shape[-1]
+    x2 = x.reshape(-1, n)
+    r2 = residual.reshape(-1, n)
+    m = x2.shape[0]
+    out = torch.empty((m, n), dtype=x.dtype, device=x.device)
+    res_out = torch.empty((m, n), dtype=x.dtype, device=x.device)
+    block_n = triton.next_power_of_2(n)
+    _gemma_fused_add_rmsnorm_kernel[(m,)](
+        x2,
+        r2,
+        weight,
+        out,
+        res_out,
+        n,
+        x2.stride(0),
+        x2.stride(1),
+        r2.stride(0),
+        r2.stride(1),
+        eps,
+        BLOCK_N=block_n,
+        num_warps=_num_warps(block_n),
+    )
+    return out.reshape(orig_shape), res_out.reshape(orig_shape)


### PR DESCRIPTION
## Purpose
Tune the `_num_warps` heuristic in the portable Triton **Gemma-RMSNorm** used by the MiniMax-M3 XPU path (`gemma_rmsnorm` / `gemma_fused_add_rmsnorm`).

On Intel BMG/Xe2 the old heuristic selected 16 warps for the M3 hidden sizes (`BLOCK_N` up to 4096), which over-subscribes a single normalized row and regresses these bandwidth-bound kernels. The new ramp uses 16 only for `BLOCK_N >= 8192`, else 8/4/2. **Kernel math is unchanged.**

## Test plan / results
- Pinned @ 2.4 GHz on Intel Arc Pro B60 (BMG), unitrace device timing:
  - `gemma_rmsnorm`: 7,656 → 6,341 ns/call
  - `gemma_fused_add_rmsnorm`: 10,033 → 8,942 ns/call
- Numerical parity vs an fp32 reference verified across `n ∈ {128, 2048, 3072, 4096, 6144}` (rtol/atol 1e-2, matching the existing XPU tests).

## Not a duplicate
Checked `gh pr list --repo vllm-project/vllm --state open` for MiniMax-M3 / gemma rmsnorm / XPU — no open PR touches this heuristic.

## Notes
- `gemma_rmsnorm.py` is part of the **in-flight MiniMax-M3 XPU enablement** and is not yet on `main`; this draft adds the file in its tuned form so the `_num_warps` change can be reviewed in isolation. It should be rebased onto the enablement branch once that lands.
- **AI assistance (GitHub Copilot CLI) was used.** A human must review every changed line and run the relevant tests before this leaves draft.
