### PR TITLE
[CI] Pin schemathesis<4 to fix test_openai_schema.py collection failure

### DIFF
--- a/requirements/test/cuda.in
+++ b/requirements/test/cuda.in
@@ -40,7 +40,7 @@ lm-eval[api]>=0.4.12 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test
 transformers==5.5.3
 tokenizers==0.22.2
-schemathesis>=3.39.15 # Required for openai schema test.
+schemathesis>=3.39.15,<4 # Required for openai schema test.
 # quantization
 bitsandbytes==0.49.2
 buildkite-test-collector==0.1.9

--- a/requirements/test/nightly-torch.txt
+++ b/requirements/test/nightly-torch.txt
@@ -31,7 +31,7 @@ lm-eval[api]>=0.4.12 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test
 transformers==5.5.3
 tokenizers==0.22.2
-schemathesis>=3.39.15 # Required for openai schema test.
+schemathesis>=3.39.15,<4 # Required for openai schema test.
 # quantization
 bitsandbytes>=0.49.2
 buildkite-test-collector==0.1.9

--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -39,7 +39,7 @@ lm-eval[api]>=0.4.12 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test
 transformers==5.5.3
 tokenizers==0.22.2
-schemathesis>=3.39.15 # Required for openai schema test
+schemathesis>=3.39.15,<4 # Required for openai schema test
 # quantization
 bitsandbytes==0.49.2
 buildkite-test-collector==0.1.9

--- a/requirements/test/xpu.in
+++ b/requirements/test/xpu.in
@@ -27,7 +27,7 @@ soundfile
 blobfile
 rapidfuzz
 gpt-oss
-schemathesis
+schemathesis>=3.39.15,<4
 jiwer
 bm25s
 pystemmer


### PR DESCRIPTION
## Summary

- `schemathesis` v4 (released 2025-06-10) removed `GenerationConfig` from its public API, breaking `test_openai_schema.py` at collection time with `ImportError: cannot import name 'GenerationConfig' from 'schemathesis'`
- The v4 migration is non-trivial (config moved to TOML files, `from_uri` renamed to `from_url`, etc.), so this pins `<4` as the minimal fix
- Updated all four unpinned requirements files: `cuda.in`, `rocm.in`, `xpu.in`, `nightly-torch.txt`
- The locked files (`cuda.txt`, `rocm.txt`) already resolve to 3.39.15 and are unaffected

## Test plan

- [ ] `test_openai_schema.py` should collect and run successfully
- [ ] CI jobs "Entrypoints Integration (API Server OpenAI - Part 1)" and AMD equivalent should pass

AI assistance was used (Claude). No existing PR addresses this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)