### PR TITLE
Add extensible engine core outputs for OOT backends

### DIFF
--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -198,6 +198,8 @@ class EngineCoreOutput(
     # A value greater than 0 indicates that the output is corrupted.
     num_nans_in_logits: int = 0
 
+    custom_outputs: dict[str, Any] | None = None
+
     @property
     def finished(self) -> bool:
         return self.finish_reason is not None

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -197,6 +197,8 @@ class SchedulerStats:
 
     perf_stats: PerfStats | None = None
 
+    custom_stats: dict[str, Any] | None = None
+
 
 @dataclass
 class RequestStateStats:


### PR DESCRIPTION
vLLM has several extension points for [plugins](https://docs.vllm.ai/en/stable/design/plugin_system/#types-of-supported-plugins), but the data that can be transferred from the engine core to the frontend is limited by what the `EngineCoreOutputs` schema allows. `EngineCoreOutputs` does have a `utility_output` attribute, but it can't be used to add extra outputs because the normal processing path is diverted when this attribute is not `None`.

There are several use cases for extra fields, but the one I'm interested in is adding custom prometheus metrics which are specific for to a particular hardware backend. I can register a StatLogger plugin with `vllm.stat_logger_plugins` which creates new prometheus metrics, but there is no way to convey additional data from the engine core to the logger plugin.