### PR TITLE
Update MiMo to use AutoWeightsLoader. Mainly relies on Qwen2's custom…

### DIFF
--- a/vllm/model_executor/models/mimo.py
+++ b/vllm/model_executor/models/mimo.py
@@ -38,14 +38,10 @@ from vllm.distributed import get_pp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
-from vllm.model_executor.model_loader.weight_utils import (
-    default_weight_loader,
-    maybe_remap_kv_scale_name,
-)
 from vllm.model_executor.models.qwen2 import Qwen2ForCausalLM, Qwen2Model
 from vllm.sequence import IntermediateTensors
 
-from .utils import PPMissingLayer, is_pp_missing_parameter, maybe_prefix
+from .utils import AutoWeightsLoader, PPMissingLayer, maybe_prefix
 
 logger = init_logger(__name__)
 
@@ -89,50 +85,6 @@ class MiMoModel(Qwen2Model):
         hidden_states = hidden_states + residual
         return hidden_states
 
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        stacked_params_mapping = [
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-        ]
-        params_dict = dict(self.named_parameters(remove_duplicate=False))
-        loaded_params: set[str] = set()
-        for name, loaded_weight in weights:
-            if "mtp_layers" in name:
-                continue
-            if "rotary_emb.inv_freq" in name:
-                continue
-            for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in name:
-                    continue
-                name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-                if is_pp_missing_parameter(name, self):
-                    continue
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
-                break
-            else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-                # Remapping the name of FP8 kv-scale.
-                name = maybe_remap_kv_scale_name(name, params_dict)
-                if name is None:
-                    continue
-                if is_pp_missing_parameter(name, self):
-                    continue
-                param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight)
-            loaded_params.add(name)
-        return loaded_params
-
 
 class MiMoForCausalLM(Qwen2ForCausalLM, nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -174,3 +126,11 @@ class MiMoForCausalLM(Qwen2ForCausalLM, nn.Module):
         hidden_states = self.model.norm(hidden_states)
         logits = self.logits_processor(self.lm_head, hidden_states)
         return logits
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
+            skip_substrs=["mtp_layers"],
+        )
+        return loader.load_weights(weights)


### PR DESCRIPTION

## Purpose
This is for #15697 . There was an abandoned PR #41692 - I didn't look at it immediately just see where I land but ended up with the same thing eventually.

The `load_weights` override from MiMo is gone (it was simply using a copy of Qwen2's `load_weights` logic with an extra line to skip `mtp_layers`. The `load_weights` is now only in `MiMoForCausalLM` and it skips `mtp_layers` right there and then. The rest is taken care of by `AutoWeightsLoader` (and Qwen2's custom logic).

## Test Plan
  - Verify Python routing and layer-stripping logic locally using the CPU backend on macOS.
  - Created a localized mock of the MiMo architecture with `num_hidden_layers: 1` to bypass the 30GB network download constraints.
   - Injected a dummy `mtp_layers` tensor into the mock safetensors to ensure the generator correctly intercepts and discards it.
   - Run official integration tests via CI (requires NVIDIA GPU).

## Test Result

I am developing on a Mac and do not have a local NVIDIA GPU to run the full pytest suite. I am relying on the CI for the final GPU verification. But I've successfully verified the Python routing logic locally using the CPU backend. The model successfully initialized, properly stripped the MTP layers during the load phase without throwing unmapped weight errors, and completed the strict safety validation phase before moving to warmup.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

