### PR TITLE
[CI] Run pre-commit on self-hosted vllm-runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Custom self-hosted runner labels (e.g. the autoscaling vllm-runners pool) so
+# actionlint doesn't flag them as unknown in `runs-on`.
+self-hosted-runner:
+  labels:
+    - vllm-runners

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -46,12 +46,16 @@ jobs:
   pre-commit:
     needs: pre-run-check
     if: always() && (needs.pre-run-check.result == 'success' || needs.pre-run-check.result == 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, vllm-runners]
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
       with:
         python-version: "3.12"
+    # Provide shellcheck on PATH so tools/pre_commit/shellcheck.sh skips its
+    # wget + tar -xJ self-download, which the self-hosted runner image lacks
+    # (no wget/xz). Pinned to shellcheck 0.10.0 to match the script's "stable".
+    - run: python -m pip install shellcheck-py==0.10.0.1
     - run: echo "::add-matcher::.github/workflows/matchers/actionlint.json"
     - run: echo "::add-matcher::.github/workflows/matchers/markdownlint.json"
     - run: echo "::add-matcher::.github/workflows/matchers/mypy.json"


### PR DESCRIPTION
## Summary

Run the `pre-commit` job on the self-hosted **`vllm-runners`** runner group instead of GitHub-hosted `ubuntu-latest`:

```yaml
  pre-commit:
    needs: pre-run-check
    runs-on:
      group: vllm-runners
```

The lightweight `pre-run-check` gate stays on `ubuntu-latest`, so the hook-running job only lands on self-hosted runners after the trusted-author/label gate passes.

It also installs `shellcheck` via `shellcheck-py` so `tools/pre_commit/shellcheck.sh` skips its `wget` + `tar -xJ` self-download, which the self-hosted image lacks.

## Runner requirements

The `vllm-runners` image must provide:

- **Python 3.12** (or a populated `actions/setup-python` tool cache). ⚠️ Currently missing — `setup-python` fails with `The version '3.12' with architecture 'x64' was not found for this operating system`, so the job fails before any hook runs. This needs to be resolved on the runner image (or Python provisioned another way) before merge.
- `git`, plus either `shellcheck` or `wget` + `xz` (the `shellcheck-py` install above covers shellcheck).

## Security

vLLM is public, so PR code runs on self-hosted infra. This is mitigated by the `pre-run-check` gate (requires a `ready`/`verified` label or an author with ≥4 merged PRs) guarding the self-hosted job; ephemeral runners are strongly preferred.