### PR TITLE
[Model Runner V2] Enable cross layers KV Cache

### DIFF
--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -7,10 +7,12 @@ from typing import Any, cast
 import torch
 
 from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.config.cache import CacheDType
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.attention.backend import (
+    AttentionBackend,
     AttentionCGSupport,
     CommonAttentionMetadata,
 )
@@ -22,6 +24,9 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.model_states.interface import ModelSpecificAttnMetadata
+from vllm.v1.worker.kv_connector_model_runner_mixin import (
+    KVConnectorModelRunnerMixin,
+)
 from vllm.v1.worker.utils import (
     AttentionGroup,
     add_kv_sharing_layers_to_kv_cache_groups,
@@ -350,24 +355,44 @@ def init_kv_cache(
     kv_cache_config: KVCacheConfig,
     attn_groups: list[list[AttentionGroup]],
     device: torch.device,
-    cache_dtype: str,
+    cache_dtype: CacheDType,
     kernel_block_sizes: list[int],
     vllm_config: VllmConfig,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], torch.Tensor | None, type[AttentionBackend] | None]:
     shared_kv_cache_layers = get_shared_kv_cache_layers(vllm_config)
-    kv_cache_raw_tensors = _allocate_kv_cache(
-        kv_cache_config, shared_kv_cache_layers, device
-    )
-    flattened_attn_groups = list(group for groups in attn_groups for group in groups)
-    kv_caches = _reshape_kv_cache(
-        attn_groups=flattened_attn_groups,
-        kv_cache_raw_tensors=kv_cache_raw_tensors,
-        kernel_block_sizes=kernel_block_sizes,
-        cache_dtype=cache_dtype,
-        shared_kv_cache_layers=shared_kv_cache_layers,
-    )
+
+    cross_layers_kv_cache: torch.Tensor | None = None
+    cross_layers_attn_backend: type[AttentionBackend] | None = None
+
+    if KVConnectorModelRunnerMixin.use_uniform_kv_cache(attn_groups, cache_dtype):
+        kv_caches, cross_layers_kv_cache, cross_layers_attn_backend = (
+            KVConnectorModelRunnerMixin.allocate_uniform_kv_caches(
+                kv_cache_config,
+                attn_groups,
+                cache_dtype,
+                device,
+                kernel_block_sizes,
+            )
+        )
+        for layer_name, target_layer_name in shared_kv_cache_layers.items():
+            kv_caches[layer_name] = kv_caches[target_layer_name]
+    else:
+        kv_cache_raw_tensors = _allocate_kv_cache(
+            kv_cache_config, shared_kv_cache_layers, device
+        )
+        flattened_attn_groups = list(
+            group for groups in attn_groups for group in groups
+        )
+        kv_caches = _reshape_kv_cache(
+            attn_groups=flattened_attn_groups,
+            kv_cache_raw_tensors=kv_cache_raw_tensors,
+            kernel_block_sizes=kernel_block_sizes,
+            cache_dtype=cache_dtype,
+            shared_kv_cache_layers=shared_kv_cache_layers,
+        )
+
     bind_kv_cache(kv_caches, forward_context, runner_kv_caches)
