### PR TITLE
[KV Offloading] Add metric label and tiering plumbing support

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_metrics.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_metrics.py
@@ -33,6 +33,7 @@ STORE_SIZE = _TransferMetricName.STORE_SIZE
 STORES_SKIPPED = "vllm:kv_offload_stores_skipped"
 PENDING_STORES = "vllm:kv_offload_pending_stores"
 LOOKUP_LATENCY = "vllm:kv_offload_lookup_latency_seconds"
+TIER_BYTES = "vllm:kv_offload_tier_bytes"
 
 
 class _FakeMetric:
@@ -96,7 +97,15 @@ def _metric_metadata():
         LOOKUP_LATENCY: OffloadingHistogramMetadata(
             documentation="lookup latency",
         ),
+        TIER_BYTES: OffloadingCounterMetadata(
+            documentation="tier bytes",
+            labelnames=("tier",),
+        ),
     }
+
+
+def _unlabeled(values: dict[str, Any], metric_name: str) -> Any:
+    return values[metric_name][()]
 
 
 def test_build_kv_connector_stats_with_none():
@@ -145,13 +154,13 @@ def test_build_kv_connector_stats_reconstructs_offload_stats():
 
     assert isinstance(stats, OffloadingConnectorStats)
     values = stats.data[_StatsKey.DATA]
-    assert values[LOAD_BYTES] == 24
-    assert values[LOAD_TIME] == 1.5
-    assert values[LOAD_SIZE] == [16, 8]
-    assert values[STORE_BYTES] == 3
-    assert values[STORE_TIME] == 0.3
-    assert values[STORE_SIZE] == [1, 2]
-    assert values[STORES_SKIPPED] == 5
+    assert _unlabeled(values, LOAD_BYTES) == 24
+    assert _unlabeled(values, LOAD_TIME) == 1.5
+    assert _unlabeled(values, LOAD_SIZE) == [16, 8]
+    assert _unlabeled(values, STORE_BYTES) == 3
+    assert _unlabeled(values, STORE_TIME) == 0.3
+    assert _unlabeled(values, STORE_SIZE) == [1, 2]
+    assert _unlabeled(values, STORES_SKIPPED) == 5
 
 
 def _make_stats_data(
@@ -215,15 +224,63 @@ def test_aggregate_same_connector():
 
     assert result is stats1  # Should return self
     values = result.data[_StatsKey.DATA]
-    assert values[LOAD_BYTES] == 34
-    assert values[LOAD_TIME] == 2.6
-    assert values[LOAD_SIZE] == [16, 8, 3, 7]
-    assert values[STORE_BYTES] == 19
-    assert values[STORE_TIME] == 2.3
-    assert values[STORE_SIZE] == [1, 2, 16]
-    assert values[STORES_SKIPPED] == 4
-    assert values[PENDING_STORES] == 1
-    assert values[LOOKUP_LATENCY] == [0.1, 0.2, 0.3]
+    assert _unlabeled(values, LOAD_BYTES) == 34
+    assert _unlabeled(values, LOAD_TIME) == 2.6
+    assert _unlabeled(values, LOAD_SIZE) == [16, 8, 3, 7]
+    assert _unlabeled(values, STORE_BYTES) == 19
+    assert _unlabeled(values, STORE_TIME) == 2.3
+    assert _unlabeled(values, STORE_SIZE) == [1, 2, 16]
+    assert _unlabeled(values, STORES_SKIPPED) == 4
+    assert _unlabeled(values, PENDING_STORES) == 1
+    assert _unlabeled(values, LOOKUP_LATENCY) == [0.1, 0.2, 0.3]
+
+
+def test_aggregate_labeled_metrics():
+    metadata = _metric_metadata()
+    stats1 = OffloadingConnectorStats(
+        data=_make_stats_data(
+            {
+                TIER_BYTES: {
+                    ("cpu",): 10,
+                    ("disk",): 3,
+                },
+            },
+            metadata,
+        ),
+    )
+    stats2 = OffloadingConnectorStats(
+        data=_make_stats_data(
+            {
+                TIER_BYTES: {
+                    ("cpu",): 7,
+                    ("remote",): 5,
+                },
+            },
+            metadata,
+        ),
+    )
+
+    stats1.aggregate(stats2)
+
+    values = stats1.data[_StatsKey.DATA][TIER_BYTES]
+    assert values[("cpu",)] == 17
+    assert values[("disk",)] == 3
+    assert values[("remote",)] == 5
+
+
+def test_helper_methods_accept_labeled_metrics():
+    stats = OffloadingConnectorStats()
+
+    stats.increase_counter(TIER_BYTES, 3, ("cpu",))
+    stats.increase_counter(TIER_BYTES, 4, ("cpu",))
+    stats.set_gauge(PENDING_STORES, 2, ("tier0",))
+    stats.observe_histogram(LOOKUP_LATENCY, 0.1, ("tier0",))
+    stats.observe_histogram(LOOKUP_LATENCY, 0.2, ("tier0",))
+
+    values = stats.data[_StatsKey.DATA]
+    assert values[TIER_BYTES][("cpu",)] == 7
+    assert values[PENDING_STORES][("tier0",)] == 2
+    assert values[LOOKUP_LATENCY][("tier0",)] == [0.1, 0.2]
 
 
 def test_aggregate_merges_types():
@@ -242,7 +299,7 @@ def test_aggregate_merges_types():
 
     result = stats1.aggregate(stats2)
 
-    assert result.data[_StatsKey.DATA][PENDING_STORES] == 2
+    assert _unlabeled(result.data[_StatsKey.DATA], PENDING_STORES) == 2
     assert result.data[_StatsKey.TYPES][PENDING_STORES] == _MetricType.GAUGE
 
 
@@ -281,6 +338,26 @@ def test_reduce():
     assert reduced[PENDING_STORES] == 2
     assert reduced[f"{LOOKUP_LATENCY}_count"] == 3
     assert reduced[f"{LOOKUP_LATENCY}_sum"] == sum([0.1, 0.2, 0.3])
+
+
+def test_reduce_labeled_metrics():
+    metadata = _metric_metadata()
+    stats = OffloadingConnectorStats(
+        data=_make_stats_data(
+            {
+                TIER_BYTES: {
+                    ("cpu",): 17,
+                    ("disk",): 3,
+                },
+            },
+            metadata,
+        ),
+    )
+
+    reduced = stats.reduce()
+
+    assert reduced[f"{TIER_BYTES}{{cpu}}"] == 17
+    assert reduced[f"{TIER_BYTES}{{disk}}"] == 3
 
 
 def test_reset():
@@ -330,7 +407,7 @@ def test_prom_metrics_observes_manager_counter():
         }
     )
 
