### PR TITLE
[compile] SupportsStockCompile: migrate GPT-OSS off VllmBackend onto stock torch.compile (decoupled cudagraph wrapper)

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -174,6 +174,66 @@ def test_stock_torch_compile(vllm_runner, monkeypatch):
 
 # forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
 @pytest.mark.forked
+def test_stock_torch_compile_piecewise_graph_partition(vllm_runner, monkeypatch):
+    # Stock + use_inductor_graph_partition recovers piecewise cudagraphs (step 2 of
+    # the VllmBackend migration): Inductor partitions at the attention ops and the
+    # external wrapper captures each partition (FULL_AND_PIECEWISE). opt-125m at one
+    # capture size -> 13 piecewise + 1 full decode = 14 captured graphs (the same
+    # count as the VllmBackend FaP path), proving the stock piecewise path actually
+    # captures rather than running attention inside the cudagraph.
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    with (
+        compilation_counter.expect(
+            stock_torch_compile_count=1,
+            num_gpu_runner_capture_triggers=1,
+            num_cudagraph_captured=14,
+        ),
+        vllm_runner(
+            "facebook/opt-125m",
+            compilation_config={
+                "mode": CompilationMode.STOCK_TORCH_COMPILE,
+                "use_inductor_graph_partition": True,
+                "cudagraph_capture_sizes": [100],
+            },
+            gpu_memory_utilization=0.4,
+        ) as _,
+    ):
+        pass
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
+def test_stock_uses_decoupled_cudagraph_wrapper(vllm_runner, monkeypatch):
+    # The stock path must capture via its own StockTorchCompileCUDAGraphWrapper,
+    # never the shared CUDAGraphWrapper (which is coupled to vLLM's
+    # non-torch.compile full-cudagraph path). Forked so the wrapper-class
+    # instance registries start empty.
+    from vllm.compilation.cuda_graph import CUDAGraphWrapper
+    from vllm.compilation.stock_cudagraph import StockTorchCompileCUDAGraphWrapper
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    with vllm_runner(
+        "facebook/opt-125m",
+        compilation_config={
+            "mode": CompilationMode.STOCK_TORCH_COMPILE,
+            "use_inductor_graph_partition": True,
+            "cudagraph_capture_sizes": [100],
+        },
+        gpu_memory_utilization=0.4,
+    ) as _:
+        assert len(StockTorchCompileCUDAGraphWrapper._all_instances) > 0
+        assert len(CUDAGraphWrapper._all_instances) == 0
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
 def test_no_compilation(vllm_runner, monkeypatch):
     # Disable multiprocessing so that the counter is in the same process
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
@@ -788,3 +848,956 @@ def test_inductor_asserts_user_override(monkeypatch):
     assert config.inductor_compile_config.get("size_asserts") is True
     if not _is_torch_equal_or_newer(torch.__version__, "2.12.0.dev"):
         assert config.inductor_compile_config.get("alignment_asserts") is False
