### PR TITLE
[security] fix(lora): contain filesystem resolver paths

### DIFF
--- a/tests/lora/test_filesystem_resolver.py
+++ b/tests/lora/test_filesystem_resolver.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from vllm.plugins.lora_resolvers.filesystem_resolver import FilesystemResolver
+
+BASE_MODEL_NAME = "base-model"
+
+
+def _write_adapter(path: Path, base_model_name: str = BASE_MODEL_NAME) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "adapter_config.json").write_text(
+        json.dumps({"peft_type": "LORA", "base_model_name_or_path": base_model_name})
+    )
+
+
+@pytest.mark.asyncio
+async def test_filesystem_resolver_loads_adapter_inside_cache(tmp_path):
+    cache_dir = tmp_path / "lora-cache"
+    adapter = cache_dir / "safe-adapter"
+    _write_adapter(adapter)
+
+    resolver = FilesystemResolver(str(cache_dir))
+
+    request = await resolver.resolve_lora(BASE_MODEL_NAME, "safe-adapter")
+
+    assert request is not None
+    assert request.lora_name == "safe-adapter"
+    assert os.path.realpath(request.lora_path) == os.path.realpath(adapter)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_resolver_rejects_absolute_path_escape(tmp_path):
+    cache_dir = tmp_path / "lora-cache"
+    outside_adapter = tmp_path / "outside-adapter"
+    cache_dir.mkdir()
+    _write_adapter(outside_adapter)
+
+    resolver = FilesystemResolver(str(cache_dir))
+
+    request = await resolver.resolve_lora(BASE_MODEL_NAME, str(outside_adapter))
+
+    assert request is None
+
+
+@pytest.mark.asyncio
+async def test_filesystem_resolver_rejects_parent_directory_escape(tmp_path):
+    cache_dir = tmp_path / "lora-cache"
+    outside_adapter = tmp_path / "outside-adapter"
+    cache_dir.mkdir()
+    _write_adapter(outside_adapter)
+
+    resolver = FilesystemResolver(str(cache_dir))
+    escape_name = os.path.relpath(outside_adapter, cache_dir)
+
+    request = await resolver.resolve_lora(BASE_MODEL_NAME, escape_name)
+
+    assert escape_name.startswith("..")
+    assert request is None
+
+
+@pytest.mark.asyncio
+async def test_filesystem_resolver_rejects_symlink_escape(tmp_path):
+    cache_dir = tmp_path / "lora-cache"
+    outside_adapter = tmp_path / "outside-adapter"
+    cache_dir.mkdir()
+    _write_adapter(outside_adapter)
+    (cache_dir / "linked-adapter").symlink_to(outside_adapter, target_is_directory=True)
+
+    resolver = FilesystemResolver(str(cache_dir))
+
+    request = await resolver.resolve_lora(BASE_MODEL_NAME, "linked-adapter")
+
+    assert request is None

--- a/vllm/plugins/lora_resolvers/filesystem_resolver.py
+++ b/vllm/plugins/lora_resolvers/filesystem_resolver.py
@@ -11,11 +11,26 @@ from vllm.lora.resolver import LoRAResolver, LoRAResolverRegistry
 class FilesystemResolver(LoRAResolver):
     def __init__(self, lora_cache_dir: str):
         self.lora_cache_dir = lora_cache_dir
+        self._resolved_lora_cache_dir = os.path.realpath(lora_cache_dir)
+
+    def _resolve_lora_path(self, lora_name: str) -> str | None:
+        if os.path.isabs(lora_name):
+            return None
+
+        lora_path = os.path.realpath(
+            os.path.join(self._resolved_lora_cache_dir, lora_name)
+        )
+        common_path = os.path.commonpath([self._resolved_lora_cache_dir, lora_path])
+        if common_path != self._resolved_lora_cache_dir:
+            return None
+        return lora_path
 
     async def resolve_lora(
         self, base_model_name: str, lora_name: str
     ) -> LoRARequest | None:
-        lora_path = os.path.join(self.lora_cache_dir, lora_name)
+        lora_path = self._resolve_lora_path(lora_name)
+        if lora_path is None:
+            return None
         maybe_lora_request = await self._get_lora_req_from_path(
             lora_name, lora_path, base_model_name
         )


### PR DESCRIPTION
## Purpose

This PR hardens the filesystem LoRA resolver's cache-directory boundary.

When `lora_filesystem_resolver` is enabled, request-controlled LoRA/model names are resolved under `VLLM_LORA_RESOLVER_CACHE_DIR`. Before this change, absolute paths and `..` segments were joined directly with the cache directory, allowing a request to resolve a valid adapter directory outside the configured cache.

This PR:

- rejects absolute LoRA names before path resolution;
- resolves candidate paths and enforces containment under the configured cache root;
- rejects symlink escapes that resolve outside the cache directory;
- adds focused regression coverage for inside-cache, absolute-path, parent-directory, and symlink cases.

### Security issues covered

| Issue | Impact | Severity |
| --- | --- | --- |
| Filesystem LoRA resolver cache-dir escape | An admitted API caller can cause the resolver to load or attempt to load a valid LoRA adapter from outside `VLLM_LORA_RESOLVER_CACHE_DIR` when runtime LoRA updating and the filesystem resolver plugin are enabled. | Medium |

### Before this PR

- `FilesystemResolver.resolve_lora()` used `os.path.join(self.lora_cache_dir, lora_name)` directly.
- Absolute `lora_name` values could discard the cache root.
- `../` paths could resolve outside the cache root.
- Symlinks inside the cache could point to adapter directories outside the cache.

