### PR TITLE
[Hybrid] Decoupling block_size from allocation block size

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -122,6 +122,11 @@ class CacheConfig:
     """Size of a contiguous cache block in number of tokens for mamba cache.
     Can be set only when prefix caching is enabled.
     Value must be a multiple of 8 to align with causal_conv1d kernel."""
+    mamba_large_block_factor: int = Field(default=1, gt=0)
+    """Number `N` of attention `block_size`-sized blocks that one mamba block
+    spans in the shared backing tensor. `mamba_block_size = N * block_size`.
+    Set automatically by `check_and_update_kv_cache_block_size`; defaults to 1
+    for non-hybrid models."""
     mamba_cache_dtype: MambaDType = "auto"
     """The data type to use for the Mamba cache (both the conv as well as the
     ssm state). If set to 'auto', the data type will be inferred from the model
@@ -208,6 +213,7 @@ class CacheConfig:
             "mamba_page_size_padded",
             "user_specified_block_size",
             "user_specified_mamba_block_size",
+            "mamba_large_block_factor",
             "_block_size_resolved",
             # Post-init/derived counters
             "num_gpu_blocks",

--- a/vllm/model_executor/layers/mamba/abstract.py
+++ b/vllm/model_executor/layers/mamba/abstract.py
@@ -57,6 +57,7 @@ class MambaBase(AttentionLayerBase):
                 if vllm_config.speculative_config
                 else 0
             ),
+            large_block_factor=vllm_config.cache_config.mamba_large_block_factor,
         )
 
     def get_attn_backend(self) -> type[AttentionBackend]:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -648,8 +648,16 @@ class Platform:
                 cache_config.block_size,
             )
 
+        # Bump attention block_size up to kernel_block_alignment_size if needed,
+        # but otherwise leave it at the (small) user/default value. Attention no
+        # longer inherits the mamba state size; instead, mamba allocates large
+        # blocks each spanning N small attention blocks.
+        if cache_config.block_size < kernel_block_alignment_size:
+            cache_config.block_size = kernel_block_alignment_size
+
         if cache_config.mamba_cache_mode == "all":
-            # With prefix caching, align to mamba chunk size for kernel perf
+            # With prefix caching, align mamba block size to mamba chunk size
+            # for kernel perf.
             # TODO(tdoublep): this constraint can be relaxed fairly
             # easily by changing the way we layout chunks in the
             # mamba2 kernels.
@@ -657,29 +665,37 @@ class Platform:
             assert base_chunk_size is not None
             attn_tokens_per_mamba_state = cdiv(mamba_page_size, attn_page_size_1_token)
             chunk_size = lcm(base_chunk_size, kernel_block_alignment_size)
-            attn_block_size = chunk_size * cdiv(attn_tokens_per_mamba_state, chunk_size)
-            cache_config.mamba_block_size = attn_block_size
+            mamba_block_size_tokens = chunk_size * cdiv(
+                attn_tokens_per_mamba_state, chunk_size
+            )
         else:
-            # Without prefix caching, use minimum block size that satisfies
-            # both backend alignment and mamba page size compatibility
-            attn_block_size = kernel_block_alignment_size * cdiv(
+            # Without prefix caching, use minimum mamba block size that satisfies
+            # both backend alignment and mamba page size compatibility.
+            mamba_block_size_tokens = kernel_block_alignment_size * cdiv(
                 mamba_page_size,
                 kernel_block_alignment_size * attn_page_size_1_token,
             )
 
-        if cache_config.block_size < attn_block_size:
-            cache_config.block_size = attn_block_size
+        # `mamba_block_size_tokens` is a multiple of kernel_block_alignment_size,
+        # which is >= cache_config.block_size and (since we just bumped) the
+        # latter equals kernel_block_alignment_size, so divisibility holds.
+        assert mamba_block_size_tokens % cache_config.block_size == 0
+        large_block_factor = mamba_block_size_tokens // cache_config.block_size
+        cache_config.mamba_block_size = mamba_block_size_tokens
+        cache_config.mamba_large_block_factor = large_block_factor
+
+        if large_block_factor > 1:
             logger.info(
-                "Setting attention block size to %d tokens "
-                "to ensure that attention page size is >= mamba page size.",
-                attn_block_size,
+                "Mamba block spans %d attention blocks of %d tokens "
+                "(mamba_block_size=%d).",
+                large_block_factor,
+                cache_config.block_size,
+                mamba_block_size_tokens,
             )
 
-        if cache_config.mamba_cache_mode == "align":
-            cache_config.mamba_block_size = cache_config.block_size
-
-        # Pad mamba page size to exactly match attention page size
-        attn_page_size = cache_config.block_size * attn_page_size_1_token
+        # Pad mamba page size to exactly match a mamba-sized run of attention
+        # pages so views over the shared backing tensor align byte-exactly.
+        attn_page_size = mamba_block_size_tokens * attn_page_size_1_token
         assert attn_page_size >= mamba_page_size
 
         if attn_page_size == mamba_page_size:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -681,16 +681,27 @@ class Platform:
         # latter equals kernel_block_alignment_size, so divisibility holds.
         assert mamba_block_size_tokens % cache_config.block_size == 0
         large_block_factor = mamba_block_size_tokens // cache_config.block_size
-        cache_config.mamba_block_size = mamba_block_size_tokens
         cache_config.mamba_large_block_factor = large_block_factor
+
+        # In "all" mode the kernel uses ``mamba_block_size`` as the cadence at
+        # which intermediate states are checkpointed (chunk_stride math), so it
+        # must stay at the large value. In "align"/"none" modes the kernel only
+        # writes/reads state at the request boundary, so ``mamba_block_size``
+        # is just the prefix-cache step granularity; keep it at the small
+        # attention block size so cache hits land on attention boundaries.
+        if cache_config.mamba_cache_mode == "all":
+            cache_config.mamba_block_size = mamba_block_size_tokens
+        else:
+            cache_config.mamba_block_size = cache_config.block_size
 
         if large_block_factor > 1:
             logger.info(
                 "Mamba block spans %d attention blocks of %d tokens "
-                "(mamba_block_size=%d).",
+                "(mamba_block_size=%d, prefix-cache step=%d).",
                 large_block_factor,
                 cache_config.block_size,
                 mamba_block_size_tokens,
+                cache_config.mamba_block_size,
             )
 
         # Pad mamba page size to exactly match a mamba-sized run of attention

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -648,8 +648,16 @@ class Platform:
                 cache_config.block_size,
             )
 
+        # Bump attention block_size up to kernel_block_alignment_size if needed,
+        # but otherwise leave it at the (small) user/default value. Attention no
+        # longer inherits the mamba state size; instead, mamba allocates large
+        # blocks each spanning N small attention blocks.
+        if cache_config.block_size < kernel_block_alignment_size:
+            cache_config.block_size = kernel_block_alignment_size
+
         if cache_config.mamba_cache_mode == "all":
-            # With prefix caching, align to mamba chunk size for kernel perf
+            # With prefix caching, align mamba block size to mamba chunk size
+            # for kernel perf.
             # TODO(tdoublep): this constraint can be relaxed fairly
             # easily by changing the way we layout chunks in the
             # mamba2 kernels.
@@ -657,29 +665,48 @@ class Platform:
             assert base_chunk_size is not None
             attn_tokens_per_mamba_state = cdiv(mamba_page_size, attn_page_size_1_token)
             chunk_size = lcm(base_chunk_size, kernel_block_alignment_size)
-            attn_block_size = chunk_size * cdiv(attn_tokens_per_mamba_state, chunk_size)
-            cache_config.mamba_block_size = attn_block_size
+            mamba_block_size_tokens = chunk_size * cdiv(
+                attn_tokens_per_mamba_state, chunk_size
+            )
         else:
-            # Without prefix caching, use minimum block size that satisfies
-            # both backend alignment and mamba page size compatibility
-            attn_block_size = kernel_block_alignment_size * cdiv(
+            # Without prefix caching, use minimum mamba block size that satisfies
+            # both backend alignment and mamba page size compatibility.
+            mamba_block_size_tokens = kernel_block_alignment_size * cdiv(
                 mamba_page_size,
                 kernel_block_alignment_size * attn_page_size_1_token,
             )
 
-        if cache_config.block_size < attn_block_size:
-            cache_config.block_size = attn_block_size
-            logger.info(
-                "Setting attention block size to %d tokens "
-                "to ensure that attention page size is >= mamba page size.",
-                attn_block_size,
-            )
+        # `mamba_block_size_tokens` is a multiple of kernel_block_alignment_size,
+        # which is >= cache_config.block_size and (since we just bumped) the
+        # latter equals kernel_block_alignment_size, so divisibility holds.
+        assert mamba_block_size_tokens % cache_config.block_size == 0
+        large_block_factor = mamba_block_size_tokens // cache_config.block_size
+        cache_config.mamba_large_block_factor = large_block_factor
 
-        if cache_config.mamba_cache_mode == "align":
+        # In "all" mode the kernel uses ``mamba_block_size`` as the cadence at
+        # which intermediate states are checkpointed (chunk_stride math), so it
+        # must stay at the large value. In "align"/"none" modes the kernel only
+        # writes/reads state at the request boundary, so ``mamba_block_size``
+        # is just the prefix-cache step granularity; keep it at the small
+        # attention block size so cache hits land on attention boundaries.
+        if cache_config.mamba_cache_mode == "all":
+            cache_config.mamba_block_size = mamba_block_size_tokens
+        else:
             cache_config.mamba_block_size = cache_config.block_size
 
-        # Pad mamba page size to exactly match attention page size
-        attn_page_size = cache_config.block_size * attn_page_size_1_token
+        if large_block_factor > 1:
+            logger.info(
+                "Mamba block spans %d attention blocks of %d tokens "
+                "(mamba_block_size=%d, prefix-cache step=%d).",
+                large_block_factor,
+                cache_config.block_size,
+                mamba_block_size_tokens,
+                cache_config.mamba_block_size,
+            )
+
+        # Pad mamba page size to exactly match a mamba-sized run of attention
+        # pages so views over the shared backing tensor align byte-exactly.
+        attn_page_size = mamba_block_size_tokens * attn_page_size_1_token
         assert attn_page_size >= mamba_page_size
 
         if attn_page_size == mamba_page_size:

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -273,15 +273,20 @@ class XPUPlatform(Platform):
         if new_block_size == cache_config.block_size:
             return
 
-        if cache_config.mamba_cache_mode == "align":
-            cache_config.mamba_block_size = new_block_size
         original_mamba_page_size_padded = cache_config.mamba_page_size_padded
+        # `mamba_block_size` is N * block_size; when block_size grows, recompute N.
+        if cache_config.mamba_block_size is not None:
+            assert cache_config.mamba_block_size % new_block_size == 0
+            cache_config.mamba_large_block_factor = (
+                cache_config.mamba_block_size // new_block_size
+            )
         if cache_config.mamba_page_size_padded is not None:
             attn_page_size_1_token = (
                 cache_config.mamba_page_size_padded // cache_config.block_size
             )
+            assert cache_config.mamba_block_size is not None
             cache_config.mamba_page_size_padded = (
-                new_block_size * attn_page_size_1_token
+                cache_config.mamba_block_size * attn_page_size_1_token
             )
         cache_config.block_size = new_block_size
         logger.info(

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -20,6 +20,7 @@ from vllm.v1.core.kv_cache_utils import (
     ExternalBlockHash,
     FreeKVCacheBlockQueue,
     KVCacheBlock,
+    LargeBlockMeta,
     generate_block_hash_extra_keys,
     get_block_hash,
     get_group_id,
@@ -144,6 +145,11 @@ class BlockPool:
             actual block size can be a multiple of hash_block_size.
         enable_kv_cache_events: Whether to enable kv cache events.
         metrics_collector: Optional metrics collector for tracking block residency.
+        large_block_factor: Number `N` of small (attention) blocks that one
+            large (mamba) block spans. ``N == 1`` (default) means flat / legacy
+            behaviour. ``N > 1`` enables hierarchical allocation: small blocks
+            are dispensed from inside parent large blocks, and large blocks
+            are managed by their own free-queue.
     """
 
     def __init__(
@@ -153,28 +159,63 @@ class BlockPool:
         hash_block_size: int,
         enable_kv_cache_events: bool = False,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        large_block_factor: int = 1,
     ):
         assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
