### PR TITLE
[KV Offload] Use background thread for mmap / cpu_tensors pinning

### DIFF
--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import functools
+import threading
 import time
 from collections import deque
 from dataclasses import dataclass
@@ -121,53 +122,48 @@ def compute_sub_block_ptrs(
     output[:] = flat[skip_count : skip_count + num_sub_blocks]
 
 
-def pin_mmap_region(region: SharedOffloadRegion) -> None:
-    """Register the entire mmap as CUDA pinned memory via cudaHostRegister."""
+def pin_tensor(
+    cpu_tensors: list[torch.Tensor],
+    mmap_region: SharedOffloadRegion | None,
+) -> None:
+    """Register the CPU offload memory as CUDA pinned memory."""
     if not current_platform.is_cuda_alike():
         logger.info(
-            "Skipping mmap host registration on %s; cudaHostRegister is only "
+            "Skipping host registration on %s; cudaHostRegister is only "
             "available on CUDA/ROCm.",
             current_platform.device_name,
         )
         return
 
-    rank = region.rank
-
-    base_ptr = region._base.data_ptr()
-    result = torch.cuda.cudart().cudaHostRegister(base_ptr, region.total_size_bytes, 0)
-    if result.value != 0:
-        logger.warning(
-            "cudaHostRegister failed for rank=%d (code=%d) — "
-            "transfers will still work but may be slower (unpinned DMA)",
-            rank,
-            result,
-        )
+    if mmap_region is not None:
+        if mmap_region.is_pinned:
+            logger.debug("Region already pinned; skipping cudaHostRegister for mmap.")
+            return
+        tensors = [(mmap_region._base, f"mmap rank={mmap_region.rank}")]
     else:
-        logger.debug(
-            "cudaHostRegister rank=%d %.2f GB",
-            rank,
-            region.total_size_bytes / 1e9,
-        )
-        region.is_pinned = True
+        tensors = [(tensor, "CPU tensor") for tensor in cpu_tensors]
 
-def pin_cpu_tensors(cpu_tensors: list[torch.Tensor]) -> None:
-    """Register a CPU tensor as CUDA pinned memory via cudaHostRegister."""
-
-    for tensor in cpu_tensors:
-        base_ptr = tensor.data_ptr()
+    for tensor, description in tensors:
         total_size_bytes = tensor.numel() * tensor.element_size()
-        result = torch.cuda.cudart().cudaHostRegister(base_ptr, total_size_bytes, 0)
+        result = torch.cuda.cudart().cudaHostRegister(
+            tensor.data_ptr(), total_size_bytes, 0
+        )
         if result.value != 0:
             logger.warning(
-                "cudaHostRegister failed for CPU tensor (code=%d) — "
-                "transfers will still work but may be slower (unpinned DMA)",
-                result,
+                "cudaHostRegister failed for %s (code=%d) - transfers will "
+                "still work but may be slower (unpinned DMA)",
+                description,
+                result.value,
             )
-        else:
-            logger.debug(
-                "cudaHostRegister CPU tensor %.2f GB",
-                total_size_bytes / 1e9,
-            )
+            continue
+
+        logger.debug(
+            "cudaHostRegister %s %.2f GB",
+            description,
+            total_size_bytes / 1e9,
+        )
+        if mmap_region is not None:
+            mmap_region.is_pinned = True
 
 
 def _new_descriptor_buffers(
@@ -199,6 +195,7 @@ class SingleDirectionOffloadingHandler:
         kv_cache_groups_data_refs: list[list[CanonicalKVCacheRef]],
         gpu_to_cpu: bool,
         mmap_region: SharedOffloadRegion | None = None,
+        pin_thread: threading.Thread | None = None,
     ):
         """
         Initialize a SingleDirectionOffloadingHandler.
@@ -246,6 +243,7 @@ class SingleDirectionOffloadingHandler:
 
         # mmap_region to clean up on shutdown (gpu_to_cpu handler owns it)
         self._mmap_region = mmap_region
+        self._pin_thread = pin_thread
         # job_id -> event
         self._transfer_events: dict[int, torch.Event] = {}
         # queue of transfers (job_id, stream, event)
@@ -471,6 +469,10 @@ class SingleDirectionOffloadingHandler:
                 event.synchronize()
 
     def shutdown(self) -> None:
+        if self._pin_thread is not None:
+            self._pin_thread.join()
+            self._pin_thread = None
+
         while self._transfers:
             transfer = self._transfers.popleft()
             transfer.end_event.synchronize()
@@ -501,9 +503,8 @@ class CPUOffloadingWorker(OffloadingWorker):
         mmap_region: SharedOffloadRegion | None = None,
     ):
         pin_memory = PIN_MEMORY
-        async_pin_memory = pin_memory and current_platform.is_cuda_alike()
         self.pin_thread: threading.Thread | None = None
-        
+
         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
         self._mmap_region = mmap_region
 
@@ -537,25 +538,13 @@ class CPUOffloadingWorker(OffloadingWorker):
             cpu_tensors.append(cpu_tensor)
 
         if pin_memory:
-            if mmap_region is not None:
-                pin_fn = pin_mmap_region
-                pin_args = (mmap_region,)
-                pin_thread_name = "MmapPinThread"
-            else:
-                pin_fn = pin_cpu_tensors
-                pin_args = (cpu_tensors,)
-                pin_thread_name = "CPUTensorsPinThread"
-
-            if async_pin_memory:
-                self.pin_thread = threading.Thread(
-                    target=pin_fn,
-                    args=pin_args,
-                    name=pin_thread_name,
-                )
-                self.pin_thread.start()
-                logger.info("Starting to pin memory in background...")
-            else:
-                pin_fn(*pin_args)
+            self.pin_thread = threading.Thread(
+                target=pin_tensor,
+                args=(cpu_tensors, mmap_region),
+                name="CPUTensorPinThread",
+            )
+            self.pin_thread.start()
+            logger.info("Starting to pin memory in background...")
 
         self._store_handler = SingleDirectionOffloadingHandler(
             gpu_tensors=gpu_tensors,
@@ -564,6 +553,7 @@ class CPUOffloadingWorker(OffloadingWorker):
             kv_cache_groups_data_refs=kv_caches.group_data_refs,
             gpu_to_cpu=True,
             mmap_region=mmap_region,
+            pin_thread=self.pin_thread,
         )
 
         self._load_handler = SingleDirectionOffloadingHandler(
@@ -572,6 +562,7 @@ class CPUOffloadingWorker(OffloadingWorker):
             block_size_factor=block_size_factor,
             kv_cache_groups_data_refs=kv_caches.group_data_refs,
             gpu_to_cpu=False,
+            pin_thread=self.pin_thread,
         )
         
         if self.pin_thread is not None:
@@ -599,3 +590,4 @@ class CPUOffloadingWorker(OffloadingWorker):
     def shutdown(self) -> None:
         self._store_handler.shutdown()
         self._load_handler.shutdown()
+

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -152,6 +152,7 @@ class SingleDirectionOffloadingHandler:
         gpu_to_cpu: bool,
         mmap_region: SharedOffloadRegion | None = None,
         pin_thread: threading.Thread | None = None,
+        manually_pinned_tensors: list[torch.Tensor] | None = None,
     ):
         """
         Initialize a SingleDirectionOffloadingHandler.
@@ -200,6 +201,7 @@ class SingleDirectionOffloadingHandler:
         # mmap_region to clean up on shutdown (gpu_to_cpu handler owns it)
         self._mmap_region = mmap_region
         self._pin_thread = pin_thread
+        self._manually_pinned_tensors = manually_pinned_tensors
         # job_id -> event
         self._transfer_events: dict[int, torch.Event] = {}
         # queue of transfers (job_id, stream, event)
@@ -433,27 +435,25 @@ class SingleDirectionOffloadingHandler:
         self._event_pool.clear()
         self._buffer_pool.clear()
 
+        if self._pin_thread is not None:
+            self._pin_thread.join()
+            self._pin_thread = None
+
+        if self._manually_pinned_tensors is not None:
+            for tensor in self._manually_pinned_tensors:
+                result = torch.cuda.cudart().cudaHostUnregister(tensor.data_ptr())
+                if result.value != 0:
+                    logger.warning(
+                        "cudaHostUnregister failed for CPU tensor (code=%d)",
+                        result.value,
+                    )
+
+        self.src_tensors.clear()
+        self.dst_tensors.clear()
+
         if self._mmap_region is not None:
-            self.src_tensors.clear()
-            self.dst_tensors.clear()
-            if self._pin_thread is not None:
-                self._pin_thread.join()
-                self._pin_thread = None
             self._mmap_region.cleanup()
             self._mmap_region = None
-        else:
-            if self._pin_thread is not None:
-                self._pin_thread.join()
-                self._pin_thread = None
-                for tensor in self.dst_tensors:
-                    result = torch.cuda.cudart().cudaHostUnregister(tensor.data_ptr())
-                    if result.value != 0:
-                        logger.warning(
-                            "cudaHostUnregister failed for CPU tensor (code=%d)",
-                            result.value,
-                        )
-                self.src_tensors.clear()
-                self.dst_tensors.clear()
 
 
 class CPUOffloadingWorker(OffloadingWorker):
@@ -473,6 +473,7 @@ class CPUOffloadingWorker(OffloadingWorker):
     ):
         pin_memory = PIN_MEMORY
         self.pin_thread: threading.Thread | None = None
