### PR TITLE
[Bugfix] DeepSeek V4: recover tool calls within reasoning content

### DIFF
--- a/tests/tool_parsers/test_deepseekv4_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv4_tool_parser.py
@@ -16,6 +16,10 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionToolsParam,
     FunctionDefinition,
 )
+from vllm.parser.abstract_parser import DelegatingParser
+from vllm.reasoning.deepseek_v3_reasoning_parser import (
+    DeepSeekV3ReasoningWithThinkingParser,
+)
 from vllm.tool_parsers import ToolParserManager
 from vllm.tool_parsers.deepseekv4_tool_parser import DeepSeekV4ToolParser
 
@@ -350,3 +354,130 @@ def test_composed_schema_converts_object_and_array_params():
         "wait": {"type": "for", "minutes": 2880},
         "patches": [{"op": "replace", "path": "/schedule", "value": "quiet"}],
     }
+
+
+# ---------------------------------------------------------------------------
+# In-reasoning tool-call recovery (missing </think>) regression.
+#
+# The model occasionally omits </think> before a <｜DSML｜tool_calls> block.
+# Reasoning extraction is gated on </think>, so the whole block stays in the
+# reasoning channel, the tool parser never sees it, and the tool call is
+# silently lost (finish_reason=stop, empty content).
+#
+# These exercise the *composed* DelegatingParser (reasoning + tool), since the
+# bug lives in that interaction rather than in the tool parser alone. They are
+# CPU-only and need no model download (stub tokenizer supplies the think vocab).
+# ---------------------------------------------------------------------------
+
+
+class _V4Parser(DelegatingParser):
+    """Mirrors what ParserManager composes for the `deepseek_v4` model."""
+
+    reasoning_parser_cls = DeepSeekV3ReasoningWithThinkingParser
+    tool_parser_cls = DeepSeekV4ToolParser
+
+
+def make_full_parser() -> _V4Parser:
+    tokenizer = MagicMock()
+    # The reasoning parser only needs these tokens to exist in the vocab;
+    # non-streaming parse() is string-based so the ids are arbitrary.
+    tokenizer.get_vocab.return_value = {"<think>": 1, "</think>": 2}
+    return _V4Parser(tokenizer)
+
+
+def make_auto_request() -> MagicMock:
+    req = MagicMock()
+    req.tools = None
+    req.tool_choice = "auto"
+    req.request_id = "test-missing-think-close"
+    return req
+
+
+def stream_full(
+    parser: _V4Parser,
+    full_text: str,
+    request: MagicMock,
+    chunk_size: int = 7,
+) -> list:
+    """Drive the composed parser's streaming entry point chunk by chunk.
+
+    Mirrors a prefilled `<think>` generation: the prompt carries the think
+    start token (id 1) so the parser begins in the reasoning phase, and the
+    generated deltas never contain the `</think>` end token (id 2) -- exactly
+    the missing-`</think>` shape. Placeholder id 3 stands in for ordinary
+    (non-special) generated tokens.
+    """
+    deltas = []
+    n = len(full_text)
+    for start in range(0, n, chunk_size):
+        delta_text = full_text[start : start + chunk_size]
+        delta = parser.parse_delta(
+            delta_text=delta_text,
+            delta_token_ids=[3],
+            request=request,
+            prompt_token_ids=[1] if start == 0 else None,
+            finished=start + chunk_size >= n,
+        )
+        if delta is not None:
+            deltas.append(delta)
+    return deltas
+
+
+def reconstruct_tool_names(deltas) -> list[str]:
+    return [
+        tool_call.function.name
+        for delta in deltas
+        if delta.tool_calls
+        for tool_call in delta.tool_calls
+        if tool_call.function and tool_call.function.name
+    ]
+
+
+def test_tool_call_without_think_close_is_recovered():
+    """Regression: a complete DSML tool block with NO preceding `</think>`.
+
+    The block would otherwise stay inside `reasoning` with empty content and
+    the tool call silently lost. The guarded non-streaming recovery promotes it
+    to a real tool call and keeps the leading prose as reasoning.
+    """
+    parser = make_full_parser()
+    # No </think> anywhere: the canonical lost-tool-call shape.
+    model_output = "Let me check.\n\n" + build_tool_call(
+        "terminal", {"command": "git --no-pager log -1"}
+    )
+
+    reasoning, content, tool_calls = parser.parse(
+        model_output, make_auto_request(), enable_auto_tools=True
+    )
+
+    assert tool_calls and len(tool_calls) == 1
+    assert tool_calls[0].name == "terminal"
+    assert json.loads(tool_calls[0].arguments) == {"command": "git --no-pager log -1"}
+    # Reasoning prose is kept, but the DSML block must not remain inside it.
+    assert reasoning is not None and TC_START not in reasoning
+
+
+def test_tool_call_without_think_close_is_recovered_streaming():
+    """Streaming counterpart of the in-reasoning (missing-`</think>`) recovery.
+
+    Same canonical lost-tool-call shape, but fed through ``parse_delta`` chunk
+    by chunk. Because no ``</think>`` token ever arrives, the reasoning channel
+    never ends on its own; the recovery detects the ``<｜DSML｜tool_calls>``
+    marker mid-stream (buffering partial markers across chunks), stops reasoning
+    right before it, and routes the block to the tool-call phase so it surfaces
+    as a real tool call instead of being streamed as reasoning.
+    """
+    parser = make_full_parser()
+    request = make_auto_request()
+    # No </think> anywhere: the canonical lost-tool-call shape.
+    full_text = "Let me check.\n\n" + build_tool_call(
+        "terminal", {"command": "git --no-pager log -1"}
+    )
+
+    deltas = stream_full(parser, full_text, request, chunk_size=5)
+
+    assert reconstruct_tool_names(deltas) == ["terminal"]
+    assert json.loads(reconstruct_args(deltas)) == {"command": "git --no-pager log -1"}
+    # The DSML block must not leak into the streamed reasoning channel.
+    streamed_reasoning = "".join(delta.reasoning for delta in deltas if delta.reasoning)
+    assert TC_START not in streamed_reasoning

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -32,6 +32,7 @@ from vllm.tool_parsers.streaming import (
     extract_named_tool_call_streaming,
     extract_required_tool_call_streaming,
 )
