### PR TITLE
[Bugfix] DeepSeek-V4 tokenizer: honor add_generation_prompt and continue_final_message

### DIFF
--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -288,3 +288,60 @@ def test_deepseek_v4_matches_reference_golden_fixtures(case_id, kwargs):
 
     expected = (FIXTURES_DIR / f"test_output_{case_id}.txt").read_text()
     assert prompt == expected
+
+
+def test_deepseek_v4_add_generation_prompt_appended_by_default():
+    prompt = _tokenizer().apply_chat_template(
+        [{"role": "user", "content": "Hello"}],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+    assert prompt.endswith("<｜Assistant｜></think>")
+
+
+def test_deepseek_v4_add_generation_prompt_false_omits_cue():
+    prompt = _tokenizer().apply_chat_template(
+        [{"role": "user", "content": "Hello"}],
+        tokenize=False,
+        add_generation_prompt=False,
+    )
+
+    assert "<｜Assistant｜>" not in prompt
+
+
+def test_deepseek_v4_add_generation_prompt_after_assistant_opens_turn():
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+    assert prompt.endswith("Hi<｜end▁of▁sentence｜><｜Assistant｜></think>")
+
+
+def test_deepseek_v4_continue_final_message_keeps_turn_open():
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Partial answer"},
+        ],
+        tokenize=False,
+        continue_final_message=True,
+    )
+
+    assert prompt.endswith("Partial answer")
+    assert not prompt.endswith("<｜end▁of▁sentence｜>")
+    assert "<｜Assistant｜>" in prompt
+
+
+def test_deepseek_v4_continue_final_message_requires_assistant_last():
+    with pytest.raises(ValueError):
+        _tokenizer().apply_chat_template(
+            [{"role": "user", "content": "Hello"}],
+            tokenize=False,
+            continue_final_message=True,
+        )

--- a/vllm/tokenizers/deepseek_v4.py
+++ b/vllm/tokenizers/deepseek_v4.py
@@ -55,6 +55,8 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
                 thinking_mode=thinking_mode,
                 drop_thinking=kwargs.get("drop_thinking", True),
                 reasoning_effort=reasoning_effort,
+                add_generation_prompt=kwargs.get("add_generation_prompt", True),
+                continue_final_message=kwargs.get("continue_final_message", False),
             )
 
             prompt_str = encode_messages(messages, **encode_config)  # type: ignore

--- a/vllm/tokenizers/deepseek_v4_encoding.py
+++ b/vllm/tokenizers/deepseek_v4_encoding.py
@@ -226,7 +226,7 @@ def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
 # Message Rendering
 # ============================================================
 
-def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: str, drop_thinking: bool = True, reasoning_effort: Optional[str] = None) -> str:
+def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: str, drop_thinking: bool = True, reasoning_effort: Optional[str] = None, add_generation_prompt: bool = True, continue_final_message: bool = False) -> str:
     """
     Render a single message at the given index into its encoded string form.
 
@@ -256,7 +256,9 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
     response_format = msg.get("response_format")
     tool_calls = msg.get("tool_calls")
     reasoning = msg.get("reasoning")
-    wo_eos = msg.get("wo_eos", False)
+    wo_eos = msg.get("wo_eos", False) or (
+        continue_final_message and index == len(messages) - 1
+    )
 
     if tools:
         tools = tools_from_openai_format(tools)
@@ -388,14 +390,26 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
             prompt += task_sp_token
 
     elif messages[index].get("role") in ["user", "developer"]:
-        # Normal generation: append Assistant + thinking token
+        # This Assistant token is both the turn separator (when an assistant
+        # message follows) and the generation prompt (when this is the last
+        # message). Only the latter is suppressed by add_generation_prompt=False.
+        if index + 1 != len(messages) or add_generation_prompt:
+            prompt += ASSISTANT_SP_TOKEN
+            if not drop_thinking and thinking_mode == "thinking":
+                prompt += thinking_start_token
+            elif drop_thinking and thinking_mode == "thinking" and index >= last_user_idx:
+                prompt += thinking_start_token
+            else:
+                prompt += thinking_end_token
+
+    elif (
+        add_generation_prompt
+        and index + 1 == len(messages)
+        and messages[index].get("role") == "assistant"
+    ):
+        # add_generation_prompt after an assistant turn -> open a fresh turn.
         prompt += ASSISTANT_SP_TOKEN
-        if not drop_thinking and thinking_mode == "thinking":
-            prompt += thinking_start_token
-        elif drop_thinking and thinking_mode == "thinking" and index >= last_user_idx:
-            prompt += thinking_start_token
-        else:
-            prompt += thinking_end_token
+        prompt += thinking_start_token if thinking_mode == "thinking" else thinking_end_token
 
     return prompt
 
@@ -516,6 +530,8 @@ def encode_messages(
     drop_thinking: bool = True,
     add_default_bos_token: bool = True,
     reasoning_effort: Optional[str] = None,
+    add_generation_prompt: bool = True,
+    continue_final_message: bool = False,
 ) -> str:
     """
     Encode a list of messages into the DeepSeek-V4 prompt format.
