### PR TITLE
[Docs] Add Phi-3.5-mini-instruct to batch invariance tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -107,6 +107,7 @@ Batch invariance has been tested and verified on the following models:
 - **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.2-3B-Instruct` for example
 - **GPT-OSS**: `openai/gpt-oss-20b`, `openai/gpt-oss-120b`
 - **Mistral**: `mistralai/Mistral-7B-v0.3`
+- **Phi series**: `microsoft/Phi-3.5-mini-instruct`
 
 Other models may also work, but these have been explicitly validated. If you encounter issues with a specific model, please report them on the [GitHub issue tracker](https://github.com/vllm-project/vllm/issues/new/choose).
 


### PR DESCRIPTION
## Description

Adds `microsoft/Phi-3.5-mini-instruct` to the list of tested models for batch invariance.

## Test Results

**Model:** microsoft/Phi-3.5-mini-instruct (3.8B)

**Results:**
```
Trial 1: MATCH
Trial 2: MATCH
Trial 3: MATCH
Trial 4: MATCH
Trial 5: MATCH

[determinism] total=5, passed=5, failed=0, max_batch_size=8

✓ TEST PASSED - Batch invariance verified!
```

**Test Configuration:**
- Hardware: 4x NVIDIA A10G GPUs (23GB each)
- Tensor Parallelism: 4
- Backend: FLASH_ATTN
- vLLM Version: v0.21.0
- Environment: `VLLM_BATCH_INVARIANT=1`, `VLLM_USE_FLASHINFER_SAMPLER=0`
- Temperature: 0.0 (greedy decoding)

**Test Methodology:**
Used the official test script from `tests/v1/determinism/test_batch_invariance.py` with needle-in-batch testing methodology.

## Motivation

Phi-3.5-mini-instruct is a popular small model (3.8B) from Microsoft, ideal for edge deployments and applications requiring deterministic inference with batch invariance.

Closes part of #27433