### PR TITLE
[Spec Decode] Fix hidden-state extraction block size for hybrid verifiers

### DIFF
--- a/tests/v1/kv_connector/unit/test_hidden_states_connector.py
+++ b/tests/v1/kv_connector/unit/test_hidden_states_connector.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only unit tests for ExampleHiddenStatesConnector KV-cache-group logic.
+
+These exercise the hybrid-model fix: the hidden-states group must be located by
+spec type and its block size read from that group's spec (not the global
+``cache_config.block_size``, which vLLM bumps for hybrid verifiers).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.distributed.kv_transfer.kv_connector.v1.example_hidden_states_connector import (  # noqa: E501
+    ExampleHiddenStatesConnector,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    HiddenStateCacheSpec,
+    KVCacheGroupSpec,
+)
+
+
+def _full(block_size: int) -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=block_size, num_kv_heads=8, head_size=128, dtype=torch.bfloat16
+    )
+
+
+def _hidden(block_size: int) -> HiddenStateCacheSpec:
+    return HiddenStateCacheSpec(
+        block_size=block_size, num_kv_heads=6, head_size=2048, dtype=torch.bfloat16
+    )
+
+
+def _config(*specs):
+    """Minimal stand-in exposing only ``kv_cache_groups`` (all the helpers read)."""
+    return SimpleNamespace(
+        kv_cache_groups=[
+            KVCacheGroupSpec(layer_names=[f"layer.{i}"], kv_cache_spec=spec)
+            for i, spec in enumerate(specs)
+        ]
+    )
+
+
+# ---- _find_cache_kv_group_id ------------------------------------------------
+
+
+def test_find_group_id_none_config_returns_zero():
+    assert ExampleHiddenStatesConnector._find_cache_kv_group_id(None) == 0
+
+
+def test_find_group_id_single_non_hidden_group_returns_zero():
+    # Uniform (dense) model: one group, no HiddenStateCacheSpec -> group 0.
+    cfg = _config(_full(16))
+    assert ExampleHiddenStatesConnector._find_cache_kv_group_id(cfg) == 0
+
+
+def test_find_group_id_locates_hidden_group_when_not_first():
+    # Hybrid layout: the hidden-states group is not group 0.
+    cfg = _config(_full(528), _hidden(22), _full(528))
+    assert ExampleHiddenStatesConnector._find_cache_kv_group_id(cfg) == 1
+
+
+def test_find_group_id_locates_hidden_group_last():
+    cfg = _config(_full(528), _full(528), _hidden(22))
+    assert ExampleHiddenStatesConnector._find_cache_kv_group_id(cfg) == 2
+
+
+def test_find_group_id_raises_when_no_hidden_group_and_multiple_groups():
+    cfg = _config(_full(16), _full(16))
+    with pytest.raises(ValueError, match="Could not uniquely identify"):
+        ExampleHiddenStatesConnector._find_cache_kv_group_id(cfg)
+
+
+def test_find_group_id_raises_when_multiple_hidden_groups():
+    cfg = _config(_hidden(22), _hidden(22))
+    with pytest.raises(ValueError, match="Could not uniquely identify"):
+        ExampleHiddenStatesConnector._find_cache_kv_group_id(cfg)
+
+
+# ---- _get_cache_block_size --------------------------------------------------
+
+
+def test_get_block_size_reads_hidden_group_spec_not_global():
+    # The hidden-states group keeps its own (smaller) block size (22), while the
+    # global cache_config.block_size is bumped to a common multiple (528) for
+    # hybrid models. The connector must read the group's value.
+    vllm_config = SimpleNamespace(cache_config=SimpleNamespace(block_size=528))
+    cfg = _config(_full(528), _hidden(22))
+    block_size = ExampleHiddenStatesConnector._get_cache_block_size(
+        vllm_config, cfg, cache_kv_group_id=1
+    )
+    assert block_size == 22
+
+
+def test_get_block_size_falls_back_to_cache_config_when_no_kv_cache_config():
+    vllm_config = SimpleNamespace(cache_config=SimpleNamespace(block_size=16))
+    block_size = ExampleHiddenStatesConnector._get_cache_block_size(
+        vllm_config, None, cache_kv_group_id=0
+    )
+    assert block_size == 16
+
+
+# ---- _cache_block_ids -------------------------------------------------------
+
+
+def test_cache_block_ids_selects_correct_group():
+    stub = SimpleNamespace(_cache_kv_group_id=2)
+    block_ids = ([10], [20], [30, 31])
+    assert ExampleHiddenStatesConnector._cache_block_ids(stub, block_ids) == [30, 31]
+
+
+def test_cache_block_ids_raises_when_group_out_of_range():
+    stub = SimpleNamespace(_cache_kv_group_id=5)
+    with pytest.raises(ValueError, match="out of range"):
+        ExampleHiddenStatesConnector._cache_block_ids(stub, ([10], [20]))

