### PR TITLE
[Test] Cover multimodal models without language models (#45806)

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import torch
 
+from vllm.model_executor.models import interfaces
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
 from vllm.v1.worker.gpu import eplb_utils as eplb
 from vllm.v1.worker.gpu import model_runner as mrv2
@@ -149,6 +150,16 @@ def test_v2_load_model_with_dummy_weights_skips_eplb_registration(monkeypatch):
     assert runner.eplb_state is not None
     assert runner.eplb_state.add_model_calls == []
     assert runner.eplb_state.async_started is False
+
+
+def test_moe_detection_handles_multimodal_without_language_model(monkeypatch):
+    class NoLMMultiModal:
+        def get_language_model(self):
+            raise NotImplementedError
+
+    monkeypatch.setattr(interfaces, "SupportsMultiModal", NoLMMultiModal)
+
+    assert interfaces.get_mixture_of_experts_model(NoLMMultiModal()) is None
 
 
 def test_v2_setup_eplb_from_mapping_rebuilds_state(monkeypatch):

--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import torch
 
+from vllm.model_executor.models import interfaces
 from vllm.model_executor.warmup.jit_warmup import JitWarmupRegistry
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
 from vllm.v1.worker.gpu import eplb_utils as eplb
@@ -152,6 +153,16 @@ def test_v2_load_model_with_dummy_weights_skips_eplb_registration(monkeypatch):
     assert runner.eplb_state is not None
     assert runner.eplb_state.add_model_calls == []
     assert runner.eplb_state.async_started is False
+
+
+def test_moe_detection_handles_multimodal_without_language_model(monkeypatch):
+    class NoLMMultiModal:
+        def get_language_model(self):
+            raise NotImplementedError
+
+    monkeypatch.setattr(interfaces, "SupportsMultiModal", NoLMMultiModal)
+
+    assert interfaces.get_mixture_of_experts_model(NoLMMultiModal()) is None
 
 
 def test_v2_setup_eplb_from_mapping_rebuilds_state(monkeypatch):


### PR DESCRIPTION
## Purpose

Closes #45806.

PR #48355 centralized MoE detection in `get_mixture_of_experts_model()` and absorbed the implementation fix while this PR was waiting for review. This PR is now reduced to one regression test: when a multimodal model has no separable language model and `get_language_model()` raises `NotImplementedError`, MoE detection returns `None` instead of aborting model load.

The obsolete v1 and v2 implementation hunks have been dropped.

## Test plan / results

- Direct CPU invocation of the exact helper branch: pass.
- Catch-free equivalent: raises `NotImplementedError`, proving the assertion detects the regression.
- Ruff check and format on the changed file: pass.
- `git diff --check`: pass.

The full existing test module could not be collected in this local worktree because its model-runner imports require the optional precompiled FlashAttention extension. CI can run the standard focused command:

```bash
python -m pytest tests/v1/worker/test_gpu_model_runner_v2_eplb.py -k moe_detection_handles_multimodal_without_language_model
```

AI-assisted: developed with AI assistance and reviewed end-to-end by the submitter.