### PR TITLE
[Bugfix][Qwen3-VL] Fix multi-video crash with list-valued fps/num_frames

### DIFF
--- a/tests/models/multimodal/processing/test_qwen3_vl.py
+++ b/tests/models/multimodal/processing/test_qwen3_vl.py
@@ -138,3 +138,49 @@ def test_processor_multi_video(
         assert video_phs[i].offset >= prev_end, (
             f"Placeholder {i} overlaps with placeholder {i - 1}"
         )
+
+
+@pytest.mark.parametrize("model_id", [MODEL_ID])
+@pytest.mark.parametrize(
+    "hf_mm_kwargs",
+    [{"num_frames": [8, 16]}, {"fps": [2.0, 4.0]}],
+)
+def test_processor_multi_video_list_kwargs(
+    model_id: str,
+    hf_mm_kwargs: dict[str, Any],
+) -> None:
+    """Regression test: a multi-video request with list-valued per-video
+    ``mm_processor_kwargs`` (one ``fps``/``num_frames`` per video) must not
+    crash.
+
+    Before the fix, ``_call_hf_processor`` copied the whole kwargs to every
+    video without slicing, so ``_get_video_second_idx`` received the list
+    where a scalar was expected and raised ``TypeError``.
+    """
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"image": 0, "video": 2},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+
+    prompt = (
+        "<|vision_start|><|video_pad|><|vision_end|>"
+        "<|vision_start|><|video_pad|><|vision_end|>"
+    )
+    mm_data = {
+        "video": [
+            _build_video_mm_data(num_frames=16)["video"][0],
+            _build_video_mm_data(num_frames=32)["video"][0],
+        ]
+    }
+
+    processed = processor(
+        prompt,
+        mm_items=processor.info.parse_mm_data(mm_data),
+        hf_processor_mm_kwargs=hf_mm_kwargs,
+    )
+
+    video_phs = processed["mm_placeholders"].get("video", [])
+    assert len(video_phs) == 2, (
+        f"Expected exactly 2 video placeholders, got {len(video_phs)}"
+    )

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1271,7 +1271,7 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
             vision_end_token_id = hf_config.vision_end_token_id
             video_token_id = hf_config.video_token_id
 
-            for item in videos:
+            for item_idx, item in enumerate(videos):
                 video_array, metadata = item
 
                 # NOTE: @JJJYmmm new attr metadata.frames_indices indicates
@@ -1282,6 +1282,12 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
                 # NOTE: a copy of is created to update do_sample_frames,
                 # otherwise mm_hash for the object will be incorrect.
                 video_mm_kwargs = dict(**mm_kwargs)
+                sampled_fps = video_mm_kwargs.get("fps")
+                if is_list_of(sampled_fps, float):
+                    video_mm_kwargs["fps"] = sampled_fps[item_idx]
+                sampled_num_frames = video_mm_kwargs.get("num_frames")
+                if is_list_of(sampled_num_frames, int):
+                    video_mm_kwargs["num_frames"] = sampled_num_frames[item_idx]
                 if "do_sample_frames" not in video_mm_kwargs:
                     # qwen_vl_utils already has "do_sample_frames" in
                     # mm_kwargs, don't overwrite it.
@@ -1363,10 +1369,15 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
         else:
             video_outputs = dict()
 
+        # fps/num_frames are video-only kwargs already consumed by the loop;
+        # exclude them so the text/image processor call below never gets a list.
+        text_mm_kwargs = {
+            k: v for k, v in mm_kwargs.items() if k not in ("fps", "num_frames")
+        }
         processed_outputs = super()._call_hf_processor(
             prompt=prompt,
             mm_data=mm_data,
-            mm_kwargs=mm_kwargs,
+            mm_kwargs=text_mm_kwargs,
             tok_kwargs=tok_kwargs,
         )
 

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1371,13 +1371,13 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
 
         # fps/num_frames are video-only kwargs already consumed by the loop;
         # exclude them so the text/image processor call below never gets a list.
