### PR TITLE
Fix: ValueError/OverflowError in Mamba utils

### DIFF
--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -409,7 +409,8 @@ class MambaSpecDecodeGPUContext:
 
                 for state_type_idx, state in enumerate(kv_caches):
                     # Base address
-                    self.state_base_addrs[idx] = state.data_ptr()
+                    import ctypes
+                    self.state_base_addrs[idx] = ctypes.c_int64(state.data_ptr()).value
 
                     # Block stride (bytes between consecutive blocks)
                     # state shape: [num_blocks, ...], stride(0) = elements per block
@@ -469,7 +470,8 @@ class MambaSpecDecodeGPUContext:
         )
         self.block_table_stride_req = int(next(iter(strides)))
         for i, bt in enumerate(block_tables):
-            self.block_table_ptrs[i] = bt.data_ptr()
+            import ctypes
+            self.block_table_ptrs[i] = ctypes.c_int64(bt.data_ptr()).value
 
         self.is_initialized = True
 
@@ -600,8 +602,9 @@ def collect_mamba_copy_meta(
                     state, block_ids, src_block_idx, accept_token_bias + 1
                 )
 
-                src_ptrs_np[offset] = copy_spec.start_addr
-                dst_ptrs_np[offset] = state[dest_block_id].data_ptr()
+                import ctypes
+                src_ptrs_np[offset] = ctypes.c_int64(copy_spec.start_addr).value
+                dst_ptrs_np[offset] = ctypes.c_int64(state[dest_block_id].data_ptr()).value
                 sizes_np[offset] = copy_spec.num_elements * state.element_size()
                 offset += 1
 


### PR DESCRIPTION
Python 3.13 handles pointer unpacking of unsigned 64-bit GPU memory addresses into signed int64 structures differently than Python 3.12, causing ValueError/OverflowError when converting long long to C long.

Cast unsigned data pointers into signed int64 values via ctypes.

This seems to only be an issue on XPU and with newest driver and kernel versions.




## Purpose
Stop crash created by python not being able to convert value into c-type int

## Test Plan
I have verified it on my machine with Qwen3.6-27b model

it needs also to be regression tested against setups with older drivers and kernel, and with setups not using XPU

## Test Result
have run on B70 for about 1 hour doing agentic tasks withut crashing


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>

