### PR TITLE
[Bugfix] Pass TP group to FlashInfer all-reduce fusion

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -129,13 +129,7 @@ def enable_act_fusion(cfg: "VllmConfig") -> bool:
 
 
 def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:
-    """Enable if TP > 1, PP == 1, Hopper/Blackwell, and flashinfer installed.
-
-    Gated off for PP > 1: the fused op's GPU-side peer-signal spin-wait
-    assumes byte-identical kernel launches across TP peers, but concurrent
-    independent warmup of multiple TP subgroups lets ranks pick divergent
-    FlashInfer launch configs and deadlock.
-    """
+    """Enable if TP > 1 and Hopper/Blackwell and flashinfer installed."""
     from vllm.platforms import current_platform
     from vllm.utils.flashinfer import has_flashinfer
 
@@ -148,7 +142,6 @@ def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:
 
     return (
         cfg.parallel_config.tensor_parallel_size > 1
-        and cfg.parallel_config.pipeline_parallel_size == 1
         and current_platform.is_cuda()
         and has_flashinfer()
         and (

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -53,6 +53,10 @@ def _create_workspace(
     rng_state = random.getstate()
     try:
         random.seed(int.from_bytes(os.urandom(16), byteorder="big"))
+        # Pass the (TP) process group so FlashInfer scopes its symmetric-
+        # memory rendezvous to this group instead of world size.
+        # Omitting it hangs during warmup when TP>1 and DP>1.
+        # Needs FlashInfer >= 0.6.11
         workspace = flashinfer_comm.create_allreduce_fusion_workspace(
             backend=backend,
             world_size=world_size,
@@ -61,6 +65,7 @@ def _create_workspace(
             hidden_dim=hidden_dim,
             dtype=dtype,
             comm_backend=comm_backend,
+            group=group,
         )
     except Exception as e:
         if "multicast" in str(e).lower():

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -53,10 +53,6 @@ def _create_workspace(
     rng_state = random.getstate()
     try:
         random.seed(int.from_bytes(os.urandom(16), byteorder="big"))
-        # Pass the (TP) process group so FlashInfer scopes its symmetric-
-        # memory rendezvous to this group instead of world size.
-        # Omitting it hangs during warmup when TP>1 and DP>1.
-        # Needs FlashInfer >= 0.6.11
         workspace = flashinfer_comm.create_allreduce_fusion_workspace(
             backend=backend,
             world_size=world_size,


### PR DESCRIPTION
## Purpose

### Symptom
Serving Nemotron-3-Ultra-NVFP4 with `--tensor-parallel-size > 1` and `--data-parallel-size > 1` hangs at startup during CUDA-graph capture / warmup: workers freeze and `EngineCore` repeatedly logs `No available shared memory broadcast block found in 60 seconds`.
The server never becomes ready.

Bug reproduced on both H100 and GB200.

Using `TP>1/DP=1`, `TP=1/DP>1`, and `TP=1/DP=1` works (with expert parallelism on or off).

Tested Docker images:
* `vllm/vllm-openai:v0.21.0` - OK (flashinfer 0.6.8.post1)
* `vllm/vllm-openai:v0.22.0` - fails (flashinfer 0.6.11.post2)
* `vllm/vllm-openai:v0.22.1` - fails
* `vllm/vllm-openai:v0.23.0` - fails (flashinfer 0.6.12)

### Root cause

The all-reduce + RMSNorm fusion (`compilation_config.pass_config.fuse_allreduce_rms`) builds a FlashInfer workspace via `create_allreduce_fusion_workspace(...)`.
FlashInfer performs a symmetric-memory rendezvous for that workspace over a process group, defaulting to `torch.distributed.group.WORLD` when no `group=` is passed.

vLLM's `_create_workspace` (`flashinfer_all_reduce.py`) passed only `comm_backend` and never `group=`, so the rendezvous ran over WORLD.
With `DP>1`, WORLD spans multiple independent TP subgroups, so each TP group's rendezvous blocks waiting for ranks that never join it, this leads to a deadlock during warmup.
(FlashInfer PR 3247 describes the same "4 devices, world size 2 hang in warmup" case.)

### Workaround

Using this vllm serve flag `--compilation_config.pass_config.fuse_allreduce_rms false` allows use of TP>1 and DP>1.

Disabling fuse_allreduce_rms was used as a solution for a similar bug with PP>1:
https://github.com/vllm-project/vllm/pull/43616

### Fix

In flashinfer file `flashinfer/comm/allreduce.py` and function `create_allreduce_fusion_workspace`,
the description of the `group` input is:
```
    group : Optional[ProcessGroup]
        Process group used for symmetric-memory rendezvous (TRT-LLM backend
        only). Defaults to ``torch.distributed.group.WORLD``.
```

So the fix is to pass the TP process group to `create_allreduce_fusion_workspace`.
This scopes FlashInfer's symm-mem rendezvous to the TP group instead of WORLD.

### History

Timeline of related changes in vLLM and flashinfer:

- **2026-02-15 - vLLM [#34392](https://github.com/vllm-project/vllm/pull/34392)** (`[torch.compile] Disable ar-rms fusion for ds3-fp4 & DP`): AR+RMSNorm fusion disabled for DP, so DP+TP did not use the FlashInfer fused all-reduce - no hang.
- **2026-04-24 - FlashInfer [#2955](https://github.com/flashinfer-ai/flashinfer/pull/2955)** (`unifying all reduce memory allocation for single-node and multi-node nvlink`): reworked workspace allocation to use a symmetric-memory rendezvous that defaults to `torch.distributed.group.WORLD`. Only a problem when a caller that uses AR fusion with a sub-WORLD group.
- **2026-05-01 - vLLM [#41458](https://github.com/vllm-project/vllm/pull/41458)** (`Re-enable allreduce rms fusion for DP / PP`): removed the DP exclusion, so DP+TP again uses the fused all-reduce.
- **2026-05-07 - FlashInfer [#3247](https://github.com/flashinfer-ai/flashinfer/pull/3247)** (`fix hang in allreduce comms in SGL`): added the `group=` parameter so callers can scope the rendezvous to their process group (first available in v0.6.10.post1 / v0.6.11). vLLM did not yet pass it, so the hang persisted.
- **2026-05-29 - vLLM [#43616](https://github.com/vllm-project/vllm/pull/43616)** (`[Bugfix] Disable allreduce_rms_fusion when pipeline_parallel_size > 1`): a related PP>1 deadlock in the same fusion was worked around by disabling the fusion for PP. DP>1 remained affected.

## Test Plan

## Test Result

GB200 (4 GPUs), Nemotron-Ultra-550B-A55B-NVFP4 (`fuse_allreduce_rms` is **enabled**).

Results:
- vLLM main: `TP2/DP2` (EP off and on) **hang** at warmup, eventually times out.
- vLLM with fix: `TP2/DP2` (EP off and on) **successful init**.
- `TP1/DP4` and `TP4/DP1` pass in both builds (TP=1 has no fusion, TP4/DP1 has world_size == the TP group).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
