### PR TITLE
[Kernel] Start SWA/chunked KV-tile loop at first allowed key (#44575)

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -93,7 +93,15 @@ def ref_paged_attn(
 
 
 @pytest.mark.parametrize(
-    "seq_lens", [[(1, 1328), (5, 18), (129, 463)], [(1, 523), (1, 37), (1, 2011)]]
+    "seq_lens",
+    [
+        [(1, 1328), (5, 18), (129, 463)],
+        [(1, 523), (1, 37), (1, 2011)],
+        # Issue #44575: kv_lens chosen so first_allowed_key lands at varied
+        # residues mod TILE_SIZE for the 64/128/256 windows below, exercising
+        # the non-tile-aligned sliding-window loop base.
+        [(1, 1001), (1, 1015), (1, 1031)],
+    ],
 )
 @pytest.mark.parametrize("num_heads", NUM_HEADS)
 @pytest.mark.parametrize("head_size", HEAD_SIZES)

--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -237,6 +237,91 @@ def test_triton_unified_attn(
     )
 
 
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="byte-identical check is CUDA-only"
+)
+@torch.inference_mode()
+def test_triton_unified_attn_swa_residue_byte_identical():
+    """Issue #44575: the SWA loop now starts exactly at ``first_allowed_key``,
+    so the online-softmax reduction order no longer depends on the window's
+    residue mod ``TILE_SIZE``. Identical Q over identical (K, V) window content
+    must give byte-identical output whether ``first_allowed_key`` is tile
+    aligned or not. Forces the 2D-pointer decode path (``seq_threshold_3D=0``);
+    with ``head_size=128`` and ``block_size=16`` the decode tile size is 16.
+    """
+    torch.set_default_device(DEVICE_TYPE)
+    set_random_seed(0)
+
+    dtype = torch.bfloat16
+    num_query_heads, num_kv_heads = 8, 2
+    head_size = 128
+    block_size = 16  # TILE_SIZE_DECODE == 16 for this config
+    window = 256
+    scale = head_size**-0.5
+    num_blocks = 2048
+
+    # Shared query and windowed K/V content, reused verbatim in both runs.
+    query = torch.randn(1, num_query_heads, head_size, dtype=dtype)
+    win_k = torch.randn(window, num_kv_heads, head_size, dtype=dtype)
+    win_v = torch.randn_like(win_k)
+
+    def run(first_allowed_key: int) -> torch.Tensor:
+        # Decode query at position kv_len - 1 attends to [kv_len - window,
+        # kv_len - 1], so kv_len = first_allowed_key + window.
+        kv_len = first_allowed_key + window
+        n_logical = (kv_len + block_size - 1) // block_size
+        key_cache = torch.randn(
+            num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+        )
+        value_cache = torch.randn_like(key_cache)
+        # Place the identical window content at absolute positions
+        # [first_allowed_key, kv_len - 1] via an identity block table.
+        pos = torch.arange(window) + first_allowed_key
+        key_cache[pos // block_size, pos % block_size] = win_k
+        value_cache[pos // block_size, pos % block_size] = win_v
+        block_table = torch.arange(n_logical, dtype=torch.int32).view(1, n_logical)
+
+        out = torch.empty_like(query)
+        unified_attention(
+            q=query,
+            k=key_cache,
+            v=value_cache,
+            out=out,
+            cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
+            seqused_k=torch.tensor([kv_len], dtype=torch.int32),
+            max_seqlen_q=1,
+            max_seqlen_k=kv_len,
+            softmax_scale=scale,
+            causal=True,
+            window_size=(window - 1, 0),
+            block_table=block_table,
+            softcap=0,
+            q_descale=None,
+            k_descale=None,
+            v_descale=None,
+            seq_threshold_3D=0,
+            num_par_softmax_segments=16,
+            softmax_segm_output=torch.empty(
+                (0, num_query_heads, 16, next_power_of_2(head_size)),
+                dtype=torch.float32,
+            ),
+            softmax_segm_max=torch.empty((0, num_query_heads, 16), dtype=torch.float32),
+            softmax_segm_expsum=torch.empty(
+                (0, num_query_heads, 16), dtype=torch.float32
+            ),
+            kv_quant_mode=KVQuantMode.NONE,
+        )
+        return out
+
+    out_aligned = run(first_allowed_key=0)  # residue 0
+    out_shifted = run(first_allowed_key=block_size // 2)  # residue 8
+
+    assert torch.equal(out_aligned, out_shifted), (
+        "SWA output depends on first_allowed_key residue mod TILE_SIZE; "
+        f"max abs diff = {(out_aligned - out_shifted).abs().max().item()}"
+    )
+
+
 @pytest.mark.parametrize(
     "seq_lens", [[(1, 1328), (5, 18), (129, 463)], [(1, 523), (1, 37), (1, 2011)]]
 )

--- a/tests/kernels/attention/test_triton_unified_attention_diffkv.py
+++ b/tests/kernels/attention/test_triton_unified_attention_diffkv.py
@@ -71,6 +71,8 @@ def _alloc_segm_buffers(seq_threshold_3D: int, num_query_heads: int, head_size_v
     [
         [(1, 1328), (5, 18), (129, 463)],  # mixed prefill + decode
         [(1, 523), (1, 37), (1, 2011)],  # decode-only (exercises 3D path)
+        # Issue #44575: non-tile-aligned sliding-window loop base
+        [(1, 1001), (1, 1015), (1, 1031)],
     ],
 )
 @pytest.mark.parametrize("num_heads", NUM_HEADS)

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -157,6 +157,7 @@ def compute_tile_loop_bounds(
     USE_PER_SEQ_CAUSAL: tl.constexpr = False,
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
+    USE_TD: tl.constexpr = False,
 ):
     """Compute the tile-loop bounds ``(loop_lo, loop_hi)`` and the
     derived ``max_seq_prefix_len`` used for per-tile masking.
@@ -173,6 +174,14 @@ def compute_tile_loop_bounds(
     3. 3D scoping: when ``IS_3D`` is True, further narrows to the
        segment's slice via ``(segm_idx * tiles_per_segment,
        (segm_idx + 1) * tiles_per_segment)``.
+
+    Returns:
+        A tuple ``(loop_lo, loop_hi, max_seq_prefix_len, tile_base)``.
+        ``tile_base`` is the per-slot offset added on top of
+        ``j * TILE_SIZE`` so the sliding-window/chunked loop starts exactly
+        at ``first_allowed_key`` instead of its tile floor (issue #44575).
+        It is non-zero only for the 2D-pointer SWA/chunked path; the USE_TD
+        and 3D-segmented paths index in absolute tile units and keep it 0.
     """
     # compute the length of the longest sequence prefix spanned by any
     # query token in the current q_block (q_block_local_idx)
@@ -196,6 +205,7 @@ def compute_tile_loop_bounds(
     # Default: keep previous global behavior
     tile_start = 0
     tile_end = num_tiles
+    tile_base = 0
     # TODO(Isotr0py): sliding window pruning with image bidirectional mask
     if SLIDING_WINDOW > 0 and not USE_MM_PREFIX:
         # Query rows covered by this Q-block
@@ -225,6 +235,15 @@ def compute_tile_loop_bounds(
         # Convert to tile indices and clamp
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
         tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
+        # Issue #44575: start exactly at first_allowed_key (not its tile
+        # floor) so a window of W keys spans ceil(W / TILE_SIZE) tiles, not
+        # ceil((r + W) / TILE_SIZE) where r = first_allowed_key % TILE_SIZE.
+        # Only the 2D-pointer path (per-slot block index) can absorb a
+        # non-tile-aligned base; USE_TD and IS_3D index in absolute tile
+        # units, so they keep tile_base = 0. tile_end (from last_allowed_key)
+        # is unchanged, so the iteration count never grows.
+        if not USE_TD and not IS_3D:
+            tile_base = tl.maximum(0, first_allowed_key) - tile_start * TILE_SIZE
 
     if IS_3D:
         loop_lo = max(segm_idx_or_0 * tiles_per_segment_or_0, tile_start)
@@ -233,7 +252,7 @@ def compute_tile_loop_bounds(
         loop_lo = tile_start
         loop_hi = tile_end
 
-    return loop_lo, loop_hi, max_seq_prefix_len
+    return loop_lo, loop_hi, max_seq_prefix_len, tile_base
 
 
 @triton.jit

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -378,7 +378,7 @@ def kernel_unified_attention(
     if USE_QQ_BIAS:
         qq_bias_row_ptrs = qq_bias_ptr + query_pos[:, None] * qq_bias_stride_0
 
-    loop_lo, loop_hi, max_seq_prefix_len = compute_tile_loop_bounds(
+    loop_lo, loop_hi, max_seq_prefix_len, tile_base = compute_tile_loop_bounds(
         context_len,
         seq_len,
         cur_batch_query_len,
@@ -396,11 +396,12 @@ def kernel_unified_attention(
         USE_PER_SEQ_CAUSAL,
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
+        USE_TD,
     )
 
     # iterate through tiles (now limited to the sliding window range)
     for j in range(loop_lo, loop_hi):
-        seq_offset = j * TILE_SIZE + offs_t
+        seq_offset = tile_base + j * TILE_SIZE + offs_t
         tile_mask = seq_offset < max_seq_prefix_len
 
         physical_block_idx = tl.load(

--- a/vllm/v1/attention/ops/triton_unified_attention_diffkv.py
+++ b/vllm/v1/attention/ops/triton_unified_attention_diffkv.py
@@ -170,7 +170,7 @@ def kernel_unified_attention_diffkv(
             alibi_slopes_ptr + query_offset_1, mask=query_mask_1, other=0.0
         )
 
-    loop_lo, loop_hi, max_seq_prefix_len = compute_tile_loop_bounds(
+    loop_lo, loop_hi, max_seq_prefix_len, tile_base = compute_tile_loop_bounds(
         context_len,
         seq_len,
         cur_batch_query_len,
@@ -187,7 +187,7 @@ def kernel_unified_attention_diffkv(
     )
 
     for j in range(loop_lo, loop_hi):
-        seq_offset = j * TILE_SIZE + offs_t
+        seq_offset = tile_base + j * TILE_SIZE + offs_t
         tile_mask = seq_offset < max_seq_prefix_len
 
         physical_block_idx = tl.load(


### PR DESCRIPTION
## Summary

Fixes #44575. The sliding-window/chunked KV-tile loop started at a floor-rounded
tile (`max(0, first_allowed_key // TILE_SIZE)`), so a window of `W` keys spanned
up to one extra `TILE_SIZE` tile beyond the minimal `ceil(W / TILE_SIZE)`.

`compute_tile_loop_bounds` now returns a `tile_base` so the loop starts exactly at
`first_allowed_key`. It's non-zero only for the 2D-pointer path; a new `USE_TD`
constexpr keeps it 0 for the tensor-descriptor and 3D paths. `tile_end` is
unchanged, so the iteration count never grows. The `diffkv` variant shares the
helper and is updated too.

## Tests

Added a residue-sweep `seq_lens` row, validated against the PyTorch reference on a B200:

```
test_triton_unified_attention.py -k seq_lens2        576 passed
test_triton_unified_attention_diffkv.py -k seq_lens2  48 passed
```

Pre-existing `use_td` failures reproduce on clean main (#44850); untouched here.
No open PR targets #44575.