--- a/tests/v1/kv_connector/unit/test_hidden_states_connector.py
+++ b/tests/v1/kv_connector/unit/test_hidden_states_connector.py
@@ -1,11 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""CPU-only unit tests for ExampleHiddenStatesConnector KV-cache-group logic.
-
-These exercise the hybrid-model fix: the hidden-states group must be located by
-spec type and its block size read from that group's spec (not the global
-``cache_config.block_size``, which vLLM bumps for hybrid verifiers).
-"""
+"""CPU-only unit tests for ExampleHiddenStatesConnector KV-cache-group logic."""
 
 from types import SimpleNamespace
 
@@ -15,10 +10,13 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.example_hidden_states_connector import (  # noqa: E501
     ExampleHiddenStatesConnector,
 )
+from vllm.v1.core.kv_cache_utils import get_kv_cache_groups
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     HiddenStateCacheSpec,
     KVCacheGroupSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
 )
 
 
@@ -84,9 +82,7 @@ def test_find_group_id_raises_when_multiple_hidden_groups():
 
 
 def test_get_block_size_reads_hidden_group_spec_not_global():
-    # The hidden-states group keeps its own (smaller) block size (22), while the
-    # global cache_config.block_size is bumped to a common multiple (528) for
-    # hybrid models. The connector must read the group's value.
+    # Hidden group keeps block size 22; the global is bumped to 528 for hybrids.
     vllm_config = SimpleNamespace(cache_config=SimpleNamespace(block_size=528))
     cfg = _config(_full(528), _hidden(22))
     block_size = ExampleHiddenStatesConnector._get_cache_block_size(
@@ -103,16 +99,28 @@ def test_get_block_size_falls_back_to_cache_config_when_no_kv_cache_config():
     assert block_size == 16
 
 
-# ---- _cache_block_ids -------------------------------------------------------
+# ---- MLA-verifier absorption ------------------------------------------------
 
 
-def test_cache_block_ids_selects_correct_group():
-    stub = SimpleNamespace(_cache_kv_group_id=2)
-    block_ids = ([10], [20], [30, 31])
-    assert ExampleHiddenStatesConnector._cache_block_ids(stub, block_ids) == [30, 31]
-
-
-def test_cache_block_ids_raises_when_group_out_of_range():
-    stub = SimpleNamespace(_cache_kv_group_id=5)
-    with pytest.raises(ValueError, match="out of range"):
-        ExampleHiddenStatesConnector._cache_block_ids(stub, ([10], [20]))
+def test_find_group_id_errors_clearly_when_absorbed_by_mla_swa_verifier():
+    # HiddenStateCacheSpec subclasses MLAAttentionSpec, so an MLA + sliding-
+    # window MLA verifier absorbs it into the MLA group instead of isolating it.
+    dt = torch.bfloat16
+    spec = {
+        "layers.0.mla": MLAAttentionSpec(
+            block_size=64, num_kv_heads=1, head_size=576, dtype=dt
+        ),
+        "layers.1.swa": SlidingWindowMLASpec(
+            block_size=64, num_kv_heads=1, head_size=576, dtype=dt, sliding_window=512
+        ),
+        "cache_only_layers.61": _hidden(64),
+    }
+    vllm_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        speculative_config=None,
+    )
+    groups = get_kv_cache_groups(vllm_config, spec)
+    assert not any(isinstance(g.kv_cache_spec, HiddenStateCacheSpec) for g in groups)
+    cfg = SimpleNamespace(kv_cache_groups=groups)
+    with pytest.raises(ValueError, match="MLA verifiers are unsupported"):
+        ExampleHiddenStatesConnector._find_cache_kv_group_id(cfg)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -109,6 +109,63 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         # Must be False so that drafter kv cache isn't merged with verifier's
         return False
 
+    @classmethod
+    def _find_cache_kv_group_id(cls, kv_cache_config: "KVCacheConfig | None") -> int:
+        """Index of the KV cache group that stores the extracted hidden states.
+
+        The extract_hidden_states draft layer registers a HiddenStateCacheSpec,
+        which vLLM isolates into its own KV cache group. Match on the spec type
+        rather than layer-name substrings so detection does not depend on the
+        layer naming convention, and works on both scheduler and worker side.
+        """
+        if kv_cache_config is None:
+            return 0
+
+        from vllm.v1.kv_cache_interface import HiddenStateCacheSpec
+
+        group_ids = [
+            gid
+            for gid, group in enumerate(kv_cache_config.kv_cache_groups)
+            if isinstance(group.kv_cache_spec, HiddenStateCacheSpec)
+        ]
+        if len(group_ids) == 1:
+            return group_ids[0]
+        if not group_ids and len(kv_cache_config.kv_cache_groups) == 1:
+            return 0
+
+        raise ValueError(
+            "Could not uniquely identify the extract-hidden-states KV cache "
+            f"group from {len(kv_cache_config.kv_cache_groups)} groups."
+        )
+
+    @staticmethod
+    def _get_cache_block_size(
+        vllm_config: "VllmConfig",
+        kv_cache_config: "KVCacheConfig | None",
+        cache_kv_group_id: int,
+    ) -> int:
+        """Block size of the hidden-states KV cache group.
+
+        Must come from that group's spec, not ``cache_config.block_size``: for
+        hybrid (Mamba + attention) verifiers vLLM bumps the global block size to
+        a common multiple, while the page-aligned hidden-states group keeps its
+        own (smaller) block size.
+        """
+        if kv_cache_config is None:
+            return vllm_config.cache_config.block_size
+        cache_group = kv_cache_config.kv_cache_groups[cache_kv_group_id]
+        return cache_group.kv_cache_spec.block_size
+
+    def _cache_block_ids(self, block_ids: tuple[list[int], ...]) -> list[int]:
+        """Select the hidden-states group's block ids from the per-group tuple."""
+        if self._cache_kv_group_id >= len(block_ids):
+            raise ValueError(
+                "Extract-hidden-states KV cache group index "
+                f"{self._cache_kv_group_id} is out of range for block ids with "
+                f"{len(block_ids)} groups."
+            )
+        return block_ids[self._cache_kv_group_id]
+
     def __init__(
         self,
         vllm_config: "VllmConfig",
@@ -120,7 +177,27 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
             role=role,
             kv_cache_config=kv_cache_config,
         )
