### PR TITLE
[Misc] Update Mergify tool-calling label 

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -388,9 +388,13 @@ pull_request_rules:
     - or:
       - files~=^tests/tool_use/
       - files~=^tests/tool_parsers/
+      - files~=^tests/parser/
+      - files~=^tests/reasoning/
       - files~=^tests/entrypoints/openai/.*tool.*
       - files~=^tests/entrypoints/anthropic/.*tool.*
       - files~=^vllm/tool_parsers/
+      - files~=^vllm/parser/
+      - files~=^vllm/reasoning/
       - files=docs/features/tool_calling.md
       - files~=^examples/tool_calling/
   actions:


### PR DESCRIPTION
## Purpose
PRs that touch vllm/parser/, vllm/reasoning/, tests/parser/, or tests/reasoning/ are closely related to tool-calling but weren't getting the tool-calling label automatically. This adds those directories to the Mergify labeling rule so they're tagged consistently.