### PR TITLE
[PD][Core] Add partial prefix caching for hybrid model in PD disaggregation

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -27,7 +27,11 @@ from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
 from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
-from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
+from vllm.v1.core.kv_cache_utils import (
+    get_group_id,
+    get_request_block_hasher,
+    init_none_hash,
+)
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.core.single_type_kv_cache_manager import register_all_kvcache_specs
@@ -37,6 +41,8 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     MambaSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
 )
 from vllm.v1.outputs import (
     DraftTokenIds,
@@ -5543,12 +5549,15 @@ def test_async_load_reservation_prevents_wedge_e2e():
     assert b.request_id not in req_to_blocks
 
 
-def _create_hybrid_mamba_connector_scheduler(
+def _create_hybrid_connector_scheduler(
     matched_tokens: int,
     block_size: int = 16,
     num_blocks: int = 100,
+    *,
+    hash_block_size: int | None = None,
+    kv_cache_groups: list[KVCacheGroupSpec] | None = None,
 ) -> Scheduler:
-    """FA + Mamba ("all" cache mode) scheduler with a MockKVConnector."""
+    """Hybrid scheduler with a MockKVConnector."""
     model_config = ModelConfig(
         model="facebook/opt-125m",
         trust_remote_code=True,
@@ -5581,10 +5590,8 @@ def _create_hybrid_mamba_connector_scheduler(
         ),
     )
     vllm_config.cache_config.num_gpu_blocks = num_blocks
-    kv_cache_config = KVCacheConfig(
-        num_blocks=num_blocks,
-        kv_cache_tensors=[],
-        kv_cache_groups=[
+    if kv_cache_groups is None:
+        kv_cache_groups = [
             KVCacheGroupSpec(
                 ["fa"],
                 FullAttentionSpec(
@@ -5603,7 +5610,11 @@ def _create_hybrid_mamba_connector_scheduler(
                     mamba_cache_mode="all",
                 ),
             ),
-        ],
+        ]
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=kv_cache_groups,
     )
     register_all_kvcache_specs(vllm_config)
     return Scheduler(
@@ -5611,7 +5622,7 @@ def _create_hybrid_mamba_connector_scheduler(
         kv_cache_config=kv_cache_config,
         structured_output_manager=StructuredOutputManager(vllm_config),
         block_size=block_size,
-        hash_block_size=block_size,
+        hash_block_size=hash_block_size or block_size,
         log_stats=True,
     )
 
@@ -5637,7 +5648,7 @@ def test_hybrid_per_group_hit_divergence_with_connector(
     every group is consistent at.
     """
     block_size = 16
-    scheduler = _create_hybrid_mamba_connector_scheduler(matched_tokens)
+    scheduler = _create_hybrid_connector_scheduler(matched_tokens)
     manager = scheduler.kv_cache_manager
     assert isinstance(manager.coordinator, HybridKVCacheCoordinator)
 
@@ -5693,7 +5704,7 @@ def test_hybrid_per_group_hit_divergence_fa_deeper_no_external():
     convergent boundary that every group agrees on (block 0's surviving state).
     """
     block_size = 16
-    scheduler = _create_hybrid_mamba_connector_scheduler(matched_tokens=0)
+    scheduler = _create_hybrid_connector_scheduler(matched_tokens=0)
     manager = scheduler.kv_cache_manager
     assert isinstance(manager.coordinator, HybridKVCacheCoordinator)
 
@@ -5832,3 +5843,229 @@ def test_encoder_instance_finishes_request_once_prompt_is_consumed():
     assert request.status == RequestStatus.FINISHED_STOPPED
     # The encoder instance publishes an embedding, not tokens.
     assert request.num_output_tokens == 0
+
+
+def _dsv4_like_kv_cache_groups() -> list[KVCacheGroupSpec]:
+    return [
+        KVCacheGroupSpec(
+            ["dense_mla"],
+            MLAAttentionSpec(
+                block_size=256,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.uint8,
+                compress_ratio=4,
+                model_version="deepseek_v4",
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["swa_tail"],
+            SlidingWindowMLASpec(
+                block_size=64,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.uint8,
+                sliding_window=128,
+                model_version="deepseek_v4",
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["c4_state"],
+            SlidingWindowMLASpec(
+                block_size=4,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.uint8,
+                sliding_window=8,
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["c128_state"],
+            SlidingWindowMLASpec(
+                block_size=8,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.uint8,
+                sliding_window=128,
+            ),
+        ),
+    ]
+
+
+def _seed_hybrid_prefix_and_evict_groups(
+    scheduler: Scheduler, group_ids: set[int]
+) -> None:
+    [fill] = create_requests(
+        num_requests=1,
+        num_tokens=1024,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=4,
+        req_ids=["fill"],
+    )
+    manager = scheduler.kv_cache_manager
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(fill)
+    assert num_computed == 0
+    assert (
+        manager.allocate_slots(
+            fill,
+            fill.num_tokens,
+            num_new_computed_tokens=0,
+            new_computed_blocks=computed_blocks,
+        )
+        is not None
+    )
+    manager.free(fill)
+
+    if not group_ids:
+        return
+
+    block_ids = {
+        block.block_id
+        for block in manager.block_pool.blocks
+        if block.block_hash is not None and get_group_id(block.block_hash) in group_ids
+    }
+    assert block_ids
+    manager.evict_blocks(block_ids)
+
+
+@pytest.mark.parametrize(
+    "kv_cache_groups,evicted_group_ids,num_tokens,expected_target_counts",
+    [
+        pytest.param(
+            _dsv4_like_kv_cache_groups(),
+            {1, 2, 3},
+            1280,
+            [1, 2, 2, 16],
+            id="dsv4-missing-tail",
+        ),
+        pytest.param(
+            _dsv4_like_kv_cache_groups(),
+            set(),
+            1100,
+            [1, 2, 2, 10],
+            id="dsv4-retained-tail",
+        ),
+        pytest.param(None, {1}, 1280, [1, 1], id="mamba-like"),
+    ],
+)
+def test_remote_prefill_hybrid_uses_dense_local_hit(
+    kv_cache_groups: list[KVCacheGroupSpec] | None,
+    evicted_group_ids: set[int],
+    num_tokens: int,
+    expected_target_counts: list[int],
+):
+    scheduler = _create_hybrid_connector_scheduler(
+        matched_tokens=0,
+        block_size=256,
+        hash_block_size=4,
+        num_blocks=800,
+        kv_cache_groups=kv_cache_groups,
+    )
+    _seed_hybrid_prefix_and_evict_groups(scheduler, evicted_group_ids)
+
+    queried_local_hits: list[int] = []
+    allocated_targets: list[list[list[int]]] = []
+
+    def get_external_hit(request: Request, num_computed_tokens: int):
+        queried_local_hits.append(num_computed_tokens)
+        return request.num_tokens - num_computed_tokens, True
+
+    def record_targets(_request: Request, blocks, _num_external_tokens: int):
+        allocated_targets.append(blocks.get_unhashed_block_ids_all_groups())
+
+    assert scheduler.connector is not None
+    scheduler.connector.get_num_new_matched_tokens = get_external_hit
+    scheduler.connector.update_state_after_alloc = record_targets
+
+    [replay] = create_requests(
+        num_requests=1,
+        num_tokens=num_tokens,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=4,
+        req_ids=["replay"],
+    )
+    replay.kv_transfer_params = {"do_remote_prefill": True}
+    scheduler.add_request(replay)
+    output = scheduler.schedule()
+
+    assert queried_local_hits == [1024]
+    assert [len(group) for group in allocated_targets[0]] == expected_target_counts
+    assert output.scheduled_new_reqs == []
+    assert replay.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+
+
+def test_remote_prefill_hybrid_falls_back_without_external_hit():
+    scheduler = _create_hybrid_connector_scheduler(
+        matched_tokens=0,
+        block_size=256,
+        hash_block_size=4,
+        num_blocks=800,
+        kv_cache_groups=_dsv4_like_kv_cache_groups(),
+    )
+    _seed_hybrid_prefix_and_evict_groups(scheduler, {1, 2, 3})
+
+    queried_local_hits: list[int] = []
+
+    def miss(_request: Request, num_computed_tokens: int):
+        queried_local_hits.append(num_computed_tokens)
+        return 0, False
+
+    assert scheduler.connector is not None
+    scheduler.connector.get_num_new_matched_tokens = miss
+
+    [replay] = create_requests(
+        num_requests=1,
+        num_tokens=1280,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=4,
+        req_ids=["replay"],
+    )
+    replay.kv_transfer_params = {"do_remote_prefill": True}
+    scheduler.add_request(replay)
+    output = scheduler.schedule()
+
+    assert queried_local_hits == [1024]
+    assert output.num_scheduled_tokens[replay.request_id] == 1280
+    assert output.scheduled_new_reqs[0].num_computed_tokens == 0
+
+
+def test_hybrid_connector_without_remote_prefill_keeps_convergent_hit():
+    scheduler = _create_hybrid_connector_scheduler(
+        matched_tokens=0,
+        block_size=256,
+        hash_block_size=4,
+        num_blocks=800,
+        kv_cache_groups=_dsv4_like_kv_cache_groups(),
+    )
+    _seed_hybrid_prefix_and_evict_groups(scheduler, {1, 2, 3})
+
+    queried_local_hits: list[int] = []
+    allocated_targets: list[list[list[int]]] = []
+
+    def get_external_hit(_request: Request, num_computed_tokens: int):
+        queried_local_hits.append(num_computed_tokens)
+        return 1024, True
+
+    def record_targets(_request: Request, blocks, _num_external_tokens: int):
+        allocated_targets.append(blocks.get_unhashed_block_ids_all_groups())
+
+    assert scheduler.connector is not None
+    scheduler.connector.get_num_new_matched_tokens = get_external_hit
+    scheduler.connector.update_state_after_alloc = record_targets
+
+    [replay] = create_requests(
+        num_requests=1,
+        num_tokens=1280,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=4,
+        req_ids=["replay"],
+    )
+    scheduler.add_request(replay)
+    scheduler.schedule()
+
+    assert queried_local_hits == [0]
+    assert [len(group) for group in allocated_targets[0]] == [4, 2, 2, 16]

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -299,17 +299,18 @@ class KVCacheManager:
     ) -> tuple[KVCacheBlocks, int, int, bool]:
         """Local prefix-cache lookup for a request scheduled with a KV connector.
 
-        Hybrid (Mamba + full-attention) models can have per-group prefix hits
-        diverge under block pressure: the full-attention tail may be evicted
-        while a deeper Mamba state survives, or vice versa. Report the
-        full-attention hit as the local prefix - the connector transfers the
-        remaining suffix and the Mamba state is transferred unconditionally by
-        nixl's ``_apply_prefix_caching`` - and flag when that hit ran deeper
-        than a lagging group. Such a hit only has a valid Mamba state at its
-        boundary if the connector supplies it, so the caller must fall back to
-        ``get_computed_blocks`` to reconcile when no external tokens are found.
+        Hybrid models can have per-group prefix hits diverge under block
+        pressure: the full-attention tail may be evicted while a deeper hit in
+        another group survives, or vice versa. Hybrid layouts with full
+        attention use group 0 for it by default. For remote prefill, report the
+        full-attention hit as the local prefix - the connector supplies the
+        remaining suffix and any lagging group data - and flag when that hit
+        runs deeper than another group. Such a hit is valid at its boundary
+        only if the connector supplies the missing data, so the caller must
+        fall back to ``get_computed_blocks`` when no external tokens are found.
 
-        Non-hybrid models and already-convergent hits use ``get_computed_blocks``.
+        Other requests and already-convergent hits keep the existing
+        ``get_computed_blocks`` semantics.
 
         Returns:
             The ``get_computed_blocks`` triple (blocks, number of local computed
@@ -317,7 +318,8 @@ class KVCacheManager:
         """
         coordinator = self.coordinator
         if not (
-            self.kv_cache_config.has_mamba_layers
+            request.kv_transfer_params
+            and request.kv_transfer_params.get("do_remote_prefill")
             and isinstance(coordinator, HybridKVCacheCoordinator)
             and coordinator.full_attention_group_id is not None
         ):


### PR DESCRIPTION
## Purpose

This PR is a follow-up to #42524 and #44243.

#42524 identified a D-side prefix-cache hit accounting issue for PD-disaggregated hybrid Mamba models, where a Mamba group may collapse valid dense attention KV hits to zero. #44243 fixed that issue with per-group cache-hit accounting for the Mamba Hybrid path.

This PR extends the same idea to more hybrid KV-cache layouts, including DeepSeek V4 style layouts. The core idea is to let the scheduler distinguish reusable dense prefix KV from non-dense/state/tail groups that still require KV connector handling.

## Design Details

### Dense Prefix Hit Accounting

For hybrid coordinators, the scheduler now obtains local cache hits per KV group through `find_longest_cache_hit_per_group(...)`.

The connector-facing scalar `num_new_local_computed_tokens` is computed from dense attention groups only:

- `FULL_ATTENTION`
- `MLA_ATTENTION`
- `SINK_FULL_ATTENTION`

This scalar represents the dense prefix KV that is already reusable on the D node.


## Benchmark
### Set-up
Model: Deepseek-V4-FP8
Hardware: 8 × NVIDIA H20
Transport: NIXL 
Server Flags (P and D sides):
  --enforce-eager
  --max-model-len 65536
  --max-num-batched-tokens 16384
  --max-num-seqs 512
  --block-size 256
  --no-disable-hybrid-kv-cache-manager
  --async-scheduling

Prefix caching set:
P side: --enable-prefix-caching
D side: toggled --enable-prefix-caching (ON, with PR) vs --no-enable-prefix-caching (OFF, baseline)

vllm bench serve:
  --dataset-name prefix_repetition 
  --prefix-repetition-prefix-len 32000
  --prefix-repetition-suffix-len 1024
  --prefix-repetition-num-prefixes 2
  --prefix-repetition-output-len 1024
  --num_prompts 512
  --max-concurrency 
### Results
Some of the requests failed due to the VRAM capacity constraints of the H20 GPU, where the memory footprint of the DeepSeek-V4 model weights is too large to be fully accommodated alongside the required KV cache under high concurrency. Consequently, the server dropped connections mid-stream due to timeouts or OOM, causing incomplete response payloads.

ON:
```bash
============ Serving Benchmark Result ============
Successful requests:                     474       
Failed requests:                         38        
Maximum request concurrency:             512       
Benchmark duration (s):                  235.71    
Total input tokens:                      15653389  
Total generated tokens:                  485376    
Request throughput (req/s):              2.01      
Output token throughput (tok/s):         2059.22   
Peak output token throughput (tok/s):    3464.00   
Peak concurrent requests:                474.00    
Total token throughput (tok/s):          68469.16  
---------------Time to First Token----------------
Mean TTFT (ms):                          50572.71  
Median TTFT (ms):                        50798.90  
P99 TTFT (ms):                           83112.55  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          152.30    
Median TPOT (ms):                        152.37    
P99 TPOT (ms):                           153.99    
---------------Inter-token Latency----------------
Mean ITL (ms):                           152.30    
Median ITL (ms):                         163.51    
P99 ITL (ms):                            357.97    
==================================================
```

OFF:
```bash
============ Serving Benchmark Result ============
Successful requests:                     475       
Failed requests:                         37        
Maximum request concurrency:             512       
Benchmark duration (s):                  1075.68   
Total input tokens:                      15686412  
Total generated tokens:                  486400    
Request throughput (req/s):              0.44      
Output token throughput (tok/s):         452.18    
Peak output token throughput (tok/s):    7053.00   
Peak concurrent requests:                475.00    
Total token throughput (tok/s):          15035.02  
---------------Time to First Token----------------
Mean TTFT (ms):                          412872.86 
Median TTFT (ms):                        168872.68 
P99 TTFT (ms):                           954640.53 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          384.76    
Median TPOT (ms):                        422.23    
P99 TPOT (ms):                           922.59    
---------------Inter-token Latency----------------
Mean ITL (ms):                           385.09    
Median ITL (ms):                         121.54    
P99 ITL (ms):                            2170.11   
==================================================
```

OFF: D-side prefix caching disabled.
ON: D-side prefix caching enabled with this PR.
P-side prefix caching is enabled in both cases.

| OFF TTFT (ms) | ON TTFT (ms) | ΔTTFT | OFF Output TPS | ON Output TPS | ΔTPS |
| :--- | :--- | :--- | :--- | :--- | :--- |
| 412872.86 | 50572.71 | -87.75% | 452.18 | 2059.22 | +355.40% |

Accuracy(ON):
|   Tasks   |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_local|      3|flexible-extract|     5|exact_match|↑  |0.9688|±  |0.0109|
|           |       |strict-match    |     5|exact_match|↑  |0.9688|±  |0.0109|

## Test Plan
- Added a scheduler unit test for hybrid KV-cache local prefix hits with KVConnector enabled.
- The test seeds local prefix cache, evicts non-dense/state groups, and verifies that the connector receives the dense local prefix-hit length instead of the minimum hit across all groups.
- Covered:
  - DSV4-like MLA + SWA/C4/C128 layout
  - Mamba-like full-attention + state layout

## Test Result
```bash
python3 -m py_compile vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
.venv/bin/python -m pytest -q tests/v1/core/test_scheduler.py -k "hybrid_uses_dense_local_prefix_hit"
.venv/bin/python -m pytest -q tests/v1/core/test_scheduler.py -k "kv_connector_basic or external_prefix_cache_metrics or hybrid_uses_dense_local_prefix_hit"
```

2 passed, 107 deselected, 16 warnings in 3.93s
8 passed, 101 deselected, 17 warnings in 19.29s
