### PR TITLE
[Bugfix][Model] Gemma 4: stack variable-length audio clips for multi-audio prompts

### DIFF
--- a/tests/models/multimodal/processing/test_gemma4_audio_stacking.py
+++ b/tests/models/multimodal/processing/test_gemma4_audio_stacking.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for Gemma 4 multi-clip audio input stacking.
+
+A chat prompt carrying multiple audio clips of differing MEL-frame length used
+to crash in ``_process_audio_input`` with
+``AttributeError: 'list' object has no attribute 'squeeze'``: the
+``input_features_padded`` field is ``MultiModalFieldConfig.batched("audio")``,
+whose re-pad is a no-op when the per-clip frame counts differ, so it arrives as
+a list of per-clip tensors rather than one stacked tensor. ``.squeeze(1)`` then
+fails on the list. ``stack_audio_input_features`` pads each clip to the batch
+maximum and stacks. These tests are pure-tensor and run on CPU.
+"""
+import torch
+
+from vllm.model_executor.models.gemma4_mm import stack_audio_input_features
+
+_F = 80  # MEL bins
+
+
+def test_list_of_3d_clips_pads_and_stacks():
+    # Two clips of different frame counts, each [1, s, f] (the multi-audio case).
+    feats = [torch.randn(1, 50, _F), torch.randn(1, 73, _F)]
+    masks = [
+        torch.ones(1, 50, dtype=torch.bool),
+        torch.ones(1, 73, dtype=torch.bool),
+    ]
+
+    out_feats, out_masks = stack_audio_input_features(feats, masks)
+
+    assert out_feats.shape == (2, 73, _F)  # padded to batch-max, stacked
+    assert out_masks.shape == (2, 73)
+    # Original frames preserved; pad region zeroed and masked out.
+    torch.testing.assert_close(out_feats[0, :50], feats[0].squeeze(0))
+    torch.testing.assert_close(out_feats[1], feats[1].squeeze(0))
+    assert bool(out_masks[0, :50].all()) and not bool(out_masks[0, 50:].any())
+    assert bool(out_masks[1].all())
+    assert torch.count_nonzero(out_feats[0, 50:]) == 0
+
+
+def test_list_of_2d_clips_also_stacks():
+    feats = [torch.randn(40, _F), torch.randn(64, _F)]
+    masks = [torch.ones(40, dtype=torch.bool), torch.ones(64, dtype=torch.bool)]
+
+    out_feats, out_masks = stack_audio_input_features(feats, masks)
+
+    assert out_feats.shape == (2, 64, _F)
+    assert out_masks.shape == (2, 64)
+    assert not bool(out_masks[0, 40:].any())
+
+
+def test_single_batched_tensor_fast_path():
+    # The original single-clip path: [bn, 1, s, f] -> squeeze(1) -> [bn, s, f].
+    feats = torch.randn(3, 1, 55, _F)
+    masks = torch.ones(3, 1, 55, dtype=torch.bool)
+
+    out_feats, out_masks = stack_audio_input_features(feats, masks)
+
+    assert out_feats.shape == (3, 55, _F)
+    assert out_masks.shape == (3, 55)

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -170,6 +170,12 @@ def stack_audio_input_features(
     of one stacked tensor. Pad each clip to the batch-max frame count and stack;
     otherwise just drop the singleton batch dim. Without this, a multi-clip
     audio prompt reaches ``.squeeze(1)`` on a list and raises ``AttributeError``.
+
+    The zero-padding is only safe because the downstream audio tower honors
+    ``input_features_mask`` at every conv layer and never lets the padded
+    frames reach the encoder output; a future change that drops or ignores
+    the mask would silently corrupt transcriptions for the shorter clips in
+    a batch.
     """
     if not isinstance(feats, (list, tuple)):
         return feats.squeeze(1), masks.squeeze(1)

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -157,6 +157,35 @@ class Gemma4AudioInputs(TensorSchema):
     ]
 
 
