### PR TITLE
Run DeepSeek-V2-Lite prefetch-offload eval eager on ROCm

### DIFF
--- a/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh
+++ b/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh
@@ -33,6 +33,14 @@ if [[ -n "${ATTENTION_BACKEND:-}" ]]; then
   EXTRA_ARGS+=(--attention-backend "${ATTENTION_BACKEND}")
 fi
 
+# ROCm HIP-graph replay intermittently corrupts decode output for this MoE model
+# (bisected to a ROCm/clr 7.2.x regression, not a vLLM bug); run eager on ROCm
+# until the runtime fix lands.
+if command -v rocm-smi &> /dev/null || [[ -d /opt/rocm ]] || [[ -n "${ROCM_PATH:-}" ]]; then
+  echo "ROCm platform detected: adding --enforce-eager to avoid HIP-graph decode corruption"
+  EXTRA_ARGS+=(--enforce-eager)
+fi
+
 cleanup() {
   if [[ -n "${SERVER_PID:-}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
     kill "${SERVER_PID}" 2>/dev/null || true

--- a/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh
+++ b/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh
@@ -33,10 +33,9 @@ if [[ -n "${ATTENTION_BACKEND:-}" ]]; then
   EXTRA_ARGS+=(--attention-backend "${ATTENTION_BACKEND}")
 fi
 
-# ROCm HIP-graph replay intermittently corrupts decode output for this MoE model
-# (bisected to a ROCm/clr 7.2.x regression, not a vLLM bug); run eager on ROCm
-# until the runtime fix lands.
-if command -v rocm-smi &> /dev/null || [[ -d /opt/rocm ]] || [[ -n "${ROCM_PATH:-}" ]]; then
+# ROCm: run eager to avoid intermittent HIP-graph decode corruption.
+# See https://github.com/ROCm/clr/issues/279
+if command -v rocm-smi &> /dev/null || command -v amd-smi &> /dev/null || [[ -d /opt/rocm ]] || [[ -n "${ROCM_PATH:-}" ]]; then
   echo "ROCm platform detected: adding --enforce-eager to avoid HIP-graph decode corruption"
   EXTRA_ARGS+=(--enforce-eager)
 fi

--- a/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh
+++ b/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh
@@ -35,6 +35,7 @@ fi
 
 # ROCm: run eager to avoid intermittent HIP-graph decode corruption.
 # See https://github.com/ROCm/clr/issues/279
+# TODO(aarushjain29): Revert after TheRock 7.14
 if command -v rocm-smi &> /dev/null || command -v amd-smi &> /dev/null || [[ -d /opt/rocm ]] || [[ -n "${ROCM_PATH:-}" ]]; then
   echo "ROCm platform detected: adding --enforce-eager to avoid HIP-graph decode corruption"
   EXTRA_ARGS+=(--enforce-eager)


### PR DESCRIPTION
The mi300_1: deepseek-v2-lite-prefetch-offload-accuracy nightly is flaky on MI300X — ~1 in 5 fresh servers emits ~45% garbage decode tokens, dropping GSM8K accuracy below the 0.25 threshold. 

The corruption is nondeterministic across identical runs and reproduces on the plain non-offload baseline. Root cause is a HIP graph capture/replay regression in the ROCm runtime (ROCm/clr), not vLLM or the offload feature: bisecting libamdhip64 (rest of stack fixed) shows clr 7.1.1 clean and 7.2.0/7.2.2/7.2.3 broken; the same kernels run clean under HIP graphs on CUDA and on ROCm 7.13. Eager is always correct.


 This forces --enforce-eager on ROCm only until the runtime fix lands. CUDA path unchanged. Restores deterministic ~0.34 accuracy at lower decode throughput (still within timeout).