### PR TITLE
[ROCm] Relax AITER hipBLASLt fp8 accuracy check

### DIFF
--- a/tests/rocm/aiter/test_aiter_hipb_mm_linear_kernel.py
+++ b/tests/rocm/aiter/test_aiter_hipb_mm_linear_kernel.py
@@ -353,11 +353,24 @@ def test_hipb_mm_kernel_forward_accuracy(enable_hipb_mm_kernel):
     expected = (x_dequant @ w_dequant.t() + bias.to(torch.float32)).to(torch.bfloat16)
 
     assert out.shape == (num_tokens, weight_shape[0])
-    # K=4096 fp8 reduction leaves room for accumulation order drift and
-    # catastrophic cancellation on near-zero outputs; tolerances are loose
-    # enough to absorb that but tight enough to catch wrong layouts, missing
-    # bias, swapped scales, etc.
-    torch.testing.assert_close(out, expected, atol=5.0, rtol=0.1)
+    # K=4096 fp8 reduction leaves room for accumulation-order drift and
+    # catastrophic cancellation on near-zero outputs. The relaxed AITER FP8
+    # check absorbs that -- allowing up to 5% of elements past base atol, but
+    # the max diff must stay within 4x base atol -- while still catching wrong
+    # layouts, missing bias, swapped scales, and similar bugs.
+    base_atol = 5.0
+    max_pct_allowed = 5.0
+    relaxed_atol = base_atol * 4
+    diff = (out.to(torch.float32) - expected.to(torch.float32)).abs()
+    max_diff = diff.max().item()
+    pct_exceed = (diff > base_atol).float().mean().item() * 100
+    assert pct_exceed <= max_pct_allowed, (
+        f"AITER FP8: {pct_exceed:.2f}% elements exceed atol={base_atol} "
+        f"(max allowed {max_pct_allowed}%)"
+    )
+    assert max_diff <= relaxed_atol, (
+        f"AITER FP8: max_diff={max_diff:.6f} exceeds relaxed limit {relaxed_atol}"
+    )
 
 
 def test_hipb_mm_kernel_online_tuning_writes_csv(


### PR DESCRIPTION
## Purpose
Fixes `test_hipb_mm_kernel_forward_accuracy` on MI300. The strict element-wise `assert_close(atol=5.0, rtol=0.1)`fails because fp8 math over K=4096 produces a few values that drift slightly from the reference.

The fix references the solution in https://github.com/ROCm/aiter/issues/2421 , already used for AITER fp8 MoE (`test_modular_kernel_combinations.py`):
allow up to 5% of elements past base atol, with max diff capped at 4x base atol.


## Test Plan
On MI300:
```bash
pytest -v tests/rocm/aiter/test_aiter_hipb_mm_linear_kernel.py
```
## Test Result
Before: 
Fails — a few outlier elements exceed atol=5.0.

After: 
Passes consistently, pct_exceed under 5% and max_diff within 4x cap.
Negative tests (swapped layout / scales) still fails, so regression coverage is preserved.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>