### PR TITLE
[Bugfix] Defer KV offload re-admit with pending jobs

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -1431,7 +1431,8 @@ def test_pending_transfer_defers_prefix_lookup():
     worker before the scheduler consumes its completion. If the request is
     re-admitted in that window, the connector should defer it instead of
     looking up offloaded blocks and later asserting when a load is queued while
-    the store job is still tracked.
+    the store job is still tracked. Deferring must preserve the tracked GPU
+    blocks so the request can resume correctly after the transfer completes.
     """
     scheduler = object.__new__(OffloadingConnectorScheduler)
     scheduler.manager = MagicMock(spec=OffloadingManager)
@@ -1451,7 +1452,7 @@ def test_pending_transfer_defers_prefix_lookup():
 
     assert matched_tokens is None
     assert is_async is False
-    assert group_state.block_ids == []
+    assert group_state.block_ids == [1, 2, 3]
     scheduler.manager.lookup.assert_not_called()
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -712,15 +712,15 @@ class OffloadingConnectorScheduler:
                   (between scheduler steps).
         """
         req_status = self._req_status[request.request_id]
-        for group_state in req_status.group_states:
-            group_state.block_ids.clear()
-
         if req_status.transfer_jobs:
             logger.debug(
-                "Delaying request %s since it still has in-flight transfers",
+                "Request %s has pending offload jobs; deferring prefix lookup",
                 request.request_id,
             )
             return None, False
+
+        for group_state in req_status.group_states:
+            group_state.block_ids.clear()
 
         req_status.update_offload_keys()
         req_status.num_locally_computed_tokens = num_computed_tokens


### PR DESCRIPTION
Fixes #46014.

A preempted request can still have in-flight offload store jobs when the async scheduler considers it for re-admission. If the external prefix lookup hits before those jobs are reported complete, the connector tries to issue a load while the request still tracks store jobs, tripping the existing `assert not req_status.transfer_jobs` invariant.

This defers prefix lookup for requests that still have pending offload jobs, so the scheduler keeps the request waiting and retries after connector completions drain the job set. The load/store invariant remains in `update_state_after_alloc`.

Verification:
- `git diff --check`
- `python3 -m py_compile vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py`

Local test note:
- `python3 -m pytest --confcutdir=tests/v1/kv_connector/unit/offloading_connector tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_preempted_request_with_in_flight_store_is_deferred_on_readmit -q` currently stops during collection in this local checkout because `torch` is not installed. I did not install dependencies in this environment.