### PR TITLE
[NVFP4 MoE/Deepseek V4] Marlin: wire SwiGLU clamp + allow it for clamped models on non-Blackwell

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -861,6 +861,7 @@ def nvfp4_w4a16_moe_quant_config(
     g2_alphas: torch.Tensor,
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
+    gemm1_clamp_limit: float | None = None,
 ) -> FusedMoEQuantConfig:
     """
     Construct a quant config for 16-but activations and nvp4 weights.
@@ -872,6 +873,7 @@ def nvfp4_w4a16_moe_quant_config(
         g1_alphas=g1_alphas,
         g2_alphas=g2_alphas,
         weight_dtype="nvfp4",
+        gemm1_clamp_limit=gemm1_clamp_limit,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -174,6 +174,7 @@ def select_nvfp4_moe_backend(
 
     NVFP4_BACKENDS_WITH_CLAMP = {
         NvFp4MoeBackend.FLASHINFER_TRTLLM,
+        NvFp4MoeBackend.MARLIN,
     }
 
     if config.swiglu_limit is not None:
@@ -423,6 +424,7 @@ def make_nvfp4_moe_quant_config(
             g2_alphas=w2_scale_2,
             w1_scale=w13_scale,
             w2_scale=w2_scale,
+            gemm1_clamp_limit=swiglu_limit,
         )
     elif backend == NvFp4MoeBackend.EMULATION:
         return nvfp4_moe_quant_config(


### PR DESCRIPTION
## Purpose

Address https://github.com/vllm-project/vllm/issues/45859.

NVFP4 MoE models that declare a SwiGLU clamp (`config.swiglu_limit`, e.g. DeepSeek-V4) cannot be served on any non-Blackwell GPU (SM80/SM89/SM90). `select_nvfp4_moe_backend()` raises:

```
NotImplementedError: No NvFp4 MoE backend supports the deployment configuration.
```

When `swiglu_limit` is set, the selector restricts candidates to `NVFP4_BACKENDS_WITH_CLAMP`, which previously contained only `FLASHINFER_TRTLLM` (Blackwell/SM100-only). On SM80/89/90 that leaves no candidate. The Marlin NVFP4 MoE backend runs on those architectures and its kernel already applies the SwiGLU clamp (`swiglu_limit_func`), but it was excluded from the clamp-capable set and was never handed the clamp value.

This PR wires the clamp through to Marlin and allows it for clamped models on non-Blackwell:

1. `nvfp4_w4a16_moe_quant_config()` accepts `gemm1_clamp_limit` and forwards it to `FusedMoEQuantConfig.make()`.
2. The `MARLIN` branch of `make_nvfp4_moe_quant_config()` passes `gemm1_clamp_limit=swiglu_limit`.
3. `MARLIN` is added to `NVFP4_BACKENDS_WITH_CLAMP`.

All three are required together. Without (1)+(2) the clamp would arrive as `None` and Marlin would silently skip it, producing unclamped (numerically incorrect) output — so adding `MARLIN` to the set alone would be unsafe. With all three, `MarlinExperts` receives `gemm1_clamp_limit` and the kernel applies `swiglu_limit_func` (identical math to `SiluAndMulWithClamp`), reproducing the intended clamped SwiGLU. Unclamped models (`swiglu_limit is None`) are unaffected — the filter is skipped and Marlin is selected as before.

## Test Plan

- Serve an NVFP4 MoE checkpoint that sets `config.swiglu_limit` (DeepSeek-V4-Flash) on a non-Blackwell GPU (SM90 / H100) at TP=4 and TP=8.
- Confirm the model now selects the Marlin NVFP4 MoE backend instead of raising `NotImplementedError: No NvFp4 MoE backend ...`.
- Issue a `/v1/chat/completions` request and verify a correct response.

Sample H100 invocation:
```
  vllm serve nvidia/DeepSeek-V4-Flash-NVFP4 \
    --tokenizer nvidia/DeepSeek-V4-Flash-NVFP4 \
    --served-model-name dsv4flash-nvfp4-sanity \
    --tensor-parallel-size 4 \
    --kv-cache-dtype fp8 \
    --trust-remote-code \
    --max-model-len 16384 \
    --max-num-batched-tokens 2560 \
    --max-num-seqs 1 \
    --gpu-memory-utilization 0.85 \
    --port 8652 \
    --tokenizer-mode deepseek_v4 \
    --reasoning-parser deepseek_v4 \
    --dtype auto
  ```

## Test Result

- **Before:** serving the clamped NVFP4 MoE model on non-Blackwell fails at load with `No NvFp4 MoE backend supports the deployment configuration`.
- **After:** the model loads and serves on H100 (SM90) at TP=4 and TP=8; `/v1/chat/completions` returns `200 OK` with a correct answer (e.g. *"What is the capital of Japan?"* → *"Tokyo"*).

---

This change is self-contained (only `fused_moe/config.py` and `fused_moe/oracle/nvfp4.py`). Serving DeepSeek-V4 end-to-end additionally requires, separately from this MoE-backend fix: sharing tied weights for quantized embeddings or model that use tied embeddings, and an fp8 KV-cache path for the model's MLA attention. (Available on Hopper but not Ampere today)