-        self._block_size = vllm_config.cache_config.block_size
+        # Identify the hidden-states KV cache group (by spec type) and read its
+        # block size from that group's spec. Using cache_config.block_size here
+        # is wrong for hybrid verifiers (it is bumped to a common multiple),
+        # which makes the deferred slot-mapping read the wrong slots -> all-zero
+        # hidden states, and out-of-bounds at scale.
+        self._cache_kv_group_id = self._find_cache_kv_group_id(kv_cache_config)
+        self._block_size = self._get_cache_block_size(
+            vllm_config, kv_cache_config, self._cache_kv_group_id
+        )
+        # Correctness hinge: _get_cache_block_size falls back to the global
+        # (hybrid-wrong) block size when kv_cache_config is None. Log so we can
+        # confirm both scheduler- and worker-side instances resolve the real
+        # hidden-states group block size.
+        logger.info(
+            "ExampleHiddenStatesConnector role=%s kv_cache_config=%s "
+            "hs_group_idx=%d block_size=%d",
+            role,
+            "none" if kv_cache_config is None else "set",
+            self._cache_kv_group_id,
+            self._block_size,
+        )
         self._storage_path = self._kv_transfer_config.get_from_extra_config(
             "shared_storage_path", "/tmp"
         )
@@ -151,13 +228,6 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         # Worker-side state (set by register_kv_caches).
         self._kv_cache: torch.Tensor | None = None
 
-        # Identify which KV cache group holds the hidden-states layer.
-        self._hs_group_idx: int = 0
-        if self._kv_cache_config is not None:
-            for i, group in enumerate(self._kv_cache_config.kv_cache_groups):
-                if any("cache_only_layers" in n for n in group.layer_names):
-                    self._hs_group_idx = i
-                    break
         # Only TP rank 0 writes hidden states to disk; other TP ranks no-op.
         # Set in register_kv_caches (after distributed init).
         self._is_tp_rank_zero: bool = True
