### PR TITLE
[ROCm] Release physical VRAM on sleep, scoped to the Python unmap path

### DIFF
--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -674,6 +674,32 @@ static PyObject* python_unmap_and_release(PyObject* self, PyObject* args) {
 
   free(p_memHandle);
   free(chunk_sizes);
+
+  // ROCm: hipMemRelease does not return physical VRAM to the free pool while the
+  // virtual-address (VA) reservation is still held. Cycle cuMemAddressFree ->
+  // cuMemAddressReserve at the same address to force the driver to release the
+  // physical pages, keeping the VA for a later wake_up (create_and_map).
+  //
+  // Scoped to the sleep / pool-cleanup path only; NOT in my_free, which frees the
+  // VA itself. Doing this in the shared path regressed TP=2 (see #37533, #40686).
+  if (error_code == no_error) {
+    CUresult st = cuMemAddressFree(d_mem_ptr, recv_size);
+    if (st == no_error) {
+      CUdeviceptr d_mem_new = 0;
+      st = cuMemAddressReserve(&d_mem_new, recv_size, 0, d_mem_ptr, 0);
+      if (st == no_error && d_mem_new != d_mem_ptr) {
+        cuMemAddressFree(d_mem_new, recv_size);
+        snprintf(error_msg, sizeof(error_msg),
+                 "ROCm: VA re-reserve got %p instead of %p", (void*)d_mem_new,
+                 (void*)d_mem_ptr);
+        st = hipErrorNotSupported;
+        std::cerr << error_msg << std::endl;
+      }
+    }
+    if (st != no_error) {
+      error_code = st;
+    }
+  }
 #endif
 
   if (error_code != 0) {


### PR DESCRIPTION



## Purpose

On ROCm, sleep mode did not actually free physical GPU memory. `CuMemAllocator.sleep()`
unmapped and released the allocation handles, but `hipMemRelease` does **not** return
physical VRAM to the free pool while the virtual-address (VA) reservation is still held.
Since the sleep path intentionally keeps the VA reserved (so `wake_up()` can re-map at the
same address), the device memory stayed resident and sleep reclaimed (almost) nothing.

### Background / history

| Commit | PR | What it did |
| --- | --- | --- |
| `10a1018c1` | #37533 | Added the ROCm fix: cycle `cuMemAddressFree -> cuMemAddressReserve` so the driver releases physical pages while keeping the VA. |
| `66d1cc0c7` | #40686 | **Reverted** #37533 — it caused `invalid argument` on Qwen3.5 with TP=2. |
| `2385e140d` | #43022 | "Stabilize sleep-mode memory release" — only fixed a *separate* VA-reservation alignment OOM (`reserve_rocm_address`); it did **not** restore the physical-VRAM release. |

So after #40686 the original bug is still present upstream. This PR re-lands the fix without
the regression.

### Root cause of the previous regression

Two paths free memory and both call the shared `unmap_and_release()`:

- `my_free` (torch free callback) — frees the VA itself (`cuMemAddressFree`) right after
  `unmap_and_release()`, so physical pages are reclaimed there.
- `python_unmap_and_release` (sleep / pool cleanup) — intentionally keeps the VA reserved.

#37533 put the VA cycle inside the **shared** `unmap_and_release()`, so it also ran on the
`my_free` path, which then freed the same VA again → double-handling → `invalid argument`
on TP=2.

### Fix

Re-introduce the VA cycle but **scope it to `python_unmap_and_release()` only** (the sleep
path), after the `unmap_and_release()` call — never in the shared helper. `my_free` is left
untouched, so the TP=2 double-free cannot happen. The re-reservation requests the **same**
VA via the address hint and raises a `RuntimeError` if the driver returns a different
address (instead of silently corrupting state).

One file changed: `csrc/cumem_allocator.cpp`.

## Test Plan

Hardware: AMD MI300 (gfx942), ROCm.

```bash
# Functional sleep-mode tests
pytest -v tests/basic_correctness/test_mem.py

# TP=2 sleep/wake regression check (the scenario that caused #37533 to be reverted)
# 2 GPUs, full model load -> sleep -> wake cycle, verifying memory is released and
# no "invalid argument" is raised.
```

## Test Result

`tests/basic_correctness/test_mem.py` (pinned to a dedicated GPU):

| Test | Result |
| --- | --- |
| `test_end_to_end[hmellor/tiny-random-LlamaForCausalLM]` | PASSED |
| `test_end_to_end[facebook/opt-125m]` | PASSED |
| `test_deep_sleep` | PASSED |
| `test_deep_sleep_async` | PASSED |
| `test_deep_sleep_fp8_kvcache` | PASSED |
| `test_python_error` | logic PASSES (`1 passed`); see note |
| `test_basic_cumem` | logic PASSES (`1 passed`); see note |
| `test_cumem_with_cudagraph` | logic PASSES (`1 passed`); see note |

- Before this PR: on ROCm, `sleep()` reported freeing ~0 GiB of physical VRAM.
- After this PR: `sleep()` actually releases device memory, e.g.
  `CuMemAllocator: sleep freed 134.39 GiB memory in total`.
- TP=2: a full sleep/wake cycle releases ~176 GiB across 2 GPUs with **no**
  `invalid argument` error (the exact case that motivated the #40686 revert).

### Note: separate, pre-existing teardown crashes (out of scope here, fixed in follow-ups)

`test_python_error`, `test_basic_cumem`, and `test_cumem_with_cudagraph` pass their test
logic (`1 passed`) but the **process** can crash during interpreter shutdown. The
faulthandler stack shows the crash is entirely inside torch's HIP caching allocator, with
no vLLM frames:

```
c10::hip::HIPCachingAllocator::Native::DeviceCachingAllocator::release_block(...)
c10::hip::HIPCachingAllocator::Native::NativeCachingAllocator::emptyCache(...)
std::_Sp_counted_base::_M_release()
pybind11::class_<at::cuda::MemPool>::dealloc_without_manipulating_gil(...)
pybind11_object_dealloc
_PyObject_ClearManagedDict
Py_FinalizeEx
```

This is independent of this PR — it reproduces **without any `sleep()` call** (a cumem pool
 plus a CUDA graph at process exit is enough), and surfaces as either SIGSEGV or SIGABRT
(`pure virtual method called`) depending on teardown timing. Since opening this PR I've
root-caused it and split it into two separate, focused PRs (both independent of this one
and of the base image):

- **#46050 — teardown destruction-ordering.** `CuMemAllocator` holds a
  `(MemPool, CUDAPluggableAllocator)` tuple per tag; at finalization the final GC can
  destroy the allocator wrapper before its `MemPool`, and `MemPool` teardown then calls
  allocator virtual methods on a half-destroyed object → "pure virtual method called" /
  SIGSEGV. Fixed (Python only) by an `atexit`-driven `release_pools()` that drops
  references in a controlled two-phase order, mirroring the existing XPU path
  (`xpumem.py::release_pools`, #37149). This is what fixes the `test_basic_cumem` /
  `test_cumem_with_cudagraph` teardown crash.

- **#46054 — OOM double-free in the C extension.** On the OOM `wake_up()` path,
  `create_and_map()`'s cleanup releases the partially-created handles but leaves them
  non-zero, so a later `unmap_and_release()` releases the same handles again
  (`hipMemRelease` on a freed handle) → double free. Fixed by making handle release
  idempotent (zero each handle after release, skip zero handles). This is what fixes the
  intermittent `test_python_error` crash.

With #46050 and #46054 applied, the full `tests/basic_correctness/test_mem.py` passes 8/8
with no teardown segfault.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

