### PR TITLE
[Bugfix] DeepseekV4 (nvidia): thread is_sequence_parallel into shared_experts to fix SP-MoE construct/load mismatch

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -572,6 +572,7 @@ class DeepseekV4MoE(nn.Module):
                 swiglu_limit=self.swiglu_limit,
                 quant_config=quant_config,
                 reduce_results=self.use_mega_moe,
+                is_sequence_parallel=vllm_config.parallel_config.use_sequence_parallel_moe,
                 prefix=f"{prefix}.shared_experts",
             )
 


### PR DESCRIPTION
## What

In `DeepseekV4MoE.__init__`, `shared_experts` (`DeepseekV4MLP`) was constructed without forwarding `is_sequence_parallel`, so it defaulted to `False`.

On the `use_sequence_parallel_moe=True` path (EP + TP>1 + DP>1 with an all2all backend) this disagrees with weight loading:

- **Construction** (`is_sequence_parallel=False`): the block-FP8 `cdiv` padding in `DeepseekV4MLP.__init__` runs and `down_proj` is TP-row-split (`disable_tp=False`).
- **`load_weights`**: `pad_shared_expert = (weight_block_size is not None) and (not use_sequence_parallel_moe)` is `False`, so shared-expert weights are **not** padded.

As a result, the padded, TP-split parameter shape doesn't match the unpadded checkpoint shard, and also disagrees with the surrounding sequence-parallel MoE (which expects `shared_experts` replicated, with no TP collective).

## Fix

Pass `is_sequence_parallel=vllm_config.parallel_config.use_sequence_parallel_moe` so construction matches the load path:

- On the SP path, `shared_experts` are replicated (`disable_tp=True`, no `cdiv` padding).
- On every other path, `use_sequence_parallel_moe` is `False`, so this is a no-op.

## Note

This does **not** fix the TEP TP=16 `block_k=192` error from #45784. That path (no DP → `use_sequence_parallel_moe=False`) is already handled on `main` by the shared-expert block-FP8 padding (`DeepseekV4MLP.__init__` `cdiv` + `DeepseekV4Model._pad_shared_expert_weight`), which rounds intermediate `3072 → 4096` so `4096 / 16 = 256` stays block-aligned.