### PR TITLE
[Kernel][DCP][MLA] Pre-reserve packed A2A decode workspace (long-term…

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -420,6 +420,18 @@ def _distributed_packed_a2a_worker(env: dict[str, str]) -> None:
             dtype=torch.float32,
             generator=generator,
         )
+        if env.get("RESERVE_WORKSPACE") == "1":
+            from vllm.v1.attention.ops.dcp_alltoall import (
+                dcp_a2a_reserve_decode_workspace,
+            )
+
+            dcp_a2a_reserve_decode_workspace(
+                num_tokens=B + 3,
+                num_heads_per_rank=h_per_rank,
+                head_dim=D,
+                dcp_world_size=world_size,
+                output_dtype=dtype,
+            )
         actual = dcp_a2a_lse_reduce(
             cp_attn_out,
             cp_attn_lse,
@@ -496,6 +508,84 @@ def test_distributed_packed_a2a_with_workspace_matches_reference():
             "USE_WORKSPACE": "1",
         },
     )
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 4, reason="Need at least 4 GPUs."
+)
+@pytest.mark.parametrize("dtype_name", ["float16", "bfloat16", "float32"])
+def test_distributed_packed_a2a_with_reserved_workspace(dtype_name: str):
+    _distributed_run(
+        _distributed_packed_a2a_worker,
+        world_size=4,
+        extra_env={
+            "TEST_DTYPE": dtype_name,
+            "RETURN_LSE": "1",
+            "LSE_BASE_E": "1",
+            "USE_WORKSPACE": "1",
+            "RESERVE_WORKSPACE": "1",
+        },
+    )
+
+
+@pytest.mark.parametrize("dtype_name", ["float16", "bfloat16", "float32"])
+def test_packed_workspace_specs(dtype_name: str):
+    from vllm.v1.attention.ops.dcp_alltoall import (
+        _dcp_a2a_lse_pack_dim,
+        dcp_a2a_packed_workspace_specs,
+    )
+
+    dtype = _dtype_from_name(dtype_name)
+    world_size, num_tokens, h_per_rank, D = 4, 16, 2, 32
+    specs = dcp_a2a_packed_workspace_specs(
+        num_tokens=num_tokens,
+        num_heads_per_rank=h_per_rank,
+        head_dim=D,
+        dcp_world_size=world_size,
+        output_dtype=dtype,
+    )
+    lse_pack_dim = _dcp_a2a_lse_pack_dim(dtype)
+    expected_shape = (world_size, num_tokens, h_per_rank, D + lse_pack_dim)
+    assert len(specs) == 2  # send + recv
+    for shape, spec_dtype in specs:
+        assert shape == expected_shape
+        assert spec_dtype == dtype
+
+
+@pytest.mark.parametrize("dtype_name", ["float16", "bfloat16", "float32"])
+def test_reserve_decode_workspace(dtype_name: str):
+    from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_reserve_decode_workspace
+    from vllm.v1.worker.workspace import (
+        current_workspace_manager,
+        init_workspace_manager,
+        reset_workspace_manager,
+    )
+
+    dtype = _dtype_from_name(dtype_name)
+    world_size, num_tokens, h_per_rank, D = 4, 16, 2, 32
+    init_workspace_manager(torch.device("cpu"))
+    try:
+        dcp_a2a_reserve_decode_workspace(
+            num_tokens=num_tokens,
+            num_heads_per_rank=h_per_rank,
+            head_dim=D,
+            dcp_world_size=world_size,
+            output_dtype=dtype,
+        )
+        reserved = current_workspace_manager().get_simultaneous(
+            (
+                (
+                    world_size,
+                    num_tokens,
+                    h_per_rank,
+                    D + (2 if dtype != torch.float32 else 1),
+                ),
+                dtype,
+            ),
+        )[0]
+        assert reserved.shape[1] == num_tokens
+    finally:
+        reset_workspace_manager()
 
 
 if __name__ == "__main__":

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -269,7 +269,10 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
-from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    dcp_a2a_reserve_workspace,
+)
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.attention.selector import get_attn_backend
 from vllm.v1.kv_cache_interface import (
@@ -647,6 +650,25 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 device=k_c_normed.device,
                 dtype=k_c_normed.dtype,
             )
+            if self.dcp_a2a:
+                dcp_world_size = get_dcp_group().world_size
+                local_heads = self.q_pad_num_heads or self.num_heads
+                speculative_config = self._vllm_config.speculative_config
+                num_spec_tokens = (
+                    speculative_config.num_speculative_tokens
+                    if speculative_config is not None
+                    else 0
+                )
+                dcp_a2a_reserve_workspace(
+                    num_tokens=(
+                        self._vllm_config.scheduler_config.max_num_seqs
+                        * (1 + num_spec_tokens)
+                    ),
+                    num_heads_per_rank=local_heads,
+                    head_dim=self.kv_lora_rank,
+                    dcp_world_size=dcp_world_size,
+                    output_dtype=q.dtype,
+                )
 
             # The zero fill is required when used with DP + EP
             # to ensure all ranks within a DP group compute the

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -29,7 +29,10 @@ from vllm.v1.attention.backends.fa_utils import (
 )
 from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
 from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
