### PR TITLE
[KV Connector][Mooncake]Support DeepSeek V4 Mooncake PP/PD shared KV metadata

### DIFF
--- a/tests/quantization/test_fp8_utils.py
+++ b/tests/quantization/test_fp8_utils.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    _upcast_e8m0_scales_for_triton,
+)
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "float8_e8m0fnu"),
+    reason="torch.float8_e8m0fnu is unavailable in this PyTorch build.",
+)
+def test_upcast_e8m0_scales_for_triton_decodes_only_e8m0_scales():
+    e8m0 = torch.tensor([1.0, 2.0], dtype=torch.float32).to(torch.float8_e8m0fnu)
+    fp32 = torch.tensor([3.0, 4.0], dtype=torch.float32)
+
+    decoded_e8m0, unchanged_fp32 = _upcast_e8m0_scales_for_triton(e8m0, fp32)
+
+    assert decoded_e8m0.dtype == torch.float32
+    assert decoded_e8m0.is_contiguous()
+    torch.testing.assert_close(decoded_e8m0, torch.tensor([1.0, 2.0]))
+    assert unchanged_fp32 is fp32

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1250,6 +1250,76 @@ def test_project_kv_cache_groups_to_worker():
     assert set(proj_spec.kv_cache_specs.keys()) == {"layer1", "layer3"}
 
 
+def test_deepseek_v4_projected_pp_groups_preserve_shared_layer_identity():
+    full_specs: dict[str, KVCacheSpec] = {}
+    for idx in range(8):
+        full_specs[f"model.layers.{idx}.self_attn"] = new_dsv4_mla_spec(
+            block_size=256,
+            num_kv_heads=1 if idx % 2 == 0 else 2,
+        )
+
+    swa_specs: dict[str, KVCacheSpec] = {}
+    for idx in range(4, 8):
+        swa_specs[f"model.layers.{idx}.swa_attn"] = new_dsv4_swa_mla_spec(
+            block_size=256,
+            num_kv_heads=1 if idx % 2 == 0 else 2,
+            sliding_window=512,
+        )
+
+    global_groups = [
+        KVCacheGroupSpec(
+            layer_names=list(full_specs),
+            kv_cache_spec=make_dsv4_uniform_group(full_specs),
+        ),
+        KVCacheGroupSpec(
+            layer_names=list(swa_specs),
+            kv_cache_spec=make_dsv4_uniform_group(swa_specs),
+        ),
+    ]
+
+    worker_spec = {
+        **{
+            name: spec
+            for name, spec in full_specs.items()
+            if name.startswith("model.layers.4.")
+            or name.startswith("model.layers.5.")
+            or name.startswith("model.layers.6.")
+            or name.startswith("model.layers.7.")
+        },
+        **swa_specs,
+    }
+
+    projected = kv_cache_utils._project_kv_cache_groups_to_worker(
+        global_groups,
+        worker_spec,
+    )
+
+    assert [group.layer_names for group in projected] == [
+        [
+            "model.layers.4.self_attn",
+            "model.layers.5.self_attn",
+            "model.layers.6.self_attn",
+            "model.layers.7.self_attn",
+        ],
+        [
+            "model.layers.4.swa_attn",
+            "model.layers.5.swa_attn",
+            "model.layers.6.swa_attn",
+            "model.layers.7.swa_attn",
+        ],
+    ]
+
+    for group in projected:
+        assert isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
+        assert set(group.kv_cache_spec.kv_cache_specs) == set(group.layer_names)
+        assert list(group.kv_cache_spec.kv_cache_specs) == group.layer_names
+
+    full_group_spec = projected[0].kv_cache_spec
+    assert isinstance(full_group_spec, UniformTypeKVCacheSpecs)
+    page_sizes = full_group_spec.get_page_sizes()
+    assert sorted(page_sizes) == [32768, 65536]
+
+
 def test_merge_kv_cache_spec():
     same_layer_specs = [
         new_kv_cache_spec(num_kv_heads=32),
@@ -1946,6 +2016,46 @@ def new_mla_spec(cache_dtype_str=None):
         dtype=torch.float32,
         cache_dtype_str=cache_dtype_str,
     )
+
+
+def new_dsv4_mla_spec(
+    block_size: int,
+    num_kv_heads: int,
+    head_size: int = 64,
+    dtype: torch.dtype = torch.float16,
+) -> MLAAttentionSpec:
+    return MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        dtype=dtype,
+        model_version="deepseek_v4",
+    )
+
+
+def new_dsv4_swa_mla_spec(
+    block_size: int,
+    num_kv_heads: int,
+    sliding_window: int,
+    head_size: int = 64,
+    dtype: torch.dtype = torch.float16,
+) -> SlidingWindowMLASpec:
+    return SlidingWindowMLASpec(
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        dtype=dtype,
+        sliding_window=sliding_window,
+        model_version="deepseek_v4",
+    )
+
+
+def make_dsv4_uniform_group(
+    specs: dict[str, KVCacheSpec],
+) -> UniformTypeKVCacheSpecs:
+    group = UniformTypeKVCacheSpecs.from_specs(specs)
+    assert group is not None
+    return group
 
 
 def test_get_kv_cache_spec_kind_prefers_specific_attention_subclasses():

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -68,6 +68,31 @@ def _make_test_kv_cache_config() -> KVCacheConfig:
     )
 
 
+def _make_unsplit_transfer_topo():
+    return SimpleNamespace(
+        split_k_and_v=False,
+        virtually_split_kv_in_blocks=False,
+        get_transfer_cache_regions=lambda cache, layer_spec: [cache],
+    )
+
+
+def _populate_worker_layer_metadata(worker: MooncakeConnectorWorker):
+    worker._layer_specs = {}
+    worker._layer_group_indices = {}
+    worker._layer_logical_group_indices = {}
+    for group_index, group in enumerate(worker.kv_cache_config.kv_cache_groups):
+        group_spec = group.kv_cache_spec
+        specs_by_layer = getattr(group_spec, "kv_cache_specs", {})
+        for layer_name in group.layer_names:
+            worker._layer_specs[layer_name] = specs_by_layer.get(
+                layer_name, group_spec
+            )
+            worker._layer_group_indices[layer_name] = group_index
+            worker._layer_logical_group_indices.setdefault(layer_name, []).append(
+                group_index
+            )
+
+
 class FakeMooncakeWrapper:
     """Mock Mooncake TransferEngine for unit testing environments."""
 
@@ -1380,7 +1405,7 @@ def test_register_kv_caches_skips_speculative_layers_outside_base_model():
         speculative_config=SimpleNamespace(method="mtp"),
     )
     worker.kv_cache_config = _make_test_kv_cache_config()
-    worker.transfer_topo = SimpleNamespace(split_k_and_v=False)
+    worker.transfer_topo = _make_unsplit_transfer_topo()
     worker.engine = MagicMock()
     worker.engine.batch_register_memory.return_value = 0
     worker.async_zmq_ctx = MagicMock()
@@ -1388,6 +1413,7 @@ def test_register_kv_caches_skips_speculative_layers_outside_base_model():
     worker.is_kv_producer = False
     worker.receiver_loop = MagicMock()
     worker.receiver_loop.is_running.return_value = False
+    _populate_worker_layer_metadata(worker)
 
     kv_cache_shape = FlashAttentionBackend.get_kv_cache_shape(
         num_blocks=2, block_size=16, num_kv_heads=4, head_size=64
@@ -1422,7 +1448,7 @@ def test_register_kv_caches_keeps_non_mtp_speculative_layers_outside_base_model(
         speculative_config=SimpleNamespace(method="eagle"),
     )
     worker.kv_cache_config = _make_test_kv_cache_config()
-    worker.transfer_topo = SimpleNamespace(split_k_and_v=False)
+    worker.transfer_topo = _make_unsplit_transfer_topo()
     worker.engine = MagicMock()
     worker.engine.batch_register_memory.return_value = 0
     worker.async_zmq_ctx = MagicMock()
@@ -1430,6 +1456,7 @@ def test_register_kv_caches_keeps_non_mtp_speculative_layers_outside_base_model(
     worker.is_kv_producer = False
     worker.receiver_loop = MagicMock()
     worker.receiver_loop.is_running.return_value = False
+    _populate_worker_layer_metadata(worker)
 
     kv_cache_shape = FlashAttentionBackend.get_kv_cache_shape(
         num_blocks=2, block_size=16, num_kv_heads=4, head_size=64
@@ -1490,10 +1517,7 @@ def test_register_kv_caches_preserves_dsv4_shared_region_group_aliases():
             ),
         ],
     )
-    worker.transfer_topo = SimpleNamespace(
-        split_k_and_v=False,
-        virtually_split_kv_in_blocks=False,
-    )
+    worker.transfer_topo = _make_unsplit_transfer_topo()
     worker.engine = MagicMock()
     worker.engine.batch_register_memory.return_value = 0
     worker.async_zmq_ctx = MagicMock()
@@ -1501,6 +1525,7 @@ def test_register_kv_caches_preserves_dsv4_shared_region_group_aliases():
     worker.is_kv_producer = False
     worker.receiver_loop = MagicMock()
     worker.receiver_loop.is_running.return_value = False
+    _populate_worker_layer_metadata(worker)
 
     shared_cache = torch.zeros((2, 16, 4, 16), dtype=torch.float16)
     kv_caches = {

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import contextlib
+import logging
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -17,6 +18,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     KVConnectorRole,
     MooncakeConnector,
     MooncakeConnectorMetadata,
+    MooncakeConnectorScheduler,
     MooncakeConnectorWorker,
     MooncakeXferMetadata,
     MooncakeXferResponse,
@@ -37,6 +39,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    SlidingWindowSpec,
 )
 from vllm.v1.request import RequestStatus
 
@@ -373,7 +376,8 @@ def test_align_transfer_regions_matches_shared_aliases():
                 "model.layers.4.swa_attn",
             ),
             layer_indices=(4, 4),
-            group_indices=(0, 1),
+            logical_group_indices=(0, 1),
+            alias_group_indices=((0,), (1,)),
         ),
     ]
     remote_regions = [
@@ -388,7 +392,8 @@ def test_align_transfer_regions_matches_shared_aliases():
                 "model.layers.4.self_attn",
             ),
             layer_indices=(4, 4),
-            group_indices=(1, 0),
+            logical_group_indices=(1, 0),
+            alias_group_indices=((1,), (0,)),
         ),
     ]
 
@@ -417,7 +422,8 @@ def test_align_transfer_regions_fans_out_split_alias_regions():
                 "model.layers.4.swa_attn",
             ),
             layer_indices=(4, 4),
-            group_indices=(0, 1),
+            logical_group_indices=(0, 1),
+            alias_group_indices=((0,), (1,)),
         ),
     ]
     remote_regions = [
@@ -429,7 +435,8 @@ def test_align_transfer_regions_fans_out_split_alias_regions():
             kv_block_len=4096,
             layer_aliases=("model.layers.4.self_attn",),
             layer_indices=(4,),
-            group_indices=(0,),
+            logical_group_indices=(0,),
+            alias_group_indices=((0,),),
         ),
         TransferRegion(
             layer_name="model.layers.4.swa_attn",
@@ -439,7 +446,8 @@ def test_align_transfer_regions_fans_out_split_alias_regions():
             kv_block_len=4096,
             layer_aliases=("model.layers.4.swa_attn",),
             layer_indices=(4,),
-            group_indices=(1,),
+            logical_group_indices=(1,),
+            alias_group_indices=((1,),),
         ),
     ]
 
@@ -465,7 +473,8 @@ def test_align_transfer_regions_rejects_single_alias_occurrence_mismatch():
             kv_block_len=4096,
             layer_aliases=("model.layers.4.self_attn",),
             layer_indices=(4,),
-            group_indices=(0,),
+            logical_group_indices=(0,),
+            alias_group_indices=((0,),),
         ),
     ]
     remote_regions = [
@@ -477,7 +486,8 @@ def test_align_transfer_regions_rejects_single_alias_occurrence_mismatch():
             kv_block_len=4096,
             layer_aliases=("model.layers.4.self_attn",),
             layer_indices=(4,),
-            group_indices=(0,),
+            logical_group_indices=(0,),
+            alias_group_indices=((0,),),
         ),
         TransferRegion(
             layer_name="model.layers.4.self_attn",
@@ -487,7 +497,8 @@ def test_align_transfer_regions_rejects_single_alias_occurrence_mismatch():
             kv_block_len=4096,
             layer_aliases=("model.layers.4.self_attn",),
             layer_indices=(4,),
-            group_indices=(0,),
+            logical_group_indices=(0,),
+            alias_group_indices=((0,),),
         ),
     ]
 
@@ -499,7 +510,7 @@ def test_align_transfer_regions_rejects_single_alias_occurrence_mismatch():
     assert aligned_local == []
     assert aligned_remote == []
     assert err is not None
-    assert "alias occurrence mismatch" in err
+    assert "duplicate alias group match" in err
 
 
 def test_basic_interface():
