### PR TITLE
[Attention][DSA][DCP] Support DCP for DeepSeek Sparse Attention

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -233,7 +233,7 @@ MLA decode backends are selected using the standard
 | `FLASHINFER_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 32, 64 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | 10.x |
 | `FLASHINFER_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 32, 64 | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | 10.x |
 | `FLASHMLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 64 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 9.x-10.x |
-| `FLASHMLA_SPARSE` | bf16 | `auto`, `bfloat16`, `fp8_ds_mla` | 64 | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | 9.x-10.x |
+| `FLASHMLA_SPARSE` | bf16 | `auto`, `bfloat16`, `fp8_ds_mla` | 64 | 576 | ❌ | ❌ | ✅ | ❌ | ✅ | Decoder | 9.x-10.x |
 | `FLASH_ATTN_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16` | %16 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 9.x |
 | `ROCM_AITER_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %1 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 1, 64 | Any | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | N/A |

--- a/docs/serving/context_parallel_deployment.md
+++ b/docs/serving/context_parallel_deployment.md
@@ -36,6 +36,8 @@ For DeepSeek-R1, we have 1 kv-head when MLA is enabled. The typical single-node 
 
 For Kimi-K2, the architecture is similar to DeepSeek-R1, but with more parameters. When we deploy it with `-tp 16`, the KV cache duplication is 16x. We can add `-dcp 16` to completely remove the KV cache duplication, at the cost of more communication overhead. We can also add `-dcp 8` to reduce the KV cache duplication to 2x. Although it still duplicates the KV cache twice, the communication overhead is smaller since the DCP communication only happens inside one node.
 
+For GLM-5.2 with DeepSeek Sparse Attention, the same single-kv-head duplication pressure applies. Deployments using `FLASHMLA_SPARSE` can enable DCP to shard the sparse MLA KV cache across the DCP group; this path is used in production to serve GLM-5.2 with 1M context on 16xH100.
+
 For Qwen3-235B-A22B, we have 4 kv-heads. When we deploy it with `-tp 8`, the KV cache duplication is 2x. Then we can add `-dcp 2` to remove the KV cache duplication.
 
 In short, for decode context parallel, try to increase `-tp` size until you get satisfactory performance, and then add `-dcp` to reduce the KV cache duplication.

--- a/tests/v1/attention/test_dcp_sparse_indexer.py
+++ b/tests/v1/attention/test_dcp_sparse_indexer.py
@@ -32,6 +32,7 @@ from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV32IndexerMetadataBuilder,
     _dcp_local_indexer_seq_lens,
     _decode_topk_max_seq_len,
+    _localize_decode_seq_lens_inplace,
     split_indexer_prefill_chunks,
 )
 
@@ -244,6 +245,39 @@ def test_prepare_decode_tensors_uses_precomputed_dcp_local_for_plain_decode():
     assert batch_size == 2
     assert not requires_padding
     assert torch.equal(seq_lens, dcp_local_seq_lens)
+
+
+@pytest.mark.skipif(
+    not (HAS_TRITON and current_platform.is_cuda() and torch.cuda.is_available()),
+    reason="CUDA Triton kernel test requires a CUDA Triton runtime",
+)
+def test_localize_decode_seq_lens_inplace_cuda_matches_reference():
+    seq_lens_cpu = torch.tensor(
+        [
+            [8, 9, 10],
+            [9, 10, 11],
+        ],
+        dtype=torch.int32,
+    )
+    expected = _dcp_local_indexer_seq_lens(
+        seq_lens_cpu.flatten(),
+        compress_ratio=1,
+        dcp_world_size=2,
+        dcp_rank=1,
+        cp_interleave_size=2,
+    ).view_as(seq_lens_cpu)
+    seq_lens = seq_lens_cpu.cuda()
+    data_ptr = seq_lens.data_ptr()
+
+    _localize_decode_seq_lens_inplace(
+        seq_lens,
+        dcp_world_size=2,
+        dcp_rank=1,
+        cp_interleave_size=2,
+    )
+
+    assert seq_lens.data_ptr() == data_ptr
+    assert torch.equal(seq_lens.cpu(), expected)
 
 
 def test_pack_topk_candidates_preserves_score_bits_and_row_starts():

--- a/tests/v1/attention/test_dcp_sparse_indexer.py
+++ b/tests/v1/attention/test_dcp_sparse_indexer.py
@@ -21,8 +21,12 @@ import vllm.v1.attention.backends.mla.flashmla_sparse as sparse_mla_mod
 from vllm.model_executor.layers.sparse_attn_indexer import (
     _global_to_local_position,
     _local_to_global_position,
+    _use_persistent_topk_decode,
 )
-from vllm.v1.attention.backends.mla.indexer import _dcp_local_indexer_seq_lens
+from vllm.v1.attention.backends.mla.indexer import (
+    _dcp_local_indexer_seq_lens,
+    split_indexer_prefill_chunks,
+)
 
 
 class _FakeDCPGroup:
@@ -52,6 +56,16 @@ class _FakeDCPGroup:
 
 def _local_to_global(local_idx, rank, world_size, interleave):
     return _local_to_global_position(local_idx, rank, world_size, interleave)
+
+
+def test_decode_persistent_topk_disabled_for_dcp(monkeypatch):
+    monkeypatch.setattr(idx_mod.current_platform, "is_cuda", lambda: True)
+
+    assert _use_persistent_topk_decode(512, dcp_world_size=1)
+    assert _use_persistent_topk_decode(1024, dcp_world_size=1)
+    assert _use_persistent_topk_decode(2048, dcp_world_size=1)
+    assert not _use_persistent_topk_decode(256, dcp_world_size=1)
+    assert not _use_persistent_topk_decode(512, dcp_world_size=2)
 
 
 @pytest.mark.parametrize("interleave", [1, 2, 4])
@@ -123,6 +137,48 @@ def test_dcp_prefill_visible_lengths_support_compressed_indexer_cache():
     )
 
     assert got.tolist() == [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2]
+
+
+def _chunk_specs_as_tuples(chunks):
+    return [(req.start, req.stop, query.start, query.stop) for req, query in chunks]
+
+
+def test_dcp_prefill_chunking_uses_all_rank_max_lengths_for_collective_order():
+    seq_lens_cpu = torch.tensor([1, 3], dtype=torch.int32)
+    query_lens_cpu = torch.tensor([1, 1], dtype=torch.int32)
+    workspace_size = 2
+    max_logits_bytes = 1024 * 1024
+
+    all_local = _dcp_local_indexer_seq_lens(
+        seq_lens_cpu,
+        compress_ratio=1,
+        dcp_world_size=2,
+        dcp_rank=None,
+        cp_interleave_size=1,
+    )
+
+    rank_specs = [
+        _chunk_specs_as_tuples(
+            split_indexer_prefill_chunks(
+                all_local[:, rank],
+                query_lens_cpu,
+                workspace_size,
+                max_logits_bytes,
+            )
+        )
+        for rank in range(2)
+    ]
+    safe_specs = _chunk_specs_as_tuples(
+        split_indexer_prefill_chunks(
+            all_local.max(dim=1).values,
+            query_lens_cpu,
+            workspace_size,
+            max_logits_bytes,
+        )
+    )
+
+    assert rank_specs[0] != rank_specs[1]
+    assert safe_specs == [(0, 1, 0, 1), (1, 2, 0, 1)]
 
 
 @pytest.mark.parametrize(
@@ -315,6 +371,41 @@ def test_prefill_global_topk_uses_row_starts(monkeypatch):
                         ).item()
                     )
         assert union == set(ref[row].tolist())
+
+
+def test_global_topk_remap_allows_empty_local_rank(monkeypatch):
+    interleave, world_size, topk_tokens = 1, 2, 2
+    pos_list = [
+        torch.tensor([[0, 2]], dtype=torch.int32),
+        torch.tensor([[-1, -1]], dtype=torch.int32),
+    ]
+    scores_list = [
+        torch.tensor([[5.0, 4.0]], dtype=torch.float32),
+        torch.full((1, topk_tokens), float("-inf"), dtype=torch.float32),
+    ]
+
+    per_rank_final = []
+    for rank in range(world_size):
+        fake = _FakeDCPGroup(world_size, rank)
+        fake.set_all(pos_list, scores_list)
+        monkeypatch.setattr(idx_mod, "get_dcp_group", lambda f=fake: f)
+
+        topk_buf = (
+            torch.tensor([[0, 1]], dtype=torch.int32)
+            if rank == 0
+            else torch.full((1, topk_tokens), -1, dtype=torch.int32)
+        )
+        logits = torch.tensor([[5.0, 4.0]], dtype=torch.float32) if rank == 0 else None
+        idx_mod._dcp_global_topk_remap(
+            topk_buf,
+            logits,
+            topk_tokens,
+            interleave,
+        )
+        per_rank_final.append(topk_buf)
+
+    assert per_rank_final[0].tolist() == [[0, 1]]
+    assert per_rank_final[1].tolist() == [[-1, -1]]
 
 
 def test_global_topk_ownership_partition(monkeypatch):

--- a/tests/v1/attention/test_dcp_sparse_indexer.py
+++ b/tests/v1/attention/test_dcp_sparse_indexer.py
@@ -18,6 +18,9 @@ import torch
 
 import vllm.model_executor.layers.sparse_attn_indexer as idx_mod
 import vllm.v1.attention.backends.mla.flashmla_sparse as sparse_mla_mod