-    counter = prom_metrics.offloading_metrics[(0, STORES_SKIPPED)]
+    counter = prom_metrics.offloading_metrics[(0, STORES_SKIPPED, ())]
     assert counter.increments == [7]
     counter_def = prom_metrics._offloading_metric_defs[STORES_SKIPPED]
     assert counter_def.kwargs["name"] == "vllm:kv_offload_stores_skipped"
@@ -370,12 +447,12 @@ def test_prom_metrics_observes_flat_transfer_metrics_and_legacy_metrics():
         }
     )
 
-    assert prom_metrics.offloading_metrics[(0, LOAD_BYTES)].increments == [24]
-    assert prom_metrics.offloading_metrics[(0, LOAD_TIME)].increments == [1.5]
-    assert prom_metrics.offloading_metrics[(0, LOAD_SIZE)].observed == [16, 8]
-    assert prom_metrics.offloading_metrics[(0, STORE_BYTES)].increments == [3]
-    assert prom_metrics.offloading_metrics[(0, STORE_TIME)].increments == [0.3]
-    assert prom_metrics.offloading_metrics[(0, STORE_SIZE)].observed == [1, 2]
+    assert prom_metrics.offloading_metrics[(0, LOAD_BYTES, ())].increments == [24]
+    assert prom_metrics.offloading_metrics[(0, LOAD_TIME, ())].increments == [1.5]
+    assert prom_metrics.offloading_metrics[(0, LOAD_SIZE, ())].observed == [16, 8]
+    assert prom_metrics.offloading_metrics[(0, STORE_BYTES, ())].increments == [3]
+    assert prom_metrics.offloading_metrics[(0, STORE_TIME, ())].increments == [0.3]
+    assert prom_metrics.offloading_metrics[(0, STORE_SIZE, ())].observed == [1, 2]
 
     assert prom_metrics.counter_kv_bytes[(0, "CPU_to_GPU")].increments == [24]
     assert prom_metrics.counter_kv_transfer_time[(0, "CPU_to_GPU")].increments == [1.5]
@@ -422,12 +499,79 @@ def test_prom_metrics_observes_manager_gauge_and_histogram():
         }
     )
 
-    gauge = prom_metrics.offloading_metrics[(0, PENDING_STORES)]
-    histogram = prom_metrics.offloading_metrics[(0, LOOKUP_LATENCY)]
+    gauge = prom_metrics.offloading_metrics[(0, PENDING_STORES, ())]
+    histogram = prom_metrics.offloading_metrics[(0, LOOKUP_LATENCY, ())]
     assert gauge.set_values == [5]
     assert histogram.observed == [0.2, 0.4]
     histogram_def = prom_metrics._offloading_metric_defs[LOOKUP_LATENCY]
     assert histogram_def.kwargs["buckets"] == (0.1, 1.0)
+
+
+def test_prom_metrics_lazily_observes_labeled_metric():
+    metric_definitions = {
+        TIER_BYTES: OffloadingCounterMetadata(
+            documentation="Number of bytes served from a tier.",
+            labelnames=("tier",),
+        ),
+    }
+    with patch.object(
+        CPUOffloadingSpec, "build_metric_definitions", return_value=metric_definitions
+    ):
+        prom_metrics = OffloadPromMetrics(
+            vllm_config=_FakeVllmConfig(store_threshold=0),  # type: ignore[arg-type]
+            metric_types={
+                Gauge: _FakeMetric,
+                Counter: _FakeMetric,
+                Histogram: _FakeMetric,
+            },
+            labelnames=["model_name", "engine"],
+            per_engine_labelvalues={0: ["model", "0"]},
+        )
+
+    assert (0, TIER_BYTES, ("cpu",)) not in prom_metrics.offloading_metrics
+
+    prom_metrics.observe(
+        {
+            _StatsKey.TYPES: {TIER_BYTES: _MetricType.COUNTER},
+            _StatsKey.DATA: {TIER_BYTES: {("cpu",): 7}},
+        }
+    )
+
+    counter = prom_metrics.offloading_metrics[(0, TIER_BYTES, ("cpu",))]
+    assert counter.increments == [7]
+    assert counter.labelvalues == ("model", "0", "cpu")
+    counter_def = prom_metrics._offloading_metric_defs[TIER_BYTES]
+    assert counter_def.kwargs["labelnames"] == ["model_name", "engine", "tier"]
+
+
+def test_prom_metrics_rejects_wrong_label_count():
+    metric_definitions = {
+        TIER_BYTES: OffloadingCounterMetadata(
+            documentation="Number of bytes served from a tier.",
+            labelnames=("tier",),
+        ),
+    }
+    with patch.object(
+        CPUOffloadingSpec, "build_metric_definitions", return_value=metric_definitions
+    ):
+        prom_metrics = OffloadPromMetrics(
+            vllm_config=_FakeVllmConfig(store_threshold=0),  # type: ignore[arg-type]
+            metric_types={
+                Gauge: _FakeMetric,
+                Counter: _FakeMetric,
+                Histogram: _FakeMetric,
+            },
+            labelnames=["model_name", "engine"],
+            per_engine_labelvalues={0: ["model", "0"]},
+        )
+
+    with pytest.raises(AssertionError, match="expects 1 labels"):
+        prom_metrics.observe(
+            {
+                _StatsKey.TYPES: {TIER_BYTES: _MetricType.COUNTER},
+                _StatsKey.DATA: {TIER_BYTES: {("cpu", "extra"): 7}},
+            }
+        )
 
 
 def test_prom_metrics_uses_configured_manager_metrics():
@@ -469,9 +613,9 @@ def test_aggregate_into_empty_stats():
 
     assert result is empty
     values = result.data[_StatsKey.DATA]
-    assert values[LOAD_BYTES] == 42
-    assert values[LOAD_SIZE] == [10, 20]
-    assert values[PENDING_STORES] == 3
+    assert _unlabeled(values, LOAD_BYTES) == 42
+    assert _unlabeled(values, LOAD_SIZE) == [10, 20]
+    assert _unlabeled(values, PENDING_STORES) == 3
 
 
 def test_prom_metrics_multi_engine_routing():
@@ -495,8 +639,8 @@ def test_prom_metrics_multi_engine_routing():
         engine_idx=1,
     )
 
