### PR TITLE
[CPU] Fix segfault in mixed-batch GQA attention scheduling

### DIFF
--- a/csrc/cpu/cpu_attn_impl.hpp
+++ b/csrc/cpu/cpu_attn_impl.hpp
@@ -419,8 +419,7 @@ class AttentionScheduler {
     int32_t q_head_per_kv = input.num_heads_q / input.num_heads_kv;
     const bool supports_gqa = q_head_per_kv <= max_num_q_per_iter;
     const bool use_gqa_fast_path = supports_gqa && decode_only_batch;
-    const bool use_gqa_scratchpad = supports_gqa && has_decode_request;
-    if (!use_gqa_scratchpad) {
+    if (!use_gqa_fast_path) {
       q_head_per_kv = 1;  // fallback to MHA
     }
     const int32_t min_split_kv_len =
@@ -1482,6 +1481,10 @@ class AttentionMainLoop {
               sizeof(q_buffer_t), sizeof(logits_buffer_t),
               sizeof(partial_output_buffer_t), max_q_head_num_per_iter,
               max_q_head_num_per_iter);
+      const int32_t max_q_token_num_per_iter =
+          max_q_head_num_per_iter / actual_q_heads_per_kv;
+      const int32_t default_q_tile_token_num =
+          default_tile_size / actual_q_heads_per_kv;
 
       const int32_t effective_thread_num = metadata.effective_thread_num;
       const int32_t reduction_item_num = metadata.reduction_item_num;
@@ -1539,21 +1542,8 @@ class AttentionMainLoop {
             const int32_t q_token_id_start =
                 current_workitem_group->q_token_id_start;
             const int32_t q_token_num = current_workitem_group->q_token_num;
-            const bool curr_use_gqa =
-                use_gqa_fast_path || (supports_gqa && q_token_num == 1);
-            if (!use_gqa_fast_path && curr_use_gqa &&
-                kv_head_idx % q_heads_per_kv != 0) {
-              continue;
-            }
-            const int32_t curr_q_heads_per_kv =
-                curr_use_gqa ? q_heads_per_kv : 1;
-            const int32_t curr_max_q_token_num_per_iter =
-                max_q_head_num_per_iter / curr_q_heads_per_kv;
-            const int32_t curr_default_q_tile_token_num =
-                default_tile_size / curr_q_heads_per_kv;
             const int32_t q_head_start_idx =
-                use_gqa_fast_path ? (kv_head_idx * q_heads_per_kv)
-                                  : kv_head_idx;
+                kv_head_idx * actual_q_heads_per_kv;
 
             // taskgroup general information
             const int32_t q_end = input->query_start_loc[current_group_idx + 1];
@@ -1567,7 +1557,7 @@ class AttentionMainLoop {
                              current_workitem_group->local_split_id == 0);
 
             for (int32_t q_token_offset = 0; q_token_offset < q_token_num;
-                 q_token_offset += curr_default_q_tile_token_num) {
+                 q_token_offset += default_q_tile_token_num) {
               bool first_iter_flag[AttentionScheduler::MaxQTileIterNum];
               for (int32_t i = 0; i < AttentionScheduler::MaxQTileIterNum;
                    ++i) {
@@ -1577,9 +1567,9 @@ class AttentionMainLoop {
               const int32_t q_token_start_idx =
                   q_start + q_token_offset + q_token_id_start;
               const int32_t actual_q_token_num = std::min(
-                  curr_default_q_tile_token_num, q_token_num - q_token_offset);
+                  default_q_tile_token_num, q_token_num - q_token_offset);
               const int32_t q_head_tile_size =
-                  actual_q_token_num * curr_q_heads_per_kv;
+                  actual_q_token_num * actual_q_heads_per_kv;
               const int32_t rounded_q_head_tile_size =
                   ((q_head_tile_size + max_q_head_num_per_iter - 1) /
                    max_q_head_num_per_iter) *
@@ -1653,11 +1643,11 @@ class AttentionMainLoop {
                   (s_aux != nullptr ? s_aux + q_head_start_idx : nullptr);
 
               // copy the Q tile to q_buffer, the logical layout of q_buffer is
-              // [actual_q_token_num, curr_q_heads_per_kv, head_dim]
+              // [actual_q_token_num, actual_q_heads_per_kv, head_dim]
               {
                 attn_impl.copy_q_heads_tile(
                     q_tile_ptr, q_buffer, actual_q_token_num,
-                    curr_q_heads_per_kv, q_token_num_stride, q_head_num_stride,
+                    actual_q_heads_per_kv, q_token_num_stride, q_head_num_stride,
                     scale);
               }
 
@@ -1672,29 +1662,29 @@ class AttentionMainLoop {
                 float* __restrict__ curr_max_buffer = max_buffer;
                 for (int32_t token_idx = 0; token_idx < actual_q_token_num;
                      ++token_idx) {
-                  for (int32_t head_idx = 0; head_idx < curr_q_heads_per_kv;
+                  for (int32_t head_idx = 0; head_idx < actual_q_heads_per_kv;
                        ++head_idx) {
                     curr_sum_buffer[head_idx] = 1.0f;
                     curr_max_buffer[head_idx] = s_aux_fp32[head_idx];
                   }
 
-                  curr_sum_buffer += curr_q_heads_per_kv;
-                  curr_max_buffer += curr_q_heads_per_kv;
+                  curr_sum_buffer += actual_q_heads_per_kv;
+                  curr_max_buffer += actual_q_heads_per_kv;
                 }
               } else {
                 float* __restrict__ curr_sum_buffer = sum_buffer;
                 float* __restrict__ curr_max_buffer = max_buffer;
                 for (int32_t token_idx = 0; token_idx < actual_q_token_num;
                      ++token_idx) {
-                  for (int32_t head_idx = 0; head_idx < curr_q_heads_per_kv;
+                  for (int32_t head_idx = 0; head_idx < actual_q_heads_per_kv;
                        ++head_idx) {
                     curr_sum_buffer[head_idx] = 0.0f;
                     curr_max_buffer[head_idx] =
                         std::numeric_limits<float>::lowest();
                   }
 
-                  curr_sum_buffer += curr_q_heads_per_kv;
-                  curr_max_buffer += curr_q_heads_per_kv;
+                  curr_sum_buffer += actual_q_heads_per_kv;
+                  curr_max_buffer += actual_q_heads_per_kv;
                 }
               }
 
@@ -1708,16 +1698,16 @@ class AttentionMainLoop {
                 for (int32_t q_head_tile_token_offset = 0;
                      q_head_tile_token_offset < actual_q_token_num;
                      q_head_tile_token_offset +=
-                     curr_max_q_token_num_per_iter) {
+                     max_q_token_num_per_iter) {
                   const int32_t q_tile_pos_left =
                       q_tile_start_pos + q_head_tile_token_offset;
                   const int32_t q_tile_token_num =
-                      std::min(curr_max_q_token_num_per_iter,
+                      std::min(max_q_token_num_per_iter,
                                actual_q_token_num - q_head_tile_token_offset);
                   const int32_t q_tile_head_offset =
-                      q_head_tile_token_offset * curr_q_heads_per_kv;
+                      q_head_tile_token_offset * actual_q_heads_per_kv;
                   const int32_t q_tile_head_num =
-                      q_tile_token_num * curr_q_heads_per_kv;
+                      q_tile_token_num * actual_q_heads_per_kv;
                   const int32_t q_tile_pos_right =
                       q_tile_pos_left + q_tile_token_num;
                   const auto [actual_kv_tile_pos_left,
@@ -1727,7 +1717,7 @@ class AttentionMainLoop {
                           q_tile_pos_right, sliding_window_left,
                           sliding_window_right);
                   const int32_t q_iter_idx =
-                      q_head_tile_token_offset / curr_max_q_token_num_per_iter;
+                      q_head_tile_token_offset / max_q_token_num_per_iter;
 
                   if (actual_kv_tile_pos_right <= actual_kv_tile_pos_left) {
                     continue;
@@ -1793,7 +1783,7 @@ class AttentionMainLoop {
                       aligned_actual_kv_tile_pos_left,
                       aligned_actual_kv_tile_pos_right, actual_kv_token_num,
                       kv_cache_block_num_stride, q_tile_head_num,
-                      q_tile_token_num, q_tile_pos_left, curr_q_heads_per_kv,
+                      q_tile_token_num, q_tile_pos_left, actual_q_heads_per_kv,
                       block_size, sliding_window_left, sliding_window_right,
                       scale, softcap_scale, curr_alibi_slopes,
                       first_iter_flag[q_iter_idx], use_sink, debug_info);
@@ -1807,11 +1797,11 @@ class AttentionMainLoop {
                   final_output(partial_q_buffer,
                                reinterpret_cast<query_t*>(input->output) +
                                    output_buffer_offset,
-                               sum_buffer, curr_q_heads_per_kv,
+                               sum_buffer, actual_q_heads_per_kv,
                                actual_q_token_num, q_head_num, output_v_scale);
                 } else {
                   const int32_t stride =
-                      curr_q_heads_per_kv * split_kv_q_token_num_threshold;
+                      actual_q_heads_per_kv * split_kv_q_token_num_threshold;
                   buffer_manager.update(kv_head_idx, total_reduction_split_num,
                                         head_dim, stride, sizeof(float));
                   volatile bool* split_flag_buffer =
@@ -1847,26 +1837,19 @@ class AttentionMainLoop {
           const int32_t curr_split_id = curr_workitem_groups->split_start_id;
           const int32_t curr_split_num = curr_workitem_groups->split_num;
           const int32_t current_group_idx = curr_workitem_groups->req_id;
-          const bool curr_use_gqa =
-              use_gqa_fast_path || (supports_gqa && curr_output_token_num == 1);
-          if (!use_gqa_fast_path && curr_use_gqa &&
-              kv_head_idx % q_heads_per_kv != 0) {
-            continue;
-          }
-          const int32_t curr_q_heads_per_kv = curr_use_gqa ? q_heads_per_kv : 1;
           const int32_t curr_output_head_num =
-              curr_output_token_num * curr_q_heads_per_kv;
+              curr_output_token_num * actual_q_heads_per_kv;
 
           const int32_t q_start = input->query_start_loc[current_group_idx];
           const int32_t q_token_start_idx = q_start + curr_output_token_idx;
           const int32_t q_head_start_idx =
-              use_gqa_fast_path ? (kv_head_idx * q_heads_per_kv) : kv_head_idx;
+              kv_head_idx * actual_q_heads_per_kv;
           size_t output_buffer_offset =
               q_token_start_idx * q_head_num * head_dim +
               q_head_start_idx * head_dim;
 
           const int32_t stride =
-              curr_q_heads_per_kv * split_kv_q_token_num_threshold;
+              actual_q_heads_per_kv * split_kv_q_token_num_threshold;
           buffer_manager.update(kv_head_idx, total_reduction_split_num,
                                 head_dim, stride, sizeof(float));
           volatile bool* split_flag_buffer =
@@ -1885,7 +1868,7 @@ class AttentionMainLoop {
           final_output(
               split_output_buffer,
               reinterpret_cast<query_t*>(input->output) + output_buffer_offset,
-              split_sum_buffer, curr_q_heads_per_kv, curr_output_token_num,
+              split_sum_buffer, actual_q_heads_per_kv, curr_output_token_num,
               q_head_num, output_v_scale);
         }
       }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -218,6 +218,10 @@ COPY requirements/common.txt requirements/common.txt
 COPY requirements/cuda.txt requirements/cuda.txt
 COPY use_existing_torch.py use_existing_torch.py
 COPY pyproject.toml pyproject.toml
+# nvidia-cutlass-dsl[cu13] installs -libs-base and -libs-cu13 wheels that
+# share paths with different content. uv can extract them in either order,
+# leaving base files that break CUDA 13 CuTe DSL JIT.
+# TODO(mmangkad): Remove this after NVIDIA/cutlass#3259 is fixed.
 RUN --mount=type=cache,target=/opt/uv/cache \
     if [ "$(echo $CUDA_VERSION | cut -d. -f1)" = "12" ]; then \
         sed -i 's/^nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' requirements/cuda.txt; \
@@ -234,6 +238,13 @@ RUN --mount=type=cache,target=/opt/uv/cache \
     else \
         uv pip install --python /opt/venv/bin/python3 -r requirements/cuda.txt \
         --extra-index-url ${PYTORCH_CUDA_INDEX_BASE_URL}/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.'); \
+    fi \
+    && if [ "$(echo $CUDA_VERSION | cut -d. -f1)" = "13" ]; then \
+        CUTLASS_DSL_VERSION=$(uv pip show --python /opt/venv/bin/python3 nvidia-cutlass-dsl 2>/dev/null | awk '/^Version:/{print $2}') && \
+        if [ -n "$CUTLASS_DSL_VERSION" ]; then \
+            uv pip install --python /opt/venv/bin/python3 --force-reinstall --no-deps \
+                "nvidia-cutlass-dsl-libs-cu13==${CUTLASS_DSL_VERSION}"; \
+        fi; \
     fi
 
 # Track PyTorch lib versions used during build and match in downstream instances.
@@ -745,6 +756,10 @@ ENV VLLM_ENABLE_CUDA_COMPATIBILITY=0
 ARG PYTORCH_CUDA_INDEX_BASE_URL
 COPY requirements/common.txt /tmp/common.txt
 COPY requirements/cuda.txt /tmp/requirements-cuda.txt
+# nvidia-cutlass-dsl[cu13] installs -libs-base and -libs-cu13 wheels that
+# share paths with different content. uv can extract them in either order,
+# leaving base files that break CUDA 13 CuTe DSL JIT.
+# TODO(mmangkad): Remove this after NVIDIA/cutlass#3259 is fixed.
 RUN --mount=type=cache,target=/opt/uv/cache \
     if [ "$(echo $CUDA_VERSION | cut -d. -f1)" = "12" ]; then \
         sed -i 's/^nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' /tmp/requirements-cuda.txt; \
@@ -752,6 +767,13 @@ RUN --mount=type=cache,target=/opt/uv/cache \
     fi && \
     uv pip install --system -r /tmp/requirements-cuda.txt \
         --extra-index-url ${PYTORCH_CUDA_INDEX_BASE_URL}/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.') && \
+    if [ "$(echo $CUDA_VERSION | cut -d. -f1)" = "13" ]; then \
+        CUTLASS_DSL_VERSION=$(uv pip show --system nvidia-cutlass-dsl 2>/dev/null | awk '/^Version:/{print $2}') && \
+        if [ -n "$CUTLASS_DSL_VERSION" ]; then \
+            uv pip install --system --force-reinstall --no-deps \
+                "nvidia-cutlass-dsl-libs-cu13==${CUTLASS_DSL_VERSION}"; \
+        fi; \
+    fi && \
     rm /tmp/requirements-cuda.txt /tmp/common.txt
 
 # Install FlashInfer JIT cache (requires CUDA-version-specific index URL)
@@ -841,6 +863,19 @@ RUN --mount=type=bind,from=build,src=/tmp/ep_kernels_workspace/dist,target=/vllm
     --mount=type=cache,target=/opt/uv/cache \
     uv pip install --system ep_kernels/dist/*.whl --verbose \
         --extra-index-url ${PYTORCH_CUDA_INDEX_BASE_URL}/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')
+
+# nvidia-cutlass-dsl[cu13] installs -libs-base and -libs-cu13 wheels that
+# share paths with different content. Force -libs-cu13 last after runtime
+# dependency installs so uv cannot leave base files behind.
+# TODO(mmangkad): Remove this after NVIDIA/cutlass#3259 is fixed.
+RUN --mount=type=cache,target=/opt/uv/cache \
+    if [ "$(echo $CUDA_VERSION | cut -d. -f1)" = "13" ]; then \
+        CUTLASS_DSL_VERSION=$(uv pip show --system nvidia-cutlass-dsl 2>/dev/null | awk '/^Version:/{print $2}') && \
+        if [ -n "$CUTLASS_DSL_VERSION" ]; then \
+            uv pip install --system --force-reinstall --no-deps \
+                "nvidia-cutlass-dsl-libs-cu13==${CUTLASS_DSL_VERSION}"; \
+        fi; \
+    fi
 
 # Download FlashInfer precompiled cubins AFTER all pip installs are done.
 # This must run after the vLLM wheel and EP kernels installs above, because

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -168,6 +168,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ######################### TRITON-CPU BUILD IMAGE #########################
 FROM base AS vllm-triton-cpu-build
 
+# Support for cross-compilation with x86 ISA including AVX2 and AVX512: docker build --build-arg VLLM_CPU_X86="true" ...
+# Re-declared here because this stage is `FROM base` (not `vllm-build`), so it
+# does not inherit the ARG/ENV defined there. Without it, the guard below would
+# see an empty value and build triton-cpu on non-x86 targets (e.g. arm64).
+ARG VLLM_CPU_X86=0
+
 WORKDIR /vllm-workspace
 
 RUN mkdir dist
@@ -268,6 +274,11 @@ ENV HF_HUB_DOWNLOAD_TIMEOUT 60
 
 ######################### RELEASE IMAGE #########################
 FROM base AS vllm-openai
+
+# Re-declared here because this stage is `FROM base` (not `vllm-build`), so the
+# RUN below that gates the triton-cpu wheel install on $VLLM_CPU_X86 would
+# otherwise see an empty value and try to install it on non-x86 targets.
+ARG VLLM_CPU_X86=0
 
 WORKDIR /vllm-workspace
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -11,7 +11,7 @@ transformers >= 4.56.0, != 5.0.*, != 5.1.*, != 5.2.*, != 5.3.*, != 5.4.*, != 5.5
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 safetensors >= 0.6.2  # MXFP4/MXFP6 dtype support (F8_E8M0, F4) added in 0.6.0: https://github.com/huggingface/safetensors/pull/611
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
-fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.
+fastapi[standard] >= 0.115.0, < 0.137 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint; <0.137 due to prometheus-fastapi-instrumentator#370.
 aiohttp >= 3.13.3
 openai >= 2.0.0  # For Responses API with reasoning content
 pydantic >= 2.12.0

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -23,6 +23,7 @@ timm>=1.0.17
 # To be consistent with test_quark.py
 amd-quark>=0.8.99
 tilelang==0.1.10
-
+# Required apache-tvm-ffi matching tilelang version
+apache-tvm-ffi==0.1.10 
 # Required for faster safetensors model loading
 fastsafetensors >= 0.3.2

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -44,6 +44,7 @@ anyio==4.13.0
     #   watchfiles
 apache-tvm-ffi==0.1.10
     # via
+    #   -c requirements/rocm.txt
     #   tilelang
     #   xgrammar
 arctic-inference==0.1.1

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -340,6 +340,16 @@ def rocm_aiter_fused_experts(
             moe_config.intermediate_size_per_partition
             - moe_config.intermediate_size_per_partition_unpadded
         )
+        # Round hidden_pad/intermediate_pad to match AITER's CK/FlyDSL MoE
+        # dispatch (currently pinned to v0.1.13.post1):
+        # https://github.com/ROCm/aiter/blob/v0.1.13.post1/aiter/fused_moe.py#L1073
+        # https://github.com/ROCm/aiter/blob/v0.1.13.post1/aiter/fused_moe.py#L1099
+        # TODO: Revisit this once we bump AITER to 0.1.15 with padding fixes
+        # for CK/FlyDSL MoE GEMM e.g. https://github.com/ROCm/aiter/pull/3401
+        hidden_pad = hidden_pad // 128 * 128
+        intermediate_pad = (
+            intermediate_pad // 64 * 64 * (2 if moe_config.tp_size == 1 else 1)
+        )
 
         return rocm_aiter_ops.fused_moe(
             hidden_states,
@@ -357,8 +367,8 @@ def rocm_aiter_fused_experts(
             doweight_stage1=apply_router_weight_on_input,
             num_local_tokens=num_local_tokens,
             output_dtype=output_dtype,
-            hidden_pad=hidden_pad // 128 * 128,
-            intermediate_pad=intermediate_pad // 64 * 64 * 2,
+            hidden_pad=hidden_pad,
+            intermediate_pad=intermediate_pad,
             bias1=quant_config.w1_bias if quant_config.use_mxfp4_w4a16 else None,
             bias2=quant_config.w2_bias if quant_config.use_mxfp4_w4a16 else None,
             moe_sorting_dispatch_policy=moe_sorting_dispatch_policy,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -242,7 +242,12 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 vllm_config.model_config.max_model_len,
                 vllm_config.scheduler_config.max_num_batched_tokens,
             )
-            self._init_fp8_prefill_ps_buffers(max_num_reqs, max_prefill_qlen, device)
+            self._init_fp8_prefill_ps_buffers(
+                max_num_reqs,
+                max_prefill_qlen,
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                device,
+            )
 
         if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
             self.paged_kv_indptr = torch.zeros(
@@ -257,21 +262,29 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         self,
         max_num_reqs: int,
         max_prefill_qlen: int,
+        max_num_batched_tokens: int,
         device: torch.device,
     ) -> None:
         """Pre-allocate persistent buffers for FP8 MLA prefill PS metadata.
 
         Uses ``get_ps_metadata_info_v1`` with max values so the buffers are
         large enough for any batch.  ``get_ps_metadata_v1`` fills them
-        per-batch in ``build()``.
+        per-batch in ``build()``.  The FP8 prefill forward path also uses the
+        global workspace manager for per-call scratch, so reserve its maximum
+        shape here before the workspace manager is locked after warmup.
 
         Args:
             max_num_reqs: Maximum number of concurrent requests.
             max_prefill_qlen: Maximum Q-length for a single request in one
                 prefill batch.  Should be ``min(max_model_len,
-                max_num_batched_tokens)`` — the chunked-prefill scheduler
-                never emits more than ``max_num_batched_tokens`` new tokens
-                per batch.
+                max_num_batched_tokens)`` — a single request never exceeds
+                ``max_model_len`` tokens, nor the per-batch token budget.
+            max_num_batched_tokens: Maximum number of tokens scheduled in one
+                batch.  The ``final_lse`` scratch is sized by ``total_q`` (the
+                summed Q-length over all prefill requests in the batch), which
+                is bounded by this budget rather than by a single request's
+                ``max_prefill_qlen`` — concurrent requests can sum to more than
+                ``max_model_len`` when ``max_model_len < max_num_batched_tokens``.
             device: Target device for the buffers.
         """
         from aiter import get_ps_metadata_info_v1
@@ -279,6 +292,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         # After kv_b_proj decompression, K has num_heads heads (same as Q).
         # So gqa_ratio=1 and num_head_k=num_heads for the PS kernel.
         num_head_k = self.num_heads
+        v_head_dim = self.mla_dims.v_head_dim
         # gqa_ratio = 1
         # qlen_granularity = _FP8_PREFILL_TILE_Q // max(gqa_ratio, 1)
         qlen_granularity = _FP8_PREFILL_TILE_Q
@@ -316,6 +330,21 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             reduce_partial_map_size,
             dtype=reduce_partial_map_dtype,
             device=device,
+        )
+
+        from vllm.v1.worker.workspace import current_workspace_manager
+
+        max_num_partial_tiles = reduce_partial_map_size
+        current_workspace_manager().get_simultaneous(
+            (
+                (max_num_partial_tiles * _FP8_PREFILL_TILE_Q, num_head_k, v_head_dim),
+                torch.float32,
+            ),
+            (
+                (max_num_partial_tiles * _FP8_PREFILL_TILE_Q, num_head_k),
+                torch.float32,
+            ),
+            ((max_num_batched_tokens, num_head_k), torch.float32),
         )
 
         logger.info(


### PR DESCRIPTION
# [CPU][Bug] Segfault in DNNL matmul during mixed-batch GQA after #43032 (v0.23.0 regression)

### Your current environment

- vLLM version: v0.23.0+cpu
- PyTorch version: 2.11.0+cpu
- OS: Ubuntu 22.04
- CPU: AMD EPYC (Zen4 Genoa) — no AVX512-AMX, no GPU
- Python: 3.12
- lm_eval: 0.4.12
- transformers: 5.12.1

### Model

Multiple GQA models affected:
| Model | Architecture | Heads / KV Heads | GQA Ratio |
|---|---|---|---|
| `ibm-granite/granite-3.2-8b-instruct` | GraniteForCausalLM | 32 / 8 | 4:1 |
| `internlm/internlm2-chat-7b` | InternLM2ForCausalLM | 32 / 8 | 4:1 |
| `internlm/internlm2_5-20b-chat` | InternLM2ForCausalLM | 48 / 8 | 6:1 |

### Describe the bug

After upgrading from vLLM v0.22.1 to v0.23.0, we observe segfaults and worker crashes during CPU-based offline inference (`lm_eval` accuracy runs) on AMD Zen4 CPUs. All three failures are in GQA models that passed cleanly on v0.22.1 with the same configuration. The only changes between runs are `vllm 0.22.1+cpu → 0.23.0+cpu` and `transformers 5.10.2 → 5.12.1`.

The crashes manifest in two patterns:

**Pattern 1 — Segfault during warmup** (Granite 8B):
```
(Worker pid=1193) INFO [cpu_model_runner.py:121] Warming up model for the compilation...
!!!!!!! Segfault encountered !!!!!!!
  File "/vllm/csrc/cpu/dnnl_helper.cpp", line 146, in DNNLMatMulPrimitiveHandler::get_runtime_memory_ptr
  File "/vllm/csrc/cpu/dnnl_helper.cpp", line 441, in MatMulPrimitiveHandler::execute
  File "/vllm/csrc/cpu/dnnl_kernels.cpp", line 544, in onednn_mm
```

**Pattern 2 — Worker death on first inference step** (InternLM2 7B, 20B):
```
terminate called recursively (x8)
(EngineCore) Worker proc VllmWorker-0 died unexpectedly, shutting down executor.
(EngineCore) EngineCore encountered a fatal error.
RuntimeError: cancelled
```
The worker completes warmup and KV cache allocation successfully, then crashes on the first `generate_until` batch from `lm_eval`.

### Key observations

1. **v0.22.1 is clean**: All 300 tests pass (0 failures). Same zentorch v2.11.0.2, same torch 2.11.0+cpu, same hosts, same test scripts.
2. **Only accuracy runs fail**: Throughput runs (`TASK=THROUGHPUT`) for all three models pass on v0.23.0. The difference is that accuracy runs use `lm_eval` which batches prompts via `generate_until`, producing mixed prefill+decode batches.
3. **3 of 31 GQA models fail**: Other GQA models (Llama-3.1, Falcon3, EXAONE, Gemma-2, etc.) with the same 4:1 head ratio pass. The failure is batch-composition dependent.
5. **DNNL source is identical**: `dnnl_helper.cpp` and `dnnl_kernels.cpp` have the same SHA in both v0.22.1 and v0.23.0. The segfault is a symptom (corrupted memory), not the root cause.

### Configuration

All runs use:
```
enable_chunked_prefill=True
enable_prefix_caching=True
dtype=bfloat16
tensor_parallel_size=1
```

### Suspected root cause

PR #43032 (`[CPU] Enable non-divisible GQA for decode workitems in mixed batches`, commit `771e1e48b153`) refactored the GQA logic in `csrc/cpu/cpu_attn_impl.hpp`. The change introduces per-workitem GQA decisions inside the inner loop for mixed batches, but the **reduction scratchpad sizing** uses the batch-level `use_gqa_fast_path` flag:

```cpp
// Scratchpad sized at batch level (line 690):
metadata_ptr->reduction_scratchpad_size_per_kv_head *
    (use_gqa_fast_path ? input.num_heads_kv : input.num_heads_q);

// But inner loop uses per-workitem GQA (line 1539+):
const bool curr_use_gqa = use_gqa_fast_path || (supports_gqa && q_token_num == 1);
const int32_t curr_q_heads_per_kv = curr_use_gqa ? q_heads_per_kv : 1;
```

For mixed batches (chunked prefill + decode):
- `use_gqa_fast_path = false` → scratchpad sized for `num_heads_q` (MHA fallback)
- But `curr_use_gqa = true` for decode workitems → processes with `q_heads_per_kv` grouping and different `q_head_start_idx` calculation

This mismatch can cause out-of-bounds writes to the reduction scratchpad buffer, corrupting adjacent heap memory. The next DNNL matmul then segfaults when it accesses that corrupted memory.

The Gemini code review bot flagged a related concern during the PR review — that performing the decode-only check within the parallel region could lead to "inconsistent `use_gqa` flags."

### How to reproduce

```bash
lm_eval --model vllm \
  --tasks gsm8k \
  --batch_size auto \
  --trust_remote_code \
  --num_fewshot 5 \
  --gen_kwargs max_gen_toks=2048 \
  --apply_chat_template \
  --model_args pretrained=ibm-granite/granite-3.2-8b-instruct,dtype=bfloat16
```

Run on an AMD EPYC CPU (no GPU). Crashes on v0.23.0, passes on v0.22.1.

### Workaround

Pin to `vllm==0.22.1+cpu`, or potentially disable chunked prefill (`--enable-chunked-prefill=False`) to avoid mixed batches that trigger the scratchpad sizing bug.

### Related

- PR #43032 — the change that introduced the regression