### PR TITLE
[ROCm][CI] Skip Quark mxfp4 tests unless Quark version is compatible with Torch version

### DIFF
--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -26,6 +26,7 @@ from .gsm8k_eval import evaluate_gsm8k
 # MXFP4 via quark requires amd-quark >= 0.12 on torch >= 2.11.
 # Earlier torch releases work with older quark versions. See
 # https://github.com/amd/Quark/issues/34
+# TODO: Remove once amd-quark>=0.12.0
 QUARK_MXFP4_TORCH_COMPATIBLE = find_spec("quark") is not None and (
     version.parse(importlib.metadata.version("amd-quark")) >= version.parse("0.12.0")
     if version.parse(torch.__version__.split("+")[0]) >= version.parse("2.11")

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -9,15 +9,28 @@ pytest -s -v tests/evals/gsm8k/test_gsm8k_correctness.py \
     --config-list-file=configs/models-small.txt
 """
 
+import importlib.metadata
 import shlex
+from importlib.util import find_spec
 
 import pytest
+import torch
 import yaml
+from packaging import version
 
 from tests.utils import RemoteOpenAIServer
 from vllm.platforms import current_platform
 
 from .gsm8k_eval import evaluate_gsm8k
+
+# MXFP4 via quark requires amd-quark >= 0.12 on torch >= 2.11.
+# Earlier torch releases work with older quark versions. See
+# https://github.com/amd/Quark/issues/34
+QUARK_MXFP4_TORCH_COMPATIBLE = find_spec("quark") is not None and (
+    version.parse(importlib.metadata.version("amd-quark")) >= version.parse("0.12.0")
+    if version.parse(torch.__version__.split("+")[0]) >= version.parse("2.11")
+    else True
+)
 
 
 def run_gsm8k_eval(eval_config: dict, server_url: str) -> dict:
@@ -78,15 +91,18 @@ def test_gsm8k_correctness(config_filename):
             "Skipping DeepSeek-V3.2 and DeepSeek-R1 on ROCm platforms "
             "due to agent pool disk space issues and pod evictions."
         )
-    if current_platform.is_rocm() and (
-        "Qwen3.5-35B-A3B-MXFP4-AITER-TP2" in config_filename.name
-    ):
+    if current_platform.is_rocm() and ("Qwen3.5-35B-A3B-MXFP4" in config_filename.name):
         from vllm.platforms.rocm import on_gfx950
 
-        if not on_gfx950():
+        if not on_gfx950() and "AITER-TP2" in config_filename.name:
             pytest.skip(
                 "Skipping Qwen3.5-35B-A3B-MXFP4-AITER-TP2 on non-GFX950 platforms. "
                 "The quantization scheme is not supported on non-GFX950 platforms."
+            )
+        if not QUARK_MXFP4_TORCH_COMPATIBLE:
+            pytest.skip(
+                "Skipping Qwen3.5-35B-A3B-MXFP4: amd-quark >= 0.12 is required "
+                "on torch >= 2.11."
             )
     # Parse server arguments from config (use shlex to handle quoted strings)
     server_args_str = eval_config.get("server_args", "")

--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -13,9 +13,14 @@ from vllm._aiter_ops import is_aiter_found
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
 
-QUARK_MXFP4_AVAILABLE = find_spec("quark") is not None and version.parse(
-    importlib.metadata.version("amd-quark")
-) >= version.parse("0.8.99")
+# MXFP4 via quark requires amd-quark >= 0.12 on torch >= 2.11.
+# Earlier torch releases work with older quark versions. See
+# https://github.com/amd/Quark/issues/34
+QUARK_MXFP4_TORCH_COMPATIBLE = find_spec("quark") is not None and (
+    version.parse(importlib.metadata.version("amd-quark")) >= version.parse("0.12.0")
+    if version.parse(torch.__version__.split("+")[0]) >= version.parse("2.11")
+    else True
+)
 
 TRTLLM_GEN_MXFP4_AVAILABLE = (
     current_platform.is_cuda() and current_platform.is_device_capability_family(100)
@@ -87,7 +92,10 @@ def enable_pickle(monkeypatch):
         ModelCase("fxmarty/Llama-3.1-70B-Instruct-2-layers-mxfp6", tp=4),
     ],
 )
-@pytest.mark.skipif(not QUARK_MXFP4_AVAILABLE, reason="amd-quark>=0.9 is not available")
+@pytest.mark.skipif(
+    not QUARK_MXFP4_TORCH_COMPATIBLE,
+    reason="MXFP4 via quark requires amd-quark >= 0.12 on torch >= 2.11.",
+)
 def test_mxfp4_loading_and_execution_moe(vllm_runner, model_case: ModelCase):
     if torch.accelerator.device_count() < model_case.tp:
         pytest.skip(

--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -16,6 +16,7 @@ from vllm.utils.flashinfer import has_flashinfer
 # MXFP4 via quark requires amd-quark >= 0.12 on torch >= 2.11.
 # Earlier torch releases work with older quark versions. See
 # https://github.com/amd/Quark/issues/34
+# TODO: Remove once amd-quark>=0.12.0
 QUARK_MXFP4_TORCH_COMPATIBLE = find_spec("quark") is not None and (
     version.parse(importlib.metadata.version("amd-quark")) >= version.parse("0.12.0")
     if version.parse(torch.__version__.split("+")[0]) >= version.parse("2.11")


### PR DESCRIPTION

We're seeing an issue in Quark with Torch 2.11. https://buildkite.com/vllm/amd-ci/builds/9797/list?jid=019ef091-cd38-413c-b6af-ca6920a07a81&tab=output

```
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]     from quark.torch.kernel.hw_emulation.hw_emulation_interface import (
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]   File "/usr/local/lib/python3.12/dist-packages/quark/torch/__init__.py", line 14, in <module>
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]     from quark.torch.quantization.api import ModelQuantizer, load_params
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]   File "/usr/local/lib/python3.12/dist-packages/quark/torch/quantization/api.py", line 27, in <module>
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]     from quark.torch.quantization.graph.processor.processor import (
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]   File "/usr/local/lib/python3.12/dist-packages/quark/torch/quantization/graph/processor/processor.py", line 15, in <module>
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]     from quark.torch.quantization.graph.optimization.model_optimization import (
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]   File "/usr/local/lib/python3.12/dist-packages/quark/torch/quantization/graph/optimization/model_optimization.py", line 9, in <module>
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]     import quark.torch.quantization.graph.optimization.post_calib as opt_post_calib_pass
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]   File "/usr/local/lib/python3.12/dist-packages/quark/torch/quantization/graph/optimization/post_calib/__init__.py", line 5, in <module>
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]     from .adjust_bias_scale import AdjustBiasScaleQOPass
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]   File "/usr/local/lib/python3.12/dist-packages/quark/torch/quantization/graph/optimization/post_calib/adjust_bias_scale.py", line 12, in <module>
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]     from quark.torch.quantization.graph.optimization.utils import get_quantizer_scale_pos, is_quantizer_node
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]   File "/usr/local/lib/python3.12/dist-packages/quark/torch/quantization/graph/optimization/utils.py", line 8, in <module>
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229]     from torch.ao.quantization.pt2e.utils import _get_tensor_constant_from_node
(EngineCore pid=3109) ERROR 06-22 18:45:33 [core.py:1229] ModuleNotFoundError: No module named 'torch.ao.quantization.pt2e'
```


The fix will be in Quark 0.12.0 https://github.com/amd/Quark/issues/34.

For now we will skip these tests until Quark 0.12.0 is released.