### PR TITLE
[specdec][v1] Fix sampler peak memory profiling for speculative decoding (revives #38220)

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6100,7 +6100,8 @@ class GPUModelRunner(
             else:
                 raise e
         if self.speculative_config:
-            draft_token_ids = [[0] for _ in range(num_reqs)]
+            num_spec_tokens = self.speculative_config.num_speculative_tokens
+            draft_token_ids = [[0] * num_spec_tokens for _ in range(num_reqs)]
             dummy_spec_decode_metadata = SpecDecodeMetadata.make_dummy(
                 draft_token_ids, self.device
             )


### PR DESCRIPTION
_New to vLLM and LLM-serving internals. Most of the beginner-friendly issues I found were already claimed (open PR) or already fixed, and the rest needed hardware I don't have yet, so I revived an issue that had stale PRs instead._

## What this fixes

`_dummy_sampler_run` (sampler memory profiling) used a single dummy draft token per request under speculative decoding:

```python
draft_token_ids = [[0] for _ in range(num_reqs)]
```

so peak sampler memory was profiled with 1 draft token instead of `num_speculative_tokens` — under-estimating peak memory for spec-decode runs (OOM risk at real load). Fix uses the real count:

```python
num_spec_tokens = self.speculative_config.num_speculative_tokens
draft_token_ids = [[0] * num_spec_tokens for _ in range(num_reqs)]
```

## Why this isn't a duplicate

The same one-line fix already exists in two **open but abandoned** PRs, which is why I'm flagging them up front rather than opening a blind duplicate:
- **#38220** — labeled `ready` (accepted in principle), but stalled on an Apr-2 CI failure the author never returned to (~2.5 months).
- **#37521** — identical fix, stalled on a missing DCO sign-off (~3 months).

This re-submits the fix rebased on current `main`, DCO-signed, and verified green, so it can actually land. The original #38220 author is credited via `Co-authored-by`.

## Test

The change is confined to the dummy memory-profiling run (`_dummy_sampler_run`). On a single A100, current `main` + this branch:

```
pytest tests/v1/spec_decode/test_max_len.py::test_ngram_max_len   # 3 passed (num_speculative_tokens = 1, 3, 10)
pytest tests/v1/spec_decode/test_ngram.py                          # 2 passed
```

`test_ngram_max_len[10]` exercises exactly the changed multi-draft-token profiling path; `ruff` clean. (I couldn't retrieve the 2.5-month-old Buildkite log from #38220, so I re-ran the runnable `v1-spec-decode` tests green on current main instead.)

> AI assistance was used to revive and verify this change; the diff and tests were reviewed and run locally.
