### PR TITLE
[DCP] Enable Decode Context Parallelism for sparse MLA (bf16 + fp8 KV)

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -233,7 +233,7 @@ MLA decode backends are selected using the standard
 | `FLASHINFER_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 32, 64 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | 10.x |
 | `FLASHINFER_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 32, 64 | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | 10.x |
 | `FLASHMLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 64 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 9.x-10.x |
-| `FLASHMLA_SPARSE` | bf16 | `auto`, `bfloat16`, `fp8_ds_mla` | 64 | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | 9.x-10.x |
+| `FLASHMLA_SPARSE` | bf16 | `auto`, `bfloat16`, `fp8_ds_mla` | 64 | 576 | ❌ | ❌ | ✅ | ❌ | ✅ | Decoder | 9.x-10.x |
 | `FLASH_ATTN_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16` | %16 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 9.x |
 | `ROCM_AITER_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %1 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 1, 64 | Any | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | N/A |

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -785,7 +785,17 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             else:
                 mqa_q = (mqa_ql_nope, mqa_q_pe)
             if self.impl.dcp_world_size > 1:
-                assert not fp8_attention, "DCP not support fp8 kvcache now."
+                # DCP head-dim all-gather of Q is incompatible with per-rank
+                # Q fp8 quantization (supports_quant_query_input: each rank
+                # quantizes Q with its own _q_scale, so all-gathered Q shards
+                # have inconsistent scales). Sparse MLA is exempt: its
+                # supports_quant_query_input is False, so Q stays bf16 here
+                # and the fp8 KV scale is handled inside the sparse kernel
+                # (flash_mla_with_kvcache is_fp8_kvcache=True) — no
+                # cross-rank scale issue.
+                assert not fp8_attention or is_sparse_impl, (
+                    "DCP not support fp8 kvcache now (except sparse MLA)."
+                )
                 # concatenate mqa_ql_nope and mqa_q_pe -> (B, N, L + P)
                 mqa_q = torch.cat(mqa_q, dim=-1)
                 # mqa_q do allgather in head dim.

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -8,6 +8,7 @@ import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
+from vllm.distributed.parallel_state import get_dcp_group
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
@@ -255,6 +256,53 @@ def sparse_attn_indexer(
                 topk_tokens,
             )
 
+            # DCP prefill: each rank picked a local top-k over its 1/N KV
+            # shard (the kernel above used DCP-aware cu_seq_len_ke so logits
+            # cover only the local shard). Merge per-rank local top-k into a
+            # global top-k, mirroring the decode merge below. Local top-k
+            # indices are request-relative LOCAL positions [0, local_ke);
+            # remap to GLOBAL: cp_rank + local_idx * dcp_world_size
+            # (CP_INTERLEAVE=1, compress_ratio=1).
+            dcp_ws = attn_metadata_narrowed.dcp_world_size
+            if dcp_ws > 1:
+                cp_rank = attn_metadata_narrowed.cp_rank
+                invalid = topk_indices < 0
+                idx_safe = topk_indices.clamp(min=0)
+                # Each query token's row only has (ke - ks) valid KV slots in
+                # this rank's shard. A row whose shard holds 0 tokens (e.g.
+                # rank r for a token attending [0, r)) must contribute nothing
+                # — top_k_per_row_prefill may not emit -1 for an empty range,
+                # so mask by the explicit valid count.
+                local_valid = (
+                    chunk.cu_seqlen_ke - chunk.cu_seqlen_ks
+                )[:num_rows].to(torch.int32)
+                invalid = invalid | (idx_safe >= local_valid.unsqueeze(1))
+                local_scores = torch.gather(
+                    logits.float(), 1, idx_safe.to(torch.int64)
+                ).masked_fill(invalid, float("-inf"))
+                global_pos = cp_rank + idx_safe.to(torch.int32) * dcp_ws
+                global_pos = torch.where(
+                    invalid, torch.full_like(global_pos, -1), global_pos
+                )
+                T = num_rows
+                K = topk_tokens
+                cand = torch.stack(
+                    [global_pos, local_scores.to(torch.float32)], dim=-1
+                )  # [T, K, 2]
+                cand_all = get_dcp_group().all_gather(cand, dim=0).view(
+                    dcp_ws, T, K, 2
+                )
+                # [dcp_ws, T, K] -> [T, dcp_ws*K]: per row, rank0's K then
+                # rank1's K, ... so a global top-K over the concatenated
+                # candidates is correct. permute before reshape (a bare
+                # reshape would interleave rows across ranks).
+                gp = cand_all[..., 0].permute(1, 0, 2).reshape(T, dcp_ws * K)
+                sc = cand_all[..., 1].permute(1, 0, 2).reshape(T, dcp_ws * K)
+                _, sel = torch.topk(sc, K, dim=1)  # [T, K]
+                topk_indices.copy_(
+                    torch.gather(gp, 1, sel.to(torch.int64)).to(torch.int32)
+                )
+
     if has_decode:
         decode_metadata = attn_metadata_narrowed.decode
         assert decode_metadata is not None
