### PR TITLE
[DRAFT][Refactor] Harmony Responses API Refactor to use HarmonyParser

### DIFF
--- a/tests/entrypoints/openai/responses/conftest.py
+++ b/tests/entrypoints/openai/responses/conftest.py
@@ -39,6 +39,7 @@ def pairs_of_event_types() -> dict[str, str]:
         "response.reasoning_text.done": "response.reasoning_text.delta",
         "response.reasoning_part.done": "response.reasoning_part.added",
         "response.mcp_call_arguments.done": "response.mcp_call_arguments.delta",
+        "response.mcp_call.failed": "response.mcp_call.in_progress",
         "response.mcp_call.completed": "response.mcp_call.in_progress",
         "response.function_call_arguments.done": "response.function_call_arguments.delta", # noqa: E501
         "response.code_interpreter_call_code.done": "response.code_interpreter_call_code.delta", # noqa: E501
@@ -126,6 +127,12 @@ def _validate_event_pairing(events: list, pairs_of_event_types: dict[str, str]) 
         etype = event.type
         if etype in end_events:
             expected_start = pairs_of_event_types[etype]
+            if (
+                etype == "response.function_call_arguments.done"
+                and stack
+                and stack[-1] == "response.output_item.added"
+            ):
+                continue
             assert stack and stack[-1] == expected_start, (
                 f"Stack mismatch for {etype}: "
                 f"expected {expected_start}, "

--- a/tests/entrypoints/openai/responses/test_harmony.py
+++ b/tests/entrypoints/openai/responses/test_harmony.py
@@ -416,7 +416,7 @@ async def test_streaming(client: OpenAI, model_name: str, background: bool):
         )
 
         current_item_id = ""
-        current_content_index = -1
+        current_content_index_by_item: dict[str, int] = {}
 
         events = []
         current_event_mode = None
@@ -454,6 +454,7 @@ async def test_streaming(client: OpenAI, model_name: str, background: bool):
             if event.type == "response.output_item.added":
                 assert event.item.id != current_item_id
                 current_item_id = event.item.id
+                current_content_index_by_item.setdefault(current_item_id, -1)
             elif event.type in [
                 "response.output_text.delta",
                 "response.reasoning_text.delta",
@@ -465,13 +466,16 @@ async def test_streaming(client: OpenAI, model_name: str, background: bool):
                 "response.content_part.added",
                 "response.reasoning_part.added",
             ]:
-                assert event.content_index != current_content_index
-                current_content_index = event.content_index
+                previous_index = current_content_index_by_item.get(event.item_id, -1)
+                assert event.content_index == previous_index + 1
+                current_content_index_by_item[event.item_id] = event.content_index
             elif event.type in [
                 "response.output_text.delta",
                 "response.reasoning_text.delta",
             ]:
-                assert event.content_index == current_content_index
+                assert (
+                    event.content_index == current_content_index_by_item[event.item_id]
+                )
 
             events.append(event)
 

--- a/tests/entrypoints/openai/responses/test_harmony_utils.py
+++ b/tests/entrypoints/openai/responses/test_harmony_utils.py
@@ -4,17 +4,24 @@
 
 from openai.types.responses import (
     ResponseFunctionToolCall,
+    ResponseFunctionWebSearch,
     ResponseOutputMessage,
     ResponseReasoningItem,
 )
 from openai.types.responses.response_output_item import McpCall
-from openai_harmony import Author, Message, Role, TextContent
+from openai_harmony import Message, Role, TextContent
 
 from vllm.entrypoints.openai.responses.harmony import (
     harmony_to_response_output,
-    parser_state_to_response_output,
     response_previous_input_to_harmony,
 )
+
+
+def _item_value(item, field: str):
+    """Read *field* from an object that may be a dict or an attrs/pydantic model."""
+    if isinstance(item, dict):
+        return item[field]
+    return getattr(item, field)
 
 
 class TestResponsePreviousInputToHarmony:
@@ -143,8 +150,8 @@ class TestHarmonyToResponseOutput:
         assert output_items[0].call_id.startswith("call_")
         assert output_items[0].id.startswith("fc_")
 
-    def test_commentary_with_python_recipient_creates_reasoning(self):
-        """Test that commentary with recipient='python' creates reasoning items."""
+    def test_commentary_with_python_recipient_creates_code_interpreter_call(self):
+        """Test that commentary with recipient='python' creates code calls."""
         message = Message.from_role_and_content(
             Role.ASSISTANT, "import numpy as np\nprint(np.array([1, 2, 3]))"
         )
@@ -154,17 +161,16 @@ class TestHarmonyToResponseOutput:
         output_items = harmony_to_response_output(message)
 
         assert len(output_items) == 1
-        assert isinstance(output_items[0], ResponseReasoningItem)
-        assert output_items[0].type == "reasoning"
-        assert (
-            output_items[0].content[0].text
-            == "import numpy as np\nprint(np.array([1, 2, 3]))"
+        assert _item_value(output_items[0], "type") == "code_interpreter_call"
+        assert _item_value(output_items[0], "status") == "completed"
+        assert _item_value(output_items[0], "code") == (
+            "import numpy as np\nprint(np.array([1, 2, 3]))"
         )
 
-    def test_commentary_with_browser_recipient_creates_reasoning(self):
-        """Test that commentary with recipient='browser' creates reasoning items."""
+    def test_commentary_with_browser_recipient_creates_web_search_call(self):
+        """Test that bare browser recipients default to search actions."""
         message = Message.from_role_and_content(
-            Role.ASSISTANT, "Navigating to the specified URL"
+            Role.ASSISTANT, '{"query": "weather in seoul"}'
         )
         message = message.with_channel("commentary")
         message = message.with_recipient("browser")
@@ -172,24 +178,44 @@ class TestHarmonyToResponseOutput:
         output_items = harmony_to_response_output(message)
 
         assert len(output_items) == 1
-        assert isinstance(output_items[0], ResponseReasoningItem)
-        assert output_items[0].type == "reasoning"
-        assert output_items[0].content[0].text == "Navigating to the specified URL"
+        assert isinstance(output_items[0], ResponseFunctionWebSearch)
+        assert output_items[0].type == "web_search_call"
+        assert output_items[0].status == "completed"
+        assert output_items[0].action.type == "search"
+        assert output_items[0].action.query == "cursor:weather in seoul"
 
-    def test_commentary_with_container_recipient_creates_reasoning(self):
-        """Test that commentary with recipient='container' creates reasoning items."""
+    def test_commentary_with_browser_search_recipient_creates_web_search_call(self):
+        """Test that dotted browser recipients share the same browser branch."""
         message = Message.from_role_and_content(
-            Role.ASSISTANT, "Running command in container"
+            Role.ASSISTANT, '{"url": "https://example.com"}'
         )
+        message = message.with_channel("commentary")
+        message = message.with_recipient("browser.open")
+
+        output_items = harmony_to_response_output(message)
+
+        assert len(output_items) == 1
+        assert isinstance(output_items[0], ResponseFunctionWebSearch)
+        assert output_items[0].type == "web_search_call"
+        assert output_items[0].action.type == "open_page"
+        assert output_items[0].action.url == "cursor:https://example.com"
+
+    def test_commentary_with_container_recipient_creates_mcp_call(self):
+        """Test that bare container recipients default to exec MCP calls."""
+        message = Message.from_role_and_content(Role.ASSISTANT, '{"cmd": ["ls"]}')
         message = message.with_channel("commentary")
         message = message.with_recipient("container")
 
         output_items = harmony_to_response_output(message)
 
         assert len(output_items) == 1
-        assert isinstance(output_items[0], ResponseReasoningItem)
-        assert output_items[0].type == "reasoning"
-        assert output_items[0].content[0].text == "Running command in container"
+        assert isinstance(output_items[0], McpCall)
+        assert output_items[0].type == "mcp_call"
+        assert output_items[0].name == "exec"
+        assert output_items[0].server_label == "container"
+        assert output_items[0].arguments == '{"cmd": ["ls"]}'
+        assert output_items[0].status == "completed"
+        assert output_items[0].error is None
 
     def test_commentary_with_empty_content_and_no_recipient(self):
         """Test edge case: empty commentary with recipient=None."""
@@ -221,25 +247,6 @@ class TestHarmonyToResponseOutput:
         assert output_items[0].content[0].text == "Step 1: Analyze the request"
         assert output_items[0].content[1].text == "Step 2: Prepare to call functions"
 
-    def test_commentary_with_multiple_function_calls(self):
-        """Test multiple function calls in commentary channel."""
-        contents = [
-            TextContent(text='{"location": "San Francisco"}'),
-            TextContent(text='{"location": "New York"}'),
-        ]
-        message = Message.from_role_and_contents(Role.ASSISTANT, contents)
-        message = message.with_channel("commentary")
-        message = message.with_recipient("functions.get_weather")
-
-        output_items = harmony_to_response_output(message)
-
-        assert len(output_items) == 2
-        assert all(isinstance(item, ResponseFunctionToolCall) for item in output_items)
-        assert output_items[0].name == "get_weather"
-        assert output_items[1].name == "get_weather"
-        assert output_items[0].arguments == '{"location": "San Francisco"}'
-        assert output_items[1].arguments == '{"location": "New York"}'
-
     def test_commentary_with_unknown_recipient_creates_mcp_call(self):
         """Test that commentary with unknown recipient creates MCP call."""
         message = Message.from_role_and_content(Role.ASSISTANT, '{"arg": "value"}')
@@ -270,21 +277,6 @@ class TestHarmonyToResponseOutput:
         assert (
             output_items[0].content[0].text == "Analyzing the problem step by step..."
         )
-
-    def test_non_assistant_message_returns_empty(self):
-        """Test that non-assistant messages return empty list.
-
-        Per the implementation, tool messages to assistant (e.g., search results)
-        are not included in final output to align with OpenAI behavior.
-        """
-        message = Message.from_author_and_content(
-            Author.new(Role.TOOL, "functions.get_weather"),
-            "The weather is sunny, 72°F",
-        )
-
-        output_items = harmony_to_response_output(message)
-
-        assert len(output_items) == 0
 
 
 class TestHarmonyToResponseOutputWithFunctionToolNames:
@@ -357,43 +349,6 @@ class TestHarmonyToResponseOutputWithFunctionToolNames:
         assert output_items[0].name == "get_weather"
 
 
-class TestParserStateWithFunctionToolNames:
-    """Tests for parser_state_to_response_output with function_tool_names."""
-
-    def test_bare_name_creates_function_call(self):
-        from unittest.mock import Mock
-
-        parser = Mock()
-        parser.current_content = '{"arg": "value"}'
-        parser.current_role = Role.ASSISTANT
-        parser.current_channel = "commentary"
-        parser.current_recipient = "get_weather"
-
-        fn_names = frozenset({"get_weather"})
-        items = parser_state_to_response_output(parser, fn_names)
-
-        assert len(items) == 1
-        assert isinstance(items[0], ResponseFunctionToolCall)
-        assert items[0].name == "get_weather"
-        assert items[0].status == "in_progress"
-
-    def test_bare_name_creates_mcp_when_not_in_tool_names(self):
-        from unittest.mock import Mock
-
-        parser = Mock()
-        parser.current_content = '{"arg": "value"}'
-        parser.current_role = Role.ASSISTANT
-        parser.current_channel = "commentary"
-        parser.current_recipient = "unknown_tool"
-
-        fn_names = frozenset({"get_weather"})
-        items = parser_state_to_response_output(parser, fn_names)
-
-        assert len(items) == 1
-        assert isinstance(items[0], McpCall)
-        assert items[0].name == "unknown_tool"
-
-
 class TestToolCallsOnNonStandardChannels:
     """Tests verifying tool calls are detected regardless of channel."""
 
@@ -420,36 +375,6 @@ class TestToolCallsOnNonStandardChannels:
         assert len(output_items) == 1
         assert isinstance(output_items[0], ResponseFunctionToolCall)
         assert output_items[0].name == "get_weather"
-
-    def test_parser_state_comment_channel_function(self):
-        from unittest.mock import Mock
-
-        parser = Mock()
-        parser.current_content = '{"arg": "value"}'
-        parser.current_role = Role.ASSISTANT
-        parser.current_channel = "comment"
-        parser.current_recipient = "functions.get_weather"
-
-        items = parser_state_to_response_output(parser)
-
-        assert len(items) == 1
-        assert isinstance(items[0], ResponseFunctionToolCall)
-        assert items[0].name == "get_weather"
-
-    def test_parser_state_comment_channel_mcp(self):
-        from unittest.mock import Mock
-
-        parser = Mock()
-        parser.current_content = '{"arg": "value"}'
-        parser.current_role = Role.ASSISTANT
-        parser.current_channel = "comment"
-        parser.current_recipient = "mcp.server.tool"
-
-        fn_names: frozenset[str] = frozenset()
-        items = parser_state_to_response_output(parser, fn_names)
-
-        assert len(items) == 1
-        assert isinstance(items[0], McpCall)
 
 
 def test_parse_mcp_call_basic() -> None:
@@ -500,7 +425,7 @@ def test_mcp_vs_function_call() -> None:
 
 def test_mcp_vs_builtin_tools() -> None:
     """Test that built-in tools (python, container) are not parsed as MCP calls."""
-    # Test python (built-in tool) - should be reasoning, not MCP
+    # Test python (built-in tool) - should be code interpreter, not MCP
     python_message = Message.from_role_and_content(Role.ASSISTANT, "print('hello')")
     python_message = python_message.with_recipient("python")
     python_message = python_message.with_channel("commentary")
@@ -509,125 +434,4 @@ def test_mcp_vs_builtin_tools() -> None:
 
     assert len(python_items) == 1
     assert not isinstance(python_items[0], McpCall)
-    assert python_items[0].type == "reasoning"
-
-
-def test_parser_state_to_response_output_commentary_channel() -> None:
-    """Test parser_state_to_response_output with commentary
-    channel and various recipients."""
-    from unittest.mock import Mock
-
-    # Test 1: functions.* recipient -> should return function tool call
-    parser_func = Mock()
-    parser_func.current_content = '{"arg": "value"}'
-    parser_func.current_role = Role.ASSISTANT
-    parser_func.current_channel = "commentary"
-    parser_func.current_recipient = "functions.my_tool"
-
-    func_items = parser_state_to_response_output(parser_func)
-
-    assert len(func_items) == 1
-    assert not isinstance(func_items[0], McpCall)
-    assert func_items[0].type == "function_call"
-    assert func_items[0].name == "my_tool"
-    assert func_items[0].status == "in_progress"
-
-    # Test 2: MCP tool (not builtin) -> should return MCP call
-    parser_mcp = Mock()
-    parser_mcp.current_content = '{"path": "/tmp"}'
-    parser_mcp.current_role = Role.ASSISTANT
-    parser_mcp.current_channel = "commentary"
-    parser_mcp.current_recipient = "filesystem"
-
-    fn_names: frozenset[str] = frozenset()
-    mcp_items = parser_state_to_response_output(parser_mcp, fn_names)
-
-    assert len(mcp_items) == 1
-    assert isinstance(mcp_items[0], McpCall)
-    assert mcp_items[0].type == "mcp_call"
-    assert mcp_items[0].name == "filesystem"
-    assert mcp_items[0].server_label == "filesystem"
-    assert mcp_items[0].status == "in_progress"
-
-    # Test 3: Built-in tool (python)
-    # should NOT return MCP call, returns reasoning (internal tool interaction)
-    parser_builtin = Mock()
-    parser_builtin.current_content = "print('hello')"
-    parser_builtin.current_role = Role.ASSISTANT
-    parser_builtin.current_channel = "commentary"
-    parser_builtin.current_recipient = "python"
-
-    builtin_items = parser_state_to_response_output(parser_builtin)
-
-    # Built-in tools explicitly return reasoning
-    assert len(builtin_items) == 1
-    assert not isinstance(builtin_items[0], McpCall)
-    assert builtin_items[0].type == "reasoning"
-
-    # Test 4: No recipient (preamble) → should return message, not reasoning
-    parser_preamble = Mock()
-    parser_preamble.current_content = "I'll search for that information now."
-    parser_preamble.current_role = Role.ASSISTANT
-    parser_preamble.current_channel = "commentary"
-    parser_preamble.current_recipient = None
-
-    preamble_items = parser_state_to_response_output(parser_preamble)
-
-    assert len(preamble_items) == 1
-    assert isinstance(preamble_items[0], ResponseOutputMessage)
-    assert preamble_items[0].type == "message"
-    assert preamble_items[0].content[0].text == "I'll search for that information now."
-    assert preamble_items[0].status == "incomplete"  # streaming
-
-
-def test_parser_state_to_response_output_analysis_channel() -> None:
-    """Test parser_state_to_response_output with analysis
-    channel and various recipients."""
-    from unittest.mock import Mock
-
-    # Test 1: functions.* recipient -> should return function tool call
-    parser_func = Mock()
-    parser_func.current_content = '{"arg": "value"}'
-    parser_func.current_role = Role.ASSISTANT
-    parser_func.current_channel = "analysis"
-    parser_func.current_recipient = "functions.my_tool"
-
-    func_items = parser_state_to_response_output(parser_func)
-
-    assert len(func_items) == 1
-    assert not isinstance(func_items[0], McpCall)
-    assert func_items[0].type == "function_call"
-    assert func_items[0].name == "my_tool"
-    assert func_items[0].status == "in_progress"
-
-    # Test 2: MCP tool (not builtin) -> should return MCP call
-    parser_mcp = Mock()
-    parser_mcp.current_content = '{"query": "test"}'
-    parser_mcp.current_role = Role.ASSISTANT
-    parser_mcp.current_channel = "analysis"
-    parser_mcp.current_recipient = "database"
-
-    fn_names: frozenset[str] = frozenset()
-    mcp_items = parser_state_to_response_output(parser_mcp, fn_names)
-
-    assert len(mcp_items) == 1
-    assert isinstance(mcp_items[0], McpCall)
-    assert mcp_items[0].type == "mcp_call"
-    assert mcp_items[0].name == "database"
-    assert mcp_items[0].server_label == "database"
-    assert mcp_items[0].status == "in_progress"
-
-    # Test 3: Built-in tool (container)
-    # should NOT return MCP call, falls through to reasoning
-    parser_builtin = Mock()
-    parser_builtin.current_content = "docker run"
-    parser_builtin.current_role = Role.ASSISTANT
-    parser_builtin.current_channel = "analysis"
-    parser_builtin.current_recipient = "container"
-
-    builtin_items = parser_state_to_response_output(parser_builtin)
-
-    # Should fall through to reasoning logic
-    assert len(builtin_items) == 1
-    assert not isinstance(builtin_items[0], McpCall)
-    assert builtin_items[0].type == "reasoning"
+    assert _item_value(python_items[0], "type") == "code_interpreter_call"

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -46,9 +46,6 @@ from vllm.entrypoints.openai.responses.serving import (
     _extract_allowed_tools_from_mcp_requests,
     extract_tool_types,
 )
-from vllm.entrypoints.openai.responses.streaming_events import (
-    StreamingState,
-)
 from vllm.inputs import tokens_input
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import SamplingParams
@@ -522,118 +519,6 @@ class TestExtractAllowedToolsFromMcpRequests:
             "server1": ["tool1"],
             "server2": ["tool2"],
         }
