### PR TITLE
[WIP][XPU][Release] add xpu release pipeline

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -118,6 +118,21 @@ steps:
         env:
           DOCKER_BUILDKIT: "1"
 
+      - label: "Build wheel - x86_64 - XPU"
+        depends_on: ~
+        id: build-wheel-x86-xpu
+        agents:
+          queue: cpu_queue_release
+        commands:
+          - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --tag vllm-ci:build-image --target vllm-build --progress plain -f docker/Dockerfile.xpu ."
+          - "mkdir artifacts"
+          - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
+          - "bash .buildkite/scripts/upload-xpu-wheels.sh"
+          - 'bash .buildkite/scripts/annotate-build-artifact.sh "$$BUILDKITE_LABEL" "s3://vllm-wheels/xpu/$$BUILDKITE_COMMIT/$(cd artifacts/dist && echo *.whl)"'
+        env:
+          DOCKER_BUILDKIT: "1"
+          S3_BUCKET: "vllm-wheels"
+
   - label: "Generate and upload wheel indices"
     depends_on: "build-wheels"
     allow_dependency_failure: true
@@ -839,6 +854,80 @@ steps:
       DOCKERHUB_USERNAME: "vllmbot"
 
   # =============================================================================
+  # XPU Release Pipeline (x86_64 only)
+  # =============================================================================
+  #
+  # vLLM version is determined by the Buildkite checkout (like CUDA pipeline).
+  # XPU release artifacts:
+  #   * wheels published under s3://vllm-wheels/xpu/<commit>/  (built in the
+  #     `build-wheels` group via Build wheel - x86_64 - XPU step)
+  #   * a single x86_64 release Docker image (no multi-arch -- XPU is x86 only)
+  #
+  # The image build depends on the manual block step block-build-release-images
+  # so it's gated identically to the CUDA images on release runs, but runs
+  # automatically on NIGHTLY=1 runs (the block step is omitted in that mode).
+  # =============================================================================
+
+  - label: ":xpu: Build release image - x86_64 - XPU"
+    id: build-xpu-release-image
+    depends_on:
+      - step: block-build-release-images
+        allow_failure: true
+    agents:
+      queue: cpu_queue_release
+    timeout_in_minutes: 180
+    commands:
+      - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
+      - |
+        DOCKER_BUILDKIT=1 docker build \
+          --build-arg max_jobs=16 \
+          --build-arg GIT_REPO_CHECK=1 \
+          --tag public.ecr.aws/q9t5s3a7/vllm-release-repo:$$BUILDKITE_COMMIT-xpu \
+          --target vllm-openai \
+          --progress plain \
+          -f docker/Dockerfile.xpu .
+      - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT-xpu"
+      - 'bash .buildkite/scripts/annotate-build-artifact.sh "$$BUILDKITE_LABEL" "public.ecr.aws/q9t5s3a7/vllm-release-repo:$$BUILDKITE_COMMIT-xpu"'
+    env:
+      DOCKER_BUILDKIT: "1"
+
+  - label: "Publish nightly XPU image to DockerHub"
+    depends_on:
+      - build-xpu-release-image
+    if: build.env("NIGHTLY") == "1"
+    agents:
+      queue: small_cpu_queue_release
+    commands:
+      - "bash .buildkite/scripts/push-nightly-builds-xpu.sh"
+      # Clean up old nightly builds (keep only last 14)
+      - "bash .buildkite/scripts/cleanup-nightly-builds.sh nightly- vllm/vllm-openai-xpu"
+    plugins:
+      - docker-login#v3.0.0:
+          username: vllmbot
+          password-env: DOCKERHUB_TOKEN
+    env:
+      DOCKER_BUILDKIT: "1"
+      DOCKERHUB_USERNAME: "vllmbot"
+
+  # XPU Release Job: Generate Root Index for XPU Wheels (for release only).
+  # Creates https://wheels.vllm.ai/xpu/ allowing users to install with
+  # `uv pip install vllm --extra-index-url https://wheels.vllm.ai/xpu/`.
+  - block: "Generate Root Index for XPU Wheels for Release"
+    key: block-generate-root-index-xpu-wheels
+    depends_on: build-wheel-x86-xpu
+
+  - label: ":package: Generate Root Index for XPU Wheels for Release"
+    depends_on: block-generate-root-index-xpu-wheels
+    id: generate-root-index-xpu-wheels
+    agents:
+      queue: cpu_queue_release
+    commands:
+      - "bash tools/vllm-xpu/generate-xpu-wheels-root-index.sh"
+    env:
+      S3_BUCKET: "vllm-wheels"
+      VARIANT: "xpu"
+
+  # =============================================================================
   # Publish to DockerHub and PyPI (at the end so all builds complete first)
   # =============================================================================
 
