### PR TITLE
[Bugfix] YaRN RoPE: honor explicit attention_factor from the rope config

### DIFF
--- a/tests/model_executor/test_yarn_attention_factor.py
+++ b/tests/model_executor/test_yarn_attention_factor.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import math
+
+import pytest
+import torch
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.rotary_embedding import get_rope
+
+
+def _yarn_mscale(factor, attention_factor=None):
+    rope_parameters = {
+        "rope_type": "yarn",
+        "factor": float(factor),
+        "original_max_position_embeddings": 4096,
+        "rope_theta": 10000,
+    }
+    if attention_factor is not None:
+        rope_parameters["attention_factor"] = attention_factor
+    with set_current_vllm_config(VllmConfig()):
+        rope = get_rope(
+            head_size=128,
+            max_position=int(4096 * factor),
+            is_neox_style=True,
+            rope_parameters=rope_parameters,
+            dtype=torch.float32,
+        )
+    return float(rope.mscale)
+
+
+@pytest.mark.parametrize("factor", [8.0, 64.0])
+def test_yarn_uses_explicit_attention_factor(factor):
+    assert _yarn_mscale(factor, attention_factor=1.0) == pytest.approx(1.0)
+
+
+def test_yarn_default_mscale_unchanged():
+    factor = 64.0
+    assert _yarn_mscale(factor) == pytest.approx(0.1 * math.log(factor) + 1.0)

--- a/vllm/model_executor/layers/rotary_embedding/__init__.py
+++ b/vllm/model_executor/layers/rotary_embedding/__init__.py
@@ -271,6 +271,10 @@ def get_rope(
                 **extra_kwargs,
             )
         else:
+            # Forward HF's `attention_factor` (the final YaRN mscale) when set.
+            af = rope_parameters.get("attention_factor")
+            if af is not None:
+                extra_kwargs["attention_factor"] = af
             rotary_emb = YaRNScalingRotaryEmbedding(
                 head_size,
                 rotary_dim,

--- a/vllm/model_executor/layers/rotary_embedding/yarn_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/yarn_scaling_rope.py
@@ -29,6 +29,7 @@ class YaRNScalingRotaryEmbedding(RotaryEmbedding):
         beta_slow: int = 1,
         apply_yarn_scaling: bool = True,
         truncate: bool = True,
+        attention_factor: float | None = None,
     ) -> None:
         self.scaling_factor = scaling_factor
         self.extrapolation_factor = extrapolation_factor
@@ -36,12 +37,15 @@ class YaRNScalingRotaryEmbedding(RotaryEmbedding):
         self.beta_fast = beta_fast
         self.beta_slow = beta_slow
         self.truncate = truncate
-        # Get n-d magnitude scaling corrected for interpolation
-        self.mscale = (
-            float(yarn_get_mscale(self.scaling_factor) * attn_factor)
-            if apply_yarn_scaling
-            else float(attn_factor)
-        )
+        # HF supplies the final YaRN mscale as `attention_factor`; use it when set.
+        if attention_factor is not None:
+            self.mscale = float(attention_factor)
+        else:
+            self.mscale = (
+                float(yarn_get_mscale(self.scaling_factor) * attn_factor)
+                if apply_yarn_scaling
+                else float(attn_factor)
+            )
         super().__init__(
             head_size, rotary_dim, max_position_embeddings, base, is_neox_style, dtype
         )


### PR DESCRIPTION
## Purpose

`get_rope()` builds the YaRN branch's keyword arguments from a whitelist that includes `attn_factor` but not `attention_factor` (`vllm/model_executor/layers/rotary_embedding/__init__.py`). HF stores the final YaRN magnitude scaling under `attention_factor` and applies it to cos/sin (`transformers/modeling_rope_utils.py::_compute_yarn_parameters`), while vLLM expresses the same value as `mscale = yarn_get_mscale(factor) * attn_factor` (`yarn_scaling_rope.py`). A config that sets `attention_factor` is therefore not forwarded, and vLLM uses the default `yarn_get_mscale(factor)`.

`poolside/Laguna-XS.2` sets `factor=64` and `attention_factor=1.0`, so vLLM uses `mscale=1.4158883` where the config asks for `1.0`.

This PR lets `YaRNScalingRotaryEmbedding` accept `attention_factor` and use it as the mscale when present (matching transformers), and `get_rope` forwards it on the YaRN path. Configs without `attention_factor` are unchanged. This PR intentionally handles only the explicit `attention_factor` on the plain YaRN path; it does not claim full HF YaRN parity for the `mscale`/`mscale_all_dim` fallback or the MRoPE-yarn path.

## Test Plan

`pytest tests/model_executor/test_yarn_attention_factor.py`

The test reads `get_rope(...).mscale` for a YaRN config and checks that an explicit `attention_factor=1.0` gives `mscale==1.0`, and that a config without `attention_factor` keeps the default `yarn_get_mscale(factor)`.

## Test Result

`get_rope` with `{rope_type: yarn, factor: 64, attention_factor: 1.0}`:

| config | main | this PR |
| --- | --- | --- |
| `attention_factor=1.0` | 1.4158883 | 1.0 |
| no `attention_factor` | 1.4158883 | 1.4158883 |

## Duplicate work check

I searched open, closed, and merged vLLM PRs and issues for `attention_factor`, yarn `mscale`, and the Laguna YaRN scaling before opening this PR. I did not find another fix for this path.
