### PR TITLE
[CI test] Validate pre-commit step placement (ci-infra#378)

### DIFF
--- a/tests/entrypoints/unit_tests/test_context.py
+++ b/tests/entrypoints/unit_tests/test_context.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+# No-op change to trigger CI for testing the dedicated pre-commit pipeline step.
+
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
Throwaway draft PR to validate [vllm-project/ci-infra#378](https://github.com/vllm-project/ci-infra/pull/378) — confirming the dedicated pre-commit Buildkite step renders right after bootstrap. Do not merge/review; will be closed.