+
+
+# --- STOCK_TORCH_COMPILE migration (SupportsStockCompile) config resolution ---
+# These build VllmConfig directly (no model load / GPU memory) and assert the
+# resolved compile mode / cudagraph mode. The cudagraph-mode assertions need a
+# platform that supports static graph mode (FDO is otherwise forced to NONE).
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+@pytest.mark.parametrize(
+    "user_cudagraph_mode,expected_mode,expected_cudagraph",
+    [
+        # Unset, partition explicitly off -> the opt-level default is a piecewise
+        # mode the stock path can't honor without partition, so fall back to the
+        # legacy VllmBackend (keeping the piecewise default) rather than silently
+        # degrading to a different cudagraph strategy. The partition-on default is
+        # covered by test_stock_defaults_to_graph_partition_piecewise.
+        (None, CompilationMode.VLLM_COMPILE, CUDAGraphMode.FULL_AND_PIECEWISE),
+        # Explicit NONE is the user's deliberate choice and must be preserved.
+        (CUDAGraphMode.NONE, CompilationMode.STOCK_TORCH_COMPILE, CUDAGraphMode.NONE),
+        # An explicit piecewise mode needs graph partition (off here); the stock path
+        # can't provide it, so fall back to the legacy VllmBackend (which has its own
+        # FX splitting) rather than silently dropping cudagraphs.
+        (
+            CUDAGraphMode.PIECEWISE,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+        ),
+        (
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        # Explicit full modes need no piecewise capture, so they stay on stock as-is.
+        (CUDAGraphMode.FULL, CompilationMode.STOCK_TORCH_COMPILE, CUDAGraphMode.FULL),
+        (
+            CUDAGraphMode.FULL_DECODE_ONLY,
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        ),
+    ],
+)
+def test_stock_cudagraph_mode_resolution(
+    user_cudagraph_mode, expected_mode, expected_cudagraph
+):
+    # Pin partition off so this isolates the no-partition resolution regardless of
+    # the torch version (the default auto-enables partition on torch>=2.9).
+    cc_kwargs = {
+        "mode": CompilationMode.STOCK_TORCH_COMPILE,
+        "use_inductor_graph_partition": False,
+    }
+    if user_cudagraph_mode is not None:
+        cc_kwargs["cudagraph_mode"] = user_cudagraph_mode
+    config = VllmConfig(compilation_config=CompilationConfig(**cc_kwargs))
+    assert config.compilation_config.mode == expected_mode
+    assert config.compilation_config.cudagraph_mode == expected_cudagraph
+    # A fallen-back stock config must be indistinguishable from a native
+    # VLLM_COMPILE one: ir_enable_torch_wrap follows the FINAL mode, not the
+    # transient STOCK mode it started in.
+    assert config.compilation_config.ir_enable_torch_wrap is (
+        expected_mode == CompilationMode.VLLM_COMPILE
+    )
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_late_fallback_resolves_torch_wrap():
+    # A piecewise cudagraph_mode re-introduced LATE (here via the dynamic
+    # speculative-decoding (SD) override, but also reachable via pooler /
+    # KV-connector / platform check_and_update_config) forces a
+    # stock->VLLM_COMPILE fallback AFTER the
+    # point mode is normally settled. ir_enable_torch_wrap must still resolve to
+    # True so custom IR torch-wrap/lowering stays enabled, matching a config that
+    # started as VLLM_COMPILE. Regression guard for resolving it too early.
+    def _force_piecewise(self):
+        self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+
+    with patch.object(
+        VllmConfig, "_maybe_override_dynamic_sd_cudagraph_mode", _force_piecewise
+    ):
+        config = VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.STOCK_TORCH_COMPILE,
+                use_inductor_graph_partition=False,
+            )
+        )
+    assert config.compilation_config.mode == CompilationMode.VLLM_COMPILE
+    assert config.compilation_config.ir_enable_torch_wrap is True
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_inert_flag_warning_emitted_after_final_mode():
+    # End-to-end ordering guard for the warn-before-fallback fix: the inert-flag
+    # warning must be evaluated only after every late mode fallback in __post_init__.
+    # We force a late STOCK->VLLM_COMPILE fallback (the dynamic-SD override turns the
+    # mode piecewise on a no-partition stock config) and capture the mode the warning
+    # method observes; moving the call back up next to where mode is first settled
+    # would make it observe STOCK here and re-introduce the false "flags are inert"
+    # warning.
+    def _force_piecewise(self):
+        self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+
+    observed = {}
+    orig = VllmConfig._warn_ignored_vllm_backend_only_flags
+
+    def spy(self):
+        observed["mode"] = self.compilation_config.mode
+        return orig(self)
+
+    with (
+        patch.object(
+            VllmConfig, "_maybe_override_dynamic_sd_cudagraph_mode", _force_piecewise
+        ),
+        patch.object(VllmConfig, "_warn_ignored_vllm_backend_only_flags", spy),
+    ):
+        VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.STOCK_TORCH_COMPILE,
+                use_inductor_graph_partition=False,
+                cudagraph_copy_inputs=True,
+            )
+        )
+    # By the time the warning is evaluated the mode has settled to VLLM_COMPILE
+    # (which honors cudagraph_copy_inputs), so the mode gate suppresses the false
+    # "flags are inert" diagnostic.
+    assert observed["mode"] == CompilationMode.VLLM_COMPILE
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_dynamic_sd_reenables_graph_partition():
+    # Guards the re-resolve of _resolve_stock_default_cudagraph_mode after the
+    # dynamic-SD override: a stock config whose mode only becomes piecewise LATE
+    # (dynamic-SD turning an explicit FULL into PIECEWISE) must auto-enable Inductor
+    # graph partition and STAY on stock, rather than needlessly falling back to
+    # VLLM_COMPILE. Reverting the re-resolve flips both asserts below (mode becomes
+    # VLLM_COMPILE, partition stays False). As a downstream consequence the user-set
+    # splitting_ops is then the honored partition boundary; that it is not reported
+    # inert (and the emission-ordering guarding it) is covered by
+    # test_stock_inert_flag_warning_emitted_after_final_mode.
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+
+    def _force_piecewise(self):
+        self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+
+    with patch.object(
+        VllmConfig, "_maybe_override_dynamic_sd_cudagraph_mode", _force_piecewise
+    ):
+        config = VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.STOCK_TORCH_COMPILE,
+                cudagraph_mode=CUDAGraphMode.FULL,
+                splitting_ops=["vllm::unified_attention"],
+            )
+        )
+    assert config.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE
+    assert config.compilation_config.use_inductor_graph_partition is True
+
+
+def test_stock_falls_back_to_vllm_compile_for_v2_model_runner():
+    # The V2 model runner does not support stock torch.compile. A stock-eligible
+    # arch force-run on V2 (VLLM_USE_V2_MODEL_RUNNER=1 -> use_v2_model_runner True)
+    # must fall back to VLLM_COMPILE instead of hard-failing _validate_v2_model_runner.
+    # Regression guard for the GPT-OSS default-to-stock migration.
+    forced = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    with patch.object(VllmConfig, "use_v2_model_runner", property(lambda self: True)):
+        forced._maybe_fallback_stock_for_v2_model_runner(user_set_graph_partition=False)
+    assert forced.compilation_config.mode == CompilationMode.VLLM_COMPILE
+    assert forced.compilation_config.use_inductor_graph_partition is False
+
+    # An explicit user use_inductor_graph_partition=True is preserved across the V2
+    # fallback: VLLM_COMPILE (which V2 supports) honors graph partition, so the
+    # deliberate request must not be silently reset to False.
+    explicit = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    explicit.compilation_config.use_inductor_graph_partition = True
+    with patch.object(VllmConfig, "use_v2_model_runner", property(lambda self: True)):
+        explicit._maybe_fallback_stock_for_v2_model_runner(
+            user_set_graph_partition=True
+        )
+    assert explicit.compilation_config.mode == CompilationMode.VLLM_COMPILE
+    assert explicit.compilation_config.use_inductor_graph_partition is True
+
+    # V2 not in use -> stock is preserved (the auto path instead keeps stock on the
+    # V1 runner via _get_v2_model_runner_unsupported_features).
+    keep = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    with patch.object(VllmConfig, "use_v2_model_runner", property(lambda self: False)):
+        keep._maybe_fallback_stock_for_v2_model_runner(user_set_graph_partition=False)
+    assert keep.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_defaults_to_graph_partition_piecewise():
+    # A stock-compile model with nothing set defaults to graph-partition piecewise
+    # (FULL_AND_PIECEWISE) on torch>=2.9, auto-enabling use_inductor_graph_partition;
+    # on older torch the piecewise default can't be honored, so it falls back to the
+    # legacy VllmBackend (preserving the cudagraph mode). The flag is folded into the
+    # SupportsStockCompile default rather than being opt-in.
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    cc = config.compilation_config
+    if is_torch_equal_or_newer("2.9.0.dev"):
+        assert cc.mode == CompilationMode.STOCK_TORCH_COMPILE
+        assert cc.use_inductor_graph_partition is True
+        assert cc.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
+    else:
+        assert cc.mode == CompilationMode.VLLM_COMPILE
+        assert cc.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+@pytest.mark.parametrize(
+    "supported,user_mode,expected_mode,expected_cudagraph",
+    [
+        (
+            True,
+            None,
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        (
+            False,
+            None,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        # An explicit mode always wins over the allowlist auto-selection.
+        (
+            True,
+            CompilationMode.VLLM_COMPILE,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+    ],
+)
+def test_stock_mode_auto_selection(
+    supported, user_mode, expected_mode, expected_cudagraph
+):
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    cc_kwargs = {} if user_mode is None else {"mode": user_mode}
+    with patch.object(VllmConfig, "_stock_compile_supported", lambda self: supported):
+        config = VllmConfig(compilation_config=CompilationConfig(**cc_kwargs))
+    # The stock default is graph-partition piecewise only on torch>=2.9; on older
+    # torch the piecewise default can't be honored, so it falls back to VllmBackend
+    # (the cudagraph mode is preserved across the fallback).
+    if (
+        expected_mode == CompilationMode.STOCK_TORCH_COMPILE
+        and not is_torch_equal_or_newer("2.9.0.dev")
+    ):
+        expected_mode = CompilationMode.VLLM_COMPILE
+    assert config.compilation_config.mode == expected_mode
+    assert config.compilation_config.cudagraph_mode == expected_cudagraph
+
+
+@pytest.mark.parametrize(
+    "mode,cudagraph_mode,partition,expected_mode,expected_cudagraph",
+    [
+        # STOCK + a piecewise mode without graph partition can't be honored, so the
+        # engine falls back to the legacy VllmBackend (which has its own FX splitting),
+        # leaving cudagraph_mode intact for that backend to consume.
+        (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+            False,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+        ),
+        (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            False,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        # STOCK + piecewise WITH graph partition is supported, so it stays on stock.
+        (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+            True,
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+        ),
+        # A non-piecewise mode never needs fixing.
+        (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+            False,
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        ),
+        # VLLM_COMPILE honors piecewise itself, so it is left untouched.
+        (
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+            False,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+        ),
+        # NONE / DYNAMO_TRACE_ONCE have no compiled graph to capture piecewise, so the
+        # piecewise cudagraph_mode drops to NONE (no fallback -- there is nothing to
+        # fall back to for these explicit modes).
+        (
+            CompilationMode.NONE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            False,
+            CompilationMode.NONE,
+            CUDAGraphMode.NONE,
+        ),
+        (
+            CompilationMode.DYNAMO_TRACE_ONCE,
+            CUDAGraphMode.PIECEWISE,
+            False,
+            CompilationMode.DYNAMO_TRACE_ONCE,
+            CUDAGraphMode.NONE,
+        ),
+    ],
+)
+def test_fix_unsupported_piecewise_cudagraph_mode(
+    mode, cudagraph_mode, partition, expected_mode, expected_cudagraph
+):
+    # Construct with a benign non-piecewise cudagraph_mode so the config settles in
+    # the requested `mode`: an unset (piecewise) default would itself trip the
+    # stock->VLLM_COMPILE fallback during __post_init__. Then set the mode under test
+    # and invoke the helper in isolation.
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=mode,
+            use_inductor_graph_partition=partition,
+            cudagraph_mode=CUDAGraphMode.NONE,
+        )
+    )
+    config.compilation_config.cudagraph_mode = cudagraph_mode
+    config._fix_unsupported_piecewise_cudagraph_mode()
+    assert config.compilation_config.mode == expected_mode
+    assert config.compilation_config.cudagraph_mode == expected_cudagraph
+
+
+# --- step 2: piecewise cudagraphs on the stock path via Inductor graph partition ---
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+@pytest.mark.parametrize(
+    "user_cudagraph_mode,expected",
+    [
+        # Unset + graph partition -> prefill can be piecewise-captured, so default to
+        # FULL_AND_PIECEWISE rather than FULL_DECODE_ONLY.
+        (None, CUDAGraphMode.FULL_AND_PIECEWISE),
+        # Explicit piecewise modes are now honored on the stock path (Inductor graph
+        # partition provides them) instead of being clamped to NONE.
+        (CUDAGraphMode.PIECEWISE, CUDAGraphMode.PIECEWISE),
+        (CUDAGraphMode.FULL_AND_PIECEWISE, CUDAGraphMode.FULL_AND_PIECEWISE),
+        # Explicit NONE is still the user's deliberate choice.
+        (CUDAGraphMode.NONE, CUDAGraphMode.NONE),
+    ],
+)
+def test_stock_graph_partition_cudagraph_mode(user_cudagraph_mode, expected):
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    cc_kwargs = {
+        "mode": CompilationMode.STOCK_TORCH_COMPILE,
+        "use_inductor_graph_partition": True,
+    }
+    if user_cudagraph_mode is not None:
+        cc_kwargs["cudagraph_mode"] = user_cudagraph_mode
+    config = VllmConfig(compilation_config=CompilationConfig(**cc_kwargs))
+    assert config.compilation_config.cudagraph_mode == expected
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_graph_partition_populates_splitting_ops():
+    # With graph partition, splitting_ops must name the attention ops so Inductor
+    # partitions there; without it the stock path cannot provide piecewise cudagraphs
+    # and falls back to the legacy VllmBackend.
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+
+    partition = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=True,
+        )
+    )
+    assert partition.compilation_config.splitting_ops == list(
+        CompilationConfig._attention_ops
+    )
+
+    # An explicit empty list with partition on must still be populated (else
+    # FULL_AND_PIECEWISE would have zero piecewise partitions, silently capturing
+    # attention inside the cudagraph).
+    explicit_empty = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=True,
+            splitting_ops=[],
+        )
+    )
+    assert explicit_empty.compilation_config.splitting_ops == list(
+        CompilationConfig._attention_ops
+    )
+
+    # Partition explicitly off on the stock path can't provide piecewise cudagraphs,
+    # so it falls back to the legacy VllmBackend rather than silently degrading to a
+    # whole-graph stock path.
+    no_partition = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=False,
+        )
+    )
+    assert no_partition.compilation_config.mode == CompilationMode.VLLM_COMPILE
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="stock inductor-options pass wiring is exercised on CUDA",
+)
+def test_stock_inductor_options_merges_user_post_grad_pass():
+    # A user-supplied post_grad_custom_post_pass must be merged into the stock path's
+    # PostGradPassManager (mirroring VllmBackend.configure_post_pass), not clobbered by
+    # the manager registration. Regression guard: the stock path used to overwrite the
+    # pass_key unconditionally, silently dropping the user's post-grad pass.
+    from types import SimpleNamespace
+
+    import vllm.compilation.passes.inductor_pass as inductor_pass_mod
+    from vllm.compilation.passes.inductor_pass import InductorPass
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    class _MarkerPass(InductorPass):
+        def __call__(self, graph):
+            pass
+
+    marker = _MarkerPass()
+    # Pin the whole-graph stock path (partition off, decode-only cudagraphs) with a real
+    # fusion pass active (enable_qk_norm_rope_fusion) so _stock_inductor_options
+    # registers the pass manager and reaches the merge branch instead of returning the
+    # base options early.
+    vc = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=False,
+            cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+            pass_config=PassConfig(
+                eliminate_noops=True, enable_qk_norm_rope_fusion=True
+            ),
+            inductor_compile_config={current_platform.pass_key: marker},
+        )
+    )
+    vc.model_config = MagicMock(dtype=torch.bfloat16)
+    # max_num_tokens is the upper bound of the pass-context Range the stock options
+    # install; mirror the runner's self.max_num_tokens (scheduler
+    # max_num_batched_tokens).
+    stub = SimpleNamespace(
+        compilation_config=vc.compilation_config,
+        vllm_config=vc,
+        max_num_tokens=vc.scheduler_config.max_num_batched_tokens,
+    )
+
+    # set_pass_context installs process-global state with no teardown by design;
+    # restore it so this unit test leaves no global leak for other tests.
+    prev_pass_context = inductor_pass_mod._pass_context
+    try:
+        opts, has_fusion = GPUModelRunner._stock_inductor_options(stub)
+        # The installed pass context must be the finite [0, max_num_tokens] range,
+        # not an unbounded end: end-bounded fusions (allreduce+rmsnorm, rope+kvcache)
+        # gate on compile_range.end <= max_token_num, so an unbounded end would
+        # silently drop every one of them. Regression guard for that range fix.
+        installed_range = inductor_pass_mod._pass_context.compile_range
+        assert installed_range.start == 0
+        assert installed_range.end == vc.scheduler_config.max_num_batched_tokens
+    finally:
+        inductor_pass_mod._pass_context = prev_pass_context
+
+    assert has_fusion
+    manager = opts[current_platform.pass_key]
+    # The manager replaces the raw pass under pass_key, and the user's pass is merged
+    # into the manager's pass list rather than dropped.
+    assert manager is not marker
+    assert marker in manager.passes
+
+
+def test_stock_inert_flag_warning():
+    # VllmBackend-only flags on a stock model emit one warning that names the
+    # working escape hatch and never the broken -O.mode=3 form.
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE, compile_sizes=[1, 2]
+        )
+    )
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 1
+    fmt, *fmt_args = mock_warn.call_args.args
+    assert "--compilation-config" in fmt
+    assert "-O.mode=3" not in fmt
+    assert "compile_sizes" in " ".join(str(a) for a in fmt_args)
+
+    # cudagraph_copy_inputs and splitting_ops (without graph partition) are also
+    # VllmBackend-only on the stock path and must each surface in the warning args.
+    copy_cfg = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE, cudagraph_copy_inputs=True
+        )
+    )
+    copy_cfg.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        copy_cfg._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 1
+    assert "cudagraph_copy_inputs" in " ".join(str(a) for a in mock_warn.call_args.args)
+
+    # VLLM_COMPILE honors these flags, so no warning.
+    other = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE, compile_sizes=[1, 2]
+        )
+    )
+    other.model_config = MagicMock(architectures=["LlamaForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        other._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 0
+
+
+def test_stock_inert_flag_warning_suppressed_after_fallback():
+    # Regression guard for the warn-before-fallback ordering bug: the warning is
+    # gated on the FINAL mode. A config that LATE-falls-back to VLLM_COMPILE (dynamic
+    # SD / pooler / KV connector / platform check_and_update_config re-introducing a
+    # piecewise mode) must NOT be warned that its VllmBackend-only flags are inert --
+    # VLLM_COMPILE honors them.
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE, cudagraph_copy_inputs=True
+        )
+    )
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    # Control: while still on the stock path the flag DOES warn.
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 1
+    # Simulate the late fallback to the legacy backend: the same flag is now honored.
+    config.compilation_config.mode = CompilationMode.VLLM_COMPILE
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 0
+
+
+def test_stock_graph_partition_no_piecewise_override_warning():
+    # With use_inductor_graph_partition the stock path provides piecewise cudagraphs,
+    # so resolving to FULL_AND_PIECEWISE must NOT warn about an unsupported/overridden
+    # cudagraph_mode (regression: the inert-flag warning used to fire here).
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=True,
+        )
+    )
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 0
+
+
+def test_stock_compile_cache_flags_warn(monkeypatch):
+    # vLLM's own compile cache is inert on the stock path (torch.compile uses its
+    # own cache); setting any of its knobs must warn, not be silently ignored.
+    monkeypatch.setenv("VLLM_COMPILE_CACHE_SAVE_FORMAT", "binary")
+
+    def warn_parts(**cc):
+        config = VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.STOCK_TORCH_COMPILE, **cc
+            )
+        )
+        config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+        with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+            config._warn_ignored_vllm_backend_only_flags()
+        assert mock_warn.call_count == 1
+        return " ".join(str(a) for a in mock_warn.call_args.args)
+
+    assert "cache_dir" in warn_parts(cache_dir="/tmp/vllm-cache")
+    assert "compile_cache_save_format" in warn_parts(
+        compile_cache_save_format="unpacked"
+    )
+
+    # VLLM_DISABLE_COMPILE_CACHE is an env var, not a field.
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 1
+    assert "VLLM_DISABLE_COMPILE_CACHE" in " ".join(
+        str(a) for a in mock_warn.call_args.args
+    )
+
+
+def test_stock_warn_no_false_positive_on_autopopulated_fields():
+    # compile_ranges_endpoints is auto-populated later in __post_init__ (and
+    # __post_init__ may re-run on a reused compilation_config), so a resolved
+    # non-empty value must NOT trigger a warning when the user set no inert flags.
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    # simulate the resolved/auto-populated state seen on a real run / re-run
+    config.compilation_config.compile_ranges_endpoints = [16384]
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 0
+
+
+def test_stock_warning_handles_missing_model_config():
+    # mode==STOCK with no model_config must not raise (the warn helper dereferences
+    # model_config.architectures only after a None guard).
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE, compile_sizes=[1, 2]
+        )
+    )
+    config.model_config = None
+    config._warn_ignored_vllm_backend_only_flags()
+
+
+def test_stock_compile_supported_safe_defaults():
+    # The real _stock_compile_supported (not patched out) must return False for
+    # both the no-model case and any registry resolution error, so a broken/unknown
+    # model never gets auto-selected onto the stock path.
+    no_model = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    no_model.model_config = None
+    assert no_model._stock_compile_supported() is False
+
+    raising = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    registry = MagicMock()
+    registry.is_stock_compile_supported_model.side_effect = RuntimeError("boom")
+    raising.model_config = MagicMock(
+        architectures=["GptOssForCausalLM"], registry=registry
+    )
+    # A swallowed resolution error must still return the safe default AND be
+    # surfaced at a visible level so a stock-eligible arch silently falling
+    # back to VllmBackend is diagnosable.
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        assert raising._stock_compile_supported() is False
+    assert mock_warn.call_count == 1
+    warn_text = " ".join(str(a) for a in mock_warn.call_args.args)
+    assert "GptOssForCausalLM" in warn_text
+    assert "boom" in warn_text
+
+
+@pytest.mark.parametrize("decorate_outer", [True, False])
+def test_stock_support_torch_compile_routes_to_runner_compile(decorate_outer):
+    # Spec-decode drafters run under the engine-global STOCK mode with their
+    # @support_torch_compile decorator not using vLLM's custom backend
+    # (do_not_use_custom_torch_compile_backend), and the runner
+    # compiles the drafter model via nn.Module.compile().
+    # - decorate_outer=True (MTP shape): the compiled module IS the decorated class.
+    #   Because the decorator overrides nn.Module.__call__, .compile() only takes
+    #   effect if that __call__ routes to _compiled_call_impl -- with the pre-fix
+    #   decorator the backend is never invoked (calls == 0). This case guards the fix.
+    # - decorate_outer=False (eagle-head shape): an undecorated outer wraps the
+    #   decorated inner; the outer's .compile() works regardless of the fix. This is a
+    #   regression guard that the eagle shape still compiles under stock.
+    import torch
+    import torch.nn as nn
+
+    from vllm.compilation.decorators import support_torch_compile
+    from vllm.config import set_current_vllm_config
+
+    @support_torch_compile
+    class Decorated(nn.Module):
+        def __init__(self, *, vllm_config=None, prefix=""):
+            super().__init__()
+            self.lin = nn.Linear(8, 8)
+
+        def forward(self, x: torch.Tensor):
+            return self.lin(x)
+
+    cfg = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=False,
+            cudagraph_mode=CUDAGraphMode.NONE,
+        )
+    )
+    with set_current_vllm_config(cfg):
+        decorated = Decorated(vllm_config=cfg)
+
+    # decorate_outer=True compiles the decorated module directly (the MTP-drafter
+    # shape); False wraps it in an undecorated outer (the eagle-head shape).
+    module = decorated if decorate_outer else nn.Sequential(decorated)
+
+    calls = {"n": 0}
+
+    def counting_backend(gm, example_inputs):
+        calls["n"] += 1
+        return gm.forward
+
+    module.compile(fullgraph=True, backend=counting_backend)
+    module(torch.randn(4, 8))
+    assert calls["n"] >= 1, (
+        "nn.Module.compile() did not take effect under STOCK_TORCH_COMPILE; the "
+        "drafter would run eager"
+    )
+
+
+def test_support_torch_compile_none_mode_runs_eager():
+    # The __call__ routing that sends do_not_use_custom_torch_compile_backend modules
+    # to _compiled_call_impl is STOCK-only: under CompilationMode.NONE the module has
+    # do_not_use_custom_torch_compile_backend set and nothing calls nn.Module.compile()
+    # on it, so _compiled_call_impl stays None and it runs eager (guards the shared
+    # decorator path against a regression).
+    import torch
+    import torch.nn as nn
+
+    from vllm.compilation.decorators import support_torch_compile
+    from vllm.config import set_current_vllm_config
+
+    @support_torch_compile
+    class Decorated(nn.Module):
+        def __init__(self, *, vllm_config=None, prefix=""):
+            super().__init__()
+            self.ran_eager = False
+
+        def forward(self, x: torch.Tensor):
+            self.ran_eager = True
+            return x
+
+    cfg = VllmConfig(compilation_config=CompilationConfig(mode=CompilationMode.NONE))
+    with set_current_vllm_config(cfg):
+        m = Decorated(vllm_config=cfg)
+    assert getattr(m, "_compiled_call_impl", None) is None
+    m(torch.randn(2, 2))
+    assert m.ran_eager
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="glue-kernel resolution comparison is CUDA-specific",
+)
+def test_stock_uses_default_glue_kernels_like_vllm_backend():
+    # Stock must NOT force the vLLM custom RMSNorm/RoPE glue kernels. A TP1-TP8 sweep
+    # found the custom glue (+rotary_embedding, ir_op_priority.rms_norm=vllm_c) is ~10%
+    # slower at batch-1 decode than the Inductor glue VllmBackend actually uses
+    # (custom_ops=none), with no throughput or prefill benefit (PR #46423). Stock must
+    # resolve to the same glue as VllmBackend so they run identical kernels.
+    stock = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    vllm = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.VLLM_COMPILE)
+    )
+    # No forced custom RoPE kernel, and RMSNorm priority is not forced to vllm_c.
+    assert "+rotary_embedding" not in stock.compilation_config.custom_ops
+    assert stock.kernel_config.ir_op_priority.rms_norm[0] != "vllm_c"
+    assert stock.kernel_config.ir_op_priority.fused_add_rms_norm[0] != "vllm_c"
+    # Stock resolves to the same glue kernels as VllmBackend.
+    assert (
+        stock.kernel_config.ir_op_priority.rms_norm
+        == vllm.kernel_config.ir_op_priority.rms_norm
+    )
+    assert (
+        stock.kernel_config.ir_op_priority.fused_add_rms_norm
+        == vllm.kernel_config.ir_op_priority.fused_add_rms_norm
+    )
+
+
+@pytest.mark.parametrize(
+    "method,expected_mode",
+    [
+        # Validated drafter methods keep the stock path (runner compiles the drafter).
+        ("eagle", CompilationMode.STOCK_TORCH_COMPILE),
+        ("eagle3", CompilationMode.STOCK_TORCH_COMPILE),
+        # Algorithmic (model-less) drafters have nothing to compile, so stay stock.
+        ("ngram", CompilationMode.STOCK_TORCH_COMPILE),
+        ("ngram_gpu", CompilationMode.STOCK_TORCH_COMPILE),
+        ("suffix", CompilationMode.STOCK_TORCH_COMPILE),
+        # Unvalidated model-backed drafters fall back so they compile as before
+        # (fullgraph-compiling them on stock is unchecked / would graph-break). mtp is
+        # not yet e2e-validated on stock, so it falls back too.
+        ("mtp", CompilationMode.VLLM_COMPILE),
+        ("draft_model", CompilationMode.VLLM_COMPILE),
+        ("medusa", CompilationMode.VLLM_COMPILE),
+        ("dflash", CompilationMode.VLLM_COMPILE),
+        ("extract_hidden_states", CompilationMode.VLLM_COMPILE),
+    ],
+)
+def test_stock_drafter_method_fallback(method, expected_mode):
+    from types import SimpleNamespace
+
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    config.speculative_config = SimpleNamespace(method=method)
+    config._maybe_fallback_stock_for_unsupported_drafter()
+    assert config.compilation_config.mode == expected_mode
+
+
+def test_stock_drafter_fallback_noop_cases():
+    from types import SimpleNamespace
+
+    # No speculative config -> stock preserved.
+    cfg = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    cfg.speculative_config = None
+    cfg._maybe_fallback_stock_for_unsupported_drafter()
+    assert cfg.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE
+
+    # Non-stock mode is left untouched even with an unvalidated model-backed drafter.
+    cfg = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.VLLM_COMPILE)
+    )
+    cfg.speculative_config = SimpleNamespace(method="medusa")
+    cfg._maybe_fallback_stock_for_unsupported_drafter()
+    assert cfg.compilation_config.mode == CompilationMode.VLLM_COMPILE
+
+
+def test_algorithmic_drafter_methods_stay_stock():
+    from types import SimpleNamespace
+
+    # Iterate the shared constant (not a hardcoded list) so the single source of
+    # truth used by _maybe_fallback_stock_for_unsupported_drafter is what gets
+    # exercised: any model-less method added to _ALGORITHMIC_DRAFTER_METHODS is
+    # covered automatically, and the disjointness check guards against a method
+    # being listed as both algorithmic and validated-model-backed.
+    assert VllmConfig._ALGORITHMIC_DRAFTER_METHODS
+    assert not (
+        set(VllmConfig._ALGORITHMIC_DRAFTER_METHODS)
+        & set(VllmConfig._STOCK_SUPPORTED_DRAFTER_METHODS)
+    )
+    for method in VllmConfig._ALGORITHMIC_DRAFTER_METHODS:
+        config = VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.STOCK_TORCH_COMPILE
+            )
+        )
+        config.speculative_config = SimpleNamespace(method=method)
+        config._maybe_fallback_stock_for_unsupported_drafter()
+        assert config.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE, (
+            method
+        )
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_torch_compile_compiles_spec_decode_drafter(vllm_runner, monkeypatch):
+    # A model-backed spec-decode drafter must be compiled on the stock path (no
+    # fallback to VLLM_COMPILE): the runner compiles both the target and the eagle
+    # drafter model via stock torch.compile, so stock_torch_compile_count == 2. The
+    # drafter's own @support_torch_compile decorator is disabled under STOCK, and its
+    # piecewise cudagraphs come from the same Inductor graph partition as the target.
+    # Llama-3.2-1B is not SupportsStockCompile, so mode=STOCK is forced here.
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    with (
+        compilation_counter.expect(stock_torch_compile_count=2),
+        vllm_runner(
+            "meta-llama/Llama-3.2-1B-Instruct",
+            speculative_config={
+                "method": "eagle3",
+                "model": "nm-testing/Llama3_2_1B_speculator.eagle3",
+                "num_speculative_tokens": 3,
+            },
+            compilation_config={"mode": CompilationMode.STOCK_TORCH_COMPILE},
+            max_model_len=2048,
+            gpu_memory_utilization=0.55,
+        ) as _,
+    ):
+        pass
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_torch_compile_captures_full_cudagraph(vllm_runner, monkeypatch):
+    # The headline parity path: a stock-compiled model must still attach vLLM's
+    # external FULL cudagraph wrapper and actually capture a FULL_DECODE_ONLY graph.
+    # opt-125m is not SupportsStockCompile, so mode=STOCK is forced explicitly here;
+    # the auto-FDO promotion is allowlist-independent, so this isolates the cudagraph
+    # fall-through (not the SupportsStockCompile selection).
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    with (
+        compilation_counter.expect(
+            stock_torch_compile_count=1,
+            num_gpu_runner_capture_triggers=1,
+            num_cudagraph_captured=1,
+        ),
+        vllm_runner(
+            "facebook/opt-125m",
+            compilation_config={
+                "mode": CompilationMode.STOCK_TORCH_COMPILE,
+                # Pin partition off: this test isolates the FULL_DECODE_ONLY fall-
+                # through, while the default now auto-enables graph-partition
+                # piecewise (covered by test_stock_torch_compile_piecewise_*).
+                "use_inductor_graph_partition": False,
+                "cudagraph_capture_sizes": [100],
+            },
+            gpu_memory_utilization=0.4,
+        ) as _,
+    ):
+        pass

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -136,3 +136,27 @@ def test_hf_registry_coverage():
         "Please add the following architectures to "
         f"`tests/models/registry.py`: {untested_archs}"
     )
