### PR TITLE
[Bugfix] Align hybrid model prefix cache hit lengths to prevent block missing on EAGLE

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2778,6 +2778,95 @@ def test_eagle_grouped_swa_siblings_use_same_cache_mask():
     assert num_computed_tokens == 8 * block_size
 
 
+def test_hybrid_model_full_attn_missing_block_on_eagle():
+    """
+    Bug is reported as https://github.com/vllm-project/vllm/issues/43559.
+
+    When using MTP/EAGLE with a hybrid model (Full Attention + Mamba, such as the
+    Qwen 3.5 family),the FullAttentionManager and MambaManager will return different
+    hit_blocks lengths because the FullAttentionManager drops the last hit block. In
+    this case, the final hit blocks and their length should be aligned to the shortest
+    one among multiple attention groups. Otherwise, the misaligned blocks will skip
+    the computation of certain layers (such as the full attn layers in Qwen 3.5),
+    leading to a loss of information contained within those blocks andresulting in
+    precision errors.
+    """
+    block_size = 16
+    # kv_cache_config = make_kv_cache_config_hybrid_model(block_size, 100, 0, 'mamba')
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                    num_speculative_blocks=1,
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+
+    # Prime the cache with a prompt of 1 blocks
+    token_ids = [i for i in range(1) for _ in range(block_size)]
+    req0 = make_request("req0", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    blocks = manager.allocate_slots(
+        req0, len(token_ids), num_computed_tokens, computed_blocks
+    )
+    manager.free(req0)
+    assert num_computed_tokens == 0
+    assert len(computed_blocks.blocks[0]) == 0
+    assert len(computed_blocks.blocks[1]) == 0
+    assert blocks is not None
+
+    # Prime the cache with a prompt of 2 blocks
+    # Prompt of 2 blocks tokens should get num_computed_tokens = 0,
+    # because full attn manager drop it's only hit block.
+    token_ids = [i for i in range(2) for _ in range(block_size)]
+    req1 = make_request("req1", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+    blocks = manager.allocate_slots(
+        req1, len(token_ids), num_computed_tokens, computed_blocks
+    )
+    manager.free(req1)
+    assert num_computed_tokens == 0
+    assert len(computed_blocks.blocks[0]) == 0
+    assert len(computed_blocks.blocks[1]) == 0
+
+    # Prompt of 3 blocks tokens should get num_computed_tokens = 0,
+    # because full attn manager drop it's last hit block and remain one.
+    token_ids = [i for i in range(3) for _ in range(block_size)]
+    req2 = make_request("req2", token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
+    blocks = manager.allocate_slots(
+        req2, len(token_ids), num_computed_tokens, computed_blocks
+    )
+    manager.free(req2)
+    assert num_computed_tokens == block_size
+    assert len(computed_blocks.blocks[0]) == 1
+    assert len(computed_blocks.blocks[1]) == 1
+
+
 def test_different_block_size():
     block_size = 16
     # full attention and sliding window attention layers have the same page size:

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -22,6 +22,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
+    MambaSpec,
     SlidingWindowSpec,
 )
 from vllm.v1.request import Request
@@ -683,7 +684,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 drop_eagle_block = use_eagle and idx not in eagle_verified
 
                 _max_length = curr_hit_length
-                if drop_eagle_block:
+                if drop_eagle_block and not isinstance(spec, MambaSpec):
                     # Eagle needs to match one more block and then pop the last.
                     _max_length = min(
                         curr_hit_length + spec.block_size, max_cache_hit_length


### PR DESCRIPTION

## Purpose
Fix the accuracy drop when both using --enable-prefix-caching and MTP on mamba and full attn hybrid model like Qwen 3.5/3.6 family.

**Associated issue:** [43559](https://github.com/vllm-project/vllm/issues/43559)

### Root Cause Analysis
The reason is `HybridKVCacheCoordinator.find_longest_cache_hit` returns mismatched `hit_length` and full attn's hit blocks, and tokens under this mismatching are lost and do not participate in the full attention calculation when prefilling. 

**Technical Details & Example:**

Detailed, when the mamba groups hit N blocks (N > 0) and the `hit_length` is N * `block_size`, unfortunately the full attn group only hit N-1 blocks, because the MTP/EAGLE is enabled and the last block is popped.  In this case, the prefill forward will resume from token `hit_length`+1 (N*`block_size`+1), whereas the correct index should be (N-1)*`block_size` +1, so the tokens at block N are totally lost and not participated in the calculation. 

### Regression Source

This issue was introduced in PR [#40860](https://github.com/vllm-project/vllm/pull/40860). It changed the `while` loop's `max_length` value in `HybridKVCacheCoordinator.find_longest_cache_hit` from `curr_hit_length` to `min(curr_hit_length + spec.block_size, max_cache_hit_length)`. Since this change, `MambaManager` returns one additional hit block and does not pop it, leading to a mismatch with the hit block count from `FullAttentionManager`.

## Test Plan

### New Test Case: `test_hybrid_model_full_attn_missing_block_on_eagle` 
Added to `tests/v1/core/test_prefix_caching.py`, this new test case verifies that the hit block counts from different attention groups in `computed_blocks` and the `num_computed_tokens` returned by `get_computed_blocks` exactly match and align with each other.
 
### Third-Party Tool Verification: [tool-eval-bench](https://github.com/SeraphimSerapis/tool-eval-bench)
An issue [comment](https://github.com/vllm-project/vllm/issues/43559#issuecomment-4655086131) reports that this tool can easily replicate the accuracy drop. Evaluation using `tool-eval-bench` with Qwen 3.5 4B on an NVIDIA RTX 5070 Ti demonstrates that applying this patch successfully recovers the model's accuracy.

## Test Result

### Test Case
| code version | `pytest ./tests/v1/core/test_prefix_caching.py` |
| --- | --- |
| unpatched| 1 failed, 80 passed, 16 warnings <br> FAILED tests/v1/core/test_prefix_caching.py::test_hybrid_model_full_attn_missing_block_on_eagle - assert 16 == 0 |
| patched| 81 passed, 16 warnings |

### Tool tool-eval-bench
**Environment:** Qwen3.5-4B on an NVIDIA RTX 5070 Ti

**Core Parameters:**

```text
--tensor-parallel-size 1
--max-model-len 10000
--reasoning-parser qwen3
--enable-prefix-caching
--kv-cache-dtype bfloat16
--speculative-config '{"method": "mtp", "num_speculative_tokens": 1}'
--served-model-name "Qwen/Qwen3.5-4B"
--enable-auto-tool-choice
--tool-call-parser qwen3_coder
```

**Test Command:** `tool-eval-bench --short`

**unpatched code score**
- **Final Score**: **63** / 100
- **Total Points**: 19 / 30

**patched code score**
- **Final Score**: **90** / 100
- **Total Points**: 27 / 30
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

