### PR TITLE
Skip stop string matching inside <think> blocks

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -355,6 +355,14 @@ class OpenAIServingChat(OpenAIServing):
                 else:
                     reasoning_ended = None
 
+                reasoning_markers = None
+                rp = parser.reasoning_parser if parser is not None else None
+                if rp is not None:
+                    start = rp.reasoning_start_str
+                    end = rp.reasoning_end_str
+                    if start and end:
+                        reasoning_markers = (start, end)
+
                 generator = self.engine_client.generate(
                     engine_input,
                     sampling_params,
@@ -369,6 +377,7 @@ class OpenAIServingChat(OpenAIServing):
                     }
                     if parser is not None and parser.reasoning_parser is not None
                     else None,
+                    reasoning_markers=reasoning_markers,
                 )
 
             generators.append(generator)

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -127,6 +127,7 @@ class EngineCoreRequest(
 
     reasoning_ended: bool | None = None
     reasoning_parser_kwargs: dict[str, Any] | None = None
+    reasoning_markers: tuple[str, str] | None = None
 
     # If True, the request should be added to the scheduler's waiting queue
     # and immediately aborted, so connector-side cleanup runs via the standard

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -294,6 +294,7 @@ class AsyncLLM(EngineClient):
         prompt_text: str | None = None,
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
+        reasoning_markers: tuple[str, str] | None = None,
     ) -> RequestOutputCollector:
         """Add new request to the AsyncLLM."""
 
@@ -364,6 +365,8 @@ class AsyncLLM(EngineClient):
             request.reasoning_ended = reasoning_ended
         if reasoning_parser_kwargs is not None:
             request.reasoning_parser_kwargs = reasoning_parser_kwargs
+        if reasoning_markers is not None:
+            request.reasoning_markers = reasoning_markers
 
         self.input_processor.assign_request_id(request)
 
@@ -538,6 +541,7 @@ class AsyncLLM(EngineClient):
         data_parallel_rank: int | None = None,
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
+        reasoning_markers: tuple[str, str] | None = None,
     ) -> AsyncGenerator[RequestOutput, None]:
         """
         Main function called by the API server to kick off a request
@@ -568,6 +572,7 @@ class AsyncLLM(EngineClient):
                 prompt_text=prompt_text,
                 reasoning_ended=reasoning_ended,
                 reasoning_parser_kwargs=reasoning_parser_kwargs,
+                reasoning_markers=reasoning_markers,
             )
 
             # The output_handler task pushes items into the queue.

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -89,8 +89,24 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
             self.stop_buffer_length = 0
         self._last_output_text_offset: int = 0
 
+        self._reasoning_start: str | None = None
+        self._reasoning_end: str | None = None
+        self._in_reasoning: bool = False
+        if request.reasoning_markers is not None:
+            self._reasoning_start, self._reasoning_end = request.reasoning_markers
+
         # Generation data
         self.output_text = ""
+
+    def _update_reasoning_state(self) -> None:
+        if self._reasoning_start is None:
+            return
+        if not self._in_reasoning:
+            if self._reasoning_start in self.output_text:
+                self._in_reasoning = True
+        if self._in_reasoning:
+            if self._reasoning_end in self.output_text:
+                self._in_reasoning = False
 
     def update(self, new_token_ids: list[int], stop_terminated: bool) -> str | None:
         """
@@ -125,19 +141,21 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
             # Cleanup after skipping detokenization.
             self.token_ids.append(skipped_stop_token_id)
 
-        # 2) Evaluate stop strings.
+        # 2) Evaluate stop strings (skip while inside reasoning block).
+        self._update_reasoning_state()
         stop_string = None
         if self.stop and self.num_output_tokens() > self.min_tokens:
-            stop = check_stop_strings(
-                output_text=self.output_text,
-                new_char_count=len(self.output_text) - stop_check_offset,
-                stop=self.stop,
-                include_in_output=self.include_stop_str_in_output,
-            )
-            if stop is not None:
-                stop_string, truncate_to = stop
-                if truncate_to != -1:
-                    self.output_text = self.output_text[:truncate_to]
+            if not self._in_reasoning:
+                stop = check_stop_strings(
+                    output_text=self.output_text,
+                    new_char_count=len(self.output_text) - stop_check_offset,
+                    stop=self.stop,
+                    include_in_output=self.include_stop_str_in_output,
+                )
+                if stop is not None:
+                    stop_string, truncate_to = stop
+                    if truncate_to != -1:
+                        self.output_text = self.output_text[:truncate_to]
 
         return stop_string
 


### PR DESCRIPTION
## Purpose

check_stop_strings() matches against the full output text including reasoning tokens. If the model's thinking contains a stop string (e.g. "Question:" from lm_eval), generation is killed before any content is produced.

Pass reasoning markers from the serving layer to the detokenizer so it can track <think>/<​/think> boundaries and suppress stop checks while inside a reasoning block.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

