### PR TITLE
[Bugfix][RL] Set vLLM config during weight reload

### DIFF
--- a/tests/v1/worker/test_gpu_worker_weight_transfer.py
+++ b/tests/v1/worker/test_gpu_worker_weight_transfer.py
@@ -9,6 +9,7 @@ session is active. These tests verify that delegation and the session guard.
 
 import pytest
 
+from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.v1.worker.gpu_worker import Worker
 
 
@@ -21,27 +22,53 @@ class _RecordingEngine:
         self.finished = False
         self.reset_count = 0
         self.update_calls: list[dict] = []
+        self.seen_configs: list[VllmConfig] = []
+
+    def _record_config(self) -> None:
+        self.seen_configs.append(get_current_vllm_config())
 
     def start_weight_update(self) -> None:
+        self._record_config()
         self.started = True
 
     def update_weights(self, update_info: dict) -> None:
+        self._record_config()
         self.update_calls.append(update_info)
         if self.raise_on_update:
             raise ValueError("boom")
 
     def finish_weight_update(self) -> None:
+        self._record_config()
         self.finished = True
 
     def reset_weight_update_target(self) -> None:
         self.reset_count += 1
 
 
+class _RecordingModelRunner:
+    def __init__(self) -> None:
+        self.seen_config: VllmConfig | None = None
+
+    def reload_weights(self) -> None:
+        self.seen_config = get_current_vllm_config()
+
+
 def _make_worker(engine: _RecordingEngine | None) -> Worker:
     worker = object.__new__(Worker)
+    worker.vllm_config = VllmConfig()
     worker.weight_transfer_engine = engine
     worker._weight_update_active = False
     return worker
+
+
+def test_reload_weights_sets_current_config():
+    worker = _make_worker(None)
+    model_runner = _RecordingModelRunner()
+    worker.model_runner = model_runner  # type: ignore[assignment]
+
+    Worker.reload_weights(worker)
+
+    assert model_runner.seen_config is worker.vllm_config
 
 
 def test_start_update_finish_delegates_to_engine():
@@ -60,6 +87,7 @@ def test_start_update_finish_delegates_to_engine():
     assert engine.finished is True
     assert engine.reset_count == 1
     assert worker._weight_update_active is False
+    assert engine.seen_configs == [worker.vllm_config] * 3
 
 
 def test_double_start_raises():

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -442,7 +442,8 @@ class Worker(WorkerBase):
         self.model_runner.update_config(overrides)
 
     def reload_weights(self, *args, **kwargs) -> None:
-        self.model_runner.reload_weights(*args, **kwargs)
+        with set_current_vllm_config(self.vllm_config):
+            self.model_runner.reload_weights(*args, **kwargs)
 
     @torch.inference_mode()
     def determine_available_memory(self) -> int:
