### PR TITLE
[Rust Frontend] Add /tokenizer_info endpoint 

### DIFF
--- a/rust/src/chat/src/backend/hf.rs
+++ b/rust/src/chat/src/backend/hf.rs
@@ -1,6 +1,9 @@
+use std::fs;
 use std::sync::Arc;
 
-use tracing::info;
+use serde_json::Value as JsonValue;
+use thiserror_ext::AsReport as _;
+use tracing::{info, warn};
 use vllm_text::backend::hf::{HfTextBackend, ResolvedModelFiles, load_model_config};
 use vllm_text::tokenizer::DynTokenizer;
 use vllm_text::{DynTextBackend, TextBackend as _};
@@ -14,7 +17,9 @@ use crate::multimodal::MultimodalModelInfo;
 use crate::output::{
     DefaultChatOutputProcessor, HarmonyChatOutputProcessor, validate_harmony_parser_overrides,
 };
-use crate::renderer::hf::{HfChatRenderer, MultimodalRenderInfo};
+use crate::renderer::hf::{
+    HfChatRenderer, MultimodalRenderInfo, load_chat_template, resolve_chat_template,
+};
 use crate::renderer::{DeepSeekV4ChatRenderer, DeepSeekV32ChatRenderer, DynChatRenderer};
 use crate::request::ChatRequest;
 use crate::{DynChatOutputProcessor, RendererSelection};