+def stack_audio_input_features(
+    feats: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
+    masks: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Normalize Gemma 4 audio inputs to ``([bn, s_max, f], [bn, s_max])``.
+
+    ``input_features_padded`` is a ``MultiModalFieldConfig.batched("audio")``
+    field. When a single prompt carries multiple audio clips of differing
+    MEL-frame length, the ``batched()`` re-pad is a no-op (the per-clip frame
+    counts differ) and the field arrives as a list of per-clip tensors instead
+    of one stacked tensor. Pad each clip to the batch-max frame count and stack;
+    otherwise just drop the singleton batch dim. Without this, a multi-clip
+    audio prompt reaches ``.squeeze(1)`` on a list and raises ``AttributeError``.
+    """
+    if not isinstance(feats, (list, tuple)):
+        return feats.squeeze(1), masks.squeeze(1)
+    feats = [f.squeeze(0) if f.dim() == 3 and f.shape[0] == 1 else f for f in feats]
+    masks = [m.squeeze(0) if m.dim() == 2 and m.shape[0] == 1 else m for m in masks]
+    bn = len(feats)
+    s_max = max(f.shape[-2] for f in feats)
+    fdim = feats[0].shape[-1]
+    out_feats = feats[0].new_zeros((bn, s_max, fdim))
+    out_masks = masks[0].new_zeros((bn, s_max), dtype=torch.bool)
+    for i, (f, m) in enumerate(zip(feats, masks)):
+        out_feats[i, : f.shape[-2]] = f
+        out_masks[i, : m.shape[-1]] = m.to(torch.bool)
+    return out_feats, out_masks
+
+
 Gemma4ImageInputs = Gemma4ImagePixelInputs
 
 
@@ -1469,8 +1498,10 @@ class Gemma4ForConditionalGeneration(
         self,
         audio_input: Gemma4AudioInputs,
     ) -> list[torch.Tensor]:
-        input_features = audio_input["input_features_padded"].squeeze(1)
-        input_features_mask = audio_input["input_features_mask"].squeeze(1)
+        input_features, input_features_mask = stack_audio_input_features(
+            audio_input["input_features_padded"],
+            audio_input["input_features_mask"],
+        )
 
         # Run audio tower — mask convention: True=valid, False=padding.
         audio_outputs = self.audio_tower(input_features, input_features_mask)

--- a/vllm/model_executor/models/gemma4_unified.py
+++ b/vllm/model_executor/models/gemma4_unified.py
@@ -44,6 +44,7 @@ from vllm.model_executor.models.gemma4_mm import (
     Gemma4MultiModalProcessor,
     Gemma4ProcessingInfo,
     _get_max_soft_tokens,
+    stack_audio_input_features,
 )
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.multimodal import MULTIMODAL_REGISTRY
@@ -423,8 +424,10 @@ class Gemma4UnifiedForConditionalGeneration(Gemma4ForConditionalGeneration):
         No audio tower: the per-frame raw features are passed straight
         through the multimodal embedder, then padding is stripped.
         """
-        input_features = audio_input["input_features_padded"].squeeze(1)
-        input_features_mask = audio_input["input_features_mask"].squeeze(1)
+        input_features, input_features_mask = stack_audio_input_features(
+            audio_input["input_features_padded"],
+            audio_input["input_features_mask"],
+        )
 
         target_dtype = self.embed_audio.embedding_projection.weight.dtype
         audio_features = self.embed_audio(input_features.to(target_dtype))


### PR DESCRIPTION
## Purpose

A chat request carrying multiple audio clips of differing MEL-frame length crashes Gemma 4 during
`_process_audio_input`:

```
AttributeError: 'list' object has no attribute 'squeeze'
  File ".../vllm/model_executor/models/gemma4_mm.py", in _process_audio_input
    input_features = audio_input["input_features_padded"].squeeze(1)
```

`input_features_padded` is a `MultiModalFieldConfig.batched("audio")` field. Its `batched()` re-pad is a
no-op when the per-clip MEL-frame counts differ, so the field arrives as a *list* of per-clip tensors
instead of one stacked tensor, and `.squeeze(1)` fails on the list. Single-clip prompts (a single tensor)
are unaffected, which is why this only triggers with two or more audio clips of unequal duration.

Fix: a shared `stack_audio_input_features()` helper pads each clip to the batch-max frame count and stacks
into `[bn, s_max, f]` (building the validity mask alongside), keeping the single-tensor fast path. Both
`Gemma4ForConditionalGeneration` (`gemma4_mm`) and the unified variant (`gemma4_unified`) carried the same
bug and now share the helper.

> **Note on fix placement:** the root cause is that `batched("audio")` does not re-pad variable-length MEL
> features, so this could in principle affect any future consumer of the field. I fixed it at the model
> layer (where both Gemma 4 variants converge on one helper) to keep the change tightly scoped, but I am
> happy to relocate it to the multimodal field-config / processing layer if you would prefer it solved once
> for all consumers.

## Test Plan

```
pytest tests/models/multimodal/processing/test_gemma4_audio_stacking.py
```

CPU-only, no model weights — the bug is in tensor batching, not the audio encoder.

## Test Result

- **Before:** `_process_audio_input` raises `AttributeError: 'list' object has no attribute 'squeeze'` on a
  two-or-more-clip differing-length audio prompt.
- **After:** clips pad to the batch maximum and stack to `[bn, s_max, f]`; the new test asserts shapes,
  pad-region zeroing, and mask correctness across the 3-D list, 2-D list, and single-tensor fast paths:

```
test_list_of_3d_clips_pads_and_stacks PASSED
test_list_of_2d_clips_also_stacks      PASSED
test_single_batched_tensor_fast_path   PASSED
3 passed
```

---

*AI assistance disclosure: this change was developed with AI assistance (Claude); see the `Co-authored-by`
trailer on the commit. The human author reviewed every changed line, validated the behavior, and ran the
test before submission, per vLLM's AI-Assisted Contributions Policy.*

## Duplicate-work check

Two other open PRs address the same Gemma 4 audio batching crash in `gemma4_mm.py`:

- **#42573** (ereish64, opened 2026-05-13) — `gemma4_mm.py` +16/-2, plus a `multiaudio.py` added at repository root.
- **#47459** (fikrikarim, opened 2026-07-02) — `gemma4_mm.py` +21/-2 with a processing test.

This PR additionally fixes `gemma4_unified.py`, which neither of the others touches, and covers the audio-tower mask dependency. I have no attachment to which lands: if a maintainer prefers #42573 or #47459, I am happy to close this and port the `gemma4_unified.py` fix and the mask-dependency note onto whichever is chosen. Flagging the overlap rather than leaving three PRs racing.
