### PR TITLE
[Bugfix] [Parser] Fix Qwen3 latent bug in partial params dropping values containing `<`

### DIFF
--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -615,6 +615,24 @@ class TestArgConverter:
         assert result["command"] == "ls -la"
         assert result["desc"] == "\npartial value"
 
+    def test_partial_value_with_angle_bracket(self):
+        from vllm.parser.qwen3 import (
+            _qwen3_arg_converter,
+        )
+
+        raw = "<parameter=expr>x<5"
+        result = json.loads(_qwen3_arg_converter(raw, partial=True))
+        assert result == {"expr": "x<5"}
+
+    def test_partial_value_with_angle_bracket_and_complete_param(self):
+        from vllm.parser.qwen3 import (
+            _qwen3_arg_converter,
+        )
+
+        raw = "<parameter=city>Tokyo</parameter>\n<parameter=expr>x<5"
+        result = json.loads(_qwen3_arg_converter(raw, partial=True))
+        assert result == {"city": "Tokyo", "expr": "x<5"}
+
 
 class TestSchemaAwareTypeCoercion:
     """Verify that _fix_arg_types corrects miscoerced values using the

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -49,7 +49,7 @@ _PARAM_RE = re.compile(
     r"(?:<\s*/\s*parameter\s*>|(?=<\s*parameter\s*=))",
     re.DOTALL,
 )
-_PARTIAL_PARAM_RE = re.compile(r"<\s*parameter\s*=\s*([^>]+)>([^<]*)$", re.DOTALL)
+_PARTIAL_PARAM_RE = re.compile(r"<\s*parameter\s*=\s*([^>]+)>(.*)$", re.DOTALL)
 
 
 def _qwen3_arg_converter(raw_args: str, partial: bool) -> str:


### PR DESCRIPTION
## Purpose

In the new Qwen3 parser, `_PARTIAL_PARAM_RE` used `[^<]*$` to capture in-progress parameter content. When a value contained a literal `<` (HTML, code, math like x<5), the regex failed to match entirely. In practice this appears to be handled gracefully by the holdback mechanism. But, it is a latent bug even though I have not been able to trigger that in the real world so far outside of the unit tests here. There could be some specific scenario of generated arguments that triggers this in a live server, so better to clean this up before users hit it.

Fix by changing `[^<]*$` to `(.*)$` so the capture group accepts any character including <.

## Test Plan

### Unit Tests

I added a couple unit tests specifically to reproduce. The test plan below runs those as well as all other parser engine, qwen3 and nemotron_v3 reasoning tests (because the nemotron parser inherits from the qwen one).

```
pytest -v \
  tests/parser/engine/ \
  tests/reasoning/test_qwen3_reasoning_parser.py \
  tests/reasoning/test_nemotron_v3_reasoning_parser.py \
  tests/tool_parsers/test_qwen3coder_tool_parser.py
```

## Test Result

### Unit Tests

```
1762 passed, 2 warnings
```