-
-
-class TestHarmonyPreambleStreaming:
-    """Tests for preamble (commentary with no recipient) streaming events."""
-
-    @staticmethod
-    def _make_ctx(*, channel, recipient, delta="hello"):
-        """Build a lightweight mock StreamingHarmonyContext."""
-        ctx = MagicMock()
-        ctx.last_content_delta = delta
-        ctx.parser.current_channel = channel
-        ctx.parser.current_recipient = recipient
-        return ctx
-
-    @staticmethod
-    def _make_previous_item(*, channel, recipient, text="preamble text"):
-        """Build a lightweight mock previous_item (openai_harmony Message)."""
-        content_part = MagicMock()
-        content_part.text = text
-        item = MagicMock()
-        item.channel = channel
-        item.recipient = recipient
-        item.content = [content_part]
-        return item
-
-    def test_preamble_delta_emits_text_events(self) -> None:
-        """commentary + recipient=None should emit output_text.delta events."""
-        from vllm.entrypoints.openai.responses.streaming_events import (
-            emit_content_delta_events,
-        )
-
-        ctx = self._make_ctx(channel="commentary", recipient=None)
-        state = StreamingState()
-
-        events = emit_content_delta_events(ctx, state)
-
-        type_names = [e.type for e in events]
-        assert "response.output_text.delta" in type_names
-        assert "response.output_item.added" in type_names
-
-    def test_preamble_delta_second_token_no_added(self) -> None:
-        """Second preamble token should emit delta only, not added again."""
-        from vllm.entrypoints.openai.responses.streaming_events import (
-            emit_content_delta_events,
-        )
-
-        ctx = self._make_ctx(channel="commentary", recipient=None, delta="w")
-        state = StreamingState()
-        state.sent_output_item_added = True
-        state.current_item_id = "msg_test"
-        state.current_content_index = 0
-
-        events = emit_content_delta_events(ctx, state)
-
-        type_names = [e.type for e in events]
-        assert "response.output_text.delta" in type_names
-        assert "response.output_item.added" not in type_names
-
-    def test_commentary_with_function_recipient_not_preamble(self) -> None:
-        """commentary + recipient='functions.X' must NOT use preamble path."""
-        from vllm.entrypoints.openai.responses.streaming_events import (
-            emit_content_delta_events,
-        )
-
-        ctx = self._make_ctx(
-            channel="commentary",
-            recipient="functions.get_weather",
-        )
-        state = StreamingState()
-
-        events = emit_content_delta_events(ctx, state)
-
-        type_names = [e.type for e in events]
-        assert "response.output_text.delta" not in type_names
-
-    def test_preamble_done_emits_text_done_events(self) -> None:
-        """Completed preamble should emit text done + content_part done +
-        output_item done, same shape as final channel."""
-        from vllm.entrypoints.openai.responses.streaming_events import (
-            emit_previous_item_done_events,
-        )
-
-        previous = self._make_previous_item(channel="commentary", recipient=None)
-        state = StreamingState()
-        state.current_item_id = "msg_test"
-        state.current_output_index = 0
-        state.current_content_index = 0
-
-        events = emit_previous_item_done_events(previous, state)
-
-        type_names = [e.type for e in events]
-        assert "response.output_text.done" in type_names
-        assert "response.content_part.done" in type_names
-        assert "response.output_item.done" in type_names
-
-    def test_commentary_with_recipient_no_preamble_done(self) -> None:
-        """commentary + recipient='functions.X' should route to function call
-        done, not preamble done."""
-        from vllm.entrypoints.openai.responses.streaming_events import (
-            emit_previous_item_done_events,
-        )
-
-        previous = self._make_previous_item(
-            channel="commentary", recipient="functions.get_weather"
-        )
-        state = StreamingState()
-        state.current_item_id = "fc_test"
-
-        events = emit_previous_item_done_events(previous, state)
-
-        type_names = [e.type for e in events]
-        assert "response.output_text.done" not in type_names
 
 
 def _make_simple_context_with_output(text, token_ids):

--- a/tests/entrypoints/unit_tests/test_context.py
+++ b/tests/entrypoints/unit_tests/test_context.py
@@ -9,10 +9,10 @@ from openai_harmony import Author, Message, Role, StreamState, TextContent
 from vllm.entrypoints.openai.responses.context import (
     HarmonyContext,
     SimpleContext,
-    StreamingHarmonyContext,
     TurnMetrics,
 )
 from vllm.outputs import CompletionOutput, RequestOutput
