### PR TITLE
[Feat] Support FlashQLA backend for qwen3.5

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -717,7 +717,7 @@ class EngineArgs:
     )
 
     fail_on_environ_validation: bool = False
-    gdn_prefill_backend: Literal["flashinfer", "triton", "cutedsl"] | None = None
+    gdn_prefill_backend: Literal["flashinfer", "flashqla", "triton", "cutedsl"] | None = None
 
     def __post_init__(self):
         # support `EngineArgs(compilation_config={...})`

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -149,11 +149,16 @@ def _is_libs_cu13_install_intact() -> bool:
 
 def _resolve_gdn_prefill_backend(
     vllm_config: VllmConfig,
-) -> tuple[str, Literal["triton", "flashinfer", "cutedsl"]]:
+) -> tuple[str, Literal["triton", "flashinfer", "flashqla", "cutedsl"]]:
     """Resolve GDN prefill backend.
 
+    FlashQLA's GDN prefill kernel is chosen when:
+    * ``requested in ["flashqla", "auto"]``;
+    * ``platform == cuda``;
+    * Hopper (SM90).
+
     FlashInfer's GDN prefill kernel is chosen when:
-    * ``requested in ["flashinfer", "auto"]``;
+    * ``requested == "flashinfer"``;
     * ``platform == cuda``;
     * one of the following:
       - Hopper (SM90) — no further constraints;
@@ -204,7 +209,9 @@ def _resolve_gdn_prefill_backend(
                 "--no-deps nvidia-cutlass-dsl-libs-cu13"
             )
 
-    if backend in ["flashinfer", "auto"] and supports_flashinfer:
+    if backend in ["flashqla", "auto"] and current_platform.is_device_capability(90):
+        return backend, "flashqla"
+    if backend == "flashinfer" and supports_flashinfer:
         return backend, "flashinfer"
     if backend == "cutedsl" and supports_cutedsl:
         return backend, "cutedsl"
@@ -222,6 +229,7 @@ def _log_gdn_backend_decision(
     )
     chosen = {
         "flashinfer": "FlashInfer",
+        "flashqla": "FlashQLA",
         "cutedsl": "CuteDSL",
         "triton": "Triton/FLA",
     }[active_backend]
@@ -235,6 +243,10 @@ def _log_gdn_backend_decision(
         logger.warning_once(
             "FlashInfer GDN prefill is JIT-compiled; first run may take a "
             "while. Set --gdn-prefill-backend triton to skip JIT.",
+        )
+    if active_backend == "flashqla":
+        logger.warning_once(
+            "FlashQLA GDN prefill currently supports SM90 only.",
         )
 
 
@@ -287,6 +299,42 @@ def fi_chunk_gated_delta_rule(
         return result.unsqueeze(0), None
 
 
+def flashqla_chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = True,
+):
+    from flash_qla import chunk_gated_delta_rule as chunk_gated_delta_rule_qla
+
+    if use_qk_l2norm_in_kernel:
+        q = l2norm_fwd(q)
+        k = l2norm_fwd(k)
+
+    # vLLM stores recurrent state as [B, H_v, V, K], while FlashQLA expects
+    # [B, H_v, K, V].
+    qla_state = initial_state.transpose(-1, -2).contiguous().to(torch.float32)
+    output, final_state = chunk_gated_delta_rule_qla(
+        q=q.contiguous(),
+        k=k.contiguous(),
+        v=v.contiguous(),
+        g=g.contiguous().to(torch.float32),
+        beta=beta.contiguous().to(torch.float32),
+        initial_state=qla_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=False,
+    )
+    if output_final_state and final_state is not None:
+        final_state = final_state.transpose(-1, -2).contiguous()
+    return output, final_state
+
+
 @CustomOp.register("chunk_gated_delta_rule")
 class ChunkGatedDeltaRule(CustomOp):
     def __init__(self) -> None:
@@ -295,7 +343,7 @@ class ChunkGatedDeltaRule(CustomOp):
         backend, active_backend = _resolve_gdn_prefill_backend(vllm_config)
         self.gdn_prefill_backend = active_backend
 
-        if backend in ("flashinfer", "cutedsl") and active_backend != backend:
+        if backend in ("flashinfer", "flashqla", "cutedsl") and active_backend != backend:
             logger.warning_once(
                 "GDN prefill backend '%s' is selected but cannot use this "
                 "kernel on the current platform. Falling back to Triton/FLA.",
@@ -305,6 +353,8 @@ class ChunkGatedDeltaRule(CustomOp):
 
         if active_backend == "flashinfer":
             self._forward_method = self.forward_cuda
+        elif active_backend == "flashqla":
+            self._forward_method = self.forward_flashqla
         elif active_backend == "cutedsl":
             self._forward_method = self.forward_cutedsl
         else:
@@ -371,6 +421,39 @@ class ChunkGatedDeltaRule(CustomOp):
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
             core_attn_out=core_attn_out,
         )
+
+    def forward_flashqla(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor,
+        output_final_state: bool,
+        cu_seqlens: torch.Tensor | None = None,
+        chunk_indices: torch.Tensor | None = None,
+        chunk_offsets: torch.Tensor | None = None,
+        use_qk_l2norm_in_kernel: bool = True,
+        core_attn_out: torch.Tensor | None = None,
+    ):
+        del chunk_indices, chunk_offsets
+        o, final_state = flashqla_chunk_gated_delta_rule(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+        if core_attn_out is not None:
+            o_flat = o.squeeze(0).reshape(-1)
+            co_flat = core_attn_out.reshape(-1)
+            co_flat[: o_flat.numel()].copy_(o_flat)
+        return o, final_state
 
     def forward_cutedsl(
         self,

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -99,7 +99,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             _resolve_gdn_prefill_backend,
         )
 
-        self.gdn_prefill_backend: Literal["triton", "flashinfer", "cutedsl"]
+        self.gdn_prefill_backend: Literal["triton", "flashinfer", "flashqla", "cutedsl"]
         _, self.gdn_prefill_backend = _resolve_gdn_prefill_backend(vllm_config)
 
         if self.speculative_config:


### PR DESCRIPTION
## Purpose
This PR adds support for the [FlashQLA](https://github.com/QwenLM/FlashQLA) backend for the Qwen3.5 model. 

## Changes
- Adapte the `flash_qla.chunk_gated_delta_rule` kernel for Qwen3.5 models.
- Introduce a new flashqla option for the `--gdn-prefill-backend` parameter. Users can enable this backend by appending `--gdn-prefill-backend flashqla` to the startup command.

<details>
  <summary>NOTE：FlashQLA should be installed first.</summary>

  ```
  git clone https://github.com/QwenLM/FlashQLA.git
  cd FlashQLA
  pip install -v .
  ```
</details>


## Performance — Qwen3.5-35B-A3B 1xH20 

<details>
  <summary>Command</summary>

  ```bash
  vllm serve Qwen/Qwen3.5-35B-A3B -tp 1 \
    --enable-auto-tool-choice \
    --tool-call-parser qwen3_coder \
    --reasoning-parser qwen3 \
    --trust-remote-code \
    --enable-prefix-caching \
    --gdn-prefill-backend {flashinfer|flashqla|triton|cutedsl}

  vllm bench serve \
    --backend vllm \
    --model Qwen/Qwen3.5-35B-A3B \
    --endpoint /v1/completions \
    --dataset-name random \
    --random-input  {8192|20480|40960} \
    --random-output 1 \
    --max-concurrency 128 \
    --num-prompt 128 \
    --seed 13 \
    --ignore-eos \
    --temperature 0.0
  ```
</details>


We evaluated prefill performance across different input lengths. **The mean TTFT improved by 1%, 2% and 3% for 8k, 20k and 40k input lengths, respectively.** However, severe request queuing caused queuing time to dominate the TTFT, making it hard to reflect the inference speed differences.

Mean TTFT (ms)
| Input-Output | flashqla | flashinfer | triton | cutedsl |
|---|---:|---:|---:|---:|
| 8k-1  | 29263.3 | 29585.83 | 30564.64 | 30826.78 |
| 20k-1 | 81840.46 | 83970.84 | 84510.33 | 84523.51 |
| 40k-1 | 194468.26 | 198357.43 | 198625.38 | 199203.64 |

<details>
  <summary>Full Table</summary>

| Input-Output | flashqla | flashinfer | triton | cutedsl |
|---|---:|---:|---:|---:|
| 8k-1  | 30252.24/28833.54/28704.12 | 30441.07/29179.84/29136.58 | 31492.06/30094.73/30107.14 | 31688.67/30393.43/30398.25 |
| 20k-1 | 81869.26/81796.02/81856.10 | 83911.08/83990.70/84010.73 | 84628.52/84384.72/84517.76 | 84548.79/84480.21/84541.53 |
| 40k-1 | 195290.94/194161.35/193952.49 | 198927.68/198115.23/198029.37 | 199186.11/198348.05/198341.97 | 199807.67/198883.53/198919.71 |

</details>

We reduced the request sending rate to alleviate request queuing. The prefill performance is as follows: for a 20k input length and 1‑token output, **the mean TTFT is reduced by 5% compared to FlashInfer** .

<details>
  <summary>Command</summary>

  ```bash
  vllm bench serve \
    --backend vllm \
    --model Qwen/Qwen3.5-35B-A3B \
    --endpoint /v1/completions \
    --dataset-name random \
    --random-input  20480 \
    --random-output 1 \
    --request-rate 0.5 \
    --num-prompt 128 \
    --seed 42 \
    --ignore-eos \
    --temperature 0.0
  ```
</details>


| Input-Output | flashqla | flashinfer | triton | cutedsl |
|---|---:|---:|---:|---:|
| 20k-1  | 2873.01 | 3016.69 | 3078.51 | 3062.28 |


<details>
  <summary>Full Table</summary>

| Input-Output | flashqla | flashinfer | triton | cutedsl |
|---|---:|---:|---:|---:|
| 20k-1  | 3147.42/2850.92/2620.69 | 3300.31/3016.75/2733.02 | 3362.40/3081.47/2791.65 | 3345.02/3060.02/2781.81 |

</details>