+        self._manually_pinned_tensors: list[torch.Tensor] = []
 
         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
         self._mmap_region = mmap_region
@@ -494,6 +495,9 @@ class CPUOffloadingWorker(OffloadingWorker):
                     (num_cpu_blocks, cpu_page_size_bytes),
                     dtype=torch.int8,
                     device="cpu",
+                    # CUDA/ROCm memory is registered asynchronously below.
+                    # Pinning here would block worker initialization; other
+                    # hardware need PyTorch allocation-time pinning.
                     pin_memory=PIN_MEMORY and not current_platform.is_cuda_alike(),
                 )
                 logger.debug(
@@ -530,6 +534,7 @@ class CPUOffloadingWorker(OffloadingWorker):
             gpu_to_cpu=True,
             mmap_region=mmap_region,
             pin_thread=self.pin_thread,
+            manually_pinned_tensors=self._manually_pinned_tensors,
         )
 
         self._load_handler = SingleDirectionOffloadingHandler(
@@ -549,6 +554,7 @@ class CPUOffloadingWorker(OffloadingWorker):
             if self._mmap_region is not None
             else self.cpu_tensors
         )
+        num_pinned = 0
         for tensor in tensors_to_pin:
             total_size_bytes = tensor.numel() * tensor.element_size()
             result = torch.cuda.cudart().cudaHostRegister(
@@ -563,6 +569,9 @@ class CPUOffloadingWorker(OffloadingWorker):
                 continue
             if self._mmap_region is not None:
                 self._mmap_region.is_pinned = True
+            else:
+                self._manually_pinned_tensors.append(tensor)
+            num_pinned += 1
 
             logger.debug(
                 "cudaHostRegister pin %.2f GB",
@@ -571,7 +580,7 @@ class CPUOffloadingWorker(OffloadingWorker):
 
         logger.info(
             "Completed CPU memory pinning: %d tensors pinned in %.3f s",
-            len(tensors_to_pin),
+            num_pinned,
             time.monotonic() - t0,
         )
         

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -525,7 +525,7 @@ class CPUOffloadingWorker(OffloadingWorker):
                     dtype=torch.int8,
                     device="cpu",
                 )
-                logger.info(
+                logger.debug(
                     "torch.zeros tensor %d×%d (%.2f GB): %.3f s",
                     num_cpu_blocks,
                     cpu_page_size_bytes,

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -463,7 +463,7 @@ class CPUOffloadingWorker(OffloadingWorker):
         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
         self._mmap_region = mmap_region
 
-        self.gpu_tensors: list[torch.Tensor] = []
+        gpu_tensors: list[torch.Tensor] = []
         self.cpu_tensors: list[torch.Tensor] = []
         for kv_cache_tensor in kv_caches.tensors:
             gpu_page_size_bytes = kv_cache_tensor.page_size_bytes
@@ -489,19 +489,26 @@ class CPUOffloadingWorker(OffloadingWorker):
                     time.monotonic() - t0,
                 )
 
-            self.gpu_tensors.append(gpu_tensor)
+            gpu_tensors.append(gpu_tensor)
             self.cpu_tensors.append(cpu_tensor)
 
         if pin_memory:
-            self.pin_thread = threading.Thread(
-                target=self._pin_tensors,
-                name="CPUTensorPinThread",
-            )
-            self.pin_thread.start()
-            logger.info("Starting to pin memory in background...")
+            if not current_platform.is_cuda_alike():
+                logger.info(
+                    "Skipping host registration on %s; cudaHostRegister is only "
+                    "available on CUDA/ROCm.",
+                    current_platform.device_name,
+                )
+            else:
+                self.pin_thread = threading.Thread(
+                    target=self._pin_cpu_tensors,
+                    name="CPUTensorPinThread",
+                )
+                self.pin_thread.start()
+                logger.info("Starting to pin memory in background...")
 
         self._store_handler = SingleDirectionOffloadingHandler(
-            gpu_tensors=self.gpu_tensors,
+            gpu_tensors=gpu_tensors,
             cpu_tensors=self.cpu_tensors,
             block_size_factor=block_size_factor,
             kv_cache_groups_data_refs=kv_caches.group_data_refs,
@@ -511,25 +518,19 @@ class CPUOffloadingWorker(OffloadingWorker):
         )
 
         self._load_handler = SingleDirectionOffloadingHandler(
-            gpu_tensors=self.gpu_tensors,
+            gpu_tensors=gpu_tensors,
             cpu_tensors=self.cpu_tensors,
             block_size_factor=block_size_factor,
             kv_cache_groups_data_refs=kv_caches.group_data_refs,
             gpu_to_cpu=False,
         )
 
-    def _pin_tensors(self) -> None:
+    def _pin_cpu_tensors(self) -> None:
         """Register the CPU offload memory as CUDA pinned memory."""
-        if not current_platform.is_cuda_alike():
-            logger.info(
-                "Skipping host registration on %s; cudaHostRegister is only "
-                "available on CUDA/ROCm.",
-                current_platform.device_name,
-            )
-            return
 
+        t0 = time.monotonic()
         tensors_to_pin = (
-            self._mmap_region._base
+            [self._mmap_region._base]
             if self._mmap_region is not None
             else self.cpu_tensors
         )
@@ -546,10 +547,18 @@ class CPUOffloadingWorker(OffloadingWorker):
                 )
                 continue
 
-            logger.info(
+            logger.debug(
                 "cudaHostRegister pin %.2f GB",
                 total_size_bytes / 1e9,
             )
+
+        logger.info(
+            "Completed CPU memory pinning: %d tensors pinned in %.3f s",
+            len(tensors_to_pin),
+            time.monotonic() - t0,
+        )
+        if self._mmap_region is not None:
+            self._mmap_region.is_pinned = True
         
         if self.pin_thread is not None:
             self.pin_thread.join()

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -122,50 +122,6 @@ def compute_sub_block_ptrs(
     output[:] = flat[skip_count : skip_count + num_sub_blocks]
 
 
-def pin_tensor(
-    cpu_tensors: list[torch.Tensor],
-    mmap_region: SharedOffloadRegion | None,
-) -> None:
-    """Register the CPU offload memory as CUDA pinned memory."""
-    if not current_platform.is_cuda_alike():
-        logger.info(
-            "Skipping host registration on %s; cudaHostRegister is only "
-            "available on CUDA/ROCm.",
-            current_platform.device_name,
-        )
-        return
-
-    if mmap_region is not None:
-        if mmap_region.is_pinned:
-            logger.debug("Region already pinned; skipping cudaHostRegister for mmap.")
-            return
-        tensors = [(mmap_region._base, f"mmap rank={mmap_region.rank}")]
-    else:
-        tensors = [(tensor, "CPU tensor") for tensor in cpu_tensors]
-
-    for tensor, description in tensors:
-        total_size_bytes = tensor.numel() * tensor.element_size()
-        result = torch.cuda.cudart().cudaHostRegister(
-            tensor.data_ptr(), total_size_bytes, 0
-        )
-        if result.value != 0:
-            logger.warning(
-                "cudaHostRegister failed for %s (code=%d) - transfers will "
-                "still work but may be slower (unpinned DMA)",
-                description,
-                result.value,
-            )
-            continue
-
-        logger.debug(
-            "cudaHostRegister %s %.2f GB",
-            description,
-            total_size_bytes / 1e9,
-        )
-        if mmap_region is not None:
-            mmap_region.is_pinned = True
-
-
 def _new_descriptor_buffers(
     num_copy_ops: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -469,10 +425,6 @@ class SingleDirectionOffloadingHandler:
                 event.synchronize()
 
     def shutdown(self) -> None:
-        if self._pin_thread is not None:
-            self._pin_thread.join()
-            self._pin_thread = None
-
         while self._transfers:
             transfer = self._transfers.popleft()
             transfer.end_event.synchronize()
@@ -482,6 +434,9 @@ class SingleDirectionOffloadingHandler:
         self._buffer_pool.clear()
         self.src_tensors.clear()
         self.dst_tensors.clear()
+        if self._pin_thread is not None:
+            self._pin_thread.join()
+            self._pin_thread = None
         if self._mmap_region is not None:
             self._mmap_region.cleanup()
             self._mmap_region = None
@@ -508,8 +463,8 @@ class CPUOffloadingWorker(OffloadingWorker):
         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
         self._mmap_region = mmap_region
 
-        gpu_tensors: list[torch.Tensor] = []
-        cpu_tensors: list[torch.Tensor] = []
+        self.gpu_tensors: list[torch.Tensor] = []
+        self.cpu_tensors: list[torch.Tensor] = []
         for kv_cache_tensor in kv_caches.tensors:
             gpu_page_size_bytes = kv_cache_tensor.page_size_bytes
             gpu_tensor = kv_cache_tensor.tensor.view(torch.int8).view(
@@ -534,21 +489,20 @@ class CPUOffloadingWorker(OffloadingWorker):
                     time.monotonic() - t0,
                 )
 
-            gpu_tensors.append(gpu_tensor)
-            cpu_tensors.append(cpu_tensor)
+            self.gpu_tensors.append(gpu_tensor)
+            self.cpu_tensors.append(cpu_tensor)
 
         if pin_memory:
             self.pin_thread = threading.Thread(
-                target=pin_tensor,
-                args=(cpu_tensors, mmap_region),
+                target=self._pin_tensors,
                 name="CPUTensorPinThread",
             )
             self.pin_thread.start()
             logger.info("Starting to pin memory in background...")
 
         self._store_handler = SingleDirectionOffloadingHandler(
-            gpu_tensors=gpu_tensors,
-            cpu_tensors=cpu_tensors,
+            gpu_tensors=self.gpu_tensors,
+            cpu_tensors=self.cpu_tensors,
             block_size_factor=block_size_factor,
             kv_cache_groups_data_refs=kv_caches.group_data_refs,
             gpu_to_cpu=True,
@@ -557,13 +511,45 @@ class CPUOffloadingWorker(OffloadingWorker):
         )
 
         self._load_handler = SingleDirectionOffloadingHandler(
-            gpu_tensors=gpu_tensors,
-            cpu_tensors=cpu_tensors,
+            gpu_tensors=self.gpu_tensors,
+            cpu_tensors=self.cpu_tensors,
             block_size_factor=block_size_factor,
             kv_cache_groups_data_refs=kv_caches.group_data_refs,
             gpu_to_cpu=False,
-            pin_thread=self.pin_thread,
         )
+
+    def _pin_tensors(self) -> None:
+        """Register the CPU offload memory as CUDA pinned memory."""
+        if not current_platform.is_cuda_alike():
+            logger.info(
+                "Skipping host registration on %s; cudaHostRegister is only "
+                "available on CUDA/ROCm.",
+                current_platform.device_name,
+            )
+            return
+
+        tensors_to_pin = (
+            self._mmap_region._base
+            if self._mmap_region is not None
+            else self.cpu_tensors
+        )
+        for tensor in tensors_to_pin:
+            total_size_bytes = tensor.numel() * tensor.element_size()
+            result = torch.cuda.cudart().cudaHostRegister(
+                tensor.data_ptr(), total_size_bytes, 0
+            )
+            if result.value != 0:
+                logger.warning(
+                    "cudaHostRegister failed for host tensor (code=%d) "
+                    "- transfers will still work but may be slower (unpinned DMA)",
+                    result.value,
+                )
+                continue
+
+            logger.info(
+                "cudaHostRegister pin %.2f GB",
+                total_size_bytes / 1e9,
+            )
         
         if self.pin_thread is not None:
             self.pin_thread.join()

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 
 import numpy as np
 import torch
-import threading
 
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
@@ -583,10 +582,7 @@ class CPUOffloadingWorker(OffloadingWorker):
             num_pinned,
             time.monotonic() - t0,
         )
-        
-        if self.pin_thread is not None:
-            self.pin_thread.join()
-            logger.info("Background pin memory finished.")
+
     def submit_store(
         self, job_id: int, src_spec: GPULoadStoreSpec, dst_spec: LoadStoreSpec
     ) -> bool:
@@ -609,4 +605,3 @@ class CPUOffloadingWorker(OffloadingWorker):
     def shutdown(self) -> None:
         self._store_handler.shutdown()
         self._load_handler.shutdown()
-

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 import numpy as np
 import torch
+import threading
 
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
@@ -148,6 +149,25 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
             region.total_size_bytes / 1e9,
         )
         region.is_pinned = True
+
+def pin_cpu_tensors(cpu_tensors: list[torch.Tensor]) -> None:
+    """Register a CPU tensor as CUDA pinned memory via cudaHostRegister."""
+
+    for tensor in cpu_tensors:
+        base_ptr = tensor.data_ptr()
+        total_size_bytes = tensor.numel() * tensor.element_size()
+        result = torch.cuda.cudart().cudaHostRegister(base_ptr, total_size_bytes, 0)
+        if result.value != 0:
+            logger.warning(
+                "cudaHostRegister failed for CPU tensor (code=%d) — "
+                "transfers will still work but may be slower (unpinned DMA)",
+                result,
+            )
+        else:
+            logger.debug(
+                "cudaHostRegister CPU tensor %.2f GB",
+                total_size_bytes / 1e9,
+            )
 
 
 def _new_descriptor_buffers(
@@ -481,9 +501,11 @@ class CPUOffloadingWorker(OffloadingWorker):
         mmap_region: SharedOffloadRegion | None = None,
     ):
         pin_memory = PIN_MEMORY
+        async_pin_memory = pin_memory and current_platform.is_cuda_alike()
+        self.pin_thread: threading.Thread | None = None
+        
         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
-        if mmap_region is not None and pin_memory:
-            pin_mmap_region(mmap_region)
+        self._mmap_region = mmap_region
 
         gpu_tensors: list[torch.Tensor] = []
         cpu_tensors: list[torch.Tensor] = []
@@ -502,10 +524,9 @@ class CPUOffloadingWorker(OffloadingWorker):
                     (num_cpu_blocks, cpu_page_size_bytes),
                     dtype=torch.int8,
                     device="cpu",
-                    pin_memory=pin_memory,
                 )
-                logger.debug(
-                    "torch.zeros pinned tensor %d×%d (%.2f GB): %.3f s",
+                logger.info(
+                    "torch.zeros tensor %d×%d (%.2f GB): %.3f s",
                     num_cpu_blocks,
                     cpu_page_size_bytes,
                     num_cpu_blocks * cpu_page_size_bytes / 1e9,
@@ -514,6 +535,27 @@ class CPUOffloadingWorker(OffloadingWorker):
 
             gpu_tensors.append(gpu_tensor)
             cpu_tensors.append(cpu_tensor)
+
+        if pin_memory:
+            if mmap_region is not None:
+                pin_fn = pin_mmap_region
+                pin_args = (mmap_region,)
+                pin_thread_name = "MmapPinThread"
+            else:
+                pin_fn = pin_cpu_tensors
+                pin_args = (cpu_tensors,)
+                pin_thread_name = "CPUTensorsPinThread"
+
+            if async_pin_memory:
+                self.pin_thread = threading.Thread(
+                    target=pin_fn,
+                    args=pin_args,
+                    name=pin_thread_name,
+                )
+                self.pin_thread.start()
+                logger.info("Starting to pin memory in background...")
+            else:
+                pin_fn(*pin_args)
 
         self._store_handler = SingleDirectionOffloadingHandler(
             gpu_tensors=gpu_tensors,
@@ -531,7 +573,10 @@ class CPUOffloadingWorker(OffloadingWorker):
             kv_cache_groups_data_refs=kv_caches.group_data_refs,
             gpu_to_cpu=False,
         )
-
+        
+        if self.pin_thread is not None:
+            self.pin_thread.join()
+            logger.info("Background pin memory finished.")
     def submit_store(
         self, job_id: int, src_spec: GPULoadStoreSpec, dst_spec: LoadStoreSpec
     ) -> bool:

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -432,14 +432,28 @@ class SingleDirectionOffloadingHandler:
         self._stream_pool.clear()
         self._event_pool.clear()
         self._buffer_pool.clear()
-        self.src_tensors.clear()
-        self.dst_tensors.clear()
-        if self._pin_thread is not None:
-            self._pin_thread.join()
-            self._pin_thread = None
+
         if self._mmap_region is not None:
+            self.src_tensors.clear()
+            self.dst_tensors.clear()
+            if self._pin_thread is not None:
+                self._pin_thread.join()
+                self._pin_thread = None
             self._mmap_region.cleanup()
             self._mmap_region = None
+        else:
+            if self._pin_thread is not None:
+                self._pin_thread.join()
+                self._pin_thread = None
+                for tensor in self.dst_tensors:
+                    result = torch.cuda.cudart().cudaHostUnregister(tensor.data_ptr())
+                    if result.value != 0:
+                        logger.warning(
+                            "cudaHostUnregister failed for CPU tensor (code=%d)",
+                            result.value,
+                        )
+                self.src_tensors.clear()
+                self.dst_tensors.clear()
 
 
 class CPUOffloadingWorker(OffloadingWorker):

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -480,6 +480,7 @@ class CPUOffloadingWorker(OffloadingWorker):
                     (num_cpu_blocks, cpu_page_size_bytes),
                     dtype=torch.int8,
                     device="cpu",
+                    pin_memory=PIN_MEMORY and not current_platform.is_cuda_alike(),
                 )
                 logger.debug(
                     "torch.zeros tensor %d×%d (%.2f GB): %.3f s",
@@ -546,6 +547,8 @@ class CPUOffloadingWorker(OffloadingWorker):
                     result.value,
                 )
                 continue
+            if self._mmap_region is not None:
+                self._mmap_region.is_pinned = True
 
             logger.debug(
                 "cudaHostRegister pin %.2f GB",
@@ -557,8 +560,6 @@ class CPUOffloadingWorker(OffloadingWorker):
             len(tensors_to_pin),
             time.monotonic() - t0,
         )
-        if self._mmap_region is not None:
-            self._mmap_region.is_pinned = True
         
         if self.pin_thread is not None:
             self.pin_thread.join()


### PR DESCRIPTION
## Purpose
This pull request introduces improvements to how CPU tensors / mmap are pinned for CUDA transfers in `vllm/v1/kv_offload/cpu/gpu_worker.py`, including asynchronous pinning for better startup performance. The changes add a dedicated function for pinning CPU tensors, enable background pinning on CUDA platforms, and ensure logging and synchronization of the pinning process at the end of `CpuGpuOffloadingHandlers.__init__`.

Partial #33689.

**Memory Pinning Improvements:**

* Added a new function, `pin_cpu_tensors`, to explicitly register CPU tensors as CUDA pinned memory using `cudaHostRegister` for  pinning operations.
* Refactored the memory pinning logic in the `__init__` method to support asynchronous pinning (via a background thread) when running on CUDA platforms, improving startup time for large memory allocations. 
* Ensured that the main thread waits for the background pinning thread to finish before proceeding, guaranteeing pinned memory is ready before use.
* Improved logging to provide clearer status updates on the pinning process and potential warnings if pinning fails.

**Code Cleanliness:**

* Removed the use of `pin_memory` in `torch.zeros` for CPU tensors, since explicit pinning is now handled separately.

## Test Plan

- Run KV offloading unit tests
- Run a benchmark using Llama-3.1-8B with CPU offloading enabled and a 200 GB CPU offloading buffer.
- Verify that:
  mmap regions are pinned successfully;
  CPU tensors are pinned successfully;
  the background pinning thread is joined before the first offload operation.

## Test Result

All KV offloading unit tests pass.

Benchmark setup:

- Model: Llama-3.1-8B-Instruct
- CPU offloading buffer: 200 GB
- Attention backend: auto

| Implementation | Avg startup time (s) | Speedup |
|----------------|----------------------|---------|
| Before | 135.633 | 1.0× |
| After (background pinning) | 64.824 | 2.09× |

The improvement is especially noticeable when CPU offloading allocates a large amount of pinned memory (e.g., hundreds of GBs), where synchronous pinning dominates engine startup time.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