@@ -357,6 +405,50 @@ def sparse_attn_indexer(
                 logits.stride(0),
                 logits.stride(1),
                 topk_tokens,
+            )
+
+        # DCP decode: each rank picked a local top-k over its 1/N KV shard
+        # (the paged logits kernel read only the local shard). Merge the
+        # per-rank local top-k into a global top-k. Exact: any global top-K
+        # token is in its shard's local top-K; the indexer q is replicated
+        # across DCP ranks so scores are comparable. CP_INTERLEAVE=1 remap:
+        # global_pos = cp_rank + local_idx * dcp_world_size.
+        dcp_ws = attn_metadata_narrowed.dcp_world_size
+        if dcp_ws > 1:
+            cp_rank = attn_metadata_narrowed.cp_rank
+            invalid = topk_indices < 0
+            idx_safe = topk_indices.clamp(min=0)
+            # Each query token's row only has `seq_lens` valid KV slots in this
+            # rank's shard (4a passed dcp_local_seq_lens). A shard holding few
+            # tokens (e.g. 2-3 under DCP=8 on a short prompt) must not
+            # contribute out-of-range local indices — persistent_topk pads to
+            # topk_tokens and may emit indices >= seq_lens. Mask by the
+            # explicit valid count so they map to -1 instead of an out-of-range
+            # global position (cp_rank + idx*dcp_ws).
+            local_valid = seq_lens.reshape(-1)[: topk_indices.shape[0]].to(
+                torch.int32
+            )
+            invalid = invalid | (idx_safe >= local_valid.unsqueeze(1))
+            local_scores = torch.gather(
+                logits.float(), 1, idx_safe.to(torch.int64)
+            ).masked_fill(invalid, float("-inf"))
+            global_pos = cp_rank + idx_safe.to(torch.int32) * dcp_ws
+            global_pos = torch.where(
+                invalid, torch.full_like(global_pos, -1), global_pos
+            )
+            T = topk_indices.shape[0]
+            K = topk_tokens
+            cand = torch.stack(
+                [global_pos, local_scores.to(torch.float32)], dim=-1
+            )  # [T, K, 2]
+            cand_all = get_dcp_group().all_gather(cand, dim=0).view(
+                dcp_ws, T, K, 2
+            )
+            gp = cand_all[..., 0].permute(1, 0, 2).reshape(T, dcp_ws * K)
+            sc = cand_all[..., 1].permute(1, 0, 2).reshape(T, dcp_ws * K)
+            _, sel = torch.topk(sc, K, dim=1)  # [T, K]
+            topk_indices.copy_(
+                torch.gather(gp, 1, sel.to(torch.int64)).to(torch.int32)
             )
 
         if decode_metadata.requires_padding:

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -298,7 +298,19 @@ def sparse_attn_indexer(
                 # reshape would interleave rows across ranks).
                 gp = cand_all[..., 0].permute(1, 0, 2).reshape(T, dcp_ws * K)
                 sc = cand_all[..., 1].permute(1, 0, 2).reshape(T, dcp_ws * K)
-                _, sel = torch.topk(sc, K, dim=1)  # [T, K]
+                # Deterministic total-order key (see decode merge below): fp8
+                # logits tie often, and plain torch.topk breaks ties
+                # nondeterministically per-rank, so ranks can select different
+                # global token sets. Pack score bits (high 32) and ~global_pos
+                # (low 32, lowest position wins) into an int64 key biased by
+                # 2**63 so signed topk compares unsigned.
+                sc_bits = sc.view(torch.int32)
+                not_bits = sc_bits.bitwise_not()
+                ordered = torch.where(sc_bits < 0, not_bits, sc_bits ^ 0x80000000)
+                high = ordered.to(torch.uint32).to(torch.int64) << 32
+                low = (~gp.to(torch.int32)).to(torch.int64) & 0xFFFFFFFF
+                key = (high | low) + (1 << 63)
+                _, sel = torch.topk(key, K, dim=1)  # [T, K], deterministic
                 topk_indices.copy_(
                     torch.gather(gp, 1, sel.to(torch.int64)).to(torch.int32)
                 )
@@ -446,10 +458,33 @@ def sparse_attn_indexer(
             )
             gp = cand_all[..., 0].permute(1, 0, 2).reshape(T, dcp_ws * K)
             sc = cand_all[..., 1].permute(1, 0, 2).reshape(T, dcp_ws * K)
-            _, sel = torch.topk(sc, K, dim=1)  # [T, K]
-            topk_indices.copy_(
-                torch.gather(gp, 1, sel.to(torch.int64)).to(torch.int32)
-            )
+            # DCP correctness: every rank independently selects the global
+            # top-K from the same all-gathered candidates, so the selected
+            # SET must be identical across ranks. fp8 indexer scores have few
+            # distinct values, so ties are common; plain torch.topk breaks
+            # ties nondeterministically per-launch, so ranks can pick
+            # different tied candidates -> each rank's sparse_utils kernel
+            # filters a different global token set -> LSE-merged output is
+            # inconsistent -> intermittent garbled tokens (0.1-0.5%, long
+            # context where boundary ties are more likely).
+            #
+            # Build a strict total order as an int64 key: the score's
+            # monotone uint32 bits in the high 32 bits (higher score -> larger
+            # key), and ~global_pos in the low 32 bits (lowest global position
+            # wins among equal scores, matching a stable sort). torch.topk is
+            # signed, so bias by 2**63 to make the comparison unsigned (the
+            # high bit set after ^SIGN would otherwise look negative). All
+            # ranks compute identical keys, so topk is deterministic and
+            # rank-agnostic. Invalid candidates (score=-inf, gp=-1) map to the
+            # minimum key and sort last naturally -- no special-casing.
+            sc_bits = sc.view(torch.int32)
+            not_bits = sc_bits.bitwise_not()
+            ordered = torch.where(sc_bits < 0, not_bits, sc_bits ^ 0x80000000)
+            high = ordered.to(torch.uint32).to(torch.int64) << 32
+            low = (~gp.to(torch.int32)).to(torch.int64) & 0xFFFFFFFF
+            key = (high | low) + (1 << 63)
+            _, sel = torch.topk(key, K, dim=1)  # [T, K], deterministic
+            topk_indices.copy_(torch.gather(gp, 1, sel.to(torch.int64)).to(torch.int32))
 
         if decode_metadata.requires_padding:
             # if padded, we need to unpack

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -538,6 +538,13 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
 
 
 class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
+    # Enables DCP for sparse MLA. The public MLA DCP path
+    # (mla_attention.py:forward_impl) wraps forward_mqa with a head-dim Q
+    # all-gather + LSE log-sum-exp merge + head reduce-scatter; sparse reuses
+    # it for free once forward_mqa returns the per-rank decode LSE. The
+    # indexer-side global top-k is handled separately (see sparse_attn_indexer).
+    can_return_lse_for_decode: bool = True
+
     @staticmethod
     def _compute_fp8_decode_padded_heads(num_heads: int) -> int:
         # FP8 decode kernel only supports h_q = 64 or 128
@@ -581,6 +588,9 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         self.fp8_decode_padded_heads = self._compute_fp8_decode_padded_heads(num_heads)
 
         vllm_config = get_current_vllm_config()
+        self.cp_interleave = (
+            vllm_config.parallel_config.cp_kv_cache_interleave_size
+        )
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         q_concat_shape = (max_tokens, num_heads, head_size)
         if is_quantized_kv_cache(kv_cache_dtype):
@@ -613,7 +623,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         # Convert per-request indices to global slots (decode) or workspace
         # offsets (prefill).
         topk_indices, topk_length = triton_convert_req_index_to_global_index(
@@ -623,7 +633,19 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             BLOCK_SIZE=attn_metadata.block_size,
             NUM_TOPK_TOKENS=topk_indices.shape[1],
             return_valid_counts=True,
+            cp_rank=self.dcp_rank,
+            cp_size=self.dcp_world_size,
+            cp_interleave=self.cp_interleave,
         )
+
+        # Under DCP, triton_convert_req_index_to_global_index marks non-local
+        # slots as -1 scattered across the topk row. flash_mla_sparse_fwd's
+        # topk_length reads the FIRST N indices contiguously, so scattered -1s
+        # in the front would cause OOB reads. Pass topk_length=None so the
+        # kernel consumes all indices and skips -1 itself (the kernel treats
+        # -1 as an invalid index).
+        if self.dcp_world_size > 1:
+            topk_length = None
 
         return self._bf16_flash_mla_kernel(
             q,
@@ -667,6 +689,9 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             prefill_workspace_request_ids=prefill_request_ids,
             prefill_workspace_starts=prefill_workspace_starts,
             return_valid_counts=True,
+            cp_rank=self.dcp_rank,
+            cp_size=self.dcp_world_size,
+            cp_interleave=self.cp_interleave,
         )
 
         fp8_metadata = attn_metadata.fp8_extra_metadata
@@ -761,6 +786,9 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             topk_indices,
             BLOCK_SIZE=attn_metadata.block_size,
             NUM_TOPK_TOKENS=topk_indices.shape[1],
+            cp_rank=self.dcp_rank,
+            cp_size=self.dcp_world_size,
+            cp_interleave=self.cp_interleave,
         )
 
         assert attn_metadata.fp8_extra_metadata is not None