-from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    dcp_a2a_reserve_workspace,
+)
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.worker.workspace import current_workspace_manager
 
@@ -692,11 +695,22 @@ class FlashAttentionImpl(AttentionImpl):
             and vllm_config.parallel_config.decode_context_parallel_size > 1
             and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
+        self.dcp_a2a = dcp_a2a
         self.dcp_combine = dcp_a2a_lse_reduce if dcp_a2a else cp_lse_ag_out_rs
 
         self._dcp_dtype: torch.dtype | None = None
+        self._dcp_decode_workspace_tokens = 0
         if vllm_config is not None and self.dcp_world_size > 1:
             self._dcp_dtype = vllm_config.model_config.dtype
+            speculative_config = vllm_config.speculative_config
+            num_spec_tokens = (
+                speculative_config.num_speculative_tokens
+                if speculative_config is not None
+                else 0
+            )
+            self._dcp_decode_workspace_tokens = (
+                vllm_config.scheduler_config.max_num_seqs * (1 + num_spec_tokens)
+            )
 
     def forward(
         self,
@@ -736,6 +750,14 @@ class FlashAttentionImpl(AttentionImpl):
 
         if attn_metadata is None:
             # Profiling run.
+            if self.dcp_a2a:
+                dcp_a2a_reserve_workspace(
+                    num_tokens=self._dcp_decode_workspace_tokens,
+                    num_heads_per_rank=self.num_heads,
+                    head_dim=self.head_size,
+                    dcp_world_size=get_dcp_group().world_size,
+                    output_dtype=self._dcp_dtype or query.dtype,
+                )
             return output.fill_(0)
 
         attn_type = self.attn_type

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -67,7 +67,10 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
-from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    dcp_a2a_reserve_workspace,
+)
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -1371,6 +1374,18 @@ class FlashInferImpl(AttentionImpl):
             and vllm_config.parallel_config.decode_context_parallel_size > 1
             and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
+        self.dcp_a2a = dcp_a2a
+        self._dcp_decode_workspace_tokens = 0
+        if vllm_config is not None and dcp_a2a:
+            speculative_config = vllm_config.speculative_config
+            num_spec_tokens = (
+                speculative_config.num_speculative_tokens
+                if speculative_config is not None
+                else 0
+            )
+            self._dcp_decode_workspace_tokens = (
+                vllm_config.scheduler_config.max_num_seqs * (1 + num_spec_tokens)
+            )
         if dcp_a2a:
             self.dcp_combine = partial(dcp_a2a_lse_reduce, is_lse_base_on_e=False)
         else:
