### PR TITLE
[CI][ROCm] Restrict MLA cross-layer KV cache test to supported backends on ROCm

### DIFF
--- a/tests/v1/kv_connector/unit/test_kv_cache_layout.py
+++ b/tests/v1/kv_connector/unit/test_kv_cache_layout.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+from vllm.platforms import current_platform
 
 
 def test_mla_common_backend_rejects_cross_layer_kv_cache():
@@ -25,6 +26,10 @@ def test_mla_common_backend_rejects_cross_layer_kv_cache():
 @pytest.mark.parametrize(
     "backend_path",
     [
+        "vllm.v1.attention.backends.mla.triton_mla.TritonMLABackend",
+    ]
+    if current_platform.is_rocm()
+    else [
         "vllm.v1.attention.backends.mla.triton_mla.TritonMLABackend",
         "vllm.v1.attention.backends.mla.cutlass_mla.CutlassMLABackend",
         "vllm.v1.attention.backends.mla.flashattn_mla.FlashAttnMLABackend",

--- a/tests/v1/kv_connector/unit/test_kv_cache_layout.py
+++ b/tests/v1/kv_connector/unit/test_kv_cache_layout.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+
 from vllm.platforms import current_platform
 
 
@@ -25,6 +26,10 @@ def test_mla_common_backend_rejects_cross_layer_kv_cache():
 
 @pytest.mark.parametrize(
     "backend_path",
+    # On ROCm only Triton MLA is supported and verified for the cross-layer
+    # layout; the FlashAttn/FlashInfer backends require CUDA-only extensions and
+    # AITER MLA is not yet verified for cross-layer (keeps the identity default).
+    # See: https://github.com/vllm-project/vllm/issues/46411
     [
         "vllm.v1.attention.backends.mla.triton_mla.TritonMLABackend",
     ]

--- a/tests/v1/kv_connector/unit/test_kv_cache_layout.py
+++ b/tests/v1/kv_connector/unit/test_kv_cache_layout.py
@@ -26,9 +26,6 @@ def test_mla_common_backend_rejects_cross_layer_kv_cache():
 
 @pytest.mark.parametrize(
     "backend_path",
-    # On ROCm only Triton MLA is supported and verified for the cross-layer
-    # layout; the FlashAttn/FlashInfer backends require CUDA-only extensions and
-    # AITER MLA is not yet verified for cross-layer (keeps the identity default).
     # See: https://github.com/vllm-project/vllm/issues/46411
     [
         "vllm.v1.attention.backends.mla.triton_mla.TritonMLABackend",


### PR DESCRIPTION
This PR Fixes `test_verified_mla_backends_support_cross_layer_kv_cache[FlashAttnMLABackend]` on ROCm (MI300/MI325).

## Test Plan
On MI300/MI325:
```bash
pytest -v tests/v1/kv_connector/unit/test_kv_cache_layout.py


Test Result
Before (ROCm):

FAILED ...test_verified_mla_backends_support_cross_layer_kv_cache[...FlashAttnMLABackend]
1 failed, 3 passed, 1 skipped
After (ROCm):

3 passed