-    engine0 = prom_metrics.offloading_metrics[(0, LOAD_BYTES)]
-    engine1 = prom_metrics.offloading_metrics[(1, LOAD_BYTES)]
+    engine0 = prom_metrics.offloading_metrics[(0, LOAD_BYTES, ())]
+    engine1 = prom_metrics.offloading_metrics[(1, LOAD_BYTES, ())]
     assert engine0.increments == []
     assert engine1.increments == [100]
 

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -12,6 +12,9 @@ from tests.v1.kv_connector.unit.offloading_connector.utils import (
 )
 from tests.v1.kv_connector.unit.utils import EOS_TOKEN_ID
 from vllm.distributed.kv_events import BlockRemoved, BlockStored
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    _ConnectorMetricName,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     OffloadingConnectorScheduler,
 )
@@ -30,6 +33,42 @@ from vllm.v1.kv_offload.base import (
     get_offload_block_hash,
 )
 from vllm.v1.request import RequestStatus
+
+
+def test_scheduler_reports_allocation_failure(request_runner):
+    runner = request_runner(
+        block_size=4,
+        num_gpu_blocks=10,
+        async_scheduling=False,
+    )
+    runner.new_request(token_ids=[0] * 4)
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: None
+
+    runner.run(decoded_tokens=[EOS_TOKEN_ID])
+
+    stats = runner.connector_scheduler.get_stats()
+    assert stats is not None
+    assert stats.reduce()[_ConnectorMetricName.ALLOCATION_FAILURE] == 1
+
+
+def test_scheduler_reports_lookup_delay_on_finish(request_runner):
+    runner = request_runner(
+        block_size=4,
+        num_gpu_blocks=10,
+        async_scheduling=False,
+    )
+    runner.new_request(token_ids=[1] * 4)
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output([])
+    )
+
+    runner.run(decoded_tokens=[EOS_TOKEN_ID])
+
+    stats = runner.connector_scheduler.get_stats()
+    assert stats is not None
+    reduced = stats.reduce()
+    assert reduced[f"{_ConnectorMetricName.LOOKUP_DELAY}_count"] == 1
+    assert reduced[f"{_ConnectorMetricName.LOOKUP_DELAY}_sum"] >= 0
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])

--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
@@ -121,6 +121,7 @@ class MockOffloadingSpec(OffloadingSpec):
         self.manager.lookup.return_value = 0
         self.manager.prepare_load = lambda keys, req_context: MockLoadStoreSpec(keys)
         self.manager.lookup.return_value = False
+        self.manager.get_stats.return_value = None
         self.manager.on_new_request.return_value = RequestOffloadingContext()
         self.handler = MockOffloadingHandler()
 

--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -14,7 +14,10 @@ from vllm.v1.kv_offload.base import (
     ReqContext,
     make_offload_key,
 )
-from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+from vllm.v1.kv_offload.cpu.common import (
+    METRIC_CPU_ALLOCATION_SIZE,
+    CPULoadStoreSpec,
+)
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
 from vllm.v1.kv_offload.cpu.policies.arc import ARCCachePolicy
 
@@ -185,6 +188,22 @@ def test_filter_reused_manager_reports_stores_skipped_counter():
     stats = manager.get_stats()
     assert stats is not None
     assert stats.reduce()[STORES_SKIPPED] == 0
+
+
+def test_cpu_manager_reports_allocation_size_histogram():
+    manager = make_cpu_manager(num_blocks=4, cache_policy="lru")
+
+    manager.prepare_store(to_keys([1, 2]), _EMPTY_REQ_CTX)
+    manager.complete_store(to_keys([1, 2]), _EMPTY_REQ_CTX)
+    manager.prepare_store(to_keys([1, 2, 3]), _EMPTY_REQ_CTX)
+
+    stats = manager.get_stats()
+
+    assert stats is not None
+    reduced = stats.reduce()
+    assert reduced[f"{METRIC_CPU_ALLOCATION_SIZE}_count"] == 2
+    assert reduced[f"{METRIC_CPU_ALLOCATION_SIZE}_sum"] == 3
+    assert manager.get_stats() is None
 
 
 def test_cpu_manager():

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -17,21 +17,33 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OffloadingConnectorStats,
+)
 from vllm.v1.kv_offload.base import (
+    OffloadingCounterMetadata,
     OffloadKey,
     OffloadPolicy,
     ReqContext,
     RequestOffloadingContext,
     make_offload_key,
 )
+from vllm.v1.kv_offload.tiering.base import (
+    JobMetadata,
+    JobResult,
+    SecondaryTierManager,
+)
 from vllm.v1.kv_offload.tiering.example.manager import ExampleSecondaryTierManager
+from vllm.v1.kv_offload.tiering.factory import SecondaryTierFactory
 from vllm.v1.kv_offload.tiering.manager import (
     CPUPrimaryTierOffloadingManager,
     TieringOffloadingManager,
 )
+from vllm.v1.kv_offload.tiering.spec import TieringOffloadingSpec
 
 _CTX = ReqContext(req_id="test")
 _MOCK_OFFLOADING_SPEC = MagicMock()
+_TEST_TIER_METRIC = "vllm:kv_offload_test_tier_bytes"
 
 
 def _mock_mmap_region(num_blocks: int, row_bytes: int = 16):
@@ -61,6 +73,84 @@ def count_hits(manager, keys: list[OffloadKey]) -> int | None:
             break
         count += 1
     return count
