### PR TITLE
[Bugfix] Fix humming lm_head crash and FusedMoE weight_shape coercion

### DIFF
--- a/tests/evals/gsm8k/configs/gemma-4-E4B-it-qat-mobile-ct.yaml
+++ b/tests/evals/gsm8k/configs/gemma-4-E4B-it-qat-mobile-ct.yaml
@@ -1,0 +1,5 @@
+model_name: "google/gemma-4-E4B-it-qat-mobile-ct"
+accuracy_threshold: 0.48
+num_questions: 1319
+num_fewshot: 5
+server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/gemma-4-E4B-it-qat-mobile-ct.yaml
+++ b/tests/evals/gsm8k/configs/gemma-4-E4B-it-qat-mobile-ct.yaml
@@ -1,5 +1,5 @@
 model_name: "google/gemma-4-E4B-it-qat-mobile-ct"
-accuracy_threshold: 0.48
+accuracy_threshold: 0.50
 num_questions: 1319
 num_fewshot: 5
 server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/models-small.txt
+++ b/tests/evals/gsm8k/configs/models-small.txt
@@ -5,3 +5,4 @@ Qwen2.5-VL-3B-Instruct-FP8-dynamic.yaml
 Qwen1.5-MoE-W4A16-CT.yaml
 DeepSeek-V2-Lite-Instruct-FP8.yaml
 Qwen3-30B-A3B-MXFP4A16.yaml
+gemma-4-E4B-it-qat-mobile-ct.yaml

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -69,6 +69,15 @@ def test_gsm8k_correctness(config_filename):
             "Marlin kernels are not supported."
         )
 
+    if (
+        not current_platform.is_cuda()
+        and "gemma-4-E4B-it-qat-mobile-ct" in eval_config["model_name"]
+    ):
+        pytest.skip(
+            "Skipping gemma-4-E4B-it-qat-mobile-ct on non-CUDA platforms. "
+            "Its W2A16 (uint2b2) scheme has no kernel outside CUDA."
+        )
+
     # TODO(akaratza): Enable DeepSeek-V3.2 and DeepSeek-R1 on ROCm platforms
     if current_platform.is_rocm() and (
         "deepseek-ai/DeepSeek-V3.2" in eval_config["model_name"]

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -530,8 +530,10 @@ class RoutedExperts(PluggableLayer):
     ):
         param_data = param.data
 
-        # Input scales can be loaded directly and should be equal.
-        param_data[expert_id] = self._to_scalar(loaded_weight)
+        # Used for both scalar input_scale and the size-2 `weight_shape`
+        # param (compressed-tensors). Assign directly so both shapes load;
+        # _to_scalar's reshape(()) would reject the size-2 weight_shape.
+        param_data[expert_id] = loaded_weight
 
     def _load_g_idx(
         self,

--- a/vllm/model_executor/layers/quantization/utils/humming_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -83,10 +83,13 @@ def prepare_humming_layer(layer: LinearBase, quant_config: dict):
     input_schema = HummingInputSchema()
 
     # ReplicatedLinear has no TP partitioning and so does not set
-    # input_size_per_partition; for it that is just input_size.
-    input_size_per_partition = getattr(
-        layer, "input_size_per_partition", layer.input_size
-    )
+    # input_size_per_partition; for it that is just input_size. Use hasattr
+    # rather than getattr's default arg, which is evaluated eagerly and would
+    # raise on layers lacking input_size (e.g. ParallelLMHead).
+    if hasattr(layer, "input_size_per_partition"):
+        input_size_per_partition = layer.input_size_per_partition
+    else:
+        input_size_per_partition = layer.input_size
     shape_k_stacks = [input_size_per_partition]
     shape_n_stacks = layer.output_partition_sizes
 


### PR DESCRIPTION
Two unrelated compressed-tensors startup crashes:

**1. Humming `prepare` on `ParallelLMHead`** — `prepare_humming_layer` used `getattr(layer, "input_size_per_partition", layer.input_size)`. The default arg is evaluated eagerly, so quantizing `lm_head` with the `wNa8o8` scheme crashed:

```
AttributeError: 'ParallelLMHead' object has no attribute 'input_size'
```

Guard with `hasattr`. Added a GSM8K config for `google/gemma-4-E4B-it-qat-mobile-ct` covering the path (acc 0.528, threshold 0.48).

**2. FusedMoE `weight_shape` coercion** — #43362 applied `_to_scalar()` (`reshape(())`) to `_load_single_value`, which is shared by the scalar `input_scale` loader and the size-2 `weight_shape` loader (compressed-tensors). `reshape(())` rejects the size-2 tensor, crashing every compressed-tensors WNA16 MoE model:

```
RuntimeError: shape '[]' is invalid for input of size 2
```

Revert that one assignment to a direct copy; the intended per-tensor weight-scale coercion (#43297) is untouched.

AI assistance (Claude) was used.