@@ -1415,6 +1430,14 @@ class FlashInferImpl(AttentionImpl):
         """
         if attn_metadata is None:
             # Profiling run.
+            if self.dcp_a2a:
+                dcp_a2a_reserve_workspace(
+                    num_tokens=self._dcp_decode_workspace_tokens,
+                    num_heads_per_rank=self.num_heads,
+                    head_dim=self.head_size,
+                    dcp_world_size=get_dcp_group().world_size,
+                    output_dtype=query.dtype,
+                )
             return output.fill_(0)
 
         # Ensure query dtype matches the expected dtype from attention metadata

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -26,6 +26,10 @@ import torch
 import torch.distributed as dist
 
 from vllm.triton_utils import tl, triton
+from vllm.v1.worker.workspace import (
+    current_workspace_manager,
+    is_workspace_manager_initialized,
+)
 
 if TYPE_CHECKING:
     from vllm.distributed.parallel_state import GroupCoordinator
@@ -108,21 +112,49 @@ def _dcp_a2a_lse_pack_dim(output_dtype: torch.dtype) -> int:
     raise ValueError(f"Cannot pack fp32 LSE into output dtype {output_dtype}.")
 
 
+def dcp_a2a_packed_workspace_specs(
+    num_tokens: int,
+    num_heads_per_rank: int,
+    head_dim: int,
+    dcp_world_size: int,
+    output_dtype: torch.dtype,
+) -> list[tuple[tuple[int, ...], torch.dtype]]:
+    """Return (shape, dtype) specs for the two DCP A2A packed send/recv
+    staging buffers, each (N, tokens, H/N, D + lse_pack)."""
+    lse_pack_dim = _dcp_a2a_lse_pack_dim(output_dtype)
+    shape = (dcp_world_size, num_tokens, num_heads_per_rank, head_dim + lse_pack_dim)
+    return [(shape, output_dtype), (shape, output_dtype)]
+
+
+def dcp_a2a_reserve_workspace(
+    num_tokens: int,
+    num_heads_per_rank: int,
+    head_dim: int,
+    dcp_world_size: int,
+    output_dtype: torch.dtype,
+) -> None:
+    """Pre-size packed DCP A2A decode staging buffers in the workspace."""
+    current_workspace_manager().get_simultaneous(
+        *dcp_a2a_packed_workspace_specs(
+            num_tokens=num_tokens,
+            num_heads_per_rank=num_heads_per_rank,
+            head_dim=head_dim,
+            dcp_world_size=dcp_world_size,
+            output_dtype=output_dtype,
+        )
+    )
+
+
 def _dcp_a2a_send_recv_buffers(
     shape: tuple[int, ...],
     device: torch.device,
     dtype: torch.dtype,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    # Don't use the shared WorkspaceManager here. A FULL cudagraph bakes in the
-    # buffer address at capture, but the workspace is growable and sized only to
-    # the largest *captured* batch (the cudagraph capture cap). Any eager a2a
-    # with a bigger batch regrows it, freeing that address and poisoning every
-    # captured graph -> illegal memory access on replay. This bites the very
-    # first request: the post-capture warmup runs an eager decode at
-    # max_num_seqs (> the cap), so the graphs are already dangling before the
-    # server is ready. torch.empty buffers instead live in the graph's private
-    # pool and stay valid for its lifetime (as _dcp_a2a_unpack_combine and the
-    # AG+RS combine path already rely on).
+    if is_workspace_manager_initialized():
+        send_buffer, recv_buffer = current_workspace_manager().get_simultaneous(
+            (shape, dtype), (shape, dtype)
+        )
+        return send_buffer, recv_buffer
     return (
         torch.empty(shape, device=device, dtype=dtype),
         torch.empty(shape, device=device, dtype=dtype),
@@ -426,13 +458,21 @@ def dcp_a2a_lse_reduce(
     if H % world_size != 0:
         raise ValueError(f"H={H} must be divisible by DCP world size {world_size}.")
     H_per_rank = H // world_size
-    lse_pack_dim = _dcp_a2a_lse_pack_dim(cp_attn_out.dtype)
+    workspace_specs = dcp_a2a_packed_workspace_specs(
+        num_tokens=B,
+        num_heads_per_rank=H_per_rank,
+        head_dim=D,
+        dcp_world_size=world_size,
+        output_dtype=cp_attn_out.dtype,
+    )
+    (staging_shape, staging_dtype), _ = workspace_specs
 
     send_buffer, recv_buffer = _dcp_a2a_send_recv_buffers(
-        (world_size, B, H_per_rank, D + lse_pack_dim),
+        staging_shape,
         device=cp_attn_out.device,
-        dtype=cp_attn_out.dtype,
+        dtype=staging_dtype,
     )
+    lse_pack_dim = staging_shape[-1] - D
 
     _dcp_a2a_pack_send(
         cp_attn_out,
@@ -453,5 +493,9 @@ def dcp_a2a_lse_reduce(
     work.wait()
 
     return _dcp_a2a_unpack_combine(
-        recv_buffer, D, lse_pack_dim, return_lse, is_lse_base_on_e
+        recv_buffer,
+        D,
+        lse_pack_dim,
+        return_lse,
+        is_lse_base_on_e,
     )


### PR DESCRIPTION
# draft — Pre-reserve packed A2A decode workspace (long-term fix for #45487)

> Draft for the upstream PR body. Commit under test: `66e9fc665`. All numbers from full-CUDA-graph runs on B200; eager/CUTLASS results excluded.

## Purpose

Under Decode Context Parallelism (DCP) with the packed all-to-all (`a2a`) decode combine, the A2A send/recv staging buffers are taken from the shared growable `WorkspaceManager`. The workspace is sized to the largest **captured** batch and then **locked** at the end of `capture_model()`. A later decode whose batch exceeds the captured size tries to **grow the workspace after it is locked**, which under CUDA graphs frees an address baked into a captured graph → illegal memory access (the failure #45487 worked around by moving staging to per-call `torch.empty`).

This PR implements the **long-term fix** maintainers asked for on #45487: **pre-reserve the worst-case A2A decode staging during the profile run** (before the workspace is locked), sized to `max_num_seqs × (1 + num_speculative_tokens)`, and keep staging on the pooled workspace. The reservation is added in all three DCP-a2a callers (MLA, FlashAttention, FlashInfer). This restores workspace pooling (vs #45487's per-call `torch.empty`) while guaranteeing no post-lock growth.

---

## How we benchmarked

**Hardware** 1× node, 8× NVIDIA B200 

**Model / serving shape.** DeepSeek-R1-0528-NVFP4-v2, **TP8 / DCP8**, `--dcp-comm-backend a2a`, `--attention-backend FLASHINFER_MLA` (`mla_prefill_backend=FLASHINFER`), `--kv-cache-dtype fp8_e4m3`, `--max-num-seqs 32`, `--max-model-len 32768`, **full CUDA graph**. 

**Metrics:**
1. **TPOT & throughput** — `vllm bench serve` (vLLM's own serving benchmark), `--dataset-name random`, 128 in / 512 out, 256 prompts, `--max-concurrency 32`, `--ignore-eos`. Reports Median/P99 TTFT, **Median TPOT**, ITL, output-token throughput, total-token throughput.
2. **GSM8K accuracy** — `lm_eval` (lm-evaluation-harness) `--model local-completions` against the running server, standard `gsm8k` task (5-shot), exact-match.



---

## Reproduction

```bash
# Serve (per arm; baseline omits the PR-B overlay). Run inside the container.
export VLLM_DCP_Q_REPLICATE=1
vllm serve <DeepSeek-R1-0528-NVFP4-v2> \
  --trust-remote-code --enable-expert-parallel --dtype auto \
  --tensor-parallel-size 8 --decode-context-parallel-size 8 \
  --dcp-comm-backend a2a \
  --attention-backend FLASHINFER_MLA \
  --attention-config '{"mla_prefill_backend":"FLASHINFER"}' \
  --kv-cache-dtype fp8_e4m3 \
  --max-model-len 32768 --max-num-seqs 32 \
  -cc.cudagraph_mode=FULL --cudagraph-capture-sizes 1 2 4 8 16 32

# GSM8K accuracy — lm-evaluation-harness against the running server
lm_eval --model local-completions \
  --model_args base_url=http://127.0.0.1:PORT/v1/completions,model=<model>,num_concurrent=32 \
  --tasks gsm8k --num_fewshot 5

# TPOT / throughput — vLLM's own serving benchmark
vllm bench serve --backend openai --base-url http://127.0.0.1:PORT --model <model> \
  --dataset-name random --random-input-len 128 --random-output-len 512 \
  --num-prompts 256 --max-concurrency 32 --ignore-eos \
  --percentile-metrics ttft,tpot,itl,e2el
```


---

## Results

### 1. No performance / accuracy regression (DeepSeek-R1-NVFP4, full CUDA graph)

| Metric | baseline | PR-B | Δ |
|---|---|---|---|
| GSM8K flexible-extract | 0.9492 | 0.9447 | −0.45 pp |
| GSM8K strict-match | 0.9462 | 0.9416 | −0.46 pp |
| Median TPOT (ms) | 16.48 | 16.61 | +0.8% |
| P99 TPOT (ms) | 16.96 | 17.07 | +0.6% |
| Output throughput (tok/s) | 1857.96 | 1844.58 | −0.7% |
| Median TTFT (ms) | 390.73 | 383.38 | −1.9% |
| Successful requests | 256/256 | 256/256 | — |

### 2. IMA safety — the failure PR-B prevents (negative control)

The post-lock workspace-growth failure reproduces deterministically on the **GQA `flash_attn` A2A path** (no-fix, captured max < `max_num_seqs`):

- **Config:** Qwen3-235B-A22B-NVFP4, `FLASH_ATTN`, TP8/DCP2, `a2a`, `--max-num-seqs 32`, cudagraph capture sizes `1 2 4 8 16`, bf16 KV.
- **Result:** first request → **HTTP 500**, `AssertionError`:
  ```
  Workspace is locked but allocation from
  'dcp_alltoall.py:121:_dcp_a2a_send_recv_buffers' requires 0.17 MB,
  current size is 0.13 MB. Workspace growth is not allowed after locking.
  ```
- **With PR:** the worst-case staging is reserved during the profile run (before lock), so no post-lock growth occurs and the request is served.

**Negative control = #45487's own documented repro (MLA/Kimi).** #45487 reproduced the IMA on `nvidia/Kimi-K2.5-NVFP4`, `-tp 4 -ep --decode-context-parallel-size 4 --dcp-comm-backend a2a --all2all-backend flashinfer_nvlink_one_sided --enable-ep-weight-filter --kv-cache-dtype fp8 --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'`, where the **post-capture warmup regrows the locked workspace** → captured graphs dereference freed memory. With #45487 reverted (no-fix) this faults; **with this PR the worst-case staging is reserved before the workspace locks, so no regrow occurs and the request serves.** The bug lives in the *shared* a2a staging (`_dcp_a2a_send_recv_buffers`, used by MLA *and* GQA), so this PR's reservation in all three backends covers both. 


