### PR TITLE
[ROCm][Perf] Avoid fp32 round-trip dequant in fp8 KV paged decode

### DIFF
--- a/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
@@ -187,9 +187,11 @@ def kernel_paged_attention_2d(
         )
 
         if K_load.dtype.is_fp8():
-            K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
+            K = K_load.to(Q.dtype)
+            qk_scale = scale * tl.load(k_scale)
         else:
             K = K_load
+            qk_scale = scale
 
         # V : (BLOCK_SIZE, HEAD_SIZE)
         V_load = tl.load(
@@ -200,16 +202,18 @@ def kernel_paged_attention_2d(
         )
 
         if V_load.dtype.is_fp8():
-            V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
+            V = V_load.to(Q.dtype)
+            v_post = tl.load(v_scale)
         else:
             V = V_load
+            v_post = 1.0
 
         seq_offset = j * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
         boundary = tl.full([BLOCK_SIZE], seq_len, dtype=tl.int32)
         seq_mask = seq_offset[None, :] < boundary
 
         # First calculate the dot, then apply the mask.
-        qk = scale * tl.dot(Q, K)
+        qk = qk_scale * tl.dot(Q, K)
         S = tl.where(head_mask[:, None] & seq_mask, qk, float("-inf"))
 
         context_len = seq_len - 1
@@ -243,7 +247,7 @@ def kernel_paged_attention_2d(
         M = m_j
 
         # acc : (num_queries_per_kv, BLOCK_SIZE,)
-        acc += tl.dot(p.to(V.dtype), V)
+        acc += tl.dot(p.to(V.dtype), V) * v_post
 
     # epilogue
     acc = acc / (L[:, None] + 1e-10)


### PR DESCRIPTION
kernel_paged_attention_2d dequantized fp8 KV via a per-element fp32 multiply every decode step. Since fp8 KV scales are per-tensor scalars, cast fp8 to the compute dtype and fold the scalar k_scale/v_scale into the score/output instead. ~+22% fp8 KV decode on gfx1201, output unchanged; no effect on the bf16 path.




## Purpose

Speeds up fp8 KV-cache decode on ROCm. When `--kv-cache-dtype fp8` is used, the fast HIP custom paged-attention kernel doesn't support fp8 KV, so decode falls back to the Triton `kernel_paged_attention_2d` in `vllm/v1/attention/ops/chunked_prefill_paged_decode.py`. That kernel dequantizes the whole K/V tile element-wise in fp32 **every decode step**:

```python
K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
```

On gfx1201 (RDNA4) that fp32 round-trip is ~3x slower than a plain cast.

**Fix:** fp8 KV `k_scale`/`v_scale` are per-tensor scalars, so they commute out of the matmul. Cast fp8 → compute dtype (hardware fp8→bf16 convert) and fold the scalar scales into the much smaller score / output instead of multiplying the big K/V tiles in fp32:

- `K = K_load.to(Q.dtype)` and apply `k_scale` to the QK scores via `qk_scale`
- `V = V_load.to(Q.dtype)` and apply `v_scale` to the accumulated output via `v_post`

This is mathematically exact for per-tensor fp8 KV scales. The bf16 KV path is unchanged (`v_post` stays `1.0`, `qk_scale` stays `scale`).

## Test Plan

- **gfx1201 (2x AMD Radeon AI PRO R9700), ROCm 7.2.x, vLLM v0.22.1, TP=2, `--kv-cache-dtype fp8`:** serve a model and measure single-stream decode tok/s at 8K context before vs after the change; confirm generated output is unchanged.
- Confirm the **bf16 KV path** (default `--kv-cache-dtype auto`) is byte-for-byte unaffected (the fp8 branches are guarded by `K_load.dtype.is_fp8()` / `V_load.dtype.is_fp8()`).

## Test Result

`Qwen/Qwen3.6-35B-A3B-FP8`, TP=2, gfx1201, 8K-context single-stream decode:

| | fp8 KV decode @8K |
|---|---|
| before (fp32 round-trip dequant) | ~34 tok/s |
| after (cast + scalar score/output scale) | **~41.5 tok/s (+22%)** |

Output quality unchanged — cosine similarity vs the fp32 reference ~0.9993 (identical to the pre-change fp8 path; this only removes redundant fp32 work, it does not change the numerics class). The bf16 KV path is unaffected.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