+        assert isinstance(large_block_factor, int) and large_block_factor >= 1
         self.num_gpu_blocks = num_gpu_blocks
         self.enable_caching = enable_caching
         self.hash_block_size = hash_block_size
-        # All kv-cache blocks.
+        self.large_block_factor = large_block_factor
+        # All kv-cache blocks (small / attention granularity).
         self.blocks: list[KVCacheBlock] = [
             KVCacheBlock(idx) for idx in range(num_gpu_blocks)
         ]
-        # Free block queue that constructs and manipulates a doubly linked
-        # list of free blocks (including eviction candidates when caching is
-        # enabled).
-        self.free_block_queue = FreeKVCacheBlockQueue(self.blocks)
+        if large_block_factor == 1:
+            # Flat / legacy mode: one global free queue over all blocks. No
+            # large-block hierarchy.
+            self.free_block_queue = FreeKVCacheBlockQueue(self.blocks)
+            self.large_block_metas: list[LargeBlockMeta] = []
+            self.free_large_block_queue: FreeKVCacheBlockQueue | None = None
+
+            # To represent a placeholder block with block_id=0.
+            # The ref_cnt of null_block is not maintained, needs special care to
+            # avoid freeing it.
+            self.null_block = self.free_block_queue.popleft()
+            self.null_block.is_null = True
+        else:
+            # Hierarchical mode: small blocks live inside parent large blocks
+            # and are dispensed via per-meta cursors. The flat ``free_block_queue``
+            # is created empty and unused; ``free_large_block_queue`` owns
+            # whole large blocks.
+            num_large_blocks = num_gpu_blocks // large_block_factor
+            assert num_large_blocks >= 2, (
+                "Hierarchical block pool requires at least 2 large blocks "
+                "(one is reserved for the null block)."
+            )
+            self.large_block_metas = [
+                LargeBlockMeta(
+                    large_block=KVCacheBlock(L),
+                    small_blocks=self.blocks[
+                        L * large_block_factor : (L + 1) * large_block_factor
+                    ],
+                )
+                for L in range(num_large_blocks)
+            ]
+            # Reserve large block 0 to host the null small block; never enters
+            # any free queue.
+            self.large_block_metas[0].num_small_in_use = large_block_factor
+            self.large_block_metas[0].next_small_idx = large_block_factor
+            self.null_block = self.large_block_metas[0].small_blocks[0]
+            self.null_block.is_null = True
+            # Truncated free queue carrying only large blocks for ids >= 1.
+            self.free_block_queue = FreeKVCacheBlockQueue([])
+            self.free_large_block_queue = FreeKVCacheBlockQueue(
+                [meta.large_block for meta in self.large_block_metas[1:]]
+            )
 
         # Cache for block lookup
         self.cached_block_hash_to_block: BlockHashToBlockMap = BlockHashToBlockMap()
-
-        # To represent a placeholder block with block_id=0.
-        # The ref_cnt of null_block is not maintained, needs special care to
-        # avoid freeing it.
-        self.null_block = self.free_block_queue.popleft()
-        self.null_block.is_null = True
 
         self.enable_kv_cache_events = enable_kv_cache_events
         self.kv_event_queue: list[KVCacheEvent] = []
@@ -330,21 +371,55 @@ class BlockPool:
                 )
             )
 
-    def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
+    def get_new_blocks(
+        self,
+        num_blocks: int,
+        large_block: bool = False,
+        last_hit_block_id: int | None = None,
+    ) -> list[KVCacheBlock]:
         """Get new blocks from the free block pool.
 
         Note that we do not check block cache in this function.
 
         Args:
             num_blocks: The number of blocks to allocate.
+            large_block: If True (only valid when ``large_block_factor > 1``),
+                allocate whole large blocks (returning ``KVCacheBlock`` objects
+                whose ``block_id`` is the large id). If False, allocate small
+                blocks (the legacy semantics).
+            last_hit_block_id: Optional small-block id of the last prefix-cache
+                hit for this request. When provided, the allocator tries to
+                continue allocating small blocks from the same parent large
+                block to keep the request's blocks within one large block.
+                Ignored for ``large_block=True`` and for legacy flat pools.
 
         Returns:
-            A list of new block.
+            A list of new blocks.
         """
-        if num_blocks > self.get_num_free_blocks():
+        if num_blocks == 0:
+            return []
+        capacity = (
+            self.get_num_free_large_blocks()
+            if large_block
+            else self.get_num_free_blocks()
+        )
+        if num_blocks > capacity:
             raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
 
-        ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+        if self.large_block_factor == 1:
+            # Legacy / flat path. ``large_block`` and ``last_hit_block_id`` are
+            # no-ops here; small ids and large ids coincide.
+            ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+        elif large_block:
+            assert self.free_large_block_queue is not None
+            large_blocks = self.free_large_block_queue.popleft_n(num_blocks)
+            for blk in large_blocks:
+                meta = self.large_block_metas[blk.block_id]
+                meta.num_small_in_use = self.large_block_factor
+                meta.next_small_idx = self.large_block_factor
+            ret = large_blocks
+        else:
+            ret = self._dispense_small_blocks(num_blocks, last_hit_block_id)
 
         # In order to only iterate the list once, we duplicated code a bit
         if self.enable_caching:
@@ -360,6 +435,52 @@ class BlockPool:
                 block.ref_cnt += 1
                 if self.metrics_collector:
                     self.metrics_collector.on_block_allocated(block)
