### PR TITLE
[Test] Add MoE dtype asserts for hidden states and logits

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -811,6 +811,13 @@ class MoERunner(MoERunnerInterface):
             else:
                 router_logits, _ = self.gate(hidden_states)
 
+        assert hidden_states.dtype == self.moe_config.in_dtype, (
+            f"{hidden_states.dtype} == {self.moe_config.in_dtype}"
+        )
+        assert router_logits.dtype == self.moe_config.router_logits_dtype, (
+            f"{router_logits.dtype} == {self.moe_config.router_logits_dtype}"
+        )
+
         with self._sequence_parallel_context():
             # TODO(bnell): parts of the dispatch/combine steps will go away once
             # #32567 lands and the remaining kernels are made MKs.  The PCP


### PR DESCRIPTION

## Purpose

Add asserts to validate that the `hidden_states` and `router_logits` dtypes match what is in the `FusedMoEConfig`.

## Test Plan

Run in CI to see if anything trips the asserts.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

