### PR TITLE
[rust][server] Add generative scoring route

### DIFF
--- a/rust/src/engine-core-client/src/mock_engine.rs
+++ b/rust/src/engine-core-client/src/mock_engine.rs
@@ -72,6 +72,7 @@ pub fn default_ready_response() -> EngineCoreReadyResponse {
         weight_transfer_backend: None,
         enable_sleep_mode: false,
         supports_draft_weight_updates: false,
+        use_spec_decode: false,
     }
 }
 

--- a/rust/src/engine-core-client/src/protocol/handshake.rs
+++ b/rust/src/engine-core-client/src/protocol/handshake.rs
@@ -104,6 +104,9 @@ pub struct EngineCoreReadyResponse {
     /// Whether the engine has a speculative draft model that can be updated.
     #[serde(default)]
     pub supports_draft_weight_updates: bool,
+    /// Whether the engine was started with speculative decoding enabled.
+    #[serde(default)]
+    pub use_spec_decode: bool,
 }
 
 /// Frontend-owned ZMQ addresses that are sent to the engine during startup

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2852,6 +2852,7 @@ fn python_msgpack_fixtures_match_rust_encoding() {
     );
     assert!(ready_response.enable_sleep_mode);
     assert!(ready_response.supports_draft_weight_updates);
+    assert!(ready_response.use_spec_decode);
     let kv_events_config = ready_response.kv_events_config.expect("KV events config should decode");
     assert!(kv_events_config.enable_kv_cache_events);
     assert_eq!(kv_events_config.publisher, "zmq");

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -421,6 +421,7 @@ class EngineCoreReadyResponse:
     weight_transfer_backend: str | None = None
     enable_sleep_mode: bool = False
     supports_draft_weight_updates: bool = False
