### PR TITLE
[Cohere] Remove dead prepare_structured_tag override in Cohere parser 

### DIFF
--- a/vllm/reasoning/cohere_command_reasoning_parser.py
+++ b/vllm/reasoning/cohere_command_reasoning_parser.py
@@ -20,7 +20,6 @@ except ImportError as e:
     ) from e
 
 
-from vllm.entrypoints.mcp.tool_server import ToolServer
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
@@ -480,15 +479,6 @@ class BaseCohereCommandReasoningParser(ReasoningParser):
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         return any(tid == self.end_token_id for tid in reversed(input_ids))
-
-    def prepare_structured_tag(
-        self, original_tag: str | None, tool_server: ToolServer | None
-    ) -> str | None:
-        # Responses API replaces ``structural_tag`` via the reasoning parser.
-        # Default ``ReasoningParser.prepare_structured_tag`` returns None, which
-        # would clear a Cohere tag produced in ``adjust_request`` and break
-        # ``StructuredOutputsParams`` validation. Preserve the existing tag.
-        return original_tag
 
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest


### PR DESCRIPTION
## Purpose
`BaseCohereCommandReasoningParser` overrode `prepare_structured_tag` solely to `return original_tag`, with a comment claiming the base default returns `None` and would otherwise clear the structural tag produced in `adjust_request`.

That comment is now stale. #45396 (`3b8fc3fe6d`) changed the base `ReasoningParser.prepare_structured_tag` from `return None` to `return original_tag`. The Cohere override is therefore an exact duplicate of the base method, guarding against a default that no longer exists.

This PR removes the override and the now-orphaned `ToolServer` import (its only use was that method's signature).


