### PR TITLE
[Bugfix] Disable FlashInfer per-tensor FP8 bmm on sm_12x

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/flashinfer.py
@@ -50,6 +50,20 @@ class FlashInferFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         if compute_capability is not None and compute_capability < 100:
             return False, "requires compute capability 100 and above."
 
+        # The FlashInfer bmm_fp8 path resolves backend="auto" to the cuDNN
+        # fp8_gemm_sm100 kernel, which is only valid on datacenter Blackwell
+        # (sm_10x). On the consumer/workstation Blackwell family (sm_12x: RTX
+        # PRO / GeForce RTX 50 / GB10) cuDNN's FP8 GEMM heuristic returns too
+        # few execution plans, so the autotuner-selected plan index can be out
+        # of range and raises "Plan index N is invalid" at runtime. Fall back
+        # to CUTLASS there. See https://github.com/flashinfer-ai/flashinfer/issues/3566
+        if compute_capability is not None and compute_capability >= 120:
+            return False, (
+                "FlashInfer FP8 bmm is unsupported on the sm_12x "
+                "(consumer/workstation Blackwell) family; "
+                "see flashinfer-ai/flashinfer#3566."
+            )
+
         return True, None
 
     @classmethod


### PR DESCRIPTION
## Purpose

Per-tensor FP8 on sm_12x (RTX PRO Blackwell, RTX6000BSE) crashes at cudagraph capture with "Plan index N is invalid": FlashInferFP8ScaledMMLinearKernel only gates cc<100, so sm_120/121 dispatch bmm_fp8("auto") into the cuDNN fp8_gemm_sm100 path that is valid only on datacenter Blackwell (sm_10x). Gate cc>=120 out; selection falls back to CUTLASS.

Temporary mitigation; the root defect needs a deep dive in FlashInfer/cuDNN sm_12x FP8 GEMM plan selection (flashinfer-ai/flashinfer#3566).

## Test Plan

Built and linked vllm to the image. Deploy the model on the same env + hardware

## Test Result

The startup completed successfully.