### PR TITLE
[Model] Enable tower/connector LoRA for Qwen2-Audio via a native audio encoder

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -617,7 +617,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `Phi4ForCausalLMV` | Phi-4-reasoning-vision | T + I<sup>+</sup> | `microsoft/Phi-4-reasoning-vision-15B`, etc. | | ✅︎ |
 | `PixtralForConditionalGeneration` | Ministral 3 (Mistral format), Mistral 3 (Mistral format), Mistral Large 3 (Mistral format), Pixtral (Mistral format) | T + I<sup>+</sup> | `mistralai/Ministral-3-3B-Instruct-2512`, `mistralai/Mistral-Small-3.1-24B-Instruct-2503`, `mistralai/Mistral-Large-3-675B-Instruct-2512` `mistralai/Pixtral-12B-2409` etc. | ✅︎ | ✅︎ |
 | `QianfanOCRForConditionalGeneration` | QianfanOCR | T + I<sup>E+</sup> | `baidu/Qianfan-OCR`, etc. | ✅︎ | ✅︎ |
-| `Qwen2AudioForConditionalGeneration` | Qwen2-Audio | T + A<sup>+</sup> | `Qwen/Qwen2-Audio-7B-Instruct` | | ✅︎ |
+| `Qwen2AudioForConditionalGeneration` | Qwen2-Audio | T + A<sup>+</sup> | `Qwen/Qwen2-Audio-7B-Instruct` | ✅︎ | ✅︎ |
 | `Qwen2VLForConditionalGeneration` <sup>Q</sup> | QVQ, Qwen2-VL | T + I<sup>E+</sup> + V<sup>E+</sup> | `Qwen/QVQ-72B-Preview`, `Qwen/Qwen2-VL-7B-Instruct`, `Qwen/Qwen2-VL-72B-Instruct`, etc. | ✅︎ | ✅︎ |
 | `Qwen2_5_VLForConditionalGeneration` <sup>Q</sup> | Qwen2.5-VL | T + I<sup>E+</sup> + V<sup>E+</sup> | `Qwen/Qwen2.5-VL-3B-Instruct`, `Qwen/Qwen2.5-VL-72B-Instruct`, etc. | ✅︎ | ✅︎ |
 | `Qwen2_5OmniThinkerForConditionalGeneration` | Qwen2.5-Omni | T + I<sup>E+</sup> + V<sup>E+</sup> + A<sup>+</sup> | `Qwen/Qwen2.5-Omni-3B`, `Qwen/Qwen2.5-Omni-7B` | ✅︎ | ✅︎ |

--- a/vllm/model_executor/models/qwen2_audio.py
+++ b/vllm/model_executor/models/qwen2_audio.py
@@ -31,7 +31,6 @@ import torch.nn as nn
 from transformers import BatchFeature
 from transformers.models.qwen2_audio import (
     Qwen2AudioConfig,
-    Qwen2AudioEncoder,
     Qwen2AudioProcessor,
 )
 from transformers.models.whisper import WhisperFeatureExtractor
