### PR TITLE
[BugFix] Fix latent-MoE crash when MoE runner holds the gate (is_internal_router)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -802,14 +802,25 @@ class MoERunner(MoERunnerInterface):
         self._maybe_sync_shared_experts_stream(shared_experts_input)
 
         # If the Runner holds the gate, apply it after the stream sync,
-        # so it can run overlapped with the
+        # so it can run overlapped with the shared expert.
         # NOTE: in future PR, MoE runner will always hold the gate.
         if self.gate is not None:
+            # For latent-MoE models the routed `hidden_states` has already been
+            # projected to `moe_latent_size` by `apply_routed_input_transform`,
+            # but the gate is defined on the original `hidden_size`. The
+            # pre-latent activations are preserved in `shared_experts_input`, so
+            # route the gate to those when present. Falls back to `hidden_states`
+            # for non-latent models (shared_experts_input is None or identical).
+            gate_input = (
+                shared_experts_input
+                if shared_experts_input is not None
+                else hidden_states
+            )
             if self._fse_fuse_gate:
                 self._maybe_fuse_gate_weights()
-                router_logits = F.linear(hidden_states, self._combined_gate_weight)
+                router_logits = F.linear(gate_input, self._combined_gate_weight)
             else:
-                router_logits, _ = self.gate(hidden_states)
+                router_logits, _ = self.gate(gate_input)
 
         with self._sequence_parallel_context():
             # TODO(bnell): parts of the dispatch/combine steps will go away once


### PR DESCRIPTION
## Purpose

Fix a crash in the MoE runner's internal-router path for **latent-MoE** models (e.g. Nemotron-H).

When a model passes `gate=self.gate` into `FusedMoE` (so `MoERunner.is_internal_router` is `True`), the runner applies the gate itself inside `_forward_impl`. That gate application happens **after** `apply_routed_input_transform`, which for a latent-MoE model has already projected `hidden_states` from `hidden_size` down to `moe_latent_size`. The gate, however, is defined on the original `hidden_size`, so it receives a tensor of the wrong width and the matmul fails.

This path is currently dormant for latent-MoE models only because none of them pass `gate=self.gate` today. Any attempt to enable the internal-router/shared-expert-overlap path on a latent-MoE model hits this immediately, during the profile run (before serving):

```
File ".../vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 812, in _forward_impl
    router_logits, _ = self.gate(hidden_states)
File ".../vllm/model_executor/layers/fused_moe/router/gate_linear.py", line 136, in forward
RuntimeError: mat1 and mat2 shapes cannot be multiplied (8192x1024 and 4096x512)
```

Here `hidden_states` is `[8192 tokens × 1024]` (post-latent `moe_latent_size = 1024`), but the gate weight is `[4096 → n_experts]` (defined on `hidden_size = 4096`).

## Fix

Route the gate to the **pre-latent** activations, which are already preserved in `shared_experts_input` for exactly this kind of reason. Fall back to `hidden_states` when `shared_experts_input` is `None` — i.e. for non-latent models, where the two are identical — so the change is a no-op there.

```python
if self.gate is not None:
    gate_input = (
        shared_experts_input
        if shared_experts_input is not None
        else hidden_states
    )
    if self._fse_fuse_gate:
        self._maybe_fuse_gate_weights()
        router_logits = F.linear(gate_input, self._combined_gate_weight)
    else:
        router_logits, _ = self.gate(gate_input)
```

This aligns the internal-router gate input with the gate's defined dimension, matching how the shared expert (which also operates on the pre-latent activations) is already fed. It is forward-looking for the noted intent that *"in future PR, MoE runner will always hold the gate."*

## Test Plan

All on 8×H200, TP=8, greedy (`temperature=0`, `seed=0`), 8 prompts × 40 tokens.

1. **Repro the crash (latent-MoE):** enable the internal-router path on Nemotron-H (`NemotronHForCausalLM`, `hidden_size=4096`, `moe_latent_size=1024`, 512 routed experts) and confirm it crashes before the fix.
2. **Latent-MoE correctness after fix:** with the fix, the internal-router path on Nemotron-H must produce the **same routing/output as the trusted serial in-model gate path** (the path used today, where the model computes `router_logits` itself and does not pass `gate=` to `FusedMoE`).
3. **No-op for non-latent models:** on a non-latent MoE (`Qwen/Qwen3-30B-A3B`, no shared experts), confirm the fix changes nothing, since `shared_experts_input is None` ⇒ `gate_input = hidden_states` (the same object).

## Test Result

### 1. Crash reproduced (Nemotron-H, before fix)

Enabling the internal-router path on Nemotron-H crashes at the profile run, on every TP rank:

```
File ".../vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 812, in _forward_impl
    router_logits, _ = self.gate(hidden_states)
File ".../vllm/model_executor/layers/fused_moe/router/gate_linear.py", line 136, in forward
RuntimeError: mat1 and mat2 shapes cannot be multiplied (8192x1024 and 4096x512)
```

`hidden_states` is `[8192 × 1024]` (post-latent), gate weight is `[4096 → n_experts]` (pre-latent).

### 2. Latent-MoE correctness (Nemotron-H, after fix)

With the fix, Nemotron-H boots cleanly (torch.compile + CUDA-graph capture, PIECEWISE + FULL decode) and the internal-router path produces **byte-for-byte identical** generations to the trusted serial in-model gate path:

```
$ diff gen_serial_gate.txt gen_internal_router_fixed.txt
(no output — identical)

$ md5sum gen_serial_gate.txt gen_internal_router_fixed.txt
c1922e08a93a69a89a33994c1ef2183f  gen_serial_gate.txt
c1922e08a93a69a89a33994c1ef2183f  gen_internal_router_fixed.txt
```

This shows the fix routes the gate correctly (the pre-latent activations give the same routing the model computes for itself today), not merely that it stops crashing.

### 3. No-op for non-latent models (Qwen3-30B-A3B)

For a non-latent model `shared_experts_input is None`, so `gate_input` **is** `hidden_states` (the same Python object) — verified at runtime:

```
[MOE_GATE_DBG] shared_experts_input=None hidden_states=(8192, 2048) gate_input_is_hidden=True fse_fuse=False
```

In **eager** mode (no torch.compile, so no kernel-selection variance) the before/after generations are byte-for-byte identical:

```
$ diff gen_eager_before.txt gen_eager_after.txt
(no output — identical)

$ md5sum gen_eager_before.txt gen_eager_after.txt
248b171c099fc76fdf4c9a7b7b845859  gen_eager_before.txt
248b171c099fc76fdf4c9a7b7b845859  gen_eager_after.txt
```

> Note: under `torch.compile` + CUDA graphs, a few greedy continuations diverge after ~30 tokens. This is **not** a semantic change — `gate_input is hidden_states` so the math is unchanged — but the cosmetic source edit shifts which fused kernels inductor selects, producing sub-ULP FP differences that occasionally flip the greedy argmax on near-tied logits. The eager-mode equality above isolates and confirms this.
