### PR TITLE
[Bugfix] Fix Llama4ForCausalLM initialization test failure

### DIFF
--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -507,7 +507,13 @@ def dummy_hf_overrides(
     # Only set MoE related config when the model has MoE layers.
     # Otherwise all models detected as MoE by _get_transformers_backend_cls.
     if model_arch_config.num_experts > 0:
-        num_experts_per_tok = 1 if model_arch == "Llama4ForConditionalGeneration" else 2
+        num_experts_per_tok = 2
+        if model_arch in (
+            "Llama4ForConditionalGeneration",
+            "Llama4ForCausalLM",
+            "EagleLlama4ForCausalLM",
+        ):
+            num_experts_per_tok = 1
         update_dict.update(
             {
                 "num_experts": num_experts,


### PR DESCRIPTION



## Purpose
dummy_hf_overrides only set `num_experts_per_tok=1` for Llama4ForConditionalGeneration, causing Llama4ForCausalLM and
EagleLlama4ForCausalLM to get num_experts_per_tok=2. This conflicts with `apply_router_weight_on_input=True` which only supports topk=1.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

