### PR TITLE
Sanitize server file paths from validation error responses

### DIFF
--- a/tests/entrypoints/serve/utils/test_api_utils.py
+++ b/tests/entrypoints/serve/utils/test_api_utils.py
@@ -118,3 +118,49 @@ class TestGetMaxTokens:
                 input_length=150,
                 default_sampling_params={"max_tokens": 2048},
             )
+
+
+class TestSanitizeMessageFilePaths:
+    """sanitize_message should also strip file paths and traceback
+    frames, not just memory addresses - see #31683."""
+
+    def test_strips_traceback_style_frame(self):
+        msg = (
+            "1 validation error:\n"
+            "  {'type': 'list_type', 'loc': ('body', 'messages')}\n"
+            '\n  File "/usr/local/lib/python3.12/dist-packages/vllm/'
+            'entrypoints/serve/utils/api_utils.py", line 40, '
+            "in create_chat_completion\n"
+            "    POST /v1/chat/completions"
+        )
+        result = sanitize_message(msg)
+        assert "/usr/local/" not in result
+        assert "api_utils.py" not in result
+        assert "list_type" in result
+
+    def test_strips_arbitrary_absolute_path(self):
+        result = sanitize_message("Error in /home/user/project/vllm/server.py")
+        assert "/home/user" not in result
+
+    def test_strips_single_parent_container_path(self):
+        """Regression: /app/server.py and /workspace/server.py (common in
+        container deployments) were missed by the original {2,} quantifier."""
+        assert "/app/" not in sanitize_message("Error in /app/server.py")
+        assert "/workspace/" not in sanitize_message("Error in /workspace/server.py")
+
+    def test_preserves_api_endpoint_paths(self):
+        msg = "POST /v1/chat/completions failed"
+        assert "/v1/chat/completions" in sanitize_message(msg)
+
+    def test_preserves_short_field_references(self):
+        msg = "Invalid value for field 'body.messages'"
+        assert sanitize_message(msg) == msg
+
+    def test_strips_both_address_and_path(self):
+        msg = (
+            "<Request at 0x7f123> failed at "
+            "/usr/local/lib/python3.12/dist-packages/vllm/server.py"
+        )
+        result = sanitize_message(msg)
+        assert "0x" not in result
+        assert "/usr/local/" not in result

--- a/tests/entrypoints/serve/utils/test_server_utils.py
+++ b/tests/entrypoints/serve/utils/test_server_utils.py
@@ -100,3 +100,54 @@ class TestCleanLocForParam:
         dot-join rather than returning an empty string."""
         loc = ("function-wrap[__log_extra_fields__()]",)
         assert clean_loc_for_param(loc) == "function-wrap[__log_extra_fields__()]"
+
+
+class TestValidationErrorDoesNotLeakServerPaths:
+    """FastAPI sets endpoint_file/line/function/path on the exception
+    during routing, not in the constructor - so we set them manually
+    here to reproduce the real leak. See #31683."""
+
+    @pytest.mark.asyncio
+    async def test_handler_strips_endpoint_file_context(self):
+        errors = [
+            {
+                "type": "list_type",
+                "loc": ("body", "messages"),
+                "msg": "Input should be a valid list",
+                "input": "not-a-list",
+            }
+        ]
+        exc = RequestValidationError(errors)
+        exc.endpoint_file = (
+            "/usr/local/lib/python3.12/dist-packages/vllm/"
+            "entrypoints/serve/utils/api_utils.py"
+        )
+        exc.endpoint_line = 40
+        exc.endpoint_function = "create_chat_completion"
+        exc.endpoint_path = "POST /v1/chat/completions"
+
+        response = await validation_exception_handler(_fake_request(), exc)
+        body = json.loads(response.body)
+        message = body["error"]["message"]
+
+        assert "/usr/local/" not in message
+        assert "api_utils.py" not in message
+        assert "create_chat_completion" not in message
+        assert "list_type" in message
+        assert "Input should be a valid list" in message
+
+    @pytest.mark.asyncio
+    async def test_handler_strips_endpoint_path_only_variant(self):
+        """Covers the branch where only endpoint_path is set."""
+        errors = [
+            {"type": "missing", "loc": ("body", "messages"), "msg": "Field required"}
+        ]
+        exc = RequestValidationError(errors)
+        exc.endpoint_path = "POST /v1/chat/completions"
+
+        response = await validation_exception_handler(_fake_request(), exc)
+        body = json.loads(response.body)
+        message = body["error"]["message"]
+
+        assert "missing" in message
+        assert "Field required" in message

