### PR TITLE
[Bugfix] Fix NVFP4+MTP crash: force unquantized mtp.fc for Qwen3Next

### DIFF
--- a/vllm/model_executor/models/qwen3_next_mtp.py
+++ b/vllm/model_executor/models/qwen3_next_mtp.py
@@ -64,13 +64,22 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
             config.hidden_size,
         )
 
+        # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is
+        # missing from the checkpoint quant exclude list (its `ignore` glob
+        # does not cover `mtp.fc`). Force unquantized to match the weights,
+        # mirroring the Qwen3.5 MTP handling (PR #38832).
+        fc_quant = (
+            None
+            if (quant_config and quant_config.get_name() == "modelopt_fp4")
+            else quant_config
+        )
         self.fc = ColumnParallelLinear(
             self.config.hidden_size * 2,
             self.config.hidden_size,
             gather_output=True,
             bias=False,
             return_bias=False,
-            quant_config=quant_config,
+            quant_config=fc_quant,
             prefix=f"{prefix}.fc",
         )
 
@@ -242,7 +251,7 @@ class Qwen3NextMTP(nn.Module, QwenNextMixtureOfExperts):
             "k_proj",
             "v_proj",
         ],
-        "gate_up_proj": ["up_proj", "down_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
     }
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):


### PR DESCRIPTION

## Problem
Serving an NVFP4 Qwen3-Next checkpoint (e.g. `nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4`) with MTP speculative decoding crashes while loading the draft model:

`AssertionError` in `load_column_parallel_weight` — param `[2048, 2048]` vs checkpoint `[2048, 4096]`.

`mtp.fc` is stored **bf16** in the checkpoint, but the quant `ignore` glob `"mtp.layers.0*"` doesn't match the sibling `mtp.fc`, so vLLM builds it NVFP4-quantized and the packed param can't load the bf16 weight.

## Fix — mirrors merged #38832
Same bug the merged **#38832** ( We apply the identical pattern to `qwen3_next_mtp.py`:
```python
fc_quant = None if (quant_config and quant_config.get_name() == "modelopt_fp4") else quant_config
self.fc = ColumnParallelLinear(..., quant_config=fc_quant, ...)
```
Also corrects `packed_modules_mapping["gate_up_proj"]` (`["up_proj","down_proj"]` → `["gate_proj","up_proj"]`)
to match this file's own `stacked_params_mapping` and the base/sibling models.

**Scope:** Qwen3-Next + MTP, NVFP4 only; hardware-agnostic (weight-loading bug, no kernel).

## What this closes
- **Fixes #35031** — the bug this resolves.
- **#35675** (stale Qwen3.5 `fc` fix) can be closed: already superseded by the merged #38832; this PR completes the same fix for Qwen3-Next, the remaining gap.

## Test
DGX-Spark / GB10 / sm_121, CUDA-13 source build, `nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4`, `--method mtp --num-speculative-tokens 1`:
- **Before:** `AssertionError` loading `mtp.fc` (~82% of shards).
- **After:** loads cleanly; generates `"The capital of France is"` → `" Paris. The capital of Germany is Berlin. ..."`

cc: @mgoin 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

