### PR TITLE
[Performence]Erease the synconize h2d copy when enable samping params

### DIFF
--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -311,11 +311,11 @@ class RejectionSampler(nn.Module):
         )
         if need_repeat_indices:
             num_requests = len(metadata.num_draft_tokens)
-            num_draft_tokens = torch.tensor(metadata.num_draft_tokens, device="cpu")
-            original_indices = torch.arange(num_requests, device="cpu")
-            repeat_indices_cpu = original_indices.repeat_interleave(num_draft_tokens)
-            repeat_indices = repeat_indices_cpu.to(
-                device=logits.device, non_blocking=True
+            original_indices = torch.arange(num_requests, device=logits.device, dtype=torch.long)
+            repeat_indices = expand_batch_to_tokens(
+                original_indices,
+                metadata.cu_num_draft_tokens,
+                logits.shape[0],
             )
             logits = self.apply_penalties(
                 logits, sampling_metadata, metadata, repeat_indices, output_token_ids


### PR DESCRIPTION



## Purpose
When enable sampling params, there will be an invalid async h2d copy in apply_logits_processors func.The synconize operation can be replaced with an existing triton kernel(expand_kernel).
## Test Plan
Test Qwen3.5 models with enabling the sampling params.
## Test Result
The profiling results: the syncoize disappear after enabling this pr.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

