### PR TITLE
fix(moe_wna16): prevent int32 overflow in output index for large token counts

### DIFF
--- a/csrc/libtorch_stable/moe/moe_wna16.cu
+++ b/csrc/libtorch_stable/moe/moe_wna16.cu
@@ -216,7 +216,7 @@ __global__ void moe_wna16_gemm_kernel(
       if (mul_topk_weight) {
         res[m] *= topk_weights[token_index];
       }
-      atomicAdd(&output[token_index * size_n + offset_n],
+      atomicAdd(&output[static_cast<int64_t>(token_index) * size_n + offset_n],
                 Dtype::float2num(res[m]));
     }
 


### PR DESCRIPTION
## Summary

Fixes #45884.

In `moe_wna16_gemm_kernel`, the output index is computed as:

```cpp
atomicAdd(&output[token_index * size_n + offset_n], ...);
```

`token_index` is `int32_t` and `size_n` is a 32-bit value, so the product
`token_index * size_n` is evaluated in 32-bit arithmetic. For large MoE
workloads (large `size_m * top_k` and `size_n`), this product can exceed
`2**31 - 1` and wrap around, producing an out-of-bounds address that is then
written via `atomicAdd` — silent memory corruption.

The reproduction in the issue gives a concrete case:

```
sorted_token_ids[...] = 1525201, size_n = 2816, offset_n = 2570
=> 1525201 * 2816 + 2570 = 4,294,968,831 > 2**31 - 1  (and > 2**32 - 1)
```

## Fix

Promote the index computation to 64-bit by casting `token_index` to
`int64_t`, so the whole expression is evaluated in 64-bit. This mirrors the
existing convention already used a few lines above in the same kernel for
`expert_offset`:

```cpp
// note that (size_n * size_k * expert_id) may greater than 2 ** 31
const uint64_t expert_offset = ((uint64_t)size_n) * size_k * expert_id;
```

One-line, behavior-preserving change for in-range indices.

## Test plan

- [ ] Existing MoE WNA16 unit tests should be unaffected (no behavior change for in-range indices).
- [ ] A maintainer with the affected large-MoE configuration can confirm the out-of-bounds write no longer occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