@@ -850,6 +939,7 @@ steps:
       - create-multi-arch-manifest-ubuntu2404
       - create-multi-arch-manifest-cuda-12-9-ubuntu2404
       - build-rocm-release-image
+      - build-xpu-release-image
       - input-release-version
       # Wait for CPU builds if their block steps were unblocked, so publish
       # doesn't race the in-progress CPU build. allow_failure lets publish

--- a/.buildkite/scripts/generate-nightly-index.py
+++ b/.buildkite/scripts/generate-nightly-index.py
@@ -91,9 +91,9 @@ def parse_from_filename(file: str) -> WheelFileInfo:
     else:
         if "+" in version:
             version_part, suffix = version.split("+", 1)
-            # Only treat known patterns as variants (rocmXXX, cuXXX, cpu)
+            # Only treat known patterns as variants (rocmXXX, cuXXX, cpu, xpu)
             # Git hashes and other suffixes are NOT variants
-            if suffix.startswith(("rocm", "cu", "cpu")):
+            if suffix.startswith(("rocm", "cu", "cpu", "xpu")):
                 variant = suffix
                 version = version_part
             # Otherwise keep the full version string (variant stays None)

--- a/.buildkite/scripts/publish-release-images.sh
+++ b/.buildkite/scripts/publish-release-images.sh
@@ -130,6 +130,16 @@ docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${ROCM_BASE_CACHE_KEY}-rocm
 docker push vllm/vllm-openai-rocm:latest-base
 docker push vllm/vllm-openai-rocm:v${RELEASE_VERSION}-base
 
+# ---- XPU ----
+# XPU is x86_64 only; no multi-arch manifest is needed.
+
+docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-xpu
+
+docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-xpu vllm/vllm-openai-xpu:latest
+docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-xpu vllm/vllm-openai-xpu:v${RELEASE_VERSION}
+docker push vllm/vllm-openai-xpu:latest
+docker push vllm/vllm-openai-xpu:v${RELEASE_VERSION}
+
 # ---- CPU ----
 # CPU images are behind separate block steps and may not have been built.
 # All-or-nothing: inspect both arches first, then either publish everything

