### PR TITLE
fix: DeepSeek-V4 tokenizer pickling error 'mlir_global_dtors' (closes #44949)

### DIFF
--- a/vllm/tokenizers/deepseek_v32.py
+++ b/vllm/tokenizers/deepseek_v32.py
@@ -74,11 +74,13 @@ def get_deepseek_v32_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
             return added_vocab.copy()
 
         def __reduce__(self):
-            return get_deepseek_v32_tokenizer, (tokenizer,)
+            # Ensure the tokenizer used for reconstruction is the unwrapped base tokenizer
+            return get_deepseek_v32_tokenizer, (tokenizer.__class__.from_pretrained(tokenizer.name_or_path),)
 
     _DeepseekV32Tokenizer.__name__ = f"DSV32{tokenizer.__class__.__name__}"
 
     dsv32_tokenizer.__class__ = _DeepseekV32Tokenizer
+    dsv32_tokenizer.__reduce_ex__ = dsv32_tokenizer.__reduce__
     return dsv32_tokenizer
 
 


### PR DESCRIPTION
## What
The DeepSeek-V4 tokenizer wrapper fails with `mlir_global_dtors() missing 1 required positional argument: "data"` when the model is loaded in certain environments. The root cause is improper pickling of the patched tokenizer class in `get_deepseek_v32_tokenizer`. The `__reduce__` method returns the original tokenizer object directly, which can cause corruption or missing state during multiprocessing serialization.

## Fix
- Updated `__reduce__` to reconstruct the tokenizer from its pretrained path rather than passing the already-wrapped tokenizer instance. This ensures proper serialization without corruption.
- Added assignment of `__reduce_ex__` to ensure consistency.

Closes #44949