### PR TITLE
[V1][KVConnector] Reclaim KV blocks leaked by aborted remote KV recv

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -346,6 +346,62 @@ def test_throttle_prefills_excludes_remote_kv_resume():
     assert "r1" in output.num_scheduled_tokens
 
 
+def test_aborted_remote_kv_recv_blocks_reclaimed_on_timeout():
+    """A request aborted while WAITING_FOR_REMOTE_KVS holds its KV blocks
+    pending a finished/failed_recving signal that may never arrive (e.g. the
+    remote side also aborted). The scheduler must reclaim those blocks after
+    the grace period instead of leaking them.
+    See https://github.com/vllm-project/vllm/issues/46283.
+    """
+    from tests.v1.kv_connector.unit.utils import create_model_runner_output
+
+    BLOCK_SIZE = 16
+    NUM_MATCHED = BLOCK_SIZE * 2
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        use_kv_connector=mock_kv(matched_tokens=NUM_MATCHED, is_async=True),
+        block_size=BLOCK_SIZE,
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=NUM_MATCHED * 2,
+        max_tokens=20,
+        block_size=BLOCK_SIZE,
+        req_ids=["r"],
+    )
+    scheduler.add_request(request)
+    scheduler.schedule()  # r -> WAITING_FOR_REMOTE_KVS, blocks allocated
+    assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+
+    # Abort while waiting, with NO finished/failed_recving signal.
+    scheduler.finish_requests("r", RequestStatus.FINISHED_ABORTED)
+
+    # Blocks are held (delayed free) and tracked for reclaim -- not freed yet,
+    # but not leaked either.
+    assert "r" in scheduler.requests
+    assert "r" in scheduler._aborted_kv_recv_reclaim
+
+    # Before the grace period elapses, the sweep must not reclaim.
+    scheduler._reclaim_expired_aborted_kv_recvs()
+    assert "r" in scheduler.requests
+
+    # Force the deadline into the past (monotonic clock is always > 0); the
+    # next sweep reclaims the held blocks.
+    req_obj, _ = scheduler._aborted_kv_recv_reclaim["r"]
+    scheduler._aborted_kv_recv_reclaim["r"] = (req_obj, -1.0)
+    scheduler._reclaim_expired_aborted_kv_recvs()
+    assert "r" not in scheduler.requests
+    assert "r" not in scheduler._aborted_kv_recv_reclaim
+
+    # A late finished_recving for the already-reclaimed request must be
+    # ignored gracefully instead of crashing on a missing request.
+    late_output = scheduler.schedule()
+    scheduler.update_from_output(
+        late_output, create_model_runner_output([], finished_recving={"r"})
+    )
+    assert "r" not in scheduler.requests
+
+
 def test_throttle_defers_inflight_prefill_chunk():
     """DP prefill balancing throttles ALL prefill compute on a throttled step,
     not just new admissions: an in-progress (chunked) prefill already in the

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -64,6 +64,15 @@ from vllm.v1.utils import record_function_or_nullcontext
 
 logger = init_logger(__name__)
 
+# Grace period before reclaiming KV blocks held for a remote KV recv that was
+# aborted mid-flight (request finished while WAITING_FOR_REMOTE_KVS) and never
+# completed -- i.e. no finished/failed_recving signal ever arrives because the
+# remote side also aborted. Chosen comfortably above the connector-side KV
+# lease so a slow remote prefill still gets its full window before we reclaim.
+# See https://github.com/vllm-project/vllm/issues/46283.
+# TODO: maintainers may want this surfaced via vllm.envs.
+_KV_RECV_RECLAIM_TIMEOUT_S = 300.0
+
 
 class Scheduler(SchedulerInterface):
     def __init__(
@@ -196,6 +205,29 @@ class Scheduler(SchedulerInterface):
         # KV Connector: requests in process of async KV loading or recving
         self.finished_recving_kv_req_ids: set[str] = set()
         self.failed_recving_kv_req_ids: set[str] = set()
+        # KV Connector: blocks held for a remote KV recv that was aborted
+        # while WAITING_FOR_REMOTE_KVS. Release normally waits on a
+        # finished/failed_recving signal from the worker; if the remote side
+        # also aborted that signal never arrives and the blocks leak. Track
+        # (request, deadline) so we can reclaim them after a grace period.
+        # See https://github.com/vllm-project/vllm/issues/46283.
+        self._aborted_kv_recv_reclaim: dict[str, tuple[Request, float]] = {}
+        # The grace period must stay above the connector's KV lease so we never
+        # reclaim while a slow remote prefill could still be writing (#32255).
+        # MultiConnector nests per-connector configs under "connectors", so scan
+        # both the top level and any children and take the largest lease.
+        _kv_lease_duration = 0.0
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        if kv_transfer_config is not None:
+            _extra = kv_transfer_config.kv_connector_extra_config or {}
+            _lease_candidates = [_extra.get("kv_lease_duration", 30)]
+            for _child in _extra.get("connectors", []) or []:
+                _child_extra = (_child or {}).get("kv_connector_extra_config", {}) or {}
+                _lease_candidates.append(_child_extra.get("kv_lease_duration", 30))
+            _kv_lease_duration = max(float(_c) for _c in _lease_candidates)
+        self._kv_recv_reclaim_timeout_s: float = max(
+            _KV_RECV_RECLAIM_TIMEOUT_S, _kv_lease_duration + 60.0
+        )
 
         # Encoder-related.
         # Calculate encoder cache size if applicable
@@ -1733,6 +1765,10 @@ class Scheduler(SchedulerInterface):
         if kv_connector_output:
             self._update_from_kv_xfer_finished(kv_connector_output)
 
+        # KV Connector: reclaim blocks held for aborted remote-KV recvs that
+        # never completed within the grace period. See #46283.
+        self._reclaim_expired_aborted_kv_recvs()
+
         # Worker-side KV connector stats from the model runner output.
         kv_connector_stats: KVConnectorStats | None = (
             kv_connector_output.kv_connector_stats if kv_connector_output else None
@@ -2041,6 +2077,16 @@ class Scheduler(SchedulerInterface):
 
             request.status = finished_status
             self._free_request(request, delay_free_blocks=delay_free_blocks)
+            if delay_free_blocks and request.request_id in self.requests:
+                # Blocks were held for a remote KV recv that was aborted while
+                # WAITING_FOR_REMOTE_KVS. Arm a reclaim deadline so they are
+                # not leaked if no finished/failed_recving ever arrives (e.g.
+                # the remote side also aborted).
+                # See https://github.com/vllm-project/vllm/issues/46283.
+                self._aborted_kv_recv_reclaim[request.request_id] = (
+                    request,
+                    time.monotonic() + self._kv_recv_reclaim_timeout_s,
+                )
 
         return [(r.request_id, r.client_index) for r in valid_requests]
 
@@ -2066,6 +2112,9 @@ class Scheduler(SchedulerInterface):
     def _free_blocks(self, request: Request):
         assert request.is_finished()
         self._free_request_blocks(request)
+        # Drop any pending reclaim entry: the blocks are being freed now
+        # (via finished/failed_recving or the reclaim sweep). See #46283.
+        self._aborted_kv_recv_reclaim.pop(request.request_id, None)
         del self.requests[request.request_id]
 
     @property
@@ -2432,7 +2481,11 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            if req_id not in self.requests:
+                # The request was already reclaimed -- its remote KV recv was
+                # aborted and the grace period elapsed before this (late)
+                # finished_recving arrived. Nothing left to free. See #46283.
+                continue
             req = self.requests[req_id]
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
@@ -2441,8 +2494,40 @@ class Scheduler(SchedulerInterface):
                 self._free_blocks(self.requests[req_id])
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            if req_id not in self.requests:
+                # Already reclaimed before this late finished_sending. See #46283.
+                continue
             self._free_blocks(self.requests[req_id])
+
+    def _reclaim_expired_aborted_kv_recvs(self) -> None:
+        """Reclaim KV blocks held for aborted remote-KV recvs.
+
+        A request finished (aborted) while ``WAITING_FOR_REMOTE_KVS`` keeps its
+        blocks held until a finished/failed_recving signal arrives. If the
+        remote side also aborted, that signal never comes and the blocks would
+        leak. Free them once their grace period elapses.
+        See https://github.com/vllm-project/vllm/issues/46283.
+        """
+        if not self._aborted_kv_recv_reclaim:
+            return
+        now = time.monotonic()
+        expired = [
+            req_id
+            for req_id, (_, deadline) in self._aborted_kv_recv_reclaim.items()
+            if deadline <= now
+        ]
+        for req_id in expired:
+            request, _ = self._aborted_kv_recv_reclaim.pop(req_id)
+            # May already be gone if a finished/failed_recving raced in.
+            if req_id not in self.requests:
+                continue
+            logger.warning(
+                "Reclaiming KV blocks for request %s: remote KV recv was "
+                "aborted and did not complete within %.0fs.",
+                req_id,
+                self._kv_recv_reclaim_timeout_s,
+            )
+            self._free_blocks(request)
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Summary

Fixes #46283.

When a request is aborted while in `WAITING_FOR_REMOTE_KVS`, its KV blocks are
held via the delayed-free path until a `finished_recving` / `failed_recving`
signal arrives from the worker. If the **remote (prefill) side also aborts**,
that signal never arrives, so the held blocks are never released and leak for
the lifetime of the engine. Under NixlPush PD-disaggregation this is easy to
hit when a client disconnects mid-transfer.

## Fix (scheduler-side)

- Track each request aborted while `WAITING_FOR_REMOTE_KVS` together with a
  reclaim deadline (`_aborted_kv_recv_reclaim`).
- On each `update_from_output`, sweep expired entries and free their blocks via
  the existing `_free_blocks` path.
- The grace period is kept comfortably above the connector's `kv_lease_duration`
  (scanning `MultiConnector` children too) so a slow remote prefill still gets
  its full lease window before we reclaim — preserving the cross-request
  KV-corruption protection from #32255.
- Harden the late-signal paths: a `finished_recving` / `finished_sending` that
  arrives *after* the request was already reclaimed is now ignored instead of
  tripping an `assert`.

## Test

`tests/v1/core/test_scheduler.py::test_aborted_remote_kv_recv_blocks_reclaimed_on_timeout`
covers: abort in `WAITING_FOR_REMOTE_KVS` with no signal → blocks held & armed;
sweep before deadline → still held; deadline elapsed → reclaimed; late
`finished_recving` for the reclaimed request → ignored without crashing.

## Open questions for maintainers

- **Draft** pending direction from @shliba123 on the intended safe-release
  condition and a repro.
- I put the reclaim **scheduler-side**, reusing the existing lease / delayed-free
  machinery. If you'd rather drive this from the worker/connector (where the
  watchdog `_push_registration_deadlines` already detects the dead lease), I'm
  happy to move it.
- The grace period is currently a module constant (`_KV_RECV_RECLAIM_TIMEOUT_S
  = 300s`, floored at `lease + 60s`). Happy to surface it via `vllm.envs` if
  preferred.
- E2E NIXL PD validation from anyone with a disagg setup would be very welcome —
  my verification here is a deterministic scheduler unit test for the
  block-accounting path.