### PR TITLE
[Config] Migrate weight-offloading env vars to OffloadConfig

### DIFF
--- a/tests/model_executor/offloader/test_weight_offload_config.py
+++ b/tests/model_executor/offloader/test_weight_offload_config.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for migrating weight-offloading env vars to OffloadConfig (#25700)."""
+
+import pytest
+
+import vllm.envs as envs
+from vllm.config.offload import OffloadConfig
+from vllm.model_executor.offloader import base
+
+pytestmark = pytest.mark.cpu_test
+
+PIN_ENV = "VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY"
+UVA_ENV = "VLLM_WEIGHT_OFFLOADING_DISABLE_UVA"
+
+
+def test_new_fields_default_to_none():
+    cfg = OffloadConfig()
+    assert cfg.disable_pin_memory is None
+    assert cfg.uva.disable_uva is None
+
+
+@pytest.mark.parametrize("config_value", [True, False])
+def test_config_takes_precedence_over_env(monkeypatch, config_value):
+    # Explicit config wins even when the deprecated env var disagrees.
+    monkeypatch.setattr(envs, PIN_ENV, not config_value)
+    assert base.resolve_offload_flag(config_value, PIN_ENV) is config_value
+
+
+def test_env_fallback_when_config_unset_and_warns_once(monkeypatch):
+    monkeypatch.setattr(envs, UVA_ENV, True)
+    base._warned_deprecated_offload_envs.discard(UVA_ENV)
+
+    assert base.resolve_offload_flag(None, UVA_ENV) is True
+    assert UVA_ENV in base._warned_deprecated_offload_envs
+
+    # A second resolution must not re-add / re-warn (idempotent).
+    before = set(base._warned_deprecated_offload_envs)
+    assert base.resolve_offload_flag(None, UVA_ENV) is True
+    assert base._warned_deprecated_offload_envs == before
+
+
+def test_env_unset_defaults_to_false(monkeypatch):
+    monkeypatch.setattr(envs, PIN_ENV, False)
+    assert base.resolve_offload_flag(None, PIN_ENV) is False

--- a/vllm/config/offload.py
+++ b/vllm/config/offload.py
@@ -43,6 +43,11 @@ class UVAOffloadConfig:
     This allows distinguishing parameters like "w2_weight" and "w2_weight_scale".
     """
 
+    disable_uva: bool | None = None
+    """Disable UVA (Unified Virtual Addressing) zero-copy offloading even when
+    it is available. `None` falls back to the deprecated
+    `VLLM_WEIGHT_OFFLOADING_DISABLE_UVA` env var (default off)."""
+
 
 @config
 class PrefetchOffloadConfig:
@@ -93,6 +98,12 @@ class OffloadConfig:
 
     prefetch: PrefetchOffloadConfig = Field(default_factory=PrefetchOffloadConfig)
     """Parameters for prefetch offloading backend."""
+
+    disable_pin_memory: bool | None = None
+    """Disable pinned host memory for weight offloading. On unified-memory
+    systems (e.g. GH200) pinned memory eats into GPU memory. `None` falls back
+    to the deprecated `VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY` env var
+    (default off)."""
 
     @model_validator(mode="after")
     def validate_offload_config(self) -> "OffloadConfig":

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -514,8 +514,10 @@ class EngineArgs:
     disable_sliding_window: bool = ModelConfig.disable_sliding_window
     disable_cascade_attn: bool = ModelConfig.disable_cascade_attn
     offload_backend: str = OffloadConfig.offload_backend
+    disable_pin_memory: bool | None = OffloadConfig.disable_pin_memory
     cpu_offload_gb: float = UVAOffloadConfig.cpu_offload_gb
     cpu_offload_params: set[str] = get_field(UVAOffloadConfig, "cpu_offload_params")
+    disable_uva: bool | None = UVAOffloadConfig.disable_uva
     offload_group_size: int = PrefetchOffloadConfig.offload_group_size
     offload_num_in_group: int = PrefetchOffloadConfig.offload_num_in_group
     offload_prefetch_step: int = PrefetchOffloadConfig.offload_prefetch_step
@@ -1203,9 +1205,16 @@ class EngineArgs:
         offload_group.add_argument(
             "--offload-backend", **offload_kwargs["offload_backend"]
         )
+        offload_group.add_argument(
+            "--offload-disable-pin-memory",
+            **offload_kwargs["disable_pin_memory"],
+        )
         offload_group.add_argument("--cpu-offload-gb", **uva_kwargs["cpu_offload_gb"])
         offload_group.add_argument(
             "--cpu-offload-params", **uva_kwargs["cpu_offload_params"]
+        )
+        offload_group.add_argument(
+            "--offload-disable-uva", **uva_kwargs["disable_uva"]
         )
         offload_group.add_argument(
             "--offload-group-size",
@@ -2298,9 +2307,11 @@ class EngineArgs:
 
         offload_config = OffloadConfig(
             offload_backend=self.offload_backend,
+            disable_pin_memory=self.disable_pin_memory,
             uva=UVAOffloadConfig(
                 cpu_offload_gb=self.cpu_offload_gb,
                 cpu_offload_params=self.cpu_offload_params,
+                disable_uva=self.disable_uva,
             ),
             prefetch=PrefetchOffloadConfig(
                 offload_group_size=self.offload_group_size,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1848,10 +1848,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_DEBUG_MFU_METRICS", "0"))
     ),
     # Disable using pytorch's pin memory for CPU offloading.
+    # DEPRECATED: use `--offload-disable-pin-memory` /
+    # `OffloadConfig.disable_pin_memory` instead.
     "VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY": lambda: bool(
         int(os.getenv("VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY", "0"))
     ),
     # Disable using UVA (Unified Virtual Addressing) for CPU offloading.
+    # DEPRECATED: use `--offload-disable-uva` /
+    # `OffloadConfig.uva.disable_uva` instead.
     "VLLM_WEIGHT_OFFLOADING_DISABLE_UVA": lambda: bool(
         int(os.getenv("VLLM_WEIGHT_OFFLOADING_DISABLE_UVA", "0"))
     ),

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -12,7 +12,6 @@ import torch
 from torch import nn
 from typing_extensions import assert_never
 
-import vllm.envs as envs
 from vllm.config import ModelConfig, VllmConfig, set_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import (
@@ -31,7 +30,6 @@ from vllm.model_executor.model_loader.reload import (
 from vllm.model_executor.models.interfaces import SupportsQuant
 from vllm.tracing import instrument
 from vllm.utils.mem_utils import release_device_memory_under_pressure
-from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
 
 logger = init_logger(__name__)
@@ -154,10 +152,9 @@ def device_loading_context(module: torch.nn.Module, target_device: torch.device)
         yield module
 
     finally:
-        use_pin_memory = (
-            is_pin_memory_available()
-            and not envs.VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY
-        )
+        from vllm.model_executor.offloader.base import should_pin_memory
+
+        use_pin_memory = should_pin_memory()
         # Restore parameters to their original devices, ignoring new parameters
         for name, p in module.named_parameters():
             if name in original_device_states:

--- a/vllm/model_executor/offloader/base.py
+++ b/vllm/model_executor/offloader/base.py
@@ -19,17 +19,57 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+# Tracks deprecated offload env vars we have already warned about, so the
+# deprecation warning is emitted at most once per process.
+_warned_deprecated_offload_envs: set[str] = set()
+
+
+def resolve_offload_flag(config_value: bool | None, env_name: str) -> bool:
+    """Resolve a weight-offloading boolean from config, with env-var fallback.
+
+    The config value takes precedence. When it is ``None`` (unset), fall back to
+    the deprecated environment variable, warning once if the user enabled it.
+
+    Args:
+        config_value: The value from ``OffloadConfig`` (``None`` if unset).
+        env_name: Name of the deprecated env var to fall back to.
+
+    Returns:
+        The resolved boolean flag.
+    """
+    if config_value is not None:
+        return config_value
+    env_value = bool(getattr(envs, env_name))
+    if env_value and env_name not in _warned_deprecated_offload_envs:
+        _warned_deprecated_offload_envs.add(env_name)
+        logger.warning(
+            "%s is deprecated and will be removed in a future release. Use the "
+            "offload config (e.g. `--offload-config`) instead.",
+            env_name,
+        )
+    return env_value
+
 
 def should_pin_memory() -> bool:
     """Check if pinned memory should be used for weight offloading.
 
-    Combines the platform capability check with the user override env var.
-    On unified-memory systems (e.g. GH200) pinned memory eats into GPU
-    memory, so users can disable it via VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY.
+    Combines the platform capability check with the user override from
+    ``OffloadConfig.disable_pin_memory`` (falling back to the deprecated
+    ``VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY`` env var). On unified-memory
+    systems (e.g. GH200) pinned memory eats into GPU memory.
     """
-    return (
-        is_pin_memory_available() and not envs.VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY
+    from vllm.config import get_current_vllm_config_or_none
+
+    vllm_config = get_current_vllm_config_or_none()
+    config_value = (
+        vllm_config.offload_config.disable_pin_memory
+        if vllm_config is not None
+        else None
     )
+    disable_pin_memory = resolve_offload_flag(
+        config_value, "VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY"
+    )
+    return is_pin_memory_available() and not disable_pin_memory
 
 
 """

--- a/vllm/model_executor/offloader/uva.py
+++ b/vllm/model_executor/offloader/uva.py
@@ -8,9 +8,12 @@ import torch
 import torch.nn as nn
 from torch.func import functional_call
 
-import vllm.envs as envs
 from vllm.logger import init_logger
-from vllm.model_executor.offloader.base import BaseOffloader, should_pin_memory
+from vllm.model_executor.offloader.base import (
+    BaseOffloader,
+    resolve_offload_flag,
+    should_pin_memory,
+)
 from vllm.utils.mem_utils import format_gib
 from vllm.utils.platform_utils import is_uva_available
 from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
@@ -43,10 +46,19 @@ class UVAOffloader(BaseOffloader):
         self.cpu_offload_bytes = 0
         self.cpu_offload_params = cpu_offload_params or set()
 
+        from vllm.config import get_current_vllm_config_or_none
+
         self.pin_memory = should_pin_memory()
-        self.uva_offloading = (
-            is_uva_available() and not envs.VLLM_WEIGHT_OFFLOADING_DISABLE_UVA
+        vllm_config = get_current_vllm_config_or_none()
+        config_value = (
+            vllm_config.offload_config.uva.disable_uva
+            if vllm_config is not None
+            else None
         )
+        disable_uva = resolve_offload_flag(
+            config_value, "VLLM_WEIGHT_OFFLOADING_DISABLE_UVA"
+        )
+        self.uva_offloading = is_uva_available() and not disable_uva
 
     def wrap_modules(
         self,


### PR DESCRIPTION
## Purpose

Part of **RFC #25700** (limit the use of env vars in vLLM). Environment
variables lack type safety, CLI documentation, and hierarchical grouping, and
are the path of least resistance for new flags. This migrates the two
weight-offloading toggles to first-class config under the existing
`OffloadConfig`, following the same pattern used for the attention-config
migration (#26315).

| Deprecated env var | New config | New CLI flag |
|---|---|---|
| `VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY` | `OffloadConfig.disable_pin_memory` | `--offload-disable-pin-memory` |
| `VLLM_WEIGHT_OFFLOADING_DISABLE_UVA` | `OffloadConfig.uva.disable_uva` | `--offload-disable-uva` |

## Design

- Both new fields default to `None`, meaning *"fall back to the deprecated env
  var"*.
- `resolve_offload_flag()` (`vllm/model_executor/offloader/base.py`) centralizes
  the precedence rule: an explicitly set config value always wins; otherwise the
  deprecated env var is used, emitting a **one-time** deprecation warning.
- `should_pin_memory()` and `UVAOffloader` read through it;
  `model_loader/utils.py` now routes its pin-memory check through
  `should_pin_memory()` instead of reading the env var directly.

## Backward compatibility

The env vars are kept and marked deprecated in `vllm/envs.py`. Existing
deployments that set them keep working unchanged (with a deprecation warning);
the new CLI flags / config take precedence when provided.

## Not a duplicate

Checked open PRs (`gh pr list --search "WEIGHT_OFFLOADING"`, `"25700 in:body"`,
`"disable_pin_memory offload"`) — no existing PR migrates these env vars to
config. The offload-related open PRs (#43453, #37190) address different
functionality.

## Test plan

- Added `tests/model_executor/offloader/test_weight_offload_config.py`
  (`cpu_test`): covers config-over-env precedence, env fallback when the config
  field is unset, the one-time deprecation warning, and the default-off path.

```bash
pytest tests/model_executor/offloader/test_weight_offload_config.py -v
pre-commit run --all-files
```

> **Draft status:** kept as a draft until the author runs the full local test
> suite + `pre-commit` on GPU hardware and pastes the results here. The change
> set was syntax-checked and the new unit test is self-contained
> (`cpu_test`), but has not yet been executed in a full vLLM environment.

## Note

AI assistance was used to prepare this change; every line was reviewed by the
submitter per `AGENTS.md`.