@@ -1301,14 +1302,16 @@ class Worker(WorkerBase):
         the configured weight transfer engine. The worker only tracks that a
         session is active.
         """
-        self._start_weight_update()
+        with set_current_vllm_config(self.vllm_config):
+            self._start_weight_update()
 
     def start_draft_weight_update(self) -> None:
         """
         Like start_weight_update, but retargets the engine at the speculative
         draft model for this session.
         """
-        self._start_weight_update(is_draft=True)
+        with set_current_vllm_config(self.vllm_config):
+            self._start_weight_update(is_draft=True)
 
     def _start_weight_update(self, is_draft: bool = False) -> None:
         self._check_weight_transfer_engine()
@@ -1355,12 +1358,13 @@ class Worker(WorkerBase):
                 "start_weight_update must be called before update_weights."
             )
 
-        try:
-            self.weight_transfer_engine.update_weights(update_info)
-        except BaseException:
-            self._weight_update_active = False
-            self.weight_transfer_engine.reset_weight_update_target()
-            raise
+        with set_current_vllm_config(self.vllm_config):
+            try:
+                self.weight_transfer_engine.update_weights(update_info)
+            except BaseException:
+                self._weight_update_active = False
+                self.weight_transfer_engine.reset_weight_update_target()
+                raise
 
     def finish_weight_update(self) -> None:
         """Finish the current weight update session."""
@@ -1372,9 +1376,10 @@ class Worker(WorkerBase):
                 "finish_weight_update called without a matching start_weight_update."
             )
 
-        self.weight_transfer_engine.finish_weight_update()
-        self.weight_transfer_engine.reset_weight_update_target()
-        self._weight_update_active = False
+        with set_current_vllm_config(self.vllm_config):
+            self.weight_transfer_engine.finish_weight_update()
+            self.weight_transfer_engine.reset_weight_update_target()
+            self._weight_update_active = False
 
     def shutdown(self) -> None:
         gc.unfreeze()


### PR DESCRIPTION
## Summary

RL weight updates re-run layer post-processing after model initialization.
Those paths may call `get_current_vllm_config()`, but the worker reload APIs did
not establish the config context, causing an assertion failure on the FP8 MoE +
DeepEP path.

This PR wraps the stable worker-level reload boundaries with
`set_current_vllm_config()`:

- regular `reload_weights`
- RL `start_weight_update`, `update_weights`, and `finish_weight_update`
- draft-model weight updates

V1 and the default V2 runner both use these worker entry points. The context is
scoped to each synchronous operation and restored afterward.

## Lifecycle investigation

We audited when `VllmConfig` is first consumed, when it can change, and why the
same config-dependent code is reached again during reload.

### Initial model load

1. `VllmConfig.__post_init__` validates the configuration and derives startup
   settings.
2. `GPUWorker.load_model` enters `set_current_vllm_config(self.vllm_config)`.
   `initialize_model` also scopes the model constructor, so modules can read the
   current config without threading it through every constructor.
3. Initial weight post-processing builds quantized kernels. For the affected
   MoE/EP path, V2 then calls:

   ```text
   prepare_communication_buffer_for_model(model)
     -> EP communicator.prepare_communication_buffer_for_model
     -> MoE.maybe_init_modular_kernel
     -> maybe_make_prepare_finalize
   ```

   Some quantization paths create the modular kernel directly from
   `process_weights_after_loading`; both initial paths are still inside the
   outer `GPUWorker.load_model` config scope.
4. Startup may subsequently update the live config: auto-fit writes
   `model_config.max_model_len`, KV-cache initialization writes
   `cache_config.num_gpu_blocks`, and compilation/CUDA-graph settings are
   finalized during startup. By engine-ready time, these values are available
   on the same `VllmConfig` instance.

### After initialization

Normal inference mostly consumes the finalized config. The explicit exceptions
we found are:

- `update_config`, which can replace `model_config` or `load_config`; V2 keeps
  `self.vllm_config` synchronized. There is no default internal production
  caller—the interface is triggered explicitly by an integration/RPC or tests.
- Elastic EP / dynamic DP reconfiguration, which updates parallel configuration.
- Reloading from an explicit `weights_path`, which updates
  `model_config.model` to that path.

The RL paths covered by this PR—`weights_iterator` and the weight-transfer
engines—do **not** modify `VllmConfig`.

### Why reload still needs the context

Although RL reload does not change the config, it deliberately re-enters code
normally associated with initialization:

```text
Worker.update_weights
  -> weight transfer engine.receive_weights
  -> model.load_weights
  -> layerwise _layerwise_process
  -> quant_method.process_weights_after_loading
  -> rebuild MoE kernel / maybe_make_prepare_finalize
  -> get_current_vllm_config
```

Regular `reload_weights` similarly runs `initialize_layerwise_reload`,
`model.load_weights`, and `finalize_layerwise_reload`. Any current or future
quantization/layer post-processing reached from those hooks may legitimately
need the worker's live config.

This is why fixing individual `get_current_vllm_config()` call sites is fragile:
the repository has many constructor and post-load consumers, and new consumers
can be added later. Establishing the context once at the reload boundaries makes
the already-finalized, live worker config available to the entire operation
without copying fields into every subsystem or keeping a process-global context
active permanently.

## Tests

- `.venv/bin/python -m pytest tests/v1/worker/test_gpu_worker_weight_transfer.py -q`
  (`7 passed`)
- `pre-commit run --files vllm/v1/worker/gpu_worker.py tests/v1/worker/test_gpu_worker_weight_transfer.py`
  (all hooks passed, including ruff and mypy)

## Duplicate-work check

This updates the existing fix in #45989 rather than opening another PR. Searches
for open PRs covering the same config-context failure found no duplicate; the
other weight-reload PRs address different problems.

## AI assistance

OpenAI Codex was used to help investigate, implement, and test this change. The
human submitter is responsible for reviewing every changed line and defending
the change end-to-end.