@@ -538,6 +554,16 @@ def encode_messages(
     Returns:
         The encoded prompt string.
     """
+    if continue_final_message:
+        add_generation_prompt = False
+    if messages:
+        _last_role = messages[-1].get("role")
+        if continue_final_message and _last_role != "assistant":
+            raise ValueError(
+                "Cannot set `continue_final_message`=True when the last message is "
+                "not from the assistant."
+            )
+
     context = context if context else []
 
     # Preprocess: merge tool messages and sort tool results
@@ -573,6 +599,8 @@ def encode_messages(
             thinking_mode=thinking_mode,
             drop_thinking=effective_drop_thinking,
             reasoning_effort=reasoning_effort,
+            add_generation_prompt=add_generation_prompt,
+            continue_final_message=continue_final_message,
         )
 
     return prompt


### PR DESCRIPTION
## Purpose

Fixes #46256.

The `deepseek_v4` tokenizer-mode chat encoder derives the generation prompt solely from the last message's role and ignores `add_generation_prompt` and `continue_final_message`, even though both are forwarded to `apply_chat_template`. Consequences:

- `add_generation_prompt` has no effect.
- `continue_final_message=True` is a silent no-op.
- A conversation ending in an assistant message gets **no** generation prompt → the model is prompted right after the EOS token (off-distribution) → empty/garbled output, with no error.

Sibling custom tokenizers honor both: `vllm/tokenizers/mistral.py` validates + supports them, and `vllm/tokenizers/grok2.py` uses `{% if add_generation_prompt %}`. This threads both params into `encode_messages`/`render_message`:

- `add_generation_prompt=False` → omit the trailing generation prompt (inter-turn `<｜Assistant｜>` separators preserved).
- `add_generation_prompt=True` → append the generation prompt, **including after an assistant-terminated conversation** (open a fresh assistant turn). Agent frameworks (e.g. opencode summary/compaction sub-calls) legitimately send assistant-terminated conversations with the default `add_generation_prompt=True`.
- `continue_final_message=True` → render the final assistant turn without EOS so the model continues it.

See #46256 for the discovery story, captured failure outputs, and a tokenizer-only + end-to-end reproduction. Scoped to `deepseek_v4` (validated against a live deployment); `deepseek_v32` has the same gap but a structurally different generation-prompt mechanism — happy to extend with guidance.

## Test Plan

```bash
pytest tests/tokenizers_/test_deepseek_v4.py -k "add_generation_prompt or continue_final_message"
```

Five deterministic unit tests (mock tokenizer, no model) cover: cue appended by default; `add_generation_prompt=False` omits it; `add_generation_prompt=True` opens a fresh turn after an assistant-terminated conversation; `continue_final_message` keeps the final turn open with the separator preserved; `continue_final_message` requires an assistant-last message.

## Test Result

**Rendered prompt, before → after** (deterministic, tokenizer-only via `apply_chat_template(..., tokenize=False)`):

```text
# add_generation_prompt=False  (user-terminated)
before:  <｜begin▁of▁sentence｜><｜User｜>Hello<｜Assistant｜></think>    # ignored: cue still appended
after :  <｜begin▁of▁sentence｜><｜User｜>Hello                         # honored: no cue

# continue_final_message=True  (assistant-terminated)
before:  …<｜Assistant｜></think>Partial answer<｜end▁of▁sentence｜>      # ignored: turn closed with EOS
after :  …<｜Assistant｜></think>Partial answer                         # continues: no trailing EOS

# add_generation_prompt=True  (assistant-terminated)
before:  …<｜Assistant｜></think>Partial answer<｜end▁of▁sentence｜>                      # no generation prompt (off-distribution)
after :  …<｜Assistant｜></think>Partial answer<｜end▁of▁sentence｜><｜Assistant｜></think>   # opens a fresh turn
```

**End-to-end** on a live DeepSeek-V4-Flash deployment (`--tokenizer-mode deepseek_v4`): an assistant-terminated conversation now yields sensible output — e.g. a summary sub-call produces a clean summary — where before the model was prompted off-distribution. The unit tests are deterministic and run in CI; I couldn't run the full suite locally (no `torch`), but the encoder output is shown above and confirmed end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
