### PR TITLE
[Bugfix] Fix type-sensitive tool argument coercion

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -681,6 +681,15 @@ class TestFixArgTypes:
         assert parsed["active"] is True
         assert parsed["score"] == 3.14
 
+    @pytest.mark.parametrize(("raw", "expected"), [(1, True), (0, False)])
+    def test_numeric_boolean_coerced(self, raw, expected):
+        tool = _make_tool("f", {"flag": {"type": "boolean"}})
+        engine = _make_engine(tools=[tool])
+
+        result = engine._fix_arg_types(json.dumps({"flag": raw}), "f")
+
+        assert json.loads(result)["flag"] is expected
+
     def test_nested_object_coercion(self):
         tool = _make_tool(
             "f",

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -684,6 +684,15 @@ class TestFixArgTypes:
         assert parsed["active"] is True
         assert parsed["score"] == 3.14
 
+    @pytest.mark.parametrize(("raw", "expected"), [(1, True), (0, False)])
+    def test_numeric_boolean_coerced(self, raw, expected):
+        tool = _make_tool("f", {"flag": {"type": "boolean"}})
+        engine = _make_engine(tools=[tool])
+
+        result = engine._fix_arg_types(json.dumps({"flag": raw}), "f")
+
+        assert json.loads(result)["flag"] is expected
+
     def test_nested_object_coercion(self):
         tool = _make_tool(
             "f",

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -245,7 +245,7 @@ class ParserEngine(Parser):
         types = extract_types_from_schema(schema)
         as_str = json.dumps(value, ensure_ascii=False)
         coerced = coerce_to_schema_type(as_str, types)
-        if coerced != value:
+        if type(coerced) is not type(value) or coerced != value:
             return coerced, True
         return value, False
 


### PR DESCRIPTION
## Purpose

Fix schema-aware tool argument coercion when the coerced value compares equal to the original value but has a different type.

Python considers `1 == True` and `0 == False`, so numeric values for boolean parameters were incorrectly treated as unchanged and remained integers.

This change compares both type and value, ensuring `1`/`0` are correctly converted to `true`/`false`.

## Test Plan

```bash
pytest tests/parser/engine/test_parser_engine.py::TestFixArgTypes::test_numeric_boolean_coerced -q
pytest tests/parser/engine -q
ruff check vllm/parser/engine/parser_engine.py tests/parser/engine/test_parser_engine.py
ruff format --check vllm/parser/engine/parser_engine.py tests/parser/engine/test_parser_engine.py
```

## Test Result

- Targeted regression tests: `2 passed`
- Parser engine suite: `2094 passed`
- Ruff and formatting checks passed

AI assistance was used to identify the issue and prepare the fix. The changes were reviewed and tested manually.
