### PR TITLE
[Architecture] Refactor w4a8 MoE Oracle to OOP

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/base.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/base.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any
+
+from torch.nn import Module
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.config.kernel import MoEBackend
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEQuantConfig,
+)
+
+
+class MoEKernelOracle(ABC):
+    """
+    Abstract base class for MoE Oracles.
+    An oracle encapsulates the logic for selecting the most optimal
+    kernel backend and preparing weights for a specific quantization format.
+    """
+
+    @classmethod
+    @abstractmethod
+    def get_priority_backends(
+        cls,
+        moe_config: FusedMoEConfig,
+        *args, **kwargs
+    ) -> list[Enum]:
+        """Return a list of supported backends in priority order."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def backend_to_kernel_cls(
+        cls,
+        backend: Enum,
+    ) -> list[type[mk.FusedMoEExperts]] | type[mk.FusedMoEExperts]:
+        """Map a backend to its corresponding FusedMoEExperts class."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def map_backend(cls, runner_backend: MoEBackend) -> Enum:
+        """Map a string identifier from configuration to the Enum backend."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def select_backend(
+        cls,
+        config: FusedMoEConfig,
+        *args, **kwargs
+    ) -> tuple[Enum, type[mk.FusedMoEExperts] | None]:
+        """Select the most optimal backend based on configuration."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def convert_to_kernel_format(
+        cls,
+        backend: Enum,
+        layer: Module,
+        *args, **kwargs
+    ) -> Any:
+        """Convert weights into the format required by the selected kernel."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def make_quant_config(
+        cls,
+        backend: Enum,
+        *args, **kwargs
+    ) -> FusedMoEQuantConfig | None:
+        """Construct a FusedMoEQuantConfig instance for the selected backend."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def make_kernel(
+        cls,
+        moe_quant_config: FusedMoEQuantConfig | None,
+        moe_config: FusedMoEConfig,
+        backend: Enum,
+        experts_cls: type[mk.FusedMoEExperts],
+        *args, **kwargs
+    ) -> mk.FusedMoEKernel:
+        """Instantiate the FusedMoEKernel for the selected backend."""
+        pass

--- a/vllm/model_executor/layers/fused_moe/oracle/w4a8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/w4a8.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 import torch
+from torch.nn import Module
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.logger import init_logger
@@ -15,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     int4_w4afp8_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8DynamicTokenSym,
@@ -33,163 +35,197 @@ class W4A8MoeBackend(Enum):
     CUTLASS = "CUTLASS"
 
 
-def backend_to_kernel_cls(
-    backend: W4A8MoeBackend,
-) -> list[type["CutlassExpertsW4A8Fp8"]]:
-    if backend == W4A8MoeBackend.CUTLASS:
-        from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
-            CutlassExpertsW4A8Fp8,
+class W4a8MoEKernelOracle(MoEKernelOracle):
+    @classmethod
+    def get_priority_backends(
+        cls,
+        moe_config: FusedMoEConfig,
+        *args, **kwargs
+    ) -> list[Enum]:
+        return [W4A8MoeBackend.CUTLASS]
+
+    @classmethod
+    def backend_to_kernel_cls(
+        cls,
+        backend: Enum,
+    ) -> list[type["CutlassExpertsW4A8Fp8"]]:
+        if backend == W4A8MoeBackend.CUTLASS:
+            from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
+                CutlassExpertsW4A8Fp8,
+            )
+
+            return [CutlassExpertsW4A8Fp8]
+        else:
+            raise ValueError(f"Unknown W4A8 MoE backend: {backend.value}")
+
+    @classmethod
+    def map_backend(cls, runner_backend: str) -> Enum:
+        if runner_backend == "cutlass":
+            return W4A8MoeBackend.CUTLASS
+        raise ValueError(
+            f"moe_backend='{runner_backend}' is not supported for W4A8 MoE."
         )
 
-        return [CutlassExpertsW4A8Fp8]
-    else:
-        raise ValueError(f"Unknown W4A8 MoE backend: {backend.value}")
+    @classmethod
+    def select_backend(
+        cls,
+        config: FusedMoEConfig,
+        weight_key: QuantKey | None = kInt4Static,
+        activation_key: QuantKey | None = kFp8DynamicTokenSym,
+        *args, **kwargs
+    ) -> tuple[Enum, type["CutlassExpertsW4A8Fp8"]]:
+        backend = W4A8MoeBackend.CUTLASS
 