--- a/.buildkite/scripts/push-nightly-builds-xpu.sh
+++ b/.buildkite/scripts/push-nightly-builds-xpu.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Push XPU nightly image from ECR to Docker Hub as
+# vllm/vllm-openai-xpu:nightly and vllm/vllm-openai-xpu:nightly-<commit>.
+# Run when NIGHTLY=1 after build-xpu-release-image has pushed to ECR.
+#
+# Local testing (no push to Docker Hub):
+#   BUILDKITE_COMMIT=<commit-with-xpu-image-in-ecr> DRY_RUN=1 \
+#     bash .buildkite/scripts/push-nightly-builds-xpu.sh
+# Requires: AWS CLI configured (for ECR public login), Docker.
+# For full run: Docker Hub login.
+
+set -ex
+
+# Use BUILDKITE_COMMIT from env (required; set to a commit that has the
+# XPU image in ECR for local test).
+BUILDKITE_COMMIT="${BUILDKITE_COMMIT:?Set BUILDKITE_COMMIT to the commit SHA that has the XPU image in ECR (e.g. from a previous release pipeline run)}"
+DRY_RUN="${DRY_RUN:-0}"
+
+ORIG_TAG="${BUILDKITE_COMMIT}-xpu"
+TAG_NAME="nightly"
+TAG_NAME_COMMIT="nightly-${BUILDKITE_COMMIT}"
+
+echo "Pushing XPU release image from ECR tag: $ORIG_TAG to Docker Hub as $TAG_NAME and $TAG_NAME_COMMIT"
+[[ "$DRY_RUN" == "1" ]] && echo "[DRY_RUN] Skipping push to Docker Hub"
+
+# Login to ECR and pull the image built by build-xpu-release-image.
+aws ecr-public get-login-password --region us-east-1 | \
+  docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7
+docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:"$ORIG_TAG"
+
+# Tag for Docker Hub (nightly and nightly-<commit>).
+docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:"$ORIG_TAG" vllm/vllm-openai-xpu:"$TAG_NAME"
+docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:"$ORIG_TAG" vllm/vllm-openai-xpu:"$TAG_NAME_COMMIT"
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "[DRY_RUN] Would push vllm/vllm-openai-xpu:$TAG_NAME and vllm/vllm-openai-xpu:$TAG_NAME_COMMIT"
+  echo "[DRY_RUN] Local tags created. Exiting without push."
+  exit 0
+fi
+
+# Push to Docker Hub (docker-login plugin runs before this step in CI).
+docker push vllm/vllm-openai-xpu:"$TAG_NAME"
+docker push vllm/vllm-openai-xpu:"$TAG_NAME_COMMIT"
+
+echo "Pushed vllm/vllm-openai-xpu:$TAG_NAME and vllm/vllm-openai-xpu:$TAG_NAME_COMMIT"

