### PR TITLE
Fix unresolved cutlass_moe_mm_sm100 symbol in stable libtorch 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
       "csrc/libtorch_stable/cuda_utils_kernels.cu"
       "csrc/libtorch_stable/cutlass_extensions/common.cpp"
       "csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_entry.cu"
+      "csrc/libtorch_stable/quantization/w8a8/cutlass/moe/grouped_mm_c3x_sm100.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_quant_entry.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_scaled_mm_entry.cu"
       "csrc/libtorch_stable/quantization/awq/gemm_kernels.cu"


### PR DESCRIPTION
extension on Nvidia Jetson Thor Developer Kit

This PR adds the SM100 CUTLASS MoE implementation source file to the stable libtorch extension build:

```cmake
csrc/libtorch_stable/quantization/w8a8/cutlass/moe/grouped_mm_c3x_sm100.cu
```

`scaled_mm_entry.cu` can reference `cutlass_moe_mm_sm100`, but the final `_C_stable_libtorch.abi3.so` did not include the source file that defines that symbol. As a result, importing vLLM could fail at runtime with an unresolved symbol error.

```text
ImportError: .../vllm/_C_stable_libtorch.abi3.so:
undefined symbol: _Z20cutlass_moe_mm_sm100RN5torch6stable6TensorERKS1_S4_S4_S4_S4_S4_S4_S4_S4_bb
```

Before this change:

```text
U cutlass_moe_mm_sm100(...)
```

After rebuilding with this source included, the symbol is defined in the extension and `import vllm` succeeds.

Tested by rebuilding vLLM from source and launching:

```bash
vllm serve nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4 \
  --host 127.0.0.1 \
  --port 8000 \
  --max-model-len 8192 \
  --kv-cache-memory-bytes 8G \
  --max-num-seqs 1 \
  --max-num-batched-tokens 2048 \
  --trust-remote-code
```




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

