### PR TITLE
[Rust Frontend] Correct `--reasoning-parser` semantics

### DIFF
--- a/.buildkite/test_areas/rust_frontend.yaml
+++ b/.buildkite/test_areas/rust_frontend.yaml
@@ -26,7 +26,7 @@ steps:
   - export VLLM_USE_RUST_FRONTEND=1
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s benchmarks/test_serve_cli.py -k "not insecure and not (test_bench_serve and not test_bench_serve_chat)"
-  - pytest -v -s entrypoints/openai/chat_completion/test_chat_completion.py
+  - pytest -v -s entrypoints/openai/chat_completion/test_chat_completion.py -k "not test_invalid_json_schema and not test_invalid_regex"
   # - pytest -v -s entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py -k "not invalid"
 
   # - pytest -v -s entrypoints/openai/completion/test_prompt_validation.py -k "not prompt_embeds"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5750,6 +5750,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "vllm-chat",
  "vllm-engine-core-client",
  "vllm-managed-engine",
  "vllm-server",

--- a/rust/src/cmd/Cargo.toml
+++ b/rust/src/cmd/Cargo.toml
@@ -29,6 +29,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
+vllm-chat.workspace = true
 vllm-engine-core-client.workspace = true
 vllm-managed-engine.workspace = true
 vllm-server.workspace = true

--- a/rust/src/cmd/src/cli.rs
+++ b/rust/src/cmd/src/cli.rs
@@ -19,6 +19,7 @@ use serde_json::Value;
 use serde_with::{DefaultOnNull, OneOrMany, serde_as};
 use thiserror_ext::AsReport as _;
 use uuid::Uuid;
+use vllm_chat::ReasoningParserFactory;
 use vllm_engine_core_client::TransportMode;
 use vllm_managed_engine::ManagedEngineConfig;
 use vllm_managed_engine::cli::{ManagedEngineArgs, repartition_managed_engine_args};
@@ -535,15 +536,29 @@ impl ServeArgs {
     /// Build the managed Python-engine spawn configuration with the given
     /// handshake port.
     pub fn to_managed_engine_config(&self, handshake_port: u16) -> ManagedEngineConfig {
+        let reasoning_parser =
+            effective_engine_reasoning_parser(&self.runtime.reasoning_parser, &self.runtime.model);
+
         self.managed_engine.clone().into_config(
             self.runtime.model.clone(),
             self.runtime.max_model_len,
             self.runtime.max_logprobs,
+            reasoning_parser.as_deref(),
             self.runtime.language_model_only,
             self.runtime.disable_log_stats,
             self.runtime.shutdown_timeout,
             handshake_port,
         )
+    }
+}
+
+fn effective_engine_reasoning_parser(selection: &ParserSelection, model: &str) -> Option<String> {
+    match selection {
+        ParserSelection::Auto => ReasoningParserFactory::global()
+            .resolve_name_for_model(model)
+            .map(str::to_string),
+        ParserSelection::None => None,
+        ParserSelection::Explicit(name) => Some(name.clone()),
     }
 }
 

