### PR TITLE
[XPU][CI] Enable shared loader test

### DIFF
--- a/.buildkite/intel_jobs/models_distributed_intel.yaml
+++ b/.buildkite/intel_jobs/models_distributed_intel.yaml
@@ -1,0 +1,27 @@
+group: Models - Distributed
+depends_on: 
+  - image-build-xpu
+steps:
+- label: Distributed Model Tests (2 GPUs)
+  key: distributed-model-tests-2-gpus
+  timeout_in_minutes: 50
+  device: intel_gpu
+  agent_tags:
+    label: production
+    gpu: 2+
+    mem: 24+
+  no_plugin: true
+  working_dir: "."
+  env:
+    REGISTRY: "public.ecr.aws/q9t5s3a7"
+    REPO: "vllm-ci-test-repo"
+    VLLM_TEST_DEVICE: "xpu"
+  source_file_dependencies:
+  - vllm/model_executor/model_loader/sharded_state_loader.py
+  - vllm/model_executor/models/
+  - tests/model_executor/model_loader/test_sharded_state_loader.py
+  commands:
+    - >-
+      bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+      'cd tests &&
+      pytest -v -s model_executor/model_loader/test_sharded_state_loader.py -m "not slow_test"'

--- a/tests/model_executor/model_loader/test_sharded_state_loader.py
+++ b/tests/model_executor/model_loader/test_sharded_state_loader.py
@@ -97,7 +97,7 @@ def test_sharded_state_loader(
     ctx = mp.get_context("spawn")
 
     platform_args = {}
-    if current_platform.is_rocm():
+    if current_platform.is_rocm() or current_platform.is_xpu():
         platform_args["max_num_seqs"] = 1
 
     # Run in separate processes for memory & CUDA isolation


### PR DESCRIPTION
## Summary

This PR improves stability of `test_sharded_state_loader` on XPU by forcing `max_num_seqs=1` in the XPU test path.

- Apply `max_num_seqs=1` only when running on XPU.
- Keep behavior unchanged for non-XPU platforms.
 