### PR TITLE
fix gpt_oss pp>1 with ep

### DIFF
--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -1078,7 +1078,7 @@ class GptOssModel(nn.Module, EagleModelMixin):
         head_start = tp_rank * heads_per_rank
 
         ep_size = get_ep_group().world_size
-        ep_rank = get_ep_group().rank
+        ep_rank = get_ep_group().rank_in_group
         num_experts = self.config.num_local_experts
         experts_per_rank = num_experts // ep_size
         ep_rank_start = ep_rank * experts_per_rank


### PR DESCRIPTION
**Bug**: In GptOssModel.load_weights(), get_ep_group().rank returns the global rank across all workers, but the code uses it to slice expert weights as if it were the rank within the EP group.

With pipeline parallelism, PP stage 1 workers have global ranks offset by pp_rank * tp_size (e.g., ranks 2 and 3 for a 2-stage pipeline). This causes ep_rank_start = 2 * experts_per_rank, which is out-of-bounds for the checkpoint tensor (which only has num_experts entries), producing an empty slice and silently skipping all expert weight loading for PP stage 1.

**Fix**: Replace get_ep_group().rank with get_ep_group().rank_in_group, which correctly returns the 0-based rank within the EP group regardless of pipeline stage.

Affected configs: Any combination of --enable-expert-parallel with --pipeline-parallel-size > 1