@@ -824,35 +852,40 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         topk_length: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         num_tokens = q.shape[0]
         kv_c_and_k_pe_cache = kv_c_and_k_pe_cache.view(
             -1, 1, kv_c_and_k_pe_cache.shape[-1]
         )
 
         # NOTE(Chen): kernel requires num_local_head to be a multiple of
-        # 64 on hopper and 128 on blackwell
-        if self.num_heads % self.prefill_padding != 0:
-            assert self.prefill_padding % self.num_heads == 0
+        # 64 on hopper and 128 on blackwell. Use q's actual head count
+        # (num_heads * dcp_world_size under DCP, after the public path's
+        # head-dim all-gather) rather than self.num_heads, which is only the
+        # per-rank (pre-all-gather) count.
+        num_heads_q = q.shape[1]
+        if num_heads_q % self.prefill_padding != 0:
+            assert self.prefill_padding % num_heads_q == 0
             logger.warning_once(
-                f"Padding num_heads from {self.num_heads} to "
+                f"Padding num_heads from {num_heads_q} to "
                 f"{self.prefill_padding} for BF16 sparse prefill kernel"
             )
             q_padded = q.new_empty((q.shape[0], self.prefill_padding, q.shape[2]))
-            q_padded[:, : self.num_heads, :] = q
+            q_padded[:, :num_heads_q, :] = q
             q = q_padded
 
         topk_indices = topk_indices.view(num_tokens, 1, -1)
-        output = flash_mla_sparse_fwd(
+        output, _, lse = flash_mla_sparse_fwd(
             q,
             kv_c_and_k_pe_cache,
             topk_indices,
             self.softmax_scale,
             topk_length=topk_length,
-        )[0]
+        )
 