@@ -115,6 +120,7 @@ pub(super) async fn load_model_backends(
     options: LoadModelBackendsOptions,
 ) -> Result<LoadedModelBackends> {
     let files = ResolvedModelFiles::new(model_id).await?;
+    let tokenizer_config_snapshot = build_tokenizer_config_snapshot(&files, &options);
     let text_backend =
         HfTextBackend::from_resolved_model_files(files.clone(), model_id.to_string())?;
     let tokenizer = text_backend.tokenizer();
@@ -130,7 +136,112 @@ pub(super) async fn load_model_backends(
     Ok(LoadedModelBackends {
         text_backend,
         chat_backend,
+        tokenizer_config_snapshot,
     })
+}
+
+fn build_tokenizer_config_snapshot(
+    files: &ResolvedModelFiles,
+    options: &LoadModelBackendsOptions,
+) -> Option<JsonValue> {
+    let tokenizer_config_path = files.tokenizer_config_path.as_deref()?;
+    let content = match fs::read_to_string(tokenizer_config_path) {
+        Ok(content) => content,
+        Err(error) => {
+            warn!(
+                path = %tokenizer_config_path.display(),
+                error = %error.as_report(),
+                "failed to read tokenizer config for /tokenizer_info"
+            );
+            return None;
+        }
+    };
+    let mut snapshot: JsonValue = match serde_json::from_str(&content) {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            warn!(
+                path = %tokenizer_config_path.display(),
+                error = %error.as_report(),
+                "failed to parse tokenizer config for /tokenizer_info"
+            );
+            return None;
+        }
+    };
+
+    let Some(object) = snapshot.as_object_mut() else {
+        warn!(
+            path = %tokenizer_config_path.display(),
+            "tokenizer config for /tokenizer_info is not a JSON object"
+        );
+        return None;
+    };
+    object.remove("vocab_file");
+    object.remove("merges_file");
+
+    if resolved_renderer(files, options)? == RendererSelection::Hf
+        && !patch_effective_chat_template(object, files, options)
+    {
+        return None;
+    }
+
+    Some(snapshot)
+}
+
+fn resolved_renderer(
+    files: &ResolvedModelFiles,
+    options: &LoadModelBackendsOptions,
+) -> Option<RendererSelection> {
+    let model_config = match load_model_config(files.config_path.as_deref()) {
+        Ok(model_config) => model_config,
+        Err(error) => {
+            warn!(
+                error = %error.as_report(),
+                "failed to resolve model config for /tokenizer_info"
+            );
+            return None;
+        }
+    };
+    Some(options.renderer.resolve(model_config.model_type().unwrap_or_default()))
+}
+
+fn patch_effective_chat_template(
+    object: &mut serde_json::Map<String, JsonValue>,
+    files: &ResolvedModelFiles,
+    options: &LoadModelBackendsOptions,
+) -> bool {
+    if let Some(configured_template) = options.chat_template.as_deref() {
+        match resolve_chat_template(configured_template) {
+            Ok(template) => {
+                object.insert("chat_template".to_string(), JsonValue::String(template));
+                true
+            }
+            Err(error) => {
+                warn!(
+                    error = %error.as_report(),
+                    "failed to resolve configured chat template for /tokenizer_info"
+                );
+                false
+            }
+        }
+    } else if let Some(chat_template_path) = files.chat_template_path.as_deref() {
+        match load_chat_template(chat_template_path) {
+            Ok(Some(template)) if !template.trim().is_empty() => {
+                object.insert("chat_template".to_string(), JsonValue::String(template));
+                true
+            }
+            Ok(_) => true,
+            Err(error) => {
+                warn!(
+                    path = %chat_template_path.display(),
+                    error = %error.as_report(),
+                    "failed to load chat template for /tokenizer_info"
+                );
+                false
+            }
+        }
+    } else {
+        true
+    }
 }
 
 fn resolve_multimodal_render_info(
@@ -147,11 +258,12 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
+    use serde_json::json;
     use tempfile::tempdir;
     use vllm_text::backend::hf::TokenizerSource;
     use vllm_text::tokenizer::{DynTokenizer, Tokenizer};
 
-    use super::HfChatBackend;
+    use super::{HfChatBackend, build_tokenizer_config_snapshot};
     use crate::RendererSelection;
     use crate::backend::{ChatBackend, LoadModelBackendsOptions};
     use crate::request::{ChatContent, ChatMessage, ChatRequest};
@@ -219,6 +331,16 @@ mod tests {
         Arc::new(TestTokenizer)
     }
 
+    fn load_options(renderer: RendererSelection) -> LoadModelBackendsOptions {
+        LoadModelBackendsOptions {
+            renderer,
+            language_model_only: false,
+            chat_template_content_format: Default::default(),
+            chat_template: None,
+            default_chat_template_kwargs: HashMap::new(),
+        }
+    }
+
     fn render_prompt(
         renderer: RendererSelection,
         config_json: &str,
@@ -227,13 +349,7 @@ mod tests {
         let backend = HfChatBackend::from_resolved_model_files(
             resolved_files(config_json, tokenizer_config_json),
             "test-model".to_string(),
-            LoadModelBackendsOptions {
-                renderer,
-                language_model_only: false,
-                chat_template_content_format: Default::default(),
-                chat_template: None,
-                default_chat_template_kwargs: HashMap::new(),
-            },
+            load_options(renderer),
             test_tokenizer(),
         )
         .unwrap();
@@ -245,6 +361,79 @@ mod tests {
             .prompt
             .into_text()
             .expect("renderer should return text prompt")
+    }
+
+    #[test]
+    fn tokenizer_config_snapshot_strips_path_fields_and_preserves_extra_fields() {
+        let files = resolved_files(
+            r#"{"model_type":"qwen2"}"#,
+            r#"{"tokenizer_class":"Qwen2Tokenizer","chat_template":"raw","vocab_file":"/tmp/vocab.json","merges_file":"/tmp/merges.txt","bos_token":"<s>","extra":{"x":1}}"#,
+        );
+
+        let snapshot =
+            build_tokenizer_config_snapshot(&files, &load_options(RendererSelection::Hf))
+                .expect("snapshot");
+
+        assert_eq!(
+            snapshot,
+            json!({
+                "tokenizer_class": "Qwen2Tokenizer",
+                "chat_template": "raw",
+                "bos_token": "<s>",
+                "extra": {"x": 1}
+            })
+        );
+    }
+
+    #[test]
+    fn tokenizer_config_snapshot_uses_configured_hf_chat_template_override() {
+        let files = resolved_files(
+            r#"{"model_type":"qwen2"}"#,
+            r#"{"tokenizer_class":"Qwen2Tokenizer","chat_template":"raw"}"#,
+        );
+        let mut options = load_options(RendererSelection::Hf);
+        options.chat_template = Some("{{ override }}".to_string());
+
+        let snapshot = build_tokenizer_config_snapshot(&files, &options).expect("snapshot");
+
+        assert_eq!(snapshot["chat_template"], "{{ override }}");
+    }
+
+    #[test]
+    fn tokenizer_config_snapshot_uses_hf_chat_template_file() {
+        let mut files = resolved_files(
+            r#"{"model_type":"qwen2"}"#,
+            r#"{"tokenizer_class":"Qwen2Tokenizer","chat_template":"raw"}"#,
+        );
+        let template_path = files
+            .config_path
+            .as_ref()
+            .expect("config path")
+            .parent()
+            .expect("model dir")
+            .join("chat_template.jinja");
+        std::fs::write(&template_path, "{{ file_template }}").unwrap();
+        files.chat_template_path = Some(template_path);
+
+        let snapshot =
+            build_tokenizer_config_snapshot(&files, &load_options(RendererSelection::Hf))
+                .expect("snapshot");
+
+        assert_eq!(snapshot["chat_template"], "{{ file_template }}");
+    }
+
+    #[test]
+    fn tokenizer_config_snapshot_keeps_raw_template_for_deepseek_renderer() {
+        let files = resolved_files(
+            r#"{"model_type":"deepseek_v32"}"#,
+            r#"{"tokenizer_class":"DeepSeekTokenizer","chat_template":"raw"}"#,
+        );
+        let mut options = load_options(RendererSelection::Auto);
+        options.chat_template = Some("{{ override }}".to_string());
+
+        let snapshot = build_tokenizer_config_snapshot(&files, &options).expect("snapshot");
+
+        assert_eq!(snapshot["chat_template"], "raw");
     }
 
     #[test]

--- a/rust/src/chat/src/backend/mod.rs
+++ b/rust/src/chat/src/backend/mod.rs
@@ -77,6 +77,7 @@ pub struct LoadModelBackendsOptions {
 pub struct LoadedModelBackends {
     pub text_backend: DynTextBackend,
     pub chat_backend: DynChatBackend,
+    pub tokenizer_config_snapshot: Option<Value>,
 }
 
 /// Load text and chat backends for the given model id.

--- a/rust/src/cmd/src/cli.rs
+++ b/rust/src/cmd/src/cli.rs
@@ -202,6 +202,16 @@ pub struct SharedRuntimeArgs {
     #[serde(default)]
     pub enable_request_id_headers: bool,
 
+    /// Enable the `/tokenizer_info` endpoint. May expose chat templates and
+    /// other tokenizer configuration.
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1
+    )]
+    #[serde(default)]
+    pub enable_tokenizer_info_endpoint: bool,
+
     /// If provided, the server will require one of these keys to be presented
     /// in the Authorization header.
     #[educe(Debug(ignore))]
@@ -381,6 +391,7 @@ impl SharedRuntimeArgs {
             enable_log_requests: self.enable_log_requests,
             enable_prompt_tokens_details: self.enable_prompt_tokens_details,
             enable_request_id_headers: self.enable_request_id_headers,
+            enable_tokenizer_info_endpoint: self.enable_tokenizer_info_endpoint,
         }
     }
 

--- a/rust/src/cmd/src/cli/tests.rs
+++ b/rust/src/cmd/src/cli/tests.rs
@@ -47,6 +47,7 @@ fn serve_args_forward_python_flags_with_separator() {
                         enable_log_requests: false,
                         enable_prompt_tokens_details: false,
                         enable_request_id_headers: false,
+                        enable_tokenizer_info_endpoint: false,
                         disable_log_stats: false,
                         served_model_name: [],
                         allowed_origins: JsonStringList(
@@ -239,6 +240,23 @@ fn serve_passes_enable_prompt_tokens_details_into_config() {
 }
 
 #[test]
+fn serve_passes_enable_tokenizer_info_endpoint_into_config() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "serve",
+        "Qwen/Qwen3-0.6B",
+        "--enable-tokenizer-info-endpoint",
+    ])
+    .unwrap();
+
+    let Command::Serve(args) = cli.command else {
+        panic!("expected serve args");
+    };
+    let config = args.to_frontend_config("tcp://127.0.0.1:62100".to_string());
+    assert!(config.api_server_options.enable_tokenizer_info_endpoint);
+}
+
+#[test]
 fn frontend_args_json_passes_enable_request_id_headers_into_config() {
     let cli = Cli::try_parse_from([
         "vllm-rs",
@@ -259,6 +277,29 @@ fn frontend_args_json_passes_enable_request_id_headers_into_config() {
     };
     let config = args.into_config();
     assert!(config.api_server_options.enable_request_id_headers);
+}
+
+#[test]
+fn frontend_args_json_passes_enable_tokenizer_info_endpoint_into_config() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "frontend",
+        "--listen-fd",
+        "3",
+        "--input-address",
+        "ipc:///tmp/input.sock",
+        "--output-address",
+        "ipc:///tmp/output.sock",
+        "--args-json",
+        r#"{"model_tag":"Qwen/Qwen3-0.6B","enable_tokenizer_info_endpoint":true}"#,
+    ])
+    .unwrap();
+
+    let Command::Frontend(args) = cli.command else {
+        panic!("expected frontend args");
+    };
+    let config = args.into_config();
+    assert!(config.api_server_options.enable_tokenizer_info_endpoint);
 }
 
 #[test]
