### PR TITLE
[SimpleCPUOffloadConnector] Fix remaining global→block conversions under PCP/DCP

### DIFF
--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -1655,6 +1655,7 @@ def test_cp_block_size_scaling(dcp_world_size: int, pcp_world_size: int) -> None
     expected_cp = dcp_world_size * pcp_world_size
     assert sched.cp_world_size == expected_cp
     assert sched.block_size == BLOCK_SIZE * expected_cp
+    assert sched.fa_block_size == BLOCK_SIZE * expected_cp
 
 
 # ---------------------------------------------------------------------------
@@ -1732,6 +1733,86 @@ def test_cp_eager_store_and_load_roundtrip(
     assert meta2.load_event >= 0, "Expected a load event"
     assert len(meta2.load_gpu_blocks) == num_blocks
     assert len(meta2.load_cpu_blocks) == num_blocks
+
+
+# ---------------------------------------------------------------------------
+# Test 18: CP store and load use effective block size
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "dcp_world_size, pcp_world_size",
+    [
+        (2, 1),
+        (1, 2),
+        (2, 2),
+    ],
+)
+def test_cp_effective_block_size_store_and_load(
+    dcp_world_size: int, pcp_world_size: int
+) -> None:
+    """Verify ready_blocks_g (store) and n_take_g (load) use the effective
+    (physical * cp) block size, not the per-rank physical size."""
+    fix = _make_cp_scheduler(
+        dcp_world_size=dcp_world_size, pcp_world_size=pcp_world_size
+    )
+    sched = fix.scheduler
+    gpu_pool = fix.gpu_block_pool
+    cp = dcp_world_size * pcp_world_size
+    vbs = BLOCK_SIZE * cp
+
+    # Store: allocate 2 blocks, confirm only 1. Without the fix,
+    # ready_blocks_g = vbs / BLOCK_SIZE = 2, storing both blocks.
+    req = _make_cp_request(num_blocks=2, virtual_block_size=vbs)
+    gpu_blocks = _allocate_cp_gpu_blocks(gpu_pool, req, 2, vbs)
+    kv = KVCacheBlocks(blocks=(gpu_blocks,))
+    req.num_computed_tokens = vbs
+    sched.update_state_after_alloc(req, kv, num_external_tokens=0)
+    m1 = sched.build_connector_meta(
+        make_scheduler_output(
+            {req.request_id: vbs},
+            new_reqs={req.request_id: kv.get_block_ids()},
+        )
+    )
+    assert len(m1.store_gpu_blocks) == 1
+    assert len(m1.store_cpu_blocks) == 1
+    simulate_store_completion(sched, m1.store_event)
+
+    # Load: store 2 blocks from a second request, accept only 1 as external.
+    # Without the fix, n_take_g = vbs / BLOCK_SIZE = 2, loading both.
+    req2 = _make_cp_request(num_blocks=2, virtual_block_size=vbs)
+    kv2 = KVCacheBlocks(blocks=(_allocate_cp_gpu_blocks(gpu_pool, req2, 2, vbs),))
+    req2.num_computed_tokens = 2 * vbs
+    sched.update_state_after_alloc(req2, kv2, num_external_tokens=0)
+    m2 = sched.build_connector_meta(
+        make_scheduler_output(
+            {req2.request_id: 2 * vbs},
+            new_reqs={req2.request_id: kv2.get_block_ids()},
+        )
+    )
+    simulate_store_completion(sched, m2.store_event)
+
+    req3 = Request(
+        request_id="req-cp-partial-load",
+        prompt_token_ids=req2.prompt_token_ids,
+        sampling_params=req2.sampling_params,
+        pooling_params=None,
+        mm_features=None,
+        block_hasher=req2._block_hasher,
+    )
+    hit, _ = sched.get_num_new_matched_tokens(req3, num_computed_tokens=0)
+    assert hit == 2 * vbs
+
+    kv3 = KVCacheBlocks(blocks=(gpu_pool.get_new_blocks(2),))
+    sched.update_state_after_alloc(req3, kv3, num_external_tokens=vbs)
+    m3 = sched.build_connector_meta(
+        make_scheduler_output(
+            {req3.request_id: vbs},
+            new_reqs={req3.request_id: kv3.get_block_ids()},
+        )
+    )
+    assert m3.load_event >= 0
+    assert len(m3.load_gpu_blocks) == 1
+    assert len(m3.load_cpu_blocks) == 1
+    assert m3.load_gpu_blocks == [kv3.get_block_ids()[0][0]]
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -103,9 +103,12 @@ class SimpleCPUOffloadScheduler:
         assert 0 <= self.fa_gidx < len(self.cpu_kv_cache_config.kv_cache_groups)
         # FA group's own block_size; divides scheduler_block_size (the LCM)
         # but is NOT assumed to equal it.
