### PR TITLE
[codex] Deduplicate quant_fp8 custom op enablement

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ import vllm.envs as envs
 from vllm.compilation.backends import VllmBackend
 from vllm.config import (
     CompilationConfig,
+    DeviceConfig,
     KernelConfig,
     ModelConfig,
     ParallelConfig,
@@ -1379,6 +1380,33 @@ def test_fusion_pass_op_priority():
     cfg4 = VllmConfig(model_config=ModelConfig("Qwen/Qwen3-4B-FP8"))
     assert "+quant_fp8" in cfg4.compilation_config.custom_ops
     assert cfg4.compilation_config.pass_config.fuse_norm_quant
+
+
+@pytest.mark.skip_global_cleanup
+def test_blocked_fp8_enables_quant_fp8_custom_op_once():
+    class FakeBlockedQuantConfig:
+        weight_block_size = (128, 128)
+
+    cfg = VllmConfig(
+        device_config=DeviceConfig(device="cpu"),
+        quant_config=FakeBlockedQuantConfig(),
+        compilation_config=CompilationConfig(backend="inductor"),
+    )
+
+    assert cfg.compilation_config.custom_ops.count("+quant_fp8") == 1
+    assert cfg.compilation_config.is_custom_op_enabled("quant_fp8")
+
+    cfg = VllmConfig(
+        device_config=DeviceConfig(device="cpu"),
+        quant_config=FakeBlockedQuantConfig(),
+        compilation_config=CompilationConfig(
+            backend="inductor", custom_ops=["-quant_fp8"]
+        ),
+    )
+
+    assert "+quant_fp8" not in cfg.compilation_config.custom_ops
+    assert "-quant_fp8" in cfg.compilation_config.custom_ops
+    assert not cfg.compilation_config.is_custom_op_enabled("quant_fp8")
 
 
 def test_scheduler_config_init():

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1130,14 +1130,17 @@ class VllmConfig:
                     return self.quant_config.has_blocked_weights()
             return False
 
+        def maybe_enable_quant_fp8_custom_op():
+            custom_ops = self.compilation_config.custom_ops
+            if "+quant_fp8" not in custom_ops and "-quant_fp8" not in custom_ops:
+                custom_ops.append("+quant_fp8")
+
         # Enable quant_fp8 CUDA ops (TODO disable in follow up)
         # On H100 the CUDA kernel is faster than
         # native implementation
         # https://github.com/vllm-project/vllm/issues/25094
         if has_blocked_weights():
-            custom_ops = self.compilation_config.custom_ops
-            if "-quant_fp8" not in custom_ops:
-                custom_ops.append("+quant_fp8")
+            maybe_enable_quant_fp8_custom_op()
 
         current_platform.apply_config_platform_defaults(self)
 
@@ -1560,9 +1563,7 @@ class VllmConfig:
         # native implementation
         # https://github.com/vllm-project/vllm/issues/25094
         if has_blocked_weights():
-            custom_ops = self.compilation_config.custom_ops
-            if "-quant_fp8" not in custom_ops:
-                custom_ops.append("+quant_fp8")
+            maybe_enable_quant_fp8_custom_op()
 
         self._verify_kv_transfer_compat()
         # Log the custom passes that are enabled


### PR DESCRIPTION
## Summary
- deduplicate automatic `+quant_fp8` insertion for blocked-FP8 quant configs
- preserve explicit `-quant_fp8` user overrides
- add a CPU-only config regression test that exercises both post-init insertion sites

## Root Cause
`VllmConfig.__post_init__` checks blocked-FP8 weights twice so `+quant_fp8` is available before fusion defaults and after later config updates. The second insertion only checked for `-quant_fp8`, so blocked-FP8 configs could end up with duplicate `+quant_fp8` entries.

## Duplicate Work Check
This is not intended to duplicate an existing PR. I checked open PRs/issues for `quant_fp8 custom_ops` and `custom_ops duplicate`; the results showed related FP8/kernel work, but no open change that fixes duplicate `+quant_fp8` insertion in `VllmConfig.__post_init__`.

## AI Assistance
AI assistance was used to investigate the configuration path, prepare the patch, and run local verification.

## Validation
- `.venv/bin/python -m pytest -q tests/test_config.py::test_blocked_fp8_enables_quant_fp8_custom_op_once`
- `.venv/bin/python -m compileall -q vllm/config/vllm.py tests/test_config.py`
- `.venv/bin/python -m ruff check vllm/config/vllm.py tests/test_config.py`
