### PR TITLE
[Bugfix] Handle GPU/MIG UUIDs in CUDA_VISIBLE_DEVICES

### DIFF
--- a/tests/test_platform_device_id.py
+++ b/tests/test_platform_device_id.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for ``Platform.device_id_to_physical_device_id``.
+
+Regression coverage for the ``ValueError`` raised when the device-control env
+var (e.g. ``CUDA_VISIBLE_DEVICES``) contains a GPU or MIG instance UUID rather
+than an integer index.
+"""
+
+from vllm.platforms.interface import Platform
+
+
+class _StubPlatform(Platform):
+    device_control_env_var = "CUDA_VISIBLE_DEVICES"
+    device_name = "stub"
+
+
+def test_integer_indices_unchanged(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
+    assert _StubPlatform.device_id_to_physical_device_id(0) == 2
+    assert _StubPlatform.device_id_to_physical_device_id(1) == 3
+
+
+def test_mig_uuid_does_not_crash(monkeypatch):
+    # Single MIG instance pinned by UUID -- CUDA exposes it as logical device 0.
+    monkeypatch.setenv(
+        "CUDA_VISIBLE_DEVICES", "MIG-377e0049-554c-540b-93c6-d0976f8426cb"
+    )
+    assert _StubPlatform.device_id_to_physical_device_id(0) == 0
+
+
+def test_gpu_uuid_list(monkeypatch):
+    monkeypatch.setenv(
+        "CUDA_VISIBLE_DEVICES",
+        "GPU-16d07083-ab1d-cd47-d8bb-9e7f83104985,"
+        "GPU-aa11bb22-cc33-dd44-ee55-ff6677889900",
+    )
+    assert _StubPlatform.device_id_to_physical_device_id(0) == 0
+    assert _StubPlatform.device_id_to_physical_device_id(1) == 1
+
+
+def test_empty_env_returns_logical_id(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    assert _StubPlatform.device_id_to_physical_device_id(3) == 3

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -307,7 +307,18 @@ class Platform:
         ):
             device_ids = os.environ[cls.device_control_env_var].split(",")
             physical_device_id = device_ids[device_id]
-            return cls.device_control_id_to_physical_device_id(physical_device_id)
+            try:
+                return cls.device_control_id_to_physical_device_id(physical_device_id)
+            except ValueError:
+                # The device-control env var (e.g. CUDA_VISIBLE_DEVICES)
+                # accepts device UUIDs as well as integer indices -- a
+                # full-GPU UUID ("GPU-...") or a MIG instance UUID
+                # ("MIG-..."). These are valid, documented CUDA device
+                # specifiers but cannot be parsed as ints. The runtime
+                # remaps the listed visible devices to logical ids in
+                # order, so the caller's logical ``device_id`` is already
+                # the correct index into the visible set.
+                return device_id
         else:
             return device_id
 


### PR DESCRIPTION
## Purpose

`Platform.device_id_to_physical_device_id()` calls `int()` directly on each entry of `CUDA_VISIBLE_DEVICES`. CUDA accepts **UUIDs** as device specifiers — both full-GPU (`GPU-...`) and MIG instance (`MIG-...`) UUIDs — so pinning vLLM to a device by UUID crashes on startup:

```
File ".../vllm/platforms/interface.py", line 247, in device_id_to_physical_device_id
    return int(physical_device_id)
ValueError: invalid literal for int() with base 10: 'MIG-4c60d78c-506f-5593-938d-a136eaa1fa52'
```

On the `serve` path this surfaces three frames up, inside the model-inspection subprocess, as a misleading `pydantic ValidationError: Model architectures [...] failed to be inspected` — which points debugging at entirely the wrong subsystem.

Pinning a process to one MIG instance by UUID (`CUDA_VISIBLE_DEVICES=MIG-...`) is the NVIDIA-recommended way to address a MIG slice, and is completely broken today — the server never reaches model load. Verified the identical crash on **vLLM 0.10.0 / A100-SXM4-40GB (sm_80), MIG 2g.10gb, CUDA 12.8, driver 570**; matches earlier reports on H100 (#20939) and the open UUID request (#32569).

## Fix

Fall back to the logical `device_id` when an entry is not an integer. CUDA remaps the listed visible devices to logical ids in order, so the caller's `device_id` is already the correct index into the visible set. Integer-index behavior is unchanged.

## Test Plan

`tests/test_platform_device_id.py` covers the integer path (unchanged), a single MIG UUID, a list of GPU UUIDs, and the empty-env case.

## Test Result

- New unit tests pass (CPU-only, no GPU needed).
- End-to-end on a real **A100 MIG 2g.10gb** slice: with this change, `CUDA_VISIBLE_DEVICES=MIG-<uuid> vllm serve TinyLlama/TinyLlama-1.1B-Chat-v1.0` passes model inspection, completes CUDA-graph capture, reaches `Application startup complete`, and serves `/v1/*` (HTTP 200). Without it, startup dies at the `int()` call.

Fixes #20939 (closed as stale but never fixed). Fixes #41848. Relates to #32569.

cc @youkaichao @WoosukKwon @simon-mo — platform/device path.
