### PR TITLE
[Bugfix] Reject matryoshka embedding dimensions above hidden size

### DIFF
--- a/tests/test_pooling_params.py
+++ b/tests/test_pooling_params.py
@@ -74,6 +74,29 @@ def test_embed_dimensions(model_info: EmbedModelInfo):
         pooling_params.verify(model_config)
 
 
+@dataclass()
+class MockMatryoshkaModelConfig:
+    pooler_config: PoolerConfig
+    is_matryoshka: bool = True
+    matryoshka_dimensions: list[int] | None = None
+    served_model_name: str = "mock-matryoshka-model"
+    embedding_size: int = 32
+
+
+def test_embed_dimensions_matryoshka_without_list_upper_bound():
+    task = "embed"
+    model_config = MockMatryoshkaModelConfig(
+        pooler_config=PoolerConfig(seq_pooling_type="CLS"),
+        matryoshka_dimensions=None,
+        embedding_size=32,
+    )
+
+    PoolingParams(task=task, dimensions=16).verify(model_config)
+
+    with pytest.raises(ValueError):
+        PoolingParams(task=task, dimensions=64).verify(model_config)
+
+
 @pytest.mark.parametrize("task", ["classify"])
 def test_classify(task):
     model_config = MockModelConfig(pooler_config=PoolerConfig(seq_pooling_type="CLS"))

--- a/vllm/pooling_params.py
+++ b/vllm/pooling_params.py
@@ -182,6 +182,11 @@ class PoolingParams(
                         )
                 elif self.dimensions < 1:
                     raise ValueError("Dimensions must be greater than 0")
+                elif self.dimensions > model_config.embedding_size:
+                    raise ValueError(
+                        "Dimensions must be less than or equal to the model's "
+                        f"embedding size ({model_config.embedding_size})"
+                    )
 
         elif self.task in ["classify", "token_classify"]:
             if self.use_activation is None:


### PR DESCRIPTION
## Summary
For matryoshka embedding models without an explicit `matryoshka_dimensions` list, `PoolingParams._set_default_parameters` only checked `dimensions >= 1`. A `dimensions` value above the model's hidden size was then silently used to slice the embedding (`[..., :d]`), returning a `hidden_size`-length vector instead of rejecting the request. Add the upper-bound check (mirrors sglang's `_validate_for_matryoshka_dim`).

## Test
`tests/test_pooling_params.py`: oversized `dimensions` for a matryoshka model (no dimensions list) now raises `ValueError`. Silently truncates on current `main`.
