### PR TITLE
Avoid streaming tool parser for requests without tools

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -889,9 +889,9 @@ class _CombinedDelegating(DelegatingParser):
     tool_parser_cls = _CombinedToolAdapter
 
 
-def _make_delegating_request():
+def _make_delegating_request(*, with_tools: bool = False):
     req = MagicMock(spec=ChatCompletionRequest)
-    req.tools = []
+    req.tools = [_make_tool("f", {})] if with_tools else []
     req.tool_choice = "auto"
     return req
 
@@ -928,7 +928,7 @@ class TestAdapterFinishOnStreamEnd:
         mid-tool-call (closing brace held back in buffer)."""
         tokenizer = make_mock_tokenizer(_VOCAB)
         parser = _CombinedDelegating(tokenizer)
-        request = _make_delegating_request()
+        request = _make_delegating_request(with_tools=True)
 
         parser.parse_delta("</think>", [201], request, finished=False)
         parser.parse_delta("<tool_call>", [202], request, finished=False)
@@ -940,6 +940,24 @@ class TestAdapterFinishOnStreamEnd:
         assert delta is not None, (
             "Engine finish should produce a delta with flushed args/end"
         )
+
+    def test_no_tools_content_bypasses_tool_parser_after_reasoning(self):
+        """A configured tool parser must not process no-tools requests."""
+        tokenizer = make_mock_tokenizer(_VOCAB)
+        parser = _CombinedDelegating(tokenizer)
+        request = _make_delegating_request()
+
+        parser.parse_delta("thinking", [], request, finished=False)
+        parser.parse_delta("</think>", [201], request, finished=False)
+
+        first = parser.parse_delta(" limit <", [], request, finished=False)
+        second = parser.parse_delta(" 2:\n       ", [], request, finished=False)
+
+        assert first is not None
+        assert first.content == " limit <"
+        assert second is not None
+        assert second.content == " 2:\n       "
+        assert not parser._stream_state.tool_call_text_started
 
 
 # ── TestReasoningOnlyDelegatingParser ─────────────────────────────

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -689,6 +689,12 @@ class DelegatingParser(Parser):
             return False
         return state.reasoning_ended
 
+    @staticmethod
+    def _request_has_tools(
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> bool:
+        return bool(getattr(request, "tools", None))
+
     def _append_unstreamed_tool_args(
         self,
         delta_message: DeltaMessage | None,
@@ -809,8 +815,20 @@ class DelegatingParser(Parser):
                     )
                     delta_text = current_text
 
-        # Tool call extraction
-        if self._in_tool_call_phase(state):
+        # Tool call extraction. A server can have a tool parser configured
+        # globally while an individual request provides no tools. In that
+        # case, post-reasoning text is ordinary content and must not be routed
+        # through the streaming tool parser.
+        if self._in_tool_call_phase(state) and not self._request_has_tools(request):
+            if current_text:
+                if delta_message is None:
+                    delta_message = DeltaMessage(content=current_text)
+                elif delta_message.content:
+                    delta_message.content += current_text
+                else:
+                    delta_message.content = current_text
+
+        elif self._in_tool_call_phase(state):
             if not state.tool_call_text_started:
                 state.tool_call_text_started = True
                 state.previous_text = ""
@@ -884,6 +902,11 @@ class DelegatingParser(Parser):
             # skip_tool_parsing=True.  Flushing that would leak spurious
             # content (e.g. a stray '"'), so skip it.
             if parser is self._reasoning_parser and reasoning_ended:
+                continue
+            if (
+                parser is self._tool_parser
+                and not self._stream_state.tool_call_text_started
+            ):
                 continue
             finish = getattr(parser, "finish_streaming", None)
             if finish is None:


### PR DESCRIPTION
## Summary

- Bypass streaming tool-call extraction when an individual request has no `tools`, even if the server has a tool parser configured globally.
- Avoid flushing an engine-based tool parser at stream end if tool-call streaming was never started for that request.
- Add regression coverage for a reasoning+tool delegating parser where post-reasoning no-tools content must stream as ordinary content.

## Problem

`DelegatingParser` can be constructed with both a reasoning parser and a tool parser when auto tool choice is enabled at server startup. Today `_in_tool_call_phase()` only checks whether a tool parser exists and whether reasoning has ended. That means a request without `tools` still routes post-reasoning text through the streaming tool parser.

For engine-based tool parsers this can corrupt normal content streaming: the tool parser is initialized even though no tool call can be valid for the request, then its internal buffering/flushing can re-emit previously seen text as content. The fix keeps the existing behavior for requests that actually provide tools, but treats no-tools requests as plain content after reasoning ends.

## Validation

- `python3 -m py_compile vllm/parser/abstract_parser.py tests/parser/engine/test_parser_engine.py`
- `git diff --check`
- Manual runtime regression in a vLLM Docker image with `PYTHONPATH=/work`, covering:
  - no-tools post-reasoning content is emitted exactly once and does not start the tool parser
  - tools-present mid-tool-call stream still flushes through the tool parser at finish

`pytest` and `ruff` are not installed in the host environment used for this patch, so I did not install extra packages there.
