### PR TITLE
[feat] Expose vllm.inputs.data for Ray Data LLM compatibility

### DIFF
--- a/tests/inputs/test_inputs_data_submodule.py
+++ b/tests/inputs/test_inputs_data_submodule.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Ray Data LLM and similar tools import ``vllm.inputs.data.*``."""
+
+import pytest
+
+import vllm.inputs as vllm_inputs
+from vllm.inputs import TextPrompt as TextPromptTop
+from vllm.inputs import TokensPrompt as TokensPromptTop
+from vllm.inputs.data import TextPrompt, TokensPrompt
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_inputs_data_submodule_exposed():
+    assert hasattr(vllm_inputs, "data")
+    assert TextPrompt is TextPromptTop
+    assert TokensPrompt is TokensPromptTop

--- a/vllm/inputs/__init__.py
+++ b/vllm/inputs/__init__.py
@@ -62,3 +62,7 @@ __all__ = [
     "SingletonInput",
     "EngineInput",
 ]
+
+# Subpackage for integrations (e.g. Ray Data LLM) that expect
+# `vllm.inputs.data.{TextPrompt,TokensPrompt}`.
+from . import data  # noqa: F401

--- a/vllm/inputs/data.py
+++ b/vllm/inputs/data.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Prompt types exposed as ``vllm.inputs.data`` for external (Ray) integrations.
+
+Ray Data's LLM batch pipeline imports ``vllm.inputs.data.TextPrompt`` and
+``vllm.inputs.data.TokensPrompt``. Those types live in :mod:`vllm.inputs.llm`;
+this submodule re-exports them so ``import vllm.inputs`` always binds a real
+``data`` attribute (subpackages are not auto-loaded on attribute access).
+"""
+
+from .llm import TextPrompt, TokensPrompt
+
+__all__ = ["TextPrompt", "TokensPrompt"]


### PR DESCRIPTION


## Purpose
Ray Data’s LLM batch path expects` vllm.inputs.data.{TextPrompt, TokensPrompt}`. Those types already live in `vllm.inputs.llm`; this PR adds a small `vllm.inputs.data `submodule that re-exports them and imports it from` vllm.inputs` so import` vllm.inputs` always exposes a real data attribute (fixes `AttributeError: module 'vllm.inputs' has no attribute 'data'`).


## Test Plan

- `pytest tests/inputs/test_inputs_data_submodule.py -v`
- `python -c "import vllm.inputs as i; from vllm.inputs.data import TokensPrompt; assert i.data.TokensPrompt is TokensPrompt"`


## Test Result

`tests/inputs/test_inputs_data_submodule.py::test_inputs_data_submodule_exposed PASSED [100%]`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

