### PR TITLE
[Bugfix] MLA: use _kv_b_proj_w_dtype for chunked-prefill cast (fix AWQ/GPTQ crash)

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2118,7 +2118,7 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
             if (
                 use_fp8_prefill or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
             ) and _kv_b_proj_w_dtype != torch.uint8:
-                kv_c_normed = kv_c_normed.to(self.kv_b_proj.weight.dtype)
+                kv_c_normed = kv_c_normed.to(_kv_b_proj_w_dtype)
 
             k_pe = workspace[:toks][..., self.kv_lora_rank :].unsqueeze(1)
             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(


### PR DESCRIPTION
## Purpose

In `MLAAttention._compute_prefill_context`, `_kv_b_proj_w_dtype` is computed with an AWQ/GPTQ-safe fallback (it uses `params_dtype` when the quantized layer has no `.weight`), and the surrounding `if` condition already uses this variable. However, the cast on the next line still dereferences `self.kv_b_proj.weight.dtype` directly:

```python
_kv_b_proj_w_dtype = (
    self.kv_b_proj.weight.dtype
    if hasattr(self.kv_b_proj, "weight")
    else self.kv_b_proj.params_dtype
)
if (
    use_fp8_prefill or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
) and _kv_b_proj_w_dtype != torch.uint8:
    kv_c_normed = kv_c_normed.to(self.kv_b_proj.weight.dtype)  # <-- still raw .weight
```

For weight-only quantized MLA models (AWQ / GPTQ), `kv_b_proj` is a quantized linear that has **no `.weight` attribute**, so this raises:

```
AttributeError: 'ColumnParallelLinear' object has no attribute 'weight'
```

Because it lives in `_compute_prefill_context`, it only triggers on **chunked prefill** (prompts long enough to exceed the prefill chunk size). Short prompts skip this path entirely, so the bug is easy to miss in basic testing and only shows up under long-context requests.

Affected: any AWQ/GPTQ-quantized MLA model (DeepSeek-V3/V3.2, GLM-4.5/4.6/5.x, etc.) served with chunked prefill.

## Fix

Use the already-computed `_kv_b_proj_w_dtype` for the cast — consistent with the comment immediately above it ("For quantized layers (AWQ/GPTQ) that lack a `.weight` attribute, use `params_dtype`") and with the condition that guards the cast. One-line change.

## Test Plan

1. Serve an AWQ-quantized MLA model with chunked prefill enabled (default), e.g. a DeepSeek-V3 or GLM AWQ checkpoint.
2. Send a prompt long enough to trigger chunked prefill (> `max_num_batched_tokens`).
   - **Before:** worker crashes during prefill with `'ColumnParallelLinear' object has no attribute 'weight'`.
   - **After:** request completes normally.
3. Short prompts are unaffected (they never enter this path), so existing behavior is preserved.