-        text_mm_kwargs = {
+        non_video_mm_kwargs = {
             k: v for k, v in mm_kwargs.items() if k not in ("fps", "num_frames")
         }
         processed_outputs = super()._call_hf_processor(
             prompt=prompt,
             mm_data=mm_data,
-            mm_kwargs=text_mm_kwargs,
+            mm_kwargs=non_video_mm_kwargs,
             tok_kwargs=tok_kwargs,
         )
 


### PR DESCRIPTION

## Purpose

A Qwen3-VL request that carries more than one video and passes per-video `mm_processor_kwargs` as a list (one value per video, e.g. `fps=[2.0, 4.0]` or `num_frames=[8, 16]`) crashes during preprocessing, before the request reaches inference.

`Qwen3VLMultiModalProcessor._call_hf_processor()` processes videos in a per-item loop, but it copies the full `mm_kwargs` to every video without slicing the list-valued per-video kwargs. `_get_video_second_idx()` then receives the whole list where it expects a scalar:

- `num_frames=[8, 16]` raises `TypeError: '>' not supported between instances of 'int' and 'list'`
- `fps=[2.0, 4.0]` raises `TypeError: can't multiply sequence by non-int of type 'float'`

List-valued per-video `fps` is an intended representation: `_get_prompt_updates.get_video_replacement_qwen3vl` already slices it with `is_list_of(sampled_fps, float)` / `sampled_fps[item_idx]`. The later per-video processing path simply missed the same slicing.

There is a second leak in the same method: after the video loop, the text/image HF processor call also receives the unsliced `mm_kwargs`. `fps`/`num_frames` are video-only kwargs already consumed by the loop, so forwarding the list there fails again with `ValueError: Failed to apply Qwen3VLProcessor`.

This PR slices list-valued `fps`/`num_frames` by item index inside the per-video loop (mirroring `_get_prompt_updates`), and drops these video-only kwargs from the final text/image processor call. The scalar path is unchanged.

This is not covered by #36136 (single-video scalar `num_frames` timestamp) or #37439 (`merge_size` timestamp fix).

## Test Plan

Processor-level regression added to `tests/models/multimodal/processing/test_qwen3_vl.py`: a two-video request with list-valued `num_frames=[8, 16]` and `fps=[2.0, 4.0]`, asserting two video placeholders are produced.

```bash
pytest tests/models/multimodal/processing/test_qwen3_vl.py -q
```

End-to-end repro on a real `LLM.generate` with `Qwen3-VL-4B-Instruct`, two videos, four cases: scalar `num_frames`/`fps` as negative controls and list `num_frames`/`fps` as the failing cases.

## Test Result

Processor tests (current main + fix), all pass; without the fix the two new list-kwargs cases fail:

```text
PASSED test_processor_num_frames_timestamp[8-...]
PASSED test_processor_num_frames_timestamp[16-...]
PASSED test_processor_multi_video[2-...]
PASSED test_processor_multi_video[4-...]
PASSED test_processor_multi_video_list_kwargs[hf_mm_kwargs0-...]   # num_frames=[8,16]
PASSED test_processor_multi_video_list_kwargs[hf_mm_kwargs1-...]   # fps=[2.0,4.0]
6 passed

# baseline (fix reverted), same two new cases:
FAILED test_processor_multi_video_list_kwargs[hf_mm_kwargs0-...]
FAILED test_processor_multi_video_list_kwargs[hf_mm_kwargs1-...]
2 failed
```

<details>
<summary>End-to-end repro (hardware, environment, script, before/after output)</summary>

Hardware: 1x RTX 4090. Model: `Qwen3-VL-4B-Instruct`, `enforce_eager=True`, `max_model_len=2048`.

```python
import numpy as np
from vllm import LLM, SamplingParams


def video(num_frames, fps=30.0):
    arr = np.zeros((num_frames, 128, 128, 3), dtype=np.uint8)
    metadata = {
        "fps": fps,
        "duration": num_frames / fps,
        "total_num_frames": num_frames,
        "frames_indices": list(range(num_frames)),
        "video_backend": "opencv",
        "do_sample_frames": True,
    }
    return arr, metadata


prompt = {
    "prompt": (
        "<|vision_start|><|video_pad|><|vision_end|>"
        "<|vision_start|><|video_pad|><|vision_end|>"
        "Describe the two videos briefly."
    ),
    "multi_modal_data": {"video": [video(16), video(32)]},
}

llm = LLM(
    model="Qwen/Qwen3-VL-4B-Instruct",
    max_model_len=2048,
    max_num_seqs=1,
    enforce_eager=True,
    limit_mm_per_prompt={"image": 0, "video": 2},
)
sp = SamplingParams(temperature=0.0, max_tokens=2)

for name, kwargs in [
    ("scalar_num_frames", {"num_frames": 8}),
    ("list_num_frames", {"num_frames": [8, 16]}),
    ("scalar_fps", {"fps": 2.0}),
    ("list_fps", {"fps": [2.0, 4.0]}),
]:
    try:
        llm.generate(prompt, sampling_params=sp, mm_processor_kwargs=kwargs)
        print(f"CASE {name} OK")
    except Exception as exc:
        print(f"CASE {name} FAIL {type(exc).__name__}: {exc}")
```

Before (current main):

```text
CASE scalar_num_frames OK
CASE list_num_frames FAIL TypeError: '>' not supported between instances of 'int' and 'list'
CASE scalar_fps OK
CASE list_fps FAIL TypeError: can't multiply sequence by non-int of type 'float'
```

After (with fix):

```text
CASE scalar_num_frames OK
CASE list_num_frames OK
CASE scalar_fps OK
CASE list_fps OK
```

</details>

AI assistance was used to investigate, reproduce, and draft this change; the author reviewed the diff and validation output.


cc @DarkLight1337