@@ -443,6 +484,7 @@ fn frontend_args_accept_json() {
                         enable_log_requests: false,
                         enable_prompt_tokens_details: false,
                         enable_request_id_headers: false,
+                        enable_tokenizer_info_endpoint: false,
                         disable_log_stats: false,
                         served_model_name: [],
                         allowed_origins: JsonStringList(
@@ -931,6 +973,7 @@ fn serve_args_accept_handshake_aliases() {
                         enable_log_requests: false,
                         enable_prompt_tokens_details: false,
                         enable_request_id_headers: false,
+                        enable_tokenizer_info_endpoint: false,
                         disable_log_stats: false,
                         served_model_name: [],
                         allowed_origins: JsonStringList(
@@ -1069,6 +1112,7 @@ fn serve_frontend_config_uses_dp_address_as_advertised_host() {
                 enable_log_requests: false,
                 enable_prompt_tokens_details: false,
                 enable_request_id_headers: false,
+                enable_tokenizer_info_endpoint: false,
             },
             cors: CorsConfig {
                 allow_origins: [
@@ -1150,6 +1194,7 @@ fn serve_frontend_config_keeps_tcp_transport_for_non_local_only_topology() {
                 enable_log_requests: false,
                 enable_prompt_tokens_details: false,
                 enable_request_id_headers: false,
+                enable_tokenizer_info_endpoint: false,
             },
             cors: CorsConfig {
                 allow_origins: [
@@ -1249,6 +1294,7 @@ fn frontend_config_uses_external_coordinator_when_coordinator_address_is_present
                 enable_log_requests: false,
                 enable_prompt_tokens_details: false,
                 enable_request_id_headers: false,
+                enable_tokenizer_info_endpoint: false,
             },
             cors: CorsConfig {
                 allow_origins: [

--- a/rust/src/cmd/src/cli/unsupported.rs
+++ b/rust/src/cmd/src/cli/unsupported.rs
@@ -454,16 +454,6 @@ pub struct ServerUnsupportedArgs {
     )]
     pub enable_force_include_usage: Option<Unsupported>,
 
-    /// Enable the `/tokenizer_info` endpoint. May expose chat
-    /// templates and other tokenizer configuration.
-    #[arg(
-        long,
-        visible_alias = "no-enable-tokenizer-info-endpoint",
-        default_missing_value = "true",
-        num_args = 0..=1
-    )]
-    pub enable_tokenizer_info_endpoint: Option<Unsupported>,
-
     /// If set to True, log model outputs (generations).
     /// Requires `--enable-log-requests`. As with `--enable-log-requests`,
     /// information is only logged at INFO level at maximum.

--- a/rust/src/server/src/config.rs
+++ b/rust/src/server/src/config.rs
@@ -44,6 +44,8 @@ pub struct ApiServerOptions {
     pub enable_prompt_tokens_details: bool,
     /// When `true`, set `X-Request-Id` on every HTTP response.
     pub enable_request_id_headers: bool,
+    /// When `true`, expose `/tokenizer_info` if tokenizer metadata was loaded.
+    pub enable_tokenizer_info_endpoint: bool,
 }
 
 /// CORS settings mirroring Python's `CORSMiddleware`; the default is permissive.

--- a/rust/src/server/src/lib.rs
+++ b/rust/src/server/src/lib.rs
@@ -71,6 +71,7 @@ async fn build_state(config: &Config) -> Result<Arc<AppState>> {
     .context("failed to create chat/text backends")?;
     let text_backend = loaded.text_backend;
     let chat_backend = loaded.chat_backend;
+    let tokenizer_config_snapshot = loaded.tokenizer_config_snapshot;
 
     let coordinator_mode = config.effective_coordinator_mode(text_backend.is_moe());
     info!(
@@ -96,14 +97,19 @@ async fn build_state(config: &Config) -> Result<Arc<AppState>> {
         .with_tool_call_parser(config.tool_call_parser.clone())
         .with_reasoning_parser(config.reasoning_parser.clone());
 
-    Ok(Arc::new(
-        AppState::new(served_model_names, chat)
-            .with_model_path(config.model.clone())
-            .with_api_server_options(config.api_server_options)
-            .with_server_info(ServerInfoSnapshot::from_config(config))
-            .with_api_keys(config.api_keys.clone())
-            .with_cors(config.cors.clone()),
-    ))
+    let mut state = AppState::new(served_model_names, chat)
+        .with_model_path(config.model.clone())
+        .with_api_server_options(config.api_server_options)
+        .with_server_info(ServerInfoSnapshot::from_config(config))
+        .with_api_keys(config.api_keys.clone())
+        .with_cors(config.cors.clone());
+    if config.api_server_options.enable_tokenizer_info_endpoint
+        && let Some(snapshot) = tokenizer_config_snapshot
+    {
+        state = state.with_tokenizer_info(snapshot);
+    }
+
+    Ok(Arc::new(state))
 }
 
 /// Run the OpenAI-compatible HTTP server until the supplied shutdown token is

--- a/rust/src/server/src/middleware/metrics.rs
+++ b/rust/src/server/src/middleware/metrics.rs
@@ -16,6 +16,7 @@ const EXCLUDED_HANDLERS: &[&str] = &[
     "/ping",
     "/version",
     "/server_info",
+    "/tokenizer_info",
     // Rust frontend extra:
     "/reset_prefix_cache",
     "/reset_mm_cache",

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -80,6 +80,10 @@ fn build_router_with_options(
         .route("/detokenize", post(tokenize::detokenize))
         .route("/inference/v1/generate", post(inference::generate));
 
+    if state.tokenizer_info().is_some() {
+        router = router.route("/tokenizer_info", get(tokenize::tokenizer_info));
+    }
+
     if runtime_lora_updating_enabled {
         router = router
             .route("/v1/load_lora_adapter", post(lora::load_lora_adapter))

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -830,6 +830,19 @@ async fn test_dev_mode_app_with_ready(
     (app, engine_task)
 }
 
+async fn test_app_with_tokenizer_info(snapshot: serde_json::Value) -> axum::Router {
+    let (chat, _engine_task) = test_models_with_engine_outputs_and_backend(
+        b"engine-openai-tokenizer-info",
+        default_stream_output_specs(),
+        Arc::new(FakeChatBackend::new()),
+    )
+    .await;
+    build_router(Arc::new(
+        AppState::new(vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()], chat)
+            .with_tokenizer_info(snapshot),
+    ))
+}
+
 async fn test_app_with_request_id_headers() -> (axum::Router, MockEngineTask) {
     let (chat, engine_task) = test_models_with_engine_outputs_and_backend(
         b"engine-openai-request-id",
@@ -1673,6 +1686,49 @@ async fn server_info_endpoint_is_dev_mode_only() {
         .expect("call app");
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn tokenizer_info_endpoint_is_hidden_without_snapshot() {
+    let mut app = test_app().await;
+    let response = app
+        .call(
+            Request::builder()
+                .uri("/tokenizer_info")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn tokenizer_info_endpoint_returns_snapshot() {
+    let expected = json!({
+        "tokenizer_class": "Qwen2Tokenizer",
+        "chat_template": "{{ messages }}",
+        "bos_token": "<s>",
+        "extra": {"x": 1}
+    });
+    let mut app = test_app_with_tokenizer_info(expected.clone()).await;
+    let response = app
+        .call(
+            Request::builder()
+                .uri("/tokenizer_info")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let actual: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+    assert_eq!(actual, expected);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust/src/server/src/routes/tokenize.rs
+++ b/rust/src/server/src/routes/tokenize.rs
@@ -1,4 +1,5 @@
-//! `POST /tokenize` and `POST /detokenize` (root paths, matching Python).
+//! `POST /tokenize`, `POST /detokenize`, and `GET /tokenizer_info`
+//! (root paths, matching Python).
 //!
 //! Encode/decode runs entirely in-process via [`DynTokenizer`]; the inference
 //! engine is not involved.
@@ -9,7 +10,7 @@ use std::sync::Arc;
 
 use axum::Json;
 use axum::extract::State;
-use axum::http::HeaderMap;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use thiserror_ext::AsReport as _;
 
@@ -122,6 +123,13 @@ pub async fn detokenize(
     match tokenizer.decode(&body.tokens, /* skip_special_tokens = */ false) {
         Ok(prompt) => Json(DetokenizeResponse { prompt }).into_response(),
         Err(e) => server_error!("detokenize failed: {}", e.to_report_string()).into_response(),
+    }
+}
+
+pub async fn tokenizer_info(State(state): State<Arc<AppState>>) -> Response {
+    match state.tokenizer_info() {
+        Some(snapshot) => Json(snapshot.clone()).into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
     }
 }
 

--- a/rust/src/server/src/state.rs
+++ b/rust/src/server/src/state.rs
@@ -34,6 +34,8 @@ pub struct AppState {
     pub cors: CorsConfig,
     /// Runtime server information returned by `/server_info`, when available.
     server_info: Option<ServerInfoSnapshot>,
+    /// Tokenizer metadata returned by `/tokenizer_info`, when enabled.
+    tokenizer_info: Option<Value>,
     /// SHA-256 hashes of API keys accepted as bearer tokens for guarded routes.
     api_key_hashes: Vec<ApiKeyHash>,
     /// Number of in-flight inference requests currently owned by this frontend.
@@ -64,6 +66,7 @@ impl AppState {
             api_server_options: ApiServerOptions::default(),
             cors: CorsConfig::default(),
             server_info: None,
+            tokenizer_info: None,
             api_key_hashes: Vec::new(),
             server_load: AtomicU64::new(0),
             lora_manager: LoraManager::new(),
@@ -101,6 +104,17 @@ impl AppState {
         config_format: ServerInfoConfigFormat,
     ) -> Option<Value> {
         self.server_info.as_ref().map(|server_info| server_info.response(config_format))
+    }
+
+    /// Attach the tokenizer metadata snapshot used by `/tokenizer_info`.
+    pub(crate) fn with_tokenizer_info(mut self, tokenizer_info: Value) -> Self {
+        self.tokenizer_info = Some(tokenizer_info);
+        self
+    }
+
+    /// Return the `/tokenizer_info` response payload.
+    pub(crate) fn tokenizer_info(&self) -> Option<&Value> {
+        self.tokenizer_info.as_ref()
     }
 
     /// Configure API keys accepted by guarded HTTP routes.


### PR DESCRIPTION


## Summary

Adds `GET /tokenizer_info` endpoint as part of #44222 (also included on #44280) . The endpoint remains disabled by default and is registered when `--enable-tokenizer-info-endpoint` is passed. The response is built once at startup from `tokenizer_config.json` and cached in `AppState`.

- Python behavior in `vllm/entrypoints/openai/serving_tokenization.py` flag name (`--enable-tokenizer-info-endpoint`) with the same opt-in semantics.
  - `vocab_file` and `merges_file` stripped (deployment-specific paths, same as Python)
  - `chat_template` reflected in the snapshot: (CLI `--chat-template` override takes
  precedence → separate template file → raw value from `tokenizer_config.json`
  - Returns 404 when the flag is not set 



## Tests

  `cargo clippy -p vllm-server -p vllm-chat --tests`  (clean)
  `cargo fmt --check`(clean)
  `cargo nextest run -p vllm-server -E 'test(tokenizer_info)'` 2 passed
  `cargo nextest run -p vllm-chat -E 'test(tokenizer_config)'` 4 passed

  Added integration tests in `routes/tests.rs`:
  - Returns snapshot with correct `tokenizer_class` and `chat_template`
  - Strips `vocab_file` / `merges_file` from the response
  - Returns 404 when `tokenizer_info` not loaded in `AppState`


---

CC: @BugenZhao 