### PR TITLE
[Bugfix] Make Kimi's tool parser accept numeric only tool call IDs

### DIFF
--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -3,6 +3,7 @@
 # ruff: noqa: E501
 
 import json
+from collections.abc import Mapping
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,6 +14,8 @@ from tests.tool_parsers.utils import (
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
+    ChatCompletionToolsParam,
+    FunctionDefinition,
 )
 from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers.kimi_k2_tool_parser import KimiK2ToolParser
@@ -30,6 +33,14 @@ def parser(kimi_k2_tokenizer):
     return KimiK2ToolParser(kimi_k2_tokenizer)
 
 
+@pytest.fixture
+def mock_tokenizer():
+    tokenizer = MagicMock()
+    tokenizer.get_vocab.return_value = {}
+    tokenizer.tokenize.return_value = []
+    return tokenizer
+
+
 SECTION_BEGIN = "<|tool_calls_section_begin|>"
 SECTION_END = "<|tool_calls_section_end|>"
 TOOL_BEGIN = "<|tool_call_begin|>"
@@ -43,6 +54,52 @@ def _tool(tool_id: str, args: str) -> str:
 
 def _wrap(*tool_strs: str) -> str:
     return SECTION_BEGIN + "".join(tool_strs) + SECTION_END
+
+
+WEATHER_TOOL = ChatCompletionToolsParam(
+    type="function",
+    function=FunctionDefinition(
+        name="get_weather",
+        parameters={
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "unit": {"type": "string"},
+            },
+        },
+    ),
+)
+READ_FILE_TOOL = ChatCompletionToolsParam(
+    type="function",
+    function=FunctionDefinition(
+        name="read_file",
+        parameters={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+        },
+    ),
+)
+BOOK_FLIGHT_TOOL = ChatCompletionToolsParam(
+    type="function",
+    function=FunctionDefinition(
+        name="book_flight",
+        parameters={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+        },
+    ),
+)
+
+
+def _assert_tool_call(
+    tool_call,
+    tool_id: str,
+    name: str,
+    arguments: Mapping[str, object],
+):
+    assert tool_call.id == tool_id
+    assert tool_call.function.name == name
+    assert json.loads(tool_call.function.arguments) == arguments
 
 
 class TestExtractToolCalls:
@@ -209,6 +266,59 @@ class TestExtractToolCalls:
         assert len(turn2_tools) == 1
         assert turn2_tools[0].id == "functions.get_news:0"
 
