### PR TITLE
[OOT Platform][CPU] use compiled TopKTopPSampler if device supports

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -118,7 +118,17 @@ class TopKTopPSampler(nn.Module):
             )
             self.forward = self.forward_hip
         else:
-            self.forward = self.forward_native
+            if current_platform.device_type == "cpu":
+                arch = current_platform.get_cpu_architecture()
+                # Fall back to native implementation for POWERPC and RISCV.
+                # On PowerPC argmax produces incorrect output with torch.compile.
+                # PR: https://github.com/vllm-project/vllm/pull/26987
+                if arch in (CpuArchEnum.RISCV, CpuArchEnum.POWERPC):
+                    self.forward = self.forward_native
+                else:
+                    self.forward = self.forward_cpu
+            else:
+                self.forward = self.forward_native
 
     def forward_native(
         self,


### PR DESCRIPTION


## Purpose
In TopKTopPSampler use torch compiled implementation of sampling instead of native implementation when platform.device_type is "cpu" and current_platform is not cpu.

Usage

Out of Tree (OOT) Platform like "openvino" when run on CPU should be able to leverage such compiled kernels if the underlying device supports such implementation.

This work is contributed by @ashwins990 & @abhijain1204fujitsu

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

