### PR TITLE
[Bugfix][Parser] Recover tool calls emitted before the reasoning-end marker

### DIFF
--- a/tests/parser/test_streaming.py
+++ b/tests/parser/test_streaming.py
@@ -365,3 +365,50 @@ def test_parse_delta_tool_choice_none_with_reasoning(tokenizer, request_obj):
     assert len(tool_calls) == 0
     assert "<tool_call>" in content
     assert "get_weather" in content
+
+
+# A tool call that begins *before* the reasoning-end marker (the model skipped
+# </think>). The tool call must still be parsed, and the raw tool-call syntax
+# must not leak into the reasoning channel.
+TOOL_CALL_IN_REASONING_OUTPUT = (
+    "<think>checking the weather now"
+    '<tool_call>\n{"name": "get_weather", '
+    '"arguments": {"city": "Dallas"}}\n</tool_call>'
+)
+
+
+def test_parse_delta_recovers_tool_call_before_reasoning_end(tokenizer, request_obj):
+    parser = make_parser(tokenizer, reasoning=True, tool=True)
+    results = stream_text(
+        parser,
+        tokenizer,
+        TOOL_CALL_IN_REASONING_OUTPUT,
+        request_obj,
+        prompt_token_ids=[],
+    )
+    reasoning, content, tool_calls = collect_fields(results)
+
+    # reasoning is preserved, but the tool-call syntax is not leaked into it
+    assert "checking the weather now" in reasoning
+    assert "<tool_call>" not in reasoning
+
+    # the tool call is recovered and parsed
+    assert len(tool_calls) > 0
+    assert tool_calls[0].function.name == "get_weather"
+    tool_args = "".join(
+        tc.function.arguments for tc in tool_calls if tc.function.arguments
+    )
+    assert json.loads(tool_args) == {"city": "Dallas"}
+
+
+def test_parse_delta_reasoning_with_lt_char_not_corrupted(tokenizer, request_obj):
+    # A "<" in reasoning that is *not* the start of a tool call must still be
+    # emitted as reasoning (the hold-back buffer must flush false prefixes).
+    output = "<think>compare a < b and c < d here</think>regular answer"
+    parser = make_parser(tokenizer, reasoning=True, tool=True)
+    results = stream_text(parser, tokenizer, output, request_obj, prompt_token_ids=[])
+    reasoning, content, tool_calls = collect_fields(results)
+
+    assert "compare a < b and c < d here" in reasoning
+    assert len(tool_calls) == 0
+    assert "regular answer" in content

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -36,6 +36,20 @@ from vllm.tool_parsers.streaming import (
 logger = init_logger(__name__)
 
 
+def _reasoning_tail_overlap(text: str, marker: str) -> int:
+    """Length of the longest non-empty suffix of ``text`` that is a proper
+    prefix of ``marker``.
+
+    Used while streaming reasoning to hold back a partial tool-call-start token
+    so it is not emitted as reasoning content before we know whether it
+    completes into a real tool call.
+    """
+    for k in range(min(len(text), len(marker) - 1), 0, -1):
+        if marker.startswith(text[-k:]):
+            return k
+    return 0
+
+
 @dataclass
 class StreamState:
     """Mutable state for ``Parser.parse_delta()``. One per stream."""
@@ -51,6 +65,9 @@ class StreamState:
     # tracks whether function name has been fully returned in the stream yet
     function_name_returned: bool = False
     engine_based: bool = False
+    # Buffered reasoning tail that may be the start of a tool call emitted before
+    # the reasoning-end marker. Held back so it is not streamed as reasoning.
+    reasoning_holdback: str = ""
 
     def advance(
         self,
@@ -808,6 +825,54 @@ class DelegatingParser(Parser):
                         else ""
                     )
                     delta_text = current_text
+                if state.reasoning_holdback:
+                    # Flush any buffered tool-call-start prefix as reasoning.
+                    if delta_message is None:
+                        delta_message = DeltaMessage()
+                    delta_message.reasoning = state.reasoning_holdback + (
+                        delta_message.reasoning or ""
+                    )
+                    state.reasoning_holdback = ""
+            elif (
+                not self._engine_based
+                and self._tool_parser is not None
+                and (tc_start := self._tool_parser.tool_call_start_token)
+            ):
+                # Recovery: some reasoning models occasionally begin a tool call
+                # before emitting the reasoning-end marker (e.g. </think>).
+                # Without this the call leaks into reasoning content and is never
+                # parsed. Buffer any partial tool-call-start token so it is not
+                # emitted as reasoning; once the full start token appears, treat
+                # it as the reasoning end and hand it (and what follows) to the
+                # tool parser.
+                pending = state.reasoning_holdback + (
+                    delta_message.reasoning
+                    if delta_message and delta_message.reasoning
+                    else ""
+                )
+                state.reasoning_holdback = ""
+                tc_idx = pending.find(tc_start)
+                if tc_idx != -1:
+                    state.reasoning_ended = True
+                    reasoning_transitioned = True
+                    if delta_message is None:
+                        delta_message = DeltaMessage()
+                    delta_message.reasoning = pending[:tc_idx] or None
+                    delta_message.content = None
+                    current_text = pending[tc_idx:]
+                    delta_text = current_text
+                else:
+                    overlap = _reasoning_tail_overlap(pending, tc_start)
+                    state.reasoning_holdback = (
+                        pending[len(pending) - overlap :] if overlap else ""
+                    )
+                    emitted = pending[: len(pending) - overlap]
+                    if emitted:
+                        if delta_message is None:
+                            delta_message = DeltaMessage()
+                        delta_message.reasoning = emitted
+                    elif delta_message is not None:
+                        delta_message.reasoning = None
 
         # Tool call extraction
         if self._in_tool_call_phase(state):
@@ -861,6 +926,16 @@ class DelegatingParser(Parser):
             and not self._in_tool_call_phase(state)
         ):
             delta_message = DeltaMessage(content=delta_text)
