### PR TITLE
[CI] Fix CPU-Multi-Modal Model Tests timeout by adding a 4th shard

### DIFF
--- a/.buildkite/hardware_tests/cpu.yaml
+++ b/.buildkite/hardware_tests/cpu.yaml
@@ -136,7 +136,7 @@ steps:
     - |
       bash .buildkite/scripts/hardware_ci/run-cpu-test.sh 45m "
       pytest -x -v -s tests/models/multimodal/generation --ignore=tests/models/multimodal/generation/test_pixtral.py -m cpu_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB"
-  parallelism: 3
+  parallelism: 4
 
 - label: "Arm CPU Test"
   depends_on: []


### PR DESCRIPTION
## Summary

- The `CPU-Multi-Modal Model Tests 1` (shard 0) is recurring-failing due to the 45-minute timeout being too tight when the CI node is slow
- With 3 shards, pytest-shard assigns ~20 tests to shard 0 but only ~10 to the others — shard 0 is the bottleneck
- Increase `parallelism` from 3 to 4 so each shard gets ~10 tests, completing well within the timeout on any node

## Evidence

**Build [#73220](https://buildkite.com/vllm/ci/builds/73220) (Jun 20 daily) — TIMED OUT:**
- Shard 0 ran for 43+ minutes, hit the 45m timeout with 4 tests remaining (14/18 passed)
- Average time per test: **185 seconds** (slow node)
- Exit status 1 — container killed by `timeout 45m`

**Build [#73260](https://buildkite.com/vllm/ci/builds/73260) (Jun 21 nightly) — PASSED (barely):**
- Shard 0 completed in 38m25s with 18 passed, 2 skipped
- Average time per test: **126 seconds** (faster node)
- Only 6.5 minutes of headroom — would timeout on a slower node

**Build [#73005](https://buildkite.com/vllm/ci/builds/73005) — TIMED OUT:**
- Exit status 124 (timeout signal) with 16 tests passed

**Shard distribution (build #73260, all 3 shards):**
| Shard | Tests | Duration |
|-------|-------|----------|
| 0 | 18 passed, 2 skipped | 38m 25s |
| 1 | 9 passed, 1 skipped | 22m 03s |
| 2 | 10 passed | 30m 40s |

**Projected with 4 shards (~10 tests each):**
- Slow node (185s/test): ~31 min — safely within 45m
- Fast node (126s/test): ~21 min

## Test plan

- [ ] Verify the 4 shards each pick up a roughly equal share of the `cpu_model`-marked tests
- [ ] Monitor the next nightly build for timeout regressions

AI assistance was used (Claude). This is not duplicating an existing PR — no tracking issue exists for this recurring timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)