### PR TITLE
[Bugfix][Model] Fix DiffusionGemma self-conditioning with tensor parallelism

### DIFF
--- a/tests/model_executor/test_diffusion_gemma.py
+++ b/tests/model_executor/test_diffusion_gemma.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.models import diffusion_gemma
+
+
+def test_soft_embeddings_from_probs_matches_full_vocab_embedding():
+    embed_tokens = nn.Embedding(3, 2)
+    embed_tokens.weight.data = torch.tensor(
+        [[1.0, 2.0], [3.0, 5.0], [7.0, 11.0]]
+    )
+    probs = torch.tensor([[[0.2, 0.3, 0.5]]])
+    normalizer = torch.tensor(2.0)
+
+    soft_embeds = diffusion_gemma._soft_embeddings_from_probs(
+        probs, embed_tokens, normalizer
+    )
+
+    expected = torch.matmul(probs, embed_tokens.weight) * normalizer
+    torch.testing.assert_close(soft_embeds, expected)
+
+
+def test_soft_embeddings_from_probs_uses_tensor_parallel_vocab_shard(monkeypatch):
+    embed_tokens = nn.Embedding(5, 2)
+    embed_tokens.weight.data = torch.tensor(
+        [
+            [10.0, 1.0],
+            [20.0, 2.0],
+            [30.0, 3.0],
+            [40.0, 4.0],
+            [50.0, 5.0],
+        ]
+    )
+    embed_tokens.shard_indices = SimpleNamespace(
+        org_vocab_start_index=1,
+        org_vocab_end_index=3,
+        added_vocab_start_index=6,
+        added_vocab_end_index=8,
+        num_org_elements_padded=3,
+    )
+    probs = torch.tensor([[[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]]])
+    normalizer = torch.tensor(0.5)
+
+    all_reduce_inputs = []
+
+    def fake_all_reduce(tensor):
+        all_reduce_inputs.append(tensor.clone())
+        return tensor
+
+    monkeypatch.setattr(
+        diffusion_gemma, "tensor_model_parallel_all_reduce", fake_all_reduce
+    )
+
+    soft_embeds = diffusion_gemma._soft_embeddings_from_probs(
+        probs, embed_tokens, normalizer
+    )
+
+    local_probs = torch.tensor([[[0.1, 0.2, 0.0, 0.6, 0.7]]])
+    expected_local = torch.matmul(local_probs, embed_tokens.weight)
+    torch.testing.assert_close(all_reduce_inputs[0], expected_local)
+    torch.testing.assert_close(soft_embeds, expected_local * normalizer)
+
+
+def test_soft_embeddings_from_probs_requires_shard_metadata_for_vocab_mismatch():
+    embed_tokens = nn.Embedding(2, 2)
+    probs = torch.zeros(1, 1, 3)
+
+    with pytest.raises(RuntimeError, match="shapes are incompatible"):
+        diffusion_gemma._soft_embeddings_from_probs(
+            probs, embed_tokens, torch.tensor(1.0)
+        )

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -28,6 +28,7 @@ from transformers import AutoModel
 
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -478,9 +479,6 @@ def _compiled_sample_step(
     step_tensor: torch.Tensor,  # [max_num_reqs]
     is_encoder_phase: torch.Tensor,  # [max_num_reqs]
     confident_tensor: torch.Tensor,  # [max_num_reqs]
-    sc_embeds: torch.Tensor,  # [max_num_reqs, CL, hidden]
-    embed_weight: torch.Tensor,  # [vocab, hidden]
-    normalizer: torch.Tensor,
     history: torch.Tensor,  # [max_num_reqs, ST, CL]
     history_len_tensor: torch.Tensor,  # [max_num_reqs]
     # Output tensors (modified in-place)
@@ -620,16 +618,6 @@ def _compiled_sample_step(
         is_commit, is_commit.new_zeros(num_decode), converged
     )
 
-    # SC soft embedding: store ``probs @ embed_weight`` (the value the next step's
-    # self-conditioning MLP consumes) only for slots that will denoise next — i.e.
-    # this step denoised AND it isn't about to commit (is_encoder_phase now False).
-    # Masking here (rather than in the consumer) lets _apply_self_conditioning read
-    # sc_embeds directly. Storing the [.., hidden] soft embed instead of the full
-    # [.., vocab] probs avoids a giant persistent buffer.
-    sc_keep = (is_denoise & ~is_encoder_phase[decode_slots])[:, None, None]
-    soft_embeds = torch.matmul(probs.to(embed_weight.dtype), embed_weight) * normalizer
-    sc_embeds[decode_slots] = soft_embeds * sc_keep
-
     # Overwrite canvas with argmax for newly converged denoise requests
     newly_converged = (converged & is_denoise).unsqueeze(1)
     canvas[decode_slots] = torch.where(
@@ -640,6 +628,48 @@ def _compiled_sample_step(
     draft_tokens[all_slots, :CL] = canvas[all_slots]
 
     return scaled
+
+
+def _soft_embeddings_from_probs(
+    probs: torch.Tensor,
+    embed_tokens: Any,
+    normalizer: torch.Tensor,
+) -> torch.Tensor:
+    """Compute ``probs @ embedding_weight`` for TP-sharded embeddings."""
+    embed_weight = embed_tokens.weight
+    probs = probs.to(embed_weight.dtype)
+
+    if probs.shape[-1] == embed_weight.shape[0]:
+        soft_embeds = torch.matmul(probs, embed_weight)
+        return soft_embeds * normalizer
+
+    shard_indices = getattr(embed_tokens, "shard_indices", None)
+    if shard_indices is None:
+        raise RuntimeError(
+            "DiffusionGemma self-conditioning logits and embedding weight "
+            f"shapes are incompatible: {probs.shape[-1]} vs "
+            f"{embed_weight.shape[0]}."
+        )
+
+    local_probs = probs.new_zeros(*probs.shape[:-1], embed_weight.shape[0])
+    org_start = shard_indices.org_vocab_start_index
+    org_end = shard_indices.org_vocab_end_index
+    org_len = org_end - org_start
+    if org_len > 0:
+        local_probs[..., :org_len] = probs[..., org_start:org_end]
+
+    added_start = shard_indices.added_vocab_start_index
+    added_end = shard_indices.added_vocab_end_index
+    added_len = added_end - added_start
+    if added_len > 0:
+        added_offset = shard_indices.num_org_elements_padded
+        local_probs[..., added_offset : added_offset + added_len] = probs[
+            ..., added_start:added_end
+        ]
+
+    soft_embeds = torch.matmul(local_probs, embed_weight)
+    soft_embeds = tensor_model_parallel_all_reduce(soft_embeds)
+    return soft_embeds * normalizer
 
 
 class DiffusionGemmaRequestStates:
@@ -850,7 +880,7 @@ class DiffusionGemmaModelState(ModelState):
             t_max=gen["t_max"],
             entropy_bound=entropy_bound,
             confidence_threshold=gen["confidence_threshold"],
-            embed_weight=self.model.model.embed_tokens.weight,
+            embed_tokens=self.model.model.embed_tokens,
             normalizer=self.model.model.normalizer,
         ), None
 
@@ -1052,14 +1082,14 @@ class DiffusionSampler:
         t_min: float,
         t_max: float,
         entropy_bound: float,
-        embed_weight: torch.Tensor,
+        embed_tokens: Any,
         normalizer: torch.Tensor,
     ):
         self.sampling_states = sampler.sampling_states
         self.req_states = sampler.req_states
         # Self-conditioning soft embed = probs @ embed_weight * normalizer,
-        # computed in the sampler (see _compiled_sample_step).
-        self.embed_weight = embed_weight
+        # computed in the sampler after _compiled_sample_step.
+        self.embed_tokens = embed_tokens
         self.normalizer = normalizer
         self.canvas_length = (
             diffusion_config.canvas_length if diffusion_config is not None else 32
@@ -1281,9 +1311,6 @@ class DiffusionSampler:
             states.step,
             states.is_encoder_phase,
             states.confident,
-            states.self_conditioning_embeds,
-            self.embed_weight,
-            self.normalizer,
             states.accepted_canvas_history,
             states.accepted_canvas_history_len,
             # Output
@@ -1300,6 +1327,26 @@ class DiffusionSampler:
             ST=states.stability_threshold,
             entropy_bound=self.entropy_bound,
         )
+
+        # Store ``probs @ embed_weight`` (the value the next step's
+        # self-conditioning MLP consumes) only for slots that will denoise next
+        # — i.e. this step denoised AND it isn't about to commit. This lives
+        # outside _compiled_sample_step because embed_tokens.weight is
+        # vocabulary-sharded under tensor parallelism and needs a TP all-reduce.
+        sc_keep = (~is_committing) & ~states.is_encoder_phase[decode_slots]
+        if sc_keep.any():
+            probs = scaled.log_softmax(dim=-1).exp()
+            soft_embeds = _soft_embeddings_from_probs(
+                probs,
+                self.embed_tokens,
+                self.normalizer,
+            )
+            soft_embeds = soft_embeds.to(states.self_conditioning_embeds.dtype)
+            states.self_conditioning_embeds[decode_slots] = soft_embeds * sc_keep[
+                :, None, None
+            ].to(soft_embeds.dtype)
+        else:
+            states.self_conditioning_embeds[decode_slots] = 0
 
         # --- Logprobs: stash on convergence, return on commit ---
         slots_np = input_batch.idx_mapping_np[:num_reqs]


### PR DESCRIPTION



## Purpose

Fix DiffusionGemma self-conditioning when the LM head/embedding table is tensor-parallel sharded.

Fixes - https://github.com/vllm-project/vllm/issues/45719

Previously, the sampler computed soft self-conditioning embeddings as:

```python
soft_embeds = probs @ embed_weight
```

This assumes `embed_weight` contains the full vocabulary. Under tensor parallelism, each rank only owns a local vocab shard, so the full-vocab probability tensor is incompatible with the rank-local embedding table.

This PR moves the soft-embedding computation into a helper that:

1. preserves the existing full-vocab path for non-TP execution,
2. slices the full-vocab probabilities into each rank's local vocab shard,
3. handles both original and added vocab ranges using embed_tokens.shard_indices,
4. computes each rank's local hidden contribution,
5. all-reduces the hidden contribution across tensor-parallel ranks.

Conceptually, instead of requiring every rank to compute:
`P @ W`

each TP rank computes:
`P_r @ W_r`

and vLLM sums the result across TP ranks:
`sum_r(P_r @ W_r) == P @ W`

## Test Plan

Added `ests/model_executor/test_diffusion_gemma.py` covering:

1. full-vocab / non-sharded behavior,
2. tensor-parallel shard probability slicing,
3. error handling for vocab mismatch without shard metadata.

Local checks
```
python -m py_compile vllm/model_executor/models/diffusion_gemma.py tests/model_executor/test_diffusion_gemma.py
git diff --check
```

CI should run:

```
pytest tests/model_executor/test_diffusion_gemma.py
```

## Test Result
Local checks passed:
```
python -m py_compile vllm/model_executor/models/diffusion_gemma.py tests/model_executor/test_diffusion_gemma.py
git diff --check
```

I also validated the behavior locally with an 8-way tensor-parallel DiffusionGemma smoke test:

Before this change, the unpatched path fails at the old self-conditioning matmul because probs is full-vocab while `embed_weight` is rank-local:

```
RuntimeError: a and b must have the same reduction dim ... X [32768, 2816]

from user code:
  File "vllm/model_executor/models/diffusion_gemma.py", in _compiled_sample_step
    soft_embeds = torch.matmul(probs.to(embed_weight.dtype), embed_weight) * normalizer
```

After this change, the same TP configuration initializes and completes successfully.

Disclosure: This PR was developed with AI assistance. I reviewed the changed code and validated the behavior with the checks listed above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

