### PR TITLE
[Bugfix][Core] Skip stale KV xfer finish notifications for already-freed requests

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4171,6 +4171,41 @@ def test_abort_request_finished_recving():
     assert not scheduler.finished_recving_kv_req_ids
 
 
+def test_aborted_request_both_kv_xfers_same_step():
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+
+    # Aborted request with in-flight recv+send; blocks still held.
+    request.status = RequestStatus.FINISHED_ABORTED
+    assert request.request_id in scheduler.requests
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={},
+        total_num_scheduled_tokens=0,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(
+            finished_recving={request.request_id},
+            finished_sending={request.request_id},
+        ),
+    )
+
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert request.request_id not in scheduler.requests
+
+
 def test_delayed_kv_connector_free_keeps_scheduler_active():
     scheduler = create_scheduler(use_kv_connector=True)
     queued_request, request = create_requests(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2432,7 +2432,8 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            if req_id not in self.requests:
+                continue
             req = self.requests[req_id]
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
@@ -2441,7 +2442,8 @@ class Scheduler(SchedulerInterface):
                 self._free_blocks(self.requests[req_id])
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            if req_id not in self.requests:
+                continue
             self._free_blocks(self.requests[req_id])
 
     def _update_requests_with_invalid_blocks(


### PR DESCRIPTION
## Purpose

Fix EngineCore crash in v1 P/D when an aborted request reports both
`finished_recving` and `finished_sending` in the same scheduler step.

The recv loop frees the request; the send loop then hits
`assert req_id in self.requests` and kills EngineCore (cascades across
DP ranks via `sync_dp_state`).

Closes #46240.

Duplicate-work check: searched open PRs for #46240 and
`kv_xfer_finished`/`finished_recving finished_sending`. #45628 addresses
a related stale-notification path for #43226 but does not include a
regression test for the same-step dual-completion scenario described in
#46240.

AI assistance: Dhiwahar Adhithya reviewed every changed line; AI
(Cursor/Claude) assisted with investigation and test scaffolding.

## Test Plan

.venv/bin/python -m pytest tests/v1/core/test_scheduler.py::test_aborted_request_both_kv_xfers_same_step -v --noconftest

pre-commit run ruff-check --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py

pre-commit run ruff-format --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py

## Test Result

```
tests/v1/core/test_scheduler.py::test_aborted_request_both_kv_xfers_same_step PASSED [100%]

1 passed in 21.45s
```

```
ruff check...............................................................Passed
ruff format..............................................................Passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose linked to #46240
- [x] Test command provided
- [x] Test results pasted above
- [x] No docs update needed (internal scheduler fix)
</details>