### PR TITLE
[V1][Core] Add non-blocking get_output_nowait() to engine core client

### DIFF
--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -27,7 +27,11 @@ from vllm.platforms import current_platform
 from vllm.pooling_params import LateInteractionParams, PoolingParams
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.torch_utils import set_default_torch_num_threads
-from vllm.v1.engine import EngineCoreReadyResponse, EngineCoreRequest
+from vllm.v1.engine import (
+    EngineCoreOutputs,
+    EngineCoreReadyResponse,
+    EngineCoreRequest,
+)
 from vllm.v1.engine.core import EngineCore
 from vllm.v1.engine.core_client import (
     AsyncMPClient,
@@ -235,6 +239,37 @@ def test_dplb_non_late_interaction_still_uses_lb():
 
     assert chosen_engine == client.core_engines[1]
     assert client.lb_engines[1][0] == 1
+
+
+def test_async_mp_client_get_output_nowait_drains_without_blocking():
+    """``get_output_nowait`` drains ready outputs in a bounded pass and returns
+    ``None`` on an empty queue instead of blocking, so callers can poll many
+    stages per round without head-of-line blocking.
+    See vllm-project/vllm-omni#4561.
+    """
+    client = object.__new__(AsyncMPClient)
+    client.outputs_queue = asyncio.Queue()
+    # No background output-handler task is started in this unit test.
+    client._ensure_output_queue_task = lambda: None
+    client._format_exception = lambda exc: exc
+
+    # Empty queue -> immediate None (non-blocking).
+    assert client.get_output_nowait() is None
+
+    first = EngineCoreOutputs()
+    second = EngineCoreOutputs()
+    client.outputs_queue.put_nowait(first)
+    client.outputs_queue.put_nowait(second)
+
+    # Drains already-ready outputs in FIFO order, then reports empty again.
+    assert client.get_output_nowait() is first
+    assert client.get_output_nowait() is second
+    assert client.get_output_nowait() is None
+
+    # Queued exceptions propagate, consistent with get_output_async.
+    client.outputs_queue.put_nowait(ValueError("boom"))
+    with pytest.raises(ValueError, match="boom"):
+        client.get_output_nowait()
 
 
 def test_apply_ready_response_syncs_block_size():

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -212,6 +212,16 @@ class EngineCoreClient(ABC):
     async def get_output_async(self) -> EngineCoreOutputs:
         raise NotImplementedError
 
+    def get_output_nowait(self) -> EngineCoreOutputs | None:
+        """Non-blocking variant of :meth:`get_output_async`.
+
+        Returns a ready ``EngineCoreOutputs`` immediately, or ``None`` when no
+        output is currently available, without blocking on an empty queue.
+        Lets callers drain already-ready outputs in a bounded pass instead of
+        consuming at most one item per round. See vllm-project/vllm-omni#4561.
+        """
+        raise NotImplementedError
+
     async def get_supported_tasks_async(self) -> tuple[SupportedTask, ...]:
         raise NotImplementedError
 
@@ -1057,6 +1067,17 @@ class AsyncMPClient(MPClient):
         # from this (run_output_handler) task to shut down the server.
         assert self.outputs_queue is not None
         outputs = await self.outputs_queue.get()
+        if isinstance(outputs, Exception):
+            raise self._format_exception(outputs) from None
+        return outputs
+
+    def get_output_nowait(self) -> EngineCoreOutputs | None:
+        self._ensure_output_queue_task()
+        assert self.outputs_queue is not None
+        try:
+            outputs = self.outputs_queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return None
         if isinstance(outputs, Exception):
             raise self._format_exception(outputs) from None
         return outputs


### PR DESCRIPTION
## Summary

Enabling primitive towards vllm-project/vllm-omni#4561 (head-of-line blocking in
the Omni orchestrator's stage-output polling).

Adds a **non-blocking** dequeue method `get_output_nowait()` next to the existing
blocking `get_output_async()`:

- returns a ready `EngineCoreOutputs` immediately,
- returns `None` when the output queue is currently empty (queued values are only
  `EngineCoreOutputs | Exception`, so `None` is unambiguous and avoids
  exception-as-control-flow in a hot poll loop),
- propagates queued exceptions exactly like `get_output_async()`.

Implemented on `AsyncMPClient` (whose `outputs_queue` is an `asyncio.Queue`), so
`DPAsyncMPClient` / `DPLBAsyncMPClient` inherit it; the abstract base declares the
contract.

## Motivation

The Omni orchestrator currently drains at most one output per stage replica per
round, and its non-blocking workaround wraps the **blocking** `get_output_async()`
in `asyncio.wait_for(..., timeout=0.001)`. That has two problems:

1. it cancels the in-flight `outputs_queue.get()` on timeout, which can drop a
   just-delivered item;
2. it cannot drain a backlog in a bounded pass, so a frontend-visible audio packet
   sitting behind non-user-visible raw outputs is delayed by many rounds — the
   TTFP inflation reported in vllm-omni#4561.

`get_output_nowait()` gives the consumer a correct, allocation-free way to drain
ready outputs without blocking or cancellation.

## Test

`tests/v1/engine/test_engine_core_client.py::test_async_mp_client_get_output_nowait_drains_without_blocking`
— empty queue → `None`; FIFO drain of ready items → `None`; queued exception
propagates. Lightweight (no engine spin-up).

## Note

Opened as **draft**: the consumer is the vLLM-Omni side of #4561 (separate PR to
follow). Happy to adjust the shape (e.g. raise `QueueEmpty` instead of returning
`None`, or expose it differently) per maintainer preference.