### PR TITLE
[Bugfix] Forward upstream error message in Anthropic streaming converter (#46028)

### DIFF
--- a/tests/entrypoints/anthropic/test_stream_error.py
+++ b/tests/entrypoints/anthropic/test_stream_error.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for mid-stream error handling in the Anthropic messages converter.
+
+Regression for issue #46028: an upstream engine failure is delivered to
+``message_stream_converter`` as an ``ErrorResponse`` payload
+(``{"error": {...}}``), not a ``ChatCompletionStreamResponse``. The converter
+must forward the real upstream message as an Anthropic ``error`` event instead
+of masking it with a pydantic schema-validation error.
+
+These tests are CPU-only and do not start a server.
+"""
+
+import json
+
+import pytest
+
+from vllm.entrypoints.anthropic.serving import (
+    AnthropicServingMessages,
+    parse_streaming_error_chunk,
+)
+from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse
+
+
+def _error_chunk(message: str) -> str:
+    """Build the SSE line an upstream engine emits for a mid-stream failure.
+
+    Mirrors ``create_streaming_error_response`` in the OpenAI serving layer:
+    ``json.dumps(ErrorResponse(...).model_dump())`` wrapped in an SSE ``data:``
+    frame.
+    """
+    payload = ErrorResponse(
+        error=ErrorInfo(message=message, type="InternalServerError", code=500)
+    )
+    return f"data: {json.dumps(payload.model_dump())}\n\n"
+
+
+def test_parse_streaming_error_chunk_detects_error_payload():
+    err = parse_streaming_error_chunk(
+        '{"error": {"message": "Internal Server Error", '
+        '"type": "InternalServerError", "code": 500}}'
+    )
+    assert err is not None
+    assert err.error.message == "Internal Server Error"
+
+
+def test_parse_streaming_error_chunk_ignores_normal_chunk():
+    # A regular (non-error) streaming chunk has no top-level ``error`` field.
+    assert (
+        parse_streaming_error_chunk(
+            '{"id": "x", "object": "chat.completion.chunk", '
+            '"created": 0, "model": "m", "choices": []}'
+        )
+        is None
+    )
+
+
+def test_parse_streaming_error_chunk_ignores_malformed_json():
+    assert parse_streaming_error_chunk("not json") is None
+    assert parse_streaming_error_chunk('{"foo": 1}') is None
+
+
+@pytest.mark.asyncio
+async def test_converter_forwards_upstream_error_message():
+    async def upstream():
+        yield _error_chunk("Internal Server Error")
+        yield "data: [DONE]\n\n"
+
+    # The error path never touches initialized instance state, so a bare
+    # instance is sufficient to exercise the converter.
+    serving = object.__new__(AnthropicServingMessages)
+    events = [event async for event in serving.message_stream_converter(upstream())]
+
+    joined = "".join(events)
+    assert "event: error" in joined
+    assert "Internal Server Error" in joined
+    # The real message must not be masked by a schema-validation error.
+    assert "validation error" not in joined.lower()
+
+    # The error event must carry the upstream message in the Anthropic shape.
+    error_lines = [e for e in events if "event: error" in e]
+    assert len(error_lines) == 1
+    data_str = error_lines[0].split("data:", 1)[1].strip()
+    parsed = json.loads(data_str)
+    assert parsed["type"] == "error"
+    assert parsed["error"]["message"] == "Internal Server Error"

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import jinja2
 from fastapi import Request
+from pydantic import ValidationError
 
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.anthropic.protocol import (
@@ -56,6 +57,22 @@ logger = logging.getLogger(__name__)
 
 def wrap_data_with_event(data: str, event: str):
     return f"event: {event}\ndata: {data}\n\n"
+
+
+def parse_streaming_error_chunk(data_str: str) -> ErrorResponse | None:
+    """Parse a streaming chunk as an upstream ``ErrorResponse``, if it is one.
+
+    Mid-stream engine failures are delivered to the converter as an
+    ``ErrorResponse`` payload (``{"error": {...}}``) rather than a
+    ``ChatCompletionStreamResponse``. Returning the parsed error lets the
+    converter forward the real upstream message instead of masking it with a
+    schema-validation error (issue #46028). Returns ``None`` for any chunk that
+    is not a well-formed error payload.
+    """
+    try:
+        return ErrorResponse.model_validate_json(data_str)
+    except ValidationError:
+        return None
 
 
 class AnthropicServingMessages(OpenAIServingChat):
@@ -745,9 +762,31 @@ class AnthropicServingMessages(OpenAIServingChat):
                         )
                         yield wrap_data_with_event(data, "message_stop")
                     else:
-                        origin_chunk = ChatCompletionStreamResponse.model_validate_json(
-                            data_str
-                        )
+                        try:
+                            origin_chunk = (
+                                ChatCompletionStreamResponse.model_validate_json(
+                                    data_str
+                                )
+                            )
+                        except ValidationError:
+                            # A mid-stream engine failure is delivered as an
+                            # ErrorResponse payload ({"error": {...}}), not a
+                            # ChatCompletionStreamResponse. Forward the upstream
+                            # message instead of letting schema validation mask
+                            # it (issue #46028).
+                            error_payload = parse_streaming_error_chunk(data_str)
+                            if error_payload is None:
+                                raise
+                            error_event = AnthropicStreamEvent(
+                                type="error",
+                                error=AnthropicError(
+                                    type="internal_error",
+                                    message=error_payload.error.message,
+                                ),
+                            )
+                            data = error_event.model_dump_json(exclude_unset=True)
+                            yield wrap_data_with_event(data, "error")
+                            return
 
                         if first_item:
                             chunk = AnthropicStreamEvent(


### PR DESCRIPTION
## Purpose

Fixes #46028.

When the engine fails mid-stream, the OpenAI serving layer emits an `ErrorResponse` payload (`{"error": {...}}`) via `create_streaming_error_response`, followed by `[DONE]`. The Anthropic adapter's `message_stream_converter` validated **every** chunk as a `ChatCompletionStreamResponse`, so the error chunk raised a pydantic `ValidationError`. The outer `except` then re-emitted that as a generic `internal_error` carrying the *pydantic* message — masking the real upstream failure. The reporter hit this serving GLM-5.2, where an engine 500 surfaced only as `2 validation errors for ChatCompletionStreamResponse ... model Field required input_value={'error': {'message': 'Internal Server Error'...}}`.

This PR detects the error payload (new `parse_streaming_error_chunk` helper, mirroring the existing module-level `wrap_data_with_event` helper) and forwards its message as an Anthropic `error` event, reusing the converter's existing `AnthropicStreamEvent(type="error", ...)` shape. Only the failure path changes; valid chunks validate exactly as before.

## Not a duplicate

- `gh pr list --search "46028 in:body"` → none.
- `gh pr list --search "message_stream_converter"` → only #45807 (stop_sequence `stop_reason`), unrelated.
- #34053 (`[Anthropic API]` 6 protocol bugs) also edits `serving.py`, but for message/tool-call ID and `tool_result` formats; it does not touch the streaming error path.

## Test Plan / Test Result

Added CPU-only unit test `tests/entrypoints/anthropic/test_stream_error.py` (the existing `test_messages.py` needs a live server):

```
$ .venv/bin/python -m pytest tests/entrypoints/anthropic/test_stream_error.py -v
test_parse_streaming_error_chunk_detects_error_payload PASSED
test_parse_streaming_error_chunk_ignores_normal_chunk  PASSED
test_parse_streaming_error_chunk_ignores_malformed_json PASSED
test_converter_forwards_upstream_error_message          PASSED
4 passed in 1.13s

$ .venv/bin/python -m pytest tests/entrypoints/anthropic/test_stream_error.py \
    tests/entrypoints/anthropic/test_protocol_exports.py \
    tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -q
45 passed in 11.17s

$ .venv/bin/pre-commit run --files \
    vllm/entrypoints/anthropic/serving.py tests/entrypoints/anthropic/test_stream_error.py
ruff check ... Passed | ruff format ... Passed | mypy ... Passed | (all hooks Passed)
```

Before/after on the exact upstream payload:
- **Old** — `ChatCompletionStreamResponse.model_validate_json(chunk)` → `2 validation errors for ChatCompletionStreamResponse` (masked by outer handler).
- **New** — `parse_streaming_error_chunk(chunk).error.message` → `'Internal Server Error'` (real message forwarded).

## AI assistance

This change was prepared with AI assistance (Claude). I reviewed every changed line and ran the tests above.
