### PR TITLE
[Doc] Clarify prompt embeds token IDs in offline example

### DIFF
--- a/docs/features/prompt_embeds.md
+++ b/docs/features/prompt_embeds.md
@@ -11,12 +11,15 @@ The traditional flow of text data for a Large Language Model goes from text to t
 To input multi-modal data, follow this schema in [vllm.inputs.EmbedsPrompt][]:
 
 - `prompt_embeds`: A torch tensor representing a sequence of prompt/token embeddings. This has the shape (sequence_length, hidden_size), where sequence length is the number of tokens embeddings and hidden_size is the hidden size (embedding size) of the model.
+- `prompt_token_ids` and `prompt_is_token_ids`: Optional fields for inputs that keep token IDs alongside embeddings, such as mixed token/embed prompts or model paths that consult token IDs while preparing positions. For an all-embedding prompt, pass the token IDs used to produce the embeddings and set every `prompt_is_token_ids` entry to `false`.
 
 ### Hugging Face Transformers Inputs
 
 You can pass prompt embeddings from Hugging Face Transformers models to the  `'prompt_embeds'` field of the prompt embedding dictionary, as shown in the following examples:
 
 [examples/features/prompt_embed/prompt_embed_offline.py](../../examples/features/prompt_embed/prompt_embed_offline.py)
+
+Some multimodal model paths, including Qwen-style M-RoPE deployments, can still consult token IDs while preparing positions even when the forward pass consumes pre-computed embeddings. Providing `prompt_token_ids` with a `prompt_is_token_ids` mask keeps that relationship explicit and also demonstrates the shape used by mixed token/embed prompts. A `false` value means vLLM should use the corresponding row from `prompt_embeds`; a `true` value means vLLM should use the model's embedding lookup for that token ID.
 
 ## Online Serving
 

--- a/examples/features/prompt_embed/prompt_embed_offline.py
+++ b/examples/features/prompt_embed/prompt_embed_offline.py
@@ -32,29 +32,31 @@ def init_tokenizer_and_llm(model_name: str):
     return tokenizer, embedding_layer, llm
 
 
-def get_prompt_embeds(
+def get_prompt_embed_input(
     chat: list[dict[str, str]],
     tokenizer: PreTrainedTokenizer,
     embedding_layer: torch.nn.Module,
-):
+) -> dict[str, object]:
     token_ids = tokenizer.apply_chat_template(
         chat, add_generation_prompt=True, return_tensors="pt", return_dict=True
     ).input_ids
+    token_ids = token_ids.to(embedding_layer.weight.device)
     prompt_embeds = embedding_layer(token_ids).squeeze(0)
-    return prompt_embeds
+    prompt_token_ids = token_ids.squeeze(0).tolist()
+    return {
+        "prompt_embeds": prompt_embeds,
+        "prompt_token_ids": prompt_token_ids,
+        "prompt_is_token_ids": [False] * len(prompt_token_ids),
+    }
 
 
 def single_prompt_inference(
     llm: LLM, tokenizer: PreTrainedTokenizer, embedding_layer: torch.nn.Module
 ):
     chat = [{"role": "user", "content": "Please tell me about the capital of France."}]
-    prompt_embeds = get_prompt_embeds(chat, tokenizer, embedding_layer)
+    prompt_embed_input = get_prompt_embed_input(chat, tokenizer, embedding_layer)
 
-    outputs = llm.generate(
-        {
-            "prompt_embeds": prompt_embeds,
-        }
-    )
+    outputs = llm.generate(prompt_embed_input)
 
     print("\n[Single Inference Output]")
     print("-" * 30)
@@ -72,11 +74,11 @@ def batch_prompt_inference(
         [{"role": "user", "content": "Where is bigger, the moon or the sun?"}],
     ]
 
-    prompt_embeds_list = [
-        get_prompt_embeds(chat, tokenizer, embedding_layer) for chat in chats
+    prompt_embed_inputs = [
+        get_prompt_embed_input(chat, tokenizer, embedding_layer) for chat in chats
     ]
 
-    outputs = llm.generate([{"prompt_embeds": embeds} for embeds in prompt_embeds_list])
+    outputs = llm.generate(prompt_embed_inputs)
 
     print("\n[Batch Inference Outputs]")
     print("-" * 30)


### PR DESCRIPTION
## Purpose

Related to #44842.

The offline prompt embeddings example previously passed only `prompt_embeds` to `LLM.generate()`. Recent runtime fixes in #45252 and #45383 cover prompt-embeds-only execution for M-RoPE and multimodal paths; this PR is a smaller docs/example follow-up that shows how to pass token IDs explicitly when users want to keep token IDs alongside pre-computed embeddings.

This updates the example to pass the token IDs that produced the embeddings plus a `prompt_is_token_ids` mask. For the all-embedding case, every mask entry is `false`, so vLLM still uses the provided embedding row at each position. The token IDs remain available for mixed token/embed prompts and model paths that consult token IDs while preparing positions.

The docs now also describe when `prompt_token_ids` and `prompt_is_token_ids` can be provided for `EmbedsPrompt`.

## Why this is not a duplicate

Per AGENTS.md, I checked:

```bash
gh issue view 44842 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "44842 in:body"
gh pr list --repo vllm-project/vllm --state open --search "prompt_embeds M-RoPE token ids offline example"
```

No open PR references #44842, and no open PR appears to update the offline prompt-embeds example/docs with the explicit token-id form. PR #42963 is related to ModelRunnerV2 prompt embeds support, but it does not cover this example/docs clarification.

The runtime issue reported in #44842 has related merged fixes in #45252 and #45383. This PR does not duplicate those runtime changes; it only updates the offline example and prompt-embeds docs to show the explicit token-id form for users who need or prefer it.

## Test Plan

Local Windows:

```bash
git diff --check
uv run --with ruff ruff check examples/features/prompt_embed/prompt_embed_offline.py
uv run python -m py_compile examples/features/prompt_embed/prompt_embed_offline.py
```

DGX Spark Linux/aarch64:

```bash
git diff --check
/home/nvidia/workspace/pr/vllm/.venv/bin/python -m py_compile examples/features/prompt_embed/prompt_embed_offline.py
/home/nvidia/workspace/pr/vllm/.venv/bin/python -m pre_commit run --files examples/features/prompt_embed/prompt_embed_offline.py docs/features/prompt_embeds.md
```

## Test Results

- `git diff --check`: passed locally and on DGX Spark
- `ruff check`: passed locally
- `py_compile`: passed locally and on DGX Spark
- file-targeted pre-commit on DGX Spark: passed

I did not run the full example because the default model is gated on Hugging Face Hub access and requires model download/runtime GPU execution.

## AI Assistance

AI assistance was used to inspect the issue, check for duplicate PRs, prepare the docs/example change, and run validation. I reviewed the resulting diff and validation results before submission.