--- a/vllm/entrypoints/serve/utils/api_utils.py
+++ b/vllm/entrypoints/serve/utils/api_utils.py
@@ -310,8 +310,14 @@ def process_lora_modules(
 
 
 def sanitize_message(message: str) -> str:
-    # Avoid leaking memory address from object reprs
-    return re.sub(r" at 0x[0-9a-f]+>", ">", message)
+    """Strip memory addresses, tracebacks, and file paths from error messages."""
+    message = re.sub(r" at 0x[0-9a-f]+>", ">", message)
+    message = re.sub(r'\n?\s*File "[^"]+", line \d+, in \S+(\n\s+.*)?', "", message)
+    message = re.sub(
+        r"/(?:home|usr|opt|var|tmp|root|lib|mnt|srv)(?:/[\w.\-]+)+", "<path>", message
+    )
+    message = re.sub(r"(?:/[\w\-]+)+/[\w\-]+\.\w+", "<path>", message)
+    return message.strip()
 
 
 def log_version_and_model(lgr: Logger, version: str, model_name: str) -> None:

--- a/vllm/entrypoints/serve/utils/server_utils.py
+++ b/vllm/entrypoints/serve/utils/server_utils.py
@@ -509,13 +509,16 @@ async def validation_exception_handler(req: Request, exc: RequestValidationError
         if loc:
             param = clean_loc_for_param(loc)
 
-    exc_str = str(exc)
-    errors_str = str(errors)
-
-    if errors and errors_str and errors_str != exc_str:
-        message = f"{exc_str} {errors_str}"
+    # Build the message from exc.errors() instead of str(exc) - str(exc)
+    # leaks the server's file path via FastAPI's endpoint context.
+    if errors:
+        count = len(errors)
+        label = "error" if count == 1 else "errors"
+        message = f"{count} validation {label}:\n"
+        message += "".join(f"  {err}\n" for err in errors)
+        message = message.rstrip()
     else:
-        message = exc_str
+        message = "Validation error"
 
     err = ErrorResponse(
         error=ErrorInfo(


### PR DESCRIPTION
## Purpose

FastAPI's `ValidationException.__str__` calls `_format_endpoint_context()`, which embeds the server's absolute installed-package file path, line number, and function name into `str(exc)`. `validation_exception_handler` was forwarding `str(exc)` to the client via the error response body, leaking server internals on every validation error across every endpoint (chat/completions, completions, tokenize, etc.).

Fix:
- Build the handler's message from `exc.errors()` directly, never `str(exc)`
- Harden `sanitize_message` to strip traceback-style frame lines and absolute filesystem paths as defense-in-depth

Refs #31683

## Test Plan

Reproduction (before fix):
```bash
curl -s -X POST http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"x","messages":"not-a-list"}'
```

Verified against a live vLLM nightly server before and after the fix, across `/v1/chat/completions` and `/tokenize`.

New tests added:
- `TestSanitizeMessageFilePaths` in `test_api_utils.py`
- `TestValidationErrorDoesNotLeakServerPaths` in `test_server_utils.py` (sets `endpoint_file`/`endpoint_line`/`endpoint_function`/`endpoint_path` on the exception to simulate what FastAPI's routing layer does on a live request, since constructing the exception bare does not exercise the leak)

## Test Result

Before fix, response contained:
**File "/usr/local/lib/.../vllm/entrypoints/serve/utils/api_utils.py", line 40, in create_chat_completion**

After fix: clean, no server internals.

All 22 tests in `tests/entrypoints/serve/utils/test_api_utils.py` and `tests/entrypoints/serve/utils/test_server_utils.py` pass. `ruff check` and `ruff format --check` pass on both modified files.