### PR TITLE
docs: clarify uv-specific install options

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -26,6 +26,9 @@ This guide will help you quickly get started with vLLM to perform:
 
     `uv` can [automatically select the appropriate PyTorch index at runtime](https://docs.astral.sh/uv/guides/integration/pytorch/#automatic-backend-selection) by inspecting the installed CUDA driver version via `--torch-backend=auto` (or `UV_TORCH_BACKEND=auto`). To select a specific backend (e.g., `cu126`), set `--torch-backend=cu126` (or `UV_TORCH_BACKEND=cu126`).
 
+    !!! note
+        Options such as `--torch-backend` and `--index-strategy` are specific to `uv pip install`. If you use `pip install` directly, omit these options and use the `pip` command from the [CUDA installation guide](installation/gpu.md#pre-built-wheels).
+
     Another delightful way is to use `uv run` with `--with [dependency]` option, which allows you to run commands such as `vllm serve` without creating any permanent environment:
 
     ```bash


### PR DESCRIPTION

Clarifies that `--torch-backend` and `--index-strategy` are `uv pip install` options, and points direct `pip install` users to the CUDA installation guide command.

## Purpose

Fixes #39462 by making the Quickstart installation section explicit about which installer supports the advanced index/backend options.

## Test Plan

- Verified the Quickstart markdown contains the new note and CUDA installation guide link with a small `python3` assertion.

## Test Result

```text
docs quickstart note present
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0). Not applicable for this small docs clarification.
</details>