-    return kv_caches
+    return kv_caches, cross_layers_kv_cache, cross_layers_attn_backend
 
 
 def build_slot_mappings_by_layer(

--- a/vllm/v1/worker/gpu/kv_connector.py
+++ b/vllm/v1/worker/gpu/kv_connector.py
@@ -23,6 +23,7 @@ from vllm.v1.outputs import (
 )
 
 if TYPE_CHECKING:
+    from vllm.v1.attention.backend import AttentionBackend
     from vllm.v1.core.sched.output import SchedulerOutput
 
 
@@ -46,14 +47,21 @@ class KVConnector:
 
 class ActiveKVConnector(KVConnector):
     def __init__(
-        self, vllm_config: VllmConfig, kv_caches_dict: dict[str, torch.Tensor]
+        self,
+        vllm_config: VllmConfig,
+        kv_caches_dict: dict[str, torch.Tensor],
+        cross_layers_kv_cache: torch.Tensor | None = None,
+        cross_layers_attn_backend: "type[AttentionBackend] | None" = None,
     ):
         self.vllm_config = vllm_config
         self.kv_connector = get_kv_transfer_group()
-        # Register kv caches with KV Connector if applicable.
-        # TODO: support cross_layers_kv_cache
-        # (see https://github.com/vllm-project/vllm/pull/27743)
-        self.kv_connector.register_kv_caches(kv_caches_dict)
+        if cross_layers_kv_cache is not None:
+            assert cross_layers_attn_backend is not None
+            self.kv_connector.register_cross_layers_kv_cache(
+                cross_layers_kv_cache, cross_layers_attn_backend
+            )
+        else:
+            self.kv_connector.register_kv_caches(kv_caches_dict)
         self.kv_connector.set_host_xfer_buffer_ops(copy_kv_blocks)
 
         self._disabled = False
@@ -114,10 +122,18 @@ NO_OP_KV_CONNECTOR = KVConnector()
 
 
 def get_kv_connector(
-    vllm_config: VllmConfig, kv_caches_dict: dict[str, torch.Tensor]
+    vllm_config: VllmConfig,
+    kv_caches_dict: dict[str, torch.Tensor],
+    cross_layers_kv_cache: torch.Tensor | None = None,
+    cross_layers_attn_backend: "type[AttentionBackend] | None" = None,
 ) -> KVConnector:
     if not has_kv_transfer_group():
         # No-op connector.
         return NO_OP_KV_CONNECTOR
 
-    return ActiveKVConnector(vllm_config, kv_caches_dict)
+    return ActiveKVConnector(
+        vllm_config,
+        kv_caches_dict,
+        cross_layers_kv_cache,
+        cross_layers_attn_backend,
+    )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -482,17 +482,24 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             )
 
         self.kv_caches: list[torch.Tensor] = []
-        kv_caches_dict = init_kv_cache(
-            self.kv_caches,
-            self.compilation_config.static_forward_context,
-            self.kv_cache_config,
-            self.attn_groups,
-            self.device,
-            self.cache_config.cache_dtype,
-            self.kernel_block_sizes,
-            self.vllm_config,
+        kv_caches_dict, cross_layers_kv_cache, cross_layers_attn_backend = (
+            init_kv_cache(
+                self.kv_caches,
+                self.compilation_config.static_forward_context,
+                self.kv_cache_config,
+                self.attn_groups,
+                self.device,
+                self.cache_config.cache_dtype,
+                self.kernel_block_sizes,
+                self.vllm_config,
+            )
         )
-        self.kv_connector = get_kv_connector(self.vllm_config, kv_caches_dict)
+        self.kv_connector = get_kv_connector(
+            self.vllm_config,
+            kv_caches_dict,
+            cross_layers_kv_cache,
+            cross_layers_attn_backend,
+        )
 
     def _init_kv_zero_meta(self) -> None:
         """Build KV-block zeroing metadata; invoked from gpu_worker."""


### PR DESCRIPTION


Enable cross layers KV cache for model runner V2

```
if __name__ == "__main__":
    kv = KVTransferConfig(
        kv_connector="OffloadingConnector", kv_role="kv_both",
        kv_connector_extra_config={"cpu_bytes_to_use": 8 << 30, "block_size": 48},
    )
    llm = LLM(model="/models/Llama-3.1-70B", max_model_len=8192, gpu_memory_utilization=0.92,
              kv_transfer_config=kv, attention_config={"backend": "TRITON_ATTN"},
              max_num_seqs=1, enforce_eager=False)
```

```
INFO kv_connector_model_runner_mixin.py:255] Allocating a cross layer KV cache of shape (8724, 8, 80, 2, 16, 128)
prompt_len = 3072 tokens
cold (full prefill): 2140.5 ms
cpu-hit (reload from CPU):  1280.4 ms 
```