--- a/.buildkite/scripts/upload-xpu-wheels.sh
+++ b/.buildkite/scripts/upload-xpu-wheels.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Upload XPU wheels to S3 with proper index generation.
+#
+# Two kinds of wheels end up in the per-commit XPU index:
+#   1. The vLLM XPU wheel built in this CI run (artifacts/dist/*.whl).
+#   2. Redistributed upstream wheels that vLLM ships from its own index
+#      (because they are not on PyPI or conflict with PyPI names):
+#        - triton (Intel XPU shim, name 'triton', version '3.7.1+xpu')
+#        - vllm-xpu-kernels
+#      These are uploaded manually (out of band) to
+#      ``s3://vllm-wheels/xpu/redist/`` and copied into every per-commit
+#      directory at upload time so the per-commit index is self-contained
+#      and 'pip install vllm --extra-index-url https://wheels.vllm.ai/xpu/<commit>/'
+#      Just Works without a separate index.
+#
+# Required environment variables:
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (or IAM role)
+#   S3_BUCKET (default: vllm-wheels)
+#
+# S3 path structure:
+#   s3://vllm-wheels/xpu/redist/                - Hand-uploaded shim wheels
+#   s3://vllm-wheels/xpu/{commit}/              - Per-commit wheel + index
+#   s3://vllm-wheels/xpu/nightly/               - Index pointing to latest main
+#   s3://vllm-wheels/xpu/{version}/             - Index for release versions
+
+set -ex
+
+# ======== Configuration ========
+BUCKET="${S3_BUCKET:-vllm-wheels}"
+XPU_SUBPATH="xpu/${BUILDKITE_COMMIT}"
+S3_COMMIT_PREFIX="s3://$BUCKET/$XPU_SUBPATH/"
+S3_REDIST_PREFIX="s3://$BUCKET/xpu/redist/"
+INDICES_OUTPUT_DIR="xpu-indices"
+
+echo "========================================"
+echo "XPU Wheel Upload Configuration"
+echo "========================================"
+echo "S3 Bucket: $BUCKET"
+echo "S3 Path: $XPU_SUBPATH"
+echo "Redist source: $S3_REDIST_PREFIX"
+echo "Commit: $BUILDKITE_COMMIT"
+echo "Branch: $BUILDKITE_BRANCH"
+echo "========================================"
+
+# ======== Part 0: Setup Python and helpers ========
+
+# Pick a Python interpreter for index generation.
+# shellcheck source=lib/select-python.sh
+source .buildkite/scripts/lib/select-python.sh
+select_python
+
+# Set up auditwheel-in-a-container for the manylinux retagging step.
+# shellcheck source=lib/manylinux.sh
+source .buildkite/scripts/lib/manylinux.sh
+
+# ======== Part 1: Collect and prepare wheels ========
+
+mkdir -p all-xpu-wheels
+
+# vLLM wheel built in this run.
+if compgen -G "artifacts/dist/*.whl" > /dev/null; then
+    cp artifacts/dist/*.whl all-xpu-wheels/
+else
+    echo "ERROR: No wheel found in artifacts/dist/" >&2
+    exit 1
+fi
+
+# Pull redistributed upstream wheels (triton-xpu shim, vllm-xpu-kernels).
+# These are uploaded manually to s3://$BUCKET/xpu/redist/; if the directory
+# is empty the per-commit index will only contain the vLLM wheel.
+mkdir -p xpu-redist
+if aws s3 ls "$S3_REDIST_PREFIX" 2>/dev/null | grep -q "\.whl"; then
+    aws s3 sync "$S3_REDIST_PREFIX" xpu-redist/ --exclude "*" --include "*.whl"
+    cp xpu-redist/*.whl all-xpu-wheels/ 2>/dev/null || true
+else
+    echo "WARNING: No redistributed wheels found at $S3_REDIST_PREFIX"
+    echo "         Upload triton-3.7.1+xpu and vllm_xpu_kernels wheels there"
+    echo "         before users can install vllm from this index."
+fi
+
+WHEEL_COUNT=$(find all-xpu-wheels -maxdepth 1 -name '*.whl' 2>/dev/null | wc -l)
+echo "Total wheels to upload: $WHEEL_COUNT"
+
+# Detect manylinux platform tag and rename in place for any wheel that
+# still carries the generic ``linux_<arch>`` tag (mirrors ROCm flow).
+for wheel in all-xpu-wheels/*.whl; do
+    if [[ "$wheel" == *"linux"* ]] && [[ "$wheel" != *"manylinux"* ]]; then
+        new_wheel="$(apply_manylinux_tag "$wheel")"
+        echo "Renamed: $(basename "$wheel") -> $(basename "$new_wheel")"
+    fi
+done
+
+echo ""
+echo "Wheels to upload:"
+ls -lh all-xpu-wheels/
+
+# ======== Part 2: Upload wheels to S3 ========
+
+echo ""
+echo "Uploading wheels to $S3_COMMIT_PREFIX"
+for wheel in all-xpu-wheels/*.whl; do
+    aws s3 cp "$wheel" "$S3_COMMIT_PREFIX"
+done
+
+# ======== Part 3: Generate and upload indices ========
+
+echo ""
+echo "Generating indices..."
+obj_json="xpu-objects.json"
+aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$XPU_SUBPATH/" --delimiter / --output json > "$obj_json"
+
+mkdir -p "$INDICES_OUTPUT_DIR"
+
+# HACK: Replace regex module with stdlib re (same as CUDA/ROCm scripts).
+sed -i 's/import regex as re/import re/g' .buildkite/scripts/generate-nightly-index.py
+
+$PYTHON .buildkite/scripts/generate-nightly-index.py \
+    --version "$XPU_SUBPATH" \
+    --current-objects "$obj_json" \
+    --output-dir "$INDICES_OUTPUT_DIR" \
+    --comment "XPU commit $BUILDKITE_COMMIT"
+
+# Upload indices to commit directory.
+echo "Uploading indices to $S3_COMMIT_PREFIX"
+aws s3 cp --recursive "$INDICES_OUTPUT_DIR/" "$S3_COMMIT_PREFIX"
+
+# Update xpu/nightly/ if on main branch and not a PR.
+if [[ "$BUILDKITE_BRANCH" == "main" && "$BUILDKITE_PULL_REQUEST" == "false" ]] || [[ "$NIGHTLY" == "1" ]]; then
+    echo "Updating xpu/nightly/ index..."
+    aws s3 cp --recursive "$INDICES_OUTPUT_DIR/" "s3://$BUCKET/xpu/nightly/"
+fi
+
+# Extract version from vLLM wheel and update version-specific index.
+VLLM_WHEEL=$(find all-xpu-wheels -maxdepth 1 -name 'vllm-*.whl' 2>/dev/null | head -1)
+if [ -n "$VLLM_WHEEL" ]; then
+    VERSION=$(unzip -p "$VLLM_WHEEL" '**/METADATA' | grep '^Version: ' | cut -d' ' -f2)
+    echo "Version in wheel: $VERSION"
+    PURE_VERSION="${VERSION%%+*}"
+    PURE_VERSION="${PURE_VERSION%%.xpu}"
+    echo "Pure version: $PURE_VERSION"
+
+    if [[ "$VERSION" != *"dev"* ]]; then
+        echo "Updating xpu/$PURE_VERSION/ index..."
+        aws s3 cp --recursive "$INDICES_OUTPUT_DIR/" "s3://$BUCKET/xpu/$PURE_VERSION/"
+    fi
+fi
+
+# ======== Part 4: Summary ========
+
+echo ""
+echo "========================================"
+echo "XPU Wheel Upload Complete!"
+echo "========================================"
+echo ""
+echo "Wheels available at:"
+echo "  s3://$BUCKET/$XPU_SUBPATH/"
+echo ""
+echo "Install command (by commit):"
+echo "  pip install vllm --extra-index-url https://${BUCKET}.s3.amazonaws.com/$XPU_SUBPATH/"
+echo ""
+if [[ "$BUILDKITE_BRANCH" == "main" ]] || [[ "$NIGHTLY" == "1" ]]; then
+    echo "Install command (nightly):"
+    echo "  pip install vllm --extra-index-url https://${BUCKET}.s3.amazonaws.com/xpu/nightly/"
+fi
+echo ""
+echo "Wheel count: $WHEEL_COUNT"
+echo "========================================"

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -126,6 +126,44 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
 CMD ["/bin/bash"]
 
