### PR TITLE
[Bugfix]: Fix unquantized gpt-oss weight loading broken by FusedMoE r…

### DIFF
--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -979,7 +979,11 @@ class GptOssModel(nn.Module, EagleModelMixin):
         tp_rank_start = tp_rank * per_rank_intermediate_size
         tp_rank_end = min((tp_rank + 1) * per_rank_intermediate_size, intermediate_size)
 
-        for name, weight in weights:
+        # Use centralized weight remapping for MoE expert parameters.
+        # The FusedMoE refactor moved expert params under
+        # `mlp.experts.routed_experts.*`; this remaps checkpoint names so
+        # MoE weight/bias keys resolve against params_dict.
+        for name, weight in remap_moe_expert_weights(weights, params_dict):
             # Skip layers on other devices.
             if is_pp_missing_parameter(name, self):
                 continue


### PR DESCRIPTION
The FusedMoE/MoERunner inversion refactor (#41184) moved expert weight
parameters into a nested `RoutedExperts` submodule, renaming params from
`...mlp.experts.<w>` to `...mlp.experts.routed_experts.<w>`. The
unquantized loading path (`_load_weights_other`) still indexed
`params_dict` with the raw checkpoint names, causing a KeyError when
loading standard (non-mxfp4/non-quark) gpt-oss checkpoints.
Route the weights through the shared `remap_moe_expert_weights` helper
(already used by the Quark path) instead of a local string replace. The
helper only remaps known expert params and only when the nested name
exists in `params_dict`, keeping backward compatibility with old
checkpoint layouts.

issue: #45830 

Signed-off-by: priyansh jain <priyansh.jain2@amd.com>

Change-Id: If4053663e4cbd7ce1a808d92a148e994e979a59a