### PR TITLE
[Bugfix] fix _load_weights_other in gpt_oss.py

### DIFF
--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -984,6 +984,8 @@ class GptOssModel(nn.Module, EagleModelMixin):
             if is_pp_missing_parameter(name, self):
                 continue
 
+            routed_name = name.replace(".mlp.experts.", ".mlp.experts.routed_experts.")
+
             if ".w13_weight" in name:
                 # Handle MLP gate and up projection weights
                 # Extract gate and up projection parts
@@ -993,10 +995,10 @@ class GptOssModel(nn.Module, EagleModelMixin):
                     narrow_weight = weight[:, :, 2 * tp_rank_start : 2 * tp_rank_end]
 
                 narrow_weight = narrow_weight.permute(0, 2, 1).contiguous()
-                param = params_dict[name]
+                param = params_dict[routed_name]
 
                 param.copy_(narrow_weight)
-                loaded_params.add(name)
+                loaded_params.add(routed_name)
                 continue
             elif ".w2_weight" in name:
                 # Handle MLP down projection weights
@@ -1005,10 +1007,10 @@ class GptOssModel(nn.Module, EagleModelMixin):
                 else:
                     narrow_weight = weight[:, tp_rank_start:tp_rank_end, :]
                 narrow_weight = narrow_weight.permute(0, 2, 1).contiguous()
-                param = params_dict[name]
+                param = params_dict[routed_name]
 
                 param.copy_(narrow_weight)
-                loaded_params.add(name)
+                loaded_params.add(routed_name)
                 continue
             elif ".w13_bias" in name:
                 # Handle MLP gate and up projection biases
@@ -1018,9 +1020,9 @@ class GptOssModel(nn.Module, EagleModelMixin):
                 else:
                     narrow_weight = weight[:, 2 * tp_rank_start : 2 * tp_rank_end]
 
-                param = params_dict[name]
+                param = params_dict[routed_name]
                 param.copy_(narrow_weight)
-                loaded_params.add(name)
+                loaded_params.add(routed_name)
                 continue
             elif ".w2_bias" in name:
                 # Handle MLP down projection bias
@@ -1030,9 +1032,9 @@ class GptOssModel(nn.Module, EagleModelMixin):
                     # (only load on rank 0 to avoid duplication)
                     if tp_rank != 0:
                         weight.zero_()
-                param = params_dict[name]
+                param = params_dict[routed_name]
                 param.copy_(weight)
-                loaded_params.add(name)
+                loaded_params.add(routed_name)
                 continue
             elif "sinks" in name:
                 # Handle attention sinks (distributed across ranks)


### PR DESCRIPTION

## Purpose

Fix for #45830.  Replace ".mlp.experts." with ".mlp.experts.routed_experts." in `_load_weights_other`.

## Test Plan

Verified that `vllm serve unsloth/gpt-oss-20b-BF16 --dtype bfloat16 --trust-remote-code` passes weight loading.

## Test Result

The model loads.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

