### PR TITLE
[Rust Frontend] Validate tokenized bad_words vocabulary range

### DIFF
--- a/rust/src/text/src/lower.rs
+++ b/rust/src/text/src/lower.rs
@@ -288,6 +288,32 @@ mod tests {
         StubTokenizer
     }
 
+    struct FixedTokenizer {
+        token_ids: Vec<u32>,
+    }
+
+    impl Tokenizer for FixedTokenizer {
+        fn encode(
+            &self,
+            _text: &str,
+            _add_special_tokens: bool,
+        ) -> vllm_tokenizer::Result<Vec<u32>> {
+            Ok(self.token_ids.clone())
+        }
+
+        fn decode(
+            &self,
+            _token_ids: &[u32],
+            _skip_special_tokens: bool,
+        ) -> vllm_tokenizer::Result<String> {
+            Ok(String::new())
+        }
+
+        fn token_to_id(&self, _token: &str) -> Option<u32> {
+            None
+        }
+    }
+
     fn sample_request() -> TextRequest {
         TextRequest {
             prompt: Prompt::TokenIds(vec![1, 2, 3]),
@@ -821,6 +847,33 @@ mod tests {
             error,
             Error::OutOfVocab(OutOfVocabError {
                 parameter: "allowed_token_ids",
+                token_ids,
+                vocab_size: 2000,
+            }) if token_ids == vec![2000]
+        ));
+    }
+
+    #[test]
+    fn lower_sampling_params_rejects_out_of_vocab_bad_words() {
+        let tokenizer = FixedTokenizer {
+            token_ids: vec![1999, 2000],
+        };
+        let error = lower_sampling_params(
+            SamplingParams {
+                bad_words: Some(vec!["blocked".to_string()]),
+                ..Default::default()
+            },
+            SamplingHints::default(),
+            sample_sampling_limits(),
+            3,
+            &tokenizer,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::OutOfVocab(OutOfVocabError {
+                parameter: "bad_words",
                 token_ids,
                 vocab_size: 2000,
             }) if token_ids == vec![2000]

--- a/rust/src/text/src/lower/token_ids.rs
+++ b/rust/src/text/src/lower/token_ids.rs
@@ -85,6 +85,14 @@ pub(crate) fn validate_vocab_range(
         )?;
     }
 
+    if let Some(bad_words_token_ids) = params.bad_words_token_ids.as_deref() {
+        validate_param(
+            "bad_words",
+            bad_words_token_ids.iter().flatten().copied(),
+            limits.tokenizer_vocab_size,
+        )?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
  Rust sampling parameter lowering.

  This matches Python behavior and rejects out-of-vocab bad word token IDs
  before they are forwarded to engine-core.




## Purpose

  Fix a Rust frontend validation gap for `bad_words`.

The Rust lowering path tokenizes `bad_words` into `_bad_words_token_ids`, but previously did not validate those token IDs before forwarding sampling params to engine-core. Python validates the tokenized bad word IDs against the tokenizer
vocabulary in `SamplingParams.update_from_tokenizer()` and raises a `bad_words` validation error if any token ID is out
of range.

 Without this check, an out-of-vocabulary bad word token ID can reach the sampler/logits masking path and fail later with
  a less clear engine-side error.

## Test Plan

```
cargo test -p vllm-text lower_sampling_params_rejects_out_of_vocab_bad_words
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.13s
     Running unittests src/lib.rs (target/debug/deps/vllm_text-b895ba6e49a8f640)

running 1 test
test lower::tests::lower_sampling_params_rejects_out_of_vocab_bad_words ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 58 filtered out; finished in 0.00s

```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