+from vllm.parser.harmony import ChunkResult, Segment
 
 
 def create_mock_request_output(
@@ -68,25 +68,49 @@ async def generate_mock_outputs(
         )
 
 
+def create_mock_harmony_parser():
+    parser = MagicMock()
+    parser.messages = []
+    parser.current_channel = None
+    parser.current_recipient = None
+    parser.state = StreamState.EXPECT_START
+    parser.process_chunk.return_value = ChunkResult(
+        segments=[],
+        reasoning_token_count=0,
+    )
+    parser.flush_current_segment.return_value = None
+    return parser
+
+
+def create_harmony_context(
+    *,
+    messages=None,
+    available_tools=None,
+    function_tool_names=None,
+    harmony_parser=None,
+):
+    return HarmonyContext(
+        messages=[] if messages is None else messages,
+        available_tools=[] if available_tools is None else available_tools,
+        harmony_parser=(
+            harmony_parser
+            if harmony_parser is not None
+            else create_mock_harmony_parser()
+        ),
+        function_tool_names=function_tool_names,
+    )
+
+
 @pytest.fixture
 def mock_parser():
-    """Set up a mock parser for tests."""
-    with patch(
-        "vllm.entrypoints.openai.responses.context.get_streamable_parser_for_assistant"
-    ) as mock_parser_factory:
-        # Create a mock parser object
-        parser = MagicMock()
-        parser.messages = []
-        parser.current_channel = None
-        parser.state = StreamState.EXPECT_START
-        mock_parser_factory.return_value = parser
-        yield parser
+    """Set up a mock HarmonyParser for tests."""
+    return create_mock_harmony_parser()
 
 
 def test_single_turn_token_counting():
     """Test token counting behavior for a single turn."""
     # Create a context
-    context = HarmonyContext(messages=[], available_tools=[])
+    context = create_harmony_context()
 
     # Create a mock RequestOutput with specific token counts
     mock_output = create_mock_request_output(
@@ -105,7 +129,6 @@ def test_single_turn_token_counting():
     assert context.num_tool_output_tokens == 0  # No tool tokens in first turn
 
     # Verify internal state tracking
-    assert not context.is_first_turn
     assert len(context.all_turn_metrics) == 1
     previous_turn = context.all_turn_metrics[0]
     assert previous_turn.input_tokens == 5
@@ -118,7 +141,7 @@ def test_single_turn_token_counting():
 async def test_multi_turn_token_counting():
     """Test token counting behavior across multiple turns with tool output."""
     # Create a context
-    context = HarmonyContext(messages=[], available_tools=["browser"])
+    context = create_harmony_context(available_tools=["browser"])
 
     # Simulate a conversation with 3 turns
     # Turn 1: prefill 5, decode 3, tool 7
@@ -177,7 +200,7 @@ async def test_multi_turn_token_counting():
 
 def test_empty_output_tokens():
     """Test behavior when RequestOutput has empty output tokens."""
-    context = HarmonyContext(messages=[], available_tools=[])
+    context = create_harmony_context()
 
     # Create a RequestOutput with empty output tokens
     mock_output = create_mock_request_output(
@@ -197,7 +220,7 @@ def test_empty_output_tokens():
 
 def test_missing_prompt_token_ids():
     """Test behavior when RequestOutput has None prompt_token_ids."""
-    context = HarmonyContext(messages=[], available_tools=[])
+    context = create_harmony_context()
 
     mock_output = create_mock_request_output(
         prompt_token_ids=None,  # No prompt token IDs
@@ -218,15 +241,16 @@ def test_missing_prompt_token_ids():
 
 def test_reasoning_tokens_counting(mock_parser):
     """Test that reasoning tokens are counted correctly."""
-    context = HarmonyContext(messages=[], available_tools=[])
-
-    # Mock parser to simulate reasoning channel
-    mock_parser.current_channel = "analysis"  # Reasoning channel
+    context = create_harmony_context(harmony_parser=mock_parser)
 
     mock_output = create_mock_request_output(
         prompt_token_ids=[1, 2, 3],
         output_token_ids=[4, 5, 6, 7],  # 4 tokens, all in reasoning
         num_cached_tokens=0,
+    )
+    mock_parser.process_chunk.return_value = ChunkResult(
+        segments=[],
+        reasoning_token_count=len(mock_output.outputs[0].token_ids),
     )
 
     context.append_output(mock_output)
@@ -239,10 +263,7 @@ def test_reasoning_tokens_counting(mock_parser):
 def test_preamble_tokens_not_counted_as_reasoning(mock_parser):
     """Preambles (commentary with no recipient) are visible user text,
     not hidden reasoning. They must NOT inflate num_reasoning_tokens."""
-    context = HarmonyContext(messages=[], available_tools=[])
-
-    mock_parser.current_channel = "commentary"
-    mock_parser.current_recipient = None  # preamble
+    context = create_harmony_context(harmony_parser=mock_parser)
 
     mock_output = create_mock_request_output(
         prompt_token_ids=[1, 2, 3],
@@ -258,15 +279,16 @@ def test_preamble_tokens_not_counted_as_reasoning(mock_parser):
 def test_commentary_with_recipient_counted_as_reasoning(mock_parser):
     """Commentary directed at a tool (recipient != None) is hidden from
     the user, so it should still count as reasoning tokens."""
-    context = HarmonyContext(messages=[], available_tools=[])
-
-    mock_parser.current_channel = "commentary"
-    mock_parser.current_recipient = "python"
+    context = create_harmony_context(harmony_parser=mock_parser)
 
     mock_output = create_mock_request_output(
         prompt_token_ids=[1, 2, 3],
         output_token_ids=[4, 5, 6],
         num_cached_tokens=0,
+    )
+    mock_parser.process_chunk.return_value = ChunkResult(
+        segments=[],
+        reasoning_token_count=len(mock_output.outputs[0].token_ids),
     )
     context.append_output(mock_output)
 
@@ -276,7 +298,7 @@ def test_commentary_with_recipient_counted_as_reasoning(mock_parser):
 
 def test_zero_tokens_edge_case():
     """Test behavior with all zero token counts."""
-    context = HarmonyContext(messages=[], available_tools=[])
+    context = create_harmony_context()
 
     # Create a request with empty lists (not None) for both prompt and
     # output tokens
@@ -299,10 +321,7 @@ def test_zero_tokens_edge_case():
 @pytest.mark.asyncio
 async def test_single_turn_no_tool_output():
     """Test that first turn never generates tool output tokens."""
-    context = HarmonyContext(
-        messages=[],
-        available_tools=["browser"],  # Tools available
-    )
+    context = create_harmony_context(available_tools=["browser"])
 
     # Even with large prompt in first turn, no tool tokens should be counted
     mock_output = create_mock_request_output(
@@ -315,7 +334,7 @@ async def test_single_turn_no_tool_output():
 
     # First turn should never have tool output tokens
     assert context.num_tool_output_tokens == 0
-    assert context.is_first_turn is False  # Should be updated after first turn
+    assert len(context.all_turn_metrics) == 1
 
 
 @pytest.mark.asyncio
@@ -324,7 +343,7 @@ async def test_negative_tool_tokens_edge_case():
     tokens. We should log an error and clamp the value to 0."""
     # Use patch to check if logger.error was called
     with patch("vllm.entrypoints.openai.responses.context.logger.error") as mock_log:
-        context = HarmonyContext(messages=[], available_tools=["browser"])
+        context = create_harmony_context(available_tools=["browser"])
 
         # First turn
         mock_output1 = create_mock_request_output(
@@ -363,12 +382,25 @@ async def test_negative_tool_tokens_edge_case():
 async def test_streaming_multi_turn_token_counting(mock_parser):
     """Test token counting for streaming multi-turn conversations.
 
-    This test focuses on how StreamingHarmonyContext counts tokens in a
-    multi-turn conversation with streaming (token-by-token) outputs and
-    message boundaries.
+    This test focuses on how HarmonyContext counts tokens in a multi-turn
+    conversation with streaming (token-by-token) outputs and message
+    boundaries.
     """
     # Create a streaming context
-    context = StreamingHarmonyContext(messages=[], available_tools=["browser"])
+    context = create_harmony_context(
+        available_tools=["browser"],
+        harmony_parser=mock_parser,
+    )
+    mock_parser.process_chunk.side_effect = [
+        ChunkResult(segments=[], reasoning_token_count=0),
+        ChunkResult(segments=[], reasoning_token_count=0),
+        ChunkResult(segments=[], reasoning_token_count=0),
+        ChunkResult(segments=[], reasoning_token_count=1),
+        ChunkResult(segments=[], reasoning_token_count=1),
+        ChunkResult(segments=[], reasoning_token_count=1),
+        ChunkResult(segments=[], reasoning_token_count=0),
+        ChunkResult(segments=[], reasoning_token_count=0),
+    ]
 
     num_prompt_tokens = [3, 8, 13]
     num_output_tokens = [3, 3, 2]
@@ -411,10 +443,7 @@ async def test_streaming_multi_turn_token_counting(mock_parser):
     assert context.num_output_tokens == 3  # Three output tokens
     assert context.num_cached_tokens == 0
     assert context.num_tool_output_tokens == 0  # No tool output in first turn
-    assert context.first_tok_of_message is True  # Ready for next message
-
-    # Second turn: reasoning tokens in analysis channel
-    mock_parser.current_channel = "analysis"  # Set to reasoning channel
+    assert context.is_first_append_of_turn is True  # Ready for next message
 
     # First token of second turn
     context.append_output(
@@ -459,9 +488,6 @@ async def test_streaming_multi_turn_token_counting(mock_parser):
     # Formula: this turn prompt tokens - last turn prompt - last turn output
     expected_tool_tokens = 8 - 3 - 3  # = 2
     assert context.num_tool_output_tokens == expected_tool_tokens
-
-    # Third turn: regular output channel
-    mock_parser.current_channel = "final"  # Switch back to regular channel
 
     # Third turn (with more cached tokens)
     context.append_output(
@@ -521,12 +547,7 @@ async def test_streaming_multi_turn_token_counting(mock_parser):
 
 @pytest.mark.asyncio
 async def test_streaming_message_synchronization(mock_parser):
-    """Test message synchronization logic from lines 413-417 in context.py.
-
-    This test verifies that when parser.messages contains more messages than
-    the context's _messages (minus initial messages), the context properly
-    extends its message list with the new parser messages.
-    """
+    """Completed Harmony segments should sync into the context message list."""
 
     # Create a streaming context with some initial messages
     initial_messages = [
@@ -536,23 +557,51 @@ async def test_streaming_message_synchronization(mock_parser):
             recipient=Role.ASSISTANT,
         )
     ]
-    context = StreamingHarmonyContext(messages=initial_messages, available_tools=[])
+    context = create_harmony_context(
+        messages=initial_messages,
+        harmony_parser=mock_parser,
+    )
 
     # Verify initial state
     assert len(context._messages) == 1
     assert context.num_init_messages == 1
 
-    # Mock parser to have more messages than context
-    # Simulate parser having processed 3 new messages
-    mock_parser.messages = [
-        Message(
-            author=Author(role=Role.ASSISTANT, name="assistant"),
-            content=[TextContent(text="Response 1")],
-            recipient=Role.USER,
+    first_message = Message(
+        author=Author(role=Role.ASSISTANT, name="assistant"),
+        content=[TextContent(text="Response 1")],
+        recipient=Role.USER,
+    )
+    second_message = Message(
+        author=Author(role=Role.ASSISTANT, name="assistant"),
+        content=[TextContent(text="Response 4")],
+        recipient=Role.USER,
+    )
+    mock_parser.process_chunk.side_effect = [
+        ChunkResult(
+            segments=[
+                Segment(
+                    channel=None,
+                    recipient=None,
+                    delta="",
+                    completed_message=first_message,
+                )
+            ],
+            reasoning_token_count=0,
+        ),
+        ChunkResult(
+            segments=[
+                Segment(
+                    channel=None,
+                    recipient=None,
+                    delta="",
+                    completed_message=second_message,
+                )
+            ],
+            reasoning_token_count=0,
         ),
     ]
 
-    # This should trigger the message synchronization logic
+    # This should sync the completed message from the batch segments.
     context.append_output(
         create_mock_request_output(
             prompt_token_ids=[1, 2, 3], output_token_ids=[101], finished=False
@@ -564,23 +613,6 @@ async def test_streaming_message_synchronization(mock_parser):
 
     # Verify the new messages were added correctly
     assert context._messages[1].content[0].text == "Response 1"
-
-    # Test the specific condition from line 413-414:
-    # len(self._messages) - self.num_init_messages < len(self.parser.messages)
-    messages_minus_init = len(context._messages) - context.num_init_messages
-    parser_messages_count = len(mock_parser.messages)
-
-    # After synchronization, they should be equal (no longer less than)
-    assert messages_minus_init == parser_messages_count
-
-    # Test edge case: add one more parser message
-    mock_parser.messages.append(
-        Message(
-            author=Author(role=Role.ASSISTANT, name="assistant"),
-            content=[TextContent(text="Response 4")],
-            recipient=Role.USER,
-        )
-    )
 
     # Create another output to trigger synchronization again
     mock_output2 = create_mock_request_output(

--- a/tests/parser/test_harmony.py
+++ b/tests/parser/test_harmony.py
@@ -10,6 +10,7 @@ from openai_harmony import (
     Message,
     RenderConversationConfig,
     Role,
+    StreamState,
 )
 from transformers import AutoTokenizer
 
@@ -435,7 +436,7 @@ class TestParseDelta:
                 "<|end|><|start|>assistant<|channel|>final<|message|>Answer"
             ),
             request=chat_request,
-            finished=False,
+            finished=True,
         )
 
         assert first_delta is not None
@@ -734,3 +735,20 @@ class TestProcessChunk:
             ("analysis", "One"),
             ("final", "Two"),
         ]
+
+
+class TestFlushCurrentSegment:
+    def test_flush_current_segment(self, harmony_parser):
+        harmony_parser.process_chunk(
+            encode_output("<|channel|>analysis<|message|>Think")
+        )
+
+        flushed = harmony_parser.flush_current_segment()
+
+        assert flushed is not None
+        assert flushed.channel == "analysis"
+        assert flushed.recipient is None
+        assert flushed.delta == ""
+        assert flushed.completed_message is not None
+        assert get_text(flushed.completed_message) == "Think"
+        assert harmony_parser.state == StreamState.EXPECT_START

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -18,7 +18,7 @@ from openai.types.responses.response_output_item import McpCall
 from openai.types.responses.response_output_message import ResponseOutputMessage
 from openai.types.responses.response_output_text import ResponseOutputText
 from openai.types.responses.tool import Mcp
-from openai_harmony import Author, Message, Role, StreamState, TextContent
+from openai_harmony import Author, Message, Role, TextContent
 
 from vllm import envs
 from vllm.entrypoints.chat_utils import (
@@ -31,8 +31,12 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.entrypoints.openai.parser.harmony_utils import (
     get_encoding,
-    get_streamable_parser_for_assistant,
     render_for_completion,
+)
+from vllm.entrypoints.openai.responses.harmony import (
+    ResponseItemKind,
+    message_text_content,
+    resolve_response_item_type,
 )
 from vllm.entrypoints.openai.responses.protocol import (
     ResponseInputOutputItem,
@@ -46,6 +50,7 @@ from vllm.entrypoints.openai.responses.utils import (
 from vllm.entrypoints.serve.utils.constants import MCP_PREFIX
 from vllm.outputs import RequestOutput
 from vllm.parser.abstract_parser import Parser
+from vllm.parser.harmony import HarmonyParser, Segment
 from vllm.tokenizers import TokenizerLike
 from vllm.utils import random_uuid
 
@@ -140,28 +145,6 @@ class ConversationContext(ABC):
     @abstractmethod
     async def cleanup_session(self) -> None:
         raise NotImplementedError("Should not be called.")
-
-
-def _create_json_parse_error_messages(
-    last_msg: Message, e: json.JSONDecodeError
-) -> list[Message]:
-    """
-    Creates an error message when json parse failed.
-    """
-    error_msg = (
-        f"Error parsing tool arguments as JSON: {str(e)}. "
-        "Please ensure the tool call arguments are valid JSON and try again."
-    )
-    content = TextContent(text=error_msg)
-    author = Author(role=Role.TOOL, name=last_msg.recipient)
-    return [
-        Message(
-            author=author,
-            content=[content],
-            recipient=Role.ASSISTANT,
-            channel=last_msg.channel,
-        )
-    ]
 
 
 class SimpleContext(ConversationContext):
@@ -441,8 +424,9 @@ class ParsableContext(ConversationContext):
         if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
                 args = json.loads(last_msg.arguments)
-            except json.JSONDecodeError as e:
-                return _create_json_parse_error_messages(last_msg, e)
+            except json.JSONDecodeError:
+                # TODO: Handle error and retry
+                raise
         else:
             args = json.loads(last_msg.arguments)
         result = await tool_session.call_tool("search", args)
@@ -484,8 +468,9 @@ class ParsableContext(ConversationContext):
         if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
                 args = json.loads(last_msg.arguments)
-            except json.JSONDecodeError as e:
-                return _create_json_parse_error_messages(last_msg, e)
+            except json.JSONDecodeError:
+                # TODO: Handle error and retry
+                raise
         else:
             args = json.loads(last_msg.arguments)
         result = await tool_session.call_tool("exec", args)
@@ -590,6 +575,7 @@ class HarmonyContext(ConversationContext):
         self,
         messages: list,
         available_tools: list[str],
+        harmony_parser: HarmonyParser,
         function_tool_names: frozenset[str] | None = None,
     ):
         self._messages = messages
@@ -599,7 +585,10 @@ class HarmonyContext(ConversationContext):
         self._tool_sessions: dict[str, ClientSession | Tool] = {}
         self.called_tools: set[str] = set()
 
-        self.parser = get_streamable_parser_for_assistant()
+        self.parser = harmony_parser
+        self.encoding = get_encoding()
+        self.last_tok: int | None = None
+        self.batch_segments: list[Segment] = []
         self.num_init_messages = len(messages)
         self.num_prompt_tokens = 0
         self.num_output_tokens = 0
@@ -611,44 +600,52 @@ class HarmonyContext(ConversationContext):
         self.current_turn_metrics = TurnMetrics()
         # Track metrics for all turns
         self.all_turn_metrics: list[TurnMetrics] = []
-        self.is_first_turn = True
-        self.first_tok_of_message = True  # For streaming support
+        self.is_first_append_of_turn = True
         self.kv_transfer_params: dict[str, Any] | None = None
 
-    def _update_num_reasoning_tokens(self):
-        channel = self.parser.current_channel
-        if channel == "analysis":
-            self.num_reasoning_tokens += 1
-        elif channel == "commentary" and self.parser.current_recipient is not None:
-            # Tool interactions (python/browser/container) are hidden.
-            # Preambles (recipient=None) are visible user text.
-            self.num_reasoning_tokens += 1
+    def _sync_completed_messages(self, segments: list[Segment]) -> None:
+        for seg in segments:
+            if seg.completed_message is not None:
+                self._messages.append(seg.completed_message)
 
     def append_output(self, output: RequestOutput) -> None:
-        output_token_ids = output.outputs[0].token_ids
-        self.parser = get_streamable_parser_for_assistant()
-        for token_id in output_token_ids:
-            self.parser.process(token_id)
-            # Check if the current token is part of reasoning content
-            self._update_num_reasoning_tokens()
-        self._update_prefill_token_usage(output)
+        token_ids = output.outputs[0].token_ids or ()
+
+        if self.is_first_append_of_turn:
+            self._update_prefill_token_usage(output)
+
+        result = self.parser.process_chunk(token_ids)
+        if output.finished:
+            tail = self.parser.flush_current_segment()
+            if tail is not None:
+                result.segments.append(tail)
+
+        self.batch_segments = result.segments
+        self._sync_completed_messages(result.segments)
+        self.num_reasoning_tokens += result.reasoning_token_count
         self._update_decode_token_usage(output)
+
         if output.kv_transfer_params is not None:
             self.kv_transfer_params = output.kv_transfer_params
-        # Append current turn to all turn list for next turn's calculations
-        self.all_turn_metrics.append(self.current_turn_metrics.copy())
-        self.current_turn_metrics.reset()
-        # append_output is called only once before tool calling
-        # in non-streaming case
-        # so we can append all the parser messages to _messages
-        output_msgs = self.parser.messages
-        # The responses finish reason is set in the last message
-        self.finish_reason = output.outputs[0].finish_reason
-        self._messages.extend(output_msgs)
+
+        if token_ids:
+            self.last_tok = token_ids[-1]
+
+        self.is_first_append_of_turn = output.finished
+        if output.finished:
+            self.finish_reason = output.outputs[0].finish_reason
+            self.all_turn_metrics.append(self.current_turn_metrics.copy())
+            self.current_turn_metrics.reset()
 
     def append_tool_output(self, output: list[Message]) -> None:
-        output_msgs = output
-        self._messages.extend(output_msgs)
+        for msg in output:
+            if msg.author.role == Role.TOOL and msg.recipient is None:
+                msg.recipient = "assistant"
+            toks = self.encoding.render(msg)
+            assert toks, "Tool output should render to at least one token"
+            result = self.parser.process_chunk(toks)
+            self._sync_completed_messages(result.segments)
+            self.last_tok = toks[-1]
 
     def _update_prefill_token_usage(self, output: RequestOutput) -> None:
         """Update token usage statistics for the prefill phase of generation.
@@ -677,10 +674,8 @@ class HarmonyContext(ConversationContext):
         self.current_turn_metrics.input_tokens = this_turn_input_tokens
         self.num_prompt_tokens += this_turn_input_tokens
 
-        # Calculate tool tokens (except on first turn)
-        if self.is_first_turn:
-            self.is_first_turn = False
-        else:
+        # Calculate tool tokens when there is a previous completed turn.
+        if self.all_turn_metrics:
             previous_turn = self.all_turn_metrics[-1]
             # start counting tool after first turn
             # tool tokens = this turn prefill - last turn prefill -
@@ -746,56 +741,72 @@ class HarmonyContext(ConversationContext):
 
     def need_builtin_tool_call(self) -> bool:
         last_msg = self.messages[-1]
-        recipient = last_msg.recipient
-        if recipient is None:
-            return False
-        if recipient.startswith("browser."):
-            return "browser" in self.available_tools
-        if recipient.startswith("python"):
-            return "python" in self.available_tools
-        if recipient.startswith("container."):
-            return "container" in self.available_tools
-        return False
+        item_type = resolve_response_item_type(
+            last_msg.channel,
+            last_msg.recipient,
+            self.function_tool_names,
+        )
+        return item_type.kind in (
+            ResponseItemKind.CODE_INTERPRETER,
+            ResponseItemKind.WEB_SEARCH,
+            ResponseItemKind.CONTAINER,
+        )
 
     async def call_tool(self) -> list[Message]:
         if not self.messages:
             return []
         last_msg = self.messages[-1]
-        recipient = last_msg.recipient
-        if recipient is not None:
-            if recipient.startswith("browser."):
-                return await self.call_search_tool(
-                    self._tool_sessions["browser"], last_msg
-                )
-            elif recipient.startswith("python"):
+        item_type = resolve_response_item_type(
+            last_msg.channel,
+            last_msg.recipient,
+            self.function_tool_names,
+        )
+        match item_type.kind:
+            case ResponseItemKind.CODE_INTERPRETER:
                 return await self.call_python_tool(
                     self._tool_sessions["python"], last_msg
                 )
-            elif recipient.startswith("container."):
-                return await self.call_container_tool(
-                    self._tool_sessions["container"], last_msg
+            case ResponseItemKind.WEB_SEARCH:
+                assert item_type.action is not None
+                return await self.call_search_tool(
+                    self._tool_sessions["browser"], item_type.action, last_msg
                 )
-        raise ValueError("No tool call found")
+            case ResponseItemKind.CONTAINER:
+                assert item_type.action is not None
+                return await self.call_container_tool(
+                    self._tool_sessions["container"], item_type.action, last_msg
+                )
+            case _:
+                raise ValueError("No tool call found")
 
     def render_for_completion(self) -> list[int]:
-        return render_for_completion(self.messages)
+        rendered_tokens = render_for_completion(self.messages)
+
+        last_n = -1
+        to_process = []
+        while rendered_tokens[last_n] != self.last_tok:
+            to_process.append(rendered_tokens[last_n])
+            last_n -= 1
+        if to_process:
+            self.parser.process_chunk(list(reversed(to_process)))
+
+        return rendered_tokens
 
     async def call_search_tool(
-        self, tool_session: Union["ClientSession", Tool], last_msg: Message
+        self, tool_session: Union["ClientSession", Tool], action: str, last_msg: Message
     ) -> list[Message]:
         self.called_tools.add("browser")
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
-        tool_name = last_msg.recipient.split(".")[1]
-        if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
-            try:
-                args = json.loads(last_msg.content[0].text)
-            except json.JSONDecodeError as e:
-                return _create_json_parse_error_messages(last_msg, e)
+        try:
+            args = json.loads("".join(message_text_content(last_msg)))
+        except json.JSONDecodeError as e:
+            if not envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
+                raise
+            result_str = f"Invalid tool call JSON arguments: {e}"
         else:
-            args = json.loads(last_msg.content[0].text)
-        result = await tool_session.call_tool(tool_name, args)
-        result_str = result.content[0].text
+            result = await tool_session.call_tool(action, args)
+            result_str = result.content[0].text
         content = TextContent(text=result_str)
         author = Author(role=Role.TOOL, name=last_msg.recipient)
         return [
@@ -852,7 +863,7 @@ class HarmonyContext(ConversationContext):
                     exit_stack.push_async_exit(self.cleanup_session)
 
     async def call_container_tool(
-        self, tool_session: Union["ClientSession", Tool], last_msg: Message
+        self, tool_session: Union["ClientSession", Tool], action: str, last_msg: Message
     ) -> list[Message]:
         """
         Call container tool. Expect this to be run in a stateful docker
@@ -873,16 +884,15 @@ class HarmonyContext(ConversationContext):
         self.called_tools.add("container")
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
-        tool_name = last_msg.recipient.split(".")[1].split(" ")[0]
-        if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
-            try:
-                args = json.loads(last_msg.content[0].text)
-            except json.JSONDecodeError as e:
-                return _create_json_parse_error_messages(last_msg, e)
+        try:
+            args = json.loads("".join(message_text_content(last_msg)))
+        except json.JSONDecodeError as e:
+            if not envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
+                raise
+            result_str = f"Invalid tool call JSON arguments: {e}"
         else:
-            args = json.loads(last_msg.content[0].text)
-        result = await tool_session.call_tool(tool_name, args)
-        result_str = result.content[0].text
+            result = await tool_session.call_tool(action, args)
+            result_str = result.content[0].text
         content = TextContent(text=result_str)
         author = Author(role=Role.TOOL, name=last_msg.recipient)
         return [
@@ -911,88 +921,3 @@ class HarmonyContext(ConversationContext):
                 for tool in self.called_tools
             )
         )
-
-
-class StreamingHarmonyContext(HarmonyContext):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.last_output = None
-
-        self.parser = get_streamable_parser_for_assistant()
-        self.encoding = get_encoding()
-        self.last_tok = None
-        self.first_tok_of_message = True
-        self.last_content_delta = None
-
-    @property
-    def messages(self) -> list:
-        return self._messages
-
-    def append_output(self, output: RequestOutput) -> None:
-        # append_output is called for each output token in streaming case,
-        # so we only want to add the prompt tokens once for each message.
-        self.last_content_delta = None
-        if self.first_tok_of_message:
-            self._update_prefill_token_usage(output)
-        # Reset self.first_tok_of_message if needed:
-        # if the current token is the last one of the current message
-        # (finished=True), then the next token processed will mark the
-        # beginning of a new message
-        self.first_tok_of_message = output.finished
-        last_delta_text = ""
-        for tok in output.outputs[0].token_ids:
-            self.parser.process(tok)
-            last_delta_text += self.parser.last_content_delta or ""
-        if last_delta_text:
-            self.last_content_delta = last_delta_text
-        self._update_decode_token_usage(output)
-        if output.kv_transfer_params is not None:
-            self.kv_transfer_params = output.kv_transfer_params
-
-        # For streaming, update previous turn when message is complete
-        if output.finished:
-            self.all_turn_metrics.append(self.current_turn_metrics.copy())
-            self.current_turn_metrics.reset()
-        # Check if the current token is part of reasoning content
-        self._update_num_reasoning_tokens()
-        self.last_tok = tok
-        if len(self._messages) - self.num_init_messages < len(self.parser.messages):
-            self._messages.extend(
-                self.parser.messages[len(self._messages) - self.num_init_messages :]
-            )
-
-    def append_tool_output(self, output: list[Message]) -> None:
-        # Handle the case of tool output in direct message format
-        assert len(output) == 1, "Tool output should be a single message"
-        msg = output[0]
-        # Sometimes the recipient is not set for tool messages,
-        # so we set it to "assistant"
-        if msg.author.role == Role.TOOL and msg.recipient is None:
-            msg.recipient = "assistant"
-        toks = self.encoding.render(msg)
-        for tok in toks:
-            self.parser.process(tok)
-        self.last_tok = toks[-1]
-        # TODO: add tool_output messages to self._messages
-
-    def is_expecting_start(self) -> bool:
-        return self.parser.state == StreamState.EXPECT_START
-
-    def is_assistant_action_turn(self) -> bool:
-        return self.last_tok in self.encoding.stop_tokens_for_assistant_actions()
-
-    def render_for_completion(self) -> list[int]:
-        # now this list of tokens as next turn's starting tokens
-        # `<|start|>assistant`,
-        # we need to process them in parser.
-        rendered_tokens = super().render_for_completion()
-
-        last_n = -1
-        to_process = []
-        while rendered_tokens[last_n] != self.last_tok:
-            to_process.append(rendered_tokens[last_n])
-            last_n -= 1
-        for tok in reversed(to_process):
-            self.parser.process(tok)
-
-        return rendered_tokens

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -9,8 +9,11 @@ Handles two directions:
 """
 
 import json
+from dataclasses import dataclass
+from enum import Enum, auto
 
 from openai.types.responses import (
+    ResponseCodeInterpreterToolCall,
     ResponseFunctionToolCall,
     ResponseOutputItem,
     ResponseOutputMessage,
@@ -27,7 +30,7 @@ from openai.types.responses.response_output_item import McpCall
 from openai.types.responses.response_reasoning_item import (
     Content as ResponseReasoningTextContent,
 )
-from openai_harmony import Author, Message, Role, StreamableParser, TextContent
+from openai_harmony import Author, Message, Role, TextContent
 
 from vllm.entrypoints.openai.parser.harmony_utils import (
     BUILTIN_TOOL_TO_MCP_SERVER_LABEL,
@@ -257,166 +260,244 @@ def construct_harmony_previous_input_messages(
 # ---------------------------------------------------------------------------
 
 
-def _parse_browser_tool_call(message: Message, recipient: str) -> ResponseOutputItem:
-    """Parse browser tool calls (search, open, find) into web search items."""
-    if len(message.content) != 1:
-        raise ValueError("Invalid number of contents in browser message")
-    content = message.content[0]
+class ResponseItemKind(Enum):
+    REASONING = auto()
+    TEXT = auto()
+    FUNCTION = auto()
+    CODE_INTERPRETER = auto()
+    WEB_SEARCH = auto()
+    CONTAINER = auto()
+    MCP = auto()
+    IGNORE = auto()
 
-    # Parse JSON args (with retry detection)
+
+@dataclass(frozen=True)
+class ResponseItemType:
+    """Normalized response target derived from a Harmony channel/recipient."""
+
+    kind: ResponseItemKind
+    name: str | None = None
+    action: str | None = None
+
+
+_VALID_BROWSER_ACTIONS = frozenset({"search", "open", "find"})
+_VALID_CONTAINER_ACTIONS = frozenset({"exec"})
+
+
+def resolve_response_item_type(
+    channel: str | None,
+    recipient: str | None,
+    function_tool_names: frozenset[str] | None = None,
+) -> ResponseItemType:
+    """Classify and normalize Harmony channel/recipient pairs."""
+    if recipient == "assistant":
+        # TODO: In reality, we should emit built-in tool calls
+        # based on whether the tool result was successful or not.
+        # For now, we assume ignore the actual result and assumes
+        # tool calls are always successful.
+        return ResponseItemType(ResponseItemKind.IGNORE)
+
+    if recipient:
+        if is_function_recipient(recipient, function_tool_names):
+            return ResponseItemType(
+                ResponseItemKind.FUNCTION,
+                name="functions",
+                action=extract_function_from_recipient(recipient),
+            )
+
+        recipient_parts = recipient.split(".", 1)
+        name = recipient_parts[0].lower()
+        name_or_server_label = BUILTIN_TOOL_TO_MCP_SERVER_LABEL.get(name, name)
+        action = recipient_parts[1].lower() if len(recipient_parts) > 1 else None
+
+        if name_or_server_label == "code_interpreter":
+            return ResponseItemType(
+                ResponseItemKind.CODE_INTERPRETER,
+                name_or_server_label,
+            )
+
+        if name_or_server_label == "web_search_preview":
+            return ResponseItemType(
+                ResponseItemKind.WEB_SEARCH,
+                name_or_server_label,
+                action if action in _VALID_BROWSER_ACTIONS else "search",
+            )
+
+        if name_or_server_label == "container":
+            return ResponseItemType(
+                ResponseItemKind.CONTAINER,
+                name_or_server_label,
+                action if action in _VALID_CONTAINER_ACTIONS else "exec",
+            )
+
+        return ResponseItemType(
+            ResponseItemKind.MCP,
+            name_or_server_label,
+            action or name_or_server_label,
+        )
+
+    if channel == "analysis":
+        return ResponseItemType(ResponseItemKind.REASONING)
+
+    if channel in ("commentary", "final"):
+        return ResponseItemType(ResponseItemKind.TEXT)
+
+    return ResponseItemType(ResponseItemKind.IGNORE)
+
+
+def build_code_interpreter_call(
+    item_type: ResponseItemType,
+    code: str,
+    item_id: str,
+    status: str = "completed",
+) -> ResponseCodeInterpreterToolCall:
+    assert item_type.kind == ResponseItemKind.CODE_INTERPRETER
+    return ResponseCodeInterpreterToolCall(
+        id=item_id,
+        code=code,
+        container_id="auto",
+        outputs=[],
+        status=status,
+        type="code_interpreter_call",
+    )
+
+
+def build_web_search_call(
+    item_type: ResponseItemType,
+    arguments: str,
+    item_id: str,
+) -> ResponseFunctionWebSearch:
+    assert item_type.kind == ResponseItemKind.WEB_SEARCH
+    browser_action = item_type.action
+
     try:
-        browser_call = json.loads(content.text)
-    except json.JSONDecodeError:
-        logger.warning(
-            "Invalid JSON in browser tool call, using error placeholder: %s",
-            content.text,
+        browser_args = json.loads(arguments)
+    except json.JSONDecodeError as e:
+        # ResponseFunctionWebSearch does not allow an error message
+        # so we return a failed MCP call instead
+        return McpCall(
+            arguments=arguments,
+            name=browser_action,
+            server_label="browser",
+            id=item_id,
+            status="failed",
+            error=f"Invalid JSON arguments: {e}",
+            type="mcp_call",
         )
-        json_retry_output_message = (
-            f"Invalid JSON args, caught and retried: {content.text}"
-        )
-        browser_call = {
-            "query": json_retry_output_message,
-            "url": json_retry_output_message,
-            "pattern": json_retry_output_message,
-        }
 
-    # Create appropriate action based on recipient
-    if recipient == "browser.search":
-        action = ActionSearch(
-            query=f"cursor:{browser_call.get('query', '')}", type="search"
-        )
-    elif recipient == "browser.open":
-        action = ActionOpenPage(
-            url=f"cursor:{browser_call.get('url', '')}", type="open_page"
-        )
-    elif recipient == "browser.find":
-        action = ActionFind(
-            pattern=browser_call.get("pattern", ""),
-            url=f"cursor:{browser_call.get('url', '')}",
-            type="find",
-        )
-    else:
-        raise ValueError(f"Unknown browser action: {recipient}")
+    match browser_action:
+        case "search":
+            action = ActionSearch(
+                query=f"cursor:{browser_args.get('query', '')}",
+                type="search",
+            )
+        case "open":
+            action = ActionOpenPage(
+                type="open_page",
+                url=f"cursor:{browser_args.get('url', '')}",
+            )
+        case "find":
+            action = ActionFind(
+                pattern=browser_args.get("pattern", ""),
+                type="find_in_page",
+                url=f"cursor:{browser_args.get('url', '')}",
+            )
+        case _:
+            raise ValueError(f"Invalid browser action: {browser_action}")
 
     return ResponseFunctionWebSearch(
-        id=f"ws_{random_uuid()}",
+        id=item_id,
         action=action,
         status="completed",
         type="web_search_call",
     )
 
 
-def _parse_function_call(message: Message, recipient: str) -> list[ResponseOutputItem]:
-    """Parse function calls into function tool call items."""
-    function_name = extract_function_from_recipient(recipient)
-    output_items = []
-    for content in message.content:
-        random_id = random_uuid()
-        response_item = ResponseFunctionToolCall(
-            arguments=content.text,
-            call_id=f"call_{random_id}",
-            type="function_call",
-            name=function_name,
-            id=f"fc_{random_id}",
-        )
-        output_items.append(response_item)
-    return output_items
+def build_mcp_or_container_call(
+    item_type: ResponseItemType,
+    arguments: str,
+    item_id: str,
+    status: str = "completed",
+) -> McpCall:
+    assert item_type.kind in (ResponseItemKind.MCP, ResponseItemKind.CONTAINER)
+    server_label, name = item_type.name, item_type.action
+
+    return McpCall(
+        arguments=arguments,
+        name=name,
+        server_label=server_label,
+        id=item_id,
+        status=status,
+        type="mcp_call",
+    )
 
 
-def _parse_reasoning(message: Message) -> list[ResponseOutputItem]:
-    """Parse reasoning/analysis content into reasoning items."""
-    output_items = []
-    for content in message.content:
-        reasoning_item = ResponseReasoningItem(
-            id=f"rs_{random_uuid()}",
-            summary=[],
-            type="reasoning",
-            content=[
-                ResponseReasoningTextContent(text=content.text, type="reasoning_text")
-            ],
-            status=None,
-        )
-        output_items.append(reasoning_item)
-    return output_items
+def build_reasoning(
+    item_type: ResponseItemType,
+    content: list[str],
+    item_id: str,
+) -> ResponseReasoningItem:
+    """TODO: Unify ResponseReasoningItem creation between
+    Harmony and non-Harmony and streaming and non-streaming"""
+    assert item_type.kind == ResponseItemKind.REASONING
+    return ResponseReasoningItem(
+        id=item_id,
+        summary=[],
+        type="reasoning",
+        content=[
+            ResponseReasoningTextContent(text=c, type="reasoning_text") for c in content
+        ],
+    )
 
 
-def _parse_final_message(message: Message) -> ResponseOutputItem:
-    """Parse final channel messages into output message items."""
-    contents = []
-    for content in message.content:
-        output_text = ResponseOutputText(
-            text=content.text,
-            annotations=[],  # TODO
-            type="output_text",
-            logprobs=None,  # TODO
-        )
-        contents.append(output_text)
+def build_output_message(
+    item_type: ResponseItemType,
+    content: list[str],
+    item_id: str,
+) -> ResponseOutputMessage:
+    """TODO: Unify ResponseOutputMessage creation between
+    Harmony and non-Harmony and streaming and non-streaming"""
+    assert item_type.kind == ResponseItemKind.TEXT
     return ResponseOutputMessage(
-        id=f"msg_{random_uuid()}",
-        content=contents,
-        role=message.author.role,
+        id=item_id,
+        content=[
+            ResponseOutputText(text=c, annotations=[], type="output_text")
+            for c in content
+        ],
+        role="assistant",
         status="completed",
         type="message",
     )
 
 
-def _parse_mcp_recipient(recipient: str) -> tuple[str, str]:
-    """Parse MCP recipient into (server_label, tool_name).
+def build_function_call(
+    item_type: ResponseItemType,
+    arguments: str,
+    call_id: str,
+    item_id: str,
+) -> ResponseFunctionToolCall:
+    """TODO: Unify ResponseFunctionToolCall creation between
+    Harmony and non-Harmony and streaming and non-streaming"""
+    assert item_type.kind == ResponseItemKind.FUNCTION
 
-    For dotted recipients like "repo_browser.list":
-        - server_label: "repo_browser" (namespace/server)
-        - tool_name: "list" (specific tool)
+    try:
+        arguments = json.dumps(json.loads(arguments))
+    except json.JSONDecodeError:
+        # Ignore JSON decode error
+        arguments = arguments.strip()
 
-    For simple recipients like "filesystem":
-        - server_label: "filesystem"
-        - tool_name: "filesystem"
-    """
-    if "." in recipient:
-        server_label = recipient.split(".")[0]
-        tool_name = recipient.split(".")[-1]
-    else:
-        server_label = recipient
-        tool_name = recipient
-    return server_label, tool_name
-
-
-def _parse_mcp_call(message: Message, recipient: str) -> list[ResponseOutputItem]:
-    """Parse MCP calls into MCP call items."""
-    # Handle built-in tools that need server_label mapping
-    if recipient in BUILTIN_TOOL_TO_MCP_SERVER_LABEL:
-        server_label = BUILTIN_TOOL_TO_MCP_SERVER_LABEL[recipient]
-        tool_name = recipient
-    else:
-        server_label, tool_name = _parse_mcp_recipient(recipient)
-
-    output_items = []
-    for content in message.content:
-        response_item = McpCall(
-            arguments=content.text,
-            type="mcp_call",
-            name=tool_name,
-            server_label=server_label,
-            id=f"mcp_{random_uuid()}",
-            status="completed",
-        )
-        output_items.append(response_item)
-    return output_items
+    return ResponseFunctionToolCall(
+        id=item_id,
+        arguments=arguments,
+        call_id=call_id,
+        name=item_type.action,
+        type="function_call",
+    )
 
 
-def _parse_message_no_recipient(
-    message: Message,
-) -> list[ResponseOutputItem]:
-    """Parse a Harmony message with no recipient based on its channel."""
-    if message.channel == "analysis":
-        return _parse_reasoning(message)
-
-    if message.channel in ("commentary", "final"):
-        # Per Harmony format, preambles (commentary with no recipient) and
-        # final channel content are both intended to be shown to end-users.
-        # See: https://cookbook.openai.com/articles/openai-harmony
-        return [_parse_final_message(message)]
-
-    raise ValueError(f"Unknown channel: {message.channel}")
+def message_text_content(message: Message) -> list[str]:
+    """Extract text content from a Harmony message."""
+    return [c.text for c in message.content]
 
 
 # ---------------------------------------------------------------------------
@@ -432,149 +513,41 @@ def harmony_to_response_output(
 
     This is the main dispatcher that routes based on channel and recipient.
     """
-    if message.author.role != "assistant":
-        # This is a message from a tool to the assistant (e.g., search result).
-        # Don't include it in the final output for now. This aligns with
-        # OpenAI's behavior on models like o4-mini.
-        return []
-
-    output_items: list[ResponseOutputItem] = []
-    recipient = message.recipient
-
-    if recipient is not None:
-        # Browser tool calls (browser.search, browser.open, browser.find)
-        if recipient.startswith("browser."):
-            output_items.append(_parse_browser_tool_call(message, recipient))
-
-        # Function calls (with or without "functions." prefix)
-        elif is_function_recipient(recipient, function_tool_names):
-            output_items.extend(_parse_function_call(message, recipient))
-
-        # Built-in MCP tools (python, browser, container)
-        elif recipient in BUILTIN_TOOL_TO_MCP_SERVER_LABEL:
-            output_items.extend(_parse_reasoning(message))
-
-        # All other recipients are MCP calls
-        else:
-            output_items.extend(_parse_mcp_call(message, recipient))
-
-    # No recipient - handle based on channel for non-tool messages
-    else:
-        output_items.extend(_parse_message_no_recipient(message))
-
-    return output_items
-
-
-def parser_state_to_response_output(
-    parser: StreamableParser,
-    function_tool_names: frozenset[str] | None = None,
-) -> list[ResponseOutputItem]:
-    """Extract in-progress response items from incomplete parser state.
-
-    Called when the parser has buffered content that hasn't formed a
-    complete message yet (e.g., generation was cut short).
-    """
-    if not parser.current_content:
-        return []
-    if parser.current_role != Role.ASSISTANT:
-        return []
-    current_recipient = parser.current_recipient
-    if current_recipient is not None and current_recipient.startswith("browser."):
-        return []
-
-    if current_recipient:
-        if is_function_recipient(current_recipient, function_tool_names):
+    item_type = resolve_response_item_type(
+        message.channel,
+        message.recipient,
+        function_tool_names,
+    )
+    content = message_text_content(message)
+    match item_type.kind:
+        case ResponseItemKind.REASONING:
+            return [build_reasoning(item_type, content, f"rs_{random_uuid()}")]
+        case ResponseItemKind.TEXT:
+            return [build_output_message(item_type, content, f"msg_{random_uuid()}")]
+        case ResponseItemKind.FUNCTION:
             rid = random_uuid()
+            item_id = f"fc_{rid}"
+            tool_call_id = f"call_{rid}"
+            return [build_function_call(item_type, content[0], tool_call_id, item_id)]
+        case ResponseItemKind.CODE_INTERPRETER:
             return [
-                ResponseFunctionToolCall(
-                    arguments=parser.current_content,
-                    call_id=f"call_{rid}",
-                    type="function_call",
-                    name=extract_function_from_recipient(current_recipient),
-                    id=f"fc_{rid}",
-                    status="in_progress",
+                build_code_interpreter_call(
+                    item_type, content[0], f"ci_{random_uuid()}"
                 )
             ]
-        # Built-in MCP tools (python, browser, container)
-        elif current_recipient in BUILTIN_TOOL_TO_MCP_SERVER_LABEL:
+        case ResponseItemKind.WEB_SEARCH:
+            return [build_web_search_call(item_type, content[0], f"ws_{random_uuid()}")]
+        case ResponseItemKind.CONTAINER:
             return [
-                ResponseReasoningItem(
-                    id=f"rs_{random_uuid()}",
-                    summary=[],
-                    type="reasoning",
-                    content=[
-                        ResponseReasoningTextContent(
-                            text=parser.current_content, type="reasoning_text"
-                        )
-                    ],
-                    status=None,
+                build_mcp_or_container_call(
+                    item_type, content[0], f"container_{random_uuid()}"
                 )
             ]
-        # All other recipients are MCP calls
-        else:
-            rid = random_uuid()
-            server_label, tool_name = _parse_mcp_recipient(current_recipient)
+        case ResponseItemKind.MCP:
             return [
-                McpCall(
-                    arguments=parser.current_content,
-                    type="mcp_call",
-                    name=tool_name,
-                    server_label=server_label,
-                    id=f"mcp_{rid}",
-                    status="in_progress",
+                build_mcp_or_container_call(
+                    item_type, content[0], f"mcp_{random_uuid()}"
                 )
             ]
-
-    if parser.current_channel == "commentary":
-        # Per Harmony format, preambles (commentary with no recipient) are
-        # intended to be shown to end-users, unlike analysis channel content.
-        output_text = ResponseOutputText(
-            text=parser.current_content,
-            annotations=[],
-            type="output_text",
-            logprobs=None,
-        )
-        return [
-            ResponseOutputMessage(
-                id=f"msg_{random_uuid()}",
-                content=[output_text],
-                role="assistant",
-                status="incomplete",
-                type="message",
-            )
-        ]
-
-    if parser.current_channel == "analysis":
-        return [
-            ResponseReasoningItem(
-                id=f"rs_{random_uuid()}",
-                summary=[],
-                type="reasoning",
-                content=[
-                    ResponseReasoningTextContent(
-                        text=parser.current_content, type="reasoning_text"
-                    )
-                ],
-                status=None,
-            )
-        ]
-
-    if parser.current_channel == "final":
-        output_text = ResponseOutputText(
-            text=parser.current_content,
-            annotations=[],  # TODO
-            type="output_text",
-            logprobs=None,  # TODO
-        )
-        text_item = ResponseOutputMessage(
-            id=f"msg_{random_uuid()}",
-            content=[output_text],
-            role="assistant",
-            # if the parser still has messages (ie if the generator got cut
-            # abruptly), this should be incomplete
-            status="incomplete",
-            type="message",
-        )
-        return [text_item]
-
-    return []
+        case ResponseItemKind.IGNORE:
+            return []

--- a/vllm/entrypoints/openai/responses/harmony_streaming_events.py
+++ b/vllm/entrypoints/openai/responses/harmony_streaming_events.py
@@ -1,0 +1,418 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Harmony-specific streaming SSE event builders for the Responses API.
+
+Translates Harmony protocol segments into OpenAI Response API SSE events.
+Delegates to the shared leaf helpers in streaming_events.py for text,
+reasoning, and function call events.
+
+The file is organized as:
+  1. Leaf helpers — open events (MCP, code interpreter)
+  2. Leaf helpers — delta events (MCP, code interpreter)
+  3. Leaf helpers — done events (MCP, code interpreter, browser)
+  4. Harmony segment dispatchers (entry point + open/delta/done routing)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from openai.types.responses import (
+    ResponseCodeInterpreterCallCodeDeltaEvent,
+    ResponseCodeInterpreterCallCodeDoneEvent,
+    ResponseCodeInterpreterCallCompletedEvent,
+    ResponseCodeInterpreterCallInProgressEvent,
+    ResponseCodeInterpreterCallInterpretingEvent,
+    ResponseMcpCallArgumentsDeltaEvent,
+    ResponseMcpCallArgumentsDoneEvent,
+    ResponseMcpCallCompletedEvent,
+    ResponseMcpCallFailedEvent,
+    ResponseMcpCallInProgressEvent,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseWebSearchCallCompletedEvent,
+    ResponseWebSearchCallInProgressEvent,
+    ResponseWebSearchCallSearchingEvent,
+)
+from openai_harmony import Message as HarmonyMessage
+
+from vllm.entrypoints.openai.responses.harmony import (
+    ResponseItemKind,
+    ResponseItemType,
+    build_code_interpreter_call,
+    build_mcp_or_container_call,
+    build_web_search_call,
+    message_text_content,
+    resolve_response_item_type,
+)
+from vllm.entrypoints.openai.responses.protocol import (
+    StreamingResponsesResponse,
+)
+from vllm.entrypoints.openai.responses.streaming_events import (
+    emit_function_call_delta_events,
+    emit_function_call_done_events,
+    emit_function_call_open_events,
+    emit_reasoning_delta_events,
+    emit_reasoning_done_events,
+    emit_reasoning_open_events,
+    emit_text_delta_events,
+    emit_text_done_events,
+    emit_text_open_events,
+)
+from vllm.parser.harmony import Segment
+from vllm.utils import random_uuid
+
+# =====================================================================
+# Leaf helpers — open events
+# =====================================================================
+
+
+def emit_mcp_open_events(
+    item_type: ResponseItemType,
+    state: HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    return [
+        ResponseOutputItemAddedEvent(
+            type="response.output_item.added",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item=build_mcp_or_container_call(
+                item_type, "", state.current_item_id, status="in_progress"
+            ),
+        ),
+        ResponseMcpCallInProgressEvent(
+            type="response.mcp_call.in_progress",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+        ),
+    ]
+
+
+def emit_code_interpreter_open_events(
+    item_type: ResponseItemType,
+    state: HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    return [
+        ResponseOutputItemAddedEvent(
+            type="response.output_item.added",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item=build_code_interpreter_call(
+                item_type, "", state.current_item_id, status="in_progress"
+            ),
+        ),
+        ResponseCodeInterpreterCallInProgressEvent(
+            type="response.code_interpreter_call.in_progress",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+        ),
+    ]
+
+
+# =====================================================================
+# Leaf helpers — delta events
+# =====================================================================
+
+
+def emit_mcp_delta_events(
+    delta: str,
+    state: HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    return [
+        ResponseMcpCallArgumentsDeltaEvent(
+            type="response.mcp_call_arguments.delta",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+            delta=delta,
+        )
+    ]
+
+
+def emit_code_interpreter_delta_events(
+    delta: str,
+    state: HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    return [
+        ResponseCodeInterpreterCallCodeDeltaEvent(
+            type="response.code_interpreter_call_code.delta",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+            delta=delta,
+        )
+    ]
+
+
+# =====================================================================
+# Leaf helpers — done events
+# =====================================================================
+
+
+def emit_mcp_or_container_done_events(
+    item_type: ResponseItemType,
+    arguments: str,
+    state: HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    item = build_mcp_or_container_call(item_type, arguments, state.current_item_id)
+    return [
+        ResponseMcpCallArgumentsDoneEvent(
+            type="response.mcp_call_arguments.done",
+            arguments=arguments,
+            name=item.name,
+            item_id=state.current_item_id,
+            output_index=state.output_index,
+            sequence_number=-1,
+        ),
+        (
+            ResponseMcpCallCompletedEvent(
+                type="response.mcp_call.completed",
+                sequence_number=-1,
+                output_index=state.output_index,
+                item_id=state.current_item_id,
+            )
+            if item.error is None
+            else ResponseMcpCallFailedEvent(
+                type="response.mcp_call.failed",
+                sequence_number=-1,
+                output_index=state.output_index,
+                item_id=state.current_item_id,
+            )
+        ),
+        ResponseOutputItemDoneEvent(
+            type="response.output_item.done",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item=item,
+        ),
+    ]
+
+
+def emit_code_interpreter_done_events(
+    item_type: ResponseItemType,
+    code: str,
+    state: HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    return [
+        ResponseCodeInterpreterCallCodeDoneEvent(
+            type="response.code_interpreter_call_code.done",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+            code=code,
+        ),
+        ResponseCodeInterpreterCallInterpretingEvent(
+            type="response.code_interpreter_call.interpreting",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+        ),
+        ResponseCodeInterpreterCallCompletedEvent(
+            type="response.code_interpreter_call.completed",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+        ),
+        ResponseOutputItemDoneEvent(
+            type="response.output_item.done",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item=build_code_interpreter_call(item_type, code, state.current_item_id),
+        ),
+    ]
+
+
+def emit_browser_done_events(
+    item_type: ResponseItemType,
+    text: str,
+    state: HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    item = build_web_search_call(item_type, text, state.current_item_id)
+    events: list[StreamingResponsesResponse] = [
+        ResponseOutputItemAddedEvent(
+            type="response.output_item.added",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item=item,
+        ),
+        ResponseWebSearchCallInProgressEvent(
+            type="response.web_search_call.in_progress",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+        ),
+        ResponseWebSearchCallSearchingEvent(
+            type="response.web_search_call.searching",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+        ),
+        ResponseWebSearchCallCompletedEvent(
+            type="response.web_search_call.completed",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+        ),
+        ResponseOutputItemDoneEvent(
+            type="response.output_item.done",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item=item,
+        ),
+    ]
+
+    return events
+
+
+# =====================================================================
+# Harmony segment dispatchers
+# =====================================================================
+
+
+@dataclass
+class HarmonyStreamingState:
+    """Mutable state for Harmony streaming event processing."""
+
+    output_index: int = 0
+    content_index: int = -1
+    current_item_id: str = ""
+    tool_call_id: str = ""
+    current_kind: ResponseItemKind | None = None
+
+    def reset_for_new_item(self) -> None:
+        """Reset state when expecting a new output item."""
+        self.output_index += 1
+        self.content_index = -1
+        self.current_item_id = ""
+        self.tool_call_id = ""
+        self.current_kind = None
+
+
+def emit_harmony_open(
+    item_type: ResponseItemType,
+    state: HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    assert state.current_kind is None, (
+        "Attempted to open a new Harmony item before closing"
+    )
+
+    state.current_kind = item_type.kind
+    match item_type.kind:
+        case ResponseItemKind.REASONING:
+            state.current_item_id = f"rs_{random_uuid()}"
+            state.content_index = 0
+            events = emit_reasoning_open_events(state)
+        case ResponseItemKind.TEXT:
+            state.current_item_id = f"msg_{random_uuid()}"
+            state.content_index = 0
+            events = emit_text_open_events(state)
+        case ResponseItemKind.FUNCTION:
+            assert item_type.action is not None
+            rid = random_uuid()
+            state.current_item_id = f"fc_{rid}"
+            state.tool_call_id = f"call_{rid}"
+            events = emit_function_call_open_events(
+                item_type.action,
+                state,
+            )
+        case ResponseItemKind.MCP | ResponseItemKind.CONTAINER:
+            assert item_type.action is not None
+            state.current_item_id = f"mcp_{random_uuid()}"
+            events = emit_mcp_open_events(item_type, state)
+        case ResponseItemKind.CODE_INTERPRETER:
+            state.current_item_id = f"tool_{random_uuid()}"
+            events = emit_code_interpreter_open_events(item_type, state)
+        case ResponseItemKind.WEB_SEARCH:
+            state.current_item_id = f"ws_{random_uuid()}"
+            events = []
+        case _:
+            events = []
+    return events
+
+
+def emit_harmony_delta(
+    item_type: ResponseItemType,
+    delta: str,
+    state: HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    assert state.current_kind is item_type.kind
+    assert state.current_item_id
+
+    match item_type.kind:
+        case _ if not delta:
+            events = []
+        case ResponseItemKind.TEXT:
+            events = emit_text_delta_events(delta, state, logprobs=[])
+        case ResponseItemKind.REASONING:
+            events = emit_reasoning_delta_events(delta, state)
+        case ResponseItemKind.FUNCTION:
+            events = emit_function_call_delta_events(delta, state)
+        case ResponseItemKind.MCP | ResponseItemKind.CONTAINER:
+            events = emit_mcp_delta_events(delta, state)
+        case ResponseItemKind.CODE_INTERPRETER:
+            events = emit_code_interpreter_delta_events(delta, state)
+        case _:
+            events = []
+
+    return events
+
+
+def emit_harmony_done(
+    item_type: ResponseItemType,
+    completed_message: HarmonyMessage,
+    state: HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    assert state.current_item_id, "Harmony item closed before it was opened"
+    assert state.current_kind is item_type.kind
+
+    text = message_text_content(completed_message)[0]
+    match item_type.kind:
+        case ResponseItemKind.REASONING:
+            events = emit_reasoning_done_events(text, state)
+        case ResponseItemKind.TEXT:
+            events = emit_text_done_events(text, state)
+        case ResponseItemKind.FUNCTION:
+            assert item_type.action is not None
+            events = emit_function_call_done_events(item_type.action, text, state)
+        case ResponseItemKind.MCP | ResponseItemKind.CONTAINER:
+            events = emit_mcp_or_container_done_events(item_type, text, state)
+        case ResponseItemKind.CODE_INTERPRETER:
+            events = emit_code_interpreter_done_events(item_type, text, state)
+        case ResponseItemKind.WEB_SEARCH:
+            events = emit_browser_done_events(item_type, text, state)
+        case _:
+            events = []
+
+    state.reset_for_new_item()
+    return events
+
+
+def emit_harmony_segment_events(
+    segment: Segment,
+    state: HarmonyStreamingState,
+    function_tool_names: frozenset[str] | None = None,
+) -> list[StreamingResponsesResponse]:
+    completed_message = segment.completed_message
+    if completed_message is not None:
+        assert not segment.delta
+        channel = completed_message.channel
+        recipient = completed_message.recipient
+    else:
+        channel = segment.channel
+        recipient = segment.recipient
+
+    item_type = resolve_response_item_type(channel, recipient, function_tool_names)
+    if item_type.kind is ResponseItemKind.IGNORE:
+        return []
+
+    if completed_message is not None:
+        return emit_harmony_done(item_type, completed_message, state)
+
+    events = []
+    if state.current_kind is None:
+        events.extend(emit_harmony_open(item_type, state))
+    events.extend(emit_harmony_delta(item_type, segment.delta, state))
+    return events

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -19,6 +19,7 @@ from openai.types.responses import (
     ResponseMcpCallArgumentsDeltaEvent,
     ResponseMcpCallArgumentsDoneEvent,
     ResponseMcpCallCompletedEvent,
+    ResponseMcpCallFailedEvent,
     ResponseMcpCallInProgressEvent,
     ResponseOutputItem,
     ResponseOutputItemAddedEvent,
@@ -818,4 +819,5 @@ StreamingResponsesResponse: TypeAlias = (
     | ResponseMcpCallArgumentsDoneEvent
     | ResponseMcpCallInProgressEvent
     | ResponseMcpCallCompletedEvent
+    | ResponseMcpCallFailedEvent
 )

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -55,13 +55,15 @@ from vllm.entrypoints.openai.responses.context import (
     HarmonyContext,
     ParsableContext,
     SimpleContext,
-    StreamingHarmonyContext,
 )
 from vllm.entrypoints.openai.responses.harmony import (
     construct_harmony_previous_input_messages,
     harmony_to_response_output,
-    parser_state_to_response_output,
     response_input_to_harmony,
+)
+from vllm.entrypoints.openai.responses.harmony_streaming_events import (
+    HarmonyStreamingState,
+    emit_harmony_segment_events,
 )
 from vllm.entrypoints.openai.responses.protocol import (
     InputTokensDetails,
@@ -78,11 +80,7 @@ from vllm.entrypoints.openai.responses.protocol import (
 )
 from vllm.entrypoints.openai.responses.streaming_events import (
     SimpleStreamingEventProcessor,
-    StreamingState,
     _StateType,
-    emit_content_delta_events,
-    emit_previous_item_done_events,
-    emit_tool_action_events,
     split_delta,
 )
 from vllm.entrypoints.openai.responses.utils import (
@@ -102,7 +100,7 @@ from vllm.logprobs import Logprob as SampleLogprob
 from vllm.logprobs import SampleLogprobs
 from vllm.lora.request import LoRARequest
 from vllm.outputs import CompletionOutput
-from vllm.parser import Parser, ParserManager
+from vllm.parser import HarmonyParser, Parser, ParserManager
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.tokenizers import TokenizerLike
 from vllm.utils import random_uuid
@@ -446,14 +444,12 @@ class OpenAIServingResponses(OpenAIServing):
             context: ConversationContext
             function_tool_names = extract_function_tool_names(request.tools)
             if self.use_harmony:
-                if request.stream:
-                    context = StreamingHarmonyContext(
-                        messages, available_tools, function_tool_names
-                    )
-                else:
-                    context = HarmonyContext(
-                        messages, available_tools, function_tool_names
-                    )
+                parser_cls = self.parser
+                assert parser_cls is not None and issubclass(parser_cls, HarmonyParser)
+                harmony_parser = parser_cls(tokenizer, request.tools)
+                context = HarmonyContext(
+                    messages, available_tools, harmony_parser, function_tool_names
+                )
             else:
                 if envs.VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT:
                     # This is a feature in development for parsing
@@ -694,7 +690,7 @@ class OpenAIServingResponses(OpenAIServing):
 
             # Create inputs for the next turn.
             # Render the next prompt token ids and update sampling_params.
-            if isinstance(context, (HarmonyContext, StreamingHarmonyContext)):
+            if isinstance(context, HarmonyContext):
                 token_ids = context.render_for_completion()
                 engine_input = tokens_input(token_ids)
 
@@ -788,8 +784,7 @@ class OpenAIServingResponses(OpenAIServing):
 
         input_messages: ResponseInputOutputMessage | None = None
         output_messages: ResponseInputOutputMessage | None = None
-        if self.use_harmony:
-            assert isinstance(context, HarmonyContext)
+        if isinstance(context, HarmonyContext):
             output = self._make_response_output_items_with_harmony(context)
             if request.enable_response_messages:
                 input_messages = context.messages[: context.num_init_messages]
@@ -1075,10 +1070,6 @@ class OpenAIServingResponses(OpenAIServing):
         fn_names = context.function_tool_names
         for msg in context.messages[num_init_messages:]:
             output_items.extend(harmony_to_response_output(msg, fn_names))
-        # Handle the generation stopped in the middle (if any).
-        last_items = parser_state_to_response_output(context.parser, fn_names)
-        if last_items:
-            output_items.extend(last_items)
         return output_items
 
     def _get_harmony_builtin_tool_descriptions(
@@ -1427,30 +1418,21 @@ class OpenAIServingResponses(OpenAIServing):
             [StreamingResponsesResponse], StreamingResponsesResponse
         ],
     ) -> AsyncGenerator[StreamingResponsesResponse, None]:
-        state = StreamingState()
+        state = HarmonyStreamingState()
 
         async for ctx in result_generator:
-            assert isinstance(ctx, StreamingHarmonyContext)
+            assert isinstance(ctx, HarmonyContext)
 
             # finish_reason='error' indicates a retryable error
             self._raise_if_error(ctx.finish_reason, request.request_id)
 
-            if ctx.is_expecting_start():
-                if len(ctx.parser.messages) > 0:
-                    previous_item = ctx.parser.messages[-1]
-                    for event in emit_previous_item_done_events(
-                        previous_item, state, ctx.function_tool_names
-                    ):
-                        yield _increment_sequence_number_and_return(event)
-                state.reset_for_new_item()
-
-            # Stream the output of a harmony message
-            for event in emit_content_delta_events(ctx, state):
-                yield _increment_sequence_number_and_return(event)
-
-            # Stream tool call outputs
-            for event in emit_tool_action_events(ctx, state, self.tool_server):
-                yield _increment_sequence_number_and_return(event)
+            for segment in ctx.batch_segments:
+                for event in emit_harmony_segment_events(
+                    segment,
+                    state,
+                    ctx.function_tool_names,
+                ):
+                    yield _increment_sequence_number_and_return(event)
 
     async def responses_stream_generator(
         self,
@@ -1481,7 +1463,7 @@ class OpenAIServingResponses(OpenAIServing):
             return event
 
         async with AsyncExitStack() as exit_stack:
-            if self.use_harmony:
+            if isinstance(context, HarmonyContext):
                 # TODO: in streaming, we noticed this bug:
                 # https://github.com/vllm-project/vllm/issues/25697
                 await self._initialize_tool_sessions(request, context, exit_stack)

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -3,42 +3,33 @@
 """
 Streaming SSE event builders for the Responses API.
 
-Pure functions that translate streaming state + delta data into
-OpenAI Response API SSE events. Used by the streaming event
-processors in serving.py.
+Contains shared leaf helpers for building SSE events (text, reasoning,
+function call) and the SimpleStreamingEventProcessor for the non-Harmony
+streaming path.
+
+Harmony-specific streaming logic lives in harmony_streaming_events.py.
 
 The file is organized as:
-  1. StreamingState dataclass + utility helpers
-  2. Shared leaf helpers — delta events (take plain strings, no context)
-  3. Shared leaf helpers — done events (take plain strings, no context)
-  4. Harmony-specific dispatchers (route ctx/previous_item → leaf helpers)
-  5. Harmony-specific tool lifecycle helpers
+  1. Shared leaf helpers — open events (text, reasoning, function call)
+  2. Shared leaf helpers — delta events (text, reasoning, function call)
+  3. Shared leaf helpers — done events (text, reasoning, function call)
+  4. Simple streaming state machine (SimpleStreamingState,
+     SimpleStreamingEventProcessor, split_delta)
 """
 
-import json
+from __future__ import annotations
+
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Any, ClassVar, Final, NamedTuple
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
 from openai.types.responses import (
-    ResponseCodeInterpreterCallCodeDeltaEvent,
-    ResponseCodeInterpreterCallCodeDoneEvent,
-    ResponseCodeInterpreterCallCompletedEvent,
-    ResponseCodeInterpreterCallInProgressEvent,
-    ResponseCodeInterpreterCallInterpretingEvent,
-    ResponseCodeInterpreterToolCallParam,
     ResponseContentPartAddedEvent,
     ResponseContentPartDoneEvent,
     ResponseFunctionCallArgumentsDeltaEvent,
     ResponseFunctionCallArgumentsDoneEvent,
     ResponseFunctionToolCall,
-    ResponseFunctionToolCallItem,
-    ResponseFunctionWebSearch,
-    ResponseMcpCallArgumentsDeltaEvent,
-    ResponseMcpCallArgumentsDoneEvent,
-    ResponseMcpCallCompletedEvent,
-    ResponseMcpCallInProgressEvent,
     ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent,
     ResponseOutputMessage,
@@ -48,25 +39,13 @@ from openai.types.responses import (
     ResponseReasoningTextDoneEvent,
     ResponseTextDeltaEvent,
     ResponseTextDoneEvent,
-    ResponseWebSearchCallCompletedEvent,
-    ResponseWebSearchCallInProgressEvent,
-    ResponseWebSearchCallSearchingEvent,
-    response_function_web_search,
     response_text_delta_event,
 )
-from openai.types.responses.response_output_item import McpCall
 from openai.types.responses.response_reasoning_item import (
     Content as ResponseReasoningTextContent,
 )
-from openai_harmony import Message as HarmonyMessage
 
-from vllm.entrypoints.mcp.tool_server import ToolServer
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage, DeltaToolCall
-from vllm.entrypoints.openai.parser.harmony_utils import (
-    extract_function_from_recipient,
-    is_function_recipient,
-)
-from vllm.entrypoints.openai.responses.context import StreamingHarmonyContext
 from vllm.entrypoints.openai.responses.protocol import (
     ResponseReasoningPartAddedEvent,
     ResponseReasoningPartDoneEvent,
@@ -75,775 +54,20 @@ from vllm.entrypoints.openai.responses.protocol import (
 from vllm.outputs import CompletionOutput
 from vllm.utils import random_uuid
 
-TOOL_NAME_TO_MCP_SERVER_LABEL: Final[dict[str, str]] = {
-    "python": "code_interpreter",
-    "container": "container",
-    "browser": "web_search_preview",
-}
-
-
-def _resolve_mcp_name_label(recipient: str) -> tuple[str, str]:
-    """Resolve MCP tool name and server label from a recipient string.
-
-    - ``mcp.*`` recipients: strip prefix, use the bare name as both
-      name and server_label.
-    - Everything else: use the recipient as the name and look up the
-      server_label in TOOL_NAME_TO_MCP_SERVER_LABEL.
-    """
-    if recipient.startswith("mcp."):
-        name = recipient[len("mcp.") :]
-        return name, name
-    return recipient, TOOL_NAME_TO_MCP_SERVER_LABEL.get(recipient, recipient)
-
-
-@dataclass
-class StreamingState:
-    """Mutable state for streaming event processing."""
-
-    current_content_index: int = -1
-    current_output_index: int = 0
-    current_item_id: str = ""
-    current_call_id: str = ""
-    sent_output_item_added: bool = False
-    is_first_function_call_delta: bool = False
-
-    def reset_for_new_item(self) -> None:
-        """Reset state when expecting a new output item."""
-        self.current_output_index += 1
-        self.sent_output_item_added = False
-        self.is_first_function_call_delta = False
-        self.current_call_id = ""
-
-
-def is_mcp_tool_by_namespace(
-    recipient: str | None,
-    allowed_function_tool_names: frozenset[str] | None = None,
-) -> bool:
-    """
-    Determine if a tool call is an MCP tool based on recipient prefix.
-
-    Inverse of :func:`is_function_recipient` — everything that is not
-    a function call is an MCP tool.
-    """
-    if recipient is None:
-        return False
-    return not is_function_recipient(recipient, allowed_function_tool_names)
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.responses.harmony_streaming_events import (
+        HarmonyStreamingState,
+    )
 
 
 # =====================================================================
-# Shared leaf helpers — delta events
+# Shared leaf helpers — open events
 # =====================================================================
 
 
-def emit_text_delta_events(
-    delta: str,
-    state: StreamingState,
+def emit_text_open_events(
+    state: SimpleStreamingState | HarmonyStreamingState,
 ) -> list[StreamingResponsesResponse]:
-    """Emit events for text content delta streaming."""
-    events: list[StreamingResponsesResponse] = []
-    if not state.sent_output_item_added:
-        state.sent_output_item_added = True
-        state.current_item_id = f"msg_{random_uuid()}"
-        events.append(
-            ResponseOutputItemAddedEvent(
-                type="response.output_item.added",
-                sequence_number=-1,
-                output_index=state.current_output_index,
-                item=ResponseOutputMessage(
-                    id=state.current_item_id,
-                    type="message",
-                    role="assistant",
-                    content=[],
-                    status="in_progress",
-                ),
-            )
-        )
-        state.current_content_index += 1
-        events.append(
-            ResponseContentPartAddedEvent(
-                type="response.content_part.added",
-                sequence_number=-1,
-                output_index=state.current_output_index,
-                item_id=state.current_item_id,
-                content_index=state.current_content_index,
-                part=ResponseOutputText(
-                    type="output_text",
-                    text="",
-                    annotations=[],
-                    logprobs=[],
-                ),
-            )
-        )
-    events.append(
-        ResponseTextDeltaEvent(
-            type="response.output_text.delta",
-            sequence_number=-1,
-            content_index=state.current_content_index,
-            output_index=state.current_output_index,
-            item_id=state.current_item_id,
-            delta=delta,
-            # TODO, use logprobs from ctx.last_request_output
-            logprobs=[],
-        )
-    )
-    return events
-
-
-def emit_reasoning_delta_events(
-    delta: str,
-    state: StreamingState,
-) -> list[StreamingResponsesResponse]:
-    """Emit events for reasoning text delta streaming."""
-    events: list[StreamingResponsesResponse] = []
-    if not state.sent_output_item_added:
-        state.sent_output_item_added = True
-        state.current_item_id = f"msg_{random_uuid()}"
-        events.append(
-            ResponseOutputItemAddedEvent(
-                type="response.output_item.added",
-                sequence_number=-1,
-                output_index=state.current_output_index,
-                item=ResponseReasoningItem(
-                    type="reasoning",
-                    id=state.current_item_id,
-                    summary=[],
-                    status="in_progress",
-                ),
-            )
-        )
-        state.current_content_index += 1
-        events.append(
-            ResponseReasoningPartAddedEvent(
-                type="response.reasoning_part.added",
-                sequence_number=-1,
-                output_index=state.current_output_index,
-                item_id=state.current_item_id,
-                content_index=state.current_content_index,
-                part=ResponseReasoningTextContent(
-                    text="",
-                    type="reasoning_text",
-                ),
-            )
-        )
-    events.append(
-        ResponseReasoningTextDeltaEvent(
-            type="response.reasoning_text.delta",
-            item_id=state.current_item_id,
-            output_index=state.current_output_index,
-            content_index=state.current_content_index,
-            delta=delta,
-            sequence_number=-1,
-        )
-    )
-    return events
-
-
-def emit_function_call_delta_events(
-    delta: str,
-    function_name: str,
-    state: StreamingState,
-) -> list[StreamingResponsesResponse]:
-    """Emit events for function call argument deltas."""
-    events: list[StreamingResponsesResponse] = []
-    if state.is_first_function_call_delta is False:
-        state.is_first_function_call_delta = True
-        state.current_item_id = f"fc_{random_uuid()}"
-        state.current_call_id = f"call_{random_uuid()}"
-        tool_call_item = ResponseFunctionToolCall(
-            name=function_name,
-            type="function_call",
-            id=state.current_item_id,
-            call_id=state.current_call_id,
-            arguments="",
-            status="in_progress",
-        )
-        events.append(
-            ResponseOutputItemAddedEvent(
-                type="response.output_item.added",
-                sequence_number=-1,
-                output_index=state.current_output_index,
-                item=tool_call_item,
-            )
-        )
-    # Always emit the delta (including on first call)
-    events.append(
-        ResponseFunctionCallArgumentsDeltaEvent(
-            item_id=state.current_item_id,
-            delta=delta,
-            output_index=state.current_output_index,
-            sequence_number=-1,
-            type="response.function_call_arguments.delta",
-        )
-    )
-    return events
-
-
-def emit_mcp_delta_events(
-    delta: str,
-    state: StreamingState,
-    recipient: str,
-) -> list[StreamingResponsesResponse]:
-    """Emit events for MCP tool delta streaming."""
-    name, server_label = _resolve_mcp_name_label(recipient)
-    events: list[StreamingResponsesResponse] = []
-    if not state.sent_output_item_added:
-        state.sent_output_item_added = True
-        state.current_item_id = f"mcp_{random_uuid()}"
-        events.append(
-            ResponseOutputItemAddedEvent(
-                type="response.output_item.added",
-                sequence_number=-1,
-                output_index=state.current_output_index,
-                item=McpCall(
-                    type="mcp_call",
-                    id=state.current_item_id,
-                    name=name,
-                    arguments="",
-                    server_label=server_label,
-                    status="in_progress",
-                ),
-            )
-        )
-        events.append(
-            ResponseMcpCallInProgressEvent(
-                type="response.mcp_call.in_progress",
-                sequence_number=-1,
-                output_index=state.current_output_index,
-                item_id=state.current_item_id,
-            )
-        )
-    events.append(
-        ResponseMcpCallArgumentsDeltaEvent(
-            type="response.mcp_call_arguments.delta",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item_id=state.current_item_id,
-            delta=delta,
-        )
-    )
-    return events
-
-
-def emit_code_interpreter_delta_events(
-    delta: str,
-    state: StreamingState,
-) -> list[StreamingResponsesResponse]:
-    """Emit events for code interpreter delta streaming."""
-    events: list[StreamingResponsesResponse] = []
-    if not state.sent_output_item_added:
-        state.sent_output_item_added = True
-        state.current_item_id = f"tool_{random_uuid()}"
-        events.append(
-            ResponseOutputItemAddedEvent(
-                type="response.output_item.added",
-                sequence_number=-1,
-                output_index=state.current_output_index,
-                item=ResponseCodeInterpreterToolCallParam(
-                    type="code_interpreter_call",
-                    id=state.current_item_id,
-                    code=None,
-                    container_id="auto",
-                    outputs=None,
-                    status="in_progress",
-                ),
-            )
-        )
-        events.append(
-            ResponseCodeInterpreterCallInProgressEvent(
-                type="response.code_interpreter_call.in_progress",
-                sequence_number=-1,
-                output_index=state.current_output_index,
-                item_id=state.current_item_id,
-            )
-        )
-    events.append(
-        ResponseCodeInterpreterCallCodeDeltaEvent(
-            type="response.code_interpreter_call_code.delta",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item_id=state.current_item_id,
-            delta=delta,
-        )
-    )
-    return events
-
-
-# =====================================================================
-# Shared leaf helpers — done events
-# =====================================================================
-
-
-def emit_text_output_done_events(
-    text: str,
-    state: StreamingState,
-) -> list[StreamingResponsesResponse]:
-    """Emit events when a final text output item completes."""
-    text_content = ResponseOutputText(
-        type="output_text",
-        text=text,
-        annotations=[],
-    )
-    events: list[StreamingResponsesResponse] = []
-    events.append(
-        ResponseTextDoneEvent(
-            type="response.output_text.done",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            content_index=state.current_content_index,
-            text=text,
-            logprobs=[],
-            item_id=state.current_item_id,
-        )
-    )
-    events.append(
-        ResponseContentPartDoneEvent(
-            type="response.content_part.done",
-            sequence_number=-1,
-            item_id=state.current_item_id,
-            output_index=state.current_output_index,
-            content_index=state.current_content_index,
-            part=text_content,
-        )
-    )
-    events.append(
-        ResponseOutputItemDoneEvent(
-            type="response.output_item.done",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item=ResponseOutputMessage(
-                id=state.current_item_id,
-                type="message",
-                role="assistant",
-                content=[text_content],
-                status="completed",
-            ),
-        )
-    )
-    return events
-
-
-def emit_reasoning_done_events(
-    text: str,
-    state: StreamingState,
-) -> list[StreamingResponsesResponse]:
-    """Emit events when a reasoning (analysis) item completes."""
-    content = ResponseReasoningTextContent(
-        text=text,
-        type="reasoning_text",
-    )
-    reasoning_item = ResponseReasoningItem(
-        type="reasoning",
-        content=[content],
-        status="completed",
-        id=state.current_item_id,
-        summary=[],
-    )
-    events: list[StreamingResponsesResponse] = []
-    events.append(
-        ResponseReasoningTextDoneEvent(
-            type="response.reasoning_text.done",
-            item_id=state.current_item_id,
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            content_index=state.current_content_index,
-            text=text,
-        )
-    )
-    events.append(
-        ResponseReasoningPartDoneEvent(
-            type="response.reasoning_part.done",
-            sequence_number=-1,
-            item_id=state.current_item_id,
-            output_index=state.current_output_index,
-            content_index=state.current_content_index,
-            part=content,
-        )
-    )
-    events.append(
-        ResponseOutputItemDoneEvent(
-            type="response.output_item.done",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item=reasoning_item,
-        )
-    )
-    return events
-
-
-def emit_function_call_done_events(
-    function_name: str,
-    arguments: str,
-    state: StreamingState,
-) -> list[StreamingResponsesResponse]:
-    """Emit events when a function call completes."""
-    events: list[StreamingResponsesResponse] = []
-    events.append(
-        ResponseFunctionCallArgumentsDoneEvent(
-            type="response.function_call_arguments.done",
-            arguments=arguments,
-            name=function_name,
-            item_id=state.current_item_id,
-            output_index=state.current_output_index,
-            sequence_number=-1,
-        )
-    )
-    function_call_item = ResponseFunctionToolCall(
-        type="function_call",
-        arguments=arguments,
-        name=function_name,
-        id=state.current_item_id,
-        output_index=state.current_output_index,
-        sequence_number=-1,
-        call_id=state.current_call_id,
-        status="completed",
-    )
-    events.append(
-        ResponseOutputItemDoneEvent(
-            type="response.output_item.done",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item=function_call_item,
-        )
-    )
-    return events
-
-
-def emit_mcp_completion_events(
-    recipient: str,
-    arguments: str,
-    state: StreamingState,
-) -> list[StreamingResponsesResponse]:
-    """Emit events when an MCP tool call completes."""
-    name, server_label = _resolve_mcp_name_label(recipient)
-    events: list[StreamingResponsesResponse] = []
-    events.append(
-        ResponseMcpCallArgumentsDoneEvent(
-            type="response.mcp_call_arguments.done",
-            arguments=arguments,
-            name=name,
-            item_id=state.current_item_id,
-            output_index=state.current_output_index,
-            sequence_number=-1,
-        )
-    )
-    events.append(
-        ResponseMcpCallCompletedEvent(
-            type="response.mcp_call.completed",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item_id=state.current_item_id,
-        )
-    )
-    events.append(
-        ResponseOutputItemDoneEvent(
-            type="response.output_item.done",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item=McpCall(
-                type="mcp_call",
-                arguments=arguments,
-                name=name,
-                id=state.current_item_id,
-                server_label=server_label,
-                status="completed",
-            ),
-        )
-    )
-    return events
-
-
-# =====================================================================
-# Harmony-specific dispatchers
-# =====================================================================
-
-
-def emit_content_delta_events(
-    ctx: StreamingHarmonyContext,
-    state: StreamingState,
-) -> list[StreamingResponsesResponse]:
-    """Emit events for content delta streaming based on channel type.
-
-    This is a Harmony-specific dispatcher that extracts values from the
-    Harmony context and delegates to shared leaf helpers.
-    """
-    delta = ctx.last_content_delta
-    if not delta:
-        return []
-
-    channel = ctx.parser.current_channel
-    recipient = ctx.parser.current_recipient
-
-    if channel in ("final", "commentary") and recipient is None:
-        # Preambles (commentary with no recipient) and final messages
-        # are both user-visible text.
-        return emit_text_delta_events(delta, state)
-    elif channel == "analysis" and recipient is None:
-        return emit_reasoning_delta_events(delta, state)
-    elif recipient is not None:
-        fn_names = ctx.function_tool_names
-        if is_function_recipient(recipient, fn_names):
-            function_name = extract_function_from_recipient(recipient)
-            return emit_function_call_delta_events(delta, function_name, state)
-        elif recipient == "python":
-            return emit_code_interpreter_delta_events(delta, state)
-        elif recipient.startswith("mcp.") or is_mcp_tool_by_namespace(
-            recipient, fn_names
-        ):
-            return emit_mcp_delta_events(delta, state, recipient)
-
-    return []
-
-
-def emit_previous_item_done_events(
-    previous_item: HarmonyMessage,
-    state: StreamingState,
-    function_tool_names: frozenset[str] | None = None,
-) -> list[StreamingResponsesResponse]:
-    """Emit done events for the previous item when expecting a new start.
-
-    This is a Harmony-specific dispatcher that extracts values from the
-    Harmony parser's message object and delegates to shared leaf helpers.
-    """
-    text = previous_item.content[0].text
-    if previous_item.recipient is not None:
-        # Deal with tool call
-        if is_function_recipient(previous_item.recipient, function_tool_names):
-            function_name = extract_function_from_recipient(previous_item.recipient)
-            return emit_function_call_done_events(function_name, text, state)
-        elif previous_item.recipient == "python":
-            return emit_code_interpreter_completion_events(previous_item, state)
-        elif (
-            is_mcp_tool_by_namespace(previous_item.recipient, function_tool_names)
-            and state.current_item_id is not None
-            and state.current_item_id.startswith("mcp_")
-        ):
-            return emit_mcp_completion_events(previous_item.recipient, text, state)
-    elif previous_item.channel == "analysis":
-        return emit_reasoning_done_events(text, state)
-    elif previous_item.channel in ("commentary", "final"):
-        # Preambles (commentary with no recipient) and final messages
-        # are both user-visible text.
-        return emit_text_output_done_events(text, state)
-    return []
-
-
-# =====================================================================
-# Harmony-specific tool lifecycle helpers
-# =====================================================================
-
-
-def emit_browser_tool_events(
-    previous_item: HarmonyMessage,
-    state: StreamingState,
-) -> list[StreamingResponsesResponse]:
-    """Emit events for browser tool calls (web search)."""
-    function_name = previous_item.recipient[len("browser.") :]
-    parsed_args = json.loads(previous_item.content[0].text)
-    action = None
-
-    if function_name == "search":
-        action = response_function_web_search.ActionSearch(
-            type="search",
-            query=parsed_args["query"],
-        )
-    elif function_name == "open":
-        action = response_function_web_search.ActionOpenPage(
-            type="open_page",
-            # TODO: translate to url
-            url=f"cursor:{parsed_args.get('cursor', '')}",
-        )
-    elif function_name == "find":
-        action = response_function_web_search.ActionFind(
-            type="find",
-            pattern=parsed_args["pattern"],
-            # TODO: translate to url
-            url=f"cursor:{parsed_args.get('cursor', '')}",
-        )
-    else:
-        raise ValueError(f"Unknown function name: {function_name}")
-
-    state.current_item_id = f"tool_{random_uuid()}"
-    events: list[StreamingResponsesResponse] = []
-    events.append(
-        ResponseOutputItemAddedEvent(
-            type="response.output_item.added",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item=response_function_web_search.ResponseFunctionWebSearch(
-                # TODO: generate a unique id for web search call
-                type="web_search_call",
-                id=state.current_item_id,
-                action=action,
-                status="in_progress",
-            ),
-        )
-    )
-    events.append(
-        ResponseWebSearchCallInProgressEvent(
-            type="response.web_search_call.in_progress",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item_id=state.current_item_id,
-        )
-    )
-    events.append(
-        ResponseWebSearchCallSearchingEvent(
-            type="response.web_search_call.searching",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item_id=state.current_item_id,
-        )
-    )
-    # enqueue
-    events.append(
-        ResponseWebSearchCallCompletedEvent(
-            type="response.web_search_call.completed",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item_id=state.current_item_id,
-        )
-    )
-    events.append(
-        ResponseOutputItemDoneEvent(
-            type="response.output_item.done",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item=ResponseFunctionWebSearch(
-                type="web_search_call",
-                id=state.current_item_id,
-                action=action,
-                status="completed",
-            ),
-        )
-    )
-    return events
-
-
-def emit_code_interpreter_completion_events(
-    previous_item: HarmonyMessage,
-    state: StreamingState,
-) -> list[StreamingResponsesResponse]:
-    """Emit events when code interpreter completes."""
-    events: list[StreamingResponsesResponse] = []
-    events.append(
-        ResponseCodeInterpreterCallCodeDoneEvent(
-            type="response.code_interpreter_call_code.done",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item_id=state.current_item_id,
-            code=previous_item.content[0].text,
-        )
-    )
-    events.append(
-        ResponseCodeInterpreterCallInterpretingEvent(
-            type="response.code_interpreter_call.interpreting",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item_id=state.current_item_id,
-        )
-    )
-    events.append(
-        ResponseCodeInterpreterCallCompletedEvent(
-            type="response.code_interpreter_call.completed",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item_id=state.current_item_id,
-        )
-    )
-    events.append(
-        ResponseOutputItemDoneEvent(
-            type="response.output_item.done",
-            sequence_number=-1,
-            output_index=state.current_output_index,
-            item=ResponseCodeInterpreterToolCallParam(
-                type="code_interpreter_call",
-                id=state.current_item_id,
-                code=previous_item.content[0].text,
-                container_id="auto",
-                outputs=[],
-                status="completed",
-            ),
-        )
-    )
-    return events
-
-
-def emit_tool_action_events(
-    ctx: StreamingHarmonyContext,
-    state: StreamingState,
-    tool_server: ToolServer | None,
-) -> list[StreamingResponsesResponse]:
-    """Emit events for tool action turn."""
-    if not ctx.is_assistant_action_turn() or len(ctx.parser.messages) == 0:
-        return []
-
-    events: list[StreamingResponsesResponse] = []
-    previous_item = ctx.parser.messages[-1]
-
-    # Handle browser tool
-    if (
-        tool_server is not None
-        and tool_server.has_tool("browser")
-        and previous_item.recipient is not None
-        and previous_item.recipient.startswith("browser.")
-    ):
-        events.extend(emit_browser_tool_events(previous_item, state))
-
-    # Handle tool completion
-    if (
-        tool_server is not None
-        and previous_item.recipient is not None
-        and state.current_item_id is not None
-        and state.sent_output_item_added
-    ):
-        recipient = previous_item.recipient
-        fn_names = ctx.function_tool_names
-        if recipient == "python":
-            events.extend(emit_code_interpreter_completion_events(previous_item, state))
-        elif recipient.startswith("mcp.") or is_mcp_tool_by_namespace(
-            recipient, fn_names
-        ):
-            events.extend(
-                emit_mcp_completion_events(
-                    recipient, previous_item.content[0].text, state
-                )
-            )
-
-    return events
-
-
-# =====================================================================
-# Simple streaming helpers
-# =====================================================================
-
-
-class _StateType(Enum):
-    NONE = auto()
-    CONTENT = auto()
-    REASONING = auto()
-    TOOL_CALL = auto()
-
-
-@dataclass
-class SimpleStreamingState:
-    output_index: int = 0
-    current_item_id: str = ""
-    content_index: int = 0
-    accumulated_text: str = ""
-    tool_call_id: str = ""
-    tool_call_name: str = ""
-    tool_call_index: int | None = None
-    has_emitted_tool_call_delta: bool = False
-    current_state: _StateType = field(default_factory=lambda: _StateType.NONE)
-
-
-def emit_simple_content_open(
-    state: SimpleStreamingState,
-) -> list[StreamingResponsesResponse]:
-    state.current_state = _StateType.CONTENT
-    state.current_item_id = random_uuid()
-    state.content_index = 0
-    state.accumulated_text = ""
     return [
         ResponseOutputItemAddedEvent(
             type="response.output_item.added",
@@ -873,77 +97,9 @@ def emit_simple_content_open(
     ]
 
 
-def emit_simple_content_delta(
-    state: SimpleStreamingState,
-    delta: str,
-    logprobs: list[response_text_delta_event.Logprob] | None = None,
+def emit_reasoning_open_events(
+    state: SimpleStreamingState | HarmonyStreamingState,
 ) -> list[StreamingResponsesResponse]:
-    state.accumulated_text += delta
-    return [
-        ResponseTextDeltaEvent(
-            type="response.output_text.delta",
-            sequence_number=-1,
-            content_index=state.content_index,
-            output_index=state.output_index,
-            item_id=state.current_item_id,
-            delta=delta,
-            logprobs=logprobs or [],
-        )
-    ]
-
-
-def emit_simple_content_done(
-    state: SimpleStreamingState,
-) -> list[StreamingResponsesResponse]:
-    part = ResponseOutputText(
-        type="output_text",
-        text=state.accumulated_text,
-        annotations=[],
-    )
-    events: list[StreamingResponsesResponse] = [
-        ResponseTextDoneEvent(
-            type="response.output_text.done",
-            sequence_number=-1,
-            output_index=state.output_index,
-            content_index=state.content_index,
-            text=state.accumulated_text,
-            logprobs=[],
-            item_id=state.current_item_id,
-        ),
-        ResponseContentPartDoneEvent(
-            type="response.content_part.done",
-            sequence_number=-1,
-            item_id=state.current_item_id,
-            output_index=state.output_index,
-            content_index=state.content_index,
-            part=part,
-        ),
-        ResponseOutputItemDoneEvent(
-            type="response.output_item.done",
-            sequence_number=-1,
-            output_index=state.output_index,
-            item=ResponseOutputMessage(
-                id=state.current_item_id,
-                type="message",
-                role="assistant",
-                content=[part] if state.accumulated_text else [],
-                status="completed",
-                summary=[],
-            ),
-        ),
-    ]
-    state.output_index += 1
-    state.current_state = _StateType.NONE
-    return events
-
-
-def emit_simple_reasoning_open(
-    state: SimpleStreamingState,
-) -> list[StreamingResponsesResponse]:
-    state.current_state = _StateType.REASONING
-    state.current_item_id = random_uuid()
-    state.content_index = 0
-    state.accumulated_text = ""
     return [
         ResponseOutputItemAddedEvent(
             type="response.output_item.added",
@@ -970,60 +126,295 @@ def emit_simple_reasoning_open(
     ]
 
 
-def emit_simple_reasoning_delta(
-    state: SimpleStreamingState,
-    delta: str,
+def emit_function_call_open_events(
+    function_name: str,
+    state: SimpleStreamingState | HarmonyStreamingState,
 ) -> list[StreamingResponsesResponse]:
-    state.accumulated_text += delta
     return [
-        ResponseReasoningTextDeltaEvent(
-            type="response.reasoning_text.delta",
-            item_id=state.current_item_id,
+        ResponseOutputItemAddedEvent(
+            type="response.output_item.added",
             sequence_number=-1,
             output_index=state.output_index,
-            content_index=state.content_index,
-            delta=delta,
+            item=ResponseFunctionToolCall(
+                name=function_name,
+                type="function_call",
+                id=state.current_item_id,
+                call_id=state.tool_call_id,
+                arguments="",
+                status="in_progress",
+            ),
         )
     ]
 
 
-def emit_simple_reasoning_done(
-    state: SimpleStreamingState,
+# =====================================================================
+# Shared leaf helpers — delta events
+# =====================================================================
+
+
+def emit_text_delta_events(
+    delta: str,
+    state: SimpleStreamingState | HarmonyStreamingState,
+    logprobs: list[response_text_delta_event.Logprob] | None = None,
 ) -> list[StreamingResponsesResponse]:
-    part = ResponseReasoningTextContent(
-        text=state.accumulated_text,
+    """Emit events for text content delta streaming."""
+    return [
+        ResponseTextDeltaEvent(
+            type="response.output_text.delta",
+            sequence_number=-1,
+            content_index=state.content_index,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+            delta=delta,
+            logprobs=logprobs or [],
+        )
+    ]
+
+
+def emit_reasoning_delta_events(
+    delta: str,
+    state: SimpleStreamingState | HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    """Emit events for reasoning text delta streaming."""
+    return [
+        ResponseReasoningTextDeltaEvent(
+            type="response.reasoning_text.delta",
+            item_id=state.current_item_id,
+            output_index=state.output_index,
+            content_index=state.content_index,
+            delta=delta,
+            sequence_number=-1,
+        )
+    ]
+
+
+def emit_function_call_delta_events(
+    delta: str,
+    state: SimpleStreamingState | HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    """Emit events for function call argument deltas."""
+    return [
+        ResponseFunctionCallArgumentsDeltaEvent(
+            item_id=state.current_item_id,
+            delta=delta,
+            output_index=state.output_index,
+            sequence_number=-1,
+            type="response.function_call_arguments.delta",
+        )
+    ]
+
+
+# =====================================================================
+# Shared leaf helpers — done events
+# =====================================================================
+
+
+def emit_text_done_events(
+    text: str,
+    state: SimpleStreamingState | HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    """Emit events when a final text output item completes."""
+    text_content = ResponseOutputText(
+        type="output_text",
+        text=text,
+        annotations=[],
+    )
+    events: list[StreamingResponsesResponse] = []
+    events.append(
+        ResponseTextDoneEvent(
+            type="response.output_text.done",
+            sequence_number=-1,
+            output_index=state.output_index,
+            content_index=state.content_index,
+            text=text,
+            logprobs=[],
+            item_id=state.current_item_id,
+        )
+    )
+    events.append(
+        ResponseContentPartDoneEvent(
+            type="response.content_part.done",
+            sequence_number=-1,
+            item_id=state.current_item_id,
+            output_index=state.output_index,
+            content_index=state.content_index,
+            part=text_content,
+        )
+    )
+    events.append(
+        ResponseOutputItemDoneEvent(
+            type="response.output_item.done",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item=ResponseOutputMessage(
+                id=state.current_item_id,
+                type="message",
+                role="assistant",
+                content=[text_content],
+                status="completed",
+            ),
+        )
+    )
+    return events
+
+
+def emit_reasoning_done_events(
+    text: str,
+    state: SimpleStreamingState | HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    """Emit events when a reasoning (analysis) item completes."""
+    content = ResponseReasoningTextContent(
+        text=text,
         type="reasoning_text",
     )
-    events: list[StreamingResponsesResponse] = [
+    reasoning_item = ResponseReasoningItem(
+        type="reasoning",
+        content=[content],
+        status="completed",
+        id=state.current_item_id,
+        summary=[],
+    )
+    events: list[StreamingResponsesResponse] = []
+    events.append(
         ResponseReasoningTextDoneEvent(
             type="response.reasoning_text.done",
             item_id=state.current_item_id,
             sequence_number=-1,
             output_index=state.output_index,
             content_index=state.content_index,
-            text=state.accumulated_text,
-        ),
+            text=text,
+        )
+    )
+    events.append(
         ResponseReasoningPartDoneEvent(
             type="response.reasoning_part.done",
             sequence_number=-1,
             item_id=state.current_item_id,
             output_index=state.output_index,
             content_index=state.content_index,
-            part=part,
-        ),
+            part=content,
+        )
+    )
+    events.append(
         ResponseOutputItemDoneEvent(
             type="response.output_item.done",
             sequence_number=-1,
             output_index=state.output_index,
-            item=ResponseReasoningItem(
-                type="reasoning",
-                content=[part],
-                status="completed",
+            item=reasoning_item,
+        )
+    )
+    return events
+
+
+def emit_function_call_done_events(
+    function_name: str,
+    arguments: str,
+    state: SimpleStreamingState | HarmonyStreamingState,
+) -> list[StreamingResponsesResponse]:
+    """Emit events when a function call completes."""
+    events: list[StreamingResponsesResponse] = []
+    events.append(
+        ResponseFunctionCallArgumentsDoneEvent(
+            type="response.function_call_arguments.done",
+            arguments=arguments,
+            name=function_name,
+            item_id=state.current_item_id,
+            output_index=state.output_index,
+            sequence_number=-1,
+        )
+    )
+    events.append(
+        ResponseOutputItemDoneEvent(
+            type="response.output_item.done",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item=ResponseFunctionToolCall(
+                type="function_call",
+                arguments=arguments,
+                name=function_name,
                 id=state.current_item_id,
-                summary=[],
+                call_id=state.tool_call_id,
+                status="completed",
             ),
-        ),
-    ]
+        )
+    )
+    return events
+
+
+# =====================================================================
+# Simple streaming helpers
+# =====================================================================
+
+
+class _StateType(Enum):
+    NONE = auto()
+    CONTENT = auto()
+    REASONING = auto()
+    TOOL_CALL = auto()
+
+
+@dataclass
+class SimpleStreamingState:
+    output_index: int = 0
+    current_item_id: str = ""
+    content_index: int = 0
+    accumulated_text: str = ""
+    tool_call_id: str = ""
+    tool_call_name: str = ""
+    tool_call_index: int | None = None
+    current_state: _StateType = field(default_factory=lambda: _StateType.NONE)
+
+
+def emit_simple_content_open(
+    state: SimpleStreamingState,
+) -> list[StreamingResponsesResponse]:
+    state.current_state = _StateType.CONTENT
+    state.current_item_id = random_uuid()
+    state.content_index = 0
+    state.accumulated_text = ""
+    return emit_text_open_events(state)
+
+
+def emit_simple_content_delta(
+    state: SimpleStreamingState,
+    delta: str,
+    logprobs: list[response_text_delta_event.Logprob] | None = None,
+) -> list[StreamingResponsesResponse]:
+    state.accumulated_text += delta
+    return emit_text_delta_events(delta, state, logprobs=logprobs)
+
+
+def emit_simple_content_done(
+    state: SimpleStreamingState,
+) -> list[StreamingResponsesResponse]:
+    events = emit_text_done_events(state.accumulated_text, state)
+    state.output_index += 1
+    state.current_state = _StateType.NONE
+    return events
+
+
+def emit_simple_reasoning_open(
+    state: SimpleStreamingState,
+) -> list[StreamingResponsesResponse]:
+    state.current_state = _StateType.REASONING
+    state.current_item_id = random_uuid()
+    state.content_index = 0
+    state.accumulated_text = ""
+    return emit_reasoning_open_events(state)
+
+
+def emit_simple_reasoning_delta(
+    state: SimpleStreamingState,
+    delta: str,
+) -> list[StreamingResponsesResponse]:
+    state.accumulated_text += delta
+    return emit_reasoning_delta_events(delta, state)
+
+
+def emit_simple_reasoning_done(
+    state: SimpleStreamingState,
+) -> list[StreamingResponsesResponse]:
+    events = emit_reasoning_done_events(state.accumulated_text, state)
     state.output_index += 1
     state.current_state = _StateType.NONE
     return events
@@ -1040,22 +431,7 @@ def emit_simple_tool_call_open(
     state.tool_call_name = name
     state.tool_call_index = index
     state.accumulated_text = ""
-    state.has_emitted_tool_call_delta = False
-    return [
-        ResponseOutputItemAddedEvent(
-            type="response.output_item.added",
-            sequence_number=-1,
-            output_index=state.output_index,
-            item=ResponseFunctionToolCallItem(
-                type="function_call",
-                id=state.current_item_id,
-                call_id=state.tool_call_id,
-                name=name,
-                arguments="",
-                status="in_progress",
-            ),
-        ),
-    ]
+    return emit_function_call_open_events(name, state)
 
 
 def emit_simple_tool_call_delta(
@@ -1063,47 +439,14 @@ def emit_simple_tool_call_delta(
     delta: str,
 ) -> list[StreamingResponsesResponse]:
     state.accumulated_text += delta
-    state.has_emitted_tool_call_delta = True
-    return [
-        ResponseFunctionCallArgumentsDeltaEvent(
-            type="response.function_call_arguments.delta",
-            sequence_number=-1,
-            output_index=state.output_index,
-            item_id=state.current_item_id,
-            delta=delta,
-        )
-    ]
+    return emit_function_call_delta_events(delta, state)
 
 
 def emit_simple_tool_call_done(
     state: SimpleStreamingState,
 ) -> list[StreamingResponsesResponse]:
-    events: list[StreamingResponsesResponse] = []
-    if state.has_emitted_tool_call_delta:
-        events.append(
-            ResponseFunctionCallArgumentsDoneEvent(
-                type="response.function_call_arguments.done",
-                sequence_number=-1,
-                output_index=state.output_index,
-                item_id=state.current_item_id,
-                arguments=state.accumulated_text,
-                name=state.tool_call_name,
-            )
-        )
-    events.append(
-        ResponseOutputItemDoneEvent(
-            type="response.output_item.done",
-            sequence_number=-1,
-            output_index=state.output_index,
-            item=ResponseFunctionToolCall(
-                type="function_call",
-                name=state.tool_call_name,
-                arguments=state.accumulated_text,
-                status="completed",
-                id=state.current_item_id,
-                call_id=state.tool_call_id,
-            ),
-        ),
+    events = emit_function_call_done_events(
+        state.tool_call_name, state.accumulated_text, state
     )
     state.output_index += 1
     state.current_state = _StateType.NONE

--- a/vllm/parser/harmony.py
+++ b/vllm/parser/harmony.py
@@ -123,26 +123,33 @@ class HarmonyParser(DelegatingParser):
         Callers must decide whether to surface them.
         """
         result = self.process_chunk(model_output_token_ids)
+        flushed_segment = self.flush_current_segment()
+        if flushed_segment is not None:
+            result.segments.append(flushed_segment)
 
         reasoning_parts: list[str] = []
         content_parts: list[str] = []
         tool_calls: list[FunctionCall] = []
 
-        def _append_parsed_message(
-            channel: str | None,
-            recipient: str | None,
-            text: str,
-            content_type: str | None = None,
-        ) -> None:
-            segment_type = _SegmentType.from_channel_and_recipient(channel, recipient)
+        for segment in result.segments:
+            msg = segment.completed_message
+            if msg is None:
+                continue
+            if msg.author.role != "assistant" or not msg.content:
+                continue
+            text = msg.content[0].text
+            segment_type = _SegmentType.from_channel_and_recipient(
+                msg.channel, msg.recipient
+            )
             match segment_type:
                 case _SegmentType.REASONING if self.reasoning_parser and text:
                     reasoning_parts.append(text)
                 case _SegmentType.CONTENT if text:
                     content_parts.append(text)
                 case _SegmentType.TOOL if self.tool_parser:
+                    recipient = msg.recipient
                     assert recipient is not None
-                    if content_type is not None and "json" not in content_type:
+                    if msg.content_type is not None and "json" not in msg.content_type:
                         arguments = text
                     else:
                         try:
@@ -155,31 +162,6 @@ class HarmonyParser(DelegatingParser):
                             arguments=arguments,
                         )
                     )
-
-        for segment in result.segments:
-            msg = segment.completed_message
-            if msg is None:
-                continue
-            if msg.author.role != "assistant" or not msg.content:
-                continue
-            _append_parsed_message(
-                channel=msg.channel,
-                recipient=msg.recipient,
-                text=msg.content[0].text,
-                content_type=msg.content_type,
-            )
-
-        if (
-            self.current_channel is not None
-            or self.current_recipient is not None
-            or self.current_content
-        ):
-            _append_parsed_message(
-                channel=self.current_channel,
-                recipient=self.current_recipient,
-                text=self.current_content,
-                content_type=self.current_content_type,
-            )
 
         reasoning = "\n".join(reasoning_parts) or None
         content = "\n".join(content_parts) or None
@@ -196,6 +178,10 @@ class HarmonyParser(DelegatingParser):
     ) -> DeltaMessage | None:
         prev_recipient = self.current_recipient
         result = self.process_chunk(delta_token_ids)
+        if finished:
+            flushed_segment = self.flush_current_segment()
+            if flushed_segment is not None:
+                result.segments.append(flushed_segment)
         combined_content = ""
         combined_reasoning = ""
         tool_messages: list[DeltaToolCall] = []
@@ -271,11 +257,7 @@ class HarmonyParser(DelegatingParser):
             channel = self.current_channel
             recipient = self.current_recipient
             delta = self._harmony_parser.last_content_delta or ""
-            completed_message = None
-            _messages = self._harmony_parser.messages
-            if len(_messages) > self._num_processed_messages:
-                completed_message = _messages[self._num_processed_messages]
-                self._num_processed_messages += 1
+            completed_message = self._take_completed_message()
 
             if channel == "analysis" or (
                 channel == "commentary" and recipient is not None
@@ -297,3 +279,29 @@ class HarmonyParser(DelegatingParser):
             segments=segments,
             reasoning_token_count=reasoning_token_count,
         )
+
+    def flush_current_segment(self) -> Segment | None:
+        try:
+            self._harmony_parser.process_eos()
+        except Exception:
+            # TODO: Consider reraising
+            return None
+
+        msg = self._take_completed_message()
+        if msg is None:
+            return None
+
+        return Segment(
+            channel=msg.channel,
+            recipient=msg.recipient,
+            delta="",
+            completed_message=msg,
+        )
+
+    def _take_completed_message(self) -> Message | None:
+        messages = self._harmony_parser.messages
+        if len(messages) <= self._num_processed_messages:
+            return None
+        msg = messages[self._num_processed_messages]
+        self._num_processed_messages += 1
+        return msg


### PR DESCRIPTION
## Purpose

Attempted follow up to https://github.com/vllm-project/vllm/pull/45171

- Merges `HarmonyContext` and `StreamingHarmonyContext` both now uses `HarmonyParser`
- Rebuilds Harmony-to-Responses translation around one shared that resolves Harmony messages into text, reasoning, python, browser, etc. So it is consistent across streaming vs non-streaming

## Test Plan

Unit
```
.venv/bin/python -m pytest -q
tests/entrypoints/unit_tests/test_context.py \
tests/entrypoints/openai/responses/test_harmony_utils.py \
tests/entrypoints/openai/responses/test_serving_responses.py
```

Integration
```
.venv/bin/python -m pytest -q tests/entrypoints/openai/responses/test_harmony.py
```

BFCL

Manual testing:
```
VLLM_LOGGING_LEVEL=DEBUG chg run -g 4 -- vllm serve RedHatAI/gpt-oss-120b \
  --port 8889 \
  --enable-auto-tool-choice \
  --reasoning-parser openai_gptoss \
  --tool-call-parser openai \
  --tensor-parallel-size 4 \
  --enable-expert-parallel \
  --enable-prefix-caching \
  --enable-log-requests \
  --stream-interval 13 \
  --enable-log-outputs | tee vllm-serve-gptoss-120b.log
```

## Test Result

Unit
```
63 passed, 16 warnings in 17.93s
```

Integration
```
31 passed, 2 skipped, 1 xpassed, 16 warnings in 278.56s
```

```
🦍 Model: openai_gpt-oss-20b
🔍 Running test: multi_turn_base
✅ Test completed: multi_turn_base. 🎯 Accuracy: 40.50%
🔍 Running test: multi_turn_long_context
✅ Test completed: multi_turn_long_context. 🎯 Accuracy: 21.00%
🔍 Running test: multi_turn_miss_func
✅ Test completed: multi_turn_miss_func. 🎯 Accuracy: 27.00%
🔍 Running test: multi_turn_miss_param
✅ Test completed: multi_turn_miss_param. 🎯 Accuracy: 27.50%
📈 Aggregating data to generate leaderboard score table...
```
on par with before

Manual testing:
[session.html](https://github.com/user-attachments/files/29111279/session.html)
No parsing failures. Works quite well.

### Why in draft

- Need to split into various PRs
- More systematic test coverage needed
- Harmony still uses its own Responses SSE translation. @sfeng33 suggests they should use the existing `SimpleStreamingEventProcessor` instead.

cc @bbrowning 

AI assistance used

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

