### PR TITLE
[Bugfix][Gemma4] Fix parsing when thinking is disabled

### DIFF
--- a/tests/tool_use/test_gemma4_responses_adjust_request.py
+++ b/tests/tool_use/test_gemma4_responses_adjust_request.py
@@ -68,28 +68,33 @@ def _build_responses_request(*, tool_choice: str | dict[str, Any]) -> ResponsesR
     )
 
 
-def _build_chat_request(*, tool_choice: str | dict[str, Any]) -> ChatCompletionRequest:
-    return ChatCompletionRequest.model_validate(
-        {
-            "model": "gemma4-test",
-            "messages": [{"role": "user", "content": "What is the weather in Hanoi?"}],
-            "tools": [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "get_weather",
-                        "description": "Get current weather for a city",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {"city": {"type": "string"}},
-                            "required": ["city"],
-                        },
+def _build_chat_request(
+    *,
+    tool_choice: str | dict[str, Any],
+    chat_template_kwargs: dict[str, Any] | None = None,
+) -> ChatCompletionRequest:
+    data: dict[str, Any] = {
+        "model": "gemma4-test",
+        "messages": [{"role": "user", "content": "What is the weather in Hanoi?"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get current weather for a city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
                     },
-                }
-            ],
-            "tool_choice": tool_choice,
-        }
-    )
+                },
+            }
+        ],
+        "tool_choice": tool_choice,
+    }
+    if chat_template_kwargs is not None:
+        data["chat_template_kwargs"] = chat_template_kwargs
+    return ChatCompletionRequest.model_validate(data)
 
 
 class _StubTokenizer:
@@ -212,3 +217,34 @@ def test_gemma4_named_skips_structured_outputs_responses() -> None:
 
     assert request.text is None
     assert request.skip_special_tokens is False
+
+
+def test_gemma4_keeps_special_tokens_with_tools_thinking_disabled() -> None:
+    """tools active + thinking disabled: ``skip_special_tokens`` must stay
+    False so ``<|tool_call>`` delimiters reach the extractor. The merged
+    enable_thinking early-return stripped them, breaking tool calling when
+    thinking is off.
+    """
+    parser = Gemma4ToolParser(_StubTokenizer())
+    request = _build_chat_request(
+        tool_choice="auto", chat_template_kwargs={"enable_thinking": False}
+    )
+
+    parser.adjust_request(request)
+
+    assert request.skip_special_tokens is False
+
+
+def test_gemma4_strips_special_tokens_when_nothing_to_preserve() -> None:
+    """No active tools + thinking disabled: keep the default
+    (``skip_special_tokens=True``) so stray delimiters do not leak into
+    content.
+    """
+    parser = Gemma4ToolParser(_StubTokenizer())
+    request = _build_chat_request(
+        tool_choice="none", chat_template_kwargs={"enable_thinking": False}
+    )
+
+    parser.adjust_request(request)
+
+    assert request.skip_special_tokens is True

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -443,16 +443,22 @@ class Gemma4Parser(ParserEngine):
         self,
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> ChatCompletionRequest | ResponsesRequest:
-        """Skip ``skip_special_tokens=False`` when thinking is disabled.
+        """Keep special tokens when thinking or tool calls need them.
 
-        When there are no reasoning channel tokens to preserve,
-        keeping the default prevents tool-call delimiter tokens
-        from leaking into content (e.g. with ``tool_choice="none"``).
+        ``skip_special_tokens`` must stay ``False`` when there is something to
+        preserve: reasoning channel tokens (thinking enabled) or tool-call
+        delimiters (tools active). Otherwise keep the default so stray
+        delimiters do not leak into content (e.g. ``tool_choice="none"`` with
+        thinking disabled).
         """
+        request = super().adjust_request(request)
         chat_template_kwargs = getattr(request, "chat_template_kwargs", None) or {}
-        if not chat_template_kwargs.get("enable_thinking", True):
-            return request
-        return super().adjust_request(request)
+        enable_thinking = chat_template_kwargs.get("enable_thinking", True)
+        has_tools = bool(getattr(request, "tools", None))
+        tools_active = has_tools and request.tool_choice != "none"
+        if not enable_thinking and not tools_active:
+            request.skip_special_tokens = True
+        return request
 
     def _reset(self, initial_state=None) -> None:
         super()._reset(initial_state=initial_state)


### PR DESCRIPTION
## Purpose

`Gemma4Parser.adjust_request` (added in #45553) returns early when thinking is
disabled (`enable_thinking=False`), so `skip_special_tokens` is never set to
`False`. With thinking disabled and tools active, the `<|tool_call>` delimiters
get stripped before the parser sees them, so tool calling breaks: `tool_calls`
is empty and the raw `call:fn{...}` body leaks into `content`, both streaming
and non-streaming.

The engine-based Gemma4 parser consumes those special tokens itself, and it
needs them to do its job. So this keeps `skip_special_tokens=False` and only
skips when there is nothing to parse: no reasoning and no active tools. That
matches the direction in the #45553 discussion.

This is separate from #45795 (required/named tool choice). I developed and
verified it on top of #45795 on the same setup.

Not a duplicate: no open PR addresses this. It is the follow-up to the merged
#45553.

cc @bbrowning @lucianommartins

## Test Plan

Unit (CPU, mock tokenizer):

```
pytest tests/tool_use/test_gemma4_responses_adjust_request.py
```

Runtime: live `google/gemma-4-31B-it` (fp8, MTP draft
`google/gemma-4-31B-it-assistant`, `num_speculative_tokens=8`,
`--tool-call-parser gemma4 --reasoning-parser gemma4`) on one RTX PRO 6000,
with `chat_template_kwargs={"enable_thinking": false}` and tools.

## Test Result

| Check | Before | After |
|---|---|---|
| thinking disabled + tools (auto), stream + non-stream | `tool_calls=[]`, content `call:get_weather{city:Milano}call:get_weather{city:Roma}` | `get_weather(Milano)` + `get_weather(Roma)`, content empty |
| thinking disabled, no active tools | default kept (no leak) | default kept (no leak) |
| new adjust_request tests (2) | 1 failed | 2 passed |
| gemma4 parser/reasoning/engine suites (with #45795 applied) | n/a | 1373 passed |

AI assistance was used.
