### PR TITLE
[Frontend] Replace xgrammar's built-in structural tag with vLLM's implementation

### DIFF
--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -14,6 +15,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionToolsParam,
 )
 from vllm.parser.abstract_parser import DelegatingParser
+from vllm.tool_parsers import structural_tag_registry
 from vllm.tool_parsers.abstract_tool_parser import ToolParser
 from vllm.tool_parsers.deepseekv3_tool_parser import DeepSeekV3ToolParser
 from vllm.tool_parsers.deepseekv4_tool_parser import DeepSeekV4ToolParser
@@ -27,8 +29,6 @@ from vllm.tool_parsers.minimax_m2_tool_parser import MinimaxM2ToolParser
 from vllm.tool_parsers.qwen3_engine_tool_parser import Qwen3EngineToolParser
 from vllm.tool_parsers.structural_tag_registry import (
     SUPPORTED_STRUCTURAL_TAG_MODELS,
-    VLLM_BUILTIN_STRUCTURAL_TAG_MODELS,
-    XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS,
     _get_function_parameters,
     get_model_structural_tag,
 )
@@ -69,15 +69,31 @@ def sample_tools_strict() -> list[ChatCompletionToolsParam]:
     ]
 
 
-def test_supported_structural_tag_models_include_vllm_builtins():
-    assert SUPPORTED_STRUCTURAL_TAG_MODELS == (
-        XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS | VLLM_BUILTIN_STRUCTURAL_TAG_MODELS
+def test_supported_structural_tag_models_include_known_formats():
+    assert (
+        frozenset(
+            {
+                "deepseek_r1",
+                "deepseek_v3_1",
+                "deepseek_v3_2",
+                "deepseek_v4",
+                "glm_4_7",
+                "harmony",
+                "hermes",
+                "kimi",
+                "llama",
+                "minimax",
+                "qwen_3",
+                "qwen_3_5",
+                "qwen_3_coder",
+            }
+        )
+        == SUPPORTED_STRUCTURAL_TAG_MODELS
     )
-    assert "hermes" in VLLM_BUILTIN_STRUCTURAL_TAG_MODELS
 
 
-@pytest.mark.parametrize("model", sorted(XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS))
-def test_get_model_structural_tag_supports_all_xgrammar_builtins(
+@pytest.mark.parametrize("model", sorted(SUPPORTED_STRUCTURAL_TAG_MODELS))
+def test_get_model_structural_tag_supports_all_known_formats(
     model: str,
     sample_tools_strict: list[ChatCompletionToolsParam],
 ):
@@ -89,6 +105,43 @@ def test_get_model_structural_tag_supports_all_xgrammar_builtins(
     )
 
     assert isinstance(tag, StructuralTag)
+
+
+def test_structural_tag_builders_are_registered_by_module_path(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    builder_module = structural_tag_registry._STRUCTURAL_TAG_BUILDERS_MODULE
+    monkeypatch.delitem(sys.modules, builder_module, raising=False)
+    monkeypatch.setattr(structural_tag_registry, "_VLLM_STRUCTURAL_TAG_REGISTRY", {})
+
+    assert builder_module not in sys.modules
+    assert structural_tag_registry._VLLM_STRUCTURAL_TAG_LAZY_REGISTRY["hermes"] == (
+        builder_module,
+        "get_hermes_structural_tag",
+    )
+
+
+def test_structural_tag_builder_loads_lazily(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_tools: list[ChatCompletionToolsParam],
+):
+    builder_module = structural_tag_registry._STRUCTURAL_TAG_BUILDERS_MODULE
+    monkeypatch.delitem(sys.modules, builder_module, raising=False)
+    monkeypatch.setattr(structural_tag_registry, "_VLLM_STRUCTURAL_TAG_REGISTRY", {})
+
+    tag = get_model_structural_tag(
+        model="hermes",
+        tools=sample_tools,
+        tool_choice="required",
+        reasoning=False,
+    )
+
+    assert isinstance(tag, StructuralTag)
+    assert builder_module in sys.modules
+    assert (
+        structural_tag_registry._VLLM_STRUCTURAL_TAG_REGISTRY["hermes"].__name__
+        == "get_hermes_structural_tag"
+    )
 
 
 def test_get_model_structural_tag_supports_vllm_hermes(
@@ -172,7 +225,7 @@ def test_hermes_required_tool_calls_use_empty_separator():
     assert tag.format.separator == ""
 
 
-@pytest.mark.parametrize("model", sorted(XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS))
+@pytest.mark.parametrize("model", sorted(SUPPORTED_STRUCTURAL_TAG_MODELS))
 def test_get_model_structural_tag_supports_named_tool_choice(
     model: str,
     sample_tools: list[ChatCompletionToolsParam],
@@ -311,7 +364,7 @@ def test_xgrammar_function_parameters_are_preserved(
     )
 
     get_model_structural_tag(
-        model="llama",
+        model="qwen_3_5",
         tools=sample_tools_strict,
         tool_choice="auto",
         reasoning=False,
@@ -324,7 +377,7 @@ def test_xgrammar_function_parameters_are_preserved(
     assert sample_tools_strict[0].function.parameters is not None
 
 
-@pytest.mark.parametrize("model", sorted(XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS))
+@pytest.mark.parametrize("model", sorted(SUPPORTED_STRUCTURAL_TAG_MODELS))
 def test_auto_tool_choice_skips_structural_tag_without_strict(
     model: str,
     sample_tools: list[ChatCompletionToolsParam],

--- a/vllm/tool_parsers/structural_tag_builders.py
+++ b/vllm/tool_parsers/structural_tag_builders.py
@@ -1,0 +1,785 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any, Literal, TypeAlias
+
+from xgrammar import StructuralTag
+from xgrammar.openai_tool_call_schema import (
+    BuiltinToolParam,
+    FunctionToolParam,
+)
+from xgrammar.structural_tag import (
+    AnyTextFormat,
+    ConstStringFormat,
+    JSONSchemaFormat,
+    RegexFormat,
+    SequenceFormat,
+    TagFormat,
+    TagsWithSeparatorFormat,
+    TriggeredTagsFormat,
+)
+
+SimplifiedToolChoice: TypeAlias = Literal["auto", "required", "forced"]
+THINK_EXCLUDES: list[str] = []  # "<tool_call>", "<tool_call>"
+
+
+def _get_function_parameters(function) -> dict[str, Any] | bool:
+    if getattr(function, "strict", None) is False:
+        return True
+    return function.parameters if function.parameters is not None else True
+
+
+def _get_builtin_tool_name(tool: BuiltinToolParam) -> str:
+    return tool.name if tool.name is not None else tool.type
+
+
+def _hermes_tool_tags(tools: list[FunctionToolParam]) -> list[TagFormat]:
+    arguments_field_prefix = '", "arguments": '
+    formats = [
+        # <tool_call>
+        # {"name": "t1", "arguments": {"q": "v"}}
+        # </tool_call>
+        ('<tool_call>\n{"name": "', "}\n</tool_call>"),
+        # <tool_call>{"name": "t1", "arguments": {"q": "v"}}</tool_call>
+        ('<tool_call>{"name": "', "}</tool_call>"),
+    ]
+
+    return [
+        TagFormat(
+            begin=begin + tool.function.name + arguments_field_prefix,
+            content=JSONSchemaFormat(
+                json_schema=_get_function_parameters(tool.function)
+            ),
+            end=end,
+        )
+        for tool in tools
+        for begin, end in formats
+    ]
+
+
+def get_hermes_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools, reasoning
+
+    tool_call_trigger = "<tool_call>"
+
+    if tool_choice == "auto":
+        tags = _hermes_tool_tags(tools)
+        suffix_tag = (
+            TriggeredTagsFormat(triggers=[tool_call_trigger], tags=tags)
+            if tags
+            else AnyTextFormat()
+        )
+    elif tool_choice == "forced":
+        suffix_tag = TagsWithSeparatorFormat(
+            tags=_hermes_tool_tags(tools),
+            separator="",
+            at_least_one=True,
+            stop_after_first=True,
+        )
+    else:
+        suffix_tag = TagsWithSeparatorFormat(
+            tags=_hermes_tool_tags(tools),
+            separator="",
+            at_least_one=True,
+        )
+
+    return StructuralTag(format=suffix_tag)
+
+
+def _minimax_tool_tags(tools: list[FunctionToolParam]) -> list[TagFormat]:
+    return [
+        TagFormat(
+            begin=f'<invoke name="{tool.function.name}">\n',
+            content=JSONSchemaFormat(
+                json_schema=_get_function_parameters(tool.function),
+                style="minimax_xml",
+            ),
+            end="</invoke>\n",
+        )
+        for tool in tools
+    ]
+
+
+def get_minimax_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools, reasoning
+
+    tool_call_begin = "<minimax:tool_call>\n"
+    tool_call_end = "</minimax:tool_call>"
+    tool_call_trigger = "<minimax:tool_call>"
+
+    tags = _minimax_tool_tags(tools)
+
+    if tool_choice == "auto":
+        suffix_tag = (
+            TriggeredTagsFormat(
+                triggers=[tool_call_trigger],
+                tags=[
+                    TagFormat(
+                        begin=tool_call_begin,
+                        content=TagsWithSeparatorFormat(
+                            tags=tags,
+                            separator="",
+                            at_least_one=True,
+                        ),
+                        end=tool_call_end,
+                    )
+                ],
+                excludes=THINK_EXCLUDES,
+            )
+            if tags
+            else AnyTextFormat(excludes=THINK_EXCLUDES)
+        )
+    elif tool_choice == "forced":
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value="\n" + tool_call_begin),
+                TagsWithSeparatorFormat(
+                    tags=tags,
+                    separator="",
+                    at_least_one=True,
+                    stop_after_first=True,
+                ),
+                ConstStringFormat(value=tool_call_end),
+            ]
+        )
+    else:
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value="\n" + tool_call_begin),
+                TagsWithSeparatorFormat(
+                    tags=tags,
+                    separator="",
+                    at_least_one=True,
+                ),
+                ConstStringFormat(value=tool_call_end),
+            ]
+        )
+
+    return StructuralTag(format=suffix_tag)
+
+
+def _json_schema_content(function, style=None):
+    kwargs = {"json_schema": _get_function_parameters(function)}
+    if style is not None:
+        kwargs["style"] = style
+    return JSONSchemaFormat(**kwargs)
+
+
+def _simple_json_tags(tools, begin_fn, end, style=None):
+    return [
+        TagFormat(
+            begin=begin_fn(tool.function.name),
+            content=_json_schema_content(tool.function, style=style),
+            end=end,
+        )
+        for tool in tools
+    ]
+
+
+def get_llama_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools, reasoning
+
+    tags = _simple_json_tags(
+        tools,
+        lambda name: f'{{"name": "{name}", "parameters": ',
+        "}",
+    )
+
+    if tool_choice == "auto":
+        suffix_tag = (
+            TriggeredTagsFormat(
+                triggers=['{"name": '],
+                tags=tags,
+                excludes=THINK_EXCLUDES,
+            )
+            if tags
+            else AnyTextFormat(excludes=THINK_EXCLUDES)
+        )
+    elif tool_choice == "forced":
+        suffix_tag = tags[0]
+    else:
+        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
+
+    return StructuralTag(format=suffix_tag)
+
+
+def _kimi_tool_tags(tools: list[FunctionToolParam]) -> list[TagFormat]:
+    return [
+        TagFormat(
+            begin=f"<|tool_call_begin|>functions.{tool.function.name}:",
+            content=SequenceFormat(
+                elements=[
+                    RegexFormat(pattern=r"\d+"),
+                    ConstStringFormat(value="<|tool_call_argument_begin|>"),
+                    JSONSchemaFormat(
+                        json_schema=_get_function_parameters(tool.function)
+                    ),
+                ]
+            ),
+            end="<|tool_call_end|>",
+        )
+        for tool in tools
+    ]
+
+
+def get_kimi_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools
+
+    tags = _kimi_tool_tags(tools)
+
+    if tool_choice == "auto":
+        if tags:
+            tool_calls = TagFormat(
+                begin="<|tool_calls_section_begin|>",
+                content=TagsWithSeparatorFormat(
+                    tags=tags, separator="", at_least_one=True
+                ),
+                end="<|tool_calls_section_end|>",
+            )
+            suffix_tag = TriggeredTagsFormat(
+                triggers=["<|tool_calls_section_begin|>"],
+                tags=[tool_calls],
+                excludes=[*THINK_EXCLUDES, "<|tool_call_begin|>"],
+            )
+        else:
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDES)
+    elif tool_choice == "forced":
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value="<|tool_calls_section_begin|>"),
+                tags[0],
+                ConstStringFormat(value="<|tool_calls_section_end|>"),
+            ]
+        )
+    else:
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value="<|tool_calls_section_begin|>"),
+                TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True),
+                ConstStringFormat(value="<|tool_calls_section_end|>"),
+            ]
+        )
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    return StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                TagFormat(begin="", content=AnyTextFormat(), end="</think>"),
+                suffix_tag,
+            ]
+        )
+    )
+
+
+def get_deepseek_r1_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools
+
+    tags = _simple_json_tags(
+        tools,
+        lambda name: f"<｜tool▁call▁begin｜>function<｜tool▁sep｜>{name}\n```json\n",
+        "\n```<｜tool▁call▁end｜>",
+    )
+
+    if tool_choice == "auto":
+        suffix_tag = (
+            TriggeredTagsFormat(
+                triggers=["<｜tool▁calls▁begin｜>"],
+                tags=[
+                    TagFormat(
+                        begin="<｜tool▁calls▁begin｜>",
+                        content=TagsWithSeparatorFormat(
+                            tags=tags, separator="\n", at_least_one=True
+                        ),
+                        end="<｜tool▁calls▁end｜>",
+                    )
+                ],
+                excludes=THINK_EXCLUDES,
+            )
+            if tags
+            else AnyTextFormat(excludes=THINK_EXCLUDES)
+        )
+    elif tool_choice == "forced":
+        function = tools[0].function
+        suffix_tag = TagFormat(
+            begin=(
+                "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function"
+                f"<｜tool▁sep｜>{function.name}\n```json\n"
+            ),
+            content=JSONSchemaFormat(json_schema=_get_function_parameters(function)),
+            end="\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+        )
+    else:
+        suffix_tag = TagFormat(
+            begin="<｜tool▁calls▁begin｜>",
+            content=TagsWithSeparatorFormat(
+                tags=tags, separator="\n", at_least_one=True
+            ),
+            end="<｜tool▁calls▁end｜>",
+        )
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    return StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                TagFormat(begin="", content=AnyTextFormat(), end="</think>"),
+                suffix_tag,
+            ]
+        )
+    )
+
+
+def get_deepseek_v3_1_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools
+
+    tags = _simple_json_tags(
+        tools,
+        lambda name: f"<｜tool▁call▁begin｜>{name}<｜tool▁sep｜>",
+        "<｜tool▁call▁end｜>",
+    )
+
+    if tool_choice == "auto":
+        suffix_tag = (
+            TriggeredTagsFormat(
+                triggers=["<｜tool▁calls▁begin｜>"],
+                tags=[
+                    TagFormat(
+                        begin="<｜tool▁calls▁begin｜>",
+                        content=TagsWithSeparatorFormat(
+                            tags=tags, separator="", at_least_one=True
+                        ),
+                        end="<｜tool▁calls▁end｜>",
+                    )
+                ],
+                excludes=THINK_EXCLUDES,
+            )
+            if tags
+            else AnyTextFormat(excludes=THINK_EXCLUDES)
+        )
+    elif tool_choice == "forced":
+        function = tools[0].function
+        suffix_tag = TagFormat(
+            begin=f"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>{function.name}<｜tool▁sep｜>",
+            content=JSONSchemaFormat(json_schema=_get_function_parameters(function)),
+            end="<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+        )
+    else:
+        suffix_tag = TagFormat(
+            begin="<｜tool▁calls▁begin｜>",
+            content=TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True),
+            end="<｜tool▁calls▁end｜>",
+        )
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    return StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                TagFormat(begin="", content=AnyTextFormat(), end="</think>"),
+                suffix_tag,
+            ]
+        )
+    )
+
+
+def _qwen_xml_tool_tags(tools: list[FunctionToolParam]) -> list[TagFormat]:
+    return _simple_json_tags(
+        tools,
+        lambda name: f"<tool_call>\n<function={name}>\n",
+        "\n</function>\n</tool_call>",
+        style="qwen_xml",
+    )
+
+
+def get_qwen_3_5_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools
+
+    tags = _qwen_xml_tool_tags(tools)
+
+    if tool_choice == "auto":
+        suffix_tag = (
+            TriggeredTagsFormat(
+                triggers=["<tool_call>\n<function="],
+                tags=tags,
+                excludes=THINK_EXCLUDES,
+            )
+            if tags
+            else AnyTextFormat(excludes=THINK_EXCLUDES)
+        )
+    elif tool_choice == "forced":
+        suffix_tag = tags[0]
+    else:
+        suffix_tag = TagsWithSeparatorFormat(
+            tags=tags, separator="\n", at_least_one=True
+        )
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    return StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                SequenceFormat(
+                    elements=[
+                        TagFormat(begin="", content=AnyTextFormat(), end="</think>"),
+                        ConstStringFormat(value="\n\n"),
+                    ]
+                ),
+                suffix_tag,
+            ]
+        )
+    )
+
+
+get_qwen_3_coder_structural_tag = get_qwen_3_5_structural_tag
+
+
+def get_qwen_3_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools
+
+    tags = _simple_json_tags(
+        tools,
+        lambda name: f'<tool_call>\n{{"name": "{name}", "arguments": ',
+        "}\n</tool_call>",
+    )
+
+    if tool_choice == "auto":
+        suffix_tag = (
+            TriggeredTagsFormat(
+                triggers=["<tool_call>"],
+                tags=tags,
+                excludes=THINK_EXCLUDES,
+            )
+            if tags
+            else AnyTextFormat(excludes=THINK_EXCLUDES)
+        )
+    elif tool_choice == "forced":
+        suffix_tag = tags[0]
+    else:
+        suffix_tag = TagsWithSeparatorFormat(
+            tags=tags, separator="\n", at_least_one=True
+        )
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    return StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                SequenceFormat(
+                    elements=[
+                        TagFormat(begin="", content=AnyTextFormat(), end="</think>"),
+                        ConstStringFormat(value="\n\n"),
+                    ]
+                ),
+                suffix_tag,
+            ]
+        )
+    )
+
+
+def _harmony_function_tool_tags(name, parameters):
+    content = JSONSchemaFormat(json_schema=parameters)
+    return [
+        TagFormat(
+            begin=(
+                f"<|channel|>commentary to=functions.{name}<|constrain|>json<|message|>"
+            ),
+            content=content,
+            end="<|call|>",
+        ),
+        TagFormat(
+            begin=(
+                f" to=functions.{name}<|channel|>commentary "
+                "<|constrain|>json<|message|>"
+            ),
+            content=content,
+            end="<|call|>",
+        ),
+        TagFormat(
+            begin=f" to=functions.{name}<|channel|>commentary json<|message|>",
+            content=content,
+            end="<|call|>",
+        ),
+    ]
+
+
+def _harmony_builtin_tool_tags(name, parameters):
+    content = JSONSchemaFormat(json_schema=parameters)
+    return [
+        TagFormat(
+            begin=f"<|channel|>commentary to={name} code<|message|>",
+            content=content,
+            end="<|call|>",
+        ),
+        TagFormat(
+            begin=f" to={name}<|channel|>commentary code<|message|>",
+            content=content,
+            end="<|call|>",
+        ),
+    ]
+
+
+def get_harmony_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    tags = []
+
+    if tool_choice == "auto":
+        for tool in tools:
+            tags.extend(
+                _harmony_function_tool_tags(
+                    tool.function.name,
+                    _get_function_parameters(tool.function),
+                )
+            )
+        for tool in builtin_tools:
+            tags.extend(
+                _harmony_builtin_tool_tags(
+                    _get_builtin_tool_name(tool),
+                    _get_function_parameters(tool),
+                )
+            )
+        tags.append(
+            TagFormat(
+                begin="<|channel|>final<|message|>",
+                content=AnyTextFormat(),
+                end=["<|end|>", "<|return|>"],
+            )
+        )
+    elif tool_choice == "forced":
+        if builtin_tools:
+            tool = builtin_tools[0]
+            tags.extend(
+                _harmony_builtin_tool_tags(
+                    _get_builtin_tool_name(tool),
+                    _get_function_parameters(tool),
+                )
+            )
+        else:
+            tool = tools[0]
+            tags.extend(
+                _harmony_function_tool_tags(
+                    tool.function.name,
+                    _get_function_parameters(tool.function),
+                )
+            )
+    else:
+        for tool in builtin_tools:
+            tags.extend(
+                _harmony_builtin_tool_tags(
+                    _get_builtin_tool_name(tool),
+                    _get_function_parameters(tool),
+                )
+            )
+        for tool in tools:
+            tags.extend(
+                _harmony_function_tool_tags(
+                    tool.function.name,
+                    _get_function_parameters(tool.function),
+                )
+            )
+
+    if reasoning:
+        tags.append(
+            TagFormat(
+                begin="<|channel|>analysis<|message|>",
+                content=AnyTextFormat(),
+                end=["<|end|>", "<|return|>"],
+            )
+        )
+
+    return StructuralTag(
+        format=TagsWithSeparatorFormat(tags=tags, separator="<|start|>assistant")
+    )
+
+
+def _deepseek_dsml_structural_tag(
+    tools: list[FunctionToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+    function_calls_begin: str,
+    function_calls_end: str,
+    function_calls_trigger: str,
+) -> StructuralTag:
+    tags = _simple_json_tags(
+        tools,
+        lambda name: f'<｜DSML｜invoke name="{name}">\n',
+        "</｜DSML｜invoke>\n",
+        style="deepseek_xml",
+    )
+
+    if tool_choice == "auto":
+        suffix_tag = (
+            TriggeredTagsFormat(
+                triggers=[function_calls_trigger],
+                tags=[
+                    TagFormat(
+                        begin=function_calls_begin,
+                        content=TagsWithSeparatorFormat(
+                            tags=tags, separator="", at_least_one=True
+                        ),
+                        end=function_calls_end,
+                    )
+                ],
+                excludes=THINK_EXCLUDES,
+            )
+            if tags
+            else AnyTextFormat(excludes=THINK_EXCLUDES)
+        )
+    elif tool_choice == "forced":
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value="\n\n" + function_calls_begin),
+                tags[0],
+                ConstStringFormat(value=function_calls_end),
+            ]
+        )
+    else:
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value="\n\n" + function_calls_begin),
+                TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True),
+                ConstStringFormat(value=function_calls_end),
+            ]
+        )
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    return StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                TagFormat(begin="", content=AnyTextFormat(), end="</think>"),
+                suffix_tag,
+            ]
+        )
+    )
+
+
+def get_deepseek_v3_2_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools
+    return _deepseek_dsml_structural_tag(
+        tools,
+        tool_choice,
+        reasoning,
+        function_calls_begin="<｜DSML｜function_calls>\n",
+        function_calls_end="</｜DSML｜function_calls>",
+        function_calls_trigger="<｜DSML｜function_calls>",
+    )
+
+
+def _glm_4_7_tool_tags(tools: list[FunctionToolParam]) -> list[TagFormat]:
+    return _simple_json_tags(
+        tools,
+        lambda name: f"<tool_call>{name}",
+        "</tool_call>",
+        style="glm_xml",
+    )
+
+
+def get_glm_4_7_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools
+
+    tags = _glm_4_7_tool_tags(tools)
+
+    if tool_choice == "auto":
+        suffix_tag = (
+            TriggeredTagsFormat(
+                triggers=["<tool_call>"],
+                tags=tags,
+                excludes=THINK_EXCLUDES,
+            )
+            if tags
+            else AnyTextFormat(excludes=THINK_EXCLUDES)
+        )
+    elif tool_choice == "forced":
+        suffix_tag = tags[0]
+    else:
+        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    return StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                TagFormat(begin="", content=AnyTextFormat(), end="</think>"),
+                suffix_tag,
+            ]
+        )
+    )
+
+
+def get_deepseek_v4_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools
+    return _deepseek_dsml_structural_tag(
+        tools,
+        tool_choice,
+        reasoning,
+        function_calls_begin="<｜DSML｜tool_calls>\n",
+        function_calls_end="</｜DSML｜tool_calls>",
+        function_calls_trigger="<｜DSML｜tool_calls>",
+    )

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -134,8 +134,8 @@ def get_model_structural_tag(
     if not tools or tool_choice == "none":
         return None
 
-    # if tool_choice == "auto" and not _any_tool_strict(tools):
-    #     return None
+    if tool_choice == "auto" and not _any_tool_strict(tools):
+        return None
 
     dumped_tools = [_dump_tool_for_xgrammar(tool) for tool in tools]
     dumped_tool_choice = _dump_tool_choice_for_xgrammar(tool_choice)

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -105,8 +105,8 @@ def get_model_structural_tag(
     if not tools or tool_choice == "none":
         return None
 
-    # if tool_choice == "auto" and not _any_tool_strict(tools):
-    #     return None
+    if tool_choice == "auto" and not _any_tool_strict(tools):
+        return None
 
     dumped_tools = [_dump_tool_for_xgrammar(tool) for tool in tools]
     dumped_tool_choice = _dump_tool_choice_for_xgrammar(tool_choice)

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import importlib
 from collections.abc import Callable, Sequence
 from typing import Any, Literal, TypeAlias
 
@@ -14,15 +15,6 @@ from xgrammar import get_model_structural_tag as get_xgrammar_model_structural_t
 from xgrammar.openai_tool_call_schema import (
     BuiltinToolParam,
     FunctionToolParam,
-)
-from xgrammar.structural_tag import (
-    AnyTextFormat,
-    ConstStringFormat,
-    JSONSchemaFormat,
-    SequenceFormat,
-    TagFormat,
-    TagsWithSeparatorFormat,
-    TriggeredTagsFormat,
 )
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -48,39 +40,76 @@ StructuralTagBuilder: TypeAlias = Callable[
     StructuralTag,
 ]
 
-# Keep this list in sync with xgrammar.builtin_structural_tag. It is used for
-# vLLM-side validation and for documenting the xgrammar builtin surface that
-# can be requested by tool parsers through ``structural_tag_model``.
-XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS = frozenset(
+SUPPORTED_STRUCTURAL_TAG_MODELS = frozenset(
     {
-        "llama",
-        "kimi",
         "deepseek_r1",
         "deepseek_v3_1",
-        "qwen_3_5",
-        "qwen_3_coder",
-        "qwen_3",
-        "harmony",
         "deepseek_v3_2",
         "deepseek_v4",
+        "glm_4_7",
+        "harmony",
+        "hermes",
+        "kimi",
+        "llama",
+        "minimax",
+        "qwen_3",
+        "qwen_3_5",
+        "qwen_3_coder",
     }
 )
-VLLM_BUILTIN_STRUCTURAL_TAG_MODELS = frozenset({"hermes"})
-SUPPORTED_STRUCTURAL_TAG_MODELS = (
-    XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS | VLLM_BUILTIN_STRUCTURAL_TAG_MODELS
-)
+
+
+_STRUCTURAL_TAG_BUILDERS_MODULE = "vllm.tool_parsers.structural_tag_builders"
 
 _VLLM_STRUCTURAL_TAG_REGISTRY: dict[str, StructuralTagBuilder] = {}
+_VLLM_STRUCTURAL_TAG_LAZY_REGISTRY: dict[str, tuple[str, str]] = {
+    "deepseek_r1": (
+        _STRUCTURAL_TAG_BUILDERS_MODULE,
+        "get_deepseek_r1_structural_tag",
+    ),
+    "deepseek_v3_1": (
+        _STRUCTURAL_TAG_BUILDERS_MODULE,
+        "get_deepseek_v3_1_structural_tag",
+    ),
+    "deepseek_v3_2": (
+        _STRUCTURAL_TAG_BUILDERS_MODULE,
+        "get_deepseek_v3_2_structural_tag",
+    ),
+    "deepseek_v4": (
+        _STRUCTURAL_TAG_BUILDERS_MODULE,
+        "get_deepseek_v4_structural_tag",
+    ),
+    "glm_4_7": (_STRUCTURAL_TAG_BUILDERS_MODULE, "get_glm_4_7_structural_tag"),
+    "harmony": (_STRUCTURAL_TAG_BUILDERS_MODULE, "get_harmony_structural_tag"),
+    "hermes": (_STRUCTURAL_TAG_BUILDERS_MODULE, "get_hermes_structural_tag"),
+    "kimi": (_STRUCTURAL_TAG_BUILDERS_MODULE, "get_kimi_structural_tag"),
+    "llama": (_STRUCTURAL_TAG_BUILDERS_MODULE, "get_llama_structural_tag"),
+    "minimax": (_STRUCTURAL_TAG_BUILDERS_MODULE, "get_minimax_structural_tag"),
+    "qwen_3": (_STRUCTURAL_TAG_BUILDERS_MODULE, "get_qwen_3_structural_tag"),
+    "qwen_3_coder": (
+        _STRUCTURAL_TAG_BUILDERS_MODULE,
+        "get_qwen_3_5_structural_tag",
+    ),
+}
 
 
-def register_vllm_structural_tag(model: str):
-    """Register a vLLM-owned structural tag builder."""
+def _load_vllm_structural_tag_builder(model: str) -> StructuralTagBuilder | None:
+    """Load and cache a lazily registered vLLM structural tag builder."""
+    if model in _VLLM_STRUCTURAL_TAG_REGISTRY:
+        return _VLLM_STRUCTURAL_TAG_REGISTRY[model]
 
-    def decorator(func: StructuralTagBuilder) -> StructuralTagBuilder:
-        _VLLM_STRUCTURAL_TAG_REGISTRY[model] = func
-        return func
+    if model not in _VLLM_STRUCTURAL_TAG_LAZY_REGISTRY:
+        return None
 
-    return decorator
+    module_path, function_name = _VLLM_STRUCTURAL_TAG_LAZY_REGISTRY[model]
+    module = importlib.import_module(module_path)
+    builder = getattr(module, function_name)
+    if not callable(builder):
+        raise TypeError(
+            f"{function_name} in {module_path} is not a structural tag builder."
+        )
+    _VLLM_STRUCTURAL_TAG_REGISTRY[model] = builder
+    return builder
 
 
 def _any_tool_strict(
@@ -105,28 +134,30 @@ def get_model_structural_tag(
     if not tools or tool_choice == "none":
         return None
 
-    if tool_choice == "auto" and not _any_tool_strict(tools):
-        return None
+    # if tool_choice == "auto" and not _any_tool_strict(tools):
+    #     return None
 
     dumped_tools = [_dump_tool_for_xgrammar(tool) for tool in tools]
     dumped_tool_choice = _dump_tool_choice_for_xgrammar(tool_choice)
-
-    if model in _VLLM_STRUCTURAL_TAG_REGISTRY:
+    builder = _load_vllm_structural_tag_builder(model)
+    if builder is not None:
         function_tools, builtin_tools, simplified_tool_choice = normalize_tool_choice(
             dumped_tools,
             dumped_tool_choice,
         )
-        return _VLLM_STRUCTURAL_TAG_REGISTRY[model](
+        return builder(
             function_tools,
             builtin_tools,
             simplified_tool_choice,
             reasoning,
         )
-
-    if model not in XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS:
-        supported = sorted(SUPPORTED_STRUCTURAL_TAG_MODELS)
+    if model not in SUPPORTED_STRUCTURAL_TAG_MODELS:
+        supported = sorted(
+            set(SUPPORTED_STRUCTURAL_TAG_MODELS)
+            | set(_VLLM_STRUCTURAL_TAG_REGISTRY)
+            | set(_VLLM_STRUCTURAL_TAG_LAZY_REGISTRY)
+        )
         raise ValueError(f"Unknown format type: {model}, supported types: {supported}")
-
     return get_xgrammar_model_structural_tag(
         model=model,
         tools=dumped_tools,
@@ -201,200 +232,3 @@ def _dump_allowed_tool_ref_for_xgrammar(tool_ref: AllowedToolRef) -> AllowedTool
             "function": {"name": tool_ref["name"]},
         }
     return tool_ref
-
-
-def _get_function_parameters(function) -> dict[str, Any] | bool:
-    if getattr(function, "strict", None) is False:
-        return True
-    return function.parameters if function.parameters is not None else True
-
-
-def _hermes_tool_tags(tools: list[FunctionToolParam]) -> list[TagFormat]:
-    arguments_field_prefix = '", "arguments": '
-    formats = [
-        # <tool_call>
-        # {"name": "t1", "arguments": {"q": "v"}}
-        # </tool_call>
-        ('<tool_call>\n{"name": "', "}\n</tool_call>"),
-        # <tool_call>{"name": "t1", "arguments": {"q": "v"}}</tool_call>
-        ('<tool_call>{"name": "', "}</tool_call>"),
-    ]
-
-    return [
-        TagFormat(
-            begin=begin + tool.function.name + arguments_field_prefix,
-            content=JSONSchemaFormat(
-                json_schema=_get_function_parameters(tool.function)
-            ),
-            end=end,
-        )
-        for tool in tools
-        for begin, end in formats
-    ]
-
-
-@register_vllm_structural_tag("hermes")
-def get_hermes_structural_tag(
-    tools: list[FunctionToolParam],
-    builtin_tools: list[BuiltinToolParam],
-    tool_choice: SimplifiedToolChoice,
-    reasoning: bool,
-) -> StructuralTag:
-    del builtin_tools, reasoning
-
-    tool_call_trigger = "<tool_call>"
-
-    if tool_choice == "auto":
-        tags = _hermes_tool_tags(tools)
-        suffix_tag = (
-            TriggeredTagsFormat(triggers=[tool_call_trigger], tags=tags)
-            if tags
-            else AnyTextFormat()
-        )
-    elif tool_choice == "forced":
-        suffix_tag = TagsWithSeparatorFormat(
-            tags=_hermes_tool_tags(tools),
-            separator="",
-            at_least_one=True,
-            stop_after_first=True,
-        )
-    else:
-        suffix_tag = TagsWithSeparatorFormat(
-            tags=_hermes_tool_tags(tools),
-            separator="",
-            at_least_one=True,
-        )
-
-    return StructuralTag(format=suffix_tag)
-
-
-def _minimax_tool_tags(tools: list[FunctionToolParam]) -> list[TagFormat]:
-    return [
-        TagFormat(
-            begin=f'<invoke name="{tool.function.name}">\n',
-            content=JSONSchemaFormat(
-                json_schema=_get_function_parameters(tool.function),
-                style="minimax_xml",
-            ),
-            end="</invoke>\n",
-        )
-        for tool in tools
-    ]
-
-
-@register_vllm_structural_tag("minimax")
-def get_minimax_structural_tag(
-    tools: list[FunctionToolParam],
-    builtin_tools: list[BuiltinToolParam],
-    tool_choice: SimplifiedToolChoice,
-    reasoning: bool,
-) -> StructuralTag:
-    del builtin_tools, reasoning
-
-    tool_call_begin = "<minimax:tool_call>\n"
-    tool_call_end = "</minimax:tool_call>"
-    tool_call_trigger = "<minimax:tool_call>"
-
-    tags = _minimax_tool_tags(tools)
-
-    if tool_choice == "auto":
-        suffix_tag = (
-            TriggeredTagsFormat(
-                triggers=[tool_call_trigger],
-                tags=[
-                    TagFormat(
-                        begin=tool_call_begin,
-                        content=TagsWithSeparatorFormat(
-                            tags=tags,
-                            separator="",
-                            at_least_one=True,
-                        ),
-                        end=tool_call_end,
-                    )
-                ],
-                # excludes=["<think>", "</think>"],
-            )
-            if tags
-            else AnyTextFormat()
-        )
-    elif tool_choice == "forced":
-        suffix_tag = SequenceFormat(
-            elements=[
-                ConstStringFormat(value="\n" + tool_call_begin),
-                TagsWithSeparatorFormat(
-                    tags=tags,
-                    separator="",
-                    at_least_one=True,
-                    stop_after_first=True,
-                ),
-                ConstStringFormat(value=tool_call_end),
-            ]
-        )
-    else:
-        suffix_tag = SequenceFormat(
-            elements=[
-                ConstStringFormat(value="\n" + tool_call_begin),
-                TagsWithSeparatorFormat(
-                    tags=tags,
-                    separator="",
-                    at_least_one=True,
-                ),
-                ConstStringFormat(value=tool_call_end),
-            ]
-        )
-
-    return StructuralTag(format=suffix_tag)
-
-
-def _glm_4_7_tool_tags(tools: list[FunctionToolParam]) -> list[TagFormat]:
-    return [
-        TagFormat(
-            begin=f"<tool_call>{tool.function.name}",
-            content=JSONSchemaFormat(
-                json_schema=_get_function_parameters(tool.function),
-                style="glm_xml",
-            ),
-            end="</tool_call>",
-        )
-        for tool in tools
-    ]
-
-
-@register_vllm_structural_tag("glm_4_7")
-def get_glm_4_7_structural_tag(
-    tools: list[FunctionToolParam],
-    builtin_tools: list[BuiltinToolParam],
-    tool_choice: SimplifiedToolChoice,
-    reasoning: bool,
-) -> StructuralTag:
-    del builtin_tools, reasoning
-
-    tool_call_trigger = "<tool_call>"
-
-    tags = _glm_4_7_tool_tags(tools)
-
-    if tool_choice == "auto":
-        suffix_tag = (
-            TriggeredTagsFormat(
-                triggers=[tool_call_trigger],
-                tags=tags,
-                # excludes=["<think>", "</think>"],
-            )
-            if tags
-            else AnyTextFormat()
-        )
-    elif tool_choice == "forced":
-        suffix_tag = TagsWithSeparatorFormat(
-            tags=tags,
-            separator="",
-            at_least_one=True,
-            stop_after_first=True,
-        )
-    else:
-        suffix_tag = TagsWithSeparatorFormat(
-            tags=tags,
-            separator="",
-            at_least_one=True,
-        )
-
-    return StructuralTag(format=suffix_tag)

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -62,7 +62,6 @@ XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS = frozenset(
         "qwen_3",
         "harmony",
         "deepseek_v3_2",
-        "glm_4_7",
         "deepseek_v4",
     }
 )
@@ -106,8 +105,8 @@ def get_model_structural_tag(
     if not tools or tool_choice == "none":
         return None
 
-    if tool_choice == "auto" and not _any_tool_strict(tools):
-        return None
+    # if tool_choice == "auto" and not _any_tool_strict(tools):
+    #     return None
 
     dumped_tools = [_dump_tool_for_xgrammar(tool) for tool in tools]
     dumped_tool_choice = _dump_tool_choice_for_xgrammar(tool_choice)
@@ -313,10 +312,10 @@ def get_minimax_structural_tag(
                         end=tool_call_end,
                     )
                 ],
-                excludes=["<think>", "</think>"],
+                # excludes=["<think>", "</think>"],
             )
             if tags
-            else AnyTextFormat(excludes=["<think>", "</think>"])
+            else AnyTextFormat()
         )
     elif tool_choice == "forced":
         suffix_tag = SequenceFormat(
@@ -342,6 +341,60 @@ def get_minimax_structural_tag(
                 ),
                 ConstStringFormat(value=tool_call_end),
             ]
+        )
+
+    return StructuralTag(format=suffix_tag)
+
+
+def _glm_4_7_tool_tags(tools: list[FunctionToolParam]) -> list[TagFormat]:
+    return [
+        TagFormat(
+            begin=f"<tool_call>{tool.function.name}",
+            content=JSONSchemaFormat(
+                json_schema=_get_function_parameters(tool.function),
+                style="glm_xml",
+            ),
+            end="</tool_call>",
+        )
+        for tool in tools
+    ]
+
+
+@register_vllm_structural_tag("glm_4_7")
+def get_glm_4_7_structural_tag(
+    tools: list[FunctionToolParam],
+    builtin_tools: list[BuiltinToolParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    del builtin_tools, reasoning
+
+    tool_call_trigger = "<tool_call>"
+
+    tags = _glm_4_7_tool_tags(tools)
+
+    if tool_choice == "auto":
+        suffix_tag = (
+            TriggeredTagsFormat(
+                triggers=[tool_call_trigger],
+                tags=tags,
+                # excludes=["<think>", "</think>"],
+            )
+            if tags
+            else AnyTextFormat()
+        )
+    elif tool_choice == "forced":
+        suffix_tag = TagsWithSeparatorFormat(
+            tags=tags,
+            separator="",
+            at_least_one=True,
+            stop_after_first=True,
+        )
+    else:
+        suffix_tag = TagsWithSeparatorFormat(
+            tags=tags,
+            separator="",
+            at_least_one=True,
         )
 
     return StructuralTag(format=suffix_tag)


### PR DESCRIPTION





## Purpose
```
    if tool_choice == "auto":
        suffix_tag = (
            TriggeredTagsFormat(
                triggers=[tool_call_trigger],
                tags=tags,
                # excludes=["<think>", "</think>"],
            )
            if tags
            else AnyTextFormat()
        )

```

I’m not using xgrammar’s built-in glm_4_7 anymore—I rewrote it locally instead. The only real difference is that I removed `excludes=["<think>", "</think>"]`.

From the logs, it seems like the FSM always gets stuck on token `154842`.

```
bk;t=1781344862278[vllm] (EngineCore pid=871) ERROR 06-13 10:01:02 [scheduler.py:1531] Unexpected: grammar rejected tokens [530, 729, 13, 154842] for request chatcmpl-baf198cfd10c0ac0-ac8af1cb. Terminating request.

_bk;t=1781344862279[vllm] (APIServer pid=1) ERROR 06-13 10:01:02 [serving.py:195] Request chatcmpl-baf198cfd10c0ac0 failed with an internal error during generation

_bk;t=1781344862280[vllm] (APIServer pid=1) INFO:     172.17.0.1:39406 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error

_bk;t=1781344862642[vllm] (EngineCore pid=871) ERROR 06-13 10:01:02 [backend_xgrammar.py:158] Failed to advance FSM for request chatcmpl-9d9455183ca31ab7-a22b027d for tokens 154842. Please file an issue.

_bk;t=1781344862642[vllm] (EngineCore pid=871) ERROR 06-13 10:01:02 [scheduler.py:1531] Unexpected: grammar rejected tokens [419, 13, 154842] for request chatcmpl-9d9455183ca31ab7-a22b027d. Terminating request.

_bk;t=1781344862643[vllm] (APIServer pid=1) ERROR 06-13 10:01:02 [serving.py:195] Request chatcmpl-9d9455183ca31ab7 failed with an internal error during generation

_bk;t=1781344862643[vllm] (APIServer pid=1) INFO:     172.17.0.1:39402 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error

_bk;t=1781344862677[vllm] (EngineCore pid=871) ERROR 06-13 10:01:02 [backend_xgrammar.py:158] Failed to advance FSM for request chatcmpl-9ab879b0369bf806-8f044675 for tokens 154842. Please file an issue.

_bk;t=1781344862677[vllm] (EngineCore pid=871) ERROR 06-13 10:01:02 [scheduler.py:1531] Unexpected: grammar rejected tokens [28, 20, 13, 154842] for request chatcmpl-9ab879b0369bf806-8f044675. Terminating request.

_bk;t=1781344862677[vllm] (EngineCore pid=871) ERROR 06-13 10:01:02 [backend_xgrammar.py:158] Failed to advance FSM for request chatcmpl-bea55bb0387b3d48-86e6b472 for tokens 154842. Please file an issue.

_bk;t=1781344862677[vllm] (EngineCore pid=871) ERROR 06-13 10:01:02 [scheduler.py:1531] Unexpected: grammar rejected tokens [5029, 13, 154842] for request chatcmpl-bea55bb0387b3d48-86e6b472. Terminating request.

```


## Test Plan
```
 OPENAI_BASE_URL=http://localhost:8000/v1  OPENAI_API_KEY=dummy uv run python -m bfcl_eval generate \
    --model zai-org/GLM-5.1-FP8-FC-ChatCompletions \
    --test-category multi_turn_base \
    --result-dir $PWD --allow-overwrite --num-threads 16

```
## Test Result
```
Rank,Model,Multi Turn Overall Acc,Base,Miss Func,Miss Param,Long Context

1,zai-org/GLM-5.1-FP8 (FC ChatCompletions),19.00%,76.00%,N/A,N/A,N/A

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

