### PR TITLE
[ROCm][Perf] MiniMax-M3 MXFP8 gemm/group gemm dispatch AITER

### DIFF
--- a/vllm/model_executor/kernels/linear/mxfp8/rocm_native.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/rocm_native.py
@@ -27,6 +27,12 @@ from .Mxfp8LinearKernel import Mxfp8LinearKernel, Mxfp8LinearLayerConfig
 
 logger = init_logger(__name__)
 
+# Optional aiter small-M HIP GEMV (gfx950). Imported once; absent -> Triton.
+try:
+    from aiter.ops.smallm_gemm_mxfp8 import mxfp8_gemv as _aiter_smallm_gemv
+except ImportError:
+    _aiter_smallm_gemv = None
+
 
 @triton.jit
 def _mxfp8_linear_kernel(
@@ -92,21 +98,17 @@ def _mxfp8_dot_scaled_linear(
     M, K = x.shape
     N = w.shape[0]
     x_q, x_scale = mxfp8_e4m3_quantize(x)
-    # aiter small-M HIP path (gfx950); returns None outside its measured
-    # envelope (or on failure), so this degrades cleanly to Triton.
-    if rocm_aiter_ops.is_linear_enabled():
-        try:
-            from aiter.ops.smallm_gemm_mxfp8 import mxfp8_gemv as _aiter_smallm_gemv
-
-            aiter_out = _aiter_smallm_gemv(x_q, x_scale, w, w_scale, x.dtype)
-            if aiter_out is not None:
-                logger.info_once(
-                    "MiniMax-M3 MXFP8 dense linear: using aiter small-M HIP GEMV."
-                )
-                return aiter_out
-        except Exception as err:
-            logger.debug("aiter dense GEMV failed, falling back to Triton: %s", err)
-    elif current_platform.supports_mx():
+    # aiter small-M HIP path (gfx950). The wrapper does the explicit shape gating
+    # (arch, K alignment, allowlist) and returns None on a miss, so this is a
+    # plain None-check -- no try/except.
+    if _aiter_smallm_gemv is not None and rocm_aiter_ops.is_linear_enabled():
+        aiter_out = _aiter_smallm_gemv(x_q, x_scale, w, w_scale, x.dtype)
+        if aiter_out is not None:
+            logger.info_once(
+                "MiniMax-M3 MXFP8 dense linear: using aiter small-M HIP GEMV."
+            )
+            return aiter_out
+    elif _aiter_smallm_gemv is not None and current_platform.supports_mx():
         # On gfx950 the slower Triton dot_scaled path runs when aiter is off;
         # surface it once so silent non-engagement is visible in the log.
         logger.info_once(

--- a/vllm/model_executor/kernels/linear/mxfp8/rocm_native.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/rocm_native.py
@@ -12,6 +12,8 @@ matrix cores. Falls back (via the kernel selector) to the BF16
 import torch
 from torch.nn.parameter import Parameter
 
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     MXFP8_BLOCK_SIZE,
     MXFP8_SCALE_DTYPE,
@@ -22,6 +24,8 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 from .Mxfp8LinearKernel import Mxfp8LinearKernel, Mxfp8LinearLayerConfig
+
+logger = init_logger(__name__)
 
 
 @triton.jit
@@ -88,6 +92,27 @@ def _mxfp8_dot_scaled_linear(
     M, K = x.shape
     N = w.shape[0]
     x_q, x_scale = mxfp8_e4m3_quantize(x)
+    # aiter small-M HIP path (gfx950); returns None outside its measured
+    # envelope (or on failure), so this degrades cleanly to Triton.
+    if rocm_aiter_ops.is_linear_enabled():
+        try:
+            from aiter.ops.smallm_gemm_mxfp8 import mxfp8_gemv as _aiter_smallm_gemv
+
+            aiter_out = _aiter_smallm_gemv(x_q, x_scale, w, w_scale, x.dtype)
+            if aiter_out is not None:
+                logger.info_once(
+                    "MiniMax-M3 MXFP8 dense linear: using aiter small-M HIP GEMV."
+                )
+                return aiter_out
+        except Exception as err:
+            logger.debug("aiter dense GEMV failed, falling back to Triton: %s", err)
+    elif current_platform.supports_mx():
+        # On gfx950 the slower Triton dot_scaled path runs when aiter is off;
+        # surface it once so silent non-engagement is visible in the log.
+        logger.info_once(
+            "MiniMax-M3 MXFP8 dense linear: aiter HIP GEMV available but "
+            "VLLM_ROCM_USE_AITER is not set; using the Triton dot_scaled path."
+        )
     out = torch.empty((M, N), dtype=x.dtype, device=x.device)
     # Regime-gated launch tiles for gfx950, tuned at MiniMax-M3 shapes:
     # for example, 8k/1k, 1k/1k

--- a/vllm/model_executor/layers/fused_moe/experts/mxfp8_native_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/mxfp8_native_moe.py
@@ -35,6 +35,12 @@ from vllm.triton_utils import tl, triton
 
 logger = init_logger(__name__)
 
+# Optional aiter small-M HIP grouped GEMM (gfx950). Imported once; absent -> Triton.
+try:
+    from aiter.ops.smallm_gemm_mxfp8 import grouped_gemm_mxfp8 as _aiter_smallm_moe
+except ImportError:
+    _aiter_smallm_moe = None
+
 
 @triton.jit
 def _mxfp8_grouped_gemm_kernel(
@@ -227,51 +233,47 @@ def _grouped_gemm_mxfp8(
     num_warps: int = 8,
     num_stages: int = 2,
 ) -> torch.Tensor:
-    """Decode grouped GEMM dispatcher: try the aiter small-M HIP kernel, else
-    fall back to the Triton ``dot_scaled`` path.
+    """Decode grouped GEMM dispatcher: the aiter small-M HIP kernel, else the
+    Triton ``dot_scaled`` path.
 
-    The aiter wrapper returns ``None`` when the shape is outside its measured
-    envelope (or on any failure), so this degrades cleanly. Expert parallelism
-    (``expert_map`` set) always uses Triton. ``block_n``/``num_warps``/
-    ``num_stages`` tune only the Triton fallback (the aiter kernel autotunes its
-    own tiles).
+    The aiter wrapper does the explicit shape gating (arch, K alignment, 2 GB
+    raw-buffer guard, allowlist) and returns ``None`` on a miss, so this is a
+    plain ``None``-check -- no try/except. Expert parallelism (``expert_map``
+    set) always uses Triton. ``block_n``/``num_warps``/``num_stages`` tune only
+    the Triton fallback (the aiter kernel autotunes its own tiles).
     """
     if (
-        topk_ids is not None
+        _aiter_smallm_moe is not None
+        and topk_ids is not None
         and expert_map is None
         and rocm_aiter_ops.is_fused_moe_enabled()
     ):
-        try:
-            from aiter.ops.smallm_gemm_mxfp8 import (
-                grouped_gemm_mxfp8 as _aiter_smallm_moe,
+        out = _aiter_smallm_moe(
+            a_q,
+            a_scale,
+            w,
+            w_scale,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            num_valid_tokens,
+            top_k,
+            block_m,
+            out_dtype,
+            a_div,
+            mul_weight_by,
+            topk_ids=topk_ids,
+        )
+        if out is not None:
+            logger.info_once(
+                "MiniMax-M3 MXFP8 decode MoE: using aiter small-M HIP grouped GEMM."
             )
-
-            out = _aiter_smallm_moe(
-                a_q,
-                a_scale,
-                w,
-                w_scale,
-                sorted_token_ids,
-                expert_ids,
-                num_tokens_post_padded,
-                num_valid_tokens,
-                top_k,
-                block_m,
-                out_dtype,
-                a_div,
-                mul_weight_by,
-                topk_ids=topk_ids,
-            )
-            if out is not None:
-                logger.info_once(
-                    "MiniMax-M3 MXFP8 decode MoE: using aiter small-M HIP grouped GEMM."
-                )
-                return out
-        except Exception as err:
-            logger.debug(
-                "aiter MoE grouped GEMM failed, falling back to Triton: %s", err
-            )
-    elif expert_map is None and current_platform.supports_mx():
+            return out
+    elif (
+        _aiter_smallm_moe is not None
+        and expert_map is None
+        and current_platform.supports_mx()
+    ):
         # On gfx950 with aiter disabled the slower Triton dot_scaled path runs;
         # surface it once so silent non-engagement is visible in the log.
         logger.info_once(

--- a/vllm/model_executor/layers/fused_moe/experts/mxfp8_native_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/mxfp8_native_moe.py
@@ -19,6 +19,7 @@ and the top-k weighted reduction run in PyTorch between/after the two GEMMs.
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.experts.mxfp8_emulation_moe import (
     Mxfp8TritonExpertsBase,
@@ -125,7 +126,7 @@ def _mxfp8_grouped_gemm_kernel(
     )
 
 
-def _grouped_gemm_mxfp8(
+def _grouped_gemm_mxfp8_triton(
     a_q: torch.Tensor,  # [M, K] fp8 e4m3
     a_scale: torch.Tensor,  # [M, K//32] uint8 (E8M0)
     w: torch.Tensor,  # [E, N, K] fp8 e4m3
@@ -206,6 +207,98 @@ def _mxfp8_moe_tiles(num_tokens: int) -> dict:
     return _MXFP8_DECODE_TILES
 
 
+def _grouped_gemm_mxfp8(
+    a_q: torch.Tensor,
+    a_scale: torch.Tensor,
+    w: torch.Tensor,
+    w_scale: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    num_valid_tokens: int,
+    top_k: int,
+    block_m: int,
+    out_dtype: torch.dtype,
+    a_div: int,
+    mul_weight_by: torch.Tensor | None = None,
+    expert_map: torch.Tensor | None = None,
+    topk_ids: torch.Tensor | None = None,
+    block_n: int = 128,
+    num_warps: int = 8,
+    num_stages: int = 2,
+) -> torch.Tensor:
+    """Decode grouped GEMM dispatcher: try the aiter small-M HIP kernel, else
+    fall back to the Triton ``dot_scaled`` path.
+
+    The aiter wrapper returns ``None`` when the shape is outside its measured
+    envelope (or on any failure), so this degrades cleanly. Expert parallelism
+    (``expert_map`` set) always uses Triton. ``block_n``/``num_warps``/
+    ``num_stages`` tune only the Triton fallback (the aiter kernel autotunes its
+    own tiles).
+    """
+    if (
+        topk_ids is not None
+        and expert_map is None
+        and rocm_aiter_ops.is_fused_moe_enabled()
+    ):
+        try:
+            from aiter.ops.smallm_gemm_mxfp8 import (
+                grouped_gemm_mxfp8 as _aiter_smallm_moe,
+            )
+
+            out = _aiter_smallm_moe(
+                a_q,
+                a_scale,
+                w,
+                w_scale,
+                sorted_token_ids,
+                expert_ids,
+                num_tokens_post_padded,
+                num_valid_tokens,
+                top_k,
+                block_m,
+                out_dtype,
+                a_div,
+                mul_weight_by,
+                topk_ids=topk_ids,
+            )
+            if out is not None:
+                logger.info_once(
+                    "MiniMax-M3 MXFP8 decode MoE: using aiter small-M HIP grouped GEMM."
+                )
+                return out
+        except Exception as err:
+            logger.debug(
+                "aiter MoE grouped GEMM failed, falling back to Triton: %s", err
+            )
+    elif expert_map is None and current_platform.supports_mx():
+        # On gfx950 with aiter disabled the slower Triton dot_scaled path runs;
+        # surface it once so silent non-engagement is visible in the log.
+        logger.info_once(
+            "MiniMax-M3 MXFP8 decode MoE: aiter HIP kernel available but "
+            "VLLM_ROCM_USE_AITER is not set; using the Triton dot_scaled path."
+        )
+    return _grouped_gemm_mxfp8_triton(
+        a_q,
+        a_scale,
+        w,
+        w_scale,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        num_valid_tokens,
+        top_k,
+        block_m,
+        out_dtype,
+        a_div,
+        mul_weight_by,
+        expert_map,
+        block_n=block_n,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+
 def fused_moe_mxfp8_native(
     hidden_states: torch.Tensor,  # [T, H] bf16
     w13: torch.Tensor,  # [E, 2I, H] fp8
@@ -254,6 +347,7 @@ def fused_moe_mxfp8_native(
         block_n=tiles["block_n"],
         num_warps=tiles["num_warps"],
         num_stages=tiles["num_stages"],
+        topk_ids=topk_ids,
     )  # [M, 2I]
 
     # SwiGLU-OAI (split layout: gate=g1[:, :I], up=g1[:, I:]) FUSED with the
@@ -285,6 +379,7 @@ def fused_moe_mxfp8_native(
         block_n=tiles["block_n"],
         num_warps=tiles["num_warps"],
         num_stages=tiles["num_stages"],
+        topk_ids=topk_ids,
     )  # [M, H] == [T*top_k, H]
 
     return g2.view(T, top_k, H).sum(dim=1).to(hidden_states.dtype)


### PR DESCRIPTION
## Summary

Dispatch the MiniMax-M3 native MXFP8 **decode** path (dense linear + MoE grouped GEMM) to the aiter small-M HIP kernels on **gfx950 (MI355X / CDNA4)**, with the existing Triton `dot_scaled` path kept as a clean fallback. 

- **MoE** (`experts/mxfp8_native_moe.py`): rename the Triton grouped GEMM to `_grouped_gemm_mxfp8_triton`; add a `_grouped_gemm_mxfp8` dispatcher that tries `aiter.ops.smallm_gemm_mxfp8.grouped_gemm_mxfp8` when `rocm_aiter_ops.is_fused_moe_enabled()` and there is no `expert_map`; thread `topk_ids` into both call sites.
- **Dense** (`kernels/linear/mxfp8/rocm_native.py`): in `_mxfp8_dot_scaled_linear`, try `aiter.ops.smallm_gemm_mxfp8.mxfp8_gemv` after activation quant.

The aiter wrappers return `None` outside their measured small-M envelope (or on any failure → `logger.debug`), so the path **degrades cleanly to Triton**. An `info_once` reports engagement, and (on gfx950 with aiter disabled) reports that the slower Triton path is running — so silent non-engagement is visible.

> **Engagement gate.** **Serve with `VLLM_ROCM_USE_AITER=1`** (the main aiter toggle, default off) or both paths stay on Triton. The existing per-category `VLLM_ROCM_USE_AITER_LINEAR` / `VLLM_ROCM_USE_AITER_MOE` flags (default on) are the second half of `is_linear_enabled()` / `is_fused_moe_enabled()`, but you normally don't touch them — the main flag alone enables both dispatchers.

## Dependency

Requires the paired **aiter PR [(ROCm/aiter #3783)](https://github.com/ROCm/aiter/pull/3783)** which adds `aiter.ops.smallm_gemm_mxfp8`. With an older/absent aiter, both dispatchers return `None` and the model runs on Triton unchanged.

## Performance (MI355X, TP8, non-MTP, decode)

Engaging the HIP kernels vs **current upstream `main`** (its own MXFP8 Triton decode tiles: dense `64,64,4,2`, MoE `block_n=64`), median decode TPOT:

**1k/1k:**
| conc | TPOT ms | tok/s | speedup |
|---|---|---|---|
| 1  | 14.83 → 8.67  | 67 → 114   | **1.71×** |
| 2  | 15.13 → 9.46  | 131 → 209  | 1.60× |
| 4  | 15.59 → 10.94 | 253 → 360  | 1.43× |
| 8  | 16.06 → 13.92 | 490 → 564  | 1.15× |
| 32 | 23.05 → 20.28 | 1388 → 1578 | 1.14× |

**8k/1k:**
| conc | TPOT ms | tok/s | speedup |
|---|---|---|---|
| 1  | 14.90 → 8.78  | 66 → 110   | **1.70×** |
| 2  | 15.34 → 9.67  | 127 → 198  | 1.59× |
| 4  | 16.07 → 11.44 | 236 → 324  | 1.40× |
| 8  | 17.37 → 17.34 | 429 → 431  | 1.01× |
| 32 | 30.86 → 28.15 | 1037 → 1137 | 1.10× |

**Up to ~1.7× decode TPOT at low concurrency (M≤64)**, tapering to ~parity by c=8–16 as the per-token GEMM leaves the small-M regime. Out-of-envelope (M>64) is unchanged (Triton). The win is a **low-concurrency / interactive-decode**
optimization, single-variable (HIP engagement toggled in place; everything else byte-identical).

## Accuracy

GSM8K (5-shot, greedy) with HIP engaged: **99/100 (99.0%)** — matches the Triton baseline; the kernels are numerically equivalent (op-level relerr ≈ 1.7e-3).

## Tests run

**Unit (numerics, gfx950):**
```bash
pytest tests/kernels/test_minimax_m3_amd_ops.py -v   # native MXFP8 linear + MoE
```

**Serve + confirm engagement (gfx950, TP8):**
```bash
VLLM_ROCM_USE_AITER=1 vllm serve $MODEL --served-model-name minimaxm3 --port 30001 \
  --tensor-parallel-size 8 --gpu-memory-utilization 0.9 --max-model-len 32768 \
  --block-size 128 --no-enable-prefix-caching --language-model-only \
  --kv-cache-dtype fp8 --attention-backend TRITON_ATTN
# expect in the server log:
#   "MiniMax-M3 MXFP8 decode MoE:  using aiter small-M HIP grouped GEMM."
#   "MiniMax-M3 MXFP8 dense linear: using aiter small-M HIP GEMV."
```

**Accuracy — GSM8K 5-shot (chat template), greedy → 99/100 (99.0%):**
```bash
lm_eval --model local-chat-completions --tasks gsm8k --num_fewshot 5 \
  --apply_chat_template \
  --model_args model=minimaxm3,base_url=http://localhost:30001/v1/chat/completions
```

**Decode TPOT sweep (the table above; sweep `--max-concurrency` 1..32):**
```bash
python benchmarks/benchmark_serving.py --model minimaxm3 --backend vllm \
  --base-url http://localhost:30001 --dataset-name random \
  --random-input-len 1024 --random-output-len 1024 --random-range-ratio 1.0 \
  --num-prompts 80 --max-concurrency 1 --request-rate inf --ignore-eos \
  --use-chat-template --tokenizer $MODEL
```

**Graceful fallback (omit the flag → Triton, identical output):**
```bash
vllm serve $MODEL ...   # without VLLM_ROCM_USE_AITER=1
# log shows: "... aiter HIP ... available but VLLM_ROCM_USE_AITER is not set;
#             using the Triton dot_scaled path."  -> runs on Triton, no crash.
```

Result: unit tests pass; GSM8K **99/100** with engagement confirmed; the sweep reproduces the table; fallback runs cleanly with identical output. The speedup was isolated single-variable (HIP on vs forced-Triton, same image).

## AI assistance

This change was prepared with AI assistance (Claude). A human author has reviewed every line, owns the design, and is responsible for the build/test validation above.