+######################### WHEEL BUILD STAGE #########################
+# Produce a vLLM XPU wheel without installing it. Used by the release
+# pipeline to harvest wheels for upload (mirrors the `vllm-build` stage
+# in docker/Dockerfile.cpu and the `build` stage in docker/Dockerfile).
+FROM vllm-base AS vllm-build
+
+ARG GIT_REPO_CHECK=0
+
+# Install Python build dependencies (subset of what vllm-openai needs --
+# no test deps, no triton uninstall/reinstall dance: requirements/xpu.txt
+# already pins the correct triton-xpu shim wheel).
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,src=requirements/common.txt,target=/workspace/vllm/requirements/common.txt \
+    --mount=type=bind,src=requirements/xpu.txt,target=/workspace/vllm/requirements/xpu.txt \
+    uv pip install grpcio-tools protobuf nanobind && \
+    uv pip install -r /workspace/vllm/requirements/xpu.txt
+
+COPY . .
+
+# Drop the pre-built Rust artifacts into the source tree. setup.py detects
+# them and ships them as-is, skipping the local Rust build.
+COPY --from=rust-build /workspace/vllm/vllm-rs vllm/vllm-rs
+COPY --from=rust-build /workspace/vllm/_rust_*.so vllm/
+
+RUN --mount=type=bind,source=.git,target=.git \
+    if [ "$GIT_REPO_CHECK" != 0 ]; then bash tools/check_repo.sh; fi
+
+ENV VLLM_TARGET_DEVICE=xpu
+
+# Build the wheel. oneAPI / oneCCL env vars are required by the C++ build
+# (XPU kernels link against MKL / oneDNN / oneCCL provided by the base image).
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=.git,target=.git \
+    source /opt/intel/oneapi/setvars.sh --force && \
+    source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force && \
+    export CMAKE_PREFIX_PATH="$(python3 -c 'import site; print(site.getsitepackages()[0])'):${CMAKE_PREFIX_PATH}" && \
+    python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38
+
 ######################### UCX + NIXL BUILD STAGE #########################
 # Build UCX and NIXL in a dedicated stage so compiler/autotools layers are
 # never included in the final runtime image (mirrors ROCm's build_rixl stage).

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -240,8 +240,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install grpcio-tools protobuf nanobind && \
     uv pip install -r /workspace/vllm/requirements/xpu.txt && \
     uv pip install --no-build-isolation -r /workspace/vllm/requirements/test/xpu.txt && \
