### PR TITLE
[Bugfix][Frontend] Anthropic /v1/messages: preserve user content order around tool_result

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -351,6 +351,44 @@ class TestToolResultContent:
         ]
         assert len(user_follow_ups) == 0
 
+    def test_text_before_tool_result_preserves_order(self):
+        """Text before a user tool_result is emitted before the tool message."""
+        request = _make_request(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_001",
+                            "name": "read_file",
+                            "input": {"path": "/tmp/f"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "here is some context"},
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_001",
+                            "content": "file contents",
+                        },
+                    ],
+                },
+            ]
+        )
+        result = _convert(request)
+
+        roles = [m["role"] for m in result.messages]
+        assert roles == ["assistant", "user", "tool"]
+
+        assert result.messages[0]["tool_calls"][0]["id"] == "call_001"
+        assert result.messages[1]["content"] == "here is some context"
+        assert result.messages[2]["content"] == "file contents"
+        assert result.messages[2]["tool_call_id"] == "call_001"
+
 
 # ======================================================================
 # Attribution header stripping

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -402,6 +402,18 @@ class AnthropicServingMessages(OpenAIServingChat):
     ) -> None:
         """Convert tool_result block to OpenAI format"""
         if role == "user":
+            # Flush preceding text/image parts before the tool message, so the
+            # order stays user(pre) -> tool and the tool_use/result pairing holds.
+            if content_parts:
+                if len(content_parts) == 1 and content_parts[0]["type"] == "text":
+                    openai_messages.append(
+                        {"role": "user", "content": content_parts[0]["text"]}
+                    )
+                else:
+                    openai_messages.append(
+                        {"role": "user", "content": list(content_parts)}
+                    )
+                content_parts.clear()
             cls._convert_user_tool_result(block, openai_messages)
         else:
             tool_result_text = str(block.content) if block.content else ""


### PR DESCRIPTION
**Closed.** Investigation showed this reorder is out-of-distribution for tool-calling models: putting `user(text)` between `assistant(tool_calls)` and the `tool` result leaves the tool_call answered by a user turn and an orphaned `<tool_response>` — sequences the models aren't trained on. vLLM's current tool-call→tool_result adjacency is the in-distribution behavior. See the closing comment for the rendered evidence. (The empty-content-block fix is in #46525.)