### PR TITLE
[Observability] Emit current OTel token usage attributes

### DIFF
--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -3,9 +3,11 @@
 
 import math
 import time
+from types import SimpleNamespace
 
 import pytest
 
+import vllm.v1.engine.output_processor as output_processor_module
 from tests.v1.engine.utils import (
     NUM_PROMPT_LOGPROBS_UNDER_TEST,
     NUM_SAMPLE_LOGPROBS_UNDER_TEST,
@@ -19,6 +21,7 @@ from vllm.lora.request import LoRARequest
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.tokenizers import TokenizerLike
+from vllm.tracing import SpanAttributes
 from vllm.v1.engine import (
     EngineCoreEvent,
     EngineCoreEventType,
@@ -28,6 +31,51 @@ from vllm.v1.engine import (
 )
 from vllm.v1.engine.output_processor import OutputProcessor, RequestOutputCollector
 from vllm.v1.metrics.stats import IterationStats, SchedulerStats
+
+
+@pytest.mark.skip_global_cleanup
+def test_tracing_emits_current_and_legacy_token_attributes(monkeypatch):
+    captured_attributes = {}
+
+    def capture_span(**kwargs):
+        captured_attributes.update(kwargs["attributes"])
+
+    monkeypatch.setattr(output_processor_module, "instrument_manual", capture_span)
+    monkeypatch.setattr(
+        output_processor_module, "extract_trace_context", lambda _: None
+    )
+
+    stats = SimpleNamespace(
+        arrival_time=1.0,
+        queued_ts=1.1,
+        scheduled_ts=1.2,
+        first_token_ts=1.4,
+        last_token_ts=1.8,
+        first_token_latency=0.4,
+        num_generation_tokens=3,
+    )
+    request_state = SimpleNamespace(
+        stats=stats,
+        prompt_token_ids=[1, 2, 3, 4],
+        prompt_embeds=None,
+        external_req_id="request-id",
+        top_p=None,
+        max_tokens_param=None,
+        temperature=None,
+        n=None,
+    )
+
+    OutputProcessor.do_tracing(
+        object(),
+        SimpleNamespace(trace_headers=None),
+        request_state,
+        SimpleNamespace(iteration_timestamp=2.0),
+    )
+
+    assert captured_attributes[SpanAttributes.GEN_AI_USAGE_INPUT_TOKENS] == 4
+    assert captured_attributes[SpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS] == 4
+    assert captured_attributes[SpanAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 3
+    assert captured_attributes[SpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS] == 3
 
 
 def _ref_convert_id_to_token(

--- a/tests/v1/tracing/test_tracing.py
+++ b/tests/v1/tracing/test_tracing.py
@@ -73,10 +73,16 @@ def test_traces(
             == sampling_params.max_tokens
         )
         assert attributes.get(SpanAttributes.GEN_AI_REQUEST_N) == sampling_params.n
-        assert attributes.get(SpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS) == len(
-            outputs[0].prompt_token_ids
+        prompt_tokens = len(outputs[0].prompt_token_ids)
+        assert attributes.get(SpanAttributes.GEN_AI_USAGE_INPUT_TOKENS) == prompt_tokens
+        assert (
+            attributes.get(SpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS) == prompt_tokens
         )
         completion_tokens = sum(len(o.token_ids) for o in outputs[0].outputs)
+        assert (
+            attributes.get(SpanAttributes.GEN_AI_USAGE_OUTPUT_TOKENS)
+            == completion_tokens
+        )
         assert (
             attributes.get(SpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS)
             == completion_tokens

--- a/vllm/tracing/utils.py
+++ b/vllm/tracing/utils.py
@@ -21,6 +21,11 @@ class SpanAttributes:
     """
 
     # Attribute names copied from OTel semantic conventions to avoid version conflicts
+    GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+    GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+
+    # Deprecated OTel GenAI semantic convention names. Keep emitting these
+    # during the migration window so existing dashboards continue to work.
     GEN_AI_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens"
     GEN_AI_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens"
     GEN_AI_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens"

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -739,6 +739,8 @@ class OutputProcessor:
             ),
             SpanAttributes.GEN_AI_LATENCY_E2E: e2e_time,
             SpanAttributes.GEN_AI_LATENCY_TIME_IN_QUEUE: queued_time,
+            SpanAttributes.GEN_AI_USAGE_INPUT_TOKENS: prompt_length,
+            SpanAttributes.GEN_AI_USAGE_OUTPUT_TOKENS: (metrics.num_generation_tokens),
             SpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS: prompt_length,
             SpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS: (
                 metrics.num_generation_tokens


### PR DESCRIPTION
## Summary
- emit the current OpenTelemetry GenAI semantic convention attributes `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens`
- continue emitting the deprecated `prompt_tokens` and `completion_tokens` names during the compatibility window
- cover the span construction path with a CPU-only unit test and extend the tracing integration assertions

## Why
OpenTelemetry renamed the token usage attributes. vLLM currently emits only the deprecated names, so current OTel backends and dashboards cannot consume token counts using the standard schema. Dual emission provides standards compliance without breaking existing dashboards.

Closes #44358.

## Validation
- `python -m pytest -q tests/v1/engine/test_output_processor.py::test_tracing_emits_current_and_legacy_token_attributes`
- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files
- `python -m compileall` on all changed Python files
- `git diff --check`