### PR TITLE
fix(config): parse compact sentence-transformer pooling mode

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 
 import vllm.config.vllm as vllm_config_module
 import vllm.envs as envs
+import vllm.transformers_utils.config as transformers_config
 from vllm.compilation.backends import VllmBackend
 from vllm.config import (
     CompilationConfig,
@@ -440,6 +441,48 @@ def test_get_pooling_config_from_args():
     model_config = ModelConfig(model_id, pooler_config=pooler_config)
 
     assert asdict(model_config.pooler_config) == asdict(pooler_config)
+
+
+def test_get_pooling_config_reads_compact_pooling_mode(monkeypatch):
+    files = {
+        "modules.json": [
+            {
+                "idx": 0,
+                "name": "0",
+                "path": "0_Transformer",
+                "type": "sentence_transformers.models.Transformer",
+            },
+            {
+                "idx": 1,
+                "name": "1",
+                "path": "1_Pooling",
+                "type": "sentence_transformers.models.Pooling",
+            },
+        ],
+        "1_Pooling/config.json": {"pooling_mode": "mean"},
+    }
+
+    def fake_file_or_path_exists(model, config_name, revision):
+        return config_name in files
+
+    def fake_get_hf_file_to_dict(config_name, model, revision):
+        return files.get(config_name)
+
+    monkeypatch.setattr(
+        transformers_config, "file_or_path_exists", fake_file_or_path_exists
+    )
+    monkeypatch.setattr(
+        transformers_config, "get_hf_file_to_dict", fake_get_hf_file_to_dict
+    )
+
+    transformers_config.get_pooling_config.cache_clear()
+    try:
+        assert transformers_config.get_pooling_config("compact-st-model") == {
+            "use_activation": False,
+            "seq_pooling_type": "MEAN",
+        }
+    finally:
+        transformers_config.get_pooling_config.cache_clear()
 
 
 @pytest.mark.parametrize(

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -839,14 +839,19 @@ def get_pooling_config(
 
         config: dict[str, Any] = {"use_activation": normalize}
         for key, val in pooling_dict.items():
-            if val is True:
+            if key == "pooling_mode" and isinstance(val, str):
+                pooling_type = parse_pooling_type(val)
+            elif val is True:
                 pooling_type = parse_pooling_type(key)
-                if pooling_type in SEQ_POOLING_TYPES:
-                    config["seq_pooling_type"] = pooling_type
-                elif pooling_type in TOK_POOLING_TYPES:
-                    config["tok_pooling_type"] = pooling_type
-                else:
-                    logger.debug("Skipping unrelated field: %r=%r", key, val)
+            else:
+                continue
+
+            if pooling_type in SEQ_POOLING_TYPES:
+                config["seq_pooling_type"] = pooling_type
+            elif pooling_type in TOK_POOLING_TYPES:
+                config["tok_pooling_type"] = pooling_type
+            else:
+                logger.debug("Skipping unrelated field: %r=%r", key, val)
 
         return config
 


### PR DESCRIPTION
## Problem

Sentence-Transformers compact pooling configs can store the pooling type as a `pooling_mode` string in `1_Pooling/config.json`. vLLM only parsed legacy boolean `pooling_mode_*` fields, so compact configs could lose the intended pooling type and fall back to the model default.

## Change

Parse string `pooling_mode` values through the existing pooling type resolver and the same seq/token pooling whitelist used for legacy boolean fields.

## Verification

- `python3 -m py_compile vllm/transformers_utils/config.py tests/test_config.py`
- `ruff check vllm/transformers_utils/config.py tests/test_config.py`
- `ruff format --check vllm/transformers_utils/config.py tests/test_config.py`
- `git diff --check HEAD~1..HEAD`

Focused pytest could not run in this local environment because `tests/conftest.py` requires `tblib`, which is not installed here.

Closes #45995