### PR TITLE
[Doc] Clarify prefix caching metrics and APC verification workflow

### DIFF
--- a/docs/features/automatic_prefix_caching.md
+++ b/docs/features/automatic_prefix_caching.md
@@ -13,6 +13,27 @@ Set `enable_prefix_caching=True` in vLLM engine to enable APC. Here is an exampl
 
 [examples/features/automatic_prefix_caching/automatic_prefix_caching_offline.py](../../examples/features/automatic_prefix_caching/automatic_prefix_caching_offline.py)
 
+## Verifying APC reuse
+
+Send two or more requests with a token-identical shared prefix and different
+suffixes. The first request typically populates the prefix cache. Later requests
+can reuse the full KV-cache blocks that correspond to the shared prefix.
+
+For online serving, compare the [`/metrics` endpoint](../usage/metrics.md) before
+and after the repeated requests. Reuse should generally increase
+`vllm:prefix_cache_hits`; the reused portion also reduces the newly computed
+prefill KV tokens reported by `vllm:request_prefill_kv_computed_tokens`.
+
+Zero or low prefix-cache hits can occur when:
+
+- The cache is cold.
+- The rendered and tokenized prefixes differ, for example because of a chat
+  template or whitespace difference.
+- The shared prefix does not contain enough complete reusable KV-cache blocks.
+- The requests use different LoRA adapters, multi-modal input hashes, or
+  `cache_salt` values.
+- The cached blocks were evicted or the prefix cache was reset.
+
 ## Example workloads
 
 We describe two example workloads, where APC can provide huge performance benefit:

--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -37,6 +37,41 @@ The following metrics are exposed:
 
 --8<-- "docs/generated/metrics/general.inc.md"
 
+## Interpreting prefix caching metrics
+
+`vllm:prefix_cache_queries` and `vllm:prefix_cache_hits` are token-level
+counters. They count the number of tokens queried in the local prefix cache and
+the number found there, rather than the number of requests. A local
+prefix-cache token hit rate can be calculated from counter increases over the
+same time window:
+
+```promql
+increase(vllm:prefix_cache_hits_total[5m])
+/
+increase(vllm:prefix_cache_queries_total[5m])
+```
+
+Prometheus client libraries expose counters with the `_total` suffix in the
+time series name.
+The ratio above is not the fraction of requests with a cache hit because a
+request can reuse only part of its prefix.
+
+Related metrics answer different questions:
+
+- `vllm:prompt_tokens_cached` counts prompt tokens skipped during prefill
+  through local prefix-cache reuse and external KV transfer.
+- `vllm:request_prefill_kv_computed_tokens` is a per-request histogram of newly
+  computed prefill KV tokens, excluding cached tokens.
+- `vllm:kv_cache_usage_perc` reports KV-cache usage from 0 to 1; it is not a
+  prefix-cache hit rate.
+- The sampled `vllm:kv_block_lifetime_seconds`,
+  `vllm:kv_block_idle_before_evict_seconds`, and
+  `vllm:kv_block_reuse_gap_seconds` histograms describe block-level residency
+  and reuse. They do not report per-request cache hit rates.
+
+See [Automatic Prefix Caching](../features/automatic_prefix_caching.md) for a
+workflow to verify prefix reuse.
+
 ## Speculative Decoding Metrics
 
 --8<-- "docs/generated/metrics/spec_decode.inc.md"


### PR DESCRIPTION
## Summary

This PR clarifies how to interpret prefix caching metrics and how to verify
Automatic Prefix Caching (APC) reuse in practice.

It documents:

* The token-level granularity of `vllm:prefix_cache_queries` and
  `vllm:prefix_cache_hits`.
* How to calculate a local prefix-cache token hit rate from Prometheus counter
  increases.
* The distinct meanings of `vllm:prompt_tokens_cached`,
  `vllm:request_prefill_kv_computed_tokens`, `vllm:kv_cache_usage_perc`, and
  the sampled `vllm:kv_block_*` metrics.
* A lightweight APC verification workflow using token-identical shared
  prefixes.
* Common reasons for zero or low prefix-cache hits.

No runtime behavior is changed. No metrics are added or removed.

## Testing

* Reviewed the Markdown diff locally.
* Ran `git diff --check`.

`mkdocs build` was not run locally because installing the documentation
dependencies failed due to a local TLS/SSL environment issue.

## AI assistance disclosure

OpenAI Codex was used to help inspect the relevant implementation and draft
the documentation. I reviewed all changed lines and validated the final wording
against the current implementation.
