### PR TITLE
[ASR] Add Voice Activity Detection (VAD)

### DIFF
--- a/requirements/test/cuda.in
+++ b/requirements/test/cuda.in
@@ -23,6 +23,8 @@ pqdm
 ray[cgraph,default]>=2.48.0 # Ray Compiled Graph, required by pipeline parallelism tests
 sentence-transformers>=5.2.0 # required for embedding tests
 soundfile # required for audio tests
+silero-vad==6.2.1
+onnxruntime==1.27.0
 jiwer # required for audio tests
 tblib # for pickling test exceptions
 timm >=1.0.17 # required for internvl and gemma3n-mm test

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -198,6 +198,8 @@ filelock==3.16.1
     #   ray
     #   torch
     #   virtualenv
+flatbuffers==25.12.19
+    # via onnxruntime
 fonttools==4.55.0
     # via matplotlib
 frozendict==2.4.6
@@ -465,6 +467,7 @@ numpy==2.2.6
     #   mistral-common
     #   mteb
     #   numba
+    #   onnxruntime
     #   opencv-python-headless
     #   optuna
     #   pandas
@@ -526,6 +529,8 @@ nvidia-nvshmem-cu13==3.4.5
     # via torch
 nvidia-nvtx==13.0.85
     # via cuda-toolkit
+onnxruntime==1.27.0
+    # via -r requirements/test/cuda.in
 open-clip-torch==2.32.0
     # via -r requirements/test/cuda.in
 openai-harmony==0.0.4
@@ -577,6 +582,7 @@ packaging==24.2
     #   huggingface-hub
     #   lazy-loader
     #   matplotlib
+    #   onnxruntime
     #   optuna
     #   peft
     #   plotly
@@ -585,6 +591,7 @@ packaging==24.2
     #   pytest-rerunfailures
     #   ray
     #   scikit-image
+    #   silero-vad
     #   statsmodels
     #   transformers
     #   typepy
@@ -656,6 +663,7 @@ protobuf==6.33.6
     #   google-api-core
     #   googleapis-common-protos
     #   grpcio-reflection
+    #   onnxruntime
     #   opentelemetry-proto
     #   proto-plus
     #   ray
@@ -889,6 +897,8 @@ shellingham==1.5.4
     # via
     #   perceptron
     #   typer
+silero-vad==6.2.1
+    # via -r requirements/test/cuda.in
 six==1.16.0
     # via
     #   -c requirements/common.txt
@@ -987,6 +997,7 @@ torch==2.11.0+cu130
     #   runai-model-streamer
     #   segmentation-models-pytorch
     #   sentence-transformers
+    #   silero-vad
     #   tensorizer
     #   timm
     #   torchvision
@@ -997,6 +1008,7 @@ torchaudio==2.11.0+cu130
     #   -c requirements/cuda.txt
     #   -r requirements/test/cuda.in
     #   encodec
+    #   silero-vad
     #   vocos
 torchvision==0.26.0+cu130
     # via

--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -25,6 +25,8 @@ pqdm
 ray[cgraph,default]>=2.48.0 # Ray Compiled Graph, required by pipeline parallelism tests
 sentence-transformers>=5.2.0 # required for embedding tests
 soundfile # required for audio tests
+silero-vad==6.2.1
+onnxruntime==1.27.0
 jiwer # required for audio tests
 tblib # for pickling test exceptions
 timm>=1.0.17 # required for internvl and gemma3n-mm test

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -250,6 +250,8 @@ filelock==3.25.2
     #   ray
     #   torch
     #   virtualenv
+flatbuffers==25.12.19
+    # via onnxruntime
 fonttools==4.62.1
     # via matplotlib
 frozendict==2.4.7
@@ -584,6 +586,7 @@ numpy==2.2.6
     #   ml-dtypes
     #   mteb
     #   numba
+    #   onnxruntime
     #   opencv-python-headless
     #   optuna
     #   pandas
@@ -611,6 +614,8 @@ numpy==2.2.6
     #   tritonclient
     #   vocos
     #   xgrammar
+onnxruntime==1.27.0
+    # via -r requirements/test/rocm.in
 open-clip-torch==2.32.0
     # via -r requirements/test/rocm.in
 openai==2.31.0
@@ -705,6 +710,7 @@ packaging==26.0
     #   lazy-loader
     #   lm-format-enforcer
     #   matplotlib
+    #   onnxruntime
     #   optuna
     #   peft
     #   plotly
