### PR TITLE
[ROCm] Register DeepSeek V4 MoE metadata for EPLB

### DIFF
--- a/tests/models/test_deepseek_v4_moe_eplb.py
+++ b/tests/models/test_deepseek_v4_moe_eplb.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+import torch.nn as nn
+
+from vllm.models.deepseek_v4.common.moe import DeepseekV4MixtureOfExperts
+
+
+class FakeExperts(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.eplb_calls = []
+        self.update_calls = 0
+
+    def get_expert_weights(self):
+        return [torch.ones(1)]
+
+    def set_eplb_state(self, **kwargs) -> None:
+        self.eplb_calls.append(kwargs)
+
+    def update_expert_map(self) -> None:
+        self.update_calls += 1
+
+
+class FakeMoE(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.experts = FakeExperts()
+        self.n_logical_experts = 8
+        self.n_physical_experts = 10
+        self.n_local_physical_experts = 5
+        self.n_routed_experts = 8
+        self.n_shared_experts = 1
+        self.n_redundant_experts = 2
+
+
+class UnsupportedExperts(nn.Module):
+    pass
+
+
+class FakeDecoder(nn.Module):
+    def __init__(self, ffn: nn.Module) -> None:
+        super().__init__()
+        self.ffn = ffn
+
+
+class FakeDeepseekV4(nn.Module, DeepseekV4MixtureOfExperts):
+    decoder_layer_cls = FakeDecoder
+    moe_layer_cls = FakeMoE
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.config = type("Config", (), {"n_group": 2})()
+        self.model = type("Model", (), {"layers": [FakeDecoder(FakeMoE())]})()
+        self.set_moe_parameters()
+
+
+def test_registers_layers_and_forwards_eplb_state():
+    model = FakeDeepseekV4()
+
+    assert model.num_moe_layers == 1
+    assert model.num_logical_experts == 8
+    assert model.num_physical_experts == 10
+
+    expert_load_view = torch.ones(8)
+    logical_to_physical_map = torch.arange(8)
+    logical_replica_count = torch.ones(8, dtype=torch.int64)
+    model.set_eplb_state(
+        expert_load_view,
+        logical_to_physical_map,
+        logical_replica_count,
+    )
+
+    assert len(model.expert_weights) == 1
+    call = model.moe_layers[0].eplb_calls[0]
+    assert call["moe_layer_idx"] == 0
+    assert call["expert_load_view"] is expert_load_view
+    assert call["logical_to_physical_map"] is logical_to_physical_map
+    assert call["logical_replica_count"] is logical_replica_count
+
+
+def test_refreshes_metadata_and_expert_map():
+    model = FakeDeepseekV4()
+
+    model.update_physical_experts_metadata(10, 5)
+
+    moe = model.moe_mlp_layers[0]
+    assert model.num_redundant_experts == 2
+    assert moe.n_physical_experts == 10
+    assert moe.n_local_physical_experts == 5
+    assert moe.experts.update_calls == 1
+
+
+def test_skips_layers_without_eplb_expert_methods():
+    model = FakeDeepseekV4()
+    model.model.layers = [FakeDecoder(FakeMoE())]
+    model.model.layers[0].ffn.experts = UnsupportedExperts()
+    model.set_moe_parameters()
+
+    assert model.num_moe_layers == 0
+    assert model.moe_layers == []

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -55,6 +55,7 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
 )
 from vllm.models.deepseek_v4.amd.rocm import DeepseekV4ROCMAiterMLAAttention
+from vllm.models.deepseek_v4.common.moe import DeepseekV4MixtureOfExperts
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
@@ -179,17 +180,28 @@ class DeepseekV4MoE(nn.Module):
                 prefix=f"{prefix}.shared_experts",
             )
 
-        self.tp_rank = get_tensor_model_parallel_rank()
-        assert config.n_routed_experts % self.tp_size == 0
+        parallel_config = vllm_config.parallel_config
+        eplb_config = parallel_config.eplb_config
+        self.n_redundant_experts = (
+            eplb_config.num_redundant_experts if parallel_config.enable_eplb else 0
+        )
+        self.n_shared_experts = config.n_shared_experts or 0
+        self.n_logical_experts = config.n_routed_experts
+        self.n_physical_experts = self.n_logical_experts + self.n_redundant_experts
+        assert self.n_physical_experts % self.tp_size == 0
 
-        self.n_local_experts = config.n_routed_experts // self.tp_size
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.n_local_physical_experts = self.n_physical_experts // self.tp_size
+        self.n_local_experts = self.n_local_physical_experts
         self.experts_start_idx = self.tp_rank * self.n_local_experts
         self.experts_end_idx = self.experts_start_idx + self.n_local_experts
+        self.physical_expert_start = self.experts_start_idx
+        self.physical_expert_end = self.experts_end_idx
 
         self.experts = FusedMoE(
             shared_experts=self.shared_experts,
             gate=self.gate,
-            num_experts=config.n_routed_experts,
+            num_experts=self.n_logical_experts,
             top_k=config.num_experts_per_tok,
             hidden_size=config.hidden_size,
             intermediate_size=config.moe_intermediate_size,
@@ -202,6 +214,8 @@ class DeepseekV4MoE(nn.Module):
             hash_indices_table=self.gate.tid2eid,
             swiglu_limit=self.swiglu_limit,
             router_logits_dtype=torch.float32,
+            enable_eplb=parallel_config.enable_eplb,
+            num_redundant_experts=self.n_redundant_experts,
         )
 
     def forward(
@@ -791,8 +805,12 @@ def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
     )
 
 
