### PR TITLE
[Bugfix] Quiet weight prefetch logs during shutdown

### DIFF
--- a/tests/model_executor/test_weight_utils.py
+++ b/tests/model_executor/test_weight_utils.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import logging
 import tempfile
 
 import huggingface_hub.constants
 import pytest
 from huggingface_hub.utils import LocalEntryNotFoundError
 
+from vllm.model_executor.model_loader import weight_utils
 from vllm.model_executor.model_loader.weight_utils import (
+    _prefetch_all_checkpoints,
     download_weights_from_hf,
     maybe_remap_kv_scale_name,
 )
@@ -279,6 +282,58 @@ class TestKvCacheScaleMapper:
             combined._map_name("model.layers.0.self_attn.k_scale")
             == "model.layers.0.self_attn.attn.k_scale"
         )
+
+
+def test_prefetch_quiet_on_executor_shutdown(monkeypatch, caplog):
+    class ShutdownExecutor:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def submit(self, *_args, **_kwargs):
+            raise RuntimeError("cannot schedule new futures after shutdown")
+
+    monkeypatch.setattr(
+        weight_utils.concurrent.futures, "ThreadPoolExecutor", ShutdownExecutor
+    )
+
+    paths = [f"/tmp/shard-{i}.safetensors" for i in range(16)]
+    with caplog.at_level(logging.DEBUG, logger=weight_utils.logger.name):
+        thread = _prefetch_all_checkpoints(paths)
+        thread.join(timeout=5.0)
+        assert not thread.is_alive(), "prefetch thread did not finish"
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and r.name == weight_utils.logger.name
+    ]
+    assert warnings == []
+
+
+def test_prefetch_warns_on_checkpoint_failure(monkeypatch, caplog):
+    def raise_prefetch_error(*_args, **_kwargs) -> None:
+        raise RuntimeError("disk read failed")
+
+    monkeypatch.setattr(weight_utils, "_prefetch_checkpoint", raise_prefetch_error)
+
+    paths = [f"/tmp/shard-{i}.safetensors" for i in range(2)]
+    with caplog.at_level(logging.WARNING, logger=weight_utils.logger.name):
+        thread = _prefetch_all_checkpoints(paths)
+        thread.join(timeout=5.0)
+        assert not thread.is_alive(), "prefetch thread did not finish"
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and r.name == weight_utils.logger.name
+    ]
+    assert len(warnings) == len(paths)
 
 
 if __name__ == "__main__":

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Utilities for downloading and initializing model weights."""
 
-import asyncio
 import concurrent.futures
 import fnmatch
 import glob
@@ -63,6 +62,11 @@ except ImportError:
 from vllm.model_executor.layers.quantization.torchao import torchao_version_at_least
 
 logger = init_logger(__name__)
+
+_EXECUTOR_SHUTDOWN_MSGS = (
+    "cannot schedule new futures after shutdown",
+    "cannot schedule new futures after interpreter shutdown",
+)
 
 # use system-level temp directory for file locks, so that multiple users
 # can share the same lock without error.
@@ -746,7 +750,7 @@ def _prefetch_all_checkpoints(
     sorted_files: list[str],
     num_prefetch_threads: int = DEFAULT_SAFETENSORS_PREFETCH_NUM_THREADS,
     block_size: int = DEFAULT_SAFETENSORS_PREFETCH_BLOCK_SIZE,
-) -> None:
+) -> threading.Thread:
     """Start prefetching checkpoint files into page cache in a background thread."""
     if num_prefetch_threads < 1:
         raise ValueError("safetensors prefetch num threads must be >= 1")
@@ -762,51 +766,77 @@ def _prefetch_all_checkpoints(
     paths_to_prefetch = sorted_files[rank::world_size]
     total_for_rank = len(paths_to_prefetch)
 
-    async def _prefetch_all() -> None:
-        loop = asyncio.get_running_loop()
+    def _prefetch_all() -> bool:
         completed = 0
         next_log_pct = 10
+        aborted = False
 
-        async def prefetch_one(
-            path: str,
-            executor: concurrent.futures.ThreadPoolExecutor,
-        ) -> None:
+        def handle_done(path: str) -> None:
             nonlocal completed, next_log_pct
-            try:
-                await loop.run_in_executor(
-                    executor, _prefetch_checkpoint, path, block_size
-                )
-                completed += 1
-                if total_for_rank > 0 and next_log_pct <= 100:
-                    pct = 100 * completed / total_for_rank
-                    if pct >= next_log_pct:
-                        logger.info(
-                            "Prefetching checkpoint files: %d%% (%d/%d)",
-                            next_log_pct,
-                            completed,
-                            total_for_rank,
-                        )
-                        next_log_pct += 10
-            except Exception:
-                logger.warning(
-                    "Failed to prefetch checkpoint file %r.", path, exc_info=True
-                )
+            completed += 1
+            if total_for_rank > 0 and next_log_pct <= 100:
+                pct = 100 * completed / total_for_rank
+                if pct >= next_log_pct:
+                    logger.info(
+                        "Prefetching checkpoint files: %d%% (%d/%d)",
+                        next_log_pct,
+                        completed,
+                        total_for_rank,
+                    )
+                    next_log_pct += 10
 
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=num_prefetch_threads
         ) as executor:
-            await asyncio.gather(
-                *(prefetch_one(p, executor) for p in paths_to_prefetch)
-            )
+            future_to_path: dict[concurrent.futures.Future[None], str] = {}
+            for path in paths_to_prefetch:
+                try:
+                    future_to_path[
+                        executor.submit(_prefetch_checkpoint, path, block_size)
+                    ] = path
+                except RuntimeError as e:
+                    if any(msg in str(e) for msg in _EXECUTOR_SHUTDOWN_MSGS):
+                        aborted = True
+                        logger.debug(
+                            "Aborting checkpoint prefetch because the executor "
+                            "is shutting down."
+                        )
+                        break
+                    logger.warning(
+                        "Failed to submit checkpoint prefetch for %r.",
+                        path,
+                        exc_info=True,
+                    )
+
+            for future in concurrent.futures.as_completed(future_to_path):
+                path = future_to_path[future]
+                try:
+                    future.result()
+                except Exception:
+                    logger.warning(
+                        "Failed to prefetch checkpoint file %r.",
+                        path,
+                        exc_info=True,
+                    )
+                else:
+                    handle_done(path)
+
+        return aborted
 
     def _run_prefetch() -> None:
         start = time.perf_counter()
-        asyncio.run(_prefetch_all())
+        aborted = _prefetch_all()
         elapsed = time.perf_counter() - start
-        logger.info(
-            "Prefetching checkpoint files into page cache finished in %.2fs",
-            elapsed,
-        )
+        if aborted:
+            logger.info(
+                "Prefetching checkpoint files interrupted by shutdown after %.2fs",
+                elapsed,
+            )
+        else:
+            logger.info(
+                "Prefetching checkpoint files into page cache finished in %.2fs",
+                elapsed,
+            )
 
     logger.info(
         "Prefetching checkpoint files into page cache started "
@@ -814,7 +844,9 @@ def _prefetch_all_checkpoints(
         num_prefetch_threads,
         block_size,
     )
-    threading.Thread(target=_run_prefetch, daemon=True).start()
+    thread = threading.Thread(target=_run_prefetch, daemon=True)
+    thread.start()
+    return thread
 
 
 def safetensors_weights_iterator(


### PR DESCRIPTION
## Purpose

Fixes #40564.

When model startup fails after checkpoint prefetch has started, the background prefetcher can encounter executor/interpreter shutdown while scheduling remaining shard reads. The previous asyncio-based implementation logged one warning traceback per remaining shard, burying the real startup failure.

This change keeps prefetching in the daemon background thread but uses a local `ThreadPoolExecutor` directly. If task submission sees the known executor/interpreter shutdown RuntimeError, prefetching is marked as interrupted and the shutdown path is logged without warning spam. Normal checkpoint read failures still emit warning tracebacks.

## Duplicate-work check

AI assistance was used for this change, and I reviewed the changed lines before submitting.

I checked:

- `gh issue view 40564 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search "40564 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "prefetch checkpoint weight_utils"`

There is no open PR for this issue. I also found the closed #40615, which attempted a similar fix but was not merged and the issue remains open.

## Tests

Passed:

```text
git diff --check HEAD~1..HEAD
uv run --no-project python -m compileall -q vllm/model_executor/model_loader/weight_utils.py tests/model_executor/test_weight_utils.py
```

Added focused unit coverage for:

- executor shutdown during checkpoint prefetch submission does not produce warning-level log spam
- ordinary checkpoint prefetch failures still produce warnings

## Validation limits

I could not run the targeted pytest locally on this Windows workstation because importing vLLM tries to load the unbuilt platform extension:

```text
ModuleNotFoundError: No module named 'vllm._C_stable_libtorch'
```

WSL was not usable for validation in this session because even minimal `wsl -e /bin/true` invocations were hanging, and I did not restart WSL to avoid disrupting the user's environment.
