### PR TITLE
fix: make NCCL collectives eager break points in breakable cudagraph

### DIFF
--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -6,12 +6,17 @@ from typing import Any
 import torch
 import torch.distributed
 
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
+
 from .parallel_state import get_tp_group
 
 
+@eager_break_during_capture
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
-    return get_tp_group().all_reduce(input_)
+    result = get_tp_group().all_reduce(input_)
+    input_.copy_(result)
+    return input_
 
 
 def tensor_model_parallel_all_gather(


### PR DESCRIPTION
Cross-node NCCL collectives (host-staged, no GPUDirect) cannot be captured in CUDA graphs. They were causing 'illegal memory access at capture_end' errors when captured by breakable_cudagraph.

Changes:
- Add @eager_break_during_capture to tensor_model_parallel_all_reduce, tensor_model_parallel_all_gather, and tensor_model_parallel_reduce_scatter
- Copy result back to input buffer for correct cudagraph replay
- Remove FULL mode skip from eager_break_during_capture decorator so communication ops break regardless of cudagraph mode

Fixes the capture phase crash on multi-node GB10 (no GPUDirect RDMA).
fixes #46253


