### PR TITLE
 [XPU] Optimize XPU worker shutdown logic to prevent resource leak

### DIFF
--- a/.buildkite/intel_jobs/basic_correctness.yaml
+++ b/.buildkite/intel_jobs/basic_correctness.yaml
@@ -23,4 +23,5 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
       'cd tests &&
       export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
+      pytest -v -s basic_correctness/test_cpu_offload.py &&
       pytest -v -s basic_correctness/test_mem.py::test_end_to_end'

--- a/.buildkite/intel_jobs/lora_intel.yaml
+++ b/.buildkite/intel_jobs/lora_intel.yaml
@@ -128,10 +128,10 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
       'cd tests &&
       export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
-      (pytest -v -s lora/test_mixtral.py --deselect="tests/lora/test_mixtral.py::test_mixtral_lora[4]" || true) &&
       pytest -v -s lora/test_quant_model.py --deselect="tests/lora/test_quant_model.py::test_quant_model_lora[model0]" --deselect="tests/lora/test_quant_model.py::test_quant_model_lora[model1]" --deselect="tests/lora/test_quant_model.py::test_quant_model_tp_equality[model0]" &&
       pytest -v -s lora/test_transformers_model.py &&
       pytest -v -s lora/test_chatglm3_tp.py &&
+      pytest -v -s lora/test_llama_tp.py::test_llama_lora &&
       pytest -s -v lora/test_minicpmv_tp.py'
 
 - label: LoRA Multimodal

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -604,6 +604,13 @@ class RemoteVLLMServer:
                         mem_info = nvmlDeviceGetMemoryInfo(handle)
                         total_used += mem_info.used
                     return total_used
+            elif current_platform.is_xpu():
+                total_used = 0
+                device_count = current_platform.device_count()
+                for i in range(device_count):
+                    free, total = torch.xpu.mem_get_info(i)
+                    total_used += total - free
+                return total_used
         except Exception as e:
             print(f"[RemoteOpenAIServer] Could not query GPU memory: {e}")
             return None

--- a/vllm/device_allocator/__init__.py
+++ b/vllm/device_allocator/__init__.py
@@ -31,8 +31,6 @@ class MemAllocator(Protocol):
 
     def get_current_usage(self) -> int: ...
 
-    def release_pools(self) -> None: ...
-
 
 def get_mem_allocator_instance() -> MemAllocator:
     if current_platform.is_cuda_alike():

--- a/vllm/device_allocator/__init__.py
+++ b/vllm/device_allocator/__init__.py
@@ -31,6 +31,8 @@ class MemAllocator(Protocol):
 
     def get_current_usage(self) -> int: ...
 
+    def release_pools(self) -> None: ...
+
 
 def get_mem_allocator_instance() -> MemAllocator:
     if current_platform.is_cuda_alike():

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -243,6 +243,16 @@ class XPUPlatform(Platform):
         if "VLLM_WORKER_MULTIPROC_METHOD" not in os.environ:
             os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