+        return ret
+
+    def _dispense_small_blocks(
+        self, num_blocks: int, last_hit_block_id: int | None
+    ) -> list[KVCacheBlock]:
+        """Hierarchical small-block dispensing.
+
+        Tries to continue inside the partial parent large block of
+        ``last_hit_block_id`` (when capacity remains there), then opens fresh
+        large blocks one at a time.
+        """
+        assert self.free_large_block_queue is not None
+        N = self.large_block_factor
+        ret: list[KVCacheBlock] = []
+        remaining = num_blocks
+
+        # 1. Try to continue inside the parent of last_hit_block_id.
+        if last_hit_block_id is not None:
+            parent_L = last_hit_block_id // N
+            if 0 <= parent_L < len(self.large_block_metas):
+                meta = self.large_block_metas[parent_L]
+                # The parent is a "partial" meta iff its cursor is in
+                # (0, N): fully-free metas live in the free-large queue;
+                # fully-consumed metas have next_small_idx == N.
+                if 0 < meta.next_small_idx < N:
+                    avail = N - meta.next_small_idx
+                    take = min(avail, remaining)
+                    for j in range(take):
+                        small = meta.small_blocks[meta.next_small_idx + j]
+                        ret.append(small)
+                    meta.next_small_idx += take
+                    meta.num_small_in_use += take
+                    remaining -= take
+
+        # 2. Open fresh large blocks as needed.
+        while remaining > 0:
+            large_blk = self.free_large_block_queue.popleft()
+            meta = self.large_block_metas[large_blk.block_id]
+            assert meta.next_small_idx == 0
+            take = min(N, remaining)
+            for j in range(take):
+                ret.append(meta.small_blocks[j])
+            meta.next_small_idx = take
+            meta.num_small_in_use = take
+            remaining -= take
+
         return ret
 
     def _maybe_evict_cached_block(self, block: KVCacheBlock) -> bool:
@@ -407,37 +528,122 @@ class BlockPool:
         Args:
             blocks: A list of blocks to touch.
         """
+        N = self.large_block_factor
         for block in blocks:
             # ref_cnt=0 means this block is in the free list (i.e. eviction
             # candidate), so remove it.
             if block.ref_cnt == 0 and not block.is_null:
-                self.free_block_queue.remove(block)
+                if N == 1:
+                    self.free_block_queue.remove(block)
+                else:
+                    # Hierarchical: figure out whether this is a large or a
+                    # small block by which list its block_id indexes into.
+                    # Mamba large blocks are touched as the ``large_block``
+                    # KVCacheBlock inside a meta; small blocks live inside a
+                    # meta's ``small_blocks`` list at idx (block_id % N).
+                    assert self.free_large_block_queue is not None
+                    meta_for_large = (
+                        self.large_block_metas[block.block_id]
+                        if block.block_id < len(self.large_block_metas)
+                        else None
+                    )
+                    if (
+                        meta_for_large is not None
+                        and meta_for_large.large_block is block
+                    ):
+                        # Large-block re-touch: reclaim from free-large.
+                        self.free_large_block_queue.remove(block)
+                        meta_for_large.num_small_in_use = N
+                        meta_for_large.next_small_idx = N
+                    else:
+                        # Small-block re-touch: parent meta may be partial
+                        # (still hosting smalls) or recycled (sitting in
+                        # free-large). Handle both.
+                        parent = self.large_block_metas[block.block_id // N]
+                        if parent.num_small_in_use == 0 and parent.next_small_idx == 0:
+                            # Recycled — pull parent back out of free-large.
+                            self.free_large_block_queue.remove(parent.large_block)
+                        slot_idx = (block.block_id % N) + 1
+                        if parent.next_small_idx < slot_idx:
+                            parent.next_small_idx = slot_idx
+                        parent.num_small_in_use += 1
             block.ref_cnt += 1
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)
 
-    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
+    def free_blocks(
+        self,
+        ordered_blocks: Iterable[KVCacheBlock],
+        large_block: bool = False,
+    ) -> None:
         """Free a list of blocks. The blocks should be ordered by their
         eviction priority, where the first block will be evicted first.
 
         Args:
             ordered_blocks: A list of blocks to free ordered by their eviction
                 priority.
+            large_block: If True (hierarchical mode only), the passed
+                ``KVCacheBlock`` ids are large ids and the corresponding meta
+                is reset wholesale.
         """
-        # Identify blocks with hash (LRU cache) and without it (will never match in APC)
-        blocks_with_hash = []
-        blocks_without_hash = []
+        if self.large_block_factor == 1:
+            # Legacy / flat path.
+            blocks_with_hash = []
+            blocks_without_hash = []
+            for block in ordered_blocks:
+                block.ref_cnt -= 1
+                if block.ref_cnt == 0 and not block.is_null:
+                    if block.block_hash is None:
+                        blocks_without_hash.append(block)
+                    else:
+                        blocks_with_hash.append(block)
+
+            self.free_block_queue.prepend_n(blocks_without_hash)
+            self.free_block_queue.append_n(blocks_with_hash)
+            return
+
+        assert self.free_large_block_queue is not None
+        if large_block:
+            # Free whole large blocks: reset their metas and return them to
+            # the free-large queue. The large_block KVCacheBlock itself can
+            # carry a hash too (mamba prefix caching), so we honour the same
+            # eviction-order convention as the small-block path.
+            larges_with_hash: list[KVCacheBlock] = []
+            larges_without_hash: list[KVCacheBlock] = []
+            for blk in ordered_blocks:
+                blk.ref_cnt -= 1
+                if blk.ref_cnt == 0 and not blk.is_null:
+                    meta = self.large_block_metas[blk.block_id]
+                    meta.num_small_in_use = 0
+                    meta.next_small_idx = 0
+                    if blk.block_hash is None:
+                        larges_without_hash.append(blk)
+                    else:
+                        larges_with_hash.append(blk)
+            self.free_large_block_queue.prepend_n(larges_without_hash)
+            self.free_large_block_queue.append_n(larges_with_hash)
+            return
+
+        # Hierarchical small-block free. Mirrors the flat path's "linger"
+        # semantics: a freed but still-cached small can serve a future hit
+        # via ``touch`` until its parent meta is recycled. Cache eviction
+        # for smalls happens lazily in ``get_new_blocks`` (the per-block
+        # ``_maybe_evict_cached_block`` loop) and at meta-recycle time
+        # below.
+        N = self.large_block_factor
         for block in ordered_blocks:
             block.ref_cnt -= 1
             if block.ref_cnt == 0 and not block.is_null:
-                if block.block_hash is None:
-                    blocks_without_hash.append(block)
-                else:
-                    blocks_with_hash.append(block)
-
-        # Blocks without hash always get evicted first - prepend them last to the tail
-        self.free_block_queue.prepend_n(blocks_without_hash)
-        self.free_block_queue.append_n(blocks_with_hash)
+                meta = self.large_block_metas[block.block_id // N]
+                meta.num_small_in_use -= 1
+                # Recycle the meta when it has no in-use smalls. We don't
+                # require ``next_small_idx == N`` because a partial meta
+                # whose request finished early would otherwise leak.
+                if meta.num_small_in_use == 0 and meta.next_small_idx > 0:
+                    meta.next_small_idx = 0
+                    # Tail-append so existing small-block free behaviour
+                    # (LRU order) is preserved as much as possible.
+                    self.free_large_block_queue.append(meta.large_block)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.
@@ -494,12 +700,31 @@ class BlockPool:
         return True
 
     def get_num_free_blocks(self) -> int:
-        """Get the number of free blocks in the pool.
+        """Get the number of free (small) blocks the pool can still dispense.
 
-        Returns:
-            The number of free blocks.
+        In hierarchical mode this counts: full free-large capacity (as
+        ``N * num_free_large``) plus the residual cursor capacity of every
+        partial meta. Smalls that were freed inside a still-partial meta
+        don't count — they're inaccessible until that meta is recycled
+        (anti-fragmentation invariant).
         """
-        return self.free_block_queue.num_free_blocks
+        if self.large_block_factor == 1:
+            return self.free_block_queue.num_free_blocks
+        assert self.free_large_block_queue is not None
+        N = self.large_block_factor
+        free = self.free_large_block_queue.num_free_blocks * N
+        for meta in self.large_block_metas:
+            if 0 < meta.next_small_idx < N:
+                free += N - meta.next_small_idx
+        return free
+
+    def get_num_free_large_blocks(self) -> int:
+        """Number of fully-free large blocks (hierarchical mode only)."""
+        if self.large_block_factor == 1:
+            # In flat mode there's no separate large-block notion.
+            return self.free_block_queue.num_free_blocks
+        assert self.free_large_block_queue is not None
+        return self.free_large_block_queue.num_free_blocks
 
     def get_usage(self) -> float:
         """Get the KV cache usage.

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -542,9 +542,11 @@ class BlockPool:
                     # KVCacheBlock inside a meta; small blocks live inside a
                     # meta's ``small_blocks`` list at idx (block_id % N).
                     assert self.free_large_block_queue is not None
+
+                    # TODO: Is this a valid condition?
                     meta_for_large = (
                         self.large_block_metas[block.block_id]
-                        if block.block_id < len(self.large_block_metas)  #TODO: Is this a valid condition?
+                        if block.block_id < len(self.large_block_metas)
                         else None
                     )
                     if (
@@ -713,7 +715,8 @@ class BlockPool:
         assert self.free_large_block_queue is not None
         N = self.large_block_factor
         free = self.free_large_block_queue.num_free_blocks * N
-        # for meta in self.large_block_metas:  #TODO: Can ignore partial ; Note can be freed from head too
+        # TODO: Can ignore partial ; Note can be freed from head too
+        # for meta in self.large_block_metas:
         #     if 0 < meta.next_small_idx < N:
         #         free += N - meta.next_small_idx
         return free

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -20,6 +20,7 @@ from vllm.v1.core.kv_cache_utils import (
     ExternalBlockHash,
     FreeKVCacheBlockQueue,
     KVCacheBlock,
+    LargeBlockMeta,
     generate_block_hash_extra_keys,
     get_block_hash,
     get_group_id,
@@ -144,6 +145,11 @@ class BlockPool:
             actual block size can be a multiple of hash_block_size.
         enable_kv_cache_events: Whether to enable kv cache events.
         metrics_collector: Optional metrics collector for tracking block residency.
+        large_block_factor: Number `N` of small (attention) blocks that one
+            large (mamba) block spans. ``N == 1`` (default) means flat / legacy
+            behaviour. ``N > 1`` enables hierarchical allocation: small blocks
+            are dispensed from inside parent large blocks, and large blocks
+            are managed by their own free-queue.
     """
 
     def __init__(
@@ -153,28 +159,63 @@ class BlockPool:
         hash_block_size: int,
         enable_kv_cache_events: bool = False,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        large_block_factor: int = 1,
     ):
         assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
