### PR TITLE
Fix PP broadcast hangs when a GPU device error (e.g. device lost) occurs on a peer worker

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -97,7 +97,8 @@ LONG_WAIT_TIME_LOG_MSG = (
     "in %d seconds. This typically happens "
     "when some processes are hanging or doing some "
     "time-consuming work (e.g. compilation, "
-    "weight/kv cache quantization)."
+    "weight/kv cache quantization), or when a GPU device "
+    "error (e.g. device lost) has occurred on a peer worker."
 )
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     VLLM_USE_MODELSCOPE: bool = False
     VLLM_USE_FASTOKENS: bool = False
     VLLM_RINGBUFFER_WARNING_INTERVAL: int = 60
+    VLLM_PP_BROADCAST_TIMEOUT_SECONDS: int = 180
     VLLM_NCCL_SO_PATH: str | None = None
     LD_LIBRARY_PATH: str | None = None
     VLLM_ROCM_SLEEP_MEM_CHUNK_SIZE: int = 256
@@ -664,6 +665,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Interval in seconds to log a warning message when the ring buffer is full
     "VLLM_RINGBUFFER_WARNING_INTERVAL": lambda: int(
         os.environ.get("VLLM_RINGBUFFER_WARNING_INTERVAL", "60")
+    ),
+    # Timeout in seconds for PP sampled-token broadcast
+    "VLLM_PP_BROADCAST_TIMEOUT_SECONDS": lambda: int(
+        os.environ.get("VLLM_PP_BROADCAST_TIMEOUT_SECONDS", "180")
     ),
     # path to cudatoolkit home directory, under which should be bin, include,
     # and lib directories.

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -386,6 +386,12 @@ class MultiprocExecutor(Executor):
                 try:
                     status, result = mq.dequeue(timeout=dequeue_timeout)
                 except TimeoutError as e:
+                    if self.is_failed:
+                        raise RuntimeError(
+                            f"A worker died during RPC call to {method}, "
+                            "please check the stack trace above "
+                            "for the root cause"
+                        ) from e
                     raise TimeoutError(f"RPC call to {method} timed out.") from e
                 if status != WorkerProc.ResponseStatus.SUCCESS:
                     raise RuntimeError(

--- a/vllm/v1/worker/gpu/pp_utils.py
+++ b/vllm/v1/worker/gpu/pp_utils.py
@@ -2,15 +2,49 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Pipeline Parallelism utils for V2 Model Runner."""
 
+import threading
 from collections import deque
 from dataclasses import dataclass
 
 import numpy as np
 import torch
 
+import vllm.envs as envs
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch
+
+
+def _broadcast_with_timeout(
+    tensor: torch.Tensor,
+    src: int,
+    group: torch.distributed.ProcessGroup,
+    stream: torch.cuda.Stream,
+    timeout: float = envs.VLLM_PP_BROADCAST_TIMEOUT_SECONDS,
+) -> None:
+    """Run ``torch.distributed.broadcast`` with a daemon-thread timeout.
+
+    ``dist.broadcast`` is a blocking collective that can hang permanently
+    when a GPU device error (e.g. device lost) occurs on a peer worker.
+    This wrapper runs the broadcast in a daemon thread so the caller can
+    propagate a ``TimeoutError`` after *timeout* seconds instead of
+    hanging indefinitely.
+    """
+
+    def _run():
+        with torch.cuda.stream(stream):
+            torch.distributed.broadcast(tensor, src=src, group=group)
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(timeout=timeout)
+    if t.is_alive():
+        raise TimeoutError(
+            f"PP broadcast timed out after {timeout}s. "
+            "This typically indicates a GPU device error "
+            "(e.g. device lost) on a peer worker. "
+            "Adjust via VLLM_PP_BROADCAST_TIMEOUT_SECONDS."
+        )
 
 
 @dataclass
@@ -142,11 +176,17 @@ class PPHandler:
                 num_reqs, self.max_sample_len, dtype=torch.int64, device=self.device
             )
             combined = torch.empty(2, num_reqs, dtype=torch.int32, device=self.device)
-            torch.distributed.broadcast(
-                sampled_tokens, src=self.last_rank, group=self.broadcast_group
+            _broadcast_with_timeout(
+                sampled_tokens,
+                src=self.last_rank,
+                group=self.broadcast_group,
+                stream=self.broadcast_stream,
             )
-            torch.distributed.broadcast(
-                combined, src=self.last_rank, group=self.broadcast_group
+            _broadcast_with_timeout(
+                combined,
+                src=self.last_rank,
+                group=self.broadcast_group,
+                stream=self.broadcast_stream,
             )
             event = self.broadcast_stream.record_event()
             num_sampled, num_rejected = combined.unbind(dim=0)
@@ -181,14 +221,18 @@ class PPHandler:
         assert sampled_token_ids.dtype == torch.int64
         with torch.cuda.stream(self.broadcast_stream):
             self.broadcast_stream.wait_stream(self.main_stream)
-            torch.distributed.broadcast(
+            _broadcast_with_timeout(
                 sampled_token_ids.contiguous(),
                 src=self.last_rank,
                 group=self.broadcast_group,
+                stream=self.broadcast_stream,
             )
             combined = torch.stack((num_sampled, num_rejected), dim=0)
-            torch.distributed.broadcast(
-                combined, src=self.last_rank, group=self.broadcast_group
+            _broadcast_with_timeout(
+                combined,
+                src=self.last_rank,
+                group=self.broadcast_group,
+                stream=self.broadcast_stream,
             )
             for tensor in (sampled_token_ids, num_sampled, num_rejected):
                 tensor.record_stream(self.broadcast_stream)


### PR DESCRIPTION


Pipeline-parallel broadcast via torch.distributed.broadcast() is a blocking collective that can hang permanently when a peer GPU experiences a device-level error (e.g. UR_RESULT_ERROR_DEVICE_LOST on Intel XPU).  The stuck worker's process stays alive, so the existing worker-monitor thread (which only detects process death) never fires. Other workers block on the shared-memory broadcast ring buffer waiting for the stuck worker's RPC response, and the engine only surfaces the error after the default 300-second RPC timeout.

Changes
-------

pp_utils.py:
  Introduce _broadcast_with_timeout() — a thin wrapper that runs
  torch.distributed.broadcast in a daemon thread and raises
  TimeoutError if the collective does not complete within the
  configured window (default 180 s).  Both PPHandler.broadcast()
  (last PP rank) and PPHandler.receive() (non-last PP rank) use
  the wrapper.

multiproc_executor.py:
  When collective_rpc catches a TimeoutError from a worker response
  message queue, check self.is_failed before re-raising.  If a worker
  died during the RPC, emit a RuntimeError naming the stalled call
  instead of the generic timeout message.

shm_broadcast.py:
  Mention GPU device errors in the long-wait warning log message so
  that users have a diagnostic hint when PP hangs.

envs.py:
  Add VLLM_PP_BROADCAST_TIMEOUT_SECONDS (default 180) to control
  the new PP broadcast timeout.

Test commands
-------------
  .venv/bin/python -m pytest tests/distributed/test_pipeline_partition.py -v

PP integration testing requires multi-GPU hardware and is not exercisable in single-GPU CI.

Fixes #46072


