### PR TITLE
[ROCm] Fix cumem teardown segfault via ordered MemPool release

### DIFF
--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -8,6 +8,7 @@
 # both of them failed because of cuda context mismatch.
 # not sure why, they are created from a different context.
 # the only successful approach is to call cuda driver API in C.
+import atexit
 import gc
 import os
 from collections.abc import Callable, Iterator
@@ -115,7 +116,62 @@ class CuMemAllocator:
         assert cumem_available, "cumem allocator is not available"
         if CuMemAllocator.instance is None:
             CuMemAllocator.instance = CuMemAllocator()
+            # Ensure MemPool/allocator wrappers are released in a controlled
+            # order before interpreter finalization. Otherwise the final GC may
+            # destroy the pluggable allocator wrapper before its MemPool, and
+            # MemPool teardown (which calls allocator virtual methods to release
+            # cached blocks) hits "pure virtual method called" / SIGSEGV. This
+            # has been observed on ROCm with CUDA graphs captured against the
+            # pool; see release_pools for details.
+            atexit.register(CuMemAllocator._shutdown_singleton)
         return CuMemAllocator.instance
+
+    @staticmethod
+    def _shutdown_singleton() -> None:
+        instance = CuMemAllocator.instance
+        if instance is None:
+            return
+        try:
+            instance.release_pools()
+        except Exception:
+            logger.exception("CuMemAllocator singleton shutdown failed")
+
+    def release_pools(self) -> None:
+        """Drop references to MemPool / pluggable allocators eagerly, in a safe
+        order, so pool destruction is not deferred to interpreter finalization.
+
+        MemPool teardown may invoke allocator virtual methods (e.g. raw_delete)
+        when releasing cached blocks. If the allocator wrappers are dropped
+        first, C++ can hit "pure virtual method called" (or SIGSEGV) during
+        shutdown. This was reproducible on ROCm/HIP when a CUDA graph was
+        captured against the pool: the final GC destroyed the
+        CUDAPluggableAllocator before its MemPool. Pure-torch (default
+        allocator) pools with the same topology tear down cleanly, so this is a
+        destruction-ordering issue specific to the pluggable allocator path.
+        """
+        if not self.allocator_and_pools:
+            return
+
+        # Keep allocators alive while MemPool objects are destroyed.
+        pool_entries = list(self.allocator_and_pools.values())
+        self.allocator_and_pools.clear()
+
+        mem_pools = [entry[0] for entry in pool_entries]
+        allocators = [entry[1] for entry in pool_entries]
+        pool_entries.clear()
+
+        try:
+            torch.cuda.synchronize()
+        except Exception:
+            logger.debug("torch.cuda.synchronize() failed during release_pools")
+
+        # Phase 1: drop MemPool refs while allocators are still strongly held.
+        mem_pools.clear()
+        gc.collect()
+
+        # Phase 2: now it is safe to release allocator wrappers.
+        allocators.clear()
+        gc.collect()
 
     def __init__(self):
         self.pointer_to_data: dict[int, AllocationData] = {}


### PR DESCRIPTION
## Purpose

On ROCm, `CuMemAllocator` (sleep mode) can crash at **interpreter shutdown** with `"pure virtual method called"` / `SIGSEGV` whenever the pluggable cumem allocator has been used together with CUDA graphs. The crash happens entirely inside torch's HIP caching allocator during finalization (`at::cuda::MemPool` dealloc → `HIPCachingAllocator::emptyCache` → `release_block` from `Py_FinalizeEx`), with no vLLM frames on the stack. It reproduces without any `sleep()` call — a cumem pool plus a CUDA graph captured against it is enough.

**Root cause is a destruction-ordering problem.** `CuMemAllocator` keeps a `(MemPool, CUDAPluggableAllocator)` tuple per tag in `allocator_and_pools`. When those references are dropped together at the final GC during interpreter finalization, the GC may destroy the `CUDAPluggableAllocator` **before** its `MemPool`. `MemPool` teardown, however, calls allocator virtual methods (e.g. `raw_delete`) to release cached blocks, so destroying the allocator first results in a virtual call on a half-destroyed C++ object → `"pure virtual method called"` / `SIGSEGV`.

This was confirmed on MI300 (gfx942): a pluggable `MemPool` with a CUDA graph captured against it crashes on teardown, while a **pure-torch default-allocator pool with the identical topology** (two pools + a graph spanning them) tears down cleanly. That isolates the issue to the pluggable-allocator destruction *order*, not a general HIP bug.

**Fix:** register an `atexit`-driven `release_pools()` that drops the references in a controlled, two-phase order while CUDA/HIP is still alive:

1. destroy `MemPool` objects while the allocator wrappers are still strongly held, then `gc.collect()`;
2. only then release the allocator wrappers.

Running it from `atexit` ensures the ordered release happens before the interpreter's final GC, so nothing crash-prone is left for finalization. This **mirrors the existing XPU implementation** in `vllm/device_allocator/xpumem.py::release_pools` (added in #37149), which documents the same `"pure virtual method called during shutdown"` symptom. The change is additive and there is **no behavior change on CUDA**.

## Test Plan

- ROCm / MI300 (gfx942).
- Run the cumem allocator correctness tests, which previously crashed at interpreter teardown:

```bash
pytest -v tests/basic_correctness/test_mem.py::test_basic_cumem
pytest -v tests/basic_correctness/test_mem.py::test_cumem_with_cudagraph
pytest -v tests/basic_correctness/test_mem.py
```

- Verify the process exits cleanly (exit code 0, no `SIGSEGV` / `SIGABRT` / `"pure virtual method called"` at shutdown).

## Test Result

- `test_basic_cumem` and `test_cumem_with_cudagraph` — which previously crashed at interpreter shutdown — now pass and tear down cleanly (exit code 0, no `SIGSEGV` / `"pure virtual method called"`).
- No regression observed on the default (non-pluggable) allocator path.

### Scope note

This PR targets only the **teardown destruction-ordering** crash. There is a **separate, pre-existing intermittent crash** in `test_python_error`: a double-free of allocation handles on the OOM `wake_up()` path (`hipMemRelease` on an already-released handle), which is timing-dependent and so passes on some runs and crashes on others (seen on both the jammy `vllm-dev:base` and `nightly-therock` images). That is **not** addressed here — it has a distinct root cause in the C extension (`csrc/cumem_allocator.cpp`) and is fixed in the follow-up PR #46054. With both this change and #46054 applied, the full `tests/basic_correctness/test_mem.py` passes 8/8 with no teardown segfault.