+    def test_bare_counter(self, mock_tokenizer):
+        """Test that bare numeric counter IDs are accepted."""
+        arguments = {"city": "Tokyo", "unit": "celsius"}
+        parser = KimiK2ToolParser(mock_tokenizer, [WEATHER_TOOL])
+        output = "Let me check. " + _wrap(_tool("0", json.dumps(arguments)))
+
+        content, tool_calls = run_tool_extraction(parser, output, streaming=False)
+
+        assert content == "Let me check. "
+        assert len(tool_calls) == 1
+        _assert_tool_call(tool_calls[0], "0", "get_weather", arguments)
+
+    def test_bare_counter_single_tool_invalid_json_still_extracted(
+        self, mock_tokenizer
+    ):
+        parser = KimiK2ToolParser(mock_tokenizer, [WEATHER_TOOL])
+        output = "Let me check. " + _wrap(_tool("0", '{"city": "Tokyo"'))
+
+        _, tool_calls = run_tool_extraction(parser, output, streaming=False)
+
+        assert len(tool_calls) == 1
+        assert tool_calls[0].id == "0"
+        assert tool_calls[0].function.name == "get_weather"
+        assert tool_calls[0].function.arguments == '{"city": "Tokyo"'
+
+    def test_bare_counter_multiple_tools_infers_by_args(self, mock_tokenizer):
+        arguments = {"city": "Tokyo", "unit": "celsius"}
+        parser = KimiK2ToolParser(mock_tokenizer, [READ_FILE_TOOL, WEATHER_TOOL])
+        output = "Let me check. " + _wrap(_tool("0", json.dumps(arguments)))
+
+        _, tool_calls = run_tool_extraction(parser, output, streaming=False)
+
+        assert len(tool_calls) == 1
+        _assert_tool_call(tool_calls[0], "0", "get_weather", arguments)
+
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            pytest.param({"city": "Tokyo"}, id="ambiguous"),
+            pytest.param('{"city": "Tokyo"', id="malformed_json"),
+        ],
+    )
+    def test_bare_counter_multiple_tools_skips_unsafe_inference(
+        self, mock_tokenizer, arguments
+    ):
+        parser = KimiK2ToolParser(mock_tokenizer, [WEATHER_TOOL, BOOK_FLIGHT_TOOL])
+        args = arguments if isinstance(arguments, str) else json.dumps(arguments)
+        output = "Let me check. " + _wrap(_tool("0", args))
+
+        _, tool_calls = run_tool_extraction(parser, output, streaming=False)
+
+        assert tool_calls == []
+
 
 def _split_tool_output_to_deltas(
     content: str, tool_strs: list[tuple[str, str]]
@@ -268,6 +378,40 @@ class TestStreamingHappyPath:
         assert rec.tool_calls[1].function.name == "get_weather"
         assert rec.tool_calls[1].id == "functions.get_weather:1"
         assert json.loads(rec.tool_calls[1].function.arguments) == {"city": "NYC"}
+
+    def test_bare_counter(self, mock_tokenizer):
+        parser = KimiK2ToolParser(mock_tokenizer, [WEATHER_TOOL])
+        arguments = {"city": "Beijing"}
+        deltas = _split_tool_output_to_deltas(
+            "I'll help. ",
+            [("0", json.dumps(arguments))],
+        )
+
+        rec = run_tool_extraction_streaming(
+            parser,
+            deltas,
+            assert_one_tool_per_delta=False,
+        )
+
+        assert len(rec.tool_calls) == 1
+        _assert_tool_call(rec.tool_calls[0], "0", "get_weather", arguments)
+
+    def test_bare_counter_multiple_tools_infers_by_args(self, mock_tokenizer):
+        parser = KimiK2ToolParser(mock_tokenizer, [READ_FILE_TOOL, WEATHER_TOOL])
+        arguments = {"city": "Beijing", "unit": "celsius"}
+        deltas = _split_tool_output_to_deltas(
+            "I'll help. ",
+            [("0", json.dumps(arguments))],
+        )
+
+        rec = run_tool_extraction_streaming(
+            parser,
+            deltas,
+            assert_one_tool_per_delta=False,
+        )
+
+        assert len(rec.tool_calls) == 1
+        _assert_tool_call(rec.tool_calls[0], "0", "get_weather", arguments)
 
     def test_content_before_tools(self, parser):
         """Content before section is streamed; markers/args don't leak."""

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from collections.abc import Sequence
 
 import regex as re
@@ -23,7 +24,7 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
-from vllm.tool_parsers.utils import partial_tag_overlap
+from vllm.tool_parsers.utils import _extract_tool_info, partial_tag_overlap
 
 logger = init_logger(__name__)
 
@@ -49,13 +50,12 @@ class KimiK2ToolParser(ToolParser):
 
         # Regex for non-streaming extraction
         self.tool_call_regex = re.compile(
-            r"<\|tool_call_begin\|>\s*(?P<tool_call_id>[^<]+:\d+)\s*"
+            r"<\|tool_call_begin\|>\s*(?P<tool_call_id>[^\s<|]+)\s*"
             r"<\|tool_call_argument_begin\|>\s*"
             r"(?P<function_arguments>(?:(?!<\|tool_call_begin\|>).)*?)\s*"
             r"<\|tool_call_end\|>",
             re.DOTALL,
         )
-
         if not self.model_tokenizer:
             raise ValueError(
                 "The model tokenizer must be passed to the ToolParser "
@@ -96,11 +96,14 @@ class KimiK2ToolParser(ToolParser):
                 tool_calls = []
                 for match in function_call_tuples:
                     function_id, function_args = match
-                    # function_id: functions.get_weather:0 or get_weather:0
-                    function_name = function_id.split(":")[0].split(".")[-1]
+                    tool_id, function_name = self._extract_tool_id_and_name(
+                        function_id, function_args
+                    )
+                    if not tool_id or not function_name:
+                        continue
                     tool_calls.append(
                         ToolCall(
-                            id=function_id,
+                            id=tool_id,
                             type="function",
                             function=FunctionCall(
                                 name=function_name, arguments=function_args
@@ -110,7 +113,7 @@ class KimiK2ToolParser(ToolParser):
 
                 content = model_output[: model_output.find(self.tool_calls_start_token)]
                 return ExtractedToolCallInformation(
-                    tools_called=True,
+                    tools_called=len(tool_calls) > 0,
                     tool_calls=tool_calls,
                     content=content if content else None,
                 )
@@ -168,21 +171,55 @@ class KimiK2ToolParser(ToolParser):
                 break
         return results
 
-    @staticmethod
     def _extract_tool_id_and_name(
+        self,
         header: str | None,
+        tool_args: str | None,
     ) -> tuple[str | None, str | None]:
         """Parse ``(tool_id, tool_name)`` from a header
-        like ``"functions.get_weather:0"``."""
+        like ``"functions.get_weather:0"``.
+
+        Kimi K2.5 may emit a bare numeric counter instead of the tool name. In
+        that case, preserve the native ID and infer the tool name when the
+        request tools make it unambiguous.
+        """
         if header is None:
             return None, None
-        match = re.match(r"(.+:\d+)", header)
-        if not match:
-            return None, None
+        tool_id = header.strip()
+        if tool_id.isdigit():
+            return tool_id, self._infer_tool_name(tool_args)
 
-        tool_id = match.group(1).strip()
-        tool_name = tool_id.split(":")[0].split(".")[-1]
-        return tool_id, tool_name
+        tool_name, sep, tool_index = tool_id.rpartition(":")
+        if sep and tool_name and tool_index.isdigit():
+            return tool_id, tool_name.split(".")[-1]
+        return None, None
+
+    def _infer_tool_name(self, tool_args: str | None) -> str | None:
+        if not self.tools:
+            return None
+        if len(self.tools) == 1:
+            return _extract_tool_info(self.tools[0])[0]
+        if not tool_args:
+            return None
+
+        try:
+            parsed_args = json.loads(tool_args)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed_args, dict) or not parsed_args:
+            return None
+
+        matching_name = None
+        arg_keys = set(parsed_args)
+        for tool in self.tools:
+            tool_name, parameters = _extract_tool_info(tool)
+            properties = (parameters or {}).get("properties", {})
+            if not isinstance(properties, dict) or not arg_keys <= properties.keys():
+                continue
+            if matching_name is not None:
+                return None
+            matching_name = tool_name
+        return matching_name
 
     def _split_tool_call(self, tool_call: str) -> tuple[str | None, str | None]:
         """Split a tool-call body into ``(header, arguments)`` at the argument marker.
@@ -237,7 +274,9 @@ class KimiK2ToolParser(ToolParser):
 
                 # Stream back tool name.
                 if "name" not in self.prev_tool_call_arr[i]:
-                    tool_id, tool_name = self._extract_tool_id_and_name(header)
+                    tool_id, tool_name = self._extract_tool_id_and_name(
+                        header, tool_args
+                    )
                     if not tool_name:
                         # Can't skip to tool i+1 if i isn't ready
                         break


### PR DESCRIPTION
## Purpose

Kimi K2/2.5 can emit bare numeric counters as tool call IDs instead of named native IDs.

For example, with the following tool call:

```text
<|tool_call_begin|>0 <|tool_call_argument_begin|>{"city":"Tokyo","unit":"celsius"}<|tool_call_end|>
```
we get `tool_call_count: 0` instead of `id: 0`, `name: get_weather`.

To fix this, we detect these calls and infer the function name by matching argument keys against the tool parameter schemas declared in the request.

## Test Plan

<details>
<summary>repro script</summary>

```bash
.venv/bin/python - <<'PY'
import json
from unittest.mock import MagicMock

from tests.tool_parsers.utils import (
    run_tool_extraction_nonstreaming,
    run_tool_extraction_streaming,
)
from vllm.entrypoints.openai.chat_completion.protocol import (
    ChatCompletionToolsParam,
    FunctionDefinition,
)
from vllm.tool_parsers.kimi_k2_tool_parser import KimiK2ToolParser

SECTION_BEGIN = "<|tool_calls_section_begin|>"
SECTION_END = "<|tool_calls_section_end|>"
TOOL_BEGIN = "<|tool_call_begin|>"
TOOL_END = "<|tool_call_end|>"
ARG_BEGIN = "<|tool_call_argument_begin|>"


def make_tool(name, properties):
    return ChatCompletionToolsParam(
        type="function",
        function=FunctionDefinition(
            name=name,
            parameters={"type": "object", "properties": properties},
        ),
    )


def tool_call(tool_id, args):
    return f"{TOOL_BEGIN}{tool_id} {ARG_BEGIN}{args}{TOOL_END}"


def wrap(*tool_strs):
    return SECTION_BEGIN + "".join(tool_strs) + SECTION_END


def streaming_deltas(content, tool_strs):
    deltas = [content, SECTION_BEGIN]
    for tool_id, args_json in tool_strs:
        deltas.extend([TOOL_BEGIN, f"{tool_id} ", ARG_BEGIN, f"{args_json} ", TOOL_END])
    deltas.append(SECTION_END)
    return deltas


def print_calls(label, tool_calls):
    print(f"{label}.tool_call_count:", len(tool_calls))
    if tool_calls:
        print(f"{label}.id:", tool_calls[0].id)
        print(f"{label}.name:", tool_calls[0].function.name)
        print(f"{label}.arguments:", tool_calls[0].function.arguments)


tokenizer = MagicMock()
tokenizer.get_vocab.return_value = {}
tokenizer.tokenize.return_value = []

read_file = make_tool("read_file", {"path": {"type": "string"}})
get_weather = make_tool(
    "get_weather",
    {"city": {"type": "string"}, "unit": {"type": "string"}},
)
book_flight = make_tool("book_flight", {"city": {"type": "string"}})

args = {"city": "Tokyo", "unit": "celsius"}
parser = KimiK2ToolParser(tokenizer, [read_file, get_weather])
extracted = run_tool_extraction_nonstreaming(
    parser,
    "Let me check. " + wrap(tool_call("0", json.dumps(args))),
)
print("nonstreaming_multi_tool.content:", repr(extracted.content))
print_calls("nonstreaming_multi_tool", extracted.tool_calls)

parser = KimiK2ToolParser(tokenizer, [read_file, get_weather])
rec = run_tool_extraction_streaming(
    parser,
    streaming_deltas("I'll help. ", [("0", json.dumps(args))]),
    assert_one_tool_per_delta=False,
)
print_calls("streaming_multi_tool", rec.tool_calls)

parser = KimiK2ToolParser(tokenizer, [get_weather])
extracted = run_tool_extraction_nonstreaming(
    parser,
    "Let me check. " + wrap(tool_call("0", '{"city": "Tokyo"')),
)
print_calls("single_tool_malformed", extracted.tool_calls)

parser = KimiK2ToolParser(tokenizer, [get_weather, book_flight])
extracted = run_tool_extraction_nonstreaming(
    parser,
    "Let me check. " + wrap(tool_call("0", json.dumps({"city": "Tokyo"}))),
)
print_calls("ambiguous_multi_tool", extracted.tool_calls)
PY
```

</details>

Unit test:
```
pytest tests/tool_parsers/test_kimi_k2_tool_parser.py -q
```

## Test Result

Before:

```text
nonstreaming_multi_tool.content: 'Let me check. '
nonstreaming_multi_tool.tool_call_count: 0
streaming_multi_tool.tool_call_count: 0
single_tool_malformed.tool_call_count: 0
ambiguous_multi_tool.tool_call_count: 0
```

After:

```text
nonstreaming_multi_tool.content: 'Let me check. '
nonstreaming_multi_tool.tool_call_count: 1
nonstreaming_multi_tool.id: 0
nonstreaming_multi_tool.name: get_weather
nonstreaming_multi_tool.arguments: {"city": "Tokyo", "unit": "celsius"}
streaming_multi_tool.tool_call_count: 1
streaming_multi_tool.id: 0
streaming_multi_tool.name: get_weather
streaming_multi_tool.arguments: {"city": "Tokyo", "unit": "celsius"} 
single_tool_malformed.tool_call_count: 1
single_tool_malformed.id: 0
single_tool_malformed.name: get_weather
single_tool_malformed.arguments: {"city": "Tokyo"
ambiguous_multi_tool.tool_call_count: 0
```