### PR TITLE
[Bugfix] Resample long audio in blocks to avoid int32 AudioFrame overflow

### DIFF
--- a/tests/multimodal/test_audio.py
+++ b/tests/multimodal/test_audio.py
@@ -36,6 +36,28 @@ def test_resample_audio_pyav(dummy_audio):
     assert np.all(out_same == dummy_audio)
 
 
+def test_resample_audio_pyav_long_input_streams_in_blocks(monkeypatch):
+    """A signal larger than one frame must resample in bounded blocks and
+    produce output identical to a single-frame resample, instead of building
+    one giant frame that overflows the int32 AudioFrame buffer.
+    See https://github.com/vllm-project/vllm/issues/46364.
+    """
+    import vllm.multimodal.audio as audio_mod
+
+    rng = np.random.default_rng(0)
+    audio = rng.standard_normal(50_000).astype(np.float32)
+
+    # Reference: a single frame for the whole signal (large per-frame cap).
+    reference = resample_audio_pyav(audio, orig_sr=48_000, target_sr=16_000)
+
+    # Force the multi-block path by shrinking the per-frame cap.
+    monkeypatch.setattr(audio_mod, "_MAX_RESAMPLE_FRAME_SAMPLES", 4096)
+    chunked = resample_audio_pyav(audio, orig_sr=48_000, target_sr=16_000)
+
+    assert chunked.shape == reference.shape
+    np.testing.assert_allclose(chunked, reference, atol=1e-5)
+
+
 def test_resample_audio_scipy(dummy_audio):
     out_down = resample_audio_scipy(dummy_audio, orig_sr=4, target_sr=2)
     out_up = resample_audio_scipy(dummy_audio, orig_sr=2, target_sr=4)

--- a/vllm/multimodal/audio.py
+++ b/vllm/multimodal/audio.py
@@ -171,6 +171,14 @@ def normalize_audio(
 # ============================================================
 
 
+# A single planar ``fltp`` AudioFrame's buffer size (``nb_samples * 4`` bytes)
+# is computed as a C ``int``, so it overflows ``INT_MAX`` once a frame holds
+# ~537M samples (~3.1h @ 48kHz). Feed the resampler in blocks below that limit;
+# this value keeps a wide margin. See
+# https://github.com/vllm-project/vllm/issues/46364.
+_MAX_RESAMPLE_FRAME_SAMPLES = 1 << 24  # 16,777,216 samples (~67 MiB at fltp)
+
+
 def resample_audio_pyav(
     audio: npt.NDArray[np.floating],
     *,
@@ -215,14 +223,19 @@ def resample_audio_pyav(
     audio_f32 = np.asarray(audio, dtype=np.float32)
     if len(audio_f32) < _MIN_SAMPLES:
         audio_f32 = np.pad(audio_f32, (0, _MIN_SAMPLES - len(audio_f32)))
-    audio_f32 = audio_f32.reshape(1, -1)
 
     resampler = av.AudioResampler(format="fltp", layout="mono", rate=target_sr_int)
 
-    frame = av.AudioFrame.from_ndarray(audio_f32, format="fltp", layout="mono")
-    frame.sample_rate = orig_sr_int
-
-    out_frames = resampler.resample(frame)
+    # Feed the (stateful) resampler in bounded blocks rather than building one
+    # giant frame for the whole signal, which overflows the int32 AudioFrame
+    # buffer for long audio (see _MAX_RESAMPLE_FRAME_SAMPLES). Streaming the
+    # blocks yields output identical to a single frame.
+    out_frames: list[av.AudioFrame] = []
+    for start in range(0, len(audio_f32), _MAX_RESAMPLE_FRAME_SAMPLES):
+        block = audio_f32[start : start + _MAX_RESAMPLE_FRAME_SAMPLES].reshape(1, -1)
+        frame = av.AudioFrame.from_ndarray(block, format="fltp", layout="mono")
+        frame.sample_rate = orig_sr_int
+        out_frames.extend(resampler.resample(frame))
     out_frames.extend(resampler.resample(None))  # flush buffered samples
 
     result = np.concatenate([f.to_ndarray() for f in out_frames], axis=1).squeeze(0)


### PR DESCRIPTION
## Summary

Fixes #46364.

`resample_audio_pyav` reshapes the whole signal into one `(1, N)` array and
pushes it through a **single** `av.AudioFrame`. A planar `fltp` frame's buffer
size (`nb_samples * 4` bytes) is computed as a C `int`, so it overflows
`INT_MAX` once `nb_samples >= 2**31 / 4 ≈ 537M` samples (~3.1h @ 48kHz, ~3.4h @
44.1kHz; half that for stereo). PyAV then raises `EINVAL`, which the audio
loader surfaces to users as the misleading `Invalid or unsupported audio file`.

16kHz input is unaffected (the resample branch is skipped), and long-form
`split_audio` chunking does not help because the file is resampled *before*
chunking. Thanks @runixer for the precise root-cause and repro.

## Fix

Feed the **stateful** `av.AudioResampler` in bounded blocks
(`_MAX_RESAMPLE_FRAME_SAMPLES = 1 << 24`, ~16.7M samples ≈ 67 MiB) instead of
one giant frame — mirroring how the sibling `load_audio_pyav` already resamples
frame by frame. One resampler is kept across blocks and flushed once at the end,
so the output is identical to the single-frame path.

## Verification

Verified with PyAV 17.1.0 that block-fed resampling is **byte-for-byte
identical** to the single-frame path (max abs diff `0.0`, same length) for a
50k-sample 48k→16k signal, and that short inputs still behave as before. Added
`test_resample_audio_pyav_long_input_streams_in_blocks`, which forces the
multi-block path (via a shrunk per-frame cap) and asserts it matches the
single-frame result.

This is purely an overflow fix — no behavior change for normal-length audio.