### PR TITLE
[Bugfix] Fix Qwen2-Audio (and similar MM models) on transformers v5: do not blindly override text_config.tie_word_embeddings

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -704,7 +704,20 @@ class VllmConfig:
             model_config.hf_config, "tie_word_embeddings"
         ):
             tie_word_embeddings = model_config.hf_config.tie_word_embeddings
-            hf_config.get_text_config().tie_word_embeddings = tie_word_embeddings
+            text_cfg = hf_config.get_text_config()
+            # Do not overwrite a tie_word_embeddings value that is already set
+            # on the text_config to a different value. Some multimodal configs
+            # (e.g. Qwen2AudioConfig) default the top-level tie_word_embeddings
+            # to True, while their text_config (Qwen2Config) has the actual,
+            # correct value (False) because the language_model's checkpoint
+            # contains an independent lm_head.weight. Blindly propagating the
+            # top-level default would force vLLM to skip lm_head weights and
+            # alias lm_head to embed_tokens, producing garbage logits at
+            # generation time (the model emits prompt-special tokens like
+            # ``<|audio_bos|>`` / ``<|audio_eos|>`` forever instead of text).
+            existing = getattr(text_cfg, "tie_word_embeddings", None)
+            if existing is None or existing == tie_word_embeddings:
+                text_cfg.tie_word_embeddings = tie_word_embeddings
 
         model_config.hf_config = hf_config
         model_config.model_arch_config = model_config.get_model_arch_config()


### PR DESCRIPTION
## Purpose

