### PR TITLE
Temporarily remove @markmc from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,16 +120,6 @@
 /vllm/model_executor/models/transformers @hmellor
 /tests/models/test_transformers.py @hmellor
 
-# Observability
-/vllm/config/observability.py @markmc
-/vllm/v1/metrics @markmc
-/tests/v1/metrics @markmc
-/vllm/tracing.py @markmc
-/tests/v1/tracing/test_tracing.py @markmc
-/vllm/config/kv_events.py @markmc
-/vllm/distributed/kv_events.py @markmc
-/tests/distributed/test_events.py @markmc
-
 # Docs
 /docs/mkdocs @hmellor
 /docs/**/*.yml @hmellor


### PR DESCRIPTION
Removing myself temporarily while I'm on leave.

For reference, much of the current observability review backlog is tracked by:

- https://github.com/orgs/vllm-project/projects/44 - Prometheus metrics
- https://github.com/orgs/vllm-project/projects/55 - OpenTelemetry tracing