+    use_spec_decode: bool = False
 
 
 ready_response = EngineCoreReadyResponse(
@@ -444,6 +445,7 @@ ready_response = EngineCoreReadyResponse(
     weight_transfer_backend="nccl",
     enable_sleep_mode=True,
     supports_draft_weight_updates=True,
+    use_spec_decode=True,
     kv_events_config=KVEventsConfig(
         enable_kv_cache_events=True,
         publisher="zmq",

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -78,7 +78,8 @@ fn build_router_with_options(
         // vLLM specific endpoints
         .route("/tokenize", post(tokenize::tokenize))
         .route("/detokenize", post(tokenize::detokenize))
-        .route("/inference/v1/generate", post(inference::generate));
+        .route("/inference/v1/generate", post(inference::generate))
+        .route("/generative_scoring", post(inference::generative_scoring));
 
     if runtime_lora_updating_enabled {
         router = router

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -115,7 +115,8 @@ fn build_router_with_options(
         .route("/v1/chat/completions", post(openai::chat_completions))
         // vLLM specific endpoints
         .route("/tokenize", post(tokenize::tokenize))
-        .route("/detokenize", post(tokenize::detokenize));
+        .route("/detokenize", post(tokenize::detokenize))
+        .route("/generative_scoring", post(inference::generative_scoring));
 
     if scale_out_endpoints_enabled {
         router = router.route("/inference/v1/generate", post(inference::generate));

--- a/rust/src/server/src/routes/inference/generative_scoring.rs
+++ b/rust/src/server/src/routes/inference/generative_scoring.rs
@@ -1,0 +1,570 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::{IntoResponse, Response};
+use futures::future::try_join_all;
+use serde::{Deserialize, Serialize};
+use thiserror_ext::AsReport as _;
+use tracing::info;
+use tracing_futures::Instrument as _;
+use validator::Validate;
+use vllm_engine_core_client::protocol::logprobs::PositionLogprobs;
+use vllm_llm::{CollectedGenerateOutput, FinishReason, GenerateOutputStreamExt as _, TokenUsage};
+use vllm_text::{Prompt, SamplingParams, TextDecodeOptions, TextRequest};
+
+use crate::error::{ApiError, bail_invalid_request, server_error, text_submit_error};
+use crate::lora::LoraModelResolution;
+use crate::routes::openai::utils::types::{Normalizable, Usage, default_true};
+use crate::routes::openai::utils::validated_json::ValidatedJson;
+use crate::state::AppState;
+use crate::utils::{ResolvedRequestContext, resolve_request_context, unix_timestamp};
+
+/// Request body for the vLLM generative scoring API.
+#[derive(Debug, Clone, Deserialize, Serialize, Validate)]
+pub struct GenerativeScoringRequest {
+    pub model: Option<String>,
+    pub query: GenerativeScoringInput,
+    pub items: GenerativeScoringItems,
+    pub label_token_ids: Vec<u32>,
+    #[serde(default = "default_true")]
+    pub apply_softmax: bool,
+    #[serde(default)]
+    pub item_first: bool,
+    #[serde(default = "default_true")]
+    pub add_special_tokens: bool,
+    #[serde(default)]
+    pub priority: i32,
+    pub request_id: Option<String>,
+}
+
+impl Normalizable for GenerativeScoringRequest {}
+
+/// Text or pre-tokenized IDs accepted by the generative scoring API.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum GenerativeScoringInput {
+    Text(String),
+    TokenIds(Vec<u32>),
+}
+
+/// Homogeneous text or token-ID item lists accepted by the API.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum GenerativeScoringItems {
+    Text(Vec<String>),
+    TokenIds(Vec<Vec<u32>>),
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GenerativeScoringItemResult {
+    index: usize,
+    object: &'static str,
+    score: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GenerativeScoringResponse {
+    id: String,
+    object: &'static str,
+    created: u64,
+    model: String,
+    data: Vec<GenerativeScoringItemResult>,
+    usage: Usage,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedGenerativeScoringRequest {
+    request_id: String,
+    response_model: String,
+    label_token_ids: Vec<u32>,
+    apply_softmax: bool,
+    text_requests: Vec<TextRequest>,
+}
+
+/// Validate, build one prompt per item, score the configured label tokens, and
+/// return probabilities in the Python `/generative_scoring` response shape.
+pub async fn generative_scoring(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    ValidatedJson(body): ValidatedJson<GenerativeScoringRequest>,
+) -> Response {
+    let request_context = resolve_request_context(&headers, body.request_id.as_deref());
+    let lora_resolution = state.resolve_model_with_loras(body.model.as_deref()).await;
+    let prepared =
+        match prepare_generative_scoring_request(body, &lora_resolution, request_context, &state) {
+            Ok(prepared) => prepared,
+            Err(error) => return error.into_response(),
+        };
+
+    let request_span = tracing::info_span!(
+        "generative_scoring",
+        request_id = %prepared.request_id,
+        engine_request_id = tracing::field::Empty,
+    );
+    let created = unix_timestamp();
+    let enable_log_requests = state.api_server_options.enable_log_requests;
+
+    let text = state.chat.text();
+    let streams = match try_join_all(
+        prepared
+            .text_requests
+            .into_iter()
+            .map(|text_request| text.generate_raw(text_request).instrument(request_span.clone())),
+    )
+    .await
+    {
+        Ok(streams) => streams,
+        Err(error) => {
+            return text_submit_error("failed to submit generative scoring request", error)
+                .into_response();
+        }
+    };
+
+    let collected = match try_join_all(
+        streams
+            .into_iter()
+            .map(|stream| stream.collect_output().instrument(request_span.clone())),
+    )
+    .await
+    {
+        Ok(outputs) => outputs,
+        Err(error) => {
+            return server_error!(
+                "generative scoring stream failed: {}",
+                error.to_report_string()
+            )
+            .into_response();
+        }
+    };
+
+    let response = match collect_generative_scoring(
+        prepared.request_id,
+        prepared.response_model,
+        created,
+        prepared.label_token_ids,
+        prepared.apply_softmax,
+        collected,
+        enable_log_requests,
+    ) {
+        Ok(response) => response,
+        Err(error) => return error.into_response(),
+    };
+
+    Json(response).into_response()
+}
+
+fn prepare_generative_scoring_request(
+    request: GenerativeScoringRequest,
+    lora_resolution: &LoraModelResolution,
+    ctx: ResolvedRequestContext,
+    state: &AppState,
+) -> Result<PreparedGenerativeScoringRequest, ApiError> {
+    validate_generative_scoring_request(&request, lora_resolution, state.chat.model_vocab_size())?;
+
+    let request_id = format!("generative-scoring-{}", ctx.request_id);
+    let response_model = lora_resolution
+        .lora_request
+        .as_ref()
+        .map(|request| request.lora_name.clone())
+        .unwrap_or_else(|| lora_resolution.model_names.first().cloned().unwrap_or_default());
+    let label_token_ids = request.label_token_ids;
+    let apply_softmax = request.apply_softmax;
+    let prompt_token_ids = build_prompt_token_ids(
+        request.query,
+        request.items,
+        request.item_first,
+        request.add_special_tokens,
+        state,
+    )?;
+
+    let logprobs = i32::try_from(label_token_ids.len()).map_err(|_| {
+        ApiError::invalid_request(
+            "label_token_ids must fit within a signed 32-bit count.".to_string(),
+            Some("label_token_ids"),
+        )
+    })?;
+
+    let text_requests = prompt_token_ids
+        .into_iter()
+        .enumerate()
+        .map(|(index, prompt_token_ids)| TextRequest {
+            request_id: format!("{request_id}-{index}"),
+            prompt: Prompt::TokenIds(prompt_token_ids),
+            mm_features: None,
+            sampling_params: SamplingParams {
+                max_tokens: Some(1),
+                logprobs: Some(logprobs),
+                logprob_token_ids: Some(label_token_ids.clone()),
+                ..Default::default()
+            },
+            decode_options: TextDecodeOptions::default(),
+            intermediate: false,
+            priority: request.priority,
+            cache_salt: None,
+            add_special_tokens: false,
+            data_parallel_rank: ctx.data_parallel_rank,
+            lora_request: lora_resolution.lora_request.clone(),
+        })
+        .collect();
+
+    Ok(PreparedGenerativeScoringRequest {
+        request_id,
+        response_model,
+        label_token_ids,
+        apply_softmax,
+        text_requests,
+    })
+}
+
+fn validate_generative_scoring_request(
+    request: &GenerativeScoringRequest,
+    lora_resolution: &LoraModelResolution,
+    model_vocab_size: usize,
+) -> Result<(), ApiError> {
+    if let Some(model) = request.model.as_ref()
+        && !lora_resolution.model_names.iter().any(|name| name == model)
+    {
+        return Err(ApiError::model_not_found(model.clone()));
+    }
+
+    if request.label_token_ids.is_empty() {
+        bail_invalid_request!(
+            param = "label_token_ids",
+            "label_token_ids must contain at least one token ID."
+        );
+    }
+
+    if request.items.is_empty() {
+        bail_invalid_request!(param = "items", "items must contain at least one item.");
+    }
+
+    let invalid_token_ids: Vec<_> = request
+        .label_token_ids
+        .iter()
+        .copied()
+        .filter(|&token_id| token_id as usize >= model_vocab_size)
+        .collect();
+    if !invalid_token_ids.is_empty() {
+        bail_invalid_request!(
+            param = "label_token_ids",
+            "label_token_id(s) {:?} are out of vocabulary range [0, {}).",
+            invalid_token_ids,
+            model_vocab_size
+        );
+    }
+
+    Ok(())
+}
+
+impl GenerativeScoringItems {
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Text(items) => items.is_empty(),
+            Self::TokenIds(items) => items.is_empty(),
+        }
+    }
+}
+
+fn build_prompt_token_ids(
+    query: GenerativeScoringInput,
+    items: GenerativeScoringItems,
+    item_first: bool,
+    add_special_tokens: bool,
+    state: &AppState,
+) -> Result<Vec<Vec<u32>>, ApiError> {
+    let tokenizer = state.chat.text().tokenizer();
+    let query_token_ids = match query {
+        GenerativeScoringInput::Text(query) => {
+            tokenizer.encode(&query, add_special_tokens).map_err(|error| {
+                server_error!(
+                    "failed to tokenize generative scoring query: {}",
+                    error.to_report_string()
+                )
+            })?
+        }
+        GenerativeScoringInput::TokenIds(token_ids) => token_ids,
+    };
+    let max_prompt_len = state.chat.engine_core_client().max_model_len().saturating_sub(1) as usize;
+
+    match items {
+        GenerativeScoringItems::Text(items) => items
+            .into_iter()
+            .map(|item| {
+                let item_token_ids = tokenizer.encode(&item, false).map_err(|error| {
+                    server_error!(
+                        "failed to tokenize generative scoring item: {}",
+                        error.to_report_string()
+                    )
+                })?;
+                Ok(concat_and_truncate_prompt(
+                    &query_token_ids,
+                    &item_token_ids,
+                    item_first,
+                    max_prompt_len,
+                ))
+            })
+            .collect(),
+        GenerativeScoringItems::TokenIds(items) => Ok(items
+            .into_iter()
+            .map(|item_token_ids| {
+                concat_and_truncate_prompt(
+                    &query_token_ids,
+                    &item_token_ids,
+                    item_first,
+                    max_prompt_len,
+                )
+            })
+            .collect()),
+    }
+}
+
+fn concat_and_truncate_prompt(
+    query_token_ids: &[u32],
+    item_token_ids: &[u32],
+    item_first: bool,
+    max_prompt_len: usize,
+) -> Vec<u32> {
+    let mut prompt = Vec::with_capacity(query_token_ids.len() + item_token_ids.len());
+    if item_first {
+        prompt.extend_from_slice(item_token_ids);
+        prompt.extend_from_slice(query_token_ids);
+    } else {
+        prompt.extend_from_slice(query_token_ids);
+        prompt.extend_from_slice(item_token_ids);
+    }
+    prompt.truncate(max_prompt_len);
+    prompt
+}
+
+fn collect_generative_scoring(
+    request_id: String,
+    response_model: String,
+    created: u64,
+    label_token_ids: Vec<u32>,
+    apply_softmax: bool,
+    outputs: Vec<CollectedGenerateOutput>,
+    enable_log_requests: bool,
+) -> Result<GenerativeScoringResponse, ApiError> {
+    let mut data = Vec::with_capacity(outputs.len());
+    let mut usage = TokenUsage::default();
+
+    for (index, output) in outputs.into_iter().enumerate() {
+        if matches!(output.finish_reason, FinishReason::Error) {
+            return Err(server_error!(
+                "generation error for generative scoring item {index}"
+            ));
+        }
+
+        let logprobs = output.logprobs.as_ref().ok_or_else(|| {
+            server_error!(
+                "no logprobs available for generative scoring item {index}; \
+                 this might indicate an issue with logprobs configuration"
+            )
+        })?;
+        let position = logprobs.positions.first().ok_or_else(|| {
+            server_error!(
+                "no logprobs available for generative scoring item {index}; \
+                 this might indicate an issue with logprobs configuration"
+            )
+        })?;
+        let score = compute_score(position, &label_token_ids, apply_softmax, index)?;
+
+        data.push(GenerativeScoringItemResult {
+            index,
+            object: "score",
+            score,
+        });
+        usage.prompt_token_count += output.usage.prompt_token_count;
+        usage.output_token_count += output.usage.output_token_count;
+        usage.cached_token_count += output.usage.cached_token_count;
+    }
+
+    if enable_log_requests {
+        info!(
+            prompt_tokens = usage.prompt_token_count,
+            output_tokens = usage.output_token_count,
+            "generative scoring finished"
+        );
+    }
+
+    Ok(GenerativeScoringResponse {
+        id: request_id,
+        object: "list",
+        created,
+        model: response_model,
+        data,
+        usage: Usage::from_counts(usage.prompt_token_count, usage.output_token_count, None),
+    })
+}
+
+fn compute_score(
+    position: &PositionLogprobs,
+    label_token_ids: &[u32],
+    apply_softmax: bool,
+    item_index: usize,
+) -> Result<f64, ApiError> {
+    let mut returned_logprobs = HashMap::new();
+    for entry in &position.entries {
+        returned_logprobs.insert(entry.token_id, f64::from(entry.logprob));
+    }
+
+    let mut label_logprobs = HashMap::new();
+    let mut missing_token_ids = Vec::new();
+    for token_id in label_token_ids {
+        if let Some(logprob) = returned_logprobs.get(token_id) {
+            label_logprobs.insert(*token_id, *logprob);
+        } else {
+            missing_token_ids.push(*token_id);
+        }
+    }
+
+    if !missing_token_ids.is_empty() {
+        return Err(server_error!(
+            "Token IDs {:?} not found in logprobs for generative scoring item {}.",
+            missing_token_ids,
+            item_index
+        ));
+    }
+
+    let first_label_id = label_token_ids[0];
+    if apply_softmax {
+        let max_logprob = label_logprobs.values().copied().fold(f64::NEG_INFINITY, f64::max);
+        let sum_exp: f64 =
+            label_logprobs.values().map(|logprob| (logprob - max_logprob).exp()).sum();
+        let first_logprob = label_logprobs[&first_label_id];
+        Ok((first_logprob - max_logprob).exp() / sum_exp)
+    } else {
+        Ok(label_logprobs[&first_label_id].exp())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vllm_engine_core_client::protocol::logprobs::TokenLogprob;
+
+    fn served(names: &[&str]) -> LoraModelResolution {
+        LoraModelResolution {
+            model_names: names.iter().map(|name| (*name).to_string()).collect(),
+            lora_request: None,
+        }
+    }
+
+    fn base_request() -> GenerativeScoringRequest {
+        serde_json::from_value(serde_json::json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "query": "question",
+            "items": ["yes"],
+            "label_token_ids": [10, 20]
+        }))
+        .expect("parse request")
+    }
+
+    #[test]
+    fn generative_scoring_request_deserializes_text_and_token_inputs() {
+        let text_request: GenerativeScoringRequest = serde_json::from_value(serde_json::json!({
+            "query": "question",
+            "items": ["yes", "no"],
+            "label_token_ids": [10, 20]
+        }))
+        .expect("parse text request");
+        assert_eq!(
+            text_request.query,
+            GenerativeScoringInput::Text("question".to_string())
+        );
+        assert_eq!(
+            text_request.items,
+            GenerativeScoringItems::Text(vec!["yes".to_string(), "no".to_string()])
+        );
+        assert!(text_request.apply_softmax);
+        assert!(text_request.add_special_tokens);
+
+        let token_request: GenerativeScoringRequest = serde_json::from_value(serde_json::json!({
+            "query": [1, 2],
+            "items": [[3, 4], [5, 6]],
+            "label_token_ids": [10, 20],
+            "apply_softmax": false,
+            "item_first": true,
+            "add_special_tokens": false
+        }))
+        .expect("parse token request");
+        assert_eq!(
+            token_request.query,
+            GenerativeScoringInput::TokenIds(vec![1, 2])
+        );
+        assert_eq!(
+            token_request.items,
+            GenerativeScoringItems::TokenIds(vec![vec![3, 4], vec![5, 6]])
+        );
+        assert!(!token_request.apply_softmax);
+        assert!(token_request.item_first);
+        assert!(!token_request.add_special_tokens);
+    }
+
+    #[test]
+    fn validate_generative_scoring_request_checks_model_items_and_labels() {
+        let served = served(&["Qwen/Qwen1.5-0.5B-Chat"]);
+
+        let wrong_model = GenerativeScoringRequest {
+            model: Some("missing".to_string()),
+            ..base_request()
+        };
+        assert!(validate_generative_scoring_request(&wrong_model, &served, 100).is_err());
+
+        let empty_labels = GenerativeScoringRequest {
+            label_token_ids: Vec::new(),
+            ..base_request()
+        };
+        assert!(validate_generative_scoring_request(&empty_labels, &served, 100).is_err());
+
+        let out_of_vocab = GenerativeScoringRequest {
+            label_token_ids: vec![99, 100],
+            ..base_request()
+        };
+        assert!(validate_generative_scoring_request(&out_of_vocab, &served, 100).is_err());
+    }
+
+    #[test]
+    fn concat_and_truncate_prompt_respects_item_order() {
+        assert_eq!(
+            concat_and_truncate_prompt(&[100, 101], &[200, 201], false, 10),
+            vec![100, 101, 200, 201]
+        );
+        assert_eq!(
+            concat_and_truncate_prompt(&[100, 101], &[200, 201], true, 10),
+            vec![200, 201, 100, 101]
+        );
+        assert_eq!(
+            concat_and_truncate_prompt(&[100, 101], &[200, 201], false, 3),
+            vec![100, 101, 200]
+        );
+    }
+
+    #[test]
+    fn compute_score_supports_softmax_and_true_probability_modes() {
+        let position = PositionLogprobs {
+            entries: vec![
+                TokenLogprob {
+                    token_id: 10,
+                    logprob: -0.5,
+                    rank: 1,
+                },
+                TokenLogprob {
+                    token_id: 20,
+                    logprob: -2.0,
+                    rank: 2,
+                },
+            ],
+        };
+
+        let softmax_score = compute_score(&position, &[10, 20], true, 0).expect("softmax score");
+        let expected = (-0.5_f64).exp() / ((-0.5_f64).exp() + (-2.0_f64).exp());
+        assert!((softmax_score - expected).abs() < 1e-9);
+
+        let true_probability = compute_score(&position, &[10, 20], false, 0).expect("true prob");
+        assert!((true_probability - (-0.5_f64).exp()).abs() < 1e-9);
+    }
+}

--- a/rust/src/server/src/routes/inference/generative_scoring.rs
+++ b/rust/src/server/src/routes/inference/generative_scoring.rs
@@ -1,0 +1,574 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::{IntoResponse, Response};
+use futures::future::try_join_all;
+use serde::{Deserialize, Serialize};
+use thiserror_ext::AsReport as _;
+use tracing::info;
+use tracing_futures::Instrument as _;
+use validator::Validate;
+use vllm_engine_core_client::protocol::logprobs::PositionLogprobs;
+use vllm_llm::{CollectedGenerateOutput, FinishReason, GenerateOutputStreamExt as _, TokenUsage};
+use vllm_text::{Prompt, SamplingParams, TextDecodeOptions, TextRequest};
+
+use crate::error::{ApiError, bail_invalid_request, server_error, text_submit_error};
+use crate::lora::LoraModelResolution;
+use crate::routes::openai::utils::types::{Normalizable, Usage, default_true};
+use crate::routes::openai::utils::validated_json::ValidatedJson;
+use crate::state::AppState;
+use crate::utils::{ResolvedRequestContext, resolve_request_context, unix_timestamp};
+
+/// Request body for the vLLM generative scoring API.
+#[derive(Debug, Clone, Deserialize, Serialize, Validate)]
+pub struct GenerativeScoringRequest {
+    pub model: Option<String>,
+    pub query: GenerativeScoringInput,
+    pub items: GenerativeScoringItems,
+    pub label_token_ids: Vec<u32>,
+    #[serde(default = "default_true")]
+    pub apply_softmax: bool,
+    #[serde(default)]
+    pub item_first: bool,
+    #[serde(default = "default_true")]
+    pub add_special_tokens: bool,
+    #[serde(default)]
+    pub priority: i32,
+    pub request_id: Option<String>,
+}
+
+impl Normalizable for GenerativeScoringRequest {}
+
+/// Text or pre-tokenized IDs accepted by the generative scoring API.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum GenerativeScoringInput {
+    Text(String),
+    TokenIds(Vec<u32>),
+}
+
+/// Homogeneous text or token-ID item lists accepted by the API.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum GenerativeScoringItems {
+    Text(Vec<String>),
+    TokenIds(Vec<Vec<u32>>),
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GenerativeScoringItemResult {
+    index: usize,
+    object: &'static str,
+    score: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GenerativeScoringResponse {
+    id: String,
+    object: &'static str,
+    created: u64,
+    model: String,
+    data: Vec<GenerativeScoringItemResult>,
+    usage: Usage,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedGenerativeScoringRequest {
+    request_id: String,
+    response_model: String,
+    label_token_ids: Vec<u32>,
+    apply_softmax: bool,
+    text_requests: Vec<TextRequest>,
+}
+
+/// Validate, build one prompt per item, score the configured label tokens, and
+/// return probabilities in the Python `/generative_scoring` response shape.
+pub async fn generative_scoring(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    ValidatedJson(body): ValidatedJson<GenerativeScoringRequest>,
+) -> Response {
+    let request_context = resolve_request_context(&headers, body.request_id.as_deref());
+    let lora_resolution = state.resolve_model_with_loras(body.model.as_deref()).await;
+    let prepared =
+        match prepare_generative_scoring_request(body, &lora_resolution, request_context, &state) {
+            Ok(prepared) => prepared,
+            Err(error) => return error.into_response(),
+        };
+
+    let request_span = tracing::info_span!(
+        "generative_scoring",
+        request_id = %prepared.request_id,
+        engine_request_id = tracing::field::Empty,
+    );
+    let created = unix_timestamp();
+    let enable_log_requests = state.api_server_options.enable_log_requests;
+
+    let text = state.chat.text();
+    let streams = match try_join_all(
+        prepared
+            .text_requests
+            .into_iter()
+            .map(|text_request| text.generate_raw(text_request).instrument(request_span.clone())),
+    )
+    .await
+    {
+        Ok(streams) => streams,
+        Err(error) => {
+            return text_submit_error("failed to submit generative scoring request", error)
+                .into_response();
+        }
+    };
+
+    let collected = match try_join_all(
+        streams
+            .into_iter()
+            .map(|stream| stream.collect_output().instrument(request_span.clone())),
+    )
+    .await
+    {
+        Ok(outputs) => outputs,
+        Err(error) => {
+            return server_error!(
+                "generative scoring stream failed: {}",
+                error.to_report_string()
+            )
+            .into_response();
+        }
+    };
+
+    let response = match collect_generative_scoring(
+        prepared.request_id,
+        prepared.response_model,
+        created,
+        prepared.label_token_ids,
+        prepared.apply_softmax,
+        collected,
+        enable_log_requests,
+    ) {
+        Ok(response) => response,
+        Err(error) => return error.into_response(),
+    };
+
+    Json(response).into_response()
+}
+
+fn prepare_generative_scoring_request(
+    request: GenerativeScoringRequest,
+    lora_resolution: &LoraModelResolution,
+    ctx: ResolvedRequestContext,
+    state: &AppState,
+) -> Result<PreparedGenerativeScoringRequest, ApiError> {
+    validate_generative_scoring_request(&request, lora_resolution, state.chat.model_vocab_size())?;
+
+    let request_id = format!("generative-scoring-{}", ctx.request_id);
+    let response_model = lora_resolution
+        .lora_request
+        .as_ref()
+        .map(|request| request.lora_name.clone())
+        .unwrap_or_else(|| lora_resolution.model_names.first().cloned().unwrap_or_default());
+    let label_token_ids = request.label_token_ids;
+    let apply_softmax = request.apply_softmax;
+    let prompt_token_ids = build_prompt_token_ids(
+        request.query,
+        request.items,
+        request.item_first,
+        request.add_special_tokens,
+        state,
+    )?;
+
+    let logprobs = i32::try_from(label_token_ids.len()).map_err(|_| {
+        ApiError::invalid_request(
+            "label_token_ids must fit within a signed 32-bit count.".to_string(),
+            Some("label_token_ids"),
+        )
+    })?;
+
+    let text_requests = prompt_token_ids
+        .into_iter()
+        .enumerate()
+        .map(|(index, prompt_token_ids)| TextRequest {
+            request_id: format!("{request_id}-{index}"),
+            prompt: Prompt::TokenIds(prompt_token_ids),
+            mm_features: None,
+            sampling_params: SamplingParams {
+                max_tokens: Some(1),
+                logprobs: Some(logprobs),
+                logprob_token_ids: Some(label_token_ids.clone()),
+                ..Default::default()
+            },
+            decode_options: TextDecodeOptions::default(),
+            intermediate: false,
+            prompt_truncation: None,
+            priority: request.priority,
+            cache_salt: None,
+            add_special_tokens: false,
+            data_parallel_rank: ctx.data_parallel_rank,
+            session_id: None,
+            reasoning_parser_kwargs: None,
+            lora_request: lora_resolution.lora_request.clone(),
+            arrival_time: None,
+        })
+        .collect();
+
+    Ok(PreparedGenerativeScoringRequest {
+        request_id,
+        response_model,
+        label_token_ids,
+        apply_softmax,
+        text_requests,
+    })
+}
+
+fn validate_generative_scoring_request(
+    request: &GenerativeScoringRequest,
+    lora_resolution: &LoraModelResolution,
+    model_vocab_size: usize,
+) -> Result<(), ApiError> {
+    if let Some(model) = request.model.as_ref()
+        && !lora_resolution.model_names.iter().any(|name| name == model)
+    {
+        return Err(ApiError::model_not_found(model.clone()));
+    }
+
+    if request.label_token_ids.is_empty() {
+        bail_invalid_request!(
+            param = "label_token_ids",
+            "label_token_ids must contain at least one token ID."
+        );
+    }
+
+    if request.items.is_empty() {
+        bail_invalid_request!(param = "items", "items must contain at least one item.");
+    }
+
+    let invalid_token_ids: Vec<_> = request
+        .label_token_ids
+        .iter()
+        .copied()
+        .filter(|&token_id| token_id as usize >= model_vocab_size)
+        .collect();
+    if !invalid_token_ids.is_empty() {
+        bail_invalid_request!(
+            param = "label_token_ids",
+            "label_token_id(s) {:?} are out of vocabulary range [0, {}).",
+            invalid_token_ids,
+            model_vocab_size
+        );
+    }
+
+    Ok(())
+}
+
+impl GenerativeScoringItems {
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Text(items) => items.is_empty(),
+            Self::TokenIds(items) => items.is_empty(),
+        }
+    }
+}
+
+fn build_prompt_token_ids(
+    query: GenerativeScoringInput,
+    items: GenerativeScoringItems,
+    item_first: bool,
+    add_special_tokens: bool,
+    state: &AppState,
+) -> Result<Vec<Vec<u32>>, ApiError> {
+    let tokenizer = state.chat.text().tokenizer();
+    let query_token_ids = match query {
+        GenerativeScoringInput::Text(query) => {
+            tokenizer.encode(&query, add_special_tokens).map_err(|error| {
+                server_error!(
+                    "failed to tokenize generative scoring query: {}",
+                    error.to_report_string()
+                )
+            })?
+        }
+        GenerativeScoringInput::TokenIds(token_ids) => token_ids,
+    };
+    let max_prompt_len = state.chat.engine_core_client().max_model_len().saturating_sub(1) as usize;
+
+    match items {
+        GenerativeScoringItems::Text(items) => items
+            .into_iter()
+            .map(|item| {
+                let item_token_ids = tokenizer.encode(&item, false).map_err(|error| {
+                    server_error!(
+                        "failed to tokenize generative scoring item: {}",
+                        error.to_report_string()
+                    )
+                })?;
+                Ok(concat_and_truncate_prompt(
+                    &query_token_ids,
+                    &item_token_ids,
+                    item_first,
+                    max_prompt_len,
+                ))
+            })
+            .collect(),
+        GenerativeScoringItems::TokenIds(items) => Ok(items
+            .into_iter()
+            .map(|item_token_ids| {
+                concat_and_truncate_prompt(
+                    &query_token_ids,
+                    &item_token_ids,
+                    item_first,
+                    max_prompt_len,
+                )
+            })
+            .collect()),
+    }
+}
+
+fn concat_and_truncate_prompt(
+    query_token_ids: &[u32],
+    item_token_ids: &[u32],
+    item_first: bool,
+    max_prompt_len: usize,
+) -> Vec<u32> {
+    let mut prompt = Vec::with_capacity(query_token_ids.len() + item_token_ids.len());
+    if item_first {
+        prompt.extend_from_slice(item_token_ids);
+        prompt.extend_from_slice(query_token_ids);
+    } else {
+        prompt.extend_from_slice(query_token_ids);
+        prompt.extend_from_slice(item_token_ids);
+    }
+    prompt.truncate(max_prompt_len);
+    prompt
+}
+
+fn collect_generative_scoring(
+    request_id: String,
+    response_model: String,
+    created: u64,
+    label_token_ids: Vec<u32>,
+    apply_softmax: bool,
+    outputs: Vec<CollectedGenerateOutput>,
+    enable_log_requests: bool,
+) -> Result<GenerativeScoringResponse, ApiError> {
+    let mut data = Vec::with_capacity(outputs.len());
+    let mut usage = TokenUsage::default();
+
+    for (index, output) in outputs.into_iter().enumerate() {
+        if matches!(output.finish_reason, FinishReason::Error) {
+            return Err(server_error!(
+                "generation error for generative scoring item {index}"
+            ));
+        }
+
+        let logprobs = output.logprobs.as_ref().ok_or_else(|| {
+            server_error!(
+                "no logprobs available for generative scoring item {index}; \
+                 this might indicate an issue with logprobs configuration"
+            )
+        })?;
+        let position = logprobs.positions.first().ok_or_else(|| {
+            server_error!(
+                "no logprobs available for generative scoring item {index}; \
+                 this might indicate an issue with logprobs configuration"
+            )
+        })?;
+        let score = compute_score(position, &label_token_ids, apply_softmax, index)?;
+
+        data.push(GenerativeScoringItemResult {
+            index,
+            object: "score",
+            score,
+        });
+        usage.prompt_token_count += output.usage.prompt_token_count;
+        usage.output_token_count += output.usage.output_token_count;
+        usage.cached_token_count += output.usage.cached_token_count;
+    }
+
+    if enable_log_requests {
+        info!(
+            prompt_tokens = usage.prompt_token_count,
+            output_tokens = usage.output_token_count,
+            "generative scoring finished"
+        );
+    }
+
+    Ok(GenerativeScoringResponse {
+        id: request_id,
+        object: "list",
+        created,
+        model: response_model,
+        data,
+        usage: Usage::from_counts(usage.prompt_token_count, usage.output_token_count, None, 0),
+    })
+}
+
+fn compute_score(
+    position: &PositionLogprobs,
+    label_token_ids: &[u32],
+    apply_softmax: bool,
+    item_index: usize,
+) -> Result<f64, ApiError> {
+    let mut returned_logprobs = HashMap::new();
+    for entry in &position.entries {
+        returned_logprobs.insert(entry.token_id, f64::from(entry.logprob));
+    }
+
+    let mut label_logprobs = HashMap::new();
+    let mut missing_token_ids = Vec::new();
+    for token_id in label_token_ids {
+        if let Some(logprob) = returned_logprobs.get(token_id) {
+            label_logprobs.insert(*token_id, *logprob);
+        } else {
+            missing_token_ids.push(*token_id);
+        }
+    }
+
+    if !missing_token_ids.is_empty() {
+        return Err(server_error!(
+            "Token IDs {:?} not found in logprobs for generative scoring item {}.",
+            missing_token_ids,
+            item_index
+        ));
+    }
+
+    let first_label_id = label_token_ids[0];
+    if apply_softmax {
+        let max_logprob = label_logprobs.values().copied().fold(f64::NEG_INFINITY, f64::max);
+        let sum_exp: f64 =
+            label_logprobs.values().map(|logprob| (logprob - max_logprob).exp()).sum();
+        let first_logprob = label_logprobs[&first_label_id];
+        Ok((first_logprob - max_logprob).exp() / sum_exp)
+    } else {
+        Ok(label_logprobs[&first_label_id].exp())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vllm_engine_core_client::protocol::logprobs::TokenLogprob;
+
+    fn served(names: &[&str]) -> LoraModelResolution {
+        LoraModelResolution {
+            model_names: names.iter().map(|name| (*name).to_string()).collect(),
+            lora_request: None,
+        }
+    }
+
+    fn base_request() -> GenerativeScoringRequest {
+        serde_json::from_value(serde_json::json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "query": "question",
+            "items": ["yes"],
+            "label_token_ids": [10, 20]
+        }))
+        .expect("parse request")
+    }
+
+    #[test]
+    fn generative_scoring_request_deserializes_text_and_token_inputs() {
+        let text_request: GenerativeScoringRequest = serde_json::from_value(serde_json::json!({
+            "query": "question",
+            "items": ["yes", "no"],
+            "label_token_ids": [10, 20]
+        }))
+        .expect("parse text request");
+        assert_eq!(
+            text_request.query,
+            GenerativeScoringInput::Text("question".to_string())
+        );
+        assert_eq!(
+            text_request.items,
+            GenerativeScoringItems::Text(vec!["yes".to_string(), "no".to_string()])
+        );
+        assert!(text_request.apply_softmax);
+        assert!(text_request.add_special_tokens);
+
+        let token_request: GenerativeScoringRequest = serde_json::from_value(serde_json::json!({
+            "query": [1, 2],
+            "items": [[3, 4], [5, 6]],
+            "label_token_ids": [10, 20],
+            "apply_softmax": false,
+            "item_first": true,
+            "add_special_tokens": false
+        }))
+        .expect("parse token request");
+        assert_eq!(
+            token_request.query,
+            GenerativeScoringInput::TokenIds(vec![1, 2])
+        );
+        assert_eq!(
+            token_request.items,
+            GenerativeScoringItems::TokenIds(vec![vec![3, 4], vec![5, 6]])
+        );
+        assert!(!token_request.apply_softmax);
+        assert!(token_request.item_first);
+        assert!(!token_request.add_special_tokens);
+    }
+
+    #[test]
+    fn validate_generative_scoring_request_checks_model_items_and_labels() {
+        let served = served(&["Qwen/Qwen1.5-0.5B-Chat"]);
+
+        let wrong_model = GenerativeScoringRequest {
+            model: Some("missing".to_string()),
+            ..base_request()
+        };
+        assert!(validate_generative_scoring_request(&wrong_model, &served, 100).is_err());
+
+        let empty_labels = GenerativeScoringRequest {
+            label_token_ids: Vec::new(),
+            ..base_request()
+        };
+        assert!(validate_generative_scoring_request(&empty_labels, &served, 100).is_err());
+
+        let out_of_vocab = GenerativeScoringRequest {
+            label_token_ids: vec![99, 100],
+            ..base_request()
+        };
+        assert!(validate_generative_scoring_request(&out_of_vocab, &served, 100).is_err());
+    }
+
+    #[test]
+    fn concat_and_truncate_prompt_respects_item_order() {
+        assert_eq!(
+            concat_and_truncate_prompt(&[100, 101], &[200, 201], false, 10),
+            vec![100, 101, 200, 201]
+        );
+        assert_eq!(
+            concat_and_truncate_prompt(&[100, 101], &[200, 201], true, 10),
+            vec![200, 201, 100, 101]
+        );
+        assert_eq!(
+            concat_and_truncate_prompt(&[100, 101], &[200, 201], false, 3),
+            vec![100, 101, 200]
+        );
+    }
+
+    #[test]
+    fn compute_score_supports_softmax_and_true_probability_modes() {
+        let position = PositionLogprobs {
+            entries: vec![
+                TokenLogprob {
+                    token_id: 10,
+                    logprob: -0.5,
+                    rank: 1,
+                },
+                TokenLogprob {
+                    token_id: 20,
+                    logprob: -2.0,
+                    rank: 2,
+                },
+            ],
+        };
+
+        let softmax_score = compute_score(&position, &[10, 20], true, 0).expect("softmax score");
+        let expected = (-0.5_f64).exp() / ((-0.5_f64).exp() + (-2.0_f64).exp());
+        assert!((softmax_score - expected).abs() < 1e-9);
+
+        let true_probability = compute_score(&position, &[10, 20], false, 0).expect("true prob");
+        assert!((true_probability - (-0.5_f64).exp()).abs() < 1e-9);
+    }
+}

--- a/rust/src/server/src/routes/inference/generative_scoring.rs
+++ b/rust/src/server/src/routes/inference/generative_scoring.rs
@@ -162,7 +162,15 @@ fn prepare_generative_scoring_request(
     ctx: ResolvedRequestContext,
     state: &AppState,
 ) -> Result<PreparedGenerativeScoringRequest, ApiError> {
-    validate_generative_scoring_request(&request, lora_resolution, state.chat.model_vocab_size())?;
+    let ready = state.chat.engine_core_client().ready_response();
+    let max_items = usize::try_from(ready.max_num_seqs).unwrap_or(usize::MAX);
+    validate_generative_scoring_request(
+        &request,
+        lora_resolution,
+        state.chat.model_vocab_size(),
+        max_items,
+        ready.use_spec_decode,
+    )?;
 
     let request_id = format!("generative-scoring-{}", ctx.request_id);
     let response_model = lora_resolution
@@ -227,6 +235,8 @@ fn validate_generative_scoring_request(
     request: &GenerativeScoringRequest,
     lora_resolution: &LoraModelResolution,
     model_vocab_size: usize,
+    max_items: usize,
+    use_spec_decode: bool,
 ) -> Result<(), ApiError> {
     if let Some(model) = request.model.as_ref()
         && !lora_resolution.model_names.iter().any(|name| name == model)
@@ -243,6 +253,19 @@ fn validate_generative_scoring_request(
 
     if request.items.is_empty() {
         bail_invalid_request!(param = "items", "items must contain at least one item.");
+    }
+
+    if request.items.len() > max_items {
+        bail_invalid_request!(
+            param = "items",
+            "items must contain at most {max_items} items for this server."
+        );
+    }
+
+    if use_spec_decode {
+        bail_invalid_request!(
+            "Generative scoring is not supported when speculative decoding is enabled."
+        );
     }
 
     let invalid_token_ids: Vec<_> = request
@@ -268,6 +291,13 @@ impl GenerativeScoringItems {
         match self {
             Self::Text(items) => items.is_empty(),
             Self::TokenIds(items) => items.is_empty(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Text(items) => items.len(),
+            Self::TokenIds(items) => items.len(),
         }
     }
 }
@@ -516,19 +546,37 @@ mod tests {
             model: Some("missing".to_string()),
             ..base_request()
         };
-        assert!(validate_generative_scoring_request(&wrong_model, &served, 100).is_err());
+        assert!(
+            validate_generative_scoring_request(&wrong_model, &served, 100, 256, false).is_err()
+        );
 
         let empty_labels = GenerativeScoringRequest {
             label_token_ids: Vec::new(),
             ..base_request()
         };
-        assert!(validate_generative_scoring_request(&empty_labels, &served, 100).is_err());
+        assert!(
+            validate_generative_scoring_request(&empty_labels, &served, 100, 256, false).is_err()
+        );
 
         let out_of_vocab = GenerativeScoringRequest {
             label_token_ids: vec![99, 100],
             ..base_request()
         };
-        assert!(validate_generative_scoring_request(&out_of_vocab, &served, 100).is_err());
+        assert!(
+            validate_generative_scoring_request(&out_of_vocab, &served, 100, 256, false).is_err()
+        );
+
+        let too_many_items = GenerativeScoringRequest {
+            items: GenerativeScoringItems::Text(vec!["one".to_string(), "two".to_string()]),
+            ..base_request()
+        };
+        assert!(
+            validate_generative_scoring_request(&too_many_items, &served, 100, 1, false).is_err()
+        );
+
+        assert!(
+            validate_generative_scoring_request(&base_request(), &served, 100, 256, true).is_err()
+        );
     }
 
     #[test]

--- a/rust/src/server/src/routes/inference/mod.rs
+++ b/rust/src/server/src/routes/inference/mod.rs
@@ -1,3 +1,5 @@
 pub mod generate;
+pub mod generative_scoring;
 
 pub use generate::generate;
+pub use generative_scoring::generative_scoring;

--- a/rust/src/server/src/routes/inference/mod.rs
+++ b/rust/src/server/src/routes/inference/mod.rs
@@ -2,5 +2,7 @@
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 pub mod generate;
+pub mod generative_scoring;
 
 pub use generate::generate;
+pub use generative_scoring::generative_scoring;

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -3598,6 +3598,264 @@ async fn non_stream_raw_generate_returns_token_output_envelope() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn generative_scoring_scores_string_items_with_requested_label_logprobs() {
+    let ipc = IpcNamespace::new().expect("create ipc namespace");
+    let handshake_address = ipc.handshake_endpoint();
+    let engine_id = b"engine-generative-scoring".to_vec();
+
+    let engine_task = MockEngineTask::new(spawn_mock_engine_task(
+        handshake_address.clone(),
+        engine_id.clone(),
+        |dealer, push| {
+            boxed_test_future(async move {
+                let expected_prompts = [
+                    vec![FAKE_BOS_TOKEN_ID, b'Q' as u32, b'A' as u32],
+                    vec![FAKE_BOS_TOKEN_ID, b'Q' as u32, b'B' as u32],
+                ];
+                let label_logprobs = [(-0.5_f32, -2.0_f32), (-2.0_f32, -0.5_f32)];
+
+                for (index, expected_prompt) in expected_prompts.into_iter().enumerate() {
+                    let add = recv_engine_message(dealer).await;
+                    let request: EngineCoreRequest =
+                        rmp_serde::from_slice(&add[1]).expect("decode request");
+                    assert_eq!(
+                        request.prompt_token_ids.as_deref(),
+                        Some(expected_prompt.as_slice())
+                    );
+                    assert_eq!(
+                        request.external_req_id.as_deref(),
+                        Some(format!("generative-scoring-score-req-{index}").as_str())
+                    );
+                    let sampling_params =
+                        request.sampling_params.as_ref().expect("sampling params");
+                    assert_eq!(sampling_params.max_tokens, 1);
+                    assert_eq!(sampling_params.logprobs, Some(2));
+                    assert_eq!(sampling_params.logprob_token_ids, Some(vec![10, 20]));
+
+                    let (first, second) = label_logprobs[index];
+                    send_outputs(
+                        push,
+                        EngineCoreOutputs {
+                            engine_index: 0,
+                            outputs: vec![request_output_with_logprobs(
+                                &request.request_id,
+                                vec![99],
+                                Some(EngineCoreFinishReason::Stop),
+                                None,
+                                Some(Logprobs {
+                                    positions: vec![PositionLogprobs {
+                                        entries: vec![
+                                            TokenLogprob {
+                                                token_id: 10,
+                                                logprob: first,
+                                                rank: 1,
+                                            },
+                                            TokenLogprob {
+                                                token_id: 20,
+                                                logprob: second,
+                                                rank: 2,
+                                            },
+                                        ],
+                                    }],
+                                }),
+                                None,
+                            )],
+                            ..Default::default()
+                        },
+                    )
+                    .await;
+                }
+            })
+        },
+    ));
+
+    let client = EngineCoreClient::connect(
+        EngineCoreClientConfig::new_single(handshake_address)
+            .with_model_name("test-model")
+            .with_local_input_output_addresses(
+                Some(ipc.input_endpoint()),
+                Some(ipc.output_endpoint()),
+            ),
+    )
+    .await
+    .expect("connect client");
+    let chat = ChatLlm::from_shared_backend(test_llm(client), Arc::new(FakeChatBackend::new()));
+    let mut app = build_router(Arc::new(AppState::new(
+        vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()],
+        chat,
+    )));
+
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/generative_scoring")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "request_id": "score-req",
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "query": "Q",
+                        "items": ["A", "B"],
+                        "label_token_ids": [10, 20]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    engine_task.await.expect("mock engine task");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+
+    assert_eq!(json["id"], "generative-scoring-score-req");
+    assert_eq!(json["object"], "list");
+    assert_eq!(json["model"], "Qwen/Qwen1.5-0.5B-Chat");
+    assert_eq!(json["data"][0]["index"], 0);
+    assert_eq!(json["data"][0]["object"], "score");
+    assert_eq!(json["data"][1]["index"], 1);
+    let first_score = json["data"][0]["score"].as_f64().expect("first score");
+    let second_score = json["data"][1]["score"].as_f64().expect("second score");
+    let expected_first = (-0.5_f64).exp() / ((-0.5_f64).exp() + (-2.0_f64).exp());
+    let expected_second = (-2.0_f64).exp() / ((-2.0_f64).exp() + (-0.5_f64).exp());
+    assert!((first_score - expected_first).abs() < 1e-6);
+    assert!((second_score - expected_second).abs() < 1e-6);
+    assert_eq!(json["usage"]["prompt_tokens"], 6);
+    assert_eq!(json["usage"]["completion_tokens"], 2);
+    assert_eq!(json["usage"]["total_tokens"], 8);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn generative_scoring_supports_token_id_item_first_and_true_probabilities() {
+    let ipc = IpcNamespace::new().expect("create ipc namespace");
+    let handshake_address = ipc.handshake_endpoint();
+    let engine_id = b"engine-generative-scoring-token-ids".to_vec();
+
+    let engine_task = MockEngineTask::new(spawn_mock_engine_task(
+        handshake_address.clone(),
+        engine_id.clone(),
+        |dealer, push| {
+            boxed_test_future(async move {
+                let add = recv_engine_message(dealer).await;
+                let request: EngineCoreRequest =
+                    rmp_serde::from_slice(&add[1]).expect("decode request");
+                assert_eq!(request.prompt_token_ids.as_deref(), Some(&[3, 4, 1, 2][..]));
+                let sampling_params = request.sampling_params.as_ref().expect("sampling params");
+                assert_eq!(sampling_params.logprob_token_ids, Some(vec![10, 20]));
+
+                send_outputs(
+                    push,
+                    EngineCoreOutputs {
+                        engine_index: 0,
+                        outputs: vec![request_output_with_logprobs(
+                            &request.request_id,
+                            vec![99],
+                            Some(EngineCoreFinishReason::Stop),
+                            None,
+                            Some(Logprobs {
+                                positions: vec![PositionLogprobs {
+                                    entries: vec![
+                                        TokenLogprob {
+                                            token_id: 10,
+                                            logprob: -0.5,
+                                            rank: 1,
+                                        },
+                                        TokenLogprob {
+                                            token_id: 20,
+                                            logprob: -2.0,
+                                            rank: 2,
+                                        },
+                                    ],
+                                }],
+                            }),
+                            None,
+                        )],
+                        ..Default::default()
+                    },
+                )
+                .await;
+            })
+        },
+    ));
+
+    let client = EngineCoreClient::connect(
+        EngineCoreClientConfig::new_single(handshake_address)
+            .with_model_name("test-model")
+            .with_local_input_output_addresses(
+                Some(ipc.input_endpoint()),
+                Some(ipc.output_endpoint()),
+            ),
+    )
+    .await
+    .expect("connect client");
+    let chat = ChatLlm::from_shared_backend(test_llm(client), Arc::new(FakeChatBackend::new()));
+    let mut app = build_router(Arc::new(AppState::new(
+        vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()],
+        chat,
+    )));
+
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/generative_scoring")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "request_id": "score-token-ids",
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "query": [1, 2],
+                        "items": [[3, 4]],
+                        "label_token_ids": [10, 20],
+                        "item_first": true,
+                        "apply_softmax": false
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    engine_task.await.expect("mock engine task");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+
+    let score = json["data"][0]["score"].as_f64().expect("score");
+    assert!((score - (-0.5_f64).exp()).abs() < 1e-6);
+    assert_eq!(json["usage"]["prompt_tokens"], 4);
+    assert_eq!(json["usage"]["completion_tokens"], 1);
+    assert_eq!(json["usage"]["total_tokens"], 5);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn generative_scoring_empty_items_returns_400() {
+    let mut app = test_app().await;
+
+    let (status, json) = post_json(
+        &mut app,
+        "/generative_scoring",
+        json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "query": "Q",
+            "items": [],
+            "label_token_ids": [10, 20]
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(json["error"]["message"].as_str().expect("message").contains("items"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn stream_raw_generate_returns_sse_chunks_and_usage() {
     let ipc = IpcNamespace::new().expect("create ipc namespace");
     let handshake_address = ipc.handshake_endpoint();

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -4530,6 +4530,62 @@ async fn generative_scoring_empty_items_returns_400() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn generative_scoring_rejects_items_above_engine_sequence_limit() {
+    let ready = vllm_engine_core_client::protocol::handshake::EngineCoreReadyResponse {
+        max_num_seqs: 1,
+        ..default_ready_response()
+    };
+    let (mut app, _engine_task) = test_dev_mode_app_with_ready(ready).await;
+
+    let (status, json) = post_json(
+        &mut app,
+        "/generative_scoring",
+        json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "query": "Q",
+            "items": ["A", "B"],
+            "label_token_ids": [10, 20]
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["error"]["param"], "items");
+    assert!(json["error"]["message"].as_str().expect("message").contains("at most 1"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn generative_scoring_rejects_speculative_decoding() {
+    let ready = vllm_engine_core_client::protocol::handshake::EngineCoreReadyResponse {
+        use_spec_decode: true,
+        ..default_ready_response()
+    };
+    let (mut app, _engine_task) = test_dev_mode_app_with_ready(ready).await;
+
+    let (status, json) = post_json(
+        &mut app,
+        "/generative_scoring",
+        json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "query": "Q",
+            "items": ["A"],
+            "label_token_ids": [10, 20]
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .expect("message")
+            .contains("speculative decoding")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn stream_raw_generate_returns_sse_chunks_and_usage() {
     let ipc = IpcNamespace::new().expect("create ipc namespace");
     let handshake_address = ipc.handshake_endpoint();

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -4272,6 +4272,264 @@ async fn non_stream_raw_generate_returns_token_output_envelope() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn generative_scoring_scores_string_items_with_requested_label_logprobs() {
+    let ipc = IpcNamespace::new().expect("create ipc namespace");
+    let handshake_address = ipc.handshake_endpoint();
+    let engine_id = b"engine-generative-scoring".to_vec();
+
+    let engine_task = MockEngineTask::new(spawn_mock_engine_task(
+        handshake_address.clone(),
+        engine_id.clone(),
+        |dealer, push| {
+            boxed_test_future(async move {
+                let expected_prompts = [
+                    vec![FAKE_BOS_TOKEN_ID, b'Q' as u32, b'A' as u32],
+                    vec![FAKE_BOS_TOKEN_ID, b'Q' as u32, b'B' as u32],
+                ];
+                let label_logprobs = [(-0.5_f32, -2.0_f32), (-2.0_f32, -0.5_f32)];
+
+                for (index, expected_prompt) in expected_prompts.into_iter().enumerate() {
+                    let add = recv_engine_message(dealer).await;
+                    let request: EngineCoreRequest =
+                        rmp_serde::from_slice(&add[1]).expect("decode request");
+                    assert_eq!(
+                        request.prompt_token_ids.as_deref(),
+                        Some(expected_prompt.as_slice())
+                    );
+                    assert_eq!(
+                        request.external_req_id.as_deref(),
+                        Some(format!("generative-scoring-score-req-{index}").as_str())
+                    );
+                    let sampling_params =
+                        request.sampling_params.as_ref().expect("sampling params");
+                    assert_eq!(sampling_params.max_tokens, 1);
+                    assert_eq!(sampling_params.logprobs, Some(2));
+                    assert_eq!(sampling_params.logprob_token_ids, Some(vec![10, 20]));
+
+                    let (first, second) = label_logprobs[index];
+                    send_outputs(
+                        push,
+                        RequestBatchOutputs {
+                            outputs: vec![request_output_with_logprobs(
+                                &request.request_id,
+                                vec![99],
+                                Some(EngineCoreFinishReason::Stop),
+                                None,
+                                Some(Logprobs {
+                                    positions: vec![PositionLogprobs {
+                                        entries: vec![
+                                            TokenLogprob {
+                                                token_id: 10,
+                                                logprob: first,
+                                                rank: 1,
+                                            },
+                                            TokenLogprob {
+                                                token_id: 20,
+                                                logprob: second,
+                                                rank: 2,
+                                            },
+                                        ],
+                                    }],
+                                }),
+                                None,
+                            )],
+                            ..Default::default()
+                        }
+                        .into(),
+                    )
+                    .await;
+                }
+            })
+        },
+    ));
+
+    let client = EngineCoreClient::connect(
+        EngineCoreClientConfig::new_single(handshake_address)
+            .with_model_name("test-model")
+            .with_local_input_output_addresses(
+                Some(ipc.input_endpoint()),
+                Some(ipc.output_endpoint()),
+            ),
+    )
+    .await
+    .expect("connect client");
+    let chat = ChatLlm::from_shared_backend(test_llm(client), Arc::new(FakeChatBackend::new()));
+    let mut app = build_router(Arc::new(AppState::new(
+        vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()],
+        chat,
+    )));
+
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/generative_scoring")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "request_id": "score-req",
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "query": "Q",
+                        "items": ["A", "B"],
+                        "label_token_ids": [10, 20]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    engine_task.await.expect("mock engine task");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+
+    assert_eq!(json["id"], "generative-scoring-score-req");
+    assert_eq!(json["object"], "list");
+    assert_eq!(json["model"], "Qwen/Qwen1.5-0.5B-Chat");
+    assert_eq!(json["data"][0]["index"], 0);
+    assert_eq!(json["data"][0]["object"], "score");
+    assert_eq!(json["data"][1]["index"], 1);
+    let first_score = json["data"][0]["score"].as_f64().expect("first score");
+    let second_score = json["data"][1]["score"].as_f64().expect("second score");
+    let expected_first = (-0.5_f64).exp() / ((-0.5_f64).exp() + (-2.0_f64).exp());
+    let expected_second = (-2.0_f64).exp() / ((-2.0_f64).exp() + (-0.5_f64).exp());
+    assert!((first_score - expected_first).abs() < 1e-6);
+    assert!((second_score - expected_second).abs() < 1e-6);
+    assert_eq!(json["usage"]["prompt_tokens"], 6);
+    assert_eq!(json["usage"]["completion_tokens"], 2);
+    assert_eq!(json["usage"]["total_tokens"], 8);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn generative_scoring_supports_token_id_item_first_and_true_probabilities() {
+    let ipc = IpcNamespace::new().expect("create ipc namespace");
+    let handshake_address = ipc.handshake_endpoint();
+    let engine_id = b"engine-generative-scoring-token-ids".to_vec();
+
+    let engine_task = MockEngineTask::new(spawn_mock_engine_task(
+        handshake_address.clone(),
+        engine_id.clone(),
+        |dealer, push| {
+            boxed_test_future(async move {
+                let add = recv_engine_message(dealer).await;
+                let request: EngineCoreRequest =
+                    rmp_serde::from_slice(&add[1]).expect("decode request");
+                assert_eq!(request.prompt_token_ids.as_deref(), Some(&[3, 4, 1, 2][..]));
+                let sampling_params = request.sampling_params.as_ref().expect("sampling params");
+                assert_eq!(sampling_params.logprob_token_ids, Some(vec![10, 20]));
+
+                send_outputs(
+                    push,
+                    RequestBatchOutputs {
+                        outputs: vec![request_output_with_logprobs(
+                            &request.request_id,
+                            vec![99],
+                            Some(EngineCoreFinishReason::Stop),
+                            None,
+                            Some(Logprobs {
+                                positions: vec![PositionLogprobs {
+                                    entries: vec![
+                                        TokenLogprob {
+                                            token_id: 10,
+                                            logprob: -0.5,
+                                            rank: 1,
+                                        },
+                                        TokenLogprob {
+                                            token_id: 20,
+                                            logprob: -2.0,
+                                            rank: 2,
+                                        },
+                                    ],
+                                }],
+                            }),
+                            None,
+                        )],
+                        ..Default::default()
+                    }
+                    .into(),
+                )
+                .await;
+            })
+        },
+    ));
+
+    let client = EngineCoreClient::connect(
+        EngineCoreClientConfig::new_single(handshake_address)
+            .with_model_name("test-model")
+            .with_local_input_output_addresses(
+                Some(ipc.input_endpoint()),
+                Some(ipc.output_endpoint()),
+            ),
+    )
+    .await
+    .expect("connect client");
+    let chat = ChatLlm::from_shared_backend(test_llm(client), Arc::new(FakeChatBackend::new()));
+    let mut app = build_router(Arc::new(AppState::new(
+        vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()],
+        chat,
+    )));
+
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/generative_scoring")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "request_id": "score-token-ids",
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "query": [1, 2],
+                        "items": [[3, 4]],
+                        "label_token_ids": [10, 20],
+                        "item_first": true,
+                        "apply_softmax": false
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    engine_task.await.expect("mock engine task");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+
+    let score = json["data"][0]["score"].as_f64().expect("score");
+    assert!((score - (-0.5_f64).exp()).abs() < 1e-6);
+    assert_eq!(json["usage"]["prompt_tokens"], 4);
+    assert_eq!(json["usage"]["completion_tokens"], 1);
+    assert_eq!(json["usage"]["total_tokens"], 5);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn generative_scoring_empty_items_returns_400() {
+    let mut app = test_app().await;
+
+    let (status, json) = post_json(
+        &mut app,
+        "/generative_scoring",
+        json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "query": "Q",
+            "items": [],
+            "label_token_ids": [10, 20]
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(json["error"]["message"].as_str().expect("message").contains("items"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn stream_raw_generate_returns_sse_chunks_and_usage() {
     let ipc = IpcNamespace::new().expect("create ipc namespace");
     let handshake_address = ipc.handshake_endpoint();

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -102,6 +102,7 @@ class EngineCoreReadyResponse:
     weight_transfer_backend: str | None = None
     enable_sleep_mode: bool = False
     supports_draft_weight_updates: bool = False
+    use_spec_decode: bool = False
 
 
 class EngineCoreRequest(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1700,6 +1700,7 @@ class EngineCoreProc(EngineCore):
             supports_draft_weight_updates=(
                 self.model_executor.supports_draft_weight_updates()
             ),
+            use_spec_decode=self.use_spec_decode,
         )
 
     def process_input_sockets(


### PR DESCRIPTION
## Summary

Adds Rust frontend parity for the vLLM `/generative_scoring` route.

This change:

- adds Rust request and response types for `/generative_scoring`
- builds one prompt per item from `query` and `items`
- supports text and pre-tokenized token-ID inputs
- supports `item_first`, `add_special_tokens`, and `apply_softmax`
- validates the model, item count, non-empty `label_token_ids`, and label-token vocabulary range
- bounds item fan-out by the engine-reported `max_num_seqs` before tokenization or request construction
- rejects generative scoring when the engine reports speculative decoding is enabled, avoiding the restricted-logprob crash tracked in #42592 while #44727 owns the sampler-level fix
- submits scoring requests through the existing raw generation path with `max_tokens = 1`, `logprobs = len(label_token_ids)`, and `logprob_token_ids = label_token_ids`
- returns Python-compatible `id`, `object`, `created`, `model`, `data`, and `usage` fields

The speculative-decoding guard adds `use_spec_decode` to the existing engine ready handshake. This PR does not change sampler or backend behavior. It is part of the Rust frontend parity work tracked in #44280.

## Current-base refresh

Rebased onto `main` at `6865e67f0b`. The route uses the current `EngineCoreOutputs` enum and `TextRequest` fields and reports zero reasoning tokens through the current usage API. The `/generative_scoring` route remains generally available; the newer `/inference/v1/generate` route remains behind `VLLM_ENABLE_SCALE_OUT_ENDPOINTS` as intended upstream.

## Non-duplication

A fresh open-PR and current-source search found no other Rust frontend implementation of `/generative_scoring`.

Related but non-duplicative PRs include #39351, #44727, #43463, #44845, and #44153. In particular, #44727 owns the sampler-level speculative-decoding fix; this PR only prevents the new Rust route from reaching that unsafe path on the current base.

## Tests

```bash
cargo fmt --all -- --check
cargo test -p vllm-server generative_scoring
cargo test -p vllm-server
cargo test -p vllm-engine-core-client
cargo clippy -p vllm-server -p vllm-engine-core-client --lib --tests -- -D warnings
.venv/bin/python -m py_compile vllm/v1/engine/__init__.py vllm/v1/engine/core.py rust/src/engine-core-client/src/tests/python_compat.py
uvx ruff@0.14.1 check vllm/v1/engine/__init__.py vllm/v1/engine/core.py rust/src/engine-core-client/src/tests/python_compat.py
uvx ruff@0.14.1 format --check vllm/v1/engine/__init__.py vllm/v1/engine/core.py rust/src/engine-core-client/src/tests/python_compat.py
git diff --check
```

Results on the current base:

- focused generative-scoring tests: `9 passed`
- full `vllm-server` suite: `391 passed`
- full `vllm-engine-core-client` suite: `102 passed`
- Rust formatting and library/test Clippy with warnings denied: passed
- Python compilation, Ruff lint, Ruff formatting, and whitespace checks: passed

The full test build emits an existing future-incompatibility warning in `external_engine_openai_qwen.rs`; this PR does not modify that example.

## AI assistance disclosure

AI assistance was used in preparing this change. I reviewed the changed files and ran the tests listed above.
