### PR TITLE
[Bugfix] Fix MiniMax M3 MSA prefill top-k contiguity

### DIFF
--- a/tests/kernels/attention/test_minimax_m3.py
+++ b/tests/kernels/attention/test_minimax_m3.py
@@ -2,10 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Correctness tests for MiniMax M3 sparse prefill attention kernels."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from vllm import _custom_ops as ops
+from vllm.forward_context import ForwardContext, override_forward_context
 from vllm.models.minimax_m3.common.indexer import (
     MiniMaxM3IndexerBackend,
 )
@@ -21,7 +24,12 @@ from vllm.models.minimax_m3.common.ops.sparse_attn import (
 )
 from vllm.models.minimax_m3.common.sparse_attention import (
     MiniMaxM3SparseBackend,
+    MiniMaxM3SparseMetadata,
+    MiniMaxM3SparsePrefillMetadata,
     MiniMaxM3SparseTritonImpl,
+)
+from vllm.models.minimax_m3.nvidia.sparse_attention_msa import (
+    MiniMaxM3SparseMSAImpl,
 )
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.utils import set_kv_cache_layout
@@ -79,6 +87,95 @@ BLOCK_SIZE = 128
 DTYPE = torch.bfloat16
 SM_SCALE = HEAD_DIM**-0.5
 TOPK = 16