+        assert isinstance(large_block_factor, int) and large_block_factor >= 1
         self.num_gpu_blocks = num_gpu_blocks
         self.enable_caching = enable_caching
         self.hash_block_size = hash_block_size
-        # All kv-cache blocks.
+        self.large_block_factor = large_block_factor
+        # All kv-cache blocks (small / attention granularity).
         self.blocks: list[KVCacheBlock] = [
             KVCacheBlock(idx) for idx in range(num_gpu_blocks)
         ]
-        # Free block queue that constructs and manipulates a doubly linked
-        # list of free blocks (including eviction candidates when caching is
-        # enabled).
-        self.free_block_queue = FreeKVCacheBlockQueue(self.blocks)
+        if large_block_factor == 1:
+            # Flat / legacy mode: one global free queue over all blocks. No
+            # large-block hierarchy.
+            self.free_block_queue = FreeKVCacheBlockQueue(self.blocks)
+            self.large_block_metas: list[LargeBlockMeta] = []
+            self.free_large_block_queue: FreeKVCacheBlockQueue | None = None
+
+            # To represent a placeholder block with block_id=0.
+            # The ref_cnt of null_block is not maintained, needs special care to
+            # avoid freeing it.
+            self.null_block = self.free_block_queue.popleft()
+            self.null_block.is_null = True
+        else:
+            # Hierarchical mode: small blocks live inside parent large blocks
+            # and are dispensed via per-meta cursors. The flat ``free_block_queue``
+            # is created empty and unused; ``free_large_block_queue`` owns
+            # whole large blocks.
+            num_large_blocks = num_gpu_blocks // large_block_factor
+            assert num_large_blocks >= 2, (
+                "Hierarchical block pool requires at least 2 large blocks "
+                "(one is reserved for the null block)."
+            )
+            self.large_block_metas = [
+                LargeBlockMeta(
+                    large_block=KVCacheBlock(L),
+                    small_blocks=self.blocks[
+                        L * large_block_factor : (L + 1) * large_block_factor
+                    ],
+                )
+                for L in range(num_large_blocks)
+            ]
+            # Reserve large block 0 to host the null small block; never enters
+            # any free queue.
+            self.large_block_metas[0].num_small_in_use = large_block_factor
+            self.large_block_metas[0].next_small_idx = large_block_factor
+            self.null_block = self.large_block_metas[0].small_blocks[0]
+            self.null_block.is_null = True
+            # Truncated free queue carrying only large blocks for ids >= 1.
+            self.free_block_queue = FreeKVCacheBlockQueue([])
+            self.free_large_block_queue = FreeKVCacheBlockQueue(
+                [meta.large_block for meta in self.large_block_metas[1:]]
+            )
 
         # Cache for block lookup
         self.cached_block_hash_to_block: BlockHashToBlockMap = BlockHashToBlockMap()
-
-        # To represent a placeholder block with block_id=0.
-        # The ref_cnt of null_block is not maintained, needs special care to
-        # avoid freeing it.
-        self.null_block = self.free_block_queue.popleft()
-        self.null_block.is_null = True
 
         self.enable_kv_cache_events = enable_kv_cache_events
         self.kv_event_queue: list[KVCacheEvent] = []
@@ -330,21 +371,55 @@ class BlockPool:
                 )
             )
 
-    def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
+    def get_new_blocks(
+        self,
+        num_blocks: int,
+        large_block: bool = False,
+        last_hit_block_id: int | None = None,
+    ) -> list[KVCacheBlock]:
         """Get new blocks from the free block pool.
 
         Note that we do not check block cache in this function.
 
         Args:
             num_blocks: The number of blocks to allocate.
+            large_block: If True (only valid when ``large_block_factor > 1``),
+                allocate whole large blocks (returning ``KVCacheBlock`` objects
+                whose ``block_id`` is the large id). If False, allocate small
+                blocks (the legacy semantics).
+            last_hit_block_id: Optional small-block id of the last prefix-cache
+                hit for this request. When provided, the allocator tries to
+                continue allocating small blocks from the same parent large
+                block to keep the request's blocks within one large block.
+                Ignored for ``large_block=True`` and for legacy flat pools.
 
         Returns:
-            A list of new block.
+            A list of new blocks.
         """
-        if num_blocks > self.get_num_free_blocks():
+        if num_blocks == 0:
+            return []
+        capacity = (
+            self.get_num_free_large_blocks()
+            if large_block
+            else self.get_num_free_blocks()
+        )
+        if num_blocks > capacity:
             raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
 
-        ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+        if self.large_block_factor == 1:
+            # Legacy / flat path. ``large_block`` and ``last_hit_block_id`` are
+            # no-ops here; small ids and large ids coincide.
+            ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+        elif large_block:
+            assert self.free_large_block_queue is not None
+            large_blocks = self.free_large_block_queue.popleft_n(num_blocks)
+            for blk in large_blocks:
+                meta = self.large_block_metas[blk.block_id]
+                meta.num_small_in_use = self.large_block_factor
+                meta.next_small_idx = self.large_block_factor
+            ret = large_blocks
+        else:
+            ret = self._dispense_small_blocks(num_blocks, last_hit_block_id)
 
         # In order to only iterate the list once, we duplicated code a bit
         if self.enable_caching:
@@ -360,6 +435,52 @@ class BlockPool:
                 block.ref_cnt += 1
                 if self.metrics_collector:
                     self.metrics_collector.on_block_allocated(block)
+        return ret
+
+    def _dispense_small_blocks(
+        self, num_blocks: int, last_hit_block_id: int | None
+    ) -> list[KVCacheBlock]:
+        """Hierarchical small-block dispensing.
+
+        Tries to continue inside the partial parent large block of
+        ``last_hit_block_id`` (when capacity remains there), then opens fresh
+        large blocks one at a time.
+        """
+        assert self.free_large_block_queue is not None
+        N = self.large_block_factor
+        ret: list[KVCacheBlock] = []
+        remaining = num_blocks
+
+        # 1. Try to continue inside the parent of last_hit_block_id.
+        if last_hit_block_id is not None:
+            parent_L = last_hit_block_id // N
+            if 0 <= parent_L < len(self.large_block_metas):
+                meta = self.large_block_metas[parent_L]
+                # The parent is a "partial" meta iff its cursor is in
+                # (0, N): fully-free metas live in the free-large queue;
+                # fully-consumed metas have next_small_idx == N.
+                if 0 < meta.next_small_idx < N:
+                    avail = N - meta.next_small_idx
+                    take = min(avail, remaining)
+                    for j in range(take):
+                        small = meta.small_blocks[meta.next_small_idx + j]
+                        ret.append(small)
+                    meta.next_small_idx += take
+                    meta.num_small_in_use += take
+                    remaining -= take
+
+        # 2. Open fresh large blocks as needed.
+        while remaining > 0:
+            large_blk = self.free_large_block_queue.popleft()
+            meta = self.large_block_metas[large_blk.block_id]
+            assert meta.next_small_idx == 0
+            take = min(N, remaining)
+            for j in range(take):
+                ret.append(meta.small_blocks[j])
+            meta.next_small_idx = take
+            meta.num_small_in_use = take
+            remaining -= take
+
         return ret
 
     def _maybe_evict_cached_block(self, block: KVCacheBlock) -> bool:
@@ -407,37 +528,122 @@ class BlockPool:
         Args:
             blocks: A list of blocks to touch.
         """
+        N = self.large_block_factor
         for block in blocks:
             # ref_cnt=0 means this block is in the free list (i.e. eviction
             # candidate), so remove it.
             if block.ref_cnt == 0 and not block.is_null:
-                self.free_block_queue.remove(block)
+                if N == 1:
+                    self.free_block_queue.remove(block)
+                else:
+                    # Hierarchical: figure out whether this is a large or a
+                    # small block by which list its block_id indexes into.
+                    # Mamba large blocks are touched as the ``large_block``
+                    # KVCacheBlock inside a meta; small blocks live inside a
+                    # meta's ``small_blocks`` list at idx (block_id % N).
+                    assert self.free_large_block_queue is not None
+                    meta_for_large = (
+                        self.large_block_metas[block.block_id]
+                        if block.block_id < len(self.large_block_metas)  #TODO: Is this a valid condition?
+                        else None
+                    )
+                    if (
+                        meta_for_large is not None
+                        and meta_for_large.large_block is block
+                    ):
+                        # Large-block re-touch: reclaim from free-large.
+                        self.free_large_block_queue.remove(block)
+                        meta_for_large.num_small_in_use = N
+                        meta_for_large.next_small_idx = N
+                    else:
+                        # Small-block re-touch: parent meta may be partial
+                        # (still hosting smalls) or recycled (sitting in
+                        # free-large). Handle both.
+                        parent = self.large_block_metas[block.block_id // N]
+                        if parent.num_small_in_use == 0 and parent.next_small_idx == 0:
+                            # Recycled — pull parent back out of free-large.
+                            self.free_large_block_queue.remove(parent.large_block)
+                        slot_idx = (block.block_id % N) + 1
+                        if parent.next_small_idx < slot_idx:
+                            parent.next_small_idx = slot_idx
+                        parent.num_small_in_use += 1
             block.ref_cnt += 1
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)
 
-    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
+    def free_blocks(
+        self,
+        ordered_blocks: Iterable[KVCacheBlock],
+        large_block: bool = False,
+    ) -> None:
         """Free a list of blocks. The blocks should be ordered by their
         eviction priority, where the first block will be evicted first.
 
         Args:
             ordered_blocks: A list of blocks to free ordered by their eviction
                 priority.
