### PR TITLE
Fix Responses streaming content_index reset

### DIFF
--- a/tests/entrypoints/openai/responses/test_harmony.py
+++ b/tests/entrypoints/openai/responses/test_harmony.py
@@ -466,7 +466,7 @@ async def test_streaming(client: OpenAI, model_name: str, background: bool):
                 "response.content_part.added",
                 "response.reasoning_part.added",
             ]:
-                assert event.content_index == current_content_index + 1
+                assert event.content_index == 0
                 current_content_index = event.content_index
             elif event.type in [
                 "response.output_text.delta",

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -583,6 +583,33 @@ class TestHarmonyPreambleStreaming:
         assert "response.output_text.delta" in type_names
         assert "response.output_item.added" not in type_names
 
+    def test_content_index_resets_for_each_output_item(self) -> None:
+        """Responses API content_index is scoped to each output item."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_reasoning_delta_events,
+            emit_text_delta_events,
+        )
+
+        state = StreamingState()
+
+        reasoning_events = emit_reasoning_delta_events("thinking", state)
+        reasoning_part_added = next(
+            event
+            for event in reasoning_events
+            if event.type == "response.reasoning_part.added"
+        )
+        assert reasoning_part_added.content_index == 0
+
+        state.reset_for_new_item()
+
+        text_events = emit_text_delta_events("answer", state)
+        content_part_added = next(
+            event
+            for event in text_events
+            if event.type == "response.content_part.added"
+        )
+        assert content_part_added.content_index == 0
+
     def test_commentary_with_function_recipient_not_preamble(self) -> None:
         """commentary + recipient='functions.X' must NOT use preamble path."""
         from vllm.entrypoints.openai.responses.streaming_events import (


### PR DESCRIPTION
## Summary\n- reset Responses API streaming content_index when moving to a new output item\n- add a regression test for Harmony reasoning followed by message text\n- tighten the Harmony streaming assertion so each output item's first content part starts at index 0\n\n## Motivation\nResponses API content_index is scoped to the output item. The Harmony streaming path reused one counter across reasoning and message items, so a message after a reasoning item could start at content_index=1 and crash OpenAI SDK stream consumers with IndexError.\n\nFixes #45742.\n\n## Tests\n- python3.11 -m py_compile vllm/entrypoints/openai/responses/streaming_events.py tests/entrypoints/openai/responses/test_serving_responses.py tests/entrypoints/openai/responses/test_harmony.py\n- git diff --check\n\nTarget pytest could not be run in this local macOS sandbox because pytest is not installed in the available Python 3.11 environment, and Python 3.14 hits an unrelated local torch import incompatibility before loading vLLM.