### PR TITLE
[Kernel] ReplaySSM opt-in AR decode for Mamba2 (#46187)

### DIFF
--- a/benchmarks/replayssm/bench_decode_ssu.py
+++ b/benchmarks/replayssm/bench_decode_ssu.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Batch-1 microbenchmark for the ReplaySSM Mamba2 AR-decode kernels.
+
+Compares the stored-state baseline ``selective_state_update`` against the
+ReplaySSM replay kernels ("output_only" / "state_and_output") for a single
+decode step, at batch size 1, on representative per-layer Mamba2 shapes.
+
+Reports per-step latency (averaged over a full ring window so flush steps are
+amortized) and the analytical per-step HBM traffic for the recurrent state +
+ring buffer. The core claim is the write-traffic reduction: the baseline writes
+the full SSM state every step; ReplaySSM writes it only once per ``buffer_len``
+steps and otherwise appends the (much smaller) input buffer.
+
+Usage:
+    python benchmarks/replayssm/bench_decode_ssu.py
+    python benchmarks/replayssm/bench_decode_ssu.py --buffer-len 16 --dtype bfloat16
+"""
+
+import argparse
+
+import torch
+
+from vllm.model_executor.layers.mamba.ops.mamba_ssm import selective_state_update
+from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_output_only import (  # noqa: E501
+    selective_state_update_replayssm_output_only,
+)
+from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_state_and_output import (  # noqa: E501
+    selective_state_update_replayssm_state_and_output,
+)
+
+# (name, nheads, headdim, dstate, ngroups) — representative hybrid-SSM configs.
+CONFIGS = [
+    ("mamba2-small", 64, 64, 128, 1),
+    ("mamba2-ng8", 80, 64, 128, 8),
+    ("mamba2-large", 128, 64, 128, 8),
+]
+
+
+def _bytes(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def analytical_traffic(nheads, headdim, dstate, ngroups, buffer_len, route, itype):
+    """Per-step HBM bytes (steady state) for state + buffer, batch=1.
+
+    The state read happens every step in all paths (the checkpoint readout needs
+    the current C). The difference is the *write* side.
+    """
+    eb = _bytes(itype)
+    fb = _bytes(torch.float32)
+    state_elems = nheads * headdim * dstate
+    # Baseline: read state + write state, every step.
+    base = state_elems * eb * 2
+    # Replay: read state every step; write state only on flush (1/buffer_len);
+    # append x_cache (nheads*headdim) + dt_cache (nheads, fp32) + B_cache
+    # (ngroups*dstate) every non-flush step; read those back over the window.
+    buf_append = (nheads * headdim) * eb + nheads * fb + (ngroups * dstate) * eb
+    # Window reads: x_cache + B_cache scale with write_pos; average ~buffer_len/2.
+    avg_pos = (buffer_len - 1) / 2.0
+    win_read = ((nheads * headdim) * eb + (ngroups * dstate) * eb) * avg_pos
+    state_write = state_elems * eb / buffer_len  # amortized flush write
+    replay = state_elems * eb + state_write + buf_append + win_read
+    return base, replay
+
+
+def _alloc(batch, nheads, ngroups, headdim, dstate, buffer_len, dev, itype):
+    x_cache = torch.zeros(batch, nheads, buffer_len, headdim, device=dev, dtype=itype)
+    dt_cache = torch.zeros(batch, nheads, buffer_len, device=dev, dtype=torch.float32)
+    B_cache = torch.zeros(batch, ngroups, buffer_len, dstate, device=dev, dtype=itype)
+    write_pos = torch.zeros(batch, dtype=torch.int32, device=dev)
+    return x_cache, dt_cache, B_cache, write_pos
+
+
+def bench_step(fn, n_warmup=20, n_iter=200):
+    for _ in range(n_warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(n_iter):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / n_iter * 1e3  # microseconds/step
+
+
+def bench_cudagraph(fn, n_warmup=5, n_iter=500):
+    """Per-step latency with launch overhead removed (vLLM's decode regime).
+
+    Captures a single step into a CUDA graph and replays it, so the measurement
+    reflects kernel execution (memory/compute) rather than Python+launch cost.
+    """
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(n_warmup):
+            fn()
+    torch.cuda.current_stream().wait_stream(s)
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(n_iter):
+        g.replay()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / n_iter * 1e3  # microseconds/step
+
+
+def run(nheads, headdim, dstate, ngroups, buffer_len, itype, dev, batch=1):
+    state = torch.randn(batch, nheads, headdim, dstate, dtype=itype, device=dev)
+    A = (
+        (-torch.rand(nheads, device=dev) - 1.0)
+        .view(nheads, 1, 1)
+        .expand(nheads, headdim, dstate)
+    )
+    dt_bias = (
+        (torch.rand(nheads, device=dev) - 4.0).view(nheads, 1).expand(nheads, headdim)
+    )
+    D = torch.randn(nheads, headdim, device=dev)
+    x = torch.randn(batch, nheads, headdim, device=dev, dtype=itype)
+    dt = (
+        torch.randn(batch, nheads, device=dev, dtype=itype)
+        .unsqueeze(-1)
+        .expand(batch, nheads, headdim)
+    )
+    B = torch.randn(batch, ngroups, dstate, device=dev, dtype=itype)
+    C = torch.randn(batch, ngroups, dstate, device=dev, dtype=itype)
+    out = torch.empty_like(x)
+
+    def baseline():
+        selective_state_update(
+            state, x, dt, A, B, C, D=D, dt_bias=dt_bias, dt_softplus=True, out=out
+        )
+
+    # Cycle write_pos through the full window so the flush step is amortized.
+    pos = [0]
+
+    def make_replay(route):
+        xc, dtc, Bc, wp = _alloc(
+            batch, nheads, ngroups, headdim, dstate, buffer_len, dev, itype
+        )
+        bc = torch.empty(batch, ngroups, buffer_len, device=dev, dtype=torch.float32)
+
+        is_flush = torch.zeros(batch, dtype=torch.int8, device=dev)
+
+        def step():
+            wp.fill_(pos[0])
+            is_flush.fill_(1 if pos[0] == buffer_len - 1 else 0)
+            if route == "output_only":
+                selective_state_update_replayssm_output_only(
+                    state,
+                    x,
+                    dt,
+                    A,
+                    B,
+                    C,
+                    D=D,
+                    dt_bias=dt_bias,
+                    dt_softplus=True,
+                    x_cache=xc,
+                    dt_cache=dtc,
+                    B_cache=Bc,
+                    bc_pre=bc,
+                    write_pos=wp,
+                    is_flush=is_flush,
+                    max_cache_len=buffer_len,
+                    out=out,
+                )
+            else:
+                selective_state_update_replayssm_state_and_output(
+                    state,
+                    x,
+                    dt,
+                    A,
+                    B,
+                    C,
+                    D=D,
+                    dt_bias=dt_bias,
+                    dt_softplus=True,
+                    x_cache=xc,
+                    dt_cache=dtc,
+                    B_cache=Bc,
+                    write_pos=wp,
+                    is_flush=is_flush,
+                    max_cache_len=buffer_len,
+                    out=out,
+                )
+            pos[0] = (pos[0] + 1) % buffer_len
+
+        return step
+
+    base_us = bench_step(baseline)
+    oo_us = bench_step(make_replay("output_only"))
+    so_us = bench_step(make_replay("state_and_output"))
+    base_b, oo_b = analytical_traffic(
+        nheads, headdim, dstate, ngroups, buffer_len, "output_only", itype
+    )
+    return base_us, oo_us, so_us, base_b, oo_b
+
+
+def run_cudagraph(nheads, headdim, dstate, ngroups, buffer_len, itype, dev, batch):
+    """CUDA-graph per-step latency for a representative non-flush step.
+
+    write_pos is fixed at buffer_len//2 (average ring depth); is_flush=0. This is
+    the common-case step (15/16 at buffer_len=16) and the regime vLLM decode runs
+    in (graph-captured, launch overhead removed).
+    """
+    state = torch.randn(batch, nheads, headdim, dstate, dtype=itype, device=dev)
+    A = (
+        (-torch.rand(nheads, device=dev) - 1.0)
+        .view(nheads, 1, 1)
+        .expand(nheads, headdim, dstate)
+    )
+    dt_bias = (
+        (torch.rand(nheads, device=dev) - 4.0).view(nheads, 1).expand(nheads, headdim)
+    )
+    D = torch.randn(nheads, headdim, device=dev)
+    x = torch.randn(batch, nheads, headdim, device=dev, dtype=itype)
+    dt = (
+        torch.randn(batch, nheads, device=dev, dtype=itype)
+        .unsqueeze(-1)
+        .expand(batch, nheads, headdim)
+    )
+    B = torch.randn(batch, ngroups, dstate, device=dev, dtype=itype)
+    C = torch.randn(batch, ngroups, dstate, device=dev, dtype=itype)
+    out = torch.empty_like(x)
+    xc, dtc, Bc, wp = _alloc(
+        batch, nheads, ngroups, headdim, dstate, buffer_len, dev, itype
+    )
+    bc = torch.empty(batch, ngroups, buffer_len, device=dev, dtype=torch.float32)
+    wp.fill_(buffer_len // 2)
+    is_flush = torch.zeros(batch, dtype=torch.int8, device=dev)
+
+    def baseline():
+        selective_state_update(
+            state, x, dt, A, B, C, D=D, dt_bias=dt_bias, dt_softplus=True, out=out
+        )
+
+    def oo():
+        selective_state_update_replayssm_output_only(
+            state,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D=D,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+            x_cache=xc,
+            dt_cache=dtc,
+            B_cache=Bc,
+            bc_pre=bc,
+            write_pos=wp,
+            is_flush=is_flush,
+            max_cache_len=buffer_len,
+            out=out,
+        )
+
+    def so():
+        selective_state_update_replayssm_state_and_output(
+            state,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D=D,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+            x_cache=xc,
+            dt_cache=dtc,
+            B_cache=Bc,
+            write_pos=wp,
+            is_flush=is_flush,
+            max_cache_len=buffer_len,
+            out=out,
+        )
+
+    return (bench_cudagraph(baseline), bench_cudagraph(oo), bench_cudagraph(so))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--buffer-len", type=int, default=16)
+    ap.add_argument(
+        "--dtype", choices=["bfloat16", "float16", "float32"], default="bfloat16"
+    )
+    args = ap.parse_args()
+    itype = getattr(torch, args.dtype)
+    dev = "cuda"
+
+    print(
+        f"\nReplaySSM batch-1 decode microbench  (dtype={args.dtype}, "
+        f"buffer_len={args.buffer_len}, device={torch.cuda.get_device_name()})\n"
+    )
+    hdr = (
+        f"{'config':<16}{'base us':>9}{'oo us':>9}{'so us':>9}"
+        f"{'state KB/step':>15}{'oo KB/step':>12}{'write-traffic':>15}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    for name, nh, hd, ds, ng in CONFIGS:
+        base_us, oo_us, so_us, base_b, oo_b = run(
+            nh, hd, ds, ng, args.buffer_len, itype, dev
+        )
+        # Write-traffic reduction: baseline writes |S|/step; replay writes
+        # |S|/buffer_len/step (amortized) + small buffer appends.
+        eb = _bytes(itype)
+        state_w = nh * hd * ds * eb
+        replay_w = state_w / args.buffer_len + (
+            (nh * hd) * eb + nh * 4 + (ng * ds) * eb
+        )
+        print(
+            f"{name:<16}{base_us:>9.2f}{oo_us:>9.2f}{so_us:>9.2f}"
+            f"{base_b / 1024:>15.1f}{oo_b / 1024:>12.1f}"
+            f"{state_w / replay_w:>13.1f}x"
+        )
+    print("\noo = output_only route, so = state_and_output route")
+    print("state KB/step = baseline total state HBM (read+write) per step")
+    print(
+        "write-traffic = baseline state write / replay state write+append "
+        "(per step, amortized over the ring window)"
+    )
+
+    # Batch sweep: at batch-1 the isolated kernel is launch/overhead-bound, so the
+    # IO reduction does not show up as latency. Sweep batch to find where the
+    # per-step SSM update becomes memory-bound and the replay path crosses over.
+    name, nh, hd, ds, ng = CONFIGS[-1]
+    print(f"\nBatch sweep ({name}, dtype={args.dtype}, buffer_len={args.buffer_len}):")
+    sweep_hdr = (
+        f"{'batch':>6}{'base us':>10}{'oo us':>10}{'so us':>10}"
+        f"{'oo speedup':>12}{'so speedup':>12}"
+    )
+    print(sweep_hdr)
+    print("-" * len(sweep_hdr))
+    for batch in [1, 8, 32, 128, 256, 512]:
+        base_us, oo_us, so_us, _, _ = run(
+            nh, hd, ds, ng, args.buffer_len, itype, dev, batch=batch
+        )
+        print(
+            f"{batch:>6}{base_us:>10.2f}{oo_us:>10.2f}{so_us:>10.2f}"
+            f"{base_us / oo_us:>11.2f}x{base_us / so_us:>11.2f}x"
+        )
+
+    # CUDA-graph sweep: launch overhead removed (vLLM's actual decode regime),
+    # representative non-flush step. This isolates the memory-bound kernel time.
+    print(f"\nCUDA-graph sweep ({name}, non-flush step, launch overhead removed):")
+    cg_hdr = (
+        f"{'batch':>6}{'base us':>10}{'oo us':>10}{'so us':>10}"
+        f"{'oo speedup':>12}{'so speedup':>12}"
+    )
+    print(cg_hdr)
+    print("-" * len(cg_hdr))
+    for batch in [1, 8, 32, 128]:
+        base_us, oo_us, so_us = run_cudagraph(
+            nh, hd, ds, ng, args.buffer_len, itype, dev, batch=batch
+        )
+        print(
+            f"{batch:>6}{base_us:>10.2f}{oo_us:>10.2f}{so_us:>10.2f}"
+            f"{base_us / oo_us:>11.2f}x{base_us / so_us:>11.2f}x"
+        )
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/mamba/test_replayssm_decode.py
+++ b/tests/kernels/mamba/test_replayssm_decode.py
@@ -1,0 +1,554 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Parity tests for the ReplaySSM opt-in Mamba2 AR-decode kernels.
+
+ReplaySSM replaces the per-step recurrent-state write-back with a per-layer
+input ring buffer that is replayed to recompute the output. These tests prove
+the replay output matches:
+  1. a pure-PyTorch replay reference, and
+  2. the existing stored-state ``selective_state_update`` decode kernel
+for both compute routes ("output_only" and "state_and_output"), including the
+padded / state-batch-indices path, the unified ``ssu_dispatch`` funnel, and a
+kernel-level TP1 == TP2 (head/group sharding) equivalence check.
+"""
+
+import pytest
+import torch
+
+from tests.kernels.mamba.utils import (
+    allocate_update_caches,
+    selective_state_update_replayssm_output_only_ref,
+    selective_state_update_replayssm_state_and_output_ref,
+)
+from vllm.model_executor.layers.mamba.ops.mamba_ssm import selective_state_update
+from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_output_only import (  # noqa: E501
+    selective_state_update_replayssm_output_only,
+)
+from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_state_and_output import (  # noqa: E501
+    selective_state_update_replayssm_state_and_output,
+)
+from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
+    selective_state_update_replayssm,
+)
+from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+
+def _tolerances(dtype: torch.dtype) -> tuple[float, float]:
+    if dtype == torch.float32:
+        return 1e-3, 1e-2
+    return 6e-2, 2e-1
+
+
+def _tied_A(nheads: int, headdim: int, dstate: int, device: str) -> torch.Tensor:
+    A = -torch.rand(nheads, device=device) - 1.0
+    return A.view(nheads, 1, 1).expand(nheads, headdim, dstate)
+
+
+def _tied_dt(
+    batch: int, nheads: int, headdim: int, device: str, dtype: torch.dtype
+) -> torch.Tensor:
+    dt = torch.randn(batch, nheads, device=device, dtype=dtype)
+    return dt.unsqueeze(-1).expand(batch, nheads, headdim)
+
+
+def _tied_dt_bias(nheads: int, headdim: int, device: str) -> torch.Tensor:
+    dt_bias = torch.rand(nheads, device=device) - 4.0
+    return dt_bias.view(nheads, 1).expand(nheads, headdim)
+
+
+def _call_replay(
+    route,
+    state,
+    x,
+    dt,
+    A,
+    B,
+    C,
+    D,
+    z,
+    dt_bias,
+    caches,
+    bc_pre,
+    write_pos,
+    is_flush,
+    max_cache_len,
+    out,
+    state_batch_indices=None,
+):
+    """Drive a single replay decode step through the chosen route."""
+    x_cache, dt_cache, B_cache = caches
+    if route == "output_only":
+        selective_state_update_replayssm_output_only(
+            state,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D=D,
+            z=z,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+            x_cache=x_cache,
+            dt_cache=dt_cache,
+            B_cache=B_cache,
+            bc_pre=bc_pre,
+            write_pos=write_pos,
+            is_flush=is_flush,
+            max_cache_len=max_cache_len,
+            state_batch_indices=state_batch_indices,
+            out=out,
+        )
+    else:
+        selective_state_update_replayssm_state_and_output(
+            state,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D=D,
+            z=z,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+            x_cache=x_cache,
+            dt_cache=dt_cache,
+            B_cache=B_cache,
+            write_pos=write_pos,
+            is_flush=is_flush,
+            max_cache_len=max_cache_len,
+            state_batch_indices=state_batch_indices,
+            out=out,
+        )
+
+
+def _ref(route):
+    if route == "output_only":
+        return selective_state_update_replayssm_output_only_ref
+    return selective_state_update_replayssm_state_and_output_ref
+
+
+@pytest.mark.parametrize("route", ["output_only", "state_and_output"])
+@pytest.mark.parametrize("itype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("has_z", [False, True])
+@pytest.mark.parametrize("ngroups", [1, 4])
+@pytest.mark.parametrize("dstate", [16, 64, 128])
+@pytest.mark.parametrize("max_cache_len", [1, 4, 8])
+def test_replayssm_matches_baseline_decode(
+    max_cache_len, dstate, ngroups, has_z, itype, route
+):
+    """Replay decode == pure-torch ref == stored-state selective_state_update."""
+    device = "cuda"
+    rtol, atol = _tolerances(itype)
+    set_random_seed(0)
+
+    batch, nheads, headdim = 2, 4, 64
+    num_steps = 2 * max_cache_len
+
+    state = torch.randn(batch, nheads, headdim, dstate, dtype=itype, device=device)
+    state_baseline = state.clone()
+    state_cached = state.clone()
+    state_ref = state.clone()
+
+    A = _tied_A(nheads, headdim, dstate, device)
+    dt_bias = _tied_dt_bias(nheads, headdim, device)
+    D = torch.randn(nheads, headdim, device=device)
+
+    x_cache, dt_cache, B_cache, write_pos = allocate_update_caches(
+        batch,
+        nheads,
+        ngroups,
+        headdim,
+        dstate,
+        max_cache_len,
+        state.device,
+        itype,
+        itype,
+    )
+    xc_r, dtc_r, Bc_r, wp_r = allocate_update_caches(
+        batch,
+        nheads,
+        ngroups,
+        headdim,
+        dstate,
+        max_cache_len,
+        state.device,
+        itype,
+        itype,
+    )
+    bc_pre = torch.empty(
+        batch, ngroups, max_cache_len, device=device, dtype=torch.float32
+    )
+
+    for _ in range(num_steps):
+        x = torch.randn(batch, nheads, headdim, device=device, dtype=itype)
+        dt = _tied_dt(batch, nheads, headdim, device, itype)
+        B = torch.randn(batch, ngroups, dstate, device=device, dtype=itype)
+        C = torch.randn(batch, ngroups, dstate, device=device, dtype=itype)
+        z = torch.randn_like(x) if has_z else None
+
+        out_baseline = torch.empty_like(x)
+        selective_state_update(
+            state_baseline,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D=D,
+            z=z,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+            out=out_baseline,
+        )
+
+        out_cached = torch.empty_like(x)
+        is_flush = write_pos == max_cache_len - 1
+        _call_replay(
+            route,
+            state_cached,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D,
+            z,
+            dt_bias,
+            (x_cache, dt_cache, B_cache),
+            bc_pre,
+            write_pos,
+            is_flush,
+            max_cache_len,
+            out_cached,
+        )
+
+        out_ref = _ref(route)(
+            state_ref,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D=D,
+            z=z,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+            x_cache=xc_r,
+            dt_cache=dtc_r,
+            B_cache=Bc_r,
+            write_pos=wp_r,
+            max_cache_len=max_cache_len,
+        )
+
+        torch.testing.assert_close(out_cached, out_ref, rtol=rtol, atol=atol)
+        torch.testing.assert_close(out_cached, out_baseline, rtol=rtol, atol=atol)
+        torch.testing.assert_close(x_cache, xc_r, rtol=rtol, atol=atol)
+        torch.testing.assert_close(dt_cache, dtc_r, rtol=rtol, atol=atol)
+        torch.testing.assert_close(B_cache, Bc_r, rtol=rtol, atol=atol)
+
+        if bool(is_flush.all()):
+            # On flush the rebuilt checkpoint must equal the stored state.
+            torch.testing.assert_close(
+                state_cached, state_baseline, rtol=rtol, atol=atol
+            )
+
+        next_wp = torch.where(is_flush, torch.zeros_like(write_pos), write_pos + 1)
+        write_pos.copy_(next_wp)
+        wp_r.copy_(next_wp)
+
+
+@pytest.mark.parametrize("route", ["output_only", "state_and_output"])
+@pytest.mark.parametrize("itype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("with_padding", [False, True])
+def test_replayssm_with_state_batch_indices(with_padding, itype, route):
+    """Padded rows (NULL_BLOCK_ID) and scattered state slots are handled."""
+    device = "cuda"
+    rtol, atol = _tolerances(itype)
+    set_random_seed(0)
+
+    batch = 3
+    padding = 2 if with_padding else 0
+    padded_batch = batch + padding
+    total_slots = 16
+    nheads, ngroups, headdim, dstate = 4, 2, 64, 16
+    max_cache_len = 4
+    num_steps = 2 * max_cache_len
+
+    state = torch.randn(
+        total_slots, nheads, headdim, dstate, dtype=itype, device=device
+    )
+    state_baseline = state.clone()
+    state_cached = state.clone()
+    state_before = state.clone()
+
+    idx = (torch.randperm(total_slots - 1, device=device)[:batch] + 1).to(torch.int32)
+    state_batch_indices = torch.cat(
+        [
+            idx,
+            torch.full((padding,), NULL_BLOCK_ID, dtype=torch.int32, device=device),
+        ]
+    )
+    unused = torch.ones(total_slots, dtype=torch.bool, device=device)
+    unused[idx] = False
+
+    A = _tied_A(nheads, headdim, dstate, device)
+    dt_bias = _tied_dt_bias(nheads, headdim, device)
+    D = torch.randn(nheads, headdim, device=device)
+    x_cache = torch.zeros(
+        total_slots, nheads, max_cache_len, headdim, device=device, dtype=itype
+    )
+    dt_cache = torch.zeros(
+        total_slots, nheads, max_cache_len, device=device, dtype=torch.float32
+    )
+    B_cache = torch.zeros(
+        total_slots, ngroups, max_cache_len, dstate, device=device, dtype=itype
+    )
+    bc_pre = torch.empty(
+        padded_batch, ngroups, max_cache_len, device=device, dtype=torch.float32
+    )
+    write_pos = torch.zeros(padded_batch, dtype=torch.int32, device=device)
+
+    for _ in range(num_steps):
+        x = torch.randn(padded_batch, nheads, headdim, device=device, dtype=itype)
+        dt = _tied_dt(padded_batch, nheads, headdim, device, itype)
+        B = torch.randn(padded_batch, ngroups, dstate, device=device, dtype=itype)
+        C = torch.randn(padded_batch, ngroups, dstate, device=device, dtype=itype)
+        z = torch.randn_like(x)
+
+        out_baseline = torch.empty_like(x)
+        selective_state_update(
+            state_baseline,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D=D,
+            z=z,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+            state_batch_indices=state_batch_indices,
+            out=out_baseline,
+        )
+
+        out_cached = torch.full_like(x, 42)
+        is_flush = write_pos == max_cache_len - 1
+        _call_replay(
+            route,
+            state_cached,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D,
+            z,
+            dt_bias,
+            (x_cache, dt_cache, B_cache),
+            bc_pre,
+            write_pos,
+            is_flush,
+            max_cache_len,
+            out_cached,
+            state_batch_indices=state_batch_indices,
+        )
+
+        torch.testing.assert_close(
+            out_cached[:batch], out_baseline[:batch], rtol=rtol, atol=atol
+        )
+        if with_padding:
+            # Padded rows must be left untouched.
+            assert torch.equal(
+                out_cached[batch:], torch.full_like(out_cached[batch:], 42)
+            )
+
+        if bool(is_flush[:batch].all()):
+            torch.testing.assert_close(
+                state_cached[idx], state_baseline[idx], rtol=rtol, atol=atol
+            )
+
+        next_wp = torch.where(is_flush, torch.zeros_like(write_pos), write_pos + 1)
+        write_pos.copy_(next_wp)
+
+    # Untouched state slots stay byte-identical.
+    assert torch.equal(state_cached[unused], state_before[unused])
+
+
+@pytest.mark.parametrize("route", ["output_only", "state_and_output"])
+def test_replayssm_dispatch_funnel_matches_direct(route):
+    """The ssu_dispatch funnel must match a direct kernel call exactly."""
+    device = "cuda"
+    set_random_seed(0)
+    batch, nheads, ngroups, headdim, dstate = 2, 4, 2, 64, 16
+    max_cache_len = 4
+    itype = torch.float32
+
+    state = torch.randn(batch, nheads, headdim, dstate, dtype=itype, device=device)
+    state_direct = state.clone()
+    state_funnel = state.clone()
+    A = _tied_A(nheads, headdim, dstate, device)
+    dt_bias = _tied_dt_bias(nheads, headdim, device)
+    D = torch.randn(nheads, headdim, device=device)
+
+    cd, cf = (
+        allocate_update_caches(
+            batch, nheads, ngroups, headdim, dstate, max_cache_len, device, itype, itype
+        )
+        for _ in range(2)
+    )
+    xcd, dtcd, Bcd, wpd = cd
+    xcf, dtcf, Bcf, wpf = cf
+    bc_d = torch.empty(
+        batch, ngroups, max_cache_len, device=device, dtype=torch.float32
+    )
+    bc_f = torch.empty_like(bc_d)
+
+    for _ in range(2 * max_cache_len):
+        x = torch.randn(batch, nheads, headdim, device=device, dtype=itype)
+        dt = _tied_dt(batch, nheads, headdim, device, itype)
+        B = torch.randn(batch, ngroups, dstate, device=device, dtype=itype)
+        C = torch.randn(batch, ngroups, dstate, device=device, dtype=itype)
+        z = torch.randn_like(x)
+
+        out_direct = torch.empty_like(x)
+        is_flush = wpd == max_cache_len - 1
+        _call_replay(
+            route,
+            state_direct,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D,
+            z,
+            dt_bias,
+            (xcd, dtcd, Bcd),
+            bc_d,
+            wpd,
+            is_flush,
+            max_cache_len,
+            out_direct,
+        )
+
+        out_funnel = torch.empty_like(x)
+        selective_state_update_replayssm(
+            state_funnel,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D=D,
+            dt_bias=dt_bias,
+            z=z,
+            dt_softplus=True,
+            x_cache=xcf,
+            dt_cache=dtcf,
+            B_cache=Bcf,
+            write_pos=wpf,
+            is_flush=is_flush,
+            bc_pre=bc_f if route == "output_only" else None,
+            route=route,
+            max_cache_len=max_cache_len,
+            out=out_funnel,
+        )
+
+        assert torch.equal(out_direct, out_funnel)
+        next_wp = torch.where(is_flush, torch.zeros_like(wpd), wpd + 1)
+        wpd.copy_(next_wp)
+        wpf.copy_(next_wp)
+
+
+@pytest.mark.parametrize("route", ["output_only", "state_and_output"])
+def test_replayssm_tp1_equals_tp2(route):
+    """Kernel-level TP1 == TP2: sharding heads/groups across two ranks and
+    concatenating reproduces the full-width output bitwise (the decode kernel
+    has no cross-head reduction, so column-parallel TP is exact)."""
+    device = "cuda"
+    set_random_seed(0)
+    itype = torch.float32
+    batch, nheads, ngroups, headdim, dstate = 2, 8, 2, 64, 16
+    max_cache_len = 4
+    tp = 2
+    hpr, gpr = nheads // tp, ngroups // tp  # per-rank heads / groups
+
+    state = torch.randn(batch, nheads, headdim, dstate, dtype=itype, device=device)
+    A = _tied_A(nheads, headdim, dstate, device)
+    dt_bias = _tied_dt_bias(nheads, headdim, device)
+    D = torch.randn(nheads, headdim, device=device)
+
+    # TP1 (full-width) state + caches.
+    s1 = state.clone()
+    xc1, dtc1, Bc1, wp1 = allocate_update_caches(
+        batch, nheads, ngroups, headdim, dstate, max_cache_len, device, itype, itype
+    )
+    bc1 = torch.empty(batch, ngroups, max_cache_len, device=device, dtype=torch.float32)
+    # TP2 (per-rank shards) state + caches.
+    shards = []
+    for r in range(tp):
+        sr = state[:, r * hpr : (r + 1) * hpr].clone()
+        xcr, dtcr, Bcr, wpr = allocate_update_caches(
+            batch, hpr, gpr, headdim, dstate, max_cache_len, device, itype, itype
+        )
+        bcr = torch.empty(batch, gpr, max_cache_len, device=device, dtype=torch.float32)
+        shards.append([sr, xcr, dtcr, Bcr, wpr, bcr])
+
+    for _ in range(2 * max_cache_len):
+        x = torch.randn(batch, nheads, headdim, device=device, dtype=itype)
+        dt = _tied_dt(batch, nheads, headdim, device, itype)
+        B = torch.randn(batch, ngroups, dstate, device=device, dtype=itype)
+        C = torch.randn(batch, ngroups, dstate, device=device, dtype=itype)
+        z = torch.randn_like(x)
+
+        out1 = torch.empty_like(x)
+        is_flush = wp1 == max_cache_len - 1
+        _call_replay(
+            route,
+            s1,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D,
+            z,
+            dt_bias,
+            (xc1, dtc1, Bc1),
+            bc1,
+            wp1,
+            is_flush,
+            max_cache_len,
+            out1,
+        )
+
+        out2 = torch.empty_like(x)
+        for r in range(tp):
+            sr, xcr, dtcr, Bcr, wpr, bcr = shards[r]
+            hs, gs = slice(r * hpr, (r + 1) * hpr), slice(r * gpr, (r + 1) * gpr)
+            _call_replay(
+                route,
+                sr,
+                x[:, hs],
+                dt[:, hs],
+                A[hs],
+                B[:, gs],
+                C[:, gs],
+                D[hs],
+                z[:, hs],
+                dt_bias[hs],
+                (xcr, dtcr, Bcr),
+                bcr,
+                wpr,
+                is_flush,
+                max_cache_len,
+                out2[:, hs],
+            )
+
+        assert torch.equal(out1, out2)
+        next_wp = torch.where(is_flush, torch.zeros_like(wp1), wp1 + 1)
+        wp1.copy_(next_wp)
+        for r in range(tp):
+            shards[r][4].copy_(next_wp)

--- a/tests/kernels/mamba/utils.py
+++ b/tests/kernels/mamba/utils.py
@@ -76,3 +76,285 @@ def selective_state_update_ref(
     if not has_heads:
         out = out.squeeze(1)
     return out
+
+
+def selective_state_update_replayssm_state_and_output_ref(
+    state: torch.Tensor,
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor | None = None,
+    z: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    dt_softplus: bool = False,
+    x_cache: torch.Tensor | None = None,
+    dt_cache: torch.Tensor | None = None,
+    B_cache: torch.Tensor | None = None,
+    write_pos: torch.Tensor | None = None,
+    max_cache_len: int = 16,
+) -> torch.Tensor:
+    """Pure-PyTorch cached-dot reference for validation."""
+    has_heads = state.dim() > 3
+    if state.dim() == 3:
+        state = state.unsqueeze(1)
+    if x.dim() == 2:
+        x = x.unsqueeze(1)
+    if dt.dim() == 2:
+        dt = dt.unsqueeze(1)
+    if A.dim() == 2:
+        A = A.unsqueeze(0)
+    if B.dim() == 2:
+        B = B.unsqueeze(1)
+    if C.dim() == 2:
+        C = C.unsqueeze(1)
+    if D is not None and D.dim() == 1:
+        D = D.unsqueeze(0)
+    if z is not None and z.dim() == 2:
+        z = z.unsqueeze(1)
+    if dt_bias is not None and dt_bias.dim() == 1:
+        dt_bias = dt_bias.unsqueeze(0)
+
+    batch, nheads, dim, dstate = state.shape
+    assert x.shape == (batch, nheads, dim)
+    assert dt.shape == x.shape
+    assert A.shape == (nheads, dim, dstate)
+    ngroups = B.shape[1]
+    assert nheads % ngroups == 0, "nheads must be divisible by ngroups"
+    assert B.shape == (batch, ngroups, dstate)
+    assert C.shape == B.shape
+    if D is not None:
+        assert D.shape == (nheads, dim)
+    if z is not None:
+        assert z.shape == x.shape
+    if dt_bias is not None:
+        assert dt_bias.shape == (nheads, dim)
+
+    assert x_cache is not None
+    assert dt_cache is not None
+    assert B_cache is not None
+    assert x_cache.shape == (batch, nheads, max_cache_len, dim)
+    assert dt_cache.shape == (batch, nheads, max_cache_len)
+    assert B_cache.shape == (batch, ngroups, max_cache_len, dstate)
+    assert write_pos is not None
+    assert write_pos.shape == (batch,) and write_pos.dtype == torch.int32
+
+    ratio = nheads // ngroups
+
+    dt_val = dt[:, :, 0].float()
+    if dt_bias is not None:
+        dt_val = dt_val + dt_bias[:, 0].float()
+    if dt_softplus:
+        dt_val = F.softplus(dt_val)
+    A_val = A[:, 0, 0].float()
+    C_heads = C.repeat_interleave(ratio, dim=1)
+    out = torch.empty(batch, nheads, dim, device=x.device, dtype=torch.float32)
+
+    for b in range(batch):
+        cache_len = int(write_pos[b].item())
+        is_flush = cache_len == max_cache_len - 1
+        n_steps = cache_len + 1
+
+        dt_all = torch.zeros(nheads, n_steps, device=x.device, dtype=torch.float32)
+        if cache_len > 0:
+            dt_all[:, :cache_len] = dt_cache[b, :, :cache_len]
+        dt_all[:, cache_len] = dt_val[b]
+
+        cumsum = torch.cumsum(dt_all, dim=-1)
+        total = cumsum[:, -1]
+        dA_cumsum = A_val[:, None] * cumsum
+        dA_total = A_val * total
+        total_decay = torch.exp(dA_total)
+        scale = dt_all * torch.exp(dA_total[:, None] - dA_cumsum)
+
+        x_all = torch.zeros(nheads, dim, n_steps, device=x.device, dtype=x.dtype)
+        if cache_len > 0:
+            x_all[..., :cache_len] = x_cache[b, :, :cache_len, :].permute(0, 2, 1)
+        x_all[..., cache_len] = x[b]
+
+        B_all = torch.zeros(ngroups, n_steps, dstate, device=B.device, dtype=B.dtype)
+        if cache_len > 0:
+            B_all[:, :cache_len, :] = B_cache[b, :, :cache_len, :]
+        B_all[:, cache_len, :] = B[b]
+
+        B_heads = B_all.repeat_interleave(ratio, dim=0)
+        x_scaled = x_all.float() * scale[:, None, :]
+        delta = torch.einsum("hdk,hkn->hdn", x_scaled, B_heads.float())
+        state_new = state[b].float() * total_decay[:, None, None] + delta
+        if is_flush:
+            state[b].copy_(state_new.to(state.dtype))
+        else:
+            x_cache[b, :, cache_len, :] = x[b]
+            dt_cache[b, :, cache_len] = dt_val[b]
+            B_cache[b, :, cache_len, :] = B[b]
+
+        out[b] = torch.einsum("hdn,hn->hd", state_new, C_heads[b].float())
+    if D is not None:
+        out = out + (x.float() * D[None]).to(out.dtype)
+    if z is not None:
+        out = out * F.silu(z.float())
+    out = out.to(x.dtype)
+    if not has_heads:
+        out = out.squeeze(1)
+    return out
+
+
+def selective_state_update_replayssm_output_only_ref(
+    state: torch.Tensor,
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor | None = None,
+    z: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    dt_softplus: bool = False,
+    x_cache: torch.Tensor | None = None,
+    dt_cache: torch.Tensor | None = None,
+    B_cache: torch.Tensor | None = None,
+    write_pos: torch.Tensor | None = None,
+    max_cache_len: int = 16,
+) -> torch.Tensor:
+    """Pure-PyTorch cached-bc reference for validation."""
+    has_heads = state.dim() > 3
+    if state.dim() == 3:
+        state = state.unsqueeze(1)
+    if x.dim() == 2:
+        x = x.unsqueeze(1)
+    if dt.dim() == 2:
+        dt = dt.unsqueeze(1)
+    if A.dim() == 2:
+        A = A.unsqueeze(0)
+    if B.dim() == 2:
+        B = B.unsqueeze(1)
+    if C.dim() == 2:
+        C = C.unsqueeze(1)
+    if D is not None and D.dim() == 1:
+        D = D.unsqueeze(0)
+    if z is not None and z.dim() == 2:
+        z = z.unsqueeze(1)
+    if dt_bias is not None and dt_bias.dim() == 1:
+        dt_bias = dt_bias.unsqueeze(0)
+
+    batch, nheads, dim, dstate = state.shape
+    assert x.shape == (batch, nheads, dim)
+    assert dt.shape == x.shape
+    assert A.shape == (nheads, dim, dstate)
+    ngroups = B.shape[1]
+    assert nheads % ngroups == 0, "nheads must be divisible by ngroups"
+    assert B.shape == (batch, ngroups, dstate)
+    assert C.shape == B.shape
+
+    ratio = nheads // ngroups
+
+    dt_val = dt[:, :, 0].float()
+    if dt_bias is not None:
+        dt_val = dt_val + dt_bias[:, 0].float()
+    if dt_softplus:
+        dt_val = F.softplus(dt_val)
+    A_val = A[:, 0, 0].float()
+    C_heads = C.repeat_interleave(ratio, dim=1)
+    out = torch.empty(batch, nheads, dim, device=x.device, dtype=torch.float32)
+
+    assert x_cache is not None
+    assert dt_cache is not None
+    assert B_cache is not None
+    assert write_pos is not None
+
+    for b in range(batch):
+        cache_len = int(write_pos[b].item())
+        is_flush = cache_len == max_cache_len - 1
+        n_steps = cache_len + 1
+
+        dt_all = torch.zeros(nheads, n_steps, device=x.device, dtype=torch.float32)
+        if cache_len > 0:
+            dt_all[:, :cache_len] = dt_cache[b, :, :cache_len]
+        dt_all[:, cache_len] = dt_val[b]
+
+        cumsum = torch.cumsum(dt_all, dim=-1)
+        total = cumsum[:, -1]
+        dA_cumsum = A_val[:, None] * cumsum
+        dA_total = A_val * total
+        total_decay = torch.exp(dA_total)
+        scale = dt_all * torch.exp(dA_total[:, None] - dA_cumsum)
+
+        x_all = torch.zeros(nheads, dim, n_steps, device=x.device, dtype=x.dtype)
+        if cache_len > 0:
+            x_all[..., :cache_len] = x_cache[b, :, :cache_len, :].permute(0, 2, 1)
+        x_all[..., cache_len] = x[b]
+
+        B_all = torch.zeros(ngroups, n_steps, dstate, device=B.device, dtype=B.dtype)
+        if cache_len > 0:
+            B_all[:, :cache_len, :] = B_cache[b, :, :cache_len, :]
+        B_all[:, cache_len, :] = B[b]
+
+        B_heads = B_all.repeat_interleave(ratio, dim=0)
+        C_heads_b = C_heads[b]
+
+        if is_flush:
+            x_scaled = x_all.float() * scale[:, None, :]
+            delta = torch.einsum("hdk,hkn->hdn", x_scaled, B_heads.float())
+            state_new = state[b].float() * total_decay[:, None, None] + delta
+            state[b].copy_(state_new.to(state.dtype))
+            out[b] = torch.einsum("hdn,hn->hd", state_new, C_heads_b.float())
+        else:
+            checkpoint_out = torch.einsum(
+                "hdn,hn->hd", state[b].float(), C_heads_b.float()
+            )
+            checkpoint_out = checkpoint_out * total_decay[:, None]
+            BC = torch.einsum("hkn,hn->hk", B_heads.float(), C_heads_b.float())
+            cache_out = torch.einsum("hdk,hk->hd", x_all.float(), scale * BC)
+            out[b] = checkpoint_out + cache_out
+            x_cache[b, :, cache_len, :] = x[b]
+            dt_cache[b, :, cache_len] = dt_val[b]
+            B_cache[b, :, cache_len, :] = B[b]
+
+    if D is not None:
+        out = out + (x.float() * D[None]).to(out.dtype)
+    if z is not None:
+        out = out * F.silu(z.float())
+    out = out.to(x.dtype)
+    if not has_heads:
+        out = out.squeeze(1)
+    return out
+
+
+def allocate_update_caches(
+    batch: int,
+    nheads: int,
+    ngroups: int,
+    dim: int,
+    dstate: int,
+    max_cache_len: int,
+    device: torch.device,
+    x_dtype: torch.dtype,
+    B_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Allocate dense reference caches for standalone validation."""
+    x_cache = torch.zeros(
+        batch,
+        nheads,
+        max_cache_len,
+        dim,
+        device=device,
+        dtype=x_dtype,
+    )
+    dt_cache = torch.zeros(
+        batch,
+        nheads,
+        max_cache_len,
+        device=device,
+        dtype=torch.float32,
+    )
+    B_cache = torch.zeros(
+        batch,
+        ngroups,
+        max_cache_len,
+        dstate,
+        device=device,
+        dtype=B_dtype,
+    )
+    write_pos = torch.zeros(batch, dtype=torch.int32, device=device)
+    return x_cache, dt_cache, B_cache, write_pos

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -35,6 +35,7 @@ CacheDType = Literal[
 ]
 MambaDType = Literal["auto", "float32", "float16", "bfloat16"]
 MambaCacheMode = Literal["all", "align", "none"]
+ReplaySSMRoute = Literal["output_only", "state_and_output"]
 PrefixCachingHashAlgo = Literal["sha256", "sha256_cbor", "xxhash", "xxhash_cbor"]
 KVOffloadingBackend = Literal["native", "lmcache"]
 
@@ -139,6 +140,23 @@ class CacheConfig:
     - "align": only cache the mamba state of the last token of each scheduler step and
            when the token is at position i * block_size.
     """
+    use_replayssm: bool = False
+    """Use the ReplaySSM Mamba2 decode kernel (cache recent SSM inputs in a
+    per-layer ring buffer and replay them to recompute state on demand, instead
+    of writing the recurrent state back to HBM each step). Opt-in; only
+    supported for autoregressive decode with mamba_cache_mode='none' and the
+    triton Mamba backend. Default behavior is unchanged when off."""
+    replayssm_buffer_len: int = Field(default=16, gt=0)
+    """ReplaySSM input-buffer capacity: the maximum number of autoregressive
+    Mamba2 decode steps to accumulate in the ring buffer before flushing the
+    recomputed checkpoint state. Only meaningful when use_replayssm is True."""
+    replayssm_route: ReplaySSMRoute = "output_only"
+    """ReplaySSM compute route (only meaningful when use_replayssm is True):
+    - "output_only" (default): inner-product route. Reads the output from the
+       checkpoint state plus the cached inputs without materializing the
+       per-step state (the state is only rebuilt on flush steps).
+    - "state_and_output": outer-product route. Reconstructs the full SSM state
+       every step via tl.dot, then reads the output from it."""
 
     # Will be set after profiling.
     num_gpu_blocks: int | None = field(default=None, init=False)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -38,7 +38,7 @@ from .kv_events import KVEventsConfig
 from .kv_transfer import KVTransferConfig
 from .load import LoadConfig
 from .lora import LoRAConfig
-from .mamba import MambaConfig
+from .mamba import MambaBackendEnum, MambaConfig
 from .model import ModelConfig
 from .observability import ObservabilityConfig
 from .offload import OffloadConfig
@@ -2146,6 +2146,30 @@ class VllmConfig:
         if mamba_block_size_is_set and not self.cache_config.enable_prefix_caching:
             raise ValueError(
                 "--mamba-block-size can only be set with --enable-prefix-caching"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_replayssm(self) -> "VllmConfig":
+        if not self.cache_config.use_replayssm:
+            if self.cache_config.replayssm_route != "output_only":
+                raise ValueError(
+                    "--replayssm-route is only meaningful when --use-replayssm "
+                    "is enabled"
+                )
+            return self
+        if self.cache_config.mamba_cache_mode != "none":
+            raise ValueError("--use-replayssm requires --mamba-cache-mode none")
+        if self.num_speculative_tokens > 0:
+            raise ValueError(
+                "--use-replayssm does not support speculative decoding "
+                "(the spec-decode replay path is a separate follow-up)"
+            )
+        if self.mamba_config.backend != MambaBackendEnum.TRITON:
+            raise ValueError("--use-replayssm requires --mamba-backend triton")
+        if self.mamba_config.enable_stochastic_rounding:
+            raise ValueError(
+                "--use-replayssm does not support Mamba cache stochastic rounding"
             )
         return self
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -70,6 +70,7 @@ from vllm.config.cache import (
     MambaCacheMode,
     MambaDType,
     PrefixCachingHashAlgo,
+    ReplaySSMRoute,
 )
 from vllm.config.device import Device
 from vllm.config.kernel import IrOpPriorityConfig, LinearBackend, MoEBackend
@@ -679,6 +680,9 @@ class EngineArgs:
     mamba_ssm_cache_dtype: MambaDType = CacheConfig.mamba_ssm_cache_dtype
     mamba_block_size: int | None = get_field(CacheConfig, "mamba_block_size")
     mamba_cache_mode: MambaCacheMode = CacheConfig.mamba_cache_mode
+    use_replayssm: bool = CacheConfig.use_replayssm
+    replayssm_buffer_len: int = CacheConfig.replayssm_buffer_len
+    replayssm_route: ReplaySSMRoute = CacheConfig.replayssm_route
 
     mamba_backend: MambaBackendEnum = MambaBackendEnum.TRITON
     enable_mamba_cache_stochastic_rounding: bool = (
@@ -1165,6 +1169,11 @@ class EngineArgs:
         cache_group.add_argument(
             "--mamba-cache-mode", **cache_kwargs["mamba_cache_mode"]
         )
+        cache_group.add_argument("--use-replayssm", **cache_kwargs["use_replayssm"])
+        cache_group.add_argument(
+            "--replayssm-buffer-len", **cache_kwargs["replayssm_buffer_len"]
+        )
+        cache_group.add_argument("--replayssm-route", **cache_kwargs["replayssm_route"])
         cache_group.add_argument(
             "--kv-offloading-size", **cache_kwargs["kv_offloading_size"]
         )
@@ -1790,6 +1799,9 @@ class EngineArgs:
             mamba_ssm_cache_dtype=self.mamba_ssm_cache_dtype,
             mamba_block_size=self.mamba_block_size,
             mamba_cache_mode=self.mamba_cache_mode,
+            use_replayssm=self.use_replayssm,
+            replayssm_buffer_len=self.replayssm_buffer_len,
+            replayssm_route=self.replayssm_route,
             kv_offloading_size=self.kv_offloading_size,
             kv_offloading_backend=self.kv_offloading_backend,
         )

--- a/vllm/model_executor/layers/mamba/ops/selective_state_update_replayssm_output_only.py
+++ b/vllm/model_executor/layers/mamba/ops/selective_state_update_replayssm_output_only.py
@@ -1,0 +1,641 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E501
+
+import torch
+
+from vllm.model_executor.layers.mamba.ops.mamba_ssm import softplus
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+
+@triton.heuristics(
+    {
+        "HAS_STATE_BATCH_INDICES": lambda args: args["state_batch_indices_ptr"]
+        is not None
+    }
+)
+@triton.heuristics(
+    {"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])}
+)
+@triton.jit
+def _replayssm_output_only_precompute_kernel(
+    B_ptr,
+    C_ptr,
+    B_cache_ptr,
+    write_pos_ptr,
+    is_flush_ptr,
+    bc_pre_ptr,
+    state_batch_indices_ptr,
+    null_block_id,
+    # Matrix dimensions
+    batch,
+    ngroups,
+    dstate,
+    # Input strides
+    stride_B_batch,
+    stride_B_group,
+    stride_B_dstate,
+    stride_C_batch,
+    stride_C_group,
+    stride_C_dstate,
+    # Cache strides
+    stride_B_cache_batch,
+    stride_B_cache_group,
+    stride_B_cache_pos,
+    stride_B_cache_dstate,
+    stride_bc_pre_batch,
+    stride_bc_pre_group,
+    stride_bc_pre_pos,
+    stride_state_indices_batch,
+    stride_state_indices_T,
+    # Meta-parameters
+    MAX_CACHE_LEN: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    # heuristic-computed
+    BLOCK_SIZE_DSTATE: tl.constexpr,
+    HAS_STATE_BATCH_INDICES: tl.constexpr,
+):
+    pid_b = tl.program_id(axis=0)
+    pid_g = tl.program_id(axis=1)
+
+    # On flush steps the main kernel does not read bc_pre, so skip the work.
+    is_flush = tl.load(is_flush_ptr + pid_b) != 0
+    if is_flush:
+        return
+
+    if HAS_STATE_BATCH_INDICES:
+        state_batch_idx = tl.load(
+            state_batch_indices_ptr
+            + pid_b * stride_state_indices_batch
+            + 0 * stride_state_indices_T
+        ).to(tl.int64)
+        if state_batch_idx == null_block_id:
+            return
+    else:
+        state_batch_idx = pid_b
+
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    offs_n = tl.arange(0, BLOCK_SIZE_DSTATE)
+
+    write_pos = tl.load(write_pos_ptr + pid_b).to(tl.int64)
+
+    B_ptr += pid_b * stride_B_batch + pid_g * stride_B_group
+    C_ptr += pid_b * stride_C_batch + pid_g * stride_C_group
+    B_cache_ptr += state_batch_idx * stride_B_cache_batch + pid_g * stride_B_cache_group
+    bc_pre_ptr += pid_b * stride_bc_pre_batch + pid_g * stride_bc_pre_group
+
+    B_cur = tl.load(
+        B_ptr + offs_n * stride_B_dstate,
+        mask=offs_n < dstate,
+        other=0.0,
+    )
+    C = tl.load(
+        C_ptr + offs_n * stride_C_dstate,
+        mask=offs_n < dstate,
+        other=0.0,
+    )
+    B_cache_ptrs = (
+        B_cache_ptr
+        + offs_k[:, None] * stride_B_cache_pos
+        + offs_n[None, :] * stride_B_cache_dstate
+    )
+    B_cache = tl.load(
+        B_cache_ptrs,
+        mask=(offs_k[:, None] < write_pos) & (offs_n[None, :] < dstate),
+        other=0.0,
+    )
+    B_all = tl.where(offs_k[:, None] == write_pos, B_cur[None, :], B_cache)
+    bc = tl.sum(B_all.to(tl.float32) * C[None, :].to(tl.float32), axis=1)
+
+    tl.store(
+        bc_pre_ptr + offs_k * stride_bc_pre_pos,
+        bc,
+        mask=(offs_k <= write_pos) & (offs_k < MAX_CACHE_LEN),
+    )
+
+
+@triton.heuristics({"HAS_DT_BIAS": lambda args: args["dt_bias_ptr"] is not None})
+@triton.heuristics({"HAS_D": lambda args: args["D_ptr"] is not None})
+@triton.heuristics({"HAS_Z": lambda args: args["z_ptr"] is not None})
+@triton.heuristics(
+    {
+        "HAS_STATE_BATCH_INDICES": lambda args: args["state_batch_indices_ptr"]
+        is not None
+    }
+)
+@triton.heuristics(
+    {"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])}
+)
+@triton.jit
+def _replayssm_output_only_kernel(
+    # Pointers to matrices
+    state_ptr,
+    x_ptr,
+    dt_ptr,
+    dt_bias_ptr,
+    A_ptr,
+    B_ptr,
+    C_ptr,
+    D_ptr,
+    z_ptr,
+    out_ptr,
+    x_cache_ptr,
+    dt_cache_ptr,
+    B_cache_ptr,
+    bc_pre_ptr,
+    write_pos_ptr,
+    is_flush_ptr,
+    state_batch_indices_ptr,
+    null_block_id,
+    # Matrix dimensions
+    batch,
+    nheads,
+    dim,
+    dstate,
+    nheads_ngroups_ratio,
+    # State strides
+    stride_state_batch,
+    stride_state_head,
+    stride_state_dim,
+    stride_state_dstate,
+    # Input strides
+    stride_x_batch,
+    stride_x_head,
+    stride_x_dim,
+    stride_dt_batch,
+    stride_dt_head,
+    stride_dt_bias_head,
+    stride_A_head,
+    stride_B_batch,
+    stride_B_group,
+    stride_B_dstate,
+    stride_C_batch,
+    stride_C_group,
+    stride_C_dstate,
+    stride_D_head,
+    stride_D_dim,
+    stride_z_batch,
+    stride_z_head,
+    stride_z_dim,
+    stride_out_batch,
+    stride_out_head,
+    stride_out_dim,
+    # Cache strides
+    stride_x_cache_batch,
+    stride_x_cache_head,
+    stride_x_cache_dim,
+    stride_x_cache_pos,
+    stride_dt_cache_batch,
+    stride_dt_cache_head,
+    stride_dt_cache_pos,
+    stride_B_cache_batch,
+    stride_B_cache_group,
+    stride_B_cache_pos,
+    stride_B_cache_dstate,
+    stride_bc_pre_batch,
+    stride_bc_pre_group,
+    stride_bc_pre_pos,
+    stride_state_indices_batch,
+    stride_state_indices_T,
+    # Meta-parameters
+    DT_SOFTPLUS: tl.constexpr,
+    MAX_CACHE_LEN: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_K_CACHE: tl.constexpr,
+    BLOCK_SIZE_K_DOT: tl.constexpr,
+    # heuristic-computed
+    BLOCK_SIZE_DSTATE: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    HAS_D: tl.constexpr,
+    HAS_Z: tl.constexpr,
+    HAS_STATE_BATCH_INDICES: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+    pid_h = tl.program_id(axis=2)
+
+    # Resolve the physical state slot for this decode row; skip padded rows.
+    if HAS_STATE_BATCH_INDICES:
+        state_batch_idx = tl.load(
+            state_batch_indices_ptr
+            + pid_b * stride_state_indices_batch
+            + 0 * stride_state_indices_T
+        ).to(tl.int64)
+        if state_batch_idx == null_block_id:
+            return
+    else:
+        state_batch_idx = pid_b
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = tl.arange(0, BLOCK_SIZE_DSTATE)
+
+    # Buffer cursor (number of cached tokens so far) and the flush flag.
+    write_pos = tl.load(write_pos_ptr + pid_b).to(tl.int64)
+    is_flush = tl.load(is_flush_ptr + pid_b) != 0
+
+    # Advance every pointer to this (row, head, group).
+    state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
+    x_ptr += pid_b * stride_x_batch + pid_h * stride_x_head
+    dt_ptr += pid_b * stride_dt_batch + pid_h * stride_dt_head
+    B_ptr += pid_b * stride_B_batch + (pid_h // nheads_ngroups_ratio) * stride_B_group
+    C_ptr += pid_b * stride_C_batch + (pid_h // nheads_ngroups_ratio) * stride_C_group
+    out_ptr += pid_b * stride_out_batch + pid_h * stride_out_head
+    x_cache_ptr += state_batch_idx * stride_x_cache_batch + pid_h * stride_x_cache_head
+    dt_cache_ptr += (
+        state_batch_idx * stride_dt_cache_batch + pid_h * stride_dt_cache_head
+    )
+    B_cache_ptr += (
+        state_batch_idx * stride_B_cache_batch
+        + (pid_h // nheads_ngroups_ratio) * stride_B_cache_group
+    )
+    bc_pre_ptr += (
+        pid_b * stride_bc_pre_batch
+        + (pid_h // nheads_ngroups_ratio) * stride_bc_pre_group
+    )
+
+    # Current-token dt (+ bias, softplus), scalar A, current x / C, checkpoint
+    # state S_0, and current-token B (shared by both routes below).
+    dt_cur = tl.load(dt_ptr).to(tl.float32)
+    if HAS_DT_BIAS:
+        dt_cur += tl.load(dt_bias_ptr + pid_h * stride_dt_bias_head).to(tl.float32)
+    if DT_SOFTPLUS:
+        dt_cur = tl.where(dt_cur <= 20.0, softplus(dt_cur), dt_cur)
+    A = tl.load(A_ptr + pid_h * stride_A_head).to(tl.float32)
+    x_cur = tl.load(x_ptr + offs_m * stride_x_dim, mask=offs_m < dim, other=0.0)
+    C = tl.load(C_ptr + offs_n * stride_C_dstate, mask=offs_n < dstate, other=0.0).to(
+        tl.float32
+    )
+    state_ptrs = (
+        state_ptr
+        + offs_m[:, None] * stride_state_dim
+        + offs_n[None, :] * stride_state_dstate
+    )
+    state = tl.load(
+        state_ptrs, mask=(offs_m[:, None] < dim) & (offs_n[None, :] < dstate), other=0.0
+    )
+    B_cur = tl.load(B_ptr + offs_n * stride_B_dstate, mask=offs_n < dstate, other=0.0)
+
+    if not is_flush:
+        # Output-only route: read y without materializing the state, using the
+        # precomputed k^T q products (`bc`):
+        #   y = total_decay * (S_0 q) + sum_j s_j (k_j^T q) v_j.
+        # Then append the current token to the buffer.
+        offs_k_cache = tl.arange(0, BLOCK_SIZE_K_CACHE)
+        # dt over the window (history + current token), then the decay weights.
+        dt_all_cache = tl.load(
+            dt_cache_ptr + offs_k_cache * stride_dt_cache_pos,
+            mask=offs_k_cache < write_pos,
+            other=0.0,
+        ).to(tl.float32)
+        dt_all_cache = tl.where(offs_k_cache == write_pos, dt_cur, dt_all_cache)
+        dA_cumsum_cache = A * tl.cumsum(dt_all_cache, axis=0)
+        dA_total_cache = A * tl.sum(dt_all_cache, axis=0)
+        total_decay_cache = tl.exp(dA_total_cache)
+        scale_cache = dt_all_cache * tl.exp(dA_total_cache - dA_cumsum_cache)
+        scale_cache = tl.where(offs_k_cache <= write_pos, scale_cache, 0.0)
+
+        # Gather buffered x over the window (history + current token).
+        x_all_cache_ptrs = (
+            x_cache_ptr
+            + offs_m[:, None] * stride_x_cache_dim
+            + offs_k_cache[None, :] * stride_x_cache_pos
+        )
+        x_all_cache = tl.load(
+            x_all_cache_ptrs,
+            mask=(offs_m[:, None] < dim) & (offs_k_cache[None, :] < write_pos),
+            other=0.0,
+        )
+        x_all_cache = tl.where(
+            offs_k_cache[None, :] == write_pos, x_cur[:, None], x_all_cache
+        )
+
+        # Decayed checkpoint readout plus the weighted sum of cached values.
+        checkpoint_out = (
+            tl.sum(state.to(tl.float32) * C[None, :], axis=1) * total_decay_cache
+        )
+        bc_cache = tl.load(
+            bc_pre_ptr + offs_k_cache * stride_bc_pre_pos,
+            mask=offs_k_cache <= write_pos,
+            other=0.0,
+        )
+        cache_out = tl.sum(
+            x_all_cache.to(tl.float32) * (scale_cache * bc_cache)[None, :], axis=1
+        )
+        out = checkpoint_out + cache_out
+
+        # Append the current token (x, dt, B) into the buffer at write_pos.
+        tl.store(
+            x_cache_ptr + offs_m * stride_x_cache_dim + write_pos * stride_x_cache_pos,
+            x_cur,
+            mask=offs_m < dim,
+        )
+        if pid_m == 0:
+            tl.store(dt_cache_ptr + write_pos * stride_dt_cache_pos, dt_cur)
+            tl.store(
+                B_cache_ptr
+                + write_pos * stride_B_cache_pos
+                + offs_n * stride_B_cache_dstate,
+                B_cur,
+                mask=offs_n < dstate,
+            )
+    else:
+        # Flush step: state route. Reconstruct the state from cached inputs,
+        # S_t = total_decay * S_0 + sum_j s_j (v_j k_j^T), persist it as the new
+        # checkpoint, then read y = S_t q.
+        offs_k_dot = tl.arange(0, BLOCK_SIZE_K_DOT)
+        dt_all_dot = tl.load(
+            dt_cache_ptr + offs_k_dot * stride_dt_cache_pos,
+            mask=offs_k_dot < write_pos,
+            other=0.0,
+        ).to(tl.float32)
+        dt_all_dot = tl.where(offs_k_dot == write_pos, dt_cur, dt_all_dot)
+        dA_cumsum_dot = A * tl.cumsum(dt_all_dot, axis=0)
+        dA_total_dot = A * tl.sum(dt_all_dot, axis=0)
+        total_decay_dot = tl.exp(dA_total_dot)
+        scale_dot = dt_all_dot * tl.exp(dA_total_dot - dA_cumsum_dot)
+        scale_dot = tl.where(offs_k_dot <= write_pos, scale_dot, 0.0)
+
+        # Gather buffered x and B over the window (history + current token).
+        x_all_dot_ptrs = (
+            x_cache_ptr
+            + offs_m[:, None] * stride_x_cache_dim
+            + offs_k_dot[None, :] * stride_x_cache_pos
+        )
+        x_all_dot = tl.load(
+            x_all_dot_ptrs,
+            mask=(offs_m[:, None] < dim) & (offs_k_dot[None, :] < write_pos),
+            other=0.0,
+        )
+        x_all_dot = tl.where(
+            offs_k_dot[None, :] == write_pos, x_cur[:, None], x_all_dot
+        )
+        B_all_dot_ptrs = (
+            B_cache_ptr
+            + offs_k_dot[:, None] * stride_B_cache_pos
+            + offs_n[None, :] * stride_B_cache_dstate
+        )
+        B_all_dot = tl.load(
+            B_all_dot_ptrs,
+            mask=(offs_k_dot[:, None] < write_pos) & (offs_n[None, :] < dstate),
+            other=0.0,
+        )
+        B_all_dot = tl.where(
+            offs_k_dot[:, None] == write_pos, B_cur[None, :], B_all_dot
+        )
+
+        # Reconstruct the state from cached inputs and store it as the checkpoint.
+        B_scaled = (B_all_dot.to(tl.float32) * scale_dot[:, None]).to(
+            x_ptr.dtype.element_ty
+        )
+        # input_precision="ieee" keeps fp32 inputs in true fp32 (no TF32) so the
+        # rebuilt checkpoint matches the baseline's elementwise fp32 update; bf16/
+        # fp16 inputs are unaffected (tl.dot accumulates them in fp32 regardless).
+        delta_state = tl.dot(
+            x_all_dot.to(x_ptr.dtype.element_ty), B_scaled, input_precision="ieee"
+        )
+        state_new = state.to(tl.float32) * total_decay_dot + delta_state.to(tl.float32)
+        tl.store(
+            state_ptrs,
+            state_new.to(state.dtype),
+            mask=(offs_m[:, None] < dim) & (offs_n[None, :] < dstate),
+        )
+        out = tl.sum(state_new * C[None, :], axis=1)
+
+    # Skip connection (D) and output gate (z).
+    if HAS_D:
+        D_ptr += pid_h * stride_D_head
+        D = tl.load(D_ptr + offs_m * stride_D_dim, mask=offs_m < dim, other=0.0).to(
+            tl.float32
+        )
+        out += x_cur.to(tl.float32) * D
+    if HAS_Z:
+        z_ptr += pid_b * stride_z_batch + pid_h * stride_z_head
+        z = tl.load(z_ptr + offs_m * stride_z_dim, mask=offs_m < dim, other=0.0).to(
+            tl.float32
+        )
+        out *= z * tl.sigmoid(z)
+
+    tl.store(out_ptr + offs_m * stride_out_dim, out, mask=offs_m < dim)
+
+
+def _get_replayssm_output_only_launch_config(dstate: int) -> tuple[int, int]:
+    """Config sweep is stronly recommend for different dstate and hardware"""
+    if dstate <= 64:
+        return 16, 1
+    if dstate <= 128:
+        return 16, 1
+    return 16, 1
+
+
+def selective_state_update_replayssm_output_only(
+    state: torch.Tensor,
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    z: torch.Tensor | None = None,
+    dt_softplus: bool = False,
+    x_cache: torch.Tensor | None = None,
+    dt_cache: torch.Tensor | None = None,
+    B_cache: torch.Tensor | None = None,
+    bc_pre: torch.Tensor | None = None,
+    write_pos: torch.Tensor | None = None,
+    is_flush: torch.Tensor | None = None,
+    max_cache_len: int = 16,
+    state_batch_indices: torch.Tensor | None = None,
+    null_block_id: int = NULL_BLOCK_ID,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Cached-bc SSM update for vLLM's autoregressive Mamba2 decode path."""
+    has_heads = state.dim() > 3
+    if state.dim() == 3:
+        state = state.unsqueeze(1)
+    if x.dim() == 2:
+        x = x.unsqueeze(1)
+    if dt.dim() == 2:
+        dt = dt.unsqueeze(1)
+    if A.dim() == 2:
+        A = A.unsqueeze(0)
+    if B.dim() == 2:
+        B = B.unsqueeze(1)
+    if C.dim() == 2:
+        C = C.unsqueeze(1)
+    if D is not None and D.dim() == 1:
+        D = D.unsqueeze(0)
+    if z is not None and z.dim() == 2:
+        z = z.unsqueeze(1)
+    if dt_bias is not None and dt_bias.dim() == 1:
+        dt_bias = dt_bias.unsqueeze(0)
+    if out is not None and out.dim() == 2:
+        out = out.unsqueeze(1)
+    if state_batch_indices is not None and state_batch_indices.dim() == 1:
+        state_batch_indices = state_batch_indices.unsqueeze(1)
+
+    _, nheads, dim, dstate = state.shape
+    batch = x.shape[0]
+    assert x.shape == (batch, nheads, dim)
+    assert dt.shape == x.shape
+    assert A.shape == (nheads, dim, dstate)
+    ngroups = B.shape[1]
+    assert nheads % ngroups == 0, "nheads must be divisible by ngroups"
+    assert B.shape == (batch, ngroups, dstate)
+    assert C.shape == B.shape
+    if D is not None:
+        assert D.shape == (nheads, dim)
+    if z is not None:
+        assert z.shape == x.shape
+    if dt_bias is not None:
+        assert dt_bias.shape == (nheads, dim)
+    assert out is not None and out.shape == x.shape
+
+    assert A.stride(-1) == 0 and A.stride(-2) == 0, (
+        "Cached kernel requires TIE_HDIM (A scalar per head)"
+    )
+    assert dt.stride(-1) == 0, "Cached kernel requires TIE_HDIM (dt scalar per head)"
+    if dt_bias is not None:
+        assert dt_bias.stride(-1) == 0, (
+            "Cached kernel requires TIE_HDIM (dt_bias scalar per head)"
+        )
+
+    assert x_cache is not None
+    assert dt_cache is not None
+    assert B_cache is not None
+    assert x_cache.shape[1:] == (nheads, max_cache_len, dim)
+    assert dt_cache.shape[1:] == (nheads, max_cache_len)
+    assert B_cache.shape[1:] == (ngroups, max_cache_len, dstate)
+    assert write_pos is not None and write_pos.shape[0] >= batch
+    assert write_pos.dtype == torch.int32
+    assert is_flush is not None and is_flush.shape[0] >= batch
+    assert is_flush.dtype in (torch.bool, torch.int8)
+    assert bc_pre is not None
+    assert bc_pre.shape[0] >= batch and bc_pre.shape[1] >= ngroups
+    assert bc_pre.shape[2] == max_cache_len
+    assert bc_pre.dtype == torch.float32
+    if state_batch_indices is not None:
+        assert state_batch_indices.shape[0] >= batch
+        assert state_batch_indices.shape[1] >= 1
+
+    block_size_k_cache = max(1, triton.next_power_of_2(max_cache_len))
+    block_size_k_dot = max(16, block_size_k_cache)
+    block_size_m, num_warps = _get_replayssm_output_only_launch_config(dstate)
+
+    grid = lambda META: (triton.cdiv(dim, META["BLOCK_SIZE_M"]), batch, nheads)
+    z_strides = (z.stride(0), z.stride(1), z.stride(2)) if z is not None else (0, 0, 0)
+    state_indices_strides = (
+        (state_batch_indices.stride(0), state_batch_indices.stride(1))
+        if state_batch_indices is not None
+        else (0, 0)
+    )
+
+    with torch.accelerator.device_index(x.device.index):
+        _replayssm_output_only_precompute_kernel[(batch, ngroups)](
+            B,
+            C,
+            B_cache,
+            write_pos,
+            is_flush,
+            bc_pre,
+            state_batch_indices,
+            null_block_id,
+            batch,
+            ngroups,
+            dstate,
+            B.stride(0),
+            B.stride(1),
+            B.stride(2),
+            C.stride(0),
+            C.stride(1),
+            C.stride(2),
+            B_cache.stride(0),
+            B_cache.stride(1),
+            B_cache.stride(2),
+            B_cache.stride(3),
+            bc_pre.stride(0),
+            bc_pre.stride(1),
+            bc_pre.stride(2),
+            state_indices_strides[0],
+            state_indices_strides[1],
+            max_cache_len,
+            block_size_k_cache,
+            num_warps=2,
+        )
+        _replayssm_output_only_kernel[grid](
+            state,
+            x,
+            dt,
+            dt_bias,
+            A,
+            B,
+            C,
+            D,
+            z,
+            out,
+            x_cache,
+            dt_cache,
+            B_cache,
+            bc_pre,
+            write_pos,
+            is_flush,
+            state_batch_indices,
+            null_block_id,
+            batch,
+            nheads,
+            dim,
+            dstate,
+            nheads // ngroups,
+            state.stride(0),
+            state.stride(1),
+            state.stride(2),
+            state.stride(3),
+            x.stride(0),
+            x.stride(1),
+            x.stride(2),
+            dt.stride(0),
+            dt.stride(1),
+            dt_bias.stride(0) if dt_bias is not None else 0,
+            A.stride(0),
+            B.stride(0),
+            B.stride(1),
+            B.stride(2),
+            C.stride(0),
+            C.stride(1),
+            C.stride(2),
+            D.stride(0) if D is not None else 0,
+            D.stride(1) if D is not None else 0,
+            z_strides[0],
+            z_strides[1],
+            z_strides[2],
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            x_cache.stride(0),
+            x_cache.stride(1),
+            x_cache.stride(3),
+            x_cache.stride(2),
+            dt_cache.stride(0),
+            dt_cache.stride(1),
+            dt_cache.stride(2),
+            B_cache.stride(0),
+            B_cache.stride(1),
+            B_cache.stride(2),
+            B_cache.stride(3),
+            bc_pre.stride(0),
+            bc_pre.stride(1),
+            bc_pre.stride(2),
+            state_indices_strides[0],
+            state_indices_strides[1],
+            dt_softplus,
+            max_cache_len,
+            block_size_m,
+            block_size_k_cache,
+            block_size_k_dot,
+            num_warps=num_warps,
+        )
+
+    if not has_heads:
+        out = out.squeeze(1)
+    return out

--- a/vllm/model_executor/layers/mamba/ops/selective_state_update_replayssm_state_and_output.py
+++ b/vllm/model_executor/layers/mamba/ops/selective_state_update_replayssm_state_and_output.py
@@ -1,0 +1,433 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E501
+
+import torch
+
+from vllm.model_executor.layers.mamba.ops.mamba_ssm import softplus
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+
+@triton.heuristics({"HAS_DT_BIAS": lambda args: args["dt_bias_ptr"] is not None})
+@triton.heuristics({"HAS_D": lambda args: args["D_ptr"] is not None})
+@triton.heuristics({"HAS_Z": lambda args: args["z_ptr"] is not None})
+@triton.heuristics(
+    {
+        "HAS_STATE_BATCH_INDICES": lambda args: args["state_batch_indices_ptr"]
+        is not None
+    }
+)
+@triton.heuristics(
+    {"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])}
+)
+@triton.jit
+def _replayssm_state_and_output_kernel(
+    # Pointers to matrices
+    state_ptr,
+    x_ptr,
+    dt_ptr,
+    dt_bias_ptr,
+    A_ptr,
+    B_ptr,
+    C_ptr,
+    D_ptr,
+    z_ptr,
+    out_ptr,
+    x_cache_ptr,
+    dt_cache_ptr,
+    B_cache_ptr,
+    write_pos_ptr,
+    is_flush_ptr,
+    state_batch_indices_ptr,
+    null_block_id,
+    # Matrix dimensions
+    batch,
+    nheads,
+    dim,
+    dstate,
+    nheads_ngroups_ratio,
+    # State strides
+    stride_state_batch,
+    stride_state_head,
+    stride_state_dim,
+    stride_state_dstate,
+    # Input strides
+    stride_x_batch,
+    stride_x_head,
+    stride_x_dim,
+    stride_dt_batch,
+    stride_dt_head,
+    stride_dt_bias_head,
+    stride_A_head,
+    stride_B_batch,
+    stride_B_group,
+    stride_B_dstate,
+    stride_C_batch,
+    stride_C_group,
+    stride_C_dstate,
+    stride_D_head,
+    stride_D_dim,
+    stride_z_batch,
+    stride_z_head,
+    stride_z_dim,
+    stride_out_batch,
+    stride_out_head,
+    stride_out_dim,
+    # Cache strides
+    stride_x_cache_batch,
+    stride_x_cache_head,
+    stride_x_cache_dim,
+    stride_x_cache_pos,
+    stride_dt_cache_batch,
+    stride_dt_cache_head,
+    stride_dt_cache_pos,
+    stride_B_cache_batch,
+    stride_B_cache_group,
+    stride_B_cache_pos,
+    stride_B_cache_dstate,
+    stride_state_indices_batch,
+    stride_state_indices_T,
+    # Meta-parameters
+    DT_SOFTPLUS: tl.constexpr,
+    MAX_CACHE_LEN: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    # heuristic-computed
+    BLOCK_SIZE_DSTATE: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    HAS_D: tl.constexpr,
+    HAS_Z: tl.constexpr,
+    HAS_STATE_BATCH_INDICES: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+    pid_h = tl.program_id(axis=2)
+
+    # Resolve the physical state slot for this decode row; skip padded rows.
+    if HAS_STATE_BATCH_INDICES:
+        state_batch_idx = tl.load(
+            state_batch_indices_ptr
+            + pid_b * stride_state_indices_batch
+            + 0 * stride_state_indices_T
+        ).to(tl.int64)
+        if state_batch_idx == null_block_id:
+            return
+    else:
+        state_batch_idx = pid_b
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = tl.arange(0, BLOCK_SIZE_DSTATE)
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # Buffer cursor (number of cached tokens so far) and the flush flag.
+    write_pos = tl.load(write_pos_ptr + pid_b).to(tl.int64)
+    is_flush = tl.load(is_flush_ptr + pid_b) != 0
+
+    # Advance every pointer to this (row, head, group).
+    state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
+    x_ptr += pid_b * stride_x_batch + pid_h * stride_x_head
+    dt_ptr += pid_b * stride_dt_batch + pid_h * stride_dt_head
+    B_ptr += pid_b * stride_B_batch + (pid_h // nheads_ngroups_ratio) * stride_B_group
+    C_ptr += pid_b * stride_C_batch + (pid_h // nheads_ngroups_ratio) * stride_C_group
+    out_ptr += pid_b * stride_out_batch + pid_h * stride_out_head
+    x_cache_ptr += state_batch_idx * stride_x_cache_batch + pid_h * stride_x_cache_head
+    dt_cache_ptr += (
+        state_batch_idx * stride_dt_cache_batch + pid_h * stride_dt_cache_head
+    )
+    B_cache_ptr += (
+        state_batch_idx * stride_B_cache_batch
+        + (pid_h // nheads_ngroups_ratio) * stride_B_cache_group
+    )
+
+    # Current-token dt (+ bias, softplus) and the per-head scalar A.
+    dt_cur = tl.load(dt_ptr).to(tl.float32)
+    if HAS_DT_BIAS:
+        dt_cur += tl.load(dt_bias_ptr + pid_h * stride_dt_bias_head).to(tl.float32)
+    if DT_SOFTPLUS:
+        dt_cur = tl.where(dt_cur <= 20.0, softplus(dt_cur), dt_cur)
+    A = tl.load(A_ptr + pid_h * stride_A_head).to(tl.float32)
+
+    # dt over the window (cached history + current token at write_pos), then the
+    # decay weights: total decay exp(A*sum dt) and the per-position scale s_j.
+    dt_all = tl.load(
+        dt_cache_ptr + offs_k * stride_dt_cache_pos, mask=offs_k < write_pos, other=0.0
+    ).to(tl.float32)
+    dt_all = tl.where(offs_k == write_pos, dt_cur, dt_all)
+    dA_cumsum = A * tl.cumsum(dt_all, axis=0)
+    dA_total = A * tl.sum(dt_all, axis=0)
+    total_decay = tl.exp(dA_total)
+    scale = dt_all * tl.exp(dA_total - dA_cumsum)
+    scale = tl.where(offs_k <= write_pos, scale, 0.0)
+
+    # Current-token x / C, the checkpoint state S_0, and current-token B.
+    x_cur = tl.load(x_ptr + offs_m * stride_x_dim, mask=offs_m < dim, other=0.0)
+    C = tl.load(C_ptr + offs_n * stride_C_dstate, mask=offs_n < dstate, other=0.0).to(
+        tl.float32
+    )
+    state_ptrs = (
+        state_ptr
+        + offs_m[:, None] * stride_state_dim
+        + offs_n[None, :] * stride_state_dstate
+    )
+    state = tl.load(
+        state_ptrs, mask=(offs_m[:, None] < dim) & (offs_n[None, :] < dstate), other=0.0
+    )
+    B_cur = tl.load(B_ptr + offs_n * stride_B_dstate, mask=offs_n < dstate, other=0.0)
+
+    # Gather buffered x and B over the window (history + current token).
+    x_all_ptrs = (
+        x_cache_ptr
+        + offs_m[:, None] * stride_x_cache_dim
+        + offs_k[None, :] * stride_x_cache_pos
+    )
+    x_all = tl.load(
+        x_all_ptrs,
+        mask=(offs_m[:, None] < dim) & (offs_k[None, :] < write_pos),
+        other=0.0,
+    )
+    x_all = tl.where(offs_k[None, :] == write_pos, x_cur[:, None], x_all)
+    B_all_ptrs = (
+        B_cache_ptr
+        + offs_k[:, None] * stride_B_cache_pos
+        + offs_n[None, :] * stride_B_cache_dstate
+    )
+    B_all = tl.load(
+        B_all_ptrs,
+        mask=(offs_k[:, None] < write_pos) & (offs_n[None, :] < dstate),
+        other=0.0,
+    )
+    B_all = tl.where(offs_k[:, None] == write_pos, B_cur[None, :], B_all)
+
+    # Reconstruct the state from cached inputs (outer-product / state route):
+    # S_t = total_decay * S_0 + sum_j s_j (v_j k_j^T). Store it back on a flush.
+    B_scaled = (B_all.to(tl.float32) * scale[:, None]).to(x_ptr.dtype.element_ty)
+    # input_precision="ieee" keeps fp32 inputs in true fp32 (no TF32) so the
+    # rebuilt state matches the baseline's elementwise fp32 update; bf16/fp16
+    # inputs are unaffected (tl.dot accumulates them in fp32 regardless).
+    delta_state = tl.dot(
+        x_all.to(x_ptr.dtype.element_ty), B_scaled, input_precision="ieee"
+    )
+    state_new = state.to(tl.float32) * total_decay + delta_state.to(tl.float32)
+    if is_flush:
+        tl.store(
+            state_ptrs,
+            state_new.to(state.dtype),
+            mask=(offs_m[:, None] < dim) & (offs_n[None, :] < dstate),
+        )
+
+    # Read the output from the reconstructed state: y = S_t q.
+    out = tl.sum(state_new * C[None, :], axis=1)
+
+    # Skip connection (D) and output gate (z).
+    if HAS_D:
+        D_ptr += pid_h * stride_D_head
+        D = tl.load(D_ptr + offs_m * stride_D_dim, mask=offs_m < dim, other=0.0).to(
+            tl.float32
+        )
+        out += x_cur.to(tl.float32) * D
+    if HAS_Z:
+        z_ptr += pid_b * stride_z_batch + pid_h * stride_z_head
+        z = tl.load(z_ptr + offs_m * stride_z_dim, mask=offs_m < dim, other=0.0).to(
+            tl.float32
+        )
+        out *= z * tl.sigmoid(z)
+
+    tl.store(out_ptr + offs_m * stride_out_dim, out, mask=offs_m < dim)
+
+    # Non-flush step: append the current token (x, dt, B) into the buffer at write_pos.
+    if not is_flush:
+        tl.store(
+            x_cache_ptr + offs_m * stride_x_cache_dim + write_pos * stride_x_cache_pos,
+            x_cur,
+            mask=offs_m < dim,
+        )
+        if pid_m == 0:
+            tl.store(dt_cache_ptr + write_pos * stride_dt_cache_pos, dt_cur)
+            tl.store(
+                B_cache_ptr
+                + write_pos * stride_B_cache_pos
+                + offs_n * stride_B_cache_dstate,
+                B_cur,
+                mask=offs_n < dstate,
+            )
+
+
+def _get_replayssm_state_and_output_launch_config(dstate: int) -> tuple[int, int]:
+    """Config sweep is stronly recommend for different dstate and hardware"""
+    if dstate <= 64:
+        return 32, 1
+    if dstate <= 128:
+        return 32, 1
+    return 32, 1
+
+
+def selective_state_update_replayssm_state_and_output(
+    state: torch.Tensor,
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    z: torch.Tensor | None = None,
+    dt_softplus: bool = False,
+    x_cache: torch.Tensor | None = None,
+    dt_cache: torch.Tensor | None = None,
+    B_cache: torch.Tensor | None = None,
+    write_pos: torch.Tensor | None = None,
+    is_flush: torch.Tensor | None = None,
+    max_cache_len: int = 16,
+    state_batch_indices: torch.Tensor | None = None,
+    null_block_id: int = NULL_BLOCK_ID,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Cached-dot SSM update for vLLM's autoregressive Mamba2 decode path."""
+    has_heads = state.dim() > 3
+    if state.dim() == 3:
+        state = state.unsqueeze(1)
+    if x.dim() == 2:
+        x = x.unsqueeze(1)
+    if dt.dim() == 2:
+        dt = dt.unsqueeze(1)
+    if A.dim() == 2:
+        A = A.unsqueeze(0)
+    if B.dim() == 2:
+        B = B.unsqueeze(1)
+    if C.dim() == 2:
+        C = C.unsqueeze(1)
+    if D is not None and D.dim() == 1:
+        D = D.unsqueeze(0)
+    if z is not None and z.dim() == 2:
+        z = z.unsqueeze(1)
+    if dt_bias is not None and dt_bias.dim() == 1:
+        dt_bias = dt_bias.unsqueeze(0)
+    if out is not None and out.dim() == 2:
+        out = out.unsqueeze(1)
+    if state_batch_indices is not None and state_batch_indices.dim() == 1:
+        state_batch_indices = state_batch_indices.unsqueeze(1)
+
+    _, nheads, dim, dstate = state.shape
+    batch = x.shape[0]
+    assert x.shape == (batch, nheads, dim)
+    assert dt.shape == x.shape
+    assert A.shape == (nheads, dim, dstate)
+    ngroups = B.shape[1]
+    assert nheads % ngroups == 0, "nheads must be divisible by ngroups"
+    assert B.shape == (batch, ngroups, dstate)
+    assert C.shape == B.shape
+    if D is not None:
+        assert D.shape == (nheads, dim)
+    if z is not None:
+        assert z.shape == x.shape
+    if dt_bias is not None:
+        assert dt_bias.shape == (nheads, dim)
+    assert out is not None and out.shape == x.shape
+
+    assert A.stride(-1) == 0 and A.stride(-2) == 0, (
+        "Cached kernel requires TIE_HDIM (A scalar per head)"
+    )
+    assert dt.stride(-1) == 0, "Cached kernel requires TIE_HDIM (dt scalar per head)"
+    if dt_bias is not None:
+        assert dt_bias.stride(-1) == 0, (
+            "Cached kernel requires TIE_HDIM (dt_bias scalar per head)"
+        )
+
+    assert x_cache is not None
+    assert dt_cache is not None
+    assert B_cache is not None
+    assert x_cache.shape[1:] == (nheads, max_cache_len, dim)
+    assert dt_cache.shape[1:] == (nheads, max_cache_len)
+    assert B_cache.shape[1:] == (ngroups, max_cache_len, dstate)
+    assert write_pos is not None and write_pos.shape[0] >= batch
+    assert write_pos.dtype == torch.int32
+    assert is_flush is not None and is_flush.shape[0] >= batch
+    assert is_flush.dtype in (torch.bool, torch.int8)
+    if state_batch_indices is not None:
+        assert state_batch_indices.shape[0] >= batch
+        assert state_batch_indices.shape[1] >= 1
+
+    block_size_k = max(16, triton.next_power_of_2(max_cache_len))
+    block_size_m, num_warps = _get_replayssm_state_and_output_launch_config(dstate)
+
+    grid = lambda META: (triton.cdiv(dim, META["BLOCK_SIZE_M"]), batch, nheads)
+    z_strides = (z.stride(0), z.stride(1), z.stride(2)) if z is not None else (0, 0, 0)
+    state_indices_strides = (
+        (state_batch_indices.stride(0), state_batch_indices.stride(1))
+        if state_batch_indices is not None
+        else (0, 0)
+    )
+
+    with torch.accelerator.device_index(x.device.index):
+        _replayssm_state_and_output_kernel[grid](
+            state,
+            x,
+            dt,
+            dt_bias,
+            A,
+            B,
+            C,
+            D,
+            z,
+            out,
+            x_cache,
+            dt_cache,
+            B_cache,
+            write_pos,
+            is_flush,
+            state_batch_indices,
+            null_block_id,
+            batch,
+            nheads,
+            dim,
+            dstate,
+            nheads // ngroups,
+            state.stride(0),
+            state.stride(1),
+            state.stride(2),
+            state.stride(3),
+            x.stride(0),
+            x.stride(1),
+            x.stride(2),
+            dt.stride(0),
+            dt.stride(1),
+            dt_bias.stride(0) if dt_bias is not None else 0,
+            A.stride(0),
+            B.stride(0),
+            B.stride(1),
+            B.stride(2),
+            C.stride(0),
+            C.stride(1),
+            C.stride(2),
+            D.stride(0) if D is not None else 0,
+            D.stride(1) if D is not None else 0,
+            z_strides[0],
+            z_strides[1],
+            z_strides[2],
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            x_cache.stride(0),
+            x_cache.stride(1),
+            x_cache.stride(3),
+            x_cache.stride(2),
+            dt_cache.stride(0),
+            dt_cache.stride(1),
+            dt_cache.stride(2),
+            B_cache.stride(0),
+            B_cache.stride(1),
+            B_cache.stride(2),
+            B_cache.stride(3),
+            state_indices_strides[0],
+            state_indices_strides[1],
+            dt_softplus,
+            max_cache_len,
+            block_size_m,
+            block_size_k,
+            num_warps=num_warps,
+        )
+
+    if not has_heads:
+        out = out.squeeze(1)
+    return out

--- a/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
+++ b/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
@@ -276,3 +276,108 @@ def selective_state_update(
         cu_seqlens=cu_seqlens,
         is_blackwell=is_blackwell,
     )
+
+
+def selective_state_update_replayssm(
+    state: torch.Tensor,
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    z: torch.Tensor | None = None,
+    dt_softplus: bool = False,
+    *,
+    x_cache: torch.Tensor,
+    dt_cache: torch.Tensor,
+    B_cache: torch.Tensor,
+    write_pos: torch.Tensor,
+    is_flush: torch.Tensor,
+    bc_pre: torch.Tensor | None = None,
+    route: str = "output_only",
+    max_cache_len: int = 16,
+    state_batch_indices: torch.Tensor | None = None,
+    null_block_id: int = NULL_BLOCK_ID,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Unified ReplaySSM decode dispatch (opt-in via ``--use-replayssm``).
+
+    Instead of writing the recurrent SSM state back to HBM each step, the
+    ReplaySSM kernels keep a per-layer ring buffer of recent inputs
+    (``x_cache``/``dt_cache``/``B_cache``) plus a cursor (``write_pos``) and
+    replay them to recompute the output, flushing the rebuilt state to the
+    checkpoint only every ``max_cache_len`` steps (``is_flush``). This trades a
+    little recompute for much less HBM traffic at batch-1 decode.
+
+    All replay decode paths (Mamba2 today; GDN as a follow-up) funnel through
+    this single dispatch rather than duplicating a decode kernel per
+    architecture.
+
+    Args:
+        route: ``"output_only"`` (inner-product, default; needs ``bc_pre``
+            scratch) or ``"state_and_output"`` (outer-product, rebuilds the
+            full state every step).
+    """
+    if route == "output_only":
+        from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_output_only import (  # noqa: E501
+            selective_state_update_replayssm_output_only,
+        )
+
+        if bc_pre is None:
+            raise ValueError(
+                "ReplaySSM 'output_only' route requires the bc_pre scratch tensor"
+            )
+        return selective_state_update_replayssm_output_only(
+            state,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D=D,
+            dt_bias=dt_bias,
+            z=z,
+            dt_softplus=dt_softplus,
+            x_cache=x_cache,
+            dt_cache=dt_cache,
+            B_cache=B_cache,
+            bc_pre=bc_pre,
+            write_pos=write_pos,
+            is_flush=is_flush,
+            max_cache_len=max_cache_len,
+            state_batch_indices=state_batch_indices,
+            null_block_id=null_block_id,
+            out=out,
+        )
+    if route == "state_and_output":
+        from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_state_and_output import (  # noqa: E501
+            selective_state_update_replayssm_state_and_output,
+        )
+
+        return selective_state_update_replayssm_state_and_output(
+            state,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D=D,
+            dt_bias=dt_bias,
+            z=z,
+            dt_softplus=dt_softplus,
+            x_cache=x_cache,
+            dt_cache=dt_cache,
+            B_cache=B_cache,
+            write_pos=write_pos,
+            is_flush=is_flush,
+            max_cache_len=max_cache_len,
+            state_batch_indices=state_batch_indices,
+            null_block_id=null_block_id,
+            out=out,
+        )
+    raise ValueError(
+        f"Unknown ReplaySSM route: {route!r}. "
+        "Valid options: 'output_only', 'state_and_output'"
+    )


### PR DESCRIPTION
## [Kernel] ReplaySSM opt-in AR decode for Mamba2 (#46187)

Draft — first scoped cut of the ReplaySSM autoregressive-decode path for hybrid-SSM models requested in #46187. Lands the **parity-validated Mamba2 AR-decode kernel + unified dispatch + opt-in flags**, with the numerical-parity and TP-correctness data the reference fork lacked. GDN and the speculative-decode rollback path are explicit follow-ups (see below).

> **AI assistance disclosure:** this change was prepared with AI assistance (Claude). Per the repo's contribution policy it is posted as a **draft**; a human submitter will review every changed line and confirm tests before marking it ready.

### What this PR does (in scope)

1. **Two Mamba2 AR-decode replay kernels** (Triton), ported from the ReplaySSM fork onto current `main`. Both keep a per-layer input ring buffer (`x_cache`/`dt_cache`/`B_cache`) + cursor (`write_pos`) and replay it, trading a little recompute for much less HBM **write** traffic on the per-step SSM update:
   - `selective_state_update_replayssm_output_only.py` — inner-product route (default). Reads `y` from the checkpoint state + cached inputs without materializing the per-step state; rebuilds and flushes the state once per ring window.
   - `selective_state_update_replayssm_state_and_output.py` — outer-product route. Reconstructs the full state every step via `tl.dot`, reads `y` from it.
2. **Unified behind the existing dispatch** (`ssu_dispatch.py`), per @mgoin's constraint — a single `selective_state_update_replayssm(...)` funnel selects the route; no duplicated per-architecture decode path. GDN replay will route here too.
3. **Opt-in flags** (default behavior unchanged when off): `--use-replayssm`, `--replayssm-buffer-len` (default 16), `--replayssm-route` (`output_only` | `state_and_output`), with a config validator that requires `--mamba-cache-mode none`, the triton Mamba backend, no speculative decoding, and no stochastic rounding.
4. **Parity + TP-correctness tests** and a **batch-1 microbenchmark** (below).

### Numerical parity (the non-negotiable bit)

`tests/kernels/mamba/test_replayssm_decode.py` — **156 passed** on H200 (SM90). Each decode step asserts the replay output matches **both** a pure-PyTorch replay reference **and** the existing stored-state `selective_state_update` kernel, across `route × {fp32, bf16} × has_z × ngroups{1,4} × dstate{16,64,128} × buffer_len{1,4,8}`, plus the padded / `state_batch_indices` (NULL_BLOCK_ID) path, the dispatch funnel, and a TP1 == TP2 check.

| metric | result |
|---|---|
| fp32, max-abs vs baseline `selective_state_update` | **≤ 7.6e-6** (all steps incl. flush) |
| bf16 (production dtype) | within `rtol=6e-2, atol=2e-1` |
| flush-step checkpoint vs stored state | matches within tol |
| **TP1 == TP2** (head/group sharding, both routes) | **bitwise equal** (`torch.equal`) |

**Parity bug found & fixed vs the fork:** the fork's reconstruction `tl.dot` ran in **TF32** on fp32 inputs, giving ~4.3e-2 fp32 error at flush steps (the baseline does elementwise fp32, no matmul). Forcing `input_precision="ieee"` drops fp32 error to 7.6e-6; bf16/fp16 are unaffected (they accumulate in fp32 regardless). TP1==TP2 is the kernel-level equivalence (column-parallel head/group sharding); end-to-end distributed TP validation comes with the model wiring (follow-up).

### Microbenchmark (H200, bf16) — honest read

`benchmarks/replayssm/bench_decode_ssu.py`. Analytical per-step state **write**-traffic reduction at `buffer_len=16` is ~**14×** (the baseline writes the full state every step; replay writes it once per window + small input appends).

Latency, however, is **launch/overhead-bound at batch-1 for an isolated single-layer kernel** — the ~2 MB state R/W is ~0.4 µs of HBM time vs ~85 µs launch overhead, so the write saving does not show up as latency there. The IO win appears once the update is memory-bound:

CUDA-graph (launch overhead removed — vLLM's decode regime), non-flush step, `mamba2-large`:

| batch | baseline µs | output_only | state_and_output |
|---|---|---|---|
| 1 | 4.07 | 0.71× | 0.96× |
| 8 | 9.65 | 0.84× | 1.07× |
| 32 | 37.85 | 1.07× | 1.13× |
| 128 | 140.6 | 1.20× | 1.20× |

`buffer_len` sensitivity (batch 64, CUDA-graph): 4 → 1.4×, 8 → 1.35×, 16 → 1.27×, 32 → ~1.0×, 64 → regresses (recompute over the window dominates). Smaller buffers are faster but reduce write savings; **default 16** balances the two (8 is competitive). `state_and_output` is consistently ≥ `output_only` in this isolated benchmark despite the latter's theoretical IO edge (it still reads the full checkpoint each step and runs an extra precompute kernel).

**Caveat I want reviewers to weigh:** at batch-1 (the regime #46187 emphasizes) the *isolated* kernel does not beat baseline even graph-captured. The fork's reported E2E gains presumably come from the full multi-layer model regime and/or the spec-decode rollback win, which this PR does not yet measure in vLLM. This cut deliberately lands the kernel + dispatch contract + parity so that wiring can be reviewed separately.

### Out of scope (follow-ups)

- **E2E model wiring**: KV-cache page extension (the 3 ring-buffer tensors), the `mamba_attn` metadata builder (`write_pos`/`is_flush`/`bc_pre` scratch, CUDA-graph safety), `gpu_model_runner` allocation, and the `mamba_mixer2` call-through. This is the bulk of the fork's diff and deserves its own review; it's also what's needed to measure real E2E throughput and end-to-end TP1==TP2.
- **GDN / `fla`** replay kernel (routes through the same dispatch).
- **Speculative-decode rollback** (`--use-replayssm-spec`) — higher value, but overlaps the SSM-state checkpointing work in #43102 / #43439; will coordinate there rather than collide.

### Open questions for @mgoin

- Dispatch shape: a sibling `selective_state_update_replayssm()` funnel vs. folding the replay kwargs into `selective_state_update()` — I chose the sibling to keep the hot baseline signature clean. Preference?
- Default `buffer_len`: 16 (more IO reduction) vs 8 (better latency in the microbench)?

### Testing

```bash
# Parity + TP (H200 / SM90):
CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m pytest tests/kernels/mamba/test_replayssm_decode.py -q
# -> 156 passed

# Dispatch regression (unchanged):
.venv/bin/python -m pytest tests/kernels/mamba/test_ssu_dispatch.py -q
# -> 8 passed, 1 skipped

# Microbench:
CUDA_VISIBLE_DEVICES=0 .venv/bin/python benchmarks/replayssm/bench_decode_ssu.py --buffer-len 16 --dtype bfloat16

# Lint (ruff v0.14.0): ruff check + ruff format --check clean on all changed files.
```

### Not a duplicate

No open PR references #46187 or "ReplaySSM" (checked via GitHub search at time of writing); the issue had no prior comments. The reference fork (https://github.com/Johnny-Liou/ReplaySSM) adds parallel per-architecture kernels and ships no parity data — this PR unifies the Mamba2 AR path behind `ssu_dispatch.py` and provides the parity/TP evidence #46187 asks for.

References #46187 (does not fully close it — GDN + spec + E2E wiring remain).
