### PR TITLE
fix(logging): use cyan for DEBUG level so logs stay legible on light terminals

### DIFF
--- a/vllm/logging_utils/formatter.py
+++ b/vllm/logging_utils/formatter.py
@@ -85,7 +85,7 @@ class ColoredFormatter(NewLineFormatter):
 
     # ANSI color codes
     COLORS = {
-        "DEBUG": "\033[37m",  # White
+        "DEBUG": "\033[36m",  # Cyan (legible on light and dark backgrounds)
         "INFO": "\033[32m",  # Green
         "WARNING": "\033[33m",  # Yellow
         "ERROR": "\033[31m",  # Red


### PR DESCRIPTION
## Summary

The colored log formatter assumed a dark terminal background. `ColoredFormatter.COLORS` mapped the `DEBUG` level to white (`\033[37m`), which is invisible on terminals with a light/white background (see #45920).

This switches `DEBUG` to cyan (`\033[36m`), which renders legibly on **both** light and dark backgrounds. The remaining level colors (green / yellow / red / magenta) and the grey metadata (`\033[90m`, bright-black) already remain readable on either background, so they are left unchanged to keep the diff minimal.

## Why cyan

White (`37m`) is the one color in the palette that is foreground-on-foreground for light terminals. Cyan is the conventional "debug/trace" color and has adequate contrast against both black and white backgrounds, so it fixes the reported readability problem without otherwise changing the look of the logs.

Fixes #45920

## Test plan
- [ ] Run with `VLLM_LOGGING_LEVEL=DEBUG VLLM_LOGGING_COLOR=1` on a light-background terminal and confirm the `DEBUG` label is now readable.
- [ ] Confirm INFO/WARNING/ERROR/CRITICAL output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