+            large_block: If True (hierarchical mode only), the passed
+                ``KVCacheBlock`` ids are large ids and the corresponding meta
+                is reset wholesale.
         """
-        # Identify blocks with hash (LRU cache) and without it (will never match in APC)
-        blocks_with_hash = []
-        blocks_without_hash = []
+        if self.large_block_factor == 1:
+            # Legacy / flat path.
+            blocks_with_hash = []
+            blocks_without_hash = []
+            for block in ordered_blocks:
+                block.ref_cnt -= 1
+                if block.ref_cnt == 0 and not block.is_null:
+                    if block.block_hash is None:
+                        blocks_without_hash.append(block)
+                    else:
+                        blocks_with_hash.append(block)
+
+            self.free_block_queue.prepend_n(blocks_without_hash)
+            self.free_block_queue.append_n(blocks_with_hash)
+            return
+
+        assert self.free_large_block_queue is not None
+        if large_block:
+            # Free whole large blocks: reset their metas and return them to
+            # the free-large queue. The large_block KVCacheBlock itself can
+            # carry a hash too (mamba prefix caching), so we honour the same
+            # eviction-order convention as the small-block path.
+            large_with_hash: list[KVCacheBlock] = []
+            large_without_hash: list[KVCacheBlock] = []
+            for blk in ordered_blocks:
+                blk.ref_cnt -= 1
+                if blk.ref_cnt == 0 and not blk.is_null:
+                    meta = self.large_block_metas[blk.block_id]
+                    meta.num_small_in_use = 0
+                    meta.next_small_idx = 0
+                    if blk.block_hash is None:
+                        large_without_hash.append(blk)
+                    else:
+                        large_with_hash.append(blk)
+            self.free_large_block_queue.prepend_n(large_without_hash)
+            self.free_large_block_queue.append_n(large_with_hash)
+            return
+
+        # Hierarchical small-block free. Mirrors the flat path's "linger"
+        # semantics: a freed but still-cached small can serve a future hit
+        # via ``touch`` until its parent meta is recycled. Cache eviction
+        # for smalls happens lazily in ``get_new_blocks`` (the per-block
+        # ``_maybe_evict_cached_block`` loop) and at meta-recycle time
+        # below.
+        N = self.large_block_factor
         for block in ordered_blocks:
             block.ref_cnt -= 1
             if block.ref_cnt == 0 and not block.is_null:
-                if block.block_hash is None:
-                    blocks_without_hash.append(block)
-                else:
-                    blocks_with_hash.append(block)
-
-        # Blocks without hash always get evicted first - prepend them last to the tail
-        self.free_block_queue.prepend_n(blocks_without_hash)
-        self.free_block_queue.append_n(blocks_with_hash)
+                meta = self.large_block_metas[block.block_id // N]
+                meta.num_small_in_use -= 1
+                # Recycle the meta when it has no in-use smalls. We don't
+                # require ``next_small_idx == N`` because a partial meta
+                # whose request finished early would otherwise leak.
+                if meta.num_small_in_use == 0 and meta.next_small_idx > 0:
+                    meta.next_small_idx = 0
+                    # Tail-append so existing small-block free behaviour
+                    # (LRU order) is preserved as much as possible.
+                    self.free_large_block_queue.append(meta.large_block)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.
@@ -494,12 +700,31 @@ class BlockPool:
         return True
 
     def get_num_free_blocks(self) -> int:
-        """Get the number of free blocks in the pool.
+        """Get the number of free (small) blocks the pool can still dispense.
 
-        Returns:
-            The number of free blocks.
+        In hierarchical mode this counts: full free-large capacity (as
+        ``N * num_free_large``) plus the residual cursor capacity of every
+        partial meta. Smalls that were freed inside a still-partial meta
+        don't count — they're inaccessible until that meta is recycled
+        (anti-fragmentation invariant).
         """
-        return self.free_block_queue.num_free_blocks
+        if self.large_block_factor == 1:
+            return self.free_block_queue.num_free_blocks
+        assert self.free_large_block_queue is not None
+        N = self.large_block_factor
+        free = self.free_large_block_queue.num_free_blocks * N
+        # for meta in self.large_block_metas:  #TODO: Can ignore partial ; Note can be freed from head too
+        #     if 0 < meta.next_small_idx < N:
+        #         free += N - meta.next_small_idx
+        return free
+
+    def get_num_free_large_blocks(self) -> int:
+        """Number of fully-free large blocks (hierarchical mode only)."""
+        if self.large_block_factor == 1:
+            # In flat mode there's no separate large-block notion.
+            return self.free_block_queue.num_free_blocks
+        assert self.free_large_block_queue is not None
+        return self.free_large_block_queue.num_free_blocks
 
     def get_usage(self) -> float:
         """Get the KV cache usage.

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -608,8 +608,8 @@ class BlockPool:
             # the free-large queue. The large_block KVCacheBlock itself can
             # carry a hash too (mamba prefix caching), so we honour the same
             # eviction-order convention as the small-block path.
-            larges_with_hash: list[KVCacheBlock] = []
-            larges_without_hash: list[KVCacheBlock] = []
+            large_with_hash: list[KVCacheBlock] = []
+            large_without_hash: list[KVCacheBlock] = []
             for blk in ordered_blocks:
                 blk.ref_cnt -= 1
                 if blk.ref_cnt == 0 and not blk.is_null:
@@ -617,11 +617,11 @@ class BlockPool:
                     meta.num_small_in_use = 0
                     meta.next_small_idx = 0
                     if blk.block_hash is None:
-                        larges_without_hash.append(blk)
+                        large_without_hash.append(blk)
                     else:
-                        larges_with_hash.append(blk)
-            self.free_large_block_queue.prepend_n(larges_without_hash)
-            self.free_large_block_queue.append_n(larges_with_hash)
+                        large_with_hash.append(blk)
+            self.free_large_block_queue.prepend_n(large_without_hash)
+            self.free_large_block_queue.append_n(large_with_hash)
             return
 
         # Hierarchical small-block free. Mirrors the flat path's "linger"

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -22,6 +22,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
+    MambaSpec,
     SlidingWindowSpec,
 )
 from vllm.v1.request import Request
@@ -87,12 +88,23 @@ class KVCacheCoordinator(ABC):
         )
         self.scheduler_block_size = scheduler_block_size
 
+        # Pick up the hierarchical large-block factor from any mamba group
+        # in the config. For pure-attention models this stays 1 and the
+        # BlockPool runs in flat / legacy mode.
+        large_block_factor = 1
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            spec = kv_cache_group.kv_cache_spec
+            if isinstance(spec, MambaSpec) and spec.large_block_factor > 1:
+                large_block_factor = spec.large_block_factor
+                break
+
         self.block_pool = BlockPool(
             num_gpu_blocks=kv_cache_config.num_blocks,
             enable_caching=enable_caching,
             hash_block_size=hash_block_size,
             enable_kv_cache_events=enable_kv_cache_events,
             metrics_collector=metrics_collector,
+            large_block_factor=large_block_factor,
         )
 
         # KV cache group indices that get the EAGLE last-block drop.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1818,7 +1818,7 @@ def _max_memory_usage_bytes_from_groups(
     page_size = get_uniform_page_size(
         [group.kv_cache_spec for group in kv_cache_groups]
     )
-    blocks_needed = sum(  #TODO: Here small blocks count is returned. Is it OK?
+    blocks_needed = sum(  # TODO: Here small blocks count is returned. Is it OK?
         cdiv(group.kv_cache_spec.max_memory_usage_bytes(vllm_config), page_size)
         for group in kv_cache_groups
     )

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -162,6 +162,28 @@ class KVCacheBlock:
         )
 
 
+@dataclass(slots=True)
+class LargeBlockMeta:
+    """Hierarchical block-pool metadata.
+
+    Each large block owns N consecutive small blocks with IDs
+    [L*N .. L*N+N-1]. ``num_small_in_use`` counts ref-held smalls; when it
+    drops to 0 *and* the cursor has been fully consumed, the parent large
+    block is recycled to the free-large queue (``next_small_idx`` reset to 0).
+    Smalls freed within a still-partial meta stay temporarily inaccessible
+    until that recycle — this is the anti-fragmentation guarantee
+    ("a fresh large block per request").
+    """
+
+    # KVCacheBlock with block_id=L (large id); lives in the free-large
+    # queue when ``num_small_in_use == 0 and next_small_idx == 0``.
+    large_block: "KVCacheBlock"
+    # Length-N list of KVCacheBlock with consecutive small ids L*N..L*N+N-1.
+    small_blocks: list["KVCacheBlock"]
+    num_small_in_use: int = 0
+    next_small_idx: int = 0
+
+
 class FreeKVCacheBlockQueue:
     """This class organizes a list of KVCacheBlock objects to a doubly linked
     list of free blocks. We implement this class instead of using Python

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -162,6 +162,28 @@ class KVCacheBlock:
         )
 
 
