### PR TITLE
[ROCm] [Bugfix] Bugfix ROCm Sparse Indexer

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -58,7 +58,9 @@ def _indexer_k_quant_and_cache_kernel(
     slot_id = tl.load(slot_mapping_ptr + tid)
     if slot_id < 0:
         return
-    block_id = slot_id // block_size
+    # The packed KV layout makes per-block strides large
+    # enough that block_id * stride can exceed 32-bit range.
+    block_id = (slot_id // block_size).to(tl.int64)
     block_offset = slot_id % block_size
     tile_block_id = block_offset // BLOCK_TILE_SIZE
     tile_block_offset = block_offset % BLOCK_TILE_SIZE
@@ -179,7 +181,9 @@ def _cp_gather_indexer_quant_cache_kernel(
         block_table_ptr + block_table_offset, mask=valid_block_table, other=-1
     )
     valid_block = valid_block_table & (block_id >= 0) & (block_id < NUM_BLOCKS)
-    safe_block_id = tl.where(valid_block, block_id, 0)
+    # The packed KV layout makes per-block strides large
+    # enough that block_id * stride can exceed 32-bit range.
+    safe_block_id = tl.where(valid_block, block_id, 0).to(tl.int64)
     safe_block_offset = tl.where(valid_block, block_offset, 0)
     tiled_block_offset = safe_block_offset % BLOCK_TILE_SIZE
     if LAYOUT == "SHUFFLE":


### PR DESCRIPTION



## Purpose

Cause: PR https://github.com/vllm-project/vllm/pull/44577 exposed a ROCm AITER sparse-indexer bug. The packed KV layout makes per-block strides large enough that `block_id * stride` can exceed 32-bit range. 

Fix: widened the physical block id to tl.int64 before cache-stride arithmetic in both indexer cache insert and gather paths
  
  
  Error log
  
```
  (Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]   File "/app/dsv4opt/optswakernel/vllm/compilation/breakable_cudagraph.py", line 97, in wrapper
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]     return fn(*args, **kwargs)
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]            ^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]   File "/app/dsv4opt/optswakernel/vllm/models/deepseek_v4/attention.py", line 505, in attention_impl
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]     self.forward_mqa(q, kv, positions, out)
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]   File "/app/dsv4opt/optswakernel/vllm/models/deepseek_v4/amd/rocm.py", line 668, in forward_mqa
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]     self._forward_decode(
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]   File "/app/dsv4opt/optswakernel/vllm/models/deepseek_v4/amd/rocm.py", line 717, in _forward_decode
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]     rocm_sparse_attn_decode(
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]   File "/app/dsv4opt/optswakernel/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py", line 2372, in rocm_sparse_attn_decode
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]     attn_out = _rocm_sparse_attn_decode_triton(
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]   File "/app/dsv4opt/optswakernel/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py", line 2260, in _rocm_sparse_attn_decode_triton
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]     return _rocm_sparse_attn_decode_ragged_triton( 
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]   File "/app/dsv4opt/optswakernel/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py", line 2154, in _rocm_sparse_attn_decode_ragged_triton
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]     _sparse_attn_decode_partial_kernel[(num_queries, num_splits, heads_blocks)](
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]   File "/usr/local/lib/python3.12/dist-packages/triton/runtime/jit.py", line 370, in <lambda>
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]   File "/usr/local/lib/python3.12/dist-packages/triton/runtime/jit.py", line 700, in run
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]     device = driver.active.get_current_device()
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]   File "/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py", line 1149, in current_device
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]     return torch._C._cuda_getDevice()
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990]            ^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990] torch.AcceleratorError: CUDA error: an illegal memory access was encountered
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990] Search for `hipErrorIllegalAddress' in https://rocm.docs.amd.com/projects/HIP/en/latest/index.html for more information.
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990] CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990] For debugging consider passing AMD_SERIALIZE_KERNEL=3
(Worker_TP1 pid=318032) ERROR 06-20 05:55:22 [multiproc_executor.py:990] Device-side assertion tracking was not enabled by user.
```

## Test Plan

lmeval of DeepSeek V4 Pro and GLM 5.2 -FP8

## Test Result

```
local-completions ({'model': 'deepseek-ai/DeepSeek-V4-Pro', 'base_url': 'http://0.0.0.0:8000/v1/completions', 'num_concurrent': 256, 'max_retries': 10, 'max_gen_toks': 2048, 'max_length': 1048576, 'timeout': 60000}), gen_kwargs: ({}), limit: None, num_fewshot: 20, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|_  |0.9409|_  |0.0065|
|     |       |strict-match    |    20|exact_match|_  |0.9416|_  |0.0065|
```

```
local-completions ({'model': 'zai-org/GLM-5.2-FP8', 'base_url': 'http://0.0.0.0:8001/v1/completions', 'num_concurrent': 256, 'max_retries': 10, 'max_gen_toks': 2048, 'max_length': 1048576, 'timeout': 60000}), gen_kwargs: ({}), limit: None, num_fewshot: 30, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    30|exact_match|_  |0.9462|_  |0.0062|
|     |       |strict-match    |    30|exact_match|_  |0.9469|_  |0.0062|
```

```
(APIServer pid=21246) INFO 06-20 08:22:17 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 4.33, Accepted throughput: 158.40 tokens/s, Drafted throughput: 237.50 tokens/s, Accepted: 1584 tokens, Drafted: 2375 tokens, Per-position acceptance rate: 0.952, 0.846, 0.657, 0.512, 0.368, Avg Draft acceptance rate: 66.7%
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