@@ -780,11 +791,22 @@ def test_scheduler_request_finished():
     and 'Aborted' (immediate free).
     """
 
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector", kv_role="kv_producer"
+    scheduler_connector = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    scheduler_connector.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            local_engines_only=True,
+            nnodes_within_dp=1,
+            master_addr="127.0.0.1",
+            data_parallel_master_ip="127.0.0.1",
+        )
     )
-    scheduler = create_scheduler(vllm_config)
-    scheduler_connector = scheduler.get_kv_connector().connector_scheduler
+    scheduler_connector.engine_id = "test-engine"
+    scheduler_connector.is_kv_producer = True
+    scheduler_connector.is_kv_consumer = False
+    scheduler_connector._is_hma_required = False
+    scheduler_connector._reqs_need_recv = {}
+    scheduler_connector._reqs_need_send = {}
+    scheduler_connector._reqs_not_processed = set()
 
     request = create_request(request_id=1, do_remote_decode=True)
     request.kv_transfer_params["transfer_id"] = request.request_id
@@ -795,13 +817,7 @@ def test_scheduler_request_finished():
         request, block_ids=([10, 11],)
     )
     assert delay_free is True
-    assert kv_transfer_params == {
-        "do_remote_prefill": True,
-        "do_remote_decode": False,
-        "remote_engine_id": scheduler_connector.engine_id,
-        "remote_bootstrap_addr": "http://127.0.0.1:8998",
-        "transfer_id": request.request_id,
-    }
+    assert kv_transfer_params is None
     assert "id-1" in scheduler_connector._reqs_need_send
     assert scheduler_connector._reqs_need_send["id-1"][1] == [[10, 11]]
 
@@ -1354,6 +1370,154 @@ def test_register_kv_caches_skips_speculative_layers_outside_base_model():
     assert registered_lens == [normal_cache.nbytes]
     assert worker.registered_layer_names == ["model.layers.0.self_attn"]
     assert worker.registered_layer_indices == [0]
+
+
+def test_register_kv_caches_keeps_non_mtp_speculative_layers_outside_base_model():
+    """Only MTP draft KV caches are filtered by model layer range."""
+
+    num_hidden_layers = 32
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.use_mla = False
+    worker.model_config = SimpleNamespace(
+        get_total_num_hidden_layers=lambda: num_hidden_layers,
+    )
+    worker.vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(method="eagle"),
+    )
+    worker.kv_cache_config = _make_test_kv_cache_config()
+    worker.transfer_topo = SimpleNamespace(split_k_and_v=False)
+    worker.engine = MagicMock()
+    worker.engine.batch_register_memory.return_value = 0
+    worker.async_zmq_ctx = MagicMock()
+    worker.is_kv_consumer = True
+    worker.is_kv_producer = False
+    worker.receiver_loop = MagicMock()
+    worker.receiver_loop.is_running.return_value = False
+
+    kv_cache_shape = FlashAttentionBackend.get_kv_cache_shape(
+        num_blocks=2, block_size=16, num_kv_heads=4, head_size=64
+    )
+    normal_cache = torch.zeros(*kv_cache_shape, dtype=torch.float16)
+    eagle_cache = torch.zeros(*kv_cache_shape, dtype=torch.float16)
+    kv_caches = {
+        "model.layers.0.self_attn": normal_cache,
+        f"model.layers.{num_hidden_layers}.attn.swa_cache": eagle_cache,
+    }
+
+    worker.register_kv_caches(kv_caches)
+
+    worker.engine.batch_register_memory.assert_called_once()
+    registered_ptrs, registered_lens = worker.engine.batch_register_memory.call_args[0]
+    assert registered_ptrs == [normal_cache.data_ptr(), eagle_cache.data_ptr()]
+    assert registered_lens == [normal_cache.nbytes, eagle_cache.nbytes]
+    assert worker.registered_layer_names == list(kv_caches)
+    assert worker.registered_layer_indices == [0, num_hidden_layers]
+
+
+def test_register_kv_caches_preserves_dsv4_shared_region_group_aliases():
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.use_mla = True
+    worker.model_config = SimpleNamespace(get_total_num_hidden_layers=lambda: 64)
+    worker.vllm_config = SimpleNamespace(speculative_config=None)
+    worker.kv_cache_config = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["model.layers.4.attn"],
+                FullAttentionSpec(
+                    block_size=16,
+                    num_kv_heads=4,
+                    head_size=16,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["model.layers.4.attn.swa_cache"],
+                SlidingWindowSpec(
+                    block_size=16,
+                    num_kv_heads=4,
+                    head_size=16,
+                    dtype=torch.float16,
+                    sliding_window=128,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["model.layers.4.attn.compressor.state_cache"],
+                FullAttentionSpec(
+                    block_size=16,
+                    num_kv_heads=4,
+                    head_size=16,
+                    dtype=torch.float16,
+                ),
+            ),
+        ],
+    )
+    worker.transfer_topo = SimpleNamespace(
+        split_k_and_v=False,
+        virtually_split_kv_in_blocks=False,
+    )
+    worker.engine = MagicMock()
+    worker.engine.batch_register_memory.return_value = 0
+    worker.async_zmq_ctx = MagicMock()
+    worker.is_kv_consumer = True
+    worker.is_kv_producer = False
+    worker.receiver_loop = MagicMock()
+    worker.receiver_loop.is_running.return_value = False
+
+    shared_cache = torch.zeros((2, 16, 4, 16), dtype=torch.float16)
+    kv_caches = {
+        "model.layers.4.attn": shared_cache,
+        "model.layers.4.attn.swa_cache": shared_cache,
+        "model.layers.4.attn.compressor.state_cache": shared_cache,
+    }
+
+    worker.register_kv_caches(kv_caches)
+
+    worker.engine.batch_register_memory.assert_called_once()
+    registered_ptrs, _ = worker.engine.batch_register_memory.call_args[0]
+    assert registered_ptrs == [shared_cache.data_ptr()]
+    assert worker.registered_layer_names == ["model.layers.4.attn"]
+    assert worker.registered_layer_aliases == [list(kv_caches)]
+    assert worker.registered_layer_index_aliases == [[4, 4, 4]]
+    assert worker.registered_group_indices == [0]
+    assert worker.registered_logical_group_indices == [[0, 1, 2]]
+    assert worker.registered_alias_group_indices == [[[0], [1], [2]]]
+
+    regions = worker._get_transfer_regions(
+        base_addrs=worker.kv_caches_base_addr,
+        block_lens=worker.block_len_per_layer,
+        kv_block_lens=worker.kv_block_len_per_layer,
+        layer_names=worker.registered_layer_names,
+        layer_indices=worker.registered_layer_indices,
+        layer_aliases=worker.registered_layer_aliases,
+        layer_index_aliases=worker.registered_layer_index_aliases,
+        group_indices=worker.registered_group_indices,
+        logical_group_indices=worker.registered_logical_group_indices,
+        alias_group_indices=worker.registered_alias_group_indices,
+    )
+
+    aligned_local, aligned_remote, err = _align_transfer_regions(regions, regions)
+    assert err is None
+    assert aligned_local == regions
+    assert aligned_remote == regions
+
+
+def test_get_transfer_regions_rejects_metadata_shape_mismatch():
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.async_zmq_ctx = MagicMock()
+    worker.is_kv_consumer = True
+    worker.is_kv_producer = True
+    worker.transfer_topo = SimpleNamespace(virtually_split_kv_in_blocks=False)
+
+    with pytest.raises(AssertionError, match="matching metadata lengths"):
+        worker._get_transfer_regions(
+            base_addrs=[0x1000],
+            block_lens=[64],
+            kv_block_lens=[64],
+            layer_names=[],
+            layer_indices=[],
+        )
 
 
 def test_register_kv_caches_supports_mixed_mla_and_eagle_shapes():

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -84,9 +84,7 @@ def _populate_worker_layer_metadata(worker: MooncakeConnectorWorker):
         group_spec = group.kv_cache_spec
         specs_by_layer = getattr(group_spec, "kv_cache_specs", {})
         for layer_name in group.layer_names:
-            worker._layer_specs[layer_name] = specs_by_layer.get(
-                layer_name, group_spec
-            )
+            worker._layer_specs[layer_name] = specs_by_layer.get(layer_name, group_spec)
             worker._layer_group_indices[layer_name] = group_index
             worker._layer_logical_group_indices.setdefault(layer_name, []).append(
                 group_index

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import contextlib
-import logging
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -511,6 +510,44 @@ def test_align_transfer_regions_rejects_single_alias_occurrence_mismatch():
     assert aligned_remote == []
     assert err is not None
     assert "duplicate alias group match" in err
+
+
+def test_align_transfer_regions_rejects_aliases_without_group_ownership():
+    local_regions = [
+        TransferRegion(
+            layer_name="model.layers.4.self_attn",
+            layer_index=4,
+            base_addr=0x1000,
+            block_len=4096,
+            kv_block_len=4096,
+            layer_aliases=("model.layers.4.self_attn",),
+            layer_indices=(4,),
+            logical_group_indices=(0,),
+        ),
+    ]
+    remote_regions = [
+        TransferRegion(
+            layer_name="model.layers.4.self_attn",
+            layer_index=4,
+            base_addr=0x2000,
+            block_len=4096,
+            kv_block_len=4096,
+            layer_aliases=("model.layers.4.self_attn",),
+            layer_indices=(4,),
+            logical_group_indices=(0,),
+            alias_group_indices=((0,),),
+        ),
+    ]
+
+    aligned_local, aligned_remote, err = _align_transfer_regions(
+        local_regions,
+        remote_regions,
+    )
+
+    assert aligned_local == []
+    assert aligned_remote == []
+    assert err is not None
+    assert "same Mooncake metadata schema" in err
 
 
 def test_basic_interface():
@@ -1510,7 +1547,7 @@ def test_get_transfer_regions_rejects_metadata_shape_mismatch():
     worker.is_kv_producer = True
     worker.transfer_topo = SimpleNamespace(virtually_split_kv_in_blocks=False)
 
-    with pytest.raises(AssertionError, match="matching metadata lengths"):
+    with pytest.raises(ValueError, match="metadata shape mismatch"):
         worker._get_transfer_regions(
             base_addrs=[0x1000],
             block_lens=[64],
@@ -1628,6 +1665,7 @@ async def test_kv_producer_heterogeneous_tp(monkeypatch, d_tp_size):
         prefill_worker.kv_block_len_per_layer = [local_block_len // 2]
         prefill_worker.registered_layer_names = ["model.layers.0.self_attn"]
         prefill_worker.registered_layer_indices = [0]
+        prefill_worker.registered_group_indices = [0]
 
         origin_sender_loop = prefill_worker.sender_loop
         prefill_worker.sender_loop = asyncio.get_event_loop()
@@ -1676,6 +1714,7 @@ async def test_kv_producer_heterogeneous_tp(monkeypatch, d_tp_size):
                     kv_block_lens=[remote_block_len // 2],
                     registered_layer_names=["model.layers.0.self_attn"],
                     registered_layer_indices=[0],
+                    registered_group_indices=[0],
                 )
 
                 mock_send_blocks.reset_mock()

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -358,6 +358,150 @@ async def test_send_kv_to_decode_aligns_consumer_regions_by_layer_metadata(
         prefill_worker.shutdown()
 
 
+def test_align_transfer_regions_matches_shared_aliases():
+    """Shared physical regions should align by alias overlap."""
+
+    local_regions = [
+        TransferRegion(
+            layer_name="model.layers.4.self_attn",
+            layer_index=4,
+            base_addr=0x1000,
+            block_len=4096,
+            kv_block_len=4096,
+            layer_aliases=(
+                "model.layers.4.self_attn",
+                "model.layers.4.swa_attn",
+            ),
+            layer_indices=(4, 4),
+            group_indices=(0, 1),
+        ),
+    ]
+    remote_regions = [
+        TransferRegion(
+            layer_name="model.layers.4.swa_attn",
+            layer_index=4,
+            base_addr=0x2000,
+            block_len=4096,
+            kv_block_len=4096,
+            layer_aliases=(
+                "model.layers.4.swa_attn",
+                "model.layers.4.self_attn",
+            ),
+            layer_indices=(4, 4),
+            group_indices=(1, 0),
+        ),
+    ]
+
+    aligned_local, aligned_remote, err = _align_transfer_regions(
+        local_regions,
+        remote_regions,
+    )
+
+    assert err is None
+    assert aligned_local == local_regions
+    assert aligned_remote == remote_regions
+
+
+def test_align_transfer_regions_fans_out_split_alias_regions():
+    """Shared producer regions can feed consumer regions split by alias."""
+
+    local_regions = [
+        TransferRegion(
+            layer_name="model.layers.4.self_attn",
+            layer_index=4,
+            base_addr=0x1000,
+            block_len=4096,
+            kv_block_len=4096,
+            layer_aliases=(
+                "model.layers.4.self_attn",
+                "model.layers.4.swa_attn",
+            ),
+            layer_indices=(4, 4),
+            group_indices=(0, 1),
+        ),
+    ]
+    remote_regions = [
+        TransferRegion(
+            layer_name="model.layers.4.self_attn",
+            layer_index=4,
+            base_addr=0x2000,
+            block_len=4096,
+            kv_block_len=4096,
+            layer_aliases=("model.layers.4.self_attn",),
+            layer_indices=(4,),
+            group_indices=(0,),
+        ),
+        TransferRegion(
+            layer_name="model.layers.4.swa_attn",
+            layer_index=4,
+            base_addr=0x3000,
+            block_len=4096,
+            kv_block_len=4096,
+            layer_aliases=("model.layers.4.swa_attn",),
+            layer_indices=(4,),
+            group_indices=(1,),
+        ),
+    ]
+
+    aligned_local, aligned_remote, err = _align_transfer_regions(
+        local_regions,
+        remote_regions,
+    )
+
+    assert err is None
+    assert aligned_local == [local_regions[0], local_regions[0]]
+    assert aligned_remote == remote_regions
+
+
+def test_align_transfer_regions_rejects_single_alias_occurrence_mismatch():
+    """Single-alias regions should still preserve occurrence counts."""
+
+    local_regions = [
+        TransferRegion(
+            layer_name="model.layers.4.self_attn",
+            layer_index=4,
+            base_addr=0x1000,
+            block_len=4096,
+            kv_block_len=4096,
+            layer_aliases=("model.layers.4.self_attn",),
+            layer_indices=(4,),
+            group_indices=(0,),
+        ),
+    ]
+    remote_regions = [
+        TransferRegion(
+            layer_name="model.layers.4.self_attn",
+            layer_index=4,
+            base_addr=0x2000,
+            block_len=4096,
+            kv_block_len=4096,
+            layer_aliases=("model.layers.4.self_attn",),
+            layer_indices=(4,),
+            group_indices=(0,),
+        ),
+        TransferRegion(
+            layer_name="model.layers.4.self_attn",
+            layer_index=4,
+            base_addr=0x3000,
+            block_len=4096,
+            kv_block_len=4096,
+            layer_aliases=("model.layers.4.self_attn",),
+            layer_indices=(4,),
+            group_indices=(0,),
+        ),
+    ]
+
+    aligned_local, aligned_remote, err = _align_transfer_regions(
+        local_regions,
+        remote_regions,
+    )
+
+    assert aligned_local == []
+    assert aligned_remote == []
+    assert err is not None
+    assert "alias occurrence mismatch" in err
+
+
 def test_basic_interface():
     """Unit test for basic MooncakeConnector interface functionality."""
 
@@ -647,8 +791,17 @@ def test_scheduler_request_finished():
 
     # Case: Capped length (Successful prefill, need to send to decoder)
     request.status = RequestStatus.FINISHED_LENGTH_CAPPED
-    delay_free, _ = scheduler_connector.request_finished(request, block_ids=([10, 11],))
+    delay_free, kv_transfer_params = scheduler_connector.request_finished(
+        request, block_ids=([10, 11],)
+    )
     assert delay_free is True
+    assert kv_transfer_params == {
+        "do_remote_prefill": True,
+        "do_remote_decode": False,
+        "remote_engine_id": scheduler_connector.engine_id,
+        "remote_bootstrap_addr": "http://127.0.0.1:8998",
+        "transfer_id": request.request_id,
+    }
     assert "id-1" in scheduler_connector._reqs_need_send
     assert scheduler_connector._reqs_need_send["id-1"][1] == [[10, 11]]
 
@@ -1159,6 +1312,48 @@ def test_register_kv_caches():
                 assert bl == tensor1.nbytes // tensor1.shape[0]
             assert worker.registered_layer_names == list(kv_caches)
             assert worker.registered_layer_indices == [0, 1]
+
+
+def test_register_kv_caches_skips_speculative_layers_outside_base_model():
+    """Speculative MTP KV caches should not be exported as Mooncake regions."""
+
+    num_hidden_layers = 32
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.use_mla = False
+    worker.model_config = SimpleNamespace(
+        get_total_num_hidden_layers=lambda: num_hidden_layers,
+    )
+    worker.vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(method="mtp"),
+    )
+    worker.kv_cache_config = _make_test_kv_cache_config()
+    worker.transfer_topo = SimpleNamespace(split_k_and_v=False)
+    worker.engine = MagicMock()
+    worker.engine.batch_register_memory.return_value = 0
+    worker.async_zmq_ctx = MagicMock()
+    worker.is_kv_consumer = True
+    worker.is_kv_producer = False
+    worker.receiver_loop = MagicMock()
+    worker.receiver_loop.is_running.return_value = False
+
+    kv_cache_shape = FlashAttentionBackend.get_kv_cache_shape(
+        num_blocks=2, block_size=16, num_kv_heads=4, head_size=64
+    )
+    normal_cache = torch.zeros(*kv_cache_shape, dtype=torch.float16)
+    mtp_cache = torch.zeros(*kv_cache_shape, dtype=torch.float16)
+    kv_caches = {
+        "model.layers.0.self_attn": normal_cache,
+        f"model.layers.{num_hidden_layers}.attn.swa_cache": mtp_cache,
+    }
+
+    worker.register_kv_caches(kv_caches)
+
+    worker.engine.batch_register_memory.assert_called_once()
+    registered_ptrs, registered_lens = worker.engine.batch_register_memory.call_args[0]
+    assert registered_ptrs == [normal_cache.data_ptr()]
+    assert registered_lens == [normal_cache.nbytes]
+    assert worker.registered_layer_names == ["model.layers.0.self_attn"]
+    assert worker.registered_layer_indices == [0]
 
 
 def test_register_kv_caches_supports_mixed_mla_and_eagle_shapes():

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -361,7 +361,7 @@ async def test_send_kv_to_decode_aligns_consumer_regions_by_layer_metadata(
         prefill_worker.shutdown()
 
 
-def test_align_transfer_regions_matches_shared_aliases():
+def test_align_transfer_regions_matches_shared_physical_region_aliases():
     """Shared physical regions should align by alias overlap."""
 
     local_regions = [
@@ -407,7 +407,7 @@ def test_align_transfer_regions_matches_shared_aliases():
     assert aligned_remote == remote_regions
 
 
-def test_align_transfer_regions_fans_out_split_alias_regions():
+def test_align_transfer_regions_fans_out_shared_region_to_split_aliases():
     """Shared producer regions can feed consumer regions split by alias."""
 
     local_regions = [

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -1455,6 +1455,12 @@ def test_register_kv_caches_keeps_non_mtp_speculative_layers_outside_base_model(
     worker.receiver_loop = MagicMock()
     worker.receiver_loop.is_running.return_value = False
     _populate_worker_layer_metadata(worker)
+    eagle_layer_name = f"model.layers.{num_hidden_layers}.attn.swa_cache"
+    worker._layer_specs[eagle_layer_name] = worker._layer_specs[
+        "model.layers.0.self_attn"
+    ]
+    worker._layer_group_indices[eagle_layer_name] = 0
+    worker._layer_logical_group_indices[eagle_layer_name] = [0]
 
     kv_cache_shape = FlashAttentionBackend.get_kv_cache_shape(
         num_blocks=2, block_size=16, num_kv_heads=4, head_size=64
@@ -1463,7 +1469,7 @@ def test_register_kv_caches_keeps_non_mtp_speculative_layers_outside_base_model(
     eagle_cache = torch.zeros(*kv_cache_shape, dtype=torch.float16)
     kv_caches = {
         "model.layers.0.self_attn": normal_cache,
-        f"model.layers.{num_hidden_layers}.attn.swa_cache": eagle_cache,
+        eagle_layer_name: eagle_cache,
     }
 
     worker.register_kv_caches(kv_caches)

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
@@ -510,6 +510,93 @@ def test_align_transfer_regions_fans_out_shared_alias_groups():
     ]
 
 
+def test_align_transfer_regions_rejects_unbound_alias_index_match():
+    local_region = TransferRegion(
+        layer_name="model.layers.10.attn",
+        layer_index=10,
+        base_addr=0x1000,
+        block_len=100,
+        kv_block_len=100,
+        layer_aliases=(
+            "model.layers.10.attn",
+            "model.layers.11.attn.swa_cache",
+        ),
+        layer_indices=(10, 11),
+        group_indices=(0, 1),
+        alias_group_indices=((0,), (1,)),
+    )
+    remote_region = TransferRegion(
+        layer_name="model.layers.12.attn",
+        layer_index=12,
+        base_addr=0x2000,
+        block_len=100,
+        kv_block_len=100,
+        layer_aliases=(
+            "model.layers.10.attn",
+            "model.layers.12.attn.swa_cache",
+        ),
+        layer_indices=(12, 11),
+        group_indices=(0, 1),
+        alias_group_indices=((0,), (1,)),
+    )
+
+    local_regions, remote_regions, err = _align_transfer_regions(
+        [local_region],
+        [remote_region],
+    )
+
+    assert local_regions == []
+    assert remote_regions == []
+    assert err is not None
+    assert "index mismatch" in err
+
+
+def test_align_transfer_regions_rejects_duplicate_remote_alias_group():
+    local_region_a = TransferRegion(
+        layer_name="model.layers.4.attn",
+        layer_index=4,
+        base_addr=0x1000,
+        block_len=100,
+        kv_block_len=100,
+        layer_aliases=("model.layers.4.attn",),
+        layer_indices=(4,),
+        group_indices=(0,),
+        alias_group_indices=((0,),),
+    )
+    local_region_b = TransferRegion(
+        layer_name="model.layers.4.attn.swa_cache",
+        layer_index=4,
+        base_addr=0x2000,
+        block_len=100,
+        kv_block_len=100,
+        layer_aliases=("model.layers.4.attn",),
+        layer_indices=(4,),
+        group_indices=(0,),
+        alias_group_indices=((0,),),
+    )
+    remote_region = TransferRegion(
+        layer_name="model.layers.4.attn",
+        layer_index=4,
+        base_addr=0x3000,
+        block_len=100,
+        kv_block_len=100,
+        layer_aliases=("model.layers.4.attn",),
+        layer_indices=(4,),
+        group_indices=(0,),
+        alias_group_indices=((0,),),
+    )
+
+    local_regions, remote_regions, err = _align_transfer_regions(
+        [local_region_a, local_region_b],
+        [remote_region],
+    )
+
+    assert local_regions == []
+    assert remote_regions == []
+    assert err is not None
+    assert "duplicate alias group" in err
+
+
 @pytest.mark.asyncio
 async def test_build_transfer_params_filters_groups_per_shared_alias():
     worker = make_transfer_worker()

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
@@ -379,7 +379,7 @@ def test_select_region_block_ids_skips_empty_remote_groups():
     assert len(local_block_ids) == len(remote_block_ids)
 
 
-def test_align_transfer_regions_fans_out_shared_alias_groups():
+def test_align_transfer_regions_fans_out_shared_physical_region_groups():
     local_swa_layer = TransferRegion(
         layer_name="model.layers.4.attn.swa_cache",
         layer_index=4,
@@ -598,7 +598,7 @@ def test_align_transfer_regions_rejects_duplicate_remote_alias_group():
 
 
 @pytest.mark.asyncio
-async def test_build_transfer_params_filters_groups_per_shared_alias():
+async def test_build_transfer_params_filters_groups_per_shared_tensor_alias():
     worker = make_transfer_worker()
     block_len = 100
     transfer_id = "xfer-dsv4-shifted-alias"

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
@@ -8,14 +8,10 @@ send trimming, and group-count invariant checking in _build_transfer_params.
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import pytest
 
-from vllm.config import set_current_vllm_config
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector import (
-    KVConnectorRole,
-    MooncakeConnector,
     MooncakeConnectorMetadata,
     MooncakeConnectorScheduler,
     MooncakeConnectorWorker,
@@ -27,8 +23,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     _select_region_block_ids,
 )
 
-from .test_mooncake_connector import FakeMooncakeWrapper, patch_worker_dependencies
-from .utils import create_request, create_vllm_config, make_kv_cache_config
+from .utils import create_request, make_kv_cache_config
 
 
 def make_transfer_worker() -> MooncakeConnectorWorker:
@@ -39,7 +34,23 @@ def make_transfer_worker() -> MooncakeConnectorWorker:
     worker.tp_rank = 0
     worker.tp_size = 1
     worker.transfer_topo = SimpleNamespace(local_replicates_kv_cache=False)
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=object()) for _ in range(5)]
+    )
     return worker
+
+
+def make_scheduler_vllm_config(
+    block_size: int,
+    kv_role: str = "kv_both",
+    disable_hma: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        kv_transfer_config=SimpleNamespace(kv_role=kv_role),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=disable_hma),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -58,13 +69,7 @@ def make_transfer_worker() -> MooncakeConnectorWorker:
 def test_sw_sizes(swa_enabled, expected_blocks_per_sw):
     """blocks_per_sw is correctly computed based on SWA enabled/disabled."""
     block_size = 16
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role="kv_both",
-        block_size=block_size,
-    )
-    # Override so HMA detection works
-    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = False
+    vllm_config = make_scheduler_vllm_config(block_size=block_size)
     kv_cache_config = make_kv_cache_config(
         block_size=block_size, swa_enabled=swa_enabled, sw_size=2048
     )
@@ -92,12 +97,10 @@ def test_sw_sizes(swa_enabled, expected_blocks_per_sw):
 def test_is_hma_required(swa_enabled, disable_hma, expected_is_hma):
     """_is_hma_required is correctly derived from kv_cache_config."""
     block_size = 16
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role="kv_both",
+    vllm_config = make_scheduler_vllm_config(
         block_size=block_size,
+        disable_hma=disable_hma,
     )
-    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = disable_hma
     kv_cache_config = make_kv_cache_config(
         block_size=block_size, swa_enabled=swa_enabled
     )
@@ -117,12 +120,7 @@ def test_is_hma_required(swa_enabled, disable_hma, expected_is_hma):
 def test_get_sw_clipped_blocks():
     """get_sw_clipped_blocks clips SWA group but keeps FA group intact."""
     block_size = 16
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role="kv_both",
-        block_size=block_size,
-    )
-    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = False
+    vllm_config = make_scheduler_vllm_config(block_size=block_size)
     # SW=128 tokens → 128/16 = 8 blocks + 1 = 9 blocks_per_sw
     kv_cache_config = make_kv_cache_config(
         block_size=block_size, swa_enabled=True, sw_size=128
@@ -153,11 +151,7 @@ def test_get_sw_clipped_blocks():
 def test_get_sw_clipped_blocks_noop_no_hma():
     """get_sw_clipped_blocks is a no-op when HMA is not required."""
     block_size = 16
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role="kv_both",
-        block_size=block_size,
-    )
+    vllm_config = make_scheduler_vllm_config(block_size=block_size)
     # FA only → _is_hma_required = False
     kv_cache_config = make_kv_cache_config(block_size=block_size, swa_enabled=False)
 
@@ -225,97 +219,75 @@ def test_metadata_hma_block_ids():
 #  test_build_transfer_params_multi_group_trimming
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
-@patch(
-    "vllm.distributed.kv_transfer.kv_connector.v1.mooncake"
-    ".mooncake_connector.TransferEngine",
-    FakeMooncakeWrapper,
-)
-async def test_build_transfer_params_multi_group_trimming(monkeypatch):
+async def test_build_transfer_params_multi_group_trimming():
     """_build_transfer_params trims per-group blocks when local > remote."""
 
-    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector", kv_role="kv_producer"
+    worker = make_transfer_worker()
+    block_len = 4096
+    transfer_id = "xfer-hma-trim"
+    send_meta = SendBlockMeta(
+        p_req_id="p-trim",
+        transfer_id=transfer_id,
+        # FA: 4 blocks, SW: 3 blocks (producer has more)
+        local_block_ids=[[10, 11, 12, 13], [20, 21, 22]],
+        ready=asyncio.Event(),
     )
-    kv_cache_config = make_kv_cache_config(
-        block_size=vllm_config.cache_config.block_size, swa_enabled=True
+
+    xfer_meta = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=1,
+        remote_tp_rank=0,
+        req_blocks={
+            "d-trim": (
+                transfer_id,
+                # FA: 2 blocks, SW: 2 blocks (consumer needs fewer)
+                [[30, 31], [40, 41]],
+            )
+        },
+        kv_caches_base_addr=[0x2000],
+        block_lens=[block_len],
+        kv_block_lens=[block_len],
     )
 
-    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
-        connector = MooncakeConnector(
-            vllm_config, KVConnectorRole.WORKER, kv_cache_config
-        )
-        worker = connector.connector_worker
+    local_regions = [
+        TransferRegion(
+            layer_name="model.layers.0.self_attn",
+            layer_index=0,
+            base_addr=0x1000,
+            block_len=block_len,
+            kv_block_len=block_len,
+        ),
+    ]
+    remote_regions = [
+        TransferRegion(
+            layer_name="model.layers.0.self_attn",
+            layer_index=0,
+            base_addr=0x2000,
+            block_len=block_len,
+            kv_block_len=block_len,
+        ),
+    ]
 
-        block_len = 4096
-        # Call _build_transfer_params directly (avoids send_kv_to_decode
-        # async event loop complexity).
-        transfer_id = "xfer-hma-trim"
-        send_meta = SendBlockMeta(
-            p_req_id="p-trim",
-            transfer_id=transfer_id,
-            # FA: 4 blocks, SW: 3 blocks (producer has more)
-            local_block_ids=[[10, 11, 12, 13], [20, 21, 22]],
-            ready=asyncio.Event(),
-        )
+    ready_reqs = [("d-trim", send_meta)]
+    (
+        src_ptrs,
+        dst_ptrs,
+        lengths,
+        err_reqs,
+        err_msg,
+    ) = await worker._build_transfer_params(
+        ready_reqs, xfer_meta, local_regions, remote_regions
+    )
 
-        xfer_meta = MooncakeXferMetadata(
-            remote_hostname="consumer-host",
-            remote_port=54321,
-            remote_tp_size=1,
-            remote_tp_rank=0,
-            req_blocks={
-                "d-trim": (
-                    transfer_id,
-                    # FA: 2 blocks, SW: 2 blocks (consumer needs fewer)
-                    [[30, 31], [40, 41]],
-                )
-            },
-            kv_caches_base_addr=[0x2000],
-            block_lens=[block_len],
-            kv_block_lens=[block_len],
-        )
-
-        local_regions = [
-            TransferRegion(
-                layer_name="model.layers.0.self_attn",
-                layer_index=0,
-                base_addr=0x1000,
-                block_len=block_len,
-                kv_block_len=block_len,
-            ),
-        ]
-        remote_regions = [
-            TransferRegion(
-                layer_name="model.layers.0.self_attn",
-                layer_index=0,
-                base_addr=0x2000,
-                block_len=block_len,
-                kv_block_len=block_len,
-            ),
-        ]
-
-        ready_reqs = [("d-trim", send_meta)]
-        (
-            src_ptrs,
-            dst_ptrs,
-            lengths,
-            err_reqs,
-            err_msg,
-        ) = await worker._build_transfer_params(
-            ready_reqs, xfer_meta, local_regions, remote_regions
-        )
-
-        # No errors
-        assert err_reqs == []
-        assert err_msg is None
-        # After trimming: FA [10..13] → last 2 → [12,13]; SW [20..22] → last 2 → [21,22]
-        # Flattened: [12,13,21,22] = 4 blocks → coalesced into some transfers
-        assert len(src_ptrs) > 0
-        assert len(dst_ptrs) == len(src_ptrs)
-        assert len(lengths) == len(src_ptrs)
-
-        worker.shutdown()
+    # No errors
+    assert err_reqs == []
+    assert err_msg is None
+    # After trimming: FA [10..13] -> last 2 -> [12,13]; SW [20..22]
+    # -> last 2 -> [21,22]. Flattened: [12,13,21,22] = 4 blocks.
+    assert len(src_ptrs) > 0
+    assert len(dst_ptrs) == len(src_ptrs)
+    assert len(lengths) == len(src_ptrs)
 
 
 def test_common_group_indices_falls_back_to_physical_group_without_logical_metadata():
@@ -633,6 +605,7 @@ async def test_build_transfer_params_filters_groups_per_shared_tensor_alias():
         },
         kv_caches_base_addr=[0x2000, 0x3000],
         block_lens=[block_len, block_len],
+        kv_block_lens=[block_len, block_len],
     )
 
     local_region = TransferRegion(
@@ -757,6 +730,7 @@ async def test_build_transfer_params_filters_groups_per_shared_region():
         },
         kv_caches_base_addr=[0x2000, 0x3000],
         block_lens=[block_len, block_len],
+        kv_block_lens=[block_len, block_len],
     )
 
     local_regions = [
@@ -834,90 +808,70 @@ async def test_build_transfer_params_filters_groups_per_shared_region():
 #  test_build_transfer_params_group_count_mismatch
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
-@patch(
-    "vllm.distributed.kv_transfer.kv_connector.v1.mooncake"
-    ".mooncake_connector.TransferEngine",
-    FakeMooncakeWrapper,
-)
-async def test_build_transfer_params_group_count_mismatch(monkeypatch):
+async def test_build_transfer_params_group_count_mismatch():
     """_build_transfer_params reports an error when group counts differ."""
 
-    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector", kv_role="kv_producer"
+    worker = make_transfer_worker()
+    block_len = 4096
+    transfer_id = "xfer-mismatch"
+    send_meta = SendBlockMeta(
+        p_req_id="p-mismatch",
+        transfer_id=transfer_id,
+        # Producer has 2 groups
+        local_block_ids=[[10, 11], [20, 21]],
+        ready=asyncio.Event(),
     )
-    kv_cache_config = make_kv_cache_config(
-        block_size=vllm_config.cache_config.block_size, swa_enabled=True
+
+    # Consumer has only 1 group: group count mismatch.
+    xfer_meta = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=1,
+        remote_tp_rank=0,
+        req_blocks={
+            "d-mismatch": (transfer_id, [[30, 31]]),
+        },
+        kv_caches_base_addr=[0x2000],
+        block_lens=[block_len],
+        kv_block_lens=[block_len],
     )
 
-    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
-        connector = MooncakeConnector(
-            vllm_config, KVConnectorRole.WORKER, kv_cache_config
-        )
-        worker = connector.connector_worker
+    local_regions = [
+        TransferRegion(
+            layer_name="model.layers.0.self_attn",
+            layer_index=0,
+            base_addr=0x1000,
+            block_len=block_len,
+            kv_block_len=block_len,
+        ),
+    ]
+    remote_regions = [
+        TransferRegion(
+            layer_name="model.layers.0.self_attn",
+            layer_index=0,
+            base_addr=0x2000,
+            block_len=block_len,
+            kv_block_len=block_len,
+        ),
+    ]
 
-        block_len = 4096
-        transfer_id = "xfer-mismatch"
-        send_meta = SendBlockMeta(
-            p_req_id="p-mismatch",
-            transfer_id=transfer_id,
-            # Producer has 2 groups
-            local_block_ids=[[10, 11], [20, 21]],
-            ready=asyncio.Event(),
-        )
+    ready_reqs = [("d-mismatch", send_meta)]
+    (
+        src_ptrs,
+        dst_ptrs,
+        lengths,
+        err_reqs,
+        err_msg,
+    ) = await worker._build_transfer_params(
+        ready_reqs, xfer_meta, local_regions, remote_regions
+    )
 
-        # Consumer has only 1 group — group count mismatch
-        xfer_meta = MooncakeXferMetadata(
-            remote_hostname="consumer-host",
-            remote_port=54321,
-            remote_tp_size=1,
-            remote_tp_rank=0,
-            req_blocks={
-                "d-mismatch": (transfer_id, [[30, 31]]),
-            },
-            kv_caches_base_addr=[0x2000],
-            block_lens=[block_len],
-            kv_block_lens=[block_len],
-        )
-
-        local_regions = [
-            TransferRegion(
-                layer_name="model.layers.0.self_attn",
-                layer_index=0,
-                base_addr=0x1000,
-                block_len=block_len,
-                kv_block_len=block_len,
-            ),
-        ]
-        remote_regions = [
-            TransferRegion(
-                layer_name="model.layers.0.self_attn",
-                layer_index=0,
-                base_addr=0x2000,
-                block_len=block_len,
-                kv_block_len=block_len,
-            ),
-        ]
-
-        ready_reqs = [("d-mismatch", send_meta)]
-        (
-            src_ptrs,
-            dst_ptrs,
-            lengths,
-            err_reqs,
-            err_msg,
-        ) = await worker._build_transfer_params(
-            ready_reqs, xfer_meta, local_regions, remote_regions
-        )
-
-        # Mismatched req is reported via err_reqs/err_msg with no transfers built.
-        assert err_reqs == ["d-mismatch"]
-        assert err_msg == "KV group count mismatch"
-        assert src_ptrs == []
-        assert dst_ptrs == []
-        assert lengths == []
-
-        worker.shutdown()
+    # Mismatched req is reported via err_reqs/err_msg with no transfers built.
+    assert err_reqs == ["d-mismatch"]
+    assert err_msg == "KV group count mismatch"
+    assert src_ptrs == []
+    assert dst_ptrs == []
+    assert lengths == []
 
 
 # ---------------------------------------------------------------------------
@@ -927,12 +881,10 @@ async def test_build_transfer_params_group_count_mismatch(monkeypatch):
 def test_request_finished_with_hma_groups():
     """request_finished correctly handles per-group block_ids."""
     block_size = 16
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role="kv_producer",
+    vllm_config = make_scheduler_vllm_config(
         block_size=block_size,
+        kv_role="kv_producer",
     )
-    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = False
     kv_cache_config = make_kv_cache_config(
         block_size=block_size, swa_enabled=True, sw_size=128
     )

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
@@ -343,16 +343,22 @@ def test_common_group_indices_rejects_missing_group_metadata():
         group_indices=(0, 2),
     )
 
-    assert _common_group_indices_for_regions(
-        local_region,
-        remote_region,
-        num_groups=3,
-    ) is None
-    assert _common_group_indices_for_regions(
-        remote_region,
-        local_region,
-        num_groups=3,
-    ) is None
+    assert (
+        _common_group_indices_for_regions(
+            local_region,
+            remote_region,
+            num_groups=3,
+        )
+        is None
+    )
+    assert (
+        _common_group_indices_for_regions(
+            remote_region,
+            local_region,
+            num_groups=3,
+        )
+        is None
+    )
     assert _common_group_indices_for_regions(
         local_region,
         annotated_remote_region,

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
@@ -318,7 +318,7 @@ async def test_build_transfer_params_multi_group_trimming(monkeypatch):
         worker.shutdown()
 
 
-def test_common_group_indices_treats_missing_metadata_as_all_groups():
+def test_common_group_indices_rejects_missing_group_metadata():
     local_region = TransferRegion(
         layer_name="model.layers.4.self_attn",
         layer_index=4,
@@ -347,12 +347,12 @@ def test_common_group_indices_treats_missing_metadata_as_all_groups():
         local_region,
         remote_region,
         num_groups=3,
-    ) == (0, 1, 2)
+    ) is None
     assert _common_group_indices_for_regions(
         remote_region,
         local_region,
         num_groups=3,
-    ) == (0, 1, 2)
+    ) is None
     assert _common_group_indices_for_regions(
         local_region,
         annotated_remote_region,

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
@@ -20,6 +20,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     MooncakeXferMetadata,
     SendBlockMeta,
     TransferRegion,
+    _align_transfer_regions,
+    _common_group_indices_for_regions,
+    _select_region_block_ids,
 )
 
 from .test_mooncake_connector import FakeMooncakeWrapper, patch_worker_dependencies
@@ -300,6 +303,481 @@ async def test_build_transfer_params_multi_group_trimming(monkeypatch):
         assert len(lengths) == len(src_ptrs)
 
         worker.shutdown()
+
+
+def test_common_group_indices_treats_missing_metadata_as_all_groups():
+    local_region = TransferRegion(
+        layer_name="model.layers.4.self_attn",
+        layer_index=4,
+        base_addr=0x1000,
+        block_len=4096,
+        kv_block_len=4096,
+        group_indices=(0,),
+    )
+    remote_region = TransferRegion(
+        layer_name="model.layers.4.self_attn",
+        layer_index=4,
+        base_addr=0x2000,
+        block_len=4096,
+        kv_block_len=4096,
+    )
+    annotated_remote_region = TransferRegion(
+        layer_name="model.layers.4.self_attn",
+        layer_index=4,
+        base_addr=0x3000,
+        block_len=4096,
+        kv_block_len=4096,
+        group_indices=(0, 2),
+    )
+
+    assert _common_group_indices_for_regions(
+        local_region,
+        remote_region,
+        num_groups=3,
+    ) == (0, 1, 2)
+    assert _common_group_indices_for_regions(
+        remote_region,
+        local_region,
+        num_groups=3,
+    ) == (0, 1, 2)
+    assert _common_group_indices_for_regions(
+        local_region,
+        annotated_remote_region,
+        num_groups=3,
+    ) == (0,)
+
+
+def test_select_region_block_ids_skips_empty_remote_groups():
+    local_block_ids, remote_block_ids, err = _select_region_block_ids(
+        local_block_ids_per_group=[
+            [10, 11],
+            [20, 21],
+        ],
+        remote_block_ids_per_group=[
+            [],
+            [120, 121],
+        ],
+        group_indices=(0, 1),
+    )
+
+    assert err is None
+    assert local_block_ids == [20, 21]
+    assert remote_block_ids == [120, 121]
+    assert len(local_block_ids) == len(remote_block_ids)
+
+
+def test_align_transfer_regions_fans_out_shared_alias_groups():
+    local_swa_layer = TransferRegion(
+        layer_name="model.layers.4.attn.swa_cache",
+        layer_index=4,
+        base_addr=0x1000,
+        block_len=100,
+        kv_block_len=100,
+        layer_aliases=(
+            "model.layers.4.attn.swa_cache",
+            "model.layers.4.attn.compressor.state_cache",
+        ),
+        layer_indices=(4, 4),
+        group_indices=(1, 3),
+        alias_group_indices=((1,), (3,)),
+    )
+    local_layer = TransferRegion(
+        layer_name="model.layers.6.attn",
+        layer_index=6,
+        base_addr=0x2000,
+        block_len=100,
+        kv_block_len=100,
+        layer_aliases=(
+            "model.layers.6.attn",
+            "model.layers.6.attn.swa_cache",
+            "model.layers.5.attn.swa_cache",
+            "model.layers.6.attn.compressor.state_cache",
+            "model.layers.5.attn.compressor.state_cache",
+        ),
+        layer_indices=(6, 6, 5, 6, 5),
+        group_indices=(0, 1, 2, 3, 4),
+        alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
+    )
+    remote_prev_layer = TransferRegion(
+        layer_name="model.layers.4.attn",
+        layer_index=4,
+        base_addr=0x3000,
+        block_len=100,
+        kv_block_len=100,
+        layer_aliases=(
+            "model.layers.4.attn",
+            "model.layers.2.attn.swa_cache",
+            "model.layers.3.attn.swa_cache",
+            "model.layers.4.attn.compressor.state_cache",
+            "model.layers.5.attn.compressor.state_cache",
+        ),
+        layer_indices=(4, 2, 3, 4, 5),
+        group_indices=(0, 1, 2, 3, 4),
+        alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
+    )
+    remote_current_layer = TransferRegion(
+        layer_name="model.layers.6.attn",
+        layer_index=6,
+        base_addr=0x4000,
+        block_len=100,
+        kv_block_len=100,
+        layer_aliases=(
+            "model.layers.6.attn",
+            "model.layers.4.attn.swa_cache",
+            "model.layers.5.attn.swa_cache",
+            "model.layers.6.attn.compressor.state_cache",
+            "model.layers.7.attn.compressor.state_cache",
+        ),
+        layer_indices=(6, 4, 5, 6, 7),
+        group_indices=(0, 1, 2, 3, 4),
+        alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
+    )
+    remote_next_layer = TransferRegion(
+        layer_name="model.layers.8.attn",
+        layer_index=8,
+        base_addr=0x5000,
+        block_len=100,
+        kv_block_len=100,
+        layer_aliases=(
+            "model.layers.8.attn",
+            "model.layers.6.attn.swa_cache",
+            "model.layers.7.attn.swa_cache",
+            "model.layers.8.attn.compressor.state_cache",
+            "model.layers.9.attn.compressor.state_cache",
+        ),
+        layer_indices=(8, 6, 7, 8, 9),
+        group_indices=(0, 1, 2, 3, 4),
+        alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
+    )
+
+    local_regions, remote_regions, err = _align_transfer_regions(
+        [local_swa_layer, local_layer],
+        [remote_prev_layer, remote_current_layer, remote_next_layer],
+    )
+
+    assert err is None
+    aligned_groups = [
+        (
+            local_region.layer_name,
+            remote_region.layer_name,
+            _common_group_indices_for_regions(
+                local_region,
+                remote_region,
+                num_groups=5,
+            ),
+        )
+        for local_region, remote_region in zip(local_regions, remote_regions)
+    ]
+    assert aligned_groups == [
+        (
+            "model.layers.4.attn.swa_cache",
+            "model.layers.4.attn",
+            (3,),
+        ),
+        (
+            "model.layers.4.attn.swa_cache",
+            "model.layers.6.attn",
+            (1,),
+        ),
+        (
+            "model.layers.6.attn",
+            "model.layers.4.attn",
+            (4,),
+        ),
+        (
+            "model.layers.6.attn",
+            "model.layers.6.attn",
+            (0, 2, 3),
+        ),
+        (
+            "model.layers.6.attn",
+            "model.layers.8.attn",
+            (1,),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.mooncake"
+    ".mooncake_connector.TransferEngine",
+    FakeMooncakeWrapper,
+)
+async def test_build_transfer_params_filters_groups_per_shared_alias(monkeypatch):
+    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector",
+        kv_role="kv_producer",
+    )
+    kv_cache_config = make_kv_cache_config(
+        block_size=vllm_config.cache_config.block_size,
+        swa_enabled=True,
+    )
+
+    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
+        connector = MooncakeConnector(
+            vllm_config,
+            KVConnectorRole.WORKER,
+            kv_cache_config,
+        )
+        worker = connector.connector_worker
+
+        try:
+            block_len = 100
+            transfer_id = "xfer-dsv4-shifted-alias"
+            send_meta = SendBlockMeta(
+                p_req_id="p-dsv4-shifted-alias",
+                transfer_id=transfer_id,
+                local_block_ids=[
+                    [10],
+                    [20],
+                    [30],
+                    [40],
+                    [50],
+                ],
+                ready=asyncio.Event(),
+            )
+            xfer_meta = MooncakeXferMetadata(
+                remote_hostname="consumer-host",
+                remote_port=54321,
+                remote_tp_size=1,
+                remote_tp_rank=0,
+                req_blocks={
+                    "d-dsv4-shifted-alias": (
+                        transfer_id,
+                        [
+                            [110],
+                            [120],
+                            [130],
+                            [140],
+                            [150],
+                        ],
+                    )
+                },
+                kv_caches_base_addr=[0x2000, 0x3000],
+                block_lens=[block_len, block_len],
+            )
+
+            local_region = TransferRegion(
+                layer_name="model.layers.30.attn",
+                layer_index=30,
+                base_addr=0x1000,
+                block_len=block_len,
+                kv_block_len=block_len,
+                layer_aliases=(
+                    "model.layers.30.attn",
+                    "model.layers.30.attn.swa_cache",
+                    "model.layers.31.attn.swa_cache",
+                    "model.layers.30.attn.compressor.state_cache",
+                    "model.layers.31.attn.compressor.state_cache",
+                ),
+                layer_indices=(30, 30, 31, 30, 31),
+                group_indices=(0, 1, 2, 3, 4),
+                alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
+            )
+            remote_current_layer = TransferRegion(
+                layer_name="model.layers.30.attn",
+                layer_index=30,
+                base_addr=0x2000,
+                block_len=block_len,
+                kv_block_len=block_len,
+                layer_aliases=(
+                    "model.layers.30.attn",
+                    "model.layers.28.attn.swa_cache",
+                    "model.layers.29.attn.swa_cache",
+                    "model.layers.30.attn.compressor.state_cache",
+                    "model.layers.31.attn.compressor.state_cache",
+                ),
+                layer_indices=(30, 28, 29, 30, 31),
+                group_indices=(0, 1, 2, 3, 4),
+                alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
+            )
+            remote_shifted_layer = TransferRegion(
+                layer_name="model.layers.32.attn",
+                layer_index=32,
+                base_addr=0x3000,
+                block_len=block_len,
+                kv_block_len=block_len,
+                layer_aliases=(
+                    "model.layers.32.attn",
+                    "model.layers.30.attn.swa_cache",
+                    "model.layers.31.attn.swa_cache",
+                    "model.layers.32.attn.compressor.state_cache",
+                    "model.layers.33.attn.compressor.state_cache",
+                ),
+                layer_indices=(32, 30, 31, 32, 33),
+                group_indices=(0, 1, 2, 3, 4),
+                alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
+            )
+
+            (
+                src_ptrs,
+                dst_ptrs,
+                lengths,
+                err_reqs,
+                err_msg,
+            ) = await worker._build_transfer_params(
+                [("d-dsv4-shifted-alias", send_meta)],
+                xfer_meta,
+                [local_region, local_region],
+                [remote_current_layer, remote_shifted_layer],
+            )
+
+            assert err_reqs == []
+            assert err_msg is None
+            assert lengths == [block_len] * 5
+            assert [(ptr - 0x1000) // block_len for ptr in src_ptrs] == [
+                10,
+                40,
+                50,
+                20,
+                30,
+            ]
+            assert [
+                (ptr - base) // block_len
+                for ptr, base in zip(
+                    dst_ptrs,
+                    [0x2000, 0x2000, 0x2000, 0x3000, 0x3000],
+                )
+            ] == [
+                110,
+                140,
+                150,
+                120,
+                130,
+            ]
+        finally:
+            worker.shutdown()
+
+
+@pytest.mark.asyncio
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.mooncake"
+    ".mooncake_connector.TransferEngine",
+    FakeMooncakeWrapper,
+)
+async def test_build_transfer_params_filters_groups_per_shared_region(monkeypatch):
+    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector",
+        kv_role="kv_producer",
+    )
+    kv_cache_config = make_kv_cache_config(
+        block_size=vllm_config.cache_config.block_size,
+        swa_enabled=True,
+    )
+
+    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
+        connector = MooncakeConnector(
+            vllm_config,
+            KVConnectorRole.WORKER,
+            kv_cache_config,
+        )
+        worker = connector.connector_worker
+
+        try:
+            block_len = 4096
+            transfer_id = "xfer-dsv4-shared"
+            send_meta = SendBlockMeta(
+                p_req_id="p-dsv4-shared",
+                transfer_id=transfer_id,
+                local_block_ids=[
+                    [10, 11],
+                    [20, 21],
+                    [30, 31],
+                ],
+                ready=asyncio.Event(),
+            )
+            xfer_meta = MooncakeXferMetadata(
+                remote_hostname="consumer-host",
+                remote_port=54321,
+                remote_tp_size=1,
+                remote_tp_rank=0,
+                req_blocks={
+                    "d-dsv4-shared": (
+                        transfer_id,
+                        [
+                            [110, 111],
+                            [120, 121],
+                            [130, 131],
+                        ],
+                    )
+                },
+                kv_caches_base_addr=[0x2000, 0x3000],
+                block_lens=[block_len, block_len],
+            )
+
+            local_regions = [
+                TransferRegion(
+                    layer_name="model.layers.4.self_attn",
+                    layer_index=4,
+                    base_addr=0x1000,
+                    block_len=block_len,
+                    kv_block_len=block_len,
+                    layer_aliases=("model.layers.4.self_attn",),
+                    layer_indices=(4,),
+                    group_indices=(0, 1),
+                ),
+                TransferRegion(
+                    layer_name="model.layers.4.swa_attn",
+                    layer_index=4,
+                    base_addr=0x4000,
+                    block_len=block_len,
+                    kv_block_len=block_len,
+                    layer_aliases=("model.layers.4.swa_attn",),
+                    layer_indices=(4,),
+                    group_indices=(2,),
+                ),
+            ]
+            remote_regions = [
+                TransferRegion(
+                    layer_name="model.layers.4.self_attn",
+                    layer_index=4,
+                    base_addr=0x2000,
+                    block_len=block_len,
+                    kv_block_len=block_len,
+                    layer_aliases=("model.layers.4.self_attn",),
+                    layer_indices=(4,),
+                    group_indices=(0,),
+                ),
+                TransferRegion(
+                    layer_name="model.layers.4.swa_attn",
+                    layer_index=4,
+                    base_addr=0x3000,
+                    block_len=block_len,
+                    kv_block_len=block_len,
+                    layer_aliases=("model.layers.4.swa_attn",),
+                    layer_indices=(4,),
+                    group_indices=(1, 2),
+                ),
+            ]
+
+            (
+                src_ptrs,
+                dst_ptrs,
+                lengths,
+                err_reqs,
+                err_msg,
+            ) = await worker._build_transfer_params(
+                [("d-dsv4-shared", send_meta)],
+                xfer_meta,
+                local_regions,
+                remote_regions,
+            )
+
+            assert err_reqs == []
+            assert err_msg is None
+            assert lengths == [2 * block_len, 2 * block_len]
+            assert src_ptrs == [
+                0x1000 + 10 * block_len,
+                0x4000 + 30 * block_len,
+            ]
+            assert dst_ptrs == [
+                0x2000 + 110 * block_len,
+                0x3000 + 130 * block_len,
+            ]
+        finally:
+            worker.shutdown()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
@@ -318,14 +318,14 @@ async def test_build_transfer_params_multi_group_trimming(monkeypatch):
         worker.shutdown()
 
 
-def test_common_group_indices_rejects_missing_group_metadata():
+def test_common_group_indices_falls_back_to_physical_group_without_logical_metadata():
     local_region = TransferRegion(
         layer_name="model.layers.4.self_attn",
         layer_index=4,
         base_addr=0x1000,
         block_len=4096,
         kv_block_len=4096,
-        group_indices=(0,),
+        logical_group_indices=(0,),
     )
     remote_region = TransferRegion(
         layer_name="model.layers.4.self_attn",
@@ -340,25 +340,19 @@ def test_common_group_indices_rejects_missing_group_metadata():
         base_addr=0x3000,
         block_len=4096,
         kv_block_len=4096,
-        group_indices=(0, 2),
+        logical_group_indices=(0, 2),
     )
 
-    assert (
-        _common_group_indices_for_regions(
-            local_region,
-            remote_region,
-            num_groups=3,
-        )
-        is None
-    )
-    assert (
-        _common_group_indices_for_regions(
-            remote_region,
-            local_region,
-            num_groups=3,
-        )
-        is None
-    )
+    assert _common_group_indices_for_regions(
+        local_region,
+        remote_region,
+        num_groups=3,
+    ) == (0,)
+    assert _common_group_indices_for_regions(
+        remote_region,
+        local_region,
+        num_groups=3,
+    ) == (0,)
     assert _common_group_indices_for_regions(
         local_region,
         annotated_remote_region,
@@ -397,7 +391,7 @@ def test_align_transfer_regions_fans_out_shared_physical_region_groups():
             "model.layers.4.attn.compressor.state_cache",
         ),
         layer_indices=(4, 4),
-        group_indices=(1, 3),
+        logical_group_indices=(1, 3),
         alias_group_indices=((1,), (3,)),
     )
     local_layer = TransferRegion(
@@ -414,7 +408,7 @@ def test_align_transfer_regions_fans_out_shared_physical_region_groups():
             "model.layers.5.attn.compressor.state_cache",
         ),
         layer_indices=(6, 6, 5, 6, 5),
-        group_indices=(0, 1, 2, 3, 4),
+        logical_group_indices=(0, 1, 2, 3, 4),
         alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
     )
     remote_prev_layer = TransferRegion(
@@ -431,7 +425,7 @@ def test_align_transfer_regions_fans_out_shared_physical_region_groups():
             "model.layers.5.attn.compressor.state_cache",
         ),
         layer_indices=(4, 2, 3, 4, 5),
-        group_indices=(0, 1, 2, 3, 4),
+        logical_group_indices=(0, 1, 2, 3, 4),
         alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
     )
     remote_current_layer = TransferRegion(
@@ -448,7 +442,7 @@ def test_align_transfer_regions_fans_out_shared_physical_region_groups():
             "model.layers.7.attn.compressor.state_cache",
         ),
         layer_indices=(6, 4, 5, 6, 7),
-        group_indices=(0, 1, 2, 3, 4),
+        logical_group_indices=(0, 1, 2, 3, 4),
         alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
     )
     remote_next_layer = TransferRegion(
@@ -465,7 +459,7 @@ def test_align_transfer_regions_fans_out_shared_physical_region_groups():
             "model.layers.9.attn.compressor.state_cache",
         ),
         layer_indices=(8, 6, 7, 8, 9),
-        group_indices=(0, 1, 2, 3, 4),
+        logical_group_indices=(0, 1, 2, 3, 4),
         alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
     )
 
@@ -528,7 +522,7 @@ def test_align_transfer_regions_rejects_unbound_alias_index_match():
             "model.layers.11.attn.swa_cache",
         ),
         layer_indices=(10, 11),
-        group_indices=(0, 1),
+        logical_group_indices=(0, 1),
         alias_group_indices=((0,), (1,)),
     )
     remote_region = TransferRegion(
@@ -542,7 +536,7 @@ def test_align_transfer_regions_rejects_unbound_alias_index_match():
             "model.layers.12.attn.swa_cache",
         ),
         layer_indices=(12, 11),
-        group_indices=(0, 1),
+        logical_group_indices=(0, 1),
         alias_group_indices=((0,), (1,)),
     )
 
@@ -566,7 +560,7 @@ def test_align_transfer_regions_rejects_duplicate_remote_alias_group():
         kv_block_len=100,
         layer_aliases=("model.layers.4.attn",),
         layer_indices=(4,),
-        group_indices=(0,),
+        logical_group_indices=(0,),
         alias_group_indices=((0,),),
     )
     local_region_b = TransferRegion(
@@ -577,7 +571,7 @@ def test_align_transfer_regions_rejects_duplicate_remote_alias_group():
         kv_block_len=100,
         layer_aliases=("model.layers.4.attn",),
         layer_indices=(4,),
-        group_indices=(0,),
+        logical_group_indices=(0,),
         alias_group_indices=((0,),),
     )
     remote_region = TransferRegion(
@@ -588,7 +582,7 @@ def test_align_transfer_regions_rejects_duplicate_remote_alias_group():
         kv_block_len=100,
         layer_aliases=("model.layers.4.attn",),
         layer_indices=(4,),
-        group_indices=(0,),
+        logical_group_indices=(0,),
         alias_group_indices=((0,),),
     )
 
@@ -655,7 +649,7 @@ async def test_build_transfer_params_filters_groups_per_shared_tensor_alias():
             "model.layers.31.attn.compressor.state_cache",
         ),
         layer_indices=(30, 30, 31, 30, 31),
-        group_indices=(0, 1, 2, 3, 4),
+        logical_group_indices=(0, 1, 2, 3, 4),
         alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
     )
     remote_current_layer = TransferRegion(
@@ -672,7 +666,7 @@ async def test_build_transfer_params_filters_groups_per_shared_tensor_alias():
             "model.layers.31.attn.compressor.state_cache",
         ),
         layer_indices=(30, 28, 29, 30, 31),
-        group_indices=(0, 1, 2, 3, 4),
+        logical_group_indices=(0, 1, 2, 3, 4),
         alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
     )
     remote_shifted_layer = TransferRegion(
@@ -689,7 +683,7 @@ async def test_build_transfer_params_filters_groups_per_shared_tensor_alias():
             "model.layers.33.attn.compressor.state_cache",
         ),
         layer_indices=(32, 30, 31, 32, 33),
-        group_indices=(0, 1, 2, 3, 4),
+        logical_group_indices=(0, 1, 2, 3, 4),
         alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
     )
 
@@ -774,7 +768,7 @@ async def test_build_transfer_params_filters_groups_per_shared_region():
             kv_block_len=block_len,
             layer_aliases=("model.layers.4.self_attn",),
             layer_indices=(4,),
-            group_indices=(0, 1),
+            logical_group_indices=(0, 1),
         ),
         TransferRegion(
             layer_name="model.layers.4.swa_attn",
@@ -784,7 +778,7 @@ async def test_build_transfer_params_filters_groups_per_shared_region():
             kv_block_len=block_len,
             layer_aliases=("model.layers.4.swa_attn",),
             layer_indices=(4,),
-            group_indices=(2,),
+            logical_group_indices=(2,),
         ),
     ]
     remote_regions = [
@@ -796,7 +790,7 @@ async def test_build_transfer_params_filters_groups_per_shared_region():
             kv_block_len=block_len,
             layer_aliases=("model.layers.4.self_attn",),
             layer_indices=(4,),
-            group_indices=(0,),
+            logical_group_indices=(0,),
         ),
         TransferRegion(
             layer_name="model.layers.4.swa_attn",
@@ -806,7 +800,7 @@ async def test_build_transfer_params_filters_groups_per_shared_region():
             kv_block_len=block_len,
             layer_aliases=("model.layers.4.swa_attn",),
             layer_indices=(4,),
-            group_indices=(1, 2),
+            logical_group_indices=(1, 2),
         ),
     ]
 

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
@@ -7,6 +7,7 @@ send trimming, and group-count invariant checking in _build_transfer_params.
 """
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -17,6 +18,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     MooncakeConnector,
     MooncakeConnectorMetadata,
     MooncakeConnectorScheduler,
