### PR TITLE
[CI] Fix compressed-tensors MoE weight_shape loading regression

### DIFF
--- a/tests/kernels/moe/test_moe_weight_loading_padded.py
+++ b/tests/kernels/moe/test_moe_weight_loading_padded.py
@@ -346,3 +346,53 @@ class TestPerTensorScaleCoercion:
         # numel > 1 must fail loudly instead of silently picking an element.
         with pytest.raises(RuntimeError):
             RoutedExperts._to_scalar(torch.tensor([0.1, 0.2]))
+
+
+class TestWeightShapeLoading:
+    """Regression test for compressed-tensors MoE weight_shape vectors."""
+
+    @staticmethod
+    def _make_minimal_wna16_moe():
+        def map_global_expert_id_to_local_expert_id(expert_id):
+            return expert_id
+
+        moe = object.__new__(RoutedExperts)
+        moe.quant_config = None
+        moe.quant_method = type("CompressedTensorsWNA16MoEMethod", (), {})()
+        moe._map_global_expert_id_to_local_expert_id = (
+            map_global_expert_id_to_local_expert_id
+        )
+        return moe
+
+    def test_loads_vector_shape(self):
+        moe = self._make_minimal_wna16_moe()
+        param = torch.nn.Parameter(torch.empty(2, 2), requires_grad=False)
+        loaded_weight = torch.tensor([4096, 14336], dtype=torch.int64)
+
+        loaded = RoutedExperts.weight_loader(
+            moe,
+            param,
+            loaded_weight,
+            weight_name="w2_weight_shape",
+            shard_id="w2",
+            expert_id=1,
+            return_success=True,
+        )
+
+        assert loaded is True
+        assert torch.equal(param.data[1], loaded_weight.to(param.data.dtype))
+
+    def test_rejects_shape_size_mismatch(self):
+        moe = self._make_minimal_wna16_moe()
+        param = torch.nn.Parameter(torch.empty(2, 2), requires_grad=False)
+        loaded_weight = torch.tensor([4096, 14336, 1], dtype=torch.int64)
+
+        with pytest.raises(ValueError, match="weight_shape checkpoint tensor size"):
+            RoutedExperts.weight_loader(
+                moe,
+                param,
+                loaded_weight,
+                weight_name="w2_weight_shape",
+                shard_id="w2",
+                expert_id=1,
+            )

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -533,6 +533,20 @@ class RoutedExperts(PluggableLayer):
         # Input scales can be loaded directly and should be equal.
         param_data[expert_id] = self._to_scalar(loaded_weight)
 
+    def _load_weight_shape(
+        self, param: torch.nn.Parameter, loaded_weight: torch.Tensor, expert_id: int
+    ):
+        param_data = param.data
+        target = param_data[expert_id]
+
+        if loaded_weight.numel() != target.numel():
+            raise ValueError(
+                "weight_shape checkpoint tensor size does not match the "
+                f"target parameter slot: {loaded_weight.numel()} != {target.numel()}"
+            )
+
+        target.copy_(loaded_weight.reshape_as(target))
+
     def _load_g_idx(
         self,
         shard_id: str,
@@ -840,7 +854,7 @@ class RoutedExperts(PluggableLayer):
         # Case weight_shape
         if "weight_shape" in weight_name:
             # only required by compressed-tensors
-            self._load_single_value(
+            self._load_weight_shape(
                 param=param, loaded_weight=loaded_weight, expert_id=expert_id
             )
             return True if return_success else None


### PR DESCRIPTION
This fixes a ROCm GSM8K startup failure for Qwen1.5-MoE-W4A16-CT. The model was not failing on accuracy, the server died while loading the compressed-tensors W4A16 MoE checkpoint:
- https://buildkite.com/vllm/ci/builds/73581/canvas?sid=019ef1bc-0b02-4f1f-bd3a-bf1609cf54dc&tab=output

The failure started showing up after [vllm-project/vllm#43362](https://github.com/vllm-project/vllm/pull/43362). That change made per-tensor scale loading stricter, which is the right behavior for scalar scale tensors, but the compressed-tensors MoE weight_shape path was still going through the same scalar loader. Those weight_shape values are two-element shape vectors, so the loader tried to reshape a size-2 tensor into a scalar and failed during startup. This PR gives weight_shape its own loading path so it copies the vector into the per-expert slot, while keeping the stricter scalar handling for real scale tensors. I also added a small regression test for the size-2 weight_shape case.