### PR TITLE
[Bugfix][Core] Skip stale KV xfer finish notifications for already-freed requests

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4206,6 +4206,33 @@ def test_aborted_request_both_kv_xfers_same_step():
     assert request.request_id not in scheduler.requests
 
 
+def test_abort_mid_recv_skips_connector():
+    """Aborting a mid-recv request must not invoke request_finished().
+
+    recv must complete before send can begin; calling request_finished()
+    while recv is still pending could cause the connector to initiate an
+    async send and emit finished_sending before finished_recving resolves.
+    """
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+    request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+
+    # Simulate a connector that would return True (async send) if asked.
+    scheduler._connector_finished = Mock(return_value=(True, None))
+
+    # Abort while recv is still pending (finished_recving not yet received).
+    scheduler.finish_requests((request.request_id,), RequestStatus.FINISHED_ABORTED)
+
+    # request_finished() must NOT have been called — the connector should
+    # never learn about this request so it cannot initiate a send.
+    scheduler._connector_finished.assert_not_called()
+
+    # Blocks must still be held (delay_free_blocks=True) until finished_recving.
+    assert request.request_id in scheduler.requests
+
+
 def test_delayed_kv_connector_free_keeps_scheduler_active():
     scheduler = create_scheduler(use_kv_connector=True)
     queued_request, request = create_requests(

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4171,6 +4171,41 @@ def test_abort_request_finished_recving():
     assert not scheduler.finished_recving_kv_req_ids
 
 
+def test_aborted_request_both_kv_xfers_same_step():
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+
+    # Aborted request with in-flight recv+send; blocks still held.
+    request.status = RequestStatus.FINISHED_ABORTED
+    assert request.request_id in scheduler.requests
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={},
+        total_num_scheduled_tokens=0,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(
+            finished_recving={request.request_id},
+            finished_sending={request.request_id},
+        ),
+    )
+
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert request.request_id not in scheduler.requests
+
+
 def test_delayed_kv_connector_free_keeps_scheduler_active():
     scheduler = create_scheduler(use_kv_connector=True)
     queued_request, request = create_requests(

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4177,7 +4177,7 @@ def test_aborted_request_both_kv_xfers_same_step():
     request = create_requests(num_requests=1)[0]
     scheduler.add_request(request)
 
-    # Aborted request with in-flight recv+send; blocks still held.
+    # Simulate abort mid-transfer: request still tracked with in-flight recv+send.
     request.status = RequestStatus.FINISHED_ABORTED
     assert request.request_id in scheduler.requests
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2032,25 +2032,42 @@ class Scheduler(SchedulerInterface):
         # Second pass: set status and free requests
         for request in valid_requests:
             delay_free_blocks = False
+            skip_connector = False
             if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
-                delay_free_blocks = (
-                    request.request_id not in self.finished_recving_kv_req_ids
-                )
+                recv_done = request.request_id in self.finished_recving_kv_req_ids
+                delay_free_blocks = not recv_done
+                # Recv must complete before send can begin: don't call
+                # request_finished() for a request still mid-recv, as that
+                # could cause the connector to initiate an async send and
+                # emit finished_sending before finished_recving is resolved.
+                skip_connector = not recv_done
                 self.finished_recving_kv_req_ids.discard(request.request_id)
                 self.failed_recving_kv_req_ids.discard(request.request_id)
 
             request.status = finished_status
-            self._free_request(request, delay_free_blocks=delay_free_blocks)
+            self._free_request(
+                request,
+                delay_free_blocks=delay_free_blocks,
+                skip_connector=skip_connector,
+            )
 
         return [(r.request_id, r.client_index) for r in valid_requests]
 
     def _free_request(
-        self, request: Request, delay_free_blocks: bool = False
+        self,
+        request: Request,
+        delay_free_blocks: bool = False,
+        skip_connector: bool = False,
     ) -> dict[str, Any] | None:
         assert request.is_finished()
 
         self._inflight_prefills.discard(request)
-        connector_delay_free_blocks, kv_xfer_params = self._connector_finished(request)
+        if skip_connector:
+            connector_delay_free_blocks, kv_xfer_params = False, None
+        else:
+            connector_delay_free_blocks, kv_xfer_params = self._connector_finished(
+                request
+            )
         self.encoder_cache_manager.free(request)
         request_id = request.request_id
         self.finished_req_ids.add(request_id)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2432,7 +2432,8 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            if req_id not in self.requests:
+                continue
             req = self.requests[req_id]
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
@@ -2441,7 +2442,8 @@ class Scheduler(SchedulerInterface):
                 self._free_blocks(self.requests[req_id])
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            if req_id not in self.requests:
+                continue
             self._free_blocks(self.requests[req_id])
 
     def _update_requests_with_invalid_blocks(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2431,20 +2431,21 @@ class Scheduler(SchedulerInterface):
 
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
-            logger.debug("Finished recving KV transfer for request %s", req_id)
-            if req_id not in self.requests:
+            req = self.requests.get(req_id)
+            if req is None:
                 continue
-            req = self.requests[req_id]
+            logger.debug("Finished recving KV transfer for request %s", req_id)
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
             else:
                 assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                self._free_blocks(req)
         for req_id in kv_connector_output.finished_sending or ():
-            logger.debug("Finished sending KV transfer for request %s", req_id)
-            if req_id not in self.requests:
+            req = self.requests.get(req_id)
+            if req is None:
                 continue
-            self._free_blocks(self.requests[req_id])
+            logger.debug("Finished sending KV transfer for request %s", req_id)
+            self._free_blocks(req)
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Purpose

Fix EngineCore crash in v1 P/D when an aborted request reports both
`finished_recving` and `finished_sending` in the same scheduler step.

The recv loop frees the request; the send loop then hits
`assert req_id in self.requests` and kills EngineCore (cascades across
DP ranks via `sync_dp_state`).

Closes #46240.

Reopened after accidental fork deletion closed #46302 (same change).

Duplicate-work check: searched open PRs for #46240 and
`kv_xfer_finished`/`finished_recving finished_sending`. #45628 addresses
a related stale-notification path for #43226 but does not include a
regression test for the same-step dual-completion scenario described in
#46240.

AI assistance: Dhiwahar Adhithya reviewed every changed line; AI
(Cursor/Claude) assisted with investigation and test scaffolding.

## Test Plan

.venv/bin/python -m pytest tests/v1/core/test_scheduler.py::test_aborted_request_both_kv_xfers_same_step -v --noconftest

pre-commit run ruff-check --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py

pre-commit run ruff-format --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py

## Test Result

```
tests/v1/core/test_scheduler.py::test_aborted_request_both_kv_xfers_same_step PASSED [100%]

1 passed in 21.45s
```

```
ruff check...............................................................Passed
ruff format..............................................................Passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose linked to #46240
- [x] Test command provided
- [x] Test results pasted above
- [x] No docs update needed (internal scheduler fix)
</details>