+    MooncakeConnectorWorker,
     MooncakeXferMetadata,
     SendBlockMeta,
     TransferRegion,
@@ -27,6 +29,17 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
 
 from .test_mooncake_connector import FakeMooncakeWrapper, patch_worker_dependencies
 from .utils import create_request, create_vllm_config, make_kv_cache_config
+
+
+def make_transfer_worker() -> MooncakeConnectorWorker:
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.async_zmq_ctx = SimpleNamespace(term=lambda: None)
+    worker.is_kv_consumer = True
+    worker.is_kv_producer = True
+    worker.tp_rank = 0
+    worker.tp_size = 1
+    worker.transfer_topo = SimpleNamespace(local_replicates_kv_cache=False)
+    return worker
 
 
 # ---------------------------------------------------------------------------
@@ -498,286 +511,236 @@ def test_align_transfer_regions_fans_out_shared_alias_groups():
 
 
 @pytest.mark.asyncio
-@patch(
-    "vllm.distributed.kv_transfer.kv_connector.v1.mooncake"
-    ".mooncake_connector.TransferEngine",
-    FakeMooncakeWrapper,
-)
-async def test_build_transfer_params_filters_groups_per_shared_alias(monkeypatch):
-    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role="kv_producer",
+async def test_build_transfer_params_filters_groups_per_shared_alias():
+    worker = make_transfer_worker()
+    block_len = 100
+    transfer_id = "xfer-dsv4-shifted-alias"
+    send_meta = SendBlockMeta(
+        p_req_id="p-dsv4-shifted-alias",
+        transfer_id=transfer_id,
+        local_block_ids=[
+            [10],
+            [20],
+            [30],
+            [40],
+            [50],
+        ],
+        ready=asyncio.Event(),
     )
