### PR TITLE
perf: Route prompt_embeds through shared memory across both IPC hops.

### DIFF
--- a/prof_embeds.py
+++ b/prof_embeds.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Profile Prefill: input_ids (text) vs prompt_embeds at matched input length.
+
+Example: Latency only:
+
+    VLLM_SHM_EMBEDS=1 VLLM_WORKER_MULTIPROC_METHOD=spawn MAX_JOBS=1 \\
+    PROF_EAGER=1 PROF_N=24000 PROF_K=3 CUDA_VISIBLE_DEVICES=0,1,2,3 \\
+    uv run --no-project python prof_embeds.py
+
+Example: With an nsys capture (adds the .nsys-rep):
+
+    VLLM_SHM_EMBEDS=1 VLLM_WORKER_MULTIPROC_METHOD=spawn MAX_JOBS=1 \\
+    PROF_EAGER=1 PROF_N=24000 PROF_K=3 CUDA_VISIBLE_DEVICES=0,1,2,3 \\
+    nsys profile --trace=cuda,nvtx,osrt -s none \\
+        --capture-range=cudaProfilerApi --capture-range-end=stop --force-overwrite=true \\
+        -o prof_updated \\
+        uv run --no-project python prof_embeds.py
+"""
+
+import os
+import random
+import statistics
+import time
+
+import torch
+
+from vllm import LLM, SamplingParams, TokensPrompt
+
+N = int(os.environ.get("PROF_N", "24000"))  # prompt length (tokens)
+K = int(os.environ.get("PROF_K", "4"))  # repeats per phase
+MODEL = os.environ.get("PROF_MODEL", "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8")
+TP = int(os.environ.get("PROF_TP", "4"))
+MAXLEN = int(os.environ.get("PROF_MAXLEN", "131072"))
+
+from transformers import AutoConfig  # noqa: E402
+
+_cfg = AutoConfig.from_pretrained(MODEL)
+H = _cfg.hidden_size  # hidden size for the embeds tensor
+VOCAB = _cfg.vocab_size  # vocab size for the model
+
+
+def tok_prompt():
+    return TokensPrompt(
+        prompt_token_ids=[random.randrange(1, VOCAB - 100) for _ in range(N)]
+    )
+
+
+def emb_prompt():
+    # bf16 [N, H]; values don't matter for kernel timing, only shape/dtype/path.
+    return {"prompt_embeds": torch.randn(N, H, dtype=torch.bfloat16)}
+
+
+def main():
+    kwargs = dict(
+        model=MODEL,
+        tensor_parallel_size=TP,
+        dtype="bfloat16",
+        max_model_len=MAXLEN,
+        enable_prompt_embeds=True,
+        enable_prefix_caching=False,  # Force full prefill every request for a clean comparison.
+        gpu_memory_utilization=0.80,
+        enforce_eager=bool(int(os.environ.get("PROF_EAGER", "0"))),
+    )
+    if "Nemotron" in MODEL:  # hybrid-mamba + FP8 MoE specific args.
+        kwargs.update(
+            kv_cache_dtype="fp8",
+            mamba_ssm_cache_dtype="float16",
+            enable_expert_parallel=True,
+        )
+    llm = LLM(**kwargs)
+    sp = SamplingParams(max_tokens=1, temperature=0.0)
+
+    # Warmup each path BEFORE the capture range.
+    print(">>> Warmup", flush=True)
+    llm.generate([tok_prompt()], sp, use_tqdm=False)
+    llm.generate([emb_prompt()], sp, use_tqdm=False)
+
+    torch.cuda.set_device(0)
+    _ctx = torch.zeros(1, device="cuda")
+    torch.cuda.synchronize()
+
+    # Pre-build ALL prompts OUTSIDE the timed window.
+    text_prompts = [tok_prompt() for _ in range(K)]
+    embed_prompts = [emb_prompt() for _ in range(K)]
+
+    print(">>> START PROFILE", flush=True)
+    torch.cuda.profiler.start()
+    text_t, emb_t = [], []
+
+    # Text prefill
+    for i in range(K):
+        torch.cuda.nvtx.range_push("TEXT_PREFILL")
+        t = time.perf_counter()
+        llm.generate([text_prompts[i]], sp, use_tqdm=False)
+        dt = time.perf_counter() - t
+        torch.cuda.nvtx.range_pop()
+        text_t.append(dt)
+        print(f"text  {i}: {dt:.3f}s", flush=True)
+
+    # Embed prefill
+    for i in range(K):
+        torch.cuda.nvtx.range_push("EMBED_PREFILL")
+        t = time.perf_counter()
+        llm.generate([embed_prompts[i]], sp, use_tqdm=False)
+        dt = time.perf_counter() - t
+        torch.cuda.nvtx.range_pop()
+        emb_t.append(dt)
+        print(f"embed {i}: {dt:.3f}s", flush=True)
+    torch.cuda.profiler.stop()
+
+    print(
+        f">>> RESULT N={N} text_median={statistics.median(text_t):.3f}s "
+        f"embed_median={statistics.median(emb_t):.3f}s "
+        f"premium={statistics.median(emb_t) / statistics.median(text_t):.2f}x",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/_shm_embeds.py
+++ b/vllm/_shm_embeds.py
@@ -1,0 +1,142 @@
+"""Broadcast prompt_embeds via a filename-based shared-memory handle instead of
+pickling the tensor bytes into the executor's shm broadcast MessageQueue.
+
+The EngineCore -> TP-workers broadcast (the SchedulerOutput) normally pickles each
+`NewRequestData.prompt_embeds` through torch's default tensor reduction
+(`torch.save`). For large embeds tensor at TP=4 that means a full serialize on the
+sender + a memcpy into the shm ring buffer + a `torch.load` deserialize on EVERY worker.
+This increases GPU-idle time for the prompt_embeds prefill path.
+
+`SharedTensorHandle` replaces the tensor with a small picklable stand-in:
+    - The storage is moved once to a /dev/shm file and only the rebuild handle (manager
+      socket + storage name + size) is broadcast.
+    - Every TP worker mmaps the same file. Zero serialize, zero per-worker copy.
+
+Enable with `VLLM_SHM_EMBEDS=1`, requires `VLLM_WORKER_MULTIPROC_METHOD=spawn`.
+"""
+
+import os
+from contextlib import contextmanager
+
+import torch
+
+_ENABLED = os.environ.get("VLLM_SHM_EMBEDS", "0") == "1"
+
+
+def enabled() -> bool:
+    return _ENABLED
+
+
+@contextmanager
+def _file_system_sharing():
+    """Temporarily force filename-based tensor sharing, then restore the default.
+
+    Scoped to just the reduce_storage() call rather than mutating the process-wide
+    strategy permanently: the rebuild handle is self-describing (a filename), so it
+    stays valid after the strategy is restored, and we avoid making unrelated tensor
+    sharing in this process inherit file_system.
+    `file_system` is required here because it is 1->N safe, the default file_descriptor
+    passes an fd over a socket that only ONE reader can claim, which breaks a broadcast
+    to N workers.
+    """
+    mp = torch.multiprocessing
+    prev = mp.get_sharing_strategy()
+    mp.set_sharing_strategy("file_system")
+    try:
+        yield
+    finally:
+        mp.set_sharing_strategy(prev)
+
+
+class SharedTensorHandle:
+    """Picklable stand-in for a CPU tensor backed by shared memory.
+
+    Pickles only the storage filename handle + shape/dtype/stride/offset metadata,
+    never the tensor data. `tensor()` then rebuilds an mmap view of the shared file.
+    """
+
+    __slots__ = ("storage_fn", "storage_args", "dtype", "shape", "stride", "offset")
+
+    def __init__(self, storage_fn, storage_args, dtype, shape, stride, offset):
+        self.storage_fn = storage_fn
+        self.storage_args = storage_args
+        self.dtype = dtype
+        self.shape = shape
+        self.stride = stride
+        self.offset = offset
+
+    def tensor(self) -> torch.Tensor:
+        storage = self.storage_fn(*self.storage_args)
+        t = torch.empty(0, dtype=self.dtype)
+        t.set_(storage, self.offset, self.shape, self.stride)
+        return t
+
+
+def shared_handle(t: torch.Tensor):
+    """Return (SharedTensorHandle, keepalive_tensor) for a CPU tensor.
+
+    The keepalive tensor owns the shared storage and MUST be held alive until every
+    reader has rebuilt, or the shm manager unlinks the backing file early.
+    """
+    from torch.multiprocessing.reductions import reduce_storage
+
+    src = t.detach().contiguous()
+    if src.is_shared():
+        # Tensor came in already shared (e.g. via the client->EngineCore tensor-IPC
+        # hop, which uses fd-based sharing). Clone to a clean, non-shared storage so
+        # reduce_storage performs a single file_system share.
+        src = src.clone()
+    with _file_system_sharing():
+        # Create a new shared-memory file and corresponding handle tuple.
+        storage_fn, storage_args = reduce_storage(src.untyped_storage())
+    handle = SharedTensorHandle(
+        storage_fn,
+        storage_args,
+        src.dtype,
+        tuple(src.shape),
+        tuple(src.stride()),
+        src.storage_offset(),
+    )
+    return handle, src
+
+
+def externalize_prompt_embeds(args: tuple) -> list:
+    """Replace prompt_embeds tensors in execute_model `args` with shared-mem handles.
+
+    - Mutates the SchedulerOutput in `args` in place.
+    - Returns a keepalive list of the shared source tensors.
+    - The caller MUST hold these alive until all workers have rebuilt (i.e. until
+      the rpc response returns) so the shm manager does not unlink the files early.
+    """
+    if not _ENABLED:
+        return []
+    keepalive: list = []
+    for a in args:
+        new_reqs = getattr(a, "scheduled_new_reqs", None)
+        if not new_reqs:
+            continue
+        for req in new_reqs:
+            # Externalize the prompt_embeds CPU tensor, skip None / non-tensors.
+            # (CUDA tensors would need the cuda-IPC path, not file_system shm.)
+            match getattr(req, "prompt_embeds", None):
+                case torch.Tensor() as t if not t.is_cuda:
+                    handle, src = shared_handle(t)
+                    # Replace the tensor with the handle to the shared memory.
+                    req.prompt_embeds = handle
+                    keepalive.append(src)
+                case _:
+                    # No prompt_embeds or not a CPU tensor, leave as-is.
+                    continue
+    return keepalive
+
+
+def internalize_prompt_embeds(args: tuple) -> None:
+    """Rebuild SharedTensorHandle stand-ins into mmap tensors (worker side)."""
+    for a in args:
+        new_reqs = getattr(a, "scheduled_new_reqs", None)
+        if not new_reqs:
+            continue
+        for req in new_reqs:
+            h = getattr(req, "prompt_embeds", None)
+            if isinstance(h, SharedTensorHandle):
+                req.prompt_embeds = h.tensor()

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -582,13 +582,13 @@ class MPClient(EngineCoreClient):
                         coordinator.get_stats_publish_address()
                     )
 
-            # Serialization setup with tensor queues for multimodal tensor IPC.
-            tensor_ipc_sender: TensorIpcSender | None = None
-            model_config = getattr(vllm_config, "model_config", None)
-            if model_config is not None and model_config.multimodal_config is not None:
-                mm_tensor_ipc = model_config.multimodal_config.mm_tensor_ipc
-                if mm_tensor_ipc == "torch_shm" and tensor_queue is not None:
-                    tensor_ipc_sender = TensorIpcSender(tensor_queue)
+            # Serialization setup with tensor queues for tensor IPC.
+            # The queue is created (in launch_core_engines) when shared-memory
+            # tensor IPC is wanted: either multimodal mm_tensor_ipc="torch_shm" or
+            # enable_prompt_embeds.
+            tensor_ipc_sender: TensorIpcSender | None = (
+                TensorIpcSender(tensor_queue) if tensor_queue is not None else None
+            )
 
             self.encoder = MsgpackEncoder(oob_tensor_consumer=tensor_ipc_sender)
             self.decoder = MsgpackDecoder(EngineCoreOutputs)

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1075,9 +1075,13 @@ def launch_core_engines(
     # Create a single tensor IPC queue for sharing multimodal tensors between
     # API servers and engine core. Returns a single queue since we only support
     # DP=1 for this data flow.
+    # Also create the IPC queue when prompt_embeds is enabled so the
+    # large prompt_embeds tensor is handed to EngineCore via shared memory (zero-copy).
     tensor_queue: Queue | None = None
     multimodal_config = vllm_config.model_config.multimodal_config
-    if multimodal_config is not None and multimodal_config.mm_tensor_ipc == "torch_shm":
+    if (
+        multimodal_config is not None and multimodal_config.mm_tensor_ipc == "torch_shm"
+    ) or vllm_config.model_config.enable_prompt_embeds:
         tensor_queue = get_mp_context().Queue()
 
     # Run the DP Coordinator process with rank 0 when in online DP mode.

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -371,6 +371,17 @@ class MultiprocExecutor(Executor):
             send_method = method
         else:
             send_method = cloudpickle.dumps(method, protocol=pickle.HIGHEST_PROTOCOL)
+
+        # Swap large `prompt_embeds` tensors for filename-based shm handles so the
+        # broadcast does not ship the full tensor. shm_keepalive holds the shared
+        # storages alive until all workers have rebuilt
+        from vllm import _shm_embeds
+
+        shm_keepalive = (
+            _shm_embeds.externalize_prompt_embeds(args)
+            if send_method == "execute_model"
+            else []
+        )
         self.rpc_broadcast_mq.enqueue((send_method, args, kwargs, output_rank))
 
         response_mqs: Sequence[MessageQueue] = self.response_mqs
@@ -398,6 +409,8 @@ class MultiprocExecutor(Executor):
         future = FutureWrapper(
             self.futures_queue, get_response=get_response, aggregate=aggregate
         )
+        if shm_keepalive:
+            future._shm_keepalive = shm_keepalive  # type: ignore[attr-defined]
 
         return future if non_block else future.result()
 
@@ -973,6 +986,11 @@ class WorkerProc:
             method, args, kwargs, output_rank = self.rpc_broadcast_mq.dequeue(
                 indefinite=True
             )
+            # Load prompt_embeds shm handles into mmap tensors before the worker method runs.
+            # No-ops unless a handle is present, so safe to call unconditionally.
+            from vllm import _shm_embeds
+
+            _shm_embeds.internalize_prompt_embeds(args)
             try:
                 if isinstance(method, str):
                     func = getattr(self.worker, method)


### PR DESCRIPTION
# Problem
`prompt_embeds` prefill stalls the GPU at the head of each request while the LARGE embeds tensor is copied/serialized across vLLM's two V1 IPC hops. GPU compute is identical to `text`-only prefill. The overhead (~2.6x at 24k, TP=4) is pure host-side starvation. 

# Solution
Route the tensor through shared memory on both hops so only a small `handle` crosses each boundary.

1. Hop 1 (`client -> EngineCore`): create the tensor-IPC queue and wire `TensorIpcSender` into the request encoder whenever `enable_prompt_embeds` is set, not only for multimodal torch_shm. The tensor is shared via `torch.mp` instead of serialized inline over ZMQ.
2. Hop 2 (`EngineCore -> TP workers`): the `SchedulerOutput` broadcast pickles `prompt_embeds` via `torch.save` (full serialize on the sender side + memcpy into the shm ring + `torch.load` on every TP worker). Replace the tensor with a small picklable `SharedTensorHandle`: `reduce_storage` moves the storage to a `/dev/shm` file once (file_system strategy, required for the 1->N fan-out) and every worker `mmaps` the same file. externalize/internalize hook collective_rpc and the worker loop.

Currently gated by `VLLM_SHM_EMBEDS=1`, requires VLLM_WORKER_MULTIPROC_METHOD=spawn.

# Results
<img width="641" height="138" alt="image" src="https://github.com/user-attachments/assets/aa826065-9528-4048-8139-e6227e455913" />

<img width="1594" height="913" alt="image" src="https://github.com/user-attachments/assets/907b261d-45fe-4e01-8558-9492c44ff960" />

<img width="1596" height="976" alt="image" src="https://github.com/user-attachments/assets/e6dd3a98-2e33-421b-bc09-4b4a72fd79ba" />