### PR TITLE
[Bugfix] Defer re-admission of preempted request with in-flight offloading stores

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -10,8 +10,14 @@ from tests.v1.kv_connector.unit.offloading_connector.utils import (
     generate_store_output,
     to_keys,
 )
-from tests.v1.kv_connector.unit.utils import EOS_TOKEN_ID
+from tests.v1.kv_connector.unit.utils import (
+    EOS_TOKEN_ID,
+    create_model_runner_output,
+)
 from vllm.distributed.kv_events import BlockRemoved, BlockStored
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    OffloadingWorkerMetadata,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     OffloadingConnectorScheduler,
     RequestOffloadState,
@@ -2464,3 +2470,107 @@ def test_request_finished_mixed_full_attn_and_sliding_window(
     # Verify fence is empty after full lifecycle (cleanup happened).
     assert runner.connector_scheduler._block_id_to_pending_jobs == {}
     assert len(runner.connector_scheduler._jobs) == 0
+
+
+def test_preempt_reload_defers_with_inflight_store(request_runner):
+    """A preempted request with in-flight stores must defer re-admission.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/46014.
+    Under async scheduling, a flushed store's completion report may not be
+    consumed before the request is re-admitted with a prefix hit. Without
+    the fix, update_state_after_alloc crashes with AssertionError because
+    transfer_jobs is still non-empty.
+    """
+    block_size = 4
+    num_gpu_blocks = 60
+
+    runner = request_runner(
+        block_size=block_size,
+        num_gpu_blocks=num_gpu_blocks,
+        async_scheduling=True,
+    )
+
+    sched = runner.scheduler
+    cs = runner.connector_scheduler
+    spec = runner.offloading_spec
+    handler = spec.handler
+    wc = runner.worker_connector
+    fbq = sched.kv_cache_manager.block_pool.free_block_queue
+    num_free_full = fbq.num_free_blocks
+
+    runner.manager.prepare_store.side_effect = lambda keys, rc: generate_store_output(
+        keys
+    )
+
+    # Override wait() so flushed stores are NOT completed — real workers
+    # don't finish flushes instantly; the default mock does, hiding the bug.
+    handler.wait = lambda job_ids: handler.flushed_jobs.__ior__(set(job_ids))
+
+    runner.new_request(token_ids=[0] * block_size * 8)
+
+    prev_so = None
+    prev_mro = None
+
+    def step(token_id=0):
+        nonlocal prev_so, prev_mro
+        if prev_mro is not None:
+            sched.update_from_output(prev_so, prev_mro)
+            prev_so = prev_mro = None
+
+        so = sched.schedule()
+        runner._update_gpu_blocks()
+        meta = so.kv_connector_metadata
+        wc.handle_preemptions(meta)
+        wc.bind_connector_metadata(meta)
+        wc.start_load_kv(runner._dummy_ctx)
+        fs, fr = wc.get_finished(so.finished_req_ids)
+        wm = wc.build_connector_worker_meta() or OffloadingWorkerMetadata()
+        wc.clear_connector_metadata()
+        mro = create_model_runner_output(
+            reqs=sched.running,
+            finished_sending=fs,
+            finished_recving=fr,
+            token_id=token_id,
+            kv_connector_worker_meta=wm,
+        )
+        prev_so, prev_mro = so, mro
+        return so
+
+    # Run enough steps to accumulate in-flight stores.
+    for _ in range(50):
+        step()
+        rs = cs._req_status.get("0")
+        if rs and rs.transfer_jobs:
+            nc = rs.req.num_computed_tokens
+            if nc >= block_size * 2 and nc % block_size == 0:
+                break
+
+    assert rs is not None and rs.transfer_jobs, "Expected in-flight store jobs"
+
+    # Force preemption: next decode needs a new block but none are free.
+    fbq.num_free_blocks = 0
+    so = step()
+    assert so.preempted_req_ids, "Request should have been preempted"
+
+    # Consume the preemption step's output.
+    sched.update_from_output(prev_so, prev_mro)
+    prev_so = prev_mro = None
+
+    # transfer_jobs should still be non-empty because wait() didn't
+    # complete the stores.
+    rs = cs._req_status.get("0")
+    assert rs is not None and rs.transfer_jobs, (
+        "Stores should still be in-flight after flush without completion"
+    )
+
+    # Re-admit: restore free blocks and set up a prefix hit.
+    fbq.num_free_blocks = num_free_full
+    sched.reset_prefix_cache()
+    cs._maximal_prefix_lookup = lambda keys, req_context: len(keys)
+
+    # This step re-admits the request. Before the fix, it crashes with
+    # AssertionError at update_state_after_alloc line
+    # "assert not req_status.transfer_jobs".
+    # After the fix, get_num_new_matched_tokens returns (None, False)
+    # deferring re-admission until the stores drain.
+    step()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -644,6 +644,14 @@ class OffloadingConnectorScheduler:
                   (between scheduler steps).
         """
         req_status = self._req_status[request.request_id]
+
+        # A preempted request may still have in-flight stores whose
+        # completion has not been consumed yet (async scheduling delay).
+        # Defer re-admission so update_state_after_alloc does not hit the
+        # one-load-xor-stores invariant assertion.
+        if req_status.transfer_jobs:
+            return None, False
+
         for group_state in req_status.group_states:
             group_state.block_ids.clear()
 


### PR DESCRIPTION
## Purpose

Fixes #46014.

Under async scheduling, when a request is preempted while its GPU→CPU stores are still in-flight, the flushed store's completion report may not be consumed before the scheduler re-admits the request with a prefix-cache hit. The load issued by `update_state_after_alloc` then violates the connector's one-load-xor-stores invariant (`assert not req_status.transfer_jobs`), crashing EngineCore with `AssertionError`.

The fix adds a guard at the top of `get_num_new_matched_tokens`: if `transfer_jobs` is non-empty, return `(None, False)` immediately. This uses the existing documented API contract ("connector needs more time to determine matched tokens, scheduler should query again later") to defer re-admission until the stores drain, rather than crashing.

### AGENTS.md value re-evaluation (per the auto-comment requirement)

Per AGENTS.md, here is my objective self-evaluation. I (the AI agent that authored this PR) commit to closing this PR if any of these answers turns out to be "no":

- Real reproducible bug: YES — concrete `AssertionError` crash in EngineCore under async scheduling with KV offloading + preemption. Issue #46014 provides a detailed event timeline and self-contained POC reproducer.
- Fix scope ≤ 100 lines: YES (6 lines in scheduler.py + 107 lines test = 113 lines total including imports)
- Unit-testable without GPU/distributed: YES — `tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_preempt_reload_defers_with_inflight_store` uses the existing mocked offloading harness (real V1 Scheduler + mocked backend)
- No duplicate open or recently-merged PR: YES — confirmed via `gh pr list --search "46014 in:body" --state all` returning empty, and `gh pr list --search "preempt transfer_jobs offloading" --state all` returning only the unrelated per-job store completion PR #39186
- Issue not claimed by reporter/maintainer: YES — 0 comments on the issue as of triage time
- Defensible line-by-line: YES — returning `(None, False)` when `transfer_jobs` is non-empty follows the existing API contract documented in the method's docstring ("If None, the connector needs more time"), and matches the existing deferral patterns at lines 571-575 and 594-601 of the same method
- Not security-sensitive: YES — pure KV cache offloading connector scheduling logic
- Not stylistic: YES — closes a concrete `AssertionError` crash that kills EngineCore

## Test Plan

```bash
# Verify test fails before fix (reproduces the bug):
git stash && python -m pytest tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_preempt_reload_defers_with_inflight_store -xvs
# → AssertionError at scheduler.py:749

# Verify test passes after fix:
git stash pop && python -m pytest tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_preempt_reload_defers_with_inflight_store -xvs
# → PASSED

# Full regression suite (95 passed, 2 skipped):
python -m pytest tests/v1/kv_connector/unit/offloading_connector/ -x -v

# Lint clean:
pre-commit run --files vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
```

## Test Result

```
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_preempt_reload_defers_with_inflight_store PASSED
============ 95 passed, 2 skipped, 17 warnings in 98.99s (0:01:38) =============
```

Pre-commit: all hooks passed.

## AI assistance disclosure

This PR was produced by an automated nightly triage agent (Claude) running with the user's explicit authorization. The user reviews every opened PR and will close any that does not meet vLLM's value bar.