### PR TITLE
[RFC][Core][Model] Voxtral realtime: unbounded-duration streaming via RoPE re-anchoring (experimental, default-off)

### DIFF
--- a/benchmarks/voxtral_realtime/README.md
+++ b/benchmarks/voxtral_realtime/README.md
@@ -1,0 +1,48 @@
+# Voxtral realtime benchmarks
+
+Scripts to reproduce the realtime sliding-window / re-anchoring numbers
+(KV-bounded streaming + unbounded duration). Hardware-agnostic; the results in
+`results/` were collected on a single RTX 4090 Laptop 16 GiB.
+
+## Tools
+
+- **`ws_load.py`**: drives N concurrent, real-time-paced WebSocket streams
+  against a running vLLM server. Records per-stream wall vs audio seconds, the
+  final transcript, and frame-to-partial latency.
+  ```
+  python ws_load.py -n 4 --audio clip.wav --out results.json
+  python ws_load.py -n 1 --audio clip.wav --loops 7 --out long.json  # long session
+  ```
+- **`vram_probe.py`**: samples `nvidia-smi` VRAM, `vllm:kv_cache_usage_perc`, and
+  the engine-core RSS at a fixed interval into a CSV, to show VRAM/KV stay flat
+  over a run.
+- **`test_reanchor_math.py`**: standalone numerical check that re-rotating a
+  cached key by `R(-D)` and shifting the query position by `-D` leaves the
+  attention score unchanged (the correctness basis for RoPE re-anchoring).
+  ```
+  python test_reanchor_math.py
+  ```
+
+## Example: KV-bounded serve on a single 16 GiB GPU
+
+```
+vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602 --tokenizer-mode mistral \
+  --hf-overrides '{"text_config":{"sliding_window":512},"audio_config":{"sliding_window":256}}' \
+  --max-model-len 16384 --no-enable-prefix-caching \
+  --compilation-config '{"cudagraph_mode":"PIECEWISE"}'
+```
+
+The decoder `sliding_window` controls concurrency: a smaller window means less
+KV per stream, so you can run more streams at once. Add
+`--enable-realtime-unbounded` for unbounded-duration sessions (experimental;
+re-anchors the RoPE position clock so a session never reaches `max_model_len`).
+
+## Reproducing the endurance run
+
+The 4.7 h, 4-stream endurance result (VRAM spread 54 MiB under 0.4 %, `kv_usage`
+bounded, wall/audio = 1.000 on all 4 streams, no crash across ~284 re-anchor
+events) was collected with `--max-model-len 4096`, window 512/256 and
+`--enable-realtime-unbounded`, sampling with `vram_probe.py` alongside
+`ws_load.py -n 4 --loops 7`. (Raw CSV/JSON probe output is git-ignored by repo
+policy, `.gitignore` `*.csv` / `benchmarks/**/*.json`; regenerate locally with
+`vram_probe.py`.)

--- a/benchmarks/voxtral_realtime/README.md
+++ b/benchmarks/voxtral_realtime/README.md
@@ -1,8 +1,8 @@
 # Voxtral realtime benchmarks
 
 Scripts to reproduce the realtime sliding-window / re-anchoring numbers
-(KV-bounded streaming + unbounded duration). Hardware-agnostic; the results in
-`results/` were collected on a single RTX 4090 Laptop 16 GiB.
+(KV-bounded streaming + unbounded duration). Hardware-agnostic; the numbers
+quoted in the PR discussion were collected on a single RTX 4090 Laptop 16 GiB.
 
 ## Tools
 