+
+
+@pytest.mark.skipif(
+    not current_platform.is_device_capability_family(100),
+    reason="fmha_sm100 sparse attention requires SM100.",
+)
+def test_msa_prefill_materializes_noncontiguous_topk(monkeypatch):
+    import vllm.third_party.fmha_sm100.sparse as msa_sparse
+
+    num_tokens = 4
+    num_index_heads = 2
+    topk_blocks = 4
+    topk_buffer = torch.arange(
+        num_index_heads * 8 * topk_blocks,
+        device="cuda",
+        dtype=torch.int32,
+    ).view(num_index_heads, 8, topk_blocks)
+    prefill_topk = topk_buffer[:, :num_tokens, :]
+    assert not prefill_topk.is_contiguous()
+
+    observed_topk: torch.Tensor | None = None
+
+    def build_k2q_csr(topk, *args, **kwargs):
+        nonlocal observed_topk
+        observed_topk = topk
+        empty = torch.empty(0, device=topk.device, dtype=torch.int32)
+        return empty, empty, None
+
+    monkeypatch.setattr(msa_sparse, "build_k2q_csr", build_k2q_csr)
+    monkeypatch.setattr(msa_sparse, "sparse_atten_func", lambda *args, **kwargs: None)
+
+    prefill_metadata = MiniMaxM3SparsePrefillMetadata(
+        cu_seqlens_q=torch.tensor([0, num_tokens], device="cuda", dtype=torch.int32),
+        cu_seqlens_k=torch.tensor([0, BLOCK_SIZE], device="cuda", dtype=torch.int32),
+        seq_lens=torch.tensor([BLOCK_SIZE], device="cuda", dtype=torch.int32),
+        context_lens=torch.tensor([0], device="cuda", dtype=torch.int32),
+        block_table=torch.zeros(1, 1, device="cuda", dtype=torch.int32),
+        max_query_len=num_tokens,
+        max_seq_len=BLOCK_SIZE,
+        total_kv_blocks=1,
+    )
+    metadata = MiniMaxM3SparseMetadata(
+        seq_lens=prefill_metadata.seq_lens,
+        max_seq_len=BLOCK_SIZE,
+        slot_mapping=torch.arange(num_tokens, device="cuda"),
+        num_actual_tokens=num_tokens,
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_prefills=1,
+        num_prefill_tokens=num_tokens,
+        prefill=prefill_metadata,
+    )
+    forward_context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={"layer": metadata},
+        slot_mapping={},
+    )
+    impl = MiniMaxM3SparseMSAImpl(
+        num_heads=4,
+        head_size=HEAD_DIM,
+        scale=SM_SCALE,
+        num_kv_heads=2,
+        topk_blocks=topk_blocks,
+        sparse_block_size=BLOCK_SIZE,
+    )
+    query = torch.empty(num_tokens, 4 * HEAD_DIM, device="cuda", dtype=DTYPE)
+    output = torch.empty_like(query)
+    kv_cache = torch.empty(
+        1,
+        2,
+        BLOCK_SIZE,
+        2,
+        HEAD_DIM,
+        device="cuda",
+        dtype=DTYPE,
+    )
+
+    with override_forward_context(forward_context):
+        impl.forward(
+            SimpleNamespace(layer_name="layer"),
+            query,
+            kv_cache,
+            (None, prefill_topk),
+            output,
+        )
+
+    assert observed_topk is not None
+    assert observed_topk.is_contiguous()
+    torch.testing.assert_close(observed_topk, prefill_topk)
 
 
 @pytest.mark.parametrize(

--- a/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
+++ b/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
@@ -73,6 +73,8 @@ class MiniMaxM3SparseMSAImpl(MiniMaxM3SparseImpl):
 
             p = main_md.prefill
             assert p is not None and prefill_topk is not None
+            # Persistent top-k buffer slices can retain a padded head stride.
+            prefill_topk = prefill_topk.contiguous()
             qp = q[nd:]
             k_cache = kv_cache[:, 0].transpose(1, 2)
             v_cache = kv_cache[:, 1].transpose(1, 2)


### PR DESCRIPTION
## Purpose

`fmha_sm100.build_k2q_csr` requires `q2k_indices` to be contiguous with layout
`[head_kv, total_q, topK]`. MiniMax M3 prefill top-k indices can instead arrive
as a strided view of a persistent `[head_kv, max_tokens, topK]` buffer. The view
keeps the padded head stride, and `build_k2q_csr` raises:

```text
ValueError: q2k_indices must be contiguous with layout [head_kv, total_q, topK]
```

This change materializes the prefill view at the MSA consumer boundary before
CSR construction. Decode behavior is unchanged. It also adds an SM100
regression test that passes a non-contiguous persistent-buffer slice through
the real `MiniMaxM3SparseMSAImpl.forward` path and verifies that the CSR builder
receives a contiguous tensor.

This does not duplicate an open fix. Searches for `MiniMax M3 MSA contiguous`,
`q2k_indices contiguous`, and `build_k2q_csr contiguous` found no open PR.
[PR #45892](https://github.com/vllm-project/vllm/pull/45892) changes the top-k
producer to use a persistent buffer, but its current head still passes a
strided token slice to the MSA consumer. This PR enforces the kernel's input
contract at the consumer boundary.

AI assistance was used for repository research, implementation support, and
validation bookkeeping. This draft remains pending submitter review before it
is marked ready.

## Test Plan

```bash
.venv/bin/pre-commit run --files \
  vllm/models/minimax_m3/nvidia/sparse_attention_msa.py \
  tests/kernels/attention/test_minimax_m3.py

.venv/bin/python -m py_compile \
  vllm/models/minimax_m3/nvidia/sparse_attention_msa.py \
  tests/kernels/attention/test_minimax_m3.py

git diff --check
```

On an SM100 system:

```bash
.venv/bin/python -m pytest \
  tests/kernels/attention/test_minimax_m3.py \
  -k test_msa_prefill_materializes_noncontiguous_topk -v
```

## Test Result

- File-scoped pre-commit hooks passed, including Ruff, mypy, SPDX, forbidden
  import, and attention backend checks.
- `py_compile` passed for both changed files.
- `git diff --check` passed.
- The CUDA regression test was not run locally because the development host is
  macOS arm64 without an SM100 GPU. It is scoped to SM100 CI.

InferenceX applied the equivalent `.contiguous()` workaround and reran every
affected configuration. All 11 before jobs contain the exact
`q2k_indices must be contiguous` error; every matched after job succeeded.

| Hardware / mode | Configuration | Before | After |
| --- | --- | --- | --- |
| B200 STP eval | 8k1k, TP8/EP8, DPA, conc 128 | [27796120896 / 82258997626](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27796120896/job/82258997626) | [27805371252 / 82286104721](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27805371252/job/82286104721) |
| B200 STP serving | 1k1k, TP4/EP4, DPA, conc 512 | [27796120896 / 82258997980](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27796120896/job/82258997980) | [27805371252 / 82286104946](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27805371252/job/82286104946) |
| B200 STP serving | 8k1k, TP8/EP8, DPA, conc 128 | [27796120896 / 82258998241](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27796120896/job/82258998241) | [27805371252 / 82286105112](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27805371252/job/82286105112) |
| B200 MTP eval | 8k1k, TP4/EP4, DPA, conc 128 | [27796128080 / 82258553699](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27796128080/job/82258553699) | [27805369633 / 82381181398](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27805369633/job/82381181398) |
| B200 MTP serving | 8k1k, TP4/EP4, DPA, conc 64 | [27796128080 / 82258553751](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27796128080/job/82258553751) | [27805369633 / 82381182027](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27805369633/job/82381182027) |
| B200 MTP serving | 1k1k, TP4/EP4, DPA, conc 512 | [27796128080 / 82258554040](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27796128080/job/82258554040) | [27805369633 / 82381181344](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27805369633/job/82381181344) |
| B300 STP eval | 8k1k, TP8/EP8, DPA, conc 512 | [27796124175 / 82257972627](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27796124175/job/82257972627) | [27797429264 / 82261388213](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27797429264/job/82261388213) |
| B300 STP serving | 8k1k, TP8/EP8, DPA, conc 256 | [27796124175 / 82257972795](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27796124175/job/82257972795) | [27797429264 / 82261388444](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27797429264/job/82261388444) |
| B300 STP serving | 1k1k, TP4/EP4, DPA, conc 512 | [27796124175 / 82257972986](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27796124175/job/82257972986) | [27797429264 / 82261388813](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27797429264/job/82261388813) |
| B300 MTP eval | 8k1k, TP8/EP8, DPA, conc 128 | [27796130302 / 82258077334](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27796130302/job/82258077334) | [27805367644 / 82285179607](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27805367644/job/82285179607) |
| B300 MTP serving | 8k1k, TP8/EP8, DPA, conc 128 | [27796130302 / 82258077529](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27796130302/job/82258077529) | [27805367644 / 82285179818](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27805367644/job/82285179818) |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and root cause are described.
- [x] The test plan includes exact commands.
- [x] Local checks and external before/after results are included.
- [x] No documentation update is required.
</details>

