### PR TITLE
[Bugfix] Guard model_config access in _log_compilation_config

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -991,11 +991,7 @@ class VllmBackend:
             },
             payload_fn=lambda: json.dumps(
                 {
-                    "model": (
-                        self.vllm_config.model_config.model
-                        if self.vllm_config.model_config is not None
-                        else "unknown"
-                    ),
+                    "model": getattr(self.vllm_config.model_config, "model", "unknown"),
                     "prefix": self.prefix,
                     "mode": str(cc.mode),
                     "backend": cc.backend,

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -991,7 +991,11 @@ class VllmBackend:
             },
             payload_fn=lambda: json.dumps(
                 {
-                    "model": self.vllm_config.model_config.model,
+                    "model": (
+                        self.vllm_config.model_config.model
+                        if self.vllm_config.model_config is not None
+                        else "unknown"
+                    ),
                     "prefix": self.prefix,
                     "mode": str(cc.mode),
                     "backend": cc.backend,


### PR DESCRIPTION
## Summary
`_log_compilation_config()` in `VllmBackend` crashes with `AttributeError: 'NoneType' object has no attribute 'model'` when `model_config` is `None`

This test creates a `VllmConfig` with only `compilation_config` set, and leaves `model_config` set to `None`
https://github.com/vllm-project/vllm/blob/main/tests/compile/passes/ir/test_inplace_functionalization.py#L412

This was passing on May 2 but seemingly should always have been a problem, unclear why it was passing before and not now. Regardless, the fix is pretty simple and straightforward

🤖 Generated with [Claude Code](https://claude.com/claude-code)