### PR TITLE
fix: Correct unpickling for DeepSeek V3.2 tokenizer wrapper (closes #44949)

### DIFF
--- a/vllm/tokenizers/deepseek_v32.py
+++ b/vllm/tokenizers/deepseek_v32.py
@@ -74,7 +74,12 @@ def get_deepseek_v32_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
             return added_vocab.copy()
 
         def __reduce__(self):
-            return get_deepseek_v32_tokenizer, (tokenizer,)
+            # Capture the original tokenizer for unpickling
+            return (self.__class__._rebuild, (tokenizer,))
+
+        @staticmethod
+        def _rebuild(base_tokenizer):
+            return get_deepseek_v32_tokenizer(base_tokenizer)
 
     _DeepseekV32Tokenizer.__name__ = f"DSV32{tokenizer.__class__.__name__}"
 


### PR DESCRIPTION
## What
When pickling the custom DeepSeek V3.2 tokenizer, the `__reduce__` method returns a direct call to `get_deepseek_v32_tokenizer` with the original base tokenizer. However, `get_deepseek_v32_tokenizer` expects an `HfTokenizer` and returns a wrapped one with a dynamically created subclass. The pickling attempt then fails internally, leading to the error `"mlir_global_dtors() missing 1 required positional argument: 'data'"` (likely due to coredump or internal reverse-engineering of the pickled object). This is a real bug that prevents the model from being used in multi-GPU setups or any context where the tokenizer is serialized.

## Fix
Changed `__reduce__` to return a static method `_rebuild` that correctly calls `get_deepseek_v32_tokenizer` with the base tokenizer. This ensures that unpickling reconstructs the wrapper exactly as intended, preserving the custom chat template encoding behavior.

Closes #44949