### PR TITLE
[ROCm] Use vLLM's fp8 quant max in AITER hipBLASLt accuracy test

### DIFF
--- a/tests/rocm/aiter/test_aiter_hipb_mm_linear_kernel.py
+++ b/tests/rocm/aiter/test_aiter_hipb_mm_linear_kernel.py
@@ -18,6 +18,7 @@ from vllm.model_executor.kernels.linear.scaled_mm.ScaledMMLinearKernel import (
     FP8ScaledMMLinearLayerConfig,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    get_fp8_min_max,
     kFp8DynamicTokenSym,
     kFp8StaticChannelSym,
     kFp8StaticTensorSym,
@@ -309,7 +310,7 @@ def test_hipb_mm_kernel_forward_accuracy(enable_hipb_mm_kernel):
     _check_bpreshuffle_runtime_support(weight_shape, num_tokens=num_tokens)
 
     fp8_dtype = current_platform.fp8_dtype()
-    fp8_max = torch.finfo(fp8_dtype).max
+    fp8_max = get_fp8_min_max()[1]
     device = torch.device("cuda")
 
     # Build a bf16 weight and quantize per output channel (one scale per row).


### PR DESCRIPTION
## Purpose
Fixes `test_hipb_mm_kernel_forward_accuracy` on MI300. The test quantized its fp8 reference with `torch.finfo(e4m3fnuz).max` (240.0), while the kernel uses vLLM's `get_fp8_min_max()`, which on fnuz intentionally
returns 224.0. That ~7% scale mismatch gave `max_diff ≈ 10` and tripped the strict `assert_close`, even though the kernel was
correct.

The fix sources the test's fp8 max from `get_fp8_min_max()`, so the reference shares the kernel's quantization grid. Only normal fp8 noise remains.
## Test Plan
On Mi300:
```bash
pytest -v tests/rocm/aiter/test_aiter_hipb_mm_linear_kernel.py
```

## Test Result
Before: max_diff ≈ 10, ~3.5% of elements exceed atol=5.0 → fails every run.
After: max_diff ≈ 0.02–2.0, 0% exceed → passes consistently.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

