### PR TITLE
[MM][CG] Add user-configurable global/local token budgets for dual-path ViT CUDA graph

### DIFF
--- a/docs/design/cuda_graphs_multimodal.md
+++ b/docs/design/cuda_graphs_multimodal.md
@@ -39,9 +39,9 @@ class BudgetGraphMetadata:
     output_buffer: torch.Tensor      # encoder hidden states
 ```
 
-Budgets are auto-generated as power-of-2 levels from a model-provided range via `get_encoder_cudagraph_budget_range()`, with the maximum budget always included even if it does not fall on a power-of-2 boundary. Budgets can also be explicitly specified by the user via `encoder_cudagraph_token_budgets` in `CompilationConfig`.
+Budgets are auto-generated as power-of-2 levels from a model-provided range via `get_encoder_cudagraph_budget_range()`, with the maximum budget always included even if it does not fall on a power-of-2 boundary. Budgets can also be explicitly specified by the user via `encoder_cudagraph_token_budgets` in `CompilationConfig`. For dual-path models, users can additionally configure per-path budgets via `encoder_cudagraph_global_token_budgets` and `encoder_cudagraph_local_token_budgets`.
 
-When `EncoderCudaGraphConfig.enable_dual_path_graph` is `True`, the manager generates two independent budget lists — `global_token_budgets` (multiples of `global_token_per_image`) and `local_token_budgets` (multiples of `local_token_per_patch`) — and stores captured graphs under `budget_graphs["global"]` and `budget_graphs["local"]` respectively.
+When `EncoderCudaGraphConfig.enable_dual_path_graph` is `True`, the manager generates (or uses user-provided) two independent budget lists — `global_token_budgets` (multiples of `global_token_per_image`) and `local_token_budgets` (multiples of `local_token_per_patch`) — and stores captured graphs under `budget_graphs["global"]` and `budget_graphs["local"]` respectively.
 
 ### Greedy bin-packing at runtime
 
@@ -62,10 +62,10 @@ For two-tower vision encoders (e.g., DeepSeek-OCR), the `EncoderCudaGraphConfig`
 
 **Budget generation.** Two separate budget lists are generated:
 
-* `global_token_budgets` — power-of-2 multiples of `global_token_per_image` (e.g., `[272, 544, 1088, 2176, 4352, 8704, 13824]` for DeepSeek-OCR).
-* `local_token_budgets` — power-of-2 multiples of `local_token_per_patch` (e.g., `[0, 100, 200, 400, 800, 1600, 3200, 6400, 12800]` for DeepSeek-OCR). A budget of `0` is always included to handle images with no local patches (images ≤ 640×640 that produce only global features).
+* `global_token_budgets` — power-of-2 multiples of `global_token_per_image` (e.g., `[272, 544, 1088, 2176, 4352, 8704, 13824]` for DeepSeek-OCR). Can be overridden by the user via `encoder_cudagraph_global_token_budgets` in `CompilationConfig`.
+* `local_token_budgets` — power-of-2 multiples of `local_token_per_patch` (e.g., `[0, 100, 200, 400, 800, 1600, 3200, 6400, 12800]` for DeepSeek-OCR). Can be overridden by the user via `encoder_cudagraph_local_token_budgets` in `CompilationConfig`. When auto-generated, a budget of `0` is always included to handle images with no local patches (images ≤ 640×640 that produce only global features). When user-provided budgets are used, the `0` budget is **not** automatically inserted — users must include it themselves if needed.
 
-Both lists are capped at the same `max_budget`.
+Both lists are capped at the same `max_budget` (derived from the model's budget range or user-provided `encoder_cudagraph_token_budgets`).
 
 **Dual-path greedy packing.** Each `EncoderItemSpec` provides both `global_output_tokens` (constant per image) and `local_output_tokens` (proportional to the patch count). The dual-path packing algorithm constrains both budgets simultaneously:
 
@@ -142,14 +142,16 @@ Models opt-in to encoder CUDA Graphs by implementing the [SupportsEncoderCudaGra
 
 ## Configuration
 
-Three fields in `CompilationConfig` control encoder CUDA Graphs:
+The following fields in `CompilationConfig` control encoder CUDA Graphs:
 
 * `cudagraph_mm_encoder` (`bool`, default `False`) — enable CUDA Graph capture for multimodal encoder. When enabled, captures the full encoder forward as a CUDA Graph for each token budget level.
 * `encoder_cudagraph_token_budgets` (`list[int]`, default `[]`) — token budget levels for capture. If empty (default), auto-inferred from model architecture as power-of-2 levels. User-provided values override auto-inference.
+* `encoder_cudagraph_global_token_budgets` (`list[int]`, default `[]`) — token budget levels for the **global** path in dual-path encoder CUDA Graph capture (e.g., DeepSeek-OCR). If non-empty, used directly instead of auto-generating from the model's `global_token_per_image`.
+* `encoder_cudagraph_local_token_budgets` (`list[int]`, default `[]`) — token budget levels for the **local** path in dual-path encoder CUDA Graph capture (e.g., DeepSeek-OCR). If non-empty, used directly instead of auto-generating from the model's `local_token_per_patch`.
 * `encoder_cudagraph_max_vision_items_per_batch` (`int`, default `0`) — maximum number of images/videos per batch during capture. If 0 (default), auto-inferred as `max_budget // min_budget`.
 * `encoder_cudagraph_max_frames_per_batch` (`int`, default `None`) — maximum number of video frames per batch during capture. If `None` (default), auto-inferred as `encoder_cudagraph_max_vision_items_per_batch * max_frames_per_video` (`max_frames_per_video` is a model-specific value from `EncoderCudaGraphConfig`, computed by `get_max_frames_per_video()` on the model). If we limit the video count per prompt to `0`, it will also be set to `0` (i.e., fall back to image-only mode).
 
