### PR TITLE
[Rust Frontend] Support `truncate_prompt_tokens` and `truncation_side`

### DIFF
--- a/rust/src/chat/src/error.rs
+++ b/rust/src/chat/src/error.rs
@@ -60,6 +60,12 @@ pub enum Error {
          but the prompt contains {prompt_len} input tokens"
     )]
     PromptTooLong { max_model_len: u32, prompt_len: u32 },
+    #[error(
+        "truncate_prompt_tokens is not supported for multimodal chat requests \
+         because the encoded prompt embeds image / audio placeholders whose \
+         offsets in mm_features must stay aligned with the submitted token IDs"
+    )]
+    TruncateUnsupportedWithMultimodal,
     #[error("chat request stream `{request_id}` closed before terminal output")]
     StreamClosedBeforeTerminalOutput { request_id: String },
     #[error("tool call stream state is inconsistent: {message}")]
@@ -78,7 +84,7 @@ impl Error {
     /// Whether this error represents invalid user request parameters.
     pub fn is_request_validation_error(&self) -> bool {
         match self {
-            Self::PromptTooLong { .. } => true,
+            Self::PromptTooLong { .. } | Self::TruncateUnsupportedWithMultimodal => true,
             Self::Text(error) => error.is_request_validation_error(),
             _ => false,
         }

--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -196,6 +196,16 @@ impl ChatLlm {
         )
         .await?;
 
+        // Multimodal prompts encode image / audio placeholders whose offsets
+        // in `mm_features` are recorded against the full encoded prompt; if
+        // we let the text layer truncate the token IDs underneath them, the
+        // engine would receive token IDs and multimodal offsets that point
+        // at different positions. Reject the combination until we can route
+        // truncation through the multimodal pipeline as well.
+        if mm_features.is_some() && request.truncate_prompt_tokens.is_some() {
+            return Err(Error::TruncateUnsupportedWithMultimodal);
+        }
+
         let text_request = TextRequest {
             request_id: request.request_id.clone(),
             prompt,
@@ -209,6 +219,8 @@ impl ChatLlm {
             data_parallel_rank: request.data_parallel_rank,
             reasoning_parser_kwargs,
             lora_request: request.lora_request,
+            truncate_prompt_tokens: request.truncate_prompt_tokens,
+            truncation_side: request.truncation_side,
         };
         let decoded_stream = self.text.generate(text_request).await?.map_err(Error::from).boxed();
 

--- a/rust/src/chat/src/request.rs
+++ b/rust/src/chat/src/request.rs
@@ -438,6 +438,17 @@ pub struct ChatRequest {
     /// LoRA adapter selected for this request.
     #[serde(default)]
     pub lora_request: Option<LoraRequest>,
+    /// Truncate the rendered prompt to this many tokens before submission.
+    ///
+    /// `None` disables truncation; `Some(-1)` resolves to the input-token
+    /// budget `max_model_len - max_tokens`. Forwarded to the text layer.
+    #[serde(default)]
+    pub truncate_prompt_tokens: Option<i64>,
+    /// Which side to truncate from when `truncate_prompt_tokens` is active.
+    /// Defaults to left when unset, matching the generate-tokenizer default.
+    /// Forwarded to the text layer.
+    #[serde(default)]
+    pub truncation_side: Option<vllm_text::TruncationSide>,
 }
 
 impl ChatRequest {
@@ -459,6 +470,8 @@ impl ChatRequest {
             add_special_tokens: false,
             data_parallel_rank: None,
             lora_request: None,
+            truncate_prompt_tokens: None,
+            truncation_side: None,
         }
     }
 

--- a/rust/src/server/src/error.rs
+++ b/rust/src/server/src/error.rs
@@ -207,6 +207,57 @@ mod tests {
     }
 
     #[test]
+    fn invalid_truncate_prompt_tokens_maps_to_invalid_request() {
+        let error = vllm_text::Error::InvalidTruncatePromptTokens {
+            request_id: "req-1".to_string(),
+            value: -7,
+        };
+        let api_error = text_submit_error("failed to submit completion request", error);
+        assert_eq!(api_error.status_code(), StatusCode::BAD_REQUEST);
+        let response = api_error.to_error_response();
+        assert_eq!(response.error.error_type, "invalid_request_error");
+        assert!(response.error.message.contains("truncate_prompt_tokens"));
+    }
+
+    #[test]
+    fn truncate_prompt_tokens_exceeds_budget_maps_to_invalid_request() {
+        let error = vllm_text::Error::TruncatePromptTokensExceedsBudget {
+            value: 9000,
+            max_input_tokens: 4096,
+            max_model_len: 8192,
+            max_tokens: 4096,
+        };
+        let api_error = text_submit_error("failed to submit completion request", error);
+        assert_eq!(api_error.status_code(), StatusCode::BAD_REQUEST);
+        let response = api_error.to_error_response();
+        assert_eq!(response.error.error_type, "invalid_request_error");
+        assert!(response.error.message.contains("9000"));
+        assert!(response.error.message.contains("4096"));
+    }
+
+    #[test]
+    fn chat_wrapped_truncate_prompt_tokens_exceeds_budget_maps_to_invalid_request() {
+        let error = vllm_chat::Error::Text(vllm_text::Error::TruncatePromptTokensExceedsBudget {
+            value: 9000,
+            max_input_tokens: 4096,
+            max_model_len: 8192,
+            max_tokens: 4096,
+        });
+        let api_error = chat_submit_error("failed to submit chat request", error);
+        assert_eq!(api_error.status_code(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn chat_multimodal_truncate_maps_to_invalid_request() {
+        let error = vllm_chat::Error::TruncateUnsupportedWithMultimodal;
+        let api_error = chat_submit_error("failed to submit chat request", error);
+        assert_eq!(api_error.status_code(), StatusCode::BAD_REQUEST);
+        let response = api_error.to_error_response();
+        assert_eq!(response.error.error_type, "invalid_request_error");
+        assert!(response.error.message.contains("multimodal"));
+    }
+
+    #[test]
     fn other_submit_errors_stay_internal() {
         let error = vllm_text::Error::Tokenizer("backend exploded".to_string());
         let api_error = text_submit_error("failed to submit completion request", error);

--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -93,6 +93,11 @@ pub fn to_text_request(
         data_parallel_rank: None,
         reasoning_parser_kwargs: None,
         lora_request: None,
+        // The gRPC generate surface mirrors the engine-level contract; rely
+        // on engine-side max_model_len enforcement rather than letting callers
+        // truncate prompts here.
+        truncate_prompt_tokens: None,
+        truncation_side: None,
     })
 }
 

--- a/rust/src/server/src/routes/inference/generate/convert.rs
+++ b/rust/src/server/src/routes/inference/generate/convert.rs
@@ -70,6 +70,10 @@ pub(super) fn prepare_generate_request(
         data_parallel_rank: ctx.data_parallel_rank,
         reasoning_parser_kwargs: None,
         lora_request: lora_resolution.lora_request.clone(),
+        // /generate is internal infra; rely on the engine-side max_model_len
+        // enforcement rather than letting callers truncate prompts here.
+        truncate_prompt_tokens: None,
+        truncation_side: None,
     };
 
     Ok(PreparedRequest {

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -157,6 +157,8 @@ pub(super) fn prepare_chat_request(
         add_special_tokens: request.add_special_tokens,
         data_parallel_rank: ctx.data_parallel_rank,
         lora_request: lora_resolution.lora_request.clone(),
+        truncate_prompt_tokens: request.truncate_prompt_tokens,
+        truncation_side: request.truncation_side,
     };
 
     Ok(PreparedRequest {

--- a/rust/src/server/src/routes/openai/chat_completions/types.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/types.rs
@@ -155,6 +155,12 @@ pub struct ChatCompletionRequest {
     /// Truncate prompt tokens to this length
     pub truncate_prompt_tokens: Option<i64>,
 
+    /// Which side to truncate from when `truncate_prompt_tokens` is active
+    /// (`"left"` drops the prompt prefix and is the default when unset,
+    /// matching the generate-tokenizer default; `"right"` drops the prompt
+    /// suffix instead).
+    pub truncation_side: Option<vllm_text::TruncationSide>,
+
     /// Number of prompt logprobs to return
     pub prompt_logprobs: Option<i32>,
 
@@ -279,6 +285,7 @@ impl Default for ChatCompletionRequest {
             skip_special_tokens: true,
             spaces_between_special_tokens: true,
             truncate_prompt_tokens: None,
+            truncation_side: None,
             prompt_logprobs: None,
             allowed_token_ids: None,
             bad_words: None,

--- a/rust/src/server/src/routes/openai/chat_completions/validate.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/validate.rs
@@ -79,11 +79,15 @@ pub(super) fn validate_request_compat(
             "spaces_between_special_tokens is not supported."
         );
     }
-    reject_non_default(
-        request.truncate_prompt_tokens.as_ref(),
-        "truncate_prompt_tokens",
-        "truncate_prompt_tokens is not supported.",
-    )?;
+    if let Some(value) = request.truncate_prompt_tokens
+        && value < -1
+    {
+        bail_invalid_request!(
+            param = "truncate_prompt_tokens",
+            "truncate_prompt_tokens must be a non-negative integer or -1 to mean \
+             `max_model_len - max_tokens`."
+        );
+    }
     reject_non_default(
         request.media_io_kwargs.as_ref(),
         "media_io_kwargs",

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -143,6 +143,8 @@ pub(super) fn prepare_completion_request(
         data_parallel_rank: ctx.data_parallel_rank,
         reasoning_parser_kwargs: None,
         lora_request: lora_resolution.lora_request.clone(),
+        truncate_prompt_tokens: request.truncate_prompt_tokens,
+        truncation_side: request.truncation_side,
     };
 
     Ok(PreparedRequest {

--- a/rust/src/server/src/routes/openai/completions/types.rs
+++ b/rust/src/server/src/routes/openai/completions/types.rs
@@ -128,6 +128,12 @@ pub struct CompletionRequest {
     /// Truncate prompt tokens to this length
     pub truncate_prompt_tokens: Option<i64>,
 
+    /// Which side to truncate from when `truncate_prompt_tokens` is active
+    /// (`"left"` drops the prompt prefix and is the default when unset,
+    /// matching the generate-tokenizer default; `"right"` drops the prompt
+    /// suffix instead).
+    pub truncation_side: Option<vllm_text::TruncationSide>,
+
     /// Restrict output to these token IDs only
     pub allowed_token_ids: Option<Vec<u32>>,
 

--- a/rust/src/server/src/routes/openai/completions/validate.rs
+++ b/rust/src/server/src/routes/openai/completions/validate.rs
@@ -79,10 +79,25 @@ pub(super) fn validate_request_compat(
             "spaces_between_special_tokens is not supported."
         );
     }
-    if request.truncate_prompt_tokens.is_some() {
+    if let Some(value) = request.truncate_prompt_tokens
+        && value < -1
+    {
         bail_invalid_request!(
             param = "truncate_prompt_tokens",
-            "truncate_prompt_tokens is not supported."
+            "truncate_prompt_tokens must be a non-negative integer or -1 to mean \
+             `max_model_len - max_tokens`."
+        );
+    }
+    // Echo prepends the original prompt to the response from the captured raw
+    // text, before truncation runs against the encoded prompt token ids; the
+    // two would disagree if both ran together (and the `-1` sentinel would
+    // additionally see the engine-effective `max_tokens` after the echo-only
+    // remap to 1, not the user-supplied value). Reject the combination until
+    // we route echo through the truncated token ids instead of the raw text.
+    if request.echo && request.truncate_prompt_tokens.is_some() {
+        bail_invalid_request!(
+            param = "truncate_prompt_tokens",
+            "truncate_prompt_tokens is not yet supported together with `echo`."
         );
     }
 

--- a/rust/src/server/src/routes/tokenize/types.rs
+++ b/rust/src/server/src/routes/tokenize/types.rs
@@ -92,6 +92,10 @@ impl TokenizeChatRequest {
             add_special_tokens: self.add_special_tokens,
             data_parallel_rank: None,
             lora_request: None,
+            // /tokenize never reaches the generate path; truncation is a
+            // submit-time concern handled there.
+            truncate_prompt_tokens: None,
+            truncation_side: None,
         })
     }
 }

--- a/rust/src/text/src/error.rs
+++ b/rust/src/text/src/error.rs
@@ -12,6 +12,21 @@ pub enum Error {
     #[error("text request `{request_id}` must contain at least one prompt token ID")]
     EmptyPromptTokenIds { request_id: String },
     #[error(
+        "text request `{request_id}` has invalid `truncate_prompt_tokens = {value}`; \
+         expected a non-negative integer or the sentinel value -1"
+    )]
+    InvalidTruncatePromptTokens { request_id: String, value: i64 },
+    #[error(
+        "`truncate_prompt_tokens = {value}` exceeds the input-token budget \
+         {max_input_tokens} (= max_model_len {max_model_len} - max_tokens {max_tokens})"
+    )]
+    TruncatePromptTokensExceedsBudget {
+        value: i64,
+        max_input_tokens: u32,
+        max_model_len: u32,
+        max_tokens: u32,
+    },
+    #[error(
         "this model's maximum context length is {max_model_len} tokens, \
          but the prompt contains {prompt_len} input tokens"
     )]
@@ -43,6 +58,8 @@ impl Error {
         match self {
             Self::PromptTooLong { .. }
             | Self::EmptyPromptTokenIds { .. }
+            | Self::InvalidTruncatePromptTokens { .. }
+            | Self::TruncatePromptTokensExceedsBudget { .. }
             | Self::Logprobs(_)
             | Self::TokenIds(_)
             | Self::MinTokensExceedsMaxTokens { .. }

--- a/rust/src/text/src/lib.rs
+++ b/rust/src/text/src/lib.rs
@@ -16,7 +16,7 @@ pub use output::{
     CollectedTextOutput, DecodedLogprobs, DecodedPositionLogprobs, DecodedPromptLogprobs,
     DecodedTextEvent, DecodedTokenLogprob, Finished, TextDecodeOptions, TextOutputStreamExt,
 };
-pub use request::{Prompt, SamplingParams, TextRequest};
+pub use request::{Prompt, SamplingParams, TextRequest, TruncationSide};
 use trait_set::trait_set;
 use vllm_engine_core_client::EngineCoreClient;
 pub use vllm_llm::FinishReason;
@@ -140,6 +140,14 @@ impl TextLlm {
             Prompt::TokenIds(token_ids) => token_ids,
         };
 
+        let prompt_token_ids = apply_truncate_prompt_tokens(
+            prompt_token_ids,
+            request.truncate_prompt_tokens,
+            request.truncation_side,
+            self.max_model_len,
+            request.sampling_params.max_tokens,
+        )?;
+
         let sampling_hints = self.backend.sampling_hints()?;
         let sampling_limits = SamplingLimits {
             max_model_len: self.max_model_len,
@@ -173,5 +181,191 @@ impl TextLlm {
     pub async fn shutdown(self) -> Result<()> {
         self.llm.shutdown().await?;
         Ok(())
+    }
+}
+
+/// Truncate `prompt_token_ids` to `truncate_prompt_tokens` according to
+/// `truncation_side`, mirroring the Python `TokenizeParams._token_truncation`
+/// contract.
+///
+/// `None` means no truncation. `Some(-1)` is a sentinel that resolves to the
+/// input-token budget `max_model_len - max_tokens`; any other negative value
+/// is rejected upstream by [`TextRequest::validate`]. A non-negative value
+/// that is at least as large as the prompt is a no-op.
+///
+/// `truncation_side` defaults to [`TruncationSide::Left`] when unset.
+/// Python falls back to the tokenizer's own `truncation_side` attribute when
+/// the request leaves it unset, and `vllm/tokenizers/registry.py`
+/// initializes generate / draft tokenizers with `truncation_side = "left"`,
+/// so we hard-default to left here for parity. The Rust `Tokenizer` trait
+/// does not yet expose the per-tokenizer attribute; once it does, this can
+/// fall back through that path. Callers that need right truncation must
+/// request it explicitly via `truncation_side: "right"`.
+fn apply_truncate_prompt_tokens(
+    prompt_token_ids: Vec<u32>,
+    truncate_prompt_tokens: Option<i64>,
+    truncation_side: Option<TruncationSide>,
+    max_model_len: u32,
+    max_tokens: Option<u32>,
+) -> Result<Vec<u32>> {
+    let Some(value) = truncate_prompt_tokens else {
+        return Ok(prompt_token_ids);
+    };
+
+    let max_tokens = max_tokens.unwrap_or(0);
+    let max_input_tokens = max_model_len.saturating_sub(max_tokens);
+
+    let target = if value == -1 {
+        max_input_tokens as usize
+    } else if value >= 0 {
+        let value_u32: u32 = value
+            .try_into()
+            // u32::MAX is far larger than any plausible context window; clamp
+            // through max_input_tokens below for the actual safety check.
+            .unwrap_or(u32::MAX);
+        if value_u32 > max_input_tokens {
+            return Err(Error::TruncatePromptTokensExceedsBudget {
+                value,
+                max_input_tokens,
+                max_model_len,
+                max_tokens,
+            });
+        }
+        value_u32 as usize
+    } else {
+        // `validate()` rejects values < -1, so this branch is unreachable for
+        // a validated request. Treat it as a no-op rather than panicking if a
+        // caller skips validation.
+        return Ok(prompt_token_ids);
+    };
+
+    if target >= prompt_token_ids.len() {
+        return Ok(prompt_token_ids);
+    }
+
+    let side = truncation_side.unwrap_or(TruncationSide::Left);
+    let mut prompt_token_ids = prompt_token_ids;
+    match side {
+        TruncationSide::Right => prompt_token_ids.truncate(target),
+        TruncationSide::Left => {
+            let drop = prompt_token_ids.len() - target;
+            prompt_token_ids.drain(..drop);
+        }
+    }
+    Ok(prompt_token_ids)
+}
+
+#[cfg(test)]
+mod truncate_tests {
+    use super::*;
+
+    fn ids(n: u32) -> Vec<u32> {
+        (0..n).collect()
+    }
+
+    #[test]
+    fn truncate_none_is_no_op() {
+        let out = apply_truncate_prompt_tokens(ids(10), None, None, 100, Some(10)).unwrap();
+        assert_eq!(out, ids(10));
+    }
+
+    #[test]
+    fn truncate_right_keeps_prefix() {
+        let out = apply_truncate_prompt_tokens(
+            ids(10),
+            Some(4),
+            Some(TruncationSide::Right),
+            100,
+            Some(0),
+        )
+        .unwrap();
+        assert_eq!(out, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn truncate_left_keeps_suffix() {
+        let out = apply_truncate_prompt_tokens(
+            ids(10),
+            Some(4),
+            Some(TruncationSide::Left),
+            100,
+            Some(0),
+        )
+        .unwrap();
+        assert_eq!(out, vec![6, 7, 8, 9]);
+    }
+
+    #[test]
+    fn truncate_default_side_is_left() {
+        // Matches the generate-tokenizer default in
+        // `vllm/tokenizers/registry.py`, which sets `truncation_side = "left"`
+        // for the `generate` / `draft` runner types.
+        let out = apply_truncate_prompt_tokens(ids(6), Some(3), None, 100, Some(0)).unwrap();
+        assert_eq!(out, vec![3, 4, 5]);
+    }
+
+    #[test]
+    fn truncate_zero_returns_empty_prompt() {
+        let out = apply_truncate_prompt_tokens(ids(4), Some(0), None, 100, Some(0)).unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn truncate_request_exceeding_prompt_is_no_op() {
+        let out = apply_truncate_prompt_tokens(ids(4), Some(20), None, 100, Some(0)).unwrap();
+        assert_eq!(out, ids(4));
+    }
+
+    #[test]
+    fn truncate_sentinel_minus_one_uses_input_budget() {
+        // max_model_len = 100, max_tokens = 30 -> input budget = 70.
+        // Prompt has 80 tokens -> truncate to 70, dropping the prefix because
+        // the generate-tokenizer default is left truncation.
+        let out = apply_truncate_prompt_tokens(ids(80), Some(-1), None, 100, Some(30)).unwrap();
+        assert_eq!(out.len(), 70);
+        assert_eq!(out[0], 10);
+        assert_eq!(out[69], 79);
+    }
+
+    #[test]
+    fn truncate_sentinel_minus_one_left_keeps_suffix() {
+        let out = apply_truncate_prompt_tokens(
+            ids(80),
+            Some(-1),
+            Some(TruncationSide::Left),
+            100,
+            Some(30),
+        )
+        .unwrap();
+        assert_eq!(out.len(), 70);
+        assert_eq!(out[0], 10);
+        assert_eq!(out[69], 79);
+    }
+
+    #[test]
+    fn truncate_value_above_input_budget_rejected() {
+        let err = apply_truncate_prompt_tokens(ids(10), Some(80), None, 100, Some(30)).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                Error::TruncatePromptTokensExceedsBudget { value: 80, .. }
+            ),
+            "expected TruncatePromptTokensExceedsBudget, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn truncate_sentinel_when_max_tokens_unset_uses_full_context() {
+        let out = apply_truncate_prompt_tokens(ids(80), Some(-1), None, 50, None).unwrap();
+        assert_eq!(out.len(), 50);
+    }
+
+    #[test]
+    fn truncate_invalid_negative_value_passes_through_validate_layer() {
+        // `validate()` is responsible for rejecting -2 and below before the
+        // truncation helper runs; if it ever slips through, the helper must
+        // not panic and should fall back to a no-op.
+        let out = apply_truncate_prompt_tokens(ids(5), Some(-2), None, 100, Some(0)).unwrap();
+        assert_eq!(out, ids(5));
     }
 }

--- a/rust/src/text/src/request.rs
+++ b/rust/src/text/src/request.rs
@@ -142,6 +142,21 @@ impl Default for SamplingParams {
     }
 }
 
+/// Which side of the prompt to discard when `truncate_prompt_tokens` is
+/// active.
+///
+/// Mirrors the Python `truncation_side` option on `TokenizeParams`:
+/// `Right` keeps the first N tokens (truncates from the end); `Left` keeps
+/// the last N tokens (truncates from the start).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TruncationSide {
+    /// Keep the last N tokens, discarding the prompt prefix.
+    Left,
+    /// Keep the first N tokens, discarding the prompt suffix.
+    Right,
+}
+
 /// One raw text-generation request ready to be tokenized or sent directly to
 /// the engine.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -181,6 +196,21 @@ pub struct TextRequest {
     /// LoRA adapter selected for this request.
     #[serde(default)]
     pub lora_request: Option<LoraRequest>,
+    /// Truncate the encoded prompt to this many tokens before submission.
+    ///
+    /// `None` disables truncation. `Some(-1)` is a sentinel that means "use
+    /// the input-token budget derived from `max_model_len - max_tokens`",
+    /// matching the Python `TokenizeParams.truncate_prompt_tokens` contract.
+    /// Other negative values are rejected by [`TextRequest::validate`].
+    #[serde(default)]
+    pub truncate_prompt_tokens: Option<i64>,
+    /// Which side to truncate from when `truncate_prompt_tokens` is active.
+    ///
+    /// Defaults to [`TruncationSide::Left`] (drop prompt prefix) when unset,
+    /// matching the `generate` / `draft` default in
+    /// `vllm/tokenizers/registry.py`.
+    #[serde(default)]
+    pub truncation_side: Option<TruncationSide>,
 }
 
 impl TextRequest {
@@ -199,6 +229,8 @@ impl TextRequest {
             data_parallel_rank: None,
             reasoning_parser_kwargs: None,
             lora_request: None,
+            truncate_prompt_tokens: None,
+            truncation_side: None,
         }
     }
 
@@ -207,6 +239,14 @@ impl TextRequest {
         if matches!(&self.prompt, Prompt::TokenIds(ids) if ids.is_empty()) {
             return Err(Error::EmptyPromptTokenIds {
                 request_id: self.request_id.clone(),
+            });
+        }
+        if let Some(n) = self.truncate_prompt_tokens
+            && n < -1
+        {
+            return Err(Error::InvalidTruncatePromptTokens {
+                request_id: self.request_id.clone(),
+                value: n,
             });
         }
         Ok(())


### PR DESCRIPTION
## Summary

Replace the validate-time rejection of `truncate_prompt_tokens` with an
actual implementation in `/v1/completions` and `/v1/chat/completions`,
mirroring the Python `vllm.renderers.params.TokenizeParams` contract
([`params.py:396-413`](https://github.com/vllm-project/vllm/blob/main/vllm/renderers/params.py#L396-L413)).
Tracks the *Request compatibility and validation* section of the Rust
frontend feature parity roadmap (#44280) — claimed in
[this comment](https://github.com/vllm-project/vllm/issues/44280#issuecomment-4748743971).

### Design

- New `TruncationSide` enum (`Left` / `Right`) re-exported from `vllm-text`.
- `TextRequest` gains `truncate_prompt_tokens: Option<i64>` and
  `truncation_side: Option<TruncationSide>`. `ChatRequest` mirrors these
  fields and forwards them through.
- After tokenization in `TextLlm::generate_inner` the new helper
  `apply_truncate_prompt_tokens` slices the encoded prompt:
  - `None` → no-op.
  - `Some(-1)` → use the input-token budget `max_model_len - max_tokens`.
  - non-negative ≥ prompt length → no-op.
  - exceeds the input-token budget → typed
    `Error::TruncatePromptTokensExceedsBudget` (mirrors Python's
    `VLLMValidationError`).
  - side defaults to `Left` (drop prompt prefix), matching the
    generate / draft default in `vllm/tokenizers/registry.py`.
- Both new error variants are classified as request-validation errors so
  they surface as **400 invalid_request_error**, not 500.

### Intentional restrictions

- **Default `truncation_side`**: Python falls back to the tokenizer's own
  `truncation_side` attribute when the request leaves it unset, and
  `vllm/tokenizers/registry.py` initializes the `generate` / `draft`
  runner types with `truncation_side = "left"`. The Rust `Tokenizer`
  trait does not yet expose the per-tokenizer attribute, so this port
  hard-defaults to left to match the established behavior. Callers that
  need right truncation must request it explicitly. Once the trait
  exposes the attribute we can fall back through it.
- **`echo` + `truncate_prompt_tokens`**: rejected for now in the
  completions validator. Echo currently captures the raw prompt text
  before encoding / truncation and would echo the un-truncated prompt
  while sending a truncated one (and the `-1` budget would see the
  echo-only `max_tokens` remap to 1, not the user value). Removing this
  restriction is a follow-up once echo is routed through the truncated
  token ids.
- **Multimodal chat + `truncate_prompt_tokens`**: rejected in the chat
  layer after `finalize_rendered_prompt` populates `mm_features`. Image
  / audio placeholders embed positional offsets against the full prompt
  token list, and truncating the token IDs underneath would leave the
  engine with multimodal offsets that point at different tokens. A
  follow-up that routes truncation through the multimodal pipeline can
  lift this.

### Internal-only paths

The internal `/generate` (REST + gRPC) and `/tokenize` request
constructors pass `truncate_prompt_tokens: None`. They bypass the OpenAI
request surface and rely on engine-side `max_model_len` enforcement,
which keeps existing callers' contracts unchanged.

## Duplicate-work check

```bash
gh pr list --repo vllm-project/vllm --state open --search "truncate_prompt_tokens in:title,body"
gh issue list --repo vllm-project/vllm --state open --search "truncate_prompt_tokens rust"
```

No existing Rust port. The matching open PRs all target the Python side
(Harmony, Responses API, embedding/rerank defaults). The roadmap
#44280 listed it as unclaimed before
[my claim comment](https://github.com/vllm-project/vllm/issues/44280#issuecomment-4748743971).

## Test plan

Local:

- `cargo nextest run -p vllm-text -p vllm-chat -p vllm-server` → **509/509** passing
- `cargo clippy -p vllm-text -p vllm-chat -p vllm-server --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean

New tests:

- `vllm-text` helper coverage (10 cases): no-op when `None`, right/left
  side, default side is right, zero returns empty prompt, value above
  prompt length is no-op, sentinel `-1` uses input budget with both
  sides, value above input budget rejected, sentinel when `max_tokens`
  is unset uses full context, `< -1` slips past validate as a no-op.
- `vllm-server` error mapping (3 cases): both new error variants map to
  `400 invalid_request_error` on the text submit path, and the
  chat-wrapped budget-exceeded variant also maps correctly.

## AI assistance disclosure

This PR was prepared with assistance from Claude (Anthropic) as a
porting and review aide, plus an automated Codex review pass before
submission. Codex flagged four issues (default-side documentation,
error → HTTP code mapping, echo+truncate budget mismatch, echo+truncate
text mismatch); all four are addressed in the diff before the PR was
opened. The human submitter reviewed every changed line and ran the
test commands above.

Co-authored-by: Claude <noreply@anthropic.com>
