### PR TITLE
[Bugfix] Ensure NIXL host ignored for torch.compile cache hash

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2076,6 +2076,8 @@ def compile_factors() -> dict[str, object]:
         "VLLM_ENABLE_CUDA_COMPATIBILITY",
         "VLLM_CUDA_COMPATIBILITY_PATH",
         "VLLM_SKIP_MODEL_NAME_VALIDATION",
+        "VLLM_NIXL_SIDE_CHANNEL_HOST",
+        "VLLM_NIXL_SIDE_CHANNEL_PORT",
         "LOCAL_RANK",
         "CUDA_VISIBLE_DEVICES",
         "NO_COLOR",


### PR DESCRIPTION



## Purpose

The torch.compile hash changes everytime a pod is restarted when using the pod's IP for NIXL connections.

Detail discovered with vllm 0.20.1 used by Dynamo 1.2.0:

https://github.com/ai-dynamo/dynamo/issues/10695

## Test Plan

Verify NIXL enabled pod can re-use the cache

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

