### PR TITLE
[Refactor] Make Int8ScaledMMLinearLayerConfig use QuantKey

### DIFF
--- a/tests/fusion/test_quant_activation_contract.py
+++ b/tests/fusion/test_quant_activation_contract.py
@@ -37,6 +37,7 @@ from vllm.model_executor.layers.fusion.quant_activation import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
+    kInt8StaticTensorSym,
     kNvfp4Dynamic,
 )
 from vllm.platforms import current_platform
@@ -71,7 +72,8 @@ def _probe(cls: type):
         obj.config = NvFp4LinearLayerConfig()
     elif issubclass(cls, Int8ScaledMMLinearKernel):
         obj.config = Int8ScaledMMLinearLayerConfig(
-            is_static_input_scheme=True, is_channelwise=False, input_symmetric=True
+            weight_quant_key=kInt8StaticTensorSym,
+            activation_quant_key=kInt8StaticTensorSym,
         )
     else:
         obj.config = FP8ScaledMMLinearLayerConfig(

--- a/tests/kernels/quantization/test_scaled_mm_kernel_selection.py
+++ b/tests/kernels/quantization/test_scaled_mm_kernel_selection.py
@@ -21,6 +21,12 @@ from vllm.model_executor.kernels.linear import (
     init_int8_linear_kernel,
     register_linear_kernel,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kDynamicTokenScale,
+    kInt8StaticChannelSym,
+    kInt8StaticTensorSym,
+)
 from vllm.platforms import PlatformEnum
 
 pytestmark = pytest.mark.cpu_test
@@ -75,14 +81,16 @@ def test_cpu_kernel_accepts_all_configs():
     """Test that CPUInt8ScaledMMLinearKernel accepts all config combinations."""
     configs = [
         Int8ScaledMMLinearLayerConfig(
-            is_channelwise=False,
-            is_static_input_scheme=True,
-            input_symmetric=True,
+            weight_quant_key=kInt8StaticTensorSym,
+            activation_quant_key=kInt8StaticTensorSym,
         ),
         Int8ScaledMMLinearLayerConfig(
-            is_channelwise=True,
-            is_static_input_scheme=False,
-            input_symmetric=False,
+            weight_quant_key=kInt8StaticChannelSym,
+            activation_quant_key=QuantKey(
+                torch.int8,
+                kDynamicTokenScale,
+                symmetric=False,
+            ),
         ),
     ]
 
@@ -122,7 +130,11 @@ def test_register_oot_linear_kernel(platform_mock):
     platform_mock._enum = PlatformEnum.OOT
     register_linear_kernel(OOTInt8ScaledMMLinearKernel, PlatformEnum.OOT, "int8")
 
-    kernel = init_int8_linear_kernel(True, True, True, "module")
+    kernel = init_int8_linear_kernel(
+        weight_quant_key=kInt8StaticChannelSym,
+        activation_quant_key=kInt8StaticTensorSym,
+        module_name="module",
+    )
 
     assert isinstance(kernel, OOTInt8ScaledMMLinearKernel), (
         "init_int8_linear_kernel should return an instance of the registered kernel"

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -602,15 +602,13 @@ def init_fp8_linear_kernel(
 
 
 def init_int8_linear_kernel(
-    is_channelwise: bool,
-    is_static_input_scheme: bool,
-    input_symmetric: bool,
+    weight_quant_key: QuantKey,
+    activation_quant_key: QuantKey,
     module_name: str,
 ) -> Int8ScaledMMLinearKernel:
     config = Int8ScaledMMLinearLayerConfig(
-        is_channelwise=is_channelwise,
-        is_static_input_scheme=is_static_input_scheme,
-        input_symmetric=input_symmetric,
+        weight_quant_key=weight_quant_key,
+        activation_quant_key=activation_quant_key,
     )
 
     kernel_type = choose_scaled_mm_linear_kernel(

--- a/vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py
@@ -23,10 +23,8 @@ from ..base import MMLinearLayerConfig
 
 @dataclass
 class Int8ScaledMMLinearLayerConfig(MMLinearLayerConfig):
-    # TODO: Change to QuantKey like FP8ScaledMMLinearLayerConfig
-    is_static_input_scheme: bool
-    is_channelwise: bool
-    input_symmetric: bool
+    weight_quant_key: QuantKey
+    activation_quant_key: QuantKey
 
 
 @dataclass

--- a/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
@@ -55,7 +55,7 @@ class AiterInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
 
     @classmethod
     def can_implement(cls, c: Int8ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:
-        if not c.input_symmetric:
+        if not c.activation_quant_key.symmetric:
             return False, "supports symmetric quantization only."
         return True, None
 

--- a/vllm/model_executor/kernels/linear/scaled_mm/cpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cpu.py
@@ -7,6 +7,7 @@ import torch
 from vllm import _custom_ops as ops
 from vllm import envs
 from vllm.model_executor.layers.quantization.utils import replace_parameter
+from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     convert_to_channelwise,
 )
@@ -45,7 +46,7 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         if (
             current_platform.get_cpu_architecture() == CpuArchEnum.X86
             and envs.VLLM_CPU_SGL_KERNEL
-            and self.config.input_symmetric
+            and self.config.activation_quant_key.symmetric
             and check_cpu_sgl_kernel(N, K, dtype)
         ):
             self.linear_method = self._apply_weights_sgl
@@ -71,7 +72,10 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         # scales being passed to the kernel), convert to the per-channel case.
         is_fused_module = len(layer.logical_widths) > 1
         weight_scale = getattr(layer, w_s_name)
-        if is_fused_module and not self.config.is_channelwise:
+        is_per_tensor = (
+            self.config.weight_quant_key.scale.group_shape == GroupShape.PER_TENSOR
+        )
+        if is_fused_module and is_per_tensor:
             weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
         replace_parameter(
             layer,
@@ -80,10 +84,10 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         )
 
         # INPUT SCALE
-        if self.config.is_static_input_scheme:
+        if self.config.activation_quant_key.scale.static:
             input_scale = getattr(layer, i_s_name)
 
-            if self.config.input_symmetric:
+            if self.config.activation_quant_key.symmetric:
                 replace_parameter(
                     layer,
                     i_s_name,
@@ -116,7 +120,8 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         # s_a * s_b * [(A - zp_a)B] + bias =
         # s_a * (s_b * AB) - s_a * s_b * zp_a * B + bias =
         # s_a * GEMM_output - s_a * zp_a * adj + bias
-        if not (self.config.input_symmetric and self.config.is_static_input_scheme):
+        act_key = self.config.activation_quant_key
+        if not (act_key.symmetric and act_key.scale.static):
             weight = getattr(layer, w_q_name)
             weight_scale = getattr(layer, w_s_name)
             azp_adj = weight.sum(dim=0, keepdim=True, dtype=torch.float32)
@@ -133,7 +138,7 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
             getattr(layer, w_s_name),
             torch.get_default_dtype(),
             getattr(layer, i_s_name) is None,
-            not self.config.input_symmetric,
+            not self.config.activation_quant_key.symmetric,
             32,
         )
         # weight is prepacked and maintained by the dnnl_handler,
@@ -160,7 +165,10 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         # CPU SGL kernels only support per-channel.
         # For per-tensor quant, convert to the per-channel case.
         weight_scale = getattr(layer, w_s_name)
-        if not self.config.is_channelwise:
+        is_per_tensor = (
+            self.config.weight_quant_key.scale.group_shape == GroupShape.PER_TENSOR
+        )
+        if is_per_tensor:
             weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
         replace_parameter(
             layer,
@@ -194,7 +202,7 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         # * dynamic, i_s is None and x_s computed from x.
         # * static, i_s is scalar and x_s is i_s.
         x_q, x_s, x_zp = ops.onednn_scaled_int8_quant(
-            x, i_s, i_zp, self.config.input_symmetric
+            x, i_s, i_zp, self.config.activation_quant_key.symmetric
         )
 
         m = x.size(0)

--- a/vllm/model_executor/kernels/linear/scaled_mm/cpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cpu.py
@@ -7,7 +7,6 @@ import torch
 from vllm import _custom_ops as ops
 from vllm import envs
 from vllm.model_executor.layers.quantization.utils import replace_parameter
-from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     convert_to_channelwise,
 )
@@ -72,9 +71,7 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         # scales being passed to the kernel), convert to the per-channel case.
         is_fused_module = len(layer.logical_widths) > 1
         weight_scale = getattr(layer, w_s_name)
-        is_per_tensor = (
-            self.config.weight_quant_key.scale.group_shape == GroupShape.PER_TENSOR
-        )
+        is_per_tensor = self.config.weight_quant_key.scale.group_shape.is_per_tensor()
         if is_fused_module and is_per_tensor:
             weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
         replace_parameter(
@@ -165,9 +162,7 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         # CPU SGL kernels only support per-channel.
         # For per-tensor quant, convert to the per-channel case.
         weight_scale = getattr(layer, w_s_name)
-        is_per_tensor = (
-            self.config.weight_quant_key.scale.group_shape == GroupShape.PER_TENSOR
-        )
+        is_per_tensor = self.config.weight_quant_key.scale.group_shape.is_per_tensor()
         if is_per_tensor:
             weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
         replace_parameter(

--- a/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
@@ -61,7 +61,10 @@ class CutlassInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         # scales being passed to the kernel), convert to the per-channel case.
         is_fused_module = len(layer.logical_widths) > 1
         weight_scale = getattr(layer, w_s_name)
-        if is_fused_module and not config.is_channelwise:
+        is_per_tensor = (
+            config.weight_quant_key.scale.group_shape == GroupShape.PER_TENSOR
+        )
+        if is_fused_module and is_per_tensor:
             weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
         replace_parameter(
             layer,
@@ -70,10 +73,10 @@ class CutlassInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         )
 
         # INPUT SCALE
-        if config.is_static_input_scheme:
+        if config.activation_quant_key.scale.static:
             input_scale = getattr(layer, i_s_name)
 
-            if config.input_symmetric:
+            if config.activation_quant_key.symmetric:
                 replace_parameter(
                     layer,
                     i_s_name,
@@ -105,10 +108,10 @@ class CutlassInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         # static and dynamic quantization.
         # For more details, see csrc/quantization/w8a8/cutlass/Epilogues.md
         # https://github.com/vllm-project/vllm/blob/main/csrc/quantization/w8a8/cutlass/Epilogues.md
-        if not config.input_symmetric:
+        if not config.activation_quant_key.symmetric:
             weight = getattr(layer, w_q_name)
             azp_adj = weight.sum(dim=0, keepdim=True, dtype=torch.int32)
-            if config.is_static_input_scheme:
+            if config.activation_quant_key.scale.static:
                 # cutlass_w8a8 requires azp to be folded into azp_adj
                 # in the per-tensor case
                 azp_adj = getattr(layer, i_zp_name) * azp_adj

--- a/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
@@ -61,9 +61,7 @@ class CutlassInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         # scales being passed to the kernel), convert to the per-channel case.
         is_fused_module = len(layer.logical_widths) > 1
         weight_scale = getattr(layer, w_s_name)
-        is_per_tensor = (
-            config.weight_quant_key.scale.group_shape == GroupShape.PER_TENSOR
-        )
+        is_per_tensor = config.weight_quant_key.scale.group_shape.is_per_tensor()
         if is_fused_module and is_per_tensor:
             weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
         replace_parameter(

--- a/vllm/model_executor/kernels/linear/scaled_mm/triton.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/triton.py
@@ -9,6 +9,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm
     triton_scaled_mm,
 )
 from vllm.model_executor.layers.quantization.utils import replace_parameter
+from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     convert_to_channelwise,
 )
@@ -53,7 +54,10 @@ class TritonInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
         # scales being passed to the kernel), convert to the per-channel case.
         is_fused_module = len(layer.logical_widths) > 1
         weight_scale = getattr(layer, w_s_name)
-        if is_fused_module and not self.config.is_channelwise:
+        is_per_tensor = (
+            self.config.weight_quant_key.scale.group_shape == GroupShape.PER_TENSOR
+        )
+        if is_fused_module and is_per_tensor:
             weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
         replace_parameter(
             layer,
@@ -62,10 +66,10 @@ class TritonInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
         )
 
         # INPUT SCALE
-        if self.config.is_static_input_scheme:
+        if self.config.activation_quant_key.scale.static:
             assert i_s is not None
 
-            if self.config.input_symmetric:
+            if self.config.activation_quant_key.symmetric:
                 replace_parameter(
                     layer,
                     i_s_name,
@@ -103,11 +107,11 @@ class TritonInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
         # It does not depend on scales or azp, so it is the same for
         # static and dynamic quantization.
         # See csrc/quantization/w8a8/cutlass/Epilogues.md for the math.
-        if not self.config.input_symmetric:
+        if not self.config.activation_quant_key.symmetric:
             weight = getattr(layer, w_q_name)
             # weight is already transposed to [K, N], sum over K (dim=0)
             azp_adj = weight.sum(dim=0, keepdim=True, dtype=torch.int32)
-            if self.config.is_static_input_scheme:
+            if self.config.activation_quant_key.scale.static:
                 # Fold azp into azp_adj for the per-tensor case
                 azp_adj = getattr(layer, i_zp_name) * azp_adj
             setattr(

--- a/vllm/model_executor/kernels/linear/scaled_mm/triton.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/triton.py
@@ -9,7 +9,6 @@ from vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm
     triton_scaled_mm,
 )
 from vllm.model_executor.layers.quantization.utils import replace_parameter
-from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     convert_to_channelwise,
 )
@@ -54,9 +53,7 @@ class TritonInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
         # scales being passed to the kernel), convert to the per-channel case.
         is_fused_module = len(layer.logical_widths) > 1
         weight_scale = getattr(layer, w_s_name)
-        is_per_tensor = (
-            self.config.weight_quant_key.scale.group_shape == GroupShape.PER_TENSOR
-        )
+        is_per_tensor = self.config.weight_quant_key.scale.group_shape.is_per_tensor()
         if is_fused_module and is_per_tensor:
             weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
         replace_parameter(

--- a/vllm/model_executor/kernels/linear/scaled_mm/zentorch.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/zentorch.py
@@ -41,11 +41,11 @@ class ZentorchInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
 
     @classmethod
     def can_implement(cls, c: Int8ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:
-        if c.is_static_input_scheme:
+        if c.activation_quant_key.scale.static:
             return False, "requires dynamic activation quantization."
-        if not c.input_symmetric:
+        if not c.activation_quant_key.symmetric:
             return False, "requires symmetric activation quantization."
-        if not c.is_channelwise:
+        if not c.weight_quant_key.scale.group_shape.is_per_channel():
             return False, "requires per-channel weight quantization."
         return True, None
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
@@ -13,6 +13,13 @@ from vllm.model_executor.kernels.linear import (
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kDynamicTokenScale,
+    kInt8StaticChannelSym,
+    kInt8StaticTensorSym,
+    kStaticTensorScale,
+)
 from vllm.model_executor.parameter import (
     BasevLLMParameter,
     ChannelQuantScaleParameter,
@@ -47,10 +54,27 @@ class CompressedTensorsW8A8Int8(CompressedTensorsScheme):
     ):
         layer.logical_widths = output_partition_sizes
 
+        is_channelwise = self.strategy == QuantizationStrategy.CHANNEL
+        weight_quant_key = (
+            kInt8StaticChannelSym if is_channelwise else kInt8StaticTensorSym
+        )
+
+        if self.is_static_input_scheme:
+            activation_quant_key = QuantKey(
+                torch.int8,
+                kStaticTensorScale,
+                symmetric=self.input_symmetric,
+            )
+        else:
+            activation_quant_key = QuantKey(
+                torch.int8,
+                kDynamicTokenScale,
+                symmetric=self.input_symmetric,
+            )
+
         self.kernel = init_int8_linear_kernel(
-            is_channelwise=(self.strategy == QuantizationStrategy.CHANNEL),
-            is_static_input_scheme=self.is_static_input_scheme,
-            input_symmetric=self.input_symmetric,
+            weight_quant_key=weight_quant_key,
+            activation_quant_key=activation_quant_key,
             module_name=self.__class__.__name__,
         )
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
@@ -54,10 +54,15 @@ class CompressedTensorsW8A8Int8(CompressedTensorsScheme):
     ):
         layer.logical_widths = output_partition_sizes
 
-        is_channelwise = self.strategy == QuantizationStrategy.CHANNEL
-        weight_quant_key = (
-            kInt8StaticChannelSym if is_channelwise else kInt8StaticTensorSym
-        )
+        if self.strategy == QuantizationStrategy.CHANNEL:
+            weight_quant_key = kInt8StaticChannelSym
+        elif self.strategy == QuantizationStrategy.TENSOR:
+            weight_quant_key = kInt8StaticTensorSym
+        else:
+            raise ValueError(
+                f"Unsupported INT8 weight quantization strategy: "
+                f"{self.strategy}. Only CHANNEL and TENSOR are supported."
+            )
 
         if self.is_static_input_scheme:
             activation_quant_key = QuantKey(

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_int8.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_int8.py
@@ -10,6 +10,13 @@ from vllm.model_executor.kernels.linear import (
     init_int8_linear_kernel,
 )
 from vllm.model_executor.layers.quantization.quark.schemes import QuarkScheme
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kDynamicTokenScale,
+    kInt8StaticChannelSym,
+    kInt8StaticTensorSym,
+    kStaticTensorScale,
+)
 from vllm.model_executor.parameter import (
     BasevLLMParameter,
     ChannelQuantScaleParameter,
@@ -58,10 +65,29 @@ class QuarkW8A8Int8(QuarkScheme):
                 loaded_weight = loaded_weight.unsqueeze(-1)
             return weight_loader(param, loaded_weight, *args, **kwargs)
 
+        is_channelwise = self.qscheme == "per_channel"
+        weight_quant_key = (
+            kInt8StaticChannelSym if is_channelwise else kInt8StaticTensorSym
+        )
+
+        is_static = self.is_static_input_scheme is True
+        input_symmetric = self.input_symmetric is True
+        if is_static:
+            activation_quant_key = QuantKey(
+                torch.int8,
+                kStaticTensorScale,
+                symmetric=input_symmetric,
+            )
+        else:
+            activation_quant_key = QuantKey(
+                torch.int8,
+                kDynamicTokenScale,
+                symmetric=input_symmetric,
+            )
+
         self.kernel = init_int8_linear_kernel(
-            is_channelwise=(self.qscheme == "per_channel"),
-            is_static_input_scheme=(self.is_static_input_scheme is True),
-            input_symmetric=(self.input_symmetric is True),
+            weight_quant_key=weight_quant_key,
+            activation_quant_key=activation_quant_key,
             module_name=self.__class__.__name__,
         )
 

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_int8.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_int8.py
@@ -65,10 +65,15 @@ class QuarkW8A8Int8(QuarkScheme):
                 loaded_weight = loaded_weight.unsqueeze(-1)
             return weight_loader(param, loaded_weight, *args, **kwargs)
 
-        is_channelwise = self.qscheme == "per_channel"
-        weight_quant_key = (
-            kInt8StaticChannelSym if is_channelwise else kInt8StaticTensorSym
-        )
+        if self.qscheme == "per_channel":
+            weight_quant_key = kInt8StaticChannelSym
+        elif self.qscheme == "per_tensor":
+            weight_quant_key = kInt8StaticTensorSym
+        else:
+            raise ValueError(
+                f"Unsupported INT8 weight quantization qscheme: "
+                f'{self.qscheme}. Only "per_channel" and "per_tensor" are supported.'
+            )
 
         is_static = self.is_static_input_scheme is True
         input_symmetric = self.input_symmetric is True

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -189,6 +189,7 @@ kInt4Static32Asym = QuantKey(
 )
 
 kInt8StaticChannelSym = QuantKey(torch.int8, kStaticChannelScale, symmetric=True)
+kInt8StaticTensorSym = QuantKey(torch.int8, kStaticTensorScale, symmetric=True)
 kInt8DynamicTokenSym = QuantKey(torch.int8, kDynamicTokenScale, symmetric=True)
 
 # INT4 W4A8 quantization keys


### PR DESCRIPTION
## Purpose

This PR refactors `Int8ScaledMMLinearLayerConfig` to use `QuantKey` objects instead of boolean flags (`is_static_input_scheme`, `is_channelwise`, `input_symmetric`), aligning it with the `FP8ScaledMMLinearLayerConfig` pattern introduced in #27814.

Fix issue #32268.

This is a follow-up of #32675, addressing all review feedback from @vllmellm:
1. QuantKey construction is moved to the callers (`compressed_tensors`, `quark`), not inside `init_int8_linear_kernel`.
2. Backward-compatible `@property` methods on the config class are removed — kernels access descriptors directly (e.g., `config.activation_quant_key.symmetric`).
3. The `input_symmetric` field is removed — replaced by `activation_quant_key.symmetric`.
4. `QuarkW8A8Int8` caller is also updated to pass `QuantKey` (this was the last unresolved review comment on #32675).

Changes:
1. `Int8ScaledMMLinearLayerConfig` now has only `weight_quant_key` and `activation_quant_key` fields.
2. `init_int8_linear_kernel` accepts `QuantKey` objects directly, matching `init_fp8_linear_kernel` pattern.
3. All kernel implementations (CUTLASS, Triton, CPU, Aiter, Zentorch) access quantization descriptors directly from the `QuantKey` objects.
4. Callers (`CompressedTensorsW8A8Int8`, `QuarkW8A8Int8`) construct `QuantKey` objects from scheme parameters.
5. Added `kInt8StaticTensorSym` constant for per-tensor static symmetric INT8 weight quantization.
6. Updated unit tests to use `QuantKey`-based config construction.

## Test Plan

End-to-end model evaluations using lm_eval.


## Test Result

CUDA (NVIDIA L40)
RedHatAI/Meta-Llama-3.1-8B-quantized.w8a8 (cutlass)

| Tasks | Version | Filter | n-shot | Metric |  | Value |  | Stderr |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| gsm8k | 3 | flexible-extract | 5 | exact_match | ↑ | 0.4756 | ± | 0.0159 |
|  |  | strict-match | 5 | exact_match | ↑ | 0.4732 | ± | 0.0159 |

Note: 
E2E evaluations on other architectures (such as `RedHatAI/phi-4-quantized.w8a8` and `RedHatAI/gemma-3-12b-it-quantized.w8a8`) are currently ongoing and results will be supplemented here.
