### PR TITLE
[Bugfix][Spec Decode] Fix GLM-5 MTP low per-position acceptance rate

### DIFF
--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -89,6 +89,14 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         self.shared_head = SharedHead(
             config=config, prefix=prefix, quant_config=quant_config
         )
+        # GLM-style NextN (e.g. GLM-5, model_type "glm_moe_dsa") reuses this
+        # DeepSeek MTP module but applies the shared-head norm at the end of
+        # every draft step, so the hidden state carried into the next step is
+        # normalized. DeepSeek-V3 instead carries the raw (pre-norm) hidden.
+        self.norm_hidden_per_step = (
+            getattr(vllm_config.model_config.hf_config, "model_type", "")
+            == "glm_moe_dsa"
+        )
         self.mtp_block = DeepseekV2DecoderLayer(
             vllm_config,
             prefix,
@@ -120,6 +128,10 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
             residual=None,
         )
         hidden_states = residual + hidden_states
+        # GLM NextN normalizes the hidden state before it is carried into the
+        # next draft step; compute_logits then skips re-normalizing it.
+        if self.norm_hidden_per_step:
+            hidden_states = self.shared_head(hidden_states)
         return hidden_states
 
 
@@ -194,9 +206,14 @@ class DeepSeekMultiTokenPredictor(nn.Module):
     ) -> torch.Tensor:
         current_step_idx = spec_step_idx % self.num_mtp_layers
         mtp_layer = self.layers[str(self.mtp_start_layer_idx + current_step_idx)]
-        logits = self.logits_processor(
-            mtp_layer.shared_head.head, mtp_layer.shared_head(hidden_states)
+        # GLM NextN already applied the shared-head norm in forward(); avoid
+        # normalizing twice.
+        normed_hidden_states = (
+            hidden_states
+            if mtp_layer.norm_hidden_per_step
+            else mtp_layer.shared_head(hidden_states)
         )
+        logits = self.logits_processor(mtp_layer.shared_head.head, normed_hidden_states)
         return logits
 
 


### PR DESCRIPTION
## Purpose

GLM-5 (`GlmMoeDsaForCausalLM`, `model_type: glm_moe_dsa`) reuses the DeepSeek MTP module (`DeepSeekMTP`) for speculative decoding. With `num_speculative_tokens > 1`, per-position acceptance collapses after position 0 (e.g. position 2 ≈ 10%).

**The Situation:** 
- GLM NextN applies the shared-head RMSNorm at the **end of every draft step**, so the hidden state carried into the next step is normalized. 
- DeepSeek-V3/V3.2 instead carries the **raw** (pre-norm) hidden and normalizes once in `compute_logits`. 

Because GLM-5 runs through the shared DeepSeek path, the hidden carried into draft steps 1+ was never normalized, leading to mis-scaling the input to the next prediction layer and destroying acceptance for positions 1 and above.

> This is a silent quality bug: no crash or error, only degraded acceptance rate.

## The Fix

`vllm/model_executor/models/deepseek_mtp.py`:

- Detect GLM NextN once via the main model's `model_type == "glm_moe_dsa"`.
- Apply the shared-head norm at the end of `forward` so the carried hidden is normalized.
- Skip the now-redundant norm in `compute_logits` to avoid double-normalizing.

DeepSeek-V3/V3.2 take the original path and are untouched.

## Results

ShareGPT, 256 prompts, `sharegpt-output-len 1024`, `num_speculative_tokens=3`.

**GLM-5-FP8** (fixed by this PR):

| | Acceptance rate | Acceptance length | Pos 0 | Pos 1 | Pos 2 |
|---|---|---|---|---|---|
| Before | 39.95% | 2.20 | 71.38% | 38.08% | 10.39% |
| After  | **49.36%** | **2.48** | 70.32% | **46.93%** | **30.83%** |

**DeepSeek-V3.2** (expected unchanged):

| | Acceptance rate | Acceptance length | Pos 0 | Pos 1 | Pos 2 |
|---|---|---|---|---|---|
| Before | 41.29% | 2.24 | 68.52% | 37.90% | 17.44% |
| After  | 41.32% | 2.24 | 68.73% | 37.87% | 17.35% |

**Comments:**
- Position 0 is unaffected (it consumes the target model's hidden).
- The fix recovers positions 1/2, which depend on the MTP module's carried hidden.
- DeepSeek V3.2 acceptance is unaffected.

## Environment

- Image: `vllm/vllm-openai-rocm:v0.23.0`
- Machine: AMD MI325X (gfx942) ×8
- OS: Ubuntu 22.04.5
- Python Version: 3.12
- Models: `zai-org/GLM-5-FP8` (FP8), `deepseek-ai/DeepSeek-V3.2`
- Dataset: [ShareGPT_V3_unfiltered_cleaned_split.json](https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/blob/main/ShareGPT_V3_unfiltered_cleaned_split.json)

## Reproduce

Serve models:

```bash
# GLM-5
VLLM_ROCM_USE_AITER=1 vllm serve zai-org/GLM-5-FP8 \
    --trust-remote-code --tensor-parallel-size 8 \
    --reasoning-parser glm45 --tool-call-parser glm47 --enable-auto-tool-choice \
    --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}'

# DeepSeek-V3.2
VLLM_ROCM_USE_AITER=1 vllm serve deepseek-ai/DeepSeek-V3.2 \
    --trust-remote-code --tensor-parallel-size 8 \
    --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}'
```

Benchmark:

```bash
MODEL=zai-org/GLM-5-FP8   # or deepseek-ai/DeepSeek-V3.2
vllm bench serve \
    --model "$MODEL" --backend vllm --base-url http://localhost:8000 \
    --dataset-name sharegpt \
    --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
    --num-prompts 256 --sharegpt-output-len 1024
```

## Test

- Lint check: **Pass**
- End-to-end serve + `vllm bench serve` for both models: **Table above**
- Expected behaviors:
    - GLM-5 acceptance **improved**
    - DeepSeek-V3.2 acceptance **unchanged**
