### PR TITLE
[ROCm] Fix cumem OOM double-free of allocation handles

### DIFF
--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -174,9 +174,13 @@ void create_and_map(unsigned long long device, ssize_t size, CUdeviceptr d_mem,
   for (auto i = 0; i < num_chunks; ++i) {
     CUDA_CHECK(cuMemCreate(p_memHandle[i], chunk_sizes[i], &prop, 0));
     if (error_code != 0) {
-      // Clean up previously created handles
+      // Clean up previously created handles. Zero each handle after release
+      // so a later unmap_and_release (e.g. at teardown after a failed wake_up
+      // OOM) does not release the same handle again and crash with a double
+      // free (hipMemRelease on an already-freed handle).
       for (auto j = 0; j < i; ++j) {
         cuMemRelease(*(p_memHandle[j]));
+        *(p_memHandle[j]) = 0;
       }
       return;
     }
@@ -193,9 +197,11 @@ void create_and_map(unsigned long long device, ssize_t size, CUdeviceptr d_mem,
         cuMemUnmap(unmap_addr, chunk_sizes[j]);
         unmapped_size += chunk_sizes[j];
       }
-      // release all created handles
+      // release all created handles; zero each so a later unmap_and_release
+      // cannot release the same handle again (double free).
       for (auto j = 0; j < num_chunks; ++j) {
         cuMemRelease(*(p_memHandle[j]));
+        *(p_memHandle[j]) = 0;
       }
       return;
     }
@@ -241,6 +247,14 @@ void unmap_and_release(unsigned long long device, ssize_t size,
   CUresult first_error = no_error;
 
   for (auto i = 0; i < num_chunks; ++i) {
+    // A zero handle marks a chunk that is not live (e.g. it was released by
+    // create_and_map's cleanup after a failed wake_up OOM). Such a chunk was
+    // never (re)mapped, so skip it; unmapping/releasing a stale handle again
+    // would double-free and crash (hipMemRelease on an already-freed handle).
+    if (*(p_memHandle[i]) == 0) {
+      allocated_size += chunk_sizes[i];
+      continue;
+    }
     void* map_addr = (void*)((uintptr_t)d_mem + allocated_size);
     CUresult status = cuMemUnmap(map_addr, chunk_sizes[i]);
     if (status != no_error && first_error == no_error) {
@@ -250,10 +264,14 @@ void unmap_and_release(unsigned long long device, ssize_t size,
   }
 
   for (auto i = 0; i < num_chunks; ++i) {
+    if (*(p_memHandle[i]) == 0) {
+      continue;
+    }
     CUresult status = cuMemRelease(*(p_memHandle[i]));
     if (status != no_error && first_error == no_error) {
       first_error = status;
     }
+    *(p_memHandle[i]) = 0;
   }
 
   if (first_error != no_error) {


### PR DESCRIPTION
## Purpose

On ROCm, `test_python_error` crashes **intermittently** at process teardown — it passes on some runs and crashes (`SIGSEGV` / `SIGABRT`) on others. This was observed on **both** the jammy `vllm-dev:base` and the `nightly-therock` images (the latest `nightly-therock` CI run hit it too).

**Root cause is a double-free of allocation handles on the OOM `wake_up()` path.** When an allocation fails (OOM), `create_and_map()` cleans up by releasing the partially-created handles with `cuMemRelease`, but it leaves the released handle values non-zero. A later `unmap_and_release()` (e.g. during teardown) then iterates the same handles and releases them **again** → `cuMemRelease` / `hipMemRelease` on an already-freed handle → double free → crash. Because it depends on teardown timing, it manifests only on some runs, which is why `test_python_error` is flaky rather than consistently failing.

**Fix:** make handle release idempotent.
- `create_and_map()` zeroes each handle right after `cuMemRelease` in its OOM/error cleanup paths.
- `unmap_and_release()` skips handles that are zero (already released, or never mapped) and zeroes each handle after releasing it.

A zero handle now reliably marks a chunk that is not live, so no handle is ever released twice. The change is confined to the ROCm/CUDA cumem C extension (`csrc/cumem_allocator.cpp`) and does not alter the success-path behavior.

This is a **separate root cause** from the teardown destruction-ordering crash fixed in #46050 (that one is a Python-level GC ordering issue in `cumem.py`; this one is a C-level double-free on the OOM path). Both are needed for the full `test_mem.py` suite to pass cleanly.

## Test Plan

- ROCm / MI300 (gfx942).
- Run the previously-flaky test repeatedly to confirm the intermittent crash is gone:

```bash
for i in 1 2 3; do pytest -q tests/basic_correctness/test_mem.py::test_python_error; done
```

- Run the full module to confirm no teardown segfault at session end:

```bash
pytest -v tests/basic_correctness/test_mem.py
```

- Verify clean exit (exit code 0, no `SIGSEGV` / `SIGABRT` / double-free).

## Test Result

- `test_python_error`: **3/3 passed**, exit code 0 each run (previously intermittent crash).
- Full `tests/basic_correctness/test_mem.py`: **8/8 passed**, exit code 0, no teardown segfault (with the teardown-ordering fix #46050 also applied).
- No change to the allocator success path.