-        self.fa_block_size: int = self.cpu_kv_cache_config.kv_cache_groups[
-            self.fa_gidx
-        ].kv_cache_spec.block_size
+        self.fa_block_size: int = (
+            self.cpu_kv_cache_config.kv_cache_groups[
+                self.fa_gidx
+            ].kv_cache_spec.block_size
+            * self.cp_world_size
+        )
         assert self.block_size % self.fa_block_size == 0
 
         logger.info(
@@ -348,10 +351,12 @@ class SimpleCPUOffloadScheduler:
         # the rest will be released along with the temp pin below.
         cpu_hit_blocks: list[list[KVCacheBlock]] = []
         for g in range(num_groups):
-            g_block_size = kv_cache_groups[g].kv_cache_spec.block_size
+            g_block_size = (
+                kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
+            )
             assert num_external_tokens % g_block_size == 0, (
                 f"num_external_tokens={num_external_tokens} not aligned to "
-                f"group {g} block_size={g_block_size}"
+                f"group {g} effective block_size={g_block_size}"
             )
             n_take_g = num_external_tokens // g_block_size
             cpu_hit_blocks.append(cpu_hit_blocks_full[g][:n_take_g])
@@ -599,7 +604,9 @@ class SimpleCPUOffloadScheduler:
                 already_stored_g = state.num_stored_blocks[g]
                 group_gpu_ids = block_ids_by_group[g]
 
-                g_block_size = kv_cache_groups[g].kv_cache_spec.block_size
+                g_block_size = (
+                    kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
+                )
                 ready_blocks_g = aligned_tokens // g_block_size
                 scannable = group_gpu_ids[already_stored_g:ready_blocks_g]
 


### PR DESCRIPTION
## Purpose

PR #39831 ("[SimpleCPUOffloadConnector] PCP + DCP support", merged as
`c88d3d477`) added context-parallel support by scaling KV block sizes by
`cp_world_size = pcp_world_size * dcp_world_size`. Under CP, each physical
block holds `block_size` *per-rank* tokens but represents
`block_size * cp_world_size` **global** tokens, while the scheduler counts
global tokens. Every place that converts a global-token count to a block
count must therefore divide by the *effective* block size
(`physical_block_size * cp_world_size`).

PR #39831 applied that scaling in only two of the conversions:

- `_estimate_lazy_target_blocks` (lazy-mode watermark), and
- the load back-trace in `update_state_after_alloc`
  (`n_computed_g = cdiv(total_computed_tokens, g_block_size)`).

Three other conversions were left dividing a **global-token** quantity by the
**physical** (per-rank) block size, which over-counts blocks by a factor of
`cp_world_size` whenever `cp_world_size > 1`:

| Location | Quantity divided | Symptom when `cp_world_size > 1` |
|---|---|---|
| `self.fa_block_size` (used in `num_computed_tokens = num_cached_fa_blocks * fa_block_size`) | block → tokens | wrong `total_computed_tokens` → wrong load back-trace offsets |
| `update_state_after_alloc` `cpu_hit_blocks` loop (`n_take_g = num_external_tokens // g_block_size` + alignment assert) | global tokens → blocks | takes `cp_world_size`× too many hit blocks; alignment assert weakened |
| `_prepare_eager_store_specs` (`ready_blocks_g = aligned_tokens // g_block_size`) | global tokens → blocks | over-counts ready blocks → scans/stores out-of-range blocks in eager mode |

This PR scales all three by `cp_world_size`, matching the inline
`* self.cp_world_size` style already merged in #39831. With
`cp_world_size == 1` (no CP) every value is unchanged, so non-CP deployments
are unaffected.

## Why this is not duplicating an existing PR

Checked open PRs touching this area:

```bash
gh pr list --repo vllm-project/vllm --state open --search "SimpleCPUOffload"
gh pr list --repo vllm-project/vllm --state open --search "simple_kv_offload"
gh pr list --repo vllm-project/vllm --state open --search "cp_world_size block_size offload"
```

The open SimpleCPUOffload PRs address unrelated concerns — eager-store
`gpu_block_ids` dedup (#42615), a GPU→CPU store cross-stream race (#46278),
flushing the final KV block on same-step finish (#41777), a lazy prefix-length
threshold (#44791), metrics (#41790), and async CPU pinning (#44127). None
touch the CP global→block conversions. This change directly completes the CP
support introduced by the already-merged #39831; it is a follow-up bugfix, not
a re-implementation.

## Changes

`vllm/v1/simple_kv_offload/manager.py` (13 insertions, 6 deletions):

- `__init__`: `self.fa_block_size` is now the FA group's effective block size
  (`physical * cp_world_size`).
- `update_state_after_alloc`: the `cpu_hit_blocks` take-count loop uses the
  effective block size for `n_take_g` and its alignment assertion.
- `_prepare_eager_store_specs`: `ready_blocks_g` uses the effective block size.

## Test commands run and results

```bash
.venv/bin/python -m pytest tests/v1/simple_kv_offload/test_scheduler.py -v
```

Result: **26 passed** in ~13s, including the CP cases added by #39831:

- `test_cp_block_size_scaling[2-1] / [1-2] / [2-2]`
- `test_cp_eager_store_and_load_roundtrip[2-1] / [1-2]` (exercises the
  eager-store path corrected here)
- `test_cp_lazy_target_blocks_scaling[1] / [2] / [4]`

Syntax/lint sanity:

```bash
.venv/bin/python -m py_compile vllm/v1/simple_kv_offload/manager.py   # OK
```

All changed lines are within the 88-character limit.

> Note: the existing suite passes both with and without this fix — #39831's
> tests cover the lazy-target and `cp_block_size_scaling` paths it already
> fixed, and the eager roundtrip passes. A targeted regression test asserting
> `n_take_g` / `fa_block_size` / `ready_blocks_g` directly under
> `cp_world_size > 1` with a partial CPU prefix hit would harden coverage of
> the three spots corrected here; happy to add it if reviewers prefer.

## AI assistance

AI assistance (Claude) was used to analyze the gap relative to the merged
#39831, apply the fix, and run the test suite. The submitting human has
reviewed every changed line and run the tests above.