+
+
+class MetricsSecondaryTierManager(SecondaryTierManager):
+    """Test-only secondary tier that declares and emits one labeled metric."""
+
+    @classmethod
+    def build_metric_definitions(cls, extra_config):
+        return {
+            _TEST_TIER_METRIC: OffloadingCounterMetadata(
+                documentation="Number of bytes served by the test tier.",
+                labelnames=("tier",),
+            )
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.stats: OffloadingConnectorStats | None = None
+
+    def lookup(self, key: OffloadKey, req_context: ReqContext) -> bool | None:
+        return False
+
+    def submit_store(self, job_metadata: JobMetadata) -> None:
+        return
+
+    def submit_load(self, job_metadata: JobMetadata) -> None:
+        return
+
+    def get_finished_jobs(self) -> Iterable[JobResult]:
+        return ()
+
+    def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
+        return RequestOffloadingContext()
+
+    def get_stats(self) -> OffloadingConnectorStats | None:
+        stats = self.stats
+        self.stats = None
+        return stats
+
+
+def test_tiering_spec_collects_secondary_metric_definitions(monkeypatch):
+    monkeypatch.setitem(
+        SecondaryTierFactory._registry,
+        "test_metrics",
+        lambda: MetricsSecondaryTierManager,
+    )
+
+    metrics = TieringOffloadingSpec.build_metric_definitions(
+        {"secondary_tiers": [{"type": "test_metrics"}]}
+    )
+
+    metadata = metrics[_TEST_TIER_METRIC]
+    assert metadata.documentation == "Number of bytes served by the test tier."
+    assert metadata.labelnames == ("tier",)
+
+
+def test_tiering_manager_aggregates_secondary_stats():
+    mock_region = _mock_mmap_region(5)
+    primary_tier = CPUPrimaryTierOffloadingManager(
+        num_blocks=5, mmap_region=mock_region
+    )
+    secondary_tier = MetricsSecondaryTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=mock_region.create_kv_memoryview(),
+        tier_type="test_metrics",
+    )
+    secondary_stats = OffloadingConnectorStats()
+    secondary_stats.increase_counter(_TEST_TIER_METRIC, 7, ("test_metrics",))
+    secondary_tier.stats = secondary_stats
+    manager = TieringOffloadingManager(
+        primary_tier=primary_tier,
+        secondary_tiers=[secondary_tier],
+    )
+
+    stats = manager.get_stats()
+
+    assert stats is not None
+    assert stats.data["data"][_TEST_TIER_METRIC][("test_metrics",)] == 7
+    assert manager.get_stats() is None
 
 
 class TestExampleSecondaryTierManager:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -28,6 +29,13 @@ class _TransferMetricName:
     STORE_BYTES = "vllm:kv_offload_store_bytes"
     STORE_TIME = "vllm:kv_offload_store_time"
     STORE_SIZE = "vllm:kv_offload_store_size"
+
+
+class _ConnectorMetricName:
+    """Connector-side metrics emitted by scheduler-side offloading code."""
+
+    LOOKUP_DELAY = "vllm:kv_offload_lookup_delay_seconds"
+    ALLOCATION_FAILURE = "vllm:kv_offload_allocation_failure"
 
 
 class _TransferType:
@@ -74,6 +82,17 @@ def get_connector_metric_definitions() -> dict[str, OffloadingMetricMetadata]:
             documentation="Histogram of KV offload store operation size, in bytes.",
             buckets=TRANSFER_SIZE_BUCKETS,
         ),
+        _ConnectorMetricName.LOOKUP_DELAY: OffloadingHistogramMetadata(
+            documentation=(
+                "Histogram of time between a request's first offload lookup and "
+                "the first matching allocation or request finish, in seconds."
+            ),
+        ),
+        _ConnectorMetricName.ALLOCATION_FAILURE: OffloadingCounterMetadata(
+            documentation=(
+                "Number of KV offload store allocation attempts that failed."
+            ),
+        ),
     }
 
 
@@ -112,7 +131,7 @@ class _StatsKey:
 
     # Maps metric name -> _MetricType value
     TYPES = "types"
-    # Maps metric name -> observed value (number or list)
+    # Maps metric name -> {label values tuple -> observed value (number or list)}
     DATA = "data"
 
 
@@ -125,20 +144,38 @@ class OffloadingConnectorStats(KVConnectorStats):
 
         {
             _StatsKey.TYPES: {name: _MetricType.*, ...},
-            _StatsKey.DATA:  {name: value, ...},
+            _StatsKey.DATA:  {name: {labelvalues: value, ...}, ...},
         }
 
     This structure is self-describing: it survives IPC serialization
     without needing the full ``OffloadingMetricMetadata`` objects on the
     receiving side.
 
-    Counter values are aggregated by summing, gauge values use the latest
-    snapshot, and histogram values are lists of observed samples.
+    Counter values are aggregated by summing per-label-tuple, gauge values
+    use the latest snapshot per-label-tuple, and histogram values are lists of
+    observed samples per-label-tuple. Unlabeled metrics use ``()`` as their
+    labelvalues tuple. Old flat payloads are normalized to this representation
+    on construction.
     """
 
     def __post_init__(self):
         if _StatsKey.DATA not in self.data:
             self.reset()
+        else:
+            self._normalize_values()
+
+    @staticmethod
+    def _is_labeled_value_map(value: Any) -> bool:
+        return isinstance(value, Mapping) and all(
+            isinstance(labelvalues, tuple) for labelvalues in value
+        )
+
+    def _normalize_values(self) -> None:
+        values = self.data[_StatsKey.DATA]
+        for metric_name, value in list(values.items()):
+            if self._is_labeled_value_map(value):
+                continue
+            values[metric_name] = {(): value}
 
     def reset(self):
         self.data: dict[str, Any] = {
@@ -160,27 +197,41 @@ class OffloadingConnectorStats(KVConnectorStats):
         assert isinstance(other, OffloadingConnectorStats)
         other_types = other._types
         other_values = other._values
-        for key, value in other_values.items():
+        for key, other_label_values in other_values.items():
             type_str = other_types.get(key)
             if type_str is None:
                 raise AssertionError(f"Unknown offloading stats key: {key}")
             self._types.setdefault(key, type_str)
-            if type_str == _MetricType.HISTOGRAM:
-                assert isinstance(value, list)
-                if key not in self._values:
-                    self._values[key] = value
+            assert self._is_labeled_value_map(other_label_values)
+            current_label_values = self._values.setdefault(key, {})
+            assert self._is_labeled_value_map(current_label_values)
+            for labelvalues, value in other_label_values.items():
+                if type_str == _MetricType.HISTOGRAM:
+                    assert isinstance(value, list)
+                    if labelvalues not in current_label_values:
+                        current_label_values[labelvalues] = list(value)
+                    else:
+                        assert isinstance(current_label_values[labelvalues], list)
+                        current_label_values[labelvalues].extend(value)
+                elif type_str == _MetricType.COUNTER:
+                    assert isinstance(value, int | float)
+                    current_label_values[labelvalues] = (
+                        current_label_values.get(labelvalues, 0) + value
+                    )
+                elif type_str == _MetricType.GAUGE:
+                    assert isinstance(value, int | float)
+                    current_label_values[labelvalues] = value
                 else:
-                    assert isinstance(self._values[key], list)
-                    self._values[key].extend(value)
-            elif type_str == _MetricType.COUNTER:
-                assert isinstance(value, int | float)
-                self._values[key] = self._values.get(key, 0) + value
-            elif type_str == _MetricType.GAUGE:
-                assert isinstance(value, int | float)
-                self._values[key] = value
-            else:
-                raise AssertionError(f"Unknown metric type '{type_str}' for key: {key}")
+                    raise AssertionError(
+                        f"Unknown metric type '{type_str}' for key: {key}"
+                    )
         return self
+
+    @staticmethod
+    def _label_suffix(labelvalues: tuple[object, ...]) -> str:
+        if not labelvalues:
+            return ""
+        return "{" + ",".join(str(value) for value in labelvalues) + "}"
 
     def reduce(self) -> dict[str, int | float]:
         """