+from vllm.tool_parsers.utils import partial_tag_overlap
 
 logger = init_logger(__name__)
 
@@ -47,6 +48,9 @@ class StreamState:
     previous_token_ids: list[int] = field(default_factory=list)
     history_tool_call_cnt: int = 0
     tool_call_id_type: str = "random"
+    # Reasoning text temporarily withheld from output because it might be the
+    # start of a tool-call start marker appearing inside the reasoning stream.
+    pending_reasoning: str = ""
     # only used for "required" and "named tool" choices,
     # tracks whether function name has been fully returned in the stream yet
     function_name_returned: bool = False
@@ -739,7 +743,148 @@ class DelegatingParser(Parser):
             request=request,
             enable_auto_tools=enable_auto_tools,
         )
+
+        # In-reasoning tool-call recovery: Check whether the model emitted a
+        # tool-call without first closing the reasoning channel. If nothing else
+        # was parsed, re-run the tool parser over the reasoning tail and promote
+        # a balanced block.
+        if not tool_calls and self._can_recover_in_reasoning_tool_calls(
+            request, content, enable_auto_tools
+        ):
+            recovered, reasoning = self._recover_tool_calls_from_reasoning(
+                reasoning, request
+            )
+            if recovered:
+                tool_calls = recovered
+
         return reasoning, content, tool_calls