### After this PR

- Absolute LoRA names are denied.
- Candidate paths are resolved with `os.path.realpath()`.
- `os.path.commonpath()` enforces that the final path remains under the configured cache root.
- Regression tests cover allowed in-cache adapters and blocked absolute, parent-directory, and symlink escapes.

### Why this matters

`VLLM_LORA_RESOLVER_CACHE_DIR` is the resolver's local allowlist boundary. Runtime LoRA loading is intentionally operator-enabled, but once the filesystem resolver is configured, the cache directory should still constrain what adapter paths request-controlled model names can select.

This does not claim arbitrary file read or unauthenticated reachability. The escaped target must be a readable valid LoRA adapter matching the served base model, and the deployment must have runtime LoRA updating plus the filesystem resolver enabled.

### Attack flow

```text
API request chooses a LoRA/model name
    -> filesystem LoRA resolver receives lora_name
        -> absolute path or ../ escapes configured cache dir
            -> resolver accepts adapter_config.json outside cache
                -> engine attempts to load adapter outside VLLM_LORA_RESOLVER_CACHE_DIR
```

### Affected code

| Issue | Files |
| --- | --- |
| Filesystem resolver cache containment | `vllm/plugins/lora_resolvers/filesystem_resolver.py`, `tests/lora/test_filesystem_resolver.py` |

### Root cause

- The resolver treated a request-selected LoRA/model name as a safe path component.
- The final filesystem path was not resolved and checked against the configured cache root before reading adapter metadata and returning a `LoRARequest`.

### CVSS assessment

| Issue | CVSS v3.1 | Vector |
| --- | --- | --- |
| Filesystem LoRA resolver cache-dir escape | 5.4 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N` |

Rationale: this requires an admitted API caller and an opt-in runtime LoRA resolver configuration. Impact is bounded to selecting valid readable adapter directories outside the intended cache boundary, not arbitrary file disclosure.

### Safe reproduction steps

1. Configure the filesystem LoRA resolver with a cache directory.
2. Place a valid matching LoRA adapter outside that cache directory.
3. Resolve a LoRA name such as an absolute path or `../outside-adapter`.
4. On vulnerable code, the resolver returns a `LoRARequest` pointing outside the cache.
5. With this PR, the resolver returns `None` for absolute, parent-directory, and symlink escapes while still accepting a valid adapter inside the cache.

### Changes in this PR

- Adds a `_resolve_lora_path()` helper to centralize path resolution and containment.
- Stores the resolved cache root once when constructing the resolver.
- Uses `realpath` plus `commonpath` before reading adapter files.
- Adds focused async tests for accepted and rejected resolver paths.

### Maintainer impact

- Narrowly scoped to the built-in filesystem LoRA resolver.
- Does not change the direct runtime LoRA loading endpoint behavior.
- Does not affect HF Hub resolver behavior.
- Preserves normal nested adapter directories inside the configured cache root.
- May block deployments that intentionally used absolute paths or symlink escapes through the filesystem resolver; those paths should be configured inside the cache root or loaded through the explicit trusted/admin mechanisms instead.

### Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

### AI assistance disclosure

AI assistance was used to help inspect the code path, draft the patch, and prepare this PR description. I reviewed the changed lines and validation outputs before submitting.

## Test Plan

- [x] Compile the changed resolver and regression test file.
- [x] Run a standalone resolver proof locally showing the benign in-cache adapter still loads and absolute, `..`, and symlink escapes are blocked.
- [x] Run the same standalone proof in Docker.
- [x] Run Ruff on the changed files.
- [x] Check formatting with Ruff.
- [x] Run `git diff --check`.
- [ ] Run the focused pytest file in the full vLLM test environment.

Commands:

```bash
.venv/bin/python -m py_compile \
  vllm/plugins/lora_resolvers/filesystem_resolver.py \
  tests/lora/test_filesystem_resolver.py

python /tmp/vllm_lora_resolver_containment_after.py

docker run --rm \
  -v "$PWD":/work:ro \
  -v /tmp/vllm_lora_resolver_containment_after.py:/proof.py:ro \
  python:3.12-slim python /proof.py

uvx ruff check \
  vllm/plugins/lora_resolvers/filesystem_resolver.py \
  tests/lora/test_filesystem_resolver.py

uvx ruff format --check \
  vllm/plugins/lora_resolvers/filesystem_resolver.py \
  tests/lora/test_filesystem_resolver.py

git diff --check
```

I attempted to run:

```bash
uv run --no-project python -m pytest -q tests/lora/test_filesystem_resolver.py
```

but this lightweight local environment did not have the full vLLM test dependency stack installed; pytest collection stopped in `tests/conftest.py` on missing test dependencies (`tblib` first, then `numpy` after installing minimal pytest helpers). The added tests are intended for the repository's normal test environment.

## Test Result

Local standalone proof result:

```text
inside_loaded= True
absolute_escape_blocked= True
relative_escape_name= ../outside-adapter
relative_escape_blocked= True
symlink_escape_blocked= True
```

Docker standalone proof result:

```text
inside_loaded= True
absolute_escape_blocked= True
relative_escape_name= ../outside-adapter
relative_escape_blocked= True
symlink_escape_blocked= True
```

Ruff result:

```text
All checks passed!
2 files already formatted
```

`git diff --check` completed without errors.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