@@ -190,44 +241,66 @@ class OffloadingConnectorStats(KVConnectorStats):
         stats for the last time interval.
         """
         return_dict: dict[str, int | float] = {}
-        for key, value in self._values.items():
+        for key, label_value_map in self._values.items():
             type_str = self._types.get(key)
             if type_str is None:
                 raise AssertionError(f"Unknown offloading stats key: {key}")
-            if type_str == _MetricType.HISTOGRAM:
-                assert isinstance(value, list)
-                return_dict[f"{key}_count"] = len(value)
-                return_dict[f"{key}_sum"] = sum(value)
-            elif type_str in (_MetricType.COUNTER, _MetricType.GAUGE):
-                assert isinstance(value, int | float)
-                return_dict[key] = value
-            else:
-                raise AssertionError(f"Unknown metric type '{type_str}' for key: {key}")
+            assert self._is_labeled_value_map(label_value_map)
+            for labelvalues, value in label_value_map.items():
+                key_with_labels = f"{key}{self._label_suffix(labelvalues)}"
+                if type_str == _MetricType.HISTOGRAM:
+                    assert isinstance(value, list)
+                    return_dict[f"{key_with_labels}_count"] = len(value)
+                    return_dict[f"{key_with_labels}_sum"] = sum(value)
+                elif type_str in (_MetricType.COUNTER, _MetricType.GAUGE):
+                    assert isinstance(value, int | float)
+                    return_dict[key_with_labels] = value
+                else:
+                    raise AssertionError(
+                        f"Unknown metric type '{type_str}' for key: {key}"
+                    )
         return return_dict
 
     def is_empty(self) -> bool:
         return not self.data.get(_StatsKey.DATA)
 
     def increase_counter(
-        self, counter_name: str, counter_increase_value: int | float
+        self,
+        counter_name: str,
+        counter_increase_value: int | float,
+        labelvalues: tuple[object, ...] = (),
     ) -> None:
         """Increase a counter on the stats payload."""
         self._types.setdefault(counter_name, _MetricType.COUNTER)
-        self._values[counter_name] = (
-            self._values.get(counter_name, 0) + counter_increase_value
+        counter_values = self._values.setdefault(counter_name, {})
+        assert self._is_labeled_value_map(counter_values)
+        counter_values[labelvalues] = (
+            counter_values.get(labelvalues, 0) + counter_increase_value
         )
 
-    def set_gauge(self, gauge_name: str, gauge_value: int | float) -> None:
+    def set_gauge(
+        self,
+        gauge_name: str,
+        gauge_value: int | float,
+        labelvalues: tuple[object, ...] = (),
+    ) -> None:
         """Set a gauge snapshot on the stats payload."""
         self._types.setdefault(gauge_name, _MetricType.GAUGE)
-        self._values[gauge_name] = gauge_value
+        gauge_values = self._values.setdefault(gauge_name, {})
+        assert self._is_labeled_value_map(gauge_values)
+        gauge_values[labelvalues] = gauge_value
 
     def observe_histogram(
-        self, histogram_name: str, histogram_value: int | float
+        self,
+        histogram_name: str,
+        histogram_value: int | float,
+        labelvalues: tuple[object, ...] = (),
     ) -> None:
         """Record a histogram observation on the stats payload."""
         self._types.setdefault(histogram_name, _MetricType.HISTOGRAM)
-        self._values.setdefault(histogram_name, []).append(histogram_value)
+        histogram_values = self._values.setdefault(histogram_name, {})
+        assert self._is_labeled_value_map(histogram_values)
+        histogram_values.setdefault(labelvalues, []).append(histogram_value)
 
 
 class OffloadPromMetrics(KVConnectorPromMetrics):
@@ -255,7 +328,9 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
 
         self._observe_deprecated_metrics = issubclass(spec_cls, CPUOffloadingSpec)
         self._offloading_metric_defs: dict[str, PromMetricT] = {}
-        self.offloading_metrics: dict[tuple[int, str], PromMetricT] = {}
+        self.offloading_metrics: dict[
+            tuple[int, str, tuple[object, ...]], PromMetricT
+        ] = {}
 
         self._counter_kv_bytes = self._counter_cls(
             name=_DEPRECATED_TOTAL_BYTES,
@@ -301,10 +376,11 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
             self._offloading_metric_defs[metric_name] = self._create_metric(
                 metric_name, metadata
             )
-            for engine_idx, labelvalues in per_engine_labelvalues.items():
-                self.offloading_metrics[(engine_idx, metric_name)] = (
-                    self._offloading_metric_defs[metric_name].labels(*labelvalues)
-                )
+            if not metadata.labelnames:
+                for engine_idx, labelvalues in per_engine_labelvalues.items():
+                    self.offloading_metrics[(engine_idx, metric_name, ())] = (
+                        self._offloading_metric_defs[metric_name].labels(*labelvalues)
+                    )
 
     def _create_metric(
         self, metric_name: str, metadata: OffloadingMetricMetadata
@@ -312,7 +388,7 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
         kwargs: dict[str, Any] = {
             "name": metric_name,
             "documentation": metadata.documentation,
-            "labelnames": self._labelnames,
+            "labelnames": self._labelnames + list(metadata.labelnames),
         }
         if isinstance(metadata, OffloadingCounterMetadata):
             metric_cls = self._counter_cls
@@ -326,11 +402,35 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
             raise AssertionError(f"Unknown offloading metric metadata: {metadata}")
         return metric_cls(**kwargs)
 
+    def _get_offloading_metric(
+        self,
+        metric_name: str,
+        labelvalues: tuple[object, ...],
+        engine_idx: int,
+    ) -> PromMetricT:
+        metadata = self._offloading_metric_metadata[metric_name]
+        if len(labelvalues) != len(metadata.labelnames):
+            raise AssertionError(
+                f"Metric {metric_name} expects {len(metadata.labelnames)} labels, "
+                f"got {len(labelvalues)}"
+            )
+        key = (engine_idx, metric_name, labelvalues)
+        if key not in self.offloading_metrics:
+            engine_labelvalues = self.per_engine_labelvalues[engine_idx]
+            self.offloading_metrics[key] = self._offloading_metric_defs[
+                metric_name
+            ].labels(*(engine_labelvalues + list(labelvalues)))
+        return self.offloading_metrics[key]
+
     def _increase_counter(
-        self, metric_name: str, value: int | float, engine_idx: int
+        self,
+        metric_name: str,
+        value: int | float,
+        labelvalues: tuple[object, ...],
+        engine_idx: int,
     ) -> None:
-        self.offloading_metrics[(engine_idx, metric_name)].inc(value)
-        if not self._observe_deprecated_metrics:
+        self._get_offloading_metric(metric_name, labelvalues, engine_idx).inc(value)
+        if labelvalues or not self._observe_deprecated_metrics:
             return
         # Keep deprecated CPU offload transfer metrics updated during the
         # transition to flat metric names.
@@ -343,15 +443,27 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
         elif metric_name == _TransferMetricName.STORE_TIME:
             self.counter_kv_transfer_time[(engine_idx, _TransferType.STORE)].inc(value)
 
-    def _set_gauge(self, metric_name: str, value: int | float, engine_idx: int) -> None:
-        self.offloading_metrics[(engine_idx, metric_name)].set(value)
+    def _set_gauge(
+        self,
+        metric_name: str,
+        value: int | float,
+        labelvalues: tuple[object, ...],
+        engine_idx: int,
+    ) -> None:
+        self._get_offloading_metric(metric_name, labelvalues, engine_idx).set(value)
 
     def _observe_histogram(
-        self, metric_name: str, value: list[int | float], engine_idx: int
+        self,
+        metric_name: str,
+        value: list[int | float],
+        labelvalues: tuple[object, ...],
+        engine_idx: int,
     ) -> None:
         for observation in value:
-            self.offloading_metrics[(engine_idx, metric_name)].observe(observation)
-            if not self._observe_deprecated_metrics:
+            self._get_offloading_metric(
+                metric_name, labelvalues, engine_idx
+            ).observe(observation)
+            if labelvalues or not self._observe_deprecated_metrics:
                 continue
             # Keep deprecated CPU offload transfer metrics updated during the
             # transition to flat metric names.
@@ -368,20 +480,25 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
         """Observe transfer statistics."""
         metric_types = transfer_stats_data.get(_StatsKey.TYPES, {})
         metric_data = transfer_stats_data.get(_StatsKey.DATA, {})
-        for key, value in metric_data.items():
+        for key, label_value_map in metric_data.items():
             type_str = metric_types.get(key)
             if type_str is None:
                 raise AssertionError(f"Unknown offloading stats key: {key}")
             assert key in self._offloading_metric_defs
-            if type_str == _MetricType.COUNTER:
-                assert isinstance(value, int | float)
-                self._increase_counter(key, value, engine_idx)
-            elif type_str == _MetricType.GAUGE:
-                assert isinstance(value, int | float)
-                self._set_gauge(key, value, engine_idx)
-            elif type_str == _MetricType.HISTOGRAM:
-                assert isinstance(value, list)
-                assert all(isinstance(v, int | float) for v in value)
-                self._observe_histogram(key, value, engine_idx)
-            else:
-                raise AssertionError(f"Unknown metric type '{type_str}' for key: {key}")
+            if not OffloadingConnectorStats._is_labeled_value_map(label_value_map):
+                label_value_map = {(): label_value_map}
+            for labelvalues, value in label_value_map.items():
+                if type_str == _MetricType.COUNTER:
+                    assert isinstance(value, int | float)
+                    self._increase_counter(key, value, labelvalues, engine_idx)
+                elif type_str == _MetricType.GAUGE:
+                    assert isinstance(value, int | float)
+                    self._set_gauge(key, value, labelvalues, engine_idx)
+                elif type_str == _MetricType.HISTOGRAM:
+                    assert isinstance(value, list)
+                    assert all(isinstance(v, int | float) for v in value)
+                    self._observe_histogram(key, value, labelvalues, engine_idx)
+                else:
+                    raise AssertionError(
+                        f"Unknown metric type '{type_str}' for key: {key}"
+                    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import time
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from itertools import islice
@@ -16,6 +17,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
+    _ConnectorMetricName,
     _TransferMetricName,
 )
 from vllm.logger import init_logger
@@ -288,6 +290,7 @@ class OffloadingConnectorScheduler:
         self.config = SchedulerOffloadConfig.from_spec(spec)
         self.manager: OffloadingManager = spec.get_manager()
         self._connector_stats: OffloadingConnectorStats | None = None
+        self._lookup_started_at: dict[ReqId, float] = {}
 
         full_attention_groups: list[int] = []
         sliding_window_groups: list[int] = []
@@ -334,6 +337,31 @@ class OffloadingConnectorScheduler:
         # protected by their ref_cnt) and for sliding window blocks (which can
         # be freed before a request finishes).
         self._block_id_to_pending_jobs: dict[int, set[int]] = {}
+
+    def _record_connector_stats(self, stats: OffloadingConnectorStats) -> None:
+        if stats.is_empty():
+            return
+        if self._connector_stats is None:
+            self._connector_stats = stats
+        else:
+            self._connector_stats.aggregate(stats)
+
+    def _start_lookup_delay(self, req_id: ReqId) -> None:
+        self._lookup_started_at.setdefault(req_id, time.monotonic())
+
+    def _observe_lookup_delay(self, req_id: ReqId) -> None:
+        start_time = self._lookup_started_at.pop(req_id, None)
+        if start_time is None:
+            return
+        stats = OffloadingConnectorStats()
+        stats.observe_histogram(
+            _ConnectorMetricName.LOOKUP_DELAY,
+            time.monotonic() - start_time,
+        )
+        self._record_connector_stats(stats)
+
+    def _clear_lookup_delay(self, req_id: ReqId) -> None:
+        self._lookup_started_at.pop(req_id, None)
 
     def _generate_job_id(self) -> int:
         job_id = self._job_counter
@@ -600,6 +628,7 @@ class OffloadingConnectorScheduler:
         if request.skip_reading_prefix_cache:
             num_hit_tokens = 0
         else:
+            self._start_lookup_delay(request.request_id)
             num_hit_tokens = self._lookup(req_status)
         req_status.update_num_hit_blocks(num_computed_tokens + (num_hit_tokens or 0))
 
@@ -613,6 +642,7 @@ class OffloadingConnectorScheduler:
         if num_external_tokens == 0:
             return
 
+        self._observe_lookup_delay(request.request_id)
         req_status = self._req_status[request.request_id]
 
         num_locally_computed_tokens = req_status.num_locally_computed_tokens
@@ -836,6 +866,9 @@ class OffloadingConnectorScheduler:
                 new_offload_keys, req_status.req_context
             )
             if store_output is None:
+                stats = OffloadingConnectorStats()
+                stats.increase_counter(_ConnectorMetricName.ALLOCATION_FAILURE, 1)
+                self._record_connector_stats(stats)
                 logger.warning("Request %s: cannot store blocks", req_id)
                 continue
 
@@ -1017,10 +1050,7 @@ class OffloadingConnectorScheduler:
                     transfer_stats.observe_histogram(
                         _TransferMetricName.STORE_SIZE, size
                     )
-            if self._connector_stats is None:
-                self._connector_stats = transfer_stats
-            else:
-                self._connector_stats.aggregate(transfer_stats)
+            self._record_connector_stats(transfer_stats)
 
         for job_id, count in meta.completed_jobs.items():
             assert count > 0
@@ -1058,6 +1088,7 @@ class OffloadingConnectorScheduler:
             del self._jobs[job_id]
             req_status.transfer_jobs.remove(job_id)
             if not req_status.transfer_jobs and req_status.req.is_finished():
+                self._clear_lookup_delay(job_status.req_id)
                 del self._req_status[job_status.req_id]
 
     def get_stats(self) -> OffloadingConnectorStats | None:
@@ -1097,7 +1128,9 @@ class OffloadingConnectorScheduler:
         self.manager.on_request_finished(req_context)
 
         if req_status is None:
+            self._clear_lookup_delay(request.request_id)
             return False, None
+        self._observe_lookup_delay(request.request_id)
         if not req_status.transfer_jobs:
             del self._req_status[request.request_id]
             return False, None

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -129,6 +129,7 @@ The class provides the following primitives:
 @dataclass(frozen=True)
 class OffloadingMetricMetadata:
     documentation: str
+    labelnames: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/vllm/v1/kv_offload/cpu/common.py
+++ b/vllm/v1/kv_offload/cpu/common.py
@@ -5,6 +5,7 @@ from typing_extensions import override
 from vllm.v1.kv_offload.base import BlockIDsLoadStoreSpec
 
 METRIC_STORES_SKIPPED = "vllm:kv_offload_stores_skipped"
+METRIC_CPU_ALLOCATION_SIZE = "vllm:kv_offload_cpu_allocation_size"
 
 
 class CPULoadStoreSpec(BlockIDsLoadStoreSpec):

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -18,7 +18,11 @@ from vllm.v1.kv_offload.base import (
     ReqContext,
     RequestOffloadingContext,
 )
-from vllm.v1.kv_offload.cpu.common import METRIC_STORES_SKIPPED, CPULoadStoreSpec
+from vllm.v1.kv_offload.cpu.common import (
+    METRIC_CPU_ALLOCATION_SIZE,
+    METRIC_STORES_SKIPPED,
+    CPULoadStoreSpec,
+)
 from vllm.v1.kv_offload.cpu.policies.arc import ARCCachePolicy
 from vllm.v1.kv_offload.cpu.policies.base import BlockStatus, CachePolicy
 from vllm.v1.kv_offload.cpu.policies.lru import LRUCachePolicy
@@ -62,6 +66,7 @@ class CPUOffloadingManager(OffloadingManager):
         self.store_threshold: int = store_threshold
         self.max_tracker_size: int = max_tracker_size
         self.stores_skipped_in_current_batch: int = 0
+        self.allocation_sizes_in_current_batch: list[int] = []
 
         # Number of block references. It is ordered so can evict the LRU entry in O(1).
         self.counts: OrderedDict[OffloadKey, int] | None = (
@@ -165,6 +170,7 @@ class CPUOffloadingManager(OffloadingManager):
         keys_to_store = [k for k in keys if self._policy.get(k) is None]
 
         if not keys_to_store:
+            self.allocation_sizes_in_current_batch.append(0)
             return PrepareStoreOutput(
                 keys_to_store=[],
                 store_spec=self._get_load_store_spec([], []),
@@ -195,6 +201,7 @@ class CPUOffloadingManager(OffloadingManager):
             )
 
         blocks = self._allocate_blocks(keys_to_store)
+        self.allocation_sizes_in_current_batch.append(len(keys_to_store))
         assert len(blocks) == len(keys_to_store), (
             "Block pool did not allocate the expected number of blocks"
         )
@@ -261,13 +268,16 @@ class CPUOffloadingManager(OffloadingManager):
             self.events.clear()
 
     def get_stats(self) -> OffloadingConnectorStats | None:
-        if self.store_threshold < 2:
-            return None
-
         stats = OffloadingConnectorStats()
-        stats.increase_counter(
-            METRIC_STORES_SKIPPED,
-            self.stores_skipped_in_current_batch,
-        )
-        self.stores_skipped_in_current_batch = 0
-        return stats
+        for allocation_size in self.allocation_sizes_in_current_batch:
+            stats.observe_histogram(METRIC_CPU_ALLOCATION_SIZE, allocation_size)
+        self.allocation_sizes_in_current_batch.clear()
+
+        if self.store_threshold >= 2:
+            stats.increase_counter(
+                METRIC_STORES_SKIPPED,
+                self.stores_skipped_in_current_batch,
+            )
+            self.stores_skipped_in_current_batch = 0
+
+        return None if stats.is_empty() else stats

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -14,11 +14,16 @@ from vllm.v1.kv_offload.base import (
     GPULoadStoreSpec,
     LoadStoreSpec,
     OffloadingCounterMetadata,
+    OffloadingHistogramMetadata,
     OffloadingManager,
     OffloadingMetricMetadata,
     OffloadingSpec,
 )
-from vllm.v1.kv_offload.cpu.common import METRIC_STORES_SKIPPED, CPULoadStoreSpec
+from vllm.v1.kv_offload.cpu.common import (
+    METRIC_CPU_ALLOCATION_SIZE,
+    METRIC_STORES_SKIPPED,
+    CPULoadStoreSpec,
+)
 from vllm.v1.kv_offload.cpu.gpu_worker import CpuGpuOffloadingHandlers
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
 from vllm.v1.kv_offload.worker.worker import OffloadingHandler
@@ -31,17 +36,24 @@ class CPUOffloadingSpec(OffloadingSpec):
     def build_metric_definitions(
         cls, extra_config: dict[str, Any]
     ) -> dict[str, OffloadingMetricMetadata]:
+        metrics: dict[str, OffloadingMetricMetadata] = {
+            METRIC_CPU_ALLOCATION_SIZE: OffloadingHistogramMetadata(
+                documentation=(
+                    "Histogram of the number of CPU blocks allocated by each "
+                    "KV offload prepare_store call."
+                ),
+            ),
+        }
         store_threshold = int(extra_config.get("store_threshold", 0))
         if store_threshold < 2:
-            return {}
-        return {
-            METRIC_STORES_SKIPPED: OffloadingCounterMetadata(
-                documentation=(
-                    "Number of KV offload stores skipped because the reuse "
-                    "threshold was not reached."
-                ),
-            )
-        }
+            return metrics
+        metrics[METRIC_STORES_SKIPPED] = OffloadingCounterMetadata(
+            documentation=(
+                "Number of KV offload stores skipped because the reuse "
+                "threshold was not reached."
+            ),
+        )
+        return metrics
 
     def __init__(self, vllm_config: VllmConfig, kv_cache_config: KVCacheConfig):
         super().__init__(vllm_config, kv_cache_config)

--- a/vllm/v1/kv_offload/tiering/base.py
+++ b/vllm/v1/kv_offload/tiering/base.py
@@ -7,13 +7,21 @@ Abstract interfaces and data types for the secondary tiering layer.
 from abc import ABC, abstractmethod
 from collections.abc import Collection, Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from vllm.v1.kv_offload.base import OffloadKey, ReqContext, RequestOffloadingContext
+from vllm.v1.kv_offload.base import (
+    OffloadingMetricMetadata,
+    OffloadKey,
+    ReqContext,
+    RequestOffloadingContext,
+)
 
 if TYPE_CHECKING:
+    from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+        OffloadingConnectorStats,
+    )
     from vllm.v1.kv_offload.base import OffloadingSpec
 
 # Type alias for job IDs used in async transfer tracking
@@ -196,3 +204,14 @@ class SecondaryTierManager(ABC):
     def shutdown(self) -> None:
         """Release resources held by this tier (threads, connections, etc.)."""
         return
+
+    @classmethod
+    def build_metric_definitions(
+        cls, extra_config: dict[str, Any]
+    ) -> dict[str, OffloadingMetricMetadata]:
+        """Return Prometheus metric definitions emitted by this tier."""
+        return {}
+
+    def get_stats(self) -> "OffloadingConnectorStats | None":
+        """Return and reset metric observations collected by this tier."""
+        return None

--- a/vllm/v1/kv_offload/tiering/factory.py
+++ b/vllm/v1/kv_offload/tiering/factory.py
@@ -37,19 +37,22 @@ class SecondaryTierFactory:
         if not tier_type:
             raise ValueError("Secondary tier configuration must include 'type'")
 
-        if tier_type not in cls._registry:
-            raise ValueError(
-                f"Unknown secondary tier type: {tier_type!r}. "
-                f"Supported types: {list(cls._registry)}"
-            )
-
-        tier_cls = cls._registry[tier_type]()
+        tier_cls = cls.get_tier_class(tier_type)
         return tier_cls(
             offloading_spec=offloading_spec,
             primary_kv_view=primary_kv_view,
             tier_type=tier_type,
             **config,
         )
+
+    @classmethod
+    def get_tier_class(cls, tier_type: str) -> type[SecondaryTierManager]:
+        if tier_type not in cls._registry:
+            raise ValueError(
+                f"Unknown secondary tier type: {tier_type!r}. "
+                f"Supported types: {list(cls._registry)}"
+            )
+        return cls._registry[tier_type]()
 
 
 SecondaryTierFactory.register_tier(

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -27,6 +27,9 @@ from dataclasses import dataclass, field
 import numpy as np
 from typing_extensions import override
 
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OffloadingConnectorStats,
+)
 from vllm.logger import init_logger
 from vllm.v1.kv_offload.base import (
     LoadStoreSpec,
@@ -589,6 +592,24 @@ class TieringOffloadingManager(OffloadingManager):
             self.events.clear()
 
         yield from self.primary_tier.take_events()
+
+    @override
+    def get_stats(self) -> OffloadingConnectorStats | None:
+        stats = self.primary_tier.get_stats()
+
+        if stats is not None and stats.is_empty():
+            stats = None
+
+        for tier in self.secondary_tiers:
+            tier_stats = tier.get_stats()
+            if tier_stats is None or tier_stats.is_empty():
+                continue
+            if stats is None:
+                stats = tier_stats
+            else:
+                stats.aggregate(tier_stats)
+
+        return stats
 
     @override
     def shutdown(self) -> None:

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -31,13 +31,19 @@ Example configuration:
 }
 """
 
