### PR TITLE
[ROCm][CI]Fix test_concat_and_cache_mla_rope_fused on ROCm

### DIFF
--- a/tests/kernels/core/test_rotary_embedding_mla_cache_fused.py
+++ b/tests/kernels/core/test_rotary_embedding_mla_cache_fused.py
@@ -17,6 +17,36 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 
+@pytest.fixture
+def default_vllm_config(monkeypatch):
+    """Enable the AITER triton rope on ROCm for fp16-consistent numerics.
+
+    The fused CUDA kernel runs native fp16 while forward_native upcasts to
+    fp32, so on ROCm we route through the AITER triton rope (+rotary_embedding)
+    to match. Its env gates are cached at import, hence refresh_env_variables().
+    """
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.config import CompilationConfig, VllmConfig, set_current_vllm_config
+
+    is_rocm = current_platform.is_rocm()
+    if is_rocm:
+        config = VllmConfig(
+            compilation_config=CompilationConfig(custom_ops=["+rotary_embedding"])
+        )
+    else:
+        config = VllmConfig()
+    try:
+        with monkeypatch.context() as m, set_current_vllm_config(config):
+            if is_rocm:
+                m.setenv("VLLM_ROCM_USE_AITER", "1")
+                m.setenv("VLLM_ROCM_USE_AITER_TRITON_ROPE", "1")
+                rocm_aiter_ops.refresh_env_variables()
+            yield config
+    finally:
+        if is_rocm:
+            rocm_aiter_ops.refresh_env_variables()
+
+
 @pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16, torch.float])
 @pytest.mark.parametrize("is_neox_style", [False, True])
 @pytest.mark.parametrize("seq_len", [11, 42])
@@ -151,6 +181,10 @@ def test_concat_and_cache_mla_rope_fused(
         kv_cache_scale,
     )
 
+    # ROCm neox-style Triton FMA diverges slightly from the fused kernel, so
+    # relax the affected tolerance: rtol for fp8 (one e4m3 ULP ~12.5%) and atol
+    # otherwise (bounded ~6e-4). Other paths use the CUDA defaults.
+    rocm_neox = current_platform.is_rocm() and is_neox_style
     if kv_cache_dtype == "fp8":
         result_temp = torch.empty_like(kv_cache, dtype=torch.float16)
         ops.convert_fp8(
@@ -163,7 +197,11 @@ def test_concat_and_cache_mla_rope_fused(
         ops.convert_fp8(
             expected_temp, ref_kv_cache, kv_cache_scale.item(), kv_dtype=kv_cache_dtype
         )
-        torch.testing.assert_close(result_temp, expected_temp, atol=0.001, rtol=0.1)
+        torch.testing.assert_close(
+            result_temp, expected_temp, atol=0.001, rtol=0.15 if rocm_neox else 0.1
+        )
+    elif rocm_neox:
+        torch.testing.assert_close(kv_cache, ref_kv_cache, atol=1e-3, rtol=1e-3)
     else:
         torch.testing.assert_close(kv_cache, ref_kv_cache)
 


### PR DESCRIPTION
This test was failing in CI on ROCm due to fp16 numerical mismatches between the reference and the fused kernel. The root cause is that the torch-native reference (forward_native) implicitly upcasts fp16×fp16 to fp32, while the fused CUDA kernel runs in native fp16.
(Also refer to the in-depth analysis by @mawong-amd - https://github.com/vllm-project/vllm/pull/32408)

Changes:

- Use the AITER path as the reference on ROCm. The default_vllm_config fixture now enables the AITER triton rope (+rotary_embedding custom op via VLLM_ROCM_USE_AITER / VLLM_ROCM_USE_AITER_TRITON_ROPE) so the reference and fused kernel share consistent fp16 numerics. Non-ROCm behavior is unchanged.
- Relax tolerances for ROCm neox-style cases. Triton FMA diverges slightly from the fused kernel; for fp8 this can land in an adjacent fp8 bucket, so rtol is relaxed (~one e4m3 ULP), and for the non-fp8 path atol is relaxed to the standard fp16 value. All other paths keep the CUDA defaults.
