### PR TITLE
fix(transformers_utils): parse compact sentence-transformers pooling_mode (>=5.4.0)

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -823,14 +823,24 @@ def get_pooling_config(
 
         config: dict[str, Any] = {"use_activation": normalize}
         for key, val in pooling_dict.items():
-            if val is True:
+            # sentence-transformers >= 5.4.0 stores the pooling strategy as a
+            # single compact string field (``"pooling_mode": "mean"``) instead
+            # of one boolean flag per mode (``"pooling_mode_mean_tokens": true``).
+            # Without handling the compact form, no pooling type is parsed and
+            # vLLM silently falls back to the architecture-default pooler.
+            if key == "pooling_mode" and isinstance(val, str):
+                pooling_type = parse_pooling_type(val)
+            elif val is True:
                 pooling_type = parse_pooling_type(key)
-                if pooling_type in SEQ_POOLING_TYPES:
-                    config["seq_pooling_type"] = pooling_type
-                elif pooling_type in TOK_POOLING_TYPES:
-                    config["tok_pooling_type"] = pooling_type
-                else:
-                    logger.debug("Skipping unrelated field: %r=%r", key, val)
+            else:
+                continue
+
+            if pooling_type in SEQ_POOLING_TYPES:
+                config["seq_pooling_type"] = pooling_type
+            elif pooling_type in TOK_POOLING_TYPES:
+                config["tok_pooling_type"] = pooling_type
+            else:
+                logger.debug("Skipping unrelated field: %r=%r", key, val)
 
         return config
 


### PR DESCRIPTION
## Purpose

Fixes #45995.

`sentence-transformers >= 5.4.0` ([huggingface/sentence-transformers#3554](https://github.com/huggingface/sentence-transformers/pull/3554), merged in v5.4) changed the on-disk schema of `1_Pooling/config.json`. The pooling strategy is now stored as a **single compact string field** instead of one boolean flag per mode:

```jsonc
// OLD (sentence-transformers <= 5.3.0)
{ "word_embedding_dimension": 768, "pooling_mode_mean_tokens": true, ... }

// NEW (sentence-transformers >= 5.4.0)
{ "embedding_dimension": 768, "pooling_mode": "mean", "include_prompt": true }
```

`get_pooling_config()` in `vllm/transformers_utils/config.py` only parsed keys whose value `is True`, so for a model serialized with the new schema **no pooling type is parsed**. `config` ends up without `seq_pooling_type`/`tok_pooling_type` and vLLM silently falls back to the architecture-default pooler — producing incorrect embeddings with no warning or error.

## Fix

Handle the compact `"pooling_mode"` string by routing its value through the existing `parse_pooling_type()`, while keeping the legacy boolean-flag path intact. `parse_pooling_type` already normalizes the short mode names (`cls`/`mean`/`lasttoken`/`mean_sqrt_len_tokens`), so coverage is identical to the legacy schema (`cls→CLS`, `mean→MEAN`, `lasttoken→LAST`; `max`/`weightedmean` remain unsupported, as before).

## Why this is not a duplicate

Per the AGENTS.md duplicate-work checks:
- `gh pr list --repo vllm-project/vllm --state open --search "45995 in:body"` → none
- `gh pr list --repo vllm-project/vllm --state open --search "pooling_mode sentence-transformers"` → none

No open PR addresses the compact `1_Pooling/config.json` schema.

## Testing

The existing `get_pooling_config` tests in `tests/test_config.py` download real HF models (integration). I verified the parsing logic in isolation by replicating `parse_pooling_type` + the patched loop against both schemas:

| input | `seq_pooling_type` before | after |
|---|---|---|
| legacy `pooling_mode_mean_tokens: true` | `MEAN` | `MEAN` (unchanged) |
| legacy `pooling_mode_cls_token: true` | `CLS` | `CLS` (unchanged) |
| compact `pooling_mode: "mean"` | `None` (bug) | `MEAN` |
| compact `pooling_mode: "cls"` | `None` (bug) | `CLS` |
| compact `pooling_mode: "lasttoken"` | `None` (bug) | `LAST` |

All legacy cases are preserved; all compact cases now resolve correctly. A maintainer with GPU/network access should additionally run the model-backed pooling tests in `tests/test_config.py`.

AI assistance was used to author this change; it has been reviewed line-by-line by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
