### PR TITLE
[Bugfix] Restore unloaded FP8 scale params during layerwise reload

### DIFF
--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -342,10 +342,34 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
         param.weight_loader = _get_original_loader(param)
 
     # Load all buffered weights into materialized layer (using original loaders)
+    loaded_names = set()
     for name, args in info.loaded_weights:
         param = getattr(layer, name)
         args.arguments["param"] = param
         param.weight_loader(*args.args, **args.kwargs)
+        loaded_names.add(name)
+
+    # During reload, scale parameters may not be provided by external weight
+    # sync (e.g. when an RL framework sends FP8 weights without scale_inv).
+    # These unloaded scales are still torch.empty (NaN) after materialization.
+    # Restore them from the previously saved kernel tensors so that
+    # process_weights_after_loading sees valid values.
+    if info.kernel_tensors is not None:
+        parameters, buffers = info.kernel_tensors
+        for name in list(parameters) + list(buffers):
+            if name in loaded_names:
+                continue
+            materialized = getattr(layer, name, None)
+            if materialized is None:
+                continue
+            if not materialized.is_floating_point():
+                continue
+            if torch.isnan(materialized).any():
+                saved = parameters.get(name) or buffers.get(name)
+                if saved is not None:
+                    materialized.data.copy_(saved.data)
+                    logger.debug("%s.%s: restored from kernel tensors",
+                                 layer.__class__.__name__, name)
 
     # Process weights (quantization, repacking, etc.)
     quant_method = getattr(layer, "quant_method", None)


### PR DESCRIPTION
## Summary
- Fix NaN inference output when external weight sync provides FP8 weights without `scale_inv` tensors during layerwise reload
- After replaying buffered weights, restore unloaded scale parameters from previously saved kernel tensors

## Root cause
When RL training frameworks sync FP8 MoE weights to vLLM via `start_weight_update`/`update_weights`, they may send only the weight data without `scale_inv` tensors. During layerwise reload:

1. `materialize_layer` allocates scale params as `torch.empty` (contains NaN)
2. Weight replay only loads the params that were actually sent — scale params stay NaN
3. `process_weights_after_loading` reads NaN scales and passes them to the MoE kernel
4. All subsequent inference produces NaN

The fix checks for unloaded parameters after replay. If they contain NaN and previously saved kernel tensors exist (from before reload), it restores the valid scale values.

## Not duplicating existing PRs
- #41670 reports the same bug family (layerwise + FP8 MoE) but no fix PR exists
- #38032 / #38446 (QeRL) addressed a different aspect (online quantization composition) and was reverted

## Test plan
- [ ] Reproduce: load FP8 MoE model, call `start_weight_update` + `update_weights` with weights only (no scale_inv), verify NaN before fix
- [ ] After fix: same flow produces valid inference output
- [ ] Normal checkpoint reload (safetensors with scale_inv) still works unchanged

## AI assistance disclosure
This fix was developed with AI assistance (Claude). The human submitter has reviewed all changed lines and understands the fix end-to-end.

Related: #41670