### PR TITLE
[KV Connector][Offloading] Disable parallel-agnostic fs-tier cache on V2 model runner

### DIFF
--- a/tests/v1/kv_offload/test_file_mapper.py
+++ b/tests/v1/kv_offload/test_file_mapper.py
@@ -64,6 +64,7 @@ def make_mapper_from_offloading_spec(**kwargs) -> FileMapper:
         "dcp_size", 1
     )
     mock_vllm_config.parallel_config.rank = kwargs.get("rank", 0)
+    mock_vllm_config.use_v2_model_runner = kwargs.get("use_v2_model_runner", False)
 
     mock_kv_cache_config = MagicMock()
     mock_kv_cache_config.kv_cache_groups = kwargs.get("kv_cache_groups", [])
@@ -207,6 +208,19 @@ def test_parallel_agnostic_excludes_mla():
     )
     fm = make_mapper_from_offloading_spec(
         tp_size=2, rank=1, kv_cache_groups=[group], parallel_agnostic=True
+    )
+    assert fm.fields["tp_size"] == 2
+    assert fm.rank == 1
+
+
+def test_parallel_agnostic_disabled_on_v2_model_runner():
+    # V2's KV layout is not known to be parallelism-invariant: don't collapse.
+    fm = make_mapper_from_offloading_spec(
+        tp_size=2,
+        rank=1,
+        kv_cache_groups=[_full_attention_group()],
+        use_v2_model_runner=True,
+        parallel_agnostic=True,
     )
     assert fm.fields["tp_size"] == 2
     assert fm.rank == 1

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -37,6 +37,7 @@ def _make_vllm_config():
             decode_context_parallel_size=1,
             rank=0,
         ),
+        use_v2_model_runner=False,
     )
 
 

--- a/vllm/v1/kv_offload/file_mapper.py
+++ b/vllm/v1/kv_offload/file_mapper.py
@@ -84,10 +84,13 @@ class FileMapper:
         ]
         # Only a single full-attention group is parallelism-invariant. MLA is
         # excluded: its latent KV is replicated per rank, never head-sharded.
+        # The V2 model runner is excluded: its KV layout is not known to be
+        # parallelism-invariant.
         groups = kv_cache_config.kv_cache_groups
         spec = groups[0].kv_cache_spec if len(groups) == 1 else None
         parallel_agnostic = (
             parallel_agnostic
+            and not vllm_config.use_v2_model_runner
             and isinstance(spec, FullAttentionSpec)
             and not isinstance(spec, MLAAttentionSpec)
         )


### PR DESCRIPTION
Disable the parallel-agnostic fs-tier KV cache (#44733) when the V2 model runner is active. The parallelism-invariant assumption it relies on does not hold under V2.
