### PR TITLE
[Bugfix][Model] Fix Qwen3-Omni crash when audio and image coexist in interleaved path

### DIFF
--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -1893,7 +1893,8 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
             if is_interleaved:
                 # Use input_ids-based mask for correct vision positions
                 # when audio and video tokens are interleaved.
-                is_vision = is_video.clone()
+                is_vision = is_video.clone() | ( is_multimodal & (input_ids_cpu == self.config.image_token_id))
+
             else:
                 is_vision = torch.zeros_like(is_multimodal)
                 mm_positions = torch.nonzero(is_multimodal, as_tuple=True)[0]


### PR DESCRIPTION
## Summary

Fix Qwen3-Omni-MoE deepstack merging when interleaved video/audio inputs also contain image placeholders.

When `use_audio_in_video=True`, the interleaved path builds the deepstack vision mask from video tokens only:

```python
is_vision = is_video.clone()
```

That misses image token positions when a request also contains images, for example images inserted in tool responses. The deepstack multimodal merge then sees fewer vision placeholders than vision embeddings and can fail with:

```text
ValueError: Attempted to assign N+M multimodal tokens to N placeholders
```

This patch includes `image_token_id` positions in the interleaved `is_vision` mask, matching the behavior of the non-interleaved path where both image and video embeddings are marked as vision positions.

## Changes

- Include image placeholder positions in the Qwen3-Omni-MoE interleaved deepstack vision mask.
- Leave audio positions excluded from the vision mask.
- Confirmed `vllm/model_executor/models/qwen3_omni_thinker.py` is not present on the upstream default branch, so only the MoE thinker file is patched.

## Validation

- Inspected the upstream default branch implementation.
- Verified the target line is in `vllm/model_executor/models/qwen3_omni_moe_thinker.py`.
- Could not run the full test suite in this environment because the local shell cannot connect to GitHub to clone the repository.

cc @huachenheli @linyueqian @Isotr0py @ywang96
