### PR TITLE
[Misc] Enable test_fla_layernorm_guard on XPU

### DIFF
--- a/tests/kernels/test_fla_layernorm_guard.py
+++ b/tests/kernels/test_fla_layernorm_guard.py
@@ -10,7 +10,10 @@ from vllm.model_executor.layers.fla.ops.layernorm_guard import (
     layernorm_fn,
     rms_norm_ref,
 )
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
+
+DEVICE = "xpu" if current_platform.is_xpu() else "cuda"
 
 
 def layer_norm_ref(
@@ -115,7 +118,7 @@ def test_layer_norm_fwd_basic(
 ) -> None:
     """Test basic layer norm forward pass without z (gate) tensor."""
     set_random_seed(seed)
-    device = torch.device("cuda:0")
+    device = torch.device(DEVICE)
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -157,7 +160,7 @@ def test_layer_norm_fwd_with_gate(
 ) -> None:
     """Test layer norm forward pass with z (gate) tensor."""
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(DEVICE)
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -214,7 +217,7 @@ def test_layer_norm_fwd_with_groups(
         )
 
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(DEVICE)
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -254,7 +257,7 @@ def test_layer_norm_rows_per_block(
 ) -> None:
     """Test that rows_per_block logic works correctly for various M sizes."""
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(DEVICE)
     hidden_size = 1024
 
     # Create inputs
@@ -279,7 +282,7 @@ def test_strided_input(dtype: torch.dtype) -> None:
     """Test that the kernel handles non-contiguous (strided)
     inputs correctly."""
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(DEVICE)
     num_tokens = 128
     hidden_size = 1024
 
@@ -319,7 +322,7 @@ def test_output_buffer_provided(
 ) -> None:
     """Test that the kernel works when an output buffer is provided."""
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(DEVICE)
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -360,7 +363,7 @@ def test_multidimensional_input(
 ) -> None:
     """Test that the autograd function handles multidimensional inputs."""
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(DEVICE)
     hidden_size = shape[-1]
 
     # Create inputs
@@ -404,7 +407,7 @@ def test_rmsnorm_gated_forward_native_dtype(
 
     from vllm.model_executor.layers.layernorm import RMSNormGated
 
-    device = torch.device("cuda:0")
+    device = torch.device(DEVICE)
     set_random_seed(42)
 
     layer = RMSNormGated(


### PR DESCRIPTION
## Purpose

Enables the existing `test_fla_layernorm_guard` unit test on XPU by making it
device-agnostic. The test covers the `layer_norm_fwd` Triton kernel
(Normalization group) in `tests/kernels/test_fla_layernorm_guard.py`, but
previously hardcoded `torch.device("cuda:0")`, so it could not run on Intel
GPUs. Replaces the hardcoded device with
`DEVICE = "xpu" if current_platform.is_xpu() else "cuda"`. No test logic,
shapes, or tolerances change.

## Test Plan

Run the full file on both backends:
`python -m pytest tests/kernels/test_fla_layernorm_guard.py -v`

## Test Result

All 1553 parametrized cases pass.