### PR TITLE
[CI/Build][LoRA] Assert sharded merged LoRA routes to _mcp_apply unde…

### DIFF
--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -1757,3 +1757,33 @@ def test_replicated_lora_preserves_base_forward_for_subclasses(
     merged_result = merged_layer(torch.cat(inputs))[0]
 
     torch.testing.assert_close(lora_result, merged_result, rtol=rtol, atol=atol)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("device", DEVICES)
+def test_merged_column_lora_sharded_routes_to_mcp_apply(
+    default_vllm_config, dist_init, device
+) -> None:
+    """Lock the fully-sharded half of the LoRA apply dispatch (see #45691,
+    #45715): MergedColumnParallelLinearWithShardedLoRA.apply must keep routing
+    to _mcp_apply (the S-LoRA all-gather path) and must not fall back to
+    _apply_sync when tp_size > 1."""
+    if current_platform.is_cuda_alike() or current_platform.is_xpu():
+        torch.accelerator.set_device_index(device)
+    torch.set_default_device(device)
+
+    layer = object.__new__(MergedColumnParallelLinearWithShardedLoRA)
+    layer.tp_size = 2
+
+    apply_sync_calls = []
+    layer._apply_sync = (
+        lambda x, bias: apply_sync_calls.append((x, bias)) or torch.zeros(4, 32)
+    )
+
+    x = torch.zeros(4, 16)
+
+    with patch("vllm.lora.layers.column_parallel_linear._mcp_apply") as mock_mcp:
+        layer.apply(x, bias=None)
+
+    assert len(apply_sync_calls) == 0
+    mock_mcp.assert_called_once()


### PR DESCRIPTION
Follow-up to #45715 as suggested in review.

#45715 split the LoRA apply dispatch: non-sharded `MergedColumnParallelLinearWithLoRA` routes to `_apply_sync` (no all-gather), sharded `*WithShardedLoRA` subclasses keep `_mcp_apply` (valid S-LoRA all-gather). #45715 added a test locking the non-sharded half.

This PR adds the symmetric assertion for the sharded half: at tp_size > 1, `MergedColumnParallelLinearWithShardedLoRA.apply` must route to `_mcp_apply` and must not fall back to `_apply_sync`. Guards against a future refactor collapsing the sharded path onto the non-sharded one.

## Test

```python
# verify_46033.py
import ast, os

with open("vllm/lora/layers/column_parallel_linear.py") as f:
    tree = ast.parse(f.read())

for node in ast.walk(tree):
    if not isinstance(node, ast.ClassDef):
        continue
    if node.name == "MergedColumnParallelLinearWithShardedLoRA":
        for item in node.body:
            if isinstance(item, ast.FunctionDef) and item.name == "apply":
                src = ast.dump(item)
                if "_mcp_apply" in src:
                    print("PASS: MergedColumnParallelLinearWithShardedLoRA.apply -> _mcp_apply")
                else:
                    print("FAIL: apply does not route to _mcp_apply")

test_file = "tests/lora/test_layers.py"
if os.path.exists(test_file):
    with open(test_file) as f:
        if "test_merged_column_lora_sharded_routes_to_mcp_apply" in f.read():
            print("PASS: regression test exists")
        else:
            print("FAIL: regression test not found")
```

```
$ python verify_46033.py
PASS: MergedColumnParallelLinearWithShardedLoRA.apply -> _mcp_apply
PASS: regression test exists
```

```
$ pytest tests/lora/test_layers.py::test_merged_column_lora_sharded_routes_to_mcp_apply -v
PASSED
```

Both halves of the dispatch split are now pinned:
- non-sharded -> `_apply_sync` (test from #45715)
- sharded -> `_mcp_apply` (this PR)