### PR TITLE
Fix MoE kernel bounds checks

### DIFF
--- a/csrc/libtorch_stable/moe/moe_wna16.cu
+++ b/csrc/libtorch_stable/moe/moe_wna16.cu
@@ -216,7 +216,9 @@ __global__ void moe_wna16_gemm_kernel(
       if (mul_topk_weight) {
         res[m] *= topk_weights[token_index];
       }
-      atomicAdd(&output[token_index * size_n + offset_n],
+      const int64_t output_offset =
+          static_cast<int64_t>(token_index) * size_n + offset_n;
+      atomicAdd(&output[output_offset],
                 Dtype::float2num(res[m]));
     }
 

--- a/csrc/libtorch_stable/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.inl
+++ b/csrc/libtorch_stable/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.inl
@@ -16,18 +16,23 @@ __global__ void expandInputRowsKernel(
   int64_t expanded_dest_row = blockIdx.x;
   int64_t const expanded_source_row =
       expanded_dest_row_to_expanded_source_row[expanded_dest_row];
+  int64_t const num_expanded_source_rows = num_rows * k;
+  bool const valid_source_row =
+      expanded_source_row >= 0 && expanded_source_row < num_expanded_source_rows;
+  bool const valid_dest_row =
+      !CHECK_SKIPPED || expanded_dest_row < *num_dest_rows;
 
-  if (threadIdx.x == 0) {
+  if (threadIdx.x == 0 && valid_source_row) {
     assert(expanded_dest_row <= INT32_MAX);
     expanded_source_row_to_expanded_dest_row[expanded_source_row] =
         static_cast<int>(expanded_dest_row);
     // skip non local expert token
-    if (!CHECK_SKIPPED || blockIdx.x < *num_dest_rows) {
+    if (valid_dest_row) {
       permuted_idx[expanded_dest_row] = expanded_source_row;
     }
   }
 
-  if (!CHECK_SKIPPED || blockIdx.x < *num_dest_rows) {
+  if (valid_source_row && valid_dest_row) {
     // Load 128-bits per thread
     constexpr int64_t ELEM_PER_THREAD = 128 / cutlass::sizeof_bits<T>::value;
     using DataElem = cutlass::Array<T, ELEM_PER_THREAD>;


### PR DESCRIPTION
Fixes #45884.
Fixes #45492.

This PR tightens two MoE CUDA kernel indexing paths:

- promotes the WNA16 output offset calculation to 64-bit before pointer indexing, avoiding overflow for large `token_index * size_n + offset_n` values
- validates `expanded_source_row` before writing `expanded_source_row_to_expanded_dest_row[expanded_source_row]`, and skips copy work for invalid skipped rows emitted by the permute path

The root cause is that both kernels trusted index values that can exceed the valid 32-bit or expanded-row range under large or skipped MoE routing inputs.

Testing:

- `git diff --check`
- local boundary script covering the examples from #45884 and #45492

I do not have local CUDA hardware in this environment, so I could not run the MoE CUDA test suite locally.
