### PR TITLE
[Config] Reject negative values for max_logprobs and long_prefill_token_threshold

### DIFF
--- a/tests/config/test_config_negative_validation.py
+++ b/tests/config/test_config_negative_validation.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests that config fields reject negative values where they are not valid.
+
+Covers the field_validator guards added for max_logprobs (ModelConfig) and
+long_prefill_token_threshold (SchedulerConfig) per issue #43985.
+"""
+import pytest
+from pydantic import ValidationError
+
+from vllm.config.model import ModelConfig
+from vllm.config.scheduler import SchedulerConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_scheduler(**kwargs) -> SchedulerConfig:
+    """Construct a minimal SchedulerConfig for validation testing."""
+    defaults = dict(max_model_len=4096, is_encoder_decoder=False)
+    defaults.update(kwargs)
+    return SchedulerConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# ModelConfig.max_logprobs
+# ---------------------------------------------------------------------------
+
+class TestMaxLogprobs:
+    def test_positive_accepted(self):
+        mc = ModelConfig(model="facebook/opt-125m", max_logprobs=5)
+        assert mc.max_logprobs == 5
+
+    def test_zero_accepted(self):
+        mc = ModelConfig(model="facebook/opt-125m", max_logprobs=0)
+        assert mc.max_logprobs == 0
+
+    def test_minus_one_accepted(self):
+        # -1 is the sentinel meaning "derive from vocab size"
+        mc = ModelConfig(model="facebook/opt-125m", max_logprobs=-1)
+        assert mc.max_logprobs == -1
+
+    def test_default_accepted(self):
+        mc = ModelConfig(model="facebook/opt-125m")
+        assert mc.max_logprobs == 20
+
+    @pytest.mark.parametrize("bad", [-2, -5, -100])
+    def test_negative_rejected(self, bad):
+        with pytest.raises(ValidationError, match="max_logprobs"):
+            ModelConfig(model="facebook/opt-125m", max_logprobs=bad)
+
+
+# ---------------------------------------------------------------------------
+# SchedulerConfig.long_prefill_token_threshold
+# ---------------------------------------------------------------------------
+
+class TestLongPrefillTokenThreshold:
+    def test_zero_accepted(self):
+        sc = make_scheduler(long_prefill_token_threshold=0)
+        assert sc.long_prefill_token_threshold == 0
+
+    def test_positive_accepted(self):
+        sc = make_scheduler(long_prefill_token_threshold=512)
+        assert sc.long_prefill_token_threshold == 512
+
+    def test_default_accepted(self):
+        sc = make_scheduler()
+        # default is 0 (off)
+        assert sc.long_prefill_token_threshold == 0
+
+    @pytest.mark.parametrize("bad", [-1, -5, -1000])
+    def test_negative_rejected(self, bad):
+        with pytest.raises(ValidationError, match="long_prefill_token_threshold"):
+            make_scheduler(long_prefill_token_threshold=bad)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -742,6 +742,16 @@ class ModelConfig:
             return value
         return handler(value)
 
+    @field_validator("max_logprobs", mode="after")
+    @classmethod
+    def _check_max_logprobs(cls, v: int) -> int:
+        if v == -1 or v >= 0:
+            return v
+        raise ValueError(
+            f"max_logprobs must be a non-negative integer or -1 "
+            f"(auto-derive to vocab size), got {v}."
+        )
+
     @field_validator("tokenizer_mode", mode="after")
     def _lowercase_tokenizer_mode(cls, tokenizer_mode: str) -> str:
         return tokenizer_mode.lower()

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -228,6 +228,16 @@ class SchedulerConfig:
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 
+    @field_validator("long_prefill_token_threshold", mode="after")
+    @classmethod
+    def _check_long_prefill_token_threshold(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError(
+                f"long_prefill_token_threshold must be >= 0 "
+                f"(0 = off, > 0 = token clamp), got {v}."
+            )
+        return v
+
     @field_validator("scheduler_cls", "async_scheduling", mode="wrap")
     @classmethod
     def _skip_none_validation(cls, value: Any, handler: Callable) -> Any:


### PR DESCRIPTION
## Summary

Two CLI-settable integer config fields silently accepted negative values with no valid meaning, producing either confusing downstream errors or silent no-ops. This PR adds `field_validator` guards for both, following the pattern established in #43794.

**`ModelConfig.max_logprobs`** (`vllm/config/model.py`)
- Valid range: `>= 0` or exactly `-1` (sentinel meaning "derive from vocab size")
- Before: any negative value other than `-1` was stored verbatim. Logprob-requesting traffic got a confusing error — `"Requested sample logprobs of 3, which is greater than max allowed: -5"`. Logprob-free traffic was a silent no-op.
- After: validation error at config construction time with a clear message.

**`SchedulerConfig.long_prefill_token_threshold`** (`vllm/config/scheduler.py`)
- Valid range: `>= 0` (`0` = off, `> 0` = token clamp)
- Before: any negative value passed through silently. The scheduler clamp is guarded by `0 < threshold`, so negatives always evaluated to `False` — semantically identical to `0` (off) but with no signal to the user.
- After: validation error at config construction time with a clear message.

## Changes

- `vllm/config/model.py`: add `_check_max_logprobs` field validator
- `vllm/config/scheduler.py`: add `_check_long_prefill_token_threshold` field validator
- `tests/config/test_config_negative_validation.py`: 10 tests covering valid sentinels, valid positive values, and rejection of negative inputs for both fields

## Related

Closes #43985