-    kv_cache_config = make_kv_cache_config(
-        block_size=vllm_config.cache_config.block_size,
-        swa_enabled=True,
-    )
-
-    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
-        connector = MooncakeConnector(
-            vllm_config,
-            KVConnectorRole.WORKER,
-            kv_cache_config,
-        )
-        worker = connector.connector_worker
-
-        try:
-            block_len = 100
-            transfer_id = "xfer-dsv4-shifted-alias"
-            send_meta = SendBlockMeta(
-                p_req_id="p-dsv4-shifted-alias",
-                transfer_id=transfer_id,
-                local_block_ids=[
-                    [10],
-                    [20],
-                    [30],
-                    [40],
-                    [50],
+    xfer_meta = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=1,
+        remote_tp_rank=0,
+        req_blocks={
+            "d-dsv4-shifted-alias": (
+                transfer_id,
+                [
+                    [110],
+                    [120],
+                    [130],
+                    [140],
+                    [150],
                 ],
-                ready=asyncio.Event(),
             )
-            xfer_meta = MooncakeXferMetadata(
-                remote_hostname="consumer-host",
-                remote_port=54321,
-                remote_tp_size=1,
-                remote_tp_rank=0,
-                req_blocks={
-                    "d-dsv4-shifted-alias": (
-                        transfer_id,
-                        [
-                            [110],
-                            [120],
-                            [130],
-                            [140],
-                            [150],
-                        ],
-                    )
-                },
-                kv_caches_base_addr=[0x2000, 0x3000],
-                block_lens=[block_len, block_len],
-            )
+        },
+        kv_caches_base_addr=[0x2000, 0x3000],
+        block_lens=[block_len, block_len],
+    )
 
-            local_region = TransferRegion(
-                layer_name="model.layers.30.attn",
-                layer_index=30,
-                base_addr=0x1000,
-                block_len=block_len,
-                kv_block_len=block_len,
-                layer_aliases=(
-                    "model.layers.30.attn",
-                    "model.layers.30.attn.swa_cache",
-                    "model.layers.31.attn.swa_cache",
-                    "model.layers.30.attn.compressor.state_cache",
-                    "model.layers.31.attn.compressor.state_cache",
-                ),
-                layer_indices=(30, 30, 31, 30, 31),
-                group_indices=(0, 1, 2, 3, 4),
-                alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
-            )
-            remote_current_layer = TransferRegion(
-                layer_name="model.layers.30.attn",
-                layer_index=30,
-                base_addr=0x2000,
-                block_len=block_len,
-                kv_block_len=block_len,
-                layer_aliases=(
-                    "model.layers.30.attn",
-                    "model.layers.28.attn.swa_cache",
-                    "model.layers.29.attn.swa_cache",
-                    "model.layers.30.attn.compressor.state_cache",
-                    "model.layers.31.attn.compressor.state_cache",
-                ),
-                layer_indices=(30, 28, 29, 30, 31),
-                group_indices=(0, 1, 2, 3, 4),
-                alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
-            )
-            remote_shifted_layer = TransferRegion(
-                layer_name="model.layers.32.attn",
-                layer_index=32,
-                base_addr=0x3000,
-                block_len=block_len,
-                kv_block_len=block_len,
-                layer_aliases=(
-                    "model.layers.32.attn",
-                    "model.layers.30.attn.swa_cache",
-                    "model.layers.31.attn.swa_cache",
-                    "model.layers.32.attn.compressor.state_cache",
-                    "model.layers.33.attn.compressor.state_cache",
-                ),
-                layer_indices=(32, 30, 31, 32, 33),
-                group_indices=(0, 1, 2, 3, 4),
-                alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
-            )
+    local_region = TransferRegion(
+        layer_name="model.layers.30.attn",
+        layer_index=30,
+        base_addr=0x1000,
+        block_len=block_len,
+        kv_block_len=block_len,
+        layer_aliases=(
+            "model.layers.30.attn",
+            "model.layers.30.attn.swa_cache",
+            "model.layers.31.attn.swa_cache",
+            "model.layers.30.attn.compressor.state_cache",
+            "model.layers.31.attn.compressor.state_cache",
+        ),
+        layer_indices=(30, 30, 31, 30, 31),
+        group_indices=(0, 1, 2, 3, 4),
+        alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
+    )
+    remote_current_layer = TransferRegion(
+        layer_name="model.layers.30.attn",
+        layer_index=30,
+        base_addr=0x2000,
+        block_len=block_len,
+        kv_block_len=block_len,
+        layer_aliases=(
+            "model.layers.30.attn",
+            "model.layers.28.attn.swa_cache",
+            "model.layers.29.attn.swa_cache",
+            "model.layers.30.attn.compressor.state_cache",
+            "model.layers.31.attn.compressor.state_cache",
+        ),
+        layer_indices=(30, 28, 29, 30, 31),
+        group_indices=(0, 1, 2, 3, 4),
+        alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
+    )
+    remote_shifted_layer = TransferRegion(
+        layer_name="model.layers.32.attn",
+        layer_index=32,
+        base_addr=0x3000,
+        block_len=block_len,
+        kv_block_len=block_len,
+        layer_aliases=(
+            "model.layers.32.attn",
+            "model.layers.30.attn.swa_cache",
+            "model.layers.31.attn.swa_cache",
+            "model.layers.32.attn.compressor.state_cache",
+            "model.layers.33.attn.compressor.state_cache",
+        ),
+        layer_indices=(32, 30, 31, 32, 33),
+        group_indices=(0, 1, 2, 3, 4),
+        alias_group_indices=((0,), (1,), (2,), (3,), (4,)),
+    )
 
-            (
-                src_ptrs,
-                dst_ptrs,
-                lengths,
-                err_reqs,
-                err_msg,
-            ) = await worker._build_transfer_params(
-                [("d-dsv4-shifted-alias", send_meta)],
-                xfer_meta,
-                [local_region, local_region],
-                [remote_current_layer, remote_shifted_layer],
-            )
+    (
+        src_ptrs,
+        dst_ptrs,
+        lengths,
+        err_reqs,
+        err_msg,
+    ) = await worker._build_transfer_params(
+        [("d-dsv4-shifted-alias", send_meta)],
+        xfer_meta,
+        [local_region, local_region],
+        [remote_current_layer, remote_shifted_layer],
+    )
 
-            assert err_reqs == []
-            assert err_msg is None
-            assert lengths == [block_len] * 5
-            assert [(ptr - 0x1000) // block_len for ptr in src_ptrs] == [
-                10,
-                40,
-                50,
-                20,
-                30,
-            ]
-            assert [
-                (ptr - base) // block_len
-                for ptr, base in zip(
-                    dst_ptrs,
-                    [0x2000, 0x2000, 0x2000, 0x3000, 0x3000],
-                )
-            ] == [
-                110,
-                140,
-                150,
-                120,
-                130,
-            ]
-        finally:
-            worker.shutdown()
+    assert err_reqs == []
+    assert err_msg is None
+    assert lengths == [block_len] * 5
+    assert [(ptr - 0x1000) // block_len for ptr in src_ptrs] == [
+        10,
+        40,
+        50,
+        20,
+        30,
+    ]
+    assert [
+        (ptr - base) // block_len
+        for ptr, base in zip(
+            dst_ptrs,
+            [0x2000, 0x2000, 0x2000, 0x3000, 0x3000],
+        )
+    ] == [
+        110,
+        140,
+        150,
+        120,
+        130,
+    ]
 
 
 @pytest.mark.asyncio
-@patch(
-    "vllm.distributed.kv_transfer.kv_connector.v1.mooncake"
-    ".mooncake_connector.TransferEngine",
-    FakeMooncakeWrapper,
-)
-async def test_build_transfer_params_filters_groups_per_shared_region(monkeypatch):
-    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role="kv_producer",
+async def test_build_transfer_params_filters_groups_per_shared_region():
+    worker = make_transfer_worker()
+    block_len = 4096
+    transfer_id = "xfer-dsv4-shared"
+    send_meta = SendBlockMeta(
+        p_req_id="p-dsv4-shared",
+        transfer_id=transfer_id,
+        local_block_ids=[
+            [10, 11],
+            [20, 21],
+            [30, 31],
+        ],
+        ready=asyncio.Event(),
     )
-    kv_cache_config = make_kv_cache_config(
-        block_size=vllm_config.cache_config.block_size,
-        swa_enabled=True,
-    )
-
-    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
-        connector = MooncakeConnector(
-            vllm_config,
-            KVConnectorRole.WORKER,
-            kv_cache_config,
-        )
-        worker = connector.connector_worker
-
-        try:
-            block_len = 4096
-            transfer_id = "xfer-dsv4-shared"
-            send_meta = SendBlockMeta(
-                p_req_id="p-dsv4-shared",
-                transfer_id=transfer_id,
-                local_block_ids=[
-                    [10, 11],
-                    [20, 21],
-                    [30, 31],
+    xfer_meta = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=1,
+        remote_tp_rank=0,
+        req_blocks={
+            "d-dsv4-shared": (
+                transfer_id,
+                [
+                    [110, 111],
+                    [120, 121],
+                    [130, 131],
                 ],
-                ready=asyncio.Event(),
             )
-            xfer_meta = MooncakeXferMetadata(
-                remote_hostname="consumer-host",
-                remote_port=54321,
-                remote_tp_size=1,
-                remote_tp_rank=0,
-                req_blocks={
-                    "d-dsv4-shared": (
-                        transfer_id,
-                        [
-                            [110, 111],
-                            [120, 121],
-                            [130, 131],
-                        ],
-                    )
-                },
-                kv_caches_base_addr=[0x2000, 0x3000],
-                block_lens=[block_len, block_len],
-            )
+        },
+        kv_caches_base_addr=[0x2000, 0x3000],
+        block_lens=[block_len, block_len],
+    )
 
-            local_regions = [
-                TransferRegion(
-                    layer_name="model.layers.4.self_attn",
-                    layer_index=4,
-                    base_addr=0x1000,
-                    block_len=block_len,
-                    kv_block_len=block_len,
-                    layer_aliases=("model.layers.4.self_attn",),
-                    layer_indices=(4,),
-                    group_indices=(0, 1),
-                ),
-                TransferRegion(
-                    layer_name="model.layers.4.swa_attn",
-                    layer_index=4,
-                    base_addr=0x4000,
-                    block_len=block_len,
-                    kv_block_len=block_len,
-                    layer_aliases=("model.layers.4.swa_attn",),
-                    layer_indices=(4,),
-                    group_indices=(2,),
-                ),
-            ]
-            remote_regions = [
-                TransferRegion(
-                    layer_name="model.layers.4.self_attn",
-                    layer_index=4,
-                    base_addr=0x2000,
-                    block_len=block_len,
-                    kv_block_len=block_len,
-                    layer_aliases=("model.layers.4.self_attn",),
-                    layer_indices=(4,),
-                    group_indices=(0,),
-                ),
-                TransferRegion(
-                    layer_name="model.layers.4.swa_attn",
-                    layer_index=4,
-                    base_addr=0x3000,
-                    block_len=block_len,
-                    kv_block_len=block_len,
-                    layer_aliases=("model.layers.4.swa_attn",),
-                    layer_indices=(4,),
-                    group_indices=(1, 2),
-                ),
-            ]
+    local_regions = [
+        TransferRegion(
+            layer_name="model.layers.4.self_attn",
+            layer_index=4,
+            base_addr=0x1000,
+            block_len=block_len,
+            kv_block_len=block_len,
+            layer_aliases=("model.layers.4.self_attn",),
+            layer_indices=(4,),
+            group_indices=(0, 1),
+        ),
+        TransferRegion(
+            layer_name="model.layers.4.swa_attn",
+            layer_index=4,
+            base_addr=0x4000,
+            block_len=block_len,
+            kv_block_len=block_len,
+            layer_aliases=("model.layers.4.swa_attn",),
+            layer_indices=(4,),
+            group_indices=(2,),
+        ),
+    ]
+    remote_regions = [
+        TransferRegion(
+            layer_name="model.layers.4.self_attn",
+            layer_index=4,
+            base_addr=0x2000,
+            block_len=block_len,
+            kv_block_len=block_len,
+            layer_aliases=("model.layers.4.self_attn",),
+            layer_indices=(4,),
+            group_indices=(0,),
+        ),
+        TransferRegion(
+            layer_name="model.layers.4.swa_attn",
+            layer_index=4,
+            base_addr=0x3000,
+            block_len=block_len,
+            kv_block_len=block_len,
+            layer_aliases=("model.layers.4.swa_attn",),
+            layer_indices=(4,),
+            group_indices=(1, 2),
+        ),
+    ]
 
-            (
-                src_ptrs,
-                dst_ptrs,
-                lengths,
-                err_reqs,
-                err_msg,
-            ) = await worker._build_transfer_params(
-                [("d-dsv4-shared", send_meta)],
-                xfer_meta,
-                local_regions,
-                remote_regions,
-            )
+    (
+        src_ptrs,
+        dst_ptrs,
+        lengths,
+        err_reqs,
+        err_msg,
+    ) = await worker._build_transfer_params(
+        [("d-dsv4-shared", send_meta)],
+        xfer_meta,
+        local_regions,
+        remote_regions,
+    )
 
-            assert err_reqs == []
-            assert err_msg is None
-            assert lengths == [2 * block_len, 2 * block_len]
-            assert src_ptrs == [
-                0x1000 + 10 * block_len,
-                0x4000 + 30 * block_len,
-            ]
-            assert dst_ptrs == [
-                0x2000 + 110 * block_len,
-                0x3000 + 130 * block_len,
-            ]
-        finally:
-            worker.shutdown()
+    assert err_reqs == []
+    assert err_msg is None
+    assert lengths == [2 * block_len, 2 * block_len]
+    assert src_ptrs == [
+        0x1000 + 10 * block_len,
+        0x4000 + 30 * block_len,
+    ]
+    assert dst_ptrs == [
+        0x2000 + 110 * block_len,
+        0x3000 + 130 * block_len,
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
@@ -14,10 +14,7 @@ from unittest.mock import patch
 import pytest
 import torch
 
-from vllm.config import set_current_vllm_config
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector import (
-    KVConnectorRole,
-    MooncakeConnector,
     MooncakeConnectorScheduler,
     MooncakeConnectorWorker,
     MooncakeXferMetadata,
@@ -33,8 +30,7 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
 )
 
-from .test_mooncake_connector import patch_worker_dependencies
-from .utils import create_request, create_vllm_config
+from .utils import create_request
 
 
 def noop_shutdown():
@@ -71,18 +67,68 @@ def make_hybrid_gdn_kv_cache_config(block_size: int) -> KVCacheConfig:
 
 
 def make_hybrid_gdn_scheduler(kv_role: str) -> MooncakeConnectorScheduler:
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role=kv_role,
+    block_size = 16
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        kv_transfer_config=SimpleNamespace(kv_role=kv_role),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
     )
-    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = False
     return MooncakeConnectorScheduler(
         vllm_config=vllm_config,
         engine_id="test-engine",
-        kv_cache_config=make_hybrid_gdn_kv_cache_config(
-            vllm_config.cache_config.block_size
-        ),
+        kv_cache_config=make_hybrid_gdn_kv_cache_config(block_size),
     )
+
+
+def make_hybrid_gdn_worker(kv_role: str = "kv_producer") -> MooncakeConnectorWorker:
+    kv_cache_config = make_hybrid_gdn_kv_cache_config(block_size=16)
+    worker = object.__new__(MooncakeConnectorWorker)
+    worker.vllm_config = SimpleNamespace(speculative_config=None)
+    worker.model_config = SimpleNamespace(
+        get_total_num_hidden_layers=lambda: 2,
+    )
+    worker.use_mla = False
+    worker.tp_rank = 0
+    worker.tp_size = 1
+    worker.is_kv_producer = kv_role == "kv_producer"
+    worker.is_kv_consumer = kv_role == "kv_consumer"
+    worker.engine = SimpleNamespace(batch_register_memory=lambda *_: 0)
+    worker.transfer_topo = SimpleNamespace(
+        get_transfer_cache_regions=lambda cache, layer_spec: [cache],
+        virtually_split_kv_in_blocks=False,
+        local_replicates_kv_cache=False,
+    )
+    worker.block_len_per_layer = []
+    worker.kv_block_len_per_layer = []
+    worker.registered_layer_names = []
+    worker.registered_layer_indices = []
+    worker.registered_group_indices = []
+    worker.registered_layer_aliases = []
+    worker.registered_layer_index_aliases = []
+    worker.registered_logical_group_indices = []
+    worker.registered_alias_group_indices = []
+    worker.seen_base_addresses = []
+    worker.kv_caches_base_addr = []
+    worker.device_kv_caches = {}
+    worker.kv_cache_config = kv_cache_config
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker._layer_specs = {
+        layer_name: group.kv_cache_spec
+        for group in kv_cache_config.kv_cache_groups
+        for layer_name in group.layer_names
+    }
+    worker._layer_group_indices = {
+        layer_name: group_index
+        for group_index, group in enumerate(kv_cache_config.kv_cache_groups)
+        for layer_name in group.layer_names
+    }
+    worker._layer_logical_group_indices = {
+        layer_name: [group_index]
+        for group_index, group in enumerate(kv_cache_config.kv_cache_groups)
+        for layer_name in group.layer_names
+    }
+    worker.shutdown = noop_shutdown
+    return worker
 
 
 @pytest.mark.cpu_test
@@ -120,28 +166,41 @@ def test_hybrid_gdn_remote_decode_truncates_prefill_once():
     assert request.prompt_token_ids == original_tokens[:-1]
 
 
-def test_register_kv_caches_emits_fa_and_gdn_regions(monkeypatch):
-    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role="kv_consumer",
+def test_register_kv_caches_emits_fa_and_gdn_regions():
+    worker = make_hybrid_gdn_worker(kv_role="kv_consumer")
+    fa_cache = torch.empty((2, 2, 11), dtype=torch.float16)
+    gdn_conv_state = torch.empty((2, 22), dtype=torch.float16)
+    gdn_ssm_state = torch.empty((2, 4), dtype=torch.float16)
+
+    worker.register_kv_caches(
+        {
+            "model.layers.0.self_attn": fa_cache,
+            "model.layers.1.linear_attn": (gdn_conv_state, gdn_ssm_state),
+        }
     )
-    kv_cache_config = make_hybrid_gdn_kv_cache_config(
-        vllm_config.cache_config.block_size
-    )
 
-    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
-        connector = MooncakeConnector(
-            vllm_config,
-            KVConnectorRole.WORKER,
-            kv_cache_config,
-        )
-        worker = connector.connector_worker
+    assert worker.kv_cache_config.has_mamba_layers is True
+    assert worker.registered_layer_names == [
+        "model.layers.0.self_attn",
+        "model.layers.1.linear_attn",
+    ]
+    assert worker.registered_group_indices == [0, 1]
+    assert worker.kv_caches_base_addr == [
+        fa_cache.data_ptr(),
+        gdn_conv_state.data_ptr(),
+    ]
 
-        fa_cache = torch.empty((2, 2, 11), dtype=torch.float16)
-        gdn_conv_state = torch.empty((2, 22), dtype=torch.float16)
-        gdn_ssm_state = torch.empty((2, 4), dtype=torch.float16)
 
+def test_register_kv_caches_deduplicates_shared_backing_memory():
+    worker = make_hybrid_gdn_worker(kv_role="kv_consumer")
+    backing = torch.empty((4, 64), dtype=torch.float16)
+    fa_cache = backing[:2, :16]
+    gdn_conv_state = backing[:3]
+    gdn_ssm_state = torch.empty((3, 4), dtype=torch.float16)
+
+    with patch.object(
+        worker.engine, "batch_register_memory", return_value=0
+    ) as batch_register_memory:
         worker.register_kv_caches(
             {
                 "model.layers.0.self_attn": fa_cache,
@@ -149,182 +208,109 @@ def test_register_kv_caches_emits_fa_and_gdn_regions(monkeypatch):
             }
         )
 
-        assert worker.transfer_topo.is_mamba is True
-        assert worker.registered_layer_names == [
-            "model.layers.0.self_attn",
-            "model.layers.1.linear_attn",
-        ]
-        assert worker.registered_group_indices == [0, 1]
-        assert worker.kv_caches_base_addr == [
-            fa_cache.data_ptr(),
-            gdn_conv_state.data_ptr(),
-        ]
-
-        worker.shutdown()
-        worker.shutdown = noop_shutdown
-        connector.connector_worker = None
+    assert worker.kv_caches_base_addr == [
+        fa_cache.data_ptr(),
+        gdn_conv_state.data_ptr(),
+    ]
+    batch_register_memory.assert_called_once()
+    registered_ptrs, registered_lens = batch_register_memory.call_args[0]
+    assert registered_ptrs == [backing.data_ptr()]
+    assert registered_lens == [backing.untyped_storage().nbytes()]
 
 
-def test_register_kv_caches_deduplicates_shared_backing_memory(monkeypatch):
-    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role="kv_consumer",
-    )
-    kv_cache_config = make_hybrid_gdn_kv_cache_config(
-        vllm_config.cache_config.block_size
-    )
+def test_hybrid_gdn_transfer_params_preserve_group_identity():
+    worker = make_hybrid_gdn_worker(kv_role="kv_producer")
+    block_len = 0x100
+    transfer_id = "xfer-hybrid-gdn"
 
-    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
-        connector = MooncakeConnector(
-            vllm_config,
-            KVConnectorRole.WORKER,
-            kv_cache_config,
+    async def build_transfer_params():
+        send_meta = SendBlockMeta(
+            p_req_id="p-hybrid-gdn",
+            transfer_id=transfer_id,
+            local_block_ids=[
+                [10, 11],
+                [NULL_BLOCK_ID, 4],
+            ],
+            ready=asyncio.Event(),
         )
-        worker = connector.connector_worker
-
-        backing = torch.empty((4, 64), dtype=torch.float16)
-        fa_cache = backing[:2, :16]
-        gdn_conv_state = backing[:3]
-        gdn_ssm_state = torch.empty((3, 4), dtype=torch.float16)
-
-        with patch.object(
-            worker.engine, "batch_register_memory", return_value=0
-        ) as batch_register_memory:
-            worker.register_kv_caches(
-                {
-                    "model.layers.0.self_attn": fa_cache,
-                    "model.layers.1.linear_attn": (gdn_conv_state, gdn_ssm_state),
-                }
-            )
-
-        assert worker.kv_caches_base_addr == [
-            fa_cache.data_ptr(),
-            gdn_conv_state.data_ptr(),
-        ]
-        batch_register_memory.assert_called_once()
-        registered_ptrs, registered_lens = batch_register_memory.call_args[0]
-        assert registered_ptrs == [backing.data_ptr()]
-        assert registered_lens == [backing.untyped_storage().nbytes()]
-
-        worker.shutdown()
-        worker.shutdown = noop_shutdown
-        connector.connector_worker = None
-
-
-def test_hybrid_gdn_transfer_params_preserve_group_identity(monkeypatch):
-    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role="kv_producer",
-    )
-    kv_cache_config = make_hybrid_gdn_kv_cache_config(
-        vllm_config.cache_config.block_size
-    )
-
-    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
-        connector = MooncakeConnector(
-            vllm_config,
-            KVConnectorRole.WORKER,
-            kv_cache_config,
+        return await worker._build_transfer_params(
+            [("d-hybrid-gdn", send_meta)],
+            xfer_meta,
+            local_regions,
+            remote_regions,
         )
-        worker = connector.connector_worker
 
-        block_len = 0x100
-        transfer_id = "xfer-hybrid-gdn"
-
-        async def build_transfer_params():
-            send_meta = SendBlockMeta(
-                p_req_id="p-hybrid-gdn",
-                transfer_id=transfer_id,
-                local_block_ids=[
-                    [10, 11],
-                    [NULL_BLOCK_ID, 4],
+    xfer_meta = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=1,
+        remote_tp_rank=0,
+        req_blocks={
+            "d-hybrid-gdn": (
+                transfer_id,
+                [
+                    [30, 31],
+                    [NULL_BLOCK_ID, 7],
                 ],
-                ready=asyncio.Event(),
             )
-            return await worker._build_transfer_params(
-                [("d-hybrid-gdn", send_meta)],
-                xfer_meta,
-                local_regions,
-                remote_regions,
-            )
+        },
+        kv_caches_base_addr=[],
+        block_lens=[],
+        kv_block_lens=[],
+    )
 
-        xfer_meta = MooncakeXferMetadata(
-            remote_hostname="consumer-host",
-            remote_port=54321,
-            remote_tp_size=1,
-            remote_tp_rank=0,
-            req_blocks={
-                "d-hybrid-gdn": (
-                    transfer_id,
-                    [
-                        [30, 31],
-                        [NULL_BLOCK_ID, 7],
-                    ],
-                )
-            },
-            kv_caches_base_addr=[],
-            block_lens=[],
-            kv_block_lens=[],
-        )
+    local_regions = [
+        TransferRegion(
+            layer_name="model.layers.1.linear_attn",
+            layer_index=1,
+            base_addr=0x5000,
+            block_len=block_len,
+            kv_block_len=block_len,
+            group_index=1,
+        ),
+        TransferRegion(
+            layer_name="model.layers.0.self_attn",
+            layer_index=0,
+            base_addr=0x1000,
+            block_len=block_len,
+            kv_block_len=block_len,
+            group_index=0,
+        ),
+    ]
+    remote_regions = [
+        TransferRegion(
+            layer_name="model.layers.1.linear_attn",
+            layer_index=1,
+            base_addr=0x6000,
+            block_len=block_len,
+            kv_block_len=block_len,
+            group_index=1,
+        ),
+        TransferRegion(
+            layer_name="model.layers.0.self_attn",
+            layer_index=0,
+            base_addr=0x2000,
+            block_len=block_len,
+            kv_block_len=block_len,
+            group_index=0,
+        ),
+    ]
 
-        local_regions = [
-            TransferRegion(
-                layer_name="model.layers.1.linear_attn",
-                layer_index=1,
-                base_addr=0x5000,
-                block_len=block_len,
-                kv_block_len=block_len,
-                group_index=1,
-            ),
-            TransferRegion(
-                layer_name="model.layers.0.self_attn",
-                layer_index=0,
-                base_addr=0x1000,
-                block_len=block_len,
-                kv_block_len=block_len,
-                group_index=0,
-            ),
-        ]
-        remote_regions = [
-            TransferRegion(
-                layer_name="model.layers.1.linear_attn",
-                layer_index=1,
-                base_addr=0x6000,
-                block_len=block_len,
-                kv_block_len=block_len,
-                group_index=1,
-            ),
-            TransferRegion(
-                layer_name="model.layers.0.self_attn",
-                layer_index=0,
-                base_addr=0x2000,
-                block_len=block_len,
-                kv_block_len=block_len,
-                group_index=0,
-            ),
-        ]
+    src_ptrs, dst_ptrs, lengths, err_reqs, err_msg = asyncio.run(
+        build_transfer_params()
+    )
 
-        src_ptrs, dst_ptrs, lengths, err_reqs, err_msg = asyncio.run(
-            build_transfer_params()
-        )
-
-        assert err_reqs == []
-        assert err_msg is None
-        assert src_ptrs == [
-            0x5000 + 4 * block_len,
-            0x1000 + 10 * block_len,
-        ]
-        assert dst_ptrs == [
-            0x6000 + 7 * block_len,
-            0x2000 + 30 * block_len,
-        ]
-        assert lengths == [block_len, 2 * block_len]
-
-        worker.shutdown()
-        worker.shutdown = noop_shutdown
-        connector.connector_worker = None
+    assert err_reqs == []
+    assert err_msg is None
+    assert src_ptrs == [
+        0x5000 + 4 * block_len,
+        0x1000 + 10 * block_len,
+    ]
+    assert dst_ptrs == [
+        0x6000 + 7 * block_len,
+        0x2000 + 30 * block_len,
+    ]
+    assert lengths == [block_len, 2 * block_len]
 
 
 def test_logical_to_kernel_block_ids_expands_fa_not_gdn():
@@ -339,48 +325,26 @@ def test_logical_to_kernel_block_ids_expands_fa_not_gdn():
     assert kernel_block_ids == [list(range(34, 51)), [2]]
 
 
-def test_hybrid_gdn_splits_fa_regions_but_keeps_gdn_state_whole(
-    monkeypatch,
-):
-    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector",
-        kv_role="kv_producer",
+def test_hybrid_gdn_splits_fa_regions_but_keeps_gdn_state_whole():
+    worker = make_hybrid_gdn_worker(kv_role="kv_producer")
+    worker.transfer_topo = SimpleNamespace(virtually_split_kv_in_blocks=True)
+    regions = worker._get_transfer_regions(
+        base_addrs=[0x1000, 0x2000],
+        block_lens=[0x100, 0x100],
+        kv_block_lens=[0x40, 0x100],
+        layer_names=[
+            "model.layers.0.self_attn",
+            "model.layers.1.linear_attn",
+        ],
+        layer_indices=[0, 1],
+        group_indices=[0, 1],
     )
-    kv_cache_config = make_hybrid_gdn_kv_cache_config(
-        vllm_config.cache_config.block_size
-    )
 
-    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
-        connector = MooncakeConnector(
-            vllm_config,
-            KVConnectorRole.WORKER,
-            kv_cache_config,
-        )
-        worker = connector.connector_worker
-
-        worker.transfer_topo = SimpleNamespace(virtually_split_kv_in_blocks=True)
-        regions = worker._get_transfer_regions(
-            base_addrs=[0x1000, 0x2000],
-            block_lens=[0x100, 0x100],
-            kv_block_lens=[0x40, 0x100],
-            layer_names=[
-                "model.layers.0.self_attn",
-                "model.layers.1.linear_attn",
-            ],
-            layer_indices=[0, 1],
-            group_indices=[0, 1],
-        )
-
-        assert [
-            (region.group_index, region.base_addr, region.kv_block_len)
-            for region in regions
-        ] == [
-            (0, 0x1000, 0x40),
-            (0, 0x1040, 0x40),
-            (1, 0x2000, 0x100),
-        ]
-
-        worker.shutdown()
-        worker.shutdown = noop_shutdown
-        connector.connector_worker = None
+    assert [
+        (region.group_index, region.base_addr, region.kv_block_len)
+        for region in regions
+    ] == [
+        (0, 0x1000, 0x40),
+        (0, 0x1040, 0x40),
+        (1, 0x2000, 0x100),
+    ]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -2055,14 +2055,19 @@ class MooncakeConnectorWorker:
         region_alias_groups_by_key: dict[
             tuple[int, int, int, int, int], list[list[int]]
         ] = defaultdict(list)
-        is_mtp_speculative = self.vllm_config.speculative_config is not None
+        speculative_config = self.vllm_config.speculative_config
+        speculative_method = getattr(speculative_config, "method", None)
+        is_mtp_speculative = speculative_method == "mtp" or (
+            isinstance(speculative_method, str)
+            and speculative_method.endswith("_mtp")
+        )
         total_num_hidden_layers = self.model_config.get_total_num_hidden_layers()
 
         for layer_name, cache_or_caches in kv_caches.items():
             layer_index = extract_layer_index(layer_name)
             if is_mtp_speculative and layer_index >= total_num_hidden_layers:
                 logger.debug(
-                    "Skipping speculative KV cache layer %s outside the "
+                    "Skipping MTP speculative KV cache layer %s outside the "
                     "base model layer range [0, %d)",
                     layer_name,
                     total_num_hidden_layers,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -1534,30 +1534,38 @@ class MooncakeConnectorWorker:
             )
             await sock.send_multipart((identity, self._encoder.encode(response)))
             return
-        local_regions = self._get_transfer_regions(
-            self.kv_caches_base_addr,
-            self.block_len_per_layer,
-            self.kv_block_len_per_layer,
-            self.registered_layer_names,
-            self.registered_layer_indices,
-            self.registered_group_indices,
-            self.registered_layer_aliases,
-            self.registered_layer_index_aliases,
-            self.registered_logical_group_indices,
-            self.registered_alias_group_indices,
-        )
-        remote_regions = self._get_transfer_regions(
-            meta.kv_caches_base_addr,
-            meta.block_lens,
-            meta.kv_block_lens,
-            meta.registered_layer_names,
-            meta.registered_layer_indices,
-            meta.registered_group_indices,
-            meta.registered_layer_aliases,
-            meta.registered_layer_index_aliases,
-            meta.registered_logical_group_indices,
-            meta.registered_alias_group_indices,
-        )
+        try:
+            local_regions = self._get_transfer_regions(
+                self.kv_caches_base_addr,
+                self.block_len_per_layer,
+                self.kv_block_len_per_layer,
+                self.registered_layer_names,
+                self.registered_layer_indices,
+                self.registered_group_indices,
+                self.registered_layer_aliases,
+                self.registered_layer_index_aliases,
+                self.registered_logical_group_indices,
+                self.registered_alias_group_indices,
+            )
+            remote_regions = self._get_transfer_regions(
+                meta.kv_caches_base_addr,
+                meta.block_lens,
+                meta.kv_block_lens,
+                meta.registered_layer_names,
+                meta.registered_layer_indices,
+                meta.registered_group_indices,
+                meta.registered_layer_aliases,
+                meta.registered_layer_index_aliases,
+                meta.registered_logical_group_indices,
+                meta.registered_alias_group_indices,
+            )
+        except ValueError as e:
+            response = MooncakeXferResponse(
+                status=MooncakeXferResponseStatus.ERROR,
+                err_msg=str(e),
+            )
+            await sock.send_multipart((identity, self._encoder.encode(response)))
+            return
         local_regions, remote_regions, align_err = _align_transfer_regions(
             local_regions, remote_regions
         )
@@ -2526,6 +2534,19 @@ class MooncakeConnectorWorker:
         logical_group_indices: list[list[int]] | None = None,
         alias_group_indices: list[list[list[int]]] | None = None,
     ) -> list[TransferRegion]:
+        if (
+            layer_names is None
+            or layer_indices is None
+            or len(layer_names) != len(base_addrs)
+            or len(layer_indices) != len(base_addrs)
+        ):
+            raise ValueError(
+                "Mooncake transfer metadata shape mismatch: "
+                f"base_addrs={len(base_addrs)} "
+                f"layer_names={None if layer_names is None else len(layer_names)} "
+                f"layer_indices="
+                f"{None if layer_indices is None else len(layer_indices)}."
+            )
         if not group_indices:
             group_indices = [
                 self._layer_group_indices.get(layer_name, 0)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -186,15 +186,17 @@ def _expand_transfer_regions(
         layer_index,
         group_index,
         split_kv_region,
-    ) in enumerate(zip(
-        base_addrs,
-        block_lens,
-        kv_block_lens,
-        layer_names,
-        layer_indices,
-        group_indices,
-        split_kv_regions,
-    )):
+    ) in enumerate(
+        zip(
+            base_addrs,
+            block_lens,
+            kv_block_lens,
+            layer_names,
+            layer_indices,
+            group_indices,
+            split_kv_regions,
+        )
+    ):
         if split_kv_region:
             aliases: tuple[str, ...] = ()
             index_aliases: tuple[int, ...] = ()
@@ -604,7 +606,9 @@ def _common_group_indices_for_regions(
             if 0 <= group_idx < num_groups
         )
     if local_region.group_index == remote_region.group_index:
-        return (local_region.group_index,) if local_region.group_index < num_groups else ()
+        return (
+            (local_region.group_index,) if local_region.group_index < num_groups else ()
+        )
     return ()
 
 
@@ -2063,12 +2067,12 @@ class MooncakeConnectorWorker:
         self.registered_logical_group_indices = []
         self.registered_alias_group_indices = []
         overlay_key_to_region_idx: dict[tuple[int, int, int, int, int], int] = {}
-        region_aliases_by_key: dict[
-            tuple[int, int, int, int, int], list[str]
-        ] = defaultdict(list)
-        region_index_aliases_by_key: dict[
-            tuple[int, int, int, int, int], list[int]
-        ] = defaultdict(list)
+        region_aliases_by_key: dict[tuple[int, int, int, int, int], list[str]] = (
+            defaultdict(list)
+        )
+        region_index_aliases_by_key: dict[tuple[int, int, int, int, int], list[int]] = (
+            defaultdict(list)
+        )
         region_logical_groups_by_key: dict[
             tuple[int, int, int, int, int], list[int]
         ] = defaultdict(list)
@@ -2078,8 +2082,7 @@ class MooncakeConnectorWorker:
         speculative_config = self.vllm_config.speculative_config
         speculative_method = getattr(speculative_config, "method", None)
         is_mtp_speculative = speculative_method == "mtp" or (
-            isinstance(speculative_method, str)
-            and speculative_method.endswith("_mtp")
+            isinstance(speculative_method, str) and speculative_method.endswith("_mtp")
         )
         total_num_hidden_layers = self.model_config.get_total_num_hidden_layers()
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -87,6 +87,14 @@ TransferId = str  # KV transfer coordination ID (shared by P/D)
 
 @dataclass(frozen=True)
 class TransferRegion:
+    """A Mooncake-registered KV buffer plus vLLM cache identity metadata.
+
+    layer_aliases mirrors KVCacheTensor.shared_by for tensors shared by
+    multiple layer names. logical_group_indices and alias_group_indices
+    preserve the KV cache group ownership needed to filter transfers for
+    hybrid caches.
+    """
+
     layer_name: str
     layer_index: int
     base_addr: int
@@ -413,10 +421,10 @@ def _align_transfer_regions(
 ) -> tuple[list[TransferRegion], list[TransferRegion], str | None]:
     """Align KV transfer regions by vLLM cache identity.
 
-    PP shards own different layer subsets. Positional matching is therefore
-    wrong once producer and consumer have different PP layouts. Shared physical
-    tensors use alias metadata to carry KVCacheTensor.shared_by names and
-    logical group metadata across the Mooncake wire boundary.
+    wrong once producer and consumer have different PP layouts. For shared
+    physical tensors, alias metadata carries the KVCacheTensor.shared_by layer
+    names and logical group metadata carries KVCacheGroupSpec ownership across
+    the Mooncake wire boundary.
     """
     has_aliases = any(
         _region_has_aliases(region) for region in local_regions + remote_regions
@@ -437,6 +445,10 @@ def _align_transfer_regions(
                 ),
             )
 
+        # DeepSeek V4 shared-cache regions bind each alias to the layer
+        # index and cache groups that own that view of the shared tensor.
+        # Matching the bound identity avoids transferring unrelated groups
+        # when one physical region backs multiple logical cache entries.
         alias_group_aligned_local: list[TransferRegion] = []
         alias_group_aligned_remote: list[TransferRegion] = []
         matched_local_indices: set[int] = set()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -2077,6 +2077,8 @@ class MooncakeConnectorWorker:
 
         for layer_name, cache_or_caches in kv_caches.items():
             layer_index = extract_layer_index(layer_name)
+            # DeepSeek V4 MTP draft caches are named after the base model
+            # layers, so their layer indices are outside the base layer range.
             if is_mtp_speculative and layer_index >= total_num_hidden_layers:
                 logger.debug(
                     "Skipping MTP speculative KV cache layer %s outside the "

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -93,6 +93,18 @@ class TransferRegion:
     block_len: int
     kv_block_len: int
     group_index: int = 0
+    layer_aliases: tuple[str, ...] = ()
+    layer_indices: tuple[int, ...] = ()
+    logical_group_indices: tuple[int, ...] = ()
+    alias_group_indices: tuple[tuple[int, ...], ...] = ()
+
+    @property
+    def match_layer_names(self) -> tuple[str, ...]:
+        return self.layer_aliases or (self.layer_name,)
+
+    @property
+    def match_layer_indices(self) -> tuple[int, ...]:
+        return self.layer_indices or (self.layer_index,)
 
 
 def _get_tp_ratio(local_tp_size: int, remote_tp_size: int) -> int:
@@ -125,6 +137,10 @@ def _expand_transfer_regions(
     is_kv_layout_blocks_first: bool,
     group_indices: list[int] | None = None,
     split_kv_regions: list[bool] | None = None,
+    layer_aliases: list[list[str]] | None = None,
+    layer_index_aliases: list[list[int]] | None = None,
+    logical_group_indices: list[list[int]] | None = None,
+    alias_group_indices: list[list[list[int]]] | None = None,
 ) -> list[TransferRegion]:
     """Expand registered KV tensors into the regions transferred by Mooncake."""
     assert (
@@ -154,7 +170,7 @@ def _expand_transfer_regions(
         f"layer_names={len(layer_names)}."
     )
     regions: list[TransferRegion] = []
-    for (
+    for idx, (
         base_addr,
         block_len,
         kv_block_len,
@@ -162,7 +178,7 @@ def _expand_transfer_regions(
         layer_index,
         group_index,
         split_kv_region,
-    ) in zip(
+    ) in enumerate(zip(
         base_addrs,
         block_lens,
         kv_block_lens,
@@ -170,7 +186,21 @@ def _expand_transfer_regions(
         layer_indices,
         group_indices,
         split_kv_regions,
-    ):
+    )):
+        if split_kv_region:
+            aliases: tuple[str, ...] = ()
+            index_aliases: tuple[int, ...] = ()
+            region_logical_group_indices: tuple[int, ...] = ()
+            region_alias_group_indices: tuple[tuple[int, ...], ...] = ()
+        else:
+            aliases = _get_region_layer_aliases(layer_aliases or [], idx)
+            index_aliases = _get_region_layer_indices(layer_index_aliases or [], idx)
+            region_logical_group_indices = _get_region_logical_group_indices(
+                logical_group_indices or [], idx
+            )
+            region_alias_group_indices = _get_region_alias_group_indices(
+                alias_group_indices or [], idx
+            )
         regions.append(
             TransferRegion(
                 layer_name=layer_name,
@@ -179,6 +209,10 @@ def _expand_transfer_regions(
                 block_len=block_len,
                 kv_block_len=kv_block_len,
                 group_index=group_index,
+                layer_aliases=aliases,
+                layer_indices=index_aliases,
+                logical_group_indices=region_logical_group_indices,
+                alias_group_indices=region_alias_group_indices,
             )
         )
         if split_kv_region:
@@ -193,6 +227,36 @@ def _expand_transfer_regions(
                 )
             )
     return regions
+
+
+def _get_region_layer_aliases(aliases: list[list[str]], idx: int) -> tuple[str, ...]:
+    if idx < len(aliases) and aliases[idx]:
+        return tuple(aliases[idx])
+    return ()
+
+
+def _get_region_layer_indices(
+    index_aliases: list[list[int]], idx: int
+) -> tuple[int, ...]:
+    if idx < len(index_aliases) and index_aliases[idx]:
+        return tuple(index_aliases[idx])
+    return ()
+
+
+def _get_region_logical_group_indices(
+    group_indices: list[list[int]], idx: int
+) -> tuple[int, ...]:
+    if idx < len(group_indices) and group_indices[idx]:
+        return tuple(group_indices[idx])
+    return ()
+
+
+def _get_region_alias_group_indices(
+    alias_group_indices: list[list[list[int]]], idx: int
+) -> tuple[tuple[int, ...], ...]:
+    if idx < len(alias_group_indices) and alias_group_indices[idx]:
+        return tuple(tuple(groups) for groups in alias_group_indices[idx])
+    return ()
 
 
 def _compute_sender_transfer_plan(
@@ -302,17 +366,153 @@ def _validate_asymmetric_region_lengths(
     return None
 
 
+def _region_has_aliases(region: TransferRegion) -> bool:
+    return bool(region.layer_aliases)
+
+
+def _alias_group_map(region: TransferRegion) -> dict[str, dict[int, set[int]]]:
+    if (
+        not region.layer_aliases
+        or not region.layer_indices
+        or not region.alias_group_indices
+    ):
+        return {}
+
+    alias_groups: dict[str, dict[int, set[int]]] = defaultdict(lambda: defaultdict(set))
+    for alias, layer_index, group_indices in zip(
+        region.layer_aliases,
+        region.layer_indices,
+        region.alias_group_indices,
+    ):
+        alias_groups[alias][layer_index].update(group_indices)
+    return alias_groups
+
+
+def _regions_have_bound_alias_layer_indices(
+    local_region: TransferRegion, remote_region: TransferRegion
+) -> bool:
+    local_alias_groups = _alias_group_map(local_region)
+    remote_alias_groups = _alias_group_map(remote_region)
+    for alias in set(local_alias_groups) & set(remote_alias_groups):
+        if set(local_alias_groups[alias]) & set(remote_alias_groups[alias]):
+            return True
+    return False
+
+
+def _regions_share_layer_identity(
+    local_region: TransferRegion, remote_region: TransferRegion
+) -> bool:
+    return bool(
+        set(local_region.match_layer_names) & set(remote_region.match_layer_names)
+    )
+
+
 def _align_transfer_regions(
     local_regions: list[TransferRegion],
     remote_regions: list[TransferRegion],
 ) -> tuple[list[TransferRegion], list[TransferRegion], str | None]:
-    """Align KV transfer regions by registered layer-name occurrence.
+    """Align KV transfer regions by vLLM cache identity.
 
     PP shards own different layer subsets. Positional matching is therefore
-    wrong once producer and consumer have different PP layouts. Multiple
-    registered transfer buffers for the same layer are represented by repeated
-    layer names and matched by occurrence order.
+    wrong once producer and consumer have different PP layouts. Shared physical
+    tensors use alias metadata to carry KVCacheTensor.shared_by names and
+    logical group metadata across the Mooncake wire boundary.
     """
+    has_aliases = any(
+        _region_has_aliases(region) for region in local_regions + remote_regions
+    )
+    if has_aliases:
+        has_alias_group_metadata = all(
+            not _region_has_aliases(region) or bool(region.alias_group_indices)
+            for region in local_regions + remote_regions
+        )
+        if not has_alias_group_metadata:
+            return (
+                [],
+                [],
+                (
+                    "Mooncake alias metadata is missing alias-group ownership. "
+                    "Producer and consumer must use the same Mooncake metadata "
+                    "schema."
+                ),
+            )
+
+        alias_group_aligned_local: list[TransferRegion] = []
+        alias_group_aligned_remote: list[TransferRegion] = []
+        matched_local_indices: set[int] = set()
+        matched_alias_group_keys: set[tuple[str, int, int]] = set()
+
+        for local_idx, local_region in enumerate(local_regions):
+            alias_group_index_mismatch_region: TransferRegion | None = None
+            for candidate_remote_region in remote_regions:
+                if not _regions_share_layer_identity(
+                    local_region, candidate_remote_region
+                ):
+                    continue
+                if not _regions_have_bound_alias_layer_indices(
+                    local_region, candidate_remote_region
+                ):
+                    if alias_group_index_mismatch_region is None:
+                        alias_group_index_mismatch_region = candidate_remote_region
+                    continue
+                shared_alias_group_keys = _shared_alias_group_keys(
+                    local_region, candidate_remote_region
+                )
+                if shared_alias_group_keys is None or not shared_alias_group_keys:
+                    continue
+                duplicate_alias_group_keys = [
+                    alias_group_key
+                    for alias_group_key in shared_alias_group_keys
+                    if alias_group_key in matched_alias_group_keys
+                ]
+                if duplicate_alias_group_keys:
+                    return (
+                        [],
+                        [],
+                        (
+                            "Mooncake duplicate alias group match for "
+                            f"{candidate_remote_region.match_layer_names}: "
+                            f"groups={duplicate_alias_group_keys}."
+                        ),
+                    )
+                matched_alias_group_keys.update(shared_alias_group_keys)
+                alias_group_aligned_local.append(local_region)
+                alias_group_aligned_remote.append(candidate_remote_region)
+                matched_local_indices.add(local_idx)
+
+            if (
+                local_idx not in matched_local_indices
+                and alias_group_index_mismatch_region is not None
+            ):
+                return (
+                    [],
+                    [],
+                    (
+                        "Mooncake registered layer index mismatch for "
+                        f"{local_region.match_layer_names}: producer="
+                        f"{local_region.match_layer_indices}, consumer="
+                        f"{alias_group_index_mismatch_region.match_layer_indices}."
+                    ),
+                )
+
+        for local_idx, local_region in enumerate(local_regions):
+            if local_idx in matched_local_indices:
+                continue
+            if any(
+                _regions_share_layer_identity(local_region, remote_region)
+                for remote_region in remote_regions
+            ):
+                return (
+                    [],
+                    [],
+                    (
+                        "Mooncake producer registered layer aliases have no "
+                        "matching consumer alias groups: "
+                        f"{sorted(local_region.match_layer_names)}."
+                    ),
+                )
+
+        return alias_group_aligned_local, alias_group_aligned_remote, None
 
     def keyed_regions(
         regions: list[TransferRegion],
@@ -369,6 +569,101 @@ def _align_transfer_regions(
     return aligned_local, aligned_remote, None
 
 
+def _common_group_indices_for_regions(
+    local_region: TransferRegion, remote_region: TransferRegion, num_groups: int
+) -> tuple[int, ...]:
+    """Return the KV cache groups shared by two aligned transfer regions."""
+
+    if num_groups <= 0:
+        return ()
+    groups_from_aliases = _common_group_indices_from_aliases(
+        local_region, remote_region, num_groups
+    )
+    if groups_from_aliases is not None:
+        return groups_from_aliases
+    if local_region.logical_group_indices and remote_region.logical_group_indices:
+        common_group_indices = sorted(
+            set(local_region.logical_group_indices)
+            & set(remote_region.logical_group_indices)
+        )
+        return tuple(
+            group_idx
+            for group_idx in common_group_indices
+            if 0 <= group_idx < num_groups
+        )
+    if local_region.group_index == remote_region.group_index:
+        return (local_region.group_index,) if local_region.group_index < num_groups else ()
+    return ()
+
+
+def _common_group_indices_from_aliases(
+    local_region: TransferRegion, remote_region: TransferRegion, num_groups: int
+) -> tuple[int, ...] | None:
+    group_indices = _shared_alias_group_indices(local_region, remote_region)
+    if group_indices is None:
+        return None
+    return tuple(g for g in group_indices if 0 <= g < num_groups)
+
+
+def _shared_alias_group_indices(
+    local_region: TransferRegion, remote_region: TransferRegion
+) -> tuple[int, ...] | None:
+    shared_alias_group_keys = _shared_alias_group_keys(local_region, remote_region)
+    if shared_alias_group_keys is None:
+        return None
+    return tuple(sorted({group_idx for _, _, group_idx in shared_alias_group_keys}))
+
+
+def _shared_alias_group_keys(
+    local_region: TransferRegion, remote_region: TransferRegion
+) -> tuple[tuple[str, int, int], ...] | None:
+    if not local_region.alias_group_indices or not remote_region.alias_group_indices:
+        return None
+
+    local_alias_groups = _alias_group_map(local_region)
+    remote_alias_groups = _alias_group_map(remote_region)
+    common_aliases = set(local_alias_groups) & set(remote_alias_groups)
+
+    alias_group_keys: set[tuple[str, int, int]] = set()
+    for alias in common_aliases:
+        common_layer_indices = set(local_alias_groups[alias]) & set(
+            remote_alias_groups[alias]
+        )
+        for layer_index in common_layer_indices:
+            common_group_indices = (
+                local_alias_groups[alias][layer_index]
+                & remote_alias_groups[alias][layer_index]
+            )
+            for group_idx in common_group_indices:
+                alias_group_keys.add((alias, layer_index, group_idx))
+    return tuple(sorted(alias_group_keys))
+
+
+def _select_region_block_ids(
+    local_block_ids_per_group: list[list[int]],
+    remote_block_ids_per_group: list[list[int]],
+    group_indices: tuple[int, ...],
+) -> tuple[list[int], list[int], str | None]:
+    local_block_ids: list[int] = []
+    remote_block_ids: list[int] = []
+
+    for group_idx in group_indices:
+        local_group = local_block_ids_per_group[group_idx]
+        remote_group = remote_block_ids_per_group[group_idx]
+        n_local = len(local_group)
+        n_remote = len(remote_group)
+        if n_remote == 0:
+            continue
+        if n_local < n_remote:
+            return [], [], "P num blocks less than D"
+        if n_local > n_remote:
+            local_group = local_group[-n_remote:]
+        local_block_ids.extend(local_group)
+        remote_block_ids.extend(remote_group)
+
+    return local_block_ids, remote_block_ids, None
+
+
 def _get_tensor_dense_flag(tensor: torch.Tensor) -> bool | None:
     is_dense = getattr(tensor, "is_non_overlapping_and_dense", None)
     if callable(is_dense):
@@ -391,6 +686,16 @@ class MooncakeXferMetadata(
     registered_layer_names: list[str] = msgspec.field(default_factory=list)
     registered_layer_indices: list[int] = msgspec.field(default_factory=list)
     registered_group_indices: list[int] = msgspec.field(default_factory=list)
+    registered_layer_aliases: list[list[str]] = msgspec.field(default_factory=list)
+    registered_layer_index_aliases: list[list[int]] = msgspec.field(
+        default_factory=list
+    )
+    registered_logical_group_indices: list[list[int]] = msgspec.field(
+        default_factory=list
+    )
+    registered_alias_group_indices: list[list[list[int]]] = msgspec.field(
+        default_factory=list
+    )
 
 
 class MooncakeXferResponseStatus(IntEnum):
@@ -959,6 +1264,10 @@ class MooncakeConnectorWorker:
         self.registered_layer_names: list[str] = []
         self.registered_layer_indices: list[int] = []
         self.registered_group_indices: list[int] = []
+        self.registered_layer_aliases: list[list[str]] = []
+        self.registered_layer_index_aliases: list[list[int]] = []
+        self.registered_logical_group_indices: list[list[int]] = []
+        self.registered_alias_group_indices: list[list[list[int]]] = []
         self.seen_base_addresses: list[int] = []
 
         assert (parallel_config := vllm_config.parallel_config)
@@ -1044,6 +1353,10 @@ class MooncakeConnectorWorker:
             for group_index, group in enumerate(kv_cache_config.kv_cache_groups)
             for layer in group.layer_names
         }
+        self._layer_logical_group_indices: dict[str, list[int]] = defaultdict(list)
+        for group_index, group in enumerate(kv_cache_config.kv_cache_groups):
+            for layer in group.layer_names:
+                self._layer_logical_group_indices[layer].append(group_index)
         self.transfer_topo = TransferTopology(
             tp_rank=self.tp_rank,
             tp_size=self.tp_size,
@@ -1216,6 +1529,10 @@ class MooncakeConnectorWorker:
             self.registered_layer_names,
             self.registered_layer_indices,
             self.registered_group_indices,
+            self.registered_layer_aliases,
+            self.registered_layer_index_aliases,
+            self.registered_logical_group_indices,
+            self.registered_alias_group_indices,
         )
         remote_regions = self._get_transfer_regions(
             meta.kv_caches_base_addr,
@@ -1224,6 +1541,10 @@ class MooncakeConnectorWorker:
             meta.registered_layer_names,
             meta.registered_layer_indices,
             meta.registered_group_indices,
+            meta.registered_layer_aliases,
+            meta.registered_layer_index_aliases,
+            meta.registered_logical_group_indices,
+            meta.registered_alias_group_indices,
         )
         local_regions, remote_regions, align_err = _align_transfer_regions(
             local_regions, remote_regions
@@ -1520,20 +1841,54 @@ class MooncakeConnectorWorker:
                 remote_block_ids_by_group
             )
 
+            selected_region_blocks: list[
+                tuple[TransferRegion, TransferRegion, list[int], list[int]]
+            ] = []
+            selected_block_count = 0
+            num_groups = len(remote_block_ids_by_group)
             for local_region, remote_region in zip(local_regions, remote_regions):
-                assert local_region.group_index == remote_region.group_index, (
-                    "Aligned Mooncake transfer regions must belong to the same "
-                    "KV group."
+                region_group_indices = _common_group_indices_for_regions(
+                    local_region,
+                    remote_region,
+                    num_groups,
                 )
-                group_index = local_region.group_index
-                assert group_index < len(local_block_ids_by_group), (
-                    "Transfer region references a missing KV group."
+                (
+                    local_block_ids,
+                    remote_block_ids,
+                    select_err,
+                ) = _select_region_block_ids(
+                    local_block_ids_by_group,
+                    remote_block_ids_by_group,
+                    region_group_indices,
                 )
-                local_block_ids = local_block_ids_by_group[group_index]
-                remote_block_ids = remote_block_ids_by_group[group_index]
+                if select_err is not None:
+                    logger.error(
+                        "req %s: local blocks < remote blocks for KV groups %s",
+                        d_req_id,
+                        region_group_indices,
+                    )
+                    err_reqs.append(d_req_id)
+                    if err_msg is None:
+                        err_msg = select_err
+                    selected_region_blocks = []
+                    break
                 if not local_block_ids:
                     continue
+                selected_block_count += len(local_block_ids)
+                selected_region_blocks.append(
+                    (local_region, remote_region, local_block_ids, remote_block_ids)
+                )
 
+            if not selected_region_blocks:
+                continue
+
+            logged_transfer_plan = False
+            for (
+                local_region,
+                remote_region,
+                local_block_ids,
+                remote_block_ids,
+            ) in selected_region_blocks:
                 # Group by indices within this region's KV-cache group only.
                 group_local_block_ids, group_remote_block_ids = (
                     group_concurrent_contiguous(local_block_ids, remote_block_ids)
@@ -1604,10 +1959,29 @@ class MooncakeConnectorWorker:
                             )
                             lengths.append(transfer_len)
 
+                if not logged_transfer_plan:
+                    logger.debug(
+                        "Mooncake transfer plan for request %s: local_tp=%d "
+                        "remote_tp=%d remote_tp_rank=%d local_block_len=%d "
+                        "remote_block_len=%d src_offset=%d dst_offset=%d "
+                        "transfer_len=%d coalesce=%s",
+                        d_req_id,
+                        self.tp_size,
+                        agent_meta.remote_tp_size,
+                        agent_meta.remote_tp_rank,
+                        local_region.block_len,
+                        remote_region.block_len,
+                        src_region_offset,
+                        dst_region_offset,
+                        transfer_len,
+                        can_coalesce,
+                    )
+                    logged_transfer_plan = True
+
             logger.debug(
                 "Sending kv_caches for request %s (%d blocks) to %s",
                 d_req_id,
-                sum(len(group) for group in local_block_ids_by_group),
+                selected_block_count,
                 remote_session,
             )
 
@@ -1664,9 +2038,36 @@ class MooncakeConnectorWorker:
         self.registered_layer_names = []
         self.registered_layer_indices = []
         self.registered_group_indices = []
+        self.registered_layer_aliases = []
+        self.registered_layer_index_aliases = []
+        self.registered_logical_group_indices = []
+        self.registered_alias_group_indices = []
+        overlay_key_to_region_idx: dict[tuple[int, int, int, int, int], int] = {}
+        region_aliases_by_key: dict[
+            tuple[int, int, int, int, int], list[str]
+        ] = defaultdict(list)
+        region_index_aliases_by_key: dict[
+            tuple[int, int, int, int, int], list[int]
+        ] = defaultdict(list)
+        region_logical_groups_by_key: dict[
+            tuple[int, int, int, int, int], list[int]
+        ] = defaultdict(list)
+        region_alias_groups_by_key: dict[
+            tuple[int, int, int, int, int], list[list[int]]
+        ] = defaultdict(list)
+        is_mtp_speculative = self.vllm_config.speculative_config is not None
+        total_num_hidden_layers = self.model_config.get_total_num_hidden_layers()
 
         for layer_name, cache_or_caches in kv_caches.items():
             layer_index = extract_layer_index(layer_name)
+            if is_mtp_speculative and layer_index >= total_num_hidden_layers:
+                logger.debug(
+                    "Skipping speculative KV cache layer %s outside the "
+                    "base model layer range [0, %d)",
+                    layer_name,
+                    total_num_hidden_layers,
+                )
+                continue
             layer_spec = self._layer_specs.get(layer_name)
             if layer_spec is None:
                 logger.debug(
@@ -1692,7 +2093,6 @@ class MooncakeConnectorWorker:
                 self._log_debug_cache_registration(layer_name, cache)
                 base_addr = cache.data_ptr()
                 block_len = cache.stride(0) * cache.element_size()
-                region_base_addresses.append(base_addr)
 
                 if isinstance(layer_spec, (MLAAttentionSpec, SlidingWindowMLASpec)):
                     kv_block_len = layer_spec.page_size_bytes
@@ -1702,6 +2102,49 @@ class MooncakeConnectorWorker:
                     kv_block_len = block_len // 2
                 else:
                     kv_block_len = block_len
+                storage = cache.untyped_storage()
+                storage_addr = storage.data_ptr()
+                if storage_addr not in seen_storage_ptrs:
+                    seen_storage_ptrs.add(storage_addr)
+                    kv_data_ptrs.append(storage_addr)
+                    kv_data_lens.append(storage.nbytes())
+                overlay_key = (
+                    storage_addr,
+                    base_addr,
+                    block_len,
+                    kv_block_len,
+                    layer_index,
+                )
+                logical_groups = list(
+                    self._layer_logical_group_indices.get(layer_name, [])
+                )
+                if layer_name not in region_aliases_by_key[overlay_key]:
+                    region_aliases_by_key[overlay_key].append(layer_name)
+                    region_index_aliases_by_key[overlay_key].append(layer_index)
+                    region_alias_groups_by_key[overlay_key].append(logical_groups)
+                for group_idx in logical_groups:
+                    if group_idx not in region_logical_groups_by_key[overlay_key]:
+                        region_logical_groups_by_key[overlay_key].append(group_idx)
+
+                if overlay_key in overlay_key_to_region_idx:
+                    region_idx = overlay_key_to_region_idx[overlay_key]
+                    self.registered_layer_aliases[region_idx] = list(
+                        region_aliases_by_key[overlay_key]
+                    )
+                    self.registered_layer_index_aliases[region_idx] = list(
+                        region_index_aliases_by_key[overlay_key]
+                    )
+                    self.registered_logical_group_indices[region_idx] = list(
+                        region_logical_groups_by_key[overlay_key]
+                    )
+                    self.registered_alias_group_indices[region_idx] = [
+                        list(groups)
+                        for groups in region_alias_groups_by_key[overlay_key]
+                    ]
+                    continue
+
+                overlay_key_to_region_idx[overlay_key] = len(region_base_addresses)
+                region_base_addresses.append(base_addr)
                 self.block_len_per_layer.append(block_len)
                 self.kv_block_len_per_layer.append(kv_block_len)
                 self.registered_layer_names.append(layer_name)
@@ -1709,12 +2152,18 @@ class MooncakeConnectorWorker:
                 self.registered_group_indices.append(
                     self._layer_group_indices[layer_name]
                 )
-                storage = cache.untyped_storage()
-                storage_addr = storage.data_ptr()
-                if storage_addr not in seen_storage_ptrs:
-                    seen_storage_ptrs.add(storage_addr)
-                    kv_data_ptrs.append(storage_addr)
-                    kv_data_lens.append(storage.nbytes())
+                self.registered_layer_aliases.append(
+                    list(region_aliases_by_key[overlay_key])
+                )
+                self.registered_layer_index_aliases.append(
+                    list(region_index_aliases_by_key[overlay_key])
+                )
+                self.registered_logical_group_indices.append(
+                    list(region_logical_groups_by_key[overlay_key])
+                )
+                self.registered_alias_group_indices.append(
+                    [list(groups) for groups in region_alias_groups_by_key[overlay_key]]
+                )
 
         self.kv_caches_base_addr = region_base_addresses
         self.seen_base_addresses = kv_data_ptrs
@@ -1837,6 +2286,10 @@ class MooncakeConnectorWorker:
             registered_layer_names=self.registered_layer_names,
             registered_layer_indices=self.registered_layer_indices,
             registered_group_indices=self.registered_group_indices,
+            registered_layer_aliases=self.registered_layer_aliases,
+            registered_layer_index_aliases=self.registered_layer_index_aliases,
+            registered_logical_group_indices=self.registered_logical_group_indices,
+            registered_alias_group_indices=self.registered_alias_group_indices,
         )
 
         encoded_data = self._encoder.encode(metadata)
@@ -2049,6 +2502,10 @@ class MooncakeConnectorWorker:
         layer_names: list[str],
         layer_indices: list[int],
         group_indices: list[int] | None = None,
+        layer_aliases: list[list[str]] | None = None,
+        layer_index_aliases: list[list[int]] | None = None,
+        logical_group_indices: list[list[int]] | None = None,
+        alias_group_indices: list[list[list[int]]] | None = None,
     ) -> list[TransferRegion]:
         if not group_indices:
             group_indices = [
@@ -2073,6 +2530,10 @@ class MooncakeConnectorWorker:
             is_kv_layout_blocks_first=self.transfer_topo.virtually_split_kv_in_blocks,
             group_indices=group_indices,
             split_kv_regions=split_kv_regions,
+            layer_aliases=layer_aliases,
+            layer_index_aliases=layer_index_aliases,
+            logical_group_indices=logical_group_indices,
+            alias_group_indices=alias_group_indices,
         )
 
     def _get_sender_transfer_plan(

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -915,14 +915,10 @@ def w8a8_triton_block_scaled_mm(
     assert len(block_size) == 2
     block_n, block_k = block_size[0], block_size[1]
 
-    # Triton cannot currently bind E8M0 scale tensors directly. On ROCm,
-    # DeepSeek-V4 checkpoints store block scales in exponent-only E8M0 format,
-    # so decode them to fp32 before launching the kernel.
-    if current_platform.is_rocm() or current_platform.is_xpu():
-        if As.dtype == torch.float8_e8m0fnu:
-            As = _upcast_e8m0_to_fp32(As).contiguous()
-        if Bs.dtype == torch.float8_e8m0fnu:
-            Bs = _upcast_e8m0_to_fp32(Bs).contiguous()
+    # Triton cannot currently bind E8M0 scale tensors directly. DeepSeek-V4
+    # checkpoints can store block scales in exponent-only E8M0 format, so
+    # decode them to fp32 before launching the kernel.
+    As, Bs = _upcast_e8m0_scales_for_triton(As, Bs)
 
     assert A.shape[-1] == B.shape[-1]
     assert A.shape[:-1] == As.shape[:-1] and A.is_contiguous()
@@ -1056,6 +1052,17 @@ def _upcast_e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
     exp_bits = scale.view(torch.uint8).to(torch.int32)
     fp32_bits = exp_bits << 23
     return fp32_bits.view(torch.float32)
+
+
+def _upcast_e8m0_scales_for_triton(
+    *scales: torch.Tensor,
+) -> tuple[torch.Tensor, ...]:
+    return tuple(
+        _upcast_e8m0_to_fp32(scale).contiguous()
+        if scale.dtype == torch.float8_e8m0fnu
+        else scale
+        for scale in scales
+    )
 
 
 def deepgemm_post_process_weight_scale_block(


### PR DESCRIPTION
## Purpose

This PR adds Mooncake transfer-region metadata so PP prefill and TP decode can match DeepSeek V4 shared KV cache tensors by vLLM cache identity, not only by the registered physical layer name.

The change is local to the Mooncake connector:

- carry layer aliases, layer-index aliases, and KV cache group ownership in `MooncakeXferMetadata`;
- align producer and consumer `TransferRegion`s using the shared cache identity from `KVCacheTensor.shared_by` / `KVCacheGroupSpec`;
- filter per-region block transfers to the KV cache groups that are actually common to the aligned producer/consumer regions;
- require same-version Mooncake workers to exchange complete shared-cache identity and KV group ownership metadata, and fail fast when alias/group metadata is incomplete;
- skip MTP draft KV cache tensors outside the base model layer range when decode-side MTP is enabled.


## Test Plan

### Deployment shape

<details>
<summary>Rendered prefill/decode vLLM startup commands</summary>

Prefill:

```bash
vllm serve /data00/DeepSeek-V4-Flash \
  --host 0.0.0.0 \
  --port 8000 \
  --served-model-name DeepSeek-V4-Flash \
  --trust-remote-code \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --data-parallel-size 1 \
  --tensor-parallel-size 1 \
  --pipeline-parallel-size 8 \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --max-num-batched-tokens 2048 \
  --max-num-seqs 16 \
  --no-disable-hybrid-kv-cache-manager \
  --disable-uvicorn-access-log \
  --kv-transfer-config '{"kv_buffer_device":"cuda","kv_connector":"MooncakeConnector","kv_connector_extra_config":{"enforce_handshake_compat":false,"mooncake_protocol":"rdma"},"kv_load_failure_policy":"fail","kv_role":"kv_producer"}' \
  --aggregate-engine-logging \
  --api-server-count 1
```

Decode:

```bash
vllm serve /data00/DeepSeek-V4-Flash \
  --host 0.0.0.0 \
  --port 8001 \
  --served-model-name DeepSeek-V4-Flash \
  --trust-remote-code \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --data-parallel-size 1 \
  --tensor-parallel-size 8 \
  --pipeline-parallel-size 1 \
  --cp-kv-cache-interleave-size 256 \
  --enable-expert-parallel \
  --all2all-backend deepep_low_latency \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --max-num-batched-tokens 512 \
  --max-num-seqs 64 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
  --no-disable-hybrid-kv-cache-manager \
  --disable-uvicorn-access-log \
  --kv-transfer-config '{"kv_buffer_device":"cuda","kv_connector":"MooncakeConnector","kv_connector_extra_config":{"enforce_handshake_compat":false,"mooncake_protocol":"rdma"},"kv_load_failure_policy":"fail","kv_role":"kv_consumer"}' \
  --aggregate-engine-logging \
  --api-server-count 1
```

</details>

### Request-path and eval commands

<details>
<summary>GSM8K-64 accuracy smoke command</summary>

```bash
evalscope eval \
  --model DeepSeek-V4-Flash \
  --api-url http://dsv4-mooncake-pp-pd-mtp-router.hank.svc.cluster.local:30080/v1/chat/completions \
  --api-key EMPTY \
  --eval-type openai_api \
  --datasets gsm8k \
  --limit 64 \
  --generation-config '{"temperature":0,"max_tokens":256}' \
  --work-dir /tmp/evalscope_artifacts/gsm8k64-mtp
```

</details>

<details>
<summary>PP8 vs TP8 prefill TTFT comparison commands</summary>

128K measured command:

```bash
evalscope perf \
  --parallel 1 \
  --number 1 \
  --model DeepSeek-V4-Flash \
  --tokenizer-path /data00/DeepSeek-V4-Flash \
  --url http://dsv4-pr-tp8-ttft128k-router.hank.svc.cluster.local:30080/v1/completions \
  --api openai \
  --dataset random \
  --dataset-offset 100000 \
  --min-prompt-length 131072 \
  --max-prompt-length 131072 \
  --prefix-length 0 \
  --min-tokens 1 \
  --max-tokens 1 \
  --extra-args '{"temperature":0,"ignore_eos":true}' \
  --apply-chat-template false \
  --stream \
  --connect-timeout 30 \
  --read-timeout 7200 \
  --total-timeout 7200
```

</details>

## Test Result

### Review-fix unit validation


### Main PP8 prefill + decode MTP validation

```text
accuracy smoke GSM8K-64: passed, mean_acc=0.9531, num=64
```

### Community baseline

### PP8 vs TP8 prefill TTFT

These are single-long-request TTFT comparisons only, not throughput-capacity results.

| Shape | Request | Result |
|---|---:|---:|
| PR prefill TP=1/PP=8, decode TP=8/PP=1 | 64K input / 1 output |TTFT 5121.18 ms |
| PR prefill TP=8/PP=1, decode TP=8/PP=1 | 64K input / 1 output |TTFT 7952.91 ms |
| PR prefill TP=1/PP=8, decode TP=8/PP=1 | 128K input / 1 output | TTFT 9705.35 ms |
| PR prefill TP=8/PP=1, decode TP=8/PP=1 | 128K input / 1 output | TTFT 17932.63 ms |

Comparison:

```text
64K: TP8 prefill was 2831.73 ms slower than PP8 prefill; TP8/PP8 ratio 1.553x; PP8 median TTFT was 35.61% lower.
128K: TP8 prefill was 8227.28 ms slower than PP8 prefill; TP8/PP8 ratio 1.848x; PP8 TTFT was 45.88% lower.
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. Not applicable: this PR changes Mooncake connector behavior and focused tests, not public model docs.
</details>