--- a/rust/src/cmd/src/cli.rs
+++ b/rust/src/cmd/src/cli.rs
@@ -91,7 +91,12 @@ pub enum Command {
 #[serde(transparent)]
 pub struct JsonStringList(pub Vec<String>);
 
-/// Runtime arguments shared by the external-engine and managed-engine paths.
+/// Runtime arguments shared by both paths of the Rust frontend:
+///
+/// - External-engine mode: Python-supervised bootstrap, `vllm serve` -> `vllm-rs frontend`.
+///   Arguments are deserialized from a single JSON object and defaults follow `serde` attrs.
+/// - Managed-engine mode: Rust-managed Python engine, `vllm-rs serve`.
+///   Arguments are parsed from CLI flags and defaults follow `clap` attrs.
 #[serde_as]
 #[derive(Educe, Clone, Args, PartialEq, Eq, Deserialize)]
 #[educe(Debug)]
@@ -114,12 +119,12 @@ pub struct SharedRuntimeArgs {
     /// Select the tool call parser depending on the model that you're using.
     /// Use `auto` to infer from the model or `none` to disable parsing.
     #[arg(long, default_value_t)]
-    #[serde(default)]
+    #[serde(default = "default_py_bootstrap_parser_selection")]
     pub tool_call_parser: ParserSelection,
     /// Select the reasoning parser depending on the model that you're using.
     /// Use `auto` to infer from the model or `none` to disable parsing.
     #[arg(long, default_value_t)]
-    #[serde(default)]
+    #[serde(default = "default_py_bootstrap_parser_selection")]
     pub reasoning_parser: ParserSelection,
     /// Select the chat renderer implementation.
     #[arg(long = "tokenizer-mode", default_value_t)]
@@ -400,6 +405,10 @@ fn default_engine_ready_timeout_secs() -> u64 {
 
 fn default_cors_wildcard() -> JsonStringList {
     JsonStringList(vec!["*".to_string()])
+}
+
+fn default_py_bootstrap_parser_selection() -> ParserSelection {
+    ParserSelection::None
 }
 
 fn parse_json<T: DeserializeOwned>(value: &str) -> Result<T, String> {

--- a/rust/src/cmd/src/cli/tests.rs
+++ b/rust/src/cmd/src/cli/tests.rs
@@ -100,10 +100,13 @@ fn serve_args_auto_forward_python_flags_without_separator() {
     let Command::Serve(args) = cli.command else {
         panic!("expected serve args");
     };
-    assert_eq!(
-        args.managed_engine.python_args,
-        vec!["--quantization", "awq"]
-    );
+    expect![[r#"
+        [
+            "--quantization",
+            "awq",
+        ]
+    "#]]
+    .assert_debug_eq(&args.managed_engine.python_args);
 }
 
 #[test]
@@ -114,7 +117,12 @@ fn serve_args_auto_forward_enable_lora_to_python() {
     let Command::Serve(args) = cli.command else {
         panic!("expected serve args");
     };
-    assert_eq!(args.managed_engine.python_args, vec!["--enable-lora"]);
+    expect![[r#"
+        [
+            "--enable-lora",
+        ]
+    "#]]
+    .assert_debug_eq(&args.managed_engine.python_args);
 }
 
 #[test]
@@ -134,10 +142,15 @@ fn serve_args_forward_shutdown_timeout_to_managed_engine() {
     assert_eq!(args.runtime.shutdown_timeout, 60);
 
     let config = args.to_managed_engine_config(5555);
-    assert_eq!(
-        config.python_args,
-        vec!["--reasoning-parser", "qwen3", "--shutdown-timeout", "60"]
-    );
+    expect![[r#"
+        [
+            "--reasoning-parser",
+            "qwen3",
+            "--shutdown-timeout",
+            "60",
+        ]
+    "#]]
+    .assert_debug_eq(&config.python_args);
 }
 
 #[test]
@@ -151,10 +164,14 @@ fn serve_args_forward_disable_log_stats_to_managed_engine() {
     assert!(args.runtime.disable_log_stats);
 
     let config = args.to_managed_engine_config(5555);
-    assert_eq!(
-        config.python_args,
-        vec!["--reasoning-parser", "qwen3", "--disable-log-stats"]
-    );
+    expect![[r#"
+        [
+            "--reasoning-parser",
+            "qwen3",
+            "--disable-log-stats",
+        ]
+    "#]]
+    .assert_debug_eq(&config.python_args);
 }
 
 #[test]
@@ -177,10 +194,15 @@ fn serve_args_forward_max_logprobs_to_frontend_and_managed_engine() {
     assert_eq!(frontend_config.max_logprobs, Some(-1));
 
     let engine_config = args.to_managed_engine_config(5555);
-    assert_eq!(
-        engine_config.python_args,
-        vec!["--max-logprobs", "-1", "--reasoning-parser", "qwen3"]
-    );
+    expect![[r#"
+        [
+            "--max-logprobs",
+            "-1",
+            "--reasoning-parser",
+            "qwen3",
+        ]
+    "#]]
+    .assert_debug_eq(&engine_config.python_args);
 }
 
 #[test]
@@ -193,7 +215,13 @@ fn serve_args_resolve_auto_reasoning_parser_for_managed_engine() {
     assert_eq!(args.runtime.reasoning_parser, ParserSelection::Auto);
 
     let config = args.to_managed_engine_config(5555);
-    assert_eq!(config.python_args, vec!["--reasoning-parser", "qwen3"]);
+    expect![[r#"
+        [
+            "--reasoning-parser",
+            "qwen3",
+        ]
+    "#]]
+    .assert_debug_eq(&config.python_args);
 }
 
 #[test]
@@ -212,10 +240,13 @@ fn serve_args_forward_explicit_reasoning_parser_to_managed_engine() {
     };
 
     let config = args.to_managed_engine_config(5555);
-    assert_eq!(
-        config.python_args,
-        vec!["--reasoning-parser", "deepseek_r1"]
-    );
+    expect![[r#"
+        [
+            "--reasoning-parser",
+            "deepseek_r1",
+        ]
+    "#]]
+    .assert_debug_eq(&config.python_args);
 }
 
 #[test]
@@ -254,15 +285,15 @@ fn serve_args_forward_reasoning_parser_even_with_passthrough_reasoning_parser() 
     };
 
     let config = args.to_managed_engine_config(5555);
-    assert_eq!(
-        config.python_args,
-        vec![
+    expect![[r#"
+        [
             "--reasoning-parser",
             "deepseek_r1",
             "--reasoning-parser",
-            "qwen3"
+            "qwen3",
         ]
-    );
+    "#]]
+    .assert_debug_eq(&config.python_args);
 }
 
 #[test]
@@ -272,10 +303,13 @@ fn serve_args_auto_forward_python_multi_char_alias_without_separator() {
     let Command::Serve(args) = cli.command else {
         panic!("expected serve args");
     };
-    assert_eq!(
-        args.managed_engine.python_args,
-        vec!["--tensor-parallel-size", "2"]
-    );
+    expect![[r#"
+        [
+            "--tensor-parallel-size",
+            "2",
+        ]
+    "#]]
+    .assert_debug_eq(&args.managed_engine.python_args);
 }
 
 #[test]
@@ -875,10 +909,15 @@ fn serve_args_keep_python_passthrough_flags_after_separator() {
     let Command::Serve(args) = cli.command else {
         panic!("expected serve args");
     };
-    assert_eq!(
-        args.managed_engine.python_args,
-        vec!["--tensor-parallel-size", "2", "--dtype", "float16"]
-    );
+    expect![[r#"
+        [
+            "--tensor-parallel-size",
+            "2",
+            "--dtype",
+            "float16",
+        ]
+    "#]]
+    .assert_debug_eq(&args.managed_engine.python_args);
 }
 
 #[test]
@@ -900,10 +939,15 @@ fn serve_args_keep_python_multi_char_alias_after_separator() {
     let Command::Serve(args) = cli.command else {
         panic!("expected serve args");
     };
-    assert_eq!(
-        args.managed_engine.python_args,
-        vec!["-tp", "2", "--dtype", "float16"]
-    );
+    expect![[r#"
+        [
+            "-tp",
+            "2",
+            "--dtype",
+            "float16",
+        ]
+    "#]]
+    .assert_debug_eq(&args.managed_engine.python_args);
 }
 
 #[test]
@@ -921,10 +965,13 @@ fn serve_args_keep_frontend_arg_after_separator() {
     let Command::Serve(args) = cli.command else {
         panic!("expected serve args");
     };
-    assert_eq!(
-        args.managed_engine.python_args,
-        vec!["--uds", "/tmp/vllm.sock"]
-    );
+    expect![[r#"
+        [
+            "--uds",
+            "/tmp/vllm.sock",
+        ]
+    "#]]
+    .assert_debug_eq(&args.managed_engine.python_args);
 }
 
 #[test]
@@ -944,10 +991,15 @@ fn serve_args_keep_python_multi_char_engine_aliases_after_separator() {
     let Command::Serve(args) = cli.command else {
         panic!("expected serve args");
     };
-    assert_eq!(
-        args.managed_engine.python_args,
-        vec!["-dpr", "1", "-dpl", "2"]
-    );
+    expect![[r#"
+        [
+            "-dpr",
+            "1",
+            "-dpl",
+            "2",
+        ]
+    "#]]
+    .assert_debug_eq(&args.managed_engine.python_args);
 }
 
 #[test]
@@ -957,7 +1009,13 @@ fn serve_args_auto_forward_unknown_flags_without_separator() {
     let Command::Serve(args) = cli.command else {
         panic!("expected serve args");
     };
-    assert_eq!(args.managed_engine.python_args, vec!["--foo", "bar"]);
+    expect![[r#"
+        [
+            "--foo",
+            "bar",
+        ]
+    "#]]
+    .assert_debug_eq(&args.managed_engine.python_args);
 }
 
 #[test]
@@ -974,10 +1032,13 @@ fn serve_args_auto_forward_negative_value_without_separator() {
     let Command::Serve(args) = cli.command else {
         panic!("expected serve args");
     };
-    assert_eq!(
-        args.managed_engine.python_args,
-        vec!["--num-gpu-blocks-override", "-1"]
-    );
+    expect![[r#"
+        [
+            "--num-gpu-blocks-override",
+            "-1",
+        ]
+    "#]]
+    .assert_debug_eq(&args.managed_engine.python_args);
 }
 
 #[test]

--- a/rust/src/cmd/src/cli/tests.rs
+++ b/rust/src/cmd/src/cli/tests.rs
@@ -134,7 +134,10 @@ fn serve_args_forward_shutdown_timeout_to_managed_engine() {
     assert_eq!(args.runtime.shutdown_timeout, 60);
 
     let config = args.to_managed_engine_config(5555);
-    assert_eq!(config.python_args, vec!["--shutdown-timeout", "60"]);
+    assert_eq!(
+        config.python_args,
+        vec!["--reasoning-parser", "qwen3", "--shutdown-timeout", "60"]
+    );
 }
 
 #[test]
@@ -148,7 +151,10 @@ fn serve_args_forward_disable_log_stats_to_managed_engine() {
     assert!(args.runtime.disable_log_stats);
 
     let config = args.to_managed_engine_config(5555);
-    assert_eq!(config.python_args, vec!["--disable-log-stats"]);
+    assert_eq!(
+        config.python_args,
+        vec!["--reasoning-parser", "qwen3", "--disable-log-stats"]
+    );
 }
 
 #[test]
@@ -171,7 +177,92 @@ fn serve_args_forward_max_logprobs_to_frontend_and_managed_engine() {
     assert_eq!(frontend_config.max_logprobs, Some(-1));
 
     let engine_config = args.to_managed_engine_config(5555);
-    assert_eq!(engine_config.python_args, vec!["--max-logprobs", "-1"]);
+    assert_eq!(
+        engine_config.python_args,
+        vec!["--max-logprobs", "-1", "--reasoning-parser", "qwen3"]
+    );
+}
+
+#[test]
+fn serve_args_resolve_auto_reasoning_parser_for_managed_engine() {
+    let cli = Cli::try_parse_from(["vllm-rs", "serve", "Qwen/Qwen3-0.6B"]).unwrap();
+
+    let Command::Serve(args) = cli.command else {
+        panic!("expected serve args");
+    };
+    assert_eq!(args.runtime.reasoning_parser, ParserSelection::Auto);
+
+    let config = args.to_managed_engine_config(5555);
+    assert_eq!(config.python_args, vec!["--reasoning-parser", "qwen3"]);
+}
+
+#[test]
+fn serve_args_forward_explicit_reasoning_parser_to_managed_engine() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "serve",
+        "Unknown/Model",
+        "--reasoning-parser",
+        "deepseek_r1",
+    ])
+    .unwrap();
+
+    let Command::Serve(args) = cli.command else {
+        panic!("expected serve args");
+    };
+
+    let config = args.to_managed_engine_config(5555);
+    assert_eq!(
+        config.python_args,
+        vec!["--reasoning-parser", "deepseek_r1"]
+    );
+}
+
+#[test]
+fn serve_args_do_not_forward_disabled_reasoning_parser_to_managed_engine() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "serve",
+        "Qwen/Qwen3-0.6B",
+        "--reasoning-parser",
+        "none",
+    ])
+    .unwrap();
+
+    let Command::Serve(args) = cli.command else {
+        panic!("expected serve args");
+    };
+
+    let config = args.to_managed_engine_config(5555);
+    assert!(config.python_args.is_empty());
+}
+
+#[test]
+fn serve_args_forward_reasoning_parser_even_with_passthrough_reasoning_parser() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "serve",
+        "Qwen/Qwen3-0.6B",
+        "--",
+        "--reasoning-parser",
+        "deepseek_r1",
+    ])
+    .unwrap();
+
+    let Command::Serve(args) = cli.command else {
+        panic!("expected serve args");
+    };
+
+    let config = args.to_managed_engine_config(5555);
+    assert_eq!(
+        config.python_args,
+        vec![
+            "--reasoning-parser",
+            "deepseek_r1",
+            "--reasoning-parser",
+            "qwen3"
+        ]
+    );
 }
 
 #[test]
@@ -429,8 +520,8 @@ fn frontend_args_accept_json() {
                     runtime: SharedRuntimeArgs {
                         model: "Qwen/Qwen3-0.6B",
                         engine_ready_timeout_secs: 600,
-                        tool_call_parser: Auto,
-                        reasoning_parser: Auto,
+                        tool_call_parser: None,
+                        reasoning_parser: None,
                         renderer: Auto,
                         language_model_only: false,
                         max_model_len: None,
@@ -1237,8 +1328,8 @@ fn frontend_config_uses_external_coordinator_when_coordinator_address_is_present
             listener_mode: InheritedFd {
                 fd: 3,
             },
-            tool_call_parser: Auto,
-            reasoning_parser: Auto,
+            tool_call_parser: None,
+            reasoning_parser: None,
             renderer: Auto,
             language_model_only: false,
             chat_template: None,

--- a/rust/src/cmd/src/cli/tests.rs
+++ b/rust/src/cmd/src/cli/tests.rs
@@ -490,8 +490,8 @@ fn frontend_args_json_applies_defaults() {
     };
     assert_eq!(args.runtime.model, "Qwen/Qwen3-0.6B");
     assert_eq!(args.runtime.engine_ready_timeout_secs, 600);
-    assert_eq!(args.runtime.tool_call_parser, ParserSelection::Auto);
-    assert_eq!(args.runtime.reasoning_parser, ParserSelection::Auto);
+    assert_eq!(args.runtime.tool_call_parser, ParserSelection::None);
+    assert_eq!(args.runtime.reasoning_parser, ParserSelection::None);
     assert_eq!(args.runtime.renderer, RendererSelection::Auto);
     assert_eq!(args.runtime.max_model_len, None);
     assert_eq!(args.runtime.max_logprobs, None);

--- a/rust/src/managed-engine/src/cli.rs
+++ b/rust/src/managed-engine/src/cli.rs
@@ -43,6 +43,11 @@ pub struct ManagedEngineArgs {
     /// Arguments after an explicit `--` are forwarded verbatim. Before `--`,
     /// `vllm-rs serve` automatically keeps recognized frontend options on
     /// the Rust side and forwards everything else to Python.
+    ///
+    /// The explicit `--` passthrough is a last-resort escape hatch. Rust does
+    /// not interpret, validate, or de-duplicate those arguments against
+    /// managed-engine arguments that it appends later; if the same Python flag
+    /// appears more than once, Python argparse owns the final result.
     #[arg(
         last = true,
         allow_hyphen_values = true,
@@ -72,6 +77,7 @@ impl ManagedEngineArgs {
         model: String,
         max_model_len: Option<u32>,
         max_logprobs: Option<i32>,
+        reasoning_parser: Option<&str>,
         language_model_only: bool,
         disable_log_stats: bool,
         shutdown_timeout: u64,
@@ -86,6 +92,10 @@ impl ManagedEngineArgs {
         if let Some(max_logprobs) = max_logprobs {
             python_args.push("--max-logprobs".to_string());
             python_args.push(max_logprobs.to_string());
+        }
+        if let Some(reasoning_parser) = reasoning_parser {
+            python_args.push("--reasoning-parser".to_string());
+            python_args.push(reasoning_parser.to_string());
         }
         if language_model_only {
             python_args.push("--language-model-only".to_string());

--- a/rust/src/text/src/lower.rs
+++ b/rust/src/text/src/lower.rs
@@ -164,6 +164,7 @@ pub fn lower_sampling_params(
         logit_bias,
         allowed_token_ids,
         bad_words_token_ids: tokenize_bad_words(bad_words.as_deref(), tokenizer)?,
+        // TODO: Validate structured-output schemas and regexes before submitting requests to engine-core.
         structured_outputs,
         logprob_token_ids,
         skip_reading_prefix_cache,


### PR DESCRIPTION
## Purpose

Align Rust frontend parser-selection semantics with the path that supplies the arguments.

Python-supervised bootstrap receives runtime args from Python through JSON. In that path, omitted `tool_call_parser` and `reasoning_parser` now deserialize to `none`, matching Python CLI semantics where parser support stays disabled unless Python explicitly validated and forwarded a concrete parser name.

Rust managed-engine serve still keeps the CLI default as `auto`. Before spawning the Python engine, Rust resolves `auto` to the effective reasoning parser for the model and forwards the concrete `--reasoning-parser` value to Python. This is necessary for  the Python engine to build the same reasoning-aware structured output manager state that the Rust frontend expects, and let `thinking_token_budget` correctly work (background: https://github.com/vllm-project/vllm/pull/46137#discussion_r3450546227).

## Test Plan

- `cargo test -p vllm-cmd cli::tests -- --nocapture`
- `cargo test -p vllm-managed-engine -- --nocapture`

## Test Result

Passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