-        output = output[:, : self.num_heads, :]
-        return output
+        output = output[:, :num_heads_q, :]
+        lse = lse[:, :num_heads_q]
+        return output, lse
 
     def forward_mqa(
         self,
@@ -878,8 +911,12 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
 
         use_fp8_cache = self.kv_cache_dtype == "fp8_ds_mla"
 
+        # DCP is bf16-only (the public MLA DCP path asserts not fp8_attention),
+        # so only the bf16 path returns the per-rank decode LSE for the DCP
+        # merge. The fp8 paths return None and are never exercised under DCP.
+        lse: torch.Tensor | None = None
         if not use_fp8_cache:
-            attn_out = self._forward_bf16_kv(
+            attn_out, lse = self._forward_bf16_kv(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
         elif attn_metadata.fp8_use_mixed_batch:
@@ -891,4 +928,4 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
 
-        return attn_out, None
+        return attn_out, lse

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -674,7 +674,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         fp8_metadata = attn_metadata.fp8_extra_metadata
         assert isinstance(fp8_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode)
         num_decodes = fp8_metadata.num_decodes
@@ -714,7 +714,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         def _fp8_decode(
             q: torch.Tensor,
             topk_indices: torch.Tensor,
-        ) -> torch.Tensor:
+        ) -> tuple[torch.Tensor, torch.Tensor]:
             # Reshape q: (num_decode_tokens, num_heads, head_dim)
             #         -> (num_decodes, seq_len, num_heads, head_dim)
             q = reshape_query_for_spec_decode(q, num_decodes)
@@ -723,7 +723,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             #                    -> (num_decodes, seq_len, topk)
             topk_indices = topk_indices.view(num_decodes, seq_len, -1)
             assert fp8_metadata.decode is not None
-            attn_out, _ = self._fp8_flash_mla_kernel(
+            attn_out, lse = self._fp8_flash_mla_kernel(
                 q=q,
                 kv_c_and_k_pe_cache=kv_c_and_k_pe_cache,
                 topk_indices=topk_indices,
@@ -731,15 +731,17 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             )
             # Reshape output: (num_decodes, seq_len, num_heads, head_dim_v)
             #              -> (num_decode_tokens, num_heads, head_dim_v)
-            return reshape_attn_output_for_spec_decode(attn_out)
+            return reshape_attn_output_for_spec_decode(attn_out), lse
 
         num_decode_tokens = fp8_metadata.num_decode_tokens
         num_prefill_tokens = fp8_metadata.num_prefill_tokens
 
-        # Pure decode: direct call without allocation
+        # Pure decode: direct call without allocation. Return the per-rank
+        # decode LSE for the DCP merge (same shape contract as the bf16 path).
         if num_decode_tokens > 0 and num_prefill_tokens == 0:
             assert fp8_metadata.decode is not None
-            attn_out = _fp8_decode(q, topk_indices)
+            attn_out, lse = _fp8_decode(q, topk_indices)
+            return attn_out, lse
         else:
             # Mixed or pure prefill: allocate output tensor
             attn_out = q.new_empty(
@@ -749,10 +751,11 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             )
 
             if num_decode_tokens > 0:
-                attn_out[:num_decode_tokens] = _fp8_decode(
+                decode_out, _decode_lse = _fp8_decode(
                     q[:num_decode_tokens],
                     topk_indices[:num_decode_tokens],
                 )
+                attn_out[:num_decode_tokens] = decode_out
 
             assert fp8_metadata.prefill is not None
             for chunk in fp8_metadata.prefill.chunks:
@@ -770,14 +773,16 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
                 chunk_topk_indices_workspace = topk_indices[chunk.tokens_slice]
                 chunk_topk_length = topk_length[chunk.tokens_slice]
 
-                attn_out[chunk.tokens_slice] = self._bf16_flash_mla_kernel(
+                attn_out[chunk.tokens_slice], _ = self._bf16_flash_mla_kernel(
                     chunk_q,
                     chunk_workspace,
                     chunk_topk_indices_workspace,
                     chunk_topk_length,
                 )
 
-        return attn_out
+        # Mixed/prefill path: DCP prefill is handled via the bf16 workspace
+        # path elsewhere, so no decode LSE here.
+        return attn_out, None
 
     def _forward_fp8_kv_mixed_batch(
         self,
@@ -785,7 +790,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Mixed batch FP8 forward path that treats all tokens as one batch.
 
         This is equivalent to main branch's approach and avoids the BF16
@@ -811,15 +816,16 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         )
         fp8_metadata = attn_metadata.fp8_extra_metadata
 
-        _attn_out, _ = self._fp8_flash_mla_kernel(
+        _attn_out, lse = self._fp8_flash_mla_kernel(
             q=q.unsqueeze(0),  # unsqueeze to add batch_dim: (T, H, D) -> (1, T, H, D)
             kv_c_and_k_pe_cache=kv_c_and_k_pe_cache,
             topk_indices=topk_indices.unsqueeze(0),  # (T, topk) -> (1, T, topk)
             kernel_metadata=fp8_metadata,
         )
 
-        # Output is (1, T, H, D_v), squeeze back to (T, H, D_v)
-        return _attn_out.squeeze(0)
+        # Output is (1, T, H, D_v), squeeze back to (T, H, D_v). LSE is
+        # (1, T, H) — squeeze the batch dim to (T, H) for the DCP merge.
+        return _attn_out.squeeze(0), lse.squeeze(0) if lse is not None else None
 
     def _fp8_flash_mla_kernel(
         self,
@@ -925,20 +931,25 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
 
         use_fp8_cache = self.kv_cache_dtype == "fp8_ds_mla"
 
-        # DCP is bf16-only (the public MLA DCP path asserts not fp8_attention),
-        # so only the bf16 path returns the per-rank decode LSE for the DCP
-        # merge. The fp8 paths return None and are never exercised under DCP.
+        # Both bf16 and fp8 paths return the per-rank decode LSE for the DCP
+        # merge. Sparse fp8 differs from dense fp8: the Q stays bf16
+        # (supports_quant_query_input=False, so the public path does not
+        # quantize Q per-rank before the head-dim all-gather), and the fp8 KV
+        # scale is handled inside flash_mla_with_kvcache(is_fp8_kvcache=True)
+        # rather than via an external _k_scale — so there is no cross-rank
+        # scale-consistency issue. The public MLA DCP assert (not fp8_attention)
+        # is relaxed for sparse below.
         lse: torch.Tensor | None = None
         if not use_fp8_cache:
             attn_out, lse = self._forward_bf16_kv(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
         elif attn_metadata.fp8_use_mixed_batch:
-            attn_out = self._forward_fp8_kv_mixed_batch(
+            attn_out, lse = self._forward_fp8_kv_mixed_batch(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
         else:
-            attn_out = self._forward_fp8_kv_separate_prefill_decode(
+            attn_out, lse = self._forward_fp8_kv_separate_prefill_decode(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
 

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -875,9 +875,12 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             softmax_scale=self.softmax_scale,
         )
 
-        # Slice output back to actual head count if we padded
+        # Slice output and LSE back to the actual head count. LSE must match
+        # attn_out's head count: the separate prefill/decode path reshapes LSE
+        # with the actual count, and a padded LSE would misalign there.
         if actual_num_heads < padded_num_heads:
             out = out[:, :, :actual_num_heads, :]
+            lse = lse[:, :actual_num_heads, :]
 
         return out, lse
 

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -729,9 +729,20 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
                 topk_indices=topk_indices,
                 kernel_metadata=fp8_metadata.decode.kernel_metadata,
             )
+            num_heads = q.shape[2]
             # Reshape output: (num_decodes, seq_len, num_heads, head_dim_v)
             #              -> (num_decode_tokens, num_heads, head_dim_v)
-            return reshape_attn_output_for_spec_decode(attn_out), lse
+            attn_out = reshape_attn_output_for_spec_decode(attn_out)
+            # Reshape lse: (num_decodes, num_heads, seq_len)
+            #           -> (num_decode_tokens, num_heads)  [decode-major layout,
+            # matching attn_out's reshape_attn_output_for_spec_decode ordering,
+            # which the DCP LSE reducer expects as [tokens, heads].]
+            lse = (
+                lse.permute(0, 2, 1)
+                .reshape(num_decodes * seq_len, num_heads)
+                .contiguous()
+            )
+            return attn_out, lse
 
         num_decode_tokens = fp8_metadata.num_decode_tokens
         num_prefill_tokens = fp8_metadata.num_prefill_tokens
@@ -823,9 +834,13 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             kernel_metadata=fp8_metadata,
         )
 
-        # Output is (1, T, H, D_v), squeeze back to (T, H, D_v). LSE is
-        # (1, T, H) — squeeze the batch dim to (T, H) for the DCP merge.
-        return _attn_out.squeeze(0), lse.squeeze(0) if lse is not None else None
+        # Output is (1, T, H, D_v), squeeze back to (T, H, D_v). The kernel
+        # returns LSE as (1, H, T) [batch, heads, seq]; permute to (1, T, H)
+        # then squeeze to (T, H) — the [tokens, heads] layout the DCP LSE
+        # reducer expects (matching the bf16 path).
+        if lse is not None:
+            lse = lse.permute(0, 2, 1).squeeze(0).contiguous()
+        return _attn_out.squeeze(0), lse
 
     def _fp8_flash_mla_kernel(
         self,

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -588,9 +588,23 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         self.fp8_decode_padded_heads = self._compute_fp8_decode_padded_heads(num_heads)
 
         vllm_config = get_current_vllm_config()
-        self.cp_interleave = (
-            vllm_config.parallel_config.cp_kv_cache_interleave_size
-        )
+        self.cp_interleave = vllm_config.parallel_config.cp_kv_cache_interleave_size
+        # Sparse MLA DCP shards the indexer's top-k selection across DCP ranks
+        # and assumes token-interleaved KV layout (CP_INTERLEAVE == 1: rank r
+        # owns global positions {r, r+N, ...}). The local->global remap in the
+        # distributed top-k merge and the per-rank seq_lens formula are only
+        # correct under that layout. Fail closed rather than silently producing
+        # a wrong global top-k; the slot conversion itself is general (mirrors
+        # block_table.py) but the indexer merge is not.
+        if self.dcp_world_size > 1 and self.cp_interleave != 1:
+            raise ValueError(
+                "Sparse MLA with Decode Context Parallelism currently "
+                "requires cp_kv_cache_interleave_size == 1, but got "
+                f"{self.cp_interleave}. The distributed top-k merge and "
+                "per-rank seq_lens assume token-interleaved KV sharding. "
+                "Set --cp-kv-cache-interleave-size 1 (the default) or "
+                "disable DCP."
+            )
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         q_concat_shape = (max_tokens, num_heads, head_size)
         if is_quantized_kv_cache(kv_cache_dtype):

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -248,8 +248,21 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
 
         # Classify single-token queries (plus num_speculative_tokens via
         # supports_spec_as_decode=True) as decodes; longer queries go to
-        # prefill.
-        self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
+        # prefill. Under DCP the fp8 mixed-batch kernel metadata is shape-only
+        # (causality comes from the indexer's top-k indices, which the indexer
+        # builder localizes per token), so multi-token (spec-decode) decode rows
+        # need no extra handling here. Declare supports_dcp_with_varlen (gated on
+        # interleave == 1, mirroring FlashAttn MLA) so reorder_batch_threshold is
+        # not forced back to 1 under DCP -- otherwise MTP verify rows (q_len>1)
+        # get classified as prefills and break the full-cudagraph decode capture
+        # (silent corruption, issue #45425).
+        self._init_reorder_batch_threshold(
+            1,
+            supports_spec_as_decode=True,
+            supports_dcp_with_varlen=(
+                parallel_config.cp_kv_cache_interleave_size == 1
+            ),
+        )
 
         sm_count = num_compute_units(device.index)
 

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -530,8 +530,17 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             # produces the same chunk boundaries for the 4b all_gather merge.
             if common_attn_metadata.dcp_local_seq_lens is not None:
                 local_seq_lens = common_attn_metadata.dcp_local_seq_lens
-                assert common_attn_metadata.dcp_local_seq_lens_cpu is not None
-                local_seq_lens_cpu = common_attn_metadata.dcp_local_seq_lens_cpu
+                # dcp_local_seq_lens_cpu is populated by the main model runner,
+                # but the MTP draft proposer (build_for_drafting path) currently
+                # only forwards the device tensor. Fall back to a D2H copy in
+                # that case so prefill chunking (which needs CPU seq lens to
+                # avoid a sync in the chunk loop) still works.
+                if common_attn_metadata.dcp_local_seq_lens_cpu is not None:
+                    local_seq_lens_cpu = (
+                        common_attn_metadata.dcp_local_seq_lens_cpu
+                    )
+                else:
+                    local_seq_lens_cpu = local_seq_lens.cpu()
                 global_seq_lens = seq_lens
                 assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
                 global_seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -6,6 +6,7 @@ import torch
 
 import vllm.envs as envs
 from vllm.config import VllmConfig
+from vllm.distributed.parallel_state import get_dcp_group
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
@@ -214,6 +215,11 @@ class DeepseekV32IndexerMetadata:
 
     decode: DeepSeekV32IndexerDecodeMetadata | None = None
     prefill: DeepseekV32IndexerPrefillMetadata | None = None
+    # DCP (Decode Context Parallelism). Populated only when DCP is active;
+    # the indexer op uses these to merge per-rank local top-k into a global
+    # top-k (see sparse_attn_indexer).
+    dcp_world_size: int = 1
+    cp_rank: int = 0
 
 
 def get_max_prefill_buffer_size(vllm_config: VllmConfig):
@@ -494,7 +500,6 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         assert num_decode_tokens + num_prefill_tokens == num_tokens
 
         compressed_slot_mapping = slot_mapping
-        compressed_seq_lens = seq_lens
         if self.compress_ratio > 1:
             compressed_slot_mapping = get_compressed_slot_mapping(
                 num_tokens,
@@ -505,30 +510,54 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 self.compress_ratio,
                 out=self.compressed_slot_mapping_buffer,
             )
-            compressed_seq_lens = seq_lens // self.compress_ratio
 
         prefill_metadata = None
+        # DCP group info (only when DCP is active, guarded by dcp_local_seq_lens
+        # being set; get_dcp_group() asserts the group is initialized). Hoisted
+        # before the prefill branch so the prefill path can use it too.
+        dcp_world_size = 1
+        cp_rank = 0
+        if common_attn_metadata.dcp_local_seq_lens is not None:
+            dcp_group = get_dcp_group()
+            dcp_world_size = dcp_group.world_size
+            cp_rank = dcp_group.rank_in_group
         if num_prefills > 0:
-            # This CPU value is an upper bound for async-spec extend rows.  It
-            # is safe for chunking/allocation because CUDA metadata below is
-            # built from exact device seq_lens and gather ignores the tail.
-            assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
-            seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
-            compressed_seq_lens_cpu = (
-                seq_lens_cpu // self.compress_ratio
-                if self.compress_ratio > 1
-                else seq_lens_cpu
-            )
+            # Under DCP each rank holds only its 1/N shard of the KV. The
+            # prefill kernel needs BOTH: GLOBAL seq lens (so `start_pos` =
+            # global context → the per-token attended count maps correctly to
+            # the rank's shard) and LOCAL seq lens (workspace/cu_seq_lens hold
+            # only this rank's shard). Chunking uses GLOBAL so every rank
+            # produces the same chunk boundaries for the 4b all_gather merge.
+            if common_attn_metadata.dcp_local_seq_lens is not None:
+                local_seq_lens = common_attn_metadata.dcp_local_seq_lens
+                assert common_attn_metadata.dcp_local_seq_lens_cpu is not None
+                local_seq_lens_cpu = common_attn_metadata.dcp_local_seq_lens_cpu
+                global_seq_lens = seq_lens
+                assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
+                global_seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+            else:
+                local_seq_lens = seq_lens
+                assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
+                local_seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+                global_seq_lens = seq_lens
+                global_seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+            compressed_local_seq_lens = local_seq_lens
+            compressed_local_seq_lens_cpu = local_seq_lens_cpu
+            compressed_global_seq_lens_cpu = global_seq_lens_cpu
+            if self.compress_ratio > 1:
+                compressed_local_seq_lens = local_seq_lens // self.compress_ratio
+                compressed_local_seq_lens_cpu = (
+                    local_seq_lens_cpu // self.compress_ratio
+                )
+                compressed_global_seq_lens_cpu = (
+                    global_seq_lens_cpu // self.compress_ratio
+                )
             prefill_query_lens_cpu = torch.diff(
                 query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
             )
             max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
-            # Upper bound is exact for prefill rows (the `[num_decodes:]`
-            # slice below).
-            assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
-            seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
             chunk_specs = split_indexer_prefill_chunks(
-                compressed_seq_lens_cpu[num_decodes:],
+                compressed_global_seq_lens_cpu[num_decodes:],
                 prefill_query_lens_cpu,
                 self.max_prefill_buffer_size,
                 max_logits_bytes,
@@ -542,13 +571,15 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     req_slice.stop,
                     query_start_loc,
                     query_start_loc_cpu,
-                    seq_lens,
-                    compressed_seq_lens,
-                    compressed_seq_lens_cpu,
+                    global_seq_lens,
+                    compressed_local_seq_lens,
+                    compressed_local_seq_lens_cpu,
                     common_attn_metadata.block_table_tensor,
                     self.compress_ratio,
                     query_slice=query_slice,
                     skip_kv_gather=query_slice.start > 0,
+                    dcp_world_size=dcp_world_size,
+                    cp_rank=cp_rank,
                 )
                 # Skip when total_seq_lens is 0 (i.e., no compressed token).
                 if metadata is not None:
@@ -566,7 +597,26 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 common_attn_metadata.query_start_loc_cpu[: num_decodes + 1]
             )
 
-            seq_lens = common_attn_metadata.seq_lens[:num_decodes]
+            # Under DCP each rank holds only its 1/N shard of the KV. The paged
+            # logits kernel + topk must operate on this rank's local tokens;
+            # sparse_attn_indexer then merges the per-rank local top-k into a
+            # global top-k.
+            dcp_active = common_attn_metadata.dcp_local_seq_lens is not None
+            if dcp_active:
+                # MTP (next_n>1): _prepare_decode_tensors computes per-candidate
+                # context as L - next_n + j + 1 by linear subtraction from
+                # seq_lens. The correct LOCAL count is ceildiv((L - next_n + j +
+                # 1), N), NOT (L/N - next_n + j + 1). So pass GLOBAL seq_lens
+                # there, then ceil-div the 2D result to local below.
+                # next_n==1: keep the pre-sharded dcp_local_seq_lens (already
+                # correct for the non-MTP case).
+                next_n_pre = 1 + self.num_speculative_tokens
+                if next_n_pre > 1:
+                    seq_lens = common_attn_metadata.seq_lens[:num_decodes]
+                else:
+                    seq_lens = common_attn_metadata.dcp_local_seq_lens[:num_decodes]
+            else:
+                seq_lens = common_attn_metadata.seq_lens[:num_decodes]
             block_table = common_attn_metadata.block_table_tensor[:num_decodes, ...]
 
             max_decode_len = int(decode_lens_cpu.max().item())
@@ -587,6 +637,28 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     max_decode_len=max_decode_len,
                 )
             )
+
+            # DCP + MTP: seq_lens is now 2D (B, next_n) of GLOBAL per-candidate
+            # context lengths (L - next_n + j + 1). Ceil-div to this rank's
+            # local count: ceildiv(global, N) = (global + N - 1) // N. The paged
+            # logits kernel then reads only this rank's shard with the right
+            # per-candidate length. (CP_INTERLEAVE=1; ceil-div matches the
+            # strided ownership rank r = {r, r+N, ...}.)
+            if dcp_active and next_n > 1:
+                dcp_ws = get_dcp_group().world_size
+                # seq_lens is per-candidate GLOBAL context lengths (L - next_n
+                # + j + 1), either 1D (flatten path on SM90, next_n>2) or 2D
+                # (native path). Ceil-div to this rank's local count IN PLACE,
+                # preserving shape so deepgemm's paged logits assert
+                # (context_lens.shape == q.shape[:2]) holds. (1D will be
+                # unsqueezed to (B,1) below, matching q's (B,1) flatten layout.)
+                orig_shape = seq_lens.shape
+                n = seq_lens.numel()
+                flat = seq_lens.reshape(-1)[:n]
+                self.decode_seq_lens_buffer[:n] = (
+                    flat + dcp_ws - 1
+                ) // dcp_ws
+                seq_lens = self.decode_seq_lens_buffer[:n].view(orig_shape)
 
             # For DeepseekV4 (compress_ratio > 1), the indexer KV cache stores
             # compressed tokens. Convert uncompressed seq_lens to compressed.
@@ -638,6 +710,8 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             num_prefill_tokens=num_prefill_tokens,
             prefill=prefill_metadata,
             decode=decode_metadata,
+            dcp_world_size=dcp_world_size,
+            cp_rank=cp_rank,
         )
 
         return attn_metadata
@@ -655,6 +729,8 @@ def build_prefill_chunk_metadata(
     compress_ratio: int,
     query_slice: slice | None = None,
     skip_kv_gather: bool = False,
+    dcp_world_size: int = 1,
+    cp_rank: int = 0,
 ) -> DeepseekV32IndexerPrefillChunkMetadata | None:
     total_seq_lens = compressed_seq_lens_cpu[start_idx:end_idx].sum().item()
     if total_seq_lens == 0:
@@ -696,8 +772,10 @@ def build_prefill_chunk_metadata(
         cu_seq_len_ke,
         qs_start,
         qs_stop,
+        cp_rank,
         BLOCK_SIZE=1024,
         COMPRESS_RATIO=compress_ratio,
+        DCP_WORLD_SIZE=dcp_world_size,
     )
 
     token_start = query_start_loc_cpu[start_idx].item()
@@ -734,8 +812,10 @@ def _build_prefill_chunk_metadata_kernel(
     cu_compressed_seq_len_ke_ptr,
     query_slice_start,
     query_slice_stop,
+    cp_rank,
     BLOCK_SIZE: tl.constexpr,
     COMPRESS_RATIO: tl.constexpr,
+    DCP_WORLD_SIZE: tl.constexpr,
 ):
     batch_idx = tl.program_id(0)
 
@@ -747,6 +827,8 @@ def _build_prefill_chunk_metadata_kernel(
     seq_end = tl.load(cu_compressed_seq_lens_ptr + batch_idx + 1)
     compressed_seq_len = seq_end - seq_start
 
+    # uncompressed_seq_len is GLOBAL; start_pos = global context before this
+    # prefill, so P = start_pos + offset is the query token's GLOBAL position.
     uncompressed_seq_len = tl.load(uncompressed_seq_lens_ptr + batch_idx)
     start_pos = uncompressed_seq_len - query_len
 
@@ -763,8 +845,19 @@ def _build_prefill_chunk_metadata_kernel(
         # Compute cu_seq_len_ks
         tl.store(cu_compressed_seq_len_ks_ptr + out_pos, seq_start, mask=mask)
 
-        # Compute cu_seq_len_ke
-        seq_len_per_token = (start_pos + 1 + offset) // COMPRESS_RATIO
+        # Compute cu_seq_len_ke. Under DCP (N>1) this rank owns global positions
+        # {r, r+N, ...}; the count it owns in [0, P+1) is ceildiv(P+1-r, N) =
+        # (P + N - r) // N (gives 0 when P < r). cu_seq_lens/workspace already
+        # use the LOCAL compressed length, so this stays within the gathered
+        # shard. N==1 reduces to the original (P+1)//COMPRESS_RATIO.
+        P = start_pos + offset
+        if DCP_WORLD_SIZE == 1:
+            seq_len_per_token = (P + 1) // COMPRESS_RATIO
+        else:
+            local_uncompressed_ke = (P + DCP_WORLD_SIZE - cp_rank) // (
+                DCP_WORLD_SIZE
+            )
+            seq_len_per_token = local_uncompressed_ke // COMPRESS_RATIO
         tl.store(
             cu_compressed_seq_len_ke_ptr + out_pos,
             seq_start + seq_len_per_token,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -648,25 +648,35 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             )
 
             # DCP + MTP: seq_lens is now 2D (B, next_n) of GLOBAL per-candidate
-            # context lengths (L - next_n + j + 1). Ceil-div to this rank's
-            # local count: ceildiv(global, N) = (global + N - 1) // N. The paged
-            # logits kernel then reads only this rank's shard with the right
-            # per-candidate length. (CP_INTERLEAVE=1; ceil-div matches the
-            # strided ownership rank r = {r, r+N, ...}.)
+            # context lengths (L - next_n + j + 1). Convert to this rank's
+            # LOCAL shard count. The paged logits kernel then reads only this
+            # rank's shard with the right per-candidate length.
+            # (CP_INTERLEAVE=1; rank r owns global positions {r, r+N, ...}.)
             if dcp_active and next_n > 1:
-                dcp_ws = get_dcp_group().world_size
+                dcp_group = get_dcp_group()
+                dcp_ws = dcp_group.world_size
+                cp_rank = dcp_group.rank_in_group
                 # seq_lens is per-candidate GLOBAL context lengths (L - next_n
                 # + j + 1), either 1D (flatten path on SM90, next_n>2) or 2D
-                # (native path). Ceil-div to this rank's local count IN PLACE,
+                # (native path). Convert to this rank's LOCAL count IN PLACE,
                 # preserving shape so deepgemm's paged logits assert
                 # (context_lens.shape == q.shape[:2]) holds. (1D will be
                 # unsqueezed to (B,1) below, matching q's (B,1) flatten layout.)
+                #
+                # Correct per-rank shard count (CP_INTERLEAVE=1, rank r owns
+                # global positions {r, r+N, ...}): local = L//N + (r < L%N).
+                # This matches get_dcp_local_seq_lens (utils.py). A bare
+                # ceildiv (L+N-1)//N would over-count by 1 for every rank
+                # r >= L%N, making the paged logits kernel read one stale/OOB
+                # KV slot per candidate per step — harmless at short context
+                # but accumulates under MTP (next_n>1) verify until output
+                # degrades (repetition) a few hundred tokens in.
                 orig_shape = seq_lens.shape
                 n = seq_lens.numel()
-                flat = seq_lens.reshape(-1)[:n]
-                self.decode_seq_lens_buffer[:n] = (
-                    flat + dcp_ws - 1
-                ) // dcp_ws
+                flat = seq_lens.reshape(-1)[:n].to(torch.int32)
+                base = flat // dcp_ws
+                local = base + (cp_rank < (flat - base * dcp_ws)).to(torch.int32)
+                self.decode_seq_lens_buffer[:n] = local
                 seq_lens = self.decode_seq_lens_buffer[:n].view(orig_shape)
 
             # For DeepseekV4 (compress_ratio > 1), the indexer KV cache stores

--- a/vllm/v1/attention/backends/mla/sparse_utils.py
+++ b/vllm/v1/attention/backends/mla/sparse_utils.py
@@ -30,6 +30,10 @@ def _convert_req_index_to_global_index_kernel(
     ti_stride1,
     out_stride0,
     out_stride1,
+    # DCP (Decode Context Parallelism)
+    cp_rank,
+    CP_SIZE: tl.constexpr,
+    CP_INTERLEAVE: tl.constexpr,
 ):
     # program_id(0) -> token_id (row)
     # program_id(1) -> tile index along columns
@@ -52,16 +56,33 @@ def _convert_req_index_to_global_index_kernel(
     if HAS_PREFILL:
         prefill_req_id = tl.load(prefill_request_id_ptr + token_id)
         is_prefill = prefill_req_id >= 0
-    # Compute block id and in-block offset
-    block_id = tok // BLOCK_SIZE
-    inblock_off = tok % BLOCK_SIZE
-
-    # Guard block_table access
-    valid_block = (block_id < max_num_blocks_per_req) & (block_id >= 0)
-    bt_ptr = block_table_ptr + req * bt_stride0 + block_id * bt_stride1
-    is_invalid_tok |= ~valid_block
-    base = tl.load(bt_ptr, mask=valid_block & ~is_prefill, other=0)
-    out_val = base * BLOCK_SIZE + inblock_off
+    # Compute block id and in-block offset. Under DCP (CP_SIZE > 1) the
+    # physical block (BLOCK_SIZE tokens, per-rank) is one shard of an
+    # amplified block (BLOCK_SIZE * CP_SIZE global positions) split across
+    # CP_SIZE ranks by CP_INTERLEAVE. Mirrors gpu/block_table.py:283-299.
+    if CP_SIZE == 1:
+        block_id = tok // BLOCK_SIZE
+        block_off = tok % BLOCK_SIZE
+        valid_block = (block_id < max_num_blocks_per_req) & (block_id >= 0)
+        bt_ptr = block_table_ptr + req * bt_stride0 + block_id * bt_stride1
+        is_invalid_tok |= ~valid_block
+        base = tl.load(bt_ptr, mask=valid_block & ~is_prefill, other=0)
+        out_val = base * BLOCK_SIZE + block_off
+    else:
+        amp_block = BLOCK_SIZE * CP_SIZE
+        block_id = tok // amp_block
+        block_off = tok % amp_block
+        valid_block = (block_id < max_num_blocks_per_req) & (block_id >= 0)
+        bt_ptr = block_table_ptr + req * bt_stride0 + block_id * bt_stride1
+        is_invalid_tok |= ~valid_block
+        base = tl.load(bt_ptr, mask=valid_block & ~is_prefill, other=0)
+        is_local = block_off // CP_INTERLEAVE % CP_SIZE == cp_rank
+        rounds = block_off // (CP_INTERLEAVE * CP_SIZE)
+        remainder = block_off % CP_INTERLEAVE
+        local_offset = rounds * CP_INTERLEAVE + remainder
+        out_val = base * BLOCK_SIZE + local_offset
+        # Positions owned by another DCP rank are not in this rank's cache.
+        is_invalid_tok |= ~is_local
 
     # Override with prefill output if prefill is enabled
     if HAS_PREFILL:
@@ -93,6 +114,9 @@ def triton_convert_req_index_to_global_index(
     prefill_workspace_request_ids: torch.Tensor | None = None,
     prefill_workspace_starts: torch.Tensor | None = None,
     return_valid_counts: bool = False,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+    cp_interleave: int = 1,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """
     out[token_id, indice_id] =
@@ -183,6 +207,10 @@ def triton_convert_req_index_to_global_index(
         ti_stride1,
         out_stride0,
         out_stride1,
+        # DCP
+        cp_rank,
+        cp_size,
+        cp_interleave,
     )
 
     if return_valid_counts:

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1066,6 +1066,7 @@ class SpecDecodeBaseProposer:
             slot_mapping=common_attn_metadata.slot_mapping[:total_num_tokens],
             causal=True,
             dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
+            dcp_local_seq_lens_cpu=common_attn_metadata.dcp_local_seq_lens_cpu,
         )
 
         return (
@@ -1177,6 +1178,7 @@ class SpecDecodeBaseProposer:
             slot_mapping=common_attn_metadata.slot_mapping[token_indices],
             causal=True,
             dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
+            dcp_local_seq_lens_cpu=common_attn_metadata.dcp_local_seq_lens_cpu,
         )
 
         return spec_common_attn_metadata, token_indices


### PR DESCRIPTION
# [DCP] Enable Decode Context Parallelism for sparse MLA (bf16 + fp8 KV)

> **Status (2026-06-23):** converging into #45426. @drakosha has unified the union/exact top-k behind `--dcp-sparse-indexer-mode` there; this PR's pieces (exact merge, a2a validation, fp8 KV) will fold in once it builds and the A/B checks out. Heading toward being folded, not grown.

## Why

Sparse MLA models (e.g. GLM-5.2 with DeepSeek Sparse Attention) use `num_kv_heads=1`, so under TP every rank holds a **full duplicate** of the latent KV cache — a `tp_size`× memory redundancy that caps servable context length. DCP converts this duplication into sequence sharding: each DCP rank stores only `1/dcp_size` of the KV, multiplying context capacity by ~`dcp_size` at no extra GPU cost. The dense MLA DCP path already exists; this PR adds it to `FlashMLASparseBackend`, and also enables fp8 KV under DCP (which the dense path does not support — sparse Q stays bf16 so there's no per-rank scale conflict).

## What

The dense MLA DCP path (Q head-dim all-gather → local-segment attention → LSE logsumexp merge → head reduce-scatter) is **reused as-is**. Sparse only adds:

1. **Return the per-rank decode LSE** so the public path can merge partial softmaxes over disjoint KV shards.
2. **Produce a global top-k across the sharded KV** — the correctness piece, since the DSA indexer has no dense analog.

Under DCP each rank holds `1/N` of the KV (interleaved, `cp_kv_cache_interleave_size=1`). Each rank picks a local top-K, remaps to global (`global_pos = cp_rank + local_idx * dcp_world_size`), `all_gather`s the `(global_pos, score)` candidates, and takes a global top-K. This is exact — any global top-K token is necessarily in its own shard's local top-K.

## Changes

| File | Change |
|---|---|
| `flashmla_sparse.py` | `can_return_lse_for_decode=True`; plumb LSE through bf16/fp8 kernels and `forward_mqa`; fix head-padding to q's actual head count; `topk_length=None` under DCP. |
| `sparse_utils.py` | DCP-aware top-k index → physical slot conversion, mirroring `gpu/block_table.py` slot mapping. |
| `indexer.py` | DCP-aware prefill chunk metadata (global vs local seq_lens, ceil-div `cu_seq_len_ke`) and decode seq_lens; thread `dcp_world_size`/`cp_rank`. |
| `sparse_attn_indexer.py` | Distributed top-k merge for prefill and decode. |
| `flashmla_sparse.py` + `mla_attention.py` (fp8) | Enable fp8 KV under DCP: plumb the fp8 kernel's LSE; relax `assert not fp8_attention` to `not fp8_attention or is_sparse_impl`. |
| `flashmla_sparse.py` (follow-ups) | Fail-closed `ValueError` if DCP + interleave != 1; declare `supports_dcp_with_varlen` (#45425, follows #45426); slice fp8 decode LSE to actual head count. |
| `sparse_attn_indexer.py` (follow-up) | Deterministic int64 total-order key for the merge — removes nondeterministic `torch.topk` tie-breaks across ranks. |
| `docs/design/attention_backends.md` | Regenerated by pre-commit hook: `FLASHMLA_SPARSE` DCP column ❌→✅. |

All changes are **gated on `dcp_world_size > 1`**; with DCP disabled every path is byte-for-byte equivalent to pre-PR.

## Verification

8× H200 SXM (NVSwitch), `zai-org/GLM-5.2-FP8`, CUDAGraph + chunked prefill.

**KV cache capacity:**

| DCP | KV cache tokens | vs DCP=1 | Concurrent 128K reqs |
|---|---|---|---|
| 1 | 346,880 | 1.0× | 2 |
| 2 | 678,784 | 1.96× | 5 |
| 4 | 1,657,344 | 4.78× | 12 |
| 8 | 2,543,616 | 7.33× | 19 |

**Decode throughput (32K prompt → 4K decode, TP8+MTP5+CUDAGraph, bs=1, p50 of 3):**

| DCP | backend | p50 latency | decode tok/s | vs DCP=1 |
|---|---|---|---|---|
| 1 | — | 43.2s | 94.9 | 1.00× |
| 2 | ag_rs | 37.5s | 109.2 | **1.15×** |
| 4 | ag_rs | 54.3s | 75.4 | 0.79× |
| 4 | a2a | 48.2s | 85.1 | 0.90× |
| 8 | ag_rs | 57.2s | 71.6 | 0.75× |
| 8 | a2a | 62.7s | 65.3 | 0.69× |

DCP=2 is a decode sweet spot (+15%); DCP=4/8 trade speed for capacity. a2a vs ag_rs is non-monotonic (a2a wins at DCP=4, loses at DCP=8). Both backends verified correct on DCP=4/8 + MTP=5. fp8 + DCP=2 fits 1M context on 8×H200 where bf16 cannot; deployed in production at 1M `max-model-len`.

## Test (accuracy)

**Perplexity (wikitext-2-raw, 40×2048 windows, 81,880 tokens, greedy) — DCP=N must match DCP=1:**

| DCP | backend | ppl | avg NLL | vs DCP=1 |
|---|---|---|---|---|
| 1 | — | 2.8871 | 1.060259 | — |
| 4 | ag_rs | 2.8857 | 1.059783 | -0.05% |
| 8 | ag_rs | 2.8861 | 1.059890 | -0.03% |

Agree to <0.05% — sharded-DCP attention is numerically equivalent to full-attention baseline. Cross-config sweep (DCP 1/2/4/8 × MTP 1/2/5 × CUDAGraph) all pass; long generation (4K-token code/math/essay) runs coherent under DCP=8+MTP=5. Non-DCP regression verified.

## Limitations / Follow-ups

- **Hang under `DCP>1 + FULL` cudagraph.** Reproducible at first decode after a long (~128K) DCP prefill (GLM-5.2, TP=4, DCP=4, `ag_rs`, 4×H200 NVL). Ablation pins it to `DCP>1 + FULL` (PIECEWISE passes, DCP=1+FULL passes, MTP irrelevant). Root cause not isolated — captured collective or triton node in the FULL decode graph; `cuda-gdb` hasn't named the kernel. Not reproduced here (our TP=8/DCP=2/FULL/8×SXM is in the risk surface but hasn't hung). **Workaround:** `cudagraph_mode=PIECEWISE` or `enforce_eager=True`. @robertoberto is preparing a PIECEWISE-fallback PR; I'm running an ablation to localize the root cause.
- **interleave > 1 / `compress_ratio > 1`:** the remap/ceil-div formulas assume both are 1 (GLM-5.2 default). Backend fails closed on interleave>1; compress_ratio>1 (DeepseekV4) needs the same treatment — straightforward extension, documented in code.
- **MTP draft proposer + DCP:** the draft forwards the main model's `dcp_local_seq_lens` unchanged while recomputing its own `seq_lens` — a performance issue (lower draft acceptance) when `num_rejected>0`, not correctness. Upstream `spec_decode` DCP gap, left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code), running on GLM-5.2 as the base model.

Co-authored-by: Claude <noreply@anthropic.com>
