### PR TITLE
[Bugfix][Multimodal] Accept data URLs without ;base64 instead of 500ing

### DIFF
--- a/tests/multimodal/media/test_connector.py
+++ b/tests/multimodal/media/test_connector.py
@@ -192,6 +192,22 @@ async def test_fetch_image_error_conversion():
         connector.fetch_image(broken_img)
 
 
+@pytest.mark.parametrize(
+    "data_url",
+    [
+        # RFC 2397 allows data URLs without ";base64"; these must surface as a
+        # clean ValueError rather than an unpack crash (HTTP 500).
+        "data:image/png,not-base64-data",
+        "data:,not-base64-data",
+    ],
+)
+def test_fetch_image_non_base64_data_url_raises_value_error(data_url: str):
+    connector = MediaConnector()
+
+    with pytest.raises(ValueError, match="base64"):
+        connector.fetch_image(data_url)
+
+
 @pytest.mark.flaky(reruns=3, reruns_delay=5)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("video_url", TEST_VIDEO_URLS)

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -241,12 +241,14 @@ class MediaConnector:
     ) -> _M:  # type: ignore[type-var]
         # Format per RFC 2397:
         # data:[<mediatype>][;base64],<data>
+        # ;base64 is optional, so parse tolerantly and raise ValueError (a
+        # clean 4xx upstream) instead of crashing on the tuple unpack.
         data_spec, data = url[5:].split(",", 1)
-        media_type, data_type = data_spec.split(";", 1)
+        media_type, _, params = data_spec.partition(";")
 
-        if data_type != "base64":
+        if params.lower() != "base64":
             msg = "Only base64 data URLs are supported for now."
-            raise NotImplementedError(msg)
+            raise ValueError(msg)
 
         return media_io.load_base64(media_type, data)
 


### PR DESCRIPTION
## Summary
`MediaConnector._load_data_url` did `media_type, data_type = data_spec.split(";", 1)`, assuming the `;base64` segment is always present. Per RFC 2397 it is optional, so `data:image/png,<data>` or `data:,<data>` produced a raw unpack `ValueError` that escaped as an **HTTP 500** (`fetch_image` only catches `UnidentifiedImageError`).

Parse with `partition(";")` and raise a clean `ValueError` for non-base64 data URLs (`ValueError` is converted to a 4xx upstream). The comparison is now case-insensitive.

## Behavior change
Non-base64 / `;base64`-less data URLs now return a 4xx instead of a 500. (The non-base64 branch previously raised `NotImplementedError`, which also escaped as a 500.)

## Test
`tests/multimodal/media/test_connector.py`: `data:image/png,...` and `data:,...` raise a clean `ValueError`. Both crash with the unpack error on current `main`.
