### PR TITLE
[Doc] Document pull request limit

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -304,9 +304,15 @@ review process:
   resources. The reviewer will add `ready` label to the PR when the PR is
   ready to merge or a full CI run is needed.
 
-### Escalating Stalled Contributions
+### Pull Request Limits and Escalation
 
-If you have an important contribution that has not yet received maintainer attention, please email us at:
+vLLM uses GitHub's [pull request limit](https://github.blog/open-source/maintainers/how-pull-request-limits-are-cutting-down-the-noise/)
+for contributors without write access. The current cap is 6 open PRs. If this
+blocks well-intentioned critical work, contact a committer to request bypass
+list access.
+
+If you need an expedited review for an important contribution, please email us
+at:
 
 <pr-review-request@vllm.ai>
 


### PR DESCRIPTION
## Summary

- Document that vLLM uses GitHub's pull request limit for contributors without write access.
- State the current cap of 6 open PRs.
- Clarify bypass-list and expedited-review contact paths for critical contributions.

## Duplicate checks

- `gh pr list --repo vllm-project/vllm --state open --search "\"pull request limit\""`: no matches.
- `gh pr list --repo vllm-project/vllm --state open --search "\"bypass list\""`: no matches.
- `gh pr list --repo vllm-project/vllm --state open --search "pr-review-request"`: found #44457, which replaces the review-request email with a form; this PR is different because it adds the PR-limit policy and keeps the current email guidance.

## Tests

- `git diff --check`
- `.venv/bin/pre-commit run markdownlint-cli2 --files docs/contributing/README.md`

AI assistance was used to prepare this PR.