-    uv pip uninstall triton triton-xpu && \
-    uv pip install triton-xpu==3.7.1 && \
     uv pip uninstall oneccl oneccl-devel && \
     source /opt/intel/oneapi/setvars.sh --force && \
     source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force && \

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -11,10 +11,22 @@ wheel
 jinja2>=3.1.6
 datasets # for benchmark scripts
 numba == 0.65.0 # Required for N-gram speculative decoding
+
+# XPU wheel index hosts:
+#   * triton (Intel XPU shim, see https://github.com/intel/intel-xpu-backend-for-triton)
+#   * vllm-xpu-kernels
+# When installing outside the official Dockerfile, pass
+#   --index-strategy unsafe-best-match (uv)  or  --use-feature truststore (pip)
+# so the XPU index is consulted alongside the PyTorch XPU index.
 --extra-index-url=https://download.pytorch.org/whl/xpu
+--extra-index-url=https://wheels.vllm.ai/xpu
+# Pin the Intel XPU triton shim BEFORE torch so torch's `triton`
+# dependency is already satisfied during resolution. The `+xpu` local
+# version identifier ensures it does not collide with NVIDIA's triton.
+triton==3.7.1+xpu
 torch==2.12.0
 torchaudio
 torchvision
 
 auto_round_lib>=0.13.3
-vllm_xpu_kernels @ https://github.com/vllm-project/vllm-xpu-kernels/releases/download/v0.1.10/vllm_xpu_kernels-0.1.10-cp38-abi3-manylinux_2_28_x86_64.whl
+vllm_xpu_kernels==0.1.10

