### PR TITLE
[Bugfix][Frontend] Keep length finish_reason for max_tokens-truncated streaming tool calls

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -699,7 +699,11 @@ class OpenAIServingChat(OpenAIServing):
                         # finish_reason is:
                         # "tool_calls" for "auto" or "required" tool calls,
                         # and "stop" for named tool calls.
-                        if tools_streamed[i] and not tool_choice_function_name:
+                        if (
+                            tools_streamed[i]
+                            and not tool_choice_function_name
+                            and output.finish_reason == "stop"
+                        ):
                             finish_reason_ = "tool_calls"
                         else:
                             finish_reason_ = (


### PR DESCRIPTION
Fixes #9053

## Purpose

When a tool call is truncated mid-JSON by `max_tokens`, the streaming `/v1/chat/completions` endpoint currently returns `finish_reason="tool_calls"` on the terminal chunk as long as any tool delta was emitted.

This causes two issues:

1. **Divergence from non-streaming**: The non-streaming endpoint already correctly returns `finish_reason="length"`.
2. **Client execution errors**: Streaming clients cannot detect truncation and may attempt to execute incomplete JSON (e.g., at `max_tokens=10`, only the function name was generated, but the terminal chunk reports `tool_calls` with `arguments="{}"`). Per the OpenAI API specification, tool calls cut off by `max_tokens` must return `finish_reason="length"`.

### Fix
Gate setting `finish_reason="tool_calls"` on the engine finishing normally (`output.finish_reason == "stop"`), aligning with the non-streaming logic. If the request was truncated (e.g., `length`), the original finish reason is preserved.

*(Note: Independent of #42213, which handles flushing buffered text when no tool delta was streamed).*

## Test Plan

1. **E2E verification**: Tested `max_tokens` values 10, 12, 16, 24, 32, and 48 on a live server (`Qwen3-0.6B`, `--enable-auto-tool-choice --tool-call-parser hermes`), comparing the terminal `finish_reason` between `stream=true` and `stream=false`.
2. **Focused regression test**: Added streaming cases for both completed (`stop` → `tool_calls`) and truncated (`length` → `length`) requests to `tests/entrypoints/openai/chat_completion/test_serving_chat.py`.

```bash
VLLM_TARGET_DEVICE=empty PYTHONPATH="$PWD" pytest -q \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_streaming_n_gt1_independent_tool_parsers
```

## Test Result

### E2E Comparison (`stream` vs `non-stream`)

Across different `max_tokens` settings, streaming terminal `finish_reason` now strictly matches non-streaming:

| `max_tokens` | non-stream | stream (before) | stream (after) |
|---|---|---|---|
| 10 | length | **tool_calls** | **length** |
| 12 | length | **tool_calls** | **length** |
| 16 | length | **tool_calls** | **length** |
| 24 | length | **tool_calls** | **length** |
| 32 | tool_calls | tool_calls | tool_calls |
| 48 | tool_calls | tool_calls | tool_calls |

The focused regression test passed both cases (`2 passed`). Without the `output.finish_reason == "stop"` check, the completed case still passes while the truncated case fails as expected.

<details>
<summary>Reproduction script and environment</summary>

Hardware: 1x RTX 4090. Model: `Qwen3-0.6B`.

Server command:

```bash
python -m vllm.entrypoints.openai.api_server \
  --model Qwen3-0.6B --served-model-name qwen \
  --enable-auto-tool-choice --tool-call-parser hermes --reasoning-parser qwen3 \
  --enforce-eager --max-model-len 2048
```

Client reproduction script:

```python
import json, urllib.request

TOOLS = [{
    "type": "function",
    "function": {
        "name": "get_weather",
        "description": "Get weather",
        "parameters": {
            "type": "object",
            "properties": {
                "city": {"type": "string", "enum": ["Vienna"]},
                "unit": {"type": "string", "enum": ["celsius"]},
            },
            "required": ["city", "unit"],
            "additionalProperties": False,
        },
    },
}]

def post(payload):
    req = urllib.request.Request(
        "http://127.0.0.1:8000/v1/chat/completions",
        data=json.dumps(payload).encode(),
        headers={"Content-Type": "application/json"},
        method="POST",
    )
    return urllib.request.urlopen(req, timeout=120)

def read_stream(resp):
    terminal, args = None, []
    for raw in resp:
        line = raw.decode(errors="replace").strip()
        if not line.startswith("data: ") or line == "data: [DONE]":
            continue
        obj = json.loads(line[6:])
        for ch in obj.get("choices", []):
            for tc in (ch.get("delta") or {}).get("tool_calls") or []:
                fn = tc.get("function") or {}
                if "arguments" in fn:
                    args.append(fn.get("arguments") or "")
            if ch.get("finish_reason") is not None:
                terminal = ch
    return terminal, "".join(args)

for mt in [10, 12, 16, 24, 32, 48]:
    common = {
        "model": "qwen",
        "messages": [{"role": "user", "content": "Call get_weather for Vienna in celsius."}],
        "tools": TOOLS,
        "tool_choice": "required",
        "chat_template_kwargs": {"enable_thinking": False},
        "temperature": 0,
        "max_tokens": mt,
    }
    with post({**common, "stream": False}) as r:
        ns = json.loads(r.read())["choices"][0]["finish_reason"]
    with post({**common, "stream": True}) as r:
        term, args = read_stream(r)
    print(f"max_tokens={mt:2d} | non_stream={ns:10s} | stream={term['finish_reason']:10s} | args={args!r}")
```

</details>

AI assistance was used to prepare this PR.

cc @sfeng33 @DarkLight1337
