### PR TITLE
fix: guard init_fp8_kv_scales against unallocated tensors during wake up after sleep

### DIFF
--- a/README_FIX.md
+++ b/README_FIX.md
@@ -58,6 +58,5 @@ After applying the patch, sleep mode wake-up should complete without errors:
 
 ```bash
 POST /sleep?level=1           → 200 OK
-POST /wake_up?tags=weights    → 200 OK
-POST /wake_up?tags=kv_cache   → 200 OK (no crash)
+POST /wake_up                 → 200 OK (no crash)
 ```

--- a/README_FIX.md
+++ b/README_FIX.md
@@ -1,0 +1,63 @@
+# Fix: init_fp8_kv_scales() crash during sleep mode wake-up
+
+## Problem
+
+When using vLLM sleep mode with FP8 KV cache (`--kv-cache-dtype fp8`) and tag-split wake-up:
+
+```bash
+POST /sleep?level=1           → 200 OK
+POST /wake_up?tags=weights    → 200 OK
+POST /wake_up?tags=kv_cache   → CRASH
+```
+
+The crash occurs because `init_fp8_kv_scales()` iterates over `self.kv_caches`
+which is a nested `list[list[Tensor]]` structure. During partial wake-up,
+some layers may contain unallocated tensors (`numel() == 0`), and calling
+`.zero_()` on these raises an `AttributeError` or CUDA error.
+
+## Fix
+
+The patch adds a guard in `init_fp8_kv_scales()` that skips unallocated tensors
+by checking `cache_tensor.numel() > 0` before calling `.zero_()`.
+
+## Installation
+
+### Option 1: Dockerfile (recommended)
+
+```dockerfile
+COPY fix_fp8_kv_scales.patch /tmp/
+RUN patch -p1 -d /opt/venv/lib/python3.12/site-packages < /tmp/fix_fp8_kv_scales.patch
+```
+
+### Option 2: Runtime patch
+
+```bash
+docker exec <container> patch -p1 -d /opt/venv/lib/python3.12/site-packages \
+  < /tmp/fix_fp8_kv_scales.patch
+```
+
+### Option 3: sed (if patch is not available)
+
+```bash
+sed -i \
+  '/kv_caches = getattr(self, "kv_caches", \[\])/a\        # Guard against unallocated tensors during partial wake-up (tags=kv_cache)' \
+  '/opt/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py
+
+sed -i \
+  's/if cache_tensor is not None:/if cache_tensor is not None and cache_tensor.numel() > 0:/' \
+  '/opt/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py
+```
+
+## Affected Files
+
+- `vllm/v1/worker/gpu_model_runner.py`
+
+## Verification
+
+After applying the patch, sleep mode wake-up should complete without errors:
+
+```bash
+POST /sleep?level=1           → 200 OK
+POST /wake_up?tags=weights    → 200 OK
+POST /wake_up?tags=kv_cache   → 200 OK (no crash)
+```

--- a/fix_fp8_kv_scales.patch
+++ b/fix_fp8_kv_scales.patch
@@ -1,0 +1,20 @@
+
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index 3221dc4..1111111 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -948,10 +948,12 @@ class GPUModelRunner(
+             return
+ 
+         kv_caches = getattr(self, "kv_caches", [])
+-        for cache_tensor in kv_caches:
+-            if cache_tensor is not None:
+-                cache_tensor.zero_()
++        # Guard against unallocated tensors during partial wake-up (tags=kv_cache)
++        for layer_kv in kv_caches:
++            for cache_tensor in layer_kv:
++                if cache_tensor is not None and cache_tensor.numel() > 0:
++                    cache_tensor.zero_()
+ 
+         k_attr_names = ("_k_scale", "k_scale")
+         v_attr_names = ("_v_scale", "v_scale")

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -948,9 +948,11 @@ class GPUModelRunner(
             return
 
         kv_caches = getattr(self, "kv_caches", [])
-        for cache_tensor in kv_caches:
-            if cache_tensor is not None:
-                cache_tensor.zero_()
+        # Guard against unallocated tensors during partial wake-up (tags=kv_cache)
+        for layer_kv in kv_caches:
+            for cache_tensor in layer_kv:
+                if cache_tensor is not None and cache_tensor.numel() > 0:
+                    cache_tensor.zero_()
 
         k_attr_names = ("_k_scale", "k_scale")
         v_attr_names = ("_v_scale", "v_scale")


### PR DESCRIPTION
During sleep/wake-up with tag-split wake-up (tags=kv_cache), kv_caches may contain empty/unallocated tensors (numel() == 0). Calling .zero_() on these raises an AttributeError or CUDA error. Add a numel() > 0 guard to skip unallocated tensors.



I researched and created this with the help of claude and qwen3.6. I'm not a senior developer, but I hope this helps someone.

