### PR TITLE
fix(cudagraph): align spec-decode capture sizes for PIECEWISE mode

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1429,9 +1429,15 @@ class CompilationConfig:
         # sizes for decode and mixed prefill-decode.
         # MRV2 handles cudagraph capture sizing in cudagraph_utils.py
         # and doesn't need below: https://github.com/vllm-project/vllm/pull/45953
+        # Apply for any non-NONE cudagraph mode, not just FULL. PIECEWISE decode
+        # graphs are captured at the same sizes; with spec-decode
+        # (uniform_decode_query_len > 1) a partial-acceptance step dispatches to a
+        # graph keyed on a size that is not a multiple of uniform_decode_query_len,
+        # so slot_mapping/positions are read at offsets from the wrong graph ->
+        # cudaErrorIllegalAddress mid-decode. See issue #28207.
         if (
             not use_v2_model_runner
-            and cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
+            and cudagraph_mode != CUDAGraphMode.NONE
             and uniform_decode_query_len > 1
         ):
             self.adjust_cudagraph_sizes_for_spec_decode(


### PR DESCRIPTION
## Purpose

`adjust_cudagraph_sizes_for_spec_decode()` rounds the CUDA-graph capture sizes up
to multiples of `uniform_decode_query_len` so that speculative-decode steps never
dispatch to a misaligned graph. Today that alignment is gated to
`cudagraph_mode.decode_mode() == CUDAGraphMode.FULL`, so the default **PIECEWISE**
mode silently skips it.

PIECEWISE decode graphs are captured at the same sizes. With speculative decoding
(`uniform_decode_query_len = 1 + num_speculative_tokens > 1`), a **partial-acceptance**
step lands on a graph keyed on a size that is *not* a multiple of
`uniform_decode_query_len`. The replayed kernel then reads `slot_mapping` / `positions`
at offsets belonging to a different (smaller) graph → `cudaErrorIllegalAddress`
mid-decode.

This PR relaxes the gate to any non-`NONE` cudagraph mode, so PIECEWISE gets the same
alignment FULL already gets. One-line condition change; the alignment routine itself is
unchanged.

```diff
-            cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
+            cudagraph_mode != CUDAGraphMode.NONE
             and uniform_decode_query_len > 1
```

## Test plan / reproduction

Reproduced on Blackwell (sm_120 / sm_121, DGX Spark GB10) serving Gemma 4 and
Qwen 3.6 (FP8) with DFlash speculative decoding, `num_speculative_tokens=15`, default
`cudagraph_mode=PIECEWISE`:

- **Without the fix:** `cudaErrorIllegalAddress` every ~5–15 min of serving; crashes pin
  to partial-acceptance request states; both Marlin and CUTLASS GEMM backends affected;
  only `--enforce-eager` fully avoids it (~30% throughput cost).
- **With the fix:** capture sizes become multiples of `(1 + num_speculative_tokens)`;
  the illegal-address crash no longer reproduces under the same workload.

I have not added a unit test in this PR because the failure is a runtime CUDA fault that
needs a GPU + spec-decode drafter to surface. Happy to add a config-level test asserting
`adjust_cudagraph_sizes_for_spec_decode` is invoked for PIECEWISE when
`uniform_decode_query_len > 1`, if maintainers prefer.

## Attribution

The fix was **adapted from [AEON-7](https://github.com/AEON-7)'s
`Qwen3.6-NVFP4-DFlash` patch set** (Apache-2.0), which first traced this crash to the
FULL-only gate on Blackwell. Credit for the root-cause analysis belongs to AEON-7; this
PR ports their one-line change onto current `main` with an explanatory comment.

Related upstream context (not part of this PR): #34668 (engine-level
`thinking_token_budget` + spec-decode compatibility, already merged) and #41703
(Gemma 4 DFlash, still open) — both surface the same PIECEWISE + spec-decode path.

Refs: #28207, #28015, #39573
