### PR TITLE
[Bugfix][Model] Add get_expert_mapping to GraniteMoeModel for LoRA support

### DIFF
--- a/vllm/model_executor/models/granitemoe.py
+++ b/vllm/model_executor/models/granitemoe.py
@@ -431,6 +431,15 @@ class GraniteMoeModel(nn.Module):
             loaded_params.add(name)
         return loaded_params
 
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return fused_moe_make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="w1",
+            ckpt_down_proj_name="w2",
+            ckpt_up_proj_name="w3",
+            num_experts=self.config.num_local_experts,
+        )
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         new_weights = {}
         for n, p in weights:
@@ -541,6 +550,9 @@ class GraniteMoeForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
                 ),
             }
         )
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return self.model.get_expert_mapping()
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(


### PR DESCRIPTION

## Purpose

`GraniteMoeForCausalLM` declares `SupportsLoRA`, but enabling LoRA on any granitemoe model crashes the engine at init, before any adapter is loaded or any request is sent:

```
AttributeError: To support LoRA for MoE model, 'get_expert_mapping' must be implemented
```

`granitemoe` instantiates a `FusedMoE`, so `is_moe_model()` is true and `vllm/lora/utils.py::process_packed_modules_mapping` requires `get_expert_mapping` when building the LoRA manager. Neither `GraniteMoeForCausalLM` nor `GraniteMoeModel` implements it, so `get_moe_expert_mapping(model)` returns empty and the load aborts. The requirement applies to every MoE + LoRA combination, independent of whether the adapter targets the experts, so LoRA is currently unusable for all granitemoe models.

This is the same class of bug already fixed for `nemotron_h` (#31539, reported as #31923) and `gemma4` (#40584); granitemoe was missed.

The fix mirrors the established idiom in `qwen2_moe` and `granitemoehybrid`: `GraniteMoeModel` returns the fused expert mapping built from the same `w1`/`w2`/`w3` checkpoint names and `num_local_experts` that `load_weights` already uses, and `GraniteMoeForCausalLM` delegates to it.

## Test Plan

Hardware: 1x RTX 4090. Model: `ibm-granite/granite-3.0-1b-a400m-instruct` (granitemoe, 32 experts, top-8).

1. Reproduce the crash on stock vLLM and confirm the fix removes it:

```python
from vllm import LLM
LLM(model="ibm-granite/granite-3.0-1b-a400m-instruct", enable_lora=True,
    max_lora_rank=16, max_loras=1, enforce_eager=True)
```

2. Confirm LoRA is actually applied (not merely no longer crashing): put an attention-only (`q/k/v/o`) LoRA on the MoE base, compare vLLM's first-token top-k logprobs against a `peft` reference, and measure the LoRA divergence against the base vLLM-vs-`peft` noise floor.

## Test Result

Before (stock vLLM, same isolated checkout), engine init aborts:

```
(EngineCore) File "vllm/lora/utils.py", line 387, in process_packed_modules_mapping
    raise AttributeError(
AttributeError: To support LoRA for MoE model, 'get_expert_mapping' must be implemented
RuntimeError: Engine core initialization failed.
```

After (patched), step 1 constructs successfully, and step 2 shows the adapter applied correctly: the LoRA first-token top-1 token matches the `peft` reference on all prompts, and the vLLM-vs-`peft` LoRA divergence stays within the base-model vLLM-vs-`peft` floor (so the adapter adds no error of its own), while the LoRA output differs from the base output.

<details>
<summary>Numerical detail (step 2)</summary>

Attention-only LoRA (rank 16, alpha 32, small random weights) on `granite-3.0-1b-a400m`, 4 prompts, comparing first-token top-10 logprobs:

```
 noise floor |vLLM_base - peft_base|  worst=0.51  top1 match=[True, True, True, True]
 test        |vLLM_lora - peft_lora|  worst=0.37  top1 match=[True, True, True, True]
 sanity      lora output != base output: True
```

The LoRA divergence (0.37) is below the base vLLM-vs-`peft` floor (0.51), i.e. enabling the adapter introduces no error beyond the pre-existing bf16 kernel gap between vLLM and HF/`peft`; top-1 matches on every prompt; and the adapter measurably changes the output. Reverting the change reintroduces the init `AttributeError`.

Scope note: this PR covers `granitemoe`. `granitemoeshared` has the same missing `get_expert_mapping`, but I could not end-to-end verify a fix there (no small public GraniteMoeShared checkpoint, and a self-built tiny checkpoint hits an unrelated weight-load error before the LoRA path), so it is left for a separate, independently verified change.
</details>

`ruff check` and `ruff format` pass on the changed file.

<details>
<summary>LoRA application check (adapter build, peft reference, vLLM comparison)</summary>

The init-crash repro above proves the engine can start after the fix. This script also checks that an attention-only LoRA is actually applied by comparing vLLM first-token logprobs against a `peft` reference and against the base-model vLLM-vs-`peft` noise floor.

```bash
cat >/tmp/granitemoe_lora_check.py <<'PY'
import json
import os
import sys

import torch
import torch.nn.functional as F

MODEL = os.environ.get("GRANITEMOE_MODEL", "ibm-granite/granite-3.0-1b-a400m-instruct")
WORKDIR = os.environ.get("GRANITEMOE_LORA_WORKDIR", "/tmp/granitemoe_lora_check")
PROMPTS = [
    "The capital of France is",
    "Once upon a time",
    "2 + 2 =",
    "The sun rises in the",
]
RANK = 16
ALPHA = 32
SEED = 9001
SCALE = 0.01
TOPK = 10
TARGETS = ["q_proj", "k_proj", "v_proj", "o_proj"]
ADIR = os.path.join(WORKDIR, "adapter_moe")
BASE_REF = os.path.join(WORKDIR, "base_ref.json")
LORA_REF = os.path.join(WORKDIR, "lora_ref.json")


def first_topk(model, tok):
    out = []
    for prompt in PROMPTS:
        ids = tok(prompt, return_tensors="pt").input_ids.cuda()
        with torch.no_grad():
            logits = model(ids).logits[0, -1].float()
        lp = F.log_softmax(logits, dim=-1)
        top = torch.topk(lp, TOPK)
        out.append([(int(t), float(v)) for t, v in zip(top.indices, top.values)])
    return out


def build_refs():
    from peft import LoraConfig, get_peft_model
    from transformers import AutoModelForCausalLM, AutoTokenizer

    os.makedirs(WORKDIR, exist_ok=True)
    tok = AutoTokenizer.from_pretrained(MODEL)

    base = AutoModelForCausalLM.from_pretrained(MODEL, dtype=torch.bfloat16).cuda().eval()
    with open(BASE_REF, "w") as f:
        json.dump(first_topk(base, tok), f)
    del base
    torch.cuda.empty_cache()

    base_for_lora = AutoModelForCausalLM.from_pretrained(MODEL, dtype=torch.bfloat16)
    cfg = LoraConfig(r=RANK, lora_alpha=ALPHA, target_modules=TARGETS, bias="none")
    peft_model = get_peft_model(base_for_lora, cfg)
    gen = torch.Generator().manual_seed(SEED)
    for name, param in peft_model.named_parameters():
        if "lora_" in name and (".lora_A" in name or ".lora_B" in name):
            param.data = torch.randn(param.shape, generator=gen, dtype=param.dtype) * SCALE

    os.makedirs(ADIR, exist_ok=True)
    peft_model.save_pretrained(ADIR)
    peft_model = peft_model.cuda().eval()
    with open(LORA_REF, "w") as f:
        json.dump(first_topk(peft_model, tok), f)
    print("ALL_REF_DONE", ADIR)


def max_delta(ref_a, ref_b):
    worst = 0.0
    top1 = []
    for i in range(len(PROMPTS)):
        a = {int(t): float(v) for t, v in ref_a[i]}
        b = {int(t): float(v) for t, v in ref_b[i]}
        shared = set(a) & set(b)
        worst = max(worst, max((abs(a[t] - b[t]) for t in shared), default=0.0))
        top1.append(ref_a[i][0][0] == ref_b[i][0][0])
    return worst, top1


def vllm_first_topk(llm, lora_dir):
    from vllm import SamplingParams
    from vllm.lora.request import LoRARequest

    sp = SamplingParams(temperature=0.0, max_tokens=1, logprobs=TOPK)
    lora_request = LoRARequest("granitemoe-attn", 1, lora_dir) if lora_dir else None
    outputs = llm.generate(PROMPTS, sp, lora_request=lora_request, use_tqdm=False)
    result = []
    for output in outputs:
        logprobs = output.outputs[0].logprobs[0]
        items = sorted(logprobs.items(), key=lambda kv: kv[1].logprob, reverse=True)
        result.append([(int(t), float(v.logprob)) for t, v in items])
    return result


def run_vllm_check():
    from vllm import LLM

    llm = LLM(
        model=MODEL,
        enable_lora=True,
        max_lora_rank=RANK,
        max_loras=1,
        gpu_memory_utilization=0.5,
        enforce_eager=True,
        dtype="bfloat16",
    )
    with open(BASE_REF) as f:
        base_ref = json.load(f)
    with open(LORA_REF) as f:
        lora_ref = json.load(f)

    vllm_base = vllm_first_topk(llm, None)
    vllm_lora = vllm_first_topk(llm, ADIR)
    floor, floor_top1 = max_delta(vllm_base, base_ref)
    test, test_top1 = max_delta(vllm_lora, lora_ref)
    base_tokens = [row[0][0] for row in vllm_base]
    lora_tokens = [row[0][0] for row in vllm_lora]

    print("noise_floor |vLLM_base - peft_base|", f"worst={floor:.4f}", f"top1={floor_top1}")
    print("test        |vLLM_lora - peft_lora|", f"worst={test:.4f}", f"top1={test_top1}")
    print("sanity      lora top1 differs from base:", lora_tokens != base_tokens)


if __name__ == "__main__":
    if len(sys.argv) != 2 or sys.argv[1] not in {"build", "run"}:
        raise SystemExit("usage: python granitemoe_lora_check.py build|run")
    if sys.argv[1] == "build":
        build_refs()
    else:
        run_vllm_check()
PY
```

Commands:

```bash
cd /path/to/vllm
export PYTHONPATH="$PWD"
export CUDA_VISIBLE_DEVICES=0
export GRANITEMOE_MODEL=ibm-granite/granite-3.0-1b-a400m-instruct

python /tmp/granitemoe_lora_check.py build
python /tmp/granitemoe_lora_check.py run
```

Observed output:

```text
# stock main, before this PR
constructing LLM(granitemoe, enable_lora=True) ...
AttributeError: To support LoRA for MoE model, 'get_expert_mapping' must be implemented

# with this PR
ALL_REF_DONE /tmp/granitemoe_lora_check/adapter_moe
noise_floor |vLLM_base - peft_base| worst=0.51 top1=[True, True, True, True]
test        |vLLM_lora - peft_lora| worst=0.37 top1=[True, True, True, True]
sanity      lora top1 differs from base: True
```

</details>

AI assistance was used to prepare this PR.
