### PR TITLE
[Misc] Validate Cohere Embed Mixed Content Payloads

### DIFF
--- a/tests/entrypoints/pooling/embed/test_io_processor.py
+++ b/tests/entrypoints/pooling/embed/test_io_processor.py
@@ -150,12 +150,54 @@ class TestCohereEmbedRequestParsing:
                     {"content": [{"type": "text", "text": "hello"}]},
                 ],
             },
+            {
+                "model": "test",
+                "inputs": [
+                    {
+                        "content": [
+                            {"type": "image_url", "image_url": {"url": "image-uri"}}
+                        ]
+                    },
+                ],
+            },
         ],
     )
     def test_accepts_exactly_one_non_empty_input_field(self, request_body):
         request = CohereEmbedRequest(**request_body)
 
         assert request.model == "test"
+
+    @pytest.mark.parametrize(
+        ("content", "error"),
+        [
+            (
+                {"type": "text"},
+                "CohereEmbedContent with type='text' requires text",
+            ),
+            (
+                {"type": "image_url"},
+                "CohereEmbedContent with type='image_url' requires image_url.url",
+            ),
+            (
+                {"type": "image_url", "image_url": {}},
+                "CohereEmbedContent with type='image_url' requires image_url.url",
+            ),
+            (
+                {"type": "image_url", "image_url": {"url": ""}},
+                "CohereEmbedContent with type='image_url' requires image_url.url",
+            ),
+        ],
+    )
+    def test_rejects_invalid_mixed_content_payloads(self, content, error):
+        with pytest.raises(ValidationError, match=error):
+            CohereEmbedRequest(
+                model="test",
+                inputs=[
+                    {
+                        "content": [content],
+                    },
+                ],
+            )
 
 
 class TestResolveTruncation:

--- a/vllm/entrypoints/pooling/embed/protocol.py
+++ b/vllm/entrypoints/pooling/embed/protocol.py
@@ -207,6 +207,17 @@ class CohereEmbedContent(BaseModel):
     text: str | None = None
     image_url: dict[str, str] | None = None
 
+    @model_validator(mode="after")
+    def validate_content_payload(self):
+        if self.type == "text":
+            if self.text is None:
+                raise ValueError("CohereEmbedContent with type='text' requires text")
+        elif not self.image_url or not self.image_url.get("url"):
+            raise ValueError(
+                "CohereEmbedContent with type='image_url' requires image_url.url"
+            )
+        return self
+
 
 class CohereEmbedInput(BaseModel):
     content: list[CohereEmbedContent]


### PR DESCRIPTION
## Purpose
The purpose of this PR is to make Cohere `/v2/embed ` mixed-content requests fail early and cleanly when a payload is _malformed_. Currently, payloads like `{"type": "text"}` or `{"type": "image_url", "image_url": {}}` would pass request parsing, then `_mixed_input_to_messages()` would skip the invalid part because it only appended valid `text` or valid `image_url` items. In some cases, the request would silently become an empty user message making it harder to debug.

This PR enforces the request contract at the protocol boundary:

- ` type="text`" must include` text`

-  `type="image_url"` must include` image_url.url`

- Invalid mixed content gets a useful validation error instead of becoming an empty prompt

## Test Plan
- `python -m pytest tests/entrypoints/pooling/embed/test_io_processor.py -q`
- `python -m pytest tests/entrypoints/pooling/embed/test_protocol.py -q`

## Test Result
- The tests should pass.
