### PR TITLE
fix(anthropic): auto-detect template support for mid-conversation system messages

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -1096,3 +1096,43 @@ class TestMessageStartIncludesTypeAndRole:
         message = events[0][1]["message"]
         assert message["type"] == "message"
         assert message["role"] == "assistant"
+
+
+# ======================================================================
+# Auto-detection of system-first template requirement
+# ======================================================================
+
+
+Q35_TEMPLATE = (
+    "{%- for message in messages %}"
+    "{%- if message.role == 'system' %}"
+    "{%- if not loop.first %}"
+    "{{- raise_exception('System message must be at the beginning.') }}"
+    "{%- endif %}"
+    "{%- endif %}"
+    "{%- endfor %}"
+)
+
+
+class TestDetectMergeInlineSystem:
+    """Verify _detect_merge_inline_system auto-detection."""
+
+    def test_qwen_template_requires_merge(self):
+        """Qwen-style template with loop.first guard → merge needed."""
+        assert AnthropicServingMessages._detect_merge_inline_system(
+            Q35_TEMPLATE
+        ) is True
+
+    def test_no_restriction_no_merge(self):
+        """Template without restriction → no merge."""
+        assert AnthropicServingMessages._detect_merge_inline_system(
+            (
+                "{%- for message in messages %}"
+                "{{- message.role }}: {{ message.content }}\\n"
+                "{%- endfor %}"
+            )
+        ) is False
+
+    def test_no_template_defaults_merge(self):
+        """None template → safe default: merge."""
+        assert AnthropicServingMessages._detect_merge_inline_system(None) is True

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -99,6 +99,34 @@ class AnthropicServingMessages(OpenAIServingChat):
             "length": "max_tokens",
             "tool_calls": "tool_use",
         }
+        type(self)._merge_inline_system = cls._detect_merge_inline_system(
+            chat_template
+        )
+
+    @classmethod
+    def _detect_merge_inline_system(cls, chat_template: str | None) -> bool:
+        """Auto-detect whether the chat template requires system-first ordering.
+
+        Renders a [system, user, system, user] conversation against the
+        template; if it raises (e.g. Qwen's ``loop.first`` guard), the
+        model needs inline system messages merged into the leading block.
+        """
+        if not chat_template:
+            return True
+        try:
+            from jinja2 import Template
+            Template(chat_template).render(
+                messages=[
+                    {"role": "system", "content": "t"},
+                    {"role": "user", "content": "t"},
+                    {"role": "system", "content": "t"},
+                    {"role": "user", "content": "t"},
+                ],
+                add_generation_prompt=False,
+            )
+            return False
+        except Exception:
+            return True
 
     @staticmethod
     def _convert_image_source_to_url(source: dict[str, Any]) -> str:
@@ -159,6 +187,26 @@ class AnthropicServingMessages(OpenAIServingChat):
                             continue
                         system_parts.append(block.text)
 
+        # When the template requires system-first ordering, extract inline
+        # system messages from the messages array and merge them into the
+        # top-level block so the template doesn't reject them.
+        if cls._merge_inline_system:
+            for msg in anthropic_request.messages:
+                if msg.role != "system":
+                    continue
+                if isinstance(msg.content, str):
+                    text = msg.content
+                    if not text.startswith("x-anthropic-billing-header"):
+                        system_parts.append(text)
+                else:
+                    for block in msg.content:
+                        if block.type == "text" and block.text:
+                            if block.text.startswith(
+                                "x-anthropic-billing-header"
+                            ):
+                                continue
+                            system_parts.append(block.text)
+
         if system_parts:
             openai_messages.append({"role": "system", "content": "".join(system_parts)})
 
@@ -190,6 +238,8 @@ class AnthropicServingMessages(OpenAIServingChat):
             # doesn't strip billing headers and may produce messages with
             # no "content" key.
             if msg.role == "system":
+                if cls._merge_inline_system:
+                    continue  # already merged into top-level by _convert_system_message
                 text = cls._extract_system_text(msg)
                 if text:
                     openai_messages.append({"role": "system", "content": text})


### PR DESCRIPTION
## Problem

#44602 preserves inline `role: system` messages at their original
position for prefix caching. However, some models (e.g., Qwen3.5/3.6)
have chat templates that reject system messages appearing after the
first position (#41114). Without mitigation, these models would
return 400 errors for valid Anthropic requests.

## Fix

Auto-detect whether the chat template supports mid-conversation system
messages by rendering a `[system, user, system, user]` test
conversation at init time:

- Template raises → inline system messages are merged into the
  top-level block (compatible with Qwen and similar models)
- Template succeeds → inline system messages are preserved in-place
  (optimal prefix caching for models that support it)

No flag or configuration needed.

## Changes

2 files, +90 lines:

- `_detect_merge_inline_system()` classmethod — runs Jinja render
  test, caches result as class attribute
- `_convert_system_message()` — when merging, extracts inline system
  messages into the top-level block
- `_convert_messages()` — when merging, skips system messages
  (already handled by `_convert_system_message`)
- Tests: 3 cases (Qwen template, unrestricted template, None
  template)

## Related

- Follow-up to #44602
- Fixes the Qwen compatibility concern from #41114

## Test Plan

(AI assistance was used; I reviewed every changed line.)

```bash
python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py::TestDetectMergeInlineSystem -v
```