### PR TITLE
[Bugfix] Fix NVFP4/OCP MX MoE emulation

### DIFF
--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -109,6 +109,7 @@ steps:
       - image-build-amd
       commands:
       - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - export PYTORCH_ROCM_ARCH=gfx942 # Limit Quark compilation to save time
       - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx.txt
 
 - label: MoE Refactor Integration Test (H100 - TEMPORARY)

--- a/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
@@ -21,7 +21,6 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
-from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
 from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
     dequantize_to_dtype,
 )
@@ -133,14 +132,6 @@ class Nvfp4QuantizationEmulationTritonExperts(TritonExperts):
             dtype=hidden_states.dtype,
             block_size=16,
             swizzle=False,
-        )
-
-        hidden_states, _ = moe_kernel_quantize_input(
-            A=hidden_states,
-            A_scale=self.quant_config.a1_gscale,
-            quant_dtype="nvfp4",
-            per_act_token_quant=False,
-            quantization_emulation=True,
         )
 
         # Activation quantization/dequantization is deferred to

--- a/vllm/model_executor/layers/fused_moe/experts/ocp_mx_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/ocp_mx_emulation_moe.py
@@ -21,7 +21,6 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
-from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import dequant_mxfp4
 from vllm.model_executor.layers.quantization.utils.mxfp6_utils import dequant_mxfp6
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import (
@@ -153,16 +152,6 @@ class OCP_MXQuantizationEmulationTritonExperts(TritonExperts):
         )
         w2_dequant = self._dequantize_weights(
             w2, self.w2_scale_val, hidden_states.dtype
-        )
-
-        # Apply activation QDQ if needed by the OCP MX scheme
-        hidden_states, _ = moe_kernel_quantize_input(
-            A=hidden_states,
-            A_scale=None,
-            quant_dtype=self.quant_config.quant_dtype,
-            per_act_token_quant=False,
-            ocp_mx_scheme=self.ocp_mx_scheme,
-            quantization_emulation=True,
         )
 
         # Activation quantization/dequantization is deferred to

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -245,7 +245,7 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
             lora_unquantized_hidden_states = hidden_states
             hidden_states, a1q_scale = moe_kernel_quantize_input(
                 hidden_states,
-                self.a1_scale,
+                self.a1_scale or self.a1_gscale,
                 self.quant_dtype,
                 self.per_act_token_quant,
                 self.block_shape,

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -296,6 +296,7 @@ def moe_kernel_quantize_input(
         if not quantization_emulation:
             return _nvfp4_quantize(A, A_scale, is_sf_swizzled_layout=is_scale_swizzled)
         else:
+            assert A_scale is not None
             A = ref_nvfp4_quant_dequant(A, A_scale, block_size=16)
             return A, None
     elif quant_dtype == "mxfp4":


### PR DESCRIPTION


## Purpose
This PR fixes an issue in the NVFP4/OCP MX MoE emulation code paths caused by https://github.com/vllm-project/vllm/pull/42120.
In that PR, `TritonExperts.apply` in `vllm/model_executor/layers/fused_moe/experts/triton_moe.py` was modified to call `moe_kernel_quantize_input` on the activations if `TritonExperts.expects_unquantized_inputs == True`. However, this flag is pre-set to `True` for NVFP4 and OCP MX emulation code paths, which also call `moe_kernel_quantize_input` on activations before entering `TritonExperts.apply`. The end-result is that `moe_kernel_quantize_input` is erroneously called twice on activations when NVFP4/OCP MX emulation is active.

## Test Plan
NVFP4 emulation is tested by the following
`pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx.txt`
which loads a NVFP4-quantized model (`nvidia/Qwen3-30B-A3B-FP4`) and runs it in emulation mode on a AMD `gfx942` based machine. This is run as part of AMD CI in the `AMD: LM Eval Large Models (H200) (mi300_8)` test group.

## Test Result
The above test group passes.

cc: @AndreasKaratzas. Also @fxmarty-amd, who noticed the same errors and has pending fixes for it in https://github.com/vllm-project/vllm/pull/46142 (for OCP MX) and https://github.com/vllm-project/vllm/pull/44667 (for NVFP4)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

