### PR TITLE
Pass quant config to Qwen3Next embeddings

### DIFF
--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -4,6 +4,102 @@
 from unittest.mock import Mock, patch
 
 
+def _make_qwen_gdn_vllm_config():
+    mock_quant_config = Mock()
+
+    mock_hf_config = Mock()
+    mock_hf_config.vocab_size = 128
+    mock_hf_config.hidden_size = 64
+    mock_hf_config.num_hidden_layers = 0
+    mock_hf_config.layer_types = []
+    mock_hf_config.rms_norm_eps = 1e-6
+
+    mock_vllm_config = Mock()
+    mock_vllm_config.model_config.hf_text_config = mock_hf_config
+    mock_vllm_config.parallel_config.eplb_config.num_redundant_experts = 0
+    mock_vllm_config.quant_config = mock_quant_config
+
+    return mock_vllm_config, mock_quant_config
+
+
+def test_qwen3_next_embedding_receives_quant_config():
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.model_executor.models.qwen3_next import Qwen3NextModel
+
+    mock_vllm_config, mock_quant_config = _make_qwen_gdn_vllm_config()
+    mock_pp_group = Mock()
+    mock_pp_group.is_last_rank = True
+
+    with (
+        set_current_vllm_config(VllmConfig()),
+        patch(
+            "vllm.model_executor.models.qwen3_next.VocabParallelEmbedding"
+        ) as MockEmbedding,
+        patch(
+            "vllm.model_executor.models.qwen3_next.make_layers",
+            return_value=(0, 0, []),
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_next."
+            "make_empty_intermediate_tensors_factory",
+            return_value=Mock(),
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_next.Qwen3NextRMSNorm",
+            return_value=Mock(),
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_next.get_pp_group",
+            return_value=mock_pp_group,
+        ),
+    ):
+        Qwen3NextModel(vllm_config=mock_vllm_config, prefix="model")
+
+        MockEmbedding.assert_called_once()
+        call_kwargs = MockEmbedding.call_args.kwargs
+        assert call_kwargs["quant_config"] is mock_quant_config
+        assert call_kwargs["prefix"] == "model.embed_tokens"
+
+
+def test_qwen3_5_embedding_receives_quant_config():
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.model_executor.models.qwen3_5 import Qwen3_5Model
+
+    mock_vllm_config, mock_quant_config = _make_qwen_gdn_vllm_config()
+    mock_pp_group = Mock()
+    mock_pp_group.is_last_rank = True
+
+    with (
+        set_current_vllm_config(VllmConfig()),
+        patch(
+            "vllm.model_executor.models.qwen3_5.VocabParallelEmbedding"
+        ) as MockEmbedding,
+        patch(
+            "vllm.model_executor.models.qwen3_5.make_layers",
+            return_value=(0, 0, []),
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_5."
+            "make_empty_intermediate_tensors_factory",
+            return_value=Mock(),
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_5.Qwen3_5RMSNorm",
+            return_value=Mock(),
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_5.get_pp_group",
+            return_value=mock_pp_group,
+        ),
+    ):
+        Qwen3_5Model(vllm_config=mock_vllm_config, prefix="model")
+
+        MockEmbedding.assert_called_once()
+        call_kwargs = MockEmbedding.call_args.kwargs
+        assert call_kwargs["quant_config"] is mock_quant_config
+        assert call_kwargs["prefix"] == "model.embed_tokens"
+
+
 def test_qwen3_5_lm_head_receives_quant_config():
     from vllm.model_executor.models.qwen3_5 import Qwen3_5ForCausalLMBase
 

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -223,10 +223,13 @@ class Qwen3_5Model(Qwen3NextModel):
         self.config = config
 
         self.vocab_size = config.vocab_size
+        quant_config = vllm_config.quant_config
 
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         def get_layer(prefix: str):

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -520,10 +520,13 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
         self.config = config
 
         self.vocab_size = config.vocab_size
+        quant_config = vllm_config.quant_config
 
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
 
         def get_layer(prefix: str):


### PR DESCRIPTION
## What

Pass `vllm_config.quant_config` and an embedding prefix into the Qwen3Next/Qwen3.5 `VocabParallelEmbedding` constructors.

## Why

Quantization plugins need the embedding layer to receive the same quantization config as linear and LM-head layers. Without it, GGUF Qwen3.5 checkpoints expose `token_embd.weight` as packed `qweight/qweight_type`, but vLLM builds `embed_tokens` as a dense embedding and the quantized embedding tensors are skipped or must be densified by the plugin.

That fallback works, but it gives up the main GGUF benefit for a large tensor. On DGX Spark, the packed embedding path reduced the Qwen3.5 GGUF smoke-test load footprint from about 1.32 GiB to 1.04 GiB.

## How

This mirrors existing quantized embedding patterns used by other vLLM models: read `quant_config` from `vllm_config`, pass it to `VocabParallelEmbedding`, and provide the full embedding prefix so `get_quant_method()` can match the layer. The added tests assert both Qwen3Next and Qwen3.5 pass the quant config and prefix into the embedding constructor.

## Validation

- `uvx ruff check vllm/model_executor/models/qwen3_next.py vllm/model_executor/models/qwen3_5.py tests/model_executor/test_qwen3_5_quantization.py`
- `uvx ruff format --check vllm/model_executor/models/qwen3_next.py vllm/model_executor/models/qwen3_5.py tests/model_executor/test_qwen3_5_quantization.py`
- `git diff --check`
- `python3 -m compileall vllm/model_executor/models/qwen3_next.py vllm/model_executor/models/qwen3_5.py tests/model_executor/test_qwen3_5_quantization.py`
- DGX Spark focused unit validation against the installed vLLM runtime with the same minimal patch applied: `4 passed`
- DGX Spark real Qwen3.5 GGUF smoke with the installed runtime minimally patched and the plugin branch without dense embedding fallback: no skipped `embed_tokens.qweight*` warnings, load footprint `1.04 GiB`, generated `QWEN35_SMOKE ' located in the south'`

The direct source-tree pytest path was not used on Spark because the copied checkout did not have the built `vllm._C` extension. The installed runtime was patched only for validation and restored afterward.
