### PR TITLE
[Docs] Add Qwen2.5-Coder-7B-Instruct to batch invariance tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -104,6 +104,7 @@ Batch invariance has been tested and verified on the following models:
 - **Qwen3 (Dense)**: `Qwen/Qwen3-1.7B`, `Qwen/Qwen3-8B`, `Qwen/Qwen3-4B-AWQ`, `Qwen/Qwen3-8B-AWQ`
 - **Qwen3 (MoE)**: `Qwen/Qwen3-30B-A3B`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, `Qwen/Qwen3-30B-A3B-Thinking-2507-FP8`
 - **Qwen2.5**: `Qwen/Qwen2.5-0.5B-Instruct`, `Qwen/Qwen2.5-1.5B-Instruct`, `Qwen/Qwen2.5-3B-Instruct`, `Qwen/Qwen2.5-7B-Instruct`, `Qwen/Qwen2.5-14B-Instruct`, `Qwen/Qwen2.5-32B-Instruct`
+- **Qwen2.5-Coder**: `Qwen/Qwen2.5-Coder-7B-Instruct`
 - **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.2-3B-Instruct` for example
 - **GPT-OSS**: `openai/gpt-oss-20b`, `openai/gpt-oss-120b`
 - **Mistral**: `mistralai/Mistral-7B-v0.3`

--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -103,8 +103,7 @@ Batch invariance has been tested and verified on the following models:
 - **DeepSeek series**: `deepseek-ai/DeepSeek-V3`, `deepseek-ai/DeepSeek-V3-0324`, `deepseek-ai/DeepSeek-R1`, `deepseek-ai/DeepSeek-V3.1`
 - **Qwen3 (Dense)**: `Qwen/Qwen3-1.7B`, `Qwen/Qwen3-8B`, `Qwen/Qwen3-4B-AWQ`, `Qwen/Qwen3-8B-AWQ`
 - **Qwen3 (MoE)**: `Qwen/Qwen3-30B-A3B`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, `Qwen/Qwen3-30B-A3B-Thinking-2507-FP8`
-- **Qwen2.5**: `Qwen/Qwen2.5-0.5B-Instruct`, `Qwen/Qwen2.5-1.5B-Instruct`, `Qwen/Qwen2.5-3B-Instruct`, `Qwen/Qwen2.5-7B-Instruct`, `Qwen/Qwen2.5-14B-Instruct`, `Qwen/Qwen2.5-32B-Instruct`
-- **Qwen2.5-Coder**: `Qwen/Qwen2.5-Coder-7B-Instruct`
+- **Qwen2.5 series**: `Qwen/Qwen2.5-7B-Instruct`, `Qwen/Qwen2.5-Coder-7B-Instruct`, etc.
 - **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.2-3B-Instruct` for example
 - **GPT-OSS**: `openai/gpt-oss-20b`, `openai/gpt-oss-120b`
 - **Mistral**: `mistralai/Mistral-7B-v0.3`


### PR DESCRIPTION
## Description

Adds `Qwen/Qwen2.5-Coder-7B-Instruct` to the list of tested models for batch invariance.

## Test Results

**Model:** Qwen/Qwen2.5-Coder-7B-Instruct

**Results:**
```
Trial 1: MATCH
Trial 2: MATCH
Trial 3: MATCH
Trial 4: MATCH
Trial 5: MATCH

[determinism] total=5, passed=5, failed=0, max_batch_size=8

✓ TEST PASSED - Batch invariance verified!
```

**Test Configuration:**
- Hardware: 4x NVIDIA A10G GPUs (23GB each)
- Tensor Parallelism: 4
- Backend: FLASH_ATTN
- vLLM Version: v0.21.0
- Environment: `VLLM_BATCH_INVARIANT=1`, `VLLM_USE_FLASHINFER_SAMPLER=0`
- Temperature: 0.0 (greedy decoding)

**Test Methodology:**
Used the official test script from `tests/v1/determinism/test_batch_invariance.py` with needle-in-batch testing methodology.

## Motivation

Qwen2.5-Coder is a popular coding model that users may want to run with batch invariance enabled for deterministic code generation in RL training or reproducible evaluation scenarios.

Closes part of #27433