### PR TITLE
[CI] Add TP=4 requirement to `test_mixed_precision_model_accuracies`

### DIFF
--- a/tests/quantization/test_mixed_precision.py
+++ b/tests/quantization/test_mixed_precision.py
@@ -13,8 +13,11 @@ from dataclasses import dataclass
 
 import lm_eval
 import pytest
-import torch
 from packaging import version
+
+from tests.utils import (
+    multi_gpu_only,
+)
 
 QUARK_MXFP4_AVAILABLE = importlib.util.find_spec("quark") is not None and version.parse(
     importlib.metadata.version("amd-quark")
@@ -53,11 +56,8 @@ TEST_CONFIGS = {
 
 @pytest.mark.parametrize("model_name, accuracy_numbers", TEST_CONFIGS.items())
 @pytest.mark.skipif(not QUARK_MXFP4_AVAILABLE, reason="amd-quark>=0.9 is not available")
+@multi_gpu_only(num_gpus=4)
 def test_mixed_precision_model_accuracies(model_name: str, accuracy_numbers: dict):
-    device_count = torch.accelerator.device_count()
-    if device_count < 4:
-        pytest.skip(f"This test requires >=4 gpus, got only {device_count}")
-
     results = lm_eval.simple_evaluate(
         model="vllm",
         model_args=EvaluationConfig(model_name).get_model_args(),

--- a/tests/quantization/test_mixed_precision.py
+++ b/tests/quantization/test_mixed_precision.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 
 import lm_eval
 import pytest
+import torch
 from packaging import version
 
 QUARK_MXFP4_AVAILABLE = importlib.util.find_spec("quark") is not None and version.parse(
@@ -53,6 +54,10 @@ TEST_CONFIGS = {
 @pytest.mark.parametrize("model_name, accuracy_numbers", TEST_CONFIGS.items())
 @pytest.mark.skipif(not QUARK_MXFP4_AVAILABLE, reason="amd-quark>=0.9 is not available")
 def test_mixed_precision_model_accuracies(model_name: str, accuracy_numbers: dict):
+    device_count = torch.accelerator.device_count()
+    if device_count < 4:
+        pytest.skip(f"This test requires >=4 gpus, got only {device_count}")
+
     results = lm_eval.simple_evaluate(
         model="vllm",
         model_args=EvaluationConfig(model_name).get_model_args(),


### PR DESCRIPTION



## Purpose

This test fails in https://buildkite.com/vllm/amd-ci/builds/9636/canvas due running in a runner not having enough devices, although this test requires `tensor_parallel_size=4`.

## Test Plan

- `CUDA_VISIBLE_DEVICES=0 pytest tests/quantization/test_mixed_precision.py -s -vvvvv -k "test_mixed_precision_model_accuracies" -rs`

## Test Result

Tests skipped.