### PR TITLE
[Bugfix] Do not select FA4 (CuTe SM100 kernel) on SM120

### DIFF
--- a/tests/kernels/attention/test_fa_version_dispatch.py
+++ b/tests/kernels/attention/test_fa_version_dispatch.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Arch gating of the FA3 -> FA4 fallback in get_flash_attn_version (vllm#45847).
+
+FA4 is the CuTe SM100 kernel and only supports SM100-SM110; on SM120 it asserts
+at init. The Blackwell FA3->FA4 fallback must therefore not select FA4 on SM120.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import vllm.v1.attention.backends.fa_utils as fa_utils
+from vllm.platforms import current_platform
+from vllm.platforms.interface import DeviceCapability
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA-only dispatch path")
+@pytest.mark.parametrize(
+    "major,minor,expected",
+    [
+        (10, 0, 4),  # SM100: CuTe FA4 kernel is supported
+        (11, 0, 4),  # SM110: still within the FA4 supported range
+        (12, 0, 2),  # SM120: FA4 unsupported -> must fall back to FA2 (#45847)
+    ],
+)
+def test_fa3_to_fa4_fallback_arch_gated(monkeypatch, major, minor, expected):
+    # Force fa_version=3 via config so the Blackwell FA3->FA4 fallback runs.
+    cfg = SimpleNamespace(
+        attention_config=SimpleNamespace(flash_attn_version=3),
+        model_config=None,
+    )
+    monkeypatch.setattr("vllm.config.get_current_vllm_config_or_none", lambda: cfg)
+    monkeypatch.setattr(
+        current_platform,
+        "get_device_capability",
+        lambda: DeviceCapability(major=major, minor=minor),
+    )
+    # Simulate a build where FA4 is compiled in, so only the arch gate decides.
+    monkeypatch.setattr(
+        "vllm.vllm_flash_attn.flash_attn_interface.is_fa_version_supported",
+        lambda v: True,
+    )
+    assert fa_utils.get_flash_attn_version() == expected

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -97,11 +97,16 @@ def get_flash_attn_version(
 
         # 3. fallback for unsupported combinations
         if device_capability.major >= 10 and fa_version == 3:
+            # FA4 is implemented by the CuTe SM100 kernel, which only supports
+            # SM100-SM110 (it asserts on init otherwise). On newer Blackwell
+            # such as SM120 the FA3 -> FA4 fallback must therefore degrade to
+            # FA2 rather than dispatching into an unsupported kernel.
+            fa4_arch_supported = device_capability.major in (10, 11)
             logger.warning_once(
                 "Cannot use FA version 3 on Blackwell platform, "
                 "defaulting to FA version 4 if supported, otherwise FA2."
             )
-            fa_version = 4 if is_fa_version_supported(4) else 2
+            fa_version = 4 if (fa4_arch_supported and is_fa_version_supported(4)) else 2
 
         if requires_alibi and fa_version == 3:
             logger.warning_once(


### PR DESCRIPTION
Fixes #45847

## Problem

On SM120 (e.g. RTX PRO 6000 / RTX 5090), starting a model whose ViT/encoder attention requests FlashAttention 3 crashes at startup:

```
File ".../vllm_flash_attn/cute/flash_fwd_sm100.py", line 142, in __init__
  assert self.arch >= Arch.sm_100 and self.arch <= Arch.sm_110f, "Only SM 10.x and 11.x are supported"
AssertionError: Only SM 10.x and 11.x are supported
```

FA4 is implemented by the CuTe SM100 kernel, which only supports `sm_100 <= arch <= sm_110`. In `get_flash_attn_version` (`vllm/v1/attention/backends/fa_utils.py`) the *default* Blackwell FA4 selection is correctly restricted to SM100 (`device_capability.major == 10`), but the FA3 → FA4 fallback used `device_capability.major >= 10`, which **also matches SM120 (major == 12)**:

```python
if device_capability.major >= 10 and fa_version == 3:   # includes SM120
    ...
    fa_version = 4 if is_fa_version_supported(4) else 2
```

So on a build where FA4 is compiled in, SM120 is routed into the SM100-only CuTe kernel and asserts.

## Fix

Gate the FA3 → FA4 fallback to the arch range the CuTe kernel actually supports (`major in (10, 11)`); other Blackwell (SM120) falls back to FA2.

## Test

New `tests/kernels/attention/test_fa_version_dispatch.py` mocks `is_fa_version_supported` so FA4 looks build-available (isolating the arch gate) and asserts `get_flash_attn_version` returns **4 on SM100/SM110** and **2 on SM120**.

Verified red/green on an RTX 5090 (SM120):
- without this change: `[12-0-2]` **fails** (returns 4 → would dispatch into the asserting kernel); SM100/SM110 pass
- with this change: all 3 pass

## Validation note

I could not reproduce the *live* CuTe assert locally: on the precompiled wheel I tested, `is_fa_version_supported(4)` returns `False` on SM120, so the dispatch already degrades to FA2 and never reaches the CuTe kernel. The crash requires a build where FA4 is compiled in (as in the original NVFP4 Kimi-K2.6 report). The unit test reproduces the faulty **dispatch decision** directly by mocking FA4 as available, and the fix corrects it.

@vvagias — could you confirm this resolves the startup crash on your SM120 / NVFP4 Kimi-K2.6 setup? I don't have a build with FA4 compiled for SM120 to verify the end-to-end path.