Fixes Qwen2-Audio (and any multimodal model whose top-level `tie_word_embeddings` defaults to a different value than its `text_config`'s) producing garbage output (`<|audio_bos|>` / `<|audio_eos|>` repeated forever, no actual text) on `transformers >= 5.x`.

Related issue: #46250.

## Reproducer (without this PR, on `transformers >= 5.0.0`)

```python
from vllm import LLM, SamplingParams
from vllm.assets.audio import AudioAsset
from transformers import AutoTokenizer

m = "Qwen/Qwen2-Audio-7B-Instruct"
audio = AudioAsset("mary_had_lamb").audio_and_sample_rate
prompt = ("<|im_start|>user\n<|audio_bos|><|AUDIO|><|audio_eos|>"
          "Can you transcribe this?<|im_end|>\n<|im_start|>assistant\n")

llm = LLM(model=m, dtype="half", enforce_eager=True,
          gpu_memory_utilization=0.5, limit_mm_per_prompt={"audio": 1})

out = llm.generate(
    [{"prompt": prompt, "multi_modal_data": {"audio": [audio]}}],
    SamplingParams(max_tokens=20, temperature=0),
)
print(AutoTokenizer.from_pretrained(m).decode(out[0].outputs[0].token_ids))
# Without this PR (transformers 5.10.2):
#   '<|audio_bos|><|audio_bos|>... x20'
# With this PR (transformers 5.10.2):
#   "The original content of this audio is: 'First words I spoke ...'"
```

The same bug also makes `tests/samplers/test_beam_search.py::test_beam_search_passes_multimodal_data` fail on transformers 5.x with a misleading diff like `Right contains 16 more items, first extra item: 151647`.

It is **not** audio-specific: a plain text prompt to the same model (e.g. `"What is 2+2?"`) also emits 20 consecutive `<|audio_eos|>` tokens. The audio path is fine — `audio_tower → multi_modal_projector` produces byte-identical embeddings on transformers `4.55.0` and `5.10.2`. The bug is on the language-model side.

## Root cause

`VllmConfig.with_hf_config` has a transformers-v5-only branch that propagates the top-level `tie_word_embeddings` flag onto the language-model `text_config`:

```python
# (transformers >= 5.0.0 path, vllm/config/vllm.py)
if model_config.is_multimodal_model and hasattr(
    model_config.hf_config, "tie_word_embeddings"
):
    tie_word_embeddings = model_config.hf_config.tie_word_embeddings
    hf_config.get_text_config().tie_word_embeddings = tie_word_embeddings
```

The rationale (preserved in the file's comment) is that for many VL models, `tie_word_embeddings` lives only on the top-level config, but vLLM places `lm_head` on `language_model`, so the value needs to be copied down. That logic is sound *when text_config doesn't already know the answer*.

For Qwen2-Audio it backfires:

| | `Qwen/Qwen2-Audio-7B-Instruct` config.json | After `AutoConfig.from_pretrained` |
|---|---|---|
| top-level `tie_word_embeddings` | **absent** | `True` (Qwen2AudioConfig default) |
| `text_config.tie_word_embeddings` | **absent** | `False` (Qwen2Config default) |
| `lm_head.weight` in ckpt | **present, independent values** | — |

HF itself warns at load time:

> The tied weights mapping and config for this model specifies to tie `model.language_model.embed_tokens.weight` to `lm_head.weight`, but both are present in the checkpoints with different values, so we will NOT tie them.

Under the old `with_hf_config` propagation rule, vLLM's Qwen2 LM took the **top-level** True and went down `lm_head = self.model.embed_tokens` plus `skip_prefixes=["lm_head."]`, which (a) made `lm_head.weight` alias `embed_tokens.weight` in memory and (b) silently dropped the real `lm_head.weight` from the safetensors. Verified by reading `data_ptr()` on the live model:

| | transformers 4.55.0 | transformers 5.10.2 (before fix) | transformers 5.10.2 (after fix) |
|---|---|---|---|
| `embed.data_ptr == lm_head.data_ptr` | **False** (correct) | **True** (bug) | **False** (correct) |
| `lm_head_norm_mean` | 0.547 | 0.647 (= embed) | 0.547 |

## Fix

Only propagate `tie_word_embeddings` onto `text_config` when `text_config` is either silent or already agrees with the top-level value. If they actively disagree, trust `text_config` — that's the value the language-model code path reads, and for models like Qwen2-Audio it's the one that matches the checkpoint.

```diff
         if model_config.is_multimodal_model and hasattr(
             model_config.hf_config, "tie_word_embeddings"
         ):
             tie_word_embeddings = model_config.hf_config.tie_word_embeddings
-            hf_config.get_text_config().tie_word_embeddings = tie_word_embeddings
+            text_cfg = hf_config.get_text_config()
+            existing = getattr(text_cfg, "tie_word_embeddings", None)
+            if existing is None or existing == tie_word_embeddings:
+                text_cfg.tie_word_embeddings = tie_word_embeddings
```

This is a minimal, conservative change: it preserves the original intent (fill the language_model's config when it would otherwise be missing the flag) and only abstains when the language_model already has an explicit, different opinion.

## Test Plan

On `transformers==5.10.2`, 1 × NVIDIA H20:

```bash
pytest -xvs tests/samplers/test_beam_search.py::test_beam_search_passes_multimodal_data[2-64-half]
```

```
================== 1 passed, 18 warnings in 99.82s (0:01:39) ===================
```

The vLLM output now matches the HF runner's output for both beam-0 and beam-1, e.g. beam-0:

```
The original content of this audio is: 'First words I spoke in the original cornograph
a little piece of practical poetry Mary had a little lamb its fleece was white as snow
and everywhere that Mary went the lamb was sure to go.'
```

Same generation also works for a plain text prompt: `"What is 2+2?"` → `"2+2 equals 4."`.

## Risk

- For models where `top-level == text_config` (the previous code-path's typical case), behavior is unchanged.
- For models where `top-level` is set but `text_config.tie_word_embeddings` is None (the case the original comment in the file describes), behavior is unchanged — the propagation still happens.
- The only behavior change is when `top-level != text_config.tie_word_embeddings` *and both are set*, which is precisely the Qwen2-Audio case. In that case we now respect `text_config`, which is what vLLM's `language_model` actually reads when building `lm_head`.

cc @DarkLight1337 @ywang96 (touching `VllmConfig.with_hf_config` / multimodal language_model setup)
