### PR TITLE
[Bugfix][Gemma4] Render reasoning on assistant turns without tool_calls

### DIFF
--- a/examples/tool_chat_template_gemma4.jinja
+++ b/examples/tool_chat_template_gemma4.jinja
@@ -234,7 +234,7 @@
     {#- Render reasoning/reasoning_content as thinking channel (tool-call turns only) -#}
     {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
     {%- set thinking_gate = (loop.index0 > ns_turn.last_user_idx) or preserve_thinking -%}
-    {%- if thinking_text and thinking_gate and message.get('tool_calls') -%}
+    {%- if thinking_text and thinking_gate -%}
         {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
     {%- endif -%}
 

--- a/examples/tool_chat_template_gemma4.jinja
+++ b/examples/tool_chat_template_gemma4.jinja
@@ -231,7 +231,7 @@
         {%- endif -%}
     {%- endif -%}
 
-    {#- Render reasoning/reasoning_content as thinking channel (tool-call turns only) -#}
+    {#- Render reasoning/reasoning_content as thinking channel -#}
     {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
     {%- set thinking_gate = (loop.index0 > ns_turn.last_user_idx) or preserve_thinking -%}
     {%- if thinking_text and thinking_gate -%}


### PR DESCRIPTION
## Purpose

Fixes a template regression introduced by #45553: the thinking channel guard `and message.get('tool_calls')` silently dropped reasoning content on assistant messages without tool calls — e.g. the final answer after a tool chain where the model reasons about the tool result before responding.

Fix: remove the `tool_calls` guard. Reasoning is now rendered whenever `thinking_text` and `thinking_gate` are both true, regardless of whether the message has tool calls.

Note: the `adjust_request` regression (also from #45553) was already fixed by #45832.

### Chat template sync

The same fix has been pushed to the upstream HuggingFace model chat template PRs:
- [google/gemma-4-E2B-it#35](https://huggingface.co/google/gemma-4-E2B-it/discussions/35)
- [google/gemma-4-E4B-it#36](https://huggingface.co/google/gemma-4-E4B-it/discussions/36)
- [google/gemma-4-12B-it#35](https://huggingface.co/google/gemma-4-12B-it/discussions/35)
- [google/gemma-4-26B-A4B-it#47](https://huggingface.co/google/gemma-4-26B-A4B-it/discussions/47)
- [google/gemma-4-31B-it#118](https://huggingface.co/google/gemma-4-31B-it/discussions/118)

## Test Plan

```bash
python -m pytest tests/tool_parsers/test_gemma4_tool_parser.py \
                 tests/reasoning/test_gemma4_reasoning_parser.py \
                 tests/renderers/test_gemma4_chat_template.py -v
```

Reproduction tests: https://gist.github.com/lucianommartins/bbaa06f3076e734fc7cd41a0462a5cb9

## Test Result

```
124 passed, 0 failed
```

cc @bbrowning @yzong-rh @m4r1k