@@ -267,12 +337,15 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         )
         self._kv_cache = kv_caches[self.cache_layers[0]]
 
-        # Find the KV cache group index for hidden states
-        if self._kv_cache_config is not None:
-            for i, group in enumerate(self._kv_cache_config.kv_cache_groups):
-                if self.cache_layers[0] in group.layer_names:
-                    self._hs_group_idx = i
-                    break
+        # Belt-and-suspenders: the block size derived from the hidden-states
+        # group spec must match the buffer we actually index into. A mismatch
+        # (e.g. the global cache_config.block_size on a hybrid model) would
+        # silently read the wrong slots and yield all-zero hidden states.
+        assert self._block_size == self._kv_cache.shape[1], (
+            f"Hidden-states block-size mismatch: derived {self._block_size} but "
+            f"buffer block size is {self._kv_cache.shape[1]}; read slots would be "
+            "wrong (likely a hybrid block-size resolution bug)."
+        )
 
     @staticmethod
     def _write_tensors(
@@ -543,7 +616,7 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         request: "Request",
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
-        return self.request_finished(request, block_ids[self._hs_group_idx])
+        return self.request_finished(request, self._cache_block_ids(block_ids))
 
     @classmethod
     def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -111,31 +111,29 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
 
     @classmethod
     def _find_cache_kv_group_id(cls, kv_cache_config: "KVCacheConfig | None") -> int:
-        """Index of the KV cache group that stores the extracted hidden states.
+        """Index of the KV cache group holding the extracted hidden states.
 
-        The extract_hidden_states draft layer registers a HiddenStateCacheSpec,
-        which vLLM isolates into its own KV cache group. Match on the spec type
-        rather than layer-name substrings so detection does not depend on the
-        layer naming convention, and works on both scheduler and worker side.
+        Located by spec type so it resolves on both scheduler and worker side.
         """
         if kv_cache_config is None:
             return 0
 
         from vllm.v1.kv_cache_interface import HiddenStateCacheSpec
 
+        groups = kv_cache_config.kv_cache_groups
         group_ids = [
             gid
-            for gid, group in enumerate(kv_cache_config.kv_cache_groups)
+            for gid, group in enumerate(groups)
             if isinstance(group.kv_cache_spec, HiddenStateCacheSpec)
         ]
         if len(group_ids) == 1:
             return group_ids[0]
-        if not group_ids and len(kv_cache_config.kv_cache_groups) == 1:
+        if not group_ids and len(groups) == 1:
             return 0
-
         raise ValueError(
             "Could not uniquely identify the extract-hidden-states KV cache "
-            f"group from {len(kv_cache_config.kv_cache_groups)} groups."
+            f"group among {len(groups)} groups; the hidden-states layer must be "
+            "isolated in its own group (MLA verifiers are unsupported)."
         )
 
     @staticmethod
@@ -144,27 +142,15 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         kv_cache_config: "KVCacheConfig | None",
         cache_kv_group_id: int,
     ) -> int:
-        """Block size of the hidden-states KV cache group.
+        """Block size of the hidden-states group, read from its own spec.
 
-        Must come from that group's spec, not ``cache_config.block_size``: for
-        hybrid (Mamba + attention) verifiers vLLM bumps the global block size to
-        a common multiple, while the page-aligned hidden-states group keeps its
-        own (smaller) block size.
+        cache_config.block_size is bumped to a common multiple for hybrid
+        verifiers; the page-aligned hidden-states group keeps a smaller one.
         """
         if kv_cache_config is None:
             return vllm_config.cache_config.block_size
         cache_group = kv_cache_config.kv_cache_groups[cache_kv_group_id]
         return cache_group.kv_cache_spec.block_size
-
-    def _cache_block_ids(self, block_ids: tuple[list[int], ...]) -> list[int]:
-        """Select the hidden-states group's block ids from the per-group tuple."""
-        if self._cache_kv_group_id >= len(block_ids):
-            raise ValueError(
-                "Extract-hidden-states KV cache group index "
-                f"{self._cache_kv_group_id} is out of range for block ids with "
-                f"{len(block_ids)} groups."
-            )
-        return block_ids[self._cache_kv_group_id]
 
     def __init__(
         self,
@@ -177,26 +163,11 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
             role=role,
             kv_cache_config=kv_cache_config,
         )
-        # Identify the hidden-states KV cache group (by spec type) and read its
-        # block size from that group's spec. Using cache_config.block_size here
-        # is wrong for hybrid verifiers (it is bumped to a common multiple),
-        # which makes the deferred slot-mapping read the wrong slots -> all-zero
-        # hidden states, and out-of-bounds at scale.
+        # Read the hidden-states group and its block size from the group spec;
+        # cache_config.block_size is bumped (wrong) for hybrid verifiers.
         self._cache_kv_group_id = self._find_cache_kv_group_id(kv_cache_config)
         self._block_size = self._get_cache_block_size(
             vllm_config, kv_cache_config, self._cache_kv_group_id
-        )
-        # Correctness hinge: _get_cache_block_size falls back to the global
-        # (hybrid-wrong) block size when kv_cache_config is None. Log so we can
-        # confirm both scheduler- and worker-side instances resolve the real
-        # hidden-states group block size.
-        logger.info(
-            "ExampleHiddenStatesConnector role=%s kv_cache_config=%s "
-            "hs_group_idx=%d block_size=%d",
-            role,
-            "none" if kv_cache_config is None else "set",
-            self._cache_kv_group_id,
-            self._block_size,
         )
         self._storage_path = self._kv_transfer_config.get_from_extra_config(
             "shared_storage_path", "/tmp"
@@ -337,15 +308,14 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         )
         self._kv_cache = kv_caches[self.cache_layers[0]]
 
-        # Belt-and-suspenders: the block size derived from the hidden-states
-        # group spec must match the buffer we actually index into. A mismatch
-        # (e.g. the global cache_config.block_size on a hybrid model) would
-        # silently read the wrong slots and yield all-zero hidden states.
-        assert self._block_size == self._kv_cache.shape[1], (
-            f"Hidden-states block-size mismatch: derived {self._block_size} but "
-            f"buffer block size is {self._kv_cache.shape[1]}; read slots would be "
-            "wrong (likely a hybrid block-size resolution bug)."
-        )
+        # Block size must match the indexed buffer, else reads hit the wrong
+        # slots. Raise (not assert) so the check survives `python -O`.
+        if self._block_size != self._kv_cache.shape[1]:
+            raise ValueError(
+                f"Hidden-states block-size mismatch: derived {self._block_size} "
+                f"but buffer block size is {self._kv_cache.shape[1]}; read slots "
+                "would be wrong (likely a hybrid block-size resolution bug)."
+            )
 
     @staticmethod
     def _write_tensors(
@@ -616,7 +586,7 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         request: "Request",
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
-        return self.request_finished(request, self._cache_block_ids(block_ids))
+        return self.request_finished(request, block_ids[self._cache_kv_group_id])
 
     @classmethod
     def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:

--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -83,8 +83,17 @@ def basic_cache(
     kv_cache: torch.Tensor,  # shape: [num_blocks, block_size, num_heads, head_size]
     slot_mapping: torch.Tensor,  # shape: [seq_len]
 ):
+    # Ignore padding slots (slot_mapping < 0): padded / chunked-prefill batches
+    # carry -1 slots that must not scatter hidden states into block 0.
+    valid = slot_mapping >= 0
+    if not valid.any():
+        return
+    valid_slot_mapping = slot_mapping[valid]
     block_size = kv_cache.shape[1]
-    kv_cache[slot_mapping // block_size, slot_mapping % block_size] = to_cache
+    kv_cache[
+        valid_slot_mapping // block_size,
+        valid_slot_mapping % block_size,
+    ] = to_cache[valid]
 
 
 ######### CacheOnlyAttentionBackend ########

--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -83,17 +83,11 @@ def basic_cache(
     kv_cache: torch.Tensor,  # shape: [num_blocks, block_size, num_heads, head_size]
     slot_mapping: torch.Tensor,  # shape: [seq_len]
 ):
-    # Ignore padding slots (slot_mapping < 0): padded / chunked-prefill batches
-    # carry -1 slots that must not scatter hidden states into block 0.
-    valid = slot_mapping >= 0
-    if not valid.any():
-        return
-    valid_slot_mapping = slot_mapping[valid]
+    # Padding slots are -1; redirect them to the null block (block 0, never
+    # allocated to a request) so the scatter stays branch-free and sync-free.
     block_size = kv_cache.shape[1]
-    kv_cache[
-        valid_slot_mapping // block_size,
-        valid_slot_mapping % block_size,
-    ] = to_cache[valid]
+    slot_mapping = slot_mapping.clamp_min(0)
+    kv_cache[slot_mapping // block_size, slot_mapping % block_size] = to_cache
 
 
 ######### CacheOnlyAttentionBackend ########


### PR DESCRIPTION

### Purpose
`extract_hidden_states` + `ExampleHiddenStatesConnector` silently produces
**all-zero hidden states** on hybrid (Mamba + attention) verifiers such as
`Qwen3.5-35B-A3B`, and crashes with a CUDA `index out of bounds` at scale.
Training on the zero/garbage states "converges" (validation looks fine) but the
resulting draft model has ~0% real acceptance — see vllm-project/speculators#613.
This supersedes #44328, narrowed to the actual root cause on current `main`.
### Root cause
Hybrid support was added in #39949, where the connector read `slot_mapping`
directly from `attn_metadata` (write-slots == read-slots, correct by
construction). The async-write rework (#43805) moved extraction to
`get_finished()`, where `attn_metadata` is gone, so it now **rebuilds**
`slot_mapping` from `block_ids × self._block_size` with
`self._block_size = cache_config.block_size`.
For hybrid models vLLM bumps the global `cache_config.block_size` to a common
multiple, while the page-aligned hidden-states KV cache group keeps its own
(smaller) block size. Concrete example for `Qwen3.5-35B-A3B`: global block size `528`,
hidden-states buffer block size `22` (`= 528/24`). Rebuilding read slots with
`528` while the buffer/decode use `22` reads block `b·24` instead of `b` →
unwritten (zero) slots, and `b·24` eventually exceeds `num_blocks` → the OOB.
#45849 fixed group detection + a NaN (block tracking) for hybrid, but did **not**
touch the block size, so the all-zeros remained.
### Changes
`vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py`
- Identify the hidden-states group by `HiddenStateCacheSpec` **type**
  (`_find_cache_kv_group_id`) instead of `"cache_only_layers"` layer-name
  substrings — robust on both scheduler and worker side.
- Derive the connector block size from that group's spec
  (`_get_cache_block_size`) instead of `cache_config.block_size`.
- Assert the derived block size matches the registered buffer in
  `register_kv_caches` (`self._block_size == self._kv_cache.shape[1]`) so this
  class of mismatch fails loudly instead of corrupting silently.
`vllm/model_executor/models/extract_hidden_states.py`
- `basic_cache` ignores padding slots (`slot_mapping < 0`) so padded /
  chunked-prefill batches don't scatter hidden states into block 0.
### Test Plan
Isolated hidden-state extraction (no training) on `Qwen/Qwen3.5-35B-A3B`,

```
#!/bin/bash
# Isolate vLLM hidden-state EXTRACTION from speculator training.
#
# Launches a vLLM hidden-states-extraction server for a (possibly hybrid)
# verifier model, then submits a small number of single requests and validates
# the extracted hidden states -- covering both the ONLINE client path
# (scripts/extract_hidden_states_smoke.py, the same call train.py makes) and the
# OFFLINE path (scripts/data_generation_offline.py).
#
# Goal: confirm hidden-state extraction works for a given verifier (e.g. the
# hybrid Qwen3.5/3.6-A3B models) independent of training, or pinpoint exactly
# where it breaks.
#
# Usage:
#   bash examples/train/extract_hidden_states_smoke.sh
# Reproduce a clean traceback on failure:
#   CUDA_LAUNCH_BLOCKING=1 TORCHDYNAMO_DISABLE=1 \
#     bash examples/train/extract_hidden_states_smoke.sh
set -euo pipefail

# ============ Configuration ============
MODEL="Qwen/Qwen3.5-35B-A3B"
DATA="./output/dflash_qwen3_5_35b_a3b_ultrachat"   # produced by prepare_data.py
TARGET_LAYER_IDS="2 11 20 29 38"                   # last layer auto-appended
VLLM_PORT=8000
MAX_MODEL_LEN=32768

NUM_SAMPLES=200            # bump this (e.g. 200) to chase multi-request issues
START_INDEX=0
REQUEST_MODE="both"     # online | offline | both

VLLM_GPUS="0,1,2,3"
# Verifier parallelism. TP=4/DP=1 = single engine sharded over 4 GPUs and
# gives the cleanest tracebacks. Set TP=1/DP=4 to mirror the training launcher.
TP_SIZE=4
DP_SIZE=1
ENFORCE_EAGER=0         # 1 => --enforce-eager (clean tracebacks); 0 => default
# =======================================

VLLM_LOG="$DATA/vllm_extract_smoke.log"
OFFLINE_OUT="$DATA/hs_smoke_offline"
mkdir -p "$DATA"

EAGER_FLAG=""
[ "$ENFORCE_EAGER" = "1" ] && EAGER_FLAG="--enforce-eager"

echo "=== Launching vLLM (hidden-states extraction) -> $VLLM_LOG ==="
CUDA_LAUNCH_BLOCKING="${CUDA_LAUNCH_BLOCKING:-1}" CUDA_VISIBLE_DEVICES="$VLLM_GPUS" \
  python scripts/launch_vllm.py "$MODEL" \
    --target-layer-ids $TARGET_LAYER_IDS \
    -- --tensor-parallel-size "$TP_SIZE" --data-parallel-size "$DP_SIZE" \
       --port "$VLLM_PORT" --max-model-len "$MAX_MODEL_LEN" $EAGER_FLAG \
  > "$VLLM_LOG" 2>&1 &
VLLM_PID=$!

cleanup() {
    echo "Stopping vLLM server ($VLLM_PID)..."
    kill "$VLLM_PID" 2>/dev/null || true
    wait "$VLLM_PID" 2>/dev/null || true
}
trap cleanup EXIT

echo "Waiting for vLLM to become healthy..."
until curl -sf "http://localhost:${VLLM_PORT}/health" > /dev/null 2>&1; do
    if ! kill -0 "$VLLM_PID" 2>/dev/null; then
        echo "ERROR: vLLM exited during startup. Tail of $VLLM_LOG:"
        tail -n 60 "$VLLM_LOG"
        exit 1
    fi
    sleep 3
done
echo "vLLM ready."

rc=0

if [ "$REQUEST_MODE" = "online" ] || [ "$REQUEST_MODE" = "both" ]; then
    echo "=== ONLINE path: $NUM_SAMPLES request(s) via extract_hidden_states_smoke.py ==="
    python scripts/extract_hidden_states_smoke.py \
        --endpoint "http://localhost:${VLLM_PORT}/v1" \
        --preprocessed-data "$DATA" \
        --num-samples "$NUM_SAMPLES" \
        --start-index "$START_INDEX" || rc=$?
fi

if [ "$REQUEST_MODE" = "offline" ] || [ "$REQUEST_MODE" = "both" ]; then
    echo "=== OFFLINE path: $NUM_SAMPLES sample(s) via data_generation_offline.py ==="
    rm -rf "$OFFLINE_OUT"
    python scripts/data_generation_offline.py \
        --endpoint "http://localhost:${VLLM_PORT}/v1" \
        --preprocessed-data "$DATA" \
        --output "$OFFLINE_OUT" \
        --max-samples "$NUM_SAMPLES" \
        --concurrency 1 \
        --validate-outputs \
        --fail-on-error || rc=$?
fi

if [ "$rc" -eq 0 ]; then
    echo "=== Hidden-state extraction smoke test PASSED ==="
else
    echo "=== Hidden-state extraction smoke test FAILED (rc=$rc). See $VLLM_LOG ==="
fi
exit "$rc"

=== extract_hidden_states_smoke.py ===
#!/usr/bin/env python3
"""Smoke test for vLLM hidden-state extraction, isolated from training.

This script does *not* launch vLLM. It expects a vLLM server already started
via ``scripts/launch_vllm.py`` (i.e. configured with the
``ExampleHiddenStatesConnector`` + ``extract_hidden_states`` speculative
config). It submits one (or a few) completion request(s), loads the extracted
hidden states from disk, and validates them exactly the way the offline/online
data pipelines do (``check_hidden_states``).

The point is to isolate hidden-state EXTRACTION from speculator training so we
can verify it works -- or pinpoint where it breaks -- for a given verifier
model, in particular hybrid-attention models (e.g. Qwen3.5/3.6-A3B).

It uses the exact same client call (``generate_hidden_states``) that the online
training data loader uses, so a pass here means the online extraction path is
healthy for the tested sample(s). For the offline path, point
``data_generation_offline.py`` at the same server.

Usage:
    python scripts/extract_hidden_states_smoke.py \
        --endpoint http://localhost:8000/v1 \
        --preprocessed-data ./output/<prepared_dataset> \
        --num-samples 1
"""

import argparse
import logging
import sys
from pathlib import Path

import openai
import torch
from datasets import load_from_disk
from safetensors.torch import load_file

from speculators.data_generation.offline import check_hidden_states
from speculators.data_generation.vllm_client import (
    DEFAULT_REQUEST_TIMEOUT,
    generate_hidden_states,
    wait_for_lock,
)
from speculators.train.data import build_client_item

logging.basicConfig(
    level=logging.INFO, format="%(asctime)s %(levelname)s [hs_smoke] %(message)s"
)
logger = logging.getLogger("hs_smoke")


def parse_args():
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument(
        "--endpoint",
        default="http://localhost:8000/v1",
        help="vLLM endpoint configured for hidden-states extraction.",
    )
    parser.add_argument(
        "--preprocessed-data",
        required=True,
        help="Path to a prepare_data.py dataset; uses its 'input_ids' column.",
    )
    parser.add_argument(
        "--num-samples",
        type=int,
        default=1,
        help="Number of consecutive samples to submit (default: 1).",
    )
    parser.add_argument(
        "--start-index",
        type=int,
        default=0,
        help="First dataset index to submit (default: 0).",
    )
    parser.add_argument(
        "--request-timeout",
        type=float,
        default=DEFAULT_REQUEST_TIMEOUT,
        help="Per-request timeout in seconds.",
    )
    parser.add_argument(
        "--model",
        default=None,
        help="Optional model id; defaults to the server's first served model.",
    )
    parser.add_argument(
        "--keep-files",
        action="store_true",
        help="Do not delete the extracted safetensors files after validation.",
    )
    return parser.parse_args()


def describe(hs: torch.Tensor) -> str:
    f = hs.detach().float()
    return (
        f"shape={tuple(hs.shape)} dtype={hs.dtype} "
        f"min={f.min().item():.4f} max={f.max().item():.4f} "
        f"mean={f.mean().item():.4f} std={f.std().item():.4f} "
        f"nan={int(hs.isnan().sum())} inf={int(hs.isinf().sum())}"
    )


def main() -> int:
    args = parse_args()

    dataset = load_from_disk(args.preprocessed_data)
    dataset = dataset.with_format(
        "torch", columns=["input_ids"], output_all_columns=True
    )

    client = openai.Client(base_url=args.endpoint, api_key="EMPTY", max_retries=0)
    model = args.model or client.models.list().data[0].id
    logger.info("model=%s endpoint=%s dataset_size=%d", model, args.endpoint, len(dataset))

    end = min(args.start_index + args.num_samples, len(dataset))
    failures = 0
    for i in range(args.start_index, end):
        item = build_client_item(dataset[i])
        tokens = item["input_ids"]
        logger.info("[sample %d] submitting num_tokens=%d", i, len(tokens))
        try:
            path = generate_hidden_states(
                client, model, item, timeout=args.request_timeout
            )
            lock_path = path + ".lock"
            if Path(lock_path).exists():
                wait_for_lock(lock_path)

            data = load_file(path)
            check_hidden_states(data, tokens)
            logger.info(
                "[sample %d] OK token_ids=%d hidden_states %s",
                i,
                data["token_ids"].shape[0],
                describe(data["hidden_states"]),
            )
            if not args.keep_files:
                Path(path).unlink(missing_ok=True)
        except Exception as e:  # noqa: BLE001
            failures += 1
            logger.exception("[sample %d] FAILED: %s", i, e)

    total = end - args.start_index
    logger.info("Done: %d/%d samples succeeded", total - failures, total)
    return 1 if failures else 0


if __name__ == "__main__":
    sys.exit(main())

```


### Test Result
Before (current `main`):
- Connector resolves `block_size=528` (global) vs buffer block size `22`.
- Hidden states are entirely zero (`min=max=mean=std=0`); fails validation, and
  OOB / `IndexKernel.cu:111 index out of bounds` at scale.

After (this branch):
- Connector resolves `block_size=22` on **both** worker and scheduler
  (`role=WORKER ... block_size=22`, `role=SCHEDULER ... block_size=22`).
- **200/200** samples succeed (online + offline) with healthy hidden states
  (`min≈-29.6, max≈43.5, mean≈0.001, std≈0.21, nan=0, inf=0`); no OOB, no OOM.