### PR TITLE
[Misc] Enable test_triton_scaled_mm on XPU

### DIFF
--- a/tests/kernels/quantization/test_triton_scaled_mm.py
+++ b/tests/kernels/quantization/test_triton_scaled_mm.py
@@ -13,7 +13,7 @@ import torch
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
-device = "cuda"
+device = current_platform.device_type
 
 triton_scaled_mm_module = importlib.import_module(
     "vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm"


### PR DESCRIPTION
## Purpose

Enables `test_triton_scaled_mm` on XPU. The test covers the `scaled_mm_kernel`
Triton kernel (via the `triton_scaled_mm` wrapper) against a PyTorch reference,
but hardcoded `device = "cuda"`, so it could not run on Intel GPUs. Replaces the
single hardcoded device with `current_platform.device_type` (already imported).
No test logic, shapes, dtypes, or tolerances change; CUDA behaviour is identical.

## Test Plan

`python -m pytest tests/kernels/quantization/test_triton_scaled_mm.py -v`

## Test Result

96 passed.