### PR TITLE
[Bugfix] Move extract_layer_index back inside is_v32 guard

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1001,24 +1001,30 @@ class DeepseekV2MLAAttention(nn.Module):
         # IndexCache config
         # Refer: https://arxiv.org/abs/2603.12201 for more details.
         _skip_topk = False
-        _index_topk_freq = getattr(config, "index_topk_freq", 1)
-        _index_topk_pattern = getattr(config, "index_topk_pattern", None)
-        _index_skip_topk_offset = getattr(config, "index_skip_topk_offset", 2)
-        layer_id = extract_layer_index(prefix)
+        is_mtp_layer = False
+        if self.is_v32:
+            _index_topk_freq = getattr(config, "index_topk_freq", 1)
+            _index_topk_pattern = getattr(config, "index_topk_pattern", None)
+            _index_skip_topk_offset = getattr(config, "index_skip_topk_offset", 2)
+            layer_id = extract_layer_index(prefix)
 
-        if _index_topk_pattern is None:
-            _skip_topk = (
-                max(layer_id - _index_skip_topk_offset + 1, 0) % _index_topk_freq != 0
+            if _index_topk_pattern is None:
+                _skip_topk = (
+                    max(layer_id - _index_skip_topk_offset + 1, 0) % _index_topk_freq
+                    != 0
+                )
+            elif 0 <= layer_id < len(_index_topk_pattern):
+                _skip_topk = _index_topk_pattern[layer_id] == "S"
+
+            # The skip pattern only governs backbone layers. MTP/nextn
+            # layers (layer_id >= num_hidden_layers) always build a full
+            # indexer: they compute indices at draft step 0 and toggle
+            # at runtime via set_skip_topk
+            # (index_share_for_mtp_iteration).
+            _num_hidden_layers = getattr(config, "num_hidden_layers", None)
+            is_mtp_layer = (
+                _num_hidden_layers is not None and layer_id >= _num_hidden_layers
             )
-        elif 0 <= layer_id < len(_index_topk_pattern):
-            _skip_topk = _index_topk_pattern[layer_id] == "S"
-
-        # The skip pattern only governs backbone layers. MTP/nextn layers
-        # (layer_id >= num_hidden_layers) always build a full indexer: they
-        # compute indices at draft step 0 and toggle at runtime via
-        # set_skip_topk (index_share_for_mtp_iteration).
-        _num_hidden_layers = getattr(config, "num_hidden_layers", None)
-        is_mtp_layer = _num_hidden_layers is not None and layer_id >= _num_hidden_layers
 
         if self.is_v32 and (not _skip_topk or is_mtp_layer):
             self.indexer_rope_emb = get_rope(


### PR DESCRIPTION
Pretty straightforward - #45895 removed the `if self.is_v32` check, which broke LongcatFlash. This PR brings it back

Claude summary:
<details>
## Summary

- Commit ab66606993 (#45895) moved `extract_layer_index(prefix)` from inside the `if self.is_v32` guard to unconditional execution in `DeepseekV2MLAAttention.__init__`
- This breaks LongcatFlash, whose layer prefixes contain two integers (e.g. `model.layers.0.self_attn.0`), causing `extract_layer_index` to assert "should only contain one integer"
- The IndexCache config (`layer_id`, `_skip_topk`, `is_mtp_layer`) is only consumed inside `if self.is_v32`, so the computation belongs inside that guard
- Fixes `test_can_initialize_large_subset[LongcatFlashForCausalLM]` and `test_can_initialize_large_subset[LongCatFlashMTPModel]`

## Test plan

- [ ] `pytest tests/models/test_initialization.py::test_can_initialize_large_subset -k "LongcatFlash" -v`
- [ ] DeepSeek v3.2 IndexCache behavior unchanged (guarded code is identical, just re-indented)

AI assistance was used (Claude). No existing PR addresses this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>