### PR TITLE
[rust][tool-parser] Add streaming invariant tests

### DIFF
--- a/rust/src/parser/src/tool/deepseek_dsml/deepseek_v32.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/deepseek_v32.rs
@@ -70,7 +70,9 @@ mod tests {
     use thiserror_ext::AsReport;
 
     use super::DeepSeekV32ToolParser;
-    use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::tool::test_utils::{
+        assert_streaming_matches_complete, collect_stream, split_by_chars, test_tools,
+    };
     use crate::tool::{ToolParser, ToolParserTestExt as _};
 
     fn build_tool_call(function_name: &str, params: &[(&str, &str)]) -> String {
@@ -430,6 +432,59 @@ mod tests {
             serde_json::from_str::<Value>(&second.calls()[0].arguments).unwrap(),
             json!({ "location": "NYC" })
         );
+    }
+
+    #[test]
+    fn deepseek_v32_streaming_matches_complete_across_boundaries() {
+        let parallel_calls = format!(
+            "{}\n<｜DSML｜invoke name=\"get_weather\">\n\
+             <｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n\
+             </｜DSML｜invoke>\n</｜DSML｜function_calls>",
+            build_tool_call("get_weather", &[("location", "SF")])
+                .trim_end_matches("</｜DSML｜function_calls>"),
+        );
+        let tools = test_tools();
+        let cases = [
+            ("plain_text", "Hello, 杭州 🌦️. No tools here.".to_string()),
+            (
+                "single_tool_call",
+                build_tool_call("get_weather", &[("location", "SF")]),
+            ),
+            ("parallel_tool_calls", parallel_calls),
+            (
+                "unicode_parameter_value",
+                build_tool_call("get_weather", &[("location", "杭州 🌦️")]),
+            ),
+            ("no_parameter_call", build_tool_call("get_weather", &[])),
+            (
+                "prefix_text",
+                format!(
+                    "Thinking... {}",
+                    build_tool_call("get_weather", &[("location", "NYC")])
+                ),
+            ),
+            (
+                "raw_closing_tag_text_in_parameter_value",
+                build_tool_call(
+                    "get_weather",
+                    &[
+                        (
+                            "location",
+                            "Hangzhou &lt;/｜DSML｜parameter&gt;&lt;/｜DSML｜invoke&gt;&lt;/｜DSML｜function_calls&gt;",
+                        ),
+                        ("date", "2026-05-08"),
+                    ],
+                ),
+            ),
+            (
+                "unterminated_tool_call",
+                "<｜DSML｜function_calls>\n<｜DSML｜invoke name=\"get_weather\">\n".to_string(),
+            ),
+        ];
+
+        for (case_name, text) in cases {
+            assert_streaming_matches_complete::<DeepSeekV32ToolParser>(&tools, case_name, &text);
+        }
     }
 
     #[test]

--- a/rust/src/parser/src/tool/deepseek_dsml/deepseek_v32.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/deepseek_v32.rs
@@ -70,7 +70,9 @@ mod tests {
     use thiserror_ext::AsReport;
 
     use super::DeepSeekV32ToolParser;
-    use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::tool::test_utils::{
+        assert_streaming_matches_complete, collect_stream, split_by_chars, test_tools,
+    };
     use crate::tool::tests::assert_tool_framing_preserves_body_whitespace;
     use crate::tool::{ToolParser, ToolParserTestExt as _};
 
@@ -431,6 +433,59 @@ mod tests {
             serde_json::from_str::<Value>(&second.calls()[0].arguments).unwrap(),
             json!({ "location": "NYC" })
         );
+    }
+
+    #[test]
+    fn deepseek_v32_streaming_matches_complete_across_boundaries() {
+        let parallel_calls = format!(
+            "{}\n<｜DSML｜invoke name=\"get_weather\">\n\
+             <｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n\
+             </｜DSML｜invoke>\n</｜DSML｜function_calls>",
+            build_tool_call("get_weather", &[("location", "SF")])
+                .trim_end_matches("</｜DSML｜function_calls>"),
+        );
+        let tools = test_tools();
+        let cases = [
+            ("plain_text", "Hello, 杭州 🌦️. No tools here.".to_string()),
+            (
+                "single_tool_call",
+                build_tool_call("get_weather", &[("location", "SF")]),
+            ),
+            ("parallel_tool_calls", parallel_calls),
+            (
+                "unicode_parameter_value",
+                build_tool_call("get_weather", &[("location", "杭州 🌦️")]),
+            ),
+            ("no_parameter_call", build_tool_call("get_weather", &[])),
+            (
+                "prefix_text",
+                format!(
+                    "Thinking... {}",
+                    build_tool_call("get_weather", &[("location", "NYC")])
+                ),
+            ),
+            (
+                "raw_closing_tag_text_in_parameter_value",
+                build_tool_call(
+                    "get_weather",
+                    &[
+                        (
+                            "location",
+                            "Hangzhou &lt;/｜DSML｜parameter&gt;&lt;/｜DSML｜invoke&gt;&lt;/｜DSML｜function_calls&gt;",
+                        ),
+                        ("date", "2026-05-08"),
+                    ],
+                ),
+            ),
+            (
+                "unterminated_tool_call",
+                "<｜DSML｜function_calls>\n<｜DSML｜invoke name=\"get_weather\">\n".to_string(),
+            ),
+        ];
+
+        for (case_name, text) in cases {
+            assert_streaming_matches_complete::<DeepSeekV32ToolParser>(&tools, case_name, &text);
+        }
     }
 
     #[test]

--- a/rust/src/parser/src/tool/kimi_k2.rs
+++ b/rust/src/parser/src/tool/kimi_k2.rs
@@ -342,7 +342,9 @@ mod tests {
         KimiK2ToolParser, TOOL_CALL_ARGUMENT_START, TOOL_CALL_END, TOOL_CALL_START, TOOL_CALLS_END,
         TOOL_CALLS_START, ToolParser, tool_header,
     };
-    use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::tool::test_utils::{
+        assert_streaming_matches_complete, collect_stream, split_by_chars, test_tools,
+    };
     use crate::tool::{ToolParserOutput, ToolParserTestExt as _};
 
     fn build_tool_call(function_name: &str, index: usize, arguments: &str) -> String {
@@ -395,6 +397,70 @@ mod tests {
             .unwrap();
 
         assert_eq!(output.calls()[0].arguments, arguments);
+    }
+
+    #[test]
+    fn kimi_k2_streaming_matches_complete_across_boundaries() {
+        let marker_literal_argument = format!(r#"{{"text":"literal {TOOL_CALL_END} inside"}}"#);
+        let tools = test_tools();
+        let cases = [
+            ("plain_text", "Hello, 上海 🌦️. No tools here.".to_string()),
+            (
+                "single_tool_call",
+                build_tool_section(&[build_tool_call("get_weather", 0, r#"{"location":"NYC"}"#)]),
+            ),
+            (
+                "parallel_tool_calls",
+                build_tool_section(&[
+                    build_tool_call("get_weather", 0, r#"{"location":"Shanghai"}"#),
+                    build_tool_call("add", 1, r#"{"x":1,"y":2}"#),
+                ]),
+            ),
+            (
+                "prefix_and_ignored_suffix",
+                format!(
+                    "Checking. {} trailing text",
+                    build_tool_section(&[build_tool_call(
+                        "get_weather",
+                        0,
+                        r#"{ "location": "NYC", "days": "3" }"#,
+                    )])
+                ),
+            ),
+            (
+                "unicode_argument_value",
+                build_tool_section(&[build_tool_call(
+                    "get_weather",
+                    0,
+                    r#"{"location":"上海 🌦️"}"#,
+                )]),
+            ),
+            (
+                "no_parameter_call",
+                build_tool_section(&[build_tool_call("get_status", 0, "{}")]),
+            ),
+            (
+                "end_marker_literal_inside_json_string",
+                build_tool_section(&[build_tool_call("echo", 0, &marker_literal_argument)]),
+            ),
+            (
+                "malformed_header",
+                format!(
+                    "{TOOL_CALLS_START}{TOOL_CALL_START}get_weather{TOOL_CALL_ARGUMENT_START}{{}}"
+                ),
+            ),
+            (
+                "unterminated_tool_call",
+                format!(
+                    "{TOOL_CALLS_START}{TOOL_CALL_START}functions.get_weather:0\
+                     {TOOL_CALL_ARGUMENT_START}{{\"location\""
+                ),
+            ),
+        ];
+
+        for (case_name, text) in cases {
+            assert_streaming_matches_complete::<KimiK2ToolParser>(&tools, case_name, &text);
+        }
     }
 
     #[test]

--- a/rust/src/parser/src/tool/minimax_m2.rs
+++ b/rust/src/parser/src/tool/minimax_m2.rs
@@ -276,7 +276,9 @@ mod tests {
 
     use super::{MinimaxM2ToolParser, TOOL_CALL_END, TOOL_CALL_START, ToolParser};
     use crate::tool::ToolParserTestExt as _;
-    use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::tool::test_utils::{
+        assert_streaming_matches_complete, collect_stream, split_by_chars, test_tools,
+    };
 
     fn build_tool_block(invokes: &[(&str, Vec<(&str, &str)>)]) -> String {
         let invokes = invokes
@@ -450,6 +452,64 @@ mod tests {
                 "precision": 2,
             })
         );
+    }
+
+    #[test]
+    fn minimax_m2_streaming_matches_complete_across_boundaries() {
+        let tools = test_tools();
+        let cases = [
+            (
+                "plain_text",
+                "Hello, München 🌦️. No tools here.".to_string(),
+            ),
+            (
+                "single_tool_call",
+                build_tool_block(&[("get_weather", vec![("city", "Seattle")])]),
+            ),
+            (
+                "parallel_tool_calls",
+                build_tool_block(&[
+                    ("get_weather", vec![("city", "Seattle")]),
+                    ("get_weather", vec![("city", "NYC")]),
+                ]),
+            ),
+            (
+                "unicode_parameter_value",
+                build_tool_block(&[("get_weather", vec![("city", "München 🌦️")])]),
+            ),
+            (
+                "no_parameter_call",
+                build_tool_block(&[("get_weather", vec![])]),
+            ),
+            (
+                "prefix_and_ignored_suffix",
+                format!(
+                    "Let me check. {} This trailing text is ignored.",
+                    build_tool_block(&[("get_weather", vec![("city", "Seattle")])])
+                ),
+            ),
+            (
+                "raw_closing_tag_text_in_parameter_value",
+                build_tool_block(&[(
+                    "get_weather",
+                    vec![
+                        (
+                            "city",
+                            "Seattle &lt;/parameter&gt;&lt;/invoke&gt;&lt;/minimax:tool_call&gt;",
+                        ),
+                        ("days", "5"),
+                    ],
+                )]),
+            ),
+            (
+                "unterminated_tool_call",
+                r#"<minimax:tool_call><invoke name="get_weather">"#.to_string(),
+            ),
+        ];
+
+        for (case_name, text) in cases {
+            assert_streaming_matches_complete::<MinimaxM2ToolParser>(&tools, case_name, &text);
+        }
     }
 
     #[test]

--- a/rust/src/parser/src/tool/minimax_m2.rs
+++ b/rust/src/parser/src/tool/minimax_m2.rs
@@ -280,7 +280,9 @@ mod tests {
 
     use super::{MinimaxM2ToolParser, TOOL_CALL_END, TOOL_CALL_START, ToolParser};
     use crate::tool::ToolParserTestExt as _;
-    use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::tool::test_utils::{
+        assert_streaming_matches_complete, collect_stream, split_by_chars, test_tools,
+    };
     use crate::tool::tests::assert_tool_framing_preserves_body_whitespace;
 
     fn build_tool_block(invokes: &[(&str, Vec<(&str, &str)>)]) -> String {
@@ -455,6 +457,64 @@ mod tests {
                 "precision": 2,
             })
         );
+    }
+
+    #[test]
+    fn minimax_m2_streaming_matches_complete_across_boundaries() {
+        let tools = test_tools();
+        let cases = [
+            (
+                "plain_text",
+                "Hello, München 🌦️. No tools here.".to_string(),
+            ),
+            (
+                "single_tool_call",
+                build_tool_block(&[("get_weather", vec![("city", "Seattle")])]),
+            ),
+            (
+                "parallel_tool_calls",
+                build_tool_block(&[
+                    ("get_weather", vec![("city", "Seattle")]),
+                    ("get_weather", vec![("city", "NYC")]),
+                ]),
+            ),
+            (
+                "unicode_parameter_value",
+                build_tool_block(&[("get_weather", vec![("city", "München 🌦️")])]),
+            ),
+            (
+                "no_parameter_call",
+                build_tool_block(&[("get_weather", vec![])]),
+            ),
+            (
+                "prefix_and_ignored_suffix",
+                format!(
+                    "Let me check. {} This trailing text is ignored.",
+                    build_tool_block(&[("get_weather", vec![("city", "Seattle")])])
+                ),
+            ),
+            (
+                "raw_closing_tag_text_in_parameter_value",
+                build_tool_block(&[(
+                    "get_weather",
+                    vec![
+                        (
+                            "city",
+                            "Seattle &lt;/parameter&gt;&lt;/invoke&gt;&lt;/minimax:tool_call&gt;",
+                        ),
+                        ("days", "5"),
+                    ],
+                )]),
+            ),
+            (
+                "unterminated_tool_call",
+                r#"<minimax:tool_call><invoke name="get_weather">"#.to_string(),
+            ),
+        ];
+
+        for (case_name, text) in cases {
+            assert_streaming_matches_complete::<MinimaxM2ToolParser>(&tools, case_name, &text);
+        }
     }
 
     #[test]

--- a/rust/src/parser/src/tool/qwen_coder.rs
+++ b/rust/src/parser/src/tool/qwen_coder.rs
@@ -295,7 +295,9 @@ mod tests {
     use thiserror_ext::AsReport;
 
     use super::{Qwen3CoderToolParser, ToolParser};
-    use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::tool::test_utils::{
+        assert_streaming_matches_complete, collect_stream, split_by_chars, test_tools,
+    };
     use crate::tool::{ToolParserOutput, ToolParserTestExt as _};
 
     fn build_tool_call(function_name: &str, params: &[(&str, &str)]) -> String {
@@ -530,6 +532,82 @@ mod tests {
                 "data": { "key": "value", "count": 42 },
             })
         );
+    }
+
+    #[test]
+    fn qwen_coder_streaming_matches_complete_across_boundaries() {
+        let between_calls = format!(
+            "I'll check two cities.{}Between calls.{}Done.",
+            build_tool_call("get_weather", &[("city", "Dallas"), ("state", "TX")]),
+            build_tool_call("get_weather", &[("city", "Orlando"), ("state", "FL")])
+        );
+        let tools = test_tools();
+        let cases = [
+            ("plain_text", "Hello, 杭州 🌦️. No tools here.".to_string()),
+            (
+                "single_tool_call",
+                build_tool_call("get_weather", &[("location", "SF")]),
+            ),
+            (
+                "parallel_tool_calls",
+                format!(
+                    "{}\n{}",
+                    build_tool_call("get_weather", &[("location", "SF")]),
+                    build_tool_call("get_weather", &[("location", "NYC")])
+                ),
+            ),
+            ("text_between_tool_calls", between_calls),
+            (
+                "unicode_parameter_value",
+                build_tool_call("get_weather", &[("location", "杭州 🌦️")]),
+            ),
+            ("no_parameter_call", build_tool_call("get_weather", &[])),
+            (
+                "xml_like_parameter_values",
+                build_tool_call(
+                    "process",
+                    &[
+                        (
+                            "html_content",
+                            r#"<div class="test"><span>Hello</span></div>"#,
+                        ),
+                        ("xml_snippet", r#"<root><child attr="value"/></root>"#),
+                    ],
+                ),
+            ),
+            (
+                "raw_closing_tag_text_in_parameter_value",
+                build_tool_call(
+                    "get_weather",
+                    &[
+                        (
+                            "location",
+                            "杭州 &lt;/parameter&gt;&lt;/function&gt;&lt;/tool_call&gt;",
+                        ),
+                        ("date", "2026-05-08"),
+                    ],
+                ),
+            ),
+            (
+                "nested_json_parameter",
+                build_tool_call(
+                    "convert",
+                    &[(
+                        "payload",
+                        r#"{"nested":{"value":[1,2,3],"child":{"enabled":true}}}"#,
+                    )],
+                ),
+            ),
+            (
+                "unterminated_tool_call",
+                "<tool_call>\n<function=get_weather>\n<parameter=location>SF</parameter>"
+                    .to_string(),
+            ),
+        ];
+
+        for (case_name, text) in cases {
+            assert_streaming_matches_complete::<Qwen3CoderToolParser>(&tools, case_name, &text);
+        }
     }
 
     #[test]

--- a/rust/src/parser/src/tool/qwen_coder.rs
+++ b/rust/src/parser/src/tool/qwen_coder.rs
@@ -294,7 +294,9 @@ mod tests {
     use thiserror_ext::AsReport;
 
     use super::{Qwen3CoderToolParser, ToolParser};
-    use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::tool::test_utils::{
+        assert_streaming_matches_complete, collect_stream, split_by_chars, test_tools,
+    };
     use crate::tool::tests::assert_tool_framing_preserves_body_whitespace;
     use crate::tool::{ToolParserOutput, ToolParserTestExt as _};
 
@@ -530,6 +532,82 @@ mod tests {
                 "data": { "key": "value", "count": 42 },
             })
         );
+    }
+
+    #[test]
+    fn qwen_coder_streaming_matches_complete_across_boundaries() {
+        let between_calls = format!(
+            "I'll check two cities.{}Between calls.{}Done.",
+            build_tool_call("get_weather", &[("city", "Dallas"), ("state", "TX")]),
+            build_tool_call("get_weather", &[("city", "Orlando"), ("state", "FL")])
+        );
+        let tools = test_tools();
+        let cases = [
+            ("plain_text", "Hello, 杭州 🌦️. No tools here.".to_string()),
+            (
+                "single_tool_call",
+                build_tool_call("get_weather", &[("location", "SF")]),
+            ),
+            (
+                "parallel_tool_calls",
+                format!(
+                    "{}\n{}",
+                    build_tool_call("get_weather", &[("location", "SF")]),
+                    build_tool_call("get_weather", &[("location", "NYC")])
+                ),
+            ),
+            ("text_between_tool_calls", between_calls),
+            (
+                "unicode_parameter_value",
+                build_tool_call("get_weather", &[("location", "杭州 🌦️")]),
+            ),
+            ("no_parameter_call", build_tool_call("get_weather", &[])),
+            (
+                "xml_like_parameter_values",
+                build_tool_call(
+                    "process",
+                    &[
+                        (
+                            "html_content",
+                            r#"<div class="test"><span>Hello</span></div>"#,
+                        ),
+                        ("xml_snippet", r#"<root><child attr="value"/></root>"#),
+                    ],
+                ),
+            ),
+            (
+                "raw_closing_tag_text_in_parameter_value",
+                build_tool_call(
+                    "get_weather",
+                    &[
+                        (
+                            "location",
+                            "杭州 &lt;/parameter&gt;&lt;/function&gt;&lt;/tool_call&gt;",
+                        ),
+                        ("date", "2026-05-08"),
+                    ],
+                ),
+            ),
+            (
+                "nested_json_parameter",
+                build_tool_call(
+                    "convert",
+                    &[(
+                        "payload",
+                        r#"{"nested":{"value":[1,2,3],"child":{"enabled":true}}}"#,
+                    )],
+                ),
+            ),
+            (
+                "unterminated_tool_call",
+                "<tool_call>\n<function=get_weather>\n<parameter=location>SF</parameter>"
+                    .to_string(),
+            ),
+        ];
+
+        for (case_name, text) in cases {
+            assert_streaming_matches_complete::<Qwen3CoderToolParser>(&tools, case_name, &text);
+        }
     }
 
     #[test]

--- a/rust/src/parser/src/tool/test_utils.rs
+++ b/rust/src/parser/src/tool/test_utils.rs
@@ -3,7 +3,7 @@
 
 use serde_json::json;
 
-use super::{ToolParser, ToolParserOutput};
+use super::{Result, ToolParser, ToolParserOutput};
 use crate::tool::Tool;
 
 /// Build a reusable set of function tools for parser unit tests.
@@ -117,4 +117,85 @@ pub fn split_by_chars(text: &str, chunk_chars: usize) -> Vec<&str> {
     }
 
     chunks
+}
+
+/// Assert every tested streaming chunking matches whole-text parsing.
+///
+/// The comparison is made after `finish()` and `coalesce()`, so parsers may
+/// still emit different intermediate deltas for different chunk boundaries.
+pub fn assert_streaming_matches_complete<P>(tools: &[Tool], case_name: &str, text: &str)
+where
+    P: ToolParser + 'static,
+{
+    let complete = parse_complete_with_parser::<P>(tools, text);
+    assert_chunking_matches::<P>(tools, case_name, text, &[text], &complete);
+
+    let boundaries = internal_char_boundaries(text);
+    for boundary in &boundaries {
+        let chunks = [&text[..*boundary], &text[*boundary..]];
+        assert_chunking_matches::<P>(tools, case_name, text, &chunks, &complete);
+    }
+
+    for window in boundaries.windows(2) {
+        let left = window[0];
+        let right = window[1];
+        let chunks = [&text[..left], &text[left..right], &text[right..]];
+        assert_chunking_matches::<P>(tools, case_name, text, &chunks, &complete);
+    }
+}
+
+fn internal_char_boundaries(text: &str) -> Vec<usize> {
+    text.char_indices().map(|(index, _)| index).filter(|index| *index > 0).collect()
+}
+
+fn parse_complete_with_parser<P>(tools: &[Tool], text: &str) -> Result<ToolParserOutput>
+where
+    P: ToolParser + 'static,
+{
+    let mut parser = P::create(tools).expect("parser should initialize");
+    let mut output = ToolParserOutput::default();
+    parser.parse_into(text, &mut output)?;
+    output.append(parser.finish()?);
+    Ok(output.coalesce())
+}
+
+fn assert_chunking_matches<P>(
+    tools: &[Tool],
+    case_name: &str,
+    text: &str,
+    chunks: &[&str],
+    complete: &Result<ToolParserOutput>,
+) where
+    P: ToolParser + 'static,
+{
+    let mut parser = P::create(tools).expect("parser should initialize");
+    let streamed = collect_stream_result(&mut *parser, chunks);
+
+    match (&streamed, complete) {
+        (Ok(streamed), Ok(complete)) => assert_eq!(
+            streamed, complete,
+            "streaming output differed for case {case_name:?}, chunks {chunks:?}, text {text:?}",
+        ),
+        (Err(_), Err(_)) => {}
+        (Ok(streamed), Err(error)) => panic!(
+            "streaming succeeded but complete parsing failed for case {case_name:?}, \
+             chunks {chunks:?}, text {text:?}, streamed {streamed:?}, complete error {error:?}",
+        ),
+        (Err(error), Ok(complete)) => panic!(
+            "streaming failed but complete parsing succeeded for case {case_name:?}, \
+             chunks {chunks:?}, text {text:?}, streaming error {error:?}, complete {complete:?}",
+        ),
+    }
+}
+
+fn collect_stream_result<T: ToolParser + ?Sized>(
+    parser: &mut T,
+    chunks: &[&str],
+) -> Result<ToolParserOutput> {
+    let mut output = ToolParserOutput::default();
+    for chunk in chunks {
+        parser.parse_into(chunk, &mut output)?;
+    }
+    output.append(parser.finish()?);
+    Ok(output.coalesce())
 }

--- a/rust/src/parser/src/unified/gemma4.rs
+++ b/rust/src/parser/src/unified/gemma4.rs
@@ -675,13 +675,72 @@ mod tests {
     }
 
     fn collect_stream(chunks: &[&str]) -> UnifiedParserOutput {
+        collect_stream_result(chunks).unwrap()
+    }
+
+    fn collect_stream_result(chunks: &[&str]) -> super::Result<UnifiedParserOutput> {
         let mut parser = test_parser();
         let mut output = UnifiedParserOutput::default();
         for chunk in chunks {
-            output.append(parser.parse_chunk(chunk).unwrap());
+            parser.parse_into(chunk, &mut output)?;
         }
-        output.append(parser.finish().unwrap());
-        output.coalesce()
+        output.append(parser.finish()?);
+        Ok(output.coalesce())
+    }
+
+    fn assert_streaming_matches_complete(case_name: &str, text: &str) {
+        let complete = parse_complete_result(text);
+        assert_chunking_matches(case_name, text, &[text], &complete);
+
+        let boundaries = internal_char_boundaries(text);
+        for boundary in &boundaries {
+            let chunks = [&text[..*boundary], &text[*boundary..]];
+            assert_chunking_matches(case_name, text, &chunks, &complete);
+        }
+
+        for window in boundaries.windows(2) {
+            let left = window[0];
+            let right = window[1];
+            let chunks = [&text[..left], &text[left..right], &text[right..]];
+            assert_chunking_matches(case_name, text, &chunks, &complete);
+        }
+    }
+
+    fn parse_complete_result(text: &str) -> super::Result<UnifiedParserOutput> {
+        let mut parser = test_parser();
+        let mut output = UnifiedParserOutput::default();
+        parser.parse_into(text, &mut output)?;
+        output.append(parser.finish()?);
+        Ok(output.coalesce())
+    }
+
+    fn internal_char_boundaries(text: &str) -> Vec<usize> {
+        text.char_indices().map(|(index, _)| index).filter(|index| *index > 0).collect()
+    }
+
+    fn assert_chunking_matches(
+        case_name: &str,
+        text: &str,
+        chunks: &[&str],
+        complete: &super::Result<UnifiedParserOutput>,
+    ) {
+        let streamed = collect_stream_result(chunks);
+
+        match (&streamed, complete) {
+            (Ok(streamed), Ok(complete)) => assert_eq!(
+                streamed, complete,
+                "streaming output differed for case {case_name:?}, chunks {chunks:?}, text {text:?}",
+            ),
+            (Err(_), Err(_)) => {}
+            (Ok(streamed), Err(error)) => panic!(
+                "streaming succeeded but complete parsing failed for case {case_name:?}, \
+                 chunks {chunks:?}, text {text:?}, streamed {streamed:?}, complete error {error:?}",
+            ),
+            (Err(error), Ok(complete)) => panic!(
+                "streaming failed but complete parsing succeeded for case {case_name:?}, \
+                 chunks {chunks:?}, text {text:?}, streaming error {error:?}, complete {complete:?}",
+            ),
+        }
     }
 
     fn first_call(output: &UnifiedParserOutput) -> ToolCallDelta {
@@ -744,6 +803,59 @@ mod tests {
             .unwrap_err();
 
         assert!(error.to_report_string().contains("incomplete Gemma4 tool call"));
+    }
+
+    #[test]
+    fn gemma4_streaming_matches_complete_across_boundaries() {
+        let cases = [
+            ("plain_text", "Hello, Zürich 🌦️. No tools here.".to_string()),
+            (
+                "single_tool_call",
+                "<|tool_call>call:get_weather{location:<|\"|>London<|\"|>}<tool_call|>".to_string(),
+            ),
+            (
+                "parallel_tool_calls",
+                "<|tool_call>call:get_weather{location:<|\"|>London<|\"|>}<tool_call|>\
+                 <|tool_call>call:get_time{timezone:<|\"|>UTC<|\"|>}<tool_call|>"
+                    .to_string(),
+            ),
+            (
+                "no_parameter_call",
+                "<|tool_call>call:get_status{}<tool_call|>".to_string(),
+            ),
+            (
+                "prefix_and_suffix_text",
+                "Let me check <|tool_call>call:get_weather{location:<|\"|>London<|\"|>}\
+                 <tool_call|><div>"
+                    .to_string(),
+            ),
+            (
+                "unicode_parameter_value",
+                "<|tool_call>call:get_weather{location:<|\"|>Zürich 🌦️<|\"|>}<tool_call|>"
+                    .to_string(),
+            ),
+            (
+                "end_marker_literal_inside_string",
+                "<|tool_call>call:todowrite{content:<|\"|>literal }<tool_call|> inside<|\"|>}\
+                 <tool_call|>"
+                    .to_string(),
+            ),
+            (
+                "html_argument",
+                "<|tool_call>call:write_file{path:<|\"|>index.html<|\"|>,\
+                 content:<|\"|><!DOCTYPE html>\n<html lang=\"zh-CN\">\n<head>\n<|\"|>}\
+                 <tool_call|>"
+                    .to_string(),
+            ),
+            (
+                "unterminated_tool_call",
+                "<|tool_call>call:get_weather{location:<|\"|>London".to_string(),
+            ),
+        ];
+
+        for (case_name, text) in cases {
+            assert_streaming_matches_complete(case_name, &text);
+        }
     }
 
     #[test]

--- a/rust/src/parser/src/unified/gemma4.rs
+++ b/rust/src/parser/src/unified/gemma4.rs
@@ -681,13 +681,72 @@ mod tests {
     }
 
     fn collect_stream(chunks: &[&str]) -> UnifiedParserOutput {
+        collect_stream_result(chunks).unwrap()
+    }
+
+    fn collect_stream_result(chunks: &[&str]) -> super::Result<UnifiedParserOutput> {
         let mut parser = test_parser();
         let mut output = UnifiedParserOutput::default();
         for chunk in chunks {
-            output.append(parser.parse_chunk(chunk).unwrap());
+            parser.parse_into(DecodedText::unattributed(*chunk), &mut output)?;
         }
-        output.append(parser.finish().unwrap());
-        output.coalesce()
+        output.append(parser.finish()?);
+        Ok(output.coalesce())
+    }
+
+    fn assert_streaming_matches_complete(case_name: &str, text: &str) {
+        let complete = parse_complete_result(text);
+        assert_chunking_matches(case_name, text, &[text], &complete);
+
+        let boundaries = internal_char_boundaries(text);
+        for boundary in &boundaries {
+            let chunks = [&text[..*boundary], &text[*boundary..]];
+            assert_chunking_matches(case_name, text, &chunks, &complete);
+        }
+
+        for window in boundaries.windows(2) {
+            let left = window[0];
+            let right = window[1];
+            let chunks = [&text[..left], &text[left..right], &text[right..]];
+            assert_chunking_matches(case_name, text, &chunks, &complete);
+        }
+    }
+
+    fn parse_complete_result(text: &str) -> super::Result<UnifiedParserOutput> {
+        let mut parser = test_parser();
+        let mut output = UnifiedParserOutput::default();
+        parser.parse_into(DecodedText::unattributed(text), &mut output)?;
+        output.append(parser.finish()?);
+        Ok(output.coalesce())
+    }
+
+    fn internal_char_boundaries(text: &str) -> Vec<usize> {
+        text.char_indices().map(|(index, _)| index).filter(|index| *index > 0).collect()
+    }
+
+    fn assert_chunking_matches(
+        case_name: &str,
+        text: &str,
+        chunks: &[&str],
+        complete: &super::Result<UnifiedParserOutput>,
+    ) {
+        let streamed = collect_stream_result(chunks);
+
+        match (&streamed, complete) {
+            (Ok(streamed), Ok(complete)) => assert_eq!(
+                streamed, complete,
+                "streaming output differed for case {case_name:?}, chunks {chunks:?}, text {text:?}",
+            ),
+            (Err(_), Err(_)) => {}
+            (Ok(streamed), Err(error)) => panic!(
+                "streaming succeeded but complete parsing failed for case {case_name:?}, \
+                 chunks {chunks:?}, text {text:?}, streamed {streamed:?}, complete error {error:?}",
+            ),
+            (Err(error), Ok(complete)) => panic!(
+                "streaming failed but complete parsing succeeded for case {case_name:?}, \
+                 chunks {chunks:?}, text {text:?}, streaming error {error:?}, complete {complete:?}",
+            ),
+        }
     }
 
     #[test]
@@ -774,6 +833,59 @@ mod tests {
             .unwrap_err();
 
         assert!(error.to_report_string().contains("incomplete Gemma4 tool call"));
+    }
+
+    #[test]
+    fn gemma4_streaming_matches_complete_across_boundaries() {
+        let cases = [
+            ("plain_text", "Hello, Zürich 🌦️. No tools here.".to_string()),
+            (
+                "single_tool_call",
+                "<|tool_call>call:get_weather{location:<|\"|>London<|\"|>}<tool_call|>".to_string(),
+            ),
+            (
+                "parallel_tool_calls",
+                "<|tool_call>call:get_weather{location:<|\"|>London<|\"|>}<tool_call|>\
+                 <|tool_call>call:get_time{timezone:<|\"|>UTC<|\"|>}<tool_call|>"
+                    .to_string(),
+            ),
+            (
+                "no_parameter_call",
+                "<|tool_call>call:get_status{}<tool_call|>".to_string(),
+            ),
+            (
+                "prefix_and_suffix_text",
+                "Let me check <|tool_call>call:get_weather{location:<|\"|>London<|\"|>}\
+                 <tool_call|><div>"
+                    .to_string(),
+            ),
+            (
+                "unicode_parameter_value",
+                "<|tool_call>call:get_weather{location:<|\"|>Zürich 🌦️<|\"|>}<tool_call|>"
+                    .to_string(),
+            ),
+            (
+                "end_marker_literal_inside_string",
+                "<|tool_call>call:todowrite{content:<|\"|>literal }<tool_call|> inside<|\"|>}\
+                 <tool_call|>"
+                    .to_string(),
+            ),
+            (
+                "html_argument",
+                "<|tool_call>call:write_file{path:<|\"|>index.html<|\"|>,\
+                 content:<|\"|><!DOCTYPE html>\n<html lang=\"zh-CN\">\n<head>\n<|\"|>}\
+                 <tool_call|>"
+                    .to_string(),
+            ),
+            (
+                "unterminated_tool_call",
+                "<|tool_call>call:get_weather{location:<|\"|>London".to_string(),
+            ),
+        ];
+
+        for (case_name, text) in cases {
+            assert_streaming_matches_complete(case_name, &text);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Add deterministic streaming/complete invariant coverage for the Rust tool-parser crate.

Tool parsers are streaming state machines, so chunk boundaries are part of the correctness surface. This PR adds a shared test helper that asserts a parser's streaming result matches whole-text parsing after `finish()` and `coalesce_calls()`.

There are no production code changes.

Related to the Rust frontend parser fixture hardening tracked in #44280.

## Changes

- Add `assert_streaming_matches_complete::<P>()` under `rust/src/parser/src/tool/test_utils.rs`.
- For each corpus string, compare `parse_complete(text)` with streaming parse using:
  - the whole input as one chunk,
  - every single internal Unicode char-boundary split,
  - adjacent two-boundary splits.
- Add invariant corpora for:
  - `minimax_m2`
  - `deepseek_v32`
  - `gemma4`
  - `kimi_k2`
  - `qwen_coder`
- Cover plain text, single and parallel tool calls, Unicode values, no-parameter calls, text around tool calls, marker/end-tag literals inside argument values, and malformed/unterminated inputs.

The invariant intentionally compares only the coalesced final output, not intermediate deltas, because intermediate streaming deltas can legitimately differ across chunkings.

## Current-base refresh

Rebased onto vLLM `main` at `4ebf61ebda8dc8bf090bd4ee14d2855f694111b0`. The rebase preserves the upstream whitespace-framing test imports and adapts the Gemma test helper to the current `DecodedText` parser API.

## Duplicate / related work

Duplicate checks run:

```bash
gh pr list --repo vllm-project/vllm --state open --search "rust tool parser streaming invariant" --json number,title,author,url
gh pr list --repo vllm-project/vllm --state open --search "streaming matches complete tool parser" --json number,title,author,url
gh pr list --repo vllm-project/vllm --state open --search "vllm-parser invariant" --json number,title,author,url
```

I did not find a direct duplicate for Rust `vllm-parser` streaming/complete invariant coverage.

Related but non-duplicative open PRs:

- #46274 adds Python parser-engine Qwen3 stream-interval regression tests.
- #46351 fixes Python parser-engine/Qwen3 streaming string-argument behavior.

This PR is limited to Rust `vllm-parser` crate unit-test infrastructure and parser-specific Rust corpus tests.

## Test Plan

```bash
cargo test --manifest-path rust/Cargo.toml -p vllm-parser streaming_matches_complete_across_boundaries -- --nocapture
cargo test --manifest-path rust/Cargo.toml -p vllm-parser
cargo fmt --manifest-path rust/Cargo.toml --all --check
cargo clippy --manifest-path rust/Cargo.toml -p vllm-parser --all-targets -- -D warnings
git --no-pager diff --check
```

## Test Result

All commands passed locally. Focused invariant result: 5 passed. Full `vllm-parser` suite result:

```text
459 passed
```

## AI assistance disclosure

AI assistance was used to help implement and validate this change. I reviewed the changed files and ran the test commands listed above.
