### PR TITLE
Revert "[Hardware][AMD][CI] Fix e2e core test group" (#46024)

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -647,7 +647,7 @@ steps:
   - pytest -v -s v1/cudagraph/test_cudagraph_mode.py
 
 - label: e2e Core (1 GPU) # TBD
-  timeout_in_minutes: 35
+  timeout_in_minutes: 180
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
   agent_pool: mi250_1
   optional: true
@@ -2074,6 +2074,19 @@ steps:
   commands:
   - export VLLM_ALLOW_INSECURE_SERIALIZATION=1
   - pytest -v -s v1/spec_decode/test_acceptance_length.py -m slow_test
+
+- label: e2e Core (1 GPU) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
+  agent_pool: mi300_1
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - vllm/v1/
+  - tests/v1/e2e/
+  - vllm/platforms/rocm.py
+  commands:
+  - pytest -v -s v1/e2e/general --ignore v1/e2e/general/test_async_scheduling.py
 
 - label: e2e Scheduling (1 GPU) # TBD
   timeout_in_minutes: 180

--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -74,16 +74,6 @@ steps:
     - tests/v1/e2e/general/
   commands:
     - pytest -v -s v1/e2e/general --ignore v1/e2e/general/test_async_scheduling.py
-  mirror:
-    amd:
-      device: mi250_1
-      timeout_in_minutes: 35
-      depends_on:
-      - image-build-amd
-      source_file_dependencies:
-      - vllm/v1/
-      - tests/v1/e2e/general/
-      - vllm/platforms/rocm.py
 
 - label: V1 e2e (2 GPUs)
   key: v1-e2e-2-gpus

--- a/tests/v1/e2e/general/test_cascade_attention.py
+++ b/tests/v1/e2e/general/test_cascade_attention.py
@@ -4,15 +4,8 @@
 import pytest
 
 from vllm import LLM, SamplingParams
-from vllm.platforms import current_platform
 
 from ....utils import create_new_process_for_each_test
-
-if current_platform.is_rocm():
-    pytest.skip(
-        "Cascade attention backends FLASH_ATTN and FLASHINFER are notsupported on ROCm",
-        allow_module_level=True,
-    )
 
 
 @create_new_process_for_each_test()


### PR DESCRIPTION
## Revert of #46024

This reverts https://github.com/vllm-project/vllm/pull/46024 (merge commit dced290).

**Reason:** `test_cascade_attention[FLASH_ATTN]` in the `e2e Core (1 GPU)` test suite now fails with an assertion error after this PR's changes to `tests/v1/e2e/general/test_cascade_attention.py`.

**CI Build:** [#73220](https://buildkite.com/vllm/ci/builds/73220) — 1 new failure linked to this PR.

---
*Auto-generated by CI failure analyzer.*