+
+
+def test_supports_stock_compile_marker():
+    # The SupportsStockCompile marker is the single bit that opts an architecture
+    # into the stock torch.compile path; guard it so the GPT-OSS opt-in cannot be
+    # dropped and no other architecture is migrated by accident.
+    from vllm.model_executor.models.interfaces import supports_stock_compile
+
+    gptoss = ModelRegistry._try_load_model_cls("GptOssForCausalLM")
+    llama = ModelRegistry._try_load_model_cls("LlamaForCausalLM")
+    assert supports_stock_compile(gptoss)
+    assert not supports_stock_compile(llama)
+
+    # Also exercise the production resolution path (the _ModelInfo field hop that
+    # config resolution actually consults), not just the marker free function.
+    from unittest.mock import MagicMock
+
+    model_config = MagicMock(model_impl="vllm")
+    assert ModelRegistry.is_stock_compile_supported_model(
+        "GptOssForCausalLM", model_config
+    )
+    assert not ModelRegistry.is_stock_compile_supported_model(
+        "LlamaForCausalLM", model_config
+    )

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -385,15 +385,18 @@ def _support_torch_compile(
         self.vllm_config = vllm_config
         self.compilation_config = self.vllm_config.compilation_config
         enable_compile = enable_if is None or enable_if(vllm_config)
-        # for CompilationMode.STOCK_TORCH_COMPILE , the upper level model runner
-        # will handle the compilation, so we don't need to do anything here.
-        self.do_not_compile = (
+        # This flag means "do not use vLLM's custom torch.compile backend
+        # (VllmBackend)". It does NOT mean the module never gets compiled: under
+        # CompilationMode.STOCK_TORCH_COMPILE the upper level model runner compiles
+        # it via nn.Module.compile() with stock Inductor. For CompilationMode.NONE,
+        # ignored classes, and disabled enable_if, nothing compiles it at all.
+        self.do_not_use_custom_torch_compile_backend = (
             self.compilation_config.mode
             in [CompilationMode.NONE, CompilationMode.STOCK_TORCH_COMPILE]
             or _should_ignore_torch_compile(self.__class__)
             or not enable_compile
         )
-        if self.do_not_compile:
+        if self.do_not_use_custom_torch_compile_backend:
             return
 
         self._dynamic_arg_dims = dynamic_arg_dims
@@ -503,7 +506,30 @@ def _support_torch_compile(
         # torch.compiler.is_compiling() means we are inside the compilation
         # e.g. TPU has the compilation logic in model runner, so we don't
         # need to compile the model inside.
-        if self.do_not_compile or torch.compiler.is_compiling():
+        if torch.compiler.is_compiling():
+            return self.forward(*args, **kwargs)
+
+        if self.do_not_use_custom_torch_compile_backend:
+            # Under CompilationMode.STOCK_TORCH_COMPILE the model runner compiles
+            # this module via nn.Module.compile(), which stores the compiled
+            # callable on _compiled_call_impl. This decorator's __call__ overrides
+            # nn.Module._wrapped_call_impl, so route to that compiled callable here;
+            # otherwise a module whose top-level class carries this decorator and is
+            # compiled directly by the runner would silently run eager. No currently-
+            # allowlisted arch hits the compiled branch (GPT-OSS and the eagle drafters
+            # are undecorated at top level; their decorated inner modules are folded
+            # submodules with _compiled_call_impl=None) -- it guards a future
+            # top-level-decorated model.
+            # skip_compiled (enc-dec: shapes/types vary, no single graph) still forces
+            # eager, matching the compiled path below. When nothing compiled the module
+            # (_compiled_call_impl is None, the case for CompilationMode.NONE and for
+            # decorated submodules folded into a parent's stock compile), run eagerly.
+            compiled_call_impl = getattr(self, "_compiled_call_impl", None)
+            skip_compiled = (
+                is_forward_context_available() and get_forward_context().skip_compiled
+            )
+            if compiled_call_impl is not None and not skip_compiled:
+                return compiled_call_impl(*args, **kwargs)
             return self.forward(*args, **kwargs)
 
         # If skip_compiled is set, bypass compiled model call. This is used e.g. for
@@ -721,6 +747,116 @@ def _support_torch_compile(
     return cls
 
 
+def _make_partition_wrapper(
+    vllm_config: VllmConfig,
+    wrapper_cls: Callable[..., Any],
+    options_cls: Callable[..., Any],
+) -> Callable[..., Any]:
+    """Build an Inductor graph-partition wrapper.
+
+    Inductor splits the FX graph into partitions (subgraphs separated by
+    cudagraph-unsafe ops); this hook wraps each partition so it is captured and
+    replayed as its own PIECEWISE cudagraph. The per-partition options key off
+    ``partition_index``: only the first partition (id 0) logs (avoids per-graph
+    spam) and runs gc (per-partition gc is very slow), and only the last
+    partition weak-refs its output (safe because no later captured graph consumes
+    it). ``wrapper_cls``/``options_cls`` select the static-cudagraph
+    implementation: the VLLM_COMPILE path uses the platform's shared wrapper, the
+    STOCK_TORCH_COMPILE path uses its decoupled StockTorchCompileCUDAGraphWrapper.
+    """
+    from torch._inductor.utils import CUDAGraphWrapperMetadata
+
+    from vllm.config import CUDAGraphMode
+
+    def customized_cudagraph_wrapper(
+        f: Callable[..., Any], metadata: CUDAGraphWrapperMetadata
+    ) -> Any:
+        partition_id = metadata.partition_index
+        num_partitions = metadata.num_partitions
+        return wrapper_cls(
+            runnable=f,
+            vllm_config=vllm_config,
+            runtime_mode=CUDAGraphMode.PIECEWISE,
+            cudagraph_options=options_cls(
+                debug_log_enable=partition_id == 0,
+                gc_disable=partition_id != 0,
+                weak_ref_output=partition_id == num_partitions - 1,
+            ),
+        )
+
+    return customized_cudagraph_wrapper
+
+
+def _make_cudagraph_partition_wrapper(vllm_config: VllmConfig) -> Callable[..., Any]:
+    """VLLM_COMPILE graph-partition wrapper using the platform's shared static
+    cudagraph wrapper."""
+    from vllm.compilation.cuda_graph import CUDAGraphOptions
+    from vllm.platforms import current_platform
+
+    static_graph_wrapper_class = resolve_obj_by_qualname(
+        current_platform.get_static_graph_wrapper_cls()
+    )
+    return _make_partition_wrapper(
+        vllm_config, static_graph_wrapper_class, CUDAGraphOptions
+    )
+
+
+def _make_stock_cudagraph_partition_wrapper(
+    vllm_config: VllmConfig,
+) -> Callable[..., Any]:
+    """STOCK_TORCH_COMPILE graph-partition wrapper. Uses the decoupled
+    StockTorchCompileCUDAGraphWrapper rather than the shared CUDAGraphWrapper, which
+    is coupled to vLLM's non-torch.compile full-cudagraph path."""
+    from vllm.compilation.stock_cudagraph import (
+        StockCUDAGraphOptions,
+        StockTorchCompileCUDAGraphWrapper,
+    )
+
+    return _make_partition_wrapper(
+        vllm_config, StockTorchCompileCUDAGraphWrapper, StockCUDAGraphOptions
+    )
+
+
+def install_cudagraph_partition_wrapper(
+    vllm_config: VllmConfig,
+) -> Callable[..., Any] | None:
+    """Persistently install the STOCK graph-partition cudagraph wrapper and return
+    the previously installed wrapper (usually None) so a caller could restore it.
+
+    Stock torch.compile is lazy: the real Inductor compile and its post_compile
+    partition wrapping fire on the first forward, not during model.compile(). That
+    first forward runs in GPUModelRunner.profile_run() (driven by the worker's
+    determine_available_memory RPC), while the piecewise cudagraphs are captured
+    later in capture_model() (compile_or_warm_up_model RPC); the install itself runs
+    in _compile_model_stock() under the load_model RPC. The compile that reads this
+    global therefore spans three separate engine-core RPCs with no single Python
+    scope, so the install must outlive this call and cannot be bracketed by a
+    context manager the way VLLM_COMPILE does.
+
+    It is intentionally never unset. Any later graph_partition compile in the
+    process would also pick up this wrapper, and the wrapper is not inherently inert:
+    it captures any partition that executes under a PIECEWISE forward context
+    (StockTorchCompileCUDAGraphWrapper.__call__). Safety rests on the invariant that
+    no unrelated graph_partition compile ever runs under a PIECEWISE forward context,
+    which vLLM upholds by disabling graph_partition on its own nested compiles via
+    maybe_disable_graph_partition. As a backstop against that invariant being
+    violated (an unrelated in-forward compile, or a cross-engine binding in a
+    multi-engine process), StockTorchCompileCUDAGraphWrapper.__call__ fails loudly at
+    capture time if the stream is already capturing or the forward is driven by a
+    different engine's config. The previous wrapper is returned only so a future
+    scoped-unset can restore it.
+
+    TODO(stock-compile): scope the install to the region spanning the lazy compile
+    and every piecewise capture and restore the returned wrapper in a finally, once
+    the worker lifecycle exposes a hook that reliably brackets both.
+    """
+    prev_wrapper = torch._inductor.utils._unstable_customized_partition_wrapper.wrapper
+    torch._inductor.utils.set_customized_partition_wrappers(
+        _make_stock_cudagraph_partition_wrapper(vllm_config)
+    )
+    return prev_wrapper
+
+
 @contextlib.contextmanager
 def maybe_use_cudagraph_partition_wrapper(
     vllm_config: VllmConfig,
@@ -735,40 +871,13 @@ def maybe_use_cudagraph_partition_wrapper(
     graph wrapper class to maintain more control over static graph
     capture and replay.
     """
-    from vllm.config import CUDAGraphMode
-
     compilation_config = vllm_config.compilation_config
     if (
         compilation_config.cudagraph_mode.has_piecewise_cudagraphs()
         and compilation_config.use_inductor_graph_partition
     ):
-        from torch._inductor.utils import CUDAGraphWrapperMetadata
-
-        from vllm.compilation.cuda_graph import CUDAGraphOptions
-        from vllm.platforms import current_platform
-
-        static_graph_wrapper_class = resolve_obj_by_qualname(
-            current_platform.get_static_graph_wrapper_cls()
-        )
-
-        def customized_cudagraph_wrapper(
-            f: Callable[..., Any], metadata: CUDAGraphWrapperMetadata
-        ) -> Any:
-            partition_id = metadata.partition_index
-            num_partitions = metadata.num_partitions
-            return static_graph_wrapper_class(
-                runnable=f,
-                vllm_config=vllm_config,
-                runtime_mode=CUDAGraphMode.PIECEWISE,
-                cudagraph_options=CUDAGraphOptions(
-                    debug_log_enable=partition_id == 0,
-                    gc_disable=partition_id != 0,
-                    weak_ref_output=partition_id == num_partitions - 1,
-                ),
-            )
-
         torch._inductor.utils.set_customized_partition_wrappers(
-            customized_cudagraph_wrapper
+            _make_cudagraph_partition_wrapper(vllm_config)
         )
 
     yield

--- a/vllm/compilation/passes/inductor_pass.py
+++ b/vllm/compilation/passes/inductor_pass.py
@@ -54,6 +54,27 @@ def pass_context(compile_range: Range) -> Generator[None, None, None]:
         _pass_context = prev_context
 
 
+def set_pass_context(compile_range: Range) -> PassContext | None:
+    """Install a process-global PassContext that outlives this call and return the
+    previous one (usually None) so a caller could restore it.
+
+    Unlike the ``pass_context`` context manager (used by VllmBackend around each
+    synchronous per-range compile), STOCK_TORCH_COMPILE is engine-global and its
+    Inductor compiles run lazily during a later forward (profile_run / warmup), so
+    there is no single span to scope. The pre/post-grad vLLM passes and
+    PostGradPassManager.uuid() must all observe one live PassContext, so this must
+    persist until that lazy compile fires. It is safe only while no co-resident
+    VllmBackend compile also reads the global: today no stock engine runs a
+    VllmBackend, but that invariant is fragile if a second SupportsStockCompile arch
+    or a multimodal encoder co-resides with a VllmBackend compile. The previous
+    context is returned so such a future caller can restore it.
+    """
+    global _pass_context
+    prev_context = _pass_context
+    _pass_context = PassContext(compile_range)
+    return prev_context
+
+
 @functools.cache
 def _hash_source_cached(*srcs: str | type | types.FunctionType) -> str:
     hasher = hashlib.sha256()

--- a/vllm/compilation/stock_cudagraph.py
+++ b/vllm/compilation/stock_cudagraph.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Stock-torch.compile cudagraph wrapper.
+
+Decoupled copy of the capture/replay logic in ``vllm/compilation/cuda_graph.py``
+for the STOCK_TORCH_COMPILE path. It is intentionally NOT the shared
+``CUDAGraphWrapper``: that class is also used by vLLM's non-torch.compile full
+cudagraph path, and keeping the stock path on its own wrapper lets vLLM evolve
+full cudagraphs without affecting torch.compile (and vice versa). The capture
+semantics mirror ``CUDAGraphWrapper`` (batch-descriptor keyed capture/replay,
+shared graph pool, weak-ref outputs); vLLM still owns padding, persistent input
+buffers, and the forward-context mode/descriptor dispatch.
+"""
+
+import dataclasses
+import weakref
+from collections.abc import Callable
+from contextlib import ExitStack
+from typing import Any, ClassVar
+from unittest.mock import patch
+
+import torch
+
+import vllm.envs as envs
+from vllm.compilation.counter import compilation_counter
+from vllm.compilation.monitor import validate_cudagraph_capturing_enabled
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.distributed.device_communicators.pynccl_allocator import set_graph_pool_id
+from vllm.forward_context import (
+    BatchDescriptor,
+    get_forward_context,
+    is_forward_context_available,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.offloader.base import get_offloader
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import current_stream, weak_ref_tensors
+
+logger = init_logger(__name__)
+
+
+@dataclasses.dataclass
+class StockCUDAGraphEntry:
+    batch_descriptor: BatchDescriptor
+    cudagraph: torch.cuda.CUDAGraph | None = None
+    output: Any | None = None
+    # For debugging: input addresses at capture, checked to be stable on replay.
+    input_addresses: list[int] | None = None
+
+
+@dataclasses.dataclass
+class StockCUDAGraphOptions:
+    debug_log_enable: bool = True
+    gc_disable: bool = False
+    weak_ref_output: bool = True
+
+
+class StockTorchCompileCUDAGraphWrapper:
+    """Capture/replay a runnable as a cudagraph, keyed on the forward-context
+    batch descriptor. See the module docstring for why this is a separate class
+    from the shared ``CUDAGraphWrapper``."""
+
+    _all_instances: ClassVar[weakref.WeakSet["StockTorchCompileCUDAGraphWrapper"]] = (
+        weakref.WeakSet()
+    )
+
+    @classmethod
+    def clear_all_graphs(cls) -> None:
+        for instance in list(cls._all_instances):
+            instance.clear_graphs()
+
+    def __init__(
+        self,
+        runnable: Callable[..., Any],
+        vllm_config: VllmConfig,
+        runtime_mode: CUDAGraphMode,
+        cudagraph_options: StockCUDAGraphOptions | None = None,
+    ) -> None:
+        self.runnable = runnable
+        self.vllm_config = vllm_config
+        self.runtime_mode = runtime_mode
+        self.compilation_config = vllm_config.compilation_config
+
+        self.is_debugging_mode = envs.VLLM_LOGGING_LEVEL == "DEBUG"
+        self._runnable_str = str(runnable) if self.is_debugging_mode else None
+
+        assert self.runtime_mode != CUDAGraphMode.NONE
+        self.graph_pool = current_platform.get_global_graph_pool()
+
+        if cudagraph_options is None:
+            cudagraph_options = StockCUDAGraphOptions()
+        self.cudagraph_options = cudagraph_options
+        self.concrete_cudagraph_entries: dict[BatchDescriptor, StockCUDAGraphEntry] = {}
+
+        StockTorchCompileCUDAGraphWrapper._all_instances.add(self)
+
+    def __getattr__(self, key: str) -> Any:
+        if hasattr(self.runnable, key):
+            return getattr(self.runnable, key)
+        if self.is_debugging_mode:
+            raise AttributeError(
+                f"Attribute {key} not exists in the runnable of "
+                f"stock cudagraph wrapper: {self._runnable_str}"
+            )
+        raise AttributeError
+
+    def unwrap(self) -> Callable[..., Any]:
+        return self.runnable
+
+    @property
+    def cudagraph_wrapper(self) -> "StockTorchCompileCUDAGraphWrapper":
+        return self
+
+    def clear_graphs(self) -> None:
+        self.concrete_cudagraph_entries.clear()
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any | None:
+        if not is_forward_context_available():
+            # Outside the normal inference path (e.g. a vision encoder forward).
+            return self.runnable(*args, **kwargs)
+
+        forward_context = get_forward_context()
+        batch_descriptor = forward_context.batch_descriptor
+        cudagraph_runtime_mode = forward_context.cudagraph_runtime_mode
+
+        if (
+            cudagraph_runtime_mode == CUDAGraphMode.NONE
+            or cudagraph_runtime_mode != self.runtime_mode
+        ):
+            # Profile/warmup run, no cudagraph, or a mode meant for a different
+            # (nested) wrapper: run directly.
+            return self.runnable(*args, **kwargs)
+
+        assert batch_descriptor is not None
+        if batch_descriptor not in self.concrete_cudagraph_entries:
+            self.concrete_cudagraph_entries[batch_descriptor] = StockCUDAGraphEntry(
+                batch_descriptor=batch_descriptor
+            )
+
+        entry = self.concrete_cudagraph_entries[batch_descriptor]
+
+        if entry.cudagraph is None:
+            # The stock partition wrapper is installed as a process-global that is
+            # never unset, so any inductor partition running under a PIECEWISE
+            # forward context reaches this capture branch -- including one from an
+            # unrelated compile or a different engine. Guard so a leaked or misowned
+            # capture fails loudly here instead of silently corrupting memory.
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "StockTorchCompileCUDAGraphWrapper attempted a nested cudagraph "
+                    "capture: the current stream is already capturing. A torch.compile "
+                    "region likely ran under a PIECEWISE forward context and was "
+                    "wrapped by the process-global stock partition wrapper; it must "
+                    "go through maybe_disable_graph_partition."
+                )
+            if (
+                forward_context.no_compile_layers
+                is not self.compilation_config.static_forward_context
+            ):
+                raise RuntimeError(
+                    "StockTorchCompileCUDAGraphWrapper is capturing a forward driven "
+                    "by a different vLLM engine than the one it was built for. The "
+                    "process-global stock partition wrapper carries a stale "
+                    "compilation config (wrong capture options / gc / weak-ref "
+                    "behavior)."
+                )
+            if self.cudagraph_options.debug_log_enable:
+                logger.debug(
+                    "Capturing a cudagraph on (%s,%s)",
+                    self.runtime_mode.name,
+                    entry.batch_descriptor,
+                )
+            validate_cudagraph_capturing_enabled()
+
+            entry.input_addresses = [
+                x.data_ptr() for x in args if isinstance(x, torch.Tensor)
+            ]
+            cudagraph = torch.cuda.CUDAGraph()
+
+            with ExitStack() as stack:
+                if self.cudagraph_options.gc_disable:
+                    # Piecewise mode captures one graph per partition; running gc
+                    # per partition is very slow, so gc only for the first.
+                    stack.enter_context(
+                        patch("gc.collect", lambda *args, **kwargs: None)
+                    )
+                    stack.enter_context(
+                        patch(
+                            "torch.accelerator.empty_cache",
+                            lambda *args, **kwargs: None,
+                        )
+                    )
+
+                if self.graph_pool is not None:
+                    set_graph_pool_id(self.graph_pool)
+                else:
+                    set_graph_pool_id(current_platform.graph_pool_handle())
+
+                get_offloader().sync_prev_onload()
+
+                with torch.cuda.graph(
+                    cudagraph,
+                    pool=self.graph_pool,
+                    stream=current_stream(),
+                ):
+                    output = self.runnable(*args, **kwargs)
+                    get_offloader().join_after_forward()
+                    if self.cudagraph_options.weak_ref_output:
+                        # Safe only for the last graph in piecewise mode: its
+                        # output is not consumed by another captured graph.
+                        output = weak_ref_tensors(output)
+
+            entry.output = weak_ref_tensors(output)
+            entry.cudagraph = cudagraph
+
+            compilation_counter.num_cudagraph_captured += 1
+
+            # Return the real output (not the weak ref) so pytorch manages the
+            # cudagraph-pool memory correctly during capture.
+            return output
+
+        if self.is_debugging_mode:
+            new_input_addresses = [
+                x.data_ptr() for x in args if isinstance(x, torch.Tensor)
+            ]
+            assert new_input_addresses == entry.input_addresses, (
+                f"Input addresses for cudagraphs are different during replay. "
+                f"Expected {entry.input_addresses}, got {new_input_addresses}"
+            )
+
+        get_offloader().sync_prev_onload()
+        entry.cudagraph.replay()
+        return entry.output

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -300,8 +300,12 @@ def reset_compile_wrapper(model: torch.nn.Module) -> None:
         model = model.model
     if not isinstance(model, TorchCompileWithNoGuardsWrapper):
         return
-    # model.do_not_compile is set by the @support_torch_compile decorator
-    if hasattr(model, "do_not_compile") and model.do_not_compile:
+    # model.do_not_use_custom_torch_compile_backend is set by the
+    # @support_torch_compile decorator
+    if (
+        hasattr(model, "do_not_use_custom_torch_compile_backend")
+        and model.do_not_use_custom_torch_compile_backend
+    ):
         return
     from vllm.compilation.counter import compilation_counter
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -430,7 +430,8 @@ class CompilationConfig:
     model.
 
     - None: If None, we will select the default compilation mode.
-      For V1 engine this is 3.
+      For V1 engine this is 3 (VLLM_COMPILE) for most architectures; architectures
+      declaring SupportsStockCompile default to 1 (STOCK_TORCH_COMPILE).
     - 0: NONE: No torch.compile compilation is applied, model runs in fully
          eager pytorch mode. The model runs as-is.
     - 1: STOCK_TORCH_COMPILE: The standard `torch.compile` compilation pipeline.
@@ -1097,10 +1098,52 @@ class CompilationConfig:
     def set_splitting_ops_for_v1(
         self, all2all_backend: str, data_parallel_size: int = 1
     ):
+        # Disable CUDA graphs for DeepEP high-throughput since it is not CG compatible.
+        # This is independent of the compile mode (the all2all kernels are the issue),
+        # so it must run before the mode-specific early return below. It used to sit at
+        # the end of this function, which the `mode != VLLM_COMPILE` return skips --
+        # fine when VLLM_COMPILE was the only mode reaching here with cudagraphs, but
+        # now the STOCK_TORCH_COMPILE path takes that early return and would otherwise
+        # capture the incompatible all2all kernels into a cudagraph.
+        if (
+            all2all_backend == "deepep_high_throughput"
+            and data_parallel_size > 1
+            and self.cudagraph_mode != CUDAGraphMode.NONE
+        ):
+            # TODO: Piecewise Cuda graph might be enabled
+            # if torch compile cache key issue fixed
+            # See https://github.com/vllm-project/vllm/pull/25093
+            logger.info(
+                "DeepEP: Disabling CUDA Graphs since DeepEP high-throughput kernels "
+                "are optimized for prefill and are incompatible with CUDA Graphs. "
+                "In order to use CUDA Graphs for decode-optimized workloads, "
+                "use --all2all-backend with another option, such as "
+                "deepep_low_latency, nixl_ep, or allgather_reducescatter."
+            )
+            self.cudagraph_mode = CUDAGraphMode.NONE
+
         # To compatible with OOT hardware plugin platform (for example vllm-ascend)
         # which currently only supports sequence parallelism in eager mode.
         if self.mode != CompilationMode.VLLM_COMPILE:
-            if self.splitting_ops is None:
+            # STOCK_TORCH_COMPILE recovers piecewise cudagraphs through Inductor graph
+            # partition (step 2 of the VllmBackend migration): Inductor partitions at
+            # the attention ops and routes each partition's capture through the
+            # external wrapper, so splitting_ops must name the attention ops exactly as
+            # the VLLM_COMPILE partition path does. Without graph partition the stock
+            # path is whole-graph (FULL_DECODE_ONLY / no piecewise), so splitting_ops
+            # stays empty.
+            if (
+                self.mode == CompilationMode.STOCK_TORCH_COMPILE
+                and self.use_inductor_graph_partition
+            ):
+                # Partition on -> always partition at the attention ops, populating
+                # even when the user passed an explicit empty list: an empty
+                # splitting_ops would otherwise leave FULL_AND_PIECEWISE with zero
+                # piecewise partitions (no piecewise capture, attention wrongly inside
+                # the cudagraph) and emit no warning.
+                if not self.splitting_ops:
+                    self.splitting_ops = list(self._attention_ops)
+            elif self.splitting_ops is None:
                 self.splitting_ops = []
             return
 
@@ -1182,24 +1225,6 @@ class CompilationConfig:
                     "Setting cudagraph_mode to FULL."
                 )
                 self.cudagraph_mode = CUDAGraphMode.FULL
-
-        # Disable CUDA graphs for DeepEP high-throughput since its not CG compatible
-        if (
-            all2all_backend == "deepep_high_throughput"
-            and data_parallel_size > 1
-            and self.cudagraph_mode != CUDAGraphMode.NONE
-        ):
-            # TODO: Piecewise Cuda graph might be enabled
-            # if torch compile cache key issue fixed
-            # See https://github.com/vllm-project/vllm/pull/25093
-            logger.info(
-                "DeepEP: Disabling CUDA Graphs since DeepEP high-throughput kernels "
-                "are optimized for prefill and are incompatible with CUDA Graphs. "
-                "In order to use CUDA Graphs for decode-optimized workloads, "
-                "use --all2all-backend with another option, such as "
-                "deepep_low_latency, nixl_ep, or allgather_reducescatter."
-            )
-            self.cudagraph_mode = CUDAGraphMode.NONE
 
     def set_splitting_ops_for_attn_fusion(self):
         assert self.pass_config.fuse_attn_quant

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -772,6 +772,194 @@ class VllmConfig:
         )
         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
+    def _stock_compile_piecewise_cudagraph_mode(self) -> CUDAGraphMode | None:
+        """Resolve the effective cudagraph_mode (filling in the opt-level default
+        when the user left it unset) and return it only if it requires piecewise
+        capture; otherwise None. Helper for the STOCK_TORCH_COMPILE resolution
+        (hence the name), which needs to know whether the mode it is about to run
+        will demand piecewise cudagraphs."""
+        from vllm.platforms import current_platform
+
+        if not current_platform.support_static_graph_mode():
+            return None
+
+        cudagraph_mode = self.compilation_config.cudagraph_mode
+        if cudagraph_mode is None:
+            cudagraph_mode = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level][
+                "compilation_config"
+            ]["cudagraph_mode"]
+
+        if (
+            cudagraph_mode is not None
+            and cudagraph_mode.requires_piecewise_compilation()
+            and not envs.VLLM_USE_BREAKABLE_CUDAGRAPH
+        ):
+            return cudagraph_mode
+        return None
+
+    def _fallback_stock_to_vllm_compile(
+        self, reason: str, *args: object, reset_graph_partition: bool = True
+    ) -> None:
+        if self.compilation_config.mode != CompilationMode.STOCK_TORCH_COMPILE:
+            return
+
+        logger.warning_once(
+            reason + " Falling back to CompilationMode.VLLM_COMPILE (the legacy custom "
+            "vLLM torch.compile backend). This compatibility fallback will be "
+            "removed in a future release; upgrade to torch>=2.9 and keep "
+            "use_inductor_graph_partition enabled to use "
+            "CompilationMode.STOCK_TORCH_COMPILE.",
+            *args,
+        )
+        self.compilation_config.mode = CompilationMode.VLLM_COMPILE
+        # Clear the stock-only auto-enabled graph partition. Suppressed
+        # (reset_graph_partition=False) when the fallback is not caused by
+        # partition being unavailable and the user explicitly asked for it:
+        # VLLM_COMPILE honors graph partition, so an explicit request is kept.
+        if reset_graph_partition:
+            self.compilation_config.use_inductor_graph_partition = False
+
+    def _resolve_stock_default_cudagraph_mode(
+        self, user_set_graph_partition: bool
+    ) -> None:
+        """Enable Inductor graph partition on the stock path when the resolved
+        cudagraph_mode needs piecewise capture. Graph partition (torch>=2.9) is the
+        only way stock torch.compile provides piecewise cudagraphs, so turn it on
+        unless the user turned it off. When partition is unavailable (torch<2.9 or
+        explicitly off) the piecewise mode is left in place and
+        _fix_unsupported_piecewise_cudagraph_mode falls the config back to the legacy
+        VllmBackend -- the stock path never silently degrades to a different
+        cudagraph strategy. Runs once, before the opt-level defaults, so fusion
+        defaults and the inert-flag warning see the resolved partition state."""
+        cc = self.compilation_config
+        if cc.mode != CompilationMode.STOCK_TORCH_COMPILE:
+            return
+        if self._stock_compile_piecewise_cudagraph_mode() is None:
+            return
+
+        from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+        if is_torch_equal_or_newer("2.9.0.dev") and not user_set_graph_partition:
+            cc.use_inductor_graph_partition = True
+
+    def _fix_unsupported_piecewise_cudagraph_mode(self) -> None:
+        """Resolve a piecewise-requiring cudagraph_mode that the current compilation
+        mode cannot honor. Piecewise cudagraphs need VLLM_COMPILE (its FX splitting)
+        or STOCK_TORCH_COMPILE with Inductor graph partition. When neither holds:
+
+        - STOCK without graph partition falls back to the legacy VLLM_COMPILE backend
+          (with a deprecation warning) so the requested piecewise cudagraphs still
+          work; graph partition is the only stock piecewise path and must be enabled
+          before splitting_ops are populated, so here we can only fall back;
+        - any other mode (NONE / DYNAMO_TRACE_ONCE) has no compiled graph to capture
+          piecewise, so its cudagraph_mode drops to NONE (matching the pre-migration
+          clamp).
+
+        Covers an explicit piecewise request and a piecewise mode re-introduced later
+        by the dynamic-SD override or a pooler / enc-dec / KV-connector / platform
+        override."""
+        cc = self.compilation_config
+        if (
+            cc.cudagraph_mode is None
+            or not cc.cudagraph_mode.requires_piecewise_compilation()
+            or envs.VLLM_USE_BREAKABLE_CUDAGRAPH
+        ):
+            return
+        if cc.mode == CompilationMode.VLLM_COMPILE:
+            return
+        if cc.mode == CompilationMode.STOCK_TORCH_COMPILE:
+            if cc.use_inductor_graph_partition:
+                return
+            self._fallback_stock_to_vllm_compile(
+                "cudagraph_mode=%s needs Inductor graph partition (torch>=2.9 with "
+                "use_inductor_graph_partition enabled) on "
+                "CompilationMode.STOCK_TORCH_COMPILE.",
+                cc.cudagraph_mode.name,
+            )
+            return
+        logger.info(
+            "cudagraph_mode=%s needs piecewise compilation, which "
+            "CompilationMode.%s does not provide; overriding cudagraph_mode to NONE.",
+            cc.cudagraph_mode.name,
+            cc.mode.name,
+        )
+        cc.cudagraph_mode = CUDAGraphMode.NONE
+
+    # Spec-decode drafter methods validated to compile on the stock path. Both wrap a
+    # decorated inner decoder in an undecorated ...ForCausalLM, so nn.Module.compile()
+    # on the outer works directly; eagle3 has an e2e stock-compile test and eagle shares
+    # its exact compile topology. Other model-backed methods (mtp, dflash, medusa,
+    # draft_model, ...) are migrated one at a time via
+    # _maybe_fallback_stock_for_unsupported_drafter; they fall back to VLLM_COMPILE
+    # until validated.
+    _STOCK_SUPPORTED_DRAFTER_METHODS = ("eagle", "eagle3")
+
+    # Algorithmic (model-less) spec-decode drafters: their proposers hold no
+    # nn.Module (no `.model` attribute for _compile_model_stock to find), so there
+    # is nothing for stock torch.compile to touch and they stay on the stock path
+    # unconditionally. Keep in sync with the model-less proposers built in
+    # GPUModelRunner (NgramProposer / NgramProposerGPU / SuffixDecodingProposer):
+    # a new algorithmic method must be added here or it silently falls back to
+    # VLLM_COMPILE.
+    _ALGORITHMIC_DRAFTER_METHODS = ("ngram", "ngram_gpu", "suffix")
+
+    def _maybe_fallback_stock_for_unsupported_drafter(self) -> None:
+        """Fall back STOCK_TORCH_COMPILE to VLLM_COMPILE for a model-backed spec-decode
+        drafter whose method is not yet validated on the stock path. Validated methods
+        (eagle / eagle3) have their drafter model compiled in
+        GPUModelRunner._compile_model_stock. Other model-backed drafters (mtp,
+        draft_model, medusa, dflash, ...) would be force-compiled fullgraph there with
+        no per-drafter check -- medusa has no @support_torch_compile at all and
+        draft_model is an arbitrary user architecture -- so restore the pre-migration
+        path where VllmBackend compiles (or eagerly runs) them. Algorithmic drafters
+        (ngram / ngram_gpu / suffix) have no model and keep the stock path. This
+        intentionally overrides an explicit mode=STOCK for an unmigrated drafter."""
+        if self.compilation_config.mode != CompilationMode.STOCK_TORCH_COMPILE:
+            return
+        if self.speculative_config is None:
+            return
+        method = self.speculative_config.method
+        if method in self._ALGORITHMIC_DRAFTER_METHODS:
+            return
+        if method in self._STOCK_SUPPORTED_DRAFTER_METHODS:
+            return
+        logger.warning_once(
+            "Speculative decoding method=%s is not yet validated on "
+            "CompilationMode.STOCK_TORCH_COMPILE; falling back to "
+            "CompilationMode.VLLM_COMPILE so the drafter compiles as before. Drafter "
+            "methods are migrated to the stock path one at a time (currently: %s).",
+            method,
+            ", ".join(self._STOCK_SUPPORTED_DRAFTER_METHODS),
+        )
+        self.compilation_config.mode = CompilationMode.VLLM_COMPILE
+
+    def _maybe_fallback_stock_for_v2_model_runner(
+        self, user_set_graph_partition: bool
+    ) -> None:
+        """Fall back STOCK_TORCH_COMPILE to VLLM_COMPILE when the V2 model runner is
+        in use. V2 lists stock torch.compile as unsupported
+        (_get_v2_model_runner_unsupported_features), so a stock-eligible arch run
+        with VLLM_USE_V2_MODEL_RUNNER=1 (which forces use_v2_model_runner True) would
+        hard-fail _validate_v2_model_runner; fall back so it runs on V2 exactly as it
+        did before the stock migration. For a normally stock-eligible arch with the
+        env unset, use_v2_model_runner instead consults the unsupported-feature check,
+        which downgrades the runner to V1 and keeps stock, so this is a no-op there.
+        (Diffusion models are the exception: they force V2 in the env-unset path too,
+        and correctly fall back here since V2 cannot serve stock.)
+
+        Unlike the partition-unavailable fallbacks, V2 supports Inductor graph
+        partition, so an explicitly user-requested use_inductor_graph_partition is
+        preserved rather than reset."""
+        if self.compilation_config.mode != CompilationMode.STOCK_TORCH_COMPILE:
+            return
+        if not self.use_v2_model_runner:
+            return
+        self._fallback_stock_to_vllm_compile(
+            "CompilationMode.STOCK_TORCH_COMPILE is not supported by the V2 model "
+            "runner (VLLM_USE_V2_MODEL_RUNNER).",
+            reset_graph_partition=not user_set_graph_partition,
+        )
+
     def _post_init_kv_transfer_config(self) -> None:
         """Update KVTransferConfig based on top-level configs in VllmConfig.
 
@@ -849,6 +1037,100 @@ class VllmConfig:
             "(sleep mode does this automatically and also "
             "routes KV allocations through CuMemAllocator's pool, where "
             "expandable_segments is automatically disabled)."
+        )
+
+    def _stock_compile_supported(self) -> bool:
+        """Whether the primary model architecture is allowlisted for the stock
+        torch.compile migration path (declares SupportsStockCompile). Migrated
+        architectures default to STOCK_TORCH_COMPILE; everything else (incl. the
+        Transformers backend, which lacks the flag) stays on VllmBackend. Any
+        resolution error returns False (the safe default)."""
+        if self.model_config is None:
+            return False
+        try:
+            return self.model_config.registry.is_stock_compile_supported_model(
+                self.model_config.architectures, self.model_config
+            )
+        except Exception as e:
+            # Model inspection is validated and @lru_cache'd during
+            # ModelConfig.__post_init__, so an error here is unexpected and not
+            # the normal unsupported-model result; surface it (a stock-eligible
+            # arch would otherwise silently fall back to VllmBackend) while
+            # still returning the safe default.
+            logger.warning_once(
+                "Could not resolve stock torch.compile support for "
+                "architecture(s) %s; falling back to the legacy VllmBackend "
+                "(CompilationMode.VLLM_COMPILE). Resolution error: %s",
+                ", ".join(self.model_config.architectures),
+                repr(e),
+            )
+            return False
+
+    def _warn_ignored_vllm_backend_only_flags(self) -> None:
+        """Warn when a model ends up on STOCK_TORCH_COMPILE but the user set
+        compilation options that only VllmBackend honors (shape specialization, FX
+        splitting, the vLLM compile cache). On the stock path these are inert, so
+        without this they read as active but do nothing.
+
+        Must run AFTER every mode fallback has settled (a stock config can still
+        fall back to VLLM_COMPILE, where these flags ARE honored and must not be
+        reported as inert) but BEFORE the splitting_ops / compile-ranges
+        auto-population later in __post_init__, so mode and
+        use_inductor_graph_partition are final while splitting_ops still reflects
+        user input rather than the resolved attention-op partition boundary."""
+        cc = self.compilation_config
+        if cc.mode != CompilationMode.STOCK_TORCH_COMPILE:
+            return
+        if self.model_config is None:
+            return
+
+        ignored = []
+        if cc.compile_sizes:
+            ignored.append("compile_sizes (per-size shape specialization)")
+        # NOTE: compile_ranges_endpoints is intentionally NOT checked here. It is
+        # auto-populated (sorted, with any user values merged in) by _set_compile_ranges
+        # (which runs before this on a re-used compilation_config), so by the time this
+        # runs the field can already be a non-empty resolved value even when the user
+        # set nothing -> false positive. We do not claim every VllmBackend-only flag is
+        # covered here; the user-facing shape-specialization flag (compile_sizes) is.
+        # use_inductor_graph_partition is NOT inert on the stock path: it enables
+        # piecewise cudagraphs via Inductor graph partition (step 2). When it is on,
+        # splitting_ops names the attention ops (the partition boundary, not VllmBackend
+        # FX splitting), so neither is warned. splitting_ops is only inert when set
+        # WITHOUT graph partition (whole-graph stock). Evaluated here (not snapshotted
+        # earlier) so a mode that only becomes piecewise late -- e.g. dynamic spec
+        # decode turning FULL into PIECEWISE, which then auto-enables partition -- sees
+        # the final partition state and is not wrongly reported inert.
+        if cc.splitting_ops and not cc.use_inductor_graph_partition:
+            ignored.append("splitting_ops (FX graph splitting)")
+        if cc.cudagraph_copy_inputs:
+            ignored.append("cudagraph_copy_inputs")
+        # vLLM's own compile cache is unused on the stock path (torch.compile uses
+        # its own cache). compile_cache_save_format defaults from an env var, so
+        # compare against that default to detect an explicit field override.
+        if cc.cache_dir:
+            ignored.append("cache_dir (vLLM compile cache; stock uses torch's cache)")
+        if cc.compile_cache_save_format != envs.VLLM_COMPILE_CACHE_SAVE_FORMAT:
+            ignored.append("compile_cache_save_format (vLLM compile cache)")
+        if envs.VLLM_DISABLE_COMPILE_CACHE:
+            ignored.append(
+                "VLLM_DISABLE_COMPILE_CACHE (vLLM compile cache; stock uses "
+                "torch's cache)"
+            )
+
+        if not ignored:
+            return
+
+        logger.warning_once(
+            "Model architecture %s is running on CompilationMode.STOCK_TORCH_COMPILE "
+            "(stock torch.compile). The following options are only honored by "
+            "CompilationMode.VLLM_COMPILE (the legacy custom backend) and have no "
+            "effect here -- %s. To restore the previous behavior, force the legacy "
+            "backend explicitly with `--compilation-config '{\"mode\": 3}'`. The "
+            "legacy backend (mode 3) is deprecated and will be removed once "
+            "VllmBackend is retired.",
+            ", ".join(self.model_config.architectures),
+            "ignored: " + ", ".join(ignored),
         )
 
     def __post_init__(self):
@@ -1058,6 +1340,16 @@ class VllmConfig:
                 "precision for chunked prefill triton kernels."
             )
 
+        # Capture whether the user set use_inductor_graph_partition before the
+        # opt-level defaults write it to False, so the stock path can default it on
+        # (graph-partition piecewise) without overriding an explicit user choice.
+        # The @config pydantic dataclass exposes no fields-set tracking, so None
+        # (the field default) is the only reliable "unset" signal and it must be
+        # read here, before the first writer mutates it.
+        user_set_graph_partition = (
+            self.compilation_config.use_inductor_graph_partition is not None
+        )
+
         if self.model_config is not None and self.model_config.enforce_eager:
             logger.warning(
                 "Enforce eager set, disabling torch.compile and CUDAGraphs. "
@@ -1134,16 +1426,36 @@ class VllmConfig:
 
         if self.compilation_config.mode is None:
             if self.optimization_level > OptimizationLevel.O0:
-                self.compilation_config.mode = CompilationMode.VLLM_COMPILE
+                # Model-by-model migration off VllmBackend: architectures
+                # allowlisted via SupportsStockCompile run the stock torch.compile
+                # path (codegen + external cudagraph + Inductor-hook fusion); all
+                # others stay on VllmBackend (the default). Users can force via -cc.
+                self.compilation_config.mode = (
+                    CompilationMode.STOCK_TORCH_COMPILE
+                    if self._stock_compile_supported()
+                    else CompilationMode.VLLM_COMPILE
+                )
             else:
                 self.compilation_config.mode = CompilationMode.NONE
 
-        # By default, enable torch wrapping only when using custom Inductor lowering
-        if self.compilation_config.ir_enable_torch_wrap is None:
-            self.compilation_config.ir_enable_torch_wrap = (
-                self.compilation_config.mode == CompilationMode.VLLM_COMPILE
-                and self.compilation_config.backend == "inductor"
-            )
+        # NOTE: do not force the vLLM custom RMSNorm / RoPE glue kernels on the stock
+        # path. A TP1-TP8 sweep found the custom glue (+rotary_embedding,
+        # ir_op_priority.rms_norm=vllm_c) is ~10% SLOWER at batch-1 decode than the
+        # Inductor-generated glue that VllmBackend actually uses (custom_ops=none), with
+        # no throughput or prefill benefit; letting stock use the Inductor glue matches
+        # VllmBackend at parity. See https://github.com/vllm-project/vllm/pull/46423.
+
+        # A model-backed spec-decode drafter whose method is not yet validated on the
+        # stock path falls the engine back to VLLM_COMPILE (validated eagle / eagle3
+        # drafters stay on stock and are compiled by the runner).
+        self._maybe_fallback_stock_for_unsupported_drafter()
+
+        # Stock piecewise cudagraphs require Inductor graph partition. Enable that
+        # path by default, then fall back to the legacy backend for any piecewise
+        # request (explicit or the opt-level default) that the stock path cannot
+        # honor because partition is unavailable.
+        self._resolve_stock_default_cudagraph_mode(user_set_graph_partition)
+        self._fix_unsupported_piecewise_cudagraph_mode()
 
         if all(s not in self.compilation_config.custom_ops for s in ("all", "none")):
             if (
@@ -1169,18 +1481,15 @@ class VllmConfig:
 
         self._maybe_override_dynamic_sd_cudagraph_mode()
 
-        if (
-            self.compilation_config.cudagraph_mode.requires_piecewise_compilation()
-            and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
-            and not envs.VLLM_USE_BREAKABLE_CUDAGRAPH
-        ):
-            logger.info(
-                "Cudagraph mode %s is not compatible with compilation mode %s."
-                "Overriding to NONE.",
-                self.compilation_config.cudagraph_mode,
-                self.compilation_config.mode,
-            )
-            self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+        # Dynamic speculative decoding can turn a non-piecewise mode (e.g. an
+        # explicit FULL) into PIECEWISE after the first stock graph-partition check.
+        # Re-resolve the stock default first so that newly-piecewise mode still
+        # auto-enables Inductor graph partition on torch>=2.9 (staying on stock)
+        # rather than needlessly falling back to VLLM_COMPILE; then re-run the
+        # fallback so a piecewise mode never survives on a stock path that genuinely
+        # cannot provide graph partition (torch<2.9 or user-disabled).
+        self._resolve_stock_default_cudagraph_mode(user_set_graph_partition)
+        self._fix_unsupported_piecewise_cudagraph_mode()
 
         # async tp is built on top of sequence parallelism and requires it.
         pass_config = self.compilation_config.pass_config
@@ -1283,6 +1592,15 @@ class VllmConfig:
                     )
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
+            # The pooler / KV-connector overrides above can re-introduce a piecewise
+            # cudagraph_mode. Re-resolve first (as the dynamic-SD site does) so a
+            # newly-piecewise stock config on torch>=2.9 auto-enables Inductor graph
+            # partition and stays on stock, rather than needlessly falling back;
+            # _fix then only falls back when partition genuinely cannot be provided
+            # (torch<2.9 or user-disabled), instead of tripping the assert below.
+            self._resolve_stock_default_cudagraph_mode(user_set_graph_partition)
+            self._fix_unsupported_piecewise_cudagraph_mode()
+
             # disable cudagraph when enforce eager execution
             if self.model_config is not None and self.model_config.enforce_eager:
                 logger.info("Cudagraph is disabled under eager mode")
@@ -1349,6 +1667,42 @@ class VllmConfig:
             )
         current_platform.check_and_update_config(self)
 
+        # check_and_update_config can itself re-introduce a piecewise cudagraph_mode
+        # (e.g. ROCm with decode/prefill context parallel). Re-resolve first (as the
+        # dynamic-SD site does) so a newly-piecewise stock config on torch>=2.9
+        # auto-enables Inductor graph partition and stays on stock; _fix then falls
+        # back to the legacy VllmBackend only when partition genuinely cannot be
+        # provided -- BEFORE set_splitting_ops_for_v1 below, so the fallen-back
+        # VLLM_COMPILE gets its splitting_ops populated (running it after would leave
+        # VLLM_COMPILE with empty splitting_ops under a piecewise mode). On stock +
+        # graph partition this is a no-op (that path legitimately supports piecewise).
+        self._resolve_stock_default_cudagraph_mode(user_set_graph_partition)
+        self._fix_unsupported_piecewise_cudagraph_mode()
+
+        # The V2 model runner does not support stock torch.compile. When V2 is
+        # force-enabled a stock-eligible arch would hard-fail _validate_v2_model_runner
+        # below, so fall back to VLLM_COMPILE (which V2 supports) -- matching the
+        # pre-migration behavior. Must run before ir_enable_torch_wrap and the
+        # inert-flag warning so both observe the final mode.
+        self._maybe_fallback_stock_for_v2_model_runner(user_set_graph_partition)
+
+        # Resolve torch wrapping AFTER every mode fallback above: a stock model that
+        # late-falls-back to VLLM_COMPILE (dynamic SD, pooler/KV connector, or a
+        # platform check_and_update_config re-introducing a piecewise mode) must get
+        # the same ir_enable_torch_wrap as a config that started as VLLM_COMPILE.
+        if self.compilation_config.ir_enable_torch_wrap is None:
+            self.compilation_config.ir_enable_torch_wrap = (
+                self.compilation_config.mode == CompilationMode.VLLM_COMPILE
+                and self.compilation_config.backend == "inductor"
+            )
+
+        # Emitted AFTER every mode fallback above (so a stock config that late-falls
+        # back to VLLM_COMPILE -- dynamic SD, pooler / KV connector, or platform
+        # check_and_update_config -- is not wrongly told its VllmBackend-only flags
+        # are inert) but BEFORE the splitting_ops / compile-ranges auto-population
+        # below (so those fields still reflect user input).
+        self._warn_ignored_vllm_backend_only_flags()
+
         if self.use_v2_model_runner:
             self._validate_v2_model_runner()
 
@@ -1406,11 +1760,20 @@ class VllmConfig:
                 )
 
             if self.compilation_config.cudagraph_mode.requires_piecewise_compilation():
+                # STOCK_TORCH_COMPILE also provides piecewise cudagraphs when Inductor
+                # graph partition is on (it partitions at the attention ops and routes
+                # capture through the external wrapper), so it is a valid mode here.
+                stock_inductor_piecewise = (
+                    self.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE
+                    and self.compilation_config.use_inductor_graph_partition
+                )
                 assert (
                     self.compilation_config.mode == CompilationMode.VLLM_COMPILE
+                    or stock_inductor_piecewise
                     or envs.VLLM_USE_BREAKABLE_CUDAGRAPH
                 ), (
                     "Compilation mode should be CompilationMode.VLLM_COMPILE "
+                    "(or STOCK_TORCH_COMPILE with use_inductor_graph_partition) "
                     "when cudagraph_mode piecewise cudagraphs is used, "
                     f"cudagraph_mode={self.compilation_config.cudagraph_mode}"
                 )

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -12,8 +12,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed import P2POp
 
-from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphWrapper
+from vllm.compilation.stock_cudagraph import StockTorchCompileCUDAGraphWrapper
 from vllm.compilation.wrapper import reset_compile_wrapper
 from vllm.config import (
     CompilationMode,
@@ -339,6 +339,12 @@ class ElasticEPScalingExecutor:
         elif isinstance(self.worker.model_runner.model, UBatchWrapper):
             raise RuntimeError("DBO is not yet supported in elastic EP")
 
+        # The stock torch.compile path wraps the model (and each Inductor partition)
+        # in StockTorchCompileCUDAGraphWrapper instances rather than CUDAGraphWrapper;
+        # clear all of them so no stale cudagraph is replayed after the rescale
+        # re-compile below.
+        StockTorchCompileCUDAGraphWrapper.clear_all_graphs()
+
         torch.compiler.reset()
         with set_current_vllm_config(self.worker.vllm_config):
             reset_compile_wrapper(self.worker.model_runner.get_model())
@@ -487,16 +493,13 @@ class ElasticEPScalingExecutor:
             self.worker.vllm_config.compilation_config.mode
             == CompilationMode.STOCK_TORCH_COMPILE
         ):
-            # NOTE(yongji): when using stock torch.compile,
-            # torch.compile is triggered during GPUModelRunner's load_model()
-            # TODO(yongji):check do we need to re-trigger torch.compile here?
-            # any changes to the tensor shapes in execution should already
-            # be handled internally by torch.compile.
-            backend = self.worker.vllm_config.compilation_config.init_backend(
-                self.worker.vllm_config
-            )
-            compilation_counter.stock_torch_compile_count += 1
-            self.worker.model_runner.model.compile(fullgraph=True, backend=backend)
+            # NOTE(yongji): when using stock torch.compile, the model was first
+            # compiled during GPUModelRunner.load_model(). After an EP scale event
+            # the expert layout changes, so re-trigger the stock compile through the
+            # shared helper to keep the fusion pass manager + pre-grad pass + pass
+            # context identical to the initial compile (a bare model.compile() here
+            # would silently drop them for fusion-needing models).
+            self.worker.model_runner._compile_model_stock()
 
         multi_block_table = self.worker.model_runner.input_batch.block_table
         saved_block_tables: list[tuple[torch.Tensor, torch.Tensor]] = []

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -57,6 +57,7 @@ from .interfaces import (
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
+    SupportsStockCompile,
 )
 from .utils import (
     AutoWeightsLoader,
@@ -1134,7 +1135,12 @@ class GptOssModel(nn.Module, EagleModelMixin):
 
 
 class GptOssForCausalLM(
-    nn.Module, SupportsPP, SupportsEagle, SupportsEagle3, SupportsLoRA
+    nn.Module,
+    SupportsPP,
+    SupportsEagle,
+    SupportsEagle3,
+    SupportsLoRA,
+    SupportsStockCompile,
 ):
     is_3d_moe_weight: bool = True
     packed_modules_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -788,6 +788,39 @@ def is_attention_free(
 
 
 @runtime_checkable
+class SupportsStockCompile(Protocol):
+    """The interface for models validated to run on the stock torch.compile path
+    (backend="inductor" + vLLM's external cudagraph wrapper + Inductor-hook fusion
+    passes) instead of the custom VllmBackend. Opt in per architecture as it passes
+    the migration gate; models without this flag stay on VllmBackend."""
+
+    supports_stock_compile: ClassVar[Literal[True]] = True
+    """
+    A flag that indicates this model is validated for the stock torch.compile path.
+
+    Note:
+        There is no need to redefine this flag if this class is in the
+        MRO of your model class.
+    """
+
+
+@overload
+def supports_stock_compile(model: object) -> TypeIs[SupportsStockCompile]: ...
+
+
+@overload
+def supports_stock_compile(
+    model: type[object],
+) -> TypeIs[type[SupportsStockCompile]]: ...
+
+
+def supports_stock_compile(
+    model: type[object] | object,
+) -> TypeIs[type[SupportsStockCompile]] | TypeIs[SupportsStockCompile]:
+    return getattr(model, "supports_stock_compile", False)
+
+
+@runtime_checkable
 class IsHybrid(Protocol):
     """The interface required for all models like Jamba that have both
     attention and mamba blocks, indicates that

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -55,6 +55,7 @@ from .interfaces import (
     supports_multimodal_encoder_tp_data,
     supports_multimodal_raw_input_only,
     supports_pp,
+    supports_stock_compile,
     supports_transcription,
 )
 from .interfaces_base import (
@@ -756,6 +757,7 @@ class _ModelInfo:
     requires_raw_input_tokens: bool
     supports_multimodal_encoder_tp_data: bool
     supports_pp: bool
+    supports_stock_compile: bool
     has_inner_state: bool
     is_attention_free: bool
     is_hybrid: bool
@@ -783,6 +785,7 @@ class _ModelInfo:
                 model
             ),
             supports_pp=supports_pp(model),
+            supports_stock_compile=supports_stock_compile(model),
             has_inner_state=has_inner_state(model),
             is_attention_free=is_attention_free(model),
             is_hybrid=is_hybrid(model),
@@ -1347,6 +1350,14 @@ class _ModelRegistry:
     ) -> bool:
         model_cls, _ = self.inspect_model_cls(architectures, model_config)
         return model_cls.has_noops
+
+    def is_stock_compile_supported_model(
+        self,
+        architectures: str | list[str],
+        model_config: ModelConfig,
+    ) -> bool:
+        model_cls, _ = self.inspect_model_cls(architectures, model_config)
+        return model_cls.supports_stock_compile
 
     def is_transcription_model(
         self,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -28,6 +28,7 @@ from vllm.compilation.breakable_cudagraph import (
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphStat, CUDAGraphWrapper
 from vllm.compilation.monitor import set_cudagraph_capturing_enabled
+from vllm.compilation.stock_cudagraph import StockTorchCompileCUDAGraphWrapper
 from vllm.config import (
     CompilationMode,
     CUDAGraphMode,
@@ -3212,7 +3213,13 @@ class GPUModelRunner(
         if not hasattr(self, "model"):
             raise ValueError("Cannot get model before model has been initialized")
         if isinstance(
-            self.model, (CUDAGraphWrapper, UBatchWrapper, BreakableCUDAGraphWrapper)
+            self.model,
+            (
+                CUDAGraphWrapper,
+                UBatchWrapper,
+                BreakableCUDAGraphWrapper,
+                StockTorchCompileCUDAGraphWrapper,
+            ),
         ):
             # get raw model out of the cudagraph wrapper.
             return self.model.unwrap()
@@ -5286,13 +5293,14 @@ class GPUModelRunner(
             self.vllm_config.compilation_config.mode
             == CompilationMode.STOCK_TORCH_COMPILE
         ):
-            from vllm.env_override import _apply_constrain_to_fx_strides_patch
-
-            _apply_constrain_to_fx_strides_patch()
-            backend = self.vllm_config.compilation_config.init_backend(self.vllm_config)
-            compilation_counter.stock_torch_compile_count += 1
-            self.model.compile(fullgraph=True, backend=backend)
-            return
+            self._compile_model_stock()
+            # Do NOT early-return here: the cudagraph-wrapping block below already
+            # attaches vLLM's external FULL cudagraph wrapper only when
+            # cudagraph_mode.has_full_cudagraphs() (a stock model resolved to
+            # FULL_DECODE_ONLY / FULL_AND_PIECEWISE), and leaves a stock PIECEWISE/NONE
+            # model unwrapped (piecewise capture is via the Inductor partition
+            # wrappers). Falling through ensures the shared tail (ubatch wrapper,
+            # get_offloader().post_init()) runs for every stock cudagraph mode.
         # for other compilation modes, cudagraph behavior is controlled by
         # CudagraphWrapper and CudagraphDispatcher of vllm.
 
@@ -5314,10 +5322,22 @@ class GPUModelRunner(
             cudagraph_mode.has_full_cudagraphs()
             and not self.parallel_config.use_ubatching
         ):
-            self.model = CUDAGraphWrapper(
-                self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
-            )
+            if self.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE:
+                # Stock path uses its own decoupled wrapper, not the shared
+                # CUDAGraphWrapper (which is coupled to vLLM full cudagraphs).
+                self.model = StockTorchCompileCUDAGraphWrapper(
+                    self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
+                )
+            else:
+                self.model = CUDAGraphWrapper(
+                    self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
+                )
         elif self.parallel_config.use_ubatching:
+            # A stock-compiled model under ubatching intentionally rides
+            # UBatchWrapper's internal shared CUDAGraphWrapper rather than the
+            # decoupled StockTorchCompileCUDAGraphWrapper: the stock wrapper mirrors
+            # the shared wrapper's batch-descriptor-keyed capture/replay, so results
+            # are correct. STOCK_TORCH_COMPILE + ubatching is not exercised in CI yet.
             if cudagraph_mode.has_full_cudagraphs():
                 self.model = UBatchWrapper(
                     self.model, self.vllm_config, CUDAGraphMode.FULL, self.device
@@ -5328,6 +5348,179 @@ class GPUModelRunner(
                 )
 
         get_offloader().post_init()
+
+    def _compile_model_stock(self) -> None:
+        """Compile self.model (and any spec-decode drafter model) with stock
+        torch.compile (Inductor codegen) for STOCK_TORCH_COMPILE mode. Shared by
+        load_model and the elastic-EP rescale path so the two compile sites cannot
+        diverge on options / pass registration.
+        """
+        from vllm.env_override import _apply_constrain_to_fx_strides_patch
+
+        _apply_constrain_to_fx_strides_patch()
+        backend = self.vllm_config.compilation_config.init_backend(self.vllm_config)
+        options: dict[str, Any] | None
+        options, has_fusion = self._stock_inductor_options()
+        if has_fusion and backend != "inductor":
+            raise ValueError(
+                "STOCK_TORCH_COMPILE with active fusion passes requires "
+                f"backend='inductor', but got backend={backend!r}. vLLM fusion "
+                "passes are registered through Inductor's custom-pass hooks and "
+                "have no effect on other backends; disable fusion or use inductor."
+            )
+        if backend != "inductor":
+            # inductor_compile_config only affects the Inductor backend; an exotic
+            # non-inductor stock backend (e.g. eager) would just warn and ignore an
+            # options dict, so drop it to keep that path behaving exactly as it did
+            # before options started always carrying the base config.
+            options = None
+        options = self._maybe_enable_stock_graph_partition(options, backend)
+
+        compilation_counter.stock_torch_compile_count += 1
+        self.model.compile(fullgraph=True, backend=backend, options=options)
+
+        # A model-backed spec-decode drafter runs under the same engine-global STOCK
+        # mode; its @support_torch_compile decorator does not use vLLM's custom
+        # backend (do_not_use_custom_torch_compile_backend), so
+        # the runner compiles the drafter model here too, reusing `options` so the two
+        # compile sites stay in lockstep on fusion passes and graph partition. With
+        # graph partition on this also gives the drafter the same piecewise cudagraphs
+        # it gets under VLLM_COMPILE (its dispatcher and dummy_run capture it exactly
+        # like the target's partitions). Algorithmic drafters (ngram / suffix) have no
+        # model and are skipped.
+        drafter = getattr(self, "drafter", None)
+        drafter_model = getattr(drafter, "model", None)
+        if isinstance(drafter_model, torch.nn.Module):
+            compilation_counter.stock_torch_compile_count += 1
+            drafter_model.compile(fullgraph=True, backend=backend, options=options)
+
+    def _maybe_enable_stock_graph_partition(
+        self, options: dict[str, Any] | None, backend: str | Callable[..., Any]
+    ) -> dict[str, Any] | None:
+        """Step 2 of the VllmBackend migration: recover piecewise cudagraphs on the
+        stock path. Inductor graph partition does the *partitioning* -- it splits the
+        FX graph at the attention ops (via the scoped compile options) -- but it does
+        not itself capture cudagraphs; it exposes a hook
+        (set_customized_partition_wrappers) that lets us choose how each partition is
+        captured. For STOCK_TORCH_COMPILE + use_inductor_graph_partition we plug in
+        StockTorchCompileCUDAGraphWrapper (running in CUDAGraphMode.PIECEWISE runtime
+        mode), which is torch.compile / Inductor driven -- NOT the eager PIECEWISE
+        cudagraph framework (the shared CUDAGraphWrapper driven by vLLM's dispatcher).
+        This mirrors how VLLM_COMPILE plugs its shared CUDAGraphWrapper into the same
+        hook: graph partition chooses *where* to split, the wrapper is *how* each
+        resulting partition is captured and replayed. Under FULL_AND_PIECEWISE the
+        whole decode forward is additionally captured by the same
+        StockTorchCompileCUDAGraphWrapper class acting as the FULL wrapper. The
+        partition wrapper is installed persistently because stock torch.compile is
+        lazy (the real compile runs on the first forward).
+        """
+        cc = self.compilation_config
+        if not (
+            cc.cudagraph_mode.has_piecewise_cudagraphs()
+            and cc.use_inductor_graph_partition
+        ):
+            return options
+        if backend != "inductor":
+            raise ValueError(
+                "STOCK_TORCH_COMPILE piecewise cudagraphs require backend='inductor' "
+                f"(Inductor graph partition), but got backend={backend!r}."
+            )
+        from vllm.compilation.decorators import install_cudagraph_partition_wrapper
+
+        options = dict(options or {})
+        options["graph_partition"] = True
+        options["custom_should_partition_ops"] = list(cc.splitting_ops or [])
+        install_cudagraph_partition_wrapper(self.vllm_config)
+        return options
+
+    def _stock_inductor_options(self) -> tuple[dict[str, Any], bool]:
+        """torch.compile options for STOCK_TORCH_COMPILE mode.
+
+        Always carries the base inductor_compile_config (enable_auto_functionalized_v2,
+        combo-kernel gating on torch>=2.9, assert gating on torch<2.12, and any user
+        --compilation-config inductor_compile_config) so those apply on the stock path
+        whether or not fusion is active. When the model has active fusion
+        passes (quantized / TP-collective models), additionally register vLLM's
+        PostGradPassManager (rms+quant / act+quant / allreduce+rmsnorm /
+        sequence-parallel fusions) and the pre-grad vLLM-IR functionalization pass via
+        Inductor's standard custom-pass hooks, so they keep their fusions without the
+        custom VllmBackend. For dense bf16 (no active fusion) we skip only the pass
+        manager registration: it would add default IR/cleanup passes that buy nothing
+        and measurably regress perf.
+
+        Returns (options, has_fusion). The caller gates the "fusion requires
+        backend=inductor" error on has_fusion, and drops options entirely for a
+        non-inductor backend since inductor_compile_config only affects Inductor.
+        """
+        import torch._inductor.config as inductor_config
+
+        from vllm.compilation.passes.inductor_pass import (
+            InductorPass,
+            set_pass_context,
+        )
+        from vllm.compilation.passes.ir.inplace_functionalization import (
+            VllmIRInplaceFunctionalizationPass,
+        )
+        from vllm.compilation.passes.pass_manager import PostGradPassManager
+        from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
+        from vllm.config.utils import Range
+        from vllm.utils.import_utils import resolve_obj_by_qualname
+
+        pass_manager = resolve_obj_by_qualname(
+            current_platform.get_pass_manager_cls()
+        )()
+        pass_manager.configure(self.vllm_config)
+
+        # Gate registration on whether configure() produced a real fusion/IR pass,
+        # not a hand-maintained flag list that drifts from PostGradPassManager (the
+        # old list had already dropped enable_qk_norm_rope_fusion). NoOp elimination
+        # is always registered (eliminate_noops defaults True) but on its own buys
+        # nothing for dense bf16 and registering the manager there measurably
+        # regresses perf, so it does not count as active fusion.
+        has_fusion = any(
+            not isinstance(p, NoOpEliminationPass) for p in pass_manager.passes
+        )
+
+        options = dict(self.compilation_config.inductor_compile_config)
+        if not has_fusion:
+            return options, False
+
+        # The vLLM passes (pre/post-grad) and PostGradPassManager.uuid() read
+        # get_pass_context(); torch.compile here is lazy (the real Inductor compile +
+        # passes run during a later forward) and STOCK mode is engine-global, so we
+        # install a persistent pass context instead of scoping a context manager. The
+        # range is [0, max_num_tokens]: stock is a single lazy compile whose one graph
+        # serves every shape from 0 up to max_num_batched_tokens (no per-range
+        # piecewise recompile), so this is the true span of that graph. End-bounded
+        # fusions (allreduce+rmsnorm, rope+kvcache) gate on compile_range.end <=
+        # max_token_num, so this finite end GRANTS them exactly when their workspace
+        # covers max_num_batched_tokens (valid for every shape the single graph runs)
+        # and correctly drops them otherwise -- matching VllmBackend, whose compile
+        # ranges are also capped at max_num_batched_tokens. Start-based passes
+        # (sequence parallelism, gated on start >= min_token_num) stay dropped on a
+        # start=0 single graph; that is inherent to stock's single-graph design.
+        set_pass_context(Range(start=0, end=self.max_num_tokens))
+
+        pre_grad_key = "pre_grad_custom_pass"
+        options[pre_grad_key] = VllmIRInplaceFunctionalizationPass(self.vllm_config)
+        options["_cache_config_ignore_prefix"] = (
+            inductor_config._cache_config_ignore_prefix + [pre_grad_key]
+        )
+        # Merge any user-supplied post_grad_custom_post_pass into the manager rather
+        # than clobbering it, mirroring VllmBackend.configure_post_pass: the config has
+        # already wrapped it as an InductorPass, so hand it straight to the manager's
+        # add() before installing the manager under pass_key.
+        pass_key = current_platform.pass_key
+        user_post_pass = options.get(pass_key)
+        if user_post_pass is not None:
+            if isinstance(user_post_pass, PostGradPassManager):
+                raise ValueError(
+                    "PostGradPassManager can not be kept in CompilationConfig."
+                )
+            assert isinstance(user_post_pass, InductorPass)
+            pass_manager.add(user_post_pass)
+        options[pass_key] = pass_manager
+        return options, True
 
     def _setup_eagle3_aux_hidden_state_outputs(self) -> None:
         if not self.use_aux_hidden_state_outputs:
@@ -6362,6 +6555,7 @@ class GPUModelRunner(
             # graph destruction can surface HSA faults in the next engine startup.
             CUDAGraphWrapper.clear_all_graphs()
             BreakableCUDAGraphWrapper.clear_all_graphs()
+            StockTorchCompileCUDAGraphWrapper.clear_all_graphs()
             self.encoder_cudagraph_manager = None
         self.compilation_config.static_forward_context.clear()
         self.model = None  # type: ignore[assignment]
@@ -6486,8 +6680,10 @@ class GPUModelRunner(
         profiling_pool = current_platform.graph_pool_handle()
         encoder_profiling_pool = current_platform.graph_pool_handle()
         original_pools: dict[int, Any] = {}
-        all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
-            BreakableCUDAGraphWrapper._all_instances
+        all_wrappers = (
+            list(CUDAGraphWrapper._all_instances)
+            + list(BreakableCUDAGraphWrapper._all_instances)
+            + list(StockTorchCompileCUDAGraphWrapper._all_instances)
         )
         for instance in all_wrappers:
             original_pools[id(instance)] = instance.graph_pool
@@ -6561,10 +6757,13 @@ class GPUModelRunner(
             set_cudagraph_capturing_enabled(False)
             CUDAGraphWrapper.clear_all_graphs()
             BreakableCUDAGraphWrapper.clear_all_graphs()
+            StockTorchCompileCUDAGraphWrapper.clear_all_graphs()
             if encoder_cudagraph_manager is not None:
                 encoder_cudagraph_manager.clear()
-            all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
-                BreakableCUDAGraphWrapper._all_instances
+            all_wrappers = (
+                list(CUDAGraphWrapper._all_instances)
+                + list(BreakableCUDAGraphWrapper._all_instances)
+                + list(StockTorchCompileCUDAGraphWrapper._all_instances)
             )
             for instance in all_wrappers:
                 if id(instance) in original_pools:


### PR DESCRIPTION
## What this does

vLLM compiles models through a custom Dynamo backend, `VllmBackend`. This PR lets
allowlisted architectures run on **stock `torch.compile`** instead (Inductor for codegen +
Inductor `graph_partition` + a small external cudagraph wrapper), selected per-architecture
via a new `SupportsStockCompile` flag (mirrors `supports_pp` / `supports_lora`). Allowlisted
archs default to `CompilationMode.STOCK_TORCH_COMPILE`; everything else is unchanged on
`VllmBackend`. **Opted in here: `GptOssForCausalLM` only** — the goal is to retire
`VllmBackend` one architecture at a time.

## When it falls back to VllmBackend (status quo)

A stock-path model logs a deprecation warning and falls back to `VLLM_COMPILE` when stock
can't serve the requested config:

- **torch < 2.9** — Inductor graph partition (required for piecewise cudagraphs) is
  unavailable.
- **explicit piecewise `cudagraph_mode` with `use_inductor_graph_partition=false`** — stock
  has no FX splitting to honor it.
- **an un-validated model-backed spec-decode drafter** — only `eagle` / `eagle3` are validated
  and compile on stock; others (`mtp`, `draft_model`, `medusa`, `dflash`, ...) fall back so they
  compile as before. Algorithmic drafters (`ngram` / `suffix`) have no model and stay on stock.

(An *unset* `cudagraph_mode` when partition is unavailable just resolves to
`FULL_DECODE_ONLY` and stays on stock — no fallback.)

## Perf: parity with VllmBackend

GPT-OSS-120B, H100 TP1, mxfp4. Stock runs the **same kernels** as VllmBackend: GPU traces
show the heavy compute (MoE mxfp4, flash attention, GEMM, routing) is byte-identical, and stock
uses the same Inductor-generated RMSNorm/RoPE glue as VllmBackend (custom_ops=none) rather than
forcing custom kernels.

| metric | VllmBackend (status quo) | stock (this PR) |
|---|---:|---:|
| output throughput (tok/s) | 2608 | 2567 |
| decode TPOT / ITL (ms) | 65.0 / 42.5 | 65.4 / 42.9 |
| prefill GPU-kernel time (ms/fwd, L=2048) | 68.0 | 67.6 |
| gsm8k | reference | parity |

`vllm bench serve`, random 1024-in / 128-out, 256 prompts, rate=inf. Throughput differences
are within the box's run-to-run noise (~5-25% at saturation); decode latency and per-forward
kernel time are at parity. Traces (chrome trace, internal; captured with cudagraphs off so
every kernel is launched individually rather than collapsed into a single graph replay, which
lets the two kernel streams be diffed directly):

prefill
[VllmBackend](https://www.internalfb.com/intern/paste/P2408767861/) /
[stock](https://www.internalfb.com/intern/paste/P2408768914/)

decode
[VllmBackend](https://www.internalfb.com/intern/paste/P2408767807/) /
[stock](https://www.internalfb.com/intern/paste/P2408768932/)

Diffing the GPU kernel streams: the two backends run the **same set of kernel types** (28 in
prefill, 32 in decode, after collapsing Inductor's volatile per-kernel numeric suffixes) and all
the heavy compute matches in launch count and per-kernel duration to within run-to-run noise --
MoE mxfp4 matmuls (`_matmul_ogs_...`), flash attention (cutlass sm90), GEMMs (`sm90_xmma_gemm`,
`gemv2T`), KV write (`reshape_and_cache_flash`), and MoE routing (`_topk_forward`,
`_combined_routing_*`, `_reduce_grouped`, `_sum_bitmatrix_rows`). Total GPU-busy time is at
parity: prefill 62.3 (stock) vs 61.0 ms (VllmBackend); decode 41.5 vs 41.5 ms.

The only differences are in the tiny elementwise/normalization glue (together <5% of GPU time,
and the two differences partially offset). Both backends emit Inductor-generated Triton for the
glue -- neither uses the hand-written CUDA kernels -- so this is a fusion-grouping difference from
the two paths running different post-grad pipelines, not a different kernel:

- **RMSNorm**: VllmBackend's post-grad passes fuse it into a named `fused_add_rms_norm` reduction
  kernel; stock leaves it decomposed into primitives (`..._mean_mul_pow_rsqrt`). Same launch count
  (73 prefill / 584 decode); stock's decomposed form is marginally slower (2.0 vs 1.2 ms prefill,
  1.5 vs 1.2 ms decode), which accounts for essentially all of the small prefill total gap.
- **Pointwise**: stock fuses the elementwise glue into a single Triton kernel
  (`triton_poi_fused_1`); VllmBackend emits 2-3 (~2x the launches: 72 vs 36 prefill, 576 vs 288
  decode). Here stock is the leaner one (0.47 vs 0.83 ms decode).

### TP sweep: STOCK_TORCH_COMPILE vs VllmBackend (interleaved A/B)

Interleaved A/B to remove pseudoreplication: 4 independent server launches per backend,
alternated in time (ABBA rounds) so launch-to-launch compile/autotune/thermal variance is
captured and balanced -- the unit of replication is the launch. Each launch discards a
throughput warmup rep, then records 3 throughput + 2 batch-1 reps; zero foreign-process
contention over the whole run. `vllm bench serve`, random 1024-in/128-out, H100, mxfp4. Mean
+/- std over the 4 launches, Welch t-test on launch means (|t|>2 ~ significant).

| metric | TP | STOCK_TORCH_COMPILE | VllmBackend | STOCK/Vllm | Welch t | verdict |
|---|---|---:|---:|---:|---:|---|
| saturated tok/s | TP1 | 2555 +/- 11 | 2567 +/- 14 | 0.996 | -1.1 | parity (n.s.) |
| saturated tok/s | TP4 | 4179 +/- 104 | 4339 +/- 21 | 0.963 | -2.6 | stock ~3.7% slower |
| batch-1 ITL (ms) | TP1 | 5.14 +/- 0.00 | 5.10 +/- 0.00 | 1.007 | +21 | stock +0.7% |
| batch-1 ITL (ms) | TP4 | 3.83 +/- 0.03 | 3.84 +/- 0.01 | 0.998 | -0.4 | parity (n.s.) |

With proper launch-level replication: **batch-1 decode latency is at parity** -- the ~10%
penalty the earlier glue-forcing caused is gone; the only statistically-significant residual is
+0.7% at TP1 (~0.04 ms). **Saturated throughput is at parity at TP1; at TP4 stock is a real
~3.7% slower and noisier** (stock std 104 vs vllm 21). That TP4 residual is not glue (that is
fixed) -- most likely the Inductor graph-partition path vs VllmBackend's FX splitting, and is a
known small cost of the stock path.

The batch-1 fix required NOT forcing the vLLM custom RMSNorm/RoPE glue on the stock path (which
also flips on fuse_norm_quant): that custom-glue bundle was ~10% slower at batch-1 decode (5.64
vs 5.11 ms at TP1) with no throughput or prefill benefit, because VllmBackend runs
Inductor-generated glue (custom_ops=none). Stock now resolves to the same glue as VllmBackend.

Caveat: flashinfer 0.6.8 + torch 2.13 nightly here fails to initialize the flashinfer
AllReduce+RMSNorm fusion, so it was inactive on both backends; this sweep does not isolate its
TP>1 contribution.

### Compile / startup time (cold vs warm cache)

Wall time from `vllm serve` launch to ready (GPT-OSS-120B, TP1, H100), fresh vs reused Inductor
+ vLLM cache dirs (single sample each; a few-% run-to-run noise).

| backend | cold | warm |
|---|---:|---:|
| STOCK_TORCH_COMPILE | 293 s | 125 s |
| VllmBackend | 229 s | 103 s |

Both benefit ~2.3x from a warm cache. Stock compiles/captures ~20-30% slower than VllmBackend
(cold 293 vs 229 s; warm 125 vs 103 s) -- the whole-graph Inductor compile + graph-partition
cudagraph capture is heavier than VllmBackend's per-range path. A one-time startup cost,
amortized after the first run via the compile cache.

**Cold breakdown -- how much is *just* compile.** The e2e number above is dominated by
backend-independent costs (weight load, KV setup) plus cudagraph capture, so it understates the
compile-driver difference. A separately-instrumented cold run (same box/config, single sample,
`max-model-len 4096`; its stock e2e reproduces the 293 s above, its VllmBackend e2e came in a bit
faster at 197 s -- both used identical config so the ratios hold) decomposes as:

| phase | VllmBackend | stock |
|---|---:|---:|
| weight load | 14 s | 19 s |
| **pure compile** | **~36 s** | **~94 s** |
| cudagraph capture | 83 s | 123 s |
| e2e launch->ready | 197 s | 299 s |

VllmBackend self-reports its compile: `init engine ... took 131.69 s (compilation: 35.97 s)`.
Stock's compile is torch.compile's own lazy compile (it fires in the profile forward and has no
`(compilation: ...)` self-report), so it is isolated from the profile-forward interval
(model-load-done -> first "GPU KV cache size" log): 105 s stock vs 47 s VllmBackend, minus the
~11 s shared profiling overhead -> **~94 s**. So **pure compile is ~2.6x (94 vs 36 s), far above
the ~1.3-1.5x the e2e rows suggest**; graph-partition cudagraph capture is a further ~1.5x
(123 vs 83 s). Both are one-time and cache-amortized (the warm column). `nested_compile_region`
(GPT-OSS is 36 identical layers -> compile-once, stamp-out) is the natural lever to cut the ~94 s
whole-graph compile.








