### PR TITLE
[ROCm] Add native MXFP4 (W4A4) MoE backend for minimax-m3

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -255,7 +255,10 @@ def rocm_aiter_fused_experts(
         activation_method = ActivationMethod.SILU
     elif activation == MoEActivation.GELU:
         activation_method = ActivationMethod.GELU
-    elif activation == MoEActivation.SWIGLUOAI:
+    elif activation in (
+        MoEActivation.SWIGLUOAI,
+        MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+    ):
         activation_method = rocm_aiter_ops.get_aiter_activation_type("swiglu")
     else:
         raise ValueError(f"Unsupported activation: {activation}")
@@ -458,6 +461,7 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             MoEActivation.SILU,
             MoEActivation.GELU,
             MoEActivation.SWIGLUOAI,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
         ]
 
     @staticmethod

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -962,12 +962,55 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
 
     elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP4:
         from vllm._aiter_ops import rocm_aiter_ops
+        from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
         if w13_bias is not None:
             w13_bias = w13_bias.data.to(torch.float32)
         if w2_bias is not None:
             w2_bias = w2_bias.data.to(torch.float32)
 
+        # AITER fused_moe dispatches W4A4 + SwiGLU-OAI (per_1x32) to the ck_tile
+        # FlatMM kernel, which needs the gate/up interleave-16 weight+scale
+        # layout (shuffle_*_a16w4; activation-dtype independent). Other
+        # activations use the classic CK 2-stage kernel (generic shuffle_weights
+        # + e8m0 scale swizzle). Select the layout by activation so both paths
+        # work.
+        if layer.activation in (
+            MoEActivation.SWIGLUOAI,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        ):
+            # ck_tile layout. M3 stores gate/up separated, so no row
+            # de-interleave (unlike the GPT-OSS W4A16 path below).
+            w13_weight.data = w13_weight.data.view(torch.float4_e2m1fn_x2)
+            w2_weight.data = w2_weight.data.view(torch.float4_e2m1fn_x2)
+
+            w13_weight.data = rocm_aiter_ops.shuffle_weight_a16w4(w13_weight, 16, True)
+            shuffled_w13_scale = rocm_aiter_ops.shuffle_scale_a16w4(
+                w13_weight_scale.view(-1, w13_weight_scale.shape[-1]),
+                num_experts,
+                True,
+            )
+
+            w2_weight.data = rocm_aiter_ops.shuffle_weight_a16w4(w2_weight, 16, False)
+            shuffled_w2_scale = rocm_aiter_ops.shuffle_scale_a16w4(
+                w2_weight_scale.view(-1, w2_weight_scale.shape[-1]),
+                num_experts,
+                False,
+            )
+
+            w13_weight.is_shuffled = True
+            w2_weight.is_shuffled = True
+
+            return (
+                w13_weight,
+                w2_weight,
+                shuffled_w13_scale,
+                shuffled_w2_scale,
+                w13_bias,
+                w2_bias,
+            )
+
+        # Classic CK 2-stage layout (non-SwiGLU W4A4).
         # e8m0_shuffle on weight scales (GFX950 swizzle layout)
         from aiter.utility.fp4_utils import e8m0_shuffle
 


### PR DESCRIPTION
MiniMax-M3 uses W4A4 MXFP4 experts with the uninterleaved OAI clamped-
SwiGLU (SWIGLUOAI_UNINTERLEAVE). Wire it onto AITER's existing W4A4
per_1x32 ck_tile MoE kernel on gfx950 (no new kernel):

- rocm_aiter_moe: map SWIGLUOAI_UNINTERLEAVE to AITER "swiglu" and add it
  to the supported activations.
- oracle/mxfp4: select the W4A4 weight-prep layout by activation. SwiGLU-OAI
  dispatches to the ck_tile FlatMM kernel and needs the gate/up interleave-16
  weight+scale layout (shuffle_weight_a16w4 / shuffle_scale_a16w4); other
  activations keep the classic CK 2-stage layout (generic shuffle_weights +
  e8m0). The old code applied the classic layout unconditionally, which
  mispaired gate/up for M3 (SwiGLU -> ck_tile) and produced garbage. M3
  stores gate/up separated, so no row de-interleave.

Additive to the AITER MXFP4 path; W4A16 (gpt-oss) and non-SwiGLU W4A4
models keep their existing layout. Validated on MiniMax-M3 (gfx950):
gsm8k 5-shot exact_match 0.95, matching the BF16 emulation baseline.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