-class DeepseekV4ForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
+class DeepseekV4ForCausalLM(
+    nn.Module, SupportsPP, SupportsEagle3, DeepseekV4MixtureOfExperts
+):
     model_cls = DeepseekV4Model
+    decoder_layer_cls = DeepseekV4DecoderLayer
+    moe_layer_cls = DeepseekV4MoE
 
     # Default mapper assumes the original FP4-expert checkpoint layout.
     # Overridden per-instance in __init__ when expert_dtype != "fp4".
@@ -822,6 +840,8 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
         self.make_empty_intermediate_tensors = (  # type: ignore[method-assign]
             self.model.make_empty_intermediate_tensors
         )
+
+        self.set_moe_parameters()
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)

--- a/vllm/models/deepseek_v4/common/moe.py
+++ b/vllm/models/deepseek_v4/common/moe.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import MutableSequence, Sequence
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm.model_executor.models.interfaces import MixtureOfExperts
+from vllm.model_executor.models.utils import PPMissingLayer
+
+
+def _supports_eplb_experts(experts: object) -> bool:
+    return all(
+        hasattr(experts, name)
+        for name in ("get_expert_weights", "set_eplb_state", "update_expert_map")
+    )
+
+
+class DeepseekV4MixtureOfExperts(MixtureOfExperts):
+    """Register DeepSeek V4 FusedMoE layers with the EPLB control plane."""
+
+    decoder_layer_cls: type[nn.Module]
+    moe_layer_cls: type[nn.Module]
+    moe_mlp_layers: list[nn.Module]
+
+    def set_moe_parameters(self) -> None:
+        self.expert_weights: MutableSequence[Sequence[torch.Tensor]] = []
+        self.num_expert_groups = getattr(self.config, "n_group", 1)
+        self.moe_layers = []
+        self.moe_mlp_layers = []
+        example_moe = None
+
+        for layer in self.model.layers:
+            if isinstance(layer, PPMissingLayer):
+                continue
+            if not isinstance(layer, self.decoder_layer_cls):
+                continue
+
+            moe: Any = layer.ffn
+            if not isinstance(moe, self.moe_layer_cls):
+                continue
+            if not _supports_eplb_experts(moe.experts):
+                continue
+
+            example_moe = moe
+            self.moe_mlp_layers.append(moe)
+            self.moe_layers.append(moe.experts)
+
+        self.num_moe_layers = len(self.moe_layers)
+        self.extract_moe_parameters(example_moe)
+
+    def extract_moe_parameters(self, example_moe: Any | None) -> None:
+        if example_moe is None:
+            self.num_expert_groups = 0
+            self.num_logical_experts = 0
+            self.num_physical_experts = 0
+            self.num_local_physical_experts = 0
+            self.num_routed_experts = 0
+            self.num_shared_experts = 0
+            self.num_redundant_experts = 0
+            return
+
+        self.num_logical_experts = example_moe.n_logical_experts
+        self.num_physical_experts = example_moe.n_physical_experts
+        self.num_local_physical_experts = example_moe.n_local_physical_experts
+        self.num_routed_experts = example_moe.n_routed_experts
+        self.num_shared_experts = example_moe.n_shared_experts
+        self.num_redundant_experts = example_moe.n_redundant_experts
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        assert self.num_local_physical_experts == num_local_physical_experts
+        self.num_physical_experts = num_physical_experts
+        self.num_local_physical_experts = num_local_physical_experts
+        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
+        for moe in self.moe_mlp_layers:
+            moe.n_local_physical_experts = num_local_physical_experts
+            moe.n_physical_experts = num_physical_experts
+            moe.n_redundant_experts = self.num_redundant_experts
+            moe.experts.update_expert_map()


### PR DESCRIPTION
## Scope

- ROCm only. Current `ParallelConfig` explicitly permits EPLB on CUDA/ROCm and rejects XPU, so this rebase intentionally drops the stale XPU claim.
- NVIDIA DeepSeek V4 already has its own MoE/EPLB registration on `main`; this patch only covers the remaining ROCm FusedMoE path.

## What changed

- expose ROCm DeepSeek V4 as `MixtureOfExperts` and register its FusedMoE runners with the EPLB control plane
- propagate physical/logical expert metadata and redundant-expert settings into `FusedMoE`
- keep metadata and expert maps in sync after EPLB placement updates
- add a CPU-only regression test for registration, state forwarding, metadata refresh, and skipping unsupported expert implementations

## Validation

Passed locally:

- `uvx ruff check vllm/models/deepseek_v4/common/moe.py vllm/models/deepseek_v4/amd/model.py tests/models/test_deepseek_v4_moe_eplb.py`
- `uvx ruff format --check vllm/models/deepseek_v4/common/moe.py vllm/models/deepseek_v4/amd/model.py tests/models/test_deepseek_v4_moe_eplb.py`
- `python3 -m py_compile vllm/models/deepseek_v4/common/moe.py vllm/models/deepseek_v4/amd/model.py tests/models/test_deepseek_v4_moe_eplb.py`
- isolated execution of the registration/state-forwarding behavior and an AST contract check for the ROCm `FusedMoE` arguments

Not run locally:

- the repository's existing local venv cannot collect the target pytest file because it is missing `cbor2`; the target command is `.venv/bin/python -m pytest -q tests/models/test_deepseek_v4_moe_eplb.py`
- no ROCm hardware/model evaluation is available locally; ROCm CI or a hardware run is still required before merging

## AI assistance

An AI coding assistant was used for rebase analysis and implementation. The PR author remains responsible for reviewing and validating the final change.