### PR TITLE
[CI][test] Replace InternVL2-1B with InternVL3-1B in test_pipeline_parallel.py

### DIFF
--- a/tests/distributed/test_pipeline_parallel.py
+++ b/tests/distributed/test_pipeline_parallel.py
@@ -175,7 +175,7 @@ MULTIMODAL_MODELS = {
     "facebook/chameleon-7b": PPTestSettings.fast(),
     "adept/fuyu-8b": PPTestSettings.fast(),
     "zai-org/glm-4v-9b": PPTestSettings.fast(),
-    "OpenGVLab/InternVL2-1B": PPTestSettings.fast(),
+    "OpenGVLab/InternVL3-1B": PPTestSettings.fast(),
     "llava-hf/llava-1.5-7b-hf": PPTestSettings.fast(),
     "llava-hf/llava-v1.6-mistral-7b-hf": PPTestSettings.fast(),
     "llava-hf/LLaVA-NeXT-Video-7B-hf": PPTestSettings.fast(),
@@ -203,7 +203,7 @@ TEST_MODELS = [
     "intfloat/e5-mistral-7b-instruct",
     "BAAI/bge-multilingual-gemma2",
     # [MULTIMODAL GENERATION]
-    "OpenGVLab/InternVL2-1B",
+    "OpenGVLab/InternVL3-1B",
     "microsoft/Phi-3.5-vision-instruct",
     "fixie-ai/ultravox-v0_5-llama-3_2-1b",
     # [LANGUAGE GENERATION - HYBRID ARCH]


### PR DESCRIPTION
## Purpose

`OpenGVLab/InternVL2-1B` (model_type=`internvl_chat`) cannot be loaded by `AutoTokenizer` on `transformers >= 5.x`:

```
ValueError: Couldn't instantiate the backend tokenizer from one of:
(1) a `tokenizers` library serialization file,
(2) a slow tokenizer instance to convert or
(3) an equivalent slow tokenizer class to instantiate and convert.
You need to have sentencepiece or tiktoken installed to convert a slow tokenizer to a fast one.
```

The error message is misleading — `sentencepiece` and `tiktoken` are both installed. The real cause is the combination of two facts:

1. `transformers 5.x` lists `internvl_chat` in `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS` (in `transformers/models/auto/tokenization_auto.py`), so `AutoTokenizer` is forced to use `TokenizersBackend` rather than the `Qwen2Tokenizer` the hub `tokenizer_config.json` declares.
2. `TokenizersBackend.vocab_files_names` only contains `tokenizer_file`, so `vocab.json` and `merges.txt` are not downloaded.

The `OpenGVLab/InternVL2-1B` hub repo ships only `vocab.json` + `merges.txt` (no `tokenizer.json`), so when `TokenizersBackend` is forced and only `tokenizer.json` is requested, the backend ends up with no vocab to load and raises the error above.

This fails on both official PyPI `transformers==5.10.2` and `transformers==5.9.0`, so it is not a fork-specific bug.

## Fix

`OpenGVLab/InternVL3-1B` is the same model family with the same `model_type` and architecture (`InternVLChatModel`). Its hub repo **includes `tokenizer.json`**, so `AutoTokenizer` (still going through `TokenizersBackend`) loads from `tokenizer.json` successfully on `transformers 5.x`.

```diff
-    "OpenGVLab/InternVL2-1B": PPTestSettings.fast(),
+    "OpenGVLab/InternVL3-1B": PPTestSettings.fast(),
...
-    "OpenGVLab/InternVL2-1B",
+    "OpenGVLab/InternVL3-1B",
```

Two occurrences in `tests/distributed/test_pipeline_parallel.py`. This change is test-only.

## Test Plan

```bash
pytest -v -s "tests/distributed/test_pipeline_parallel.py::test_tp_multimodal_generation[OpenGVLab/InternVL3-1B-parallel_setup0-mp-auto-test_options0]"
```

## Risk

Minimal. Same model family, same architecture, same PP test settings (`PPTestSettings.fast()`). The replacement targets the test scaffolding only.