@@ -713,6 +719,7 @@ packaging==26.0
     #   pytest-rerunfailures
     #   ray
     #   scikit-image
+    #   silero-vad
     #   statsmodels
     #   transformers
     #   typepy
@@ -797,6 +804,7 @@ protobuf==6.33.6
     #   google-api-core
     #   googleapis-common-protos
     #   grpcio-reflection
+    #   onnxruntime
     #   opentelemetry-proto
     #   proto-plus
     #   ray
@@ -1094,6 +1102,8 @@ shellingham==1.5.4
     # via
     #   perceptron
     #   typer
+silero-vad==6.2.1
+    # via -r requirements/test/rocm.in
 simplejson==3.20.2
     # via choreographer
 six==1.17.0

--- a/setup.py
+++ b/setup.py
@@ -1241,6 +1241,8 @@ setup(
             "scipy",
             "soundfile",
             "soxr",
+            "silero-vad==6.2.1",
+            "onnxruntime==1.27.0",
             "mistral_common[audio]",
         ],  # Required for audio processing
         "video": [],  # Kept for backwards compatibility

--- a/tests/benchmarks/test_audio_dataset.py
+++ b/tests/benchmarks/test_audio_dataset.py
@@ -198,3 +198,32 @@ def test_async_request_openai_audio_handles_decoded_audio_arrays(
     assert session.uploaded_bytes is not None
     assert output.success is True
     assert output.generated_text == "hello"
+
+
+def test_async_request_openai_audio_forwards_extra_body_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(request_func_module.aiohttp, "FormData", _FakeFormData)
+    session = _FakeSession()
+    request_input = RequestFuncInput(
+        prompt="",
+        api_url="http://localhost:8000/v1/audio/transcriptions",
+        prompt_len=1,
+        output_len=32,
+        model="openai/whisper-large-v3",
+        multi_modal_content={
+            "audio": (np.zeros(1_600, dtype=np.float32), 16_000),
+        },
+        extra_body={"vad_config.enabled": True},
+    )
+
+    output = asyncio.run(
+        request_func_module.async_request_openai_audio(request_input, session)
+    )
+
+    assert session.fields is not None
+    form_fields = {
+        name: value for name, value, _kwargs in session.fields if name != "file"
+    }
+    assert form_fields["vad_config.enabled"] == "True"
+    assert output.success is True

--- a/tests/benchmarks/test_serve_audio_cli.py
+++ b/tests/benchmarks/test_serve_audio_cli.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import argparse
+import asyncio
+
+import pytest
+
+import vllm.benchmarks.serve as serve_module
+
+
+def _parse_serve_args(*extra_args: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    serve_module.add_cli_args(parser)
+    return parser.parse_args(
+        [
+            "--backend",
+            "openai-audio",
+            "--endpoint",
+            "/v1/audio/transcriptions",
+            "--model",
+            "openai/whisper-large-v3",
+            "--dataset-name",
+            "sonnet",
+            "--num-prompts",
+            "1",
+            "--skip-tokenizer-init",
+            *extra_args,
+        ]
+    )
+
+
+@pytest.mark.benchmark
+def test_bench_serve_enable_vad_sets_audio_request_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _parse_serve_args("--enable-vad")
+    captured: dict[str, object] = {}
+
+    async def fake_benchmark(**kwargs):
+        captured.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(serve_module, "get_samples", lambda args, tokenizer: [])
+    monkeypatch.setattr(serve_module, "check_goodput_args", lambda args: {})
+    monkeypatch.setattr(serve_module, "freeze_gc_heap", lambda: None)
+    monkeypatch.setattr(serve_module, "benchmark", fake_benchmark)
+
+    result = asyncio.run(serve_module.main_async(args))
+
+    assert captured["endpoint_type"] == "openai-audio"
+    assert captured["extra_body"] == {"vad_config.enabled": True}
+    assert result["enable_vad"] is True
+
+
+@pytest.mark.benchmark
+def test_bench_serve_enable_vad_requires_audio_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _parse_serve_args(
+        "--backend",
+        "openai",
+        "--endpoint",
+        "/v1/completions",
+        "--enable-vad",
+    )
+
+    monkeypatch.setattr(serve_module, "get_samples", lambda args, tokenizer: [])
+    monkeypatch.setattr(serve_module, "check_goodput_args", lambda args: {})
+
+    with pytest.raises(ValueError, match="openai-audio"):
+        asyncio.run(serve_module.main_async(args))

--- a/tests/entrypoints/speech_to_text/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/speech_to_text/correctness/test_transcription_api_correctness.py
@@ -365,10 +365,15 @@ def test_wer_correctness(
 # checks for long audio transcription correctness and RMS split.
 @pytest.mark.parametrize(
     "model_config",
-    [("openai/whisper-large-v3", 9.5)],
+    # (model_name, expected_wer, use_vad)
+    [
+        ("openai/whisper-large-v3", 9.5, False),
+        # using VAD improves the WER from 9.5 to 8.22
+        ("openai/whisper-large-v3", 8.22, True),
+    ],
 )
 def test_long_audio_wer_correctness(model_config):
-    model_name, expected_wer = model_config
+    model_name, expected_wer, use_vad = model_config
     model_info = HF_EXAMPLE_MODELS.find_hf_info(model_name)
     server_args = [
         f"--tokenizer_mode={model_info.tokenizer_mode}",
@@ -389,11 +394,13 @@ def test_long_audio_wer_correctness(model_config):
     ) as remote_server:
         dataset = load_longform_dataset()
         client = remote_server.get_async_client()
+        extra_body = {"vad_config.enabled": use_vad}
         wer = run_longform_evaluation(
             model=model_name,
             client=client,
             dataset=dataset,
             max_concurrent_reqs=LONGFORM_NUM_SAMPLES,
+            extra_body=extra_body,
         )
 
     print(f"Expected WER: {expected_wer}, Actual WER: {wer}")

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1830,6 +1830,14 @@ def add_cli_args(parser: argparse.ArgumentParser):
         default=None,
     )
     parser.add_argument(
+        "--enable-vad",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable per-request VAD for OpenAI audio benchmarks by setting "
+        '`"vad_config.enabled"` in the multipart request body. '
+        "Only supported with --backend openai-audio.",
+    )
+    parser.add_argument(
         "--skip-tokenizer-init",
         action="store_true",
         default=False,
@@ -2072,6 +2080,13 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
 
     extra_body = args.extra_body or {}
     extra_body = {**sampling_params, **extra_body}
+    if args.enable_vad is not None:
+        if args.backend != "openai-audio":
+            raise ValueError(
+                "--enable-vad/--no-enable-vad is only supported with "
+                "--backend openai-audio."
+            )
+        extra_body["vad_config.enabled"] = args.enable_vad
 
     percentile_metrics: str = args.percentile_metrics or default_percentile_metrics
 
@@ -2140,6 +2155,8 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
     )
     result_json["burstiness"] = args.burstiness
     result_json["max_concurrency"] = args.max_concurrency
+    if args.enable_vad is not None:
+        result_json["enable_vad"] = args.enable_vad
 
     if args.ramp_up_strategy is not None:
         result_json["ramp_up_strategy"] = args.ramp_up_strategy

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -38,7 +38,11 @@ from vllm.config.profiler import ProfilerConfig
 from vllm.config.reasoning import ReasoningConfig
 from vllm.config.scheduler import SchedulerConfig
 from vllm.config.speculative import SpeculativeConfig
-from vllm.config.speech_to_text import SpeechToTextConfig, SpeechToTextParams
+from vllm.config.speech_to_text import (
+    SpeechToTextConfig,
+    SpeechToTextParams,
+    VADConfig,
+)
 from vllm.config.structured_outputs import StructuredOutputsConfig
 from vllm.config.utils import (
     ConfigType,
@@ -117,6 +121,7 @@ __all__ = [
     # From vllm.config.speech_to_text
     "SpeechToTextConfig",
     "SpeechToTextParams",
+    "VADConfig",
     # From vllm.config.structured_outputs
     "StructuredOutputsConfig",
     # From vllm.config.profiler

--- a/vllm/config/speech_to_text.py
+++ b/vllm/config/speech_to_text.py
@@ -52,6 +52,56 @@ class SpeechToTextParams:
 
 
 @config
+class VADConfig:
+    """Voice activity detection configuration.
+
+    Default values picked from faster_whisper.
+    """
+
+    # Source:
+    # https://github.com/SYSTRAN/faster-whisper/blob/ed9a06cd89a93e47838f564998a6c09b655d7f43/faster_whisper/vad.py#L41-L48  # noqa: E501
+
+    enabled: bool = False
+    """Whether voice activity detection is enabled for this request."""
+
+    threshold: float = 0.5
+    """Speech probability threshold above which audio is considered speech."""
+
+    neg_threshold: float | None = None
+    """Silence threshold used to determine the end of speech segments.
+
+    Values below this threshold are always treated as silence. Values above it
+    are only treated as speech if the previous sample was already classified as
+    speech, which smooths speech-to-silence transitions.
+    """
+
+    min_speech_duration_ms: int = 0
+    """Speech chunks shorter than this duration, in milliseconds, are dropped."""
+
+    max_speech_duration_s: float = float("inf")
+    """Maximum duration in seconds for a single speech segment.
+
+    Segments longer than this are split at the last qualifying silence when
+    possible; otherwise they are split aggressively just before the limit.
+    """
+
+    min_silence_duration_ms: int = 2000
+    """Silence duration in milliseconds required before separating segments."""
+
+    speech_pad_ms: int = 600
+    """Padding in milliseconds added before and after detected speech spans."""
+
+    min_silence_at_max_speech_ms: int = 98
+    """Minimum silence in milliseconds used to avoid abrupt forced splits."""
+
+    use_max_poss_sil_at_max_speech: bool = True
+    """Whether to prefer the largest possible silence near forced split points.
+
+    If disabled, the last qualifying silence is used instead.
+    """
+
+
+@config
 class SpeechToTextConfig:
     """Configuration for speech-to-text models."""
 

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -31,7 +31,11 @@ from vllm.inputs import EncoderDecoderInput, EngineInput
 from vllm.logger import init_logger
 from vllm.logprobs import FlatLogprobs, Logprob
 from vllm.model_executor.models import SupportsTranscription
-from vllm.multimodal.audio import get_audio_duration, split_audio
+from vllm.multimodal.audio import (
+    ThreadLocalVADProvider,
+    get_audio_duration,
+    split_audio_with_vad,
+)
 from vllm.multimodal.media.audio import load_audio
 from vllm.outputs import RequestOutput
 from vllm.renderers.inputs import DictPrompt, EncoderDecoderDictPrompt
@@ -145,6 +149,7 @@ class OpenAISpeechToText(OpenAIServing):
         self._decode_and_chunk_speech_async = make_async_with_semaphore(
             self._decode_and_chunk_speech, executor=self._preprocess_executor
         )
+        self._vad_provider = ThreadLocalVADProvider()
 
     @cached_property
     def model_cls(self) -> type[SupportsTranscription]:
@@ -159,6 +164,7 @@ class OpenAISpeechToText(OpenAIServing):
     def _decode_and_chunk_speech(
         self,
         audio_data: bytes,
+        request: SpeechToTextRequest,
     ) -> tuple[list[np.ndarray], float]:
         # Decode audio bytes.  For container formats (MP4, M4A, WebM) that
         # soundfile cannot detect from a BytesIO stream, _load_audio_bytes
@@ -178,23 +184,18 @@ class OpenAISpeechToText(OpenAIServing):
             raise ValueError("Invalid or unsupported audio file.") from exc
 
         duration = get_audio_duration(y=y, sr=sr)
-        do_split_audio = self.asr_config.allow_audio_chunking and (
-            self.asr_config.max_audio_clip_s is not None
-            and duration > self.asr_config.max_audio_clip_s
-        )
+        vad_config = request.build_vad_config()
 
-        if not do_split_audio:
-            chunks = [y]
-        else:
-            assert self.asr_config.max_audio_clip_s is not None
-            assert self.asr_config.min_energy_split_window_size is not None
-            chunks = split_audio(
-                audio_data=y,
-                sample_rate=int(sr),
-                max_clip_duration_s=self.asr_config.max_audio_clip_s,
-                overlap_duration_s=self.asr_config.overlap_chunk_second,
-                min_energy_window_size=self.asr_config.min_energy_split_window_size,
-            )
+        vad = self._vad_provider.get() if vad_config.enabled else None
+
+        chunks = split_audio_with_vad(
+            duration=duration,
+            asr_config=self.asr_config,
+            vad=vad,
+            vad_config=vad_config,
+            audio_data=y,
+            sample_rate=int(sr),
+        )
 
         return chunks, duration
 
@@ -271,7 +272,9 @@ class OpenAISpeechToText(OpenAIServing):
             )
 
         # Run cpu intensive preprocess step in a separate thread pool executor.
-        chunks, duration = await self._decode_and_chunk_speech_async(audio_data)
+        chunks, duration = await self._decode_and_chunk_speech_async(
+            audio_data, request
+        )
 
         if request.language is None and getattr(
             self.model_cls, "supports_explicit_language_detection", False

--- a/vllm/entrypoints/speech_to_text/transcription/protocol.py
+++ b/vllm/entrypoints/speech_to_text/transcription/protocol.py
@@ -12,7 +12,7 @@ from pydantic import (
     model_validator,
 )
 
-from vllm.config.speech_to_text import SpeechToTextParams
+from vllm.config.speech_to_text import SpeechToTextParams, VADConfig
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
     OpenAIBaseModel,
@@ -35,6 +35,9 @@ if TYPE_CHECKING:
     from vllm.config import ModelConfig, SpeechToTextConfig
 
 logger = init_logger(__name__)
+
+
+_DEFAULT_VAD_CONFIG = VADConfig()
 
 
 class TranscriptionResponseStreamChoice(OpenAIBaseModel):
@@ -132,6 +135,44 @@ class TranscriptionRequest(OpenAIBaseModel):
     time, but it is a placeholder for future use, matching translation api.
     """
 
+    # Flattened VAD options to simplify multipart form data.
+    vad_enabled: bool = Field(
+        default=_DEFAULT_VAD_CONFIG.enabled,
+        alias="vad_config.enabled",
+    )
+    vad_threshold: float = Field(
+        default=_DEFAULT_VAD_CONFIG.threshold,
+        alias="vad_config.threshold",
+    )
+    vad_neg_threshold: float | None = Field(
+        default=_DEFAULT_VAD_CONFIG.neg_threshold,
+        alias="vad_config.neg_threshold",
+    )
+    vad_min_speech_duration_ms: int = Field(
+        default=_DEFAULT_VAD_CONFIG.min_speech_duration_ms,
+        alias="vad_config.min_speech_duration_ms",
+    )
+    vad_max_speech_duration_s: float = Field(
+        default=_DEFAULT_VAD_CONFIG.max_speech_duration_s,
+        alias="vad_config.max_speech_duration_s",
+    )
+    vad_min_silence_duration_ms: int = Field(
+        default=_DEFAULT_VAD_CONFIG.min_silence_duration_ms,
+        alias="vad_config.min_silence_duration_ms",
+    )
+    vad_speech_pad_ms: int = Field(
+        default=_DEFAULT_VAD_CONFIG.speech_pad_ms,
+        alias="vad_config.speech_pad_ms",
+    )
+    vad_min_silence_at_max_speech_ms: int = Field(
+        default=_DEFAULT_VAD_CONFIG.min_silence_at_max_speech_ms,
+        alias="vad_config.min_silence_at_max_speech_ms",
+    )
+    vad_use_max_poss_sil_at_max_speech: bool = Field(
+        default=_DEFAULT_VAD_CONFIG.use_max_poss_sil_at_max_speech,
+        alias="vad_config.use_max_poss_sil_at_max_speech",
+    )
+
     # --8<-- [start:transcription-sampling-params]
     use_beam_search: bool = False
     """Whether or not beam search should be used."""
@@ -208,6 +249,19 @@ class TranscriptionRequest(OpenAIBaseModel):
             request_prompt=self.prompt,
             to_language=self.to_language,
             hotwords=self.hotwords,
+        )
+
+    def build_vad_config(self) -> VADConfig:
+        return VADConfig(
+            enabled=self.vad_enabled,
+            threshold=self.vad_threshold,
+            neg_threshold=self.vad_neg_threshold,
+            min_speech_duration_ms=self.vad_min_speech_duration_ms,
+            max_speech_duration_s=self.vad_max_speech_duration_s,
+            min_silence_duration_ms=self.vad_min_silence_duration_ms,
+            speech_pad_ms=self.vad_speech_pad_ms,
+            min_silence_at_max_speech_ms=self.vad_min_silence_at_max_speech_ms,
+            use_max_poss_sil_at_max_speech=(self.vad_use_max_poss_sil_at_max_speech),
         )
 
     def to_beam_search_params(

--- a/vllm/entrypoints/speech_to_text/translation/protocol.py
+++ b/vllm/entrypoints/speech_to_text/translation/protocol.py
@@ -10,7 +10,7 @@ from pydantic import (
     model_validator,
 )
 
-from vllm.config.speech_to_text import SpeechToTextParams
+from vllm.config.speech_to_text import SpeechToTextParams, VADConfig
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
     OpenAIBaseModel,
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
     from vllm.config import ModelConfig, SpeechToTextConfig
 
 logger = init_logger(__name__)
+
+
+_DEFAULT_VAD_CONFIG = VADConfig()
 
 
 class TranslationResponseStreamChoice(OpenAIBaseModel):
@@ -128,6 +131,44 @@ class TranslationRequest(OpenAIBaseModel):
     For instance, Whisper only supports `to_language=en`.
     """
 
+    # Flattened VAD options to simplify multipart form data.
+    vad_enabled: bool = Field(
+        default=_DEFAULT_VAD_CONFIG.enabled,
+        alias="vad_config.enabled",
+    )
+    vad_threshold: float = Field(
+        default=_DEFAULT_VAD_CONFIG.threshold,
+        alias="vad_config.threshold",
+    )
+    vad_neg_threshold: float | None = Field(
+        default=_DEFAULT_VAD_CONFIG.neg_threshold,
+        alias="vad_config.neg_threshold",
+    )
+    vad_min_speech_duration_ms: int = Field(
+        default=_DEFAULT_VAD_CONFIG.min_speech_duration_ms,
+        alias="vad_config.min_speech_duration_ms",
+    )
+    vad_max_speech_duration_s: float = Field(
+        default=_DEFAULT_VAD_CONFIG.max_speech_duration_s,
+        alias="vad_config.max_speech_duration_s",
+    )
+    vad_min_silence_duration_ms: int = Field(
+        default=_DEFAULT_VAD_CONFIG.min_silence_duration_ms,
+        alias="vad_config.min_silence_duration_ms",
+    )
+    vad_speech_pad_ms: int = Field(
+        default=_DEFAULT_VAD_CONFIG.speech_pad_ms,
+        alias="vad_config.speech_pad_ms",
+    )
+    vad_min_silence_at_max_speech_ms: int = Field(
+        default=_DEFAULT_VAD_CONFIG.min_silence_at_max_speech_ms,
+        alias="vad_config.min_silence_at_max_speech_ms",
+    )
+    vad_use_max_poss_sil_at_max_speech: bool = Field(
+        default=_DEFAULT_VAD_CONFIG.use_max_poss_sil_at_max_speech,
+        alias="vad_config.use_max_poss_sil_at_max_speech",
+    )
+
     stream: bool | None = False
     """Custom field not present in the original OpenAI definition. When set,
     it will enable output to be streamed in a similar fashion as the Chat
@@ -162,6 +203,19 @@ class TranslationRequest(OpenAIBaseModel):
             request_prompt=self.prompt,
             to_language=self.to_language,
             hotwords=self.hotwords,
+        )
+
+    def build_vad_config(self) -> VADConfig:
+        return VADConfig(
+            enabled=self.vad_enabled,
+            threshold=self.vad_threshold,
+            neg_threshold=self.vad_neg_threshold,
+            min_speech_duration_ms=self.vad_min_speech_duration_ms,
+            max_speech_duration_s=self.vad_max_speech_duration_s,
+            min_silence_duration_ms=self.vad_min_silence_duration_ms,
+            speech_pad_ms=self.vad_speech_pad_ms,
+            min_silence_at_max_speech_ms=self.vad_min_silence_at_max_speech_ms,
+            use_max_poss_sil_at_max_speech=(self.vad_use_max_poss_sil_at_max_speech),
         )
 
     def to_beam_search_params(

--- a/vllm/multimodal/audio.py
+++ b/vllm/multimodal/audio.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import math
+import threading
 from dataclasses import dataclass
 from enum import Enum
 from typing import Literal
@@ -9,6 +10,7 @@ import numpy as np
 import numpy.typing as npt
 import torch
 
+from vllm.config.speech_to_text import SpeechToTextConfig, VADConfig
 from vllm.utils.import_utils import PlaceholderModule
 
 try:
@@ -320,6 +322,176 @@ class AudioResampler:
 # ============================================================
 # Audio Chunking / Splitting
 # ============================================================
+
+
+class VAD:
+    def __init__(self):
+        self.model = None
+        self._get_speech_timestamps = None
+
+    def _ensure_loaded(self) -> None:
+        if self._get_speech_timestamps is not None and self.model is not None:
+            return
+
+        try:
+            from silero_vad import get_speech_timestamps, load_silero_vad
+
+            self.model = load_silero_vad(onnx=True)
+            self._get_speech_timestamps = get_speech_timestamps
+        except ImportError as exc:
+            raise ImportError(
+                "Silero VAD is not installed. Please install it using "
+                "`pip install silero-vad` and `pip install onnxruntime`."
+            ) from exc
+
+    def ensure_loaded(self) -> None:
+        self._ensure_loaded()
+
+    def get_speech_timestamps(
+        self,
+        audio_data: np.ndarray,
+        sample_rate: int,
+        vad_config: VADConfig,
+    ) -> list[dict]:
+        if not vad_config.enabled:
+            raise RuntimeError("VAD is not enabled.")
+
+        self._ensure_loaded()
+        if self._get_speech_timestamps is None or self.model is None:
+            raise RuntimeError("VAD is not enabled.")
+
+        return self._get_speech_timestamps(
+            audio_data,
+            self.model,
+            sampling_rate=sample_rate,
+            threshold=vad_config.threshold,
+            neg_threshold=vad_config.neg_threshold,
+            min_speech_duration_ms=vad_config.min_speech_duration_ms,
+            max_speech_duration_s=vad_config.max_speech_duration_s,
+            min_silence_duration_ms=vad_config.min_silence_duration_ms,
+            speech_pad_ms=vad_config.speech_pad_ms,
+            min_silence_at_max_speech=vad_config.min_silence_at_max_speech_ms,
+            use_max_poss_sil_at_max_speech=(vad_config.use_max_poss_sil_at_max_speech),
+        )
+
+
+class ThreadLocalVADProvider:
+    """
+    Create and cache one loaded ``VAD`` instance per worker thread.
+
+    Silero VAD's ONNX model is stateful (it keeps internal RNN
+    state/context that is reset per call and mutated while streaming).
+    Sharing one instance across the preprocess thread pool corrupts that
+    state under concurrency and degrades segmentation. We therefore use a
+    per-thread VAD instance so concurrent requests stay isolated without
+    serializing VAD behind a lock (which would hurt throughput).
+    """
+
+    def __init__(self) -> None:
+        self._init_lock = threading.Lock()
+        self._thread_local = threading.local()
+
+    def get(self) -> VAD:
+        vad = getattr(self._thread_local, "vad", None)
+        if vad is None:
+            vad = VAD()
+            # Loading the silero model is not thread-safe (downloads/caches),
+            # so serialize only the one-time load, not inference.
+            with self._init_lock:
+                vad.ensure_loaded()
+            self._thread_local.vad = vad
+
+        return vad
+
+
+def split_audio_with_vad(
+    duration: float,
+    asr_config: SpeechToTextConfig,
+    vad: VAD | None,
+    vad_config: VADConfig,
+    audio_data: np.ndarray,
+    sample_rate: int,
+) -> list[np.ndarray]:
+    """
+    Split audio according to the configured VAD and chunking policy.
+    * Silero VAD improves noise robustness and hallucination robustness.
+    * RMS split is used to adhere to the max_clip_duration_s limit.
+    Using Silero VAD for satisfying max_clip_duration_s limit didnt work well
+    hence we have to use 2 stage chunking for best quality.
+
+    Behavior depends on whether chunking is enabled via
+    ``SpeechToTextConfig.allow_audio_chunking`` and whether VAD is enabled:
+
+    * VAD + RMS: run Silero VAD first, then further split only those
+      individual speech segments that exceed ``max_audio_clip_s``.
+    * RMS only: run ``split_audio()`` on the full waveform when the
+      overall clip duration exceeds ``max_audio_clip_s``.
+    * VAD only: remove non-speech by concatenating detected speech spans into
+      a single trimmed chunk. If no speech is detected, return the original
+      audio unchanged.
+    * no chunking: return the original audio as a single chunk.
+    """
+    if asr_config.allow_audio_chunking:
+        assert asr_config.max_audio_clip_s is not None
+        assert asr_config.min_energy_split_window_size is not None
+
+        if vad_config.enabled:
+            # silero VAD + RMS split
+            assert vad is not None
+
+            speech_timestamps = vad.get_speech_timestamps(
+                audio_data, sample_rate, vad_config
+            )
+            chunks = []
+            for timestamp in speech_timestamps:
+                start = timestamp["start"]
+                end = timestamp["end"]
+                vad_duration_s = (end - start) / sample_rate
+                if vad_duration_s > asr_config.max_audio_clip_s:
+                    partial_chunk_output = split_audio(
+                        audio_data[start:end],
+                        sample_rate,
+                        asr_config.max_audio_clip_s,
+                        asr_config.overlap_chunk_second,
+                        asr_config.min_energy_split_window_size,
+                    )
+                    chunks.extend(partial_chunk_output)
+                else:
+                    chunks.append(audio_data[start:end])
+            return chunks
+        else:
+            if duration > asr_config.max_audio_clip_s:
+                # RMS split only
+                return split_audio(
+                    audio_data,
+                    sample_rate,
+                    asr_config.max_audio_clip_s,
+                    asr_config.overlap_chunk_second,
+                    asr_config.min_energy_split_window_size,
+                )
+            else:
+                return [audio_data]
+    else:
+        if vad_config.enabled:
+            # silero VAD only
+            assert vad is not None
+
+            speech_timestamps = vad.get_speech_timestamps(
+                audio_data, sample_rate, vad_config
+            )
+            if len(speech_timestamps) > 0:
+                chunks = []
+                for timestamp in speech_timestamps:
+                    chunks.append(
+                        audio_data[..., timestamp["start"] : timestamp["end"]]
+                    )
+                trimmed_audio_data = np.concatenate(chunks, axis=-1)
+                return [trimmed_audio_data]
+            else:
+                # TODO (ekagra): early return if no speech is detected
+                return [audio_data]
+        else:
+            return [audio_data]
 
 
 def split_audio(


### PR DESCRIPTION
Addresses: https://github.com/vllm-project/vllm/issues/25750

Current Whisper/ASR models served with vLLM can hallucinate when processing long segments of background noise. While users can build custom preprocessing pipelines around vLLM, providing an integrated Voice Activity Detection (VAD) option significantly improves the out-of-the-box ASR experience.

This PR integrates [silero-vad](https://github.com/snakers4/silero-vad) to enable VAD-based preprocessing for ASR requests. The default parameters are adopted from [faster-whisper](https://github.com/SYSTRAN/faster-whisper/blob/ed9a06cd89a93e47838f564998a6c09b655d7f43/faster_whisper/vad.py#L41-L48), while still allowing users to tune or override them based on their workload and quality requirements.

On long-audio CI benchmark, enabling VAD improves WER from 9.50 to 8.22 for whisper by filtering non-speech regions before transcription. However, this comes at a tradeoff on RTFx

RTFx on H100
* BS1: 240 -> 118
* BS128: 1740 -> 312

VAD is applied on a per-request basis and is disabled unless requested by the user. As a result, existing deployments and workloads that do not use VAD are unaffected.

The primary tradeoff is additional preprocessing overhead for requests that enable VAD. The current silero-vad implementation is not highly parallelizable due to GIL, so VAD-enabled requests may see lower throughput compared to pure transcription. Further work would be required to bring the performance of the VAD path closer to the baseline no-VAD path. Since VAD is configured on a per-request basis, users can decide whether the quality improvement justifies the additional preprocessing cost for their workload.


### Cmd
```
# no VAD
curl -v http://localhost:8000/v1/audio/transcriptions \
  -F "file=@$(realpath ${AUDIO_PATH})" \
  
# VAD with default params
curl -v http://localhost:8000/v1/audio/transcriptions \
  -F "file=@$(realpath "${AUDIO_PATH}")" \
  -F "vad_config.enabled=true"
  
# VAD with user specific params
curl -v http://localhost:8000/v1/audio/transcriptions \
  -F "file=@$(realpath "${AUDIO_PATH}")" \
  -F "vad_config.enabled=true" \
  -F "vad_config.threshold=0.7" \
  -F "vad_config.speech_pad_ms=450" \
  -F "vad_config.min_silence_duration_ms=1500"
```

### Benchmarks
```
MODEL_ID=openai/whisper-large-v3-turbo
vllm serve $MODEL_ID --trust-remote-code

MAX_CONCURRENCY=128
NUM_PROMPTS=128

time vllm bench serve \
  --backend openai-audio \
  --endpoint /v1/audio/transcriptions \
  --dataset-name hf \
  --dataset-path ArtificialAnalysis/Earnings22-Cleaned-AA \
  --hf-split test \
  --num-prompts ${NUM_PROMPTS} \
  --ready-check-timeout-sec 600 \
  --save-result \
  --save-detailed \
  --result-filename asr-bench.json \
  --max-concurrency ${MAX_CONCURRENCY}
```

Add `--enable-vad` to above bench cmd to use VAD

### Test
```
pytest -sv tests/entrypoints/speech_to_text/correctness/test_transcription_api_correctness.py::test_long_audio_wer_correctness
```

passes for with and w/o VAD