### PR TITLE
[Model][DiffusionGemma] Bound sampler buffer memory under serving pressure

### DIFF
--- a/tests/model_executor/test_diffusion_gemma_rowchunk_sampler.py
+++ b/tests/model_executor/test_diffusion_gemma_rowchunk_sampler.py
@@ -1,0 +1,909 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.models.diffusion_gemma import (
+    _get_diffusion_gemma_row_chunk_size,
+    _is_diffusion_gemma_hidden_state_input,
+    _is_diffusion_gemma_sampler_warmup_batch,
+    _materialize_diffusion_gemma_logits_from_hidden,
+    _should_use_diffusion_gemma_row_chunked_sampler,
+)
+from vllm.model_executor.models.diffusion_gemma_rowchunk import (
+    _INT64_MIX_A,
+    _stable_gumbel_argmax_from_scaled,
+    _stable_uniform_from_row_base,
+    diffusion_gemma_softcap_row_chunked_sample_soft_embeds,
+    stable_uniform_from_indices,
+)
+
+
+def test_diffusion_gemma_row_chunk_size_from_scratch_budget(monkeypatch):
+    monkeypatch.delenv("VLLM_DIFFUSION_GEMMA_ROW_CHUNK", raising=False)
+    monkeypatch.setenv("VLLM_DIFFUSION_GEMMA_ROW_CHUNK_SCRATCH_MIB", "1024")
+    assert _get_diffusion_gemma_row_chunk_size(4096, 262144) == 64
+    assert _get_diffusion_gemma_row_chunk_size(64, 262144) == 64
+
+    monkeypatch.setenv("VLLM_DIFFUSION_GEMMA_ROW_CHUNK", "17")
+    assert _get_diffusion_gemma_row_chunk_size(4096, 262144) == 17
+    assert _get_diffusion_gemma_row_chunk_size(8, 262144) == 8
+
+
+@pytest.mark.parametrize(
+    ("row_chunked_input", "real_logprobs_enabled", "expected"),
+    [
+        (True, False, True),
+        (True, True, False),
+        (False, False, False),
+    ],
+)
+def test_diffusion_gemma_row_chunked_guard(
+    row_chunked_input, real_logprobs_enabled, expected
+):
+    assert (
+        _should_use_diffusion_gemma_row_chunked_sampler(
+            row_chunked_input=row_chunked_input,
+            real_logprobs_enabled=real_logprobs_enabled,
+        )
+        is expected
+    )
+
+
+def test_diffusion_gemma_row_chunked_logprobs_fallback_materializes_logits():
+    torch.manual_seed(0)
+    hidden = torch.randn(4, 8, dtype=torch.float32)
+    weight = torch.randn(11, 8, dtype=torch.float32)
+    cap = 30.0
+
+    actual = _materialize_diffusion_gemma_logits_from_hidden(hidden, weight, 7, cap)
+    raw = hidden @ weight[:7].t()
+    expected = torch.tanh(raw.float() / cap) * cap
+
+    assert actual.shape == (4, 7)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_diffusion_gemma_sampler_warmup_batch_detection():
+    warmup = SimpleNamespace(num_reqs=2, req_ids=["_warmup_0_", "_warmup_1_"])
+    mixed = SimpleNamespace(num_reqs=2, req_ids=["_warmup_0_", "real-req"])
+    empty = SimpleNamespace(num_reqs=0, req_ids=[])
+
+    assert _is_diffusion_gemma_sampler_warmup_batch(warmup)
+    assert not _is_diffusion_gemma_sampler_warmup_batch(mixed)
+    assert not _is_diffusion_gemma_sampler_warmup_batch(empty)
+
+
+def test_diffusion_gemma_hidden_state_input_classification():
+    hidden = torch.empty((3, 64))
+    logits = torch.empty((3, 257))
+    bad = torch.empty((3, 128))
+
+    assert _is_diffusion_gemma_hidden_state_input(hidden, 257, 64)
+    assert not _is_diffusion_gemma_hidden_state_input(logits, 257, 64)
+    with pytest.raises(ValueError, match="expected hidden states"):
+        _is_diffusion_gemma_hidden_state_input(bad, 257, 64)
+
+
+def _legacy_stable_uniform_from_indices(
+    row_offsets: torch.Tensor, token_offsets: torch.Tensor, seed: int
+) -> torch.Tensor:
+    x = (
+        token_offsets[None, :].to(torch.int64)
+        + (row_offsets[:, None].to(torch.int64) + 1) * -7046029254386353131
+        + int(seed)
+    )
+    x = (x ^ (x >> 30)) * -4658895280553007687
+    x = (x ^ (x >> 27)) * -7723592293110705685
+    x = x ^ (x >> 31)
+    mantissa = torch.bitwise_and(x, (1 << 53) - 1).to(torch.float64)
+    return ((mantissa + 0.5) * (1.0 / float(1 << 53))).to(torch.float32)
+
+
+def _make_inputs(
+    rows: int,
+    hidden_size: int,
+    vocab_size: int,
+    dtype: torch.dtype = torch.bfloat16,
+):
+    generator = torch.Generator(device="cuda").manual_seed(2026061801)
+    hidden = torch.randn(
+        rows,
+        hidden_size,
+        device="cuda",
+        dtype=dtype,
+        generator=generator,
+    )
+    weight = torch.randn(
+        vocab_size,
+        hidden_size,
+        device="cuda",
+        dtype=dtype,
+        generator=generator,
+    )
+    return hidden, weight
+
+
+def _make_embed_weight(
+    vocab_size: int,
+    embed_size: int,
+    dtype: torch.dtype = torch.bfloat16,
+):
+    generator = torch.Generator(device="cuda").manual_seed(2026061802)
+    return torch.randn(
+        vocab_size,
+        embed_size,
+        device="cuda",
+        dtype=dtype,
+        generator=generator,
+    )
+
+
+def _reference_sample_soft_embeds(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    embed_weight: torch.Tensor,
+    softcap: float,
+    temperature: torch.Tensor,
+    seed: int,
+    row_seed_offsets: torch.Tensor,
+):
+    logits = hidden @ weight.t()
+    unscaled = torch.tanh(logits.float() / softcap) * softcap
+    zero_temp_rows = temperature <= 0
+    scaled = unscaled / temperature.clamp(min=1e-10)[:, None]
+    scaled = torch.where(zero_temp_rows[:, None], unscaled, scaled)
+    lse = scaled.logsumexp(dim=-1)
+    probs = scaled.softmax(dim=-1)
+    entropy = lse - (probs * scaled).sum(dim=-1)
+    entropy = torch.where(zero_temp_rows, torch.zeros_like(entropy), entropy)
+    greedy = scaled.argmax(dim=-1)
+    soft = (probs.to(embed_weight.dtype) @ embed_weight).float()
+    token_offsets = torch.arange(weight.shape[0], device="cuda", dtype=torch.int64)
+    uniform = stable_uniform_from_indices(row_seed_offsets, token_offsets, seed)
+    uniform = uniform.clamp(
+        min=torch.finfo(uniform.dtype).tiny,
+        max=1.0 - torch.finfo(uniform.dtype).eps,
+    )
+    noisy = scaled + (-torch.log(-torch.log(uniform))) * (
+        temperature > 0
+    ).float()[:, None]
+    sample = noisy.argmax(dim=-1)
+    if zero_temp_rows.any():
+        sample = torch.where(zero_temp_rows, greedy, sample)
+        soft[zero_temp_rows] = embed_weight[greedy[zero_temp_rows]].float()
+    return lse, entropy, sample, greedy, soft
+
+
+def _materialized_gumbel_argmax_from_scaled(
+    scaled: torch.Tensor,
+    row_offsets: torch.Tensor,
+    token_offsets: torch.Tensor,
+    seed: int,
+    noise_scale: float | torch.Tensor,
+) -> torch.Tensor:
+    uniform = stable_uniform_from_indices(row_offsets, token_offsets, seed)
+    uniform = uniform.clamp(
+        min=torch.finfo(uniform.dtype).tiny,
+        max=1.0 - torch.finfo(uniform.dtype).eps,
+    )
+    uniform = -torch.log(-torch.log(uniform))
+    if isinstance(noise_scale, torch.Tensor):
+        uniform = uniform * noise_scale
+    elif float(noise_scale) != 1.0:
+        uniform = uniform * float(noise_scale)
+    return (scaled + uniform).argmax(dim=-1)
+
+
+def _assert_rowchunk_outputs_close(actual, expected):
+    torch.testing.assert_close(actual[0], expected[0], rtol=3e-4, atol=2e-3)
+    torch.testing.assert_close(actual[1], expected[1], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(actual[2], expected[2], rtol=0, atol=0)
+    torch.testing.assert_close(actual[3], expected[3], rtol=0, atol=0)
+    torch.testing.assert_close(actual[4], expected[4], rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_stable_uniform_matches_legacy_float64_stream():
+    rows = torch.tensor([0, 1_000_003, 17_000_051], device="cuda", dtype=torch.int64)
+    tokens = torch.arange(1024, device="cuda", dtype=torch.int64)
+
+    actual = stable_uniform_from_indices(rows, tokens, seed=2026061807)
+    expected = _legacy_stable_uniform_from_indices(rows, tokens, seed=2026061807)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_stable_uniform_row_base_matches_inline_stream():
+    rows = torch.tensor([0, 1_000_003, 17_000_051], device="cuda", dtype=torch.int64)
+    tokens = torch.arange(32769, device="cuda", dtype=torch.int64)
+    seed = 2026062235
+    row_base = (rows[:, None] + 1) * _INT64_MIX_A + seed
+
+    actual = _stable_uniform_from_row_base(row_base, tokens)
+    expected = stable_uniform_from_indices(rows, tokens, seed=seed)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_diffusion_gemma_row_chunked_matches_materialized_reference():
+    hidden, weight = _make_inputs(rows=9, hidden_size=96, vocab_size=677)
+    embed_weight = _make_embed_weight(vocab_size=677, embed_size=48)
+    temperature = torch.tensor(
+        [0.3, 0.5, 1e-6, 1.0, 1e-9, 0.9, 0.8, 0.0, 1.1],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    row_seed_offsets = torch.tensor(
+        [8, 1, 7, 3, 5, 11, 13, 17, 19], device="cuda", dtype=torch.int64
+    )
+    token_offsets = torch.arange(weight.shape[0], device="cuda", dtype=torch.int64)
+
+    expected = _reference_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026061803,
+        row_seed_offsets=row_seed_offsets,
+    )
+    actual_uncached = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026061803,
+        row_chunk_size=4,
+        row_seed_offsets=row_seed_offsets,
+    )
+    actual_cached = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026061803,
+        row_chunk_size=4,
+        row_seed_offsets=row_seed_offsets,
+        token_offsets=token_offsets,
+    )
+
+    for actual in (actual_uncached, actual_cached):
+        torch.testing.assert_close(actual[0], expected[0], rtol=3e-4, atol=2e-3)
+        torch.testing.assert_close(actual[1], expected[1], rtol=1e-5, atol=1e-5)
+        torch.testing.assert_close(actual[2], expected[2], rtol=0, atol=0)
+        torch.testing.assert_close(actual[3], expected[3], rtol=0, atol=0)
+        torch.testing.assert_close(actual[4], expected[4], rtol=2e-2, atol=2e-2)
+
+    for cached_item, uncached_item in zip(actual_cached, actual_uncached):
+        torch.testing.assert_close(cached_item, uncached_item, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_diffusion_gemma_row_chunked_token_offsets_validation():
+    hidden, weight = _make_inputs(rows=2, hidden_size=16, vocab_size=17)
+    embed_weight = _make_embed_weight(vocab_size=17, embed_size=8)
+    temperature = torch.ones(2, device="cuda", dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="shape"):
+        diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+            hidden,
+            weight,
+            embed_weight,
+            softcap=30.0,
+            temperature=temperature,
+            seed=2026061821,
+            row_chunk_size=2,
+            token_offsets=torch.arange(16, device="cuda", dtype=torch.int64),
+        )
+
+    with pytest.raises(ValueError, match="int64"):
+        diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+            hidden,
+            weight,
+            embed_weight,
+            softcap=30.0,
+            temperature=temperature,
+            seed=2026061821,
+            row_chunk_size=2,
+            token_offsets=torch.arange(17, device="cuda", dtype=torch.int32),
+        )
+
+    with pytest.raises(ValueError, match="gumbel_vocab_chunk_size"):
+        diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+            hidden,
+            weight,
+            embed_weight,
+            softcap=30.0,
+            temperature=temperature,
+            seed=2026061821,
+            row_chunk_size=2,
+            gumbel_vocab_chunk_size=0,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_uniform_slices_match_full_uniform():
+    rows = torch.tensor([0, 19, 1_000_003], device="cuda", dtype=torch.int64)
+    tokens = torch.arange(32769, device="cuda", dtype=torch.int64)
+    full = stable_uniform_from_indices(rows, tokens, seed=2026062203).clamp(
+        min=torch.finfo(torch.float32).tiny,
+        max=1.0 - torch.finfo(torch.float32).eps,
+    )
+    pieces = []
+    for start in range(0, tokens.shape[0], 16384):
+        pieces.append(
+            stable_uniform_from_indices(
+                rows, tokens[start : start + 16384], seed=2026062203
+            ).clamp(
+                min=torch.finfo(torch.float32).tiny,
+                max=1.0 - torch.finfo(torch.float32).eps,
+            )
+        )
+
+    torch.testing.assert_close(torch.cat(pieces, dim=-1), full, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("vocab_size", [17, 1024, 16383, 16384, 16385, 32769])
+def test_blocked_gumbel_matches_materialized_reference_at_vocab_boundaries(
+    vocab_size,
+):
+    hidden, weight = _make_inputs(rows=5, hidden_size=16, vocab_size=vocab_size)
+    embed_weight = _make_embed_weight(vocab_size=vocab_size, embed_size=8)
+    temperature = torch.tensor(
+        [0.3, 0.7, 1e-6, 0.0, 1.1], device="cuda", dtype=torch.float32
+    )
+    row_seed_offsets = torch.tensor(
+        [11, 3, 19, 5, 23], device="cuda", dtype=torch.int64
+    )
+    expected = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026062205,
+        row_chunk_size=2,
+        row_seed_offsets=row_seed_offsets,
+        gumbel_vocab_chunk_size=vocab_size + 1,
+    )
+
+    gumbel_vocab_chunk_sizes = (
+        (1, 7, 1024, 16384) if vocab_size <= 1024 else (1024, 16384)
+    )
+    for gumbel_vocab_chunk_size in gumbel_vocab_chunk_sizes:
+        actual = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+            hidden,
+            weight,
+            embed_weight,
+            softcap=30.0,
+            temperature=temperature,
+            seed=2026062205,
+            row_chunk_size=2,
+            row_seed_offsets=row_seed_offsets,
+            gumbel_vocab_chunk_size=gumbel_vocab_chunk_size,
+        )
+        _assert_rowchunk_outputs_close(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_row_chunk_and_vocab_chunk_invariant():
+    hidden, weight = _make_inputs(rows=7, hidden_size=32, vocab_size=4097)
+    embed_weight = _make_embed_weight(vocab_size=4097, embed_size=16)
+    temperature = torch.tensor(
+        [0.3, 0.5, 0.7, 1.0, 0.0, 1e-9, 1.1],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    row_seed_offsets = torch.arange(7, device="cuda", dtype=torch.int64) * 13
+    expected = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026062207,
+        row_chunk_size=7,
+        row_seed_offsets=row_seed_offsets,
+        gumbel_vocab_chunk_size=weight.shape[0] + 1,
+    )
+
+    for row_chunk_size, gumbel_vocab_chunk_size in (
+        (1, 1),
+        (2, 7),
+        (3, 1024),
+        (4, 4096),
+    ):
+        actual = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+            hidden,
+            weight,
+            embed_weight,
+            softcap=30.0,
+            temperature=temperature,
+            seed=2026062207,
+            row_chunk_size=row_chunk_size,
+            row_seed_offsets=row_seed_offsets,
+            gumbel_vocab_chunk_size=gumbel_vocab_chunk_size,
+        )
+        _assert_rowchunk_outputs_close(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_preserves_cross_block_tie_first_index():
+    scaled = torch.zeros((3, 12), device="cuda", dtype=torch.float32)
+    scaled[0, 3] = 2.0
+    scaled[0, 4] = 2.0
+    scaled[1, 7] = 5.0
+    scaled[1, 11] = 5.0
+    # Row 2 is all equal and should choose token 0.
+    row_offsets = torch.arange(3, device="cuda", dtype=torch.int64)
+    token_offsets = torch.arange(12, device="cuda", dtype=torch.int64)
+    zero_noise = torch.zeros((3, 1), device="cuda", dtype=torch.float32)
+
+    actual = _stable_gumbel_argmax_from_scaled(
+        scaled,
+        row_offsets,
+        token_offsets,
+        seed=2026062211,
+        noise_scale=zero_noise,
+        gumbel_vocab_chunk_size=4,
+    )
+
+    torch.testing.assert_close(
+        actual, torch.tensor([3, 7, 0], device="cuda"), rtol=0, atol=0
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_matches_independent_materialized_reference():
+    generator = torch.Generator(device="cuda").manual_seed(2026062213)
+    scaled = torch.randn(
+        (5, 1031), device="cuda", dtype=torch.float32, generator=generator
+    )
+    row_offsets = torch.tensor([0, 7, 11, 23, 101], device="cuda", dtype=torch.int64)
+    token_offsets = torch.arange(scaled.shape[1], device="cuda", dtype=torch.int64)
+    noise_scale = torch.tensor(
+        [1.0, 0.7, 0.0, 2.0, 0.3], device="cuda", dtype=torch.float32
+    )[:, None]
+
+    actual = _stable_gumbel_argmax_from_scaled(
+        scaled,
+        row_offsets,
+        token_offsets,
+        seed=2026062213,
+        noise_scale=noise_scale,
+        gumbel_vocab_chunk_size=17,
+    )
+    expected = _materialized_gumbel_argmax_from_scaled(
+        scaled,
+        row_offsets,
+        token_offsets,
+        seed=2026062213,
+        noise_scale=noise_scale,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_applies_scalar_noise_scale():
+    generator = torch.Generator(device="cuda").manual_seed(2026062214)
+    scaled = torch.randn(
+        (4, 257), device="cuda", dtype=torch.float32, generator=generator
+    )
+    row_offsets = torch.arange(4, device="cuda", dtype=torch.int64)
+    token_offsets = torch.arange(scaled.shape[1], device="cuda", dtype=torch.int64)
+
+    actual = _stable_gumbel_argmax_from_scaled(
+        scaled,
+        row_offsets,
+        token_offsets,
+        seed=2026062214,
+        noise_scale=0.125,
+        gumbel_vocab_chunk_size=19,
+    )
+    expected = _materialized_gumbel_argmax_from_scaled(
+        scaled,
+        row_offsets,
+        token_offsets,
+        seed=2026062214,
+        noise_scale=0.125,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_handles_infinite_scores_like_argmax():
+    scaled = torch.full((3, 12), float("-inf"), device="cuda", dtype=torch.float32)
+    scaled[1, 5] = 1.0
+    scaled[1, 8] = float("inf")
+    scaled[2, 6] = float("inf")
+    scaled[2, 9] = float("inf")
+    row_offsets = torch.arange(3, device="cuda", dtype=torch.int64)
+    token_offsets = torch.arange(12, device="cuda", dtype=torch.int64)
+    zero_noise = torch.zeros((3, 1), device="cuda", dtype=torch.float32)
+
+    actual = _stable_gumbel_argmax_from_scaled(
+        scaled,
+        row_offsets,
+        token_offsets,
+        seed=2026062217,
+        noise_scale=zero_noise,
+        gumbel_vocab_chunk_size=4,
+    )
+    expected = scaled.argmax(dim=-1)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual[0].item() == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_handles_nan_scores_like_argmax():
+    scaled = torch.zeros((4, 12), device="cuda", dtype=torch.float32)
+    scaled[0, 5] = float("nan")
+    scaled[1, 9] = float("nan")
+    scaled[1, 2] = float("nan")
+    scaled[2, 1] = 3.0
+    scaled[2, 10] = float("nan")
+    scaled[3, 0] = float("nan")
+    scaled[3, :] = float("nan")
+    row_offsets = torch.arange(4, device="cuda", dtype=torch.int64)
+    token_offsets = torch.arange(12, device="cuda", dtype=torch.int64)
+    zero_noise = torch.zeros((4, 1), device="cuda", dtype=torch.float32)
+
+    actual = _stable_gumbel_argmax_from_scaled(
+        scaled,
+        row_offsets,
+        token_offsets,
+        seed=2026062218,
+        noise_scale=zero_noise,
+        gumbel_vocab_chunk_size=4,
+    )
+    expected = scaled.argmax(dim=-1)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    # Row 1 has NaNs in block 0 and block 2; the global first NaN wins.
+    assert actual[1].item() == 2
+    # Row 2 has a finite score in block 0 and a NaN in block 2; NaN wins like
+    # torch.argmax over the full materialized row.
+    assert actual[2].item() == 10
+    # Row 3 is all NaN; first vocab id wins.
+    assert actual[3].item() == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_matches_materialized_nan_inf_scores_with_noise():
+    scaled = torch.zeros((5, 16), device="cuda", dtype=torch.float32)
+    # Row 0 has an all-finite first block and a later NaN in the same block
+    # as a larger finite value. Match materialized torch.argmax behavior.
+    scaled[0, 3] = 9.0
+    scaled[0, 4] = 99.0
+    scaled[0, 6] = float("nan")
+    # Row 1 has NaNs in multiple blocks. The first full-row NaN wins.
+    scaled[1, 2] = float("nan")
+    scaled[1, 7] = float("nan")
+    # Row 2 has +inf in multiple blocks. The first +inf wins.
+    scaled[2, 1] = float("inf")
+    scaled[2, 11] = float("inf")
+    # Row 3 is all -inf. Full-row argmax returns the first token.
+    scaled[3, :] = float("-inf")
+    # Row 4 mixes an earlier +inf with a later NaN. NaN wins like torch.argmax.
+    scaled[4, 3] = float("inf")
+    scaled[4, 10] = float("nan")
+
+    row_offsets = torch.arange(scaled.shape[0], device="cuda", dtype=torch.int64)
+    token_offsets = torch.arange(scaled.shape[1], device="cuda", dtype=torch.int64)
+    noise_scale = torch.ones((scaled.shape[0], 1), device="cuda", dtype=torch.float32)
+
+    actual = _stable_gumbel_argmax_from_scaled(
+        scaled,
+        row_offsets,
+        token_offsets,
+        seed=2026062231,
+        noise_scale=noise_scale,
+        gumbel_vocab_chunk_size=4,
+    )
+    expected = _materialized_gumbel_argmax_from_scaled(
+        scaled,
+        row_offsets,
+        token_offsets,
+        seed=2026062231,
+        noise_scale=noise_scale,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual[0].item() == expected[0].item()
+    assert actual[1].item() == 2
+    assert actual[2].item() == 1
+    assert actual[3].item() == 0
+    assert actual[4].item() == 10
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_rejects_non_float32_scaled_scores():
+    scaled = torch.zeros((2, 8), device="cuda", dtype=torch.float64)
+    row_offsets = torch.arange(2, device="cuda", dtype=torch.int64)
+    token_offsets = torch.arange(8, device="cuda", dtype=torch.int64)
+
+    with pytest.raises(ValueError, match="scaled must be float32"):
+        _stable_gumbel_argmax_from_scaled(
+            scaled,
+            row_offsets,
+            token_offsets,
+            seed=2026062219,
+            noise_scale=1.0,
+            gumbel_vocab_chunk_size=4,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_rejects_bad_noise_scale_shape():
+    scaled = torch.zeros((2, 8), device="cuda", dtype=torch.float32)
+    row_offsets = torch.arange(2, device="cuda", dtype=torch.int64)
+    token_offsets = torch.arange(8, device="cuda", dtype=torch.int64)
+    noise_scale = torch.ones((2,), device="cuda", dtype=torch.float32)
+
+    with pytest.raises(ValueError, match=r"noise_scale tensor.*\[rows, 1\]"):
+        _stable_gumbel_argmax_from_scaled(
+            scaled,
+            row_offsets,
+            token_offsets,
+            seed=2026062220,
+            noise_scale=noise_scale,
+            gumbel_vocab_chunk_size=4,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_rejects_bad_noise_scale_dtype():
+    scaled = torch.zeros((2, 8), device="cuda", dtype=torch.float32)
+    row_offsets = torch.arange(2, device="cuda", dtype=torch.int64)
+    token_offsets = torch.arange(8, device="cuda", dtype=torch.int64)
+    noise_scale = torch.ones((2, 1), device="cuda", dtype=torch.float64)
+
+    with pytest.raises(ValueError, match="noise_scale tensor must be float32"):
+        _stable_gumbel_argmax_from_scaled(
+            scaled,
+            row_offsets,
+            token_offsets,
+            seed=2026062221,
+            noise_scale=noise_scale,
+            gumbel_vocab_chunk_size=4,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_blocked_gumbel_matches_reference_for_supported_input_dtypes(dtype):
+    hidden, weight = _make_inputs(
+        rows=4, hidden_size=16, vocab_size=1025, dtype=dtype
+    )
+    embed_weight = _make_embed_weight(vocab_size=1025, embed_size=8, dtype=dtype)
+    temperature = torch.tensor(
+        [0.3, 0.7, 0.0, 1e-6], device="cuda", dtype=torch.float32
+    )
+    row_seed_offsets = torch.arange(4, device="cuda", dtype=torch.int64) * 17
+    expected = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026062223,
+        row_chunk_size=2,
+        row_seed_offsets=row_seed_offsets,
+        gumbel_vocab_chunk_size=weight.shape[0] + 1,
+    )
+    actual = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026062223,
+        row_chunk_size=2,
+        row_seed_offsets=row_seed_offsets,
+        gumbel_vocab_chunk_size=128,
+    )
+
+    _assert_rowchunk_outputs_close(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_scalar_temperature_matches_reference():
+    hidden, weight = _make_inputs(rows=4, hidden_size=16, vocab_size=1025)
+    embed_weight = _make_embed_weight(vocab_size=1025, embed_size=8)
+    temperature = torch.full((4,), 0.7, device="cuda", dtype=torch.float32)
+    row_seed_offsets = torch.arange(4, device="cuda", dtype=torch.int64) * 19
+    expected = _reference_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026062229,
+        row_seed_offsets=row_seed_offsets,
+    )
+    actual = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=0.7,
+        seed=2026062229,
+        row_chunk_size=2,
+        row_seed_offsets=row_seed_offsets,
+        gumbel_vocab_chunk_size=128,
+    )
+
+    _assert_rowchunk_outputs_close(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_blocked_gumbel_scalar_zero_temperature_skips_sampling():
+    hidden, weight = _make_inputs(rows=4, hidden_size=16, vocab_size=257)
+    embed_weight = _make_embed_weight(vocab_size=257, embed_size=8)
+    lse, entropy, sample, greedy, soft = (
+        diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+            hidden,
+            weight,
+            embed_weight,
+            softcap=30.0,
+            temperature=0.0,
+            seed=2026062233,
+            row_chunk_size=2,
+            gumbel_vocab_chunk_size=64,
+        )
+    )
+
+    assert lse.shape == entropy.shape == sample.shape == greedy.shape == (4,)
+    torch.testing.assert_close(sample, greedy, rtol=0, atol=0)
+    torch.testing.assert_close(entropy, torch.zeros_like(entropy), rtol=0, atol=0)
+    torch.testing.assert_close(soft, embed_weight[greedy].float(), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_diffusion_gemma_row_chunked_positive_temperature_fast_path_matches():
+    hidden, weight = _make_inputs(rows=6, hidden_size=64, vocab_size=257)
+    embed_weight = _make_embed_weight(vocab_size=257, embed_size=32)
+    temperature = torch.tensor(
+        [0.3, 0.5, 0.7, 1.0, 0.9, 1.1],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    row_seed_offsets = torch.arange(6, device="cuda", dtype=torch.int64) * 5
+
+    expected = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026061819,
+        row_chunk_size=3,
+        row_seed_offsets=row_seed_offsets,
+    )
+    actual = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026061819,
+        row_chunk_size=3,
+        row_seed_offsets=row_seed_offsets,
+        temperature_is_positive=True,
+    )
+
+    for idx, (actual_item, expected_item) in enumerate(zip(actual, expected)):
+        if idx in (2, 3):
+            torch.testing.assert_close(actual_item, expected_item, rtol=0, atol=0)
+        elif idx == 4:
+            torch.testing.assert_close(
+                actual_item, expected_item, rtol=2e-2, atol=2e-2
+            )
+        else:
+            torch.testing.assert_close(actual_item, expected_item, rtol=3e-4, atol=2e-3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_diffusion_gemma_row_chunked_chunk_size_invariant():
+    hidden, weight = _make_inputs(rows=7, hidden_size=64, vocab_size=257)
+    embed_weight = _make_embed_weight(vocab_size=257, embed_size=32)
+    temperature = torch.tensor(
+        [0.3, 0.5, 0.7, 1.0, 0.0, 0.9, 1.1],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    row_seed_offsets = torch.arange(7, device="cuda", dtype=torch.int64) * 3
+    expected = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026061804,
+        row_chunk_size=7,
+        row_seed_offsets=row_seed_offsets,
+    )
+
+    for row_chunk_size in (1, 2, 3):
+        actual = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+            hidden,
+            weight,
+            embed_weight,
+            softcap=30.0,
+            temperature=temperature,
+            seed=2026061804,
+            row_chunk_size=row_chunk_size,
+            row_seed_offsets=row_seed_offsets,
+        )
+        for idx, (actual_item, expected_item) in enumerate(zip(actual, expected)):
+            if idx in (2, 3):
+                torch.testing.assert_close(actual_item, expected_item, rtol=0, atol=0)
+            elif idx == 4:
+                torch.testing.assert_close(
+                    actual_item, expected_item, rtol=2e-2, atol=2e-2
+                )
+            else:
+                torch.testing.assert_close(
+                    actual_item, expected_item, rtol=3e-4, atol=2e-3
+                )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_diffusion_gemma_row_chunked_row_seed_offsets_are_reorder_stable():
+    hidden, weight = _make_inputs(rows=8, hidden_size=64, vocab_size=257)
+    embed_weight = _make_embed_weight(vocab_size=257, embed_size=32)
+    temperature = torch.tensor(
+        [0.3, 0.5, 0.7, 1.0, 0.6, 0.9, 0.8, 1.1],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    row_seed_offsets = torch.tensor(
+        [11, 3, 20, 7, 15, 99, 2, 42], device="cuda", dtype=torch.int64
+    )
+    expected = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden,
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature,
+        seed=2026061805,
+        row_chunk_size=3,
+        row_seed_offsets=row_seed_offsets,
+    )
+    perm = torch.tensor([3, 0, 7, 1, 6, 4, 2, 5], device="cuda")
+    actual = diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+        hidden[perm],
+        weight,
+        embed_weight,
+        softcap=30.0,
+        temperature=temperature[perm],
+        seed=2026061805,
+        row_chunk_size=2,
+        row_seed_offsets=row_seed_offsets[perm],
+    )
+    inv = torch.argsort(perm)
+    for idx, (actual_item, expected_item) in enumerate(zip(actual, expected)):
+        if idx in (2, 3):
+            torch.testing.assert_close(actual_item[inv], expected_item, rtol=0, atol=0)
+        elif idx == 4:
+            torch.testing.assert_close(
+                actual_item[inv], expected_item, rtol=2e-2, atol=2e-2
+            )
+        else:
+            torch.testing.assert_close(
+                actual_item[inv], expected_item, rtol=3e-4, atol=2e-3
+            )

--- a/tests/v1/worker/test_diffusion_sampler_memory_reserve.py
+++ b/tests/v1/worker/test_diffusion_sampler_memory_reserve.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+import vllm.envs as envs
+from vllm.model_executor.models.diffusion_gemma import (
+    DiffusionGemmaModelState,
+    _get_diffusion_gemma_sampler_memory_reserve_bytes,
+)
+
+DEFAULT_SHAPE = dict(
+    max_num_seqs=16,
+    max_num_batched_tokens=4096,
+    canvas_length=256,
+    vocab_size=262144,
+)
+
+
+@pytest.mark.parametrize(
+    ("reserve_mib", "scale", "shape", "expected"),
+    [
+        ("", 1.0, DEFAULT_SHAPE, 0),
+        ("512", 1.0, DEFAULT_SHAPE, 512 * (1 << 20)),
+        ("512", -1.0, DEFAULT_SHAPE, 512 * (1 << 20)),
+        (
+            " auto ",
+            1.0,
+            dict(
+                max_num_seqs=1,
+                max_num_batched_tokens=256,
+                canvas_length=256,
+                vocab_size=1024,
+            ),
+            256 * 1024 * 4 * 2,
+        ),
+        (
+            " AUTO ",
+            1.0,
+            dict(
+                max_num_seqs=1,
+                max_num_batched_tokens=256,
+                canvas_length=256,
+                vocab_size=1024,
+            ),
+            256 * 1024 * 4 * 2,
+        ),
+    ],
+)
+def test_diffusion_sampler_memory_reserve_parses_supported_modes(
+    reserve_mib, scale, shape, expected
+):
+    assert (
+        _get_diffusion_gemma_sampler_memory_reserve_bytes(
+            reserve_mib, scale, **shape
+        )
+        == expected
+    )
+
+
+def test_diffusion_sampler_memory_reserve_auto_estimate():
+    reserve = _get_diffusion_gemma_sampler_memory_reserve_bytes(
+        "auto",
+        1.0,
+        canvas_length=256,
+        max_num_seqs=16,
+        max_num_batched_tokens=4096,
+        vocab_size=262144,
+    )
+
+    assert reserve == 16 * 256 * 262144 * 4 * 2
+
+
+def test_diffusion_sampler_memory_reserve_auto_respects_token_cap():
+    reserve = _get_diffusion_gemma_sampler_memory_reserve_bytes(
+        "auto",
+        1.25,
+        canvas_length=256,
+        max_num_seqs=64,
+        max_num_batched_tokens=4096,
+        vocab_size=1024,
+    )
+
+    # max_num_batched_tokens limits the materialized decode shape to 16
+    # diffusion requests, not max_num_seqs=64.
+    assert reserve == int(16 * 256 * 1024 * 4 * 2 * 1.25)
+
+
+@pytest.mark.parametrize(
+    ("reserve_mib", "scale", "shape_override", "match"),
+    [
+        ("-1", 1.0, {}, None),
+        ("not-a-number", 1.0, {}, "auto"),
+        ("auto", -0.1, {}, None),
+        ("auto", 1.0, {"canvas_length": 0}, "canvas_length"),
+        ("auto", 1.0, {"max_num_seqs": 0}, "max_num_seqs"),
+        ("auto", 1.0, {"max_num_batched_tokens": 0}, "max_num_batched_tokens"),
+        ("auto", 1.0, {"vocab_size": 0}, "vocab_size"),
+    ],
+)
+def test_diffusion_sampler_memory_reserve_rejects_invalid_inputs(
+    reserve_mib, scale, shape_override, match
+):
+    shape = {**DEFAULT_SHAPE, **shape_override}
+    with pytest.raises(ValueError, match=match):
+        _get_diffusion_gemma_sampler_memory_reserve_bytes(
+            reserve_mib, scale, **shape
+        )
+
+
+def test_diffusion_model_state_reports_global_vocab_reserve(monkeypatch):
+    state = DiffusionGemmaModelState.__new__(DiffusionGemmaModelState)
+    state.max_num_reqs = 64
+    state.max_num_tokens = 4096
+    state.diffusion_states = SimpleNamespace(canvas_length=256)
+    state.model_config = SimpleNamespace(get_vocab_size=lambda: 262144)
+
+    monkeypatch.setattr(
+        envs,
+        "VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_MIB",
+        "auto",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        envs,
+        "VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_SCALE",
+        1.1,
+        raising=False,
+    )
+
+    assert state.get_extra_non_kv_cache_memory_bytes() == int(
+        16 * 256 * 262144 * 4 * 2 * 1.1
+    )

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1638,3 +1638,65 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
 
         with pytest.raises(ValueError, match="max_num_seqs"):
             runner.initialize_kv_cache(kv_cache_config)
+
+
+def _make_structured_output():
+    return SimpleNamespace(
+        structured_output_request_ids={},
+        grammar_bitmask=torch.empty((0,), dtype=torch.int32),
+    )
+
+
+def _make_runner_for_structured_output(logits: torch.Tensor | None):
+    from vllm.v1.worker.gpu.model_runner import GPUModelRunner as V2GPUModelRunner
+
+    runner = V2GPUModelRunner.__new__(V2GPUModelRunner)
+    runner.vocab_size = 11
+    runner.model = SimpleNamespace(compute_logits=lambda _: logits)
+    runner.structured_outputs_worker = Mock()
+    runner.rejection_sampler = None
+    runner.sampler = Mock(
+        return_value=SimpleNamespace(num_sampled=0, num_rejected=0)
+    )
+    return runner
+
+
+def _make_input_batch_for_structured_output(req_id: str):
+    return SimpleNamespace(
+        logits_indices=torch.tensor([0]),
+        num_draft_tokens=0,
+        num_reqs=1,
+        req_ids=[req_id],
+    )
+
+
+def test_v2_model_runner_rejects_structured_outputs_for_hidden_states():
+    runner = _make_runner_for_structured_output(torch.empty((1, 7)))
+    input_batch = _make_input_batch_for_structured_output("real-request")
+
+    with pytest.raises(ValueError, match="Structured outputs require"):
+        runner.sample(torch.empty((1, 7)), input_batch, _make_structured_output())
+
+    runner.structured_outputs_worker.apply_grammar_bitmask.assert_not_called()
+    runner.sampler.assert_not_called()
+
+
+def test_v2_model_runner_skips_structured_output_warmup_for_hidden_states():
+    runner = _make_runner_for_structured_output(torch.empty((1, 7)))
+    input_batch = _make_input_batch_for_structured_output("_warmup_0_")
+
+    runner.sample(torch.empty((1, 7)), input_batch, _make_structured_output())
+
+    runner.structured_outputs_worker.apply_grammar_bitmask.assert_not_called()
+    runner.sampler.assert_called_once()
+
+
+def test_v2_model_runner_applies_structured_outputs_to_materialized_logits():
+    runner = _make_runner_for_structured_output(torch.empty((1, 11)))
+    input_batch = _make_input_batch_for_structured_output("real-request")
+    grammar_output = _make_structured_output()
+
+    runner.sample(torch.empty((1, 7)), input_batch, grammar_output)
+
+    runner.structured_outputs_worker.apply_grammar_bitmask.assert_called_once()
+    runner.sampler.assert_called_once()

--- a/tests/v1/worker/test_model_memory_reserve.py
+++ b/tests/v1/worker/test_model_memory_reserve.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.v1.worker.gpu_worker import _subtract_model_memory_reserve
+
+
+def test_model_memory_reserve_noop():
+    assert _subtract_model_memory_reserve(1024, 0) == 1024
+
+
+def test_model_memory_reserve_subtracts_from_available_kv_memory():
+    assert _subtract_model_memory_reserve(4096, 1024) == 3072
+
+
+def test_model_memory_reserve_rejects_negative_reserve():
+    with pytest.raises(ValueError, match="non-negative"):
+        _subtract_model_memory_reserve(4096, -1)
+
+
+def test_model_memory_reserve_rejects_exhausting_kv_memory():
+    with pytest.raises(ValueError, match="leaves no available KV cache"):
+        _subtract_model_memory_reserve(1024, 1024)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -277,6 +277,11 @@ if TYPE_CHECKING:
     VLLM_ELASTIC_EP_SCALE_UP_LAUNCH: bool = False
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = True
+    VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_MIB: str = ""
+    VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_SCALE: float = 1.0
+    VLLM_DIFFUSION_GEMMA_SAMPLER_BACKEND: str = "materialized"
+    VLLM_DIFFUSION_GEMMA_ROW_CHUNK: int = 0
+    VLLM_DIFFUSION_GEMMA_ROW_CHUNK_SCRATCH_MIB: int = 1024
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
@@ -1924,6 +1929,31 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # memory allocation. Enabled by default as of v0.21.0
     "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS": lambda: bool(
         int(os.getenv("VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS", "1"))
+    ),
+    # Extra KV-sizing reserve for DiffusionGemma sampler runtime scratch.
+    # Empty or "0" disables the reserve; "auto" estimates token-capped
+    # [sampler_rows, vocab] fp32 sampler/logits buffers; an integer value is
+    # interpreted as MiB.
+    "VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_MIB": lambda: os.getenv(
+        "VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_MIB", ""
+    ),
+    # Optional multiplier for the DiffusionGemma sampler reserve auto estimate.
+    "VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_SCALE": lambda: float(
+        os.getenv("VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_SCALE", "1.0")
+    ),
+    # DiffusionGemma sampler backend. "materialized" keeps the default full
+    # logits path. "row_chunked" explicitly enables bounded row chunks.
+    "VLLM_DIFFUSION_GEMMA_SAMPLER_BACKEND": lambda: os.getenv(
+        "VLLM_DIFFUSION_GEMMA_SAMPLER_BACKEND", "materialized"
+    ),
+    # Explicit row chunk. 0 means derive from the scratch budget below.
+    "VLLM_DIFFUSION_GEMMA_ROW_CHUNK": lambda: int(
+        os.getenv("VLLM_DIFFUSION_GEMMA_ROW_CHUNK", "0")
+    ),
+    # Scratch budget for the row-chunked sampler. The estimate intentionally
+    # over-counts Gumbel/noisy-argmax temporaries, not only score/prob tiles.
+    "VLLM_DIFFUSION_GEMMA_ROW_CHUNK_SCRATCH_MIB": lambda: int(
+        os.getenv("VLLM_DIFFUSION_GEMMA_ROW_CHUNK_SCRATCH_MIB", "1024")
     ),
     # NIXL EP environment variables
     "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -26,6 +26,7 @@ from torch import nn
 from torch.nn import functional as F
 from transformers import AutoModel
 
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.parallel_state import get_tp_group
@@ -57,6 +58,9 @@ from vllm.v1.worker.gpu.sample.output import SamplerOutput
 from vllm.v1.worker.gpu.sample.penalties import use_penalty
 from vllm.v1.worker.gpu.states import RequestState
 
+from .diffusion_gemma_rowchunk import (
+    diffusion_gemma_softcap_row_chunked_sample_soft_embeds,
+)
 from .interfaces import (
     SupportsMultiModal,
     SupportsPP,
@@ -64,6 +68,150 @@ from .interfaces import (
 )
 
 logger = init_logger(__name__)
+
+_DIFFUSION_GEMMA_SAMPLER_RESERVE_ENV = (
+    "VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_MIB"
+)
+_DIFFUSION_GEMMA_SAMPLER_RESERVE_SCALE_ENV = (
+    "VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_SCALE"
+)
+_DIFFUSION_GEMMA_SAMPLER_BACKEND_ENV = "VLLM_DIFFUSION_GEMMA_SAMPLER_BACKEND"
+_DIFFUSION_GEMMA_ROW_CHUNK_ENV = "VLLM_DIFFUSION_GEMMA_ROW_CHUNK"
+_DIFFUSION_GEMMA_ROW_CHUNK_SCRATCH_MIB_ENV = (
+    "VLLM_DIFFUSION_GEMMA_ROW_CHUNK_SCRATCH_MIB"
+)
+_DIFFUSION_GEMMA_SAMPLER_BACKENDS = {"materialized", "row_chunked"}
+_DIFFUSION_GEMMA_ROW_CHUNK_BYTES_PER_ELEMENT = 64
+_DIFFUSION_GEMMA_ROW_CHUNK_ALIGNMENT = 64
+
+
+def _get_diffusion_gemma_sampler_memory_reserve_bytes(
+    reserve_spec: str,
+    reserve_scale: float,
+    *,
+    max_num_seqs: int,
+    max_num_batched_tokens: int,
+    canvas_length: int,
+    vocab_size: int,
+) -> int:
+    """Estimate extra KV-sizing reserve for DiffusionGemma sampler scratch."""
+    reserve_spec = reserve_spec.strip()
+    if not reserve_spec or reserve_spec == "0":
+        return 0
+
+    if reserve_spec.lower() != "auto":
+        try:
+            reserve_mib = int(reserve_spec)
+        except ValueError as err:
+            raise ValueError(
+                f"{_DIFFUSION_GEMMA_SAMPLER_RESERVE_ENV} must be >= 0 or 'auto'"
+            ) from err
+        if reserve_mib < 0:
+            raise ValueError(
+                f"{_DIFFUSION_GEMMA_SAMPLER_RESERVE_ENV} must be >= 0 or 'auto'"
+            )
+        return reserve_mib * (1 << 20)
+
+    if canvas_length <= 0:
+        raise ValueError("DiffusionGemma canvas_length must be positive")
+    if max_num_seqs <= 0:
+        raise ValueError("DiffusionGemma max_num_seqs must be positive")
+    if max_num_batched_tokens <= 0:
+        raise ValueError("DiffusionGemma max_num_batched_tokens must be positive")
+    if vocab_size <= 0:
+        raise ValueError("DiffusionGemma vocab_size must be positive")
+    if reserve_scale < 0:
+        raise ValueError(
+            f"{_DIFFUSION_GEMMA_SAMPLER_RESERVE_SCALE_ENV} must be >= 0"
+        )
+
+    max_decode_reqs = min(
+        int(max_num_seqs),
+        max(1, int(max_num_batched_tokens) // int(canvas_length)),
+    )
+    sampler_rows = max_decode_reqs * int(canvas_length)
+    # DiffusionGemma's materialized decode path can have more than one
+    # full-vocab fp32 transient live across logits softcap/gather/sampler.
+    # Reserve two [sampler_rows, global_vocab] fp32 buffers for the auto
+    # setting; callers can still tune this with the scale env.
+    return int(sampler_rows * int(vocab_size) * 4 * 2 * reserve_scale)
+
+
+def _get_diffusion_gemma_sampler_backend() -> str:
+    backend = envs.VLLM_DIFFUSION_GEMMA_SAMPLER_BACKEND.strip().lower()
+    if backend not in _DIFFUSION_GEMMA_SAMPLER_BACKENDS:
+        supported = ", ".join(sorted(_DIFFUSION_GEMMA_SAMPLER_BACKENDS))
+        raise ValueError(
+            f"{_DIFFUSION_GEMMA_SAMPLER_BACKEND_ENV}={backend!r} is not "
+            f"supported; expected one of: {supported}"
+        )
+    return backend
+
+
+def _should_use_diffusion_gemma_row_chunked_sampler(
+    *,
+    row_chunked_input: bool,
+    real_logprobs_enabled: bool,
+) -> bool:
+    # Logprobs require materialized vocab logits for top-k logprob output.
+    # Do not raise here: this helper is called from the EngineCore worker path,
+    # where uncaught exceptions kill the engine. The caller handles the safe
+    # materialized fallback when hidden states were returned by compute_logits.
+    return row_chunked_input and not real_logprobs_enabled
+
+
+def _is_diffusion_gemma_sampler_warmup_batch(input_batch: Any) -> bool:
+    req_ids = getattr(input_batch, "req_ids", ())
+    num_reqs = getattr(input_batch, "num_reqs", 0)
+    return num_reqs > 0 and all(
+        str(req_id).startswith("_warmup_") for req_id in req_ids[:num_reqs]
+    )
+
+
+def _is_diffusion_gemma_hidden_state_input(
+    logits: torch.Tensor, vocab_size: int, hidden_size: int
+) -> bool:
+    last_dim = logits.shape[-1]
+    is_materialized_logits = last_dim == vocab_size
+    is_hidden_states = last_dim == hidden_size
+    if not is_materialized_logits and not is_hidden_states:
+        raise ValueError(
+            "DiffusionGemma row-chunked sampler expected hidden states "
+            f"with hidden size {hidden_size} or materialized logits with "
+            f"vocab size {vocab_size}, got shape {tuple(logits.shape)}."
+        )
+    return is_hidden_states
+
+
+def _get_diffusion_gemma_row_chunk_size(rows: int, vocab_size: int) -> int:
+    if rows < 0:
+        raise ValueError("rows must be >= 0")
+    if vocab_size <= 0:
+        raise ValueError("vocab_size must be positive")
+    if rows == 0:
+        return 1
+
+    explicit = envs.VLLM_DIFFUSION_GEMMA_ROW_CHUNK
+    if explicit < 0:
+        raise ValueError(f"{_DIFFUSION_GEMMA_ROW_CHUNK_ENV} must be >= 0")
+    if explicit > 0:
+        return min(rows, explicit)
+
+    scratch_mib = envs.VLLM_DIFFUSION_GEMMA_ROW_CHUNK_SCRATCH_MIB
+    if scratch_mib <= 0:
+        raise ValueError(
+            f"{_DIFFUSION_GEMMA_ROW_CHUNK_SCRATCH_MIB_ENV} must be > 0"
+        )
+    scratch_bytes = scratch_mib * (1 << 20)
+    per_row = vocab_size * _DIFFUSION_GEMMA_ROW_CHUNK_BYTES_PER_ELEMENT
+    chunk = max(1, scratch_bytes // max(1, per_row))
+    if chunk >= _DIFFUSION_GEMMA_ROW_CHUNK_ALIGNMENT:
+        chunk = (
+            chunk
+            // _DIFFUSION_GEMMA_ROW_CHUNK_ALIGNMENT
+            * _DIFFUSION_GEMMA_ROW_CHUNK_ALIGNMENT
+        )
+    return max(1, min(rows, int(chunk)))
 
 
 class DiffusionGemmaSelfConditioning(nn.Module):
@@ -130,6 +278,19 @@ def _softcap_logits(logits: torch.Tensor, cap: float) -> torch.Tensor:
     # the [num_tokens, vocab] logits instead of four separate passes.
     logits = logits.float()
     return torch.tanh(logits / cap) * cap
+
+
+def _materialize_diffusion_gemma_logits_from_hidden(
+    hidden_states: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    vocab_size: int,
+    final_logit_softcapping: float | None,
+) -> torch.Tensor:
+    """Project row-chunk backend hidden states to vocab logits for fallback paths."""
+    logits = F.linear(hidden_states, lm_head_weight[:vocab_size])
+    if final_logit_softcapping is not None:
+        logits = _softcap_logits(logits, final_logit_softcapping)
+    return logits
 
 
 @MULTIMODAL_REGISTRY.register_processor(
@@ -249,6 +410,39 @@ class DiffusionGemmaForConditionalGeneration(
         self.final_logit_softcapping = getattr(
             text_config, "final_logit_softcapping", None
         )
+
+        self.sampler_backend = _get_diffusion_gemma_sampler_backend()
+        self.use_row_chunked_sampler = self.sampler_backend == "row_chunked"
+        if self.use_row_chunked_sampler:
+            tensor_parallel_size = vllm_config.parallel_config.tensor_parallel_size
+            if tensor_parallel_size != 1:
+                raise ValueError(
+                    "DiffusionGemma row-chunked sampler currently requires "
+                    f"tensor_parallel_size=1, got {tensor_parallel_size}. TP "
+                    "support needs a global LSE/soft-embed merge before this "
+                    "pressure-mode path can be enabled."
+                )
+            if self.lm_head.weight.shape[0] != text_config.vocab_size:
+                raise ValueError(
+                    "DiffusionGemma row-chunked sampler requires an unsharded "
+                    "lm_head with one row per vocab entry, got "
+                    f"{self.lm_head.weight.shape[0]} local rows for global "
+                    f"vocab {text_config.vocab_size}."
+                )
+            if self.final_logit_softcapping is None:
+                raise ValueError(
+                    "DiffusionGemma row-chunked sampler requires "
+                    "final_logit_softcapping so it can match the materialized "
+                    "sampler numerics."
+                )
+            logger.warning_once(
+                "DiffusionGemma row-chunked sampler backend is enabled "
+                "(%s=%s). This opt-in pressure-mode path bounds sampler "
+                "scratch for large decode batches; logprobs are not supported "
+                "with this backend.",
+                _DIFFUSION_GEMMA_SAMPLER_BACKEND_ENV,
+                self.sampler_backend,
+            )
         self.logits_processor = LogitsProcessor(
             text_config.vocab_size,
             soft_cap=None,
@@ -331,6 +525,8 @@ class DiffusionGemmaForConditionalGeneration(
         )
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        if self.use_row_chunked_sampler:
+            return hidden_states
         logits = self.logits_processor(self.lm_head, hidden_states)
         if logits is not None and self.final_logit_softcapping is not None:
             logits = _softcap_logits(logits, self.final_logit_softcapping)
@@ -662,6 +858,121 @@ def _compiled_sample_step(
     return scaled
 
 
+@torch.compile(dynamic=True)
+def _compiled_sample_step_from_row_chunked(
+    new_tokens: torch.Tensor,
+    argmax_tokens: torch.Tensor,
+    token_entropy: torch.Tensor,
+    soft_embeds: torch.Tensor,
+    decode_slots: torch.Tensor,
+    decode_idx: torch.Tensor,
+    all_slots: torch.Tensor,
+    valid_canvas_len: torch.Tensor,
+    canvas: torch.Tensor,
+    argmax_canvas: torch.Tensor,
+    step_tensor: torch.Tensor,
+    is_encoder_phase: torch.Tensor,
+    confident_tensor: torch.Tensor,
+    sc_embeds: torch.Tensor,
+    normalizer: torch.Tensor,
+    history: torch.Tensor,
+    history_len_tensor: torch.Tensor,
+    sampled: torch.Tensor,
+    num_sampled: torch.Tensor,
+    draft_tokens: torch.Tensor,
+    max_denoising_steps: float,
+    confidence_threshold: float,
+    vocab_size: int,
+    CL: int,
+    ST: int,
+    entropy_bound: float,
+) -> torch.Tensor:
+    """Post-process row-chunked sampler outputs without full-vocab logits."""
+    num_decode = decode_slots.shape[0]
+    device = decode_slots.device
+
+    sampled.zero_()
+    num_sampled.zero_()
+
+    mean_entropy = token_entropy.mean(dim=-1)
+    confident_tensor[decode_slots] = mean_entropy < confidence_threshold
+
+    sorted_ent, sorted_idx = torch.sort(token_entropy, dim=-1)
+    cumsum_ent = torch.cumsum(sorted_ent, dim=-1)
+    cummax_ent = torch.cummax(sorted_ent, dim=-1).values
+    sorted_mask = (cumsum_ent - cummax_ent) <= entropy_bound
+    eb_mask = torch.zeros_like(sorted_mask)
+    eb_mask.scatter_(1, sorted_idx, sorted_mask)
+
+    is_commit = is_encoder_phase[decode_slots]
+    is_denoise = ~is_commit
+    cur_step = step_tensor[decode_slots].float()
+
+    new_step_val = torch.where(
+        is_denoise,
+        (cur_step + 1).to(step_tensor.dtype),
+        step_tensor.new_zeros(num_decode),
+    )
+    step_tensor[decode_slots] = new_step_val
+
+    random_tokens = torch.randint(
+        0, vocab_size, (num_decode, CL), device=device, dtype=canvas.dtype
+    )
+    denoise_canvas = torch.where(eb_mask, new_tokens, random_tokens)
+    canvas[decode_slots] = torch.where(
+        is_commit.unsqueeze(1), random_tokens, denoise_canvas
+    )
+
+    hist_len = history_len_tensor[decode_slots]
+    write_pos = hist_len % ST
+    for i in range(ST):
+        write_here = ((write_pos == i) & is_denoise).unsqueeze(1)
+        history[decode_slots, i] = torch.where(
+            write_here, argmax_tokens, history[decode_slots, i]
+        )
+
+    argmax_canvas[decode_slots] = torch.where(
+        is_denoise.unsqueeze(1), argmax_tokens, argmax_canvas[decode_slots]
+    )
+
+    new_hist_len = torch.where(is_denoise, hist_len + 1, hist_len.new_zeros(num_decode))
+    history_len_tensor[decode_slots] = new_hist_len
+
+    sampled[decode_idx] = argmax_canvas[decode_slots].to(
+        sampled.dtype
+    ) * is_commit.unsqueeze(1).to(sampled.dtype)
+    num_sampled[decode_idx] = is_commit.to(num_sampled.dtype) * valid_canvas_len.to(
+        num_sampled.dtype
+    )
+
+    ref = history[decode_slots, 0]
+    mismatch = torch.zeros(num_decode, device=device, dtype=torch.int32)
+    for h in range(1, ST):
+        mismatch = mismatch + (ref != history[decode_slots, h]).sum(dim=-1).int()
+    stable = mismatch == 0
+
+    step_after = step_tensor[decode_slots]
+    converged = (stable & confident_tensor[decode_slots] & (new_hist_len >= ST)) | (
+        step_after >= max_denoising_steps
+    )
+    is_encoder_phase[decode_slots] = torch.where(
+        is_commit, is_commit.new_zeros(num_decode), converged
+    )
+
+    sc_keep = (is_denoise & ~is_encoder_phase[decode_slots])[:, None, None]
+    sc_embeds[decode_slots] = (soft_embeds * normalizer * sc_keep).to(
+        sc_embeds.dtype
+    )
+
+    newly_converged = (converged & is_denoise).unsqueeze(1)
+    canvas[decode_slots] = torch.where(
+        newly_converged, argmax_canvas[decode_slots], canvas[decode_slots]
+    )
+    draft_tokens[all_slots, :CL] = canvas[all_slots]
+
+    return token_entropy.new_empty((0,))
+
+
 class DiffusionGemmaRequestStates:
     """Pre-allocated GPU tensors for DiffusionGemma per-request state.
 
@@ -824,6 +1135,29 @@ class DiffusionGemmaModelState(ModelState):
     def get_supported_generation_tasks(self):
         return ("generate",)
 
+    def get_extra_non_kv_cache_memory_bytes(self) -> int:
+        reserve = _get_diffusion_gemma_sampler_memory_reserve_bytes(
+            envs.VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_MIB,
+            envs.VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_SCALE,
+            max_num_seqs=self.max_num_reqs,
+            max_num_batched_tokens=self.max_num_tokens,
+            canvas_length=self.diffusion_states.canvas_length,
+            # LogitsProcessor all-gathers vocab-parallel logits before the
+            # materialized sampler, so reserve global-vocab scratch.
+            vocab_size=self.model_config.get_vocab_size(),
+        )
+        if reserve > 0:
+            logger.info_once(
+                "DiffusionGemma sampler memory reserve: %s GiB "
+                "(%s=%s, %s=%s)",
+                reserve / (1 << 30),
+                _DIFFUSION_GEMMA_SAMPLER_RESERVE_ENV,
+                envs.VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_MIB,
+                _DIFFUSION_GEMMA_SAMPLER_RESERVE_SCALE_ENV,
+                envs.VLLM_DIFFUSION_GEMMA_SAMPLER_MEMORY_RESERVE_SCALE,
+            )
+        return reserve
+
     def custom_sampler(self, sampler: Any) -> tuple[Any, Any] | None:
         diffusion_config = self.vllm_config.diffusion_config
         gen = self.gen_config
@@ -851,7 +1185,11 @@ class DiffusionGemmaModelState(ModelState):
             entropy_bound=entropy_bound,
             confidence_threshold=gen["confidence_threshold"],
             embed_weight=embed_tokens.weight,
+            lm_head_weight=self.model.lm_head.weight,
+            final_logit_softcapping=self.model.final_logit_softcapping,
             normalizer=self.model.model.normalizer,
+            sampler_backend=self.model.sampler_backend,
+            use_row_chunked_sampler=self.model.use_row_chunked_sampler,
             sc_vocab_start=shard.org_vocab_start_index,
             sc_vocab_end=shard.org_vocab_end_index,
             tp_size=tp_group.world_size,
@@ -1057,7 +1395,11 @@ class DiffusionSampler:
         t_max: float,
         entropy_bound: float,
         embed_weight: torch.Tensor,
+        lm_head_weight: torch.Tensor,
+        final_logit_softcapping: float | None,
         normalizer: torch.Tensor,
+        sampler_backend: str = "materialized",
+        use_row_chunked_sampler: bool = False,
         sc_vocab_start: int = 0,
         sc_vocab_end: int | None = None,
         tp_size: int = 1,
@@ -1071,11 +1413,21 @@ class DiffusionSampler:
         # rank's slice of the full vocab and tp_* drive the cross-rank
         # all-reduce.
         self.embed_weight = embed_weight
+        self.lm_head_weight = lm_head_weight
+        self.final_logit_softcapping = final_logit_softcapping
         self.normalizer = normalizer
+        self.sampler_backend = sampler_backend
+        self.use_row_chunked_sampler = use_row_chunked_sampler
+        self._row_chunked_sampler_logged = False
         self.sc_vocab_start = sc_vocab_start
         self.sc_vocab_end = sc_vocab_end if sc_vocab_end is not None else vocab_size
         self.tp_size = tp_size
         self.tp_group_name = tp_group_name
+        if self.use_row_chunked_sampler and self.tp_size != 1:
+            raise ValueError(
+                "DiffusionGemma row-chunked sampler backend currently supports "
+                "tensor_parallel_size=1 only; use the materialized backend for TP."
+            )
         self.canvas_length = (
             diffusion_config.canvas_length if diffusion_config is not None else 32
         )
@@ -1108,6 +1460,32 @@ class DiffusionSampler:
         # Populated after the post-sample kernel detects convergence; consumed
         # on the subsequent commit step when num_sampled=CANVAS_LEN.
         self._pending_logprobs: dict[int, LogprobsTensors] = {}
+        self._row_chunk_token_offsets: torch.Tensor | None = None
+        self._canvas_offsets: torch.Tensor | None = None
+
+    def _get_row_chunk_token_offsets(self, device: torch.device) -> torch.Tensor:
+        token_offsets = self._row_chunk_token_offsets
+        if (
+            token_offsets is None
+            or token_offsets.device != device
+            or token_offsets.shape[0] != self.vocab_size
+        ):
+            token_offsets = torch.arange(
+                self.vocab_size, device=device, dtype=torch.int64
+            )
+            self._row_chunk_token_offsets = token_offsets
+        return token_offsets
+
+    def _get_canvas_offsets(self, device: torch.device, length: int) -> torch.Tensor:
+        canvas_offsets = self._canvas_offsets
+        if (
+            canvas_offsets is None
+            or canvas_offsets.device != device
+            or canvas_offsets.shape[0] != length
+        ):
+            canvas_offsets = torch.arange(length, device=device, dtype=torch.int64)
+            self._canvas_offsets = canvas_offsets
+        return canvas_offsets
 
     def add_request(self, req_idx: int, prompt_len: int, sampling_params: Any) -> None:
         if use_penalty(sampling_params):
@@ -1267,7 +1645,7 @@ class DiffusionSampler:
         # entropy (no premature convergence) and argmax 0 (stable); they are
         # never committed (num_sampled == real length).
         if num_decode > 0 and valid_canvas_len_np.min() < CL:
-            ar = torch.arange(CL, device=device)
+            ar = self._get_canvas_offsets(device, CL)
             starts = valid_canvas_len.cumsum(0) - valid_canvas_len  # row offset per req
             valid = ar.unsqueeze(0) < valid_canvas_len.unsqueeze(1)  # [num_decode, CL]
             src = (starts.unsqueeze(1) + ar.unsqueeze(0)).clamp_max(logits.shape[0] - 1)
@@ -1283,50 +1661,151 @@ class DiffusionSampler:
         # since it mutates is_encoder_phase (commit→False, converge→True).
         is_committing = states.is_encoder_phase[decode_slots].clone()
 
-        # --- Single compiled call: temp → sample → probs → post-process ---
-        scaled = _compiled_sample_step(
-            logits,
-            decode_slots,
-            decode_idx,
-            all_slots,
-            valid_canvas_len,
-            # State
-            states.canvas,
-            states.argmax_canvas,
-            states.step,
-            states.is_encoder_phase,
-            states.confident,
-            states.self_conditioning_embeds,
-            self.embed_weight,
-            self.normalizer,
-            states.accepted_canvas_history,
-            states.accepted_canvas_history_len,
-            # Output
-            sampled,
-            num_sampled,
-            self.req_states.draft_tokens,
-            # Config
-            max_denoising_steps=float(states.max_denoising_steps),
-            t_min=self.t_min,
-            t_max=self.t_max,
-            confidence_threshold=self.confidence_threshold,
-            vocab_size=self.vocab_size,
-            CL=self.canvas_length,
-            ST=states.stability_threshold,
-            entropy_bound=self.entropy_bound,
-            sc_vocab_start=self.sc_vocab_start,
-            sc_vocab_end=self.sc_vocab_end,
-            tp_size=self.tp_size,
-            tp_group_name=self.tp_group_name,
+        slots_np = input_batch.idx_mapping_np[:num_reqs]
+        max_num_logprobs = self.sampling_states.max_num_logprobs(slots_np)
+        is_sampler_warmup = _is_diffusion_gemma_sampler_warmup_batch(input_batch)
+        real_logprobs_enabled = max_num_logprobs >= 0 and not is_sampler_warmup
+        row_chunked_input = False
+        if self.use_row_chunked_sampler:
+            row_chunked_input = _is_diffusion_gemma_hidden_state_input(
+                logits, self.vocab_size, self.lm_head_weight.shape[1]
+            )
+        sampler_rows = num_decode * CL
+        use_row_chunked = _should_use_diffusion_gemma_row_chunked_sampler(
+            row_chunked_input=row_chunked_input,
+            real_logprobs_enabled=real_logprobs_enabled,
         )
+        if use_row_chunked:
+            row_chunk_size = _get_diffusion_gemma_row_chunk_size(
+                sampler_rows, self.vocab_size
+            )
+            if not self._row_chunked_sampler_logged:
+                logger.warning_once(
+                    "DiffusionGemma row-chunked sampler path is active "
+                    "(row_chunk_env=%d, row_chunk_scratch_mib=%d, "
+                    "resolved_row_chunk=%d).",
+                    envs.VLLM_DIFFUSION_GEMMA_ROW_CHUNK,
+                    envs.VLLM_DIFFUSION_GEMMA_ROW_CHUNK_SCRATCH_MIB,
+                    row_chunk_size,
+                )
+                self._row_chunked_sampler_logged = True
+
+            steps_f = states.step[decode_slots].float()
+            remaining = (float(states.max_denoising_steps) - steps_f).clamp(min=1.0)
+            temp = self.t_min + (self.t_max - self.t_min) * (
+                remaining / float(states.max_denoising_steps)
+            )
+            temperature = temp[:, None].expand(num_decode, CL).reshape(-1)
+            canvas_offsets = self._get_canvas_offsets(device, CL)
+            request_seeds = self.sampling_states.seeds.gpu[decode_slots].to(
+                torch.int64
+            )
+            step_offsets = states.step[decode_slots].to(torch.int64)
+            row_seed_offsets = (
+                (request_seeds[:, None] + (step_offsets[:, None] + 1) * 1_000_003)
+                * CL
+                + canvas_offsets[None, :]
+            ).reshape(-1)
+
+            _, token_entropy, new_tokens, argmax_tokens, soft_embeds = (
+                diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+                    logits,
+                    self.lm_head_weight[: self.vocab_size],
+                    self.embed_weight[: self.vocab_size],
+                    float(self.final_logit_softcapping),
+                    temperature,
+                    # Request seeds are already folded into row_seed_offsets.
+                    0,
+                    row_chunk_size=row_chunk_size,
+                    row_seed_offsets=row_seed_offsets,
+                    token_offsets=self._get_row_chunk_token_offsets(device),
+                    temperature_is_positive=min(self.t_min, self.t_max) > 0,
+                )
+            )
+            scaled = _compiled_sample_step_from_row_chunked(
+                new_tokens.view(num_decode, CL),
+                argmax_tokens.view(num_decode, CL),
+                token_entropy.view(num_decode, CL),
+                soft_embeds.view(num_decode, CL, -1),
+                decode_slots,
+                decode_idx,
+                all_slots,
+                valid_canvas_len,
+                states.canvas,
+                states.argmax_canvas,
+                states.step,
+                states.is_encoder_phase,
+                states.confident,
+                states.self_conditioning_embeds,
+                self.normalizer,
+                states.accepted_canvas_history,
+                states.accepted_canvas_history_len,
+                sampled,
+                num_sampled,
+                self.req_states.draft_tokens,
+                max_denoising_steps=float(states.max_denoising_steps),
+                confidence_threshold=self.confidence_threshold,
+                vocab_size=self.vocab_size,
+                CL=self.canvas_length,
+                ST=states.stability_threshold,
+                entropy_bound=self.entropy_bound,
+            )
+        else:
+            if row_chunked_input:
+                logger.warning_once(
+                    "DiffusionGemma row-chunked sampler disabled because this "
+                    "batch needs logprobs; falling back to materialized logits "
+                    "for correctness."
+                )
+                logits = _materialize_diffusion_gemma_logits_from_hidden(
+                    logits,
+                    self.lm_head_weight,
+                    self.vocab_size,
+                    self.final_logit_softcapping,
+                )
+
+            # --- Single compiled call: temp → sample → probs → post-process ---
+            scaled = _compiled_sample_step(
+                logits,
+                decode_slots,
+                decode_idx,
+                all_slots,
+                valid_canvas_len,
+                # State
+                states.canvas,
+                states.argmax_canvas,
+                states.step,
+                states.is_encoder_phase,
+                states.confident,
+                states.self_conditioning_embeds,
+                self.embed_weight,
+                self.normalizer,
+                states.accepted_canvas_history,
+                states.accepted_canvas_history_len,
+                # Output
+                sampled,
+                num_sampled,
+                self.req_states.draft_tokens,
+                # Config
+                max_denoising_steps=float(states.max_denoising_steps),
+                t_min=self.t_min,
+                t_max=self.t_max,
+                confidence_threshold=self.confidence_threshold,
+                vocab_size=self.vocab_size,
+                CL=self.canvas_length,
+                ST=states.stability_threshold,
+                entropy_bound=self.entropy_bound,
+                sc_vocab_start=self.sc_vocab_start,
+                sc_vocab_end=self.sc_vocab_end,
+                tp_size=self.tp_size,
+                tp_group_name=self.tp_group_name,
+            )
 
         # --- Logprobs: stash on convergence, return on commit ---
-        slots_np = input_batch.idx_mapping_np[:num_reqs]
         is_decode_np = per_req_nlogits_np > 0
 
         logprobs_tensors = None
-        max_num_logprobs = self.sampling_states.max_num_logprobs(slots_np)
-        if max_num_logprobs >= 0:
+        if real_logprobs_enabled:
             # Denoise steps that just converged: the compiled step flipped
             # is_encoder_phase from False→True. Detect as slots where
             # is_encoder_phase is now True but is_committing was False.

--- a/vllm/model_executor/models/diffusion_gemma_rowchunk.py
+++ b/vllm/model_executor/models/diffusion_gemma_rowchunk.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Row-chunked DiffusionGemma sampler helpers.
+
+This module intentionally keeps the production-candidate pressure path small:
+it uses PyTorch/cuBLAS GEMMs over bounded row chunks and does not include the
+experimental Triton or vocab-recompute prototypes.
+"""
+
+from __future__ import annotations
+
+import torch
+
+_INT64_MIX_A = -7046029254386353131
+_INT64_MIX_B = -4658895280553007687
+_INT64_MIX_C = -7723592293110705685
+_INT64_MASK_53 = (1 << 53) - 1
+_FLOAT_2_NEG_53 = 1.0 / float(1 << 53)
+# Keep the Gumbel tile small enough for the opt-in rowchunk memory-pressure
+# path while avoiding excessive per-tile launch overhead. For DiffusionGemma's
+# 262k vocab this makes the throwaway Gumbel tile about 8 MiB per 64 rows.
+_GUMBEL_VOCAB_CHUNK_SIZE = 32_768
+
+
+def _uniform_from_mantissa(mantissa: torch.Tensor) -> torch.Tensor:
+    return ((mantissa.to(torch.float64) + 0.5) * _FLOAT_2_NEG_53).to(torch.float32)
+
+
+def stable_uniform_from_indices(
+    row_offsets: torch.Tensor,
+    token_offsets: torch.Tensor,
+    seed: int,
+) -> torch.Tensor:
+    """Generate deterministic U(0, 1) values keyed by row and token id.
+
+    Each value depends only on ``(row_offsets[i], token_offsets[j], seed)``.
+    Changing row chunk size therefore does not change Gumbel-max samples.  This
+    is a stateless pressure-mode RNG; a lower-level kernel can replace it with
+    vLLM's Philox/counter RNG contract later.
+
+    This preserves the original int64 hash / 53-bit mantissa / fp64-scale /
+    fp32 stream exactly.
+    """
+    x = (
+        token_offsets[None, :].to(torch.int64)
+        + (row_offsets[:, None].to(torch.int64) + 1) * _INT64_MIX_A
+        + int(seed)
+    )
+    return _stable_uniform_from_mixed_int64(x)
+
+
+def _stable_uniform_from_mixed_int64(x: torch.Tensor) -> torch.Tensor:
+    x = (x ^ (x >> 30)) * _INT64_MIX_B
+    x = (x ^ (x >> 27)) * _INT64_MIX_C
+    x = x ^ (x >> 31)
+    mantissa = torch.bitwise_and(x, _INT64_MASK_53)
+    return _uniform_from_mantissa(mantissa)
+
+
+def _stable_uniform_from_row_base(
+    row_base: torch.Tensor,
+    token_offsets: torch.Tensor,
+) -> torch.Tensor:
+    return _stable_uniform_from_mixed_int64(token_offsets[None, :] + row_base)
+
+
+def _stable_gumbel_argmax_from_scaled(
+    scaled: torch.Tensor,
+    row_offsets: torch.Tensor,
+    token_offsets: torch.Tensor,
+    seed: int,
+    noise_scale: float | torch.Tensor,
+    *,
+    gumbel_vocab_chunk_size: int = _GUMBEL_VOCAB_CHUNK_SIZE,
+) -> torch.Tensor:
+    """Sample argmax over vocab without materializing full-vocab noise.
+
+    ``scaled`` is expected to be the fp32 softcapped/temperature-scaled scores
+    produced by ``diffusion_gemma_softcap_row_chunked_sample_soft_embeds``.
+    Ties are resolved like ``torch.argmax`` over the full vocab row: the lowest
+    token id wins. If NaNs leak into a row, the first NaN wins, matching
+    ``torch.max``/``torch.argmax`` behavior.
+    """
+    if gumbel_vocab_chunk_size <= 0:
+        raise ValueError("gumbel_vocab_chunk_size must be positive")
+    if scaled.ndim != 2:
+        raise ValueError("scaled must be rank-2")
+    if scaled.dtype != torch.float32:
+        raise ValueError("scaled must be float32")
+    rows, vocab = scaled.shape
+    if row_offsets.ndim != 1 or row_offsets.shape[0] != rows:
+        raise ValueError("row_offsets must have shape [rows]")
+    if token_offsets.ndim != 1 or token_offsets.shape[0] != vocab:
+        raise ValueError("token_offsets must have shape [vocab]")
+    if row_offsets.device != scaled.device or token_offsets.device != scaled.device:
+        raise ValueError("offset tensors must be on the same device as scaled")
+    if row_offsets.dtype != torch.int64 or token_offsets.dtype != torch.int64:
+        raise ValueError("offset tensors must be int64")
+    if isinstance(noise_scale, torch.Tensor):
+        if noise_scale.shape != (rows, 1):
+            raise ValueError("noise_scale tensor must have shape [rows, 1]")
+        if noise_scale.device != scaled.device:
+            raise ValueError("noise_scale tensor must be on the same device as scaled")
+        if noise_scale.dtype != torch.float32:
+            raise ValueError("noise_scale tensor must be float32")
+    best_values = torch.full(
+        (rows,),
+        float("-inf"),
+        device=scaled.device,
+        dtype=torch.float32,
+    )
+    best_tokens = torch.zeros((rows,), device=scaled.device, dtype=torch.int64)
+    row_base = (row_offsets[:, None] + 1) * _INT64_MIX_A + int(seed)
+    uniform_min = torch.finfo(torch.float32).tiny
+    uniform_max = 1.0 - torch.finfo(torch.float32).eps
+    for vocab_start in range(0, vocab, gumbel_vocab_chunk_size):
+        vocab_end = min(vocab_start + gumbel_vocab_chunk_size, vocab)
+        uniform = _stable_uniform_from_row_base(
+            row_base,
+            token_offsets[vocab_start:vocab_end],
+        )
+        uniform.clamp_(
+            min=uniform_min,
+            max=uniform_max,
+        )
+        # In-place Gumbel transform on the throwaway uniform tile:
+        # uniform = -log(-log(uniform)).
+        uniform.log_()
+        uniform.neg_()
+        uniform.log_()
+        uniform.neg_()
+        if isinstance(noise_scale, torch.Tensor):
+            uniform.mul_(noise_scale)
+        elif float(noise_scale) != 1.0:
+            uniform.mul_(float(noise_scale))
+        uniform.add_(scaled[:, vocab_start:vocab_end])
+        block_values, block_tokens = uniform.max(dim=-1)
+        block_tokens = block_tokens + vocab_start
+        # Full-tensor argmax returns the first max. Since vocab blocks are visited
+        # in order, update only on a strict improvement to preserve tie behavior.
+        # torch.max treats NaN as the row maximum. Preserve that behavior by
+        # updating to the first NaN block, then keeping that first NaN index.
+        update = (block_values > best_values) | (
+            torch.isnan(block_values) & ~torch.isnan(best_values)
+        )
+        best_values = torch.where(update, block_values, best_values)
+        best_tokens = torch.where(update, block_tokens, best_tokens)
+    return best_tokens
+
+
+def diffusion_gemma_softcap_row_chunked_sample_soft_embeds(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    embed_weight: torch.Tensor,
+    softcap: float,
+    temperature: float | torch.Tensor,
+    seed: int,
+    *,
+    row_chunk_size: int = 128,
+    row_seed_offsets: torch.Tensor | None = None,
+    token_offsets: torch.Tensor | None = None,
+    temperature_is_positive: bool = False,
+    gumbel_vocab_chunk_size: int = _GUMBEL_VOCAB_CHUNK_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Row-chunked DiffusionGemma sampler using bounded materialized tiles.
+
+    The fast materialized sampler builds full ``[rows, vocab]`` transients. This
+    helper keeps the same dense cuBLAS-friendly math but bounds transients to
+    ``[row_chunk_size, vocab]`` so high-concurrency decode can avoid OOM. The
+    stateless Gumbel RNG is deterministic and chunk-size invariant, but it is
+    not sample-stream identical to the default materialized sampler RNG.
+    ``token_offsets`` is an optional precomputed ``torch.arange(vocab)`` for
+    callers that reuse the helper every decode step.
+    ``gumbel_vocab_chunk_size`` bounds the throwaway Gumbel/noisy argmax tile
+    inside the already opt-in rowchunk memory-pressure path. Smaller values use
+    less scratch and more loop overhead; this is not a throughput knob.
+    ``temperature_is_positive`` is a caller-provided precondition for tensor
+    temperatures: set it only when every row temperature is strictly positive.
+    It skips zero-temperature greedy handling to avoid a per-chunk CUDA sync.
+
+    Returns ``(lse, entropy, sampled_tokens, greedy_tokens, soft_embeds)`` with
+    one row per input hidden row. ``lse``, ``entropy``, ``greedy_tokens``, and
+    ``soft_embeds`` describe the pre-Gumbel distribution; only
+    ``sampled_tokens`` uses Gumbel noise.
+    """
+    if hidden.ndim != 2 or weight.ndim != 2 or embed_weight.ndim != 2:
+        raise ValueError("hidden, weight, and embed_weight must be rank-2")
+    if hidden.shape[1] != weight.shape[1]:
+        raise ValueError("hidden and weight hidden dimensions must match")
+    if weight.shape[0] != embed_weight.shape[0]:
+        raise ValueError("vocab dimensions must match")
+    if not hidden.is_cuda or not weight.is_cuda or not embed_weight.is_cuda:
+        raise ValueError("all inputs must be CUDA tensors")
+    if softcap <= 0:
+        raise ValueError("softcap must be positive")
+    if row_chunk_size <= 0:
+        raise ValueError("row_chunk_size must be positive")
+    if gumbel_vocab_chunk_size <= 0:
+        raise ValueError("gumbel_vocab_chunk_size must be positive")
+
+    if isinstance(temperature, torch.Tensor):
+        if temperature.ndim != 1 or temperature.shape[0] != hidden.shape[0]:
+            raise ValueError("temperature tensor must have shape [rows]")
+        if not temperature.is_cuda:
+            raise ValueError("temperature tensor must be CUDA")
+        if (temperature < 0).any():
+            raise ValueError("temperature must be non-negative")
+        temperature = temperature.to(device=hidden.device, dtype=torch.float32)
+    elif temperature < 0:
+        raise ValueError("temperature must be non-negative")
+
+    rows = hidden.shape[0]
+    vocab = weight.shape[0]
+    embed_size = embed_weight.shape[1]
+    device = hidden.device
+    if vocab == 0:
+        raise ValueError("weight must have at least one vocab row")
+    if rows == 0:
+        empty = torch.empty((0,), device=device, dtype=torch.float32)
+        empty_tokens = torch.empty((0,), device=device, dtype=torch.int64)
+        empty_soft = torch.empty((0, embed_size), device=device, dtype=torch.float32)
+        return empty, empty, empty_tokens, empty_tokens, empty_soft
+
+    if row_seed_offsets is None:
+        row_seed_offsets = torch.arange(rows, device=device, dtype=torch.int64)
+    else:
+        if row_seed_offsets.ndim != 1 or row_seed_offsets.shape[0] != rows:
+            raise ValueError("row_seed_offsets must have shape [rows]")
+        if not row_seed_offsets.is_cuda:
+            raise ValueError("row_seed_offsets must be CUDA")
+        row_seed_offsets = row_seed_offsets.to(device=device, dtype=torch.int64)
+
+    if token_offsets is None:
+        token_offsets = torch.arange(vocab, device=device, dtype=torch.int64)
+    else:
+        if token_offsets.ndim != 1 or token_offsets.shape[0] != vocab:
+            raise ValueError("token_offsets must have shape [vocab]")
+        if token_offsets.device != device:
+            raise ValueError("token_offsets must be on the same CUDA device")
+        if token_offsets.dtype != torch.int64:
+            raise ValueError("token_offsets must be int64")
+    lse_out = torch.empty((rows,), device=device, dtype=torch.float32)
+    entropy_out = torch.empty_like(lse_out)
+    sample_out = torch.empty((rows,), device=device, dtype=torch.int64)
+    greedy_out = torch.empty_like(sample_out)
+    soft_out = torch.empty((rows, embed_size), device=device, dtype=torch.float32)
+
+    # Avoid copying persistent model weights. Chunk temporaries are newly
+    # allocated below, so in-place softcap/temperature transforms are safe.
+    hidden = hidden.contiguous()
+
+    for row_start in range(0, rows, row_chunk_size):
+        row_end = min(row_start + row_chunk_size, rows)
+        logits = hidden[row_start:row_end] @ weight.t()
+        scaled = logits.float()
+        scaled.div_(float(softcap)).tanh_().mul_(float(softcap))
+
+        if isinstance(temperature, torch.Tensor):
+            temp = temperature[row_start:row_end]
+            if temperature_is_positive:
+                scaled = scaled / temp[:, None]
+                zero_temp_rows = None
+                has_zero_temp = False
+                noise_scale = 1.0
+            else:
+                zero_temp_rows = temp <= 0
+                scaled = scaled / temp.clamp(min=1e-10)[:, None]
+                # For temp==0 DiffusionGemma uses greedy behavior. Keep finite
+                # untemperatured softcapped scores for argmax/LSE diagnostics.
+                has_zero_temp = bool(zero_temp_rows.any())
+                if has_zero_temp:
+                    unscaled = logits.float()
+                    unscaled.div_(float(softcap)).tanh_().mul_(float(softcap))
+                    scaled = torch.where(zero_temp_rows[:, None], unscaled, scaled)
+                noise_scale = (temp > 0).to(torch.float32)[:, None]
+            skip_gumbel = False
+        else:
+            scalar_zero_temp = float(temperature) <= 0
+            zero_temp_rows = torch.full(
+                (row_end - row_start,),
+                scalar_zero_temp,
+                device=device,
+                dtype=torch.bool,
+            )
+            has_zero_temp = scalar_zero_temp
+            skip_gumbel = scalar_zero_temp
+            if not scalar_zero_temp:
+                scaled.div_(float(temperature))
+                noise_scale = 1.0
+            else:
+                noise_scale = 0.0
+
+        greedy = scaled.argmax(dim=-1)
+        log_probs = scaled.log_softmax(dim=-1)
+        greedy_col = greedy[:, None]
+        lse = (
+            scaled.gather(1, greedy_col) - log_probs.gather(1, greedy_col)
+        ).squeeze(1)
+        probs = log_probs.exp_()
+        entropy = lse - (probs * scaled).sum(dim=-1)
+        if has_zero_temp:
+            assert zero_temp_rows is not None
+            entropy = torch.where(zero_temp_rows, torch.zeros_like(entropy), entropy)
+        soft = (probs.to(embed_weight.dtype) @ embed_weight).float()
+
+        if skip_gumbel:
+            sample = greedy
+        else:
+            sample = _stable_gumbel_argmax_from_scaled(
+                scaled,
+                row_seed_offsets[row_start:row_end],
+                token_offsets,
+                seed,
+                noise_scale,
+                gumbel_vocab_chunk_size=gumbel_vocab_chunk_size,
+            )
+
+        if has_zero_temp:
+            assert zero_temp_rows is not None
+            sample = torch.where(zero_temp_rows, greedy, sample)
+            soft[zero_temp_rows] = embed_weight[greedy[zero_temp_rows]].float()
+
+        lse_out[row_start:row_end] = lse
+        entropy_out[row_start:row_end] = entropy
+        sample_out[row_start:row_end] = sample.to(torch.int64)
+        greedy_out[row_start:row_end] = greedy.to(torch.int64)
+        soft_out[row_start:row_end] = soft
+
+    return lse_out, entropy_out, sample_out, greedy_out, soft_out

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -371,6 +371,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def get_model(self) -> nn.Module:
         return self.model
 
+    def get_extra_non_kv_cache_memory_bytes(self) -> int:
+        return self.model_state.get_extra_non_kv_cache_memory_bytes()
+
     def reload_weights(self, *args, **kwargs) -> None:
         # TODO(Wentao): Use full version instead of import when fully migrated to v2
         from vllm.v1.worker.gpu_model_runner import GPUModelRunner as GPUModelRunnerV1
@@ -1054,14 +1057,32 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         sample_hidden_states = hidden_states[input_batch.logits_indices]
         logits = self.model.compute_logits(sample_hidden_states)
         if grammar_output is not None:
-            # Apply grammar bitmask to the logits in-place.
-            assert self.structured_outputs_worker is not None
-            self.structured_outputs_worker.apply_grammar_bitmask(
-                logits,
-                input_batch,
-                grammar_output.structured_output_request_ids,
-                grammar_output.grammar_bitmask,
+            logits_are_materialized = (
+                logits is not None and logits.shape[-1] == self.vocab_size
             )
+            is_sampler_warmup = input_batch.num_reqs > 0 and all(
+                str(req_id).startswith("_warmup_")
+                for req_id in input_batch.req_ids[: input_batch.num_reqs]
+            )
+            if not logits_are_materialized:
+                if not is_sampler_warmup:
+                    raise ValueError(
+                        "Structured outputs require materialized vocab logits; "
+                        "disable any model-specific sampler backend that returns "
+                        "hidden states from compute_logits."
+                    )
+            else:
+                # Apply grammar bitmask to the logits in-place. Warmup may use a
+                # model-specific sampler path that intentionally returns hidden
+                # states instead of vocab logits; skip the synthetic grammar
+                # exercise there rather than forcing a full materialized sampler.
+                assert self.structured_outputs_worker is not None
+                self.structured_outputs_worker.apply_grammar_bitmask(
+                    logits,
+                    input_batch,
+                    grammar_output.structured_output_request_ids,
+                    grammar_output.grammar_bitmask,
+                )
 
         if input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:
             assert self.sampler is not None

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -174,6 +174,16 @@ class ModelState(ABC):
         """
         return None
 
+    def get_extra_non_kv_cache_memory_bytes(self) -> int:
+        """Extra non-KV memory to reserve during KV-cache sizing.
+
+        Model states can override this when startup profiling does not cover a
+        runtime allocation that must coexist with KV cache. The GPU worker
+        treats the returned value generically and subtracts it from available KV
+        memory without knowing model-specific details.
+        """
+        return 0
+
     num_new_sampled_tokens_per_step: int = 1
     """New tokens sampled on each decode step 
     (excluding accepted draft tokens, a.k.a num bonus tokens)."""

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -91,6 +91,30 @@ if TYPE_CHECKING:
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
+def _subtract_model_memory_reserve(
+    available_kv_cache_memory_bytes: int,
+    extra_non_kv_cache_memory: int,
+) -> int:
+    if extra_non_kv_cache_memory < 0:
+        raise ValueError(
+            "Model-reported non-KV runtime memory reserve must be "
+            f"non-negative, got {extra_non_kv_cache_memory}."
+        )
+
+    available_kv_cache_memory_bytes -= extra_non_kv_cache_memory
+    if extra_non_kv_cache_memory > 0 and available_kv_cache_memory_bytes <= 0:
+        raise ValueError(
+            "Model-reported non-KV runtime memory reserve leaves no "
+            "available KV cache memory. Reduce the model-specific reserve, "
+            "lower --gpu-memory-utilization, or reduce "
+            "--max-model-len/--max-num-seqs. Reserve: "
+            f"{format_gib(extra_non_kv_cache_memory)} GiB; "
+            "available KV cache memory after reserve: "
+            f"{format_gib(available_kv_cache_memory_bytes)} GiB."
+        )
+    return available_kv_cache_memory_bytes
+
+
 class AsyncIntermediateTensors(IntermediateTensors):
     """IntermediateTensors with lazy comm synchronization"""
 
@@ -167,6 +191,7 @@ class Worker(WorkerBase):
             raise ValueError(f"Unknown profiler type: {self.profiler_config.profiler}")
 
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
+        self.extra_non_kv_cache_memory = 0
         # pending non-blocking PP send work from the previous iteration
         self._pp_send_work: list[Handle] = []
 
@@ -503,6 +528,9 @@ class Worker(WorkerBase):
         self.non_torch_memory = profile_result.non_torch_increase
         self.peak_activation_memory = profile_result.torch_peak_increase
         self.cudagraph_memory_estimate = cudagraph_memory_estimate
+        self.extra_non_kv_cache_memory = (
+            self.model_runner.get_extra_non_kv_cache_memory_bytes()
+        )
 
         free_gpu_memory = profile_result.after_profile.free_memory
         # NOTE(woosuk): Here we assume that the other processes using the same
@@ -516,10 +544,11 @@ class Worker(WorkerBase):
             "To fix this, ensure consistent GPU memory allocation or "
             "isolate vLLM in its own container."
         )
-        self.available_kv_cache_memory_bytes = (
+        self.available_kv_cache_memory_bytes = _subtract_model_memory_reserve(
             self.requested_memory
             - profile_result.non_kv_cache_memory
-            - cudagraph_memory_estimate_applied
+            - cudagraph_memory_estimate_applied,
+            self.extra_non_kv_cache_memory,
         )
 
         unrequested_memory = self.init_snapshot.free_memory - self.requested_memory
@@ -535,6 +564,12 @@ class Worker(WorkerBase):
             format_gib(free_gpu_memory - unrequested_memory),
         )
         logger.debug(profile_result)
+        if self.extra_non_kv_cache_memory > 0:
+            logger.info_once(
+                "Reserving %s GiB for model-reported non-KV runtime memory "
+                "outside the startup profile.",
+                format_gib(self.extra_non_kv_cache_memory),
+            )
         logger.info_once(
             "Available KV cache memory: %s GiB",
             format_gib(self.available_kv_cache_memory_bytes),
@@ -793,11 +828,13 @@ class Worker(WorkerBase):
             # So leave a small buffer (=150MiB) to avoid OOM.
             redundancy_buffer_memory = 150 * (1 << 20)
 
+            extra_non_kv_cache_memory = self.extra_non_kv_cache_memory
             non_kv_cache_memory = (
                 self.model_runner.model_memory_usage
                 + self.peak_activation_memory
                 + self.non_torch_memory
                 + cuda_graph_memory_bytes
+                + extra_non_kv_cache_memory
             )
             kv_cache_memory_bytes_to_gpu_limit = (
                 self.init_snapshot.free_memory
@@ -810,6 +847,13 @@ class Worker(WorkerBase):
                 - redundancy_buffer_memory
             )
 
+            extra_memory_msg = (
+                ", "
+                f"{format_gib(extra_non_kv_cache_memory)} GiB for "
+                "model-reported non-KV runtime memory"
+                if extra_non_kv_cache_memory > 0
+                else ""
+            )
             msg = (
                 f"Free memory on device "
                 f"({format_gib(self.init_snapshot.free_memory)}/"
@@ -820,8 +864,9 @@ class Worker(WorkerBase):
                 f"Actual usage is {format_gib(self.model_runner.model_memory_usage)} "
                 f"GiB for weight, {format_gib(self.peak_activation_memory)} GiB "
                 f"for peak activation, {format_gib(self.non_torch_memory)} GiB "
-                f"for non-torch memory, and {format_gib(cuda_graph_memory_bytes)} "
-                f"GiB for CUDAGraph memory. Replace gpu_memory_utilization "
+                f"for non-torch memory{extra_memory_msg}, and "
+                f"{format_gib(cuda_graph_memory_bytes)} GiB for CUDAGraph "
+                f"memory. Replace gpu_memory_utilization "
                 f"config with `--kv-cache-memory="
                 f"{kv_cache_memory_bytes_to_requested_limit}` "
                 f"({format_gib(kv_cache_memory_bytes_to_requested_limit)} GiB) to fit "


### PR DESCRIPTION
Draft PR for maintainer feedback.

## Summary

DiffusionGemma decode can create full-vocab sampler buffers sized by sampler rows times vocabulary after KV-cache sizing. At serving pressure, that temporary allocation can OOM even when model loading and KV allocation succeed.

This PR adds an opt-in `row_chunked` DiffusionGemma sampler path. In that path, `compute_logits()` returns hidden states and the sampler projects a bounded number of rows at a time. The dominant live full-vocab sampler term changes from `O(R * V)` to `O(K * V)`, where:

```text
R = num_decode_requests * canvas_length
V = vocab_size
K = row_chunk_size
```

Default behavior is unchanged. The current materialized sampler remains the default.

```bash
VLLM_DIFFUSION_GEMMA_SAMPLER_BACKEND=row_chunked
```

The branch also includes a default-no-op model hook for model-reported non-KV runtime memory reserve, applies that reserve during GPU KV-cache sizing, and falls back to the existing materialized sampler when logprobs are requested. I can split the reserve hook if maintainers prefer that as a separate change.

## Implementation notes

- Avoid pre-sampler full-vocab logits in the opt-in path: `compute_logits()` returns hidden states for `row_chunked` instead of materializing `[sampler_rows, vocab]` logits before sampling.
- Bound live sampler rows: the rowchunk sampler projects only `row_chunk_size` rows at a time, changing the dominant live full-vocab term from `O(R * V)` to `O(K * V)`.
- Preserve chunk-size invariance: non-greedy sampling uses stateless row/token-indexed randomness, so the sampled token for a row is independent of row chunk size.
- Bound random-sampling scratch: Gumbel generation is tiled over vocab inside each row chunk.
- Reduce per-chunk overhead: the helper reuses `log_softmax` normalization results and hoists row-local RNG setup outside the inner vocab-tile loop.
- Keep logprobs safe: requests that need logprobs use the existing materialized sampler path.

Only the dominant shape change is quantified: with `R=4096` and `K=64`, the live full-vocab row term is `R / K = 64x` smaller. The measured peak numbers below are for the combined rowchunk path; the smaller optimizations are not separately attributed.

## Related work

- #45672 is the closest overlap. It bounds DiffusionGemma sampler transient memory by tiling request groups inside the materialized sampler path.
- I measured the two shapes locally. Request tiling is effective for sampler transient when the request group is small. The architectural difference is that request tiling still starts from full materialized logits, while this branch avoids that full logits tensor in the opt-in path.
- I am happy to contribute the validation harness or rework this as a follow-up if maintainers prefer #45672 as the base direction.
- #45689 is relevant to the logprobs fallback path.
- #45719 is relevant DiffusionGemma multi-GPU context. TP/PP support is outside this PR.
- #37518 is related to sampler memory accounting and KV sizing.
- #45369 uses a similar full-vocab buffer reduction pattern in another sampler path.

## Test plan

Local checks:

```bash
ruff check <changed files>
.venv/bin/python -m py_compile <changed python files>
git diff --check
.venv/bin/python -m pytest tests/model_executor/test_diffusion_gemma_rowchunk_sampler.py -q
.venv/bin/python -m pytest tests/v1/worker/test_diffusion_sampler_memory_reserve.py -q
.venv/bin/python -m pytest tests/v1/worker/test_model_memory_reserve.py -q
```

A100 validation used:

- isolated sampler-buffer microbench over the production materialized sampler core and rowchunk helper;
- rowchunk K-sweep at fixed `R=4096`;
- correctness checks for helper extraction, greedy parity, chunk-size invariance, and non-greedy distribution sanity against a same-sampler noise floor;
- same-pod A100 serving A/B with ShareGPT traffic, using a minimal overlay identical for both backends.

Serving command shape. Row chunk sizing is exposed as an env var in this draft and can move to auto-sizing if maintainers prefer that shape:

```bash
export VLLM_DIFFUSION_GEMMA_SAMPLER_BACKEND=row_chunked
export VLLM_DIFFUSION_GEMMA_ROW_CHUNK=64
export VLLM_DIFFUSION_GEMMA_ROW_CHUNK_SCRATCH_MIB=1024

.venv/bin/python -m vllm.entrypoints.cli.main serve \
  google/diffusiongemma-26B-A4B-it \
  --host 0.0.0.0 \
  --port 8000 \
  --dtype bfloat16 \
  --gpu-memory-utilization 0.90 \
  --max-model-len 8192 \
  --max-num-seqs 16 \
  --max-num-batched-tokens 4096 \
  --trust-remote-code
```

Benchmark shape:

```bash
.venv/bin/python -m vllm.entrypoints.cli.main bench serve \
  --backend openai-chat \
  --endpoint /v1/chat/completions \
  --base-url http://127.0.0.1:8000 \
  --model google/diffusiongemma-26B-A4B-it \
  --dataset-name sharegpt \
  --dataset-path /path/to/sharegpt_first1000.json \
  --disable-shuffle \
  --num-prompts 500 \
  --sharegpt-output-len 128 \
  --ignore-eos \
  --request-rate inf \
  --max-concurrency 16 \
  --seed 123
```

## Test results

Latest tested branch head:

```text
bb80632dc478752bd7aba58cc78e76ab1f766558
```

Targeted unit/CUDA checks for the three pytest files listed above: `55 passed, 21 warnings in 47.74s`.

### Isolated sampler-buffer microbench

This microbench measures isolated sampler-buffer peak for the production materialized sampler core after helper extraction and for the rowchunk helper; it is separate from end-to-end serving VRAM.

At `R=4096`, `K=64`, current materialized peaked at `32,768 MiB`; `row_chunked` peaked at `248 MiB`, about `132x` lower for this isolated helper shape.

| sampler rows R | current materialized peak | row_chunked peak, K=64 | ratio |
|---:|---:|---:|---:|
| 256 | 2,048 MiB | 233 MiB | 8.8x |
| 1,024 | 8,192 MiB | 236 MiB | 34.7x |
| 3,072 | 24,576 MiB | 244 MiB | 100.6x |
| 4,096 | 32,768 MiB | 248 MiB | 131.9x |

K-sweep at fixed `R=4096`:

| row chunk K | row_chunked peak |
|---:|---:|
| 16 | 74 MiB |
| 32 | 132 MiB |
| 64 | 248 MiB |
| 128 | 481 MiB |
| 256 | 945 MiB |

The K-sweep is the direct shape proof for `O(K * V)` live full-vocab memory in the rowchunk path.

### Correctness checks

- Extracted materialized helper matched the original inline production-core block exactly in the small equivalence check: sampled tokens, greedy tokens, scaled logits, entropy, and soft embeddings matched.
- `row_chunked` sample and greedy token IDs were exact across tested chunk sizes: `K=16`, `32`, `64`, `128`, and `257` (`K=257` is the full-batch control for that input).
- Temperature-zero sample and greedy IDs matched between materialized and rowchunk paths with 0 mismatches.
- Non-greedy distribution sanity checks routed through `diffusion_gemma_softcap_row_chunked_sample_soft_embeds` and landed within the materialized-vs-materialized finite-sample noise-floor gate at temperatures `1.0` and `0.7`.
- Continuous side outputs can differ slightly across chunk sizes due to reduction order. The exact invariance claim is for sampled and greedy token IDs.

Distribution sanity summary, top 128 probability tokens plus one tail bin over 200,000 samples. The gate is set at `2x` the materialized-vs-materialized same-sampler control TV, so these are finite-sample noise-floor comparisons rather than absolute quality scores:

| temperature | materialized control TV | rowchunk entrypoint TV | effective TV limit | result |
|---:|---:|---:|---:|---|
| 1.0 | 0.007840 | 0.008440 | 0.015680 | pass |
| 0.7 | 0.010345 | 0.010060 | 0.020690 | pass |

### Serving pressure validation

This was a same-pod A100 validation using a minimal overlay identical for both backends, not a packaged wheel.

Dataset: ShareGPT. Output length: 128. Request rate: infinite. Shuffle disabled.

| case | backend | serving limits | traffic | readiness | completed | errors | output tok/s | total tok/s | observed max VRAM | OOM markers |
|---|---|---|---|---|---:|---:|---:|---:|---:|---:|
| lower pressure | current sampler | seqs=8, tokens=2048 | c4/o128/n200 | ready | 200/200 | 0 | 231.12 | 671.93 | 78,269 MiB | 0 |
| lower pressure | row_chunked | seqs=8, tokens=2048 | c4/o128/n200 | ready | 200/200 | 0 | 153.20 | 445.39 | 73,853 MiB | 0 |
| crossover | current sampler | seqs=8, tokens=2048 | c8/o128/n200 | ready | 8/200 | 192 | n/a | n/a | 80,745 MiB | 2 |
| crossover | row_chunked | seqs=8, tokens=2048 | c8/o128/n200 | ready | 200/200 | 0 | 176.70 | 513.71 | 73,903 MiB | 0 |
| high pressure | current sampler | seqs=16, tokens=4096 | readiness only | server died | n/a | n/a | n/a | n/a | 79,683 MiB | 4 |
| high pressure | row_chunked | seqs=16, tokens=4096 | c16/o128/n500 | ready | 500/500 | 0 | 186.87 | 559.86 | 73,947 MiB | 0 |

At lower pressure, both backends completed and the current sampler was faster. The goal of this branch is memory capacity under pressure. In the crossover case, the current sampler hit a sampler-path OOM that killed the engine; the remaining requests then failed against the downed server. At the high-pressure setting, the current sampler OOMed before reaching a usable ready state, while `row_chunked` completed. Throughput is listed as `n/a` for failed current-sampler rows because those benchmark runs did not complete.

## Known limitations

- TP/PP support is outside this PR. The rowchunk path here is TP=1 only.
- Structured output serving is not validated here.
- Quantized backends are not validated here.
- Logprobs requests fall back to the existing materialized sampler path.

## Checklist

- [x] Purpose and related work described.
- [x] Test commands included.
- [x] Test results included with separate isolated sampler-buffer and serving VRAM measurements.
- [x] AI assistance was used; the submitter reviewed the final diff and validation results.
- [ ] Documentation updates, if maintainers want an operator-facing note for the opt-in backend.
