### PR TITLE
[ROCm][CI] Increase the max wait time for server startup

### DIFF
--- a/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-EMU-TP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-EMU-TP2.yaml
@@ -3,6 +3,7 @@ accuracy_threshold: 0.89
 tolerance: 0.03
 num_questions: 1319
 num_fewshot: 5
+startup_max_wait_seconds: 1800
 server_args: >-
   --max-model-len 4096
   --tensor-parallel-size 2

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -115,17 +115,12 @@ def test_gsm8k_correctness(config_filename):
     print(f"Server args: {' '.join(server_args)}")
     print(f"Environment variables: {env_dict}")
 
-    max_wait_seconds = eval_config.get("startup_max_wait_seconds", 600)
-    # To increase the timeout for ROCm platforms due to slow startup times.
-    if current_platform.is_rocm():
-        max_wait_seconds += 600
-
     # Launch server and run evaluation
     with RemoteOpenAIServer(
         eval_config["model_name"],
         server_args,
         env_dict=env_dict,
-        max_wait_seconds=max_wait_seconds,
+        max_wait_seconds=eval_config.get("startup_max_wait_seconds", 600),
     ) as remote_server:
         server_url = remote_server.url_for("v1")
         print(f"Server started at: {server_url}")

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -115,12 +115,17 @@ def test_gsm8k_correctness(config_filename):
     print(f"Server args: {' '.join(server_args)}")
     print(f"Environment variables: {env_dict}")
 
+    max_wait_seconds = eval_config.get("startup_max_wait_seconds", 600)
+    # To increase the timeout for ROCm platforms due to slow startup times.
+    if current_platform.is_rocm():
+        max_wait_seconds += 600
+
     # Launch server and run evaluation
     with RemoteOpenAIServer(
         eval_config["model_name"],
         server_args,
         env_dict=env_dict,
-        max_wait_seconds=eval_config.get("startup_max_wait_seconds", 600),
+        max_wait_seconds=max_wait_seconds,
     ) as remote_server:
         server_url = remote_server.url_for("v1")
         print(f"Server started at: {server_url}")


### PR DESCRIPTION
The mi300_8: LM Eval Large Models (8xH200-8xMI300) TG is still failing because the it takes too long to start the server.