### PR TITLE
[Bugfix] Normalize slashes in Helion GPU names

### DIFF
--- a/tests/kernels/helion/test_utils.py
+++ b/tests/kernels/helion/test_utils.py
@@ -17,6 +17,7 @@ from vllm.kernels.helion.utils import canonicalize_gpu_name
         ("NVIDIA H100 SXM5", "nvidia_h100"),
         ("NVIDIA GeForce RTX 4090", "nvidia_geforce_rtx_4090"),
         ("AMD Instinct MI300X", "amd_instinct_mi300x"),
+        ("AMD Instinct MI250X / MI250", "amd_instinct_mi250x_mi250"),
         ("Tesla V100-SXM2-32GB", "tesla_v100"),
     ],
 )

--- a/vllm/kernels/helion/utils.py
+++ b/vllm/kernels/helion/utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Utility functions for Helion kernel management."""
 
-import re
+import regex as re
 
 import torch
 

--- a/vllm/kernels/helion/utils.py
+++ b/vllm/kernels/helion/utils.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Utility functions for Helion kernel management."""
 
+import re
+
 import torch
 
 from vllm.logger import init_logger
@@ -62,7 +64,7 @@ def canonicalize_gpu_name(name: str) -> str:
     """
     Canonicalize GPU name for use as a platform identifier.
 
-    Converts to lowercase, replaces spaces and hyphens with underscores,
+    Converts to lowercase, replaces separators with underscores,
     and maps known variant names to their canonical form via _GPU_NAME_ALIASES.
     e.g., "NVIDIA H100 80GB HBM3" -> "nvidia_h100"
           "NVIDIA A100-SXM4-80GB" -> "nvidia_a100"
@@ -70,9 +72,7 @@ def canonicalize_gpu_name(name: str) -> str:
     """
     if not name or not name.strip():
         raise ValueError("GPU name cannot be empty")
-    name = name.lower()
-    name = name.replace(" ", "_")
-    name = name.replace("-", "_")
+    name = re.sub(r"[\s/-]+", "_", name.lower())
     if name in _GPU_NAME_ALIASES:
         return _GPU_NAME_ALIASES[name]
     return name

--- a/vllm/kernels/helion/utils.py
+++ b/vllm/kernels/helion/utils.py
@@ -3,7 +3,6 @@
 """Utility functions for Helion kernel management."""
 
 import regex as re
-
 import torch
 
 from vllm.logger import init_logger


### PR DESCRIPTION
## Purpose

Fixes #46084.

Helion uses `canonicalize_gpu_name()` to build stable GPU identifiers. ROCm can report composite GPU names such as `AMD Instinct MI250X / MI250`; the slash currently survives normalization, which makes the identifier unsuitable for config lookup or path-like keys.

This normalizes separator runs made of whitespace, hyphens, or `/` to a single underscore while preserving the existing alias lookup behavior.

I checked for duplicate work before marking this ready: searches for #46084, `canonicalize_gpu_name`, `Helion GPU name slash`, and `vllm/kernels/helion/utils.py` found no other open PR on this surface.

AI assistance was used to prepare this patch; I reviewed the changed lines.

## Test Plan

- `git diff --check HEAD~1..HEAD -- vllm/kernels/helion/utils.py tests/kernels/helion/test_utils.py`
- Intended focused test: `.venv/bin/python -m pytest tests/kernels/helion/test_utils.py -q`

## Test Result

- `git diff --check HEAD~1..HEAD -- vllm/kernels/helion/utils.py tests/kernels/helion/test_utils.py` passed.
- The focused pytest command could not run locally because `.venv/bin/python` is present but `pytest` is not installed (`No module named pytest`). I did not install dependencies while preparing this PR.