### PR TITLE
[Mooncake] Optimize lookup pool key string construction

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -1279,6 +1279,7 @@ def _make_bare_worker(
         scheduler_block_size=block_size,
         hash_block_size=block_size,
     )
+    worker._init_lookup_key_prefixes()
     return worker
 
 
@@ -1346,6 +1347,7 @@ def test_lookup_checks_all_potential_swa_hit_boundaries():
         hash_block_size=8,
         retention_interval=0,
     )
+    worker._init_lookup_key_prefixes()
     # Candidate order: 3 full-attention chunks, then SWA chunks 3, 7, 11.
     # Only the first full chunk and the SWA chunk ending at token 32 exist, so
     # lookup should recover a 32-token external prefix hit. A sparse

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -149,12 +149,11 @@ class PoolKey:
             f"@dcp{key_metadata.dcp_rank}"
             f"@pp_rank:{key_metadata.pp_rank if pp_rank is None else pp_rank}"
             f"@group:{key_metadata.group_id}"
-            "@"
         )
 
     @staticmethod
     def build_key_string(key_prefix: str, chunk_hash: str) -> str:
-        return key_prefix + chunk_hash
+        return f"{key_prefix}@{chunk_hash}"
 
     def to_string(self) -> str:
         return self.build_key_string(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -132,21 +132,33 @@ class PoolKey:
             )
         )
 
-    def to_string(self) -> str:
-        prefix = (
-            f"{self.key_metadata.cache_prefix}@"
-            if self.key_metadata.cache_prefix
-            else ""
-        )
+    @staticmethod
+    def build_prefix(
+        key_metadata: KeyMetadata,
+        *,
+        tp_rank: int | None = None,
+        pp_rank: int | None = None,
+    ) -> str:
+        """Return the stable prefix for a Mooncake pool key."""
+        prefix = f"{key_metadata.cache_prefix}@" if key_metadata.cache_prefix else ""
         return (
             f"{prefix}"
-            f"{self.key_metadata.model_name}"
-            f"@tp_rank:{self.key_metadata.tp_rank}"
-            f"@pcp{self.key_metadata.pcp_rank}"
-            f"@dcp{self.key_metadata.dcp_rank}"
-            f"@pp_rank:{self.key_metadata.pp_rank}"
-            f"@group:{self.key_metadata.group_id}"
-            f"@{self.chunk_hash}"
+            f"{key_metadata.model_name}"
+            f"@tp_rank:{key_metadata.tp_rank if tp_rank is None else tp_rank}"
+            f"@pcp{key_metadata.pcp_rank}"
+            f"@dcp{key_metadata.dcp_rank}"
+            f"@pp_rank:{key_metadata.pp_rank if pp_rank is None else pp_rank}"
+            f"@group:{key_metadata.group_id}"
+            "@"
+        )
+
+    @staticmethod
+    def build_key_string(key_prefix: str, chunk_hash: str) -> str:
+        return key_prefix + chunk_hash
+
+    def to_string(self) -> str:
+        return self.build_key_string(
+            self.build_prefix(self.key_metadata), self.chunk_hash
         )
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -1132,7 +1132,7 @@ class MooncakeStoreWorker:
             )
             for db in self.token_dbs
         )
-        self._lookup_expected_per_key = max(1, tp_count * self.pp_size)
+        self._lookup_expected_per_key = tp_count * self.pp_size
 
     def register_cross_layers_kv_caches(self, kv_cache: torch.Tensor) -> None:
         """Register a cross-layers KV cache tensor.
@@ -1395,9 +1395,9 @@ class MooncakeStoreWorker:
             return 0
 
         # Build per-(group, hash) candidate keys expanded across TP/PP.
-        # candidate_meta stores the key slice for each logical candidate.
+        # candidate_meta stores the (group, hash_bytes) for key slice.
         candidate_keys: list[str] = []
-        candidate_meta: list[tuple[int, bytes, int, int]] = []
+        candidate_meta: list[tuple[int, bytes]] = []
         lookup_masks = self.coord.lookup_mask(token_len)
         for g_idx, db in enumerate(self.token_dbs):
             spec_block_size = db.block_size
@@ -1415,12 +1415,11 @@ class MooncakeStoreWorker:
                 ):
                     continue
                 hash_hex = h.hex()
-                key_start = len(candidate_keys)
                 for key_prefix in key_prefixes:
                     candidate_keys.append(
                         PoolKey.build_key_string(key_prefix, hash_hex)
                     )
-                candidate_meta.append((g_idx, bytes(h), key_start, len(key_prefixes)))
+                candidate_meta.append((g_idx, bytes(h)))
 
         if not candidate_keys:
             return 0
@@ -1445,15 +1444,15 @@ class MooncakeStoreWorker:
             return 0
 
         # A (group, hash) is "present" only when every TP*PP rank has it.
-        exists_set: set[tuple[int, bytes]] = set()
-        for g_idx, hash_bytes, key_start, num_keys in candidate_meta:
-            all_ranks_present = num_keys >= self._lookup_expected_per_key
-            for key_idx in range(key_start, key_start + num_keys):
-                if res[key_idx] != 1:
-                    all_ranks_present = False
-                    break
-            if all_ranks_present:
-                exists_set.add((g_idx, hash_bytes))
+        ranks_per_candidate = self._lookup_expected_per_key
+        exists_set = {
+            (g_idx, hash_bytes)
+            for i, (g_idx, hash_bytes) in enumerate(candidate_meta)
+            if all(
+                res[i * ranks_per_candidate + j] == 1
+                for j in range(ranks_per_candidate)
+            )
+        }
 
         _masks, hit_length = self.coord.find_longest_cache_hit(
             block_hashes, token_len, ExternalCachedBlockPool(exists_set)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -1119,6 +1119,20 @@ class MooncakeStoreWorker:
             )
             for g_idx, g in enumerate(self._kv_cache_groups)
         ]
+        self._init_lookup_key_prefixes()
+
+    def _init_lookup_key_prefixes(self) -> None:
+        """Precompute per-group key prefixes expanded across TP/PP ranks."""
+        tp_count = min(self.tp_size, self.num_kv_head)
+        self._lookup_key_prefixes = tuple(
+            tuple(
+                PoolKey.build_prefix(db.metadata, tp_rank=tp, pp_rank=pp)
+                for tp in range(tp_count)
+                for pp in range(self.pp_size)
+            )
+            for db in self.token_dbs
+        )
+        self._lookup_expected_per_key = max(1, tp_count * self.pp_size)
 
     def register_cross_layers_kv_caches(self, kv_cache: torch.Tensor) -> None:
         """Register a cross-layers KV cache tensor.