-
-def select_w4a8_moe_backend(
-    config: FusedMoEConfig,
-    weight_key: QuantKey | None = kInt4Static,
-    activation_key: QuantKey | None = kFp8DynamicTokenSym,
-) -> tuple[W4A8MoeBackend, type["CutlassExpertsW4A8Fp8"]]:
-    backend = W4A8MoeBackend.CUTLASS
-
-    activation_format = (
-        mk.FusedMoEActivationFormat.BatchedExperts
-        if config.moe_parallel_config.use_batched_activation_format
-        else mk.FusedMoEActivationFormat.Standard
-    )
-
-    last_reason: str | None = None
-    for kernel_cls in backend_to_kernel_cls(backend):
-        supported, reason = kernel_cls.is_supported_config(
-            kernel_cls,
-            config,
-            weight_key,
-            activation_key,
-            activation_format,
+        activation_format = (
+            mk.FusedMoEActivationFormat.BatchedExperts
+            if config.moe_parallel_config.use_batched_activation_format
+            else mk.FusedMoEActivationFormat.Standard
         )
-        if supported:
-            logger.info_once("Using %s W4A8 MoE backend.", backend.value)
-            return backend, kernel_cls
-        last_reason = reason
 
-    raise NotImplementedError(
-        f"W4A8 MoE backend {backend.value} does not support the "
-        f"deployment configuration: {last_reason}."
-    )
+        last_reason: str | None = None
+        for kernel_cls in cls.backend_to_kernel_cls(backend):
+            supported, reason = kernel_cls.is_supported_config(
+                kernel_cls,
+                config,
+                weight_key,
+                activation_key,
+                activation_format,
+            )
+            if supported:
+                logger.info_once("Using %s W4A8 MoE backend.", backend.value)
+                return backend, kernel_cls
+            last_reason = reason
+
+        raise NotImplementedError(
+            f"W4A8 MoE backend {backend.value} does not support the "
+            f"deployment configuration: {last_reason}."
+        )
+
+    @classmethod
+    def convert_to_kernel_format(
+        cls,
+        backend: Enum,
+        layer: Module,
+        w13_weight_packed: torch.Tensor,
+        w2_weight_packed: torch.Tensor,
+        w13_weight_scale: torch.Tensor,
+        w2_weight_scale: torch.Tensor,
+        *args, **kwargs
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        from vllm import _custom_ops as ops
+        from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+        from vllm.model_executor.layers.quantization.utils.quant_utils import (
+            GroupShape,
+            convert_bf16_scales_to_fp8,
+            convert_packed_uint4b8_to_signed_int4_inplace,
+        )
+
+        quant_fp8 = QuantFP8(static=False, group_shape=GroupShape.PER_TOKEN)
+
+        convert_packed_uint4b8_to_signed_int4_inplace(w13_weight_packed)
+        # Mirror the sync in CutlassW4A8LinearKernel; required for TP>1 correctness.
+        torch.accelerator.synchronize()
+        w13_weight_shuffled, b_strides1 = ops.cutlass_encode_and_reorder_int4b_grouped(
+            w13_weight_packed
+        )
+
+        convert_packed_uint4b8_to_signed_int4_inplace(w2_weight_packed)
+        # Mirror the sync in CutlassW4A8LinearKernel; required for TP>1 correctness.
+        torch.accelerator.synchronize()
+        w2_weight_shuffled, b_strides2 = ops.cutlass_encode_and_reorder_int4b_grouped(
+            w2_weight_packed
+        )
+
+        w13_weight_scale, w13_weight_chan_scale = convert_bf16_scales_to_fp8(
+            quant_fp8, w13_weight_scale
+        )
+        w2_weight_scale, w2_weight_chan_scale = convert_bf16_scales_to_fp8(
+            quant_fp8, w2_weight_scale
+        )
+
+        # Scales are stored as (E, N, K // 128), but the kernel expects
+        # (E, K // 128, N) in row-major format.
+        w13_weight_scale_packed = ops.cutlass_pack_scale_fp8(
+            w13_weight_scale.permute(0, 2, 1).contiguous()
+        )
+        w2_weight_scale_packed = ops.cutlass_pack_scale_fp8(
+            w2_weight_scale.permute(0, 2, 1).contiguous()
+        )
+
+        return (
+            w13_weight_shuffled,
+            w2_weight_shuffled,
+            w13_weight_scale_packed,
+            w2_weight_scale_packed,
+            w13_weight_chan_scale,
+            w2_weight_chan_scale,
+            b_strides1,
+            b_strides2,
+        )
+
+    @classmethod
+    def make_quant_config(
+        cls,
+        backend: Enum,
+        w1_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+        g1_alphas: torch.Tensor,
+        g2_alphas: torch.Tensor,
+        *args, **kwargs
+    ) -> FusedMoEQuantConfig:
+        return int4_w4afp8_moe_quant_config(
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            g1_alphas=g1_alphas,
+            g2_alphas=g2_alphas,
+            per_act_token_quant=True,
+            per_out_ch_quant=True,
+        )
+
+    @classmethod
+    def make_kernel(
+        cls,
+        moe_quant_config: FusedMoEQuantConfig | None,
+        moe_config: FusedMoEConfig,
+        backend: Enum,
+        experts_cls: type["CutlassExpertsW4A8Fp8"],
+        b_strides1: torch.Tensor,
+        b_strides2: torch.Tensor,
+        group_size: int,
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+        *args, **kwargs
+    ) -> mk.FusedMoEKernel:
+        assert moe_quant_config is not None
+        prepare_finalize = maybe_make_prepare_finalize(
+            moe=moe_config,
+            quant_config=moe_quant_config,
+            routing_tables=routing_tables,
+            allow_new_interface=True,
+        )
+        assert prepare_finalize is not None
+
+        logger.info_once("Using %s", prepare_finalize.__class__.__name__)
+
+        experts = experts_cls(
+            moe_config=moe_config,
+            quant_config=moe_quant_config,
+            b_strides1=b_strides1,
+            b_strides2=b_strides2,
+            group_size=group_size,
+        )
+
+        return mk.FusedMoEKernel(
+            prepare_finalize,
+            experts,
+        )
 
 
-def convert_to_w4a8_moe_kernel_format(
-    w13_weight_packed: torch.Tensor,
-    w2_weight_packed: torch.Tensor,
-    w13_weight_scale: torch.Tensor,
-    w2_weight_scale: torch.Tensor,
-) -> tuple[
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-]:
-    from vllm import _custom_ops as ops
-    from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
-    from vllm.model_executor.layers.quantization.utils.quant_utils import (
-        GroupShape,
-        convert_bf16_scales_to_fp8,
-        convert_packed_uint4b8_to_signed_int4_inplace,
-    )
-
-    quant_fp8 = QuantFP8(static=False, group_shape=GroupShape.PER_TOKEN)
-
-    convert_packed_uint4b8_to_signed_int4_inplace(w13_weight_packed)
-    # Mirror the sync in CutlassW4A8LinearKernel; required for TP>1 correctness.
-    torch.accelerator.synchronize()
-    w13_weight_shuffled, b_strides1 = ops.cutlass_encode_and_reorder_int4b_grouped(
-        w13_weight_packed
-    )
-
-    convert_packed_uint4b8_to_signed_int4_inplace(w2_weight_packed)
-    # Mirror the sync in CutlassW4A8LinearKernel; required for TP>1 correctness.
-    torch.accelerator.synchronize()
-    w2_weight_shuffled, b_strides2 = ops.cutlass_encode_and_reorder_int4b_grouped(
-        w2_weight_packed
-    )
-
-    w13_weight_scale, w13_weight_chan_scale = convert_bf16_scales_to_fp8(
-        quant_fp8, w13_weight_scale
-    )
-    w2_weight_scale, w2_weight_chan_scale = convert_bf16_scales_to_fp8(
-        quant_fp8, w2_weight_scale
-    )
-
-    # Scales are stored as (E, N, K // 128), but the kernel expects
-    # (E, K // 128, N) in row-major format.
-    w13_weight_scale_packed = ops.cutlass_pack_scale_fp8(
-        w13_weight_scale.permute(0, 2, 1).contiguous()
-    )
-    w2_weight_scale_packed = ops.cutlass_pack_scale_fp8(
-        w2_weight_scale.permute(0, 2, 1).contiguous()
-    )
-
-    return (
-        w13_weight_shuffled,
-        w2_weight_shuffled,
-        w13_weight_scale_packed,
-        w2_weight_scale_packed,
-        w13_weight_chan_scale,
-        w2_weight_chan_scale,
-        b_strides1,
-        b_strides2,
-    )
-
-
-def make_w4a8_moe_quant_config(
-    w1_scale: torch.Tensor,
-    w2_scale: torch.Tensor,
-    g1_alphas: torch.Tensor,
-    g2_alphas: torch.Tensor,
-) -> FusedMoEQuantConfig:
-    return int4_w4afp8_moe_quant_config(
-        w1_scale=w1_scale,
-        w2_scale=w2_scale,
-        g1_alphas=g1_alphas,
-        g2_alphas=g2_alphas,
-        per_act_token_quant=True,
-        per_out_ch_quant=True,
-    )
-
-
-def make_w4a8_moe_kernel(
-    moe_quant_config: FusedMoEQuantConfig,
-    moe_config: FusedMoEConfig,
-    experts_cls: type["CutlassExpertsW4A8Fp8"],
-    b_strides1: torch.Tensor,
-    b_strides2: torch.Tensor,
-    group_size: int,
-    routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
-) -> mk.FusedMoEKernel:
-    prepare_finalize = maybe_make_prepare_finalize(
-        moe=moe_config,
-        quant_config=moe_quant_config,
-        routing_tables=routing_tables,
-        allow_new_interface=True,
-    )
-    assert prepare_finalize is not None
-
-    logger.info_once("Using %s", prepare_finalize.__class__.__name__)
-
-    experts = experts_cls(
-        moe_config=moe_config,
-        quant_config=moe_quant_config,
-        b_strides1=b_strides1,
-        b_strides2=b_strides2,
-        group_size=group_size,
-    )
-
-    return mk.FusedMoEKernel(
-        prepare_finalize,
-        experts,
-    )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_fp8.py
@@ -17,10 +17,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.oracle.w4a8 import (
-    convert_to_w4a8_moe_kernel_format,
-    make_w4a8_moe_kernel,
-    make_w4a8_moe_quant_config,
-    select_w4a8_moe_backend,
+    W4a8MoEKernelOracle,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
     CompressedTensorsMoEMethod,
@@ -50,7 +47,7 @@ class CompressedTensorsW4A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         assert self.weight_quant.actorder != "group"
         assert self.group_size == 128, "Only group size 128 supported for W4A8 MoE"
 
-        self.w4a8_backend, self.experts_cls = select_w4a8_moe_backend(
+        self.w4a8_backend, self.experts_cls = W4a8MoEKernelOracle.select_backend(
             config=self.moe,
         )
 
@@ -174,7 +171,9 @@ class CompressedTensorsW4A8Fp8MoEMethod(CompressedTensorsMoEMethod):
             w2_weight_chan_scale,
             b_strides1,
             b_strides2,
-        ) = convert_to_w4a8_moe_kernel_format(
+        ) = W4a8MoEKernelOracle.convert_to_kernel_format(
+            backend=self.w4a8_backend,
+            layer=layer,
             w13_weight_packed=layer.w13_weight_packed,
             w2_weight_packed=layer.w2_weight_packed,
             w13_weight_scale=layer.w13_weight_scale,
@@ -194,9 +193,10 @@ class CompressedTensorsW4A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         if self.moe_quant_config is not None:
             assert self.experts_cls is not None
-            self.moe_kernel = make_w4a8_moe_kernel(
+            self.moe_kernel = W4a8MoEKernelOracle.make_kernel(
                 moe_quant_config=self.moe_quant_config,
                 moe_config=self.moe,
+                backend=self.w4a8_backend,
                 experts_cls=self.experts_cls,
                 b_strides1=self.b_strides1,
                 b_strides2=self.b_strides2,
@@ -205,7 +205,8 @@ class CompressedTensorsW4A8Fp8MoEMethod(CompressedTensorsMoEMethod):
             )
 
     def get_fused_moe_quant_config(self, layer: torch.nn.Module) -> FusedMoEQuantConfig:
-        return make_w4a8_moe_quant_config(
+        return W4a8MoEKernelOracle.make_quant_config(
+            backend=self.w4a8_backend,
             w1_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
             g1_alphas=layer.w13_weight_chan_scale,


### PR DESCRIPTION
## Background
This PR introduces the base OOP architecture for `MoEKernelOracle` to clean up and standardize the MoE kernel backend selection and configuration logic. Currently, each quantization format exposes standalone functions (like `select_backend`, `convert_to_kernel_format`), which leads to scattered and repeated logic.

By standardizing around a central `MoEKernelOracle` class, we can encapsulate backend priority selection, kernel mapping, and weight conversions into a unified, extensible interface.

This PR establishes the `MoEKernelOracle` abstract base class and migrates **only the `w4a8` oracle** to this new standard. This ensures the PR remains small, easily reviewable, and establishes the pattern.

## Roadmap for Future PRs
To avoid a massive diff and simplify reviews, the migration of all remaining oracles is split into a series of smaller, focused PRs:

- **Phase 1 (This PR)**: Base Architecture (`MoEKernelOracle`) and Migration of `w4a8`
- **Phase 2**: Migration of `unquantized` and `int8` (Fundamental/standard formats)
- **Phase 3**: Migration of `fp8` and `mxfp8` (FP8-related formats)
- **Phase 4**: Migration of `mxfp4` and `nvfp4` (FP4-related formats)
- **Phase 5**: Migration of `w4a8_int8` and `int_wna16` (Complex multi-format oracles)

## Verification
- Verified successful import of `vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w4a8_fp8`.
- Ran `pre-commit run ruff-check` successfully on the modified files.

*Note: This does not duplicate any existing PR as it introduces a new architectural cleanup pattern discussed internally.*

Co-authored-by: Claude
