### PR TITLE
[CPUOffloadingManager] Maintain evictable list in LRUCachePolicy

### DIFF
--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -299,7 +299,6 @@ def test_cpu_manager():
 
     # prepare store [6, 7, 8] -> evicts [4, 5, 2] (oldest)
     prepare_store_output = cpu_manager.prepare_store(to_keys([6, 7, 8]), _EMPTY_REQ_CTX)
-    print(f"{prepare_store_output=}")
     verify_store_output(
         prepare_store_output,
         ExpectedPrepareStoreOutput(

--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -294,25 +294,26 @@ def test_cpu_manager():
     # prepare store with no space ([2, 3] is being loaded)
     assert cpu_manager.prepare_store(to_keys([6, 7, 8]), _EMPTY_REQ_CTX) is None
 
-    # complete load [2, 3]
+    # complete load [2, 3]. Load changes the eviction list, making 2, 3 recent.
     cpu_manager.complete_load(to_keys([2, 3]), _EMPTY_REQ_CTX)
 
-    # prepare store [6, 7, 8] -> evicts [2, 3, 4] (oldest)
+    # prepare store [6, 7, 8] -> evicts [4, 5, 2] (oldest)
     prepare_store_output = cpu_manager.prepare_store(to_keys([6, 7, 8]), _EMPTY_REQ_CTX)
+    print(f"{prepare_store_output=}")
     verify_store_output(
         prepare_store_output,
         ExpectedPrepareStoreOutput(
             keys_to_store=[6, 7, 8],
-            store_block_ids=[3, 2, 1],
-            evicted_keys=[2, 3, 4],
+            store_block_ids=[1, 0, 3],
+            evicted_keys=[4, 5, 2],
         ),
     )
 
     # complete store [6, 7, 8]
     cpu_manager.complete_store(to_keys([6, 7, 8]), _EMPTY_REQ_CTX)
 
-    # touch [5, 6, 7] (move to end of LRU order)
-    cpu_manager.touch(to_keys([5, 6, 7]), _EMPTY_REQ_CTX)
+    # touch [3, 6, 7] (move to end of LRU order)
+    cpu_manager.touch(to_keys([3, 6, 7]), _EMPTY_REQ_CTX)
 
     # prepare store [7, 9] -> evicts [8] (oldest following previous touch)
     prepare_store_output = cpu_manager.prepare_store(to_keys([9]), _EMPTY_REQ_CTX)
@@ -320,7 +321,7 @@ def test_cpu_manager():
         prepare_store_output,
         ExpectedPrepareStoreOutput(
             keys_to_store=[9],
-            store_block_ids=[1],
+            store_block_ids=[3],
             evicted_keys=[8],
         ),
     )
@@ -335,7 +336,7 @@ def test_cpu_manager():
     verify_events(
         cpu_manager.take_events(),
         expected_stores=({3, 4, 5}, {6, 7, 8}),
-        expected_evictions=({2, 3, 4}, {8}),
+        expected_evictions=({4, 5, 2}, {8}),
     )
 
 

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -295,6 +295,8 @@ class TestTieringOffloadingManager:
         self.manager.prepare_store(blocks, _CTX)
         self.manager.complete_store(blocks, _CTX, success=True)
         self._simulate_on_schedule_end()
+        # for secondary tiers to drain jobs, so primary tier's blocks are evictable.
+        self._simulate_on_schedule_end()
 
         self.secondary_tier1.touch = MagicMock(wraps=self.secondary_tier1.touch)
         self.secondary_tier2.touch = MagicMock(wraps=self.secondary_tier2.touch)
@@ -303,7 +305,7 @@ class TestTieringOffloadingManager:
         self.manager.touch(blocks, _CTX)
 
         # Verify touch was called on primary tier (check LRU order)
-        primary_keys = list(self.primary_tier._policy.blocks.keys())
+        primary_keys = list(self.primary_tier._policy.evictable_blocks.keys())
         assert primary_keys[-3:] == list(reversed(blocks))
 
         # Verify touch was propagated to all secondary tiers

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -140,6 +140,7 @@ class CPUOffloadingManager(OffloadingManager):
             assert block is not None, f"Block {key!r} not found in cache"
             assert block.is_ready, f"Block {key!r} is not ready for reading"
             if block.ref_cnt == 0:
+                self._policy.mark_non_evictable(key)
                 self._num_evictable_cache_blocks -= 1  # ref_cnt 0 -> 1
                 assert self._num_evictable_cache_blocks >= 0
             block.ref_cnt += 1
@@ -161,6 +162,7 @@ class CPUOffloadingManager(OffloadingManager):
             block.ref_cnt -= 1
             if block.ref_cnt == 0:
                 self._num_evictable_cache_blocks += 1  # ref_cnt 1 -> 0
+                self._policy.mark_evictable(key)
 
     @override
     def prepare_store(
@@ -248,6 +250,7 @@ class CPUOffloadingManager(OffloadingManager):
                 if block is not None and not block.is_ready:
                     block.ref_cnt = 0
                     self._num_evictable_cache_blocks += 1
+                    self._policy.mark_evictable(key)
                     stored_keys.append(key)
         else:
             for key in keys:

--- a/vllm/v1/kv_offload/cpu/policies/base.py
+++ b/vllm/v1/kv_offload/cpu/policies/base.py
@@ -82,3 +82,11 @@ class CachePolicy(ABC):
 
         Ghost lists and adaptive state are also reset.
         """
+
+    def mark_evictable(self, key: OffloadKey) -> None:
+        """Called when a block's ref_cnt transitions to 0."""
+        return
+
+    def mark_non_evictable(self, key: OffloadKey) -> None:
+        """Called when a block's ref_cnt transitions from 0."""
+        return

--- a/vllm/v1/kv_offload/cpu/policies/lru.py
+++ b/vllm/v1/kv_offload/cpu/policies/lru.py
@@ -8,13 +8,23 @@ from typing_extensions import override
 from vllm.v1.kv_offload.base import OffloadKey
 from vllm.v1.kv_offload.cpu.policies.base import BlockStatus, CachePolicy
 
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 
 class LRUCachePolicy(CachePolicy):
-    """LRU cache policy backed by a single OrderedDict."""
+    """
+    LRU Caching policy that keeps a dedicated evictable list for fast eviction.
+    A use is indicated by,
+     - First time the key is added (store).
+     - Load job completion
+     - touch
+    """
 
     def __init__(self, cache_capacity: int):
-        # cache_capacity unused by LRU but accepted for a uniform constructor
-        self.blocks: OrderedDict[OffloadKey, BlockStatus] = OrderedDict()
+        # Blocks with ref_cnt 0 (not participating in any loads/stores) ordered in LRU
+        self.evictable_blocks: OrderedDict[OffloadKey, None] = OrderedDict()
+        self.blocks: dict[OffloadKey, BlockStatus] = {}
 
     @override
     def get(self, key: OffloadKey) -> BlockStatus | None:
@@ -23,19 +33,25 @@ class LRUCachePolicy(CachePolicy):
     @override
     def insert(self, key: OffloadKey, block: BlockStatus) -> None:
         self.blocks[key] = block
+        if block.ref_cnt == 0:
+            self.evictable_blocks[key] = None
 
     @override
     def remove(self, key: OffloadKey) -> None:
         del self.blocks[key]
+        self.evictable_blocks.pop(key, None)
 
     @override
     def touch(self, keys: Iterable[OffloadKey]) -> None:
         for key in reversed(list(keys)):
-            if key in self.blocks:
-                self.blocks.move_to_end(key)
+            if key in self.evictable_blocks:
+                self.evictable_blocks.move_to_end(key)
+            # active blocks are untouched as they are non-evictable now. They
+            # will eventually reach the end of evictable_blocks when they finish.
 
     @override
     def clear(self) -> None:
+        self.evictable_blocks.clear()
         self.blocks.clear()
 
     @override
@@ -44,14 +60,33 @@ class LRUCachePolicy(CachePolicy):
     ) -> list[tuple[OffloadKey, BlockStatus]] | None:
         if n == 0:
             return []
+
         candidates: list[tuple[OffloadKey, BlockStatus]] = []
-        for key, block in self.blocks.items():
-            if block.ref_cnt == 0 and key not in protected:
-                candidates.append((key, block))
-                if len(candidates) == n:
-                    break
+        for key, _ in self.evictable_blocks.items():
+            if key in protected:
+                continue
+
+            block = self.blocks[key]
+            assert block.ref_cnt == 0
+            candidates.append((key, block))
+            if len(candidates) == n:
+                break
+
         if len(candidates) < n:
             return None
         for key, _ in candidates:
+            del self.evictable_blocks[key]
             del self.blocks[key]
         return candidates
+
+    @override
+    def mark_evictable(self, key: OffloadKey) -> None:
+        # blocks can become evictable when,
+        # store completes - i.e. ref_cnt -1 -> 0 # not in evictable list
+        # all loads complete - i.e ref_cnt 1 -> 0  # not in evictable list
+        self.evictable_blocks[key] = None
+
+    @override
+    def mark_non_evictable(self, key: OffloadKey) -> None:
+        # key must have been in the evictable list.
+        del self.evictable_blocks[key]

--- a/vllm/v1/kv_offload/cpu/policies/lru.py
+++ b/vllm/v1/kv_offload/cpu/policies/lru.py
@@ -8,9 +8,6 @@ from typing_extensions import override
 from vllm.v1.kv_offload.base import OffloadKey
 from vllm.v1.kv_offload.cpu.policies.base import BlockStatus, CachePolicy
 
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
 
 class LRUCachePolicy(CachePolicy):
     """


### PR DESCRIPTION
## Purpose
Add evictable list to LRUCachePolicy for fast evictions.

#### Why
`vllm serve command` : 
```
KV_TRANSFER_CONFIG=$(cat <<EOF
{
  "kv_connector": "OffloadingConnector",
  "kv_role": "kv_both",
  "kv_connector_extra_config": {
    "spec_name": "TieringOffloadingSpec",
    "cpu_bytes_to_use": 429496729600,
    "eviction_policy": "lru",
    "secondary_tiers": [{
      "type": "fs",
      "root_dir": "/mnt/nvme_storage"
    }]
  }
}
EOF
)

vllm serve google/gemma-4-31B-it \
        --chat-template  "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>\n'}}{% endfor %}{% if add_generation_prompt %}{{'<|im_start|>assistant\n'}}{% endif %}" \
      --tensor-parallel-size=2 \
      --kv-transfer-config "${KV_TRANSFER_CONFIG}" \
      --enable-prefix-caching \
      --no-enable-prefix-caching \
      --no-disable-hybrid-kv-cache-manager
```
`guidellm command`
```
TARGET_URL="http://localhost:8000"
BENCH_RATE="100"
BENCH_RATE_TYPE="concurrent"
BENCH_MAX_SECONDS="700"
BENCH_RANDOM_SEED="889"
BENCH_TURNS=5
BENCH_PROMPT_TOKENS="128"
BENCH_OUTPUT_TOKENS="128"
BENCH_PREFIX_TOKENS="10000"
PREFIX_COUNT=$((2 * BENCH_RATE))

DATA="{\"prompt_tokens\":${BENCH_PROMPT_TOKENS},\"output_tokens\":${BENCH_OUTPUT_TOKENS},\"prefix_tokens\":${BENCH_PREFIX_TOKENS},\"turns\":${BENCH_TURNS},\"prefix_count\":${PREFIX_COUNT}}"

guidellm benchmark run \
  --target="${TARGET_URL}" \
  --rate-type="${BENCH_RATE_TYPE}" \
  --rate="${BENCH_RATE}" \
  --max-seconds="${BENCH_MAX_SECONDS}" \
  --random-seed="${BENCH_RANDOM_SEED}" \
  --data="${DATA}" \
  --sample-requests=0
```

##### main
```
ℹ Server Throughput Statistics (All Requests)
|============|=======|=======|=========|==============|===============|==============|
| Benchmark  | Requests              ||| Input Tokens | Output Tokens | Total Tokens |
| Strategy   | Concurrency  || Per Sec | Per Sec      | Per Sec       | Per Sec      |
|            | Mdn   | Mean  | Mean                                               ||||
|------------|-------|-------|---------|--------------|---------------|--------------|
| concurrent | 100.0 | 100.0 | 0.1     | 1936.9       | 22.1          | 1959.0       |
|============|=======|=======|=========|==============|===============|==============|
```
<img width="1140" height="290" alt="main-fs-offload-throughput" src="https://github.com/user-attachments/assets/7f510392-a9df-4897-9e1e-7cf20d797342" />

py-spy top --pid <engine-core-pid>
<img width="856" height="458" alt="main-fs-offload" src="https://github.com/user-attachments/assets/2d42c5c9-7685-400f-879d-070e2a7d5c33" />

As can be seen from the py-spy output, the `evict` operation is very expensive. 

##### PR
```
ℹ Server Throughput Statistics (All Requests)
|============|=======|=======|=========|==============|===============|==============|
| Benchmark  | Requests              ||| Input Tokens | Output Tokens | Total Tokens |
| Strategy   | Concurrency  || Per Sec | Per Sec      | Per Sec       | Per Sec      |
|            | Mdn   | Mean  | Mean                                               ||||
|------------|-------|-------|---------|--------------|---------------|--------------|
| concurrent | 100.0 | 100.0 | 1.1     | 11562.3      | 138.0         | 11700.3      |
|============|=======|=======|=========|==============|===============|==============|
```
<img width="1145" height="296" alt="prom-fs-pr" src="https://github.com/user-attachments/assets/09857775-8bcd-4799-8079-6c5e37a113d1" />
<img width="1293" height="639" alt="py-spy PR" src="https://github.com/user-attachments/assets/04d66790-3764-4577-8d6d-8f4aa21cd95f" />

There is still performance on the table. The `lookup` and `get` functions are interrupting the scheduler loop.  

## Test Plan

## Test Result