@@ -1381,22 +1395,17 @@ class MooncakeStoreWorker:
             return 0
 
         # Build per-(group, hash) candidate keys expanded across TP/PP.
-        # candidate_meta[i] is the (group_id, hash_bytes) for candidate_keys[i].
+        # candidate_meta stores the key slice for each logical candidate.
         candidate_keys: list[str] = []
-        candidate_meta: list[tuple[int, bytes]] = []
+        candidate_meta: list[tuple[int, bytes, int, int]] = []
         lookup_masks = self.coord.lookup_mask(token_len)
-        tp_count = min(self.tp_size, self.num_kv_head)
         for g_idx, db in enumerate(self.token_dbs):
             spec_block_size = db.block_size
             lookup_mask = lookup_masks[g_idx]
+            key_prefixes = self._lookup_key_prefixes[g_idx]
             group_hashes = self.coord.block_hashes_for_spec(
                 block_hashes, self._kv_cache_groups[g_idx].kv_cache_spec
             )
-            metadata_templates = [
-                dataclasses.replace(db.metadata, tp_rank=tp, pp_rank=pp)
-                for tp in range(tp_count)
-                for pp in range(self.pp_size)
-            ]
             for chunk_id, h in enumerate(group_hashes):
                 start_idx = chunk_id * spec_block_size
                 if start_idx >= token_len:
@@ -1405,11 +1414,13 @@ class MooncakeStoreWorker:
                     chunk_id >= len(lookup_mask) or not lookup_mask[chunk_id]
                 ):
                     continue
-                h_hex = h.hex()
-                h_bytes = bytes(h)
-                for md in metadata_templates:
-                    candidate_keys.append(PoolKey(md, h_hex).to_string())
-                    candidate_meta.append((g_idx, h_bytes))
+                hash_hex = h.hex()
+                key_start = len(candidate_keys)
+                for key_prefix in key_prefixes:
+                    candidate_keys.append(
+                        PoolKey.build_key_string(key_prefix, hash_hex)
+                    )
+                candidate_meta.append((g_idx, bytes(h), key_start, len(key_prefixes)))
 
         if not candidate_keys:
             return 0
@@ -1434,12 +1445,15 @@ class MooncakeStoreWorker:
             return 0
 
         # A (group, hash) is "present" only when every TP*PP rank has it.
-        expected_per_key = max(1, tp_count * self.pp_size)
-        present_count: dict[tuple[int, bytes], int] = {}
-        for gh, exists in zip(candidate_meta, res, strict=True):
-            if exists == 1:
-                present_count[gh] = present_count.get(gh, 0) + 1
-        exists_set = {gh for gh, c in present_count.items() if c >= expected_per_key}
+        exists_set: set[tuple[int, bytes]] = set()
+        for g_idx, hash_bytes, key_start, num_keys in candidate_meta:
+            all_ranks_present = num_keys >= self._lookup_expected_per_key
+            for key_idx in range(key_start, key_start + num_keys):
+                if res[key_idx] != 1:
+                    all_ranks_present = False
+                    break
+            if all_ranks_present:
+                exists_set.add((g_idx, hash_bytes))
 
         _masks, hit_length = self.coord.find_longest_cache_hit(
             block_hashes, token_len, ExternalCachedBlockPool(exists_set)


### PR DESCRIPTION
## Purpose
This PR optimizes the Mooncake store lookup key construction by building TP/PP prefixes in advance and reuse them, avoiding `KeyMetadata` instantiation and reducing f-string construction overhead.

edit: much of the optimization is already covered by https://github.com/vllm-project/vllm/pull/45969, this PR adds some minor improvment.

## Performance Benchmark
DeepSeek v4 TP4 on 4 x GB300:

<img width="1632" height="1036" alt="inferencex-agentx-mvp" src="https://github.com/user-attachments/assets/7f79e3f2-8730-42d1-aa6a-3ab8bf7c7fbf" />


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