@@ -39,6 +38,8 @@ from transformers.models.whisper import WhisperFeatureExtractor
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.inputs import ModalityData, MultiModalDataDict
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (
     AudioItem,
@@ -62,8 +63,15 @@ from vllm.multimodal.processing import (
 from vllm.sequence import IntermediateTensors
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
-from .interfaces import MultiModalEmbeddings, SupportsMultiModal, SupportsPP
+from .interfaces import (
+    MultiModalEmbeddings,
+    SupportsLoRA,
+    SupportsMultiModal,
+    SupportsPP,
+)
+from .module_mapping import MultiModelKeys
 from .utils import AutoWeightsLoader, init_vllm_registered_model, maybe_prefix
+from .whisper import WhisperEncoderLayer
 
 
 # # === Audio Inputs === #
@@ -109,12 +117,26 @@ Qwen2AudioInputs: TypeAlias = Qwen2AudioFeatureInputs | Qwen2AudioEmbeddingInput
 
 
 class Qwen2AudioMultiModalProjector(nn.Module):
-    def __init__(self, audio_hidden_size: int, text_hidden_size: int):
+    def __init__(
+        self,
+        audio_hidden_size: int,
+        text_hidden_size: int,
+        quant_config=None,
+        prefix: str = "",
+    ):
         super().__init__()
-        self.linear = nn.Linear(audio_hidden_size, text_hidden_size, bias=True)
+        # ReplicatedLinear (a vLLM-native linear) so the connector can be
+        # wrapped for LoRA; a plain nn.Linear is left unwrapped by from_layer.
+        self.linear = ReplicatedLinear(
+            audio_hidden_size,
+            text_hidden_size,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear",
+        )
 
     def forward(self, audio_features):
-        hidden_states = self.linear(audio_features)
+        hidden_states, _ = self.linear(audio_features)
         return hidden_states
 
 
@@ -123,6 +145,102 @@ def _get_feat_extract_output_lengths(input_lengths: torch.Tensor):
     feat_lengths = (input_lengths - 1) // 2 + 1
     output_lengths = (feat_lengths - 2) // 2 + 1
     return feat_lengths, output_lengths
+
+
+class Qwen2AudioWhisperEncoder(nn.Module):
+    """vLLM-native Qwen2-Audio audio tower.
+
+    The HuggingFace ``Qwen2AudioEncoder`` is a Whisper encoder followed by an
+    average pooler. This re-implementation reuses vLLM's ``WhisperEncoderLayer``
+    (whose ``qkv_proj``/``out_proj``/``fc1``/``fc2`` are vLLM-native linears) so
+    the tower can be wrapped for LoRA, while the surrounding ``forward`` mirrors
+    the HuggingFace encoder numerically. The mel input is padded to 30s, so the
+    attention mask the HuggingFace encoder ignores is unnecessary here.
+    """
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        embed_dim = config.d_model
+        self.num_mel_bins = config.num_mel_bins
+        self.max_source_positions = config.max_source_positions
+
+        self.conv1 = nn.Conv1d(self.num_mel_bins, embed_dim, kernel_size=3, padding=1)
+        self.conv2 = nn.Conv1d(embed_dim, embed_dim, kernel_size=3, stride=2, padding=1)
+        self.embed_positions = nn.Embedding(self.max_source_positions, embed_dim)
+        self.layers = nn.ModuleList(
+            [
+                WhisperEncoderLayer(
+                    vllm_config=vllm_config, prefix=f"{prefix}.layers.{idx}"
+                )
+                for idx in range(config.encoder_layers)
+            ]
+        )
+        self.avg_pooler = nn.AvgPool1d(2, stride=2)
+        self.layer_norm = nn.LayerNorm(embed_dim)
+
+    def forward(self, input_features: torch.Tensor) -> torch.Tensor:
+        input_features = input_features.to(self.conv1.weight.dtype)
+        inputs_embeds = nn.functional.gelu(self.conv1(input_features))
+        inputs_embeds = nn.functional.gelu(self.conv2(inputs_embeds))
+
+        inputs_embeds = inputs_embeds.permute(0, 2, 1)
+        hidden_states = inputs_embeds + self.embed_positions.weight
+
+        for encoder_layer in self.layers:
+            hidden_states = encoder_layer(hidden_states)
+
+        hidden_states = hidden_states.permute(0, 2, 1)
+        hidden_states = self.avg_pooler(hidden_states)
+        hidden_states = hidden_states.permute(0, 2, 1)
+
+        hidden_states = self.layer_norm(hidden_states)
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            (".self_attn.qkv_proj", ".self_attn.q_proj", "q"),
+            (".self_attn.qkv_proj", ".self_attn.k_proj", "k"),
+            (".self_attn.qkv_proj", ".self_attn.v_proj", "v"),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        def _with_k_proj_bias(
+            weights: Iterable[tuple[str, torch.Tensor]],
+        ) -> Iterable[tuple[str, torch.Tensor]]:
+            # The HuggingFace encoder's k_proj has no bias, but vLLM fuses
+            # q/k/v into a single qkv_proj with bias. Emit a zero k-bias so the
+            # fused bias' k-slice is initialized instead of left as uninitialized
+            # memory (mirrors WhisperModel.load_weights).
+            for name, weight in weights:
+                yield name, weight
+                if name.endswith(".self_attn.k_proj.weight"):
+                    yield name.replace(".weight", ".bias"), torch.zeros(weight.size(0))
+
+        for name, loaded_weight in _with_k_proj_bias(weights):
+            # transformers stores the feed-forward directly on the layer; vLLM's
+            # WhisperEncoderLayer nests it under ``.mlp``.
+            name = name.replace(".fc1", ".mlp.fc1").replace(".fc2", ".mlp.fc2")
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                # k_proj has no bias in the HuggingFace encoder.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                param = params_dict[name]
+                param.weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
 
 
 def _qwen2audio_field_config(hf_inputs: Mapping[str, torch.Tensor]):
@@ -328,7 +446,14 @@ class Qwen2AudioMultiModalProcessor(BaseMultiModalProcessor[Qwen2AudioProcessing
     info=Qwen2AudioProcessingInfo,
     dummy_inputs=Qwen2AudioDummyInputsBuilder,
 )
-class Qwen2AudioForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
+class Qwen2AudioForConditionalGeneration(
+    nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA
+):
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
         if modality.startswith("audio"):
@@ -346,9 +471,15 @@ class Qwen2AudioForConditionalGeneration(nn.Module, SupportsMultiModal, Supports
         self.quant_config = quant_config
 
         with self._mark_tower_model(vllm_config, "audio"):
-            self.audio_tower = Qwen2AudioEncoder(config.audio_config)
+            self.audio_tower = Qwen2AudioWhisperEncoder(
+                vllm_config=vllm_config.with_hf_config(config.audio_config),
+                prefix=maybe_prefix(prefix, "audio_tower"),
+            )
             self.multi_modal_projector = Qwen2AudioMultiModalProjector(
-                config.audio_config.d_model, config.text_config.hidden_size
+                config.audio_config.d_model,
+                config.text_config.hidden_size,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "multi_modal_projector"),
             )
 
         with self._mark_language_model(vllm_config):
@@ -397,44 +528,14 @@ class Qwen2AudioForConditionalGeneration(nn.Module, SupportsMultiModal, Supports
         input_features = audio_input["input_features"]
         feature_attention_mask = audio_input["feature_attention_mask"]
 
-        audio_feat_lengths, audio_output_lengths = (
-            self.audio_tower._get_feat_extract_output_lengths(
-                feature_attention_mask.sum(-1)
-            )
+        _, audio_output_lengths = _get_feat_extract_output_lengths(
+            feature_attention_mask.sum(-1)
         )
 
-        batch_size, _, max_mel_seq_len = input_features.shape
-        max_seq_len = (max_mel_seq_len - 2) // 2 + 1
-        # Create a sequence tensor of shape (batch_size, max_seq_len)
-        seq_range = (
-            torch.arange(
-                0,
-                max_seq_len,
-                dtype=audio_feat_lengths.dtype,
-                device=audio_feat_lengths.device,
-            )
-            .unsqueeze(0)
-            .expand(batch_size, max_seq_len)
-        )
-        lengths_expand = audio_feat_lengths.unsqueeze(-1).expand(
-            batch_size, max_seq_len
-        )
-        # Create mask
-        padding_mask = seq_range >= lengths_expand
-
-        audio_attention_mask_ = padding_mask.view(batch_size, 1, 1, max_seq_len).expand(
-            batch_size, 1, max_seq_len, max_seq_len
-        )
-        audio_attention_mask = audio_attention_mask_.to(
-            dtype=self.audio_tower.conv1.weight.dtype,
-            device=self.audio_tower.conv1.weight.device,
-        )
-        audio_attention_mask[audio_attention_mask_] = float("-inf")
-
-        audio_outputs = self.audio_tower(
-            input_features, attention_mask=audio_attention_mask
-        )
-        selected_audio_feature = audio_outputs.last_hidden_state
+        # The mel input is padded to 30s, so the audio tower runs on the full
+        # padded sequence (the HuggingFace encoder ignores the attention mask)
+        # and the padded outputs are trimmed to ``audio_output_lengths`` below.
+        selected_audio_feature = self.audio_tower(input_features)
         audio_features = self.multi_modal_projector(selected_audio_feature)
         num_audios, max_audio_tokens, embed_dim = audio_features.shape
         audio_output_lengths = audio_output_lengths.unsqueeze(1)
@@ -483,3 +584,24 @@ class Qwen2AudioForConditionalGeneration(nn.Module, SupportsMultiModal, Supports
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)
+
+    def get_mm_mapping(self) -> MultiModelKeys:
+        """Get the module prefix in multimodal models."""
+        return MultiModelKeys.from_string_field(
+            language_model="language_model",
+            connector="multi_modal_projector",
+            tower_model="audio_tower",
+        )
+
+    def get_num_mm_encoder_tokens(self, num_audio_tokens: int) -> int:
+        # The Whisper-style tower requires a fixed 30s mel input, so its
+        # transformer layers (the LoRA-wrapped linears) always run on
+        # ``max_source_positions`` conv-downsampled tokens, independent of the
+        # valid placeholder count. The avg_pooler then halves this length.
+        return self.config.audio_config.max_source_positions
+
+    def get_num_mm_connector_tokens(self, num_encoder_tokens: int) -> int:
+        # The connector runs on the avg-pooled tower output (avg_pooler with
+        # stride 2), i.e. half the encoder length, before it is trimmed to the
+        # valid placeholder count.
+        return num_encoder_tokens // 2


### PR DESCRIPTION
## Purpose

Make tower and connector LoRA work for **Qwen2-Audio** (part of #31479) by reimplementing its
audio tower with vLLM-native primitives and converting the connector projector to a native
linear, so vLLM's `from_layer` can actually wrap them.

Today Qwen2-Audio's tower is the HuggingFace `transformers.Qwen2AudioEncoder` (built from
`nn.Linear`) and its connector is an `nn.Linear` projector. `from_layer` only wraps native vLLM
linears, so declaring the #31479 token-count helpers alone is a no-op — and loading a
tower/connector adapter hits `check_unexpected_modules` and kills the engine. This PR fixes the
root cause.

This also brings Qwen2-Audio in line with the other audio models whose encoders are already
vLLM-native: Qwen3-Omni (#32167), Qwen2.5-Omni (#44518), and Voxtral.

## What changed (`vllm/model_executor/models/qwen2_audio.py`)

- **New `Qwen2AudioWhisperEncoder`** — reuses vLLM's `WhisperEncoderLayer` (native
  `QKVParallelLinear` / `ColumnParallelLinear` / `RowParallelLinear`) plus
  `conv1`/`conv2`/`embed_positions`/`avg_pooler`/`layer_norm`. `forward` mirrors the HF encoder
  op-for-op (`gelu(conv1) → gelu(conv2) → +embed_positions → layers → avg_pooler → layer_norm`).
  The mel input is padded to 30s, so the attention mask the HF encoder explicitly ignores is
  dropped.
- **`load_weights`** — fuse `q/k/v_proj → qkv_proj`, remap `fc1/fc2 → mlp.fc1/fc2`, and
  synthesize a zero `k_proj` bias (HF `k_proj` has `bias=False`, but the fused QKV carries a
  bias, so the k-slice must be zeroed — same trick as `WhisperModel.load_weights`).
- **Connector `nn.Linear → ReplicatedLinear`** so the connector is LoRA-wrappable.
- Add `SupportsLoRA` + `packed_modules_mapping` + `get_mm_mapping` +
  `get_num_mm_encoder_tokens` / `get_num_mm_connector_tokens`.
  - **Token counts are not 1:1.** The `avg_pooler` (stride 2) halves the sequence, so
    `get_num_mm_encoder_tokens = audio_config.max_source_positions` (the conv-downsampled length
    the tower layers run on for the 30s-padded input) and `get_num_mm_connector_tokens =
    encoder // 2`.
- `docs/models/supported_models.md` — flip the LoRA flag for Qwen2-Audio.

`_process_audio_input` is simplified (the native tower runs on the padded batch directly; the
old attention-mask construction is removed).

**Usage:** tower/connector LoRA requires `--enable-tower-connector-lora` (the engine warns and
points to the flag otherwise).

## Why this is not a duplicate

Searched open + merged PRs (`Qwen2-Audio`, `Qwen2AudioEncoder`) and #31479 comments
(2026-06-17): no PR reimplements the Qwen2-Audio encoder or adds its tower/connector LoRA, and
no one has claimed Qwen2-Audio on #31479. The neighbouring native-audio-encoder PRs (#32167
Qwen3-Omni, #44518 Qwen2.5-Omni) are different models. The earlier "just add the helpers"
approach on the HF encoder cannot work because the modules are unwrappable.

## Testing

Built from this branch on an A100 (CUDA 12.8 driver) and verified:

1. **CPU numerical parity vs `transformers.Qwen2AudioEncoder`** — weights transferred via
   `load_weights`, same random mel input: **max abs diff `9.5e-7`**.
2. **GPU numerical parity through the real vLLM fused attention kernel** — **max abs diff
   `1.6e-3`** (expected fused-vs-eager delta).
3. **Module types** — tower attn = `QKVParallelLinear` / `RowParallelLinear`, MLP =
   `ColumnParallelLinear` / `RowParallelLinear`, connector = `ReplicatedLinear`.
4. **Full engine** — `LLM("Qwen/Qwen2-Audio-7B-Instruct", load_format="dummy",
   enable_lora=True, enable_tower_connector_lora=True, ...)` loads and generates; the ~100
   `audio_tower.*` / `multi_modal_projector` `"no matching PunicaWrapper … will be ignored"`
   warnings seen on the HF encoder are gone (those modules are now wrapped), and the
   tower/connector punica wrappers are sized via the token-count helpers without error.

`ruff check` + `ruff format` clean. (The real PEFT adapter-load + numerical LoRA eval is left to
the GPU LoRA CI.)

## Note

AI assistance was used to develop this change. I have reviewed every changed line and run the
tests above.