-Dual-path mode is configured at the model level via `EncoderCudaGraphConfig` fields (`enable_dual_path_graph`, `global_token_per_image`, `local_token_per_patch`) — no additional user configuration is required. The manager automatically generates separate budget lists and routes to dual-path execution when the model opts in.
+Dual-path mode is enabled at the model level via `EncoderCudaGraphConfig` fields (`enable_dual_path_graph`, `global_token_per_image`, `local_token_per_patch`). The manager automatically generates separate budget lists and routes to dual-path execution when the model opts in. Users can override the auto-generated per-path budgets via `encoder_cudagraph_global_token_budgets` and `encoder_cudagraph_local_token_budgets`.
 
 ## Usage guide
 
@@ -196,6 +198,40 @@ model = vllm.LLM(
 ```
 
 The manager tracks hit/miss statistics and logs them periodically. A "hit" means an image was processed via CUDA Graph replay; a "miss" means eager fallback (image exceeded all budgets).
+
+### Dual-path inference (DeepSeek-OCR)
+
+For dual-path models like DeepSeek-OCR, use `encoder_cudagraph_global_token_budgets` and `encoder_cudagraph_local_token_budgets` to independently control the global and local path budgets:
+
+```bash
+vllm serve deepseek-ai/DeepSeek-OCR \
+  --compilation-config '{"cudagraph_mm_encoder": true, "encoder_cudagraph_global_token_budgets": [272], "encoder_cudagraph_local_token_budgets": [0, 100, 400, 800]}'
+```
+
+If omitted, both budget lists are auto-generated from the model's `global_token_per_image` and `local_token_per_patch` values:
+
+```bash
+vllm serve deepseek-ai/DeepSeek-OCR \
+  --compilation-config '{"cudagraph_mm_encoder": true}'
+# Auto-generated: global_budgets=[272, 544, 1088, ...], local_budgets=[0, 100, 200, 400, ...]
+```
+
+Python example:
+
+```python
+import vllm
+
+compilation_config = {
+    "cudagraph_mm_encoder": True,
+    "encoder_cudagraph_global_token_budgets": [272],
+    "encoder_cudagraph_local_token_budgets": [0, 100, 400, 800],
+}
+
+model = vllm.LLM(
+    model="deepseek-ai/DeepSeek-OCR",
+    compilation_config=compilation_config,
+)
+```
 
 ### Video inference
 

--- a/tests/models/multimodal/generation/test_vit_cudagraph.py
+++ b/tests/models/multimodal/generation/test_vit_cudagraph.py
@@ -186,7 +186,8 @@ MODEL_CONFIGS: dict[str, VitCudagraphTestConfig] = {
         image_prompt="<image>\nWhat is in this image?",
         marks=[pytest.mark.core_model],
         compilation_config_overrides={
-            "encoder_cudagraph_token_budgets": [272],
+            "encoder_cudagraph_global_token_budgets": [272],
+            "encoder_cudagraph_local_token_budgets": [0, 100, 200, 400, 800],
             "mode": 0,
             "cudagraph_mode": 2,
         },
@@ -196,8 +197,8 @@ MODEL_CONFIGS: dict[str, VitCudagraphTestConfig] = {
                 dummy_hf_overrides,
                 model_arch="DeepseekOCRForCausalLM",
             ),
+            "gpu_memory_utilization": 0.6,
         },
-        skip=True,  # TODO: Re-enable this once OOM issues are resolved on CI.
     ),
 }
 

--- a/tests/v1/cudagraph/test_encoder_cudagraph.py
+++ b/tests/v1/cudagraph/test_encoder_cudagraph.py
@@ -41,10 +41,14 @@ class _MockCompilationConfig:
         self,
         token_budgets: list[int] | None = None,
         max_mm_items: int = 0,
+        global_token_budgets: list[int] | None = None,
+        local_token_budgets: list[int] | None = None,
     ):
         self.encoder_cudagraph_token_budgets = token_budgets or []
         self.encoder_cudagraph_max_vision_items_per_batch = max_mm_items
         self.encoder_cudagraph_max_frames_per_batch = None
+        self.encoder_cudagraph_global_token_budgets = global_token_budgets or []
+        self.encoder_cudagraph_local_token_budgets = local_token_budgets or []
 
 
 class _MockMultimodalConfig:
@@ -71,8 +75,15 @@ class _MockVllmConfig:
         self,
         token_budgets: list[int] | None = None,
         max_mm_items: int = 0,
+        global_token_budgets: list[int] | None = None,
+        local_token_budgets: list[int] | None = None,
     ):
-        self.compilation_config = _MockCompilationConfig(token_budgets, max_mm_items)
+        self.compilation_config = _MockCompilationConfig(
+            token_budgets,
+            max_mm_items,
+            global_token_budgets=global_token_budgets,
+            local_token_budgets=local_token_budgets,
+        )
         self.model_config = _MockModelConfig()
         self.parallel_config = _MockParallelConfig()
 
@@ -98,6 +109,35 @@ class _MockModel(SupportsEncoderCudaGraph):
         return (self._min_budget, self._max_budget)
 
 
+class _MockDualPathModel(SupportsEncoderCudaGraph):
+    """Minimal mock for dual-path encoder CUDA graph models (e.g. DeepSeek-OCR)."""
+
+    def __init__(
+        self,
+        min_budget: int = 4,
+        max_budget: int = 128,
+        global_token_per_image: int = 272,
+        local_token_per_patch: int = 100,
+    ):
+        self._min_budget = min_budget
+        self._max_budget = max_budget
+        self._global_token_per_image = global_token_per_image
+        self._local_token_per_patch = local_token_per_patch
+
+    def get_encoder_cudagraph_config(self) -> EncoderCudaGraphConfig:
+        return EncoderCudaGraphConfig(
+            modalities=["image"],
+            buffer_keys=["pixel_values"],
+            out_hidden_size=32,
+            enable_dual_path_graph=True,
+            global_token_per_image=self._global_token_per_image,
+            local_token_per_patch=self._local_token_per_patch,
+        )
+
+    def get_encoder_cudagraph_budget_range(self, vllm_config):
+        return (self._min_budget, self._max_budget)
+
+
 def _make_manager_with_budgets(budgets: list[int]) -> EncoderCudaGraphManager:
     """Create a minimal EncoderCudaGraphManager with only token_budgets set.
 
@@ -105,6 +145,11 @@ def _make_manager_with_budgets(budgets: list[int]) -> EncoderCudaGraphManager:
     by patching the attributes directly after construction.
     """
     mgr = object.__new__(EncoderCudaGraphManager)
+    mgr.config = EncoderCudaGraphConfig(
+        modalities=["image"],
+        buffer_keys=["pixel_values"],
+        out_hidden_size=32,
+    )
     mgr.token_budgets = sorted(budgets)
     mgr.max_batch_size = 16
     mgr.use_dp = False
@@ -853,9 +898,27 @@ class TestInitInvariantValidation:
         max_mm_items=0,
         min_budget=4,
         max_budget=128,
+        global_token_budgets=None,
+        local_token_budgets=None,
+        dual_path=False,
+        global_token_per_image=272,
+        local_token_per_patch=100,
     ):
-        vllm_config = _MockVllmConfig(token_budgets, max_mm_items)
-        model = _MockModel(min_budget, max_budget)
+        vllm_config = _MockVllmConfig(
+            token_budgets,
+            max_mm_items,
+            global_token_budgets=global_token_budgets,
+            local_token_budgets=local_token_budgets,
+        )
+        if dual_path:
+            model = _MockDualPathModel(
+                min_budget,
+                max_budget,
+                global_token_per_image=global_token_per_image,
+                local_token_per_patch=local_token_per_patch,
+            )
+        else:
+            model = _MockModel(min_budget, max_budget)
         return EncoderCudaGraphManager(
             vllm_config=vllm_config,
             device=torch.device("cpu"),
@@ -947,3 +1010,125 @@ class TestInitInvariantValidation:
 
         with pytest.raises(ValueError, match="must be positive"):
             CompilationConfig(encoder_cudagraph_token_budgets=[-1, 64])
+
+
+# ---------------------------------------------------------------------------
+# Dual-path budget configuration tests
+# ---------------------------------------------------------------------------
+
+
+class TestDualPathBudgetConfig:
+    """User-configurable global/local token budgets for dual-path graphs."""
+
+    def _make_dual_path_mgr(
+        self,
+        token_budgets=None,
+        max_mm_items=8,
+        min_budget=64,
+        max_budget=16384,
+        global_token_budgets=None,
+        local_token_budgets=None,
+        global_token_per_image=272,
+        local_token_per_patch=100,
+    ):
+        vllm_config = _MockVllmConfig(
+            token_budgets=token_budgets,
+            max_mm_items=max_mm_items,
+            global_token_budgets=global_token_budgets,
+            local_token_budgets=local_token_budgets,
+        )
+        model = _MockDualPathModel(
+            min_budget=min_budget,
+            max_budget=max_budget,
+            global_token_per_image=global_token_per_image,
+            local_token_per_patch=local_token_per_patch,
+        )
+        return EncoderCudaGraphManager(
+            vllm_config=vllm_config,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            model=model,
+        )
+
+    def test_user_global_budgets_used_directly(self):
+        """User-provided global budgets are sorted and used as-is."""
+        mgr = self._make_dual_path_mgr(
+            token_budgets=[256, 512, 1024, 2048],
+            global_token_budgets=[544, 272, 1088],
+        )
+        assert mgr.global_token_budgets == [272, 544, 1088]
+
+    def test_user_local_budgets_used_directly(self):
+        """User-provided local budgets are sorted and used as-is."""
+        mgr = self._make_dual_path_mgr(
+            token_budgets=[256, 512, 1024, 2048],
+            local_token_budgets=[200, 100, 400],
+        )
+        assert mgr.local_token_budgets == [100, 200, 400]
+
+    def test_user_both_budgets_used_directly(self):
+        """Both global and local budgets use user-provided values."""
+        mgr = self._make_dual_path_mgr(
+            token_budgets=[256, 512, 1024, 2048],
+            global_token_budgets=[272, 1088, 2176],
+            local_token_budgets=[200, 800],
+        )
+        assert mgr.global_token_budgets == [272, 1088, 2176]
+        assert mgr.local_token_budgets == [200, 800]
+
+    def test_auto_generate_fallback_when_empty(self):
+        """When both are empty, fall back to auto-generation."""
+        mgr = self._make_dual_path_mgr(
+            token_budgets=[256, 512, 1024, 2048, 16384],
+        )
+        # global: min=272, max=16384 → [272, 544, 1088, 2176, 4352, 8704, 16384]
+        assert mgr.global_token_budgets[0] == 272
+        assert mgr.global_token_budgets[-1] == 16384
+        # local: min=100, max=16384 → [0, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 16384] # noqa: E501
+        assert mgr.local_token_budgets[0] == 0  # auto-inserted for small images
+        assert mgr.local_token_budgets[1] == 100
+        assert mgr.local_token_budgets[-1] == 16384
+
+    def test_user_local_budgets_no_zero_insert(self):
+        """User-provided local budgets do NOT get 0 auto-inserted."""
+        mgr = self._make_dual_path_mgr(
+            token_budgets=[256, 512, 1024, 2048],
+            local_token_budgets=[100, 400],
+        )
+        assert 0 not in mgr.local_token_budgets
+
+    def test_global_user_local_auto(self):
+        """User provides global budgets, local budgets auto-generated."""
+        mgr = self._make_dual_path_mgr(
+            token_budgets=[256, 512, 1024, 2048],
+            global_token_budgets=[272, 544, 1088, 2176],
+        )
+        # global stays as provided
+        assert mgr.global_token_budgets == [272, 544, 1088, 2176]
+        # local auto-generated with 0 inserted
+        assert mgr.local_token_budgets[0] == 0
+
+    def test_local_user_global_auto(self):
+        """User provides local budgets, global budgets auto-generated."""
+        mgr = self._make_dual_path_mgr(
+            token_budgets=[256, 512, 1024, 2048],
+            local_token_budgets=[100, 400, 800],
+        )
+        # local stays as provided
+        assert mgr.local_token_budgets == [100, 400, 800]
+        # global auto-generated
+        assert mgr.global_token_budgets[0] == 272
+
+    def test_global_budgets_negative_validation(self):
+        """Negative values in global budgets raise validation error."""
+        from vllm.config.compilation import CompilationConfig
+
+        with pytest.raises(ValueError, match="must be positive"):
+            CompilationConfig(encoder_cudagraph_global_token_budgets=[-1, 272])
+
+    def test_local_budgets_zero_validation(self):
+        """Zero values in local budgets raise validation error."""
+        from vllm.config.compilation import CompilationConfig
+
+        with pytest.raises(ValueError, match="must be positive"):
+            CompilationConfig(encoder_cudagraph_local_token_budgets=[0, 100])

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -535,6 +535,20 @@ class CompilationConfig:
     User-provided values override auto-inference.
     Example: [2048, 4096, 8192, 13824]"""
 
+    encoder_cudagraph_global_token_budgets: list[int] = field(default_factory=list)
+    """Token budget levels for the global path in dual-path encoder CUDA graph
+    capture. If non-empty, used directly instead of auto-generating from the
+    model's ``global_token_per_image``. Only relevant when the model uses
+    dual-path graphs (e.g. DeepSeek-OCR). All values must be positive.
+    Example: [272, 544, 1088, 2176]"""
+
+    encoder_cudagraph_local_token_budgets: list[int] = field(default_factory=list)
+    """Token budget levels for the local path in dual-path encoder CUDA graph
+    capture. If non-empty, used directly instead of auto-generating from the
+    model's ``local_token_per_patch``. Only relevant when the model uses
+    dual-path graphs (e.g. DeepSeek-OCR). All values must be positive.
+    Example: [100, 200, 400, 800]"""
+
     encoder_cudagraph_max_vision_items_per_batch: int = 0
     """Maximum number of images/videos per batch for encoder CUDA graph capture.
     Determines the fixed batch size used during graph capture.
@@ -1018,6 +1032,24 @@ class CompilationConfig:
             raise ValueError(
                 f"All encoder_cudagraph_token_budgets must be positive, "
                 f"got {self.encoder_cudagraph_token_budgets}"
+            )
+
+        if self.encoder_cudagraph_global_token_budgets and any(
+            b <= 0 for b in self.encoder_cudagraph_global_token_budgets
+        ):
+            raise ValueError(
+                f"All encoder_cudagraph_global_token_budgets must be "
+                f"positive, got "
+                f"{self.encoder_cudagraph_global_token_budgets}"
+            )
+
+        if self.encoder_cudagraph_local_token_budgets and any(
+            b <= 0 for b in self.encoder_cudagraph_local_token_budgets
+        ):
+            raise ValueError(
+                f"All encoder_cudagraph_local_token_budgets must be "
+                f"positive, got "
+                f"{self.encoder_cudagraph_local_token_budgets}"
             )
 
         if self.backend == "":

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -73,7 +73,11 @@ class EncoderCudaGraphManager:
         user_max_vision_items = comp_config.encoder_cudagraph_max_vision_items_per_batch
         user_max_frames = comp_config.encoder_cudagraph_max_frames_per_batch
 
-        multimodal_config = vllm_config.model_config.multimodal_config
+        self.budget_graphs: dict[str, dict[int, BudgetGraphMetadata]] = {}
+        self.graph_pool: Any | None = None
+        self.graph_hits = 0
+        self.graph_misses = 0
+        self.log_stats_interval = 100
 
         # Invariant: max_batch_size <= min_token_budget.
         # This ensures per_image_output = budget // max_batch_size >= 1
@@ -135,6 +139,7 @@ class EncoderCudaGraphManager:
                     min(self.token_budgets),
                 )
 
+        multimodal_config = vllm_config.model_config.multimodal_config
         assert multimodal_config is not None
         if multimodal_config.get_limit_per_prompt("video") == 0:
             self.max_frames_per_batch = 0
@@ -145,47 +150,53 @@ class EncoderCudaGraphManager:
             max_frames_per_video = self.config.max_frames_per_video
             self.max_frames_per_batch = self.max_batch_size * max_frames_per_video
 
-        mm_config = vllm_config.model_config.multimodal_config
         self.use_dp = (
-            mm_config is not None
-            and mm_config.mm_encoder_tp_mode == "data"
+            multimodal_config.mm_encoder_tp_mode == "data"
             and vllm_config.parallel_config.tensor_parallel_size > 1
         )
 
-        self.budget_graphs: dict[str, dict[int, BudgetGraphMetadata]] = {}
-        self.graph_pool: Any | None = None
-        self.graph_hits = 0
-        self.graph_misses = 0
-        self.log_stats_interval = 100
-
         if self.config.enable_dual_path_graph:
-            max_budget = self.token_budgets[-1]
-            self.global_token_budgets = self._generate_budgets(
-                self.config.global_token_per_image,
-                max_budget,
-            )
-            self.local_token_budgets = self._generate_budgets(
-                self.config.local_token_per_patch,
-                max_budget,
-            )
-            # When `image_width <= 640 and image_height <= 640`, the mm inputs
-            # will only contain global image, without generating local patches.
-            self.local_token_budgets.insert(0, 0)
+            user_global_budgets = comp_config.encoder_cudagraph_global_token_budgets
+            user_local_budgets = comp_config.encoder_cudagraph_local_token_budgets
+
+            if user_global_budgets:
+                self.global_token_budgets = sorted(user_global_budgets)
+            else:
+                max_budget = self.token_budgets[-1]
+                self.global_token_budgets = self._generate_budgets(
+                    self.config.global_token_per_image,
+                    max_budget,
+                )
+
+            if user_local_budgets:
+                self.local_token_budgets = sorted(user_local_budgets)
+            else:
+                max_budget = self.token_budgets[-1]
+                self.local_token_budgets = self._generate_budgets(
+                    self.config.local_token_per_patch,
+                    max_budget,
+                )
+                # When `image_width <= 640 and image_height <= 640`, the mm
+                # inputs will only contain global image, without generating
+                # local patches.
+                self.local_token_budgets.insert(0, 0)
+
             logger.info(
                 "EncoderCudaGraphManager dual-path mode: "
                 "global_budgets=%s, local_budgets=%s",
                 self.global_token_budgets,
                 self.local_token_budgets,
             )
-        else:
-            logger.info(
-                "EncoderCudaGraphManager initialized with "
-                "budgets=%s, max_batch_size=%d, max_frames_per_batch=%s, use_dp=%s",
-                self.token_budgets,
-                self.max_batch_size,
-                self.max_frames_per_batch,
-                self.use_dp,
-            )
+            return
+
+        logger.info(
+            "EncoderCudaGraphManager initialized with "
+            "budgets=%s, max_batch_size=%d, max_frames_per_batch=%s, use_dp=%s",
+            self.token_budgets,
+            self.max_batch_size,
+            self.max_frames_per_batch,
+            self.use_dp,
+        )
 
     @staticmethod
     def _generate_budgets(min_budget: int, max_budget: int) -> list[int]:


### PR DESCRIPTION
## Purpose

In dual-path vision encoder CUDA Graph mode (e.g., DeepSeek-OCR), the global and local token budgets were previously auto-generated as power-of-2 multiples of the model's `global_token_per_image` and `local_token_per_patch` values, respectively. Users had no way to independently control each path's budget levels — the only knob was the shared `encoder_cudagraph_token_budgets`, which set the overall `max_budget` cap.

In practice, the global path produces a fixed number of tokens per image (e.g., 272 for DeepSeek-OCR), making multiple budget levels wasteful. Users need to keep only one global budget while keeping several local budgets to cover varying patch counts. Conversely, some deployments may want fine-grained global budgets but sparse local budgets.

This PR adds two new fields to `CompilationConfig` — `encoder_cudagraph_global_token_budgets` and `encoder_cudagraph_local_token_budgets` — that allow users to independently specify per-path token budgets. When non-empty, these override auto-generation for that path; when empty (default), behavior is unchanged.

## Test Plan

CI:

```bash
pytest -sv tests/models/multimodal/generation/test_vit_cudagraph.py::test_vit_cudagraph_image[deepseek_ocr]
```

UT:

```bash
pytest -sv tests/v1/cudagraph/test_encoder_cudagraph.py
```

## Test Result

CI:

```bash
# Before:
# Set {"encoder_cudagraph_token_budgets": [1152]} -> only support auto-infer for global/local token budgets
EncoderCudaGraphManager dual-path mode: global_budgets=[272, 544, 1088, 1152], local_budgets=[0, 100, 200, 400, 800, 1152]

# After:
# Set {"encoder_cudagraph_global_token_budgets": [272], "encoder_cudagraph_local_token_budgets": [0, 100, 200, 400, 800]}
EncoderCudaGraphManager dual-path mode: global_budgets=[272], local_budgets=[0, 100, 200, 400, 800]
```

UT:

```bash
--- 60 passed, 17 warnings in 15.75s ---
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