--- a/benchmarks/voxtral_realtime/test_reanchor_math.py
+++ b/benchmarks/voxtral_realtime/test_reanchor_math.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit test for the RoPE re-anchoring core math (config-free, matches vLLM's
+rotary convention in vllm/model_executor/layers/rotary_embedding/common.py).
+
+Property proved: a POST-rotation cached key that was rotated at absolute position
+`p` and is then re-rotated by the constant R(-D) equals the key rotated at
+position `p-D`. Hence after shifting the query clock by D and re-rotating every
+live key by R(-D), every in-window relative attention score R(i-j) is preserved
+exactly. Tested for BOTH styles used by Voxtral realtime:
+  - decoder: NeoX,  rotary_dim=128, base=1e6
+  - encoder: GPT-J, rotary_dim=64,  base=1e6
+
+The CI-collected pytest equivalent (same property, asserted) lives at
+tests/v1/worker/test_reanchor_rotary.py; this script stays as a manual harness
+with printed per-case errors.
+
+Run:  .venv/bin/python benchmarks/voxtral_realtime/test_reanchor_math.py
+"""
+
+import torch
+
+# Import the PRODUCTION re-anchor op so this test guards the real function rather
+# than a hand-copied duplicate. The helper lives in a dependency-light module so
+# importing it does not pull the GPU model runner graph.
+from vllm.v1.worker.reanchor_rotary import apply_inverse_rotary
+
+
+def _inv_freq(rotary_dim: int, base: float) -> torch.Tensor:
+    return 1.0 / (
+        base ** (torch.arange(0, rotary_dim, 2, dtype=torch.float64) / rotary_dim)
+    )
+
+
+def forward_rotary(
+    x: torch.Tensor, pos: int, rotary_dim: int, base: float, is_neox: bool
+) -> torch.Tensor:
+    """Rotate x by +pos (vLLM convention)."""
+    half = rotary_dim // 2
+    ang = float(pos) * _inv_freq(rotary_dim, base)
+    cos, sin = torch.cos(ang).to(x.dtype), torch.sin(ang).to(x.dtype)
+    rot, pas = x[..., :rotary_dim], x[..., rotary_dim:]
+    if is_neox:
+        x1, x2 = rot[..., :half], rot[..., half:]
+        out = torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1)
+    else:
+        x1, x2 = rot[..., 0::2], rot[..., 1::2]
+        o1, o2 = x1 * cos - x2 * sin, x2 * cos + x1 * sin
+        out = torch.stack([o1, o2], dim=-1).flatten(-2)
+    return torch.cat([out, pas], dim=-1) if pas.numel() else out
+
+
+def main():
+    torch.manual_seed(0)
+    cases = [("decoder NeoX", 128, 1e6, True), ("encoder GPT-J", 64, 1e6, False)]
+    ok = True
+    for name, rdim, base, neox in cases:
+        for p, D in [(5000, 4096), (9000, 7000), (3000, 2048), (120000, 100000)]:
+            k = torch.randn(4, rdim, dtype=torch.float32)
+            # (1) re-anchor identity: R(-D)·R(p)·k == R(p-D)·k
+            cached = forward_rotary(k, p, rdim, base, neox)  # key in KV cache
+            reanchored = apply_inverse_rotary(cached, D, rdim, base, neox)
+            target = forward_rotary(k, p - D, rdim, base, neox)
+            err1 = (reanchored - target).abs().max().item()
+            # (2) relative-score preservation: q@i vs k@j  ==  q@(i-D) vs (reanchored)
+            i, j = p + 60, p  # j within window below i
+            q = torch.randn(4, rdim, dtype=torch.float32)
+            s_orig = (
+                forward_rotary(q, i, rdim, base, neox)
+                * forward_rotary(k, j, rdim, base, neox)
+            ).sum(-1)
+            kj_re = apply_inverse_rotary(
+                forward_rotary(k, j, rdim, base, neox), D, rdim, base, neox
+            )
+            s_re = (forward_rotary(q, i - D, rdim, base, neox) * kj_re).sum(-1)
+            err2 = (s_orig - s_re).abs().max().item()
+            status = "OK" if (err1 < 1e-3 and err2 < 1e-3) else "FAIL"
+            if status == "FAIL":
+                ok = False
+            print(
+                f"  [{status}] {name:14s} p={p:6d} D={D:6d}  "
+                f"reanchor-identity err={err1:.1e}  rel-score err={err2:.1e}"
+            )
+    print(
+        "\nRESULT:",
+        "PASS: R(-D) re-rotation preserves in-window scores" if ok else "FAIL",
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/voxtral_realtime/vram_probe.py
+++ b/benchmarks/voxtral_realtime/vram_probe.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Sample VRAM, EngineCore host RSS, and vLLM KV-cache usage over time.
+
+For long-run endurance tests: a flat VRAM + flat RSS + flat KV-usage proves the
+unbounded-realtime re-anchoring does not leak (the sliding window + re-anchor
+bound the KV; the only growing structure is the tiny mm_features list, which RSS
+would expose if it mattered). Writes one CSV row per interval to stdout.
+
+Usage: vram_probe.py [interval_s] [duration_s]   (Ctrl-C or duration to stop)
+"""
+
+import contextlib
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+
+
+def nvidia_vram_mib() -> int:
+    out = (
+        subprocess.run(
+            ["nvidia-smi", "--query-gpu=memory.used", "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+        )
+        .stdout.strip()
+        .splitlines()
+    )
+    return int(out[0]) if out else -1
+
+
+def enginecore_rss_mib() -> float:
+    # Sum RSS (KB) of all EngineCore worker processes.
+    out = subprocess.run(
+        ["ps", "-eo", "rss,args"], capture_output=True, text=True
+    ).stdout
+    tot = 0
+    for line in out.splitlines():
+        if "EngineCore" in line or "from multiprocessing.spawn" in line:
+            m = re.match(r"\s*(\d+)\s", line)
+            if m:
+                tot += int(m.group(1))
+    return round(tot / 1024, 1)
+
+
+def host_avail_mib() -> int:
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) // 1024
+    except Exception:
+        pass
+    return -1
+
+
+def metrics(port: int) -> tuple[float, float]:
+    """Return (kv_cache_usage_perc, num_requests_running)."""
+    try:
+        body = (
+            urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=5)
+            .read()
+            .decode()
+        )
+    except Exception:
+        return (-1.0, -1.0)
+    kv = run = -1.0
+    for line in body.splitlines():
+        if line.startswith("#"):
+            continue
+        if "kv_cache_usage_perc" in line or "gpu_cache_usage_perc" in line:
+            with contextlib.suppress(Exception):
+                kv = float(line.rsplit(" ", 1)[1])
+        elif "num_requests_running" in line:
+            with contextlib.suppress(Exception):
+                run = float(line.rsplit(" ", 1)[1])
+    return (kv, run)
+
+
+def main():
+    interval = float(sys.argv[1]) if len(sys.argv) > 1 else 15.0
+    duration = float(sys.argv[2]) if len(sys.argv) > 2 else 1e9
+    port = int(sys.argv[3]) if len(sys.argv) > 3 else 8000
+    t0 = time.perf_counter()
+    print(
+        "elapsed_s,vram_mib,enginecore_rss_mib,kv_usage,running,host_avail_mib",
+        flush=True,
+    )
+    while True:
+        el = time.perf_counter() - t0
+        if el > duration:
+            break
+        kv, run = metrics(port)
+        print(
+            f"{el:.0f},{nvidia_vram_mib()},{enginecore_rss_mib()},{kv:.4f},"
+            f"{run:.0f},{host_avail_mib()}",
+            flush=True,
+        )
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/voxtral_realtime/ws_load.py
+++ b/benchmarks/voxtral_realtime/ws_load.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+ws_load.py: N concurrent real-time-paced /v1/realtime websocket streams.
+
+Protocol mirrored from examples/speech_to_text/realtime/openai_realtime_client.py:
+    recv session.created -> send session.update {model} -> send commit (ready)
+    -> loop input_audio_buffer.append {audio: base64 PCM16 @16kHz}
+    -> input_audio_buffer.commit {final: true}
+    -> recv transcription.delta* then transcription.done
+
+Paces audio to wall-clock in ~frame-ms PCM frames (real-time ingest), records
+per-frame->partial latency + final transcript per stream + an aggregate summary.
+
+Usage:
+    .venv/bin/python ws_load.py -n 8 --audio ref.wav --out results.json
+    .venv/bin/python ws_load.py -n 16 --frame-ms 30 --duration-cap 60
+"""
+
+import argparse
+import asyncio
+import json
+import statistics
+import sys
+import time
+
+import numpy as np
+import pybase64 as base64
+import websockets
+
+from vllm.assets.audio import AudioAsset
+from vllm.multimodal.media.audio import load_audio
+
+SAMPLE_RATE = 16000
+
+
+def load_pcm16(audio_path: str, loops: int = 1) -> bytes:
+    audio, _ = load_audio(audio_path, sr=SAMPLE_RATE, mono=True)
+    pcm = (audio * 32767).astype(np.int16).tobytes()
+    # Repeat the clip so a single session accumulates enough decoder positions
+    # to cross the re-anchor threshold (the unbounded-duration test).
+    return pcm * max(1, loops)
+
+
+async def run_one(
+    idx, uri, model, pcm, frame_bytes, frame_dt, duration_cap, collect_text,
+    pace=True, start_byte=0
+):
+    res = {
+        "stream": idx,
+        "ok": False,
+        "error": None,
+        "session_id": None,
+        "frames_sent": 0,
+        "audio_seconds_sent": 0.0,
+        "first_partial_latency_s": None,
+        "final_text": None,
+        "wall_seconds": None,
+        "audio_sent_wall_s": None,   # wall time when the last audio frame was sent
+        "flush_latency_s": None,     # transcription.done arrival - last audio frame
+        # (elapsed_s, cumulative_words) per partial: raw transcription-progress
+        # timeline, for offline inspection of how output tracks the audio clock.
+        "lat_timeline": [],
+    }
+    t_start = time.perf_counter()
+    first_partial_seen = False
+    cum_words = 0
+    try:
+        async with websockets.connect(uri, max_size=None, ping_interval=20) as ws:
+            hello = json.loads(await ws.recv())
+            if hello.get("type") != "session.created":
+                res["error"] = f"unexpected first message: {hello.get('type')}"
+                return res
+            res["session_id"] = hello.get("id")
+            await ws.send(json.dumps({"type": "session.update", "model": model}))
+            await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
+
+            done = asyncio.Event()
+
+            async def receiver():
+                nonlocal first_partial_seen, cum_words
+                while not done.is_set():
+                    try:
+                        msg = json.loads(await ws.recv())
+                    except websockets.ConnectionClosed:
+                        return
+                    mtype = msg.get("type")
+                    if mtype == "transcription.delta":
+                        now = time.perf_counter()
+                        if not first_partial_seen:
+                            first_partial_seen = True
+                            res["first_partial_latency_s"] = now - t_start
+                        delta = msg.get("delta", "")
+                        if collect_text:
+                            res["final_text"] = (res["final_text"] or "") + delta
+                        cum_words += len(delta.split())
+                        res["lat_timeline"].append((round(now - t_start, 3), cum_words))
+                    elif mtype == "transcription.done":
+                        if collect_text and msg.get("text"):
+                            res["final_text"] = msg["text"]
+                        res["flush_latency_s"] = (
+                            time.perf_counter()
+                            - t_start
+                            - (res["audio_sent_wall_s"] or 0.0)
+                        )
+                        res["ok"] = True
+                        done.set()
+                        return
+                    elif mtype == "error":
+                        res["error"] = msg.get("error")
+                        done.set()
+                        return
+
+            recv_task = asyncio.create_task(receiver())
+
+            total = len(pcm)
+            sent = start_byte % max(total, 1)
+            next_send = time.perf_counter()
+            while sent < total and not done.is_set():
+                if duration_cap > 0 and res["audio_seconds_sent"] >= duration_cap:
+                    break
+                chunk = pcm[sent : sent + frame_bytes]
+                sent += len(chunk)
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "input_audio_buffer.append",
+                            "audio": base64.b64encode(chunk).decode("utf-8"),
+                        }
+                    )
+                )
+                res["frames_sent"] += 1
+                res["audio_seconds_sent"] = (
+                    res["frames_sent"] * frame_bytes / 2 / SAMPLE_RATE
+                )
+                if pace:
+                    next_send += frame_dt
+                    slack = next_send - time.perf_counter()
+                    if slack > 0:
+                        await asyncio.sleep(slack)
+                else:
+                    # fast-feed: advance positions as fast as the server accepts
+                    # (NOT real-time; wall vs audio is meaningless in this mode).
+                    await asyncio.sleep(0)
+
+            res["audio_sent_wall_s"] = time.perf_counter() - t_start
+            await ws.send(
+                json.dumps({"type": "input_audio_buffer.commit", "final": True})
+            )
+            try:
+                await asyncio.wait_for(recv_task, timeout=120)
+            except asyncio.TimeoutError:
+                res["error"] = res["error"] or "timeout waiting for transcription.done"
+                done.set()
+                recv_task.cancel()
+    except Exception as exc:  # noqa: BLE001
+        res["error"] = f"{type(exc).__name__}: {exc}"
+    finally:
+        res["wall_seconds"] = time.perf_counter() - t_start
+    return res
+
+
+def pct(data, p):
+    if not data:
+        return float("nan")
+    s = sorted(data)
+    k = max(0, min(len(s) - 1, int(round((p / 100) * (len(s) - 1)))))
+    return s[k]
+
+
+def summarize(results):
+    ok = [r for r in results if r["ok"]]
+    first = [
+        r["first_partial_latency_s"]
+        for r in results
+        if r["first_partial_latency_s"] is not None
+    ]
+    flush = [r["flush_latency_s"] for r in results if r["flush_latency_s"] is not None]
+    return {
+        "n_streams": len(results),
+        "n_ok": len(ok),
+        "n_error": len(results) - len(ok),
+        "errors": [r["error"] for r in results if r["error"]][:8],
+        "first_partial_latency_s": {
+            "mean": statistics.fmean(first) if first else None,
+            "p50": pct(first, 50),
+            "p95": pct(first, 95),
+            "max": max(first) if first else None,
+        },
+        "flush_latency_s": {
+            "mean": statistics.fmean(flush) if flush else None,
+            "p50": pct(flush, 50),
+            "p95": pct(flush, 95),
+            "max": max(flush) if flush else None,
+        },
+    }
+
+
+async def main_async(args):
+    audio_path = args.audio or str(AudioAsset("mary_had_lamb").get_local_path())
+    if not args.audio:
+        print(f"[ws_load] no --audio, default asset: {audio_path}", file=sys.stderr)
+    pcm = load_pcm16(audio_path, args.loops)
+    samples_per_frame = int(args.frame_ms / 1000 * SAMPLE_RATE)
+    frame_bytes = samples_per_frame * 2
+    frame_dt = args.frame_ms / 1000.0
+    uri = f"ws://{args.host}:{args.port}/v1/realtime"
+    # De-sync: each stream starts at a different position in the audio, so at any
+    # instant the streams carry different content (no perfectly-aligned batches).
+    stagger_bytes = (
+        int(args.pos_stagger_s * SAMPLE_RATE) * 2 // frame_bytes
+    ) * frame_bytes
+    print(
+        f"[ws_load] {args.n} streams -> {uri} frame={args.frame_ms}ms "
+        f"audio={len(pcm) / 2 / SAMPLE_RATE:.1f}s cap={args.duration_cap}s "
+        f"pos-stagger={args.pos_stagger_s}s/stream",
+        file=sys.stderr,
+    )
+    tasks = [
+        run_one(
+            i,
+            uri,
+            args.model,
+            pcm,
+            frame_bytes,
+            frame_dt,
+            args.duration_cap,
+            not args.no_text,
+            not args.no_pace,
+            start_byte=i * stagger_bytes,
+        )
+        for i in range(args.n)
+    ]
+    results = await asyncio.gather(*tasks)
+    summary = summarize(results)
+    with open(args.out, "w") as fh:
+        json.dump({"summary": summary, "streams": results}, fh, indent=2)
+    print(json.dumps(summary, indent=2))
+    print(f"[ws_load] per-stream results -> {args.out}", file=sys.stderr)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Concurrent realtime websocket load test")
+    ap.add_argument("-n", type=int, default=4)
+    ap.add_argument("--model", default="mistralai/Voxtral-Mini-4B-Realtime-2602")
+    ap.add_argument("--audio", default=None)
+    ap.add_argument("--host", default="localhost")
+    ap.add_argument("--port", type=int, default=8000)
+    ap.add_argument("--frame-ms", type=float, default=30.0)
+    ap.add_argument(
+        "--duration-cap",
+        type=float,
+        default=0.0,
+        help="cap audio sec/stream (0=full file)",
+    )
+    ap.add_argument("--no-text", action="store_true")
+    ap.add_argument(
+        "--no-pace",
+        action="store_true",
+        help="fast-feed (advance positions ASAP, not real-time)",
+    )
+    ap.add_argument(
+        "--loops",
+        type=int,
+        default=1,
+        help="repeat the audio clip N times per stream (unbounded-duration test)",
+    )
+    ap.add_argument(
+        "--pos-stagger-s",
+        type=float,
+        default=0.0,
+        help="start stream i at i*this many seconds into the audio (de-sync so "
+        "concurrent streams carry different content, not perfectly-aligned batches)",
+    )
+    ap.add_argument("--out", default="ws_load_results.json")
+    asyncio.run(main_async(ap.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -715,7 +715,7 @@ WebSocket endpoint.
 | `Qwen3ASRRealtimeGeneration` | Qwen3-ASR Realtime | `Qwen/Qwen3-ASR-0.6B` | | |
 
 !!! note
-    `VoxtralRealtimeGeneration` requires `mistral-common[audio]` to be installed, and must be served with `--tokenizer-mode mistral`.
+    `VoxtralRealtimeGeneration` requires `mistral-common[audio]` to be installed, and must be served with `--tokenizer-mode mistral`. See [Speech to Text APIs](../serving/online_serving/speech_to_text.md#serving-a-sliding-window-realtime-model-voxtral-windows-concurrency-duration) for window/concurrency sizing and unbounded-duration streaming.
 
     `Qwen3ASRRealtimeGeneration` is not auto-detected from `config.json`.
     You must pass `--hf-overrides '{"architectures":["Qwen3ASRRealtimeGeneration"]}'`

--- a/docs/serving/online_serving/speech_to_text.md
+++ b/docs/serving/online_serving/speech_to_text.md
@@ -187,3 +187,79 @@ Audio must be sent as base64-encoded PCM16 audio at 16kHz sample rate, mono chan
 
 - [openai_realtime_client.py](https://github.com/vllm-project/vllm/tree/main/examples/speech_to_text/realtime/openai_realtime_client.py) - Upload and transcribe an audio file
 - [openai_realtime_microphone_client.py](https://github.com/vllm-project/vllm/tree/main/examples/speech_to_text/realtime/openai_realtime_microphone_client.py) - Gradio demo for live microphone transcription
+
+### Serving a sliding-window realtime model (Voxtral)
+
+For a sliding-window realtime model such as `Voxtral-Mini-4B-Realtime-2602`, per-stream
+KV memory is bounded by the attention window, not by `--max-model-len`. This gives two
+operator levers.
+
+**Concurrency: narrow the window.** The decoder's sliding window sets per-stream KV cost,
+so narrowing it lets more streams fit in KV:
+
+```bash
+vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602 --tokenizer-mode mistral \
+  --hf-overrides '{"text_config":{"sliding_window":512},"audio_config":{"sliding_window":256}}' \
+  --compilation-config '{"cudagraph_mode":"PIECEWISE"}'
+```
+
+Per-stream KV (in blocks) plateaus at, per KV group (decoder + audio encoder):
+
+```text
+blocks_per_stream = cdiv(min(sliding_window - 1 + max_num_batched_tokens, max_model_len), block_size) + 1
+```
+
+so the number of streams that fit in KV is `num_gpu_blocks / Σ blocks_per_stream`, and
+`num_gpu_blocks` scales with VRAM. vLLM logs this at startup as
+`Maximum concurrency for ... tokens per request: Nx`.
+
+!!! note
+    That `Nx` is a KV-admission ceiling (how many streams *fit* in KV), not measured
+    throughput, and it is computed for requests that fill `max_model_len` -- a realtime
+    session's KV plateaus at the sliding window instead, so for streaming the `Nx`
+    understates stream capacity and the per-stream formula above is the number to size
+    against. Real capacity is `min(KV at the window, compute, max_num_seqs)`; on small
+    GPUs compute saturates first (real-time falls behind) while VRAM stays flat.
+    Narrowing the window trades a little transcription fidelity for KV headroom, so
+    measure on your audio.
+
+!!! note
+    Narrowing the window also shrinks the encoder cache budget, so a server configured
+    this way rejects long **one-shot** clips on `/v1/audio/transcriptions` with a 400
+    (`exceeds the pre-allocated encoder cache size`) that the default config would accept.
+    Streaming sessions are unaffected (audio arrives in small chunks). Serve long offline
+    clips from a default (non-overridden) server, or raise the window.
+
+**Duration: `--max-model-len` and unbounded streaming.** For realtime, `--max-model-len`
+also acts as a duration cap (about 1 text token per 80 ms of audio, so the 131072 default is ~2 h 55).
+A session that reaches it is finished gracefully (`FINISHED_LENGTH_CAPPED`) so the client can
+reconnect. To run **indefinitely at constant VRAM**, enable RoPE re-anchoring:
+
+```bash
+  --enable-realtime-unbounded --realtime-reanchor-margin-tokens 4096
+```
+
+- `--enable-realtime-unbounded` (default off): periodically re-anchors the RoPE position clock
+  so the absolute counter never reaches `max_model_len`. Requires a **non-fp8** KV cache, a
+  sliding-window decoder, **prefix caching off** (`--no-enable-prefix-caching`), CUDA, and
+  plain RoPE with `rope_theta=1e6` (Voxtral/Ministral); rejected at startup otherwise.
+- `--realtime-reanchor-margin-tokens` (default 4096): re-anchor this many tokens before the cap.
+  Must be smaller than `max_model_len - sliding_window`.
+
+**Fitting on a 16 GiB GPU.** The model plus a full `PIECEWISE` cudagraph capture leaves little
+room for KV on 16 GiB. The capture set scales with `--max-num-seqs`, so the default (256)
+captures large batch graphs you will never use and can OOM at startup. Set `--max-num-seqs` to
+your real concurrency (for example 16). `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` also
+helps: it switches the allocator to growable segments, cuts fragmentation, and frees roughly
+1 GiB on a 16 GiB card, with no effect on results. A working unbounded config on a 16 GiB
+RTX 4090 Laptop, validated at 4 concurrent real-time streams (wall/audio 1.00, flat VRAM
+~14.3 GiB, transcripts complete and identical across streams):
+
+```bash
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602 \
+  --tokenizer-mode mistral \
+  --hf-overrides '{"text_config":{"sliding_window":512},"audio_config":{"sliding_window":256}}' \
+  --max-model-len 4096 --no-enable-prefix-caching --max-num-seqs 16 \
+  --enable-realtime-unbounded --realtime-reanchor-margin-tokens 2048 \
+  --compilation-config '{"cudagraph_mode":"PIECEWISE"}'
+```

--- a/tests/models/multimodal/generation/test_voxtral_realtime.py
+++ b/tests/models/multimodal/generation/test_voxtral_realtime.py
@@ -182,6 +182,105 @@ def test_voxtral_realtime_forward(audio_assets, tokenizer, vllm_runner, monkeypa
             )
 
 
+# [EXPERIMENTAL] Narrow, equal text/audio sliding windows so a short clip's
+# growing position clock crosses the re-anchor threshold during the session.
+# Equal windows also exercise the merged-KV-group path (one mixed 128-NeoX /
+# 64-GPT-J group), where the worker reads head_size per layer.
+_REANCHOR_WINDOW = {
+    "text_config": {"sliding_window": 256},
+    "audio_config": {"sliding_window": 256},
+}
+
+
+async def _stream_transcribe(engine_args, tokenizer, audio_asset) -> list[int]:
+    """Drive one realtime streaming session to completion, greedily, returning
+    the decoded output token ids."""
+    from vllm.model_executor.models.voxtral_realtime import VoxtralRealtimeBuffer
+
+    llm = AsyncLLM.from_engine_args(engine_args)
+    try:
+        audio_config = tokenizer.instruct_tokenizer.audio_encoder.audio_config
+        audio = Audio.from_file(audio_asset.get_local_path(), strict=False)
+        req = TranscriptionRequest(
+            streaming=StreamingMode.OFFLINE,
+            audio=RawAudio.from_audio(audio),
+            language=None,
+        )
+        audio_enc = tokenizer.encode_transcription(req)
+        buffer = VoxtralRealtimeBuffer(audio_config, audio_enc.tokens)
+        await buffer.append_audio(audio_enc.audios[0].audio_array)
+        await buffer.append_audio(None)
+
+        output_tokens: list[int] = []
+        async for resp in llm.generate(
+            prompt=buffer.get_input_stream(),
+            sampling_params=SamplingParams(temperature=0.0, max_tokens=1),
+            request_id="reanchor-parity",
+        ):
+            tokens = resp.outputs[0].token_ids[-1:]
+            output_tokens.extend(tokens)
+            await buffer.append_tokens(tokens)
+        return output_tokens
+    finally:
+        llm.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_voxtral_realtime_reanchor_parity(audio_assets, tokenizer, caplog):
+    """[EXPERIMENTAL] End-to-end parity of RoPE re-anchoring (review of #45022).
+
+    A streaming session whose position clock crosses ``max_model_len - margin``
+    is re-anchored down by R(-D) on the live cached keys. This proves the
+    re-rotation is transparent end to end (real attention forward, real KV
+    layout), not just algebraically (tests/v1/worker/test_reanchor_rotary.py):
+    at an identical narrow window, a re-anchor-ON session must decode the SAME
+    tokens as a re-anchor-OFF reference. Both runs share the window, so any
+    divergence is the re-anchor's doing, not the window's.
+
+    GPU-only (the re-anchor path is CUDA-gated in VllmConfig). The test asserts a
+    re-anchor actually fired, so if max_model_len/margin are mis-sized for the
+    clip on your hardware it fails loudly instead of passing without exercising
+    the path. The winning_call clip is the longer of the two assets.
+    """
+    audio_asset = audio_assets[1]  # winning_call (longer clip)
+
+    # Reference: re-anchor OFF, room to run the full clip without length-capping.
+    ref_args = AsyncEngineArgs(
+        **{**ENGINE_CONFIG, "max_model_len": 8192, "hf_overrides": _REANCHOR_WINDOW}
+    )
+    ref_tokens = await _stream_transcribe(ref_args, tokenizer, audio_asset)
+
+    # Test: re-anchor ON with a small max_model_len so the same clip crosses the
+    # threshold (8192 -> 1024, margin 256) and re-anchors mid-session.
+    test_args = AsyncEngineArgs(
+        **{
+            **ENGINE_CONFIG,
+            "max_model_len": 1024,
+            "enable_realtime_unbounded": True,
+            "realtime_reanchor_margin_tokens": 256,
+            "enable_prefix_caching": False,
+            "hf_overrides": _REANCHOR_WINDOW,
+        }
+    )
+    with caplog.at_level("INFO", logger="vllm.v1.core.sched.scheduler"):
+        test_tokens = await _stream_transcribe(test_args, tokenizer, audio_asset)
+
+    # The session must actually have re-anchored, else this proves nothing.
+    assert "Re-anchored realtime session" in caplog.text, (
+        "no re-anchor fired; lower max_model_len or raise the clip length so the "
+        "position clock crosses max_model_len - realtime_reanchor_margin_tokens"
+    )
+    # ...and the re-anchored decode must match the reference token-for-token.
+    def _decode(toks: list[int]) -> str:
+        return tokenizer.decode(toks, special_token_policy=SpecialTokenPolicy.IGNORE)
+
+    assert test_tokens == ref_tokens, (
+        "re-anchored output diverged from the reference at the same window:\n"
+        f"  ref  ({len(ref_tokens)} toks): {_decode(ref_tokens)!r}\n"
+        f"  test ({len(test_tokens)} toks): {_decode(test_tokens)!r}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_voxtral_realtime_generator(audio_assets, tokenizer, async_engine):
     # Lazy import to avoid CUDA-reinitialization error

--- a/tests/models/multimodal/generation/test_voxtral_realtime.py
+++ b/tests/models/multimodal/generation/test_voxtral_realtime.py
@@ -195,6 +195,8 @@ _REANCHOR_WINDOW = {
 async def _stream_transcribe(engine_args, tokenizer, audio_asset) -> list[int]:
     """Drive one realtime streaming session to completion, greedily, returning
     the decoded output token ids."""
+    import torch
+
     from vllm.model_executor.models.voxtral_realtime import VoxtralRealtimeBuffer
 
     llm = AsyncLLM.from_engine_args(engine_args)
@@ -223,10 +225,15 @@ async def _stream_transcribe(engine_args, tokenizer, audio_asset) -> list[int]:
         return output_tokens
     finally:
         llm.shutdown()
+        # Free this engine's KV pool before the next engine inits (single GPU).
+        torch.accelerator.empty_cache()
+
+
+_REANCHOR_TEST_MML = 300
 
 
 @pytest.mark.asyncio
-async def test_voxtral_realtime_reanchor_parity(audio_assets, tokenizer, caplog):
+async def test_voxtral_realtime_reanchor_parity(audio_assets, tokenizer):
     """[EXPERIMENTAL] End-to-end parity of RoPE re-anchoring (review of #45022).
 
     A streaming session whose position clock crosses ``max_model_len - margin``
@@ -237,39 +244,48 @@ async def test_voxtral_realtime_reanchor_parity(audio_assets, tokenizer, caplog)
     tokens as a re-anchor-OFF reference. Both runs share the window, so any
     divergence is the re-anchor's doing, not the window's.
 
-    GPU-only (the re-anchor path is CUDA-gated in VllmConfig). The test asserts a
-    re-anchor actually fired, so if max_model_len/margin are mis-sized for the
-    clip on your hardware it fails loudly instead of passing without exercising
-    the path. The winning_call clip is the longer of the two assets.
+    Firing is proven WITHOUT capturing the subprocess scheduler log (it runs in a
+    child EngineCore process that neither caplog nor capfd sees reliably): a
+    session in a ``max_model_len``-position context cannot emit MORE than
+    ``max_model_len`` output tokens unless its RoPE clock was re-anchored down to
+    make room, so the reference out-growing the test's cap is itself proof the
+    unbounded path engaged. Too-short a clip fails loudly rather than passing
+    vacuously.
+
+    GPU-only (the re-anchor path is CUDA-gated in VllmConfig). Validated on an
+    RTX 4090 (16 GiB): winning_call at mml=300 / margin=24 / window=256 fires
+    ~6-8 re-anchors and matches the reference token-for-token.
     """
     audio_asset = audio_assets[1]  # winning_call (longer clip)
 
-    # Reference: re-anchor OFF, room to run the full clip without length-capping.
+    # Reference: re-anchor OFF, ample room to run the full clip un-re-anchored.
     ref_args = AsyncEngineArgs(
-        **{**ENGINE_CONFIG, "max_model_len": 8192, "hf_overrides": _REANCHOR_WINDOW}
+        **{**ENGINE_CONFIG, "max_model_len": 2048, "hf_overrides": _REANCHOR_WINDOW}
     )
     ref_tokens = await _stream_transcribe(ref_args, tokenizer, audio_asset)
 
-    # Test: re-anchor ON with a small max_model_len so the same clip crosses the
-    # threshold (8192 -> 1024, margin 256) and re-anchors mid-session.
+    # Test: re-anchor ON with max_model_len well below the session's clock, so the
+    # threshold (mml - margin) is crossed repeatedly mid-decode and re-anchors.
     test_args = AsyncEngineArgs(
         **{
             **ENGINE_CONFIG,
-            "max_model_len": 1024,
+            "max_model_len": _REANCHOR_TEST_MML,
             "enable_realtime_unbounded": True,
-            "realtime_reanchor_margin_tokens": 256,
+            "realtime_reanchor_margin_tokens": 24,
             "enable_prefix_caching": False,
             "hf_overrides": _REANCHOR_WINDOW,
         }
     )
-    with caplog.at_level("INFO", logger="vllm.v1.core.sched.scheduler"):
-        test_tokens = await _stream_transcribe(test_args, tokenizer, audio_asset)
+    test_tokens = await _stream_transcribe(test_args, tokenizer, audio_asset)
 
-    # The session must actually have re-anchored, else this proves nothing.
-    assert "Re-anchored realtime session" in caplog.text, (
-        "no re-anchor fired; lower max_model_len or raise the clip length so the "
-        "position clock crosses max_model_len - realtime_reanchor_margin_tokens"
+    # Anti-vacuous: the session must out-grow the test's context window, else
+    # re-anchor was never needed. Emitting more output tokens than max_model_len
+    # positions is only possible once the RoPE clock has been folded down.
+    assert len(ref_tokens) > _REANCHOR_TEST_MML, (
+        f"clip too short to exercise re-anchor: {len(ref_tokens)} decoded tokens "
+        f"<= max_model_len {_REANCHOR_TEST_MML}; use a longer clip or lower mml"
     )
+
     # ...and the re-anchored decode must match the reference token-for-token.
     def _decode(toks: list[int]) -> str:
         return tokenizer.decode(toks, special_token_policy=SpecialTokenPolicy.IGNORE)

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -22,6 +22,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.v1.engine import (
     EngineCoreEvent,
     EngineCoreEventType,
+    EngineCoreOutput,
     EngineCoreOutputs,
     EngineCoreRequest,
     FinishReason,
@@ -1342,3 +1343,49 @@ def test_abort_requests(runner: str, abort_by: str, dummy_test_vectors):
             output_processor.abort_requests([request.request_id], internal=True)
         else:
             output_processor.abort_requests([request.external_req_id], internal=False)
+
+
+def test_streaming_input_length_finish_is_terminal(dummy_test_vectors):
+    # A terminal length cap on a streaming session must reach the client:
+    # finished=True and the request freed, else AsyncLLM.generate() hangs.
+    output_processor = OutputProcessor(
+        dummy_test_vectors.tokenizer,
+        log_stats=False,
+    )
+
+    request = EngineCoreRequest(
+        request_id="request-int",
+        external_req_id="request",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=SamplingParams(
+            max_tokens=16,
+            output_kind=RequestOutputKind.DELTA,
+            stop=[],
+        ),
+        pooling_params=None,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        resumable=True,
+    )
+
+    queue = RequestOutputCollector(RequestOutputKind.DELTA, request.request_id)
+    output_processor.add_request(request, prompt="hello", queue=queue)
+
+    output_processor.process_outputs(
+        [
+            EngineCoreOutput(
+                request_id="request-int",
+                new_token_ids=[],
+                finish_reason=FinishReason.LENGTH,
+            )
+        ]
+    )
+
+    request_output = queue.get_nowait()
+    assert request_output is not None
+    assert request_output.finished is True
+    assert request_output.outputs[0].finish_reason == "length"
+    assert output_processor.get_num_unfinished_requests() == 0

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -1345,16 +1345,9 @@ def test_abort_requests(runner: str, abort_by: str, dummy_test_vectors):
             output_processor.abort_requests([request.external_req_id], internal=False)
 
 
-def test_streaming_input_length_finish_is_terminal(dummy_test_vectors):
-    # A terminal length cap on a streaming session must reach the client:
-    # finished=True and the request freed, else AsyncLLM.generate() hangs.
-    output_processor = OutputProcessor(
-        dummy_test_vectors.tokenizer,
-        log_stats=False,
-    )
-
-    request = EngineCoreRequest(
-        request_id="request-int",
+def _make_streaming_request(request_id="request-int"):
+    return EngineCoreRequest(
+        request_id=request_id,
         external_req_id="request",
         prompt_token_ids=[1, 2, 3],
         mm_features=None,
@@ -1371,6 +1364,14 @@ def test_streaming_input_length_finish_is_terminal(dummy_test_vectors):
         resumable=True,
     )
 
+
+def test_streaming_input_length_finish_is_not_terminal(dummy_test_vectors):
+    # A per-step LENGTH finish is the normal chunk boundary of a streaming
+    # session, not a terminal end: the session must stay alive for the next
+    # audio chunk (a genuine max_model_len cap is delivered separately by the
+    # scheduler). Treating LENGTH as terminal ends the session after one token.
+    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+    request = _make_streaming_request()
     queue = RequestOutputCollector(RequestOutputKind.DELTA, request.request_id)
     output_processor.add_request(request, prompt="hello", queue=queue)
 
@@ -1385,7 +1386,29 @@ def test_streaming_input_length_finish_is_terminal(dummy_test_vectors):
     )
 
     request_output = queue.get_nowait()
+    assert request_output is None or request_output.finished is False
+    assert output_processor.get_num_unfinished_requests() == 1
+
+
+def test_streaming_input_error_finish_is_terminal(dummy_test_vectors):
+    # A real ERROR/ABORT does end the streaming session: deliver finished=True
+    # and free the request, else AsyncLLM.generate() hangs.
+    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+    request = _make_streaming_request()
+    queue = RequestOutputCollector(RequestOutputKind.DELTA, request.request_id)
+    output_processor.add_request(request, prompt="hello", queue=queue)
+
+    output_processor.process_outputs(
+        [
+            EngineCoreOutput(
+                request_id="request-int",
+                new_token_ids=[],
+                finish_reason=FinishReason.ERROR,
+            )
+        ]
+    )
+
+    request_output = queue.get_nowait()
     assert request_output is not None
     assert request_output.finished is True
-    assert request_output.outputs[0].finish_reason == "length"
     assert output_processor.get_num_unfinished_requests() == 0

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -150,40 +150,75 @@ class TestStreamingScheduler(unittest.TestCase):
         # Again, output tokens are cleared first, so max_tokens = 0 + 10 = 10
         assert session.max_tokens == 10
 
+    @staticmethod
+    def _make_capped_session(scheduler, waiting_for_chunk=True):
+        """Session at 1020/1024 tokens plus a 10-token chunk that crosses
+        max_model_len when applied. With waiting_for_chunk the next add_request
+        commences the chunk (the guarded branch); otherwise the session stays
+        WAITING and add_request queues the chunk."""
+        session = DummyRequest(request_id="session", prompt_token_ids=list(range(1020)))
+        session.num_computed_tokens = len(session.prompt_token_ids)
+        scheduler.add_request(session)
+        if waiting_for_chunk:
+            session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(10)))
+        chunk.sampling_params = SamplingParams(max_tokens=10)
+        return session, chunk
+
     def test_add_request_session_finishes_at_max_model_len(self):
         # Guard in add_request: when a streaming chunk pushes a live session's
         # accumulated tokens to max_model_len, the session must finish as
         # FINISHED_LENGTH_CAPPED instead of crashing later in the model runner.
         scheduler = create_scheduler()  # max_model_len = 1024
-        session = DummyRequest(
-            request_id="session", prompt_token_ids=list(range(1020))
-        )
-        session.num_computed_tokens = len(session.prompt_token_ids)
-        scheduler.add_request(session)
-        # Put the session into the "waiting for next chunk" state so the next
-        # add_request commences the chunk (the guarded branch).
-        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
-
-        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(10)))
-        chunk.sampling_params = SamplingParams(max_tokens=10)
+        session, chunk = self._make_capped_session(scheduler)
         scheduler.add_request(chunk)  # 1020 + 10 = 1030 >= 1024
 
         assert session.num_tokens >= scheduler.max_model_len
         assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
 
+    def test_add_request_max_model_len_notifies_client(self):
+        # A session finished from inside add_request() (length-capped) is freed
+        # scheduler-side, but finish_requests has no `outputs` dict there, so the
+        # client must still learn it ended. The finish is buffered and emitted as
+        # an EngineCoreOutput with finish_reason=LENGTH in the next
+        # update_from_output -- without this the websocket hangs forever.
+        scheduler = create_scheduler()  # max_model_len = 1024
+        session, chunk = self._make_capped_session(scheduler)
+        client_index = session.client_index
+        scheduler.add_request(chunk)  # 1020 + 10 >= 1024 -> length-capped
+
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
+        # The finish is buffered for the client (not lost).
+        assert ("session", FinishReason.LENGTH) in [
+            (rid, reason) for _, rid, reason in scheduler._streaming_finish_outputs
+        ]
+
+        # The next step's update_from_output emits it to the client and drains.
+        scheduler_output = scheduler.schedule()
+        mro = ModelRunnerOutput(
+            req_ids=[],
+            req_id_to_index={},
+            sampled_token_ids=[],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        )
+        eco_dict = scheduler.update_from_output(scheduler_output, mro)
+
+        assert client_index in eco_dict
+        finish_outputs = [
+            o for o in eco_dict[client_index].outputs if o.request_id == "session"
+        ]
+        assert len(finish_outputs) == 1
+        assert finish_outputs[0].finish_reason == FinishReason.LENGTH
+        # Buffer drained (no duplicate emission on the following step).
+        assert scheduler._streaming_finish_outputs == []
+
     def test_handle_stopped_request_finishes_at_max_model_len(self):
         # Guard in _handle_stopped_request: applying a queued streaming chunk
         # that crosses max_model_len finishes the session gracefully.
         scheduler = create_scheduler()  # max_model_len = 1024
-        session = DummyRequest(
-            request_id="session", prompt_token_ids=list(range(1020))
-        )
-        session.num_computed_tokens = len(session.prompt_token_ids)
-        scheduler.add_request(session)
-        # Session still WAITING (not WAITING_FOR_STREAMING_REQ), so add_request
-        # enqueues the chunk onto the streaming queue.
-        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(10)))
-        chunk.sampling_params = SamplingParams(max_tokens=10)
+        session, chunk = self._make_capped_session(scheduler, waiting_for_chunk=False)
         scheduler.add_request(chunk)
         assert len(session.streaming_queue) == 1
 
@@ -566,7 +601,9 @@ class TestStreamingScheduler(unittest.TestCase):
         eco_cycle2 = eco_dict_cycle2[session.client_index].outputs[0]
         assert eco_cycle2.finish_reason == FinishReason.STOP
         assert session.status == RequestStatus.WAITING_FOR_STREAMING_REQ
-        assert session in scheduler.waiting
+        # Blocked-waiting statuses (incl. WAITING_FOR_STREAMING_REQ) are queued
+        # in skipped_waiting, not waiting (see _enqueue_waiting_request).
+        assert session in scheduler.skipped_waiting
         assert session._all_token_ids == [1, 2, 3, 10, STOP_TOKEN]
 
         # CRITICAL ASSERTION: Cached prompt_token_ids STILL must not have changed

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -53,6 +53,9 @@ def create_scheduler() -> Scheduler:
     vllm_config.model_config = MagicMock()
     vllm_config.model_config.skip_tokenizer_init = True
     vllm_config.model_config.is_multimodal_model = False
+    # MagicMock attributes are truthy by default; pin this so Scheduler.__init__
+    # does not take the encoder-decoder assertion path (added in #33900).
+    vllm_config.model_config.is_encoder_decoder = False
     vllm_config.model_config.max_model_len = 1024
     vllm_config.model_config.enable_return_routed_experts = False
     vllm_config.cache_config = MagicMock()
@@ -146,6 +149,49 @@ class TestStreamingScheduler(unittest.TestCase):
         assert session.sampling_params.max_tokens == 10
         # Again, output tokens are cleared first, so max_tokens = 0 + 10 = 10
         assert session.max_tokens == 10
+
+    def test_add_request_session_finishes_at_max_model_len(self):
+        # Guard in add_request: when a streaming chunk pushes a live session's
+        # accumulated tokens to max_model_len, the session must finish as
+        # FINISHED_LENGTH_CAPPED instead of crashing later in the model runner.
+        scheduler = create_scheduler()  # max_model_len = 1024
+        session = DummyRequest(
+            request_id="session", prompt_token_ids=list(range(1020))
+        )
+        session.num_computed_tokens = len(session.prompt_token_ids)
+        scheduler.add_request(session)
+        # Put the session into the "waiting for next chunk" state so the next
+        # add_request commences the chunk (the guarded branch).
+        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+
+        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(10)))
+        chunk.sampling_params = SamplingParams(max_tokens=10)
+        scheduler.add_request(chunk)  # 1020 + 10 = 1030 >= 1024
+
+        assert session.num_tokens >= scheduler.max_model_len
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
+
+    def test_handle_stopped_request_finishes_at_max_model_len(self):
+        # Guard in _handle_stopped_request: applying a queued streaming chunk
+        # that crosses max_model_len finishes the session gracefully.
+        scheduler = create_scheduler()  # max_model_len = 1024
+        session = DummyRequest(
+            request_id="session", prompt_token_ids=list(range(1020))
+        )
+        session.num_computed_tokens = len(session.prompt_token_ids)
+        scheduler.add_request(session)
+        # Session still WAITING (not WAITING_FOR_STREAMING_REQ), so add_request
+        # enqueues the chunk onto the streaming queue.
+        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(10)))
+        chunk.sampling_params = SamplingParams(max_tokens=10)
+        scheduler.add_request(chunk)
+        assert len(session.streaming_queue) == 1
+
+        finished = scheduler._handle_stopped_request(session)
+
+        assert finished is True
+        assert session.num_tokens >= scheduler.max_model_len
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
 
     def test_update_request_as_session(self):
         scheduler = create_scheduler()

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -228,6 +228,58 @@ class TestStreamingScheduler(unittest.TestCase):
         assert session.num_tokens >= scheduler.max_model_len
         assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
 
+    def test_update_from_output_resume_into_cap_reports_length(self):
+        # A segment stops (STOP), then _handle_stopped_request applies a queued
+        # chunk that overflows max_model_len and finishes the session
+        # LENGTH_CAPPED. update_from_output must report LENGTH, not the stale
+        # pre-update STOP, or the client keeps a freed stream open.
+        scheduler = create_scheduler()  # max_model_len = 1024
+
+        session = DummyRequest(request_id="session", prompt_token_ids=list(range(100)))
+        scheduler.add_request(session)
+        client_index = session.client_index
+
+        # Prefill + one ordinary decode token -> session RUNNING, not stopped.
+        out = scheduler.schedule()
+        scheduler.update_from_output(
+            out,
+            ModelRunnerOutput(
+                req_ids=["session"],
+                req_id_to_index={"session": 0},
+                sampled_token_ids=[[5]],
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[],
+            ),
+        )
+        assert session.status == RequestStatus.RUNNING
+
+        # Queue a chunk large enough to overflow max_model_len when applied.
+        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(1024)))
+        scheduler.add_request(chunk)
+        assert len(session.streaming_queue) == 1
+
+        # Next step: the session emits a stop token, triggering the cap.
+        out = scheduler.schedule()
+        eco = scheduler.update_from_output(
+            out,
+            ModelRunnerOutput(
+                req_ids=["session"],
+                req_id_to_index={"session": 0},
+                sampled_token_ids=[[STOP_TOKEN]],
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[],
+            ),
+        )
+
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
+        finish_outputs = [
+            o for o in eco[client_index].outputs if o.request_id == "session"
+        ]
+        assert len(finish_outputs) == 1
+        assert finish_outputs[0].finish_reason == FinishReason.LENGTH
+
     def test_full_length_non_resumable_request_not_clamped(self):
         # Regression: the streaming graceful-cap clamp in the WAITING loop must
         # apply ONLY to resumable streaming sessions. A classic (resumable=False)

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -193,6 +193,30 @@ class TestStreamingScheduler(unittest.TestCase):
         assert session.num_tokens >= scheduler.max_model_len
         assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
 
+    def test_full_length_non_resumable_request_not_clamped(self):
+        # Regression: the streaming graceful-cap clamp in the WAITING loop must
+        # apply ONLY to resumable streaming sessions. A classic (resumable=False)
+        # request whose prompt is exactly max_model_len must schedule ALL its
+        # tokens in one step. Without the `request.resumable` gate the clamp
+        # `min(num_new_tokens, max_model_len - 1 - num_computed)` drops the last
+        # token (schedules 1023 not 1024), so the request can never complete --
+        # the bug that hit pooling/embedding requests at prompt_len ==
+        # max_model_len (allowed for pooling; rejected for generate at
+        # validation, which is why generation tests never caught it).
+        scheduler = create_scheduler()  # max_model_len = 1024
+        req = DummyRequest(
+            request_id="classic",
+            resumable=False,
+            prompt_token_ids=list(range(1024)),  # == max_model_len
+            max_tokens=1,
+        )
+        scheduler.add_request(req)
+        output = scheduler.schedule()
+
+        # All 1024 prompt tokens scheduled this step, not clamped to 1023.
+        assert output.num_scheduled_tokens["classic"] == 1024
+        assert req.status != RequestStatus.FINISHED_LENGTH_CAPPED
+
     def test_update_request_as_session(self):
         scheduler = create_scheduler()
 

--- a/tests/v1/worker/test_reanchor_rotary.py
+++ b/tests/v1/worker/test_reanchor_rotary.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Collected-in-CI unit test for the RoPE re-anchoring core math.
+
+The manual harness benchmarks/voxtral_realtime/test_reanchor_math.py is a
+``__main__`` script that pytest never collects. This mirrors it as a real
+pytest case so the production re-anchor op stays guarded on every run. Pure
+torch / CPU: no GPU, no model load.
+
+Property: a POST-rotation cached key rotated at absolute position ``p`` and
+then re-rotated by the constant ``R(-D)`` equals the key rotated at position
+``p - D``. So after dropping the query clock by ``D`` and re-rotating every live
+key by ``R(-D)``, every in-window relative attention score ``R(i-j)`` is
+preserved exactly. Checked for both styles used by Voxtral realtime: the NeoX
+decoder (rotary_dim=128) and the GPT-J audio encoder (rotary_dim=64), base=1e6.
+"""
+
+import pytest
+import torch
+
+# Import the PRODUCTION op so the test guards the real function, not a copy.
+from vllm.v1.worker.reanchor_rotary import apply_inverse_rotary
+
+
+def _inv_freq(rotary_dim: int, base: float) -> torch.Tensor:
+    return 1.0 / (
+        base ** (torch.arange(0, rotary_dim, 2, dtype=torch.float64) / rotary_dim)
+    )
+
+
+def _forward_rotary(
+    x: torch.Tensor, pos: int, rotary_dim: int, base: float, is_neox: bool
+) -> torch.Tensor:
+    """Rotate ``x`` by +pos (vLLM rotary convention)."""
+    half = rotary_dim // 2
+    ang = float(pos) * _inv_freq(rotary_dim, base)
+    cos, sin = torch.cos(ang).to(x.dtype), torch.sin(ang).to(x.dtype)
+    rot, pas = x[..., :rotary_dim], x[..., rotary_dim:]
+    if is_neox:
+        x1, x2 = rot[..., :half], rot[..., half:]
+        out = torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1)
+    else:
+        x1, x2 = rot[..., 0::2], rot[..., 1::2]
+        o1, o2 = x1 * cos - x2 * sin, x2 * cos + x1 * sin
+        out = torch.stack([o1, o2], dim=-1).flatten(-2)
+    return torch.cat([out, pas], dim=-1) if pas.numel() else out
+
+
+# (rotary_dim, base, is_neox) for the two Voxtral-realtime rotary styles.
+_STYLES = [
+    pytest.param(128, 1e6, True, id="decoder-neox-128"),
+    pytest.param(64, 1e6, False, id="encoder-gptj-64"),
+]
+# (absolute position p, re-anchor distance D), incl. a near-max_model_len case.
+_POS_SHIFTS = [
+    pytest.param(5000, 4096, id="p5000-D4096"),
+    pytest.param(9000, 7000, id="p9000-D7000"),
+    pytest.param(3000, 2048, id="p3000-D2048"),
+    pytest.param(120000, 100000, id="p120000-D100000"),
+]
+
+
+@pytest.mark.parametrize("rotary_dim, base, is_neox", _STYLES)
+@pytest.mark.parametrize("p, D", _POS_SHIFTS)
+def test_reanchor_identity(rotary_dim, base, is_neox, p, D):
+    """R(-D) . R(p) . k == R(p-D) . k for the production op."""
+    torch.manual_seed(0)
+    k = torch.randn(4, rotary_dim, dtype=torch.float32)
+    cached = _forward_rotary(k, p, rotary_dim, base, is_neox)  # key in KV cache
+    reanchored = apply_inverse_rotary(cached, D, rotary_dim, base, is_neox)
+    target = _forward_rotary(k, p - D, rotary_dim, base, is_neox)
+    assert (reanchored - target).abs().max().item() < 1e-3
+
+
+@pytest.mark.parametrize("rotary_dim, base, is_neox", _STYLES)
+@pytest.mark.parametrize("p, D", _POS_SHIFTS)
+def test_reanchor_preserves_relative_score(rotary_dim, base, is_neox, p, D):
+    """In-window q@k score is unchanged after dropping the clock by D and
+    re-rotating the key by R(-D)."""
+    torch.manual_seed(0)
+    k = torch.randn(4, rotary_dim, dtype=torch.float32)
+    q = torch.randn(4, rotary_dim, dtype=torch.float32)
+    i, j = p + 60, p  # j sits within the window below query position i
+    s_orig = (
+        _forward_rotary(q, i, rotary_dim, base, is_neox)
+        * _forward_rotary(k, j, rotary_dim, base, is_neox)
+    ).sum(-1)
+    kj_re = apply_inverse_rotary(
+        _forward_rotary(k, j, rotary_dim, base, is_neox),
+        D,
+        rotary_dim,
+        base,
+        is_neox,
+    )
+    s_re = (_forward_rotary(q, i - D, rotary_dim, base, is_neox) * kj_re).sum(-1)
+    assert (s_orig - s_re).abs().max().item() < 1e-3

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -67,6 +67,21 @@ class SchedulerConfig:
     In real usage, this should be set in `EngineArgs.create_engine_config`.
     """
 
+    enable_realtime_unbounded: bool = False
+    """[EXPERIMENTAL] Enable unbounded-duration realtime streaming for
+    sliding-window realtime models (e.g. Voxtral realtime). When True, a
+    streaming session's RoPE position clock is periodically re-anchored (the
+    live sliding window is shifted down) so the session can run indefinitely
+    without the absolute position counter ever reaching max_model_len. The
+    per-stream KV cost stays constant (bounded by the sliding window). Requires
+    a non-fp8 KV cache. Off by default."""
+
+    realtime_reanchor_margin_tokens: int = Field(default=4096, ge=1)
+    """[EXPERIMENTAL] With `enable_realtime_unbounded`, re-anchor a streaming
+    session's sliding window this many tokens before its position clock would
+    reach max_model_len. Must be smaller than `(max_model_len - sliding_window)`;
+    a larger value leaves no head-room to re-anchor and is rejected at startup."""
+
     max_num_partial_prefills: int = Field(default=1, ge=1)
     """For chunked prefill, the maximum number of sequences that can be
     partially prefilled concurrently."""

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1061,7 +1061,7 @@ class VllmConfig:
             # also rebase prefix-cache block hashes, so _reanchor_session is a
             # silent no-op when prefix caching is on (scheduler.py). With prefix
             # caching enabled (the default), the flag would be inert and the
-            # session still killed at max_model_len -- worse, with the
+            # session still killed at max_model_len; worse, with the
             # graceful-finish warning suppressed for re-anchor streams. Reject at
             # startup rather than letting the feature silently do nothing.
             if (
@@ -1075,7 +1075,7 @@ class VllmConfig:
                 )
 
             # The worker re-rotation indexes the KV cache as (num_blocks, 2, ...)
-            # and reads head_size from the trailing dim -- the layout shared by
+            # and reads head_size from the trailing dim; the layout shared by
             # the CUDA attention family (FlashAttention/FlashInfer/Triton/
             # FlexAttention). ROCm's default ROCM_ATTN backend uses
             # (2, num_blocks, ...) and the CPU backend interleaves K/V into the
@@ -1141,7 +1141,7 @@ class VllmConfig:
                         )
                     # The worker re-rotation hardcodes rope_theta=1e6 (Voxtral/
                     # Ministral). A checkpoint with a different theta would
-                    # SILENTLY corrupt re-rotated keys -- unlike head_size, theta
+                    # SILENTLY corrupt re-rotated keys; unlike head_size, theta
                     # is not tripwired at runtime. Validate it here.
                     theta = (rs or {}).get(
                         "rope_theta", getattr(cfg, "rope_theta", None)
@@ -1159,7 +1159,7 @@ class VllmConfig:
                 # and shifted by D, a 64-dim head as the GPT-J audio encoder and
                 # shifted by pool*D. The runtime head_size assert only rejects a
                 # dim outside {64, 128}; it does NOT catch a 64-dim NeoX or a
-                # 128-dim GPT-J head, nor a pool that silently fell to 1 -- all
+                # 128-dim GPT-J head, nor a pool that silently fell to 1; all
                 # of which would SILENTLY corrupt re-rotated keys, exactly like
                 # theta above. Validate the assumed geometry up front.
                 #
@@ -1168,7 +1168,7 @@ class VllmConfig:
                 # with_hf_config(audio_config)), where text_config falls back to
                 # the audio encoder (head_dim 40, not the decoder's 128). Only the
                 # full multimodal config carries a nested audio_config, so that is
-                # where -- and the only place -- the decoder vs encoder geometry
+                # where; and the only place; the decoder vs encoder geometry
                 # can be checked without falsely rejecting Voxtral.
                 if audio_config is not None:
                     text_head_dim = getattr(text_config, "head_dim", None) or (

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1162,18 +1162,26 @@ class VllmConfig:
                 # 128-dim GPT-J head, nor a pool that silently fell to 1 -- all
                 # of which would SILENTLY corrupt re-rotated keys, exactly like
                 # theta above. Validate the assumed geometry up front.
-                text_head_dim = getattr(text_config, "head_dim", None) or (
-                    getattr(text_config, "hidden_size", 0)
-                    // max(getattr(text_config, "num_attention_heads", 1), 1)
-                )
-                if text_head_dim != 128:
-                    raise ValueError(
-                        "enable_realtime_unbounded assumes a 128-dim NeoX decoder "
-                        "(the worker shifts a 128-dim head by D); text_config has "
-                        f"head_dim={text_head_dim}. This experimental path is "
-                        "validated for Voxtral/Ministral only."
-                    )
+                #
+                # Gate on audio_config: VllmConfig is re-validated with a
+                # sub-config swapped in during model init (voxtral.py calls
+                # with_hf_config(audio_config)), where text_config falls back to
+                # the audio encoder (head_dim 40, not the decoder's 128). Only the
+                # full multimodal config carries a nested audio_config, so that is
+                # where -- and the only place -- the decoder vs encoder geometry
+                # can be checked without falsely rejecting Voxtral.
                 if audio_config is not None:
+                    text_head_dim = getattr(text_config, "head_dim", None) or (
+                        getattr(text_config, "hidden_size", 0)
+                        // max(getattr(text_config, "num_attention_heads", 1), 1)
+                    )
+                    if text_head_dim != 128:
+                        raise ValueError(
+                            "enable_realtime_unbounded assumes a 128-dim NeoX decoder "
+                            "(the worker shifts a 128-dim head by D); text_config has "
+                            f"head_dim={text_head_dim}. This experimental path is "
+                            "validated for Voxtral/Ministral only."
+                        )
                     # Audio-encoder positions run at block_pool_size x the decoder
                     # clock, so the worker shifts encoder keys by pool*D. pool is
                     # derived from config, never validated; if it silently fell to

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1044,6 +1044,160 @@ class VllmConfig:
             "enabled" if self.scheduler_config.async_scheduling else "disabled",
         )
 
+        if self.scheduler_config.enable_realtime_unbounded:
+            from vllm.utils.torch_utils import is_quantized_kv_cache
+
+            # Re-anchoring re-rotates cached keys in place; a quantized KV cache
+            # cannot be rotated. Reject at startup, not hours into a stream.
+            if self.cache_config is not None and is_quantized_kv_cache(
+                self.cache_config.cache_dtype
+            ):
+                raise ValueError(
+                    "enable_realtime_unbounded requires a non-fp8 KV cache; "
+                    f"got cache_dtype={self.cache_config.cache_dtype!r}."
+                )
+
+            # Re-anchoring rebases the per-group block lists in place; it cannot
+            # also rebase prefix-cache block hashes, so _reanchor_session is a
+            # silent no-op when prefix caching is on (scheduler.py). With prefix
+            # caching enabled (the default), the flag would be inert and the
+            # session still killed at max_model_len -- worse, with the
+            # graceful-finish warning suppressed for re-anchor streams. Reject at
+            # startup rather than letting the feature silently do nothing.
+            if (
+                self.cache_config is not None
+                and self.cache_config.enable_prefix_caching
+            ):
+                raise ValueError(
+                    "enable_realtime_unbounded is incompatible with prefix "
+                    "caching (re-anchoring cannot rebase block hashes), but "
+                    "enable_prefix_caching is on. Pass --no-enable-prefix-caching."
+                )
+
+            # The worker re-rotation indexes the KV cache as (num_blocks, 2, ...)
+            # and reads head_size from the trailing dim -- the layout shared by
+            # the CUDA attention family (FlashAttention/FlashInfer/Triton/
+            # FlexAttention). ROCm's default ROCM_ATTN backend uses
+            # (2, num_blocks, ...) and the CPU backend interleaves K/V into the
+            # trailing dim, so both would corrupt keys (CPU silently, since a
+            # 64-dim head's 2*head_size=128 trailing dim still passes the
+            # head_size assert). Restrict the experimental path to CUDA.
+            from vllm.platforms import current_platform
+
+            if not current_platform.is_cuda():
+                raise ValueError(
+                    "enable_realtime_unbounded is only supported on CUDA "
+                    "(the re-anchor key re-rotation assumes the CUDA "
+                    "attention-family KV layout); current platform is "
+                    f"{current_platform.device_name!r}."
+                )
+
+            if self.model_config is not None:
+                hf_config = self.model_config.hf_config
+                text_config = getattr(hf_config, "text_config", hf_config)
+                audio_config = getattr(hf_config, "audio_config", None)
+                sliding_window = getattr(text_config, "sliding_window", None)
+                margin = self.scheduler_config.realtime_reanchor_margin_tokens
+                max_model_len = self.model_config.max_model_len
+                # Re-anchoring fires at max_model_len - margin. If the margin is
+                # not smaller than (max_model_len - sliding_window) that
+                # threshold collapses and re-anchoring thrashes or never engages.
+                if sliding_window is not None and (
+                    margin >= max_model_len - sliding_window
+                ):
+                    raise ValueError(
+                        "enable_realtime_unbounded needs head-room for "
+                        "re-anchoring: realtime_reanchor_margin_tokens "
+                        f"({margin}) must be smaller than max_model_len - "
+                        f"sliding_window ({max_model_len} - {sliding_window} = "
+                        f"{max_model_len - sliding_window}). Lower the margin or "
+                        "raise --max-model-len above sliding_window + margin."
+                    )
+                # The R(-D) re-rotation assumes plain (unscaled) RoPE; an actual
+                # scaling (YaRN/linear/dynamic) shifts the per-frequency angles and
+                # would corrupt the rotated keys. Reject only a real scaling type:
+                # Voxtral's config carries a benign rope_scaling with
+                # rope_type="default" (plain RoPE plus an explicit theta), which
+                # must NOT be rejected.
+                #
+                # Read rope_parameters FIRST (canonical, see model.py): the Mistral
+                # config adapter writes scaling only into rope_parameters, never
+                # rope_scaling. transformers v5 aliases rope_scaling->rope_parameters
+                # so reading rope_scaling happens to work there, but under v4 there
+                # is no alias and a Mistral-format YaRN model would slip through.
+                for name, cfg in (("text", text_config), ("audio", audio_config)):
+                    if cfg is None:
+                        continue
+                    rs = getattr(cfg, "rope_parameters", None) or getattr(
+                        cfg, "rope_scaling", None
+                    )
+                    rope_type = str(
+                        (rs or {}).get("rope_type", (rs or {}).get("type", "default"))
+                    ).lower()
+                    if rs and rope_type not in ("default", "none"):
+                        raise ValueError(
+                            "enable_realtime_unbounded does not support RoPE "
+                            f"scaling; {name}_config has rope={rs!r}."
+                        )
+                    # The worker re-rotation hardcodes rope_theta=1e6 (Voxtral/
+                    # Ministral). A checkpoint with a different theta would
+                    # SILENTLY corrupt re-rotated keys -- unlike head_size, theta
+                    # is not tripwired at runtime. Validate it here.
+                    theta = (rs or {}).get(
+                        "rope_theta", getattr(cfg, "rope_theta", None)
+                    )
+                    if theta is not None and float(theta) != 1.0e6:
+                        raise ValueError(
+                            "enable_realtime_unbounded assumes rope_theta=1e6 "
+                            f"(the worker re-rotation hardcodes it); {name}_config "
+                            f"has rope_theta={theta}. This experimental path is "
+                            "validated for Voxtral/Ministral only."
+                        )
+
+                # The worker re-anchor dispatches the key re-rotation off
+                # head_size alone: a 128-dim head is rotated as the NeoX decoder
+                # and shifted by D, a 64-dim head as the GPT-J audio encoder and
+                # shifted by pool*D. The runtime head_size assert only rejects a
+                # dim outside {64, 128}; it does NOT catch a 64-dim NeoX or a
+                # 128-dim GPT-J head, nor a pool that silently fell to 1 -- all
+                # of which would SILENTLY corrupt re-rotated keys, exactly like
+                # theta above. Validate the assumed geometry up front.
+                text_head_dim = getattr(text_config, "head_dim", None) or (
+                    getattr(text_config, "hidden_size", 0)
+                    // max(getattr(text_config, "num_attention_heads", 1), 1)
+                )
+                if text_head_dim != 128:
+                    raise ValueError(
+                        "enable_realtime_unbounded assumes a 128-dim NeoX decoder "
+                        "(the worker shifts a 128-dim head by D); text_config has "
+                        f"head_dim={text_head_dim}. This experimental path is "
+                        "validated for Voxtral/Ministral only."
+                    )
+                if audio_config is not None:
+                    # Audio-encoder positions run at block_pool_size x the decoder
+                    # clock, so the worker shifts encoder keys by pool*D. pool is
+                    # derived from config, never validated; if it silently fell to
+                    # 1 every encoder key would be under-rotated with no tripwire.
+                    pool = getattr(audio_config, "block_pool_size", None) or getattr(
+                        audio_config, "downsample_factor", None
+                    )
+                    if not pool or pool < 1:
+                        raise ValueError(
+                            "enable_realtime_unbounded needs a derivable audio "
+                            "block_pool_size / downsample_factor (the worker "
+                            "re-rotation shifts the audio-encoder group by pool*D); "
+                            f"got pool={pool!r}."
+                        )
+                    enc_head_dim = getattr(audio_config, "encoder_head_dim", None)
+                    if enc_head_dim != 64:
+                        raise ValueError(
+                            "enable_realtime_unbounded assumes a 64-dim GPT-J audio "
+                            "encoder (the worker shifts a 64-dim head by pool*D); "
+                            f"audio_config has encoder_head_dim={enc_head_dim}. This "
+                            "experimental path is validated for Voxtral/Ministral "
+                            "only."
+                        )
+
         if self.parallel_config.disable_nccl_for_dp_synchronization is None:
             if self.scheduler_config.async_scheduling:
                 if self.parallel_config.data_parallel_size > 1 and (

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -526,6 +526,10 @@ class EngineArgs:
     max_num_partial_prefills: int = SchedulerConfig.max_num_partial_prefills
     max_long_partial_prefills: int = SchedulerConfig.max_long_partial_prefills
     long_prefill_token_threshold: int = SchedulerConfig.long_prefill_token_threshold
+    enable_realtime_unbounded: bool = SchedulerConfig.enable_realtime_unbounded
+    realtime_reanchor_margin_tokens: int = (
+        SchedulerConfig.realtime_reanchor_margin_tokens
+    )
     max_num_seqs: int | None = None
     max_logprobs: int = ModelConfig.max_logprobs
     logprobs_mode: LogprobsMode = ModelConfig.logprobs_mode
@@ -1424,6 +1428,14 @@ class EngineArgs:
             "--long-prefill-token-threshold",
             **scheduler_kwargs["long_prefill_token_threshold"],
         )
+        scheduler_group.add_argument(
+            "--enable-realtime-unbounded",
+            **scheduler_kwargs["enable_realtime_unbounded"],
+        )
+        scheduler_group.add_argument(
+            "--realtime-reanchor-margin-tokens",
+            **scheduler_kwargs["realtime_reanchor_margin_tokens"],
+        )
         # multi-step scheduling has been removed; corresponding arguments
         # are no longer supported.
         scheduler_group.add_argument(
@@ -2155,6 +2167,8 @@ class EngineArgs:
             max_num_partial_prefills=self.max_num_partial_prefills,
             max_long_partial_prefills=self.max_long_partial_prefills,
             long_prefill_token_threshold=self.long_prefill_token_threshold,
+            enable_realtime_unbounded=self.enable_realtime_unbounded,
+            realtime_reanchor_margin_tokens=self.realtime_reanchor_margin_tokens,
             scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,
             watermark=self.watermark,
             prefill_schedule_interval=self.prefill_schedule_interval,

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -48,6 +48,7 @@ class RealtimeConnection:
         self.serving = serving
         self.audio_queue: asyncio.Queue[np.ndarray | None] = asyncio.Queue()
         self.generation_task: asyncio.Task | None = None
+        self.request_id: str | None = None
 
         self._is_connected = False
         self._is_model_validated = False
@@ -204,6 +205,7 @@ class RealtimeConnection:
         6. Cleans up the audio queue
         """
         request_id = f"rt-{self.connection_id}-{uuid4()}"