+from typing import Any
+
 import torch
 from typing_extensions import override
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.v1.kv_cache_interface import KVCacheConfig
-from vllm.v1.kv_offload.base import CanonicalKVCaches, OffloadingManager
+from vllm.v1.kv_offload.base import (
+    CanonicalKVCaches,
+    OffloadingManager,
+    OffloadingMetricMetadata,
+)
 from vllm.v1.kv_offload.cpu.gpu_worker import CpuGpuOffloadingHandlers
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
@@ -64,6 +70,25 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
     """
 
     BLOCK_SIZE_ALIGNMENT = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+
+    @classmethod
+    def build_metric_definitions(
+        cls, extra_config: dict[str, Any]
+    ) -> dict[str, OffloadingMetricMetadata]:
+        metrics = super().build_metric_definitions(extra_config)
+        secondary_tier_configs = extra_config.get("secondary_tiers", [])
+        if not isinstance(secondary_tier_configs, list):
+            return metrics
+
+        for tier_config in secondary_tier_configs:
+            if not isinstance(tier_config, dict):
+                continue
+            tier_type = tier_config.get("type")
+            if not tier_type:
+                continue
+            tier_cls = SecondaryTierFactory.get_tier_class(tier_type)
+            metrics.update(tier_cls.build_metric_definitions(tier_config))
+        return metrics
 
     def __init__(self, vllm_config: VllmConfig, kv_cache_config: KVCacheConfig):
         super().__init__(vllm_config, kv_cache_config)


### PR DESCRIPTION
## Summary
- add generic labeled metric metadata and tuple-keyed labeled stats payload support for KV offloading metrics
- add scheduler/CPU offloading metrics for lookup delay, allocation failure, and CPU allocation size
- add secondary tier metric definition and stats plumbing through the tiering manager

## Tests
- `.venv\Scripts\python.exe -m py_compile ...` on touched source and test files: passed
- `.venv\Scripts\python.exe -m ruff check ...` on touched source and test files: passed
- Focused pytest collection is blocked in this local environment by `ModuleNotFoundError: No module named 'vllm._C'` before selected tests run.