+
+    def _can_recover_in_reasoning_tool_calls(
+        self,
+        request: ChatCompletionRequest | ResponsesRequest,
+        content: str | None,
+        enable_auto_tools: bool,
+    ) -> bool:
+        if self._tool_parser is None or not enable_auto_tools:
+            return False
+        if request.tool_choice not in ("auto", None):
+            return False
+        if content is not None and content.strip():
+            return False
+        return self._tool_parser_recovers_in_reasoning()
+
+    def _tool_parser_recovers_in_reasoning(self) -> bool:
+        tp = self._tool_parser
+        return bool(
+            tp is not None
+            and tp.recovers_tool_calls_in_reasoning
+            and tp.tool_call_start_token
+            and tp.tool_call_end_token
+        )
+
+    def _recover_tool_calls_from_reasoning(
+        self,
+        reasoning: str | None,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> tuple[list[FunctionCall] | None, str | None]:
+        """Promote a tool-call block emitted inside the reasoning channel.
+
+        Requires a *balanced* `<...tool_calls>...</...tool_calls>` block so we
+        never promote half-formed output or a marker the model merely mentioned
+        while reasoning. Returns the recovered calls and the leftover reasoning
+        prose (the text that preceded the block); on no-op the reasoning is
+        returned unchanged.
+        """
+        tool_parser = self._tool_parser
+        assert tool_parser is not None
+        start = tool_parser.tool_call_start_token
+        end = tool_parser.tool_call_end_token
+        if not start or not end:
+            return None, reasoning
+        if not reasoning or start not in reasoning or end not in reasoning:
+            return None, reasoning
+
+        info = tool_parser.extract_tool_calls(reasoning, request)  # type: ignore[arg-type]
+        if info is None or not info.tools_called:
+            return None, reasoning
+
+        recovered = [
+            FunctionCall(
+                id=tc.id,
+                name=tc.function.name,
+                arguments=tc.function.arguments,
+            )
+            for tc in info.tool_calls
+        ]
+        # The prose before the block was genuine reasoning; keep it as such.
+        new_reasoning = info.content
+        if new_reasoning and not new_reasoning.strip():
+            new_reasoning = None
+        return recovered, new_reasoning
+
+    def _intercept_in_reasoning_tool_marker(
+        self,
+        state: "StreamState",
+        delta_message: DeltaMessage | None,
+        finished: bool,
+    ) -> tuple[DeltaMessage | None, str, bool]:
+        """Detect a tool-call start marker emitted while still reasoning.
+
+        Streaming counterpart of :meth:`_recover_tool_calls_from_reasoning`.
+        When the model omits a reasoning end marker before a ``<...tool_calls>``
+        block, the block would otherwise be streamed out as reasoning and the
+        tool call lost. This watches the reasoning stream for the start marker,
+        buffering any trailing partial-marker text so it is never leaked as
+        reasoning.
+
+        Returns ``(delta_message, carry_text, ended)``. When ``ended`` is True,
+        the reasoning delta has been trimmed to stop right before the marker and
+        ``carry_text`` (marker + trailing text) should be handed to the
+        tool-call phase. Only applies to tool parsers that opt in via
+        ``recovers_tool_calls_in_reasoning``; others are left untouched.
+        """
+        if not self._tool_parser_recovers_in_reasoning():
+            return delta_message, "", False
+        tool_parser = self._tool_parser
+        assert tool_parser is not None
+        start = tool_parser.tool_call_start_token
+        assert start is not None
+
+        reasoning_delta = (
+            delta_message.reasoning if delta_message and delta_message.reasoning else ""
+        )
+        # Nothing buffered and nothing new to inspect: leave the delta as-is.
+        if not reasoning_delta and not state.pending_reasoning:
+            return delta_message, "", False
+
+        buf = state.pending_reasoning + reasoning_delta
+        idx = buf.find(start)
+        if idx != -1:
+            # Full marker found: emit reasoning up to it, hand off the rest.
+            state.pending_reasoning = ""
+            emitted = buf[:idx]
+            carry = buf[idx:]
+            if delta_message is None:
+                delta_message = DeltaMessage()
+            delta_message.reasoning = emitted or None
+            delta_message.content = None
+            return delta_message, carry, True
+
+        # No full marker. Withhold any trailing run that could begin one, unless
+        # the stream has finished (in which case it was never a marker).
+        overlap = 0 if finished else partial_tag_overlap(buf, start)
+        emitted = buf[: len(buf) - overlap] if overlap else buf
+        state.pending_reasoning = buf[len(buf) - overlap :] if overlap else ""
+
+        if not emitted:
+            # Everything is withheld this round; emit no reasoning.
+            if delta_message is not None:
+                delta_message.reasoning = None
+            return delta_message, "", False
+        if delta_message is None:
+            delta_message = DeltaMessage()
+        delta_message.reasoning = emitted
+        return delta_message, "", False
 
     def parse_delta(
         self,
@@ -801,6 +946,22 @@ class DelegatingParser(Parser):
                         else ""
                     )
                     delta_text = current_text
+            else:
+                # In-reasoning tool-call recovery: Check whether the model
+                # emitted a tool-call marker without first closing the reasoning
+                # channel. Detect it mid-stream, stop reasoning right before it,
+                # and hand the marker (plus the rest) to the tool-call phase
+                # below.
+                delta_message, carry_text, marker_ended = (
+                    self._intercept_in_reasoning_tool_marker(
+                        state, delta_message, finished=finished
+                    )
+                )
+                if marker_ended:
+                    state.reasoning_ended = True
+                    current_text = carry_text
+                    delta_text = carry_text
+                    delta_token_ids = current_token_ids
 
         # Tool call extraction
         if self._in_tool_call_phase(state):

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -70,6 +70,21 @@ class ToolParser:
         ):
             cls.supports_required_and_named = False
 
