### PR TITLE
[Bugfix] Reset Responses stream content index per item

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -726,6 +726,26 @@ class TestStreamingReasoningToContentTransition:
     transition, specifically the fix for mixed deltas that carry both
     reasoning and content simultaneously."""
 
+    def test_content_index_resets_for_each_output_item(self):
+        """The first content part of each output item should start at 0."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_reasoning_delta_events,
+            emit_text_delta_events,
+        )
+
+        def first_content_index(events):
+            for event in events:
+                content_index = getattr(event, "content_index", None)
+                if content_index is not None:
+                    return content_index
+            return None
+
+        state = StreamingState()
+
+        assert first_content_index(emit_reasoning_delta_events("x", state)) == 0
+        state.reset_for_new_item()
+        assert first_content_index(emit_text_delta_events("y", state)) == 0
+
     @pytest.mark.asyncio
     async def test_mixed_delta_reasoning_and_content_emits_reasoning_delta(
         self, monkeypatch

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -110,6 +110,7 @@ class StreamingState:
     def reset_for_new_item(self) -> None:
         """Reset state when expecting a new output item."""
         self.current_output_index += 1
+        self.current_content_index = -1
         self.sent_output_item_added = False
         self.is_first_function_call_delta = False
         self.current_call_id = ""


### PR DESCRIPTION
Fixes #45742.

The Responses streaming state currently carries `current_content_index` across output items. After a reasoning item is finished and the next message item starts, the first content part can be emitted with index 1 instead of starting from 0 for the new item.

This resets `current_content_index` together with the rest of the per-item streaming state, and adds a regression test for the reasoning-to-message transition.

Verification:
- `git diff --check HEAD~1..HEAD`
- `python3 -m py_compile vllm/entrypoints/openai/responses/streaming_events.py tests/entrypoints/openai/responses/test_serving_responses.py`

Local test note:
- `python3 -m pytest tests/entrypoints/openai/responses/test_serving_responses.py::TestStreamingReasoningToContentTransition::test_content_index_resets_for_each_output_item -q` currently stops during collection in this local checkout because `tblib` is not installed. I did not install dependencies in this environment.