### PR TITLE
[Bugfix][Frontend] Reject stop strings when skip_tokenizer_init is set

### DIFF
--- a/tests/v1/sample/test_logprobs.py
+++ b/tests/v1/sample/test_logprobs.py
@@ -429,23 +429,6 @@ def test_logprob_token_ids_validate_vocab_bounds_invalid(token_ids: list[int]):
         )
 
 
-def test_stop_strings_require_tokenizer():
-    params = SamplingParams(stop=["foo"])
-    with pytest.raises(ValueError, match="skip_tokenizer_init"):
-        params.verify(
-            _model_config(),
-            speculative_config=None,
-            structured_outputs_config=None,
-            tokenizer=None,
-        )
-    SamplingParams().verify(
-        _model_config(),
-        speculative_config=None,
-        structured_outputs_config=None,
-        tokenizer=None,
-    )
-
-
 def test_none_logprobs(vllm_model, example_prompts):
     """Engine should return `logprobs` and `prompt_logprobs` as `None`
 

--- a/tests/v1/sample/test_logprobs.py
+++ b/tests/v1/sample/test_logprobs.py
@@ -429,6 +429,23 @@ def test_logprob_token_ids_validate_vocab_bounds_invalid(token_ids: list[int]):
         )
 
 
+def test_stop_strings_require_tokenizer():
+    params = SamplingParams(stop=["foo"])
+    with pytest.raises(ValueError, match="skip_tokenizer_init"):
+        params.verify(
+            _model_config(),
+            speculative_config=None,
+            structured_outputs_config=None,
+            tokenizer=None,
+        )
+    SamplingParams().verify(
+        _model_config(),
+        speculative_config=None,
+        structured_outputs_config=None,
+        tokenizer=None,
+    )
+
+
 def test_none_logprobs(vllm_model, example_prompts):
     """Engine should return `logprobs` and `prompt_logprobs` as `None`
 

--- a/tests/v1/sample/test_sampling_params.py
+++ b/tests/v1/sample/test_sampling_params.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm import SamplingParams
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _model_config(vocab_size: int = 10):
+    return SimpleNamespace(
+        max_logprobs=20,
+        logits_processors=None,
+        get_vocab_size=lambda: vocab_size,
+    )
+
+
+def _verify_without_tokenizer(params: SamplingParams) -> None:
+    params.verify(
+        _model_config(),
+        speculative_config=None,
+        structured_outputs_config=None,
+        tokenizer=None,
+    )
+
+
+@pytest.mark.parametrize("stop", ["foo", ["foo"]])
+def test_stop_strings_require_tokenizer(stop: str | list[str]):
+    with pytest.raises(ValueError, match="skip_tokenizer_init"):
+        _verify_without_tokenizer(SamplingParams(stop=stop))
+
+
+def test_tokenizer_free_stop_params():
+    _verify_without_tokenizer(SamplingParams())
+    _verify_without_tokenizer(SamplingParams(stop_token_ids=[1]))

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -882,7 +882,8 @@ class SamplingParams(
     def _validate_stop(self, tokenizer: TokenizerLike | None) -> None:
         if tokenizer is None and self.stop:
             raise ValueError(
-                "Stop strings require a tokenizer so they can't be used with 'skip_tokenizer_init'"  # noqa: E501
+                "Stop strings require a tokenizer so they can't be used "
+                "with 'skip_tokenizer_init'"
             )
 
     def _validate_structured_outputs(

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -745,6 +745,7 @@ class SamplingParams(
         self._validate_logits_processors(model_config)
         self._validate_allowed_token_ids(tokenizer)
         self._validate_spec_decode(speculative_config)
+        self._validate_stop(tokenizer)
         self._validate_structured_outputs(
             model_config, structured_outputs_config, tokenizer
         )
@@ -876,6 +877,12 @@ class SamplingParams(
             raise ValueError(
                 "The min_p and logit_bias sampling parameters "
                 "are not yet supported with speculative decoding."
+            )
+
+    def _validate_stop(self, tokenizer: TokenizerLike | None) -> None:
+        if tokenizer is None and self.stop:
+            raise ValueError(
+                "Stop strings require a tokenizer so they can't be used with 'skip_tokenizer_init'"  # noqa: E501
             )
 
     def _validate_structured_outputs(


### PR DESCRIPTION
## Summary
Stop strings require the detokenizer to match against generated text, but `SamplingParams.verify()` did not reject them when there is no tokenizer (`skip_tokenizer_init=True`). The stop strings were silently dropped and generation ran to `max_tokens` — a silent failure. Add a `_validate_stop` guard (mirroring the existing `_validate_structured_outputs` tokenizer-required check) that raises a clear `ValueError`. sglang already guards this (cf. sgl-project/sglang#27882).

Scope: string `stop` only — `min_tokens` and `stop_token_ids` work tokenizer-free and are untouched.

## Behavior change
`SamplingParams(stop=[...])` with `skip_tokenizer_init=True` now returns a validation error instead of silently ignoring the stop strings.

## Review notes
- Duplicate-work check: searched open PRs for `skip_tokenizer_init stop string` and `stop skip_tokenizer_init`; no same-scope open PR was found.
- AI assistance was used in preparing this PR; EazyReal remains responsible for the change and test plan.

## Test
- `.venv/bin/pre-commit run --files vllm/sampling_params.py tests/v1/sample/test_logprobs.py tests/v1/sample/test_sampling_params.py`
- `.venv/bin/python -m pytest tests/v1/sample/test_sampling_params.py -q`
- `tests/v1/sample/test_sampling_params.py::test_stop_strings_require_tokenizer`: rejects string and list stop values when `tokenizer=None`; no-stop and `stop_token_ids` remain tokenizer-free. The stop-string cases fail on current `main`.
