### PR TITLE
HiSparse: host-resident sparse-MLA decode hot-buffering + GLM-5.2 indexCache opts (vLLM v0.24.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,10 +377,16 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     "csrc/libtorch_stable/attention/paged_attention_v1.cu"
     "csrc/libtorch_stable/attention/paged_attention_v2.cu"
     "csrc/libtorch_stable/cache_kernels.cu"
-    "csrc/libtorch_stable/cache_kernels.cu"
     "csrc/libtorch_stable/cache_kernels_fused.cu"
     "csrc/libtorch_stable/custom_all_reduce.cu"
     "csrc/libtorch_stable/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu")
+
+  if(VLLM_GPU_LANG STREQUAL "CUDA")
+    # Raw PTX (ld.global.nc / st.global.cg) in the row copy: CUDA-only.
+    # The op declarations and registrations are guarded by USE_ROCM.
+    list(APPEND VLLM_STABLE_EXT_SRC
+      "csrc/libtorch_stable/hisparse_kernels.cu")
+  endif()
 
   if(VLLM_GPU_LANG STREQUAL "CUDA" AND
      DEFINED CMAKE_CUDA_COMPILER_VERSION AND

--- a/csrc/libtorch_stable/cooperative_topk.cuh
+++ b/csrc/libtorch_stable/cooperative_topk.cuh
@@ -452,6 +452,16 @@ __device__ void large_topk(const float* __restrict__ row_input,
   if (rank != 0) {  // only rank 0 does tie refinement
     return;
   }
+  // Ties beyond the per-block collect cap (kMaxTies) are dropped at scatter,
+  // so the written candidate total can fall short of TopK even though the
+  // threshold bin guarantees enough true candidates. Pad the unwritten tail
+  // with -1 ("no token"): consumers read all TopK slots, and a slot left
+  // holding the previous step's index page-translates to a garbage KV row
+  // (wrong-row gather or illegal memory access downstream).
+  for (uint32_t i = s_total_above + s_total_equal + tx; i < TopK;
+       i += hist4096::kBlockSize) {
+    row_output[i] = -1u;
+  }
   if (s_total_above + s_total_equal <= TopK) {  // no ties to refine
     return;
   }

--- a/csrc/libtorch_stable/hisparse_kernels.cu
+++ b/csrc/libtorch_stable/hisparse_kernels.cu
@@ -1,0 +1,712 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// HiSparse decode hot-buffer kernels for sparse MLA (GLM-5 / DeepSeek-V3.2).
+//
+// The swap-in algorithm is a port of SGLang's hisparse
+// load_cache_to_device_buffer kernel (sgl jit_kernel/csrc/hisparse.cuh),
+// adapted to vLLM addressing:
+//  - tokens are keyed by their global KV slot id (block_table-converted
+//    indexer output) instead of in-request positions, so no per-request
+//    host-location table is needed: host pool row i is global slot i.
+//  - each batch row owns a fixed region of `region_stride` hot rows;
+//    slots [0, hot_size) are LRU-managed, slot `hot_size` holds the row's
+//    newest token (written directly by the KV-cache update).
+//
+// The kernels only move bytes; they are dtype agnostic.
+
+#include "torch_utils.h"
+#include "ops.h"
+#include "../cuda_utils.h"
+
+#include <algorithm>
+#include <cstdint>
+
+namespace {
+
+constexpr int kWarpSize = 32;
+// Sentinel in the shared top-k scratch: entry already resolved (hit /
+// newest / invalid), no miss handling needed.
+constexpr int32_t kTokenDone = -1;
+constexpr int32_t kHashEmpty = -1;
+
+__device__ __forceinline__ int32_t hash_slot(int32_t key, int32_t hash_size) {
+  // Knuth multiplicative hash for the open-addressing table.
+  return static_cast<int32_t>((static_cast<uint32_t>(key) * 2654435761u) %
+                              static_cast<uint32_t>(hash_size));
+}
+
+// Copy one row of `row_bytes` bytes with a single warp (16B vectorized;
+// callers guarantee 16B-aligned rows). Paired 64-bit loads with the .nc
+// (non-coherent, read-only path) hint and .cg (L2-only) stores keep the
+// one-shot KV rows out of L1.
+__device__ __forceinline__ void copy_row_warp(int lane_id, const char* src,
+                                              char* dst, int64_t row_bytes) {
+  const int64_t num_vec = row_bytes / 16;
+  const uint64_t* src8 = reinterpret_cast<const uint64_t*>(src);
+  uint64_t* dst8 = reinterpret_cast<uint64_t*>(dst);
+  for (int64_t j = lane_id; j < num_vec; j += kWarpSize) {
+    uint64_t lo, hi;
+    const uint64_t* s = src8 + j * 2;
+    asm volatile("ld.global.nc.v2.b64 {%0,%1},[%2];"
+                 : "=l"(lo), "=l"(hi)
+                 : "l"(s)
+                 : "memory");
+    uint64_t* d = dst8 + j * 2;
+    asm volatile("st.global.cg.v2.b64 [%0],{%1,%2};" ::"l"(d), "l"(lo), "l"(hi)
+                 : "memory");
+  }
+}
+
+// Zero one row with a single warp (16B vectorized, L2-only stores), same
+// addressing contract as copy_row_warp.
+__device__ __forceinline__ void zero_row_warp(int lane_id, char* dst,
+                                              int64_t row_bytes) {
+  const int64_t num_vec = row_bytes / 16;
+  uint64_t* dst8 = reinterpret_cast<uint64_t*>(dst);
+  for (int64_t j = lane_id; j < num_vec; j += kWarpSize) {
+    uint64_t* d = dst8 + j * 2;
+    asm volatile("st.global.cg.v2.b64 [%0],{%1,%2};" ::"l"(d), "l"(0ULL),
+                 "l"(0ULL)
+                 : "memory");
+  }
+}
+
+// In-place inclusive scan over s_data[offset, count) performed by warp 0,
+// carrying `accumulator` across calls. Returns the running total.
+__device__ __forceinline__ int warp_inclusive_scan(int32_t* s_data,
+                                                   int lane_id, int offset,
+                                                   int count,
+                                                   int accumulator) {
+  int idx = lane_id + offset;
+  int val = (idx < count) ? s_data[idx] : 0;
+#pragma unroll
+  for (int i = 1; i < 32; i *= 2) {
+    int n = __shfl_up_sync(0xffffffff, val, i);
+    if (lane_id >= i) val += n;
+  }
+  val += accumulator;
+  if (idx < count) {
+    s_data[idx] = val;
+  }
+  return __shfl_sync(0xffffffff, val, 31);
+}
+
+// One block per batch row.
+//
+// Shared memory layout (int32 region followed by int16 region):
+//   s_topk[top_k]            top-k global ids; reused as miss scratch
+//   s_chunk_off[nbc + 1]     prefix sums for hit (then miss) compaction
+//   s_evict_off[nbc + 1]     prefix sums for evictable compaction
+//   s_hash_keys[hash_size]   open addressing: global id -> top-k index
+//   s_counters[2]            [0] buffer hits, [1] resolved-in-phase-1 count
+//   s_lru_out[hot_size]      int16, compacted slots: [hits fwd | evict bwd]
+//   s_hash_vals[hash_size]   int16 hash values (top-k index)
+__global__ void hisparse_swap_in_kernel(
+    const char* __restrict__ host_cache,          // [host_rows, row_bytes]
+    char* __restrict__ hot_cache,                 // [n_rows*stride, row_bytes]
+    const int32_t* __restrict__ global_indices,   // [num_rows, top_k]
+    const int32_t* __restrict__ newest_global,    // [num_rows] or nullptr
+    int32_t* __restrict__ hot_indices,            // [num_rows, top_k]
+    int32_t* __restrict__ miss_mask,              // [num_rows, top_k] or nullptr
+    int32_t* __restrict__ device_global_indices,  // [max_rows, hot_size]
+    int16_t* __restrict__ lru_slots,              // [max_rows, hot_size]
+    unsigned long long* __restrict__ stats,       // [2] hits,misses or nullptr
+    const int32_t* __restrict__ num_real_reqs,    // [1] or nullptr
+    const int64_t host_rows, const int64_t row_bytes, const int32_t top_k,
+    const int32_t hot_size, const int32_t hash_size,
+    const int64_t region_stride) {
+  const int NUM_WARPS = blockDim.x / kWarpSize;
+  const int num_buffer_chunks = (hot_size + kWarpSize - 1) / kWarpSize;
+  const int num_token_chunks = (top_k + kWarpSize - 1) / kWarpSize;
+
+  const int row = blockIdx.x;
+  // CUDA-graph padding: rows past the real batch carry stale top-k/state and
+  // must not be processed. Read from device memory so graph replays see the
+  // per-step value.
+  if (num_real_reqs != nullptr && row >= num_real_reqs[0]) {
+    return;
+  }
+  const int tid = threadIdx.x;
+  const int warp_id = tid / kWarpSize;
+  const int lane_id = tid % kWarpSize;
+  const unsigned int lanes_before = ((unsigned int)1 << lane_id) - 1;
+
+  const int64_t hot_base = static_cast<int64_t>(row) * region_stride;
+  const int32_t newest_id =
+      (newest_global != nullptr) ? newest_global[row] : -1;
+
+  const int32_t* row_topk = global_indices + static_cast<int64_t>(row) * top_k;
+  int32_t* row_out = hot_indices + static_cast<int64_t>(row) * top_k;
+  int32_t* row_miss =
+      (miss_mask != nullptr) ? miss_mask + static_cast<int64_t>(row) * top_k
+                             : nullptr;
+  int32_t* row_dgi =
+      device_global_indices + static_cast<int64_t>(row) * hot_size;
+  int16_t* row_lru = lru_slots + static_cast<int64_t>(row) * hot_size;
+
+  extern __shared__ char smem_raw[];
+  int32_t* s_topk = reinterpret_cast<int32_t*>(smem_raw);
+  int32_t* s_chunk_off = s_topk + top_k;
+  int32_t* s_evict_off = s_chunk_off + (num_buffer_chunks + 1);
+  int32_t* s_hash_keys = s_evict_off + (num_buffer_chunks + 1);
+  int32_t* s_counters = s_hash_keys + hash_size;
+  int16_t* s_lru_out = reinterpret_cast<int16_t*>(s_counters + 2);
+  int16_t* s_hash_vals = s_lru_out + hot_size;
+
+  if (tid < 2) {
+    s_counters[tid] = 0;
+  }
+  for (int i = tid; i < hash_size; i += blockDim.x) {
+    s_hash_keys[i] = kHashEmpty;
+  }
+  for (int i = tid; i < num_buffer_chunks + 1; i += blockDim.x) {
+    s_chunk_off[i] = 0;
+    s_evict_off[i] = 0;
+  }
+  __syncthreads();
+
+  // Phase 1: resolve invalid / newest entries, hash the rest.
+  for (int i = tid; i < top_k; i += blockDim.x) {
+    const int32_t g = row_topk[i];
+    if (row_miss != nullptr) row_miss[i] = 0;
+    if (g < 0) {
+      row_out[i] = -1;
+      s_topk[i] = kTokenDone;
+      atomicAdd(&s_counters[1], 1);
+    } else if (g == newest_id) {
+      // Newest token lives in the reserved slot past the LRU range.
+      row_out[i] = static_cast<int32_t>(hot_base) + hot_size;
+      s_topk[i] = kTokenDone;
+      atomicAdd(&s_counters[1], 1);
+    } else {
+      int slot = hash_slot(g, hash_size);
+      while (true) {
+        const int32_t old = atomicCAS(&s_hash_keys[slot], kHashEmpty, g);
+        if (old == kHashEmpty || old == g) {
+          s_hash_vals[slot] = static_cast<int16_t>(i);
+          break;
+        }
+        slot = (slot + 1) % hash_size;
+      }
+      s_topk[i] = g;
+    }
+  }
+  __syncthreads();
+
+  // Phase 2: walk hot slots in LRU order, classify hit / evictable, and
+  // compact them (hits forward, evictables backward) into s_lru_out.
+  const int iters_buffer = (num_buffer_chunks + NUM_WARPS - 1) / NUM_WARPS;
+  int total_hit_count = 0;
+  int total_evict_count = 0;
+  for (int iter = 0; iter < iters_buffer; iter++) {
+    const int chunk_idx = warp_id + iter * NUM_WARPS;
+    const bool has_valid_chunk = chunk_idx < num_buffer_chunks;
+
+    const int pos = chunk_idx * kWarpSize + lane_id;
+    const bool has_valid_pos = has_valid_chunk && (pos < hot_size);
+    const int16_t slot = has_valid_pos ? row_lru[pos] : int16_t(-1);
+    // Corruption tripwire: lru/dgi are long-lived device state; if some
+    // external writer (e.g. stray RDMA into reused VRAM) corrupts a slot
+    // out of [0, hot_size), treat it as no-hit so it degrades to a re-miss
+    // instead of an unbounded dgi read (phases 3/5 bound the write side).
+    const int32_t cached_g =
+        (slot >= 0 && slot < hot_size) ? row_dgi[slot] : -1;
+
+    int found_topk_idx = -1;
+    if (cached_g >= 0) {
+      int h = hash_slot(cached_g, hash_size);
+      while (true) {
+        const int32_t k = s_hash_keys[h];
+        if (k == cached_g) {
+          found_topk_idx = static_cast<int32_t>(s_hash_vals[h]);
+          break;
+        }
+        if (k == kHashEmpty) break;
+        h = (h + 1) % hash_size;
+      }
+    }
+    const bool is_hit = found_topk_idx >= 0;
+    const bool is_evictable = has_valid_pos && !is_hit;
+
+    if (is_hit) {
+      s_topk[found_topk_idx] = kTokenDone;
+      row_out[found_topk_idx] = static_cast<int32_t>(hot_base) + slot;
+    }
+
+    int local_hit_off = 0;
+    int local_evict_off = 0;
+    if (has_valid_chunk) {
+      const unsigned int hit_mask = __ballot_sync(0xFFFFFFFF, is_hit);
+      const unsigned int evict_mask = __ballot_sync(0xFFFFFFFF, is_evictable);
+      local_hit_off = __popc(hit_mask & lanes_before);
+      local_evict_off = __popc(evict_mask & lanes_before);
+      if (lane_id == 0) {
+        s_chunk_off[chunk_idx + 1] = __popc(hit_mask);
+        s_evict_off[chunk_idx + 1] = __popc(evict_mask);
+      }
+    }
+    __syncthreads();
+
+    if (warp_id == 0) {
+      total_hit_count =
+          warp_inclusive_scan(s_chunk_off, lane_id, chunk_idx + 1,
+                              num_buffer_chunks + 1, total_hit_count);
+      total_evict_count =
+          warp_inclusive_scan(s_evict_off, lane_id, chunk_idx + 1,
+                              num_buffer_chunks + 1, total_evict_count);
+      if (tid == 0) {
+        s_counters[0] = total_hit_count;
+      }
+    }
+    __syncthreads();
+
+    if (is_hit) {
+      const int off = s_chunk_off[chunk_idx] + local_hit_off;
+      s_lru_out[off] = slot;
+    }
+    if (is_evictable) {
+      const int off = s_evict_off[chunk_idx] + local_evict_off;
+      s_lru_out[hot_size - 1 - off] = slot;
+    }
+  }
+  __syncthreads();
+
+  // Reset prefix sums for the miss compaction (token chunks <= buffer
+  // chunks because hot_size >= top_k).
+  for (int i = tid; i < num_token_chunks + 1; i += blockDim.x) {
+    s_chunk_off[i] = 0;
+  }
+  __syncthreads();
+
+  // Phase 3: compact misses, assign them eviction slots (oldest first) and
+  // record the new ownership in device_global_indices.
+  const int iters_token = (num_token_chunks + NUM_WARPS - 1) / NUM_WARPS;
+  int miss_running_total = 0;
+  for (int iter = 0; iter < iters_token; iter++) {
+    const int chunk_idx = warp_id + iter * NUM_WARPS;
+    const bool has_valid_chunk = chunk_idx < num_token_chunks;
+
+    const int i = chunk_idx * kWarpSize + lane_id;
+    const bool has_valid_token = has_valid_chunk && (i < top_k);
+
+    int32_t g = 0;
+    bool is_miss = false;
+    if (has_valid_token) {
+      is_miss = s_topk[i] != kTokenDone;
+      if (is_miss) {
+        g = s_topk[i];
+      }
+    }
+
+    int local_miss_off = 0;
+    if (has_valid_chunk) {
+      const unsigned int miss_mask = __ballot_sync(0xFFFFFFFF, is_miss);
+      local_miss_off = __popc(miss_mask & lanes_before);
+      if (lane_id == 0) {
+        s_chunk_off[chunk_idx + 1] = __popc(miss_mask);
+      }
+    }
+    __syncthreads();
+
+    if (warp_id == 0) {
+      miss_running_total =
+          warp_inclusive_scan(s_chunk_off, lane_id, chunk_idx + 1,
+                              num_token_chunks + 1, miss_running_total);
+    }
+    __syncthreads();
+
+    if (is_miss) {
+      const int m = s_chunk_off[chunk_idx] + local_miss_off;
+      const int16_t evict_slot = s_lru_out[hot_size - 1 - m];
+      if (evict_slot < 0 || evict_slot >= hot_size) {
+        // Corruption tripwire: an out-of-range slot (corrupted lru state,
+        // see phase 2) must not become a hot-cache/dgi write. Resolve the
+        // entry as invalid (-1, masked by attention, not in the miss set);
+        // it re-misses on a later step. Phase 5 re-checks the same
+        // s_lru_out value, so its copy is skipped consistently.
+        row_out[i] = -1;
+      } else {
+        // Reuse s_topk as compacted miss scratch: m < i always holds (done
+        // entries are skipped), so writes never overrun pending reads.
+        s_topk[m] = g;
+        row_out[i] = static_cast<int32_t>(hot_base) + evict_slot;
+        if (row_miss != nullptr) row_miss[i] = 1;
+        row_dgi[evict_slot] = g;
+      }
+    }
+  }
+  __syncthreads();
+
+  const int total_hits = s_counters[0];
+  const int total_misses = top_k - total_hits - s_counters[1];
+
+  // Aggregate hit/miss counters (hit rate + PCIe gather volume telemetry).
+  if (stats != nullptr && threadIdx.x == 0) {
+    atomicAdd(&stats[0], static_cast<unsigned long long>(total_hits));
+    atomicAdd(&stats[1], static_cast<unsigned long long>(total_misses));
+  }
+
+  // Phase 4: write back the LRU order: stale evictables at the front,
+  // freshly loaded misses next, hits at the MRU back.
+  const int total_evictable = hot_size - total_hits;
+  for (int i = tid; i < hot_size; i += blockDim.x) {
+    if (i < total_misses) {
+      row_lru[total_evictable - total_misses + i] =
+          s_lru_out[hot_size - 1 - i];
+    } else if (i < total_evictable) {
+      row_lru[i - total_misses] = s_lru_out[hot_size - 1 - i];
+    } else {
+      row_lru[i] = s_lru_out[i - total_evictable];
+    }
+  }
+
+  // Phase 5: copy missed rows from the host pool, one warp per miss.
+  for (int m = warp_id; m < total_misses; m += NUM_WARPS) {
+    const int32_t g = s_topk[m];
+    const int16_t evict_slot = s_lru_out[hot_size - 1 - m];
+    if (evict_slot < 0 || evict_slot >= hot_size) {
+      // Corruption tripwire (see phase 3): phase 3 skipped this entry, so
+      // s_topk[m] is stale; skip the copy instead of writing out of range.
+      continue;
+    }
+    char* dst = hot_cache + (hot_base + evict_slot) * row_bytes;
+
+    if (g >= 0 && g < host_rows) {
+      copy_row_warp(lane_id, host_cache + static_cast<int64_t>(g) * row_bytes,
+                    dst, row_bytes);
+    } else {
+      // No source row for g: never serve the evicted slot's stale bytes
+      // as g. Zero the row (deterministic, visible in output quality) and
+      // withdraw the phase-3 ownership claim so later steps re-miss instead
+      // of hitting the unfilled slot.
+      zero_row_warp(lane_id, dst, row_bytes);
+      __syncwarp();
+      if (lane_id == 0) {
+        row_dgi[evict_slot] = -1;
+      }
+    }
+  }
+}
+
+// Shared-layer plan replay. Given a plan (hot_indices + miss_mask) already
+// computed by the group's "full" layer via hisparse_swap_in, gather THIS
+// layer's own missed KV rows into the planned hot slots. No LRU resolution:
+// index-sharing shared layers see identical global_indices/hot_indices, so the
+// slot assignment is identical -- only the per-layer bytes differ. Fixed shape
+// (num_rows x top_k), so it is CUDA-graph-capture safe.
+__global__ void hisparse_gather_plan_kernel(
+    const char* __restrict__ host_cache,          // [host_rows, row_bytes]
+    char* __restrict__ hot_cache,                 // [hot_rows, row_bytes]
+    const int32_t* __restrict__ global_indices,   // [num_rows, top_k]
+    const int32_t* __restrict__ hot_indices,      // [num_rows, top_k] abs hot rows
+    const int32_t* __restrict__ miss_mask,        // [num_rows, top_k]
+    const int32_t* __restrict__ num_real_reqs,    // [1] or nullptr
+    const int64_t host_rows, const int64_t hot_rows, const int64_t row_bytes,
+    const int32_t top_k) {
+  const int NUM_WARPS = blockDim.x / kWarpSize;
+  // Columns are interleaved across gridDim.y blocks per row so few-row
+  // launches (local-prefill staging's single-row layout, small decode
+  // batches) still fill the device with outstanding host reads instead of
+  // starving on one block per row.
+  const int row = blockIdx.x;
+  if (num_real_reqs != nullptr && row >= num_real_reqs[0]) {
+    return;
+  }
+  const int warp_id = threadIdx.x / kWarpSize;
+  const int lane_id = threadIdx.x % kWarpSize;
+  const int col_start = blockIdx.y * NUM_WARPS + warp_id;
+  const int col_stride = gridDim.y * NUM_WARPS;
+  const int64_t base = static_cast<int64_t>(row) * top_k;
+  for (int col = col_start; col < top_k; col += col_stride) {
+    if (miss_mask[base + col] == 0) {
+      continue;
+    }
+    const int32_t g = global_indices[base + col];
+    const int32_t dst = hot_indices[base + col];
+    if (g < 0 || dst < 0 || dst >= hot_rows) {
+      continue;
+    }
+    char* dst_row = hot_cache + static_cast<int64_t>(dst) * row_bytes;
+    if (g < host_rows) {
+      copy_row_warp(lane_id, host_cache + static_cast<int64_t>(g) * row_bytes,
+                    dst_row, row_bytes);
+    } else {
+      // No source row for g: zero the planned slot rather than serving
+      // whatever bytes it held (see the swap-in kernel's phase 5).
+      zero_row_warp(lane_id, dst_row, row_bytes);
+    }
+  }
+}
+
+// One warp per item: gather `src_cache[src_indices[i]]` into
+// `host_cache[dst_slots[i]]`. Used to scatter KV rows into the pinned host
+// pool fully stream-ordered (no host synchronization).
+__global__ void hisparse_backup_kernel(
+    const char* __restrict__ src_cache, const int64_t* __restrict__ src_indices,
+    char* __restrict__ host_cache, const int64_t* __restrict__ dst_slots,
+    const int64_t row_bytes, const int32_t num_items, const int64_t src_rows,
+    const int64_t host_rows) {
+  const int NUM_WARPS = blockDim.x / kWarpSize;
+  const int lane_id = threadIdx.x % kWarpSize;
+  const int warp_id = blockIdx.x * NUM_WARPS + threadIdx.x / kWarpSize;
+  const int total_warps = gridDim.x * NUM_WARPS;
+
+  for (int i = warp_id; i < num_items; i += total_warps) {
+    const int64_t s = src_indices[i];
+    const int64_t d = dst_slots[i];
+    if (s < 0 || s >= src_rows || d < 0 || d >= host_rows) {
+      continue;
+    }
+    copy_row_warp(lane_id, src_cache + s * row_bytes,
+                  host_cache + d * row_bytes, row_bytes);
+  }
+}
+
+int64_t check_2d_rows(const torch::stable::Tensor& t, const char* name,
+                      int64_t row_bytes) {
+  STD_TORCH_CHECK(t.dim() == 2, name, " must be 2D");
+  STD_TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+  STD_TORCH_CHECK(t.size(1) * t.element_size() == row_bytes, name,
+              " row width mismatch");
+  return t.size(0);
+}
+
+}  // namespace
+
+void hisparse_swap_in(torch::stable::Tensor const& host_cache,
+                      torch::stable::Tensor& hot_cache,
+                      torch::stable::Tensor const& global_indices,
+                      std::optional<torch::stable::Tensor> const& newest_global_indices,
+                      torch::stable::Tensor& hot_indices,
+                      torch::stable::Tensor& device_global_indices,
+                      torch::stable::Tensor& lru_slots,
+                      std::optional<torch::stable::Tensor> const& num_real_reqs,
+                      int64_t region_stride,
+                      std::optional<torch::stable::Tensor> const& miss_mask,
+                      std::optional<torch::stable::Tensor> const& stats) {
+  STD_TORCH_CHECK(host_cache.device().is_cpu(),
+              "host_cache must be CPU memory");
+  STD_TORCH_CHECK(hot_cache.is_cuda(), "hot_cache must be on CUDA");
+  STD_TORCH_CHECK(global_indices.is_cuda() && hot_indices.is_cuda() &&
+                  device_global_indices.is_cuda() && lru_slots.is_cuda(),
+              "index tensors must be on CUDA");
+  STD_TORCH_CHECK(global_indices.scalar_type() == torch::headeronly::ScalarType::Int &&
+                  hot_indices.scalar_type() == torch::headeronly::ScalarType::Int,
+              "global_indices/hot_indices must be int32");
+  STD_TORCH_CHECK(device_global_indices.scalar_type() == torch::headeronly::ScalarType::Int,
+              "device_global_indices must be int32");
+  STD_TORCH_CHECK(lru_slots.scalar_type() == torch::headeronly::ScalarType::Short, "lru_slots must be int16");
+  STD_TORCH_CHECK(global_indices.dim() == 2 && global_indices.is_contiguous(),
+              "global_indices must be contiguous 2D");
+  STD_TORCH_CHECK(hot_indices.size(0) == global_indices.size(0) &&
+                  hot_indices.size(1) == global_indices.size(1) &&
+                  hot_indices.is_contiguous(),
+              "hot_indices must match global_indices");
+  STD_TORCH_CHECK(
+      device_global_indices.dim() == 2 && device_global_indices.is_contiguous(),
+      "device_global_indices must be contiguous 2D");
+  STD_TORCH_CHECK(lru_slots.size(0) == device_global_indices.size(0) &&
+                  lru_slots.size(1) == device_global_indices.size(1) &&
+                  lru_slots.is_contiguous(),
+              "lru_slots must match device_global_indices");
+
+  const int64_t row_bytes = hot_cache.size(-1) * hot_cache.element_size();
+  STD_TORCH_CHECK(row_bytes % 16 == 0, "KV row must be 16-byte aligned");
+  auto hot_cache_2d = torch::stable::reshape(hot_cache, {-1, hot_cache.size(-1)});
+  const int64_t hot_rows = hot_cache_2d.size(0);
+  const int64_t host_rows = check_2d_rows(host_cache, "host_cache", row_bytes);
+
+  const auto num_rows = static_cast<int32_t>(global_indices.size(0));
+  const auto top_k = static_cast<int32_t>(global_indices.size(1));
+  const auto hot_size = static_cast<int32_t>(device_global_indices.size(1));
+  STD_TORCH_CHECK(hot_size >= top_k, "hot buffer size must be >= top_k");
+  STD_TORCH_CHECK(hot_size < 32767, "hot buffer size must fit int16 slots");
+  STD_TORCH_CHECK(region_stride > hot_size,
+              "region_stride must reserve a newest slot past hot_size");
+  STD_TORCH_CHECK(device_global_indices.size(0) >= num_rows,
+              "device_global_indices has too few rows");
+  STD_TORCH_CHECK(static_cast<int64_t>(num_rows) * region_stride <= hot_rows,
+              "hot_cache has too few rows");
+  STD_TORCH_CHECK(hot_rows < INT32_MAX, "hot indices must fit int32");
+
+  const int32_t* newest_ptr = nullptr;
+  if (newest_global_indices.has_value()) {
+    auto const& newest = newest_global_indices.value();
+    STD_TORCH_CHECK(newest.is_cuda() && newest.scalar_type() == torch::headeronly::ScalarType::Int &&
+                    newest.numel() >= num_rows && newest.is_contiguous(),
+                "newest_global_indices must be contiguous int32 on CUDA");
+    newest_ptr = newest.const_data_ptr<int32_t>();
+  }
+
+  const int32_t* num_real_ptr = nullptr;
+  if (num_real_reqs.has_value()) {
+    auto const& num_real = num_real_reqs.value();
+    STD_TORCH_CHECK(num_real.is_cuda() && num_real.scalar_type() == torch::headeronly::ScalarType::Int &&
+                    num_real.numel() >= 1,
+                "num_real_reqs must be int32 on CUDA");
+    num_real_ptr = num_real.const_data_ptr<int32_t>();
+  }
+
+  // Optional plan output: 1 at columns resolved as a miss (loaded from the
+  // host pool this call), 0 elsewhere. Lets index-sharing "shared" layers
+  // replay the same gather via hisparse_gather_plan without re-resolving LRU.
+  int32_t* miss_mask_ptr = nullptr;
+  if (miss_mask.has_value()) {
+    auto const& mm = miss_mask.value();
+    STD_TORCH_CHECK(mm.is_cuda() && mm.scalar_type() == torch::headeronly::ScalarType::Int &&
+                    mm.dim() == 2 && mm.is_contiguous() &&
+                    mm.size(0) == global_indices.size(0) &&
+                    mm.size(1) == global_indices.size(1),
+                "miss_mask must be a contiguous int32 CUDA tensor matching global_indices");
+    miss_mask_ptr = mm.mutable_data_ptr<int32_t>();
+  }
+
+  unsigned long long* stats_ptr = nullptr;
+  if (stats.has_value()) {
+    auto const& st = stats.value();
+    STD_TORCH_CHECK(st.is_cuda() && st.scalar_type() == torch::headeronly::ScalarType::UInt64 &&
+                    st.numel() >= 2,
+                "stats must be a uint64 CUDA tensor with >= 2 elements");
+    stats_ptr = static_cast<unsigned long long*>(st.mutable_data_ptr());
+  }
+
+  if (num_rows == 0 || top_k == 0) {
+    return;
+  }
+
+  constexpr int kBlockSize = 1024;
+  const int hash_size = 2 * top_k;
+  const int num_buffer_chunks = (hot_size + kWarpSize - 1) / kWarpSize;
+  const size_t smem_bytes =
+      sizeof(int32_t) * (top_k + 2 * (num_buffer_chunks + 1) + hash_size + 2) +
+      sizeof(int16_t) * (hot_size + hash_size);
+
+  const torch::stable::accelerator::DeviceGuard device_guard(hot_cache.get_device_index());
+  const cudaStream_t stream = get_current_cuda_stream();
+  auto kernel = hisparse_swap_in_kernel;
+  if (smem_bytes > 48 * 1024) {
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                         smem_bytes);
+  }
+  kernel<<<num_rows, kBlockSize, smem_bytes, stream>>>(
+      static_cast<const char*>(host_cache.const_data_ptr()),
+      static_cast<char*>(hot_cache_2d.mutable_data_ptr()),
+      global_indices.const_data_ptr<int32_t>(), newest_ptr,
+      hot_indices.mutable_data_ptr<int32_t>(), miss_mask_ptr,
+      device_global_indices.mutable_data_ptr<int32_t>(),
+      lru_slots.mutable_data_ptr<int16_t>(), stats_ptr, num_real_ptr, host_rows,
+      row_bytes, top_k, hot_size, hash_size, region_stride);
+}
+
+void hisparse_gather_plan(torch::stable::Tensor const& host_cache,
+                          torch::stable::Tensor& hot_cache,
+                          torch::stable::Tensor const& global_indices,
+                          torch::stable::Tensor const& hot_indices,
+                          torch::stable::Tensor const& miss_mask,
+                          std::optional<torch::stable::Tensor> const& num_real_reqs) {
+  STD_TORCH_CHECK(host_cache.device().is_cpu(), "host_cache must be CPU memory");
+  STD_TORCH_CHECK(hot_cache.is_cuda(), "hot_cache must be on CUDA");
+  STD_TORCH_CHECK(global_indices.is_cuda() && hot_indices.is_cuda() &&
+                  miss_mask.is_cuda(),
+              "plan tensors must be on CUDA");
+  STD_TORCH_CHECK(global_indices.scalar_type() == torch::headeronly::ScalarType::Int &&
+                  hot_indices.scalar_type() == torch::headeronly::ScalarType::Int &&
+                  miss_mask.scalar_type() == torch::headeronly::ScalarType::Int,
+              "plan tensors must be int32");
+  STD_TORCH_CHECK(global_indices.dim() == 2 && global_indices.is_contiguous(),
+              "global_indices must be contiguous 2D");
+  STD_TORCH_CHECK(hot_indices.size(0) == global_indices.size(0) &&
+                  hot_indices.size(1) == global_indices.size(1) &&
+                  miss_mask.size(0) == global_indices.size(0) &&
+                  miss_mask.size(1) == global_indices.size(1) &&
+                  hot_indices.is_contiguous() && miss_mask.is_contiguous(),
+              "hot_indices/miss_mask must match contiguous 2D global_indices");
+
+  const int64_t row_bytes = hot_cache.size(-1) * hot_cache.element_size();
+  STD_TORCH_CHECK(row_bytes % 16 == 0, "KV row must be 16-byte aligned");
+  auto hot_cache_2d = torch::stable::reshape(hot_cache, {-1, hot_cache.size(-1)});
+  const int64_t host_rows = check_2d_rows(host_cache, "host_cache", row_bytes);
+
+  const auto num_rows = static_cast<int32_t>(global_indices.size(0));
+  const auto top_k = static_cast<int32_t>(global_indices.size(1));
+
+  const int32_t* num_real_ptr = nullptr;
+  if (num_real_reqs.has_value()) {
+    auto const& num_real = num_real_reqs.value();
+    STD_TORCH_CHECK(num_real.is_cuda() && num_real.scalar_type() == torch::headeronly::ScalarType::Int &&
+                    num_real.numel() >= 1,
+                "num_real_reqs must be int32 on CUDA");
+    num_real_ptr = num_real.const_data_ptr<int32_t>();
+  }
+
+  if (num_rows == 0 || top_k == 0) {
+    return;
+  }
+
+  // Match the swap-in kernel's block size: the gather serves 3 of every 4
+  // layers' misses (index-sharing replay), so per-row copy parallelism is
+  // the throughput limiter on cold rows.
+  constexpr int kBlockSize = 1024;
+  constexpr int kNumWarps = kBlockSize / kWarpSize;
+  // Interleave columns over enough blocks per row to cover the device even
+  // for few-row launches (local-prefill staging's single-row layout, small
+  // decode batches), keeping >= 1 column per warp.
+  constexpr int kTargetBlocks = 256;
+  const int max_chunks = std::max(1, (top_k + kNumWarps - 1) / kNumWarps);
+  const int num_chunks =
+      std::min(max_chunks, std::max(1, kTargetBlocks / num_rows));
+  const dim3 grid(num_rows, num_chunks);
+  const int64_t hot_rows = hot_cache_2d.size(0);
+  const torch::stable::accelerator::DeviceGuard device_guard(hot_cache.get_device_index());
+  const cudaStream_t stream = get_current_cuda_stream();
+  hisparse_gather_plan_kernel<<<grid, kBlockSize, 0, stream>>>(
+      static_cast<const char*>(host_cache.const_data_ptr()),
+      static_cast<char*>(hot_cache_2d.mutable_data_ptr()),
+      global_indices.const_data_ptr<int32_t>(),
+      hot_indices.const_data_ptr<int32_t>(),
+      miss_mask.const_data_ptr<int32_t>(), num_real_ptr, host_rows, hot_rows,
+      row_bytes, top_k);
+}
+
+void hisparse_backup(torch::stable::Tensor const& src_cache,
+                     torch::stable::Tensor const& src_indices,
+                     torch::stable::Tensor& host_cache,
+                     torch::stable::Tensor const& dst_slots) {
+  STD_TORCH_CHECK(src_cache.is_cuda(), "src_cache must be on CUDA");
+  STD_TORCH_CHECK(host_cache.device().is_cpu(),
+              "host_cache must be CPU memory");
+  STD_TORCH_CHECK(src_indices.is_cuda() && dst_slots.is_cuda(),
+              "src_indices/dst_slots must be on CUDA");
+  STD_TORCH_CHECK(
+      src_indices.scalar_type() == torch::headeronly::ScalarType::Long && src_indices.is_contiguous(),
+      "src_indices must be contiguous int64");
+  STD_TORCH_CHECK(dst_slots.scalar_type() == torch::headeronly::ScalarType::Long && dst_slots.is_contiguous(),
+              "dst_slots must be contiguous int64");
+  STD_TORCH_CHECK(src_indices.numel() == dst_slots.numel(),
+              "src_indices and dst_slots must have the same length");
+
+  const int64_t row_bytes = src_cache.size(-1) * src_cache.element_size();
+  STD_TORCH_CHECK(row_bytes % 16 == 0, "KV row must be 16-byte aligned");
+  auto src_2d = torch::stable::reshape(src_cache, {-1, src_cache.size(-1)});
+  const int64_t src_rows = src_2d.size(0);
+  const int64_t host_rows = check_2d_rows(host_cache, "host_cache", row_bytes);
+
+  const auto num_items = static_cast<int32_t>(src_indices.numel());
+  if (num_items == 0) {
+    return;
+  }
+
+  constexpr int kBlockSize = 256;
+  constexpr int kNumWarps = kBlockSize / kWarpSize;
+  const int grid = (num_items + kNumWarps - 1) / kNumWarps;
+
+  const torch::stable::accelerator::DeviceGuard device_guard(src_cache.get_device_index());
+  const cudaStream_t stream = get_current_cuda_stream();
+  hisparse_backup_kernel<<<grid, kBlockSize, 0, stream>>>(
+      static_cast<const char*>(src_2d.const_data_ptr()),
+      src_indices.const_data_ptr<int64_t>(),
+      static_cast<char*>(host_cache.mutable_data_ptr()),
+      dst_slots.const_data_ptr<int64_t>(),
+      row_bytes, num_items, src_rows, host_rows);
+}

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -515,6 +515,35 @@ void concat_and_cache_mla(torch::stable::Tensor& kv_c,
                           const std::string& kv_cache_dtype,
                           torch::stable::Tensor& scale);
 
+#ifndef USE_ROCM
+// HiSparse kernels use raw PTX in the row copy; CUDA-only.
+void hisparse_swap_in(
+    torch::stable::Tensor const& host_cache,
+    torch::stable::Tensor& hot_cache,
+    torch::stable::Tensor const& global_indices,
+    std::optional<torch::stable::Tensor> const& newest_global_indices,
+    torch::stable::Tensor& hot_indices,
+    torch::stable::Tensor& device_global_indices,
+    torch::stable::Tensor& lru_slots,
+    std::optional<torch::stable::Tensor> const& num_real_reqs,
+    int64_t region_stride,
+    std::optional<torch::stable::Tensor> const& miss_mask,
+    std::optional<torch::stable::Tensor> const& stats);
+
+void hisparse_gather_plan(
+    torch::stable::Tensor const& host_cache,
+    torch::stable::Tensor& hot_cache,
+    torch::stable::Tensor const& global_indices,
+    torch::stable::Tensor const& hot_indices,
+    torch::stable::Tensor const& miss_mask,
+    std::optional<torch::stable::Tensor> const& num_real_reqs);
+
+void hisparse_backup(torch::stable::Tensor const& src_cache,
+                     torch::stable::Tensor const& src_indices,
+                     torch::stable::Tensor& host_cache,
+                     torch::stable::Tensor const& dst_slots);
+#endif  // !USE_ROCM
+
 // NOTE: k_pe and kv_c order is flipped compared to concat_and_cache_mla
 void concat_and_cache_mla_rope_fused(
     torch::stable::Tensor& positions, torch::stable::Tensor& q_pe,

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -835,6 +835,35 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C_cache_ops, ops) {
       "                     str kv_cache_dtype,"
       "                     Tensor scale) -> ()");
 
+#ifndef USE_ROCM
+  ops.def(
+      "hisparse_swap_in(Tensor host_cache,"
+      "                 Tensor! hot_cache,"
+      "                 Tensor global_indices,"
+      "                 Tensor? newest_global_indices,"
+      "                 Tensor! hot_indices,"
+      "                 Tensor! device_global_indices,"
+      "                 Tensor! lru_slots,"
+      "                 Tensor? num_real_reqs,"
+      "                 int region_stride,"
+      "                 Tensor(a!)? miss_mask=None,"
+      "                 Tensor(b!)? stats=None) -> ()");
+
+  ops.def(
+      "hisparse_gather_plan(Tensor host_cache,"
+      "                     Tensor! hot_cache,"
+      "                     Tensor global_indices,"
+      "                     Tensor hot_indices,"
+      "                     Tensor miss_mask,"
+      "                     Tensor? num_real_reqs) -> ()");
+
+  ops.def(
+      "hisparse_backup(Tensor src_cache,"
+      "                Tensor src_indices,"
+      "                Tensor! host_cache,"
+      "                Tensor dst_slots) -> ()");
+#endif  // !USE_ROCM
+
   // Rotate Q and K, then write to kv cache for MLA
   ops.def(
       "concat_and_cache_mla_rope_fused("
@@ -933,6 +962,11 @@ STABLE_TORCH_LIBRARY_IMPL(_C_cache_ops, CUDA, ops) {
   ops.impl("reshape_and_cache", TORCH_BOX(&reshape_and_cache));
   ops.impl("reshape_and_cache_flash", TORCH_BOX(&reshape_and_cache_flash));
   ops.impl("concat_and_cache_mla", TORCH_BOX(&concat_and_cache_mla));
+#ifndef USE_ROCM
+  ops.impl("hisparse_swap_in", TORCH_BOX(&hisparse_swap_in));
+  ops.impl("hisparse_gather_plan", TORCH_BOX(&hisparse_gather_plan));
+  ops.impl("hisparse_backup", TORCH_BOX(&hisparse_backup));
+#endif  // !USE_ROCM
   ops.impl("concat_and_cache_mla_rope_fused",
            TORCH_BOX(&concat_and_cache_mla_rope_fused));
   ops.impl("convert_fp8", TORCH_BOX(&convert_fp8));

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -20,7 +20,7 @@ from tests.v1.attention.utils import (
     create_vllm_config,
 )
 from vllm import _custom_ops as ops
-from vllm.config import set_current_vllm_config
+from vllm.config import KVTransferConfig, set_current_vllm_config
 from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.platforms import current_platform
 
@@ -41,6 +41,13 @@ from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
 from vllm.v1.attention.backends.mla.flashmla_sparse import (
     FlashMLASparseBackend,
     triton_convert_req_index_to_global_index,
+)
+from vllm.v1.attention.backends.mla.hisparse import (
+    HiSparseConfig,
+    HiSparseCoordinator,
+    _has_hisparse_ops,
+    create_hisparse_coordinator,
+    is_hisparse_decode_batch,
 )
 from vllm.v1.attention.backends.mla.indexer import split_indexer_prefill_chunks
 from vllm.v1.attention.backends.utils import split_prefill_chunks
@@ -855,3 +862,907 @@ def test_triton_convert_returns_valid_counts():
     )
     assert isinstance(result_only, torch.Tensor)
     torch.testing.assert_close(result_only, result, rtol=0, atol=0)
+
+
+# HiSparse is host-resident-only and kernel-only: coordinator construction
+# raises without the compiled CUDA ops.
+requires_hisparse_ops = pytest.mark.skipif(
+    not _has_hisparse_ops(),
+    reason="HiSparse CUDA ops not compiled",
+)
+
+
+def fallback_swap_in(
+    coordinator: HiSparseCoordinator,
+    global_indices: torch.Tensor,
+    newest_global: torch.Tensor | None,
+    hot_indices: torch.Tensor,
+) -> None:
+    """Python reference for the hisparse_swap_in kernel semantics.
+
+    Writes resolved slots into ``hot_indices`` in place. Misses are always
+    served from the coordinator's host pool.
+    """
+    assert coordinator._host_cache is not None
+    num_tokens, _ = global_indices.shape
+    buf = coordinator.config.device_buffer_size
+    hot_indices.fill_(-1)
+
+    global_cpu = global_indices.cpu().tolist()
+    newest_cpu = (
+        newest_global.cpu().tolist()
+        if newest_global is not None
+        else [-1] * num_tokens
+    )
+    dgi_cpu = coordinator.device_global_indices[:num_tokens].cpu().tolist()
+    lru_cpu = coordinator.lru_slots[:num_tokens].cpu().tolist()
+
+    miss_src: list[int] = []
+    miss_dst: list[int] = []
+    for row in range(num_tokens):
+        base = row * coordinator.region_stride
+        slot_of_global = {g: slot for slot, g in enumerate(dgi_cpu[row]) if g >= 0}
+        hit_cols: dict[int, int] = {}
+        for col, g in enumerate(global_cpu[row]):
+            if g < 0:
+                continue
+            if g == newest_cpu[row]:
+                hot_indices[row, col] = base + buf
+            elif g in slot_of_global:
+                hit_cols[slot_of_global[g]] = col
+
+        # Classify slots in LRU order, like the kernel does.
+        evictables = [s for s in lru_cpu[row] if s not in hit_cols]
+        hit_slots = [s for s in lru_cpu[row] if s in hit_cols]
+        for slot in hit_slots:
+            hot_indices[row, hit_cols[slot]] = base + slot
+
+        misses = [
+            (col, g)
+            for col, g in enumerate(global_cpu[row])
+            if g >= 0 and g != newest_cpu[row] and g not in slot_of_global
+        ]
+        miss_slots = []
+        for m, (col, g) in enumerate(misses):
+            slot = evictables[m]
+            miss_slots.append(slot)
+            hot_indices[row, col] = base + slot
+            dgi_cpu[row][slot] = g
+            miss_src.append(g)
+            miss_dst.append(base + slot)
+
+        lru_cpu[row] = evictables[len(misses) :] + miss_slots + hit_slots
+
+    coordinator.device_global_indices[:num_tokens] = torch.tensor(
+        dgi_cpu, dtype=torch.int32, device=coordinator.device
+    )
+    coordinator.lru_slots[:num_tokens] = torch.tensor(
+        lru_cpu, dtype=torch.int16, device=coordinator.device
+    )
+
+    if miss_src:
+        src_cpu = torch.tensor(miss_src, dtype=torch.long)
+        dst = torch.tensor(miss_dst, dtype=torch.long, device=coordinator.device)
+        rows = coordinator._host_cache[src_cpu].to(coordinator.device)
+        coordinator.hot_cache.index_copy_(0, dst, rows)
+
+
+def _make_hisparse_vllm_config(index_topk: int = 128):
+    return SimpleNamespace(
+        attention_config=SimpleNamespace(
+            hisparse_config={
+                "device_buffer_size": 256,
+                "host_pool_gib": 1.0,
+            },
+        ),
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="P2pNcclConnector",
+            kv_role="kv_consumer",
+        ),
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                architectures=["GlmMoeDsaForCausalLM"],
+                index_topk=index_topk,
+            ),
+            get_num_layers=lambda parallel_config: 2,
+        ),
+        parallel_config=None,
+        scheduler_config=SimpleNamespace(max_num_seqs=256),
+    )
+
+
+@requires_hisparse_ops
+def test_hisparse_config_validation():
+    vllm_config = _make_hisparse_vllm_config()
+
+    cfg = HiSparseConfig.from_vllm_config(vllm_config, model_top_k=128)
+    assert cfg == HiSparseConfig(
+        top_k=128,
+        device_buffer_size=256,
+        host_pool_gib=1.0,
+    )
+
+    # No hisparse_config means disabled.
+    vllm_config.attention_config.hisparse_config = None
+    assert HiSparseConfig.from_vllm_config(vllm_config, model_top_k=128) is None
+
+    # host_pool_gib is required.
+    vllm_config.attention_config.hisparse_config = {"device_buffer_size": 256}
+    with pytest.raises(ValueError, match="host_pool_gib"):
+        HiSparseConfig.from_vllm_config(vllm_config, model_top_k=128)
+
+    # Unknown keys are rejected.
+    vllm_config.attention_config.hisparse_config = {
+        "host_pool_gib": 1.0,
+        "device_bufer_size": 256,
+    }
+    with pytest.raises(ValueError, match="Unknown hisparse_config keys"):
+        HiSparseConfig.from_vllm_config(vllm_config, model_top_k=128)
+
+    # The coordinator itself is connector-agnostic; the decode-only
+    # (kv_consumer) deployment contract is enforced by
+    # VllmConfig.__post_init__, not here.
+    vllm_config.attention_config.hisparse_config = {
+        "device_buffer_size": 256,
+        "host_pool_gib": 1.0,
+    }
+    vllm_config.kv_transfer_config = None
+    coordinator = create_hisparse_coordinator(
+        vllm_config,
+        model_top_k=128,
+        row_width=64,
+        kv_dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+    assert coordinator is not None
+    # One reserved newest slot, padded so any kernel page size (<= 128) works.
+    assert coordinator.region_stride % 64 == 0
+    assert coordinator.region_stride > coordinator.config.device_buffer_size
+
+
+def test_hisparse_decode_batch_detection():
+    assert is_hisparse_decode_batch(
+        max_query_len=1,
+        num_reqs=8,
+        num_actual_tokens=8,
+    )
+    assert not is_hisparse_decode_batch(
+        max_query_len=2,
+        num_reqs=8,
+        num_actual_tokens=16,
+    )
+    assert not is_hisparse_decode_batch(
+        max_query_len=1,
+        num_reqs=8,
+        num_actual_tokens=9,
+    )
+
+
+def _make_hisparse_coordinator(
+    *,
+    top_k: int = 4,
+    device_buffer_size: int = 4,
+    max_num_reqs: int = 2,
+    row_width: int = 8,
+) -> HiSparseCoordinator:
+    return HiSparseCoordinator(
+        config=HiSparseConfig(
+            top_k=top_k,
+            device_buffer_size=device_buffer_size,
+            host_pool_gib=1.0,
+        ),
+        max_num_reqs=max_num_reqs,
+        row_width=row_width,
+        kv_dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+
+
+def _hisparse_state(coordinator: HiSparseCoordinator):
+    return (
+        coordinator.device_global_indices.cpu().clone(),
+        coordinator.lru_slots.cpu().clone(),
+    )
+
+
+@requires_hisparse_ops
+def test_hisparse_reset_hot_rows():
+    coordinator = _make_hisparse_coordinator(max_num_reqs=3)
+    coordinator.device_global_indices.fill_(7)
+    coordinator.lru_slots.fill_(2)
+
+    coordinator.reset_hot_rows(torch.tensor([1], device=coordinator.device))
+
+    assert torch.all(coordinator.device_global_indices[0] == 7)
+    assert torch.all(coordinator.device_global_indices[1] == -1)
+    assert torch.all(coordinator.device_global_indices[2] == 7)
+    torch.testing.assert_close(coordinator.lru_slots[1], coordinator._lru_init)
+
+
+@requires_hisparse_ops
+def test_hisparse_swap_in_semantics():
+    """Hit/miss/LRU/newest semantics of the swap-in kernel."""
+    device = torch.device(DEVICE_TYPE)
+    block_size = 4
+    row_width = 8
+    num_blocks = 8
+
+    kv_pool = torch.arange(
+        num_blocks * block_size * row_width, dtype=torch.float32
+    ).view(num_blocks, block_size, row_width).pin_memory()
+    flat_pool = kv_pool.reshape(-1, row_width)
+
+    coordinator = _make_hisparse_coordinator()
+    buf = coordinator.config.device_buffer_size
+    stride = coordinator.region_stride
+
+    # One request at row 0 with 3 blocks; sequence length 9 so position 8
+    # (global slot block_table[0,2]*4 + 0 = 16) is the newest token.
+    block_table = torch.tensor([[2, 0, 4]], dtype=torch.int32, device=device)
+    req_ids = torch.tensor([0], dtype=torch.int32, device=device)
+    newest_global = 4 * block_size + 0  # slot 16
+    slot_mapping = torch.tensor([newest_global], dtype=torch.int64, device=device)
+
+    # Place the newest row into the reserved hot slot (as write_newest_rows
+    # would).
+    newest_hot_slot = 0 * stride + buf
+    coordinator.hot_cache[newest_hot_slot] = flat_pool[newest_global].to(device)
+
+    def swap(positions: list[int]) -> torch.Tensor:
+        topk = torch.full((1, 4), -1, dtype=torch.int32, device=device)
+        topk[0, : len(positions)] = torch.tensor(
+            positions, dtype=torch.int32, device=device
+        )
+        hot_cache, hot_indices = coordinator.swap_in(
+            kv_cache=kv_pool,
+            req_id_per_token=req_ids,
+            block_table=block_table,
+            topk_indices=topk,
+            block_size=block_size,
+            slot_mapping=slot_mapping,
+        )
+        assert hot_cache.shape[1:] == (block_size, row_width)
+        torch.cuda.synchronize()
+        return hot_indices
+
+    # Step 1: positions 0, 5, 8 -> global slots 8, 1, 16(newest).
+    hot = swap([0, 5, 8])
+    hot_cpu = hot.cpu().tolist()[0]
+    assert hot_cpu[3] == -1, "padded -1 position must stay invalid"
+    assert hot_cpu[2] == newest_hot_slot, "newest position must map to its slot"
+    assert all(0 <= h < buf for h in hot_cpu[:2]), "misses fill LRU slots"
+    flat_hot = coordinator.hot_cache
+    torch.testing.assert_close(flat_hot[hot_cpu[0]].cpu(), flat_pool[8])
+    torch.testing.assert_close(flat_hot[hot_cpu[1]].cpu(), flat_pool[1])
+
+    dgi, lru = _hisparse_state(coordinator)
+    assert set(dgi[0].tolist()) == {8, 1, -1}
+
+    # Step 2: same positions again -> hits, no state change.
+    hot2 = swap([0, 5, 8])
+    assert hot2.cpu().tolist()[0][:3] == hot_cpu[:3]
+    dgi2, lru2 = _hisparse_state(coordinator)
+    torch.testing.assert_close(dgi2, dgi)
+    torch.testing.assert_close(lru2, lru)
+
+    # Step 3: two new positions 1, 2 (slots 9, 10) -> evict the two
+    # least-recently-used slots; hits 8/1 must survive.
+    hot3 = swap([1, 2, 0, 5])
+    dgi3, _ = _hisparse_state(coordinator)
+    assert set(dgi3[0].tolist()) == {8, 1, 9, 10}
+    hot3_cpu = hot3.cpu().tolist()[0]
+    torch.testing.assert_close(flat_hot[hot3_cpu[0]].cpu(), flat_pool[9])
+    torch.testing.assert_close(flat_hot[hot3_cpu[1]].cpu(), flat_pool[10])
+    assert hot3_cpu[2] == hot_cpu[0], "hit keeps its slot"
+    assert hot3_cpu[3] == hot_cpu[1], "hit keeps its slot"
+
+    # Step 4: invalidation. When global slot 8 is rewritten in the host pool
+    # (block reassignment), the model runner invalidates it; the stale hot
+    # copy must turn into a miss that re-reads the pool.
+    flat_pool[8] += 1000.0
+    coordinator.invalidate_slots(torch.tensor([8], device=device))
+    dgi4, _ = _hisparse_state(coordinator)
+    assert 8 not in dgi4[0].tolist()
+    hot4 = swap([0])
+    torch.testing.assert_close(
+        flat_hot[hot4.cpu().tolist()[0][0]].cpu(), flat_pool[8]
+    )
+
+
+@requires_hisparse_ops
+def test_hisparse_kernel_matches_fallback():
+    """Fuzz the CUDA swap-in kernel against the local Python reference."""
+    device = torch.device(DEVICE_TYPE)
+    torch.manual_seed(0)
+    block_size = 64
+    row_width = 64
+    num_blocks = 64
+    top_k = 128
+    buf = 256
+    num_reqs = 4
+
+    kv_pool = torch.randn(
+        (num_blocks, block_size, row_width), dtype=torch.float32
+    ).pin_memory()
+    flat_pool = kv_pool.reshape(-1, row_width)
+
+    def make() -> HiSparseCoordinator:
+        c = _make_hisparse_coordinator(
+            top_k=top_k,
+            device_buffer_size=buf,
+            max_num_reqs=num_reqs,
+            row_width=row_width,
+        )
+        c.bind_source_cache(kv_pool)
+        return c
+
+    kernel_c = make()
+    fallback_c = make()
+
+    blocks_per_req = num_blocks // num_reqs
+    block_table = (
+        torch.arange(num_blocks, dtype=torch.int32, device=device)
+        .view(num_reqs, blocks_per_req)
+    )
+    req_ids = torch.arange(num_reqs, dtype=torch.int32, device=device)
+    seq_len = blocks_per_req * block_size
+    newest_pos = seq_len - 1
+    slot_mapping = (
+        block_table[:, -1].to(torch.int64) * block_size + (block_size - 1)
+    )
+    newest_global = slot_mapping.to(torch.int32).contiguous()
+
+    for step in range(8):
+        topk = torch.stack(
+            [
+                torch.randperm(seq_len, device=device)[:top_k].to(torch.int32)
+                for _ in range(num_reqs)
+            ]
+        )
+        # Sprinkle in padding and the newest position.
+        topk[:, -1] = -1
+        topk[:, 0] = newest_pos
+
+        hot_k, idx_k = kernel_c.swap_in(
+            kv_cache=kv_pool,
+            req_id_per_token=req_ids,
+            block_table=block_table,
+            topk_indices=topk.clone(),
+            block_size=block_size,
+            slot_mapping=slot_mapping,
+        )
+        # Reference path: same conversion swap_in performs, then the local
+        # Python reference resolution.
+        global_indices = triton_convert_req_index_to_global_index(
+            req_ids,
+            block_table,
+            topk.clone(),
+            BLOCK_SIZE=block_size,
+            NUM_TOPK_TOKENS=top_k,
+            BLOCK_N=128 if top_k % 128 == 0 else top_k,
+        )
+        idx_f = torch.full_like(global_indices, -1)
+        fallback_swap_in(fallback_c, global_indices, newest_global, idx_f)
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(idx_k, idx_f, rtol=0, atol=0)
+        torch.testing.assert_close(
+            kernel_c.device_global_indices, fallback_c.device_global_indices,
+            rtol=0, atol=0,
+        )
+        torch.testing.assert_close(
+            kernel_c.lru_slots, fallback_c.lru_slots, rtol=0, atol=0
+        )
+        torch.testing.assert_close(kernel_c.hot_cache, fallback_c.hot_cache)
+
+        # Data correctness: every valid hot index holds the right KV row.
+        flat_hot = hot_k.reshape(-1, row_width)
+        valid = idx_k >= 0
+        global_ref = _triton_convert_reference_impl(
+            req_ids, block_table, topk, block_size, top_k
+        )
+        newest_mask = topk == newest_pos
+        gathered = flat_hot[idx_k[valid].to(torch.long)].cpu()
+        expected = flat_pool[global_ref[valid].cpu().to(torch.long)]
+        # Newest rows are served from the reserved slot, which this test
+        # does not populate; exclude them from the data check.
+        data_mask = ~newest_mask[valid].cpu()
+        torch.testing.assert_close(gathered[data_mask], expected[data_mask])
+
+
+@requires_hisparse_ops
+def test_hisparse_plan_once_matches_independent():
+    """GLM-5.2 index sharing: a "shared" layer that replays the "full" layer's
+    plan via apply_plan must produce the same hot buffer as if it had run
+    swap_in independently. Covers the hisparse_gather_plan kernel + the
+    miss_mask plan output.
+    """
+    from vllm.v1.attention.backends.mla import hisparse as _hs
+
+    device = torch.device(DEVICE_TYPE)
+    torch.manual_seed(0)
+    block_size = 64
+    row_width = 64
+    num_blocks = 64
+    top_k = 128
+    buf = 256
+    num_reqs = 4
+
+    kv_pool = torch.randn(
+        (num_blocks, block_size, row_width), dtype=torch.float32
+    ).pin_memory()
+
+    def make() -> HiSparseCoordinator:
+        c = _make_hisparse_coordinator(
+            top_k=top_k, device_buffer_size=buf, max_num_reqs=num_reqs,
+            row_width=row_width,
+        )
+        c.bind_source_cache(kv_pool)
+        return c
+
+    blocks_per_req = num_blocks // num_reqs
+    block_table = torch.arange(
+        num_blocks, dtype=torch.int32, device=device
+    ).view(num_reqs, blocks_per_req)
+    req_ids = torch.arange(num_reqs, dtype=torch.int32, device=device)
+    seq_len = blocks_per_req * block_size
+    slot_mapping = block_table[:, -1].to(torch.int64) * block_size + (block_size - 1)
+
+    _hs._GROUP_PLANS.clear()
+    producer, shared, indep = make(), make(), make()
+    for step in range(8):
+        topk = torch.stack([
+            torch.randperm(seq_len, device=device)[:top_k].to(torch.int32)
+            for _ in range(num_reqs)
+        ])
+        topk[:, -1] = -1  # padding column
+        kw = dict(
+            kv_cache=kv_pool, req_id_per_token=req_ids,
+            block_table=block_table, block_size=block_size,
+            slot_mapping=slot_mapping,
+        )
+        # full layer produces the plan; independent layer resolves alone.
+        _, idx_full = producer.swap_in(
+            topk_indices=topk.clone(), produce_plan=True, **kw
+        )
+        _, idx_indep = indep.swap_in(topk_indices=topk.clone(), **kw)
+        # shared layer replays the plan (no LRU resolution of its own).
+        _, idx_shared = shared.apply_plan(
+            kv_cache=kv_pool, block_size=block_size, num_tokens=num_reqs
+        )
+        torch.cuda.synchronize()
+        # Same plan, and the replayed hot buffer == the independent one.
+        torch.testing.assert_close(idx_shared, idx_full, rtol=0, atol=0)
+        torch.testing.assert_close(idx_indep, idx_full, rtol=0, atol=0)
+        torch.testing.assert_close(shared.hot_cache, indep.hot_cache)
+
+
+@requires_hisparse_ops
+def test_hisparse_overlap_prefetch_matches_independent():
+    """Overlapped prefetch: a full layer prefetching its shared layers'
+    gathers on the copy stream yields the same hot buffers as independent
+    per-layer swap_in. Validates the copy-stream fork + per-shared event sync +
+    correctness in eager mode; graph-capture safety is exercised end-to-end.
+    """
+    from vllm.v1.attention.backends.mla import hisparse as _hs
+
+    device = torch.device(DEVICE_TYPE)
+    torch.manual_seed(0)
+    block_size, row_width, num_blocks, top_k, buf, num_reqs = 64, 64, 64, 128, 256, 4
+    kv_pool = torch.randn(
+        (num_blocks, block_size, row_width), dtype=torch.float32
+    ).pin_memory()
+    _hs._GROUP_PLANS.clear()
+
+    def make() -> HiSparseCoordinator:
+        c = _make_hisparse_coordinator(
+            top_k=top_k, device_buffer_size=buf, max_num_reqs=num_reqs,
+            row_width=row_width,
+        )
+        c.bind_source_cache(kv_pool)
+        return c
+
+    leader, s1, s2, i1, i2 = make(), make(), make(), make(), make()
+    s1.join_group(leader)
+    s2.join_group(leader)
+
+    blocks_per_req = num_blocks // num_reqs
+    block_table = torch.arange(
+        num_blocks, dtype=torch.int32, device=device
+    ).view(num_reqs, blocks_per_req)
+    req_ids = torch.arange(num_reqs, dtype=torch.int32, device=device)
+    seq_len = blocks_per_req * block_size
+    slot_mapping = block_table[:, -1].to(torch.int64) * block_size + (block_size - 1)
+    kw = dict(
+        kv_cache=kv_pool, req_id_per_token=req_ids, block_table=block_table,
+        block_size=block_size, slot_mapping=slot_mapping,
+    )
+
+    for _ in range(8):
+        topk = torch.stack([
+            torch.randperm(seq_len, device=device)[:top_k].to(torch.int32)
+            for _ in range(num_reqs)
+        ])
+        topk[:, -1] = -1
+        leader.swap_in(topk_indices=topk.clone(), produce_plan=True, **kw)  # + prefetch
+        i1.swap_in(topk_indices=topk.clone(), **kw)
+        i2.swap_in(topk_indices=topk.clone(), **kw)
+        s1.apply_plan(kv_cache=kv_pool, block_size=block_size, num_tokens=num_reqs)
+        s2.apply_plan(kv_cache=kv_pool, block_size=block_size, num_tokens=num_reqs)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(s1.hot_cache, i1.hot_cache)
+        torch.testing.assert_close(s2.hot_cache, i2.hot_cache)
+
+
+@requires_hisparse_ops
+def test_hisparse_host_resident_prefill_write_rows():
+    """write_rows_to_host scatters valid rows to their global host slots,
+    skipping -1 (padding) slots and rows beyond the slot mapping (CUDA graph
+    padding can make the KV tensors longer than slot_mapping)."""
+    device = torch.device(DEVICE_TYPE)
+    block_size = 4
+    row_width = 8
+    kv_pool = torch.zeros(
+        8, block_size, row_width, dtype=torch.float32
+    ).pin_memory()
+    flat_pool = kv_pool.reshape(-1, row_width)
+    coordinator = _make_hisparse_coordinator(row_width=row_width)
+
+    slots = torch.tensor([3, 7, -1], dtype=torch.int64, device=device)
+    kv_c = torch.randn(8, row_width - 2, device=device)
+    k_pe = torch.randn(8, 1, 2, device=device)
+
+    coordinator.write_rows_to_host(
+        kv_c,
+        k_pe,
+        kv_pool,
+        slots,
+        "auto",
+        torch.tensor(1.0, device=device),
+    )
+    torch.cuda.synchronize()
+
+    expected = torch.cat([kv_c[:2], k_pe[:2, 0]], dim=-1).cpu()
+    torch.testing.assert_close(flat_pool[torch.tensor([3, 7])], expected)
+    torch.testing.assert_close(flat_pool[8], torch.zeros(row_width))
+
+
+@requires_hisparse_ops
+def test_hisparse_host_resident_pool():
+    """The pinned host KV pool is the only full-size store.
+
+    Also covers the decode-write pad clamp: the forward can run more KV rows
+    than slot_mapping has entries (DP alignment / capture padding), and
+    write_newest_rows must ignore the extra rows.
+    """
+    device = torch.device(DEVICE_TYPE)
+    block_size = 4
+    row_width = 8
+    num_blocks = 8
+
+    kv_pool = torch.arange(
+        num_blocks * block_size * row_width, dtype=torch.float32
+    ).view(num_blocks, block_size, row_width).pin_memory()
+    flat_pool = kv_pool.reshape(-1, row_width)
+
+    coordinator = _make_hisparse_coordinator()
+    buf = coordinator.config.device_buffer_size
+    stride = coordinator.region_stride
+
+    coordinator.bind_source_cache(kv_pool)
+    assert coordinator._host_cache.data_ptr() == flat_pool.data_ptr()
+
+    block_table = torch.tensor([[2, 0, 4]], dtype=torch.int32, device=device)
+    req_ids = torch.tensor([0], dtype=torch.int32, device=device)
+    newest_global = 4 * block_size + 0  # position 8 -> slot 16
+    slot_mapping = torch.tensor([newest_global], dtype=torch.int64, device=device)
+
+    # Decode-step write: newest row lands in the reserved hot slot AND in the
+    # host pool at its global slot. kv/k_pe carry two extra padding rows
+    # beyond the single-entry slot mapping; the clamp must drop them.
+    kv_c = torch.randn(3, row_width - 2, device=device)
+    k_pe = torch.randn(3, 1, 2, device=device)
+    coordinator.write_newest_rows(
+        kv_c, k_pe, kv_pool, slot_mapping, "auto",
+        torch.tensor(1.0, device=device),
+    )
+    torch.cuda.synchronize()
+    expected_row = torch.cat([kv_c[0], k_pe[0, 0]]).cpu()
+    torch.testing.assert_close(flat_pool[newest_global], expected_row)
+    torch.testing.assert_close(
+        coordinator.hot_cache[buf].cpu(), expected_row
+    )
+    # The padding rows must not spill into the next row's reserved slot.
+    torch.testing.assert_close(
+        coordinator.hot_cache[stride + buf].cpu(), torch.zeros(row_width)
+    )
+
+    # Swap-in: positions 0 and 5 (slots 8, 1) miss -> copied from the host
+    # pool; position 8 is the newest -> reserved slot, no copy.
+    topk = torch.tensor([[0, 5, 8, -1]], dtype=torch.int32, device=device)
+    hot_cache, hot_indices = coordinator.swap_in(
+        kv_cache=kv_pool,
+        req_id_per_token=req_ids,
+        block_table=block_table,
+        topk_indices=topk,
+        block_size=block_size,
+        slot_mapping=slot_mapping,
+    )
+    torch.cuda.synchronize()
+    hot_cpu = hot_indices.cpu().tolist()[0]
+    assert hot_cpu[2] == 0 * stride + buf
+    assert hot_cpu[3] == -1
+    flat_hot = coordinator.hot_cache
+    torch.testing.assert_close(flat_hot[hot_cpu[0]].cpu(), flat_pool[8])
+    torch.testing.assert_close(flat_hot[hot_cpu[1]].cpu(), flat_pool[1])
+
+    # Recycled-slot invalidation: when slot 8's block is reassigned, the
+    # model runner invalidates it (assignment-time hook) before the new
+    # owner's first write; the stale hot copy must re-miss from the
+    # updated pool.
+    coordinator.invalidate_slots(torch.tensor([8], device=device))
+    assert 8 not in coordinator.device_global_indices.cpu().tolist()[0]
+    kv_c2 = torch.randn(1, row_width - 2, device=device)
+    k_pe2 = torch.randn(1, 1, 2, device=device)
+    coordinator.write_newest_rows(
+        kv_c2, k_pe2, kv_pool,
+        torch.tensor([8], dtype=torch.int64, device=device),
+        "auto", torch.tensor(1.0, device=device),
+    )
+    torch.cuda.synchronize()
+    hot_cache, hot_indices = coordinator.swap_in(
+        kv_cache=kv_pool,
+        req_id_per_token=req_ids,
+        block_table=block_table,
+        topk_indices=torch.tensor([[0, -1, -1, -1]], dtype=torch.int32,
+                                  device=device),
+        block_size=block_size,
+        slot_mapping=slot_mapping,
+    )
+    torch.cuda.synchronize()
+    idx = hot_indices.cpu().tolist()[0][0]
+    torch.testing.assert_close(
+        flat_hot[idx].cpu(), torch.cat([kv_c2[0], k_pe2[0, 0]]).cpu()
+    )
+
+
+@requires_hisparse_ops
+def test_hisparse_mixed_batch_bf16_row_split(
+    default_vllm_config, dist_init, workspace_init
+):
+    """Host-resident mixed batch on the bf16 path is row-split.
+
+    Two long-context decode requests + one short local-prefill chunk: decode
+    tokens must be served from the hot buffer (swap-in) and only the prefill
+    rows' blocks staged host->GPU, with the stitched output matching the
+    device-resident whole-batch reference.
+    """
+    ok, reason = flashmla.is_flashmla_sparse_supported()
+    if not ok:
+        pytest.skip(reason)
+
+    from vllm.v1.attention.backends.mla import flashmla_sparse as _fms
+
+    device = torch.device(DEVICE_TYPE)
+    dtype = torch.bfloat16
+    torch.manual_seed(0)
+
+    num_heads = 64
+    kv_lora_rank = 512
+    qk_nope_head_dim = 128
+    qk_rope_head_dim = 64
+    v_head_dim = 128
+    head_size = kv_lora_rank + qk_rope_head_dim
+    topk_tokens = 128
+    block_size = 64
+
+    # Long decode contexts + a short prefill chunk (router shortcut shape).
+    batch_spec = BatchSpec(seq_lens=[2048, 2048, 192], query_lens=[1, 1, 64])
+    max_seqlen = max(batch_spec.seq_lens)
+    total_cache_tokens = sum(batch_spec.seq_lens)
+    total_tokens = batch_spec.compute_num_tokens()
+
+    vllm_config = create_vllm_config(
+        model_name="deepseek-ai/DeepSeek-V2-Lite-Chat",
+        tensor_parallel_size=1,
+        max_model_len=max_seqlen,
+        num_gpu_blocks=max(2048, cdiv(total_cache_tokens, block_size) + 1),
+        block_size=block_size,
+        hf_config_override={
+            "index_topk": topk_tokens,
+            "attn_module_list_cfg": [{"topk_tokens": topk_tokens}],
+        },
+    )
+    vllm_config.attention_config.hisparse_config = {
+        "device_buffer_size": 2 * topk_tokens,
+        "host_pool_gib": 1.0,
+    }
+    model_config = vllm_config.model_config
+    model_config.hf_text_config = SimpleNamespace(
+        q_lora_rank=None,
+        kv_lora_rank=kv_lora_rank,
+        qk_nope_head_dim=qk_nope_head_dim,
+        qk_rope_head_dim=qk_rope_head_dim,
+        v_head_dim=v_head_dim,
+        model_type="deepseek_v2",
+    )
+    model_config.dtype = dtype
+    model_config.get_num_attention_heads = MethodType(
+        lambda self, parallel_config: num_heads, model_config
+    )
+    model_config.get_num_kv_heads = MethodType(
+        lambda self, parallel_config: 1, model_config
+    )
+    model_config.get_head_size = MethodType(lambda self: head_size, model_config)
+    model_config.get_sliding_window = MethodType(lambda self: None, model_config)
+    # create_hisparse_coordinator sizes hot buffers per layer.
+    model_config.get_num_layers = MethodType(
+        lambda self, parallel_config: 1, model_config
+    )
+
+    kv_cache_spec = create_standard_kv_cache_spec(vllm_config)
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec,
+        vllm_config.cache_config.block_size,
+        device,
+        arange_block_indices=True,
+    )
+
+    # Prepopulate every position of every sequence so the forward needs no
+    # KV-cache update (the row split itself is what is under test).
+    kv_c_contexts = [
+        torch.rand(s_len, kv_lora_rank, dtype=dtype, device=device)
+        for s_len in batch_spec.seq_lens
+    ]
+    k_pe_contexts = [
+        torch.rand(s_len, 1, qk_rope_head_dim, dtype=dtype, device=device)
+        for s_len in batch_spec.seq_lens
+    ]
+    kv_cache = create_and_prepopulate_kv_cache(
+        kv_c_contexts=kv_c_contexts,
+        k_pe_contexts=k_pe_contexts,
+        block_size=vllm_config.cache_config.block_size,
+        head_size=head_size,
+        dtype=dtype,
+        device=device,
+        num_blocks=vllm_config.cache_config.num_gpu_blocks,
+        common_attn_metadata=common_attn_metadata,
+        randomize_blocks=False,
+        kv_cache_dtype="auto",
+    )
+
+    builder_cls = FlashMLASparseBackend.get_builder_cls()
+    builder = builder_cls(kv_cache_spec, ["placeholder"], vllm_config, device)
+    metadata = builder.build(
+        common_prefix_len=0, common_attn_metadata=common_attn_metadata
+    )
+    num_decodes = metadata.num_decodes
+    assert num_decodes == 2 and metadata.num_decode_tokens == 2
+
+    # Per-token sparse indices bounded by each token's position, with unique
+    # offsets and -1 padding (same construction as the decode parity test).
+    positions = []
+    for i in range(batch_spec.batch_size):
+        ctx_len = batch_spec.seq_lens[i] - batch_spec.query_lens[i]
+        positions.extend(ctx_len + q_idx for q_idx in range(batch_spec.query_lens[i]))
+    sparse_indices = torch.empty(
+        total_tokens, topk_tokens, dtype=torch.int32, device=device
+    )
+    for tok_idx in range(total_tokens):
+        max_valid_idx = positions[tok_idx]
+        offset = tok_idx * 7  # Prime number for varied offsets
+        num_valid = min(topk_tokens // 2, max_valid_idx + 1)
+        valid_range = torch.arange(num_valid, device=device, dtype=torch.int32)
+        sparse_indices[tok_idx] = torch.cat(
+            [
+                (valid_range + offset) % (max_valid_idx + 1),
+                torch.full(
+                    (topk_tokens - num_valid,), -1, device=device, dtype=torch.int32
+                ),
+            ]
+        )
+
+    q = torch.rand(total_tokens, num_heads, head_size, dtype=dtype, device=device)
+    mock_indexer = SimpleNamespace(
+        topk_indices_buffer=sparse_indices, topk_tokens=topk_tokens
+    )
+
+    impl_cls = FlashMLASparseBackend.get_impl_cls()
+    with set_current_vllm_config(vllm_config):
+        impl = impl_cls(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=1.0 / math.sqrt(head_size),
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            logits_soft_cap=None,
+            attn_type="decoder",
+            kv_sharing_target_layer_name=None,
+            q_lora_rank=None,
+            kv_lora_rank=kv_lora_rank,
+            qk_nope_head_dim=qk_nope_head_dim,
+            qk_rope_head_dim=qk_rope_head_dim,
+            qk_head_dim=qk_nope_head_dim + qk_rope_head_dim,
+            v_head_dim=v_head_dim,
+            kv_b_proj=None,
+            indexer=mock_indexer,
+        )
+    assert impl.hisparse_coordinator is not None
+    impl.prepare_hisparse_for_batch(metadata)
+    assert not impl._hisparse_decode_batch
+
+    # Device-resident reference: the whole batch converted against the full
+    # block table and run as one kernel call over the GPU cache.
+    ref_topk, ref_topk_length = triton_convert_req_index_to_global_index(
+        metadata.req_id_per_token,
+        metadata.block_table,
+        sparse_indices,
+        BLOCK_SIZE=metadata.block_size,
+        NUM_TOPK_TOKENS=topk_tokens,
+        return_valid_counts=True,
+    )
+    reference = impl._bf16_flash_mla_kernel(q, kv_cache, ref_topk, ref_topk_length)
+
+    # Host-resident pool with identical contents.
+    kv_pool = kv_cache.cpu().pin_memory()
+
+    _fms._HISPARSE_PREFILL_REMAP = None
+    staging_calls = []
+    original_stage = impl._hisparse_host_prefill_cache
+
+    def spy_stage(self, kv, block_table, seq_lens):
+        staged, staged_bt = original_stage(kv, block_table, seq_lens)
+        staging_calls.append((block_table.clone(), seq_lens.clone(), staged.shape))
+        return staged, staged_bt
+
+    impl._hisparse_host_prefill_cache = MethodType(spy_stage, impl)
+
+    backend_output = impl._forward_bf16_kv(q, kv_pool, sparse_indices, metadata)
+    torch.cuda.synchronize()
+
+    # Only the prefill rows' blocks were staged: the decode rows' 2048-token
+    # contexts (32 blocks each) must stay off the staging gather.
+    assert len(staging_calls) == 1
+    staged_bt, staged_seq_lens, staged_shape = staging_calls[0]
+    torch.testing.assert_close(
+        staged_bt, metadata.block_table[num_decodes:], rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        staged_seq_lens, metadata.seq_lens[num_decodes:], rtol=0, atol=0
+    )
+    prefill_blocks = cdiv(batch_spec.seq_lens[-1], block_size)
+    assert staged_shape[0] <= prefill_blocks + 1  # +1: block-0 tail padding
+
+    assert backend_output.shape == reference.shape
+    torch.testing.assert_close(backend_output, reference, rtol=0.01, atol=0.01)
+
+
+def test_hisparse_prefill_staging_remap():
+    """Compacted staging references the same host rows as direct indexing."""
+    from vllm.v1.attention.backends.mla.flashmla_sparse import (
+        hisparse_prefill_staging_remap,
+    )
+
+    block_size = 4
+    block_table = torch.tensor(
+        [[5, 2, -1, -1], [2, 7, 3, -1], [9, -1, -1, -1]], dtype=torch.int32
+    )
+
+    new_bt, row_ids = hisparse_prefill_staging_remap(block_table, block_size)
+
+    assert new_bt.shape == block_table.shape
+    assert row_ids.dtype == torch.int32 and new_bt.dtype == torch.int32
+    n_unique = len({0, 2, 3, 5, 7, 9})  # -1 clamps to block 0
+    assert row_ids.shape == (1, n_unique * block_size)
+    flat_rows = row_ids.flatten()
+    for i in range(block_table.shape[0]):
+        for j in range(block_table.shape[1]):
+            orig = max(int(block_table[i, j]), 0)
+            staged = int(new_bt[i, j])
+            for k in range(block_size):
+                assert (
+                    int(flat_rows[staged * block_size + k])
+                    == orig * block_size + k
+                )

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -2060,7 +2060,7 @@ def test_shutdown_cleans_up_resources(default_vllm_config, dist_init):
         worker.shutdown()
         worker.shutdown()
 
-        mock_exec.shutdown.assert_called_with(wait=False)
+        mock_exec.shutdown.assert_called_with(wait=False, cancel_futures=True)
 
         # Same sequence on scheduler.shutdown()
         scheduler.shutdown()
@@ -2575,6 +2575,172 @@ def test_transfer_setup_failure_returns_finished(default_vllm_config, dist_init)
     # ensure request appears in get_finished
     _, done_recving = connector.get_finished(finished_req_ids=set())
     assert request_id in done_recving
+
+
+class _ScriptedXferWrapper(FakeNixlWrapper):
+    """Scripts per-handle xfer states; forbids releasing in-flight handles."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # handle -> successive states; the last one repeats.
+        self.xfer_states: dict[int, list[str]] = {}
+        self.released: list[int] = []
+
+    def check_xfer_state(self, handle: int) -> str:
+        states = self.xfer_states[handle]
+        return states.pop(0) if len(states) > 1 else states[0]
+
+    def release_xfer_handle(self, handle: int) -> None:
+        # A posted-but-unfinished transfer cannot be aborted: releasing it
+        # leaves the RDMA READ armed. Production code must never do this.
+        assert self.xfer_states.get(handle, ["DONE"])[0] != "PROC", (
+            f"released in-flight handle {handle}"
+        )
+        self.released.append(handle)
+
+
+def _make_split_read_worker(worker, request_id, states):
+    """Seed a request with scripted in-flight xfer handles + recv metadata."""
+    wrapper = _ScriptedXferWrapper("agent")
+    worker.nixl_wrapper = wrapper
+    metadata = NixlConnectorMetadata()
+    metadata.add_new_req_to_recv(
+        request_id=request_id,
+        local_block_ids=([7, 8, 9],),
+        kv_transfer_params={
+            "remote_block_ids": ([10, 11, 12],),
+            "remote_engine_id": FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
+            "remote_request_id": f"prefill-{request_id}",
+            "remote_host": "localhost",
+            "remote_port": 1234,
+            "remote_tp_size": 1,
+        },
+    )
+    worker._recving_metadata[request_id] = metadata.reqs_to_recv[request_id]
+    wrapper.xfer_states = dict(states)
+    worker._recving_transfers[request_id] = list(states)
+    return wrapper
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_split_read_failure_defers_report_until_last_handle(
+    default_vllm_config, dist_init
+):
+    """One half of a split (mixed DRAM/VRAM) read failing must not report the
+    request — nor invalidate its blocks — while the sibling xfer is still in
+    flight: a posted READ cannot be aborted and would DMA into blocks the
+    scheduler could free and reuse. The report happens exactly once, when the
+    last handle is terminal."""
+    vllm_config = create_vllm_config()
+    connector = NixlConnector(
+        vllm_config, KVConnectorRole.WORKER, make_kv_cache_config(block_size=16)
+    )
+    connector.connector_worker = FakeNixlConnectorWorker(
+        vllm_config, connector.engine_id, hand_shake_latency=0
+    )
+    worker = connector.connector_worker
+    request_id = "split_read_partial_failure"
+    err_handle, live_handle = 11, 22
+    wrapper = _make_split_read_worker(
+        worker,
+        request_id,
+        {err_handle: ["ERR"], live_handle: ["PROC", "PROC", "DONE"]},
+    )
+
+    # Poll 1: one half fails; the sibling is in flight -> nothing reported.
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert done_recving == set()
+    assert connector.get_block_ids_with_load_errors() == set()
+    assert request_id in worker._recving_metadata
+    assert wrapper.released == [err_handle]
+
+    # Poll 2: sibling still in flight.
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert done_recving == set()
+
+    # Poll 3: sibling terminal -> reported exactly once, blocks invalidated.
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert done_recving == {request_id}
+    assert connector.get_block_ids_with_load_errors() == {7, 8, 9}
+    assert request_id not in worker._recving_metadata
+    assert wrapper.released == [err_handle, live_handle]
+
+    # Poll 4: nothing left; no double report.
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert done_recving == set()
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_split_read_halves_fail_in_different_polls(default_vllm_config, dist_init):
+    """Both halves of a split read failing in different poll cycles must
+    produce exactly one failure report."""
+    vllm_config = create_vllm_config()
+    connector = NixlConnector(
+        vllm_config, KVConnectorRole.WORKER, make_kv_cache_config(block_size=16)
+    )
+    connector.connector_worker = FakeNixlConnectorWorker(
+        vllm_config, connector.engine_id, hand_shake_latency=0
+    )
+    worker = connector.connector_worker
+    request_id = "split_read_both_fail"
+    _make_split_read_worker(
+        worker,
+        request_id,
+        {31: ["ERR"], 32: ["PROC", "ERR"]},
+    )
+
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert done_recving == set()
+
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert done_recving == {request_id}
+    assert connector.get_block_ids_with_load_errors() == {7, 8, 9}
+
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert done_recving == set()
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_setup_failure_with_inflight_sibling_defers_report(
+    default_vllm_config, dist_init
+):
+    """A setup failure (second half never posted) while the first half is in
+    flight defers the report until the in-flight half is terminal; repeated
+    failure events for the same request report it only once."""
+    vllm_config = create_vllm_config()
+    connector = NixlConnector(
+        vllm_config, KVConnectorRole.WORKER, make_kv_cache_config(block_size=16)
+    )
+    connector.connector_worker = FakeNixlConnectorWorker(
+        vllm_config, connector.engine_id, hand_shake_latency=0
+    )
+    worker = connector.connector_worker
+    request_id = "split_read_setup_failure"
+    _make_split_read_worker(worker, request_id, {41: ["PROC", "DONE"]})
+
+    # The mixed-read setup path fails after the first half started.
+    worker._handle_failed_transfer(request_id, None)
+    worker._handle_failed_transfer(request_id, None)  # duplicate event
+
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert done_recving == set()
+    assert connector.get_block_ids_with_load_errors() == set()
+
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert done_recving == {request_id}
+    assert connector.get_block_ids_with_load_errors() == {7, 8, 9}
+
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert done_recving == set()
 
 
 @patch(

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -56,6 +56,13 @@ class AttentionConfig:
     """Data type for the sparse-attention indexer K cache. Quantized formats
     (fp8, mxfp4, nvfp4) require indexer kernel support in the backend."""
 
+    hisparse_config: dict[str, Any] | None = None
+    """Setting this enables experimental HiSparse sparse-MLA decode
+    hot-buffering (host-resident KV). host_pool_gib (required) sets the
+    per-rank pinned host pool size in GiB; device_buffer_size (optional,
+    default 2x the model's index_topk) sets the per-request GPU hot-buffer
+    rows."""
+
     use_non_causal: bool = False
     """Whether to use non-causal (bidirectional) attention."""
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1170,6 +1170,72 @@ class VllmConfig:
         self._maybe_override_dynamic_sd_cudagraph_mode()
 
         if (
+            self.attention_config is not None
+            and self.attention_config.hisparse_config is not None
+        ):
+            # PD-decode instances (KV arrives via a consumer connector) are
+            # the intended fast path. Local prefill also works — rows are
+            # written to the host pool and prefill attention stages the
+            # context host->GPU — but it is slower than a normal GPU prefill,
+            # so warn when the deployment will prefill routinely.
+            if (
+                self.kv_transfer_config is None
+                or not self.kv_transfer_config.is_kv_consumer
+            ):
+                logger.warning(
+                    "HiSparse host-resident KV is enabled without a "
+                    "kv_consumer connector (unified / non-PD instance). "
+                    "Every prefill gathers KV from host memory, which is "
+                    "slower than a normal GPU prefill; PD decode-only "
+                    "instances avoid this cost."
+                )
+            if self.parallel_config.use_ubatching:
+                raise ValueError(
+                    "HiSparse does not support DBO/ubatching: micro-batches "
+                    "would index the same hot-buffer rows concurrently and "
+                    "corrupt the LRU state."
+                )
+            if self.speculative_config is not None:
+                raise ValueError(
+                    "HiSparse does not support speculative decoding."
+                )
+            if self.model_config is not None and not hasattr(
+                self.model_config.hf_config, "index_topk"
+            ):
+                raise ValueError(
+                    "HiSparse is only supported for DSA models with "
+                    "index_topk."
+                )
+            if self.kv_transfer_config is not None and (
+                self.kv_transfer_config.kv_connector
+                not in (
+                    None,
+                    "NixlConnector",
+                    "MooncakeStoreConnector",
+                    "MultiConnector",
+                )
+            ):
+                logger.warning(
+                    "HiSparse host-resident KV is configured with connector "
+                    "%s. NixlConnector (direct-to-host RDMA) and "
+                    "MooncakeStoreConnector (shared-store offload) are the "
+                    "validated paths; other connectors are treated as "
+                    "debug/fallback paths.",
+                    self.kv_transfer_config.kv_connector,
+                )
+
+            from vllm.v1.attention.backends.mla.hisparse import (
+                _has_hisparse_ops,
+            )
+
+            if not _has_hisparse_ops():
+                raise RuntimeError(
+                    "HiSparse requires the compiled CUDA ops "
+                    "(_C_cache_ops.hisparse_*), which are missing from this "
+                    "build. Rebuild vLLM from source with CUDA."
+                )
+
+        if (
             self.compilation_config.cudagraph_mode.requires_piecewise_compilation()
             and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
             and not envs.VLLM_USE_BREAKABLE_CUDAGRAPH

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -389,15 +389,19 @@ class KVTransferThread(threading.Thread):
     def run(self):
         self.ready_event.set()
         while True:
+            request_data = self.request_queue.get()
             try:
-                request_data = self.request_queue.get()
                 if request_data is None:
                     logger.warning("Received a None request!")
-                    self.request_queue.task_done()
                     continue
                 self._handle_request(request_data)
             except Exception as e:
                 logger.error("Error in %s: %s", self.name, e)
+            finally:
+                # task_done accounting lives here, not in the handlers: a
+                # handler exception must not leak unfinished_tasks, which
+                # the close() drain and the RESET queue join rely on.
+                self.request_queue.task_done()
 
     def _handle_request(self, req_meta: Any):
         pass
@@ -517,12 +521,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
         current_event = req_meta.current_event
 
         if req_id not in self.stored_requests:
-            self.request_queue.task_done()
             return
 
-        # Decrement the in-flight counter and signal task_done() in `finally`
-        # so the scheduler can release the GPU blocks it pinned for this
-        # request (via `delay_free_blocks`) even when the store path raises.
+        # Decrement the in-flight counter in `finally` so the scheduler can
+        # release the GPU blocks it pinned for this request (via
+        # `delay_free_blocks`) even when the store path raises. (task_done
+        # accounting lives in the run() loop.)
         try:
             if token_len == 0:
                 return
@@ -707,7 +711,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 self.update_kv_event(stored_events)
         finally:
             self.dec_stored_request(req_id)
-            self.request_queue.task_done()
 
 
 class KVCacheStoreRecvingThread(KVTransferThread):
@@ -828,7 +831,6 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                         self.disk_offload_buffer_budget_bytes,
                     )
                     self.set_finished_request(req_id)
-                    self.request_queue.task_done()
                     return
                 load_batches = []
                 block_id_offset = 0
@@ -906,7 +908,6 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             )
 
         self.set_finished_request(req_id)
-        self.request_queue.task_done()
 
 
 # ============================================================
@@ -954,6 +955,12 @@ class MooncakeStoreWorker:
             "load_async", True
         )
         self.cache_config = vllm_config.cache_config
+        # HiSparse keeps MLA KV in pinned host memory while the indexer KV
+        # stays on the GPU, so registration spans host and device segments.
+        attention_config = getattr(vllm_config, "attention_config", None)
+        self._hisparse_enabled = (
+            getattr(attention_config, "hisparse_config", None) is not None
+        )
         self.block_size, self.hash_block_size = resolve_kv_cache_block_sizes(
             kv_cache_config, vllm_config
         )
@@ -1127,6 +1134,14 @@ class MooncakeStoreWorker:
         existing stride-based logic in register_kv_caches() produces
         the correct single-segment result (block_len = page_size * num_layers).
         """
+        if self._hisparse_enabled:
+            raise ValueError(
+                "HiSparse host-resident KV is incompatible with "
+                "enable_cross_layers_blocks: MLA layers live in pinned host "
+                "memory while indexer layers stay on the GPU, so they cannot "
+                "share one packed cross-layer tensor. Disable "
+                "enable_cross_layers_blocks for HiSparse deployments."
+            )
         self.register_kv_caches({"__cross_layer__": kv_cache})
 
     def register_kv_caches(
@@ -1152,6 +1167,10 @@ class MooncakeStoreWorker:
         seen_ptrs: set[int] = set()
         addrs: list[int] = []
         block_lens: list[int] = []
+        # Per-segment memory kind, parallel to addrs. CPU (pinned) tensors
+        # register as host segments and GPU tensors as device segments; for
+        # HiSparse this is mixed (host MLA + device indexer).
+        mem_kinds: list[str] = []
 
         for value in kv_caches.values():
             cache = _repr_tensor(value)
@@ -1161,14 +1180,17 @@ class MooncakeStoreWorker:
                 continue
             seen_ptrs.add(base_addr)
             region_len = cache_storage.nbytes()
+            mem_kind = "host" if cache.device.type == "cpu" else "device"
 
             ret = self.store.register_buffer(base_addr, region_len)
             if ret != 0:
-                logger.error(
-                    "register_buffer failed for addr %#x len %d: %d",
-                    base_addr,
-                    region_len,
-                    ret,
+                # Fail loud: continuing would advertise an unregistered
+                # segment to the store, and every later batch_put_from /
+                # batch_get_into on it fails or corrupts (for HiSparse this
+                # is the whole multi-hundred-GiB pinned MLA pool).
+                raise RuntimeError(
+                    f"Mooncake register_buffer failed for addr {base_addr:#x} "
+                    f"len {region_len} ({mem_kind}): {ret}"
                 )
 
             # Detect layout via stride: a dim whose byte-stride exceeds
@@ -1184,17 +1206,23 @@ class MooncakeStoreWorker:
                 # Blocks-first layout (FlashInfer / MLA): one segment.
                 addrs.append(base_addr)
                 block_lens.append(page_size_bytes)
+                mem_kinds.append(mem_kind)
             else:
                 # K/V-first layout (FlashAttn / ROCm): split segments.
                 seg_stride = cache.stride(outer_dims[0]) * el
                 for idx in range(cache.shape[outer_dims[0]]):
                     addrs.append(base_addr + idx * seg_stride)
                     block_lens.append(seg_stride // self.num_blocks)
+                    mem_kinds.append(mem_kind)
 
+        num_host = sum(1 for kind in mem_kinds if kind == "host")
         logger.info(
-            "Registered KV caches: num_groups=%d, num_segments=%d, num_blocks=%d",
+            "Registered KV caches: num_groups=%d, num_segments=%d "
+            "(host=%d, device=%d), num_blocks=%d",
             len(self.token_dbs),
             len(addrs),
+            num_host,
+            len(addrs) - num_host,
             self.num_blocks,
         )
 
@@ -1462,6 +1490,26 @@ class MooncakeStoreWorker:
         if store is None:
             return
         self.store = None
+        # Bounded drain of the send/recv worker queues: closing the store
+        # frees the TransferEngine under a thread that may be mid
+        # batch_put_from/batch_get_into on the registered (pinned) buffers.
+        # The daemon threads themselves stay parked on queue.get().
+        deadline = time.monotonic() + 5.0
+        for thread in (self.kv_send_thread, self.kv_recv_thread):
+            if thread is None:
+                continue
+            while (
+                thread.request_queue.unfinished_tasks
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.05)
+            if thread.request_queue.unfinished_tasks:
+                logger.warning(
+                    "Mooncake store %s still has %d in-flight requests at "
+                    "close; closing anyway.",
+                    thread.name,
+                    thread.request_queue.unfinished_tasks,
+                )
         try:
             store.close()
         except Exception as e:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -404,6 +404,11 @@ class NixlBaseConnectorWorker:
         # Number of NIXL regions. Currently one region per cache
         # (so 1 per layer for MLA, otherwise 2 per layer)
         self.num_regions = 0
+        self.region_mem_types: list[str] = []
+        self._mixed_mem_types = False
+        self._desc_is_dram_by_block_size: dict[int, np.ndarray] = {}
+        self._desc_pos_by_block_size: dict[int, np.ndarray] = {}
+        self._dram_src_handles_by_block_size: dict[int, int] = {}
 
         # nixl_prepped_dlist_handle.
         self.src_xfer_handles_by_block_size: dict[int, int] = {}
@@ -433,6 +438,26 @@ class NixlBaseConnectorWorker:
         # Uses Queue for thread-safe cross-thread coordination with the
         # background handshake thread, matching the _ready_requests pattern.
         self._failed_recv_reqs: queue.Queue[ReqId] = queue.Queue()
+        # Deferred "done reading" notifications for reads split across
+        # multiple xfers (mixed DRAM/VRAM): NIXL can attach a notif_msg to
+        # only one xfer, so the P-side notification is sent explicitly once
+        # every xfer of the request completes (see _pop_done_transfers).
+        self._pending_recv_notifs: dict[ReqId, list[tuple[str, bytes]]] = {}
+        # Requests with a failed xfer whose sibling xfers are still in
+        # flight. A posted NIXL transfer cannot be aborted (on the UCX
+        # backend release_xfer_handle silently skips the cancel and the RDMA
+        # READ keeps writing into local memory after the call), so the
+        # failure report — and with it the scheduler's block invalidation
+        # and reuse — is deferred until _pop_done_transfers reaps the
+        # request's last handle. Reporting earlier lets the surviving READ
+        # DMA into blocks the scheduler has already reallocated.
+        self._failed_recv_pending: set[ReqId] = set()
+        # Requests reported failed and not yet drained by get_finished;
+        # guards exactly-once reporting.
+        self._failed_recv_reported: set[ReqId] = set()
+        # Guards the failed-recv transitions against _recving_transfers
+        # state; shared with the background handshake thread.
+        self._failed_recv_lock = threading.Lock()
 
         # Handshake metadata of this worker for NIXL transfers.
         self.xfer_handshake_metadata: NixlHandshakePayload | None = None
@@ -982,6 +1007,7 @@ class NixlBaseConnectorWorker:
         )
 
         caches_data = []
+        region_mem_types: list[str] = []
         # With hybrid allocator, layers can share a kv cache tensor
         seen_base_addresses = []
 
@@ -1091,10 +1117,17 @@ class NixlBaseConnectorWorker:
 
                 # Need to make sure the device ID is non-negative for NIXL,
                 # Torch uses -1 to indicate CPU tensors.
-                self.device_id = max(cache.get_device(), 0)
+                if cache.device.type == "cpu":
+                    mem_type = "DRAM"
+                    region_device_id = 0
+                else:
+                    mem_type = self.nixl_memory_type
+                    region_device_id = max(cache.get_device(), 0)
+                    self.device_id = region_device_id
                 caches_data.append(
-                    (base_addr, curr_tensor_size_bytes, self.device_id, "")
+                    (base_addr, curr_tensor_size_bytes, region_device_id, "")
                 )
+                region_mem_types.append(mem_type)
 
         logger.debug(
             "Different block lengths collected: %s", set(self.block_len_per_layer)
@@ -1107,6 +1140,7 @@ class NixlBaseConnectorWorker:
 
         self.kv_caches_base_addr[self.engine_id][self.tp_rank] = seen_base_addresses
         self.num_regions = len(caches_data)
+        self.region_mem_types = region_mem_types
 
         if self.transfer_topo.virtually_split_kv_in_blocks:
             # NOTE (NickLucche) When FlashInfer is used, memory is registered
@@ -1127,11 +1161,31 @@ class NixlBaseConnectorWorker:
         # Total local FA descriptors (boundary between FA and mamba descs).
         self.num_descs = self.num_regions * self.num_blocks
 
-        descs = self.nixl_wrapper.get_reg_descs(caches_data, self.nixl_memory_type)
-        logger.debug("Registering descs: %s", caches_data)
-        self.nixl_wrapper.register_memory(descs, backends=self.nixl_backends)
-        logger.debug("Done registering descs")
-        self._registered_descs.append(descs)
+        self._mixed_mem_types = len(set(region_mem_types)) > 1
+        if self._mixed_mem_types:
+            assert self.use_mla and not self._has_mamba, (
+                "Mixed-device KV registration is only supported for MLA "
+                "models without Mamba layers."
+            )
+            assert not self.transfer_topo.is_kv_layout_blocks_first, (
+                "Mixed-device KV registration does not support blocks-first "
+                "KV layouts."
+            )
+            for mem_type in sorted(set(region_mem_types)):
+                typed = [
+                    cache
+                    for cache, cache_mem_type in zip(caches_data, region_mem_types)
+                    if cache_mem_type == mem_type
+                ]
+                descs = self.nixl_wrapper.get_reg_descs(typed, mem_type)
+                self.nixl_wrapper.register_memory(descs, backends=self.nixl_backends)
+                self._registered_descs.append(descs)
+        else:
+            descs = self.nixl_wrapper.get_reg_descs(caches_data, self.nixl_memory_type)
+            logger.debug("Registering descs: %s", caches_data)
+            self.nixl_wrapper.register_memory(descs, backends=self.nixl_backends)
+            logger.debug("Done registering descs")
+            self._registered_descs.append(descs)
 
         self.device_kv_caches = kv_caches
         self.dst_num_blocks[self.engine_id] = self.num_blocks
@@ -1401,6 +1455,48 @@ class NixlBaseConnectorWorker:
             logger.debug("Registering local Mamba descriptors (4 regions/layer)")
             blocks_data.extend(
                 self._build_mamba_local(local_base_addresses, block_size_ratio)
+            )
+
+        if self._mixed_mem_types:
+            assert len(blocks_data) % len(self.region_mem_types) == 0
+            blocks_per_region = len(blocks_data) // len(self.region_mem_types)
+            desc_is_dram = np.array(
+                [
+                    mem_type == "DRAM"
+                    for mem_type in self.region_mem_types
+                    for _ in range(blocks_per_region)
+                ],
+                dtype=bool,
+            )
+            desc_pos = np.empty(len(desc_is_dram), dtype=np.int64)
+            dram_idx = np.where(desc_is_dram)[0]
+            vram_idx = np.where(~desc_is_dram)[0]
+            desc_pos[dram_idx] = np.arange(len(dram_idx), dtype=np.int64)
+            desc_pos[vram_idx] = np.arange(len(vram_idx), dtype=np.int64)
+            self._desc_is_dram_by_block_size[block_size] = desc_is_dram
+            self._desc_pos_by_block_size[block_size] = desc_pos
+
+            # _build_fa_local stamps every descriptor with self.device_id (the
+            # local GPU index). Host (DRAM) MLA regions are registered under CPU
+            # device_id 0, so their xfer descriptors must also use 0 — otherwise
+            # prep_xfer_dlist("DRAM", ...) raises NIXL_ERR_NOT_FOUND on every TP
+            # rank whose GPU index != 0 (i.e. all ranks but rank 0).
+            blocks_data = [
+                (addr, length, 0) if is_dram else (addr, length, dev)
+                for (addr, length, dev), is_dram in zip(
+                    blocks_data, desc_is_dram, strict=True
+                )
+            ]
+            dram_blocks = [blocks_data[i] for i in dram_idx]
+            vram_blocks = [blocks_data[i] for i in vram_idx]
+            dram_descs = self.nixl_wrapper.get_xfer_descs(dram_blocks, "DRAM")
+            self._dram_src_handles_by_block_size[block_size] = (
+                self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", dram_descs)
+            )
+            descs = self.nixl_wrapper.get_xfer_descs(vram_blocks, self.nixl_memory_type)
+            return (
+                self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs),
+                blocks_data,
             )
 
         descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
@@ -1892,6 +1988,11 @@ class NixlBaseConnectorWorker:
             except queue.Empty:
                 break
 
+        # Drained: a later request reusing the same id (abort + resubmit) is
+        # a distinct lifecycle and may fail again.
+        with self._failed_recv_lock:
+            self._failed_recv_reported.difference_update(failed_recv_reqs)
+
         # Add failed requests to done_recving for scheduler tracking
         # (blocks are already marked invalid, scheduler will handle recompute)
         done_recving.update(failed_recv_reqs)
@@ -1908,10 +2009,22 @@ class NixlBaseConnectorWorker:
 
         block_ids_for_blocksize_post_process = defaultdict(list)
         block_ids_for_heterogeneous_attn_post_process = list[list[int]]()
+        late_duplicates: list[str] = []
         for req_id in done_recving:
             # clean up metadata for completed requests
             meta = self._recving_metadata.pop(req_id, None)
-            assert meta is not None, f"{req_id} not found in recving_metadata list"
+            if meta is None:
+                # Late duplicate of an already-reaped request: posted RDMA
+                # handles cannot be aborted, so a handle of a request whose
+                # failure was already reported can still reach its terminal
+                # state in a later poll cycle. Nothing is left to
+                # post-process, and the request must not be reported finished
+                # a second time.
+                logger.debug(
+                    "Skipping late duplicate completion for request %s", req_id
+                )
+                late_duplicates.append(req_id)
+                continue
 
             # Skip KV sync and post-processing for failed requests
             if req_id in failed_recv_reqs:
@@ -1970,6 +2083,8 @@ class NixlBaseConnectorWorker:
             del self._reqs_to_send[req_id]
             done_sending.add(req_id)
 
+        for req_id in late_duplicates:
+            done_recving.discard(req_id)
         return done_sending, done_recving
 
     def _get_new_notifs(self) -> set[str]:
@@ -2021,49 +2136,115 @@ class NixlBaseConnectorWorker:
                         self.nixl_wrapper.release_xfer_handle(handle)
                     elif xfer_state == "PROC":
                         in_progress.append(handle)
-                        continue
                     else:
                         self._log_failure(
                             failure_type="transfer_failed",
-                            msg="Marking blocks as invalid",
+                            msg="Deferring the failure report until the "
+                            "request's last xfer is terminal",
                             req_id=req_id,
                             xfer_state=xfer_state,
                         )
-                        self._handle_failed_transfer(req_id, handle)
+                        # ERR is terminal: UCX stops hardware placement
+                        # before completing a request with error, so the
+                        # handle can be released — unlike PROC handles,
+                        # which cannot be aborted and must be polled until
+                        # terminal.
+                        self.nixl_wrapper.release_xfer_handle(handle)
+                        self.xfer_stats.record_failed_transfer()
+                        with self._failed_recv_lock:
+                            self._failed_recv_pending.add(req_id)
                 except Exception as e:
                     self._log_failure(
                         failure_type="transfer_exception",
-                        msg="Marking blocks as invalid",
+                        msg="Handle is unpollable; treating it as terminal",
                         req_id=req_id,
                         error=e,
                     )
-                    self._handle_failed_transfer(req_id, handle)
+                    # The handle leaks: releasing an unpollable handle can
+                    # itself throw, and there is nothing left to poll.
+                    self.xfer_stats.record_failed_transfer()
+                    with self._failed_recv_lock:
+                        self._failed_recv_pending.add(req_id)
 
-            if not in_progress:
-                # Only report request as completed when all transfers are done.
-                done_req_ids.add(req_id)
+            with self._failed_recv_lock:
+                if in_progress:
+                    transfers[req_id] = in_progress
+                    continue
                 del transfers[req_id]
-            else:
-                transfers[req_id] = in_progress
+                failed = req_id in self._failed_recv_pending
+                self._failed_recv_pending.discard(req_id)
+            if failed:
+                # Every xfer of this failed request is now terminal: no DMA
+                # can land after the scheduler frees its blocks.
+                self._report_failed_recv(req_id)
+                continue
+            # Only report request as completed when all transfers are done.
+            done_req_ids.add(req_id)
+            self._send_pending_recv_notifs(req_id)
         return done_req_ids
 
-    def _handle_failed_transfer(self, req_id: str, handle: int | None):
+    def _send_pending_recv_notifs(self, req_id: str) -> None:
+        """Send deferred "done reading" notifications for a completed read.
+
+        Used for reads split across multiple xfers (mixed DRAM/VRAM), where
+        the notification cannot ride on a single xfer's notif_msg.
         """
-        Handle a failed transfer by marking all (logical) blocks as invalid and
-        recording the failure.
+        for agent_name, notif_id in self._pending_recv_notifs.pop(req_id, []):
+            try:
+                self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="notification_failed",
+                    msg="P worker blocks will be freed after timeout. "
+                    "This may indicate network issues.",
+                    req_id=req_id,
+                    error=e,
+                    remote_agent_name=agent_name,
+                )
+                self.xfer_stats.record_failed_notification()
+
+    def _handle_failed_transfer(self, req_id: str, handle: int | None):
+        """Handle a transfer that failed before (or while) being posted.
+
+        ``handle`` may only be a handle that never started: a POSTED transfer
+        cannot be aborted (on the UCX backend release_xfer_handle silently
+        skips the cancel and the RDMA READ keeps writing into local memory),
+        so in-flight handles are instead polled to a terminal state by
+        _pop_done_transfers. When sibling xfers of this request are still in
+        flight, the failure report is deferred until the last one is reaped.
 
         Args:
             req_id: The request ID.
-            handle: The transfer handle.
+            handle: A never-started transfer handle to release, if any.
         """
+        if handle is not None:
+            self.nixl_wrapper.release_xfer_handle(handle)
+        self.xfer_stats.record_failed_transfer()
+        with self._failed_recv_lock:
+            if self._recving_transfers.get(req_id):
+                self._failed_recv_pending.add(req_id)
+                return
+            self._failed_recv_pending.discard(req_id)
+        self._report_failed_recv(req_id)
+
+    def _report_failed_recv(self, req_id: str) -> None:
+        """Report a failed recv exactly once, marking its blocks invalid.
+
+        Must only be called once none of the request's xfers remains in
+        flight: the scheduler frees and reuses the blocks in response.
+        """
+        with self._failed_recv_lock:
+            if req_id in self._failed_recv_reported:
+                return
+            self._failed_recv_reported.add(req_id)
         # Use .get() here as the metadata cleanup is handled by get_finished()
         # TODO (NickLucche) handle failed transfer for HMA.
         if (meta := self._recving_metadata.get(req_id)) and not self._is_hma_required:
             self._invalid_block_ids.put(set(meta.local_block_ids[0]))
         self._failed_recv_reqs.put(req_id)
-        if handle is not None:
-            self.nixl_wrapper.release_xfer_handle(handle)
-        self.xfer_stats.record_failed_transfer()
+        # Never notify P for a failed read; its blocks are freed on lease
+        # expiry (the request is recovered on the D side).
+        self._pending_recv_notifs.pop(req_id, None)
 
     def _send_heartbeats(self, metadata: NixlConnectorMetadata) -> None:
         """
@@ -2377,20 +2558,45 @@ class NixlBaseConnectorWorker:
         if not hasattr(self, "_handshake_initiation_executor"):
             # error happens during init, no need to shutdown
             return
-        self._handshake_initiation_executor.shutdown(wait=False)
-        for handles in self._recving_transfers.values():
-            for handle in handles:
-                self.nixl_wrapper.release_xfer_handle(handle)
+        self._handshake_initiation_executor.shutdown(wait=False, cancel_futures=True)
+        # Handle releases can fail against a dead peer (e.g. releasing an
+        # in-flight PROC handle after the prefill side was killed). Teardown
+        # must still reach the MR deregister and the reference clears below,
+        # so tolerate and log per-stage failures instead of aborting.
+        try:
+            for handles in self._recving_transfers.values():
+                for handle in handles:
+                    self.nixl_wrapper.release_xfer_handle(handle)
+        except Exception:
+            logger.exception("NIXL transfer-handle release failed at shutdown.")
         self._recving_transfers.clear()
-        for handle in self.src_xfer_handles_by_block_size.values():
-            self.nixl_wrapper.release_dlist_handle(handle)
-        self.src_xfer_handles_by_block_size.clear()
-        for handles in self.src_xfer_handles_by_tp_ratio.values():
-            for handle in handles:
+        try:
+            for handle in self.src_xfer_handles_by_block_size.values():
                 self.nixl_wrapper.release_dlist_handle(handle)
+            for handles in self.src_xfer_handles_by_tp_ratio.values():
+                for handle in handles:
+                    self.nixl_wrapper.release_dlist_handle(handle)
+            for handle in self._dram_src_handles_by_block_size.values():
+                self.nixl_wrapper.release_dlist_handle(handle)
+        except Exception:
+            logger.exception("NIXL dlist-handle release failed at shutdown.")
+        self.src_xfer_handles_by_block_size.clear()
         self.src_xfer_handles_by_tp_ratio.clear()
-        for engine_id in list(self._remote_agents):
-            self._cleanup_remote_engine(engine_id, log_eviction=False)
-        for desc in self._registered_descs:
-            self.nixl_wrapper.deregister_memory(desc)
-        self._registered_descs.clear()
+        self._dram_src_handles_by_block_size.clear()
+        try:
+            for engine_id in list(self._remote_agents):
+                self._cleanup_remote_engine(engine_id, log_eviction=False)
+        except Exception:
+            logger.exception("NIXL remote-engine cleanup failed at shutdown.")
+        try:
+            for desc in self._registered_descs:
+                self.nixl_wrapper.deregister_memory(desc)
+        finally:
+            self._registered_descs.clear()
+            # Drop the kv-cache tensor references: releasing the HiSparse
+            # pinned host pool must not depend on this worker object becoming
+            # unreachable (an in-flight handshake future or stray reference
+            # would otherwise keep hundreds of GiB alive past
+            # model_runner.shutdown()).
+            self.device_kv_caches = {}
+            self.host_xfer_buffers = {}

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -168,14 +168,18 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 spec.remote_rank
             ]
 
-            self._read_blocks(
+            # Once a read routes the request to failure reporting, the
+            # scheduler may free and reuse its blocks, so no sibling READs
+            # may be posted (and P must not be notified).
+            if not self._read_blocks(
                 read_spec=spec,
                 request_id=req_id,
                 dst_engine_id=meta.remote.engine_id,
                 remote_request_id=meta.remote.request_id,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
-            )
+            ):
+                return
 
         if self.use_mla and tp_ratio < 0 and read_specs:
             # ..but we still need to notify the other remote ranks that we
@@ -194,10 +198,14 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         remote_request_id: str,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
-    ):
+    ) -> bool:
         """
         Post a READ point-to-point xfer request from a single local worker to
         a single remote worker.
+
+        Returns True when the read was posted (or was unnecessary), False
+        when the request was routed to failure reporting — the caller must
+        not post further transfers for it.
         """
         assert self.transfer_topo is not None
         remote_rank = read_spec.remote_rank
@@ -265,7 +273,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     remote_agent_name=agent_name,
                 )
                 self.xfer_stats.record_failed_notification()
-            return
+            return True
 
         assert (
             len(remote_block_ids)
@@ -300,6 +308,19 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # Prepare transfer with Nixl.
         handle = None
         try:
+            if self._mixed_mem_types:
+                self._read_blocks_mixed(
+                    request_id=request_id,
+                    local_block_size_key=remote_info.remote_block_size,
+                    local_vram_handle=local_xfer_side_handle,
+                    remote_xfer_side_handle=remote_xfer_side_handle,
+                    local_block_descs_ids=local_block_descs_ids,
+                    remote_block_descs_ids=remote_block_descs_ids,
+                    notif_agent=self._remote_agents[dst_engine_id][remote_rank],
+                    notif_id=notif_id,
+                )
+                return True
+
             handle = self.nixl_wrapper.make_prepped_xfer(
                 "READ",
                 local_xfer_side_handle,
@@ -314,6 +335,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
 
             # Use handle to check completion in future step().
             self._recving_transfers[request_id].append(handle)
+            return True
         except Exception as e:
             # mark all (logical) blocks for this request as invalid
             self._log_failure(
@@ -325,6 +347,72 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 remote_rank=remote_rank,
             )
             self._handle_failed_transfer(request_id, handle)
+            return False
+
+    def _read_blocks_mixed(
+        self,
+        request_id: str,
+        local_block_size_key: int,
+        local_vram_handle: int,
+        remote_xfer_side_handle: int,
+        local_block_descs_ids: np.ndarray,
+        remote_block_descs_ids: np.ndarray,
+        notif_agent: str,
+        notif_id: bytes,
+    ) -> None:
+        """Split a READ into DRAM and VRAM local descriptor lists.
+
+        NIXL delivers a notif_msg on completion of a single xfer, so the
+        P-side "done reading" notification cannot ride on either half of the
+        split. It is deferred instead: recorded here and sent by
+        _pop_done_transfers once every xfer of this request completes.
+        """
+        desc_is_dram = self._desc_is_dram_by_block_size[local_block_size_key]
+        desc_pos = self._desc_pos_by_block_size[local_block_size_key]
+        dram_handle = self._dram_src_handles_by_block_size[local_block_size_key]
+
+        local_ids = np.asarray(local_block_descs_ids)
+        remote_ids = np.asarray(remote_block_descs_ids)
+        is_dram = desc_is_dram[local_ids]
+
+        # Create every prepped xfer before starting any, so a setup failure
+        # leaves nothing in flight and can release all handles cleanly.
+        handles = []
+        try:
+            for type_mask, local_handle in (
+                (is_dram, dram_handle),
+                (~is_dram, local_vram_handle),
+            ):
+                handles.append(
+                    self.nixl_wrapper.make_prepped_xfer(
+                        "READ",
+                        local_handle,
+                        desc_pos[local_ids[type_mask]],
+                        remote_xfer_side_handle,
+                        remote_ids[type_mask],
+                    )
+                )
+        except Exception:
+            for handle in handles:
+                self.nixl_wrapper.release_xfer_handle(handle)
+            raise
+
+        self._pending_recv_notifs.setdefault(request_id, []).append(
+            (notif_agent, notif_id)
+        )
+        for i, handle in enumerate(handles):
+            try:
+                self.nixl_wrapper.transfer(handle)
+            except Exception:
+                # Handles not yet started can be released; already-started
+                # ones cannot be aborted, so they stay in _recving_transfers
+                # and _pop_done_transfers polls them to a terminal state.
+                # The request is reported failed exactly once, only after
+                # its last handle is terminal (see _handle_failed_transfer).
+                for unstarted in handles[i:]:
+                    self.nixl_wrapper.release_xfer_handle(unstarted)
+                raise
+            self._recving_transfers[request_id].append(handle)
 
     def _get_new_notifs(self) -> set[str]:
         """

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -336,6 +336,13 @@ def _canonicalize_sparse_mla_kv_cache_dtype(
     return kv_cache_dtype
 
 
+def _prepare_hisparse_for_batch(impl, attn_metadata) -> None:
+    """Let a HiSparse-capable impl classify the batch before the KV update."""
+    prepare = getattr(impl, "prepare_hisparse_for_batch", None)
+    if prepare is not None:
+        prepare(attn_metadata)
+
+
 class MLAAttention(nn.Module, AttentionLayerBase):
     """Multi-Head Latent Attention layer.
 
@@ -583,6 +590,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             assert isinstance(slot_mapping, dict), (
                 f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
             )
+            _prepare_hisparse_for_batch(self.impl, attn_metadata)
             self.impl.do_kv_cache_update(  # type: ignore[attr-defined]
                 kv_c_normed,
                 k_pe,
@@ -1046,8 +1054,11 @@ def unified_mla_kv_cache_update(
     the data dependency between them to ensure torch.compile preserves ordering.
     """
     layer_name = _resolve_layer_name(layer_name)
-    _, attn_layer, kv_cache, layer_slot_mapping = get_attention_context(layer_name)
+    attn_metadata, attn_layer, kv_cache, layer_slot_mapping = get_attention_context(
+        layer_name
+    )
     if layer_slot_mapping is not None:
+        _prepare_hisparse_for_batch(attn_layer.impl, attn_metadata)
         attn_layer.impl.do_kv_cache_update(  # type: ignore[attr-defined]
             kv_c_normed,
             k_pe,

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -16,7 +16,11 @@ from vllm.model_executor.layers.attention.mla_attention import (
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.platform_utils import num_compute_units
-from vllm.utils.torch_utils import is_quantized_kv_cache, np_to_pinned_tensor
+from vllm.utils.torch_utils import (
+    is_quantized_kv_cache,
+    kv_cache_dtype_str_to_dtype,
+    np_to_pinned_tensor,
+)
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -26,6 +30,12 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
     SparseMLAAttentionImpl,
+)
+from vllm.v1.attention.backends.mla.hisparse import (
+    FP8_DS_MLA_ROW_BYTES,
+    HiSparseCoordinator,
+    create_hisparse_coordinator,
+    is_hisparse_decode_batch,
 )
 from vllm.v1.attention.backends.mla.sparse_utils import (
     triton_convert_req_index_to_global_index,
@@ -49,6 +59,42 @@ if TYPE_CHECKING:
     from vllm.model_executor.models.deepseek_v2 import Indexer
 
 logger = init_logger(__name__)
+
+# Overlap group wiring: the coordinator of the most-recently-constructed
+# "full" layer, so the shared layers that follow can attach to it. Per-process
+# (one model per vLLM process); reset implicitly as each full layer is built.
+_HISPARSE_CURRENT_LEADER = None
+
+# Layer-invariant local-prefill staging remap shared by every layer in the
+# forward: single slot keyed by (data_ptr, shape, _version) of the block
+# table, so layers 2..N of a step hit and any in-place table mutation (which
+# bumps _version) invalidates. Local prefill never runs under graph capture,
+# so table contents always change through version-bumping host-side writes.
+_HISPARSE_PREFILL_REMAP: tuple | None = None
+
+
+def hisparse_prefill_staging_remap(
+    block_table: torch.Tensor, block_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compact a block table onto its unique referenced blocks.
+
+    Returns ``(new_bt, row_ids)``: ``new_bt`` renumbers the table against a
+    staged copy holding only the unique blocks, and ``row_ids`` is the
+    ``[1, n_unique * block_size]`` int32 host-pool row ids to stage, in
+    staged order. Callers bound the table to each row's used blocks first;
+    out-of-range entries map to block 0, which consumers never read past
+    ``seq_len`` (``clamp(min=0)`` covers synthetic tables with ``-1``
+    padding).
+    """
+    unique_ids, inverse = torch.unique(
+        block_table.clamp(min=0), return_inverse=True
+    )
+    new_bt = inverse.to(torch.int32)
+    row_ids = (
+        unique_ids.to(torch.int32).unsqueeze(1) * block_size
+        + torch.arange(block_size, dtype=torch.int32, device=block_table.device)
+    ).view(1, -1)
+    return new_bt, row_ids
 
 # For FP8 sparse attention we have two implementations:
 # 1. Mixed batch mode: use the FP8 decode kernel for both prefill and decode this is
@@ -156,6 +202,7 @@ class FlashMLASparseMetadata(AttentionMetadata):
 
     block_table: torch.Tensor
     req_id_per_token: torch.Tensor
+    seq_lens: torch.Tensor
     block_size: int = 64
     topk_tokens: int = 2048
 
@@ -164,6 +211,11 @@ class FlashMLASparseMetadata(AttentionMetadata):
         scheduler_metadata: FlashMLASchedMeta
         dummy_block_table: torch.Tensor
         cache_lens: torch.Tensor
+        # Host-resident (HiSparse) mixed batches run decode and prefill
+        # tokens as separate kernel calls; a FlashMLASchedMeta binds to its
+        # first call's shapes, so each sub-call needs its own metadata.
+        decode_split: "FlashMLASparseMetadata.FP8KernelMetadata | None" = None
+        prefill_split: "FlashMLASparseMetadata.FP8KernelMetadata | None" = None
 
     @dataclass
     class FP8SeparatePrefillDecode:
@@ -217,6 +269,13 @@ class FlashMLASparseMetadata(AttentionMetadata):
     fp8_extra_metadata: FP8SeparatePrefillDecode | FP8KernelMetadata | None = None
     fp8_use_mixed_batch: bool = False
 
+    # Decode/prefill split of the reordered batch (decode requests first,
+    # occupying block-table rows [0, num_decodes) and the first
+    # num_decode_tokens tokens). Used by the host-resident (HiSparse)
+    # mixed-batch row split.
+    num_decodes: int = 0
+    num_decode_tokens: int = 0
+
 
 def get_prefill_workspace_size(max_model_len: int):
     # NOTE(Lucas): 5 is a magic number for controlling the prefill buffer size.
@@ -262,6 +321,7 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
 
         self.topk_tokens = vllm_config.model_config.hf_config.index_topk
         self.use_fp8_kv_cache = cache_config.cache_dtype == "fp8_ds_mla"
+        self.use_hisparse = vllm_config.attention_config.hisparse_config is not None
         max_num_seqs = vllm_config.scheduler_config.max_num_seqs
         # Shape: [max_num_seqs], all elements = topk_tokens (constant for full-CG)
         self.topk_tokens_tensor = torch.full(
@@ -315,48 +375,58 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
     def _build_fp8_mixed_decode_prefill(
         self,
         common_attn_metadata: CommonAttentionMetadata,
+        num_decode_tokens: int,
+        num_prefill_tokens: int,
     ) -> "FlashMLASparseMetadata.FP8KernelMetadata":
         """Build FP8 metadata treating all tokens as one mixed batch.
 
         This matches main branch's approach and avoids the BF16 prefill kernel
         which has head padding overhead when num_heads is small (high TP case).
         """
-        num_tokens = common_attn_metadata.num_actual_tokens
-
         # Use padded head count since that's what the kernel will see
         padded_heads = self.fp8_decode_padded_heads
 
-        # Build metadata for all tokens as a single batch
-        scheduler_metadata, _ = get_mla_metadata(
-            cache_seqlens=self.topk_tokens_tensor[:1],  # Single batch
-            num_q_tokens_per_head_k=num_tokens * padded_heads,
-            topk=self.topk_tokens,
-            num_heads_q=padded_heads,
-            num_heads_k=1,
-            is_fp8_kvcache=True,
-        )
+        # The vendored get_mla_metadata ignores its arguments and returns an
+        # empty FlashMLASchedMeta that lazily binds (b, s_q) on its first
+        # kernel call; num_tokens documents which sub-call shape each fresh
+        # sched-meta will bind to.
+        def make_kernel_metadata(
+            num_tokens: int,
+        ) -> FlashMLASparseMetadata.FP8KernelMetadata:
+            scheduler_metadata, _ = get_mla_metadata(
+                cache_seqlens=self.topk_tokens_tensor[:1],  # Single batch
+                num_q_tokens_per_head_k=num_tokens * padded_heads,
+                topk=self.topk_tokens,
+                num_heads_q=padded_heads,
+                num_heads_k=1,
+                is_fp8_kvcache=True,
+            )
+            return FlashMLASparseMetadata.FP8KernelMetadata(
+                scheduler_metadata=scheduler_metadata,
+                cache_lens=self.max_model_len_tensor[:1],
+                dummy_block_table=self.dummy_block_table[:1],
+            )
 
-        fp8_metadata = FlashMLASparseMetadata.FP8KernelMetadata(
-            scheduler_metadata=scheduler_metadata,
-            cache_lens=self.max_model_len_tensor[:1],
-            dummy_block_table=self.dummy_block_table[:1],
-        )
+        # Metadata for all tokens as a single batch
+        fp8_metadata = make_kernel_metadata(common_attn_metadata.num_actual_tokens)
+        if self.use_hisparse and num_decode_tokens > 0 and num_prefill_tokens > 0:
+            # Host-resident mixed batches row-split into a decode and a
+            # prefill kernel call of different token counts; each needs its
+            # own FlashMLASchedMeta (shape-bound after first use).
+            fp8_metadata.decode_split = make_kernel_metadata(num_decode_tokens)
+            fp8_metadata.prefill_split = make_kernel_metadata(num_prefill_tokens)
 
         return fp8_metadata
 
     def _build_fp8_separate_prefill_decode(
         self,
         common_attn_metadata: CommonAttentionMetadata,
+        num_decodes: int,
+        num_prefills: int,
+        num_decode_tokens: int,
+        num_prefill_tokens: int,
     ) -> "FlashMLASparseMetadata.FP8SeparatePrefillDecode":
         num_tokens = common_attn_metadata.num_actual_tokens
-
-        (num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens) = (
-            split_decodes_and_prefills(
-                common_attn_metadata,
-                decode_threshold=self.reorder_batch_threshold or 1,
-                require_uniform=True,
-            )
-        )
 
         FP8Meta = FlashMLASparseMetadata.FP8SeparatePrefillDecode
         fp8_metadata = FP8Meta(
@@ -507,6 +577,14 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
         )
         req_id_per_token = self.req_id_per_token_buffer[:num_tokens]
 
+        (num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens) = (
+            split_decodes_and_prefills(
+                cm,
+                decode_threshold=self.reorder_batch_threshold or 1,
+                require_uniform=True,
+            )
+        )
+
         fp8_extra_metadata: (
             FlashMLASparseMetadata.FP8SeparatePrefillDecode
             | FlashMLASparseMetadata.FP8KernelMetadata
@@ -515,9 +593,17 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
         fp8_use_mixed_batch = self.num_heads < MIN_HEADS_FOR_BF16_PREFILL
         if self.use_fp8_kv_cache:
             if fp8_use_mixed_batch:
-                fp8_extra_metadata = self._build_fp8_mixed_decode_prefill(cm)
+                fp8_extra_metadata = self._build_fp8_mixed_decode_prefill(
+                    cm, num_decode_tokens, num_prefill_tokens
+                )
             else:
-                fp8_extra_metadata = self._build_fp8_separate_prefill_decode(cm)
+                fp8_extra_metadata = self._build_fp8_separate_prefill_decode(
+                    cm,
+                    num_decodes,
+                    num_prefills,
+                    num_decode_tokens,
+                    num_prefill_tokens,
+                )
 
         metadata = FlashMLASparseMetadata(
             num_reqs=cm.num_reqs,
@@ -528,10 +614,13 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
             slot_mapping=cm.slot_mapping,
             block_table=cm.block_table_tensor,
             req_id_per_token=req_id_per_token,
+            seq_lens=cm.seq_lens,
             block_size=self.kv_cache_spec.block_size,
             topk_tokens=self.topk_tokens,
             fp8_extra_metadata=fp8_extra_metadata,
             fp8_use_mixed_batch=fp8_use_mixed_batch,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
         )
 
         return metadata
@@ -574,6 +663,40 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         self.topk_indices_buffer: torch.Tensor | None = (
             indexer.topk_indices_buffer if indexer is not None else topk_indices_buffer
         )
+        self.hisparse_coordinator: HiSparseCoordinator | None = None
+        attention_config = get_current_vllm_config().attention_config
+        if attention_config.hisparse_config is not None:
+            if kv_cache_dtype == "fp8_ds_mla":
+                hisparse_row_width = FP8_DS_MLA_ROW_BYTES
+                hisparse_kv_dtype = torch.uint8
+            else:
+                hisparse_row_width = head_size
+                hisparse_kv_dtype = kv_cache_dtype_str_to_dtype(
+                    kv_cache_dtype, get_current_vllm_config().model_config
+                )
+            model_top_k = (
+                indexer.topk_tokens
+                if indexer is not None
+                else get_current_vllm_config().model_config.hf_config.index_topk
+            )
+            self.hisparse_coordinator = create_hisparse_coordinator(
+                get_current_vllm_config(),
+                model_top_k,
+                row_width=hisparse_row_width,
+                kv_dtype=hisparse_kv_dtype,
+            )
+            # Index sharing (GLM-5.2): a layer with an indexer is a "full"
+            # layer and leads a group; the indexer-less "shared" layers that
+            # follow (until the next full layer) replay its plan. For models
+            # without index sharing every layer has an indexer, so all groups
+            # stay empty and no plan is produced.
+            global _HISPARSE_CURRENT_LEADER
+            if indexer is not None:
+                _HISPARSE_CURRENT_LEADER = self.hisparse_coordinator
+            elif _HISPARSE_CURRENT_LEADER is not None:
+                self.hisparse_coordinator.join_group(_HISPARSE_CURRENT_LEADER)
+        self._hisparse_decode_batch = False
+        self._hisparse_dummy_batch = False
         # Prefill BF16 kernel requires 64 on Hopper, 128 on Blackwell
         self.prefill_padding = (
             128 if current_platform.is_device_capability_family(100) else 64
@@ -607,6 +730,200 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
                 (q_concat_shape, torch.bfloat16),
             )
 
+    def prepare_hisparse_for_batch(
+        self,
+        attn_metadata: FlashMLASparseMetadata | None,
+    ) -> None:
+        # Dummy runs (memory profiling, warmup) carry no attention metadata
+        # but still execute the KV-cache-update op with an all -1 slot
+        # mapping; do_kv_cache_update must no-op for them.
+        self._hisparse_dummy_batch = attn_metadata is None
+        if attn_metadata is None:
+            self._hisparse_decode_batch = False
+            return
+        self._hisparse_decode_batch = (
+            self.hisparse_coordinator is not None
+            and is_hisparse_decode_batch(
+                max_query_len=attn_metadata.max_query_len,
+                num_reqs=attn_metadata.num_reqs,
+                num_actual_tokens=attn_metadata.num_actual_tokens,
+            )
+        )
+
+    def _hisparse_swap_in(
+        self,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        topk_indices: torch.Tensor,
+        attn_metadata: FlashMLASparseMetadata,
+        num_decode_tokens: int | None = None,
+        return_valid_counts: bool = False,
+    ):
+        assert self.hisparse_coordinator is not None
+        pure_decode = num_decode_tokens is None
+        n = topk_indices.shape[0] if pure_decode else num_decode_tokens
+        # The swap-in kernel maps token row i to hot region / dgi row i, so
+        # decode rows must be 1:1 with requests. Holds today because HiSparse
+        # rejects speculative decoding at config init; guard the mixed path
+        # against a future relaxation silently corrupting hot-buffer state.
+        assert pure_decode or num_decode_tokens == attn_metadata.num_decodes, (
+            f"HiSparse mixed batch requires 1 token per decode request, got "
+            f"{num_decode_tokens} tokens for {attn_metadata.num_decodes} "
+            f"decode requests."
+        )
+        # Index-sharing "shared" layer: replay the leader's plan (produced by
+        # its swap_in earlier this pass) instead of re-resolving the LRU.
+        if self.hisparse_coordinator.leader is not None:
+            return self.hisparse_coordinator.apply_plan(
+                kv_cache=kv_c_and_k_pe_cache,
+                block_size=attn_metadata.block_size,
+                num_tokens=n,
+                return_valid_counts=return_valid_counts,
+            )
+        return self.hisparse_coordinator.swap_in(
+            kv_cache=kv_c_and_k_pe_cache,
+            req_id_per_token=attn_metadata.req_id_per_token[:n],
+            block_table=attn_metadata.block_table,
+            topk_indices=topk_indices[:n],
+            block_size=attn_metadata.block_size,
+            slot_mapping=attn_metadata.slot_mapping if pure_decode else None,
+            return_valid_counts=return_valid_counts,
+            produce_plan=bool(self.hisparse_coordinator.group_shared),
+        )
+
+    def _hisparse_host_prefill_cache(
+        self,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        block_table: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Stage the referenced context blocks from the host pool onto GPU.
+
+        Local prefill on a host-resident instance: sparse prefill attention
+        needs the context on GPU, so gather the unique blocks each row
+        actually uses (per ``seq_lens``; tail columns hold stale ids from
+        previous row occupants) host->GPU and renumber the table against the
+        staged copy. The backup kernel is stream-ordered, so freshly written
+        host rows are visible. The gather reads the pinned pool directly on
+        the GPU (hisparse_gather_plan) instead of CPU-indexing the whole
+        padded table, and the index remap — identical for every layer — is
+        cached per (block table identity, mutation version).
+        """
+        global _HISPARSE_PREFILL_REMAP
+        device = block_table.device
+        block_size = kv_c_and_k_pe_cache.shape[1]
+        row_width = kv_c_and_k_pe_cache.shape[-1]
+        key = (block_table.data_ptr(), block_table.shape, block_table._version)
+        cached = _HISPARSE_PREFILL_REMAP
+        if cached is not None and cached[0] == key:
+            _, new_bt, row_ids, dst_rows, miss_mask = cached
+        else:
+            used = (seq_lens.to(torch.int64) + block_size - 1) // block_size
+            bounded = torch.where(
+                torch.arange(block_table.shape[1], device=device)[None, :]
+                < used[:, None],
+                block_table,
+                0,
+            )
+            new_bt, row_ids = hisparse_prefill_staging_remap(
+                bounded, block_size
+            )
+            dst_rows = torch.arange(
+                row_ids.shape[1], dtype=torch.int32, device=device
+            ).view(1, -1)
+            miss_mask = torch.ones_like(row_ids)
+            _HISPARSE_PREFILL_REMAP = (key, new_bt, row_ids, dst_rows, miss_mask)
+
+        staged = torch.empty(
+            (row_ids.shape[1] // block_size, block_size, row_width),
+            dtype=kv_c_and_k_pe_cache.dtype,
+            device=device,
+        )
+        staged_2d = staged.view(-1, row_width)
+        torch.ops._C_cache_ops.hisparse_gather_plan(
+            kv_c_and_k_pe_cache.view(-1, row_width),
+            staged_2d,
+            row_ids,
+            dst_rows,
+            miss_mask,
+            None,
+        )
+        return staged, new_bt
+
+    def _hisparse_stage_prefill_rows(
+        self,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: FlashMLASparseMetadata,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Stage only the prefill rows' context from the host pool.
+
+        Decode requests occupy block-table rows [0, num_decodes) and the
+        first num_decode_tokens tokens; they are served from the hot buffer
+        (``_hisparse_swap_in``), never staged — staging them would gather
+        each decode row's whole context host->GPU on every layer.
+
+        Returns ``(staged_cache, staged_block_table, prefill_req_ids)`` for
+        the prefill segment; ``prefill_req_ids`` are rebased onto the sliced
+        table (row i is request num_decodes + i).
+        """
+        num_decodes = attn_metadata.num_decodes
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        staged_cache, staged_bt = self._hisparse_host_prefill_cache(
+            kv_c_and_k_pe_cache,
+            attn_metadata.block_table[num_decodes:],
+            attn_metadata.seq_lens[num_decodes:],
+        )
+        prefill_req_ids = attn_metadata.req_id_per_token[num_decode_tokens:]
+        if num_decodes > 0:
+            prefill_req_ids = prefill_req_ids - num_decodes
+        return staged_cache, staged_bt, prefill_req_ids
+
+    def do_kv_cache_update(
+        self,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,
+    ) -> None:
+        if self.hisparse_coordinator is None:
+            return super().do_kv_cache_update(
+                kv_c_normed,
+                k_pe,
+                kv_cache,
+                slot_mapping,
+                kv_cache_dtype,
+                k_scale,
+            )
+
+        if self._hisparse_dummy_batch:
+            # Dummy run: nothing to write (slot mapping is all -1).
+            return
+
+        if not self._hisparse_decode_batch:
+            # Local prefill on this instance (router shortcut for short
+            # suffixes, preemption resume, recompute after a failed KV
+            # load): write the rows straight to the host pool. Slower than
+            # PD prefill; correct either way.
+            self.hisparse_coordinator.write_rows_to_host(
+                kv_c_normed,
+                k_pe,
+                kv_cache,
+                slot_mapping,
+                kv_cache_dtype,
+                k_scale,
+            )
+            return
+
+        self.hisparse_coordinator.write_newest_rows(
+            kv_c_normed,
+            k_pe,
+            kv_cache,
+            slot_mapping,
+            kv_cache_dtype,
+            k_scale,
+        )
+
     def _forward_bf16_kv(
         self,
         q: torch.Tensor,
@@ -614,23 +931,80 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         topk_indices: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
     ) -> torch.Tensor:
-        # Convert per-request indices to global slots (decode) or workspace
-        # offsets (prefill).
+        # Set by prepare_hisparse_for_batch on the same metadata this step
+        # (q is already sliced to num_actual_tokens; dummy runs never reach
+        # the forward paths).
+        if self._hisparse_decode_batch:
+            kv_c_and_k_pe_cache, topk_indices, topk_length = self._hisparse_swap_in(
+                kv_c_and_k_pe_cache,
+                topk_indices,
+                attn_metadata,
+                return_valid_counts=True,
+            )
+            return self._bf16_flash_mla_kernel(
+                q,
+                kv_c_and_k_pe_cache,
+                topk_indices,
+                topk_length,
+            )
+
+        block_table = attn_metadata.block_table
+        req_id_per_token = attn_metadata.req_id_per_token
+        decode_out: torch.Tensor | None = None
+        if kv_c_and_k_pe_cache.device.type == "cpu":
+            num_decode_tokens = attn_metadata.num_decode_tokens
+            if num_decode_tokens > 0:
+                # Mixed batch on a host-resident pool: serve decode tokens
+                # from the hot buffer, exactly like the pure-decode branch.
+                # The newest rows went to the host pool this step
+                # (write_rows_to_host), so slot_mapping=None mixed mode
+                # resolves them as misses.
+                hot_cache, decode_topk, decode_topk_length = self._hisparse_swap_in(
+                    kv_c_and_k_pe_cache,
+                    topk_indices,
+                    attn_metadata,
+                    num_decode_tokens=num_decode_tokens,
+                    return_valid_counts=True,
+                )
+                decode_out = self._bf16_flash_mla_kernel(
+                    q[:num_decode_tokens],
+                    hot_cache,
+                    decode_topk,
+                    decode_topk_length,
+                )
+                if num_decode_tokens == attn_metadata.num_actual_tokens:
+                    return decode_out
+                q = q[num_decode_tokens:]
+                topk_indices = topk_indices[num_decode_tokens:]
+            # Host-resident pool + local prefill: stage the prefill rows'
+            # context on GPU.
+            kv_c_and_k_pe_cache, block_table, req_id_per_token = (
+                self._hisparse_stage_prefill_rows(
+                    kv_c_and_k_pe_cache, attn_metadata
+                )
+            )
+
+        # Convert per-request indices to global slots (decode) or staged
+        # slots (local prefill).
         topk_indices, topk_length = triton_convert_req_index_to_global_index(
-            attn_metadata.req_id_per_token,
-            attn_metadata.block_table,
+            req_id_per_token,
+            block_table,
             topk_indices,
             BLOCK_SIZE=attn_metadata.block_size,
             NUM_TOPK_TOKENS=topk_indices.shape[1],
             return_valid_counts=True,
         )
 
-        return self._bf16_flash_mla_kernel(
+        attn_out = self._bf16_flash_mla_kernel(
             q,
             kv_c_and_k_pe_cache,
             topk_indices,
             topk_length,
         )
+        if decode_out is None:
+            return attn_out
+        # Stitch back in batch token order: decode tokens first, prefill after.
+        return torch.cat([decode_out, attn_out], dim=0)
 
     def _forward_fp8_kv_separate_prefill_decode(
         self,
@@ -642,6 +1016,21 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         fp8_metadata = attn_metadata.fp8_extra_metadata
         assert isinstance(fp8_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode)
         num_decodes = fp8_metadata.num_decodes
+        num_decode_tokens = fp8_metadata.num_decode_tokens
+        num_prefill_tokens = fp8_metadata.num_prefill_tokens
+
+        decode_cache = kv_c_and_k_pe_cache
+        decode_topk: torch.Tensor | None = None
+        use_hisparse = self.hisparse_coordinator is not None
+        if use_hisparse and num_decode_tokens > 0:
+            decode_cache, decode_topk = self._hisparse_swap_in(
+                kv_c_and_k_pe_cache,
+                topk_indices,
+                attn_metadata,
+                num_decode_tokens=(
+                    None if num_prefill_tokens == 0 else num_decode_tokens
+                ),
+            )
 
         prefill_request_ids = None
         prefill_workspace_starts = None
@@ -657,17 +1046,19 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         # For BF16 cache: always use global cache slots (no workspace)
         # prefill_workspace_starts has been adjusted in-place per chunk so
         # prefill indices automatically come out chunk-local
-        topk_indices, topk_length = triton_convert_req_index_to_global_index(
-            attn_metadata.req_id_per_token,
-            attn_metadata.block_table,
-            topk_indices,
-            BLOCK_SIZE=attn_metadata.block_size,
-            NUM_TOPK_TOKENS=topk_indices.shape[1],
-            HAS_PREFILL_WORKSPACE=has_prefill_workspace,
-            prefill_workspace_request_ids=prefill_request_ids,
-            prefill_workspace_starts=prefill_workspace_starts,
-            return_valid_counts=True,
-        )
+        topk_length = None
+        if num_prefill_tokens > 0 or not use_hisparse:
+            topk_indices, topk_length = triton_convert_req_index_to_global_index(
+                attn_metadata.req_id_per_token,
+                attn_metadata.block_table,
+                topk_indices,
+                BLOCK_SIZE=attn_metadata.block_size,
+                NUM_TOPK_TOKENS=topk_indices.shape[1],
+                HAS_PREFILL_WORKSPACE=has_prefill_workspace,
+                prefill_workspace_request_ids=prefill_request_ids,
+                prefill_workspace_starts=prefill_workspace_starts,
+                return_valid_counts=True,
+            )
 
         fp8_metadata = attn_metadata.fp8_extra_metadata
         assert isinstance(fp8_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode)
@@ -686,7 +1077,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             assert fp8_metadata.decode is not None
             attn_out, _ = self._fp8_flash_mla_kernel(
                 q=q,
-                kv_c_and_k_pe_cache=kv_c_and_k_pe_cache,
+                kv_c_and_k_pe_cache=decode_cache,
                 topk_indices=topk_indices,
                 kernel_metadata=fp8_metadata.decode.kernel_metadata,
             )
@@ -694,13 +1085,11 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             #              -> (num_decode_tokens, num_heads, head_dim_v)
             return reshape_attn_output_for_spec_decode(attn_out)
 
-        num_decode_tokens = fp8_metadata.num_decode_tokens
-        num_prefill_tokens = fp8_metadata.num_prefill_tokens
-
         # Pure decode: direct call without allocation
         if num_decode_tokens > 0 and num_prefill_tokens == 0:
             assert fp8_metadata.decode is not None
-            attn_out = _fp8_decode(q, topk_indices)
+            attn_out = _fp8_decode(q, decode_topk if decode_topk is not None
+                                   else topk_indices)
         else:
             # Mixed or pure prefill: allocate output tensor
             attn_out = q.new_empty(
@@ -712,16 +1101,25 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             if num_decode_tokens > 0:
                 attn_out[:num_decode_tokens] = _fp8_decode(
                     q[:num_decode_tokens],
-                    topk_indices[:num_decode_tokens],
+                    decode_topk
+                    if decode_topk is not None
+                    else topk_indices[:num_decode_tokens],
                 )
 
             assert fp8_metadata.prefill is not None
+            host_resident = use_hisparse and kv_c_and_k_pe_cache.device.type == "cpu"
             for chunk in fp8_metadata.prefill.chunks:
                 chunk_workspace = self.prefill_bf16_workspace[: chunk.chunk_tot_seqlen]
+                if host_resident:
+                    gather_cache, gather_bt = self._hisparse_host_prefill_cache(
+                        kv_c_and_k_pe_cache, chunk.block_table, chunk.seq_lens
+                    )
+                else:
+                    gather_cache, gather_bt = kv_c_and_k_pe_cache, chunk.block_table
                 ops.cp_gather_and_upconvert_fp8_kv_cache(
-                    kv_c_and_k_pe_cache,
+                    gather_cache,
                     chunk_workspace,
-                    chunk.block_table,
+                    gather_bt,
                     chunk.seq_lens,
                     chunk.workspace_starts,
                     len(chunk.block_table),
@@ -729,6 +1127,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
 
                 chunk_q = q[chunk.tokens_slice]
                 chunk_topk_indices_workspace = topk_indices[chunk.tokens_slice]
+                assert topk_length is not None
                 chunk_topk_length = topk_length[chunk.tokens_slice]
 
                 attn_out[chunk.tokens_slice] = self._bf16_flash_mla_kernel(
@@ -753,21 +1152,85 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         prefill kernel which has head padding overhead when num_heads is small.
         Used when use_mixed_batch is True.
         """
-        # Convert per-request indices to global slots (decode) or workspace
-        # offsets (prefill).
-        topk_indices = triton_convert_req_index_to_global_index(
-            attn_metadata.req_id_per_token,
-            attn_metadata.block_table,
-            topk_indices,
-            BLOCK_SIZE=attn_metadata.block_size,
-            NUM_TOPK_TOKENS=topk_indices.shape[1],
-        )
+        # Set by prepare_hisparse_for_batch on the same metadata this step.
+        if self._hisparse_decode_batch:
+            kv_c_and_k_pe_cache, topk_indices = self._hisparse_swap_in(
+                kv_c_and_k_pe_cache,
+                topk_indices,
+                attn_metadata,
+            )
+            assert attn_metadata.fp8_extra_metadata is not None
+            assert isinstance(
+                attn_metadata.fp8_extra_metadata,
+                FlashMLASparseMetadata.FP8KernelMetadata,
+            )
+            fp8_metadata = attn_metadata.fp8_extra_metadata
+            _attn_out, _ = self._fp8_flash_mla_kernel(
+                q=q.unsqueeze(0),
+                kv_c_and_k_pe_cache=kv_c_and_k_pe_cache,
+                topk_indices=topk_indices.unsqueeze(0),
+                kernel_metadata=fp8_metadata,
+            )
+            return _attn_out.squeeze(0)
 
         assert attn_metadata.fp8_extra_metadata is not None
         assert isinstance(
             attn_metadata.fp8_extra_metadata, FlashMLASparseMetadata.FP8KernelMetadata
         )
         fp8_metadata = attn_metadata.fp8_extra_metadata
+
+        block_table = attn_metadata.block_table
+        req_id_per_token = attn_metadata.req_id_per_token
+        decode_out: torch.Tensor | None = None
+        if kv_c_and_k_pe_cache.device.type == "cpu":
+            num_decode_tokens = attn_metadata.num_decode_tokens
+            if num_decode_tokens > 0:
+                # Mixed batch on a host-resident pool: serve decode tokens
+                # from the hot buffer, exactly like the pure-decode branch.
+                # The newest rows went to the host pool this step
+                # (write_rows_to_host), so slot_mapping=None mixed mode
+                # resolves them as misses.
+                decode_cache, decode_topk = self._hisparse_swap_in(
+                    kv_c_and_k_pe_cache,
+                    topk_indices,
+                    attn_metadata,
+                    num_decode_tokens=num_decode_tokens,
+                )
+                decode_metadata = fp8_metadata
+                if num_decode_tokens < attn_metadata.num_actual_tokens:
+                    decode_metadata = fp8_metadata.decode_split
+                    fp8_metadata = fp8_metadata.prefill_split
+                    assert (
+                        decode_metadata is not None and fp8_metadata is not None
+                    ), "host-resident mixed batch requires split FP8 metadata"
+                _decode_out, _ = self._fp8_flash_mla_kernel(
+                    q=q[:num_decode_tokens].unsqueeze(0),
+                    kv_c_and_k_pe_cache=decode_cache,
+                    topk_indices=decode_topk.unsqueeze(0),
+                    kernel_metadata=decode_metadata,
+                )
+                decode_out = _decode_out.squeeze(0)
+                if num_decode_tokens == attn_metadata.num_actual_tokens:
+                    return decode_out
+                q = q[num_decode_tokens:]
+                topk_indices = topk_indices[num_decode_tokens:]
+            # Host-resident pool + local prefill: stage the prefill rows'
+            # context on GPU.
+            kv_c_and_k_pe_cache, block_table, req_id_per_token = (
+                self._hisparse_stage_prefill_rows(
+                    kv_c_and_k_pe_cache, attn_metadata
+                )
+            )
+
+        # Convert per-request indices to global slots (decode) or staged
+        # slots (local prefill).
+        topk_indices = triton_convert_req_index_to_global_index(
+            req_id_per_token,
+            block_table,
+            topk_indices,
+            BLOCK_SIZE=attn_metadata.block_size,
+            NUM_TOPK_TOKENS=topk_indices.shape[1],
+        )
 
         _attn_out, _ = self._fp8_flash_mla_kernel(
             q=q.unsqueeze(0),  # unsqueeze to add batch_dim: (T, H, D) -> (1, T, H, D)
@@ -777,7 +1240,11 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
         )
 
         # Output is (1, T, H, D_v), squeeze back to (T, H, D_v)
-        return _attn_out.squeeze(0)
+        attn_out = _attn_out.squeeze(0)
+        if decode_out is None:
+            return attn_out
+        # Stitch back in batch token order: decode tokens first, prefill after.
+        return torch.cat([decode_out, attn_out], dim=0)
 
     def _fp8_flash_mla_kernel(
         self,

--- a/vllm/v1/attention/backends/mla/hisparse.py
+++ b/vllm/v1/attention/backends/mla/hisparse.py
@@ -1,0 +1,941 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Experimental HiSparse hot-buffer decode for sparse MLA (GLM-5 / DSA).
+
+Port of SGLang's HiSparse decode design to vLLM's attention-backend boundary.
+HiSparse keeps the full-size MLA KV off the GPU and serves decode from a small
+per-request device hot buffer; that is what frees GPU memory for higher decode
+concurrency.
+
+- Full-size KV residency. The MLA KV layers are allocated in pinned host
+  memory (see ``_is_hisparse_host_layer`` and ``_allocate_kv_cache_tensors``
+  in the cache utils / model runner); only the GPU indexer pool and the
+  per-request hot buffers stay on device. Decode-step writes land in the
+  reserved hot slot and are scattered back to the host pool by a CUDA kernel
+  writing straight into pinned memory, so the backup is stream-ordered with
+  the decode kernels and needs no host synchronization.
+- Each batch row owns a fixed per-layer hot region of
+  ``region_stride = round_up(device_buffer_size + 1, 128)`` KV rows (padded to
+  128 so the flat buffer can be viewed with any kernel page size up to 128).
+  Slots ``[0, device_buffer_size)`` are LRU-managed; slot ``device_buffer_size``
+  is reserved for the newest token, which the KV-cache update writes there
+  directly.
+- At decode time, the indexer's top-k positions are converted to global slot
+  ids and a swap-in kernel resolves them against the hot region: hits are
+  reused, misses are copied from the pinned host pool, and the LRU order is
+  updated.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.utils.math_utils import round_up
+from vllm.v1.attention.backends.mla.sparse_utils import (
+    triton_convert_req_index_to_global_index,
+)
+
+logger = init_logger(__name__)
+
+# fp8_ds_mla KV row: 512 B quantized NoPE + 16 B scales + 128 B RoPE.
+FP8_DS_MLA_ROW_BYTES = 656
+
+# Hot regions are padded to a multiple of this so the flat hot buffer can be
+# viewed with any kernel page size up to 128.
+HOT_REGION_ALIGN = 128
+
+# Warn when the estimated hot-buffer footprint exceeds this fraction of total
+# GPU memory (model load will likely OOM).
+HOT_BUFFER_GPU_WARN_FRACTION = 0.5
+
+def is_hisparse_decode_batch(
+    *,
+    max_query_len: int,
+    num_reqs: int,
+    num_actual_tokens: int,
+) -> bool:
+    return max_query_len == 1 and num_reqs == num_actual_tokens
+
+@dataclass(frozen=True)
+class HiSparseConfig:
+    top_k: int
+    device_buffer_size: int
+    host_pool_gib: float
+
+    @classmethod
+    def from_vllm_config(
+        cls,
+        vllm_config: VllmConfig,
+        model_top_k: int,
+    ) -> HiSparseConfig | None:
+        raw_config = vllm_config.attention_config.hisparse_config
+        if raw_config is None:
+            return None
+
+        known_keys = {"device_buffer_size", "host_pool_gib"}
+        unknown_keys = set(raw_config) - known_keys
+        if unknown_keys:
+            raise ValueError(
+                f"Unknown hisparse_config keys: {sorted(unknown_keys)}. "
+                f"Known keys: {sorted(known_keys)}."
+            )
+
+        # Default 2x top_k: at exactly top_k the LRU has zero slack and
+        # boundary entries thrash between steps.
+        device_buffer_size = int(
+            raw_config.get("device_buffer_size", 2 * model_top_k)
+        )
+        if raw_config.get("host_pool_gib") is None:
+            raise ValueError(
+                "HiSparse requires hisparse_config.host_pool_gib: size it as "
+                "(usable node RAM - co-tenants) / ranks-per-node."
+            )
+        host_pool_gib = float(raw_config["host_pool_gib"])
+
+        if device_buffer_size < model_top_k:
+            raise ValueError(
+                "HiSparse device_buffer_size must be at least the model's "
+                f"index_topk. Got device_buffer_size={device_buffer_size}, "
+                f"index_topk={model_top_k}."
+            )
+        if host_pool_gib <= 0:
+            raise ValueError("HiSparse host_pool_gib must be positive.")
+
+        return cls(
+            top_k=model_top_k,
+            device_buffer_size=device_buffer_size,
+            host_pool_gib=host_pool_gib,
+        )
+
+
+# One per device, shared by all per-layer coordinators: number of real
+# (non-CUDA-graph-padding) requests in the current batch. Updated by the
+# model runner outside captured regions; read by the swap-in kernel from
+# device memory so graph replays observe the per-step value.
+_NUM_REAL_REQS: dict[torch.device, torch.Tensor] = {}
+
+def get_num_real_reqs_tensor(device: torch.device) -> torch.Tensor:
+    tensor = _NUM_REAL_REQS.get(device)
+    if tensor is None:
+        # Default to "all rows are real" so standalone use (tests, eager
+        # deployments without the runner hook) processes every row; the model
+        # runner overwrites this each step when driving CUDA graphs.
+        tensor = torch.full((1,), torch.iinfo(torch.int32).max, dtype=torch.int32,
+                            device=device)
+        _NUM_REAL_REQS[device] = tensor
+    return tensor
+
+# Plan-producing coordinators register here for telemetry; index-sharing
+# "shared" layers deregister via join_group (their leader's counter, with
+# stats_row_bytes summed over the group, covers them).
+_STATS: list["HiSparseCoordinator"] = []
+_STATS_INTERVAL = 2000
+_stats_calls = 0
+_stats_last = (0, 0, 0)
+
+def _maybe_log_hisparse_stats() -> None:
+    """Log aggregate hot-buffer hit rate + PCIe gather volume periodically.
+
+    Counters accumulate in-kernel (graph-safe); this host-side read costs a
+    few tiny D2H copies every _STATS_INTERVAL steps.
+    """
+    global _stats_calls, _stats_last
+    _stats_calls += 1
+    if not _STATS or _stats_calls % _STATS_INTERVAL != 0:
+        return
+    hits = misses = gather_bytes = 0
+    for c in _STATS:
+        h, m = c._swap_stats.cpu().tolist()
+        hits += h
+        misses += m
+        gather_bytes += m * c.stats_row_bytes
+    d_hits = hits - _stats_last[0]
+    d_misses = misses - _stats_last[1]
+    d_bytes = gather_bytes - _stats_last[2]
+    _stats_last = (hits, misses, gather_bytes)
+    total = d_hits + d_misses
+    if total == 0:
+        return
+    logger.info(
+        "HiSparse (last %d steps): hit rate %.1f%%, %.2f GiB gathered "
+        "host->device (%d misses).",
+        _STATS_INTERVAL,
+        100.0 * d_hits / total,
+        d_bytes / 2**30,
+        d_misses,
+    )
+
+def set_num_real_reqs(num_reqs: int) -> None:
+    """Called by the model runner before each (real or dummy) forward."""
+    for tensor in _NUM_REAL_REQS.values():
+        tensor.fill_(num_reqs)
+    _maybe_log_hisparse_stats()
+
+def _leader_coordinators(
+    static_forward_context: dict,
+) -> list[HiSparseCoordinator]:
+    """Coordinators owning live hot-buffer state (dgi/lru).
+
+    Index-sharing "shared" layers replay their leader's plan and never write
+    dgi/lru, so per-block/per-row state maintenance skips them.
+    """
+    return [
+        coordinator
+        for layer in static_forward_context.values()
+        if (coordinator := getattr(getattr(layer, "impl", None),
+                                   "hisparse_coordinator", None)) is not None
+        and coordinator.leader is None
+    ]
+
+# Persistent pinned staging for the per-step H2D index uploads below
+# (invalidated slots, reset rows). One shared buffer is
+# safe: these uploads run eagerly at batch preparation, never under
+# CUDA-graph capture, and the event guards against overwriting bytes a
+# previous upload's async copy is still reading.
+_PINNED_STAGING: torch.Tensor | None = None
+_PINNED_STAGING_EVENT: torch.cuda.Event | None = None
+
+# Host ranges the model runner pinned via cudaHostRegister for the
+# host-resident pool. torch's Tensor.is_pinned() only recognizes memory from
+# its own caching host allocator, so bind_source_cache consults this registry
+# for the fail-loud "pool must be pinned" check.
+_REGISTERED_HOST_RANGES: list[tuple[int, int]] = []
+
+def note_registered_host_range(ptr: int, nbytes: int) -> None:
+    _REGISTERED_HOST_RANGES.append((ptr, nbytes))
+
+def discard_registered_host_range(ptr: int) -> None:
+    global _REGISTERED_HOST_RANGES
+    _REGISTERED_HOST_RANGES = [
+        (p, n) for p, n in _REGISTERED_HOST_RANGES if p != ptr
+    ]
+
+def _covers_registered_host_range(ptr: int, nbytes: int) -> bool:
+    return any(
+        p <= ptr and ptr + nbytes <= p + n for p, n in _REGISTERED_HOST_RANGES
+    )
+
+def release_pinned_state() -> bool:
+    """Drop every module/coordinator reference to pinned host memory.
+
+    Graceful teardown (drain-then-free): the runner unpins the host pool
+    itself (cudaHostUnregister); this drops the module-level pinned staging
+    buffer and every coordinator's pool reference so the caller can return
+    the allocator-owned staging blocks to the OS. Shared (index-sharing)
+    coordinators are removed from _STATS by join_group, so they are reached
+    through their leader's group_shared list. Returns whether any pinned
+    reference was held.
+    """
+    global _PINNED_STAGING, _PINNED_STAGING_EVENT
+    released = _PINNED_STAGING is not None
+    _PINNED_STAGING = None
+    _PINNED_STAGING_EVENT = None
+    for leader in _STATS:
+        for coordinator in (leader, *leader.group_shared):
+            if coordinator._host_cache is not None:
+                coordinator._host_cache = None
+                released = True
+    _STATS.clear()
+    return released
+
+
+def _pinned_to_device(values: list[int], device: torch.device) -> torch.Tensor:
+    """Copy a small int list to ``device`` via pinned staging (grow-on-demand,
+    power-of-2) instead of a per-step pageable tensor."""
+    global _PINNED_STAGING, _PINNED_STAGING_EVENT
+    n = len(values)
+    if _PINNED_STAGING is None or _PINNED_STAGING.shape[0] < n:
+        size = 1 << max(10, (n - 1).bit_length())
+        _PINNED_STAGING = torch.empty(size, dtype=torch.long, pin_memory=True)
+        _PINNED_STAGING_EVENT = None
+    if _PINNED_STAGING_EVENT is not None:
+        _PINNED_STAGING_EVENT.synchronize()
+    staging = _PINNED_STAGING[:n]
+    staging.copy_(torch.from_numpy(np.asarray(values, dtype=np.int64)))
+    out = staging.to(device, non_blocking=True)
+    if _PINNED_STAGING_EVENT is None:
+        _PINNED_STAGING_EVENT = torch.cuda.Event()
+    _PINNED_STAGING_EVENT.record(torch.cuda.current_stream(device))
+    return out
+
+def invalidate_blocks(
+    static_forward_context: dict, block_ids: list[int], block_size: int
+) -> None:
+    """Drop cached HiSparse state for the given blocks in every layer.
+
+    Called by the model runner when blocks are (re)assigned to newly scheduled
+    or preemption-resumed requests, before any forward step can select them.
+    This makes block recycling safe for any writer (local prefill, connector
+    RDMA into host memory) without per-connector reporting hooks.
+    """
+    if not block_ids:
+        return
+    slots: torch.Tensor | None = None
+    for coordinator in _leader_coordinators(static_forward_context):
+        if slots is None:
+            # Built once on device and shared by every leader.
+            blocks = _pinned_to_device(block_ids, coordinator.device)
+            offsets = torch.arange(
+                block_size, dtype=torch.long, device=coordinator.device
+            )
+            slots = (blocks[:, None] * block_size + offsets[None, :]).flatten()
+        coordinator.invalidate_slots(slots)
+
+def reset_rows(static_forward_context: dict, row_ids: list[int]) -> None:
+    """Drop per-row HiSparse hot-buffer state in every layer."""
+    if not row_ids:
+        return
+    rows: torch.Tensor | None = None
+    for coordinator in _leader_coordinators(static_forward_context):
+        if rows is None:
+            rows = _pinned_to_device(row_ids, coordinator.device)
+        coordinator.reset_hot_rows(rows)
+
+def _has_hisparse_ops() -> bool:
+    try:
+        try:
+            import vllm._C_stable_libtorch  # noqa: F401
+        except ImportError:
+            import vllm._C  # noqa: F401
+    except ImportError:
+        return False
+    if not hasattr(torch.ops, "_C_cache_ops"):
+        return False
+    return (
+        hasattr(torch.ops._C_cache_ops, "hisparse_swap_in")
+        and hasattr(torch.ops._C_cache_ops, "hisparse_gather_plan")
+        and hasattr(torch.ops._C_cache_ops, "hisparse_backup")
+    )
+
+class _GroupPlan:
+    """Group-shared swap-in plan for GLM-5.2 index sharing.
+
+    A "full" layer's swap_in(produce_plan=True) writes the resolved plan here;
+    its "shared" layers replay it via apply_plan without re-resolving LRU. One
+    set per (device, max_rows, top_k), shared across all coordinators -- mirrors
+    the model-global topk_indices_buffer (layers run sequentially: full writes,
+    its shared layers read, the next full overwrites). Static shapes so the
+    replay is CUDA-graph-capture safe.
+    """
+
+    __slots__ = ("global_indices", "hot_indices", "miss_mask", "valid_counts")
+
+    def __init__(self, device: torch.device, max_rows: int, top_k: int) -> None:
+        self.global_indices = torch.full(
+            (max_rows, top_k), -1, dtype=torch.int32, device=device
+        )
+        self.hot_indices = torch.full(
+            (max_rows, top_k), -1, dtype=torch.int32, device=device
+        )
+        self.miss_mask = torch.zeros(
+            (max_rows, top_k), dtype=torch.int32, device=device
+        )
+        # Populated only when the producer resolves with return_valid_counts
+        # (the bf16 path); shared layers reuse it (identical top-k -> identical
+        # counts). None until first produced.
+        self.valid_counts: torch.Tensor | None = None
+
+_GROUP_PLANS: dict[tuple[str, int, int], _GroupPlan] = {}
+
+def _get_group_plan(device: torch.device, max_rows: int, top_k: int) -> _GroupPlan:
+    key = (str(device), max_rows, top_k)
+    plan = _GROUP_PLANS.get(key)
+    if plan is None:
+        plan = _GroupPlan(device, max_rows, top_k)
+        _GROUP_PLANS[key] = plan
+    return plan
+
+_COPY_STREAMS: dict[str, "torch.cuda.Stream"] = {}
+
+def _get_copy_stream(device: torch.device) -> "torch.cuda.Stream":
+    """One dedicated copy stream per device, shared across a group's coordinators
+    for overlapped prefetch. Capturing a fork/join around work on it into a
+    FULL_DECODE_ONLY graph is supported."""
+    key = str(device)
+    s = _COPY_STREAMS.get(key)
+    if s is None:
+        s = torch.cuda.Stream(device=device)
+        _COPY_STREAMS[key] = s
+    return s
+
+class HiSparseCoordinator:
+    """Per-layer decode-time hot buffer for sparse MLA KV rows.
+
+    The pinned host-resident KV pool is the only full-size store; misses are
+    always served from it. Hot-buffer hits are keyed by global KV slot id, so
+    correctness relies on one invariant: a recycled slot's stale state is
+    dropped before reuse — the model runner invalidates all blocks
+    (re)assigned to incoming requests (covering connector RDMA loads of any
+    kind) before any step can select them.
+    """
+
+    def __init__(
+        self,
+        config: HiSparseConfig,
+        max_num_reqs: int,
+        row_width: int,
+        kv_dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> None:
+        if not _has_hisparse_ops():
+            raise RuntimeError(
+                "HiSparse requires the compiled _C_cache_ops.hisparse_swap_in/"
+                "gather_plan/backup CUDA kernels (host-resident decode has no "
+                "Python fallback). Rebuild vLLM from source so "
+                "csrc/libtorch_stable/hisparse_kernels.cu is included."
+            )
+        self.config = config
+        self.max_num_reqs = max_num_reqs
+        self.row_width = row_width
+        self.kv_dtype = kv_dtype
+        self.device = torch.device(device)
+        # One reserved slot for the newest token; the FlashMLA FP8 sparse
+        # kernel needs a paged layout and the actual block size is only known
+        # at swap-in time, hence the alignment padding.
+        self.region_stride = round_up(config.device_buffer_size + 1, HOT_REGION_ALIGN)
+
+        row_bytes = row_width * kv_dtype.itemsize
+        if row_bytes % 16 != 0:
+            raise ValueError(
+                f"HiSparse requires 16-byte aligned KV rows, got {row_bytes}B."
+            )
+
+        hot_rows = max_num_reqs * self.region_stride
+        # Allocated eagerly so vLLM's memory profiling accounts for it when
+        # sizing the main KV cache.
+        self.hot_cache = torch.zeros(
+            (hot_rows, row_width), dtype=kv_dtype, device=self.device
+        )
+        # Per-request LRU state; released in join_group for index-sharing
+        # "shared" layers, which replay their leader's plan and never resolve
+        # the LRU themselves.
+        self.device_global_indices: torch.Tensor | None = torch.full(
+            (max_num_reqs, config.device_buffer_size),
+            -1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        lru_init = torch.arange(
+            config.device_buffer_size, dtype=torch.int16, device=self.device
+        )
+        self._lru_init: torch.Tensor | None = lru_init
+        self.lru_slots: torch.Tensor | None = lru_init.repeat(
+            max_num_reqs, 1
+        ).contiguous()
+        self._newest_hot_slots = (
+            torch.arange(max_num_reqs, dtype=torch.int64, device=self.device)
+            * self.region_stride
+            + config.device_buffer_size
+        )
+
+        self.num_real_reqs = get_num_real_reqs_tensor(self.device)
+
+        # In-kernel hit/miss counters (telemetry). stats_row_bytes converts
+        # misses to gathered bytes; plan-once wiring adds each shared
+        # layer's row bytes to its leader (the shared layers re-gather the
+        # leader's misses), so the leader's counter covers the whole group.
+        self._swap_stats = torch.zeros(2, dtype=torch.uint64, device=self.device)
+        self.stats_row_bytes = row_bytes
+        _STATS.append(self)
+
+        # Group-shared plan buffers for index-sharing plan-once (see _GroupPlan).
+        self._plan = _get_group_plan(self.device, max_num_reqs, config.top_k)
+
+        # Overlapped prefetch: a "full" layer issues its group's "shared"
+        # gathers early on a copy stream, overlapping the PCIe transfer with
+        # intervening compute (measured +24% / +41% end-to-end decode
+        # throughput at c=32 / c=96 on GLM-5.2-FP8 vs inline gathers).
+        # group_shared/leader are wired via join_group; _prefetch_event is
+        # recorded on the copy stream by the leader and awaited in the shared
+        # layer's apply_plan.
+        self.group_shared: list[HiSparseCoordinator] = []
+        self.leader: HiSparseCoordinator | None = None
+        self._prefetch_event: torch.cuda.Event | None = None
+        self._copy_stream = _get_copy_stream(self.device)
+
+        self._host_cache: torch.Tensor | None = None
+        # The host backup runs inline on the current stream: the decode
+        # KV-update executes inside the FULL_DECODE_ONLY CUDA graph, where a
+        # cross-stream wait raises "dependency created on uncaptured work in
+        # another stream" and aborts capture. The per-step backup is only the
+        # batch's newest rows, so there is no overlap worth reclaiming.
+
+    def join_group(self, leader: HiSparseCoordinator) -> None:
+        """Attach to an index-sharing group as a "shared" layer.
+
+        Shared layers replay the leader's plan: they never resolve the LRU
+        (their per-request state is released) and never produce stats (their
+        re-gathered bytes are covered by the leader's miss counter).
+        """
+        self.leader = leader
+        leader.group_shared.append(self)
+        leader.stats_row_bytes += self.stats_row_bytes
+        _STATS.remove(self)
+        self.device_global_indices = None
+        self.lru_slots = None
+        self._lru_init = None
+
+    def hot_cache_paged(self, block_size: int) -> torch.Tensor:
+        """Hot buffer shaped like a regular paged MLA cache."""
+        return self.hot_cache.view(-1, block_size, self.row_width)
+
+    def bind_source_cache(self, kv_cache: torch.Tensor) -> None:
+        flat = kv_cache.view(-1, kv_cache.shape[-1])
+        if self._host_cache is not None and (
+            self._host_cache.data_ptr() == flat.data_ptr()
+            and self._host_cache.shape == flat.shape
+        ):
+            return
+
+        if kv_cache.dtype != self.kv_dtype or kv_cache.shape[-1] != self.row_width:
+            raise ValueError(
+                "HiSparse coordinator bound to a KV cache with mismatched "
+                f"layout: expected ({self.row_width}, {self.kv_dtype}), got "
+                f"({kv_cache.shape[-1]}, {kv_cache.dtype})."
+            )
+        # Host-resident pool: the cache itself is the only full-size store;
+        # every allocated slot is written before the indexer can select it.
+        if kv_cache.device.type != "cpu":
+            raise ValueError(
+                "HiSparse requires a host-resident KV pool; got a KV cache "
+                f"on {kv_cache.device}."
+            )
+        # The pool is pinned via cudaHostRegister (exact-size, deterministic
+        # unpin at shutdown); torch's is_pinned() only recognizes its own
+        # caching-host-allocator memory, so also accept ranges the model
+        # runner explicitly registered.
+        if not (
+            kv_cache.is_pinned()
+            or _covers_registered_host_range(
+                kv_cache.data_ptr(), kv_cache.nbytes
+            )
+        ):
+            raise ValueError(
+                "HiSparse host-resident KV pool must be pinned memory."
+            )
+
+        self._host_cache = flat
+        self.reset_hot_state()
+
+    def reset_hot_state(self) -> None:
+        """Drop all hot-buffer bookkeeping (hits become misses)."""
+        if self.device_global_indices is None:
+            # Shared layer: the leader owns the group's LRU state.
+            return
+        assert self.lru_slots is not None and self._lru_init is not None
+        self.device_global_indices.fill_(-1)
+        self.lru_slots.copy_(self._lru_init.expand_as(self.lru_slots))
+
+    def reset_hot_rows(self, rows: torch.Tensor) -> None:
+        """Drop hot-buffer bookkeeping for newly assigned batch rows."""
+        assert self.device_global_indices is not None
+        assert self.lru_slots is not None and self._lru_init is not None
+        self.device_global_indices[rows] = -1
+        self.lru_slots[rows] = self._lru_init
+
+    def _invalidate_hot_copies(self, slots: torch.Tensor) -> None:
+        assert self.device_global_indices is not None
+        stale = torch.isin(
+            self.device_global_indices, slots.to(device=self.device, dtype=torch.int32)
+        )
+        self.device_global_indices[stale] = -1
+
+    def invalidate_slots(self, slots: torch.Tensor) -> None:
+        """Drop all cached state for the given global slots.
+
+        Called when blocks are (re)assigned to a request, regardless of who
+        writes them (local prefill, KV connector RDMA, ...). Hot-buffer
+        copies of recycled slots must never be served as hits.
+        """
+        if self._host_cache is None:
+            return
+        self._invalidate_hot_copies(slots)
+
+    def _backup_rows(
+        self,
+        src_cache: torch.Tensor,
+        src_indices: torch.Tensor,
+        dst_slots: torch.Tensor,
+    ) -> None:
+        assert self._host_cache is not None
+        torch.ops._C_cache_ops.hisparse_backup(
+            src_cache,
+            src_indices,
+            self._host_cache,
+            dst_slots,
+        )
+
+    # ------------------------------------------------------- newest-token path
+
+    def write_newest_rows(
+        self,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,
+    ) -> None:
+        """Decode-step KV update.
+
+        Writes the newest token of each batch row to its reserved hot slot
+        (so the swap-in kernel can serve the newest token without a host
+        roundtrip), then scatters it into the host pool at its global KV slot
+        (so later steps can miss-load it).
+        """
+        from vllm import _custom_ops as ops
+
+        if kv_cache.numel() == 0:
+            return
+        self.bind_source_cache(kv_cache)
+        # Pad clamp: the forward can run more rows than the scheduler
+        # produced (DP alignment pads to a peer's batch, eager/PIECEWISE pads
+        # to a capture size) while slot_mapping stays unpadded. Real rows are
+        # always a prefix of both, so clamp instead of asserting — a length
+        # mismatch trips the backup kernel's shape check and kills the rank
+        # (and with it the whole DP fleet).
+        num_tokens = min(
+            kv_c_normed.shape[0], slot_mapping.numel(), self.max_num_reqs
+        )
+        newest_slots = self._newest_hot_slots[:num_tokens]
+        global_slots = slot_mapping[:num_tokens].to(torch.int64)
+
+        # -1-padded slots (CUDA-graph padding) are skipped by the backup
+        # kernel.
+        ops.concat_and_cache_mla(
+            kv_c_normed[:num_tokens],
+            k_pe[:num_tokens].squeeze(1),
+            self.hot_cache.view(-1, 1, self.row_width),
+            newest_slots,
+            kv_cache_dtype=kv_cache_dtype,
+            scale=k_scale,
+        )
+        self._backup_rows(
+            self.hot_cache,
+            newest_slots,
+            global_slots,
+        )
+        # Recycled-slot hygiene is handled at block-assignment time: the
+        # model runner invalidates every block (re)assigned to any request
+        # (new, resumed, or growing) before the step that first writes it,
+        # so no per-step in-graph invalidation is needed here.
+
+    def write_rows_to_host(
+        self,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,
+    ) -> None:
+        """Write prefill/mixed-batch rows directly to the host pool.
+
+        Local prefill on a decode instance (router shortcut, preemption
+        resume, recompute after a failed KV load): quantize the rows on GPU,
+        then scatter them to their global host slots via the backup kernel.
+        Recycled-slot hygiene is handled at block-assignment time by the
+        model runner, so no hot-copy invalidation is needed here.
+        """
+        from vllm import _custom_ops as ops
+
+        if kv_cache.numel() == 0:
+            return
+        self.bind_source_cache(kv_cache)
+        # CUDA graph padding can make kv_c_normed/k_pe longer than slot_mapping.
+        # Only rows represented by slot_mapping correspond to real KV writes.
+        flat_slots = slot_mapping.flatten()[: kv_c_normed.shape[0]]
+        num_rows = flat_slots.numel()
+        if num_rows == 0:
+            return
+        # Fixed shapes only: -1 (padding) slots are carried through and
+        # skipped by the backup kernel. Masking them out here
+        # (flat_slots[flat_slots >= 0]) would force a device->host sync per
+        # layer per mixed step; a few wasted copies of padded rows into the
+        # staging tensor are cheaper.
+        dst = flat_slots.to(device=self.device, dtype=torch.int64).contiguous()
+        real_kv_rows = kv_c_normed[:num_rows]
+        real_pe_rows = k_pe[:num_rows]
+
+        if kv_cache_dtype == "fp8_ds_mla":
+            rows = torch.empty(
+                (num_rows, self.row_width),
+                dtype=self.kv_dtype,
+                device=self.device,
+            )
+            ops.concat_and_cache_mla(
+                real_kv_rows,
+                real_pe_rows.squeeze(1),
+                rows.view(-1, 1, self.row_width),
+                torch.arange(num_rows, dtype=torch.int64, device=self.device),
+                kv_cache_dtype=kv_cache_dtype,
+                scale=k_scale,
+            )
+        else:
+            rows = torch.cat(
+                [real_kv_rows, real_pe_rows.squeeze(1)], dim=-1
+            ).contiguous()
+        src = torch.arange(num_rows, dtype=torch.int64, device=self.device)
+        self._backup_rows(rows, src, dst)
+
+    # ---------------------------------------------------------------- swap-in
+
+    def swap_in(
+        self,
+        *,
+        kv_cache: torch.Tensor,
+        req_id_per_token: torch.Tensor,
+        block_table: torch.Tensor,
+        topk_indices: torch.Tensor,
+        block_size: int,
+        slot_mapping: torch.Tensor | None,
+        return_valid_counts: bool = False,
+        produce_plan: bool = False,
+    ) -> (
+        tuple[torch.Tensor, torch.Tensor]
+        | tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ):
+        """Resolve top-k positions against the hot buffer.
+
+        Returns ``(hot_cache_paged, hot_indices)`` (plus ``valid_counts`` when
+        requested). ``hot_cache_paged`` has the same paged layout as a regular
+        MLA KV cache; ``hot_indices`` are global token ids within it.
+
+        When ``produce_plan`` (an index-sharing "full" layer), the resolved plan
+        (global ids, hot slots, miss mask) is also written to the group-shared
+        buffers so the group's "shared" layers can replay it via ``apply_plan``
+        without re-resolving the LRU.
+        """
+        num_tokens = topk_indices.shape[0]
+        top_k = topk_indices.shape[1]
+        if self.region_stride % block_size != 0:
+            raise ValueError(
+                f"HiSparse region_stride {self.region_stride} is not "
+                f"divisible by the kernel block_size {block_size}."
+            )
+        self.bind_source_cache(kv_cache)
+
+        converted = triton_convert_req_index_to_global_index(
+            req_id_per_token[:num_tokens],
+            block_table,
+            topk_indices,
+            BLOCK_SIZE=block_size,
+            NUM_TOPK_TOKENS=top_k,
+            BLOCK_N=128 if top_k % 128 == 0 else top_k,
+            return_valid_counts=return_valid_counts,
+        )
+        if return_valid_counts:
+            global_indices, valid_counts = converted
+        else:
+            global_indices = converted
+            valid_counts = None
+
+        # Newest tokens resolve to the reserved hot slot the KV update wrote
+        # this step, keyed by their global slot id from the slot mapping.
+        # When slot_mapping is None (mixed batches: the newest rows were
+        # written to the host pool, not the reserved hot slots), newest
+        # tokens are resolved like any other entry (miss -> host load). That
+        # is only visible for THIS layer's compute-stream gather (its own
+        # backup ran earlier in the same forward); the overlapped prefetch of
+        # the group's shared layers is gated off below, since it would read
+        # host rows their backups have not written yet.
+        newest_global = (
+            slot_mapping[:num_tokens].to(torch.int32).contiguous()
+            if slot_mapping is not None
+            else None
+        )
+
+        # For a plan producer, resolve into the group-shared buffers so the
+        # group's shared layers can replay the identical plan.
+        if produce_plan:
+            self._plan.global_indices[:num_tokens].copy_(global_indices)
+            hot_indices = self._plan.hot_indices[:num_tokens]
+            miss_mask = self._plan.miss_mask[:num_tokens]
+            # The kernel skips CUDA-graph padding rows, so their entries in
+            # the persistent plan buffer would otherwise keep stale values;
+            # refill so padded rows come out -1 (masked by attention).
+            hot_indices.fill_(-1)
+        else:
+            hot_indices = torch.full_like(global_indices, -1)
+            miss_mask = None
+
+        # Padded rows are skipped by the kernel (num_real_reqs) and must
+        # come out as -1 so the attention kernel masks them.
+        torch.ops._C_cache_ops.hisparse_swap_in(
+            self._host_cache,
+            self.hot_cache,
+            global_indices,
+            newest_global,
+            hot_indices,
+            self.device_global_indices,
+            self.lru_slots,
+            self.num_real_reqs,
+            self.region_stride,
+            miss_mask,
+            self._swap_stats,
+        )
+
+        if produce_plan:
+            # Shared layers reuse the group's counts (identical top-k).
+            self._plan.valid_counts = valid_counts
+            # Overlapped prefetch: issue the group's shared gathers early on
+            # the copy stream so their PCIe transfer overlaps intervening
+            # compute. Pure decode only (slot_mapping present): with
+            # slot_mapping=None the newest tokens are in the miss set, served
+            # from host rows the shared layers' own backups have not written
+            # yet when the copy stream forks. apply_plan then gathers inline
+            # on the compute stream, which IS ordered after each backup.
+            if self.group_shared:
+                if slot_mapping is not None:
+                    self._prefetch_group(num_tokens)
+                else:
+                    for shared in self.group_shared:
+                        shared._prefetch_event = None
+
+        if valid_counts is None:
+            return self.hot_cache_paged(block_size), hot_indices
+        return self.hot_cache_paged(block_size), hot_indices, valid_counts
+
+    def _gather_plan_into(self, num_tokens: int) -> None:
+        """Gather THIS coord's misses per the group-shared plan into its own
+        hot cache, from the host pool, on the current stream."""
+        torch.ops._C_cache_ops.hisparse_gather_plan(
+            self._host_cache,
+            self.hot_cache,
+            self._plan.global_indices[:num_tokens],
+            self._plan.hot_indices[:num_tokens],
+            self._plan.miss_mask[:num_tokens],
+            self.num_real_reqs,
+        )
+
+    def _prefetch_group(self, num_tokens: int) -> None:
+        """Leader-side: fork the copy stream from the compute stream (plan is
+        ready) and issue each shared layer's gather on it, recording a per-shared
+        event the shared layer's apply_plan awaits. Fork here + wait_event there
+        is captured into the decode graph."""
+        compute = torch.cuda.current_stream(self.device)
+        self._copy_stream.wait_stream(compute)  # fork
+        with torch.cuda.stream(self._copy_stream):
+            for shared in self.group_shared:
+                # Need the host pool bound to serve misses. Until then, the
+                # shared layer gathers inline in apply_plan.
+                if shared._host_cache is None:
+                    shared._prefetch_event = None
+                    continue
+                shared._gather_plan_into(num_tokens)
+                if shared._prefetch_event is None:
+                    shared._prefetch_event = torch.cuda.Event()
+                shared._prefetch_event.record(self._copy_stream)
+
+    # ---------------------------------------------------------- plan replay
+
+    def apply_plan(
+        self,
+        *,
+        kv_cache: torch.Tensor,
+        block_size: int,
+        num_tokens: int,
+        return_valid_counts: bool = False,
+    ) -> (
+        tuple[torch.Tensor, torch.Tensor]
+        | tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ):
+        """Replay the group's plan for an index-sharing "shared" layer.
+
+        A "full" layer resolved the plan via ``swap_in(produce_plan=True)``;
+        this gathers only THIS layer's own missed rows into the identical
+        planned hot slots, with no LRU resolution. Fixed shape -> capture-safe.
+        """
+        n = num_tokens
+        hot_indices = self._plan.hot_indices[:n]
+        if self._prefetch_event is not None:
+            # Leader already gathered this layer's misses on the copy stream;
+            # just join so attention sees them, then consume the event so the
+            # next step re-prefetches (or falls back if it can't).
+            torch.cuda.current_stream(self.device).wait_event(self._prefetch_event)
+            self._prefetch_event = None
+        else:
+            # Not prefetched (mixed batch, or host pool not yet bound): gather
+            # this layer's misses inline, same path the leader's prefetch uses.
+            self.bind_source_cache(kv_cache)
+            self._gather_plan_into(n)
+        if return_valid_counts:
+            assert self._plan.valid_counts is not None, (
+                "apply_plan(return_valid_counts=True) requires the group's full "
+                "layer to have produced the plan with counts (bf16 path)."
+            )
+            return (
+                self.hot_cache_paged(block_size),
+                hot_indices,
+                self._plan.valid_counts[:n],
+            )
+        return self.hot_cache_paged(block_size), hot_indices
+
+def create_hisparse_coordinator(
+    vllm_config: VllmConfig,
+    model_top_k: int,
+    *,
+    row_width: int,
+    kv_dtype: torch.dtype,
+    device: torch.device | str | None = None,
+) -> HiSparseCoordinator | None:
+    config = HiSparseConfig.from_vllm_config(vllm_config, model_top_k)
+    if config is None:
+        return None
+
+    # HiSparse targets PD decode instances, where KV arrives via a consumer
+    # connector (NIXL) into the host pool. Local prefill (preemption resume,
+    # recompute after a failed KV load) is supported but stages context
+    # host->GPU, so it is slower than a normal GPU prefill.
+    hf_config = vllm_config.model_config.hf_config
+    if not hasattr(hf_config, "index_topk"):
+        raise ValueError("HiSparse is only supported for DSA models with index_topk.")
+    if hasattr(hf_config, "compress_ratios") and len(hf_config.compress_ratios) > 0:
+        raise ValueError("This HiSparse path targets GLM-5/DSA, not DeepSeek V4.")
+
+    max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+    if device is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+
+    coordinator = HiSparseCoordinator(
+        config=config,
+        max_num_reqs=max_num_reqs,
+        row_width=row_width,
+        kv_dtype=kv_dtype,
+        device=device,
+    )
+    hot_bytes = coordinator.hot_cache.numel() * kv_dtype.itemsize
+    # Hot buffers are allocated eagerly per layer and scale with
+    # max_num_seqs; a too-large product otherwise surfaces as an unrelated
+    # CUDA OOM at model load (DeepEP buffers, weights, ...).
+    num_layers = vllm_config.model_config.get_num_layers(
+        vllm_config.parallel_config
+    )
+    total_gpu = torch.cuda.get_device_properties(coordinator.device).total_memory
+    if num_layers * hot_bytes > HOT_BUFFER_GPU_WARN_FRACTION * total_gpu:
+        logger.warning_once(
+            "HiSparse hot buffers need %.1f GiB of GPU memory (%d layers x "
+            "max_num_seqs=%d x device_buffer_size=%d). This usually OOMs at "
+            "model load; lower max_num_seqs on decode instances.",
+            num_layers * hot_bytes / 2**30,
+            num_layers,
+            max_num_reqs,
+            config.device_buffer_size,
+        )
+    logger.info_once(
+        "Enabled experimental HiSparse sparse MLA hot buffer: top_k=%d, "
+        "device_buffer_size=%d (region_stride=%d), host_pool_gib=%s, "
+        "%.1f MiB GPU hot buffer per layer (max_num_seqs=%d).",
+        config.top_k,
+        config.device_buffer_size,
+        coordinator.region_stride,
+        config.host_pool_gib,
+        hot_bytes / 2**20,
+        max_num_reqs,
+    )
+    return coordinator

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -48,9 +48,12 @@ def _prepare_uniform_decode_kernel(
     req_id = idx // max_decode_len
     local_idx = idx % max_decode_len
 
-    # Compute number of KVs attended to by this token.
+    # Compute number of KVs attended to by this token. Clamp to 0: DP-padded
+    # and idle-companion rows carry seq_len 0, which goes negative here and
+    # reinterprets as ~4e9 in the uint32-reading top-k kernels (illegal
+    # memory access).
     seq_len = tl.load(seq_lens_ptr + req_id)
-    per_token_seq_len = seq_len - max_decode_len + local_idx + 1
+    per_token_seq_len = tl.maximum(seq_len - max_decode_len + local_idx + 1, 0)
     tl.store(decode_seq_lens_ptr + idx, per_token_seq_len)
 
     # Copy block table row.
@@ -459,12 +462,14 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 seq_lens_buffer = self.decode_seq_lens_buffer[
                     : num_decodes * max_decode_len
                 ].view(num_decodes, max_decode_len)
+                # clamp: DP-padded/idle rows (seq_len 0) go negative here and
+                # reinterpret as ~4e9 in the uint32-reading top-k kernels.
                 seq_lens_buffer[:] = (
                     seq_lens.unsqueeze(1)
                     - max_decode_len
                     + 1
                     + self.offsets_buffer[:max_decode_len]
-                )
+                ).clamp_(min=0)
                 seq_lens = seq_lens_buffer
             return seq_lens, block_table, decode_lens, num_decodes, requires_padding
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1315,6 +1315,64 @@ def _get_kv_cache_config_packed(
 _get_kv_cache_config_deepseek_v4 = _get_kv_cache_config_packed
 
 
+def _is_hisparse_host_layer(layer_name: str) -> bool:
+    """Whether a layer's KV tensor moves to pinned host memory."""
+    return ".indexer" not in layer_name
+
+
+def _hisparse_host_pool_bytes(vllm_config: VllmConfig) -> int | None:
+    """Per-rank pinned host budget for HiSparse host-resident KV.
+
+    ``host_pool_gib`` is parsed and validated by
+    ``HiSparseConfig.from_vllm_config`` -- the single source of truth shared
+    with the per-layer coordinator -- so sizing here cannot drift from the
+    decode path.
+    """
+    from vllm.v1.attention.backends.mla.hisparse import HiSparseConfig
+
+    if vllm_config.attention_config.hisparse_config is None:
+        return None
+    config = HiSparseConfig.from_vllm_config(
+        vllm_config, vllm_config.model_config.hf_config.index_topk
+    )
+    assert config is not None
+    return int(config.host_pool_gib * 2**30)
+
+
+def _hisparse_gpu_host_usage_split(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> tuple[int, int] | None:
+    """(gpu_bytes, host_bytes) for one max_model_len request when HiSparse
+    host residency applies to this group layout, else None.
+
+    Host-resident MLA layers are budgeted against the pinned host pool (see
+    ``get_kv_cache_config_from_groups``), so admission and auto-fit must not
+    count their bytes against GPU memory.
+    """
+    if vllm_config.attention_config.hisparse_config is None:
+        return None
+    if not (
+        len(kv_cache_groups) == 1
+        and isinstance(kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs)
+    ):
+        return None
+    per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
+    host_bytes = sum(
+        spec.max_memory_usage_bytes(vllm_config)
+        for name, spec in per_layer_specs.items()
+        if _is_hisparse_host_layer(name)
+    )
+    if host_bytes == 0:
+        return None
+    gpu_bytes = sum(
+        spec.max_memory_usage_bytes(vllm_config)
+        for name, spec in per_layer_specs.items()
+        if not _is_hisparse_host_layer(name)
+    )
+    return gpu_bytes, host_bytes
+
+
 def get_kv_cache_config_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
@@ -1347,10 +1405,68 @@ def get_kv_cache_config_from_groups(
         # Special case: all layers have the same type of KV cache but with
         # different hidden sizes. Allocate different amount of memory for each
         # layer based on its hidden size.
-        num_blocks = (
-            available_memory // kv_cache_groups[0].kv_cache_spec.page_size_bytes
-        )
-        num_blocks = may_override_num_blocks(vllm_config, num_blocks)
+        hisparse_host_budget = _hisparse_host_pool_bytes(vllm_config)
+        if hisparse_host_budget is not None:
+            specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
+            host_page = sum(
+                spec.page_size_bytes
+                for name, spec in specs.items()
+                if _is_hisparse_host_layer(name)
+            )
+            gpu_page = sum(
+                spec.page_size_bytes
+                for name, spec in specs.items()
+                if not _is_hisparse_host_layer(name)
+            )
+            assert host_page > 0, (
+                "HiSparse host-resident mode requires MLA KV layers."
+            )
+            num_blocks = hisparse_host_budget // host_page
+            if gpu_page > 0:
+                num_blocks = min(num_blocks, available_memory // gpu_page)
+            num_blocks = may_override_num_blocks(vllm_config, num_blocks)
+            if num_blocks <= 0:
+                raise ValueError(
+                    "HiSparse host-resident KV has no allocatable blocks. "
+                    f"host_budget={hisparse_host_budget / 2**30:.2f} GiB, "
+                    f"host_page={host_page / 2**20:.2f} MiB, "
+                    f"gpu_page={gpu_page / 2**20:.2f} MiB."
+                )
+            # Derive the requirement from the spec so rounding and context-
+            # parallel sharding cannot disagree with the fits()/admission
+            # checks (max_memory_usage_bytes divides by dcp*pcp per rank).
+            # Skip when num_blocks was forced (num_gpu_blocks_override): the
+            # CUDA-graph profiling path builds a deliberately minimal config,
+            # and an explicit operator override owns its own sizing.
+            group_spec = kv_cache_groups[0].kv_cache_spec
+            max_len_blocks = cdiv(
+                group_spec.max_memory_usage_bytes(vllm_config),
+                group_spec.page_size_bytes,
+            )
+            override = vllm_config.cache_config.num_gpu_blocks_override
+            if override is None and max_len_blocks > num_blocks:
+                raise ValueError(
+                    "HiSparse host-resident KV cannot hold one max_model_len "
+                    f"({vllm_config.model_config.max_model_len}) request: it "
+                    f"needs {max_len_blocks} blocks but only {num_blocks} fit "
+                    f"(host budget {hisparse_host_budget / 2**30:.1f} GiB, "
+                    f"GPU indexer budget {available_memory / 2**30:.1f} "
+                    "GiB). Raise hisparse_config.host_pool_gib / GPU "
+                    "memory, or lower max_model_len."
+                )
+            logger.info(
+                "HiSparse host-resident KV: %.1f GiB pinned host per rank for "
+                "MLA layers, %.1f GiB GPU for indexer layers (%d logical "
+                "blocks).",
+                num_blocks * host_page / 2**30,
+                num_blocks * gpu_page / 2**30,
+                num_blocks,
+            )
+        else:
+            num_blocks = (
+                available_memory // kv_cache_groups[0].kv_cache_spec.page_size_bytes
+            )
+            num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
         kv_cache_tensors = [
             KVCacheTensor(
@@ -1816,6 +1932,12 @@ def _max_memory_usage_bytes_from_groups(
         kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
     ):
         # UniformTypeKVCacheSpecs special case (single group, per-layer specs)
+        split = _hisparse_gpu_host_usage_split(vllm_config, kv_cache_groups)
+        if split is not None:
+            # Only GPU-resident (indexer) layers count against GPU memory;
+            # the host part is validated against the pinned host budget in
+            # get_kv_cache_config_from_groups and _estimate_max_model_len.
+            return split[0]
         per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
         return sum(
             spec.max_memory_usage_bytes(vllm_config)
@@ -1871,9 +1993,22 @@ def _estimate_max_model_len_from_groups(
     Returns 0 if even 1 token doesn't fit.
     """
     original_max = vllm_config.model_config.max_model_len
+    hisparse_host_budget = (
+        _hisparse_host_pool_bytes(vllm_config)
+        if _hisparse_gpu_host_usage_split(vllm_config, kv_cache_groups) is not None
+        else None
+    )
 
     def fits(model_len: int) -> bool:
         vllm_config.model_config.max_model_len = model_len
+        if hisparse_host_budget is not None:
+            split = _hisparse_gpu_host_usage_split(vllm_config, kv_cache_groups)
+            assert split is not None
+            gpu_bytes, host_bytes = split
+            return (
+                gpu_bytes <= available_memory
+                and host_bytes <= hisparse_host_budget
+            )
         return (
             _max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups)
             <= available_memory

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1124,6 +1124,122 @@ class GPUModelRunner(
             self.async_output_copy_stream = stream
         return stream
 
+    def _hisparse_host_resident_layers(self) -> set[str]:
+        """Layer names whose KV tensors live in pinned host memory."""
+        if self.vllm_config.attention_config.hisparse_config is None:
+            return set()
+        layers = set()
+        for name, layer in self.compilation_config.static_forward_context.items():
+            impl = getattr(layer, "impl", None)
+            if getattr(impl, "hisparse_coordinator", None) is not None:
+                layers.add(name)
+        return layers
+
+    def _hisparse_invalidate_new_request_blocks(
+        self, scheduler_output: "SchedulerOutput"
+    ) -> None:
+        """Drop HiSparse state for every block (re)assigned this step.
+
+        This is the single invalidation point for recycled blocks: hot-buffer
+        hits are keyed by global slot id, and a row's top-k can only name
+        slots in its own block table, so purging stale hot copies whenever a
+        block is assigned — to a new request, a resumed request, or a running
+        request that grew — keeps every later hit byte-correct.
+        """
+        if self.vllm_config.attention_config.hisparse_config is None:
+            return
+
+        block_ids: list[int] = []
+        for new_req in scheduler_output.scheduled_new_reqs:
+            block_ids.extend(new_req.block_ids[0])
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for new_block_ids in cached_reqs.new_block_ids:
+            if new_block_ids is not None:
+                block_ids.extend(new_block_ids[0])
+        if not block_ids:
+            return
+
+        from vllm.v1.attention.backends.mla.hisparse import invalidate_blocks
+
+        invalidate_blocks(
+            self.compilation_config.static_forward_context,
+            block_ids,
+            self.kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size,
+        )
+
+    def _hisparse_reset_batch_rows(self, row_ids: list[int]) -> None:
+        """Reset hot-buffer state for persistent-batch rows being assigned."""
+        if self.vllm_config.attention_config.hisparse_config is None:
+            return
+
+        from vllm.v1.attention.backends.mla.hisparse import reset_rows
+
+        reset_rows(self.compilation_config.static_forward_context, row_ids)
+
+    def _hisparse_set_num_real_reqs(self, num_reqs: int) -> None:
+        """Publish the real (unpadded) request count for the swap-in kernel.
+
+        The HiSparse swap-in kernel skips CUDA-graph padding rows by reading
+        this count from device memory, so it must be set before every (real or
+        dummy) forward — graph replays observe the per-step value.
+        """
+        if self.vllm_config.attention_config.hisparse_config is None:
+            return
+
+        from vllm.v1.attention.backends.mla.hisparse import set_num_real_reqs
+
+        set_num_real_reqs(num_reqs)
+
+    def _hisparse_check_host_memory(
+        self, kv_cache_config, host_resident_layers: set[str]
+    ) -> None:
+        """Fail fast when this rank's pinned host pool cannot fit in RAM.
+
+        Each rank checks only its OWN pool bytes against currently available
+        RAM: peers allocate concurrently, so checking the full-node need
+        against a snapshot that already reflects peers' pins would
+        double-count and spuriously reject fitting configs. A node-wide
+        advisory (total RAM vs all co-located ranks, including PP stages)
+        is emitted once, since a partial cudaHostAlloc failure mid-startup or
+        an OOM-killed co-tenant is much harder to diagnose than this warning.
+        """
+        import psutil
+
+        rank_bytes = sum(
+            t.size
+            for t in kv_cache_config.kv_cache_tensors
+            if all(name in host_resident_layers for name in t.shared_by)
+        )
+        mem = psutil.virtual_memory()
+        if rank_bytes > mem.available * 0.95:
+            raise ValueError(
+                f"HiSparse pinned host pool needs ~{rank_bytes / 2**30:.0f} "
+                f"GiB on this rank but only {mem.available / 2**30:.0f} GiB "
+                "of RAM is available. Lower hisparse_config.host_pool_gib or "
+                "leave headroom for co-tenants (KV stores, orchestrators)."
+            )
+        parallel = self.vllm_config.parallel_config
+        # Conservative per-node rank count: TP peers x PP stages x
+        # locally-hosted DP engines. Over-counts when TP/PP spans nodes,
+        # which is acceptable for a warning.
+        ranks_on_node = (
+            parallel.tensor_parallel_size
+            * parallel.pipeline_parallel_size
+            * max(parallel.data_parallel_size_local, 1)
+        )
+        need = rank_bytes * ranks_on_node
+        if need > mem.total * 0.95 and parallel.rank == 0:
+            logger.warning(
+                "HiSparse pinned host pools may need ~%.0f GiB on this node "
+                "(%d ranks x %.0f GiB) but it has %.0f GiB of RAM total. "
+                "Expect pinned allocation failures; lower "
+                "hisparse_config.host_pool_gib.",
+                need / 2**30,
+                ranks_on_node,
+                rank_bytes / 2**30,
+                mem.total / 2**30,
+            )
+
     def _update_states(self, scheduler_output: "SchedulerOutput") -> Callable | None:
         """Update the cached states and the persistent batch with the scheduler
         output.
@@ -1141,6 +1257,7 @@ class GPUModelRunner(
         self.late_interaction_runner.on_requests_finished(
             scheduler_output.finished_req_ids
         )
+        self._hisparse_invalidate_new_request_blocks(scheduler_output)
         # Remove the finished requests from the persistent batch.
         # NOTE(woosuk): There could be an edge case where finished_req_ids and
         # scheduled_req_ids overlap. This happens when a request is aborted and
@@ -1445,6 +1562,26 @@ class GPUModelRunner(
         self.input_batch.condense()
         # Allow attention backend to reorder the batch, potentially
         self._may_reorder_batch(scheduler_output)
+
+        # Reset on the requests' FINAL rows: condense/reorder can
+        # move a just-added request (e.g. short_extend classification swaps it
+        # past the decode region) and per-row hot state does not follow moves.
+        # Rows are safe against async KV receives (e.g. NIXL RDMA) without a
+        # per-connector signal: a receiving request is only admitted after its
+        # receive completes, so its row is reset here, and
+        # _hisparse_invalidate_new_request_blocks dropped stale hot copies of
+        # its (freshly assigned) block slots across all rows. Running requests
+        # moved by condense need no reset: hits are keyed by global slot id
+        # and invalidate_blocks drops recycled slots across all rows, so
+        # inherited entries can only hit on slots whose host-pool bytes are
+        # still valid.
+        if reqs_to_add:
+            self._hisparse_reset_batch_rows(
+                [
+                    self.input_batch.req_id_to_index[req.req_id]
+                    for req in reqs_to_add
+                ]
+            )
         # Refresh batch metadata with any pending updates.
         self.input_batch.refresh_metadata()
 
@@ -4306,6 +4443,10 @@ class GPUModelRunner(
             self.model_config.is_encoder_decoder and num_encoder_reqs > 0
         )
 
+        # Publish the real request count so the HiSparse swap-in kernel skips
+        # CUDA-graph padding rows (no-op unless HiSparse is enabled).
+        self._hisparse_set_num_real_reqs(num_reqs)
+
         # Run the model.
         # Use persistent buffers for CUDA graphs.
         # When spec decode is enabled, defer connector finalization
@@ -5943,6 +6084,10 @@ class GPUModelRunner(
                 if num_tokens_across_dp is not None:
                     num_tokens_across_dp[:] = num_tokens_padded
 
+            # Match the real forward: only the dummy run's real rows are valid
+            # for the HiSparse swap-in kernel (the rest are graph padding).
+            self._hisparse_set_num_real_reqs(num_reqs)
+
             with (
                 self.maybe_randomize_inputs(input_ids, inputs_embeds),
                 set_forward_context(
@@ -6355,8 +6500,31 @@ class GPUModelRunner(
         from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
         from vllm.v1.worker.workspace import reset_workspace_manager
 
+        # HiSparse drain-then-free: unpin the host pool while the process can
+        # still be reaped. Runs before _cleanup_profiling_kv_cache(), whose
+        # torch.accelerator.synchronize() raises on a poisoned CUDA context
+        # and would skip this block on crashed engines. Ordering invariant:
+        # Worker.shutdown() runs ensure_kv_transfer_shutdown() (NIXL MR
+        # deregister + mooncake store close) before model_runner.shutdown(),
+        # so no RDMA registration covers these pages when they unpin.
+        self._hisparse_unregister_host_pool()
         # Calls torch.accelerator.synchronize()
         self._cleanup_profiling_kv_cache()
+        # Drop coordinator/module references to the (now unpinned) pool and
+        # the small pinned staging buffers, then return the staging blocks to
+        # the OS. Cheap: the multi-hundred-GiB pool is no longer allocator-
+        # owned, only the MB-scale grow-on-demand staging is.
+        from vllm.v1.attention.backends.mla.hisparse import release_pinned_state
+
+        if release_pinned_state():
+            try:
+                torch._C._host_emptyCache()
+            except RuntimeError as e:
+                logger.warning(
+                    "HiSparse: pinned-staging empty_cache failed at "
+                    "shutdown: %s",
+                    e,
+                )
         if current_platform.is_rocm():
             # Drop captured graphs before distributed teardown. On ROCm, delayed
             # graph destruction can surface HSA faults in the next engine startup.
@@ -6373,7 +6541,68 @@ class GPUModelRunner(
             torch.accelerator.empty_cache()
             torch.accelerator.synchronize()
 
+    def _hisparse_unregister_host_pool(self) -> None:
+        """cudaHostUnregister the HiSparse host pool (drain-then-free).
+
+        Unpinning here, inside the graceful-shutdown window, is interruptible
+        and observable; unpinning at process exit after SIGKILL runs in
+        uninterruptible kernel context, routinely outlives SLURM's kill
+        timeout, and drains the node ("Kill task failed"). On an unusable
+        CUDA context the synchronize below raises and the pool is left
+        registered — unregister could itself hang there, and kernel exit
+        reclaim is the only remaining path (sglang gates its host-pool
+        destroy to graceful exits for the same reason). Also called from
+        _cleanup_profiling_kv_cache() so the profiling-sized pool never gets
+        freed while still registered.
+        """
+        pinned = getattr(self, "_hisparse_pinned_tensors", None)
+        if not pinned:
+            return
+        try:
+            # Drain in-flight gathers/prefetch before unpinning their source.
+            torch.accelerator.synchronize()
+        except RuntimeError as e:
+            logger.warning(
+                "HiSparse: CUDA context unusable at teardown (%s); leaving "
+                "%d host-pool tensors pinned for kernel exit reclaim.",
+                e,
+                len(pinned),
+            )
+            return
+        from vllm.v1.attention.backends.mla.hisparse import (
+            discard_registered_host_range,
+        )
+
+        cudart = torch.cuda.cudart()
+        release_start = time.perf_counter()
+        freed_bytes = 0
+        while pinned:
+            tensor = pinned[-1]
+            err = cudart.cudaHostUnregister(tensor.data_ptr())
+            if err.value != 0:
+                logger.warning(
+                    "HiSparse: cudaHostUnregister failed (code=%d); leaving "
+                    "%d host-pool tensors pinned for kernel exit reclaim.",
+                    err.value,
+                    len(pinned),
+                )
+                # Clear the sticky per-thread last-error so the rest of the
+                # teardown does not surface it as a spurious failure.
+                cudart.cudaGetLastError()
+                break
+            freed_bytes += tensor.nbytes
+            discard_registered_host_range(tensor.data_ptr())
+            pinned.pop()
+        if freed_bytes:
+            logger.info(
+                "HiSparse: unpinned %.1f GiB of host pool in-process in "
+                "%.1fs (drain-then-free).",
+                freed_bytes / 2**30,
+                time.perf_counter() - release_start,
+            )
+
     def _cleanup_profiling_kv_cache(self) -> None:
+        self._hisparse_unregister_host_pool()
         torch.accelerator.synchronize()
         if hasattr(self, "kv_caches") and self.kv_caches:
             for i in range(len(self.kv_caches)):
@@ -7039,10 +7268,61 @@ class GPUModelRunner(
             dict[str, torch.Tensor]: A map between layer names to their
             corresponding memory buffer for KV cache.
         """
+        host_resident_layers = self._hisparse_host_resident_layers()
+        if host_resident_layers:
+            self._hisparse_check_host_memory(kv_cache_config, host_resident_layers)
+        host_bytes = 0
         kv_cache_raw_tensors: dict[str, torch.Tensor] = {}
         packed_backing: torch.Tensor | None = None
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
-            if kv_cache_tensor.block_stride > 0:
+            if host_resident_layers and all(
+                name in host_resident_layers for name in kv_cache_tensor.shared_by
+            ):
+                # empty, not zeros: zero-filling a pinned pool of this size is
+                # a serial multi-GB CPU memset per rank (tens of minutes of
+                # apparent boot hang across a node's ranks), and the pool
+                # never needs it — every slot the scheduler hands out is
+                # written before the indexer can select it.
+                #
+                # Pageable alloc + cudaHostRegister instead of
+                # pin_memory=True: the caching host allocator rounds every
+                # block up to the next power of 2 (a 256 GiB pool split
+                # across 78 layers pins ~312 GiB) and releases blocks only
+                # via gc reachability. Registered memory pins exactly
+                # kv_cache_tensor.size and unpins deterministically in
+                # shutdown(), leaving plain pageable pages behind — nothing
+                # for the kernel to reclaim in uninterruptible context after
+                # SIGKILL (the "Kill task failed" node drain).
+                from vllm.v1.attention.backends.mla.hisparse import (
+                    note_registered_host_range,
+                )
+                from vllm.v1.simple_kv_offload.cuda_mem_ops import pin_tensor
+
+                # Register a page-aligned, whole-page range (the slack stays
+                # inside this allocation): cudaHostRegister pins at page
+                # granularity, and two tensors sharing a heap page would fail
+                # the second registration (HostMemoryAlreadyRegistered).
+                page = 4096
+                padded_size = round_up(kv_cache_tensor.size, page)
+                backing = torch.empty(
+                    padded_size + page,
+                    dtype=torch.int8,
+                    device="cpu",
+                )
+                aligned_offset = (-backing.data_ptr()) % page
+                registered = backing[
+                    aligned_offset : aligned_offset + padded_size
+                ]
+                pin_tensor(registered)
+                note_registered_host_range(
+                    registered.data_ptr(), registered.nbytes
+                )
+                if not hasattr(self, "_hisparse_pinned_tensors"):
+                    self._hisparse_pinned_tensors: list[torch.Tensor] = []
+                self._hisparse_pinned_tensors.append(registered)
+                tensor = registered[: kv_cache_tensor.size]
+                host_bytes += kv_cache_tensor.size
+            elif kv_cache_tensor.block_stride > 0:
                 # Allocate once; all packed tensors alias the same backing.
                 if packed_backing is None:
                     packed_backing = torch.zeros(
@@ -7057,6 +7337,13 @@ class GPUModelRunner(
                 )
             for layer_name in kv_cache_tensor.shared_by:
                 kv_cache_raw_tensors[layer_name] = tensor
+        if host_bytes:
+            logger.info(
+                "HiSparse host-resident KV: allocated %.1f GiB pinned host "
+                "memory for %d MLA layers.",
+                host_bytes / 2**30,
+                len(host_resident_layers),
+            )
 
         layer_names = set()
         for group in kv_cache_config.kv_cache_groups:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1170,8 +1170,18 @@ class Worker(WorkerBase):
         gc.unfreeze()
 
         # has_kv_transfer_group can be None during interpreter shutdown.
+        # Ordering invariant: KV-transfer shutdown (NIXL MR deregister,
+        # mooncake store close) must run before model_runner.shutdown()
+        # unpins the HiSparse host pool those registrations cover. A failure
+        # here (e.g. releasing an in-progress transfer handle against a dead
+        # peer) must not skip the unpin, so tolerate and log it.
         if ensure_kv_transfer_shutdown is not None:
-            ensure_kv_transfer_shutdown()
+            try:
+                ensure_kv_transfer_shutdown()
+            except Exception:
+                logger.exception(
+                    "KV-transfer shutdown failed; continuing worker teardown."
+                )
         if ensure_ec_transfer_shutdown is not None:
             ensure_ec_transfer_shutdown()
         if self.profiler is not None:


### PR DESCRIPTION
A port of SGLang's [HiSparse](https://www.lmsys.org/blog/2026-04-10-sglang-hisparse/): full sparse-MLA KV lives in pinned host memory, decode is served from per-request GPU hot buffers holding the indexer top-k working set. Plus GLM-5.2 indexCache plan-once sharing and overlapped prefetch, which do not exist in the SGLang implementation.

**Motivation.** GLM-5 decode instances run wide-EP (DP×EP, one single-GPU engine per rank): each rank replicates attention/dense weights and carries its expert shard, DeepEP buffers, and sparse-stack workspaces — leaving O(10 GiB) of GPU KV per rank, a single-digit ceiling of long-context requests per engine (MLA's single latent head means KV cannot be TP-sharded away). In a P/D deployment that ceiling back-pressures prefill and stalls the pipeline. Sparse MLA only attends to the indexer's top-k (2048) tokens per step, so the full KV does not need to be GPU-resident.

## Results

**16-node production stack** (GLM-5.2-FP8, 8 prefill + 8 decode nodes, DP64 wide-EP decode, llm-d router, NIXL P/D, Mooncake prefill store, 160 GiB pool/rank):

- **26,056 decode tok/s sustained** at 5,173 avg / 6,092 peak of 6,144 seats (99% peak occupancy), ITL p50/p95 201/294 ms, **zero preemptions**, host pool 62% peak — 3.3× the same stack's throughput at c=1000. The binding constraint was the configured seat cap (`max_num_seqs=96` × 64 ranks), not compute, pool, or prefill (which sat nearly idle under shortcut routing).
- **A/B vs plain GPU-KV decode** — identical topology, traffic, and 50-min saturated measurement window; per-engine cumulative deltas over all 128 engines:

| decode side | GPU-KV | HiSparse |
|---|---|---|
| generation throughput | 10,653 tok/s | **12,951 tok/s** (+22%) |
| requests completed | 84,026 | **101,653** (+21%) |
| preemptions | 5,174 | **0** |
| TTFT p99 | 99.9 s | **2.5 s** |
| queue time p99 | 101 s | **0.8 s** |
| local prefix-cache hit | 40.4% | **92.2%** |
| NIXL transfer volume | 26.5 TiB (326 MiB avg) | **7.0 TiB** (35 MiB avg) |
| KV usage peak (avg) — GPU KV vs host pool | 100.0% (28.7%), pinned | **57.5%** (16.3%) |

  The baseline's failure mode is self-amplifying: preemptions evict decode-local prefix cache, forcing ~10× larger NIXL re-pulls, which deepen the KV pressure that caused the preemptions.
- **Agentic RL workload** (r2e-gym SWE tasks through the router, c=1000, 4 prefill + 2 decode nodes): GPU-KV baseline pinned at 99.9% KV with 1,533 preemptions and solved **5 of 155** rollouts (the preemption/recompute cascade starved the agent loop). HiSparse on the same nodes: zero preemptions, **585 solved**, **+124%** steady-state decode throughput.
- **Endurance under the adversarial traffic shape** (llm-d shortcut routing → decode-local mixed prefill+decode batches, c=1000, 60 min): 99.997% success (76,463 turns), zero preemptions, zero device faults, zero NIXL failed transfers or notifications.

Steady-state hot-buffer hit rates hold at 93–99% under churn.

**Quality:** greedy decode is token-identical to plain GPU-KV PD decode (8/8 on a deterministic-weights PD smoke; 6/6 on real weights). AIME24 A/B on the same rig: 0.875 (HiSparse, 120/120) vs 0.870 (baseline) — within noise. Live failure injection (prefill killed under storm load): decode survives, no lease-expiry frees, recovers with a fresh prefill.

**Deployment lesson:** HiSparse converts queue-at-KV-ceiling into accept-and-share. `max_num_seqs` becomes the admission control — size it to sustained decode compute at the target context length (or rely on orchestrator inflight caps).

## Design

- **Host-resident KV + swap-in kernel.** MLA KV tensors are allocated in pinned host memory, sized by `host_pool_gib`; only the GPU indexer pool and per-request hot buffers stay on device. Each decode step, the `hisparse_swap_in` CUDA kernel resolves the indexer top-k against a per-request LRU working set: hits reuse resident rows, misses are gathered from the host pool, and LRU state updates in-kernel. Unlike SGLang, hot entries are keyed by **global KV slot id** (host row *i* caches slot *i*), so no per-request host-location table is needed and prefix caching keeps working. Recycled slots are invalidated at block-assignment time in the model runner, covering every writer (local prefill, connector RDMA) without per-connector hooks.
- **CUDA-graph-safe** (`FULL_DECODE_ONLY`): kernels read a device-resident `num_real_reqs` scalar per replay to skip padding rows, the newest-row host backup runs inline on the capture stream, and all state buffers are statically shaped.
- **NIXL mixed DRAM/VRAM transfers.** Host MLA regions register under `device_id 0` and READs split into DRAM/VRAM descriptor lists, so prefill→decode transfer works at TP>1. A request's KV now moves as multiple transfers, so completion notifications are deferred until all finish, and failure reporting defers until every transfer handle is terminal — a posted RDMA READ cannot be aborted; reporting early would let the scheduler reuse blocks a surviving READ is still writing.
- **GLM-5.2 indexCache plan-once.** GLM-5.2 shares the indexer top-k across groups of 4 layers (`index_topk_freq=4`). Only the group's `full` layer resolves the LRU, writing a shared plan to static buffers; the indexer-less `shared` layers replay it via `hisparse_gather_plan` — a pure gather of their own missed bytes.
- **Overlapped group prefetch.** After resolving the plan, the full layer forks a copy stream and issues the shared layers' gathers on it, overlapping PCIe with the intervening attention/MoE compute; the fork/join captures into the decode graph.
- **Mixed batches are row-split**: decode rows are served from the hot buffer; only prefill rows' contexts stage host→GPU. Local prefill on a decode instance (llm-d shortcut routing, preemption resume, `kv_load_failure_policy="recompute"`) works at full context lengths.
- **Deterministic pinned-pool teardown.** The pool is pinned via `cudaHostRegister` on page-aligned pageable allocations (exact-size; the caching host allocator's pow2 rounding hides ~+22% pinned RAM at this scale) and `cudaHostUnregister`ed in `GPUModelRunner.shutdown()`. Unpinning at process exit instead runs in uninterruptible kernel context after SIGKILL and outlives scheduler kill timeouts, draining nodes. Measured on H200: 256 GiB/rank unpins in 12–15 s, 8 ranks concurrent (2 TiB/node), full process-tree exit 66 s after SIGTERM. NIXL MR deregistration orders before the unpin; connector shutdown is exception-safe.

## Configuration

```python
attention_config.hisparse_config = {
    "host_pool_gib": 160,        # required: per-rank pinned host pool
    "device_buffer_size": 4096,  # optional: hot rows/request, default 2x index_topk
}
```

- `host_pool_gib` is per rank — each DP engine owns a disjoint pool; node KV capacity is `ranks × pool`. Size as `(usable node RAM − co-tenants) / ranks-per-node`; a startup check fails fast when it cannot fit.
- Hot buffers are allocated eagerly and scale with `max_num_seqs` (~370 MB/request across GLM-5.2's 78 sparse layers at the default `device_buffer_size`). **Cap `max_num_seqs` on decode instances** (e.g. 96) — the 1024 default OOMs at model load; a startup warning names the knob.
- Intended for the decode side of a P/D deployment (`kv_consumer` + NIXL); a non-consumer setup warns at startup. A Mooncake-store tier composes via `MultiConnector` (store hits load directly into the host pool; `enable_cross_layers_blocks` is rejected).

## Testing

- `tests/v1/attention/test_sparse_mla_backends.py -k hisparse`: swap-in kernel fuzzed bit-exact against a Python reference, plan-once == independent per-layer resolution, overlap-prefetch parity, CUDA-graph capture/replay, host-resident pool e2e, recycled-slot invalidation, config validation (H200, source build).
- `tests/v1/kv_connector/unit/test_nixl_connector.py`: mixed-read split, partial-failure deferral, cross-poll double-failure, setup-failure-with-live-sibling (with a wrapper asserting no in-flight handle is ever released).
- Mooncake-store round-trip: a fresh HiSparse engine takes a store hit loaded into the pinned host pool and decodes byte-identically; PD smoke with `MultiConnector(NIXL + MooncakeStore)` holds 8/8 parity.

## Follow-ups

- MTP (speculative_config `method="mtp"`) is ported and validated on a preserved branch (`feat/hisparse-mtp-v2`; kernel parity matrix, PD+MTP token parity, 80% k=1 acceptance at scale) but deliberately not part of this PR: spec decode scales the DeepEP token budget by (1+k), forcing a decode seat re-budget whose saturation economics are unproven.
- vLLM-main port (this PR targets the v0.24.0 release base our deployment pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