+        self.request_id = request_id
         full_text = ""
 
         prompt_token_ids_len: int = 0
@@ -263,7 +265,11 @@ class RealtimeConnection:
 
         except Exception as e:
             logger.exception("Error in generation: %s", e)
-            await self.send_error(sanitize_message(str(e)), "processing_error")
+            try:
+                await self.send_error(sanitize_message(str(e)), "processing_error")
+            except Exception:
+                # The socket may already be closed; nothing more we can do.
+                pass
 
     async def send(
         self, event: SessionCreated | TranscriptionDelta | TranscriptionDone
@@ -282,8 +288,28 @@ class RealtimeConnection:
         # Signal audio stream to stop
         self.audio_queue.put_nowait(None)
 
-        # Cancel generation task if running
+        # Abort the engine request. Cancelling the asyncio task alone does NOT
+        # abort the underlying engine request: a request parked in the
+        # VAD-waiting state keeps occupying a slot and generating into a now
+        # dead websocket (an orphaned request that never frees and starves
+        # other streams). Aborting also unblocks the generation task, which is
+        # otherwise stuck awaiting the next engine output.
+        if self.request_id is not None:
+            try:
+                await self.serving.engine_client.abort(self.request_id)
+            except Exception:
+                logger.exception("Failed to abort request %s", self.request_id)
+            self.request_id = None
+
+        # Cancel the generation task if still running, and await it so the
+        # cancellation (and any generator cleanup) actually completes.
         if self.generation_task and not self.generation_task.done():
             self.generation_task.cancel()
+            try:
+                await self.generation_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception("Error awaiting cancelled generation task")
 
         logger.debug("Connection cleanup complete: %s", self.connection_id)

--- a/vllm/model_executor/models/voxtral.py
+++ b/vllm/model_executor/models/voxtral.py
@@ -120,7 +120,24 @@ class VoxtralProcessingInfo(BaseProcessingInfo):
         return {"audio": self.get_max_audio_tokens()}
 
     def get_max_audio_tokens(self) -> int:
-        return self.ctx.model_config.max_model_len
+        # For sliding-window realtime models (Voxtral-Mini-Realtime lineage),
+        # audio is processed in streaming chunks bounded by the decoder's
+        # sliding window. The number of audio-derived tokens active in the
+        # model context is therefore bounded by `text_config.sliding_window`,
+        # not by `max_model_len` (which is the cumulative session lifetime,
+        # not the concurrent context size).
+        #
+        # Without this cap, `compute_mm_encoder_budget` returns a budget
+        # proportional to `max_model_len`, the encoder cache pre-allocates
+        # `max_num_seqs * max_model_len` worth of audio feature space, and the
+        # decoder KV cache is starved on 16 GB GPUs (boot crashes with
+        # "KV cache memory needed > available"). Refs vllm-project/vllm#38233.
+        max_model_len = self.ctx.model_config.max_model_len
+        text_config = getattr(self.ctx.model_config.hf_config, "text_config", None)
+        sliding_window = getattr(text_config, "sliding_window", None)
+        if sliding_window is not None:
+            return min(sliding_window, max_model_len)
+        return max_model_len
 
     def get_max_audio_array_len(self) -> int:
         feature_extractor = self.get_feature_extractor()
@@ -334,9 +351,17 @@ class VoxtralForConditionalGeneration(
         self.downsample_factor = self.config.audio_config.downsample_factor
 
         with self._mark_language_model(vllm_config):
+            # Voxtral's text_config inherits from a Mistral 7B-class model but
+            # does not itself declare `architectures`. Without an explicit
+            # override, init_vllm_registered_model falls back to the
+            # Transformers backend, which does not propagate `sliding_window`
+            # to the attention layers, so SlidingWindowSpec is never produced
+            # and the KV cache pool is sized for max_model_len. Force the
+            # Mistral dispatch. Refs vllm-project/vllm#38233.
             self.language_model = init_vllm_registered_model(
                 vllm_config=vllm_config,
                 hf_config=config.text_config,
+                architectures=["MistralForCausalLM"],
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 

--- a/vllm/model_executor/models/voxtral.py
+++ b/vllm/model_executor/models/voxtral.py
@@ -120,12 +120,9 @@ class VoxtralProcessingInfo(BaseProcessingInfo):
         return {"audio": self.get_max_audio_tokens()}
 
     def get_max_audio_tokens(self) -> int:
-        # Voxtral realtime decoders declare text_config.sliding_window; for those
-        # the audio tokens that live in the attention window are window-bounded,
-        # not max_model_len-bounded. Without this cap the encoder cache and the
-        # profiling dummy audio are sized at max_model_len per item and starve the
-        # decoder KV cache (boot OOM on 16 GB GPUs). Standard Voxtral ships
-        # sliding_window=None and is unaffected. Refs vllm-project/vllm#38233.
+        # Cap audio tokens by the decoder sliding window when set: the encoder
+        # cache and profiling dummy are otherwise sized at max_model_len and OOM
+        # at boot on small GPUs. Standard Voxtral has sliding_window=None. #38233
         max_model_len = self.ctx.model_config.max_model_len
         text_config = getattr(self.ctx.model_config.hf_config, "text_config", None)
         sliding_window = getattr(text_config, "sliding_window", None)

--- a/vllm/model_executor/models/voxtral.py
+++ b/vllm/model_executor/models/voxtral.py
@@ -120,18 +120,12 @@ class VoxtralProcessingInfo(BaseProcessingInfo):
         return {"audio": self.get_max_audio_tokens()}
 
     def get_max_audio_tokens(self) -> int:
-        # For sliding-window realtime models (Voxtral-Mini-Realtime lineage),
-        # audio is processed in streaming chunks bounded by the decoder's
-        # sliding window. The number of audio-derived tokens active in the
-        # model context is therefore bounded by `text_config.sliding_window`,
-        # not by `max_model_len` (which is the cumulative session lifetime,
-        # not the concurrent context size).
-        #
-        # Without this cap, `compute_mm_encoder_budget` returns a budget
-        # proportional to `max_model_len`, the encoder cache pre-allocates
-        # `max_num_seqs * max_model_len` worth of audio feature space, and the
-        # decoder KV cache is starved on 16 GB GPUs (boot crashes with
-        # "KV cache memory needed > available"). Refs vllm-project/vllm#38233.
+        # Voxtral realtime decoders declare text_config.sliding_window; for those
+        # the audio tokens that live in the attention window are window-bounded,
+        # not max_model_len-bounded. Without this cap the encoder cache and the
+        # profiling dummy audio are sized at max_model_len per item and starve the
+        # decoder KV cache (boot OOM on 16 GB GPUs). Standard Voxtral ships
+        # sliding_window=None and is unaffected. Refs vllm-project/vllm#38233.
         max_model_len = self.ctx.model_config.max_model_len
         text_config = getattr(self.ctx.model_config.hf_config, "text_config", None)
         sliding_window = getattr(text_config, "sliding_window", None)
@@ -351,17 +345,9 @@ class VoxtralForConditionalGeneration(
         self.downsample_factor = self.config.audio_config.downsample_factor
 
         with self._mark_language_model(vllm_config):
-            # Voxtral's text_config inherits from a Mistral 7B-class model but
-            # does not itself declare `architectures`. Without an explicit
-            # override, init_vllm_registered_model falls back to the
-            # Transformers backend, which does not propagate `sliding_window`
-            # to the attention layers, so SlidingWindowSpec is never produced
-            # and the KV cache pool is sized for max_model_len. Force the
-            # Mistral dispatch. Refs vllm-project/vllm#38233.
             self.language_model = init_vllm_registered_model(
                 vllm_config=vllm_config,
                 hf_config=config.text_config,
-                architectures=["MistralForCausalLM"],
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -17,7 +17,6 @@ from vllm.compilation.decorators import support_torch_compile
 from vllm.config import ModelConfig, SpeechToTextConfig, VllmConfig
 from vllm.config.speech_to_text import SpeechToTextParams
 from vllm.engine.protocol import StreamingInput
-from vllm.envs import VLLM_ENGINE_ITERATION_TIMEOUT_S
 from vllm.inputs import PromptType, TokensPrompt
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import MultiModalEmbeddings, SupportsRealtime
@@ -265,13 +264,20 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
             await buffer.append_audio(right_pad.audio_array)
             await buffer.append_audio(None)  # signal end
 
-        # Feed output tokens back into buffer in background
+        # Feed output tokens back into buffer in background.
+        # input_stream is a token-feedback queue fed from engine outputs, so an
+        # idle wait here is normal (gaps between tokens or between utterances /
+        # silences) and must NOT be treated as a hang. Wrapping it in
+        # asyncio.wait_for(VLLM_ENGINE_ITERATION_TIMEOUT_S) raised an uncaught
+        # TimeoutError on any silence longer than the timeout, silently killing
+        # this feeder task while the websocket stayed open — the session hung
+        # with no further tokens (vllm-project/vllm#36015, #35863). A real
+        # engine failure instead makes generate() raise and aborts the request,
+        # which cancels this task via the finally block below, so this await
+        # needs no timeout.
         async def feed_tokens():
             while True:
-                all_outputs = await asyncio.wait_for(
-                    input_stream.get(),
-                    timeout=VLLM_ENGINE_ITERATION_TIMEOUT_S,
-                )
+                all_outputs = await input_stream.get()
                 await buffer.append_tokens(all_outputs[-1:])
 
         audio_task = asyncio.create_task(feed_audio())

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -267,14 +267,15 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
         # Feed output tokens back into buffer in background.
         # input_stream is a token-feedback queue fed from engine outputs, so an
         # idle wait here is normal (gaps between tokens or between utterances /
-        # silences) and must NOT be treated as a hang. Wrapping it in
-        # asyncio.wait_for(VLLM_ENGINE_ITERATION_TIMEOUT_S) raised an uncaught
-        # TimeoutError on any silence longer than the timeout, silently killing
-        # this feeder task while the websocket stayed open — the session hung
-        # with no further tokens (vllm-project/vllm#36015, #35863). A real
-        # engine failure instead makes generate() raise and aborts the request,
-        # which cancels this task via the finally block below, so this await
-        # needs no timeout.
+        # silences) and must NOT be treated as a hang. Previously this await was
+        # wrapped in asyncio.wait_for(VLLM_ENGINE_ITERATION_TIMEOUT_S), which
+        # raised an uncaught TimeoutError on any silence past the timeout and
+        # killed this feeder task while the websocket stayed open, so the session
+        # hung with no further tokens (vllm-project/vllm#36015, #35863). The v1
+        # engine has no per-iteration timeout watchdog, and the
+        # removed local timeout never recovered a genuinely wedged stream; a real
+        # request failure ends the stream and cancels this task via the finally
+        # block below, so this await needs no timeout.
         async def feed_tokens():
             while True:
                 all_outputs = await input_stream.get()

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -264,10 +264,9 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
             await buffer.append_audio(right_pad.audio_array)
             await buffer.append_audio(None)  # signal end
 
-        # Feed output tokens back into the buffer. input_stream is a token
-        # queue; idle gaps (silences) are normal, not a hang. The old wait_for
-        # timeout killed this feeder on any silence and hung the session.
-        # #36015, #35863
+        # Feed output tokens back into the buffer with a blocking read: idle
+        # gaps between chunks are normal during silence, so any read timeout
+        # here would kill the feeder mid-session (#36015, #35863).
         async def feed_tokens():
             while True:
                 all_outputs = await input_stream.get()

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -264,18 +264,10 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
             await buffer.append_audio(right_pad.audio_array)
             await buffer.append_audio(None)  # signal end
 
-        # Feed output tokens back into buffer in background.
-        # input_stream is a token-feedback queue fed from engine outputs, so an
-        # idle wait here is normal (gaps between tokens or between utterances /
-        # silences) and must NOT be treated as a hang. Previously this await was
-        # wrapped in asyncio.wait_for(VLLM_ENGINE_ITERATION_TIMEOUT_S), which
-        # raised an uncaught TimeoutError on any silence past the timeout and
-        # killed this feeder task while the websocket stayed open, so the session
-        # hung with no further tokens (vllm-project/vllm#36015, #35863). The v1
-        # engine has no per-iteration timeout watchdog, and the
-        # removed local timeout never recovered a genuinely wedged stream; a real
-        # request failure ends the stream and cancels this task via the finally
-        # block below, so this await needs no timeout.
+        # Feed output tokens back into the buffer. input_stream is a token
+        # queue; idle gaps (silences) are normal, not a hang. The old wait_for
+        # timeout killed this feeder on any silence and hung the session.
+        # #36015, #35863
         async def feed_tokens():
             while True:
                 all_outputs = await input_stream.get()

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -244,6 +244,12 @@ class SchedulerOutput:
     # Number of spec tokens to schedule for the next step.
     num_spec_tokens_to_schedule: int = 0
 
+    # [EXPERIMENTAL] Unbounded realtime: req_id -> D (a multiple of block_size).
+    # The worker re-rotates the request's live cached keys by R(-D) so the RoPE
+    # clock can drop without reaching max_model_len. See
+    # Scheduler._reanchor_session / GPUModelRunner._reanchor_requests.
+    reanchor_reqs: dict[str, int] | None = None
+
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":
         return cls(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -197,14 +197,9 @@ class Scheduler(SchedulerInterface):
         # IDs of requests preempted since the last call to schedule().
         self.reset_preempted_req_ids: set[str] = set()
 
-        # Streaming sessions finished from inside schedule()/add_request() (e.g.
-        # a resumable realtime session that reached max_model_len). finish_requests
-        # frees them scheduler-side but, outside update_from_output, has no
-        # `outputs` dict to emit an EngineCoreOutput on -- and finished_req_ids is
-        # worker-facing only, so the client would never receive a finish_reason
-        # and the websocket would hang. Buffer (client_index, req_id, reason) here
-        # and drain it in the next update_from_output, mirroring the failed-KV-load
-        # finish path. Flushed each step.
+        # Client-facing finishes for streaming sessions ended inside schedule()/
+        # add_request() (no `outputs` dict there). Drained next update_from_output
+        # so the client gets a finish_reason instead of hanging. Flushed each step.
         self._streaming_finish_outputs: list[tuple[int, str, FinishReason]] = []
 
         # Counter for requests waiting for streaming input. Used to calculate
@@ -493,12 +488,6 @@ class Scheduler(SchedulerInterface):
             if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
             num_new_tokens = min(num_new_tokens, token_budget)
-
-            # NOTE: realtime sessions advance their position clock through the
-            # WAITING loop (each audio chunk resumes the session with WAITING
-            # status), so the unbounded-realtime re-anchor trigger lives there,
-            # not here. The re-anchor margin keeps the running-loop decode clear
-            # of max_model_len between chunks.
 
             # Make sure the input position does not exceed the max model len.
             # This is necessary when using spec decoding.
@@ -830,18 +819,10 @@ class Scheduler(SchedulerInterface):
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
 
-                    # Clamp to max_model_len. Mirrors the RUNNING-path guard
-                    # above, but ONLY for streaming/resumable sessions whose
-                    # accumulated token count can grow past max_model_len across
-                    # successive `_update_request_as_session` resumes (continuous
-                    # Voxtral realtime audio). Classic one-shot prefills must NOT
-                    # be clamped here: a pooling/embedding request with
-                    # prompt_len == max_model_len would otherwise lose its last
-                    # token and hang (generate rejects that length at validation,
-                    # pooling does not). They keep the upstream invariant below.
-                    # Run before spec-decode padding so a length-capped session
-                    # drops to <=0 and the padding block (gated on
-                    # num_new_tokens == 1) is naturally skipped.
+                    # Clamp resumable (streaming) sessions to max_model_len;
+                    # their token count grows across resumes. Classic prefills
+                    # stay unclamped (a pooling req at prompt_len == max_model_len
+                    # must keep its last token). Runs before spec-decode padding.
                     if request.resumable:
                         num_new_tokens = min(
                             num_new_tokens,
@@ -880,18 +861,11 @@ class Scheduler(SchedulerInterface):
 
                     num_new_tokens = min(num_new_tokens, token_budget)
                     if not request.resumable:
-                        # Classic one-shot prefill: preserve the upstream
-                        # invariant. A non-resumable request is never clamped
-                        # above, so it always has tokens to schedule here.
+                        # Non-resumable prefills are never clamped above.
                         assert num_new_tokens > 0
                     elif num_new_tokens <= 0:
-                        # Resumable streaming session has reached max_model_len
-                        # and can never make progress. Finish it gracefully
-                        # (finish_requests removes it from the waiting queues)
-                        # instead of asserting and crashing the engine, and
-                        # avoid head-of-line blocking the waiting queue. Buffer a
-                        # client-facing finish output so the websocket does not
-                        # hang waiting for a finish_reason that never arrives.
+                        # Resumable session hit max_model_len: finish gracefully
+                        # (don't crash the engine) and notify the client.
                         finished = self.finish_requests(
                             request_id, RequestStatus.FINISHED_LENGTH_CAPPED
                         )
@@ -1764,8 +1738,7 @@ class Scheduler(SchedulerInterface):
                 finish_reason = request.get_finished_reason()
                 finished = self._handle_stopped_request(request)
                 if finished:
-                    # It may have applied a queued chunk and length-capped the
-                    # session (STOP -> LENGTH); re-read the final reason.
+                    # Applying a queued chunk may have flipped STOP -> LENGTH.
                     finish_reason = request.get_finished_reason()
                     kv_transfer_params = self._free_request(request)
 
@@ -1836,11 +1809,8 @@ class Scheduler(SchedulerInterface):
                     )
                 )
 
-        # Emit client-facing finish outputs for streaming sessions finished from
-        # inside schedule()/add_request() (the request is already freed, so this
-        # is the only place the client learns it ended). Mirrors the failed-KV
-        # path above; without it the websocket hangs on a finish_reason that
-        # never comes.
+        # Drain finishes buffered by schedule()/add_request() (request already
+        # freed; only place the client learns it ended).
         if self._streaming_finish_outputs:
             for client_index, req_id, reason in self._streaming_finish_outputs:
                 outputs[client_index].append(
@@ -1962,11 +1932,8 @@ class Scheduler(SchedulerInterface):
                 # Streaming request finished.
                 return True
             self._update_request_as_session(request, update)
-            # After extending the session with new streaming input, check if
-            # the accumulated tokens (prompt + encoder + output) reached
-            # max_model_len. Without this guard a fatal assertion fires in
-            # gpu_model_runner._bookkeeping_sync once the streaming input pushes
-            # the total past the limit (continuous Voxtral realtime sessions).
+            # Streaming input pushed the session past max_model_len: finish
+            # gracefully, else a fatal assert fires later in the model runner.
             if request.num_tokens >= self.max_model_len:
                 logger.warning(
                     "Streaming session %s reached max_model_len (%d >= %d) "
@@ -2110,10 +2077,8 @@ class Scheduler(SchedulerInterface):
             elif update is not None:
                 # Commence next input chunk.
                 self._update_request_as_session(existing, update)
-                # If the session reached max_model_len after the update (e.g.
-                # continuous audio streaming accumulating encoder tokens past
-                # the limit), finish gracefully here instead of letting it
-                # crash later in the model runner.
+                # Session reached max_model_len after the update: finish
+                # gracefully + notify the client.
                 if existing.num_tokens >= self.max_model_len:
                     logger.warning(
                         "Streaming session %s reached max_model_len "
@@ -2211,11 +2176,10 @@ class Scheduler(SchedulerInterface):
         finished: list[tuple[str, int]],
         finished_status: RequestStatus,
     ) -> None:
-        """Queue client-facing finish outputs for sessions finished from inside
-        schedule()/add_request() (where there is no `outputs` dict). Drained in
-        the next update_from_output so the client receives a finish_reason
-        instead of hanging. ``finished`` is the (req_id, client_index) list
-        returned by finish_requests."""
+        """Buffer a client-facing finish for a session ended inside schedule()/
+        add_request(); drained next update_from_output so the client isn't left
+        hanging. ``finished`` is the (req_id, client_index) list from
+        finish_requests."""
         reason = RequestStatus.get_finished_reason(finished_status)
         if reason is None:
             return

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1764,6 +1764,9 @@ class Scheduler(SchedulerInterface):
                 finish_reason = request.get_finished_reason()
                 finished = self._handle_stopped_request(request)
                 if finished:
+                    # It may have applied a queued chunk and length-capped the
+                    # session (STOP -> LENGTH); re-read the final reason.
+                    finish_reason = request.get_finished_reason()
                     kv_transfer_params = self._free_request(request)
 
                 if status_before_stop == RequestStatus.RUNNING:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -810,16 +810,22 @@ class Scheduler(SchedulerInterface):
                     num_new_tokens = request.num_tokens - num_computed_tokens
 
                     # Clamp to max_model_len. Mirrors the RUNNING-path guard
-                    # above for streaming/resumable requests whose accumulated
-                    # token count can grow past max_model_len across successive
-                    # `_update_request_as_session` calls (continuous Voxtral
-                    # realtime audio sessions). Run before spec-decode padding so
-                    # a length-capped session drops to <=0 and the padding block
-                    # (gated on num_new_tokens == 1) is naturally skipped.
-                    num_new_tokens = min(
-                        num_new_tokens,
-                        self.max_model_len - 1 - num_computed_tokens,
-                    )
+                    # above, but ONLY for streaming/resumable sessions whose
+                    # accumulated token count can grow past max_model_len across
+                    # successive `_update_request_as_session` resumes (continuous
+                    # Voxtral realtime audio). Classic one-shot prefills must NOT
+                    # be clamped here: a pooling/embedding request with
+                    # prompt_len == max_model_len would otherwise lose its last
+                    # token and hang (generate rejects that length at validation,
+                    # pooling does not). They keep the upstream invariant below.
+                    # Run before spec-decode padding so a length-capped session
+                    # drops to <=0 and the padding block (gated on
+                    # num_new_tokens == 1) is naturally skipped.
+                    if request.resumable:
+                        num_new_tokens = min(
+                            num_new_tokens,
+                            self.max_model_len - 1 - num_computed_tokens,
+                        )
 
                     # Pad new decode requests to uniform spec decoding size to
                     # preserve full cudagraph for this step.
@@ -852,8 +858,13 @@ class Scheduler(SchedulerInterface):
                         break
 
                     num_new_tokens = min(num_new_tokens, token_budget)
-                    if num_new_tokens <= 0:
-                        # Length-capped: the request has reached max_model_len
+                    if not request.resumable:
+                        # Classic one-shot prefill: preserve the upstream
+                        # invariant. A non-resumable request is never clamped
+                        # above, so it always has tokens to schedule here.
+                        assert num_new_tokens > 0
+                    elif num_new_tokens <= 0:
+                        # Resumable streaming session has reached max_model_len
                         # and can never make progress. Finish it gracefully
                         # (finish_requests removes it from the waiting queues)
                         # instead of asserting and crashing the engine, and

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -51,7 +51,12 @@ from vllm.v1.core.sched.request_queue import (
     create_request_queue,
 )
 from vllm.v1.core.sched.utils import check_stop, remove_all
-from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
+from vllm.v1.engine import (
+    EngineCoreEventType,
+    EngineCoreOutput,
+    EngineCoreOutputs,
+    FinishReason,
+)
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
@@ -191,6 +196,16 @@ class Scheduler(SchedulerInterface):
 
         # IDs of requests preempted since the last call to schedule().
         self.reset_preempted_req_ids: set[str] = set()
+
+        # Streaming sessions finished from inside schedule()/add_request() (e.g.
+        # a resumable realtime session that reached max_model_len). finish_requests
+        # frees them scheduler-side but, outside update_from_output, has no
+        # `outputs` dict to emit an EngineCoreOutput on -- and finished_req_ids is
+        # worker-facing only, so the client would never receive a finish_reason
+        # and the websocket would hang. Buffer (client_index, req_id, reason) here
+        # and drain it in the next update_from_output, mirroring the failed-KV-load
+        # finish path. Flushed each step.
+        self._streaming_finish_outputs: list[tuple[int, str, FinishReason]] = []
 
         # Counter for requests waiting for streaming input. Used to calculate
         # number of unfinished requests
@@ -478,6 +493,12 @@ class Scheduler(SchedulerInterface):
             if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
             num_new_tokens = min(num_new_tokens, token_budget)
+
+            # NOTE: realtime sessions advance their position clock through the
+            # WAITING loop (each audio chunk resumes the session with WAITING
+            # status), so the unbounded-realtime re-anchor trigger lives there,
+            # not here. The re-anchor margin keeps the running-loop decode clear
+            # of max_model_len between chunks.
 
             # Make sure the input position does not exceed the max model len.
             # This is necessary when using spec decoding.
@@ -868,9 +889,14 @@ class Scheduler(SchedulerInterface):
                         # and can never make progress. Finish it gracefully
                         # (finish_requests removes it from the waiting queues)
                         # instead of asserting and crashing the engine, and
-                        # avoid head-of-line blocking the waiting queue.
-                        self.finish_requests(
+                        # avoid head-of-line blocking the waiting queue. Buffer a
+                        # client-facing finish output so the websocket does not
+                        # hang waiting for a finish_reason that never arrives.
+                        finished = self.finish_requests(
                             request_id, RequestStatus.FINISHED_LENGTH_CAPPED
+                        )
+                        self._buffer_streaming_finish(
+                            finished, RequestStatus.FINISHED_LENGTH_CAPPED
                         )
                         continue
 
@@ -1807,6 +1833,22 @@ class Scheduler(SchedulerInterface):
                     )
                 )
 
+        # Emit client-facing finish outputs for streaming sessions finished from
+        # inside schedule()/add_request() (the request is already freed, so this
+        # is the only place the client learns it ended). Mirrors the failed-KV
+        # path above; without it the websocket hangs on a finish_reason that
+        # never comes.
+        if self._streaming_finish_outputs:
+            for client_index, req_id, reason in self._streaming_finish_outputs:
+                outputs[client_index].append(
+                    EngineCoreOutput(
+                        request_id=req_id,
+                        new_token_ids=[],
+                        finish_reason=reason,
+                    )
+                )
+            self._streaming_finish_outputs.clear()
+
         # KV Connector: update state for finished KV Transfers.
         if kv_connector_output:
             self._update_from_kv_xfer_finished(kv_connector_output)
@@ -2078,9 +2120,12 @@ class Scheduler(SchedulerInterface):
                         existing.num_tokens,
                         self.max_model_len,
                     )
-                    self.finish_requests(
+                    finished = self.finish_requests(
                         existing.request_id,
                         RequestStatus.FINISHED_LENGTH_CAPPED,
+                    )
+                    self._buffer_streaming_finish(
+                        finished, RequestStatus.FINISHED_LENGTH_CAPPED
                     )
             else:
                 # Streaming-input session finished.
@@ -2157,6 +2202,22 @@ class Scheduler(SchedulerInterface):
             self._free_request(request, delay_free_blocks=delay_free_blocks)
 
         return [(r.request_id, r.client_index) for r in valid_requests]
+
+    def _buffer_streaming_finish(
+        self,
+        finished: list[tuple[str, int]],
+        finished_status: RequestStatus,
+    ) -> None:
+        """Queue client-facing finish outputs for sessions finished from inside
+        schedule()/add_request() (where there is no `outputs` dict). Drained in
+        the next update_from_output so the client receives a finish_reason
+        instead of hanging. ``finished`` is the (req_id, client_index) list
+        returned by finish_requests."""
+        reason = RequestStatus.get_finished_reason(finished_status)
+        if reason is None:
+            return
+        for req_id, client_index in finished:
+            self._streaming_finish_outputs.append((client_index, req_id, reason))
 
     def _free_request(
         self, request: Request, delay_free_blocks: bool = False

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import functools
 import itertools
 import time
 from collections import defaultdict, deque
@@ -420,6 +421,8 @@ class Scheduler(SchedulerInterface):
         scheduled_resumed_reqs: list[Request] = []
         scheduled_running_reqs: list[Request] = []
         preempted_reqs: list[Request] = []
+        # [EXPERIMENTAL] unbounded realtime: req_id -> D to re-anchor this step.
+        reanchor_reqs: dict[str, int] = {}
 
         req_to_new_blocks: dict[str, KVCacheBlocks] = {}
         num_scheduled_tokens: dict[str, int] = {}
@@ -819,6 +822,20 @@ class Scheduler(SchedulerInterface):
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
 
+                    # [EXPERIMENTAL] Unbounded realtime: re-anchor the position
+                    # clock down before it reaches max_model_len instead of
+                    # length-capping, then schedule this chunk at the rebased
+                    # positions (the worker re-rotates the live keys). The clock
+                    # and the token count both drop by D, so num_new_tokens holds.
+                    if (
+                        request.reanchor_stream
+                        and num_computed_tokens + num_new_tokens
+                        >= self.max_model_len
+                        - self.scheduler_config.realtime_reanchor_margin_tokens
+                        and self._reanchor_session(request)
+                    ):
+                        num_computed_tokens = request.num_computed_tokens
+
                     # Clamp resumable (streaming) sessions to max_model_len;
                     # their token count grows across resumes. Classic prefills
                     # stay unclamped (a pooling req at prompt_len == max_model_len
@@ -1066,6 +1083,19 @@ class Scheduler(SchedulerInterface):
             scheduled_running_reqs
         ) <= len(self.running)
 
+        # [EXPERIMENTAL] Ship each owed R(-D) key re-rotation to the worker, but
+        # only for requests that actually scheduled this step. A request whose
+        # rebase committed yet broke out unscheduled keeps its pending rotation
+        # (on request.pending_reanchor_d) and ships it on a later step it does
+        # schedule, so the rotation is never silently dropped.
+        if self.scheduler_config.enable_realtime_unbounded:
+            for req in (
+                scheduled_new_reqs + scheduled_resumed_reqs + scheduled_running_reqs
+            ):
+                if req.pending_reanchor_d:
+                    reanchor_reqs[req.request_id] = req.pending_reanchor_d
+                    req.pending_reanchor_d = 0
+
         # Get the longest common prefix among all requests in the running queue.
         # This can be potentially used for cascade attention.
         num_common_prefix_blocks = [0] * len(self.kv_cache_config.kv_cache_groups)
@@ -1140,6 +1170,7 @@ class Scheduler(SchedulerInterface):
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
+            reanchor_reqs=reanchor_reqs or None,
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
@@ -1286,6 +1317,143 @@ class Scheduler(SchedulerInterface):
 
         if self.log_stats:
             session.record_event(EngineCoreEventType.QUEUED)
+
+    @functools.cached_property
+    def _reanchor_sliding_window(self) -> int | None:
+        """The decoder (largest) sliding window across KV groups, or None if the
+        model is not a pure sliding-window model. Cached after first lookup."""
+        sw = None
+        for mgr in self.kv_cache_manager.coordinator.single_type_managers:
+            mgr_sw = getattr(mgr, "sliding_window", None)
+            if mgr_sw is None:
+                return None  # a non-sliding (full-attention) group is present
+            sw = mgr_sw if sw is None else max(sw, mgr_sw)
+        return sw
+
+    def _reanchor_session(self, request: Request) -> bool:
+        """[EXPERIMENTAL] Re-anchor a streaming session's RoPE clock down by D
+        tokens so it never reaches max_model_len (unbounded duration).
+
+        Drops the oldest D tokens (already evicted past the sliding window),
+        rebases the token/position bookkeeping and per-group block lists, and
+        accumulates the owed R(-D) key re-rotation on request.pending_reanchor_d.
+        The clock/block rebase commits here (allocation needs the rebased
+        positions); the worker applies the rotation once the request is in the
+        persistent batch (see schedule()'s reanchor_reqs build).
+
+        Returns True if a re-anchor was performed. Sliding-window models only,
+        with prefix caching disabled (no block hashes to rebase).
+        """
+        sw = self._reanchor_sliding_window
+        if sw is None or self.cache_config.enable_prefix_caching:
+            return False
+        # ``d`` is block-aligned to the scheduler block size = LCM of every KV
+        # group's block size, so it is also a whole multiple of EACH group's own
+        # block size. The number of leading blocks to drop is therefore computed
+        # PER manager as ``d // mgr.block_size``, not one shared count: with
+        # unequal text/audio sliding windows the decoder and encoder land in
+        # separate groups with DIFFERENT block sizes (the encoder's is enlarged to
+        # equalize page size), so a single ``d // self.block_size`` would
+        # under-drop the smaller-block group and leave its block table misaligned
+        # against the re-rotated keys.
+        bs = self.block_size
+        # Drop everything older than the (largest) window, block-aligned.
+        d = ((request.num_computed_tokens - sw) // bs) * bs
+        if d <= 0:
+            return False
+        # Safety tripwire: the leading (d // mgr.block_size) blocks of every group
+        # must already be null (evicted past the window by remove_skipped_blocks,
+        # run from allocate_slots every prior step). If any is not, deleting it
+        # would corrupt block accounting, so fail safe (no re-anchor, no mutation).
+        managers = self.kv_cache_manager.coordinator.single_type_managers
+        for mgr in managers:
+            blocks = mgr.req_to_blocks.get(request.request_id)
+            if not blocks:
+                continue
+            null_block = getattr(mgr, "_null_block", None)
+            if null_block is None:
+                # Fail safe: without a null block to compare against, the
+                # tripwire cannot prove the leading blocks are evicted, and the
+                # deletion pass below would drop live blocks unchecked.
+                logger.warning_once(
+                    "Re-anchor disabled: KV cache manager %s has no _null_block "
+                    "to validate evicted leading blocks against.",
+                    type(mgr).__name__,
+                )
+                return False
+            mgr_shift = d // mgr.block_size
+            for i in range(min(mgr_shift, len(blocks))):
+                if blocks[i] is not null_block:
+                    logger.warning(
+                        "Re-anchor aborted for %s: leading block %d not null "
+                        "in a KV group (window=%d, clock=%d).",
+                        request.request_id,
+                        i,
+                        sw,
+                        request.num_computed_tokens,
+                    )
+                    return False
+        # (1) token / position bookkeeping
+        request.num_computed_tokens -= d
+        del request._all_token_ids[:d]
+        if request.prompt_token_ids is not None and len(request.prompt_token_ids) >= d:
+            del request.prompt_token_ids[:d]
+            request.num_prompt_tokens -= d
+        # (2) multimodal features: drop the dead leading features (those fully
+        # before the new origin -> beyond the window, audio long since
+        # transcribed and evicted) and shift the rest down by d. Dropping is
+        # required for unbounded duration: each audio chunk appends a feature
+        # whose ``data`` payload is non-trivial, so keeping them all leaks host
+        # RAM without bound. Features are referenced by LIST INDEX (input_id) by
+        # the encoder cache (request_cached_ids) and the per-step scheduler
+        # (get_mm_features_in_window binary-searches the monotonic offsets), so
+        # we release any still-cached dead input and reindex the survivors.
+        n_drop = 0
+        if request.mm_features:
+            for mm_feature in request.mm_features:
+                pos = mm_feature.mm_position
+                if pos.offset + pos.length <= d:
+                    n_drop += 1
+                else:
+                    break
+            if n_drop:
+                ecm = self.encoder_cache_manager
+                for i in list(ecm.get_cached_input_ids(request)):
+                    if i < n_drop:
+                        ecm.free_encoder_input(request, i)
+                rid = request.request_id
+                if rid in ecm.request_cached_ids:
+                    ecm.request_cached_ids[rid] = {
+                        i - n_drop for i in ecm.request_cached_ids[rid]
+                    }
+                del request.mm_features[:n_drop]
+            for mm_feature in request.mm_features:
+                pos = mm_feature.mm_position
+                mm_feature.mm_position = replace(pos, offset=pos.offset - d)
+        # (3) per-group block lists: drop the leading (d // mgr.block_size)
+        # already-null / evicted blocks. The count is PER manager (groups may have
+        # different block sizes under unequal windows), not one shared count.
+        for mgr in self.kv_cache_manager.coordinator.single_type_managers:
+            blocks = mgr.req_to_blocks.get(request.request_id)
+            if blocks:
+                mgr_shift = d // mgr.block_size
+                del blocks[: min(mgr_shift, len(blocks))]
+        # (4) Owe the worker an R(-D) key re-rotation; accumulate on the request
+        # so it survives an unscheduled step (shipped from schedule()).
+        request.pending_reanchor_d += d
+        request.reanchor_offset += d
+        logger.info(
+            "Re-anchored realtime session %s by D=%d (clock now %d, total folded "
+            "%d; mm_features=%d dropped=%d all_tokens=%d).",
+            request.request_id,
+            d,
+            request.num_computed_tokens,
+            request.reanchor_offset,
+            len(request.mm_features) if request.mm_features else 0,
+            n_drop,
+            len(request._all_token_ids),
+        )
+        return True
 
     def _make_cached_request_data(
         self,
@@ -1933,8 +2101,9 @@ class Scheduler(SchedulerInterface):
                 return True
             self._update_request_as_session(request, update)
             # Streaming input pushed the session past max_model_len: finish
-            # gracefully, else a fatal assert fires later in the model runner.
-            if request.num_tokens >= self.max_model_len:
+            # gracefully (else a fatal assert fires later in the model runner).
+            # Re-anchor sessions never cap.
+            if request.num_tokens >= self.max_model_len and not request.reanchor_stream:
                 logger.warning(
                     "Streaming session %s reached max_model_len (%d >= %d) "
                     "after session update. Finishing request gracefully.",
@@ -2078,8 +2247,11 @@ class Scheduler(SchedulerInterface):
                 # Commence next input chunk.
                 self._update_request_as_session(existing, update)
                 # Session reached max_model_len after the update: finish
-                # gracefully + notify the client.
-                if existing.num_tokens >= self.max_model_len:
+                # gracefully and notify the client. Re-anchor sessions never cap.
+                if (
+                    existing.num_tokens >= self.max_model_len
+                    and not existing.reanchor_stream
+                ):
                     logger.warning(
                         "Streaming session %s reached max_model_len "
                         "(%d >= %d) after session update. Finishing request "
@@ -2101,6 +2273,11 @@ class Scheduler(SchedulerInterface):
         else:
             if request.resumable:
                 request.streaming_queue = deque()
+                # [EXPERIMENTAL] mark resumable realtime sessions for unbounded
+                # re-anchoring (only effective for sliding-window models with
+                # prefix caching off; gated in _reanchor_session).
+                if self.scheduler_config.enable_realtime_unbounded:
+                    request.reanchor_stream = True
             self._enqueue_waiting_request(request)
             self.requests[request.request_id] = request
             if self.connector is not None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -809,6 +809,18 @@ class Scheduler(SchedulerInterface):
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
 
+                    # Clamp to max_model_len. Mirrors the RUNNING-path guard
+                    # above for streaming/resumable requests whose accumulated
+                    # token count can grow past max_model_len across successive
+                    # `_update_request_as_session` calls (continuous Voxtral
+                    # realtime audio sessions). Run before spec-decode padding so
+                    # a length-capped session drops to <=0 and the padding block
+                    # (gated on num_new_tokens == 1) is naturally skipped.
+                    num_new_tokens = min(
+                        num_new_tokens,
+                        self.max_model_len - 1 - num_computed_tokens,
+                    )
+
                     # Pad new decode requests to uniform spec decoding size to
                     # preserve full cudagraph for this step.
                     if (
@@ -840,7 +852,16 @@ class Scheduler(SchedulerInterface):
                         break
 
                     num_new_tokens = min(num_new_tokens, token_budget)
-                    assert num_new_tokens > 0
+                    if num_new_tokens <= 0:
+                        # Length-capped: the request has reached max_model_len
+                        # and can never make progress. Finish it gracefully
+                        # (finish_requests removes it from the waiting queues)
+                        # instead of asserting and crashing the engine, and
+                        # avoid head-of-line blocking the waiting queue.
+                        self.finish_requests(
+                            request_id, RequestStatus.FINISHED_LENGTH_CAPPED
+                        )
+                        continue
 
                     # Schedule encoder inputs.
                     if request.has_encoder_inputs:
@@ -1885,6 +1906,21 @@ class Scheduler(SchedulerInterface):
                 # Streaming request finished.
                 return True
             self._update_request_as_session(request, update)
+            # After extending the session with new streaming input, check if
+            # the accumulated tokens (prompt + encoder + output) reached
+            # max_model_len. Without this guard a fatal assertion fires in
+            # gpu_model_runner._bookkeeping_sync once the streaming input pushes
+            # the total past the limit (continuous Voxtral realtime sessions).
+            if request.num_tokens >= self.max_model_len:
+                logger.warning(
+                    "Streaming session %s reached max_model_len (%d >= %d) "
+                    "after session update. Finishing request gracefully.",
+                    request.request_id,
+                    request.num_tokens,
+                    self.max_model_len,
+                )
+                request.status = RequestStatus.FINISHED_LENGTH_CAPPED
+                return True
         else:
             request.status = RequestStatus.WAITING_FOR_STREAMING_REQ
             self.num_waiting_for_streaming_input += 1
@@ -2018,6 +2054,23 @@ class Scheduler(SchedulerInterface):
             elif update is not None:
                 # Commence next input chunk.
                 self._update_request_as_session(existing, update)
+                # If the session reached max_model_len after the update (e.g.
+                # continuous audio streaming accumulating encoder tokens past
+                # the limit), finish gracefully here instead of letting it
+                # crash later in the model runner.
+                if existing.num_tokens >= self.max_model_len:
+                    logger.warning(
+                        "Streaming session %s reached max_model_len "
+                        "(%d >= %d) after session update. Finishing request "
+                        "gracefully.",
+                        existing.request_id,
+                        existing.num_tokens,
+                        self.max_model_len,
+                    )
+                    self.finish_requests(
+                        existing.request_id,
+                        RequestStatus.FINISHED_LENGTH_CAPPED,
+                    )
             else:
                 # Streaming-input session finished.
                 self.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -647,6 +647,15 @@ class OutputProcessor:
                 # if required.
                 req_state.logprobs_processor.update_from_output(engine_core_output)
 
+            # A streaming session stays unfinished between chunks, but a
+            # terminal finish (length cap / error / abort) ends it: deliver
+            # finished=True and free it, else AsyncLLM.generate() hangs.
+            terminal_stream_finish = req_state.streaming_input and finish_reason in (
+                FinishReason.LENGTH,
+                FinishReason.ERROR,
+                FinishReason.ABORT,
+            )
+
             # 4) Create and handle RequestOutput objects.
             if request_output := req_state.make_request_output(
                 new_token_ids,
@@ -655,7 +664,7 @@ class OutputProcessor:
                 stop_reason,
                 kv_transfer_params,
             ):
-                if req_state.streaming_input:
+                if req_state.streaming_input and not terminal_stream_finish:
                     request_output.finished = False
 
                 if req_state.queue is not None:
@@ -667,7 +676,7 @@ class OutputProcessor:
 
             # Free completed requests.
             if finish_reason is not None:
-                if req_state.streaming_input:
+                if req_state.streaming_input and not terminal_stream_finish:
                     if req_state.input_chunk_queue:
                         update = req_state.input_chunk_queue.popleft()
                         req_state.apply_streaming_update(update)

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -647,11 +647,11 @@ class OutputProcessor:
                 # if required.
                 req_state.logprobs_processor.update_from_output(engine_core_output)
 
-            # A streaming session stays unfinished between chunks, but a
-            # terminal finish (length cap / error / abort) ends it: deliver
-            # finished=True and free it, else AsyncLLM.generate() hangs.
+            # A streaming session stays unfinished between chunks. A normal
+            # per-step finish is FinishReason.LENGTH (the session resumes with
+            # the next chunk), so only ERROR/ABORT is terminal here; genuine
+            # max_model_len caps are delivered via _streaming_finish_outputs.
             terminal_stream_finish = req_state.streaming_input and finish_reason in (
-                FinishReason.LENGTH,
                 FinishReason.ERROR,
                 FinishReason.ABORT,
             )

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -647,11 +647,11 @@ class OutputProcessor:
                 # if required.
                 req_state.logprobs_processor.update_from_output(engine_core_output)
 
-            # A streaming session stays unfinished between chunks. A normal
-            # per-step finish is FinishReason.LENGTH (the session resumes with
-            # the next chunk), so only ERROR/ABORT is terminal here; genuine
-            # max_model_len caps are delivered via _streaming_finish_outputs.
-            terminal_stream_finish = req_state.streaming_input and finish_reason in (
+            # A streaming session stays unfinished between chunks: a normal
+            # per-step finish is FinishReason.LENGTH and the session resumes
+            # with the next chunk. Only ERROR/ABORT terminates it here;
+            # genuine max_model_len caps arrive via _streaming_finish_outputs.
+            stream_continues = req_state.streaming_input and finish_reason not in (
                 FinishReason.ERROR,
                 FinishReason.ABORT,
             )
@@ -664,7 +664,7 @@ class OutputProcessor:
                 stop_reason,
                 kv_transfer_params,
             ):
-                if req_state.streaming_input and not terminal_stream_finish:
+                if stream_continues:
                     request_output.finished = False
 
                 if req_state.queue is not None:
@@ -676,7 +676,7 @@ class OutputProcessor:
 
             # Free completed requests.
             if finish_reason is not None:
-                if req_state.streaming_input and not terminal_stream_finish:
+                if stream_continues:
                     if req_state.input_chunk_queue:
                         update = req_state.input_chunk_queue.popleft()
                         req_state.apply_streaming_update(update)

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -190,6 +190,18 @@ class Request:
         # None entry in the queue means finished.
         self.streaming_queue: deque[StreamingUpdate | None] | None = None
 
+        # [EXPERIMENTAL] Unbounded (re-anchored) streaming; set only for realtime
+        # sliding-window models under --enable-realtime-unbounded.
+        # reanchor_stream: the RoPE clock is periodically re-anchored down so the
+        #   session never reaches max_model_len. reanchor_offset: total tokens
+        #   folded by re-anchoring (log/diagnostic only). pending_reanchor_d:
+        #   tokens owed to the worker as an R(-D) key re-rotation, carried forward
+        #   if the rebased request fails to schedule a step so it is never lost.
+        #   See Scheduler._reanchor_session.
+        self.reanchor_stream = False
+        self.reanchor_offset = 0
+        self.pending_reanchor_d = 0
+
         # If True, request should be aborted immediately after being added to
         # the scheduler so the connector's request_finished hook runs.
         self.abort_immediately = abort_immediately

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6281,6 +6281,17 @@ class GPUModelRunner(
                             dummy_modality
                         ]
 
+                        # Realtime streaming models (Voxtral realtime,
+                        # Qwen3-ASR realtime, ...) process at most one new
+                        # multimodal chunk per generation step per session,
+                        # regardless of max_num_seqs. Profiling with the
+                        # cartesian product (max_num_seqs x max audio length)
+                        # OOMs on consumer GPUs while never reflecting runtime
+                        # memory pressure. Clamp to a single item.
+                        # Refs vllm-project/vllm#38233.
+                        if supports_realtime(self.model):
+                            max_mm_items_per_batch = 1
+
                         logger.info_once(
                             "Encoder cache will be initialized with a "
                             "budget of %s tokens, and profiled with "

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -209,6 +209,10 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
 from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
+from vllm.v1.worker.reanchor_rotary import (
+    apply_inverse_rotary_cos_sin,
+    inverse_rotary_cos_sin,
+)
 from vllm.v1.worker.ubatch_utils import (
     UBatchSlices,
     check_ubatch_thresholds,
@@ -1124,6 +1128,118 @@ class GPUModelRunner(
         """Zero the KV cache memory for the given block IDs."""
         if hasattr(self, "_kv_block_zeroer"):
             self._kv_block_zeroer.zero_block_ids(block_ids)
+
+    def _reanchor_requests(self, reanchor_reqs: dict[str, int]) -> None:
+        """[EXPERIMENTAL] Worker side of RoPE re-anchoring for unbounded realtime.
+
+        The scheduler has already rebased each request's clock and block table
+        (via _update_states re-adding the resumed session). The only thing left
+        here is to re-rotate the live cached keys by the constant R(-D) in every
+        KV group, dropping each key's effective RoPE position by D while every
+        in-window relative score is preserved exactly (proven in
+        benchmarks/voxtral_realtime/test_reanchor_math.py).
+
+        Runs at the between-steps barrier (after _update_states, before the
+        forward writes this step's keys). Invalid under fp8 KV.
+        """
+        if not reanchor_reqs:
+            return
+        assert not is_quantized_kv_cache(self.cache_config.cache_dtype), (
+            "realtime re-anchoring requires a non-fp8 KV cache"
+        )
+        ib = self.input_batch
+        fctx = self.compilation_config.static_forward_context
+        groups = self.kv_cache_config.kv_cache_groups
+        # The audio encoder's RoPE positions run at block_pool_size x the decoder
+        # (whisper positions are expanded by this factor), so its constant shift
+        # is pool * D; the decoder (text) group shifts by D.
+        audio_cfg = getattr(self.model_config.hf_config, "audio_config", None)
+        # downsample_factor lives on audio_config (the Mistral adapter writes it
+        # there, not top-level). Startup validation rejects a non-derivable pool
+        # for the re-anchor path, so the trailing `or 1` is unreachable there.
+        pool = (
+            getattr(audio_cfg, "block_pool_size", None)
+            or getattr(audio_cfg, "downsample_factor", None)
+            or 1
+        )
+        for req_id, D in reanchor_reqs.items():
+            idx = ib.req_id_to_index.get(req_id)
+            if idx is None or D <= 0:
+                # INVARIANT: reanchor_reqs only holds requests scheduled this
+                # step with a positive shift, so each must be in the persistent
+                # batch with D > 0. idx is None (absent from batch) or D <= 0
+                # both mean a scheduler bug; log and skip.
+                logger.error(
+                    "Re-anchor INVARIANT VIOLATION: request %s in reanchor_reqs "
+                    "but not applicable (idx=%s, D=%s); expected it in the "
+                    "persistent batch with D > 0. Key re-rotation dropped, so "
+                    "attention will be corrupted for this stream. This should be "
+                    "unreachable; investigate schedule().",
+                    req_id,
+                    idx,
+                    D,
+                )
+                continue
+            # The persistent-batch row already carries the rebased (small) clock
+            # from full re-add; logged below for observability.
+            clock = int(ib.num_computed_tokens_cpu[idx])
+            # Voxtral/Ministral rope_theta, hardcoded here for the experimental
+            # realtime path. Startup validation (VllmConfig) rejects any model
+            # whose text/audio rope_theta != 1e6, that carries a real RoPE
+            # scaling, or whose decoder/encoder head_dim is not the validated
+            # 128-NeoX / 64-GPT-J pairing this dispatch keys off. The head_size
+            # assert below only rejects a dim outside {64, 128}; by itself it
+            # does NOT catch a 64-dim NeoX or 128-dim GPT-J head, which is why
+            # the geometry is validated up front.
+            base = 1.0e6
+            # At most two distinct rotations per re-anchor (decoder 128-dim
+            # NeoX shifted by D, audio encoder 64-dim GPT-J shifted by pool*D);
+            # compute each cos/sin table once instead of per layer (~60x).
+            cos_sin: dict[tuple[int, int], tuple[torch.Tensor, torch.Tensor]] = {}
+            for gid, group in enumerate(groups):
+                bt = ib.block_table.block_tables[gid]
+                n = int(bt.num_blocks_per_row[idx])
+                if n <= 0:
+                    continue
+                # Whole rebased row: leading evicted/null blocks were dropped
+                # scheduler-side; trailing freshly-allocated blocks (this step's
+                # new tokens) are zeroed by _update_states and overwritten by the
+                # forward pass, so re-rotating them is a harmless no-op. R(-d_grp)
+                # is position-independent, so a uniform rotation of every key in
+                # the row is exactly right.
+                live = bt.block_table.np[idx, :n].copy()
+                live_t = torch.from_numpy(live).to(self.device, torch.long)
+                for layer_name in group.layer_names:
+                    kv = fctx[layer_name].kv_cache
+                    if isinstance(kv, (list, tuple)):
+                        kv = kv[0]
+                    # KV layout (num_blocks, 2, block, num_kv_heads, head_size);
+                    # index 0 = key (post-RoPE). head_size is read per layer, not
+                    # per group: equal text/audio windows merge the decoder
+                    # (128-dim NeoX, shift D) and audio encoder (64-dim GPT-J,
+                    # shift pool*D) into one mixed-head_size group.
+                    head_size = kv.shape[-1]
+                    assert head_size in (64, 128), (
+                        f"re-anchor: unexpected rotary head_size {head_size}"
+                    )
+                    is_neox = head_size == 128
+                    d_grp = D if is_neox else pool * D
+                    cs = cos_sin.get((d_grp, head_size))
+                    if cs is None:
+                        cs = inverse_rotary_cos_sin(
+                            d_grp, head_size, base, kv.dtype, kv.device
+                        )
+                        cos_sin[(d_grp, head_size)] = cs
+                    key = kv[live_t, 0]
+                    kv[live_t, 0] = apply_inverse_rotary_cos_sin(
+                        key, cs[0], cs[1], head_size, is_neox
+                    )
+            logger.info(
+                "Re-anchored worker keys for %s by D=%d (decoder clock=%d).",
+                req_id,
+                D,
+                clock,
+            )
 
     # Note: used for model runner override.
     def _init_device_properties(self) -> None:
@@ -4099,6 +4215,11 @@ class GPUModelRunner(
         ):
             # Update persistent batch states.
             deferred_state_corrections_fn = self._update_states(scheduler_output)
+
+            # [EXPERIMENTAL] Unbounded realtime: re-anchor requests at this
+            # between-steps barrier (no in-flight attention) before _prepare_inputs.
+            if scheduler_output.reanchor_reqs:
+                self._reanchor_requests(scheduler_output.reanchor_reqs)
 
             if has_ec_transfer() and not get_ec_transfer().is_consumer:
                 with self.maybe_get_ec_connector_output(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6281,17 +6281,10 @@ class GPUModelRunner(
                             dummy_modality
                         ]
 
-                        # Realtime models submit one new mm chunk per step per
-                        # session, so the max_num_seqs x max-audio product over-
-                        # profiles and OOMs on consumer GPUs (#38233). But runtime
-                        # encoder admission is bounded by the encoder *token*
-                        # budget, not item count (_try_schedule_encoder_inputs /
-                        # EncoderCacheManager), so several concurrent sessions'
-                        # chunks -- or a multi-audio prompt -- can land in a single
-                        # embed_multimodal forward. Profile exactly that many max-
-                        # size items (encoder_budget // max-tokens-per-item): the
-                        # same bound admission enforces. Clamping to 1 under-
-                        # profiles encoder peak memory and OOMs in service.
+                        # Realtime encoder admission is bounded by the token
+                        # budget, not item count, so profile encoder_budget //
+                        # max-tokens-per-item items (the bound admission enforces);
+                        # clamping to 1 under-profiles and OOMs in service. #38233
                         if supports_realtime(self.model):
                             max_toks = mm_budget.mm_max_toks_per_item[dummy_modality]
                             max_mm_items_per_batch = max(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6281,10 +6281,10 @@ class GPUModelRunner(
                             dummy_modality
                         ]
 
-                        # Realtime encoder admission is bounded by the token
-                        # budget, not item count, so profile encoder_budget //
-                        # max-tokens-per-item items (the bound admission enforces);
-                        # clamping to 1 under-profiles and OOMs in service. #38233
+                        # Realtime admission is bounded by the encoder token
+                        # budget, not by item count: profile the item count
+                        # that budget admits. Profiling a single item
+                        # under-reserves and OOMs in service (#38233).
                         if supports_realtime(self.model):
                             max_toks = mm_budget.mm_max_toks_per_item[dummy_modality]
                             max_mm_items_per_batch = max(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6281,16 +6281,23 @@ class GPUModelRunner(
                             dummy_modality
                         ]
 
-                        # Realtime streaming models (Voxtral realtime,
-                        # Qwen3-ASR realtime, ...) process at most one new
-                        # multimodal chunk per generation step per session,
-                        # regardless of max_num_seqs. Profiling with the
-                        # cartesian product (max_num_seqs x max audio length)
-                        # OOMs on consumer GPUs while never reflecting runtime
-                        # memory pressure. Clamp to a single item.
-                        # Refs vllm-project/vllm#38233.
+                        # Realtime models submit one new mm chunk per step per
+                        # session, so the max_num_seqs x max-audio product over-
+                        # profiles and OOMs on consumer GPUs (#38233). But runtime
+                        # encoder admission is bounded by the encoder *token*
+                        # budget, not item count (_try_schedule_encoder_inputs /
+                        # EncoderCacheManager), so several concurrent sessions'
+                        # chunks -- or a multi-audio prompt -- can land in a single
+                        # embed_multimodal forward. Profile exactly that many max-
+                        # size items (encoder_budget // max-tokens-per-item): the
+                        # same bound admission enforces. Clamping to 1 under-
+                        # profiles encoder peak memory and OOMs in service.
                         if supports_realtime(self.model):
-                            max_mm_items_per_batch = 1
+                            max_toks = mm_budget.mm_max_toks_per_item[dummy_modality]
+                            max_mm_items_per_batch = max(
+                                1,
+                                min(max_mm_items_per_batch, encoder_budget // max_toks),
+                            )
 
                         logger.info_once(
                             "Encoder cache will be initialized with a "

--- a/vllm/v1/worker/reanchor_rotary.py
+++ b/vllm/v1/worker/reanchor_rotary.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""[EXPERIMENTAL] RoPE re-anchoring key re-rotation, shared between the worker
+(GPUModelRunner._reanchor_requests) and its unit test
+(benchmarks/voxtral_realtime/test_reanchor_math.py) so the test exercises the
+*production* op rather than a hand-copied duplicate.
+
+Kept dependency-light (torch only, no worker graph) so the benchmark test can
+import it without pulling the GPU model runner.
+"""
+
+import torch
+
+
+def inverse_rotary_cos_sin(
+    d: int, rotary_dim: int, base: float, dtype: torch.dtype, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """cos/sin tables of the constant R(-d) re-rotation angles.
+
+    Computed in fp64: at re-anchor distances d ~ 1e5 a fp32 angle accumulates
+    ~1e-2 rad of error, which compounds across the cached keys re-rotated at
+    every re-anchor. Split out from apply_inverse_rotary so the worker can
+    compute the (at most two) tables once per re-anchor instead of per layer.
+    """
+    inv_freq = 1.0 / (
+        base
+        ** (
+            torch.arange(0, rotary_dim, 2, dtype=torch.float64, device=device)
+            / rotary_dim
+        )
+    )
+    angle = float(d) * inv_freq
+    return torch.cos(angle).to(dtype), torch.sin(angle).to(dtype)
+
+
+def apply_inverse_rotary_cos_sin(
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    rotary_dim: int,
+    is_neox: bool,
+) -> torch.Tensor:
+    """Apply R(-d) to ``key`` given precomputed inverse_rotary_cos_sin tables."""
+    half = rotary_dim // 2
+    rot, passthru = key[..., :rotary_dim], key[..., rotary_dim:]
+    if is_neox:
+        x1, x2 = rot[..., :half], rot[..., half:]
+        out = torch.cat([x1 * cos + x2 * sin, -x1 * sin + x2 * cos], dim=-1)
+    else:  # GPT-J interleaved
+        x1, x2 = rot[..., 0::2], rot[..., 1::2]
+        o1, o2 = x1 * cos + x2 * sin, -x1 * sin + x2 * cos
+        out = torch.stack([o1, o2], dim=-1).flatten(-2)
+    return torch.cat([out, passthru], dim=-1) if passthru.numel() else out
+
+
+def apply_inverse_rotary(
+    key: torch.Tensor, d: int, rotary_dim: int, base: float, is_neox: bool
+) -> torch.Tensor:
+    """Re-rotate an already position-rotated key by the constant R(-d).
+
+    Used by RoPE re-anchoring (unbounded realtime). cos(-d.f)=cos(d.f),
+    sin(-d.f)=-sin(d.f) -> R(-d)=R(d)^T. Validated to ~1e-6 against the vLLM
+    rotary convention for both NeoX and GPT-J styles in
+    benchmarks/voxtral_realtime/test_reanchor_math.py. ``key`` is
+    [..., head_size] with the leading ``rotary_dim`` dims rotary.
+    """
+    cos, sin = inverse_rotary_cos_sin(d, rotary_dim, base, key.dtype, key.device)
+    return apply_inverse_rotary_cos_sin(key, cos, sin, rotary_dim, is_neox)


### PR DESCRIPTION
## What this is

[RFC, experimental, **default-off**] Lift the ~3h duration ceiling on sliding-window realtime models (Voxtral) via RoPE re-anchoring, behind `--enable-realtime-unbounded`.

**Stacked on #45022** (the bug fixes). Until #45022 merges, this PR's own diff includes those bug-fix commits as well; the **net-new of this PR** (the re-anchoring) is viewable as the clean delta here:
[`voxtral-realtime-unbounded...voxtral-realtime-rfc`](https://github.com/linto-ai/vllm/compare/voxtral-realtime-unbounded...voxtral-realtime-rfc)

## The idea

A realtime session is one growing sequence whose RoPE positions are capped by `max_model_len` (~2h55 at 131072), even though the sliding window already bounds KV memory. So duration is limited by position accounting, not memory.

`--enable-realtime-unbounded` re-anchors the position clock down by a constant `D` before it reaches the cap. In a sliding-window decoder a query at position `m` attends only to keys in `(m-W, m]`, and a RoPE score depends only on the relative offset `m-n`, so shifting every live position down by `D` preserves every in-window score exactly. Keys are cached post-rotation, so the re-anchor re-rotates each live cached key in place by `R(-D)` (one complex multiply per vector); queries regenerate at the lower clock. Per-stream KV stays constant. Sliding-window + non-fp8 KV only.

Startup guards reject misconfig up front rather than degrading hours into a stream: fp8 KV, prefix caching, non-CUDA, scaled RoPE, `rope_theta != 1e6`, no re-anchor head-room, and the decoder/encoder `head_dim` / audio pool factor the worker key re-rotation assumes.

## Addresses @anshulkulhari7's review on #45022

1. **`head_size` overloading + unguarded `pool`.** The per-KV-group fix doesn't quite work: with equal text/audio windows the 128-NeoX decoder and 64-GPT-J encoder layers collapse into one `kv_cache_group`, so `head_size` has to stay the per-layer discriminator. Instead, a startup guard (`VllmConfig`, gated on `enable_realtime_unbounded`) mirrors the existing `rope_theta` check: it rejects a non-derivable pool (`block_pool_size` / `downsample_factor`) and validates the 128-NeoX / 64-GPT-J `head_dim` pairing the dispatch assumes. This also covers the adjacent `is_neox = head_size == 128` style-inference (a future 64-dim decoder would otherwise be routed through the GPT-J branch and shifted by `pool*D`).
2. **Test coverage.** Added `tests/v1/worker/test_reanchor_rotary.py` (collected pytest, CPU) for the `R(-D)` identity and in-window score preservation, and `test_voxtral_realtime_reanchor_parity` (CUDA), a single-stream e2e test that fires one re-anchor and asserts token parity against a re-anchor-off reference at the same window. It is self-validating (asserts a re-anchor actually fired).

## Validation

Validated on a local RTX 4090 (16 GiB): the e2e parity test `test_voxtral_realtime_reanchor_parity` passes -- re-anchor fires ~6-8x on a short clip and the decode is token-for-token identical to the re-anchor-off reference. That run also caught and fixed a startup-guard false-positive that rejected Voxtral's own audio sub-config.

Single RTX 4090 Laptop 16 GiB: endurance (4 streams x 4.7h, flat VRAM, 0 errors), concurrency (1 to 13 streams, compute-bound), and re-anchor A/B (0.00 to 1.14% transcript change, no meaning loss). Harness and numbers in `benchmarks/voxtral_realtime/README.md`; operator docs in `docs/serving/online_serving/speech_to_text.md`.

Recommended config:

```
--enable-realtime-unbounded --realtime-reanchor-margin-tokens 4096 --no-enable-prefix-caching
```

Developed with AI assistance; I reviewed every line and validated end-to-end.