### PR TITLE
[Doc] Fix %% rendering in CLI reference for --safetensors-load-strategy

### DIFF
--- a/docs/mkdocs/hooks/generate_argparse.py
+++ b/docs/mkdocs/hooks/generate_argparse.py
@@ -199,8 +199,7 @@ class MarkdownFormatter(HelpFormatter):
                 self._markdown_output.append(f":   Possible choices: {choices}\n\n")
 
             if action.help:
-                help_text = action.help.replace("%%", "%")
-                help_dd = ":" + textwrap.indent(help_text, "    ")[1:]
+                help_dd = ":" + textwrap.indent(action.help, "    ")[1:]
                 self._markdown_output.append(f"{help_dd}\n\n")
 
             # None usually means the default is determined at runtime

--- a/docs/mkdocs/hooks/generate_argparse.py
+++ b/docs/mkdocs/hooks/generate_argparse.py
@@ -199,7 +199,8 @@ class MarkdownFormatter(HelpFormatter):
                 self._markdown_output.append(f":   Possible choices: {choices}\n\n")
 
             if action.help:
-                help_dd = ":" + textwrap.indent(action.help, "    ")[1:]
+                help_text = action.help.replace("%%", "%")
+                help_dd = ":" + textwrap.indent(help_text, "    ")[1:]
                 self._markdown_output.append(f"{help_dd}\n\n")
 
             # None usually means the default is determined at runtime

--- a/vllm/config/load.py
+++ b/vllm/config/load.py
@@ -63,7 +63,7 @@ class LoadConfig:
     Specifies the loading strategy for safetensors weights.
 
     - None (default): Uses memory-mapped (lazy) loading. When an NFS
-      filesystem is detected and the total checkpoint size fits within 90%%
+      filesystem is detected and the total checkpoint size fits within 90%
       of available RAM, prefetching is enabled automatically.
     - "lazy": Weights are memory-mapped from the file. This enables
       on-demand loading and is highly efficient for models on local storage.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -247,8 +247,9 @@ def get_type_hints(type_hint: TypeHint) -> set[TypeHint]:
     return type_hints
 
 
+IS_ARGPARSE = any("--help" in arg for arg in sys.argv)  # vllm SUBCOMMAND --help
 NEEDS_HELP = (
-    any("--help" in arg for arg in sys.argv)  # vllm SUBCOMMAND --help
+    IS_ARGPARSE
     or (argv0 := sys.argv[0]).endswith("mkdocs")  # mkdocs SUBCOMMAND
     or argv0.endswith("mkdocs/__main__.py")  # python -m mkdocs SUBCOMMAND
 )
@@ -315,8 +316,9 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
         # Get the help text for the field
         name = field.name
         help = cls_docs.get(name, "").strip()
-        # Escape % for argparse
-        help = help.replace("%", "%%")
+        # Escape % for argparse's %-formatting in _expand_help
+        if IS_ARGPARSE:
+            help = help.replace("%", "%%")
 
         # Initialise the kwargs dictionary for the field
         kwargs[name] = {"default": default, "help": help}


### PR DESCRIPTION
## Summary

While exploring the [`--safetensors-load-strategy`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-safetensors-load-strategy) feature, I noticed the CLI reference docs showed `90%%%%` instead of `90%`.

## Root cause

`arg_utils.py` escapes `%` → `%%` in docstring-derived help text for argparse. `MarkdownFormatter.add_arguments` in `generate_argparse.py` reads `action.help` directly, bypassing `_expand_help` which would normally unescape `%%` → `%`. Additionally, the `load.py` docstring had `90%%` instead of `90%`, causing a double-escape to `90%%%%` in the rendered output.

## Changes

- `vllm/config/load.py`: `90%%` → `90%` in docstring
- `docs/mkdocs/hooks/generate_argparse.py`: unescape `%%` → `%` in `MarkdownFormatter.add_arguments` before writing markdown

As a side effect, this also fixes [`--bin-by`](https://docs.vllm.ai/en/latest/cli/bench/sweep/plot/#-bin-by) in the benchmark CLI reference which was showing `request_throughput%%1` instead of the correct `request_throughput%1`.

## Verification

Served docs locally with `API_AUTONAV_EXCLUDE=vllm mkdocs serve` and confirmed:

```
None (default): Uses memory-mapped (lazy) loading. When an NFS filesystem is
detected and the total checkpoint size fits within 90% of available RAM,
prefetching is enabled automatically.
```

## Notes

- No existing open PR addresses this (searched for `safetensors`, `generate_argparse`, `%%`)
- AI assistance (Claude) was used to investigate and implement this fix