+        # XPU requires graceful shutdown to allow oneCCL/Level Zero resources
+        # to be properly released. Without this, subsequent server startups on
+        # the same devices may hang during CCL initialization.
+        if vllm_config.shutdown_timeout == 0:
+            vllm_config.shutdown_timeout = 5
+            logger.info(
+                "XPU platform: set server shutdown_timeout=%d.",
+                vllm_config.shutdown_timeout,
+            )
+
     @classmethod
     def update_block_size_for_backend(cls, vllm_config: "VllmConfig") -> None:
         super().update_block_size_for_backend(vllm_config)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6385,7 +6385,7 @@ class GPUModelRunner(
         _ROPE_DICT.clear()
 
         reset_workspace_manager()
-        if current_platform.is_rocm():
+        if current_platform.is_rocm() or current_platform.is_xpu():
             gc.collect()
             torch.accelerator.empty_cache()
             torch.accelerator.synchronize()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1291,11 +1291,19 @@ class Worker(WorkerBase):
         if model_runner := getattr(self, "model_runner", None):
             model_runner.shutdown()
 
-        # Release kept-alive cumem pools while the pluggable allocator wrappers
+        # Release kept-alive xpumem/cumem pools while the pluggable allocator wrappers
         # and callbacks are still alive, so MemPool teardown is not deferred to
         # interpreter finalization (pytorch/pytorch#145168).
-        allocator = get_mem_allocator_instance()
-        allocator.release_pools()
+        if current_platform.is_cuda_alike():
+            from vllm.device_allocator.cumem import CuMemAllocator
+
+            if CuMemAllocator.instance is not None:
+                CuMemAllocator.instance.release_pools()
+        if current_platform.is_xpu():
+            from vllm.device_allocator.xpumem import XpuMemAllocator
+
+            if XpuMemAllocator.instance is not None:
+                XpuMemAllocator.instance.release_pools()
 
     def elastic_ep_execute(self, execute_method: str, *args, **kwargs):
         return self.elastic_ep_executor.execute(execute_method, *args, **kwargs)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1294,10 +1294,11 @@ class Worker(WorkerBase):
         # Release kept-alive cumem pools while the pluggable allocator wrappers
         # and callbacks are still alive, so MemPool teardown is not deferred to
         # interpreter finalization (pytorch/pytorch#145168).
-        from vllm.device_allocator.cumem import CuMemAllocator
+        if current_platform.is_cuda():
+            from vllm.device_allocator.cumem import CuMemAllocator
 
-        if CuMemAllocator.instance is not None:
-            CuMemAllocator.instance.release_pools()
+            if CuMemAllocator.instance is not None:
+                CuMemAllocator.instance.release_pools()
 
     def elastic_ep_execute(self, execute_method: str, *args, **kwargs):
         return self.elastic_ep_executor.execute(execute_method, *args, **kwargs)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1291,7 +1291,7 @@ class Worker(WorkerBase):
         if model_runner := getattr(self, "model_runner", None):
             model_runner.shutdown()
 
-        # Release kept-alive xpumem/cumem pools while the pluggable allocator wrappers
+        # Release kept-alive cumem pools while the pluggable allocator wrappers
         # and callbacks are still alive, so MemPool teardown is not deferred to
         # interpreter finalization (pytorch/pytorch#145168).
         if current_platform.is_cuda_alike():

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1299,11 +1299,6 @@ class Worker(WorkerBase):
 
             if CuMemAllocator.instance is not None:
                 CuMemAllocator.instance.release_pools()
-        if current_platform.is_xpu():
-            from vllm.device_allocator.xpumem import XpuMemAllocator
-
-            if XpuMemAllocator.instance is not None:
-                XpuMemAllocator.instance.release_pools()
 
     def elastic_ep_execute(self, execute_method: str, *args, **kwargs):
         return self.elastic_ep_executor.execute(execute_method, *args, **kwargs)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1294,11 +1294,8 @@ class Worker(WorkerBase):
         # Release kept-alive cumem pools while the pluggable allocator wrappers
         # and callbacks are still alive, so MemPool teardown is not deferred to
         # interpreter finalization (pytorch/pytorch#145168).
-        if current_platform.is_cuda():
-            from vllm.device_allocator.cumem import CuMemAllocator
-
-            if CuMemAllocator.instance is not None:
-                CuMemAllocator.instance.release_pools()
+        allocator = get_mem_allocator_instance()
+        allocator.release_pools()
 
     def elastic_ep_execute(self, execute_method: str, *args, **kwargs):
         return self.elastic_ep_executor.execute(execute_method, *args, **kwargs)

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -162,3 +162,16 @@ class XPUWorker(Worker):
             logger.debug("Starting torch profiler with trace name: %s", trace_name)
 
         super().profile(is_start=is_start, profile_prefix=profile_prefix)
+
+    def shutdown(self) -> None:
+        logger.info(
+            "XPUWorker shutdown: cleaning up (rank=%d, local_rank=%d)",
+            self.rank,
+            self.local_rank,
+        )
+        super().shutdown()
+        logger.info(
+            "XPUWorker shutdown: done (rank=%d, local_rank=%d)",
+            self.rank,
+            self.local_rank,
+        )

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -170,6 +170,10 @@ class XPUWorker(Worker):
             self.local_rank,
         )
         super().shutdown()
+        from vllm.device_allocator.xpumem import XpuMemAllocator
+
+        if XpuMemAllocator.instance is not None:
+            XpuMemAllocator.instance.release_pools()
         logger.info(
             "XPUWorker shutdown: done (rank=%d, local_rank=%d)",
             self.rank,


### PR DESCRIPTION
## Purpose:
Optimize the XPU shutdown flow to properly release oneCCL/Level Zero resources when vLLM server stops. 

This also fixes a hang issue where repeated server startups on the same XPU devices would deadlock during oneCCL initialization.

## Problem:
With the default shutdown_timeout=0 (abort mode), worker processes are force-killed without executing cleanup code. On XPU, this leaves Level Zero driver resources unreleased, causing subsequent server startups on the same devices to hang at oneCCL all_reduce.

## Fix:
- Set shutdown_timeout=5 for XPU platform, enabling drain mode so workers can run destroy_model_parallel() and
  destroy_distributed_environment() before exit
- Add gc.collect() + empty_cache() + synchronize() in model runner shutdown for XPU (matching existing ROCm behavior)

- Add XPUWorker.shutdown() with rank/local_rank logging and mem pool release 

How to reproduce (without this PR)
1. pytest -sv tests/basic_correctness/test_cpu_offload.py