### PR TITLE
[Bugfix][Spec Decode] Disable dynamic speculative decoding for fixed-K proposers instead of crashing

### DIFF
--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -53,6 +53,8 @@ def create_scheduler(
     block_size: int = 16,
     max_model_len: int | None = None,
     num_speculative_tokens: int | None = None,
+    speculative_method: str = "ngram",
+    num_speculative_tokens_per_batch_size: list[tuple[int, int, int]] | None = None,
     skip_tokenizer_init: bool = False,
     async_scheduling: bool = False,
     pipeline_parallel_size: int = 1,
@@ -125,7 +127,11 @@ def create_scheduler(
     speculative_config: SpeculativeConfig | None = None
     if num_speculative_tokens is not None:
         speculative_config = SpeculativeConfig(
-            model="ngram", num_speculative_tokens=num_speculative_tokens
+            method=speculative_method,
+            num_speculative_tokens=num_speculative_tokens,
+            num_speculative_tokens_per_batch_size=(
+                num_speculative_tokens_per_batch_size
+            ),
         )
 
     ec_transfer_config = (

--- a/tests/v1/spec_decode/test_dynamic_sd.py
+++ b/tests/v1/spec_decode/test_dynamic_sd.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Regression tests for the Dynamic SD batch-size schedule helpers."""
 
+import logging
+
 import pytest
 
 from tests.v1.core.utils import create_requests, create_scheduler
@@ -216,3 +218,41 @@ def test_scheduler_passes_max_num_seqs_as_dsd_runtime_batch_limit():
     assert len(scheduler.dynamic_sd_lookup) == 17
     assert len(output.num_scheduled_tokens) == 16
     assert output.num_spec_tokens_to_schedule == 3
+
+
+@pytest.mark.parametrize(
+    "method, expect_disabled",
+    [
+        ("ngram_gpu", True),
+        ("ngram", False),
+    ],
+)
+def test_dynamic_sd_disabled_for_fixed_k_method(method, expect_disabled, caplog_vllm):
+    schedule = [(1, 16, 3), (64, 128, 2), (256, 4096, 0)]
+    with caplog_vllm.at_level(logging.WARNING, logger="vllm"):
+        scheduler = create_scheduler(
+            max_num_seqs=256,
+            max_num_batched_tokens=2560,
+            num_speculative_tokens=3,
+            speculative_method=method,
+            num_speculative_tokens_per_batch_size=schedule,
+        )
+
+    speculative_config = scheduler.vllm_config.speculative_config
+    assert speculative_config is not None
+    if expect_disabled:
+        # Fixed-K proposers crash on a runtime K below the configured max, so
+        # dynamic SD is disabled and we fall back to a static schedule.
+        assert speculative_config.num_speculative_tokens_per_batch_size is None
+        assert not speculative_config.uses_dynamic_speculative_decoding()
+        assert scheduler.dynamic_sd_lookup is None
+        assert (
+            "Dynamic speculative decoding is not supported with the "
+            "'ngram_gpu' speculative method" in caplog_vllm.text
+        )
+    else:
+        # Proposers that honor a runtime K keep the dynamic schedule.
+        assert speculative_config.num_speculative_tokens_per_batch_size == schedule
+        assert speculative_config.uses_dynamic_speculative_decoding()
+        assert scheduler.dynamic_sd_lookup is not None
+        assert "is not supported with the" not in caplog_vllm.text

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1115,6 +1115,15 @@ class SpeculativeConfig:
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None
 
+    def supports_dynamic_speculative_decoding(self) -> bool:
+        # Fixed-K proposers assert the runtime count equals the configured max.
+        return self.method not in (
+            "ngram_gpu",
+            "suffix",
+            "medusa",
+            "extract_hidden_states",
+        )
+
     def uses_draft_model(self) -> bool:
         return self.method == "draft_model"
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -772,6 +772,25 @@ class VllmConfig:
         )
         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
+    def _maybe_disable_dynamic_sd_for_unsupported_method(self) -> None:
+        speculative_config = self.speculative_config
+        if (
+            speculative_config is None
+            or not speculative_config.uses_dynamic_speculative_decoding()
+            or speculative_config.supports_dynamic_speculative_decoding()
+        ):
+            return
+
+        logger.warning_once(
+            "Dynamic speculative decoding is not supported with the '%s' "
+            "speculative method, which always proposes a fixed number of "
+            "speculative tokens. Disabling num_speculative_tokens_per_batch_size "
+            "and falling back to static num_speculative_tokens=%d.",
+            speculative_config.method,
+            speculative_config.num_speculative_tokens,
+        )
+        speculative_config.num_speculative_tokens_per_batch_size = None
+
     def _post_init_kv_transfer_config(self) -> None:
         """Update KVTransferConfig based on top-level configs in VllmConfig.
 
@@ -1167,6 +1186,7 @@ class VllmConfig:
                 "optimization level defaults."
             )
 
+        self._maybe_disable_dynamic_sd_for_unsupported_method()
         self._maybe_override_dynamic_sd_cudagraph_mode()
 
         if (


### PR DESCRIPTION

## Purpose

Dynamic speculative decoding (`num_speculative_tokens_per_batch_size`, added in #32374) lowers the runtime speculative-token count below the configured maximum, down to 0, based on batch size. Four proposers were written before that feature and hard-assert that the runtime count equals the configured maximum:

- `ngram_proposer_gpu.py:341` `assert num_speculative_tokens == self.k`
- `extract_hidden_states.py:119` `assert num_speculative_tokens == self.num_speculative_tokens`
- `suffix_decoding.py:44` `assert num_speculative_tokens == self.num_speculative_tokens`
- `medusa.py:49` `assert num_speculative_tokens == self.num_speculative_tokens`

So enabling dynamic SD with any of `ngram_gpu` / `suffix` / `medusa` / `extract_hidden_states` lets the scheduler legally pick a runtime count below the max and the proposer crashes with `AssertionError` deep inside `LLM.generate()`, after the config was accepted and the target model already ran. Proposers that do support dynamic SD honor the runtime count instead (eagle family overwrites `self.num_speculative_tokens` in `llm_base_proposer.py`; CPU `ngram` uses `assert num_speculative_tokens <= self.k`).

This mirrors the existing contract that dynamic SD is incompatible with some configurations. Following the same pattern as the data-parallel case (`_maybe_disable_dynamic_sd_for_data_parallel` in #45963), this PR disables dynamic SD at config init for these fixed-K methods, warns, and falls back to the static `num_speculative_tokens`, instead of crashing at runtime.

## Test Plan

Real `LLM.generate()` before/after on the 3 GPU-reachable methods (`ngram_gpu`, `extract_hidden_states`, `suffix`), plus a config-level regression test.

E2E repro (crashes on current main, RTX 4090, V1 model runner):

```python
import os
os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "0"
from vllm import LLM, SamplingParams

llm = LLM(
    model="Qwen/Qwen3-0.6B",
    enforce_eager=True,
    max_model_len=256,
    gpu_memory_utilization=0.35,
    speculative_config={
        "method": "ngram_gpu",
        "prompt_lookup_min": 1,
        "prompt_lookup_max": 4,
        "num_speculative_tokens": 4,
        # dynamic SD schedule: batch size 1 -> runtime K=0
        "num_speculative_tokens_per_batch_size": [(1, 1, 0), (2, 8, 4)],
    },
)
out = llm.generate(["ha ha ha ha ha ha ha ha"],
                   SamplingParams(max_tokens=4, temperature=0.0))
print(out[0].outputs[0].text)
```

Regression test:

```
pytest tests/v1/spec_decode/test_dynamic_sd.py -q
```

## Test Result

Config regression test `test_dynamic_sd_disabled_for_fixed_k_method` (parametrized: `ngram_gpu` disabled, `ngram` unchanged) fails on current main and passes with this PR. Full file `tests/v1/spec_decode/test_dynamic_sd.py`: 18 passed.

E2E on RTX 4090, `Qwen/Qwen3-0.6B`, V1 model runner. The same `LLM.generate()` call crashes on current main and runs to completion with this PR for both `ngram_gpu` and `suffix`. `extract_hidden_states` and `medusa` have the identical assertion and are handled by the same config guard.

<details>
<summary>Before (current main): AssertionError</summary>

```
# ngram_gpu, schedule [(1, 1, 0), (2, 8, 4)], batch size 1 -> runtime K=0
File "vllm/v1/spec_decode/ngram_proposer_gpu.py", line 341, in propose
    assert num_speculative_tokens == self.k
AssertionError

# suffix, schedule [(1, 1, 0), (2, 8, 4)], batch size 1 -> runtime K=0
File "vllm/v1/spec_decode/suffix_decoding.py", line 44, in propose
    assert num_speculative_tokens == self.num_speculative_tokens
AssertionError
```
</details>

<details>
<summary>After (this PR): warns once and falls back to static num_speculative_tokens</summary>

```
# ngram_gpu
WARNING [vllm.py] Dynamic speculative decoding is not supported with the
'ngram_gpu' speculative method, which always proposes a fixed number of
speculative tokens. Disabling num_speculative_tokens_per_batch_size and
falling back to static num_speculative_tokens=4.
prompt "ha ha ha ha ha ha ha ha" -> " ha ha ha ha" [6386, 6386, 6386, 6386] (finish_reason=length)
# batch size 2 (runtime K=2) also runs:
prompt "one two one two one two one two" -> " one two one two" [825, 1378, 825, 1378]

# suffix
WARNING [vllm.py] Dynamic speculative decoding is not supported with the
'suffix' speculative method ... falling back to static num_speculative_tokens=4.
prompt "ha ha ha ha ha ha" -> " ha ha ha ha ha ha" [6386, 6386, 6386, 6386, 6386, 6386] (finish_reason=length)
```
</details>

## Checklist

- [x] Adds a regression test (`tests/v1/spec_decode/test_dynamic_sd.py::test_dynamic_sd_disabled_for_fixed_k_method`).
- [x] Behavior for methods that support dynamic SD (eagle family, CPU ngram) is unchanged (negative control in the same test).

AI assistance was used to prepare this PR.