+    # The literal tokens that wrap a tool-call block, when the model's format
+    # uses them. Optional: only parsers whose grammar has explicit start/end
+    # markers set these.
+    tool_call_start_token: str | None = None
+    tool_call_end_token: str | None = None
+
+    # Opt in to in-reasoning tool-call recovery. Some models occasionally emit
+    # a complete tool-call block without first closing the reasoning channel
+    # (a missing </think>), which would otherwise leave the block inside the
+    # reasoning output and lose the tool call. When True, DelegatingParser is
+    # allowed to treat tool_call_start_token as an implicit reasoning boundary
+    # and route the block to this parser. Requires tool_call_start_token and
+    # tool_call_end_token to be set.
+    recovers_tool_calls_in_reasoning: bool = False
+
     def __init__(
         self,
         tokenizer: TokenizerLike,

--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -54,6 +54,11 @@ class DeepSeekV32ToolParser(ToolParser):
     tool_call_start_token: str = "<｜DSML｜function_calls>"
     tool_call_end_token: str = "</｜DSML｜function_calls>"
     structural_tag_model = "deepseek_v3_2"
+    # Workaround for a model defect: DeepSeek occasionally emits a tool-call
+    # block without first closing reasoning (a missing </think>), which would
+    # otherwise leave the block inside reasoning and lose the call. Opt in so
+    # DelegatingParser can recover it.
+    recovers_tool_calls_in_reasoning: bool = True
 
     def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
         super().__init__(tokenizer, tools)


### PR DESCRIPTION
## Purpose

NOTE: This was developed with the help of Claude Opus 4.8

DeepSeek-V4-Flash (and likely also the Pro variant) occasionally omits the closing `</think>` before emitting a `<｜DSML｜tool_calls>` block. This is a model bug: the [chat template / encoder](https://github.com/vllm-project/vllm/blob/f2beaa80c8d672dc45c3313e0c8b2cec5a9b3ee3/rust/src/chat/src/renderer/deepseek_v4/encoding.rs#L246) explicitly instructs it to output its complete reasoning inside `<think>... </think>` BEFORE any tool calls or final response, and the model intermittently fails to follow that instruction. Reasoning extraction is gated on `</think>`, so when it is missing the entire tool-call block stays in the reasoning channel, the tool parser never sees it, and the call is silently lost (finish_reason=stop, empty content). [DeepSeek V4's own encoding README](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/encoding/README.md#quick-start) notes the model can emit malformed output and that production needs "additional error handling".

Workaround: a narrow, opt-in recovery in DelegatingParser that salvages a tool-call block left in the reasoning stream and promotes it to a real tool call. This is deliberately scoped as recovery from malformed model output: </think> remains the only reasoning terminator; the tool-call marker is not added to the reasoning grammar.

- ToolParser gains tool_call_start_token / tool_call_end_token and an opt-in recovers_tool_calls_in_reasoning flag, so the generic composition code keys off the declared interface instead of sniffing subclass internals. DeepSeekV32ToolParser (and thus V4) opts in.
- Non-streaming: when auto tool-choice parsed zero tool calls and produced no content, and the reasoning tail contains a *balanced* start/end tool-call block, re-run the tool parser over it and keep the preceding prose as reasoning. The balance requirement avoids promoting half-formed output or a marker the model merely mentioned.
- Streaming: watch the reasoning stream for the start marker, buffering partial markers across chunks so they never leak as reasoning; on a full marker, end reasoning right before it and route the remainder to the tool-call phase.
- Tests exercise the composed reasoning+tool DelegatingParser with a stub tokenizer for both the non-streaming and streaming missing-</think> shapes.

### Relation to existing PRs

This is not a duplicate of any open PR:

- #39055 ("Fix Qwen3 reasoning tool calls embedded inside think") targets the same *class* of bug — tool calls lost inside `<think>` reasoning — but for **Qwen3/Qwen3.5**, implemented in the **reasoning parser** (`qwen3_reasoning_parser.py`) and only for the non-streaming path. This PR is for **DeepSeek V4/V3.2**, lives in the generic `DelegatingParser` composition layer behind an opt-in `recovers_tool_calls_in_reasoning` flag, covers **both streaming and non-streaming**, and deliberately does **not** turn the tool-call marker into a reasoning terminator (`</think>` stays the only terminator). The two are complementary, not overlapping; happy to align on a shared abstraction if maintainers prefer.
- #45451 ("[Draft] Use Dynamo parser for DeepSeek V4") swaps in the Rust Dynamo parser behind an experimental env flag and does not touch this Python recovery path.
- #45413 ("[Frontend] Add Streaming Parser Engine and new Qwen3 Parser") - already merged, mentions future work to port DeepSeek V4 parser to the new engine. This is orthogonal, but future refactors should take into account this model behavior bug.

## Test Plan

```
.venv/bin/python -m pytest tests/parser tests/tool_parsers tests/reasoning \
  -p no:cacheprovider -o addopts="" -n 32 -ra \
  --timeout=60 --timeout-method=thread \
  --junit-xml=/tmp/after.xml
```

Furthermore, multiple people from the RTX Pro 6000 Discord community have been testing a backport of this patch to pre-[#45413](https://github.com/vllm-project/vllm/pull/45413) code state in production with DeepSeek V4 Flash: https://github.com/procr1337/vllm/pull/1

## Test Result

No issues or regressions reported from production testing.

Unit test results:

| Run | Tests | Passed | Failed | Errored | Skipped |
|-----|-------|--------|--------|---------|---------|
| before (`f2beaa80c`) | 3089 | 2806 | 50 | 198 | 35 |
| after (this PR) | 3091 | 2890 | 50 | 116 | 35 |

**Per-test before→after diff:**
- **0 genuine regressions.** The diff flagged 2 pass→fail tests, both in `test_mistral_tool_parser.py` (untouched by this PR) and both `error` on setup from `huggingface_hub.HfHubHTTPError` (HF Hub rate-limiting) / `xdist` worker crashes. 84 *other* tests flipped the opposite way (errored before, passed after) — confirming the `errors` column is nondeterministic network/load flakiness, not code. Re-running the 2 flagged tests in isolation: **both pass.**
- **+2 new tests** added by this PR: **pass.**

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>