+
+        if finished and state.reasoning_holdback and not state.reasoning_ended:
+            # Stream ended while still reasoning with a buffered tail that never
+            # completed into a tool call; emit it as reasoning.
+            if delta_message is None:
+                delta_message = DeltaMessage()
+            delta_message.reasoning = (
+                delta_message.reasoning or ""
+            ) + state.reasoning_holdback
+            state.reasoning_holdback = ""
 
         state.commit(current_text, current_token_ids)
 


### PR DESCRIPTION
## Purpose

Some reasoning models — notably **DeepSeek-V4** — occasionally begin a tool
call **inside** the reasoning block, before emitting the reasoning-end marker
(`</think>`). The streaming parser (`DelegatingParser.parse_delta`) only opens
the tool-call phase **after** `reasoning_ended` flips, which for these models
happens only on `</think>`. As a result the tool call is classified as
reasoning text, never parsed into a `tool_call`, and downstream agents see no
tool invocation at all (the raw `<｜DSML｜tool_calls>…` markup surfaces in the
thinking channel instead).

This reproduces with `DeepSeek-V4-Flash` + thinking + tools: deep into long
reasoning traces the model sometimes goes straight to a tool call without
closing `</think>`, and the call is silently dropped.

### Approach

Rather than trying to *prevent* the model from doing this (grammar-level
attempts to forbid the start token before `</think>` are fragile — a model
intent on emitting it routes around a masked token into malformed variants),
this **recovers** the call: when the tool parser's `tool_call_start_token`
appears while still in the reasoning phase, treat it as the reasoning end and
hand it (and everything after) to the tool parser.

A small **hold-back buffer** keeps a partially-streamed start token out of the
reasoning channel, so no raw tool-call syntax leaks into reasoning. The
recovery is gated on the start token actually appearing, and scoped to the
classic (non-engine-based) parsing path, so the normal `</think>` transition
and ordinary reasoning are unaffected. It only scans `holdback + the current
delta` (not the full transcript), so there is no per-token quadratic cost.

This is intentionally opened as a **draft** to get maintainer input on the
direction (recover vs. prevent vs. making the start token a first-class
reasoning terminator in both the parser and the structural-tag grammar). I'm
happy to adjust.

## Test Plan

New cases in `tests/parser/test_streaming.py` (generic `<think>` reasoning +
Hermes `<tool_call>`, so no model download is needed):

- `test_parse_delta_recovers_tool_call_before_reasoning_end` — a tool call that
  begins before `</think>` is parsed, and `<tool_call>` does **not** leak into
  reasoning.
- `test_parse_delta_reasoning_with_lt_char_not_corrupted` — a `<` in reasoning
  that is *not* a tool call is still emitted (the hold-back flushes false
  prefixes).

```
pytest tests/parser/test_streaming.py
```

## Test Result

The added tests are self-contained and exercise the new path. Transparency note:
I was not able to run the full suite against a freshly-built `main` locally, so
I'm relying on CI for the on-`main` run. The fix and the hold-back algorithm
were validated (a) standalone for the buffering logic, and (b) end-to-end
against a `v0.23.0`-based deployment where the bug reproduces with
`DeepSeek-V4-Flash` — there, a leaked tool call is now recovered and executed,
with the reasoning channel left clean.