+@dataclass(slots=True)
+class LargeBlockMeta:
+    """Hierarchical block-pool metadata.
+
+    Each large block owns N consecutive small blocks with IDs
+    [L*N .. L*N+N-1]. ``num_small_in_use`` counts ref-held smalls; when it
+    drops to 0 *and* the cursor has been fully consumed, the parent large
+    block is recycled to the free-large queue (``next_small_idx`` reset to 0).
+    Smalls freed within a still-partial meta stay temporarily inaccessible
+    until that recycle — this is the anti-fragmentation guarantee
+    ("a fresh large block per request").
+    """
+
+    # KVCacheBlock with block_id=L (large id); lives in the free-large
+    # queue when ``num_small_in_use == 0 and next_small_idx == 0``.
+    large_block: "KVCacheBlock"
+    # Length-N list of KVCacheBlock with consecutive small ids L*N..L*N+N-1.
+    small_blocks: list["KVCacheBlock"]
+    num_small_in_use: int = 0
+    next_small_idx: int = 0
+
+
 class FreeKVCacheBlockQueue:
     """This class organizes a list of KVCacheBlock objects to a doubly linked
     list of free blocks. We implement this class instead of using Python
@@ -1796,7 +1818,7 @@ def _max_memory_usage_bytes_from_groups(
     page_size = get_uniform_page_size(
         [group.kv_cache_spec for group in kv_cache_groups]
     )
-    blocks_needed = sum(
+    blocks_needed = sum(  #TODO: Here small blocks count is returned. Is it OK?
         cdiv(group.kv_cache_spec.max_memory_usage_bytes(vllm_config), page_size)
         for group in kv_cache_groups
     )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1228,7 +1228,11 @@ class MambaManager(SingleTypeKVCacheManager):
                     assert num_new_blocks <= 1
                 else:
                     assert num_new_blocks <= self.num_speculative_blocks + 1
-                last_hit_id = None if self._is_large_block else _last_non_null_block_id(req_blocks) #TODO: Makes no sense for Mamba -> won't reuse intra
+                last_hit_id = (
+                    None
+                    if self._is_large_block
+                    else _last_non_null_block_id(req_blocks)
+                )  # TODO: Makes no sense for Mamba -> won't reuse intra
                 new_blocks = self.block_pool.get_new_blocks(
                     num_new_blocks,
                     large_block=self._is_large_block,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -29,11 +29,28 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
 
 
+def _last_non_null_block_id(blocks: Sequence[KVCacheBlock]) -> int | None:
+    """Return the id of the last non-null block in ``blocks``, or None.
+
+    Used as the ``last_hit_block_id`` hint to ``BlockPool.get_new_blocks`` so
+    the hierarchical allocator can try to continue inside the parent large
+    block of the most recent real allocation/cache-hit.
+    """
+    for blk in reversed(blocks):
+        if not blk.is_null:
+            return blk.block_id
+    return None
+
+
 class SingleTypeKVCacheManager(ABC):
     """
     An abstract base class for a manager that handle the kv cache management
     logic of one specific type of attention layer.
     """
+
+    # Whether this manager allocates large blocks (mamba) or small blocks
+    # (attention) from the hierarchical block pool. Ignored by flat pools.
+    _is_large_block: bool = False
 
     def __init__(
         self,
@@ -263,8 +280,11 @@ class SingleTypeKVCacheManager(ABC):
             return
 
         req_blocks = self.req_to_blocks[request_id]
+        last_hit_id = _last_non_null_block_id(req_blocks)
         allocated_blocks = self.block_pool.get_new_blocks(
-            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks),
+            large_block=self._is_large_block,
+            last_hit_block_id=last_hit_id,
         )
         req_blocks.extend(allocated_blocks)
         if type(self.kv_cache_spec) in (
@@ -298,7 +318,12 @@ class SingleTypeKVCacheManager(ABC):
         if num_new_blocks <= 0:
             return []
         else:
-            new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+            last_hit_id = _last_non_null_block_id(req_blocks)
+            new_blocks = self.block_pool.get_new_blocks(
+                num_new_blocks,
+                large_block=self._is_large_block,
+                last_hit_block_id=last_hit_id,
+            )
             req_blocks.extend(new_blocks)
             if type(self.kv_cache_spec) in (
                 FullAttentionSpec,
@@ -406,7 +431,10 @@ class SingleTypeKVCacheManager(ABC):
             request_id: The request ID.
         """
         # Free blocks in reverse order so that the tail blocks are freed first.
-        self.block_pool.free_blocks(reversed(self.pop_blocks_for_free(request_id)))
+        self.block_pool.free_blocks(
+            reversed(self.pop_blocks_for_free(request_id)),
+            large_block=self._is_large_block,
+        )
 
     @abstractmethod
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
@@ -517,7 +545,7 @@ class SingleTypeKVCacheManager(ABC):
                 break
             removed_blocks.append(blocks[i])
             blocks[i] = self._null_block
-        self.block_pool.free_blocks(removed_blocks)
+        self.block_pool.free_blocks(removed_blocks, large_block=self._is_large_block)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """
@@ -956,6 +984,11 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
 
 
 class MambaManager(SingleTypeKVCacheManager):
+    # Mamba allocates from the large-block free queue when the block pool is
+    # hierarchical (large_block_factor > 1). For flat pools this attribute is
+    # ignored.
+    _is_large_block: bool = True
+
     def __init__(
         self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs
     ) -> None:
@@ -1045,7 +1078,10 @@ class MambaManager(SingleTypeKVCacheManager):
             ):
                 blocks = self.req_to_blocks[request_id]
                 if blocks[last_state_block_idx] != self._null_block:
-                    self.block_pool.free_blocks([blocks[last_state_block_idx]])
+                    self.block_pool.free_blocks(
+                        [blocks[last_state_block_idx]],
+                        large_block=self._is_large_block,
+                    )
                     blocks[last_state_block_idx] = self._null_block
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
@@ -1192,7 +1228,12 @@ class MambaManager(SingleTypeKVCacheManager):
                     assert num_new_blocks <= 1
                 else:
                     assert num_new_blocks <= self.num_speculative_blocks + 1
-                new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+                last_hit_id = _last_non_null_block_id(req_blocks)
+                new_blocks = self.block_pool.get_new_blocks(
+                    num_new_blocks,
+                    large_block=self._is_large_block,
+                    last_hit_block_id=last_hit_id,
+                )
                 req_blocks.extend(new_blocks)
                 self._allocated_block_reqs.add(request_id)
                 return req_blocks[prev_block_len:]

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -29,11 +29,28 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
 
 
+def _last_non_null_block_id(blocks: Sequence[KVCacheBlock]) -> int | None:
+    """Return the id of the last non-null block in ``blocks``, or None.
+
+    Used as the ``last_hit_block_id`` hint to ``BlockPool.get_new_blocks`` so
+    the hierarchical allocator can try to continue inside the parent large
+    block of the most recent real allocation/cache-hit.
+    """
+    for blk in reversed(blocks):
+        if not blk.is_null:
+            return blk.block_id
+    return None
+
+
 class SingleTypeKVCacheManager(ABC):
     """
     An abstract base class for a manager that handle the kv cache management
     logic of one specific type of attention layer.
     """
+
+    # Whether this manager allocates large blocks (mamba) or small blocks
+    # (attention) from the hierarchical block pool. Ignored by flat pools.
+    _is_large_block: bool = False
 
     def __init__(
         self,
@@ -263,8 +280,11 @@ class SingleTypeKVCacheManager(ABC):
             return
 
         req_blocks = self.req_to_blocks[request_id]
+        last_hit_id = _last_non_null_block_id(req_blocks)
         allocated_blocks = self.block_pool.get_new_blocks(
-            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks),
+            large_block=self._is_large_block,
+            last_hit_block_id=last_hit_id,
         )
         req_blocks.extend(allocated_blocks)
         if type(self.kv_cache_spec) in (
@@ -298,7 +318,12 @@ class SingleTypeKVCacheManager(ABC):
         if num_new_blocks <= 0:
             return []
         else:
-            new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+            last_hit_id = _last_non_null_block_id(req_blocks)
+            new_blocks = self.block_pool.get_new_blocks(
+                num_new_blocks,
+                large_block=self._is_large_block,
+                last_hit_block_id=last_hit_id,
+            )
             req_blocks.extend(new_blocks)
             if type(self.kv_cache_spec) in (
                 FullAttentionSpec,
@@ -406,7 +431,10 @@ class SingleTypeKVCacheManager(ABC):
             request_id: The request ID.
         """
         # Free blocks in reverse order so that the tail blocks are freed first.