+from vllm.model_executor.layers.attention.mla_attention import (
+    _supports_dcp_fp8_kv_cache,
+)
 from vllm.model_executor.layers.sparse_attn_indexer import (
     _dcp_finalize_topk_remap,
     _dcp_pack_topk_candidates,
@@ -35,6 +38,7 @@ from vllm.v1.attention.backends.mla.indexer import (
     _localize_decode_seq_lens_inplace,
     split_indexer_prefill_chunks,
 )
+from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
 
 
 class _FakeDCPGroup:
@@ -84,6 +88,7 @@ def _make_common_metadata(
     seq_lens_cpu: torch.Tensor,
     max_seq_len: int,
     *,
+    dcp_local_seq_lens: torch.Tensor | None = None,
     dcp_local_seq_lens_cpu: torch.Tensor | None = None,
     seq_lens_cpu_upper_bound: torch.Tensor | None = None,
     exact_seq_lens_cpu: torch.Tensor | None = None,
@@ -100,6 +105,7 @@ def _make_common_metadata(
         max_seq_len=max_seq_len,
         block_table_tensor=torch.empty((num_reqs, 1), dtype=torch.int32),
         slot_mapping=torch.empty(num_reqs, dtype=torch.int64),
+        dcp_local_seq_lens=dcp_local_seq_lens,
         dcp_local_seq_lens_cpu=dcp_local_seq_lens_cpu,
         seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
         _seq_lens_cpu=exact_seq_lens_cpu,
@@ -113,6 +119,12 @@ def test_decode_persistent_topk_enabled_for_dcp(monkeypatch):
     assert _use_persistent_topk_decode(1024)
     assert _use_persistent_topk_decode(2048)
     assert not _use_persistent_topk_decode(256)
+
+
+def test_dcp_fp8_kv_cache_allowlist_is_flashmla_sparse_only():
+    assert _supports_dcp_fp8_kv_cache("FLASHMLA_SPARSE", "fp8_ds_mla")
+    assert not _supports_dcp_fp8_kv_cache("FLASHMLA_SPARSE", "fp8")
+    assert not _supports_dcp_fp8_kv_cache("FLASHINFER_MLA_SPARSE", "fp8_ds_mla")
 
 
 def test_decode_topk_max_seq_len_uses_dcp_local_lengths():
@@ -550,6 +562,169 @@ def test_dcp_prefill_chunking_uses_all_rank_max_lengths_for_collective_order():
     assert safe_specs == [(0, 1, 0, 1), (1, 2, 0, 1)]
 
 
+def _make_fp8_sparse_metadata_builder(
+    dcp_world_size: int = 2,
+    dcp_rank: int = 1,
+    interleave: int = 2,
+) -> sparse_mla_mod.FlashMLASparseMetadataBuilder:
+    builder = object.__new__(sparse_mla_mod.FlashMLASparseMetadataBuilder)
+    builder.dcp_world_size = dcp_world_size
+    builder.dcp_rank = dcp_rank
+    builder.cp_kv_cache_interleave_size = interleave
+    builder.reorder_batch_threshold = 1
+    builder.device = torch.device("cpu")
+    builder.dummy_block_table = torch.empty((8, 1), dtype=torch.int32)
+    builder.fp8_cache_lens_tensor = torch.full((8,), 8, dtype=torch.int32)
+    builder.vllm_config = type(
+        "MockVllmConfig",
+        (),
+        {
+            "model_config": type(
+                "MockModelConfig",
+                (),
+                {"max_model_len": 2},
+            )()
+        },
+    )()
+    return builder
+
+
+def test_flashmla_sparse_fp8_decode_metadata_uses_dcp_local_lengths(monkeypatch):
+    monkeypatch.setattr(
+        sparse_mla_mod,
+        "get_mla_metadata",
+        lambda *args, **kwargs: ("sched", None),
+    )
+    builder = _make_fp8_sparse_metadata_builder()
+    global_seq_lens = torch.tensor([10, 11], dtype=torch.int32)
+    local_seq_lens = get_dcp_local_seq_lens(
+        global_seq_lens,
+        builder.dcp_world_size,
+        builder.dcp_rank,
+        builder.cp_kv_cache_interleave_size,
+    )
+    common = _make_common_metadata(
+        global_seq_lens,
+        max_seq_len=11,
+        dcp_local_seq_lens=local_seq_lens,
+    )
+
+    metadata = builder._build_fp8_separate_prefill_decode(common)
+
+    assert metadata.num_decodes == 2
+    assert metadata.prefill is None
+    assert metadata.decode is not None
+    assert torch.equal(metadata.decode.seq_lens, local_seq_lens)
+    assert torch.equal(
+        metadata.decode.kernel_metadata.cache_lens,
+        builder.fp8_cache_lens_tensor[:2],
+    )
+
+
+def test_flashmla_sparse_fp8_prefill_metadata_chunks_dcp_local_lengths():
+    builder = _make_fp8_sparse_metadata_builder()
+    query_start_loc = torch.tensor([0, 2, 5], dtype=torch.int32)
+    global_seq_lens = torch.tensor([9, 12], dtype=torch.int32)
+    local_seq_lens = get_dcp_local_seq_lens(
+        global_seq_lens,
+        builder.dcp_world_size,
+        builder.dcp_rank,
+        builder.cp_kv_cache_interleave_size,
+    )
+    common = CommonAttentionMetadata(
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+        seq_lens=global_seq_lens,
+        num_reqs=2,
+        num_actual_tokens=5,
+        max_query_len=3,
+        max_seq_len=12,
+        block_table_tensor=torch.arange(2, dtype=torch.int32).view(2, 1),
+        slot_mapping=torch.empty(5, dtype=torch.int64),
+        dcp_local_seq_lens=local_seq_lens,
+        seq_lens_cpu_upper_bound=global_seq_lens,
+    )
+
+    metadata = builder._build_fp8_separate_prefill_decode(common)
+
+    assert metadata.num_prefills == 2
+    assert metadata.decode is None
+    assert metadata.prefill is not None
+    assert torch.equal(metadata.prefill.seq_lens, local_seq_lens)
+    assert metadata.prefill.request_ids.tolist() == [0, 0, 1, 1, 1]
+    assert len(metadata.prefill.chunks) == 1
+    chunk = metadata.prefill.chunks[0]
+    assert torch.equal(chunk.seq_lens, local_seq_lens)
+    assert int(chunk.chunk_tot_seqlen) == int(local_seq_lens.sum().item())
+    assert metadata.prefill.workspace_starts.tolist() == [0, local_seq_lens[0].item()]
+
+
+def test_flashmla_sparse_fp8_decode_uses_gathered_head_count(monkeypatch):
+    impl = object.__new__(sparse_mla_mod.FlashMLASparseImpl)
+    impl.num_heads = 4
+
+    def fake_convert_req_index_to_global_index(
+        _req_id_per_token,
+        _block_table,
+        topk_indices,
+        **_kwargs,
+    ):
+        return topk_indices
+
+    def fake_fp8_kernel(_self, q, **_kwargs):
+        assert q.shape == (2, 1, 64, 576)
+        out = q.new_zeros((2, 1, 64, 512))
+        lse = torch.zeros((2, 64, 1), dtype=torch.float32)
+        return out, lse
+
+    monkeypatch.setattr(
+        sparse_mla_mod,
+        "triton_convert_req_index_to_global_index",
+        fake_convert_req_index_to_global_index,
+    )
+    monkeypatch.setattr(
+        sparse_mla_mod.FlashMLASparseImpl,
+        "_fp8_flash_mla_kernel",
+        fake_fp8_kernel,
+    )
+
+    FP8Meta = sparse_mla_mod.FlashMLASparseMetadata.FP8SeparatePrefillDecode
+    fp8_metadata = FP8Meta(num_decodes=2, num_decode_tokens=2)
+    kernel_metadata = sparse_mla_mod.FlashMLASparseMetadata.FP8KernelMetadata(
+        scheduler_metadata="sched",
+        dummy_block_table=torch.empty((2, 1), dtype=torch.int32),
+        cache_lens=torch.full((2,), 8, dtype=torch.int32),
+    )
+    fp8_metadata.decode = FP8Meta.Decode(
+        seq_lens=torch.full((2,), 4, dtype=torch.int32),
+        kernel_metadata=kernel_metadata,
+        decode_query_len=1,
+    )
+    attn_metadata = sparse_mla_mod.FlashMLASparseMetadata(
+        num_reqs=2,
+        max_query_len=1,
+        max_seq_len=4,
+        num_actual_tokens=2,
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        slot_mapping=torch.empty(2, dtype=torch.int64),
+        block_table=torch.empty((2, 1), dtype=torch.int32),
+        req_id_per_token=torch.zeros(2, dtype=torch.int32),
+        fp8_extra_metadata=fp8_metadata,
+    )
+    q = torch.randn(2, 64, 576, dtype=torch.bfloat16)
+    topk_indices = torch.zeros((2, 8), dtype=torch.int32)
+    kv_cache = torch.empty((1, 64, 656), dtype=torch.uint8)
+
+    out, lse = (
+        sparse_mla_mod.FlashMLASparseImpl._forward_fp8_kv_separate_prefill_decode(
+            impl, q, kv_cache, topk_indices, attn_metadata
+        )
+    )
+
+    assert out.shape == (2, 64, 512)
+    assert lse.shape == (2, 64)
+
+
 @pytest.mark.parametrize(
     ("input_heads", "kernel_heads", "output_heads"),
     [
@@ -567,7 +742,9 @@ def test_bf16_sparse_prefill_padding_uses_input_head_count(
 
     seen = {}
 
-    def fake_flash_mla_sparse_fwd(q, kv_cache, topk_indices, softmax_scale):
+    def fake_flash_mla_sparse_fwd(
+        q, kv_cache, topk_indices, softmax_scale, topk_length=None
+    ):
         seen["q_shape"] = tuple(q.shape)
         seen["kv_shape"] = tuple(kv_cache.shape)
         seen["topk_shape"] = tuple(topk_indices.shape)

--- a/tests/v1/attention/test_dcp_sparse_indexer.py
+++ b/tests/v1/attention/test_dcp_sparse_indexer.py
@@ -27,8 +27,10 @@ from vllm.model_executor.layers.sparse_attn_indexer import (
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON
+from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.mla.indexer import (
     _dcp_local_indexer_seq_lens,
+    _decode_topk_max_seq_len,
     split_indexer_prefill_chunks,
 )
 
@@ -76,14 +78,77 @@ def _local_to_global(local_idx, rank, world_size, interleave):
     return _local_to_global_position(local_idx, rank, world_size, interleave)
 
 
-def test_decode_persistent_topk_disabled_for_dcp(monkeypatch):
+def _make_common_metadata(
+    seq_lens_cpu: torch.Tensor,
+    max_seq_len: int,
+    *,
+    dcp_local_seq_lens_cpu: torch.Tensor | None = None,
+    seq_lens_cpu_upper_bound: torch.Tensor | None = None,
+    exact_seq_lens_cpu: torch.Tensor | None = None,
+) -> CommonAttentionMetadata:
+    num_reqs = seq_lens_cpu.shape[0]
+    query_start_loc_cpu = torch.arange(num_reqs + 1, dtype=torch.int32)
+    return CommonAttentionMetadata(
+        query_start_loc=query_start_loc_cpu,
+        query_start_loc_cpu=query_start_loc_cpu,
+        seq_lens=seq_lens_cpu,
+        num_reqs=num_reqs,
+        num_actual_tokens=num_reqs,
+        max_query_len=1,
+        max_seq_len=max_seq_len,
+        block_table_tensor=torch.empty((num_reqs, 1), dtype=torch.int32),
+        slot_mapping=torch.empty(num_reqs, dtype=torch.int64),
+        dcp_local_seq_lens_cpu=dcp_local_seq_lens_cpu,
+        seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
+        _seq_lens_cpu=exact_seq_lens_cpu,
+    )
+
+
+def test_decode_persistent_topk_enabled_for_dcp(monkeypatch):
     monkeypatch.setattr(idx_mod.current_platform, "is_cuda", lambda: True)
 
-    assert _use_persistent_topk_decode(512, dcp_world_size=1)
-    assert _use_persistent_topk_decode(1024, dcp_world_size=1)
-    assert _use_persistent_topk_decode(2048, dcp_world_size=1)
-    assert not _use_persistent_topk_decode(256, dcp_world_size=1)
-    assert not _use_persistent_topk_decode(512, dcp_world_size=2)
+    assert _use_persistent_topk_decode(512)
+    assert _use_persistent_topk_decode(1024)
+    assert _use_persistent_topk_decode(2048)
+    assert not _use_persistent_topk_decode(256)
+
+
+def test_decode_topk_max_seq_len_uses_dcp_local_lengths():
+    common = _make_common_metadata(
+        torch.tensor([100, 80, 0], dtype=torch.int32),
+        max_seq_len=100,
+        dcp_local_seq_lens_cpu=torch.tensor([13, 11, 0], dtype=torch.int32),
+    )
+
+    got = _decode_topk_max_seq_len(
+        common,
+        num_decodes=2,
+        compress_ratio=4,
+        dcp_world_size=8,
+        dcp_rank=7,
+        cp_interleave_size=16,
+    )
+
+    assert got == 3
+
+
+def test_decode_topk_max_seq_len_derives_dcp_local_upper_bound():
+    common = _make_common_metadata(
+        torch.tensor([100, 65], dtype=torch.int32),
+        max_seq_len=100,
+        seq_lens_cpu_upper_bound=torch.tensor([100, 65], dtype=torch.int32),
+    )
+
+    got = _decode_topk_max_seq_len(
+        common,
+        num_decodes=2,
+        compress_ratio=1,
+        dcp_world_size=4,
+        dcp_rank=1,
+        cp_interleave_size=8,
+    )
+
+    assert got == 24
 
 
 def test_pack_topk_candidates_preserves_score_bits_and_row_starts():

--- a/tests/v1/attention/test_dcp_sparse_indexer.py
+++ b/tests/v1/attention/test_dcp_sparse_indexer.py
@@ -19,10 +19,14 @@ import torch
 import vllm.model_executor.layers.sparse_attn_indexer as idx_mod
 import vllm.v1.attention.backends.mla.flashmla_sparse as sparse_mla_mod
 from vllm.model_executor.layers.sparse_attn_indexer import (
+    _dcp_finalize_topk_remap,
+    _dcp_pack_topk_candidates,
     _global_to_local_position,
     _local_to_global_position,
     _use_persistent_topk_decode,
 )
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON
 from vllm.v1.attention.backends.mla.indexer import (
     _dcp_local_indexer_seq_lens,
     split_indexer_prefill_chunks,
@@ -32,26 +36,40 @@ from vllm.v1.attention.backends.mla.indexer import (
 class _FakeDCPGroup:
     """Single-process stand-in for the DCP group coordinator.
 
-    `set_all` pre-stashes every rank's (global_pos, score) candidate tensors
-    (computed by the caller for each rank). `all_gather` then concatenates them
-    in rank order, emulating a real all-gather.
+    `set_all` pre-stashes every rank's packed (global_pos, score_bits)
+    candidate tensor. `all_gather` then concatenates them in rank order,
+    emulating the single packed all-gather used by the DCP remap.
     """
 
     def __init__(self, world_size: int, rank: int):
         self.world_size = world_size
         self.rank_in_group = rank
-        self._pos: list[torch.Tensor] | None = None
-        self._scores: list[torch.Tensor] | None = None
+        self._packed: list[torch.Tensor] | None = None
+        self.all_gather_calls = 0
 
     def set_all(self, pos_list, scores_list):
-        self._pos = list(pos_list)
-        self._scores = list(scores_list)
+        self._packed = []
+        for pos, scores in zip(pos_list, scores_list):
+            packed = torch.empty(
+                (pos.shape[0], 2, pos.shape[1]),
+                dtype=torch.int32,
+                device=pos.device,
+            )
+            packed[:, 0, :].copy_(pos)
+            packed[:, 1, :].copy_(
+                scores.to(torch.float32).contiguous().view(torch.int32)
+            )
+            self._packed.append(packed)
 
     def all_gather(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
-        # `tensor` is this rank's contribution (already in self._* at its rank).
-        stash = self._pos if tensor.dtype != torch.float32 else self._scores
-        assert stash is not None
-        return torch.cat(stash, dim=dim)
+        self.all_gather_calls += 1
+        assert self._packed is not None
+        assert dim == 2
+        assert tensor.dtype == torch.int32
+        assert tensor.ndim == 3
+        assert tensor.shape[1] == 2
+        assert torch.equal(tensor, self._packed[self.rank_in_group])
+        return torch.cat(self._packed, dim=dim)
 
 
 def _local_to_global(local_idx, rank, world_size, interleave):
@@ -66,6 +84,163 @@ def test_decode_persistent_topk_disabled_for_dcp(monkeypatch):
     assert _use_persistent_topk_decode(2048, dcp_world_size=1)
     assert not _use_persistent_topk_decode(256, dcp_world_size=1)
     assert not _use_persistent_topk_decode(512, dcp_world_size=2)
+
+
+def test_pack_topk_candidates_preserves_score_bits_and_row_starts():
+    topk_indices = torch.tensor(
+        [
+            [0, 2, -1, 1],
+            [1, -1, 0, 3],
+        ],
+        dtype=torch.int32,
+    )
+    logits = torch.tensor(
+        [
+            [-100.0, -100.0, 1.0, 3.0, 5.0, 7.0, -100.0, -100.0],
+            [-100.0, -100.0, -100.0, -100.0, 2.0, 4.0, 6.0, 8.0],
+        ],
+        dtype=torch.float32,
+    )
+    row_starts = torch.tensor([2, 4], dtype=torch.int32)
+
+    packed = _dcp_pack_topk_candidates(
+        topk_indices,
+        logits,
+        topk_indices.shape[1],
+        rank=1,
+        world_size=3,
+        interleave=2,
+        row_starts=row_starts,
+    )
+
+    expected_pos = _local_to_global(
+        torch.clamp(topk_indices, min=0),
+        rank=1,
+        world_size=3,
+        interleave=2,
+    )
+    expected_pos = torch.where(
+        topk_indices < 0, expected_pos.new_full((), -1), expected_pos
+    )
+    expected_scores = torch.tensor(
+        [
+            [1.0, 5.0, float("-inf"), 3.0],
+            [4.0, float("-inf"), 2.0, 8.0],
+        ],
+        dtype=torch.float32,
+    )
+
+    assert torch.equal(packed[:, 0, :], expected_pos)
+    torch.testing.assert_close(packed[:, 1, :].view(torch.float32), expected_scores)
+
+
+def test_finalize_topk_remap_matches_reference():
+    all_candidates = torch.empty((2, 2, 6), dtype=torch.int32)
+    all_candidates[:, 0, :] = torch.tensor(
+        [
+            [0, 2, 3, 4, 6, -1],
+            [1, 5, 6, 7, 8, -1],
+        ],
+        dtype=torch.int32,
+    )
+    all_candidates[:, 1, :] = 0
+    selected = torch.tensor([[1, 2, 4], [0, 3, 5]], dtype=torch.int64)
+    out = torch.zeros((2, 3), dtype=torch.int32)
+
+    _dcp_finalize_topk_remap(
+        all_candidates,
+        selected,
+        out,
+        topk_tokens=3,
+        rank=1,
+        world_size=2,
+        interleave=2,
+    )
+
+    assert out.tolist() == [[0, 1, 2], [-1, 3, -1]]
+
+
+@pytest.mark.skipif(
+    not (HAS_TRITON and current_platform.is_cuda() and torch.cuda.is_available()),
+    reason="CUDA Triton kernel test requires a CUDA Triton runtime",
+)
+def test_triton_pack_topk_candidates_matches_cpu_reference():
+    topk_indices_cpu = torch.tensor(
+        [
+            [0, 3, -1, 1],
+            [2, -1, 0, 4],
+        ],
+        dtype=torch.int32,
+    )
+    logits_cpu = torch.tensor(
+        [
+            [-100.0, 1.0, 2.0, 3.0, 4.0, -100.0],
+            [5.0, 6.0, 7.0, 8.0, 9.0, -100.0],
+        ],
+        dtype=torch.float32,
+    )
+    row_starts_cpu = torch.tensor([1, 0], dtype=torch.int32)
+    expected = _dcp_pack_topk_candidates(
+        topk_indices_cpu,
+        logits_cpu,
+        topk_indices_cpu.shape[1],
+        rank=1,
+        world_size=4,
+        interleave=2,
+        row_starts=row_starts_cpu,
+    )
+
+    got = _dcp_pack_topk_candidates(
+        topk_indices_cpu.cuda(),
+        logits_cpu.cuda(),
+        topk_indices_cpu.shape[1],
+        rank=1,
+        world_size=4,
+        interleave=2,
+        row_starts=row_starts_cpu.cuda(),
+    )
+
+    assert torch.equal(got.cpu(), expected)
+
+
+@pytest.mark.skipif(
+    not (HAS_TRITON and current_platform.is_cuda() and torch.cuda.is_available()),
+    reason="CUDA Triton kernel test requires a CUDA Triton runtime",
+)
+def test_triton_finalize_topk_remap_matches_cpu_reference():
+    all_candidates_cpu = torch.empty((2, 2, 8), dtype=torch.int32)
+    all_candidates_cpu[:, 0, :] = torch.tensor(
+        [
+            [0, 2, 3, 4, 6, 8, 9, -1],
+            [1, 5, 6, 7, 8, 10, 11, -1],
+        ],
+        dtype=torch.int32,
+    )
+    all_candidates_cpu[:, 1, :] = 0
+    selected_cpu = torch.tensor([[1, 2, 4, 6], [0, 3, 5, 7]], dtype=torch.int64)
+    expected = torch.zeros((2, 4), dtype=torch.int32)
+    _dcp_finalize_topk_remap(
+        all_candidates_cpu,
+        selected_cpu,
+        expected,
+        topk_tokens=4,
+        rank=1,
+        world_size=2,
+        interleave=2,
+    )
+
+    got = torch.zeros_like(expected, device="cuda")
+    _dcp_finalize_topk_remap(
+        all_candidates_cpu.cuda(),
+        selected_cpu.cuda(),
+        got,
+        topk_tokens=4,
+        rank=1,
+        world_size=2,
+        interleave=2,
+    )
+
+    assert torch.equal(got.cpu(), expected)
 
 
 @pytest.mark.parametrize("interleave", [1, 2, 4])
@@ -283,6 +458,7 @@ def test_global_topk_reconstructs_reference(interleave, world_size, monkeypatch)
         seed = lg.topk(k, dim=1).indices.to(torch.int32)
         topk_buf[:, :k] = seed
         idx_mod._dcp_global_topk_remap(topk_buf, lg, topk_tokens, interleave)
+        assert fake.all_gather_calls == 1
         per_rank_final.append(topk_buf)
 
     # Reference: global top-k of the FULL logits, as sets per row.
@@ -357,6 +533,7 @@ def test_prefill_global_topk_uses_row_starts(monkeypatch):
             interleave,
             row_starts=row_starts_per_rank[rank],
         )
+        assert fake.all_gather_calls == 1
         per_rank_final.append(topk_buf)
 
     ref = full_logits.topk(topk_tokens, dim=1).indices
@@ -402,6 +579,7 @@ def test_global_topk_remap_allows_empty_local_rank(monkeypatch):
             topk_tokens,
             interleave,
         )
+        assert fake.all_gather_calls == 1
         per_rank_final.append(topk_buf)
 
     assert per_rank_final[0].tolist() == [[0, 1]]
@@ -443,6 +621,7 @@ def test_global_topk_ownership_partition(monkeypatch):
         buf = torch.full((num_rows, topk_tokens), -1, dtype=torch.int32)
         buf[:, :k] = lg.topk(k, dim=1).indices.to(torch.int32)
         idx_mod._dcp_global_topk_remap(buf, lg, topk_tokens, interleave)
+        assert fake.all_gather_calls == 1
         # owned positions get a real (>=0) local idx; others are -1
         for local_idx in buf.flatten().tolist():
             if local_idx >= 0:

--- a/tests/v1/attention/test_dcp_sparse_indexer.py
+++ b/tests/v1/attention/test_dcp_sparse_indexer.py
@@ -21,6 +21,7 @@ from vllm.model_executor.layers.sparse_attn_indexer import (
     _global_to_local_position,
     _local_to_global_position,
 )
+from vllm.v1.attention.backends.mla.indexer import _dcp_local_indexer_seq_lens
 
 
 class _FakeDCPGroup:
@@ -77,6 +78,50 @@ def test_position_roundtrip(interleave, world_size):
             interleave,
         )
         assert (((gg_all // interleave) % world_size) == rank).all()
+
+
+@pytest.mark.parametrize(
+    ("rank", "expected"),
+    [
+        (0, [1, 2, 2, 2]),
+        (1, [0, 0, 1, 2]),
+    ],
+)
+def test_dcp_prefill_visible_lengths_use_global_positions(rank, expected):
+    visible_global_lens = torch.arange(1, 5, dtype=torch.int32)
+
+    got = _dcp_local_indexer_seq_lens(
+        visible_global_lens,
+        compress_ratio=1,
+        dcp_world_size=2,
+        dcp_rank=rank,
+        cp_interleave_size=2,
+    )
+
+    total = _dcp_local_indexer_seq_lens(
+        torch.tensor([4], dtype=torch.int32),
+        compress_ratio=1,
+        dcp_world_size=2,
+        dcp_rank=rank,
+        cp_interleave_size=2,
+    ).item()
+    assert got.tolist() == expected
+    assert torch.all(got >= 0)
+    assert torch.all(got <= total)
+
+
+def test_dcp_prefill_visible_lengths_support_compressed_indexer_cache():
+    visible_global_lens = torch.arange(1, 17, dtype=torch.int32)
+
+    got = _dcp_local_indexer_seq_lens(
+        visible_global_lens,
+        compress_ratio=4,
+        dcp_world_size=2,
+        dcp_rank=0,
+        cp_interleave_size=2,
+    )
+
+    assert got.tolist() == [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2]
 
 
 @pytest.mark.parametrize("interleave", [1, 2, 3])
@@ -150,6 +195,74 @@ def test_global_topk_reconstructs_reference(interleave, world_size, monkeypatch)
             sorted(union),
             sorted(ref[row].tolist()),
         )
+
+
+def test_prefill_global_topk_uses_row_starts(monkeypatch):
+    interleave, world_size, topk_tokens = 1, 2, 2
+    full_logits = torch.tensor(
+        [
+            [1.0, 5.0, 2.0, 4.0, 3.0, 0.0],
+            [0.1, 10.0, 0.2, 9.0, 0.3, 8.0],
+        ],
+        dtype=torch.float32,
+    )
+    num_rows = full_logits.shape[0]
+    total_len = full_logits.shape[1]
+    g = torch.arange(total_len)
+    owner = (g // interleave) % world_size
+
+    per_rank_logits = []
+    row_starts_per_rank = []
+    seed_topk = []
+    pos_list, scores_list = [], []
+    for rank in range(world_size):
+        local_logits = full_logits[:, owner == rank].contiguous()
+        local_len = local_logits.shape[1]
+        row_starts = torch.arange(num_rows, dtype=torch.int32) * local_len
+        logits = full_logits.new_full((num_rows, num_rows * local_len), float("-inf"))
+        for row, row_start in enumerate(row_starts.tolist()):
+            logits[row, row_start : row_start + local_len] = local_logits[row]
+
+        local_topk = local_logits.topk(topk_tokens, dim=1).indices.to(torch.int32)
+        idx_safe = torch.clamp(local_topk, min=0)
+        score_idx = idx_safe.long() + row_starts.view(-1, 1).long()
+        scores = logits.gather(1, score_idx)
+        gp = _local_to_global(idx_safe, rank, world_size, interleave)
+
+        per_rank_logits.append(logits)
+        row_starts_per_rank.append(row_starts)
+        seed_topk.append(local_topk)
+        pos_list.append(gp.contiguous())
+        scores_list.append(scores.contiguous())
+
+    per_rank_final = []
+    for rank in range(world_size):
+        fake = _FakeDCPGroup(world_size, rank)
+        fake.set_all(pos_list, scores_list)
+        monkeypatch.setattr(idx_mod, "get_dcp_group", lambda f=fake: f)
+
+        topk_buf = seed_topk[rank].clone()
+        idx_mod._dcp_global_topk_remap(
+            topk_buf,
+            per_rank_logits[rank],
+            topk_tokens,
+            interleave,
+            row_starts=row_starts_per_rank[rank],
+        )
+        per_rank_final.append(topk_buf)
+
+    ref = full_logits.topk(topk_tokens, dim=1).indices
+    for row in range(num_rows):
+        union = set()
+        for rank in range(world_size):
+            for local_idx in per_rank_final[rank][row].tolist():
+                if local_idx >= 0:
+                    union.add(
+                        _local_to_global(
+                            torch.tensor([local_idx]), rank, world_size, interleave
+                        ).item()
+                    )
+        assert union == set(ref[row].tolist())
 
 
 def test_global_topk_ownership_partition(monkeypatch):

--- a/tests/v1/attention/test_dcp_sparse_indexer.py
+++ b/tests/v1/attention/test_dcp_sparse_indexer.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the DCP-aware sparse indexer.
+
+Validates the global<->local position remap math and the global top-k
+reconstruction: for interleaved DCP sharding, the *union* over ranks of the
+per-rank `_dcp_global_topk_remap` output (mapped back to global positions)
+must equal the true global top-k of the concatenated full logits.
+
+These tests exercise the pure tensor logic in
+`vllm/model_executor/layers/sparse_attn_indexer.py` (no GPU, no real
+distributed communicator): `get_dcp_group` is monkeypatched to a fake that
+emulates all_gather by concatenating all ranks' pre-computed contributions.
+"""
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.sparse_attn_indexer as idx_mod
+from vllm.model_executor.layers.sparse_attn_indexer import (
+    _global_to_local_position,
+    _local_to_global_position,
+)
+
+
+class _FakeDCPGroup:
+    """Single-process stand-in for the DCP group coordinator.
+
+    `set_all` pre-stashes every rank's (global_pos, score) candidate tensors
+    (computed by the caller for each rank). `all_gather` then concatenates them
+    in rank order, emulating a real all-gather.
+    """
+
+    def __init__(self, world_size: int, rank: int):
+        self.world_size = world_size
+        self.rank_in_group = rank
+        self._pos: list[torch.Tensor] | None = None
+        self._scores: list[torch.Tensor] | None = None
+
+    def set_all(self, pos_list, scores_list):
+        self._pos = list(pos_list)
+        self._scores = list(scores_list)
+
+    def all_gather(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        # `tensor` is this rank's contribution (already in self._* at its rank).
+        stash = self._pos if tensor.dtype != torch.float32 else self._scores
+        assert stash is not None
+        return torch.cat(stash, dim=dim)
+
+
+def _local_to_global(local_idx, rank, world_size, interleave):
+    return _local_to_global_position(local_idx, rank, world_size, interleave)
+
+
+@pytest.mark.parametrize("interleave", [1, 2, 4])
+@pytest.mark.parametrize("world_size", [1, 2, 3, 4])
+def test_position_roundtrip(interleave, world_size):
+    total = 3 * interleave * world_size
+    g = torch.arange(total, dtype=torch.int32)
+    owner = (g // interleave) % world_size
+    for rank in range(world_size):
+        present = g[owner == rank]
+        for local_idx in range(present.numel()):
+            gg = _local_to_global(
+                torch.tensor([local_idx]), rank, world_size, interleave
+            )
+            # this global position should map back to local_idx on rank `rank`
+            assert (
+                _global_to_local_position(gg, interleave, world_size).item()
+                == local_idx
+            )
+        # cross-check the owner implied by local->global matches `rank`
+        gg_all = _local_to_global(
+            torch.arange(present.numel(), dtype=torch.int32),
+            rank,
+            world_size,
+            interleave,
+        )
+        assert (((gg_all // interleave) % world_size) == rank).all()
+
+
+@pytest.mark.parametrize("interleave", [1, 2, 3])
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_global_topk_reconstructs_reference(interleave, world_size, monkeypatch):
+    torch.manual_seed(0)
+    topk_tokens = 8
+    num_rows = 4
+    total_len = 6 * interleave * world_size
+    full_logits = torch.randn(num_rows, total_len)
+
+    # Shard full_logits to each rank per the interleave scheme. The shard's
+    # column order is chosen so local index l maps to global via the formula.
+    g = torch.arange(total_len)
+    owner = (g // interleave) % world_size
+    per_rank_logits = [
+        full_logits[:, owner == rank].contiguous() for rank in range(world_size)
+    ]
+
+    # Pre-pass: compute each rank's (global_pos, score) candidates by running the
+    # same local-topk + local->global logic the helper uses internally. When a
+    # shard is shorter than topk_tokens, the real kernel returns only as many
+    # valid indices as the shard holds and pads the rest with -1; emulate that.
+    pos_list, scores_list = [], []
+    for rank in range(world_size):
+        lg = per_rank_logits[rank]
+        k = min(topk_tokens, lg.shape[1])
+        local_topk = lg.topk(k, dim=1).indices.to(torch.int32)
+        pad = torch.full((local_topk.shape[0], topk_tokens - k), -1, dtype=torch.int32)
+        local_topk = torch.cat([local_topk, pad], dim=1)
+        invalid = local_topk < 0
+        idx_safe = torch.clamp(local_topk, min=0)
+        scores = lg.gather(1, idx_safe.long()).masked_fill(invalid, float("-inf"))
+        gp = _local_to_global(idx_safe, rank, world_size, interleave)
+        gp = torch.where(invalid, gp.new_full((), -1), gp)
+        pos_list.append(gp.contiguous())
+        scores_list.append(scores.contiguous())
+
+    # Run the real helper once per rank with a fake group that returns the full
+    # concatenation, capturing each rank's final local-index buffer.
+    per_rank_final = []
+    for rank in range(world_size):
+        fake = _FakeDCPGroup(world_size, rank)
+        fake.set_all(pos_list, scores_list)
+        monkeypatch.setattr(idx_mod, "get_dcp_group", lambda f=fake: f)
+
+        topk_buf = torch.full((num_rows, topk_tokens), -1, dtype=torch.int32)
+        # Seed the buffer with rank's local top-k (what the kernel would write).
+        lg = per_rank_logits[rank]
+        k = min(topk_tokens, lg.shape[1])
+        seed = lg.topk(k, dim=1).indices.to(torch.int32)
+        topk_buf[:, :k] = seed
+        idx_mod._dcp_global_topk_remap(topk_buf, lg, topk_tokens, interleave)
+        per_rank_final.append(topk_buf)
+
+    # Reference: global top-k of the FULL logits, as sets per row.
+    ref = full_logits.topk(topk_tokens, dim=1).indices
+    for row in range(num_rows):
+        union = set()
+        for rank in range(world_size):
+            for local_idx in per_rank_final[rank][row].tolist():
+                if local_idx < 0:
+                    continue
+                union.add(
+                    _local_to_global(
+                        torch.tensor([local_idx]), rank, world_size, interleave
+                    ).item()
+                )
+        assert union == set(ref[row].tolist()), (
+            row,
+            sorted(union),
+            sorted(ref[row].tolist()),
+        )
+
+
+def test_global_topk_ownership_partition(monkeypatch):
+    """Every selected global position is owned by exactly one rank's output."""
+    interleave, world_size, topk_tokens = 2, 2, 6
+    num_rows = 2
+    total_len = 4 * interleave * world_size
+    full_logits = torch.randn(num_rows, total_len)
+    g = torch.arange(total_len)
+    owner = (g // interleave) % world_size
+    per_rank_logits = [
+        full_logits[:, owner == r].contiguous() for r in range(world_size)
+    ]
+    pos_list, scores_list = [], []
+    for rank in range(world_size):
+        lg = per_rank_logits[rank]
+        k = min(topk_tokens, lg.shape[1])
+        local_topk = lg.topk(k, dim=1).indices.to(torch.int32)
+        pad = torch.full((local_topk.shape[0], topk_tokens - k), -1, dtype=torch.int32)
+        local_topk = torch.cat([local_topk, pad], dim=1)
+        idx_safe = torch.clamp(local_topk, min=0)
+        scores = lg.gather(1, idx_safe.long()).masked_fill(
+            local_topk < 0, float("-inf")
+        )
+        gp = _local_to_global(idx_safe, rank, world_size, interleave)
+        gp = torch.where(local_topk < 0, gp.new_full((), -1), gp)
+        pos_list.append(gp.contiguous())
+        scores_list.append(scores.contiguous())
+    for rank in range(world_size):
+        fake = _FakeDCPGroup(world_size, rank)
+        fake.set_all(pos_list, scores_list)
+        monkeypatch.setattr(idx_mod, "get_dcp_group", lambda f=fake: f)
+        lg = per_rank_logits[rank]
+        k = min(topk_tokens, lg.shape[1])
+        buf = torch.full((num_rows, topk_tokens), -1, dtype=torch.int32)
+        buf[:, :k] = lg.topk(k, dim=1).indices.to(torch.int32)
+        idx_mod._dcp_global_topk_remap(buf, lg, topk_tokens, interleave)
+        # owned positions get a real (>=0) local idx; others are -1
+        for local_idx in buf.flatten().tolist():
+            if local_idx >= 0:
+                gg = _local_to_global(
+                    torch.tensor([local_idx]), rank, world_size, interleave
+                ).item()
+                assert (gg // interleave) % world_size == rank
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/v1/attention/test_dcp_sparse_indexer.py
+++ b/tests/v1/attention/test_dcp_sparse_indexer.py
@@ -17,6 +17,7 @@ import pytest
 import torch
 
 import vllm.model_executor.layers.sparse_attn_indexer as idx_mod
+import vllm.v1.attention.backends.mla.flashmla_sparse as sparse_mla_mod
 from vllm.model_executor.layers.sparse_attn_indexer import (
     _global_to_local_position,
     _local_to_global_position,
@@ -122,6 +123,57 @@ def test_dcp_prefill_visible_lengths_support_compressed_indexer_cache():
     )
 
     assert got.tolist() == [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2]
+
+
+@pytest.mark.parametrize(
+    ("input_heads", "kernel_heads", "output_heads"),
+    [
+        (4, 64, 4),
+        (64, 64, 64),
+    ],
+)
+def test_bf16_sparse_prefill_padding_uses_input_head_count(
+    input_heads, kernel_heads, output_heads, monkeypatch
+):
+    impl = object.__new__(sparse_mla_mod.FlashMLASparseImpl)
+    impl.num_heads = 4
+    impl.prefill_padding = 64
+    impl.softmax_scale = 1.0
+
+    seen = {}
+
+    def fake_flash_mla_sparse_fwd(q, kv_cache, topk_indices, softmax_scale):
+        seen["q_shape"] = tuple(q.shape)
+        seen["kv_shape"] = tuple(kv_cache.shape)
+        seen["topk_shape"] = tuple(topk_indices.shape)
+        seen["softmax_scale"] = softmax_scale
+        out = torch.zeros(q.shape[0], q.shape[1], 512, dtype=q.dtype)
+        max_logits = torch.zeros(q.shape[0], q.shape[1], dtype=q.dtype)
+        lse = torch.zeros(q.shape[0], q.shape[1], dtype=torch.float32)
+        return out, max_logits, lse
+
+    monkeypatch.setattr(
+        sparse_mla_mod,
+        "flash_mla_sparse_fwd",
+        fake_flash_mla_sparse_fwd,
+    )
+
+    q = torch.randn(3, input_heads, 576, dtype=torch.bfloat16)
+    kv_cache = torch.randn(8, 576, dtype=torch.bfloat16)
+    topk_indices = torch.zeros(3, 8, dtype=torch.int32)
+
+    out, lse = sparse_mla_mod.FlashMLASparseImpl._bf16_flash_mla_kernel(
+        impl, q, kv_cache, topk_indices
+    )
+
+    assert seen == {
+        "q_shape": (3, kernel_heads, 576),
+        "kv_shape": (8, 1, 576),
+        "topk_shape": (3, 1, 8),
+        "softmax_scale": 1.0,
+    }
+    assert out.shape == (3, output_heads, 512)
+    assert lse.shape == (3, output_heads)
 
 
 @pytest.mark.parametrize("interleave", [1, 2, 3])

--- a/tests/v1/attention/test_dcp_sparse_indexer.py
+++ b/tests/v1/attention/test_dcp_sparse_indexer.py
@@ -29,6 +29,7 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.mla.indexer import (
+    DeepseekV32IndexerMetadataBuilder,
     _dcp_local_indexer_seq_lens,
     _decode_topk_max_seq_len,
     split_indexer_prefill_chunks,
@@ -149,6 +150,100 @@ def test_decode_topk_max_seq_len_derives_dcp_local_upper_bound():
     )
 
     assert got == 24
+
+
+def _make_decode_builder(next_n: int) -> DeepseekV32IndexerMetadataBuilder:
+    builder = object.__new__(DeepseekV32IndexerMetadataBuilder)
+    builder.decode_seq_lens_buffer = torch.zeros(16, dtype=torch.int32)
+    builder.decode_lens_buffer = torch.zeros(16, dtype=torch.int32)
+    builder.expanded_block_table_buffer = torch.zeros((16, 2), dtype=torch.int32)
+    builder.arange_buffer = torch.arange(16, dtype=torch.int32)
+    builder.offsets_buffer = torch.arange(next_n, dtype=torch.int32)
+    builder.dcp_world_size = 2
+    builder.dcp_rank = 1
+    builder.cp_kv_cache_interleave_size = 2
+    return builder
+
+
+def test_prepare_decode_tensors_expands_global_then_localizes_for_dcp_spec():
+    builder = _make_decode_builder(next_n=3)
+    global_seq_lens = torch.tensor([10, 11], dtype=torch.int32)
+    dcp_local_seq_lens = _dcp_local_indexer_seq_lens(
+        global_seq_lens,
+        compress_ratio=1,
+        dcp_world_size=2,
+        dcp_rank=1,
+        cp_interleave_size=2,
+    )
+    decode_lens = torch.tensor([3, 3], dtype=torch.int32)
+
+    seq_lens, _, _, batch_size, requires_padding = builder._prepare_decode_tensors(
+        seq_lens=global_seq_lens,
+        dcp_local_seq_lens=dcp_local_seq_lens,
+        block_table=torch.arange(4, dtype=torch.int32).view(2, 2),
+        decode_lens=decode_lens.clone(),
+        decode_lens_cpu=decode_lens,
+        query_start_loc=torch.tensor([0, 3, 6], dtype=torch.int32),
+        num_decodes=2,
+        num_decode_tokens=6,
+        use_native=True,
+        next_n=3,
+        max_decode_len=3,
+    )
+
+    global_per_token = torch.tensor(
+        [
+            [8, 9, 10],
+            [9, 10, 11],
+        ],
+        dtype=torch.int32,
+    )
+    expected = _dcp_local_indexer_seq_lens(
+        global_per_token.flatten(),
+        compress_ratio=1,
+        dcp_world_size=2,
+        dcp_rank=1,
+        cp_interleave_size=2,
+    ).view(2, 3)
+    wrong_old_math = (
+        dcp_local_seq_lens.view(2, 1) - 3 + torch.arange(1, 4, dtype=torch.int32)
+    )
+
+    assert batch_size == 2
+    assert not requires_padding
+    assert torch.equal(seq_lens, expected)
+    assert not torch.equal(seq_lens, wrong_old_math)
+
+
+def test_prepare_decode_tensors_uses_precomputed_dcp_local_for_plain_decode():
+    builder = _make_decode_builder(next_n=1)
+    global_seq_lens = torch.tensor([10, 11], dtype=torch.int32)
+    dcp_local_seq_lens = _dcp_local_indexer_seq_lens(
+        global_seq_lens,
+        compress_ratio=1,
+        dcp_world_size=2,
+        dcp_rank=1,
+        cp_interleave_size=2,
+    )
+    decode_lens = torch.tensor([1, 1], dtype=torch.int32)
+
+    seq_lens, _, _, batch_size, requires_padding = builder._prepare_decode_tensors(
+        seq_lens=global_seq_lens,
+        dcp_local_seq_lens=dcp_local_seq_lens,
+        block_table=torch.arange(4, dtype=torch.int32).view(2, 2),
+        decode_lens=decode_lens.clone(),
+        decode_lens_cpu=decode_lens,
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        num_decodes=2,
+        num_decode_tokens=2,
+        use_native=True,
+        next_n=1,
+        max_decode_len=1,
+    )
+
+    assert batch_size == 2
+    assert not requires_padding
+    assert torch.equal(seq_lens, dcp_local_seq_lens)
 
 
 def test_pack_topk_candidates_preserves_score_bits_and_row_starts():

--- a/tests/v1/attention/test_mla_dcp_shapes.py
+++ b/tests/v1/attention/test_mla_dcp_shapes.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shape contract tests for MLA DCP attention paths."""
+
+from types import SimpleNamespace
+
+import torch
+
+import vllm.v1.attention.backends.mla.flashmla as flashmla_mod
+
+
+def test_flashmla_forward_mqa_flattens_lse_with_gathered_heads(monkeypatch):
+    impl = object.__new__(flashmla_mod.FlashMLAImpl)
+    impl.kv_cache_dtype = "auto"
+    impl.kv_lora_rank = 512
+    impl.scale = 1.0
+
+    num_decodes = 2
+    seq_len = 3
+    num_heads = 64
+    head_dim = 576
+
+    q = torch.randn(num_decodes * seq_len, num_heads, head_dim)
+    kv_cache = torch.randn(8, head_dim)
+    expected_lse = torch.arange(
+        num_decodes * num_heads * seq_len, dtype=torch.float32
+    ).reshape(num_decodes, num_heads, seq_len)
+
+    def fake_flash_mla_with_kvcache(**kwargs):
+        assert kwargs["q"].shape == (num_decodes, seq_len, num_heads, head_dim)
+        out = torch.zeros(num_decodes, seq_len, num_heads, impl.kv_lora_rank)
+        return out, expected_lse
+
+    monkeypatch.setattr(
+        flashmla_mod, "flash_mla_with_kvcache", fake_flash_mla_with_kvcache
+    )
+
+    decode = flashmla_mod.FlashMLADecodeMetadata(
+        block_table=torch.zeros(num_decodes, 1, dtype=torch.int32),
+        seq_lens=torch.full((num_decodes,), 8, dtype=torch.int32),
+        dcp_tot_seq_lens=None,
+        scheduler_metadata=SimpleNamespace(),
+    )
+    metadata = flashmla_mod.FlashMLAMetadata(
+        num_reqs=num_decodes,
+        max_query_len=seq_len,
+        max_seq_len=8,
+        num_actual_tokens=num_decodes * seq_len,
+        query_start_loc=torch.tensor([0, seq_len, 2 * seq_len], dtype=torch.int32),
+        slot_mapping=torch.empty(0, dtype=torch.int64),
+        num_decodes=num_decodes,
+        num_decode_tokens=num_decodes * seq_len,
+        num_prefills=0,
+        decode=decode,
+    )
+
+    out, lse = flashmla_mod.FlashMLAImpl.forward_mqa(
+        impl,
+        q,
+        kv_cache,
+        metadata,
+        layer=SimpleNamespace(),
+    )
+
+    assert out.shape == (num_decodes * seq_len, num_heads, impl.kv_lora_rank)
+    assert lse.shape == (num_decodes * seq_len, num_heads)
+    torch.testing.assert_close(
+        lse,
+        expected_lse.permute(0, 2, 1)
+        .reshape(num_decodes * seq_len, num_heads)
+        .contiguous(),
+    )

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -283,6 +283,10 @@ logger = init_logger(__name__)
 _FP8_DTYPE = current_platform.fp8_dtype()
 
 
+def _supports_dcp_fp8_kv_cache(attn_backend_name: str, kv_cache_dtype: str) -> bool:
+    return attn_backend_name == "FLASHMLA_SPARSE" and kv_cache_dtype == "fp8_ds_mla"
+
+
 def _detect_output_quant_key(
     output: torch.Tensor,
     output_scale: torch.Tensor | None,
@@ -785,7 +789,17 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             else:
                 mqa_q = (mqa_ql_nope, mqa_q_pe)
             if self.impl.dcp_world_size > 1:
-                assert not fp8_attention, "DCP not support fp8 kvcache now."
+                if fp8_attention and not _supports_dcp_fp8_kv_cache(
+                    self.attn_backend.get_name(), self.kv_cache_dtype
+                ):
+                    raise AssertionError(
+                        "DCP with FP8 KV cache is only supported for "
+                        "FlashMLASparse with fp8_ds_mla KV cache."
+                    )
+                assert isinstance(mqa_q, tuple), (
+                    "DCP gathers unquantized MLA queries before the sparse "
+                    "attention kernel."
+                )
                 # concatenate mqa_ql_nope and mqa_q_pe -> (B, N, L + P)
                 mqa_q = torch.cat(mqa_q, dim=-1)
                 # mqa_q do allgather in head dim.

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -39,19 +39,14 @@ RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
 MXFP4_BLOCK_SIZE = 32
 
 
-def _use_persistent_topk_decode(topk_tokens: int, dcp_world_size: int) -> bool:
+def _use_persistent_topk_decode(topk_tokens: int) -> bool:
     """Return whether decode top-k should use the persistent CUDA kernel.
 
-    Under DCP, every rank enters a global top-k all-gather immediately after
-    local top-k. Avoid the optimized persistent_topk wrapper there because it
-    has load-dependent CUDA subpaths, including a large-batch FilteredTopK
-    branch, and a stalled rank would block peers in the following collective.
+    The caller must pass persistent_topk a max sequence length in the same
+    coordinate system as its seq_lens tensor. Under DCP this is rank-local, not
+    the global attention max.
     """
-    return (
-        current_platform.is_cuda()
-        and dcp_world_size == 1
-        and topk_tokens in (512, 1024, 2048)
-    )
+    return current_platform.is_cuda() and topk_tokens in (512, 1024, 2048)
 
 
 def _local_to_global_position(
@@ -701,9 +696,7 @@ def sparse_attn_indexer(
         num_rows = logits.shape[0]
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
 
-        if _use_persistent_topk_decode(
-            topk_tokens, attn_metadata_narrowed.dcp_world_size
-        ):
+        if _use_persistent_topk_decode(topk_tokens):
             workspace_manager = current_workspace_manager()
             (topk_workspace,) = workspace_manager.get_simultaneous(
                 ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
@@ -714,7 +707,7 @@ def sparse_attn_indexer(
                 topk_indices,
                 topk_workspace,
                 topk_tokens,
-                attn_metadata_narrowed.max_seq_len,
+                decode_metadata.max_seq_len,
             )
         else:
             ops.top_k_per_row_decode(

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -13,6 +13,7 @@ from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON, tl, triton
 from vllm.utils.deep_gemm import (
     fp8_fp4_mqa_logits,
     fp8_fp4_paged_mqa_logits,
@@ -39,7 +40,13 @@ MXFP4_BLOCK_SIZE = 32
 
 
 def _use_persistent_topk_decode(topk_tokens: int, dcp_world_size: int) -> bool:
-    """Return whether decode top-k should use the persistent CUDA kernel."""
+    """Return whether decode top-k should use the persistent CUDA kernel.
+
+    Under DCP, every rank enters a global top-k all-gather immediately after
+    local top-k. Avoid the optimized persistent_topk wrapper there because it
+    has load-dependent CUDA subpaths, including a large-batch FilteredTopK
+    branch, and a stalled rank would block peers in the following collective.
+    """
     return (
         current_platform.is_cuda()
         and dcp_world_size == 1
@@ -71,6 +78,238 @@ def _global_to_local_position(
     """
     big = interleave * world_size
     return (global_idx // big) * interleave + (global_idx % interleave)
+
+
+@triton.jit
+def _dcp_pack_topk_candidates_kernel(
+    topk_indices_ptr,
+    logits_ptr,
+    row_starts_ptr,
+    packed_ptr,
+    topk_stride_0: tl.constexpr,
+    topk_stride_1: tl.constexpr,
+    logits_stride_0: tl.constexpr,
+    logits_stride_1: tl.constexpr,
+    packed_stride_0: tl.constexpr,
+    packed_stride_1: tl.constexpr,
+    packed_stride_2: tl.constexpr,
+    logits_width,
+    RANK: tl.constexpr,
+    WORLD_SIZE: tl.constexpr,
+    INTERLEAVE: tl.constexpr,
+    TOPK_TOKENS: tl.constexpr,
+    HAS_LOGITS: tl.constexpr,
+    HAS_ROW_STARTS: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    mask = offsets < TOPK_TOKENS
+
+    idx = tl.load(
+        topk_indices_ptr + row * topk_stride_0 + offsets * topk_stride_1,
+        mask=mask,
+        other=-1,
+    )
+    invalid = idx < 0
+    idx_safe = tl.maximum(idx, 0)
+
+    scores = tl.full((BLOCK_K,), -float("inf"), tl.float32)
+    if HAS_LOGITS:
+        score_idx = idx_safe
+        if HAS_ROW_STARTS:
+            row_start = tl.load(row_starts_ptr + row)
+            score_idx += row_start
+        score_idx = tl.minimum(score_idx, logits_width - 1)
+        scores = tl.load(
+            logits_ptr + row * logits_stride_0 + score_idx * logits_stride_1,
+            mask=mask,
+            other=-float("inf"),
+        )
+        scores = tl.where(invalid, -float("inf"), scores)
+
+    global_pos = (
+        (idx_safe // INTERLEAVE) * (WORLD_SIZE * INTERLEAVE)
+        + RANK * INTERLEAVE
+        + (idx_safe % INTERLEAVE)
+    )
+    global_pos = tl.where(invalid, -1, global_pos)
+
+    packed_base = packed_ptr + row * packed_stride_0 + offsets * packed_stride_2
+    tl.store(packed_base, global_pos, mask=mask)
+    tl.store(
+        packed_base + packed_stride_1,
+        scores.to(tl.int32, bitcast=True),
+        mask=mask,
+    )
+
+
+@triton.jit
+def _dcp_finalize_topk_remap_kernel(
+    all_candidates_ptr,
+    selected_ptr,
+    topk_indices_ptr,
+    candidates_stride_0: tl.constexpr,
+    candidates_stride_1: tl.constexpr,
+    candidates_stride_2: tl.constexpr,
+    selected_stride_0: tl.constexpr,
+    selected_stride_1: tl.constexpr,
+    topk_stride_0: tl.constexpr,
+    topk_stride_1: tl.constexpr,
+    RANK: tl.constexpr,
+    WORLD_SIZE: tl.constexpr,
+    INTERLEAVE: tl.constexpr,
+    TOPK_TOKENS: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    mask = offsets < TOPK_TOKENS
+
+    selected = tl.load(
+        selected_ptr + row * selected_stride_0 + offsets * selected_stride_1,
+        mask=mask,
+        other=0,
+    )
+    global_pos = tl.load(
+        all_candidates_ptr + row * candidates_stride_0 + selected * candidates_stride_2,
+        mask=mask,
+        other=-1,
+    )
+
+    owner = (global_pos // INTERLEAVE) % WORLD_SIZE
+    big = INTERLEAVE * WORLD_SIZE
+    local_pos = (global_pos // big) * INTERLEAVE + (global_pos % INTERLEAVE)
+    mine = (owner == RANK) & (global_pos >= 0)
+    final = tl.where(mine, local_pos, -1)
+
+    tl.store(
+        topk_indices_ptr + row * topk_stride_0 + offsets * topk_stride_1,
+        final,
+        mask=mask,
+    )
+
+
+def _use_triton_dcp_remap(topk_indices: torch.Tensor) -> bool:
+    return HAS_TRITON and current_platform.is_cuda() and topk_indices.is_cuda
+
+
+def _dcp_pack_topk_candidates(
+    topk_indices: torch.Tensor,
+    logits: torch.Tensor | None,
+    topk_tokens: int,
+    rank: int,
+    world_size: int,
+    interleave: int,
+    row_starts: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Pack local candidate global positions and score bits for one all-gather."""
+    packed = torch.empty(
+        (topk_indices.shape[0], 2, topk_tokens),
+        dtype=torch.int32,
+        device=topk_indices.device,
+    )
+    if topk_indices.numel() == 0:
+        return packed
+
+    if _use_triton_dcp_remap(topk_indices):
+        block_k = triton.next_power_of_2(topk_tokens)
+        num_warps = 4 if block_k <= 256 else 8
+        logits_arg = logits if logits is not None else topk_indices
+        row_starts_arg = row_starts if row_starts is not None else topk_indices
+        _dcp_pack_topk_candidates_kernel[(topk_indices.shape[0],)](
+            topk_indices,
+            logits_arg,
+            row_starts_arg,
+            packed,
+            topk_indices.stride(0),
+            topk_indices.stride(1),
+            logits.stride(0) if logits is not None else 0,
+            logits.stride(1) if logits is not None else 0,
+            packed.stride(0),
+            packed.stride(1),
+            packed.stride(2),
+            logits.shape[1] if logits is not None else 1,
+            RANK=rank,
+            WORLD_SIZE=world_size,
+            INTERLEAVE=interleave,
+            TOPK_TOKENS=topk_tokens,
+            HAS_LOGITS=logits is not None,
+            HAS_ROW_STARTS=row_starts is not None,
+            BLOCK_K=block_k,
+            num_warps=num_warps,
+        )
+        return packed
+
+    invalid = topk_indices < 0
+    idx_safe = torch.clamp(topk_indices, min=0)
+    if logits is None:
+        local_scores = torch.full(
+            topk_indices.shape,
+            float("-inf"),
+            dtype=torch.float32,
+            device=topk_indices.device,
+        )
+    else:
+        score_idx = idx_safe.to(torch.int64)
+        if row_starts is not None:
+            score_idx = score_idx + row_starts.to(
+                device=score_idx.device, dtype=score_idx.dtype
+            ).view(-1, 1)
+        score_idx = torch.clamp(score_idx, min=0, max=logits.shape[1] - 1)
+        local_scores = torch.gather(logits, 1, score_idx).to(torch.float32)
+    local_scores = local_scores.masked_fill(invalid, float("-inf"))
+
+    global_pos = _local_to_global_position(idx_safe, rank, world_size, interleave)
+    global_pos = torch.where(invalid, global_pos.new_full((), -1), global_pos)
+
+    packed[:, 0, :].copy_(global_pos.to(torch.int32))
+    packed[:, 1, :].copy_(local_scores.contiguous().view(torch.int32))
+    return packed
+
+
+def _dcp_finalize_topk_remap(
+    all_candidates: torch.Tensor,
+    selected: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_tokens: int,
+    rank: int,
+    world_size: int,
+    interleave: int,
+) -> None:
+    """Finalize selected global candidates into rank-local top-k indices."""
+    if topk_indices.numel() == 0:
+        return
+
+    if _use_triton_dcp_remap(topk_indices):
+        block_k = triton.next_power_of_2(topk_tokens)
+        num_warps = 4 if block_k <= 256 else 8
+        _dcp_finalize_topk_remap_kernel[(topk_indices.shape[0],)](
+            all_candidates,
+            selected,
+            topk_indices,
+            all_candidates.stride(0),
+            all_candidates.stride(1),
+            all_candidates.stride(2),
+            selected.stride(0),
+            selected.stride(1),
+            topk_indices.stride(0),
+            topk_indices.stride(1),
+            RANK=rank,
+            WORLD_SIZE=world_size,
+            INTERLEAVE=interleave,
+            TOPK_TOKENS=topk_tokens,
+            BLOCK_K=block_k,
+            num_warps=num_warps,
+        )
+        return
+
+    sel_global = torch.gather(all_candidates[:, 0, :], 1, selected.to(torch.int64))
+    owner = (sel_global // interleave) % world_size
+    local_of_g = _global_to_local_position(sel_global, interleave, world_size)
+    mine = (owner == rank) & (sel_global >= 0)
+    final = torch.where(mine, local_of_g, local_of_g.new_full((), -1))
+    topk_indices.copy_(final.to(topk_indices.dtype))
 
 
 def _dcp_global_topk_remap(
@@ -117,46 +356,32 @@ def _dcp_global_topk_remap(
     rank = dcp_group.rank_in_group
     world_size = dcp_group.world_size
 
-    # 1. Recover local scores; clamp indices defensively and mask invalid slots.
-    invalid = topk_indices < 0
-    idx_safe = torch.clamp(topk_indices, min=0)
-    if logits is None:
-        local_scores = torch.full(
-            topk_indices.shape,
-            float("-inf"),
-            dtype=torch.float32,
-            device=topk_indices.device,
-        )
-    else:
-        score_idx = idx_safe.to(torch.int64)
-        if row_starts is not None:
-            score_idx = score_idx + row_starts.to(
-                device=score_idx.device, dtype=score_idx.dtype
-            ).view(-1, 1)
-            score_idx = torch.clamp(score_idx, min=0, max=logits.shape[1] - 1)
-        local_scores = torch.gather(logits, 1, score_idx).to(torch.float32)
-    local_scores = local_scores.masked_fill(invalid, float("-inf"))
+    # 1-3. Pack (global_pos, score_bits) and all-gather candidate pairs once.
+    candidates = _dcp_pack_topk_candidates(
+        topk_indices,
+        logits,
+        topk_tokens,
+        rank,
+        world_size,
+        interleave,
+        row_starts=row_starts,
+    )
+    all_candidates = dcp_group.all_gather(candidates.contiguous(), dim=2)
+    all_scores = all_candidates[:, 1, :].view(torch.float32)
 
-    # 2. Local -> global positions; -1 stays -1.
-    global_pos = _local_to_global_position(idx_safe, rank, world_size, interleave)
-    global_pos = torch.where(invalid, global_pos.new_full((), -1), global_pos)
-
-    # 3. All-gather candidate (global_pos, score) pairs along the candidate dim.
-    all_pos = dcp_group.all_gather(global_pos.contiguous(), dim=1)
-    all_scores = dcp_group.all_gather(local_scores.contiguous(), dim=1)
-
-    # 4. Global top-k per row.
+    # 4. Global top-k per row using gathered score bits.
     _, sel = torch.topk(all_scores, topk_tokens, dim=1)
-    sel_global = torch.gather(all_pos, 1, sel.to(torch.int64))
 
-    # 5. Global -> local; keep only this rank's owned positions, else -1.
-    owner = (sel_global // interleave) % world_size
-    local_of_g = _global_to_local_position(sel_global, interleave, world_size)
-    mine = (owner == rank) & (sel_global >= 0)
-    final = torch.where(mine, local_of_g, local_of_g.new_full((), -1))
-
-    # 6. Write back in place.
-    topk_indices.copy_(final.to(topk_indices.dtype))
+    # 5-6. Global -> local; keep only this rank's owned positions, else -1.
+    _dcp_finalize_topk_remap(
+        all_candidates,
+        sel,
+        topk_indices,
+        topk_tokens,
+        rank,
+        world_size,
+        interleave,
+    )
 
 
 def _gather_workspace_shapes(

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -38,6 +38,15 @@ RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
 MXFP4_BLOCK_SIZE = 32
 
 
+def _use_persistent_topk_decode(topk_tokens: int, dcp_world_size: int) -> bool:
+    """Return whether decode top-k should use the persistent CUDA kernel."""
+    return (
+        current_platform.is_cuda()
+        and dcp_world_size == 1
+        and topk_tokens in (512, 1024, 2048)
+    )
+
+
 def _local_to_global_position(
     local_idx: torch.Tensor, rank: int, world_size: int, interleave: int
 ) -> torch.Tensor:
@@ -66,7 +75,7 @@ def _global_to_local_position(
 
 def _dcp_global_topk_remap(
     topk_indices: torch.Tensor,
-    logits: torch.Tensor,
+    logits: torch.Tensor | None,
     topk_tokens: int,
     interleave: int,
     row_starts: torch.Tensor | None = None,
@@ -97,7 +106,8 @@ def _dcp_global_topk_remap(
         topk_indices: int32 [num_rows, topk_tokens], per-rank local indices
             (a view into topk_indices_buffer); -1 marks an unused slot.
         logits: float32 [num_rows, seq_pad], the per-row MQA scores the local
-            top-k was taken over.
+            top-k was taken over. None means this rank has no local candidates
+            for these rows, but must still participate in the DCP collective.
         topk_tokens: K, the desired global selection size.
         interleave: cp_kv_cache_interleave_size (I).
         row_starts: Optional per-row offset into ``logits``. Prefill top-k
@@ -110,13 +120,21 @@ def _dcp_global_topk_remap(
     # 1. Recover local scores; clamp indices defensively and mask invalid slots.
     invalid = topk_indices < 0
     idx_safe = torch.clamp(topk_indices, min=0)
-    score_idx = idx_safe.to(torch.int64)
-    if row_starts is not None:
-        score_idx = score_idx + row_starts.to(
-            device=score_idx.device, dtype=score_idx.dtype
-        ).view(-1, 1)
-        score_idx = torch.clamp(score_idx, min=0, max=logits.shape[1] - 1)
-    local_scores = torch.gather(logits, 1, score_idx)
+    if logits is None:
+        local_scores = torch.full(
+            topk_indices.shape,
+            float("-inf"),
+            dtype=torch.float32,
+            device=topk_indices.device,
+        )
+    else:
+        score_idx = idx_safe.to(torch.int64)
+        if row_starts is not None:
+            score_idx = score_idx + row_starts.to(
+                device=score_idx.device, dtype=score_idx.dtype
+            ).view(-1, 1)
+            score_idx = torch.clamp(score_idx, min=0, max=logits.shape[1] - 1)
+        local_scores = torch.gather(logits, 1, score_idx).to(torch.float32)
     local_scores = local_scores.masked_fill(invalid, float("-inf"))
 
     # 2. Local -> global positions; -1 stays -1.
@@ -296,6 +314,20 @@ def sparse_attn_indexer(
         for chunk in prefill_metadata.chunks:
             k_quant = k_quant_full[: chunk.total_seq_lens]
             k_scale = k_scale_full[: chunk.total_seq_lens]
+            topk_indices = topk_indices_buffer[
+                chunk.token_start : chunk.token_end, :topk_tokens
+            ]
+
+            if chunk.total_seq_lens == 0:
+                topk_indices.fill_(-1)
+                if attn_metadata_narrowed.dcp_world_size > 1:
+                    _dcp_global_topk_remap(
+                        topk_indices,
+                        None,
+                        topk_tokens,
+                        attn_metadata_narrowed.cp_interleave_size,
+                    )
+                continue
 
             if not chunk.skip_kv_gather:
                 ops.cp_gather_indexer_k_quant_cache(
@@ -343,10 +375,6 @@ def sparse_attn_indexer(
                     clean_logits=False,
                 )
             num_rows = logits.shape[0]
-
-            topk_indices = topk_indices_buffer[
-                chunk.token_start : chunk.token_end, :topk_tokens
-            ]
 
             ops.top_k_per_row_prefill(
                 logits,
@@ -448,7 +476,9 @@ def sparse_attn_indexer(
         num_rows = logits.shape[0]
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
 
-        if current_platform.is_cuda() and topk_tokens in (512, 1024, 2048):
+        if _use_persistent_topk_decode(
+            topk_tokens, attn_metadata_narrowed.dcp_world_size
+        ):
             workspace_manager = current_workspace_manager()
             (topk_workspace,) = workspace_manager.get_simultaneous(
                 ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -8,6 +8,7 @@ import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
+from vllm.distributed.parallel_state import get_dcp_group
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
@@ -35,6 +36,100 @@ RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
 
 # MXFP4 layout: 2 values packed per byte, ue8m0 (1-byte) scale per block of 32.
 MXFP4_BLOCK_SIZE = 32
+
+
+def _local_to_global_position(
+    local_idx: torch.Tensor, rank: int, world_size: int, interleave: int
+) -> torch.Tensor:
+    """Map a per-request LOCAL kv position on this rank to its GLOBAL position.
+
+    g(l, r) = (l // I) * (N * I) + r * I + (l % I)
+    with I = interleave, N = world_size. Matches get_dcp_local_seq_lens.
+    """
+    return (
+        (local_idx // interleave) * (world_size * interleave)
+        + rank * interleave
+        + (local_idx % interleave)
+    )
+
+
+def _global_to_local_position(
+    global_idx: torch.Tensor, interleave: int, world_size: int
+) -> torch.Tensor:
+    """Map a GLOBAL kv position to its LOCAL index on the rank that owns it.
+
+    local(g) = (g // (I * N)) * I + (g % I)
+    """
+    big = interleave * world_size
+    return (global_idx // big) * interleave + (global_idx % interleave)
+
+
+def _dcp_global_topk_remap(
+    topk_indices: torch.Tensor,
+    logits: torch.Tensor,
+    topk_tokens: int,
+    interleave: int,
+) -> None:
+    """In place: convert per-rank LOCAL top-k selection into the GLOBAL top-k,
+    restricted to the positions this rank owns (positions owned by other ranks
+    are written as -1).
+
+    Background: under DCP the KV cache is sharded across the DCP group (interleave
+    `I`-way, `N` ranks). Each rank's local top-k is selected from only its shard,
+    so naively LSE-merging per-rank sparse attention would reconstruct attention
+    over the *union* of per-rank selections (~N * topk positions) instead of the
+    true global top-k. To get exact global sparse attention after the DCP LSE
+    merge, every rank must select the SAME global set G and then attend only to
+    G ∩ (its own shard). This does exactly that:
+
+      1. recover local scores at the selected indices (-1 -> invalid/-inf),
+      2. map local positions -> global positions,
+      3. all-gather (global_pos, score) candidates across the DCP group,
+      4. take the global top-k per row,
+      5. map global -> local, keeping only positions owned by this rank (-1 else),
+      6. write back in place.
+
+    Rows are aligned across ranks because decode queries are replicated under
+    DCP. ``topk_indices`` and ``logits`` must share the same row count.
+
+    Args:
+        topk_indices: int32 [num_rows, topk_tokens], per-rank local indices
+            (a view into topk_indices_buffer); -1 marks an unused slot.
+        logits: float32 [num_rows, seq_pad], the per-row MQA scores the local
+            top-k was taken over.
+        topk_tokens: K, the desired global selection size.
+        interleave: cp_kv_cache_interleave_size (I).
+    """
+    dcp_group = get_dcp_group()
+    rank = dcp_group.rank_in_group
+    world_size = dcp_group.world_size
+
+    # 1. Recover local scores; clamp indices defensively and mask invalid slots.
+    invalid = topk_indices < 0
+    idx_safe = torch.clamp(topk_indices, min=0)
+    local_scores = torch.gather(logits, 1, idx_safe.to(torch.int64))
+    local_scores = local_scores.masked_fill(invalid, float("-inf"))
+
+    # 2. Local -> global positions; -1 stays -1.
+    global_pos = _local_to_global_position(idx_safe, rank, world_size, interleave)
+    global_pos = torch.where(invalid, global_pos.new_full((), -1), global_pos)
+
+    # 3. All-gather candidate (global_pos, score) pairs along the candidate dim.
+    all_pos = dcp_group.all_gather(global_pos.contiguous(), dim=1)
+    all_scores = dcp_group.all_gather(local_scores.contiguous(), dim=1)
+
+    # 4. Global top-k per row.
+    _, sel = torch.topk(all_scores, topk_tokens, dim=1)
+    sel_global = torch.gather(all_pos, 1, sel.to(torch.int64))
+
+    # 5. Global -> local; keep only this rank's owned positions, else -1.
+    owner = (sel_global // interleave) % world_size
+    local_of_g = _global_to_local_position(sel_global, interleave, world_size)
+    mine = (owner == rank) & (sel_global >= 0)
+    final = torch.where(mine, local_of_g, local_of_g.new_full((), -1))
+
+    # 6. Write back in place.
+    topk_indices.copy_(final.to(topk_indices.dtype))
 
 
 def _gather_workspace_shapes(
@@ -254,6 +349,15 @@ def sparse_attn_indexer(
                 logits.stride(1),
                 topk_tokens,
             )
+            # Under DCP, convert the per-rank local top-k into the global top-k
+            # restricted to this rank's owned positions. See _dcp_global_topk_remap.
+            if attn_metadata_narrowed.dcp_world_size > 1:
+                _dcp_global_topk_remap(
+                    topk_indices,
+                    logits,
+                    topk_tokens,
+                    attn_metadata_narrowed.cp_interleave_size,
+                )
 
     if has_decode:
         decode_metadata = attn_metadata_narrowed.decode
@@ -357,6 +461,17 @@ def sparse_attn_indexer(
                 logits.stride(0),
                 logits.stride(1),
                 topk_tokens,
+            )
+
+        # Under DCP, convert the per-rank local top-k into the global top-k
+        # restricted to this rank's owned positions. Done before the padding
+        # unpack so rows align with `logits`. See _dcp_global_topk_remap.
+        if attn_metadata_narrowed.dcp_world_size > 1:
+            _dcp_global_topk_remap(
+                topk_indices,
+                logits,
+                topk_tokens,
+                attn_metadata_narrowed.cp_interleave_size,
             )
 
         if decode_metadata.requires_padding:

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -69,6 +69,7 @@ def _dcp_global_topk_remap(
     logits: torch.Tensor,
     topk_tokens: int,
     interleave: int,
+    row_starts: torch.Tensor | None = None,
 ) -> None:
     """In place: convert per-rank LOCAL top-k selection into the GLOBAL top-k,
     restricted to the positions this rank owns (positions owned by other ranks
@@ -99,6 +100,8 @@ def _dcp_global_topk_remap(
             top-k was taken over.
         topk_tokens: K, the desired global selection size.
         interleave: cp_kv_cache_interleave_size (I).
+        row_starts: Optional per-row offset into ``logits``. Prefill top-k
+            indices are local to each row's valid [start, end) range.
     """
     dcp_group = get_dcp_group()
     rank = dcp_group.rank_in_group
@@ -107,7 +110,13 @@ def _dcp_global_topk_remap(
     # 1. Recover local scores; clamp indices defensively and mask invalid slots.
     invalid = topk_indices < 0
     idx_safe = torch.clamp(topk_indices, min=0)
-    local_scores = torch.gather(logits, 1, idx_safe.to(torch.int64))
+    score_idx = idx_safe.to(torch.int64)
+    if row_starts is not None:
+        score_idx = score_idx + row_starts.to(
+            device=score_idx.device, dtype=score_idx.dtype
+        ).view(-1, 1)
+        score_idx = torch.clamp(score_idx, min=0, max=logits.shape[1] - 1)
+    local_scores = torch.gather(logits, 1, score_idx)
     local_scores = local_scores.masked_fill(invalid, float("-inf"))
 
     # 2. Local -> global positions; -1 stays -1.
@@ -357,6 +366,7 @@ def sparse_attn_indexer(
                     logits,
                     topk_tokens,
                     attn_metadata_narrowed.cp_interleave_size,
+                    row_starts=chunk.cu_seqlen_ks,
                 )
 
     if has_decode:

--- a/vllm/v1/attention/backends/mla/flashmla.py
+++ b/vllm/v1/attention/backends/mla/flashmla.py
@@ -271,6 +271,8 @@ class FlashMLAImpl(MLACommonImpl[FlashMLAMetadata]):
 
         num_decodes = attn_metadata.num_decodes
         q = reshape_query_for_spec_decode(q, num_decodes)
+        seq_len = q.shape[1]
+        q_num_heads = q.shape[2]
 
         scheduler_metadata = attn_metadata.decode.scheduler_metadata
         if envs.VLLM_BATCH_INVARIANT and not is_quantized_kv_cache(self.kv_cache_dtype):
@@ -331,5 +333,13 @@ class FlashMLAImpl(MLACommonImpl[FlashMLAMetadata]):
             )
 
         o = reshape_attn_output_for_spec_decode(o)
+        # FlashMLA returns LSE as [batch, heads, seq_len]. The DCP reducer
+        # consumes [tokens, heads], and the head count may already include
+        # DCP-gathered heads.
+        lse = (
+            lse.permute(0, 2, 1)
+            .reshape(num_decodes * seq_len, q_num_heads)
+            .contiguous()
+        )
 
         return o, lse

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -9,6 +9,7 @@ import torch
 from vllm import _custom_ops as ops
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.config.cache import CacheDType
+from vllm.distributed.parallel_state import get_dcp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
     get_mla_dims,
@@ -31,6 +32,7 @@ from vllm.v1.attention.backends.mla.sparse_utils import (
     triton_convert_req_index_to_global_index,
 )
 from vllm.v1.attention.backends.utils import (
+    get_dcp_local_seq_lens,
     reshape_attn_output_for_spec_decode,
     reshape_query_for_spec_decode,
     split_decodes_and_prefills,
@@ -262,6 +264,15 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
 
         self.topk_tokens = vllm_config.model_config.hf_config.index_topk
         self.use_fp8_kv_cache = cache_config.cache_dtype == "fp8_ds_mla"
+        self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
+        try:
+            dcp_group = get_dcp_group()
+            self.dcp_world_size = dcp_group.world_size
+            self.dcp_rank = dcp_group.rank_in_group
+        except AssertionError:
+            self.dcp_world_size = 1
+            self.dcp_rank = 0
+
         max_num_seqs = vllm_config.scheduler_config.max_num_seqs
         # Shape: [max_num_seqs], all elements = topk_tokens (constant for full-CG)
         self.topk_tokens_tensor = torch.full(
@@ -271,6 +282,23 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
         self.max_model_len_tensor = torch.full(
             (max_num_seqs,),
             self.model_config.max_model_len,
+            device=device,
+            dtype=torch.int32,
+        )
+        local_max_model_len = self.model_config.max_model_len
+        if self.dcp_world_size > 1:
+            local_max_model_len = int(
+                get_dcp_local_seq_lens(
+                    torch.tensor([self.model_config.max_model_len], dtype=torch.int32),
+                    self.dcp_world_size,
+                    self.dcp_rank,
+                    self.cp_kv_cache_interleave_size,
+                ).item()
+            )
+        # Shape: [max_num_seqs], all elements = DCP-local max_model_len.
+        self.fp8_cache_lens_tensor = torch.full(
+            (max_num_seqs,),
+            local_max_model_len,
             device=device,
             dtype=torch.int32,
         )
@@ -338,7 +366,7 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
 
         fp8_metadata = FlashMLASparseMetadata.FP8KernelMetadata(
             scheduler_metadata=scheduler_metadata,
-            cache_lens=self.max_model_len_tensor[:1],
+            cache_lens=self.fp8_cache_lens_tensor[:1],
             dummy_block_table=self.dummy_block_table[:1],
         )
 
@@ -381,6 +409,21 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
             seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
             assert seq_lens_cpu is not None
             seq_lens = common_attn_metadata.seq_lens
+            if self.dcp_world_size > 1:
+                assert common_attn_metadata.dcp_local_seq_lens is not None, (
+                    "DCP is enabled but dcp_local_seq_lens is missing from "
+                    "the attention metadata."
+                )
+                seq_lens = common_attn_metadata.dcp_local_seq_lens
+                if common_attn_metadata.dcp_local_seq_lens_cpu is not None:
+                    seq_lens_cpu = common_attn_metadata.dcp_local_seq_lens_cpu
+                else:
+                    seq_lens_cpu = get_dcp_local_seq_lens(
+                        seq_lens_cpu,
+                        self.dcp_world_size,
+                        self.dcp_rank,
+                        self.cp_kv_cache_interleave_size,
+                    )
             query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
 
             prefill_seq_lens_cpu = seq_lens_cpu[num_decodes:]
@@ -470,6 +513,13 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
             # Compute decode_query_len for spec decode (uniform due to require_uniform)
             query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
             decode_query_len = (query_start_loc_cpu[1] - query_start_loc_cpu[0]).item()
+            decode_seq_lens = common_attn_metadata.seq_lens[:num_decodes]
+            if self.dcp_world_size > 1:
+                assert common_attn_metadata.dcp_local_seq_lens is not None, (
+                    "DCP is enabled but dcp_local_seq_lens is missing from "
+                    "the attention metadata."
+                )
+                decode_seq_lens = common_attn_metadata.dcp_local_seq_lens[:num_decodes]
 
             # Use padded head count since that's what the kernel will see
             scheduler_metadata, _ = get_mla_metadata()
@@ -477,10 +527,10 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
             kernel_meta = FlashMLASparseMetadata.FP8KernelMetadata(
                 scheduler_metadata=scheduler_metadata,
                 dummy_block_table=self.dummy_block_table[:num_decodes],
-                cache_lens=self.max_model_len_tensor[:num_decodes],
+                cache_lens=self.fp8_cache_lens_tensor[:num_decodes],
             )
             fp8_metadata.decode = FP8Meta.Decode(
-                seq_lens=common_attn_metadata.seq_lens[:num_decodes],
+                seq_lens=decode_seq_lens,
                 kernel_metadata=kernel_meta,
                 decode_query_len=decode_query_len,
             )
@@ -512,7 +562,9 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
             | FlashMLASparseMetadata.FP8KernelMetadata
             | None
         ) = None
-        fp8_use_mixed_batch = self.num_heads < MIN_HEADS_FOR_BF16_PREFILL
+        fp8_use_mixed_batch = (
+            self.num_heads < MIN_HEADS_FOR_BF16_PREFILL and self.dcp_world_size == 1
+        )
         if self.use_fp8_kv_cache:
             if fp8_use_mixed_batch:
                 fp8_extra_metadata = self._build_fp8_mixed_decode_prefill(cm)
@@ -696,6 +748,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
                 topk_indices=topk_indices,
                 kernel_metadata=fp8_metadata.decode.kernel_metadata,
             )
+            num_heads = q.shape[2]
             # Reshape output: (num_decodes, seq_len, num_heads, head_dim_v)
             #              -> (num_decode_tokens, num_heads, head_dim_v)
             attn_out = reshape_attn_output_for_spec_decode(attn_out)
@@ -703,13 +756,14 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             #           -> (num_decode_tokens, num_heads)  [decode-major layout]
             lse = (
                 lse.permute(0, 2, 1)
-                .reshape(num_decodes * seq_len, self.num_heads)
+                .reshape(num_decodes * seq_len, num_heads)
                 .contiguous()
             )
             return attn_out, lse
 
         num_decode_tokens = fp8_metadata.num_decode_tokens
         num_prefill_tokens = fp8_metadata.num_prefill_tokens
+        actual_num_heads = q.shape[1]
 
         # Pure decode: direct call without allocation
         if num_decode_tokens > 0 and num_prefill_tokens == 0:
@@ -719,13 +773,13 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
 
         # Mixed or pure prefill: allocate output + lse buffers
         attn_out = q.new_empty(
-            (attn_metadata.num_actual_tokens, self.num_heads, self.kv_lora_rank),
+            (attn_metadata.num_actual_tokens, actual_num_heads, self.kv_lora_rank),
             dtype=q.dtype,
             device=q.device,
         )
         # LSE is float32 per the DCP merge contract ([tokens, num_heads] base-e).
         lse_buf = torch.empty(
-            (attn_metadata.num_actual_tokens, self.num_heads),
+            (attn_metadata.num_actual_tokens, actual_num_heads),
             dtype=torch.float32,
             device=q.device,
         )
@@ -814,7 +868,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # q shape: (batch, seq_len, num_heads, head_dim)
         actual_num_heads = q.size(2)
-        padded_num_heads = self.fp8_decode_padded_heads
+        padded_num_heads = self._compute_fp8_decode_padded_heads(actual_num_heads)
 
         # Pad query if needed (kernel only supports h_q = 64 or 128)
         if actual_num_heads < padded_num_heads:

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -538,6 +538,12 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
 
 
 class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
+    # DCP (Decode Context Parallelism) requires each attention impl to return
+    # the softmax LSE during decode so the per-rank partial outputs can be
+    # combined. The FlashMLA sparse kernels already compute the LSE; the flag
+    # simply enables the runtime gate (see AttentionImplBase.__new__).
+    can_return_lse_for_decode: bool = True
+
     @staticmethod
     def _compute_fp8_decode_padded_heads(num_heads: int) -> int:
         # FP8 decode kernel only supports h_q = 64 or 128
@@ -613,7 +619,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         # Convert per-request indices to global slots (decode) or workspace
         # offsets (prefill).
         topk_indices, topk_length = triton_convert_req_index_to_global_index(
@@ -638,7 +644,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         fp8_metadata = attn_metadata.fp8_extra_metadata
         assert isinstance(fp8_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode)
         num_decodes = fp8_metadata.num_decodes
@@ -675,7 +681,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         def _fp8_decode(
             q: torch.Tensor,
             topk_indices: torch.Tensor,
-        ) -> torch.Tensor:
+        ) -> tuple[torch.Tensor, torch.Tensor]:
             # Reshape q: (num_decode_tokens, num_heads, head_dim)
             #         -> (num_decodes, seq_len, num_heads, head_dim)
             q = reshape_query_for_spec_decode(q, num_decodes)
@@ -684,7 +690,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             #                    -> (num_decodes, seq_len, topk)
             topk_indices = topk_indices.view(num_decodes, seq_len, -1)
             assert fp8_metadata.decode is not None
-            attn_out, _ = self._fp8_flash_mla_kernel(
+            attn_out, lse = self._fp8_flash_mla_kernel(
                 q=q,
                 kv_c_and_k_pe_cache=kv_c_and_k_pe_cache,
                 topk_indices=topk_indices,
@@ -692,7 +698,15 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             )
             # Reshape output: (num_decodes, seq_len, num_heads, head_dim_v)
             #              -> (num_decode_tokens, num_heads, head_dim_v)
-            return reshape_attn_output_for_spec_decode(attn_out)
+            attn_out = reshape_attn_output_for_spec_decode(attn_out)
+            # Reshape lse: (num_decodes, num_heads, seq_len)
+            #           -> (num_decode_tokens, num_heads)  [decode-major layout]
+            lse = (
+                lse.permute(0, 2, 1)
+                .reshape(num_decodes * seq_len, self.num_heads)
+                .contiguous()
+            )
+            return attn_out, lse
 
         num_decode_tokens = fp8_metadata.num_decode_tokens
         num_prefill_tokens = fp8_metadata.num_prefill_tokens
@@ -700,45 +714,54 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         # Pure decode: direct call without allocation
         if num_decode_tokens > 0 and num_prefill_tokens == 0:
             assert fp8_metadata.decode is not None
-            attn_out = _fp8_decode(q, topk_indices)
-        else:
-            # Mixed or pure prefill: allocate output tensor
-            attn_out = q.new_empty(
-                (attn_metadata.num_actual_tokens, self.num_heads, self.kv_lora_rank),
-                dtype=q.dtype,
-                device=q.device,
+            attn_out, lse = _fp8_decode(q, topk_indices)
+            return attn_out, lse
+
+        # Mixed or pure prefill: allocate output + lse buffers
+        attn_out = q.new_empty(
+            (attn_metadata.num_actual_tokens, self.num_heads, self.kv_lora_rank),
+            dtype=q.dtype,
+            device=q.device,
+        )
+        # LSE is float32 per the DCP merge contract ([tokens, num_heads] base-e).
+        lse_buf = torch.empty(
+            (attn_metadata.num_actual_tokens, self.num_heads),
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+        if num_decode_tokens > 0:
+            decode_out, decode_lse = _fp8_decode(
+                q[:num_decode_tokens],
+                topk_indices[:num_decode_tokens],
+            )
+            attn_out[:num_decode_tokens] = decode_out
+            lse_buf[:num_decode_tokens] = decode_lse
+
+        assert fp8_metadata.prefill is not None
+        for chunk in fp8_metadata.prefill.chunks:
+            chunk_workspace = self.prefill_bf16_workspace[: chunk.chunk_tot_seqlen]
+            ops.cp_gather_and_upconvert_fp8_kv_cache(
+                kv_c_and_k_pe_cache,
+                chunk_workspace,
+                chunk.block_table,
+                chunk.seq_lens,
+                chunk.workspace_starts,
+                len(chunk.block_table),
             )
 
-            if num_decode_tokens > 0:
-                attn_out[:num_decode_tokens] = _fp8_decode(
-                    q[:num_decode_tokens],
-                    topk_indices[:num_decode_tokens],
-                )
+            chunk_q = q[chunk.tokens_slice]
+            chunk_topk_indices_workspace = topk_indices[chunk.tokens_slice]
 
-            assert fp8_metadata.prefill is not None
-            for chunk in fp8_metadata.prefill.chunks:
-                chunk_workspace = self.prefill_bf16_workspace[: chunk.chunk_tot_seqlen]
-                ops.cp_gather_and_upconvert_fp8_kv_cache(
-                    kv_c_and_k_pe_cache,
-                    chunk_workspace,
-                    chunk.block_table,
-                    chunk.seq_lens,
-                    chunk.workspace_starts,
-                    len(chunk.block_table),
-                )
+            chunk_out, chunk_lse = self._bf16_flash_mla_kernel(
+                chunk_q,
+                chunk_workspace,
+                chunk_topk_indices_workspace,
+            )
+            attn_out[chunk.tokens_slice] = chunk_out
+            lse_buf[chunk.tokens_slice] = chunk_lse
 
-                chunk_q = q[chunk.tokens_slice]
-                chunk_topk_indices_workspace = topk_indices[chunk.tokens_slice]
-                chunk_topk_length = topk_length[chunk.tokens_slice]
-
-                attn_out[chunk.tokens_slice] = self._bf16_flash_mla_kernel(
-                    chunk_q,
-                    chunk_workspace,
-                    chunk_topk_indices_workspace,
-                    chunk_topk_length,
-                )
-
-        return attn_out
+        return attn_out, lse_buf
 
     def _forward_fp8_kv_mixed_batch(
         self,
@@ -746,7 +769,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Mixed batch FP8 forward path that treats all tokens as one batch.
 
         This is equivalent to main branch's approach and avoids the BF16
@@ -769,7 +792,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         )
         fp8_metadata = attn_metadata.fp8_extra_metadata
 
-        _attn_out, _ = self._fp8_flash_mla_kernel(
+        _attn_out, _lse = self._fp8_flash_mla_kernel(
             q=q.unsqueeze(0),  # unsqueeze to add batch_dim: (T, H, D) -> (1, T, H, D)
             kv_c_and_k_pe_cache=kv_c_and_k_pe_cache,
             topk_indices=topk_indices.unsqueeze(0),  # (T, topk) -> (1, T, topk)
@@ -777,7 +800,10 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         )
 
         # Output is (1, T, H, D_v), squeeze back to (T, H, D_v)
-        return _attn_out.squeeze(0)
+        attn_out = _attn_out.squeeze(0)
+        # lse is (1, num_heads, T); -> (T, num_heads) to match [tokens, heads].
+        lse = _lse.squeeze(0).transpose(0, 1).contiguous()
+        return attn_out, lse
 
     def _fp8_flash_mla_kernel(
         self,
@@ -815,6 +841,8 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         # Slice output back to actual head count if we padded
         if actual_num_heads < padded_num_heads:
             out = out[:, :, :actual_num_heads, :]
+            # Slice lse heads likewise so it matches the actual head count.
+            lse = lse[:, :actual_num_heads, :]
 
         return out, lse
 
@@ -824,7 +852,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         topk_length: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         num_tokens = q.shape[0]
         kv_c_and_k_pe_cache = kv_c_and_k_pe_cache.view(
             -1, 1, kv_c_and_k_pe_cache.shape[-1]
@@ -843,16 +871,20 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             q = q_padded
 
         topk_indices = topk_indices.view(num_tokens, 1, -1)
-        output = flash_mla_sparse_fwd(
+        # flash_mla_sparse_fwd returns (output, max_logits, lse).
+        output, _max_logits, lse = flash_mla_sparse_fwd(
             q,
             kv_c_and_k_pe_cache,
             topk_indices,
             self.softmax_scale,
             topk_length=topk_length,
-        )[0]
+        )
 
+        # Slice away any padded heads. lse mirrors the output head slicing so it
+        # matches the [num_tokens, num_heads] contract consumed by the DCP merge.
         output = output[:, : self.num_heads, :]
-        return output
+        lse = lse[:, : self.num_heads]
+        return output, lse
 
     def forward_mqa(
         self,
@@ -879,16 +911,18 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         use_fp8_cache = self.kv_cache_dtype == "fp8_ds_mla"
 
         if not use_fp8_cache:
-            attn_out = self._forward_bf16_kv(
+            attn_out, lse = self._forward_bf16_kv(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
         elif attn_metadata.fp8_use_mixed_batch:
-            attn_out = self._forward_fp8_kv_mixed_batch(
+            attn_out, lse = self._forward_fp8_kv_mixed_batch(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
         else:
-            attn_out = self._forward_fp8_kv_separate_prefill_decode(
+            attn_out, lse = self._forward_fp8_kv_separate_prefill_decode(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
 
-        return attn_out, None
+        # LSE is only consumed by the DCP LSE-merge (see MLAAttention.forward_impl);
+        # return None when DCP is disabled to avoid the (small) downstream cost.
+        return attn_out, (lse if self.need_to_return_lse_for_decode else None)

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -859,15 +859,22 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         )
 
         # NOTE(Chen): kernel requires num_local_head to be a multiple of
-        # 64 on hopper and 128 on blackwell
-        if self.num_heads % self.prefill_padding != 0:
-            assert self.prefill_padding % self.num_heads == 0
+        # 64 on hopper and 128 on blackwell. Under DCP, q has already been
+        # all-gathered across the DCP group, so q.shape[1] can be larger than
+        # self.num_heads (the local TP/DCP head count).
+        actual_num_heads = q.shape[1]
+        padded_num_heads = (
+            (actual_num_heads + self.prefill_padding - 1)
+            // self.prefill_padding
+            * self.prefill_padding
+        )
+        if actual_num_heads < padded_num_heads:
             logger.warning_once(
-                f"Padding num_heads from {self.num_heads} to "
-                f"{self.prefill_padding} for BF16 sparse prefill kernel"
+                f"Padding num_heads from {actual_num_heads} to "
+                f"{padded_num_heads} for BF16 sparse prefill kernel"
             )
-            q_padded = q.new_empty((q.shape[0], self.prefill_padding, q.shape[2]))
-            q_padded[:, : self.num_heads, :] = q
+            q_padded = q.new_empty((q.shape[0], padded_num_heads, q.shape[2]))
+            q_padded[:, :actual_num_heads, :] = q
             q = q_padded
 
         topk_indices = topk_indices.view(num_tokens, 1, -1)
@@ -880,10 +887,10 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             topk_length=topk_length,
         )
 
-        # Slice away any padded heads. lse mirrors the output head slicing so it
-        # matches the [num_tokens, num_heads] contract consumed by the DCP merge.
-        output = output[:, : self.num_heads, :]
-        lse = lse[:, : self.num_heads]
+        # Slice away only the heads we added for kernel padding. Under DCP the
+        # remaining gathered heads are consumed by the outer DCP LSE reducer.
+        output = output[:, :actual_num_heads, :]
+        lse = lse[:, :actual_num_heads]
         return output, lse
 
     def forward_mqa(

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -29,6 +29,9 @@ from vllm.v1.attention.backends.utils import (
 )
 from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
+from vllm.v1.worker.gpu.cp_utils import (
+    prepare_dcp_local_seq_lens as prepare_dcp_local_seq_lens_inplace,
+)
 
 logger = init_logger(__name__)
 
@@ -136,6 +139,39 @@ def _dcp_local_indexer_seq_lens(
     if compress_ratio > 1:
         seq_lens = seq_lens // compress_ratio
     return seq_lens
+
+
+def _localize_decode_seq_lens_inplace(
+    seq_lens: torch.Tensor,
+    dcp_world_size: int,
+    dcp_rank: int,
+    cp_interleave_size: int,
+) -> None:
+    """Convert global decode lengths to rank-local DCP lengths in-place."""
+    if dcp_world_size == 1 or seq_lens.numel() == 0:
+        return
+
+    assert seq_lens.dtype == torch.int32
+    assert seq_lens.is_contiguous()
+    flat_seq_lens = seq_lens.view(-1)
+    if flat_seq_lens.is_cuda:
+        prepare_dcp_local_seq_lens_inplace(
+            flat_seq_lens,
+            flat_seq_lens,
+            flat_seq_lens.numel(),
+            dcp_world_size,
+            dcp_rank,
+            cp_interleave_size,
+        )
+    else:
+        flat_seq_lens.copy_(
+            get_dcp_local_seq_lens(
+                flat_seq_lens,
+                dcp_world_size,
+                dcp_rank,
+                cp_interleave_size,
+            )
+        )
 
 
 class DeepseekV32IndexerBackend(AttentionBackend):
@@ -491,13 +527,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 self.decode_seq_lens_buffer[num_decode_tokens:] = 0
                 seq_lens = self.decode_seq_lens_buffer[:num_decode_tokens]
                 if use_dcp:
-                    seq_lens.copy_(
-                        get_dcp_local_seq_lens(
-                            seq_lens,
-                            self.dcp_world_size,
-                            self.dcp_rank,
-                            self.cp_kv_cache_interleave_size,
-                        )
+                    _localize_decode_seq_lens_inplace(
+                        seq_lens,
+                        self.dcp_world_size,
+                        self.dcp_rank,
+                        self.cp_kv_cache_interleave_size,
                     )
                 block_table = self.expanded_block_table_buffer[:num_decode_tokens]
                 decode_lens = self.decode_lens_buffer[:num_decode_tokens]
@@ -532,13 +566,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 self.decode_seq_lens_buffer[actual_expanded:] = 0
                 seq_lens = self.decode_seq_lens_buffer[:num_decode_tokens]
                 if use_dcp:
-                    seq_lens.copy_(
-                        get_dcp_local_seq_lens(
-                            seq_lens,
-                            self.dcp_world_size,
-                            self.dcp_rank,
-                            self.cp_kv_cache_interleave_size,
-                        )
+                    _localize_decode_seq_lens_inplace(
+                        seq_lens,
+                        self.dcp_world_size,
+                        self.dcp_rank,
+                        self.cp_kv_cache_interleave_size,
                     )
 
                 # Give each of the flattened entries the same block table row as the
@@ -581,13 +613,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     + self.offsets_buffer[:max_decode_len]
                 )
                 if use_dcp:
-                    seq_lens_buffer.copy_(
-                        get_dcp_local_seq_lens(
-                            seq_lens_buffer.reshape(-1),
-                            self.dcp_world_size,
-                            self.dcp_rank,
-                            self.cp_kv_cache_interleave_size,
-                        ).view_as(seq_lens_buffer)
+                    _localize_decode_seq_lens_inplace(
+                        seq_lens_buffer,
+                        self.dcp_world_size,
+                        self.dcp_rank,
+                        self.cp_kv_cache_interleave_size,
                     )
                 seq_lens = seq_lens_buffer
             elif use_dcp:

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -215,6 +215,7 @@ class DeepSeekV32IndexerDecodeMetadata:
     #   - native MTP path: 2D (B, next_n) where [b,j] = L_b - next_n + j + 1
     # Both fp8_fp4_paged_mqa_logits and the topk kernels accept both shapes.
     seq_lens: torch.Tensor
+    max_seq_len: int
     decode_lens: torch.Tensor
     requires_padding: bool
     schedule_metadata: torch.Tensor
@@ -257,6 +258,54 @@ def get_max_prefill_buffer_size(vllm_config: VllmConfig):
     # For DeepSeek-V3.2, the max_model_len is 163840.
     #   40 * 163840 * 132 = 865075200 bytes = 825 MB
     return max_model_len * 40
+
+
+def _decode_topk_max_seq_len(
+    common_attn_metadata: CommonAttentionMetadata,
+    num_decodes: int,
+    compress_ratio: int,
+    dcp_world_size: int,
+    dcp_rank: int,
+    cp_interleave_size: int,
+) -> int:
+    """Return host max seq len in the same units as decode top-k seq_lens."""
+    if num_decodes == 0:
+        return 0
+
+    seq_lens_cpu = None
+    is_dcp_local = False
+    if dcp_world_size > 1 and common_attn_metadata.dcp_local_seq_lens_cpu is not None:
+        seq_lens_cpu = common_attn_metadata.dcp_local_seq_lens_cpu[:num_decodes]
+        is_dcp_local = True
+    elif common_attn_metadata._seq_lens_cpu is not None:
+        seq_lens_cpu = common_attn_metadata._seq_lens_cpu[:num_decodes]
+    elif common_attn_metadata.seq_lens_cpu_upper_bound is not None:
+        seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound[:num_decodes]
+
+    if seq_lens_cpu is not None:
+        if dcp_world_size > 1 and not is_dcp_local:
+            seq_lens_cpu = get_dcp_local_seq_lens(
+                seq_lens_cpu,
+                dcp_world_size,
+                dcp_rank,
+                cp_interleave_size,
+            )
+        max_seq_len = int(seq_lens_cpu.max().item())
+    elif dcp_world_size > 1:
+        max_seq_len = int(
+            get_dcp_local_seq_lens(
+                torch.tensor([common_attn_metadata.max_seq_len], dtype=torch.int32),
+                dcp_world_size,
+                dcp_rank,
+                cp_interleave_size,
+            ).item()
+        )
+    else:
+        max_seq_len = common_attn_metadata.max_seq_len
+
+    if compress_ratio > 1:
+        max_seq_len //= compress_ratio
+    return max(max_seq_len, 0)
 
 
 class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
@@ -704,6 +753,15 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     self.expanded_seq_lens_buffer[num_decodes:num_decode_tokens] = 0
                     seq_lens = self.expanded_seq_lens_buffer[:num_decode_tokens]
 
+            max_seq_len = _decode_topk_max_seq_len(
+                common_attn_metadata,
+                num_decodes,
+                self.compress_ratio,
+                self.dcp_world_size,
+                self.dcp_rank,
+                self.cp_kv_cache_interleave_size,
+            )
+
             # Non-MTP: deep_gemm paged MQA logits requires 2D context_lens
             # (csrc/apis/attention.hpp). Unsqueeze to (B, 1) so downstream
             # kernels see the same (B, next_n) layout as the MTP path.
@@ -721,6 +779,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             decode_metadata = DeepSeekV32IndexerDecodeMetadata(
                 block_table=block_table,
                 seq_lens=seq_lens,
+                max_seq_len=max_seq_len,
                 decode_lens=decode_lens,
                 requires_padding=requires_padding,
                 schedule_metadata=self.scheduler_metadata_buffer,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -120,7 +120,7 @@ def _dcp_local_indexer_seq_lens(
     seq_lens: torch.Tensor,
     compress_ratio: int,
     dcp_world_size: int,
-    dcp_rank: int,
+    dcp_rank: int | None,
     cp_interleave_size: int,
 ) -> torch.Tensor:
     """Return per-rank indexer-K lengths for global uncompressed lengths."""
@@ -583,6 +583,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 else seq_lens_cpu
             )
             prefill_local_indexer_seq_lens_cpu = compressed_seq_lens_cpu
+            prefill_chunk_indexer_seq_lens_cpu = compressed_seq_lens_cpu
             if self.dcp_world_size > 1:
                 pre_local_cpu = _dcp_local_indexer_seq_lens(
                     seq_lens_cpu[num_decodes : num_decodes + num_prefills],
@@ -595,12 +596,23 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 prefill_local_indexer_seq_lens_cpu[
                     num_decodes : num_decodes + num_prefills
                 ] = pre_local_cpu
+                pre_all_local_cpu = _dcp_local_indexer_seq_lens(
+                    seq_lens_cpu[num_decodes : num_decodes + num_prefills],
+                    self.compress_ratio,
+                    self.dcp_world_size,
+                    None,
+                    self.cp_kv_cache_interleave_size,
+                )
+                prefill_chunk_indexer_seq_lens_cpu = compressed_seq_lens_cpu.clone()
+                prefill_chunk_indexer_seq_lens_cpu[
+                    num_decodes : num_decodes + num_prefills
+                ] = pre_all_local_cpu.max(dim=1).values
             prefill_query_lens_cpu = torch.diff(
                 query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
             )
             max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
             chunk_specs = split_indexer_prefill_chunks(
-                prefill_local_indexer_seq_lens_cpu[num_decodes:],
+                prefill_chunk_indexer_seq_lens_cpu[num_decodes:],
                 prefill_query_lens_cpu,
                 self.max_prefill_buffer_size,
                 max_logits_bytes,
@@ -749,7 +761,7 @@ def build_prefill_chunk_metadata(
     cp_interleave_size: int = 1,
 ) -> DeepseekV32IndexerPrefillChunkMetadata | None:
     total_seq_lens = compressed_seq_lens_cpu[start_idx:end_idx].sum().item()
-    if total_seq_lens == 0:
+    if total_seq_lens == 0 and dcp_world_size == 1:
         return None
 
     num_reqs = end_idx - start_idx

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -24,6 +24,7 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.attention.backends.mla.compressor_utils import get_compressed_slot_mapping
 from vllm.v1.attention.backends.utils import (
+    get_dcp_local_seq_lens,
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
@@ -215,6 +216,13 @@ class DeepseekV32IndexerMetadata:
     decode: DeepSeekV32IndexerDecodeMetadata | None = None
     prefill: DeepseekV32IndexerPrefillMetadata | None = None
 
+    # DCP (Decode Context Parallelism) state. Under DCP the KV/indexer K cache is
+    # sharded across dcp_world_size ranks with cp_interleave_size-way interleaving;
+    # the indexer must select a global top-k (see _dcp_global_topk_remap).
+    dcp_world_size: int = 1
+    dcp_rank: int = 0
+    cp_interleave_size: int = 1
+
 
 def get_max_prefill_buffer_size(vllm_config: VllmConfig):
     max_model_len = vllm_config.model_config.max_model_len
@@ -242,6 +250,22 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # DCP (Decode Context Parallelism) state. Under DCP the KV cache (and the
+        # indexer's own K cache) is sharded across these ranks; the decode logits
+        # must score only this rank's local shard (see the decode branch of
+        # build()). Mirror the try/except used by AttentionImplBase.__new__.
+        try:
+            from vllm.distributed.parallel_state import get_dcp_group
+
+            dcp_group = get_dcp_group()
+            self.dcp_world_size = dcp_group.world_size
+            self.dcp_rank = dcp_group.rank_in_group
+        except AssertionError:
+            self.dcp_world_size = 1
+            self.dcp_rank = 0
+        self.cp_kv_cache_interleave_size = (
+            self.vllm_config.parallel_config.cp_kv_cache_interleave_size
+        )
         scheduler_config = self.vllm_config.scheduler_config
         # NOTE(Chen):an estimated max size of flattened_kv. Need to double check.
         self.max_prefill_buffer_size = get_max_prefill_buffer_size(self.vllm_config)
@@ -507,6 +531,29 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             )
             compressed_seq_lens = seq_lens // self.compress_ratio
 
+        # Under DCP the KV/indexer-K cache is sharded across ranks, so the
+        # prefill context bounds must be LOCAL (per-rank) counts for the KV
+        # gather and the per-token context-length derivation to be correct.
+        # We keep full-length tensors (decode values left unchanged) and only
+        # overwrite the prefill rows, so the num_decodes-offset indexing used by
+        # build_prefill_chunk_metadata stays consistent.
+        prefill_seq_lens = seq_lens
+        prefill_compressed_seq_lens = compressed_seq_lens
+        if num_prefills > 0 and self.dcp_world_size > 1:
+            pre_local = get_dcp_local_seq_lens(
+                seq_lens[num_decodes : num_decodes + num_prefills],
+                self.dcp_world_size,
+                self.dcp_rank,
+                self.cp_kv_cache_interleave_size,
+            )
+            prefill_seq_lens = seq_lens.clone()
+            prefill_seq_lens[num_decodes : num_decodes + num_prefills] = pre_local
+            prefill_compressed_seq_lens = (
+                prefill_seq_lens // self.compress_ratio
+                if self.compress_ratio > 1
+                else prefill_seq_lens
+            )
+
         prefill_metadata = None
         if num_prefills > 0:
             # This CPU value is an upper bound for async-spec extend rows.  It
@@ -519,14 +566,23 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 if self.compress_ratio > 1
                 else seq_lens_cpu
             )
+            if self.dcp_world_size > 1:
+                pre_local_cpu = get_dcp_local_seq_lens(
+                    seq_lens_cpu[num_decodes : num_decodes + num_prefills],
+                    self.dcp_world_size,
+                    self.dcp_rank,
+                    self.cp_kv_cache_interleave_size,
+                )
+                compressed_seq_lens_cpu = compressed_seq_lens_cpu.clone()
+                compressed_seq_lens_cpu[num_decodes : num_decodes + num_prefills] = (
+                    pre_local_cpu // self.compress_ratio
+                    if self.compress_ratio > 1
+                    else pre_local_cpu
+                )
             prefill_query_lens_cpu = torch.diff(
                 query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
             )
             max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
-            # Upper bound is exact for prefill rows (the `[num_decodes:]`
-            # slice below).
-            assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
-            seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
             chunk_specs = split_indexer_prefill_chunks(
                 compressed_seq_lens_cpu[num_decodes:],
                 prefill_query_lens_cpu,
@@ -542,8 +598,8 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     req_slice.stop,
                     query_start_loc,
                     query_start_loc_cpu,
-                    seq_lens,
-                    compressed_seq_lens,
+                    prefill_seq_lens,
+                    prefill_compressed_seq_lens,
                     compressed_seq_lens_cpu,
                     common_attn_metadata.block_table_tensor,
                     self.compress_ratio,
@@ -566,7 +622,18 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 common_attn_metadata.query_start_loc_cpu[: num_decodes + 1]
             )
 
-            seq_lens = common_attn_metadata.seq_lens[:num_decodes]
+            # Under DCP each rank holds only its interleaved shard of the KV
+            # cache, so the decode logits kernel must score only the local
+            # shard: use dcp_local_seq_lens (the per-rank local counts) instead
+            # of the global seq_lens, mirroring MLAAttention's decode path.
+            if self.dcp_world_size > 1:
+                assert common_attn_metadata.dcp_local_seq_lens is not None, (
+                    "DCP is enabled but dcp_local_seq_lens is missing from the "
+                    "attention metadata."
+                )
+                seq_lens = common_attn_metadata.dcp_local_seq_lens[:num_decodes]
+            else:
+                seq_lens = common_attn_metadata.seq_lens[:num_decodes]
             block_table = common_attn_metadata.block_table_tensor[:num_decodes, ...]
 
             max_decode_len = int(decode_lens_cpu.max().item())
@@ -638,6 +705,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             num_prefill_tokens=num_prefill_tokens,
             prefill=prefill_metadata,
             decode=decode_metadata,
+            dcp_world_size=self.dcp_world_size,
+            dcp_rank=self.dcp_rank,
+            cp_interleave_size=self.cp_kv_cache_interleave_size,
         )
 
         return attn_metadata

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -446,6 +446,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
     def _prepare_decode_tensors(
         self,
         seq_lens: torch.Tensor,
+        dcp_local_seq_lens: torch.Tensor | None,
         block_table: torch.Tensor,
         decode_lens: torch.Tensor,
         decode_lens_cpu: torch.Tensor,
@@ -470,6 +471,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         for native MTP.
         """
         min_decode_len = int(decode_lens_cpu.min().item())
+        use_dcp = self.dcp_world_size > 1
         if not use_native and max_decode_len > 1:
             assert self.decode_seq_lens_buffer.dim() == 1
             if min_decode_len == max_decode_len:
@@ -488,6 +490,15 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 )
                 self.decode_seq_lens_buffer[num_decode_tokens:] = 0
                 seq_lens = self.decode_seq_lens_buffer[:num_decode_tokens]
+                if use_dcp:
+                    seq_lens.copy_(
+                        get_dcp_local_seq_lens(
+                            seq_lens,
+                            self.dcp_world_size,
+                            self.dcp_rank,
+                            self.cp_kv_cache_interleave_size,
+                        )
+                    )
                 block_table = self.expanded_block_table_buffer[:num_decode_tokens]
                 decode_lens = self.decode_lens_buffer[:num_decode_tokens]
                 return seq_lens, block_table, decode_lens, num_decode_tokens, False
@@ -520,6 +531,15 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 )
                 self.decode_seq_lens_buffer[actual_expanded:] = 0
                 seq_lens = self.decode_seq_lens_buffer[:num_decode_tokens]
+                if use_dcp:
+                    seq_lens.copy_(
+                        get_dcp_local_seq_lens(
+                            seq_lens,
+                            self.dcp_world_size,
+                            self.dcp_rank,
+                            self.cp_kv_cache_interleave_size,
+                        )
+                    )
 
                 # Give each of the flattened entries the same block table row as the
                 # original request.
@@ -560,7 +580,19 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     + 1
                     + self.offsets_buffer[:max_decode_len]
                 )
+                if use_dcp:
+                    seq_lens_buffer.copy_(
+                        get_dcp_local_seq_lens(
+                            seq_lens_buffer.reshape(-1),
+                            self.dcp_world_size,
+                            self.dcp_rank,
+                            self.cp_kv_cache_interleave_size,
+                        ).view_as(seq_lens_buffer)
+                    )
                 seq_lens = seq_lens_buffer
+            elif use_dcp:
+                assert dcp_local_seq_lens is not None
+                seq_lens = dcp_local_seq_lens
             return seq_lens, block_table, decode_lens, num_decodes, requires_padding
 
     def build(
@@ -702,18 +734,21 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 common_attn_metadata.query_start_loc_cpu[: num_decodes + 1]
             )
 
-            # Under DCP each rank holds only its interleaved shard of the KV
-            # cache, so the decode logits kernel must score only the local
-            # shard: use dcp_local_seq_lens (the per-rank local counts) instead
-            # of the global seq_lens, mirroring MLAAttention's decode path.
+            # Multi-token decode must expand from global sequence lengths first:
+            # the DCP-local length for token j is not simply
+            # local_final_len - decode_len + j + 1 under interleaved ownership.
+            # _prepare_decode_tensors converts expanded per-token lengths to
+            # DCP-local lengths when needed.
+            seq_lens = common_attn_metadata.seq_lens[:num_decodes]
+            dcp_local_seq_lens = None
             if self.dcp_world_size > 1:
                 assert common_attn_metadata.dcp_local_seq_lens is not None, (
                     "DCP is enabled but dcp_local_seq_lens is missing from the "
                     "attention metadata."
                 )
-                seq_lens = common_attn_metadata.dcp_local_seq_lens[:num_decodes]
-            else:
-                seq_lens = common_attn_metadata.seq_lens[:num_decodes]
+                dcp_local_seq_lens = common_attn_metadata.dcp_local_seq_lens[
+                    :num_decodes
+                ]
             block_table = common_attn_metadata.block_table_tensor[:num_decodes, ...]
 
             max_decode_len = int(decode_lens_cpu.max().item())
@@ -723,6 +758,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             seq_lens, block_table, decode_lens, batch_size, requires_padding = (
                 self._prepare_decode_tensors(
                     seq_lens=seq_lens,
+                    dcp_local_seq_lens=dcp_local_seq_lens,
                     block_table=block_table,
                     decode_lens=decode_lens,
                     decode_lens_cpu=decode_lens_cpu,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -116,6 +116,28 @@ def split_indexer_prefill_chunks(
     return chunks
 
 
+def _dcp_local_indexer_seq_lens(
+    seq_lens: torch.Tensor,
+    compress_ratio: int,
+    dcp_world_size: int,
+    dcp_rank: int,
+    cp_interleave_size: int,
+) -> torch.Tensor:
+    """Return per-rank indexer-K lengths for global uncompressed lengths."""
+    if dcp_world_size > 1:
+        seq_lens = get_dcp_local_seq_lens(
+            seq_lens,
+            dcp_world_size,
+            dcp_rank,
+            cp_interleave_size,
+        )
+    else:
+        seq_lens = seq_lens.to(torch.int32)
+    if compress_ratio > 1:
+        seq_lens = seq_lens // compress_ratio
+    return seq_lens
+
+
 class DeepseekV32IndexerBackend(AttentionBackend):
     @staticmethod
     def get_name() -> str:
@@ -531,27 +553,21 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             )
             compressed_seq_lens = seq_lens // self.compress_ratio
 
-        # Under DCP the KV/indexer-K cache is sharded across ranks, so the
-        # prefill context bounds must be LOCAL (per-rank) counts for the KV
-        # gather and the per-token context-length derivation to be correct.
-        # We keep full-length tensors (decode values left unchanged) and only
-        # overwrite the prefill rows, so the num_decodes-offset indexing used by
-        # build_prefill_chunk_metadata stays consistent.
-        prefill_seq_lens = seq_lens
-        prefill_compressed_seq_lens = compressed_seq_lens
+        # Under DCP the indexer-K cache is sharded across ranks. The gather
+        # workspace uses LOCAL indexer-token counts, but per-query causal ends
+        # must still be derived from GLOBAL sequence positions.
+        prefill_local_indexer_seq_lens = compressed_seq_lens
         if num_prefills > 0 and self.dcp_world_size > 1:
-            pre_local = get_dcp_local_seq_lens(
+            pre_local = _dcp_local_indexer_seq_lens(
                 seq_lens[num_decodes : num_decodes + num_prefills],
+                self.compress_ratio,
                 self.dcp_world_size,
                 self.dcp_rank,
                 self.cp_kv_cache_interleave_size,
             )
-            prefill_seq_lens = seq_lens.clone()
-            prefill_seq_lens[num_decodes : num_decodes + num_prefills] = pre_local
-            prefill_compressed_seq_lens = (
-                prefill_seq_lens // self.compress_ratio
-                if self.compress_ratio > 1
-                else prefill_seq_lens
+            prefill_local_indexer_seq_lens = compressed_seq_lens.clone()
+            prefill_local_indexer_seq_lens[num_decodes : num_decodes + num_prefills] = (
+                pre_local
             )
 
         prefill_metadata = None
@@ -566,25 +582,25 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 if self.compress_ratio > 1
                 else seq_lens_cpu
             )
+            prefill_local_indexer_seq_lens_cpu = compressed_seq_lens_cpu
             if self.dcp_world_size > 1:
-                pre_local_cpu = get_dcp_local_seq_lens(
+                pre_local_cpu = _dcp_local_indexer_seq_lens(
                     seq_lens_cpu[num_decodes : num_decodes + num_prefills],
+                    self.compress_ratio,
                     self.dcp_world_size,
                     self.dcp_rank,
                     self.cp_kv_cache_interleave_size,
                 )
-                compressed_seq_lens_cpu = compressed_seq_lens_cpu.clone()
-                compressed_seq_lens_cpu[num_decodes : num_decodes + num_prefills] = (
-                    pre_local_cpu // self.compress_ratio
-                    if self.compress_ratio > 1
-                    else pre_local_cpu
-                )
+                prefill_local_indexer_seq_lens_cpu = compressed_seq_lens_cpu.clone()
+                prefill_local_indexer_seq_lens_cpu[
+                    num_decodes : num_decodes + num_prefills
+                ] = pre_local_cpu
             prefill_query_lens_cpu = torch.diff(
                 query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
             )
             max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
             chunk_specs = split_indexer_prefill_chunks(
-                compressed_seq_lens_cpu[num_decodes:],
+                prefill_local_indexer_seq_lens_cpu[num_decodes:],
                 prefill_query_lens_cpu,
                 self.max_prefill_buffer_size,
                 max_logits_bytes,
@@ -598,13 +614,16 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     req_slice.stop,
                     query_start_loc,
                     query_start_loc_cpu,
-                    prefill_seq_lens,
-                    prefill_compressed_seq_lens,
-                    compressed_seq_lens_cpu,
+                    seq_lens,
+                    prefill_local_indexer_seq_lens,
+                    prefill_local_indexer_seq_lens_cpu,
                     common_attn_metadata.block_table_tensor,
                     self.compress_ratio,
                     query_slice=query_slice,
                     skip_kv_gather=query_slice.start > 0,
+                    dcp_world_size=self.dcp_world_size,
+                    dcp_rank=self.dcp_rank,
+                    cp_interleave_size=self.cp_kv_cache_interleave_size,
                 )
                 # Skip when total_seq_lens is 0 (i.e., no compressed token).
                 if metadata is not None:
@@ -725,6 +744,9 @@ def build_prefill_chunk_metadata(
     compress_ratio: int,
     query_slice: slice | None = None,
     skip_kv_gather: bool = False,
+    dcp_world_size: int = 1,
+    dcp_rank: int = 0,
+    cp_interleave_size: int = 1,
 ) -> DeepseekV32IndexerPrefillChunkMetadata | None:
     total_seq_lens = compressed_seq_lens_cpu[start_idx:end_idx].sum().item()
     if total_seq_lens == 0:
@@ -768,6 +790,9 @@ def build_prefill_chunk_metadata(
         qs_stop,
         BLOCK_SIZE=1024,
         COMPRESS_RATIO=compress_ratio,
+        DCP_WORLD_SIZE=dcp_world_size,
+        DCP_RANK=dcp_rank,
+        CP_INTERLEAVE_SIZE=cp_interleave_size,
     )
 
     token_start = query_start_loc_cpu[start_idx].item()
@@ -806,6 +831,9 @@ def _build_prefill_chunk_metadata_kernel(
     query_slice_stop,
     BLOCK_SIZE: tl.constexpr,
     COMPRESS_RATIO: tl.constexpr,
+    DCP_WORLD_SIZE: tl.constexpr,
+    DCP_RANK: tl.constexpr,
+    CP_INTERLEAVE_SIZE: tl.constexpr,
 ):
     batch_idx = tl.program_id(0)
 
@@ -833,8 +861,19 @@ def _build_prefill_chunk_metadata_kernel(
         # Compute cu_seq_len_ks
         tl.store(cu_compressed_seq_len_ks_ptr + out_pos, seq_start, mask=mask)
 
-        # Compute cu_seq_len_ke
-        seq_len_per_token = (start_pos + 1 + offset) // COMPRESS_RATIO
+        # Compute cu_seq_len_ke. Under DCP this is the number of LOCAL
+        # indexer-K tokens visible at the query token's GLOBAL causal position.
+        global_visible_len = start_pos + 1 + offset
+        if DCP_WORLD_SIZE > 1:
+            full_round = global_visible_len // (DCP_WORLD_SIZE * CP_INTERLEAVE_SIZE)
+            remainder = global_visible_len % (DCP_WORLD_SIZE * CP_INTERLEAVE_SIZE)
+            remainder = remainder - DCP_RANK * CP_INTERLEAVE_SIZE
+            remainder = tl.minimum(tl.maximum(remainder, 0), CP_INTERLEAVE_SIZE)
+            local_visible_len = full_round * CP_INTERLEAVE_SIZE + remainder
+        else:
+            local_visible_len = global_visible_len
+        seq_len_per_token = local_visible_len // COMPRESS_RATIO
+        seq_len_per_token = tl.minimum(seq_len_per_token, compressed_seq_len)
         tl.store(
             cu_compressed_seq_len_ke_ptr + out_pos,
             seq_start + seq_len_per_token,


### PR DESCRIPTION
## Purpose

Add Decode Context Parallelism (DCP) support for DeepSeek Sparse Attention through the `FLASHMLA_SPARSE` MLA backend. This lets sparse MLA models shard their KV cache across DCP ranks instead of duplicating the single KV head on every TP rank, which is the required path for serving GLM-5.2, a 758B model, with 1M context on 16xH100.

These changes have gone into production to serve GLM-5.2 with 1M context on 16xH100. I do not currently have spare comparable hardware to run isolated validation outside the production deployment.


Main changes:

- Make `FLASHMLA_SPARSE` return decode LSE so the existing DCP softmax merge can combine per-rank partial attention outputs.
- Add DCP-aware sparse indexer metadata and local/global index remapping for prefill, decode, and MTP paths.
- Merge sparse top-k candidates across DCP ranks so the selected sparse KV set is globally correct under sharded KV ownership.
- Handle gathered-head-count output/LSE shaping in FlashMLA and FlashMLA sparse.
- Support DCP with `fp8_ds_mla` KV cache only for the validated `FLASHMLA_SPARSE` path, while keeping other DCP FP8 MLA combinations fail-closed. This is valid because the sparse FlashMLA FP8 path only stores KV in FP8: the query tensor and attention output remain BF16, so the existing DCP BF16 query all-gather and output/LSE combine contract still applies.
- Add focused regression coverage for sparse DCP indexing, DCP shape handling, and FP8 sparse MLA metadata.
- Update the attention backend support table and context-parallel serving guide for `FLASHMLA_SPARSE` DCP support and the GLM-5.2 1M-context production use case.

Codex assistance was used to port the commits, resolve current-main conflicts, run local checks, and draft this PR description.

## Test Plan

Commands run from vllm worktree root with venv activated:

```bash
git diff --check origin/main..HEAD
```

```bash
python3 -m py_compile \
  vllm/model_executor/layers/attention/mla_attention.py \
  vllm/model_executor/layers/sparse_attn_indexer.py \
  vllm/v1/attention/backends/mla/flashmla.py \
  vllm/v1/attention/backends/mla/flashmla_sparse.py \
  vllm/v1/attention/backends/mla/indexer.py \
  tests/v1/attention/test_dcp_sparse_indexer.py \
  tests/v1/attention/test_mla_dcp_shapes.py
```

```bash
uvx ruff check \
  tests/v1/attention/test_dcp_sparse_indexer.py \
  tests/v1/attention/test_mla_dcp_shapes.py \
  vllm/model_executor/layers/attention/mla_attention.py \
  vllm/model_executor/layers/sparse_attn_indexer.py \
  vllm/v1/attention/backends/mla/flashmla.py \
  vllm/v1/attention/backends/mla/flashmla_sparse.py \
  vllm/v1/attention/backends/mla/indexer.py
```

```bash
uvx ruff format --check \
  tests/v1/attention/test_dcp_sparse_indexer.py \
  tests/v1/attention/test_mla_dcp_shapes.py \
  vllm/model_executor/layers/attention/mla_attention.py \
  vllm/model_executor/layers/sparse_attn_indexer.py \
  vllm/v1/attention/backends/mla/flashmla.py \
  vllm/v1/attention/backends/mla/flashmla_sparse.py \
  vllm/v1/attention/backends/mla/indexer.py
```

```bash
python3 -m pytest \
  tests/v1/attention/test_dcp_sparse_indexer.py \
  tests/v1/attention/test_mla_dcp_shapes.py \
  -q
```

## Test Result

- Production validation: these changes have gone into production to serve GLM-5.2 with 1M context on 16xH100.
- Isolated validation was not run because I do not have spare comparable hardware outside the production deployment.
- `git diff --check origin/main..HEAD`: passed.
- `py_compile` on touched source and test files: passed.
- `ruff check` on touched files: passed.
- `ruff format --check` on touched files: passed, `7 files already formatted`.
- Focused pytest command passed in the local `.venv`: `42 passed`.

The branch was also confirmed to be based on refreshed `origin/main`
(`b9a7cd464`) and is 9 commits ahead.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

