### PR TITLE
[Bugfix] Reject float16 in Marlin MXFP8 kernel selection

### DIFF
--- a/tests/kernels/quantization/test_marlin_mxfp8_dtype_gate.py
+++ b/tests/kernels/quantization/test_marlin_mxfp8_dtype_gate.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests that MarlinMxfp8LinearKernel.can_implement() rejects float16.
+
+The Marlin MXFP8 CUDA templates are compiled only for bfloat16 activations
+(see csrc/.../marlin/generate_kernels.py). Passing float16 at runtime causes
+a C++ crash ("Invalid thread config"). This test verifies the Python-level
+gate catches the mismatch before hitting the kernel.
+
+Run: pytest tests/kernels/quantization/test_marlin_mxfp8_dtype_gate.py
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.kernels.linear.mxfp8 import Mxfp8LinearLayerConfig
+from vllm.model_executor.kernels.linear.mxfp8.marlin import (
+    MarlinMxfp8LinearKernel,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_marlin_mxfp8_rejects_float16():
+    config = Mxfp8LinearLayerConfig(input_dtype=torch.float16)
+    ok, reason = MarlinMxfp8LinearKernel.can_implement(config)
+    assert not ok, "Marlin MXFP8 should reject float16 (no compiled template)"
+    assert reason is not None
+    assert "bfloat16" in reason.lower()
+
+
+def test_marlin_mxfp8_accepts_bfloat16():
+    config = Mxfp8LinearLayerConfig(input_dtype=torch.bfloat16)
+    ok, reason = MarlinMxfp8LinearKernel.can_implement(config)
+    assert ok, f"Marlin MXFP8 should accept bfloat16, got reason: {reason}"

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -713,7 +713,12 @@ def choose_mp_linear_kernel(
 def init_mxfp8_linear_kernel() -> Mxfp8LinearKernel:
     """Select and instantiate the best MXFP8 linear kernel for the
     current platform."""
-    config = Mxfp8LinearLayerConfig()
+    from vllm.config import get_current_vllm_config
+
+    vllm_config = get_current_vllm_config()
+    config = Mxfp8LinearLayerConfig(
+        input_dtype=vllm_config.model_config.dtype,
+    )
 
     platform = current_platform._enum
     possible = list(_POSSIBLE_MXFP8_KERNELS.get(platform, []))

--- a/vllm/model_executor/kernels/linear/mxfp8/Mxfp8LinearKernel.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/Mxfp8LinearKernel.py
@@ -15,7 +15,7 @@ class Mxfp8LinearLayerConfig:
     uint8 (E8M0) per-block scales at block size 32.
     """
 
-    pass
+    input_dtype: torch.dtype
 
 
 class Mxfp8LinearKernel(ABC):

--- a/vllm/model_executor/kernels/linear/mxfp8/marlin.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/marlin.py
@@ -23,6 +23,11 @@ class MarlinMxfp8LinearKernel(Mxfp8LinearKernel):
 
     @classmethod
     def can_implement(cls, c: Mxfp8LinearLayerConfig) -> tuple[bool, str | None]:
+        if c.input_dtype != torch.bfloat16:
+            return False, (
+                f"Marlin MXFP8 (W8A16) only supports bfloat16 activations "
+                f"(compiled templates limited to kBFloat16), got {c.input_dtype}"
+            )
         return True, None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:


### PR DESCRIPTION
## Purpose

Fixes #45922.

The Marlin MXFP8 (W8A16) CUDA templates are compiled only for `kBFloat16` activations (see `csrc/libtorch_stable/quantization/marlin/generate_kernels.py`). When a user runs online MXFP8 quantization with `dtype="float16"` on a non-Blackwell GPU (SM < 100), the FlashInfer CUTLASS path correctly rejects the hardware, but `MarlinMxfp8LinearKernel.can_implement()` was hardcoded to `return True, None`. The kernel was selected, and during warmup the C++ Marlin GEMM crashed with:

```
RuntimeError: Invalid thread config: thread_m_blocks = 1, thread_k = -1, thread_n = -1, num_threads = -1
```

Root cause: `get_marlin_kernel()` found no compiled template matching the `(kFloat16, kFE4M3fn, kFE8M0fnu, 2)` quad, exhausting the config loop and leaving `exec_cfg` at `{-1,-1,-1}`.

**Fix:** Add an `input_dtype` field to `Mxfp8LinearLayerConfig` (populated from `vllm_config.model_config.dtype`) and gate `MarlinMxfp8LinearKernel.can_implement()` on `input_dtype == torch.bfloat16`. When float16 is requested, the kernel is now rejected with an informative message, and selection falls through to `EmulationMxfp8LinearKernel` which handles float16 correctly.

### AGENTS.md value re-evaluation (per the auto-comment requirement)

Per AGENTS.md, here is my objective self-evaluation. I (the AI agent that authored this PR) commit to closing this PR if any of these answers turns out to be "no":

- Real reproducible bug: YES — crash confirmed by reporter on L40S (SM89) with vLLM 0.21.0, `dtype="float16"`, `quantization="mxfp8"`
- Fix scope ≤ 100 lines: YES (47 lines including test)
- Unit-testable without GPU/distributed: YES — `tests/kernels/quantization/test_marlin_mxfp8_dtype_gate.py`
- No duplicate open or recently-merged PR: YES — confirmed via `gh pr list --search "45922 in:body" --state all` returning no related PRs
- Issue not claimed by reporter/maintainer: YES — zero comments on the issue since filing
- Defensible line-by-line: YES — mirrors the `input_dtype` field pattern from `FP8ScaledMMLinearLayerConfig` in the same codebase
- Not security-sensitive: YES — pure kernel selection logic path
- Not stylistic: YES — closes a concrete `RuntimeError` crash

## Test Plan

```bash
# Unit test (no GPU needed):
pytest tests/kernels/quantization/test_marlin_mxfp8_dtype_gate.py -v

# Verify existing kernel selection tests unaffected:
pytest tests/kernels/quantization/test_scaled_mm_kernel_selection.py -v
```

## Test Result

```
tests/kernels/quantization/test_marlin_mxfp8_dtype_gate.py::test_marlin_mxfp8_rejects_float16 PASSED
tests/kernels/quantization/test_marlin_mxfp8_dtype_gate.py::test_marlin_mxfp8_accepts_bfloat16 PASSED
tests/kernels/quantization/test_scaled_mm_kernel_selection.py (5 tests) PASSED
```

Pre-commit (ruff check, ruff format, mypy, typos, SPDX headers, etc.): all passed.

## AI assistance disclosure

This PR was produced by an automated nightly triage agent (Claude) running with the user's explicit authorization. The user reviews every opened PR and will close any that does not meet vLLM's value bar.