-        self.block_pool.free_blocks(reversed(self.pop_blocks_for_free(request_id)))
+        self.block_pool.free_blocks(
+            reversed(self.pop_blocks_for_free(request_id)),
+            large_block=self._is_large_block,
+        )
 
     @abstractmethod
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
@@ -517,7 +545,7 @@ class SingleTypeKVCacheManager(ABC):
                 break
             removed_blocks.append(blocks[i])
             blocks[i] = self._null_block
-        self.block_pool.free_blocks(removed_blocks)
+        self.block_pool.free_blocks(removed_blocks, large_block=self._is_large_block)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """
@@ -956,6 +984,11 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
 
 
 class MambaManager(SingleTypeKVCacheManager):
+    # Mamba allocates from the large-block free queue when the block pool is
+    # hierarchical (large_block_factor > 1). For flat pools this attribute is
+    # ignored.
+    _is_large_block: bool = True
+
     def __init__(
         self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs
     ) -> None:
@@ -1045,7 +1078,10 @@ class MambaManager(SingleTypeKVCacheManager):
             ):
                 blocks = self.req_to_blocks[request_id]
                 if blocks[last_state_block_idx] != self._null_block:
-                    self.block_pool.free_blocks([blocks[last_state_block_idx]])
+                    self.block_pool.free_blocks(
+                        [blocks[last_state_block_idx]],
+                        large_block=self._is_large_block,
+                    )
                     blocks[last_state_block_idx] = self._null_block
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
@@ -1192,7 +1228,12 @@ class MambaManager(SingleTypeKVCacheManager):
                     assert num_new_blocks <= 1
                 else:
                     assert num_new_blocks <= self.num_speculative_blocks + 1
-                new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+                last_hit_id = None if self._is_large_block else _last_non_null_block_id(req_blocks) #TODO: Makes no sense for Mamba -> won't reuse intra
+                new_blocks = self.block_pool.get_new_blocks(
+                    num_new_blocks,
+                    large_block=self._is_large_block,
+                    last_hit_block_id=last_hit_id,
+                )
                 req_blocks.extend(new_blocks)
                 self._allocated_block_reqs.add(request_id)
                 return req_blocks[prev_block_len:]

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -643,7 +643,7 @@ class MambaSpec(KVCacheSpec):
         return page_size
 
     @property
-    def page_size_bytes(self) -> int: #TODO: Factor is 1 here all the time -> remove this property? Use state_page_size_bytes ?
+    def page_size_bytes(self) -> int:
         # In hierarchical mode the per-block byte budget equals attention's
         # (one small-block share of a state). N consecutive small blocks
         # together hold one full mamba state. In flat mode (``N == 1``) this

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -624,6 +624,10 @@ class MambaSpec(KVCacheSpec):
     mamba_type: MambaAttentionBackendEnum = MambaAttentionBackendEnum.MAMBA2
     mamba_cache_mode: str = "none"
     num_speculative_blocks: int = 0
+    # Number `N` of attention `block_size`-sized blocks that one mamba block
+    # spans in the shared backing tensor. 1 means mamba and attention share
+    # block IDs (legacy behaviour); N > 1 enables hierarchical allocation.
+    large_block_factor: int = 1
 
     @property
     def page_size_bytes(self) -> int:

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -630,7 +630,9 @@ class MambaSpec(KVCacheSpec):
     large_block_factor: int = 1
 
     @property
-    def page_size_bytes(self) -> int:
+    def state_page_size_bytes(self) -> int:
+        """Bytes per mamba state slot (one full state). Used as the stride
+        between consecutive state slots in the view tensor."""
         page_size = sum(
             prod(shape) * get_dtype_size(dtype)
             for (shape, dtype) in zip(self.shapes, self.dtypes)
@@ -640,16 +642,30 @@ class MambaSpec(KVCacheSpec):
             return self.page_size_padded
         return page_size
 
+    @property
+    def page_size_bytes(self) -> int:
+        # In hierarchical mode the per-block byte budget equals attention's
+        # (one small-block share of a state). N consecutive small blocks
+        # together hold one full mamba state. In flat mode (``N == 1``) this
+        # equals ``state_page_size_bytes`` and matches the legacy behaviour.
+        state_page = self.state_page_size_bytes
+        assert state_page % self.large_block_factor == 0
+        return state_page // self.large_block_factor
+
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+        # Memory budget accounts for full state slots, not per-small-block
+        # shares: every cached prefix needs one full state.
+        state_page = self.state_page_size_bytes
         if vllm_config.cache_config.mamba_cache_mode == "all":
             max_model_len = vllm_config.model_config.max_model_len
             return (
-                cdiv(max_model_len, self.block_size) + self.num_speculative_blocks
-            ) * self.page_size_bytes
+                cdiv(max_model_len, self.block_size * self.large_block_factor)
+                + self.num_speculative_blocks
+            ) * state_page
         elif vllm_config.cache_config.mamba_cache_mode == "align":
-            return self.page_size_bytes * (2 + self.num_speculative_blocks)
+            return state_page * (2 + self.num_speculative_blocks)
         else:
-            return self.page_size_bytes * (1 + self.num_speculative_blocks)
+            return state_page * (1 + self.num_speculative_blocks)
 
     def is_uniform_with_collection(
         self, kv_cache_specs: dict[str, KVCacheSpec]

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -624,9 +624,15 @@ class MambaSpec(KVCacheSpec):
     mamba_type: MambaAttentionBackendEnum = MambaAttentionBackendEnum.MAMBA2
     mamba_cache_mode: str = "none"
     num_speculative_blocks: int = 0
+    # Number `N` of attention `block_size`-sized blocks that one mamba block
+    # spans in the shared backing tensor. 1 means mamba and attention share
+    # block IDs (legacy behaviour); N > 1 enables hierarchical allocation.
+    large_block_factor: int = 1
 
     @property
-    def page_size_bytes(self) -> int:
+    def state_page_size_bytes(self) -> int:
+        """Bytes per mamba state slot (one full state). Used as the stride
+        between consecutive state slots in the view tensor."""
         page_size = sum(
             prod(shape) * get_dtype_size(dtype)
             for (shape, dtype) in zip(self.shapes, self.dtypes)
@@ -636,16 +642,30 @@ class MambaSpec(KVCacheSpec):
             return self.page_size_padded
         return page_size
 
+    @property
+    def page_size_bytes(self) -> int: #TODO: Factor is 1 here all the time -> remove this property? Use state_page_size_bytes ?
+        # In hierarchical mode the per-block byte budget equals attention's
+        # (one small-block share of a state). N consecutive small blocks
+        # together hold one full mamba state. In flat mode (``N == 1``) this
+        # equals ``state_page_size_bytes`` and matches the legacy behaviour.
+        state_page = self.state_page_size_bytes
+        assert state_page % self.large_block_factor == 0
+        return state_page // self.large_block_factor
+
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+        # Memory budget accounts for full state slots, not per-small-block
+        # shares: every cached prefix needs one full state.
+        state_page = self.state_page_size_bytes
         if vllm_config.cache_config.mamba_cache_mode == "all":
             max_model_len = vllm_config.model_config.max_model_len
             return (
-                cdiv(max_model_len, self.block_size) + self.num_speculative_blocks
-            ) * self.page_size_bytes
+                cdiv(max_model_len, self.block_size * self.large_block_factor)
+                + self.num_speculative_blocks
+            ) * state_page
         elif vllm_config.cache_config.mamba_cache_mode == "align":
-            return self.page_size_bytes * (2 + self.num_speculative_blocks)
+            return state_page * (2 + self.num_speculative_blocks)
         else:
-            return self.page_size_bytes * (1 + self.num_speculative_blocks)
+            return state_page * (1 + self.num_speculative_blocks)
 
     def is_uniform_with_collection(
         self, kv_cache_specs: dict[str, KVCacheSpec]

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -292,10 +292,14 @@ def _reshape_kv_cache(
                 has_mamba = True
                 state_tensors = []
                 storage_offset_bytes = 0
+                # In hierarchical mode (large_block_factor > 1), the mamba view
+                # has one slot per ``N`` consecutive small attention blocks.
+                num_state_slots = num_blocks // kv_cache_spec.large_block_factor
+                state_page_bytes = kv_cache_spec.state_page_size_bytes
                 for shape, dtype in zip(kv_cache_spec.shapes, kv_cache_spec.dtypes):
                     dtype_size = get_dtype_size(dtype)
-                    num_element_per_page = kv_cache_spec.page_size_bytes // dtype_size
-                    target_shape = (num_blocks, *shape)
+                    num_element_per_page = state_page_bytes // dtype_size
+                    target_shape = (num_state_slots, *shape)
                     stride = torch.empty(target_shape).stride()
                     target_stride = (num_element_per_page, *stride[1:])
                     assert storage_offset_bytes % dtype_size == 0

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7194,12 +7194,15 @@ class GPUModelRunner(
                     raw_tensor = kv_cache_raw_tensors[layer_name]
                     state_tensors = []
                     storage_offset_bytes = 0
+                    # In hierarchical mode (large_block_factor > 1), the mamba
+                    # view has one slot per ``N`` consecutive small attention
+                    # blocks.
+                    num_state_slots = num_blocks // kv_cache_spec.large_block_factor
+                    state_page_bytes = kv_cache_spec.state_page_size_bytes
                     for shape, dtype in zip(kv_cache_spec.shapes, kv_cache_spec.dtypes):
                         dtype_size = get_dtype_size(dtype)
-                        num_element_per_page = (
-                            kv_cache_spec.page_size_bytes // dtype_size
-                        )
-                        target_shape = (num_blocks, *shape)
+                        num_element_per_page = state_page_bytes // dtype_size
+                        target_shape = (num_state_slots, *shape)
                         stride = torch.empty(target_shape).stride()
                         target_stride = (num_element_per_page, *stride[1:])
                         assert storage_offset_bytes % dtype_size == 0


### PR DESCRIPTION
## Purpose

**Note: This is a draft PR and needs testing & verification.**

Hybrid models often comprise attention layers with relatively small KVcache states and other layer types (e.g. Mamba, GDN) with relatively large cache states. Current vLLM implementation sets the `block_size` in a way to keep the KVcache allocation unit of block the same for both attention and hybrid cache. This typically involves considerably increasing the `block_size` of attention, resulting in lower cache hit chances.

This PR separates the `block_size` setting from the size of hybrid cache entries by allowing different sizes of block allocations for attention and SSM layers. This allows to set any `block_size` for hybrid models and by default to keep the `block_size` of the attention, increasing the cache hit ratio.

Note: Currently enabled only for `align` mode, to avoid too fast memory filling of `all` mode.
**When running Mamba-based (non GDN) models switch from all to align with:  `--mamba-cache-mode align`**

In a prefill-oriented synthetic test with potential full cache hits (see test plan below), current PR substantially increases the cache hits (avoids the "steps" in the figure below), and speeds up the prefill (2.7x times) for `Qwen/Qwen3.6-35B-A3B`:

<img width="1117" height="584" alt="image" src="https://github.com/user-attachments/assets/ca2ed4af-822e-45d7-9d79-ed2e9f3368ca" />

## Technical details
**High-level design idea:**
1. Get back to the logic of flexible setting of block size also for hybrid models
1. Handle different KV cache block sizes by introducing size information in `class SingleTypeKVCacheManager(ABC):` that is set by each layer type accordingly (current PR just uses a flag `_is_large_block: bool` and sets to `True` for SSM layers, but we could make it to keep the exact size).
1. Use the size information when getting new blocks in kv cache manager:
```
       allocated_blocks = self.block_pool.get_new_blocks(
            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks),
            # NEW size information -> current flag could be replaced with size specifier:
            large_block=self._is_large_block,
            # NEW handle fragmentation - see below:
            last_hit_block_id=_last_non_null_block_id(req_blocks),
        )
```
Primary challenge with variable-sized allocations is the KV cache blocks memory fragmentation. To handle this, we pass information about previous allocation for each request to the block_pool, so that it can avoid fragmentation. Note: currently computed with `_last_non_null_block_id(req_blocks)`, but I would rather just pass `req_blocks` there and let the block_pool figure out how to defragment.

**At this point we have:**
1. [+] Minimal changes to KV cache interface API
1. [+] Variable-sized KV cache blocks allocation
1. [+] Ability to freely tune the block size
1. [-] Potential fragmentation issues

**Fragmentation avoidance policy:**
All of the complexity gets hidden into `block_pool` as follows:
1. Different `block_pool` implementation can be used, based on model configuration and defragmentation policy.
1. Current implementation uses standard code paths for non-hybrid models. For hybrid-models it uses the following solution:
   1. It creates various views of the same memory: large blocks (size of SSM state) and small blocks (size of attention state). The standard block list keeps the pointers to large blocks. Each large block keeps a list of pointers to small blocks inside it. All of this is just list and pointer arithmetic. Number of python objects/list entries is comparable to the baseline case with small block set for attention models.
   4. Assume e.g. 1 large block = 100 small blocks. These pointers overlap and have aligned memory addresses, i.e. GPU tensor address for large block number 2 is the same as small block number 200. This way all the current pointer arithmetic in `gpu_model_runner` can be reused with no changes, and `num_blocks` for tensor shape can be determined based on `state_page_bytes` for each layer type. All kernels have their own views of the shared memory.
   5. When SSM allocates, it gets a large block form the list and marks as allocated. Entire large block is assigned a single hash value and can be matched by APC.
   6. When attention allocates, it requests small blocks as follows: it marks large block as allocated but then returns the requested number of small blocks from that large block. Each small block gets assigned a hash and can be matched by APC.
   7. Fragmentation is an issue only for attention requests. There the `block_pool` checks what was the `last_hit_block_id` for that request and checks if there are small blocks available within that large block. It returns them if they are available, if not it takes small blocks from the next free large block. This bundles together memory blocks from the same request or requests that have a shared prefix, which seems like a viable heuristic. (It's much better than allowing random requests to allocate, as one frequently used small block could lock the entire large block for a long time.)

This is one possible implementation. By having a clear API decoupling between the KV cache manager allocations and the underlying `block_pool` implementation, the community could contribute other alternative implementations. (current implementation has a limitation that it handles only two allocation size: large and small, but it opens a path to new alternative implementations with more options)

@tdoublep 

## Test Plan
```
if __name__ == '__main__':
    SETUP = {'model': 'Qwen/Qwen3.6-35B-A3B', 'max_model_len': '75000', 'max_num_seqs': 50}
    import os
    os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
    from vllm import LLM, SamplingParams
    from vllm.distributed import cleanup_dist_env_and_memory
    import time, string
    sampling_params = SamplingParams(temperature=0.0, max_tokens=1)
    prefix = ( # examples/offline_inference/prefix_caching.py
        "You are an expert school principal, skilled in effectively managing "
        "faculty and staff. Draft 10-15 questions for a potential first grade "
        "Head Teacher for my K-12, all-girls', independent school that emphasizes "
        "community, joyful discovery, and life-long learning. The candidate is "
        "coming in for a first-round panel interview for a 8th grade Math "
        "teaching role. They have 5 years of previous teaching experience "
        "as an assistant teacher at a co-ed, public school with experience "
        "in middle school math teaching.")
    NUM_PROMPTS = 200
    engine = LLM(enable_prefix_caching=True,
        disable_log_stats=False, **SETUP)
    so_far_cached = 0
    for MULTIPLE in range(5, 35, 2):
        prompt = str(MULTIPLE) + MULTIPLE * prefix + ("What is the capital of France?")
        # Initial prompt
        outputs = engine.generate(prompt, sampling_params, use_tqdm=False)
        start_time = time.time()
        for i in range(NUM_PROMPTS):
            outputs = engine.generate(prompt, sampling_params, use_tqdm=False)
            #print(f"Generated text: {outputs[0].outputs[0].text!r}")
        total_time = time.time() - start_time
        for m in engine.llm_engine.get_metrics():
            if 'vllm:prompt_tokens_cached' in m.name:
                print("Multiple", MULTIPLE,
                    "Hits/prompt", (m.value - so_far_cached) // NUM_PROMPTS,
                    "Took:", total_time, "seconds")
                so_far_cached = m.value

```


## Test Result
* Main:
```
Multiple 5 Hits/prompt 0 Took: 12.20611047744751 seconds
Multiple 7 Hits/prompt 0 Took: 12.233927726745605 seconds
Multiple 9 Hits/prompt 0 Took: 12.590906381607056 seconds
Multiple 11 Hits/prompt 1056 Took: 5.146499872207642 seconds
Multiple 13 Hits/prompt 1056 Took: 12.73249340057373 seconds
Multiple 15 Hits/prompt 1056 Took: 12.883115530014038 seconds
Multiple 17 Hits/prompt 1056 Took: 12.990457773208618 seconds
Multiple 19 Hits/prompt 1056 Took: 13.023258686065674 seconds
Multiple 21 Hits/prompt 2112 Took: 5.588909864425659 seconds
Multiple 23 Hits/prompt 2112 Took: 13.212487697601318 seconds
Multiple 25 Hits/prompt 2112 Took: 13.240469217300415 seconds
Multiple 27 Hits/prompt 2112 Took: 13.315996170043945 seconds
Multiple 29 Hits/prompt 2112 Took: 13.515663623809814 seconds
Multiple 31 Hits/prompt 3168 Took: 5.614190578460693 seconds
Multiple 33 Hits/prompt 3168 Took: 14.520177841186523 seconds
```
* This PR:
```
Multiple 5 Hits/prompt 512 Took: 3.692441463470459 seconds
Multiple 7 Hits/prompt 720 Took: 3.752166748046875 seconds
Multiple 9 Hits/prompt 928 Took: 3.8311171531677246 seconds
Multiple 11 Hits/prompt 1136 Took: 3.9413886070251465 seconds
Multiple 13 Hits/prompt 1344 Took: 3.9924542903900146 seconds
Multiple 15 Hits/prompt 1552 Took: 4.049445152282715 seconds
Multiple 17 Hits/prompt 1735 Took: 4.199482679367065 seconds
Multiple 19 Hits/prompt 1952 Took: 4.246189594268799 seconds
Multiple 21 Hits/prompt 2160 Took: 4.319143056869507 seconds
Multiple 23 Hits/prompt 2368 Took: 4.434829950332642 seconds
Multiple 25 Hits/prompt 2576 Took: 4.527528524398804 seconds
Multiple 27 Hits/prompt 2784 Took: 4.6004273891448975 seconds
Multiple 29 Hits/prompt 2992 Took: 4.739585876464844 seconds
Multiple 31 Hits/prompt 3200 Took: 4.832530736923218 seconds
Multiple 33 Hits/prompt 3375 Took: 4.971061706542969 seconds
```