--- a/tools/vllm-xpu/generate-xpu-wheels-root-index.sh
+++ b/tools/vllm-xpu/generate-xpu-wheels-root-index.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Generate S3 PyPI Root Index for the Latest XPU Release
+#
+# Creates a PEP 503 compatible index.html at xpu/ pointing to the latest
+# semantic version's packages. This enables users to install with:
+#   uv pip install vllm --extra-index-url https://wheels.vllm.ai/xpu
+#
+# Usage:
+#   generate-xpu-wheels-root-index.sh [options]
+#
+# Options:
+#   --dry-run      Preview changes without uploading
+#   --version VER  Use specific version instead of auto-detecting latest
+#
+# Environment variables:
+#   S3_BUCKET   - Bucket name (default: vllm-wheels)
+#   VARIANT     - XPU variant subdir (default: xpu)
+#   DRY_RUN     - Set to 1 for preview mode (same as --dry-run)
+#
+# Mirrors tools/vllm-rocm/generate-rocm-wheels-root-index.sh.
+
+set -euo pipefail
+
+# ======== Configuration ========
+BUCKET="${S3_BUCKET:-vllm-wheels}"
+VARIANT="${VARIANT:-xpu}"
+DRY_RUN="${DRY_RUN:-0}"
+FORCE_VERSION=""
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --version)
+            FORCE_VERSION="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Working directory for generated files
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "========================================"
+echo "Generate Root Index for Latest XPU Version"
+echo "========================================"
+echo "S3 Bucket: $BUCKET"
+echo "XPU Variant: $VARIANT"
+echo "Dry Run: $DRY_RUN"
+echo "========================================"
+echo ""
+
+# ======== Step 1: Find latest semantic version ========
+
+echo "Step 1: Finding latest semantic version..."
+
+# List all directories under xpu/
+aws s3api list-objects-v2 \
+    --bucket "$BUCKET" \
+    --prefix "xpu/" \
+    --delimiter "/" \
+    --query 'CommonPrefixes[].Prefix' \
+    --output text | tr '\t' '\n' > "$WORK_DIR/all_prefixes.txt"
+
+# Filter for semantic versions (x.y.z pattern)
+grep -oE 'xpu/[0-9]+\.[0-9]+\.[0-9]+/' "$WORK_DIR/all_prefixes.txt" | \
+    sed 's|xpu/||; s|/||' | \
+    sort -V > "$WORK_DIR/versions.txt" || true
+
+if [[ ! -s "$WORK_DIR/versions.txt" ]]; then
+    echo "ERROR: No semantic versions found under s3://$BUCKET/xpu/"
+    exit 1
+fi
+
+echo "Found versions:"
+cat "$WORK_DIR/versions.txt"
+echo ""
+
+if [[ -n "$FORCE_VERSION" ]]; then
+    LATEST_VERSION="$FORCE_VERSION"
+    echo "Using forced version: $LATEST_VERSION"
+else
+    LATEST_VERSION=$(tail -1 "$WORK_DIR/versions.txt")
+    echo "Latest version (auto-detected): $LATEST_VERSION"
+fi
+
+# Verify the version exists
+if ! grep -qx "$LATEST_VERSION" "$WORK_DIR/versions.txt"; then
+    echo "ERROR: Version $LATEST_VERSION not found in bucket"
+    exit 1
+fi
+
+# ======== Step 2: List packages from latest version ========
+
+echo ""
+echo "Step 2: Listing packages from xpu/$LATEST_VERSION/$VARIANT/..."
+
+VERSION_PREFIX="xpu/$LATEST_VERSION/$VARIANT/"
+
+# List package directories
+aws s3api list-objects-v2 \
+    --bucket "$BUCKET" \
+    --prefix "$VERSION_PREFIX" \
+    --delimiter "/" \
+    --query 'CommonPrefixes[].Prefix' \
+    --output text | tr '\t' '\n' > "$WORK_DIR/package_prefixes.txt" || true
+
+if [[ ! -s "$WORK_DIR/package_prefixes.txt" ]]; then
+    echo "ERROR: No packages found under s3://$BUCKET/$VERSION_PREFIX"
+    exit 1
+fi
+
+# Extract package names
+sed "s|${VERSION_PREFIX}||; s|/||g" "$WORK_DIR/package_prefixes.txt" | \
+    grep -v '^$' > "$WORK_DIR/packages.txt"
+
+echo "Found packages:"
+cat "$WORK_DIR/packages.txt"
+echo ""
+
+# ======== Step 3: Generate root index.html ========
+
+echo "Step 3: Generating root index.html..."
+
+mkdir -p "$WORK_DIR/output"
+
+{
+    cat <<'EOF'
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="pypi:repository-version" content="1.0">
+</head>
+<body>
+EOF
+
+    while read -r pkg; do
+        echo "    <a href=\"$pkg/\">$pkg</a><br>"
+    done < "$WORK_DIR/packages.txt"
+
+    cat <<'EOF'
+</body>
+</html>
+EOF
+} > "$WORK_DIR/output/index.html"
+
+echo "Generated root index.html:"
+cat "$WORK_DIR/output/index.html"
+echo ""
+
+# ======== Step 4: Copy and adjust package index files ========
+
+echo "Step 4: Copying and adjusting package index files..."
+
+while read -r pkg; do
+    echo "Processing package: $pkg"
+
+    # Download existing index.html from versioned path.
+    SOURCE_INDEX="s3://$BUCKET/$VERSION_PREFIX$pkg/index.html"
+
+    mkdir -p "$WORK_DIR/output/$pkg"
+
+    if aws s3 cp "$SOURCE_INDEX" "$WORK_DIR/output/$pkg/index.html" 2>/dev/null; then
+        # Adjust relative paths so they resolve from the root index location:
+        # Original: href="../../../{commit}/wheel.whl"  (from xpu/X.Y.Z/xpu/vllm/)
+        # New:      href="../{commit}/wheel.whl"        (from xpu/vllm/)
+        sed -i 's|href="\.\./\.\./\.\./|href="../|g' "$WORK_DIR/output/$pkg/index.html"
+        echo "  - Downloaded and adjusted: $pkg/index.html"
+    else
+        echo "  - WARNING: Could not download index for $pkg"
+    fi
+done < "$WORK_DIR/packages.txt"
+
+echo ""
+
+# ======== Step 5: Upload to S3 ========
+
+echo "Step 5: Uploading to s3://$BUCKET/xpu/..."
+echo ""
+
+echo "Files to upload:"
+find "$WORK_DIR/output" -name "*.html" -type f | while read -r file; do
+    rel_path="${file#"$WORK_DIR"/output/}"
+    echo "  xpu/$rel_path"
+done
+echo ""
+
+if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY RUN - Skipping upload"
+    echo ""
+    echo "Preview of generated files:"
+    echo "----------------------------------------"
+    echo "xpu/index.html:"
+    cat "$WORK_DIR/output/index.html"
+    echo ""
+    echo "----------------------------------------"
+    echo "Sample package index (first package):"
+    FIRST_PKG=$(head -1 "$WORK_DIR/packages.txt")
+    if [[ -f "$WORK_DIR/output/$FIRST_PKG/index.html" ]]; then
+        echo "xpu/$FIRST_PKG/index.html:"
+        cat "$WORK_DIR/output/$FIRST_PKG/index.html"
+    fi
+else
+    aws s3 cp --recursive "$WORK_DIR/output/" "s3://$BUCKET/xpu/" \
+        --content-type "text/html"
+
+    echo "Upload complete!"
+fi
+
+# ======== Summary ========
+
+echo ""
+echo "========================================"
+echo "Root Index Generation Complete!"
+echo "========================================"
+echo ""
+echo "Latest version: $LATEST_VERSION"
+echo "Packages indexed: $(wc -l < "$WORK_DIR/packages.txt")"
+echo ""


### PR DESCRIPTION
## Purpose

Extends the release pipeline to publish Intel XPU artifacts alongside the
existing CUDA / ROCm / CPU ones:

- **Wheels** published under `s3://vllm-wheels/xpu/` (served at
  `https://wheels.vllm.ai/xpu/`), following the same per-commit + nightly +
  release index layout that ROCm uses.
- **Docker image** `vllm/vllm-openai-xpu:{latest,vX.Y.Z,nightly,nightly-<commit>}`
  built from `docker/Dockerfile.xpu` (x86_64 only -- no multi-arch manifest).

XPU has two upstream packages that don't live on PyPI and conflict with
PyPI names, so they are redistributed under
`s3://vllm-wheels/xpu/redist/`:

- `triton` (Intel XPU shim, version `3.7.1+xpu`,
  released by https://github.com/intel/intel-xpu-backend-for-triton)
- `vllm-xpu-kernels`

`upload-xpu-wheels.sh` pulls these into every per-commit directory so a
single `--extra-index-url https://wheels.vllm.ai/xpu/...` resolves all
dependencies.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

