### PR TITLE
[Model][Attention] DiffusionGemma: NVFP4 KV cache via FlashInfer VO-split + per-request causal grouping (sm120)

### DIFF
--- a/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
+++ b/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
@@ -64,7 +64,9 @@ __global__ void reshape_and_cache_nvfp4_kernel(
     const int64_t data_block_offset_stride,  // data cache stride for tokens
     const int64_t scale_block_stride,        // scale cache stride for dim 0
     const int64_t scale_head_stride,         // scale cache stride for heads
-    const int64_t scale_block_offset_stride  // scale cache stride for tokens
+    const int64_t scale_block_offset_stride,  // scale cache stride for tokens
+    const bool swizzle_v_sf  // V scale layout: true = SM100 trtllm-gen 4-token
+                             // swizzle; false = linear (FlashInfer FA2 sm12x)
 ) {
   using CudaType = typename CUDATypeConverter<scalar_t>::Type;
   using PVec = PackedVec<CudaType, CVT_FP4_PACK16>;
@@ -153,12 +155,14 @@ __global__ void reshape_and_cache_nvfp4_kernel(
 #endif
 
       // Write block scale to scale cache.
-      // K (kv==0): linear layout (no swizzle).
-      // V (kv==1): swizzled layout for SM100 trtllm-gen MHA kernel.
+      // K (kv==0): always linear layout (no swizzle).
+      // V (kv==1): swizzled layout for the SM100 trtllm-gen MHA kernel when
+      //   swizzle_v_sf is true; linear (same as K) when false, which the
+      //   FlashInfer FA2 paged nvfp4 reader on sm120/sm121 requires.
       if (sf_out_ptr != nullptr) {
         int scale_idx = group_in_head;
         uint8_t* __restrict__ scale_dst;
-        if (kv == 0) {
+        if (kv == 0 || !swizzle_v_sf) {
           scale_dst = scale_block + head * scale_head_stride +
                       block_offset * scale_block_offset_stride + scale_idx;
         } else {
@@ -207,41 +211,72 @@ void reshape_and_cache_nvfp4_dispatch(torch::stable::Tensor& key,
 
   STD_TORCH_CHECK(head_size % 16 == 0,
                   "head_size must be divisible by 16 for NVFP4 KV cache");
-  STD_TORCH_CHECK(block_size % 4 == 0,
-                  "block_size must be divisible by 4 for NVFP4 KV cache "
-                  "swizzle");
 
-  // Detect physical layout from strides (based on full_dim).
-  // HND: head stride > block_offset stride.
-  bool is_hnd = key_cache.stride(2) > key_cache.stride(1);
+  // SM120/SM121 (consumer Blackwell) serve NVFP4 KV via the FlashInfer FA2
+  // paged reader, which derives the scale-factor stride as data_stride/8 and
+  // reads V scales linearly. That requires a contiguous [all-data | all-SF]
+  // page layout (NHD), not the SM100 trtllm-gen per-page [data|scale]
+  // interleave with the 4-token V swizzle. Select the layout by arch.
+  cudaDeviceProp dev_prop;
+  cudaGetDeviceProperties(&dev_prop, key.get_device_index());
+  const bool contiguous_layout = dev_prop.major >= 12;
+  const bool swizzle_v_sf = !contiguous_layout;
 
-  int64_t data_block_stride = key_cache.stride(0);  // page_bytes
-  int64_t data_head_stride, data_block_offset_stride;
-  if (is_hnd) {
-    data_head_stride = (int64_t)block_size * data_dim;
-    data_block_offset_stride = data_dim;
-  } else {
+  STD_TORCH_CHECK(!swizzle_v_sf || block_size % 4 == 0,
+                  "block_size must be divisible by 4 for NVFP4 KV cache V "
+                  "scale-factor swizzle (SM100 trtllm-gen path)");
+
+  uint8_t* key_data_cache;
+  uint8_t* value_data_cache;
+  uint8_t* key_scale_ptr;
+  uint8_t* value_scale_ptr;
+  int64_t data_block_stride, data_head_stride, data_block_offset_stride;
+  int64_t scale_block_stride, scale_head_stride, scale_block_offset_stride;
+
+  if (contiguous_layout) {
+    // One contiguous data region (num_blocks, 2, block, heads, data_dim) in NHD
+    // order, followed by one contiguous SF region (..., scale_dim). K/V are
+    // dim 1; the per-block stride spans both sides so sf_stride == data_stride/8
+    // holds for each side (matches nvfp4_kv_cache_split_views global split).
+    int64_t num_blocks = key_cache.size(0);
+    uint8_t* buf = key_cache.mutable_data_ptr<uint8_t>();
+    int64_t kv_data_off = (int64_t)block_size * num_heads * data_dim;
+    int64_t kv_scale_off = (int64_t)block_size * num_heads * scale_dim;
+    int64_t data_count = num_blocks * 2 * kv_data_off;
+    key_data_cache = buf;
+    value_data_cache = buf + kv_data_off;
+    key_scale_ptr = buf + data_count;
+    value_scale_ptr = buf + data_count + kv_scale_off;
+    data_block_stride = 2 * kv_data_off;
     data_head_stride = data_dim;
     data_block_offset_stride = (int64_t)num_heads * data_dim;
-  }
-
-  // Page layout: [K_data | K_scale | V_data | V_scale]
-  // Scale follows data within each KV side.
-  int64_t data_per_kv = (int64_t)num_heads * block_size * data_dim;
-
-  uint8_t* key_scale_ptr = key_cache.mutable_data_ptr<uint8_t>() + data_per_kv;
-  uint8_t* value_scale_ptr =
-      value_cache.mutable_data_ptr<uint8_t>() + data_per_kv;
-
-  // Scale strides: same page stride, inner strides from layout.
-  int64_t scale_block_stride = data_block_stride;
-  int64_t scale_head_stride, scale_block_offset_stride;
-  if (is_hnd) {
-    scale_head_stride = (int64_t)block_size * scale_dim;
-    scale_block_offset_stride = scale_dim;
-  } else {
+    scale_block_stride = 2 * kv_scale_off;
     scale_head_stride = scale_dim;
     scale_block_offset_stride = (int64_t)num_heads * scale_dim;
+  } else {
+    // SM100 trtllm-gen per-page layout: [K_data | K_scale | V_data | V_scale].
+    bool is_hnd = key_cache.stride(2) > key_cache.stride(1);
+    data_block_stride = key_cache.stride(0);  // page_bytes
+    if (is_hnd) {
+      data_head_stride = (int64_t)block_size * data_dim;
+      data_block_offset_stride = data_dim;
+    } else {
+      data_head_stride = data_dim;
+      data_block_offset_stride = (int64_t)num_heads * data_dim;
+    }
+    int64_t data_per_kv = (int64_t)num_heads * block_size * data_dim;
+    key_data_cache = key_cache.mutable_data_ptr<uint8_t>();
+    value_data_cache = value_cache.mutable_data_ptr<uint8_t>();
+    key_scale_ptr = key_cache.mutable_data_ptr<uint8_t>() + data_per_kv;
+    value_scale_ptr = value_cache.mutable_data_ptr<uint8_t>() + data_per_kv;
+    scale_block_stride = data_block_stride;
+    if (is_hnd) {
+      scale_head_stride = (int64_t)block_size * scale_dim;
+      scale_block_offset_stride = scale_dim;
+    } else {
+      scale_head_stride = scale_dim;
+      scale_block_offset_stride = (int64_t)num_heads * scale_dim;
+    }
   }
 
   const float* k_scale_ptr = k_scale.const_data_ptr<float>();
@@ -265,13 +300,12 @@ void reshape_and_cache_nvfp4_dispatch(torch::stable::Tensor& key,
         vllm::reshape_and_cache_nvfp4_kernel<scalar_t>
             <<<grid, block, 0, stream>>>(
                 key.const_data_ptr<scalar_t>(),
-                value.const_data_ptr<scalar_t>(),
-                key_cache.mutable_data_ptr<uint8_t>(),
-                value_cache.mutable_data_ptr<uint8_t>(), key_scale_ptr,
-                value_scale_ptr, slot_mapping.const_data_ptr<int64_t>(),
-                k_scale_ptr, v_scale_ptr, key.stride(0), value.stride(0),
-                num_heads, head_size, block_size, data_block_stride,
-                data_head_stride, data_block_offset_stride, scale_block_stride,
-                scale_head_stride, scale_block_offset_stride);
+                value.const_data_ptr<scalar_t>(), key_data_cache,
+                value_data_cache, key_scale_ptr, value_scale_ptr,
+                slot_mapping.const_data_ptr<int64_t>(), k_scale_ptr, v_scale_ptr,
+                key.stride(0), value.stride(0), num_heads, head_size, block_size,
+                data_block_stride, data_head_stride, data_block_offset_stride,
+                scale_block_stride, scale_head_stride, scale_block_offset_stride,
+                swizzle_v_sf);
       });
 }

--- a/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
+++ b/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
@@ -217,9 +217,7 @@ void reshape_and_cache_nvfp4_dispatch(torch::stable::Tensor& key,
   // reads V scales linearly. That requires a contiguous [all-data | all-SF]
   // page layout (NHD), not the SM100 trtllm-gen per-page [data|scale]
   // interleave with the 4-token V swizzle. Select the layout by arch.
-  cudaDeviceProp dev_prop;
-  cudaGetDeviceProperties(&dev_prop, key.get_device_index());
-  const bool contiguous_layout = dev_prop.major >= 12;
+  const bool contiguous_layout = get_device_prop()->major >= 12;
   const bool swizzle_v_sf = !contiguous_layout;
 
   STD_TORCH_CHECK(!swizzle_v_sf || block_size % 4 == 0,

--- a/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
+++ b/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
@@ -183,9 +183,11 @@ __global__ void reshape_and_cache_nvfp4_kernel(
     const int64_t data_block_stride,         // data cache stride for dim 0
     const int64_t data_head_stride,          // data cache stride for heads
     const int64_t data_block_offset_stride,  // data cache stride for tokens
-    const int64_t scale_block_stride,        // scale cache stride for dim 0
-    const int64_t scale_head_stride,         // scale cache stride for heads
-    const int64_t scale_block_offset_stride  // scale cache stride for tokens
+    const int64_t scale_block_stride,         // scale cache stride for dim 0
+    const int64_t scale_head_stride,          // scale cache stride for heads
+    const int64_t scale_block_offset_stride,  // scale cache stride for tokens
+    const bool swizzle_v_sf  // V scale layout: true = SM100 trtllm-gen 4-token
+                             // swizzle; false = linear (FlashInfer FA2 sm12x)
 ) {
   using CudaType = typename CUDATypeConverter<scalar_t>::Type;
   using PVec = PackedVec<CudaType, CVT_FP4_PACK16>;
@@ -280,12 +282,14 @@ __global__ void reshape_and_cache_nvfp4_kernel(
 #endif
 
       // Write block scale to scale cache.
-      // K (kv==0): linear layout (no swizzle).
-      // V (kv==1): swizzled layout for SM100 trtllm-gen MHA kernel.
+      // K (kv==0): always linear layout (no swizzle).
+      // V (kv==1): swizzled layout for the SM100 trtllm-gen MHA kernel when
+      //   swizzle_v_sf is true; linear (same as K) when false, which the
+      //   FlashInfer FA2 paged nvfp4 reader on sm120/sm121 requires.
       if (sf_out_ptr != nullptr) {
         int scale_idx = group_in_head;
         uint8_t* __restrict__ scale_dst;
-        if (kv == 0) {
+        if (kv == 0 || !swizzle_v_sf) {
           scale_dst = scale_block + head * scale_head_stride +
                       block_offset * scale_block_offset_stride + scale_idx;
         } else {
@@ -332,9 +336,37 @@ void reshape_and_cache_nvfp4_dispatch(
 
   STD_TORCH_CHECK(head_size % 16 == 0,
                   "head_size must be divisible by 16 for NVFP4 KV cache");
-  STD_TORCH_CHECK(block_size % 4 == 0,
-                  "block_size must be divisible by 4 for NVFP4 KV cache "
-                  "swizzle");
+
+  // Select the cache's device before querying its capability: get_device_prop()
+  // reads the *active* device, so on a heterogeneous host an unguarded query
+  // could pick another GPU's architecture and write an incompatible V-scale
+  // layout. The guard stays in scope for the launch below.
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      key.get_device_index());
+
+  // SM120/SM121 (consumer Blackwell) serve NVFP4 KV via the FlashInfer FA2
+  // paged reader, which takes the scale-factor strides from the SF tensor
+  // itself and reads V scales linearly; the SM100 trtllm-gen reader keeps
+  // its 4-token V scale swizzle. Both consume the same per-page
+  // [K_data | K_scale | V_data | V_scale] layout, so only the V-scale
+  // swizzle is arch-conditional.
+  const bool swizzle_v_sf = get_device_prop()->major < 12;
+
+  STD_TORCH_CHECK(!swizzle_v_sf || block_size % 4 == 0,
+                  "block_size must be divisible by 4 for NVFP4 KV cache V "
+                  "scale-factor swizzle (SM100 trtllm-gen path)");
+
+  // swizzle_scale_offset() reshapes a page's scales as [T//4, 4, 4, S//4], so
+  // S = scale_dim must itself be a multiple of 4. head_size=80 gives
+  // scale_dim=5: s_group becomes 1, swizzled_t runs past the token's group of
+  // four and writes into the next head or page. head_size<64 is worse still,
+  // giving s_group=0 and a division by zero in the kernel. SM12x writes V
+  // scales linearly and is unaffected.
+  STD_TORCH_CHECK(!swizzle_v_sf || scale_dim % 4 == 0,
+                  "head_size must be divisible by 64 (scale_dim divisible by "
+                  "4) for the NVFP4 KV cache V scale-factor swizzle (SM100 "
+                  "trtllm-gen path); got head_size=",
+                  head_size);
 
   // Detect physical layout from strides (based on full_dim).
   // HND: head stride > block_offset stride.
@@ -381,8 +413,6 @@ void reshape_and_cache_nvfp4_dispatch(
   dim3 grid(num_tokens);
   dim3 block(num_threads);
 
-  const torch::stable::accelerator::DeviceGuard device_guard(
-      key.get_device_index());
   const cudaStream_t stream = get_current_cuda_stream();
 
   VLLM_STABLE_DISPATCH_HALF_TYPES(
@@ -400,7 +430,7 @@ void reshape_and_cache_nvfp4_dispatch(
                   num_heads, head_size, block_size, data_block_stride,
                   data_head_stride, data_block_offset_stride,
                   scale_block_stride, scale_head_stride,
-                  scale_block_offset_stride);
+                  scale_block_offset_stride, swizzle_v_sf);
         } else if (kv_cache_dtype == "nvfp4_4over6") {
           vllm::reshape_and_cache_nvfp4_kernel<
               scalar_t, vllm::NVFP4KVScaleSearch::FOUR_OVER_SIX>
@@ -414,10 +444,23 @@ void reshape_and_cache_nvfp4_dispatch(
                   num_heads, head_size, block_size, data_block_stride,
                   data_head_stride, data_block_offset_stride,
                   scale_block_stride, scale_head_stride,
-                  scale_block_offset_stride);
+                  scale_block_offset_stride, swizzle_v_sf);
         } else {
           STD_TORCH_CHECK(false,
                           "Unsupported NVFP4 KV cache dtype: ", kv_cache_dtype);
         }
+        // A launch against a binary with no SASS for this device fails with
+        // cudaErrorNoKernelImageForDevice and, unchecked, silently writes
+        // nothing -- which then surfaces as NaN/garbage "quantization"
+        // downstream. Fail loudly here instead.
+        const cudaError_t launch_err = cudaGetLastError();
+        STD_TORCH_CHECK(launch_err == cudaSuccess,
+                        "reshape_and_cache_nvfp4 launch failed: ",
+                        cudaGetErrorString(launch_err),
+                        " (device compute capability ",
+                        get_device_prop()->major, ".",
+                        get_device_prop()->minor,
+                        "; was the extension built with SASS for this "
+                        "arch, e.g. TORCH_CUDA_ARCH_LIST including it?)");
       });
 }

--- a/tests/v1/attention/test_gemma4_nvfp4_flashinfer_routing.py
+++ b/tests/v1/attention/test_gemma4_nvfp4_flashinfer_routing.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Static (no-GPU) routing check for Gemma 4 NVFP4 KV -> FLASHINFER.
+
+On consumer Blackwell (CC 12.x) the FlashInfer FA2 asymmetric paged
+kernel serves Gemma 4 heterogeneous-head full-attention layers
+(head_dim_qk=512, head_dim_vo=256) directly, so Gemma4Config must route
+NVFP4-KV configs to FLASHINFER instead of the TRITON_ATTN fallback.
+
+Runs under a mocked platform/capability; no CUDA required. Mocking
+pattern adapted from the campaign triton-retirement selection test.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+ALL_KNOBS = ("VLLM_NVFP4_KV_VOSPLIT",)
+
+CC12_0 = DeviceCapability(12, 0)
+CC12_1 = DeviceCapability(12, 1)
+CC9_0 = DeviceCapability(9, 0)
+
+
+@pytest.fixture(autouse=True)
+def _clear_knobs(monkeypatch):
+    for name in ALL_KNOBS:
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+def _mock_vllm_config(*, backend=None, cache_dtype="nvfp4",
+                      head_dim=256, global_head_dim=512):
+    return SimpleNamespace(
+        attention_config=SimpleNamespace(backend=backend,
+                                         flash_attn_version=None),
+        cache_config=SimpleNamespace(cache_dtype=cache_dtype,
+                                     kv_cache_dtype_skip_layers=None),
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(
+                head_dim=head_dim, global_head_dim=global_head_dim,
+                layer_types=["sliding_attention", "sliding_attention",
+                             "sliding_attention", "sliding_attention",
+                             "sliding_attention", "full_attention"],
+            )
+        ),
+    )
+
+
+class _FakePlatform:
+    """Delegates everything to the real current_platform except the
+    compute-capability accessors, which are pinned to ``capability``."""
+
+    def __init__(self, capability):
+        self._cap = capability
+        from vllm.platforms import current_platform as real
+        self._real = real
+
+    def is_cuda(self):
+        return True
+
+    def get_device_capability(self, device_id=0):
+        return self._cap
+
+    def is_device_capability_family(self, cap, device_id=0):
+        return (self._cap.to_int() // 10) == (cap // 10)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+@pytest.fixture
+def fake_cc(monkeypatch):
+    def _set(capability):
+        import vllm.platforms as platforms_mod
+        import vllm.v1.attention.backends.fa_utils as fa_utils_mod
+        fake = _FakePlatform(capability)
+        monkeypatch.setattr(platforms_mod, "current_platform", fake,
+                            raising=False)
+        monkeypatch.setattr(fa_utils_mod, "is_fa_version_supported",
+                            lambda v: False)
+        return fake
+    return _set
+
+
+def _gemma4_route(vllm_config):
+    from vllm.model_executor.models.config import Gemma4Config
+    Gemma4Config.verify_and_update_config(vllm_config)
+    return vllm_config.attention_config.backend
+
+
+@pytest.mark.parametrize("capability", [CC12_0, CC12_1])
+def test_nvfp4_cc12_routes_to_flashinfer(fake_cc, capability):
+    fake_cc(capability)
+    cfg = _mock_vllm_config()
+    backend = _gemma4_route(cfg)
+    assert backend == AttentionBackendEnum.FLASHINFER, backend
+
+
+def test_nvfp4_cc12_disabled_knob_falls_back_to_triton(fake_cc, monkeypatch):
+    monkeypatch.setenv("VLLM_NVFP4_KV_VOSPLIT", "0")
+    fake_cc(CC12_0)
+    cfg = _mock_vllm_config()
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN
+
+
+def test_nvfp4_hopper_does_not_route(fake_cc):
+    fake_cc(CC9_0)
+    cfg = _mock_vllm_config()
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN
+
+
+def test_nvfp4_explicit_user_backend_wins(fake_cc):
+    fake_cc(CC12_0)
+    cfg = _mock_vllm_config(backend=AttentionBackendEnum.TRITON_ATTN)
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN
+
+
+def test_bf16_kv_keeps_triton_fallback(fake_cc):
+    fake_cc(CC12_0)
+    cfg = _mock_vllm_config(cache_dtype="auto")
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN

--- a/tests/v1/attention/test_gemma4_nvfp4_flashinfer_routing.py
+++ b/tests/v1/attention/test_gemma4_nvfp4_flashinfer_routing.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Static (no-GPU) routing check for Gemma 4 NVFP4 KV -> FLASHINFER.
+
+On consumer Blackwell (CC 12.x) the FlashInfer FA2 asymmetric paged
+kernel serves Gemma 4 heterogeneous-head full-attention layers
+(head_dim_qk=512, head_dim_vo=256) directly, so Gemma4Config must route
+NVFP4-KV configs to FLASHINFER instead of the TRITON_ATTN fallback.
+
+Runs under a mocked platform/capability; no CUDA required. Mocking
+pattern adapted from the campaign triton-retirement selection test.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+ALL_KNOBS = ("VLLM_NVFP4_KV_VOSPLIT",)
+
+CC12_0 = DeviceCapability(12, 0)
+CC12_1 = DeviceCapability(12, 1)
+CC9_0 = DeviceCapability(9, 0)
+
+
+@pytest.fixture(autouse=True)
+def _clear_knobs(monkeypatch):
+    for name in ALL_KNOBS:
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+class _FakeArchConfig:
+    """Minimal stand-in for ``model_config.model_arch_config``.
+
+    Gemma4Config reads per-layer ``head_size`` by index and the total layer
+    count, so that is all this needs to expose.
+    """
+
+    def __init__(self, head_sizes):
+        self._head_sizes = head_sizes
+        self.total_num_hidden_layers = len(head_sizes)
+
+    def __getitem__(self, index):
+        return SimpleNamespace(head_size=self._head_sizes[index])
+
+
+_LAYER_TYPES = [
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "full_attention",
+]
+
+
+def _mock_vllm_config(
+    *, backend=None, cache_dtype="nvfp4", head_dim=256, global_head_dim=512
+):
+    head_sizes = [
+        global_head_dim if lt == "full_attention" else head_dim for lt in _LAYER_TYPES
+    ]
+    return SimpleNamespace(
+        attention_config=SimpleNamespace(backend=backend, flash_attn_version=None),
+        cache_config=SimpleNamespace(
+            cache_dtype=cache_dtype, kv_cache_dtype_skip_layers=None
+        ),
+        model_config=SimpleNamespace(
+            model_arch_config=_FakeArchConfig(head_sizes),
+            hf_text_config=SimpleNamespace(layer_types=list(_LAYER_TYPES)),
+        ),
+    )
+
+
+class _FakePlatform:
+    """Delegates everything to the real current_platform except the
+    compute-capability accessors, which are pinned to ``capability``."""
+
+    def __init__(self, capability):
+        self._cap = capability
+        from vllm.platforms import current_platform as real
+
+        self._real = real
+
+    def is_cuda(self):
+        return True
+
+    def get_device_capability(self, device_id=0):
+        return self._cap
+
+    def is_device_capability_family(self, cap, device_id=0):
+        return (self._cap.to_int() // 10) == (cap // 10)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+@pytest.fixture
+def fake_cc(monkeypatch):
+    def _set(capability):
+        import vllm.platforms as platforms_mod
+        import vllm.v1.attention.backends.fa_utils as fa_utils_mod
+
+        fake = _FakePlatform(capability)
+        monkeypatch.setattr(platforms_mod, "current_platform", fake, raising=False)
+        monkeypatch.setattr(fa_utils_mod, "is_fa_version_supported", lambda v: False)
+        return fake
+
+    return _set
+
+
+def _gemma4_route(vllm_config):
+    from vllm.model_executor.models.config import Gemma4Config
+
+    Gemma4Config.verify_and_update_config(vllm_config)
+    return vllm_config.attention_config.backend
+
+
+@pytest.mark.parametrize("capability", [CC12_0, CC12_1])
+def test_nvfp4_cc12_routes_to_flashinfer(fake_cc, capability):
+    fake_cc(capability)
+    cfg = _mock_vllm_config()
+    backend = _gemma4_route(cfg)
+    assert backend == AttentionBackendEnum.FLASHINFER, backend
+
+
+def test_nvfp4_cc12_disabled_knob_falls_back_to_triton(fake_cc, monkeypatch):
+    monkeypatch.setenv("VLLM_NVFP4_KV_VOSPLIT", "0")
+    fake_cc(CC12_0)
+    cfg = _mock_vllm_config()
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN
+
+
+def test_nvfp4_hopper_does_not_route(fake_cc):
+    fake_cc(CC9_0)
+    cfg = _mock_vllm_config()
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN
+
+
+def test_nvfp4_explicit_user_backend_wins(fake_cc):
+    fake_cc(CC12_0)
+    cfg = _mock_vllm_config(backend=AttentionBackendEnum.TRITON_ATTN)
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN
+
+
+def test_bf16_kv_keeps_triton_fallback(fake_cc):
+    fake_cc(CC12_0)
+    cfg = _mock_vllm_config(cache_dtype="auto")
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN

--- a/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
+++ b/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Static (no-GPU) unit tests for the FlashInfer NVFP4 VO-split factor and
+the Gemma 3/4 mm-prefix bidirectional image-span masking.
+
+These exercise pure tensor/index logic on CPU — no CUDA, no kernel launch:
+
+* ``_vo_split_factor`` — how many ``(qk=512, vo=256)`` passes a head needs.
+* ``_build_mm_prefix_custom_mask`` — the per-request boolean attention mask,
+  ``(causal AND sliding-window) OR (q in span AND kv in span)``.
+* ``_mm_prefix_prefill_spans`` — which prefill requests have an image span
+  intersecting the query window (and the byte-identical None fast path).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+try:
+    from vllm.v1.attention.backends.flashinfer import (
+        FlashInferMetadataBuilder,
+        _vo_split_factor,
+    )
+
+    HAS_FI = True
+except Exception:
+    HAS_FI = False
+
+pytestmark = pytest.mark.skipif(
+    not HAS_FI, reason="FlashInfer attention backend not importable"
+)
+
+
+# --------------------------------------------------------------------------- #
+# _vo_split_factor
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "head_size,is_nvfp4,expected",
+    [
+        (256, True, 1),   # uniform Gemma 3 head — single pass
+        (128, True, 1),
+        (256, False, 1),
+        (512, True, 2),   # Gemma 4 global head — two (qk=512, vo=256) passes
+        (512, False, 2),  # the split is dtype-independent
+    ],
+)
+def test_vo_split_factor(head_size, is_nvfp4, expected, monkeypatch):
+    # the >256 NVFP4 path requires the (default-on) VO-split knob; pin it on.
+    monkeypatch.setenv("VLLM_NVFP4_KV_VOSPLIT", "1")
+    assert _vo_split_factor(head_size, is_nvfp4) == expected
+
+
+def test_vo_split_factor_nvfp4_needs_knob(monkeypatch):
+    # NVFP4 512-wide head with the split disabled must error, not silently
+    # plan an unsupported HEAD_DIM_VO=512.
+    monkeypatch.setenv("VLLM_NVFP4_KV_VOSPLIT", "0")
+    with pytest.raises(ValueError, match="two-pass VO split"):
+        _vo_split_factor(512, True)
+
+
+# --------------------------------------------------------------------------- #
+# _build_mm_prefix_custom_mask
+# --------------------------------------------------------------------------- #
+def _mask(window_left, qo_lens, kv_lens, span_lists):
+    fake = SimpleNamespace(device=torch.device("cpu"), window_left=window_left)
+    flat = FlashInferMetadataBuilder._build_mm_prefix_custom_mask(
+        fake, qo_lens, kv_lens, span_lists
+    )
+    # single-request helper: reshape back to (qo_len, kv_len)
+    return flat.reshape(qo_lens[0], kv_lens[0])
+
+
+def test_mm_mask_pure_causal_no_span():
+    # No window, no spans -> strict lower-triangular causal mask.
+    m = _mask(-1, [4], [4], [[]])
+    expected = torch.tensor(
+        [[1, 0, 0, 0],
+         [1, 1, 0, 0],
+         [1, 1, 1, 0],
+         [1, 1, 1, 1]],
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+
+
+def test_mm_mask_span_is_bidirectional():
+    # Span [1,2]: queries 1,2 may attend *forward* to keys 1,2 inside the
+    # span (the whole point — image tokens attend bidirectionally), while
+    # everything outside the span stays causal.
+    m = _mask(-1, [4], [4], [[(1, 2)]])
+    expected = torch.tensor(
+        [[1, 0, 0, 0],
+         [1, 1, 1, 0],   # q=1 now sees k=2 (forward, in-span)
+         [1, 1, 1, 0],
+         [1, 1, 1, 1]],
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+    # q=2 still cannot see k=3 (k=3 is outside the span and non-causal)
+    assert not m[2, 3]
+
+
+def test_mm_mask_sliding_window_ands_with_causal():
+    # window_left=1: a query sees only itself and one key back, ANDed with
+    # causal. No spans.
+    m = _mask(1, [4], [4], [[]])
+    expected = torch.tensor(
+        [[1, 0, 0, 0],
+         [1, 1, 0, 0],
+         [0, 1, 1, 0],   # k=0 is outside the window for q=2
+         [0, 0, 1, 1]],
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+
+
+def test_mm_mask_span_overrides_window():
+    # The mask carries the window itself (the mm wrapper is planned
+    # window_left=-1), and an in-span pair must survive even when the window
+    # would have excluded it: q=3,k=1 are >window apart but both in span.
+    m = _mask(1, [4], [4], [[(1, 3)]])
+    assert m[3, 1]                       # span overrides the window
+    assert m[1, 3]                       # and is bidirectional
+    assert not m[3, 0]                   # k=0 outside span and window -> off
+
+
+def test_mm_mask_with_context_offset():
+    # qo_len < kv_len: the query rows are end-aligned to the KV sequence, so
+    # absolute query positions start at kv_len - qo_len (= context_len).
+    m = _mask(-1, [2], [4], [[]])  # 2 new queries over a 4-long KV
+    # q_abs = [2, 3], k_abs = [0,1,2,3]; causal k <= q
+    expected = torch.tensor(
+        [[1, 1, 1, 0],   # q=2 sees k 0..2
+         [1, 1, 1, 1]],  # q=3 sees k 0..3
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+
+
+# --------------------------------------------------------------------------- #
+# _mm_prefix_prefill_spans
+# --------------------------------------------------------------------------- #
+def _spans(mm_ranges, qo_indptr, seq_lens, num_decodes, num_prefills):
+    cam = SimpleNamespace(
+        mm_req_doc_ranges=mm_ranges,
+        query_start_loc_cpu=torch.tensor(qo_indptr, dtype=torch.int32),
+        seq_lens_cpu=torch.tensor(seq_lens, dtype=torch.int32),
+    )
+    return FlashInferMetadataBuilder._mm_prefix_prefill_spans(
+        None, cam, num_decodes, num_prefills
+    )
+
+
+def test_spans_none_when_no_mm_ranges():
+    # No image spans anywhere -> None (the scalar-causal fast path).
+    assert _spans(None, [0, 8], [8], 0, 1) is None
+    assert _spans({}, [0, 8], [8], 0, 1) is None
+
+
+def test_spans_intersecting_window_kept():
+    # One prefill request (kv_len=10, qo_len=10 -> context_len=0); span (2,5)
+    # intersects the query window and is returned.
+    out = _spans({0: [(2, 5)]}, [0, 10], [10], 0, 1)
+    assert out == [[(2, 5)]]
+
+
+def test_spans_fully_in_context_dropped():
+    # kv_len=10, qo_len=2 -> context_len=8; span (2,5) ends before the window
+    # (e=5 < context_len=8), so it needs no masking -> filtered -> None.
+    assert _spans({0: [(2, 5)]}, [0, 2], [10], 0, 1) is None
+
+
+def test_spans_skip_decode_requests():
+    # 1 decode + 1 prefill; the doc range belongs to the prefill (index 1).
+    # query_start_loc covers [decode, prefill] -> prefill qo_len = 10.
+    out = _spans({1: [(3, 6)]}, [0, 1, 11], [5, 11], 1, 1)
+    assert out == [[(3, 6)]]

--- a/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
+++ b/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Static (no-GPU) unit tests for the FlashInfer NVFP4 VO-split factor and
+the Gemma 3/4 mm-prefix bidirectional image-span masking.
+
+These exercise pure tensor/index logic on CPU — no CUDA, no kernel launch:
+
+* ``_vo_split_factor`` — how many ``(qk=512, vo=256)`` passes a head needs.
+* ``_build_mm_prefix_custom_mask`` — the per-request boolean attention mask,
+  ``(causal AND sliding-window) OR (q in span AND kv in span)``.
+* ``_mm_prefix_prefill_spans`` — which prefill requests have an image span
+  intersecting the query window (and the byte-identical None fast path).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+try:
+    from vllm.v1.attention.backends.flashinfer import (
+        FlashInferMetadataBuilder,
+        _vo_split_factor,
+    )
+
+    HAS_FI = True
+except Exception:
+    HAS_FI = False
+
+pytestmark = pytest.mark.skipif(
+    not HAS_FI, reason="FlashInfer attention backend not importable"
+)
+
+
+# --------------------------------------------------------------------------- #
+# _vo_split_factor
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "head_size,is_nvfp4,expected",
+    [
+        (256, True, 1),  # uniform Gemma 3 head — single pass
+        (128, True, 1),
+        (256, False, 1),
+        (512, True, 2),  # Gemma 4 global head — two (qk=512, vo=256) passes
+        (512, False, 2),  # the split is dtype-independent
+    ],
+)
+def test_vo_split_factor(head_size, is_nvfp4, expected, monkeypatch):
+    # the >256 NVFP4 path requires the (default-on) VO-split knob; pin it on.
+    monkeypatch.setenv("VLLM_NVFP4_KV_VOSPLIT", "1")
+    assert _vo_split_factor(head_size, is_nvfp4) == expected
+
+
+def test_vo_split_factor_nvfp4_needs_knob(monkeypatch):
+    # NVFP4 512-wide head with the split disabled must error, not silently
+    # plan an unsupported HEAD_DIM_VO=512.
+    monkeypatch.setenv("VLLM_NVFP4_KV_VOSPLIT", "0")
+    with pytest.raises(ValueError, match="two-pass VO split"):
+        _vo_split_factor(512, True)
+
+
+# --------------------------------------------------------------------------- #
+# _build_mm_prefix_custom_mask
+# --------------------------------------------------------------------------- #
+def _mask(window_left, qo_lens, kv_lens, span_lists):
+    fake = SimpleNamespace(device=torch.device("cpu"), window_left=window_left)
+    flat = FlashInferMetadataBuilder._build_mm_prefix_custom_mask(
+        fake, qo_lens, kv_lens, span_lists
+    )
+    # single-request helper: reshape back to (qo_len, kv_len)
+    return flat.reshape(qo_lens[0], kv_lens[0])
+
+
+def test_mm_mask_pure_causal_no_span():
+    # No window, no spans -> strict lower-triangular causal mask.
+    m = _mask(-1, [4], [4], [[]])
+    expected = torch.tensor(
+        [[1, 0, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1]],
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+
+
+def test_mm_mask_span_is_bidirectional():
+    # Span [1,2]: queries 1,2 may attend *forward* to keys 1,2 inside the
+    # span (the whole point — image tokens attend bidirectionally), while
+    # everything outside the span stays causal.
+    m = _mask(-1, [4], [4], [[(1, 2)]])
+    expected = torch.tensor(
+        [
+            [1, 0, 0, 0],
+            [1, 1, 1, 0],  # q=1 now sees k=2 (forward, in-span)
+            [1, 1, 1, 0],
+            [1, 1, 1, 1],
+        ],
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+    # q=2 still cannot see k=3 (k=3 is outside the span and non-causal)
+    assert not m[2, 3]
+
+
+def test_mm_mask_sliding_window_ands_with_causal():
+    # window_left=1: a query sees only itself and one key back, ANDed with
+    # causal. No spans.
+    m = _mask(1, [4], [4], [[]])
+    expected = torch.tensor(
+        [
+            [1, 0, 0, 0],
+            [1, 1, 0, 0],
+            [0, 1, 1, 0],  # k=0 is outside the window for q=2
+            [0, 0, 1, 1],
+        ],
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+
+
+def test_mm_mask_span_overrides_window():
+    # The mask carries the window itself (the mm wrapper is planned
+    # window_left=-1), and an in-span pair must survive even when the window
+    # would have excluded it: q=3,k=1 are >window apart but both in span.
+    m = _mask(1, [4], [4], [[(1, 3)]])
+    assert m[3, 1]  # span overrides the window
+    assert m[1, 3]  # and is bidirectional
+    assert not m[3, 0]  # k=0 outside span and window -> off
+
+
+def test_mm_mask_with_context_offset():
+    # qo_len < kv_len: the query rows are end-aligned to the KV sequence, so
+    # absolute query positions start at kv_len - qo_len (= context_len).
+    m = _mask(-1, [2], [4], [[]])  # 2 new queries over a 4-long KV
+    # q_abs = [2, 3], k_abs = [0,1,2,3]; causal k <= q
+    expected = torch.tensor(
+        [
+            [1, 1, 1, 0],  # q=2 sees k 0..2
+            [1, 1, 1, 1],
+        ],  # q=3 sees k 0..3
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+
+
+# --------------------------------------------------------------------------- #
+# _mm_prefix_prefill_spans
+# --------------------------------------------------------------------------- #
+def _spans(mm_ranges, qo_indptr, seq_lens, num_decodes, num_prefills):
+    cam = SimpleNamespace(
+        mm_req_doc_ranges=mm_ranges,
+        query_start_loc_cpu=torch.tensor(qo_indptr, dtype=torch.int32),
+        seq_lens_cpu=torch.tensor(seq_lens, dtype=torch.int32),
+    )
+    return FlashInferMetadataBuilder._mm_prefix_prefill_spans(
+        None, cam, num_decodes, num_prefills
+    )
+
+
+def test_spans_none_when_no_mm_ranges():
+    # No image spans anywhere -> None (the scalar-causal fast path).
+    assert _spans(None, [0, 8], [8], 0, 1) is None
+    assert _spans({}, [0, 8], [8], 0, 1) is None
+
+
+def test_spans_intersecting_window_kept():
+    # One prefill request (kv_len=10, qo_len=10 -> context_len=0); span (2,5)
+    # intersects the query window and is returned.
+    out = _spans({0: [(2, 5)]}, [0, 10], [10], 0, 1)
+    assert out == [[(2, 5)]]
+
+
+def test_spans_fully_in_context_dropped():
+    # kv_len=10, qo_len=2 -> context_len=8; span (2,5) ends before the window
+    # (e=5 < context_len=8), so it needs no masking -> filtered -> None.
+    assert _spans({0: [(2, 5)]}, [0, 2], [10], 0, 1) is None
+
+
+def test_spans_skip_decode_requests():
+    # 1 decode + 1 prefill; the doc range belongs to the prefill (index 1).
+    # query_start_loc covers [decode, prefill] -> prefill qo_len = 10.
+    out = _spans({1: [(3, 6)]}, [0, 1, 11], [5, 11], 1, 1)
+    assert out == [[(3, 6)]]

--- a/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
+++ b/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
@@ -179,3 +179,49 @@ def test_spans_skip_decode_requests():
     # query_start_loc covers [decode, prefill] -> prefill qo_len = 10.
     out = _spans({1: [(3, 6)]}, [0, 1, 11], [5, 11], 1, 1)
     assert out == [[(3, 6)]]
+
+
+# --------------------------------------------------------------------------- #
+# get_cudagraph_support: no decode-graph capture for VO-split NVFP4 groups
+# --------------------------------------------------------------------------- #
+def _sm12x_nvfp4_cg_support(head_size, monkeypatch):
+    """Cudagraph support the builder advertises for one NVFP4 KV group on
+    sm12x, with the platform capability checks pinned (no GPU needed)."""
+    import vllm.v1.attention.backends.flashinfer as fi
+    from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+    monkeypatch.setenv("VLLM_NVFP4_KV_VOSPLIT", "1")
+    monkeypatch.setattr(fi.current_platform, "is_device_capability", lambda cap: False)
+    monkeypatch.setattr(
+        fi.current_platform, "is_device_capability_family", lambda fam: fam == 120
+    )
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        cache_config=SimpleNamespace(cache_dtype="nvfp4"),
+    )
+    spec = FullAttentionSpec(
+        block_size=16, num_kv_heads=1, head_size=head_size, dtype=torch.uint8
+    )
+    return FlashInferMetadataBuilder.get_cudagraph_support(vllm_config, spec)
+
+
+def test_cudagraph_support_vo_split_nvfp4_sm12x_is_never(monkeypatch):
+    # Gemma 4 global layers (head 512) run the two-pass VO split: every
+    # request, decode included, goes through the per-step-planned prefill
+    # wrapper, which has no cudagraph buffers. Capturing a FULL decode graph
+    # around it replayed stale plan data (garbage decodes on E2B/12B), so the
+    # builder must refuse capture for these groups.
+    from vllm.v1.attention.backend import AttentionCGSupport
+
+    assert _sm12x_nvfp4_cg_support(512, monkeypatch) == AttentionCGSupport.NEVER
+
+
+def test_cudagraph_support_uniform_head_nvfp4_sm12x_keeps_decode(monkeypatch):
+    # Uniform 256-wide heads (Gemma 3, Qwen) keep the single-token decode
+    # capture they had.
+    from vllm.v1.attention.backend import AttentionCGSupport
+
+    assert (
+        _sm12x_nvfp4_cg_support(256, monkeypatch)
+        == AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
+    )

--- a/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
+++ b/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
@@ -184,9 +184,9 @@ def test_spans_skip_decode_requests():
 # --------------------------------------------------------------------------- #
 # get_cudagraph_support: no decode-graph capture for VO-split NVFP4 groups
 # --------------------------------------------------------------------------- #
-def _sm12x_nvfp4_cg_support(head_size, monkeypatch):
-    """Cudagraph support the builder advertises for one NVFP4 KV group on
-    sm12x, with the platform capability checks pinned (no GPU needed)."""
+def _sm12x_nvfp4_cg_support(head_size, monkeypatch, cache_dtype="nvfp4"):
+    """Cudagraph support the builder advertises for one KV group on sm12x,
+    with the platform capability checks pinned (no GPU needed)."""
     import vllm.v1.attention.backends.flashinfer as fi
     from vllm.v1.kv_cache_interface import FullAttentionSpec
 
@@ -197,7 +197,7 @@ def _sm12x_nvfp4_cg_support(head_size, monkeypatch):
     )
     vllm_config = SimpleNamespace(
         parallel_config=SimpleNamespace(decode_context_parallel_size=1),
-        cache_config=SimpleNamespace(cache_dtype="nvfp4"),
+        cache_config=SimpleNamespace(cache_dtype=cache_dtype),
     )
     spec = FullAttentionSpec(
         block_size=16, num_kv_heads=1, head_size=head_size, dtype=torch.uint8
@@ -224,4 +224,20 @@ def test_cudagraph_support_uniform_head_nvfp4_sm12x_keeps_decode(monkeypatch):
     assert (
         _sm12x_nvfp4_cg_support(256, monkeypatch)
         == AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
+    )
+
+
+@pytest.mark.parametrize("cache_dtype", ["nvfp4", "auto", "fp8"])
+def test_cudagraph_support_vo_split_never_regardless_of_kv_dtype(
+    cache_dtype, monkeypatch
+):
+    # _vo_split_factor() keys on head_size alone, so a 512-wide head takes the
+    # two-pass VO split for bf16 and FP8 KV as well as NVFP4 -- and with it the
+    # reorder_batch_threshold = 0 routing that makes a captured decode graph
+    # replay stale plan data. The refusal must not be conditioned on the dtype.
+    from vllm.v1.attention.backend import AttentionCGSupport
+
+    assert (
+        _sm12x_nvfp4_cg_support(512, monkeypatch, cache_dtype=cache_dtype)
+        == AttentionCGSupport.NEVER
     )

--- a/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
+++ b/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
@@ -42,7 +42,11 @@ pytestmark = pytest.mark.skipif(
         (128, True, 1),
         (256, False, 1),
         (512, True, 2),  # Gemma 4 global head — two (qk=512, vo=256) passes
-        (512, False, 2),  # the split is dtype-independent
+        # bf16 / FP8 keep head_dim_vo=512: FA2 handles it, and splitting would
+        # cost them the decode CUDA-graph path for no reason. The split is
+        # introduced for NVFP4 and must not leak into other dtypes.
+        (512, False, 1),
+        (768, False, 1),
     ],
 )
 def test_vo_split_factor(head_size, is_nvfp4, expected, monkeypatch):
@@ -195,9 +199,14 @@ def _sm12x_nvfp4_cg_support(head_size, monkeypatch, cache_dtype="nvfp4"):
     monkeypatch.setattr(
         fi.current_platform, "is_device_capability_family", lambda fam: fam == 120
     )
+    # Non-NVFP4 dtypes fall through to the trtllm-support probe; pin it so the
+    # path is deterministic without a GPU.
+    monkeypatch.setattr(fi, "can_use_trtllm_attention", lambda **kw: False)
     vllm_config = SimpleNamespace(
         parallel_config=SimpleNamespace(decode_context_parallel_size=1),
         cache_config=SimpleNamespace(cache_dtype=cache_dtype),
+        model_config=SimpleNamespace(get_num_attention_heads=lambda _pc: 8),
+        attention_config=SimpleNamespace(use_non_causal=False),
     )
     spec = FullAttentionSpec(
         block_size=16, num_kv_heads=1, head_size=head_size, dtype=torch.uint8
@@ -227,17 +236,14 @@ def test_cudagraph_support_uniform_head_nvfp4_sm12x_keeps_decode(monkeypatch):
     )
 
 
-@pytest.mark.parametrize("cache_dtype", ["nvfp4", "auto", "fp8"])
-def test_cudagraph_support_vo_split_never_regardless_of_kv_dtype(
-    cache_dtype, monkeypatch
-):
-    # _vo_split_factor() keys on head_size alone, so a 512-wide head takes the
-    # two-pass VO split for bf16 and FP8 KV as well as NVFP4 -- and with it the
-    # reorder_batch_threshold = 0 routing that makes a captured decode graph
-    # replay stale plan data. The refusal must not be conditioned on the dtype.
+@pytest.mark.parametrize("cache_dtype", ["auto", "fp8"])
+def test_cudagraph_support_wide_head_non_nvfp4_keeps_capture(cache_dtype, monkeypatch):
+    # Only NVFP4 takes the VO split, so a 512-wide head on bf16 / FP8 KV still
+    # uses the real decode wrapper and must keep its capture support. Refusing
+    # here would be exactly the side effect the NVFP4 work should not impose.
     from vllm.v1.attention.backend import AttentionCGSupport
 
     assert (
         _sm12x_nvfp4_cg_support(512, monkeypatch, cache_dtype=cache_dtype)
-        == AttentionCGSupport.NEVER
+        != AttentionCGSupport.NEVER
     )

--- a/tests/v1/e2e/general/test_gemma4_nvfp4_kv_sm12x.py
+++ b/tests/v1/e2e/general/test_gemma4_nvfp4_kv_sm12x.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end NVFP4 KV correctness for Gemma 4 on consumer Blackwell (sm120/sm121).
+
+Gemma 4's global-attention layers have head_dim 512, which the FA2 NVFP4 path
+runs as a two-pass VO split through the prefill wrapper for every request. Two
+regressions only showed up end to end, under the *default* compilation config,
+and were invisible to the kernel and CPU unit tests:
+
+* FULL cudagraph decode capture around the per-step-planned VO-split prefill
+  wrapper replayed stale plan data: every Gemma 4 decoded garbage with NVFP4 KV
+  unless ``enforce_eager`` was set (chat needle retrieval 0/8 vs 8/8).
+* KV-sharing layers (E-series ``num_kv_shared_layers``) dequantized the target
+  layer's cache with k/v scale 1.0.
+
+This test serves a Gemma-4-E2B checkpoint that carries calibrated 4-bit KV
+scales (public "NVFP4" Gemma 4 checkpoints have none and are expected to
+produce garbage), with cudagraphs on, and checks needle retrieval through a
+chat-template prompt at several filler lengths. A model with calibrated NVFP4
+KV scales can be pointed at with ``VLLM_TEST_GEMMA4_NVFP4KV_MODEL``.
+"""
+
+import os
+import random
+
+import pytest
+
+from vllm import SamplingParams
+from vllm.platforms import current_platform
+
+MODEL = os.environ.get(
+    "VLLM_TEST_GEMMA4_NVFP4KV_MODEL", "jethachan/gemma-4-E2B-it-NVFP4KV-calib"
+)
+WORDS = [
+    "the", "river", "runs", "quietly", "between", "old", "stones", "and",
+    "the", "wind", "carries", "dust", "over", "the", "fields", "while",
+    "travellers", "rest", "under", "tall", "trees",
+]  # fmt: skip
+# Word counts of neutral filler around the needle. 0 exercises the 34-token
+# prompt that already failed under the cudagraph bug; the long ones cross
+# several KV pages so prefill/decode both touch the shared cache.
+FILLER_WORDS = (0, 50, 200, 800)
+
+
+def _needle_prompt(n_words: int, seed: int) -> tuple[str, str]:
+    rng = random.Random(seed)
+    needle = str(rng.randint(10000, 99999))
+    filler = lambda n: " ".join(rng.choice(WORDS) for _ in range(n))  # noqa: E731
+    head, tail = filler(n_words // 2), filler(n_words - n_words // 2)
+    body = f"{head} The secret code is {needle}. {tail}"
+    return f"{body}\n\nWhat is the secret code? Answer with just the number.", needle
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda()
+    or not current_platform.is_device_capability_family(120),
+    reason="NVFP4 KV on the FlashInfer FA2 path is sm120/sm121 only",
+)
+def test_gemma4_e2b_nvfp4_kv_needle_with_cudagraphs(vllm_runner):
+    with vllm_runner(
+        MODEL,
+        kv_cache_dtype="nvfp4",
+        max_model_len=4096,
+        max_num_seqs=2,
+        gpu_memory_utilization=0.6,
+        enforce_eager=False,  # the regression only reproduces with graphs
+        # Keep decode capture sizes so a FULL decode graph is attempted when the
+        # backend advertises support for it (which it must not for VO-split).
+        compilation_config={"cudagraph_capture_sizes": [1, 2]},
+        enable_prefix_caching=True,
+        # VllmRunner turns chunked prefill off by default; the serving default
+        # is on, and with it off the decode batches never reach the shape that
+        # dispatches the FULL graph, which hid the regression entirely.
+        enable_chunked_prefill=True,
+    ) as vllm_model:
+        tokenizer = vllm_model.llm.get_tokenizer()
+        cases = [_needle_prompt(n, seed=n + 1) for n in FILLER_WORDS]
+        prompts = [
+            tokenizer.apply_chat_template(
+                [{"role": "user", "content": q}],
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+            for q, _ in cases
+        ]
+        # Read the completion only: VllmRunner.generate_greedy returns
+        # prompt + completion, and the prompt contains the needle.
+        req_outputs = vllm_model.llm.generate(
+            prompts, SamplingParams(temperature=0.0, max_tokens=16)
+        )
+        answers = [out.outputs[0].text for out in req_outputs]
+
+    misses = [
+        (n, needle, text.strip()[:40])
+        for n, (_, needle), text in zip(FILLER_WORDS, cases, answers)
+        if needle not in text
+    ]
+    # bf16 KV retrieves all of these; NVFP4 KV must too. Allow no misses:
+    # the failure modes here are all-or-nothing (garbage decodes, 0/N).
+    assert not misses, f"NVFP4 KV needle misses (filler_words, needle, got): {misses}"

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -190,6 +190,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
+    VLLM_NVFP4_KV_VOSPLIT: bool = True
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
@@ -1549,6 +1550,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Control the workspace buffer size for the FlashInfer backend.
     "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE": lambda: int(
         os.getenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(394 * 1024 * 1024))
+    ),
+    # NVFP4 KV cache VO-split on consumer Blackwell (CC 12.x): route
+    # Gemma-4 heterogeneous-head full-attention layers (head_dim_qk=512,
+    # head_dim_vo=256) through the FlashInfer FA2 asymmetric paged kernel
+    # instead of forcing TRITON_ATTN. Default-on for nvfp4 KV; "0" is the
+    # escape hatch back to the Triton fallback.
+    "VLLM_NVFP4_KV_VOSPLIT": lambda: bool(
+        int(os.getenv("VLLM_NVFP4_KV_VOSPLIT", "1"))
     ),
     # Control the maximum number of tokens per expert supported by the
     # NVFP4 MoE CUTLASS Kernel. This value is used to create a buffer for

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -191,6 +191,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_NVFP4_KV_VOSPLIT: bool = True
+    VLLM_FLASHINFER_MM_PREFIX: bool = True
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
@@ -1558,6 +1559,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # escape hatch back to the Triton fallback.
     "VLLM_NVFP4_KV_VOSPLIT": lambda: bool(
         int(os.getenv("VLLM_NVFP4_KV_VOSPLIT", "1"))
+    ),
+    # Let the FlashInfer backend serve mm-prefix LMs (Gemma 3 / Gemma 4
+    # multimodal): image-token spans attend bidirectionally via FA2
+    # packed custom masks on a second prefill wrapper; text requests
+    # stay on the fast causal path. Lifts the is_mm_prefix_lm backend
+    # rejection without requiring --language-model-only. Default-on so
+    # multimodal Gemma 3/4 masks image spans correctly out of the box;
+    # set to "0" to route mm-prefix models away from FlashInfer instead.
+    "VLLM_FLASHINFER_MM_PREFIX": lambda: bool(
+        int(os.getenv("VLLM_FLASHINFER_MM_PREFIX", "1"))
     ),
     # Control the maximum number of tokens per expert supported by the
     # NVFP4 MoE CUTLASS Kernel. This value is used to create a buffer for

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -220,6 +220,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_NVFP4_KV_VOSPLIT: bool = True
+    VLLM_FLASHINFER_MM_PREFIX: bool = True
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
@@ -1763,6 +1764,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # instead of forcing TRITON_ATTN. Default-on for nvfp4 KV; "0" is the
     # escape hatch back to the Triton fallback.
     "VLLM_NVFP4_KV_VOSPLIT": lambda: bool(int(os.getenv("VLLM_NVFP4_KV_VOSPLIT", "1"))),
+    # Let the FlashInfer backend serve mm-prefix LMs (Gemma 3 / Gemma 4
+    # multimodal): image-token spans attend bidirectionally via FA2
+    # packed custom masks on a second prefill wrapper; text requests
+    # stay on the fast causal path. Lifts the is_mm_prefix_lm backend
+    # rejection without requiring --language-model-only. Default-on so
+    # multimodal Gemma 3/4 masks image spans correctly out of the box;
+    # set to "0" to route mm-prefix models away from FlashInfer instead.
+    "VLLM_FLASHINFER_MM_PREFIX": lambda: bool(
+        int(os.getenv("VLLM_FLASHINFER_MM_PREFIX", "1"))
+    ),
     # Control the maximum number of tokens per expert supported by the
     # NVFP4 MoE CUTLASS Kernel. This value is used to create a buffer for
     # the blockscale tensor of activations NVFP4 Quantization.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -219,6 +219,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
+    VLLM_NVFP4_KV_VOSPLIT: bool = True
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
@@ -1756,6 +1757,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE": lambda: int(
         os.getenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(394 * 1024 * 1024))
     ),
+    # NVFP4 KV cache VO-split on consumer Blackwell (CC 12.x): route
+    # Gemma-4 heterogeneous-head full-attention layers (head_dim_qk=512,
+    # head_dim_vo=256) through the FlashInfer FA2 asymmetric paged kernel
+    # instead of forcing TRITON_ATTN. Default-on for nvfp4 KV; "0" is the
+    # escape hatch back to the Triton fallback.
+    "VLLM_NVFP4_KV_VOSPLIT": lambda: bool(int(os.getenv("VLLM_NVFP4_KV_VOSPLIT", "1"))),
     # Control the maximum number of tokens per expert supported by the
     # NVFP4 MoE CUTLASS Kernel. This value is used to create a buffer for
     # the blockscale tensor of activations NVFP4 Quantization.

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -983,10 +983,11 @@ class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
         type_ = kv_cache_scheme.get("type")
         num_bits = kv_cache_scheme.get("num_bits")
 
-        if type_ != "float" or num_bits != 8:
+        # num_bits=8 -> fp8 KV; num_bits=4 -> nvfp4 KV (consumer Blackwell FA2).
+        if type_ != "float" or num_bits not in (4, 8):
             raise NotImplementedError(
                 "Currently supported kv cache quantization is "
-                "num_bits=8, type=float, however "
+                "num_bits in (4, 8), type=float, however "
                 f"received num_bits={num_bits}, type={type_}"
             )
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1063,10 +1063,11 @@ class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
         type_ = kv_cache_scheme.get("type")
         num_bits = kv_cache_scheme.get("num_bits")
 
-        if type_ != "float" or num_bits != 8:
+        # num_bits=8 -> fp8 KV; num_bits=4 -> nvfp4 KV (consumer Blackwell FA2).
+        if type_ != "float" or num_bits not in (4, 8):
             raise NotImplementedError(
                 "Currently supported kv cache quantization is "
-                "num_bits=8, type=float, however "
+                "num_bits in (4, 8), type=float, however "
                 f"received num_bits={num_bits}, type={type_}"
             )
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1083,6 +1083,17 @@ class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
                 f" {strategy}"
             )
 
+        # NVFP4 KV stores one global scale per side: reshape_and_cache_nvfp4
+        # dereferences k_scale/v_scale as scalars, so per-head scales would
+        # silently apply head 0's scale to every head. Reject rather than
+        # quantize the whole cache against the wrong scale.
+        if num_bits == 4 and strategy != QuantizationStrategy.TENSOR:
+            raise NotImplementedError(
+                "NVFP4 KV cache (num_bits=4) supports only per-tensor scales; "
+                "the cache-store kernel reads a single k/v scale per side. "
+                f"Found strategy: {strategy}."
+            )
+
         is_symmetric = kv_cache_scheme.get("symmetric")
         if not is_symmetric:
             raise NotImplementedError(

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -75,8 +75,41 @@ class Gemma4Config(VerifyAndUpdateConfig):
         if head_dim is None or global_head_dim is None or head_dim == global_head_dim:
             return
 
-        from vllm.v1.attention.backends.fa_utils import is_fa_version_supported
         from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+        # NVFP4 KV cache on consumer Blackwell (CC 12.x): the FlashInfer
+        # FA2 asymmetric paged kernel handles head_dim_qk=512 /
+        # head_dim_vo=256 directly (the campaign VO-split path), so route
+        # the heterogeneous-head Gemma 4 config to FLASHINFER instead of
+        # the TRITON_ATTN fallback below. Gated on VLLM_NVFP4_KV_VOSPLIT
+        # (default-on for nvfp4) and only when the user did not pin a
+        # backend. Returns before the FA4/Triton selection.
+        import vllm.envs as envs
+        from vllm.platforms import current_platform
+
+        cache_config = vllm_config.cache_config
+        if (
+            cache_config is not None
+            and cache_config.cache_dtype == "nvfp4"
+            and envs.VLLM_NVFP4_KV_VOSPLIT
+            and vllm_config.attention_config.backend is None
+            and current_platform.is_device_capability_family(120)
+        ):
+            vllm_config.attention_config.backend = AttentionBackendEnum.FLASHINFER
+            logger.info(
+                "Gemma4 model has heterogeneous head dimensions "
+                "(head_dim=%d, global_head_dim=%d) with NVFP4 KV cache on "
+                "CC 12.x. Routing to FLASHINFER (FA2 VO-split asymmetric "
+                "head_dim_qk=%d/head_dim_vo=%d kernel) instead of "
+                "TRITON_ATTN.",
+                head_dim,
+                global_head_dim,
+                global_head_dim,
+                head_dim,
+            )
+            return
+
+        from vllm.v1.attention.backends.fa_utils import is_fa_version_supported
 
         max_head_dim = max(head_dim, global_head_dim)
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -156,11 +156,25 @@ class DiffusionGemmaModelForBlockDiffusionConfig(VerifyAndUpdateConfig):
 
         attention_config = vllm_config.attention_config
         if attention_config.backend == AttentionBackendEnum.FLASHINFER:
-            raise ValueError(
-                "FlashInfer does not support DiffusionGemma's mixed "
-                "causal/bidirectional attention. Use --attention-backend "
-                "FLASH_ATTN or TRITON_ATTN instead."
-            )
+            import vllm.envs as envs
+
+            if envs.VLLM_NVFP4_KV_VOSPLIT:
+                # The unified FlashInfer prefill grouping (FIPrefillGroup, keyed
+                # by ``(is_mm, causal)``) serves DiffusionGemma's mixed
+                # causal/bidirectional batches (encoder=causal, denoise=
+                # non-causal), including the D=512 NVFP4 VO-split path. Allowed
+                # when the NVFP4 VO-split path is enabled.
+                logger.info(
+                    "DiffusionGemma on FLASHINFER via unified per-request "
+                    "causal grouping (NVFP4 VO-split active)."
+                )
+            else:
+                raise ValueError(
+                    "FlashInfer does not support DiffusionGemma's mixed "
+                    "causal/bidirectional attention without the NVFP4 VO-split "
+                    "path. Use --attention-backend FLASH_ATTN or TRITON_ATTN "
+                    "instead."
+                )
         if attention_config.backend is None and not attention_config.use_non_causal:
             attention_config.use_non_causal = True
             logger.info(

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -230,8 +230,38 @@ class Gemma4Config(VerifyAndUpdateConfig):
         if len(set(head_dims.values())) <= 1:
             return
 
-        from vllm.v1.attention.backends.fa_utils import is_fa_version_supported
+        # NVFP4 KV cache on consumer Blackwell (CC 12.x): the FlashInfer
+        # FA2 asymmetric paged kernel handles head_dim_qk=512 /
+        # head_dim_vo=256 directly (the two-pass VO-split path), so route
+        # the heterogeneous-head Gemma 4 config to FLASHINFER instead of
+        # the TRITON_ATTN fallback below. Gated on VLLM_NVFP4_KV_VOSPLIT
+        # (default-on for nvfp4) and only when the user did not pin a
+        # backend. Returns before the FA4/Triton selection.
+        import vllm.envs as envs
+        from vllm.platforms import current_platform
         from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+        cache_config = vllm_config.cache_config
+        if (
+            cache_config is not None
+            and cache_config.cache_dtype.startswith("nvfp4")
+            and envs.VLLM_NVFP4_KV_VOSPLIT
+            and vllm_config.attention_config.backend is None
+            and current_platform.is_device_capability_family(120)
+        ):
+            vllm_config.attention_config.backend = AttentionBackendEnum.FLASHINFER
+            logger.info(
+                "Gemma4 model has heterogeneous head dimensions %s with NVFP4 "
+                "KV cache on CC 12.x. Routing to FLASHINFER (FA2 VO-split "
+                "asymmetric head_dim_qk=%d/head_dim_vo=%d kernel) instead of "
+                "TRITON_ATTN.",
+                head_dims,
+                max(head_dims.values()),
+                min(head_dims.values()),
+            )
+            return
+
+        from vllm.v1.attention.backends.fa_utils import is_fa_version_supported
 
         max_head_dim = max(head_dims.values())
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -305,23 +305,54 @@ class DiffusionGemmaModelForBlockDiffusionConfig(VerifyAndUpdateConfig):
         attention_config = vllm_config.attention_config
         if attention_config.backend == AttentionBackendEnum.FLASHINFER:
             import vllm.envs as envs
+            from vllm.config.compilation import CUDAGraphMode
+            from vllm.platforms import current_platform
 
-            if envs.VLLM_NVFP4_KV_VOSPLIT:
-                # The unified FlashInfer prefill grouping (FIPrefillGroup, keyed
-                # by ``(is_mm, causal)``) serves DiffusionGemma's mixed
+            cache_config = vllm_config.cache_config
+            nvfp4_vosplit = (
+                cache_config is not None
+                and cache_config.cache_dtype.startswith("nvfp4")
+                and envs.VLLM_NVFP4_KV_VOSPLIT
+                and current_platform.is_device_capability_family(120)
+            )
+            if nvfp4_vosplit:
+                # The unified FlashInfer prefill grouping (FIPrefillGroup,
+                # keyed by ``(is_mm, causal)``) serves DiffusionGemma's mixed
                 # causal/bidirectional batches (encoder=causal, denoise=
-                # non-causal), including the D=512 NVFP4 VO-split path. Allowed
-                # when the NVFP4 VO-split path is enabled.
+                # non-causal), including the D=512 NVFP4 VO-split path. Only
+                # that path builds nvfp4-aware group wrappers, so the gate
+                # matches Gemma4Config's: NVFP4 KV, the VO-split knob, and
+                # consumer Blackwell.
+                # The grouped prefill path partitions the batch in Python by
+                # (is_mm, causal), so its control flow is data-dependent and
+                # cannot be baked into a full CUDA graph. Forcing per-request
+                # causal batches off the decode split means uniform
+                # decode-shaped denoise steps reach that path too, so keep
+                # capture piecewise.
+                compilation_config = vllm_config.compilation_config
+                # cudagraph_mode is still None here (CompilationConfig
+                # defaults it later), so test for that before dereferencing.
+                if (
+                    compilation_config.cudagraph_mode is None
+                    or compilation_config.cudagraph_mode.has_full_cudagraphs()
+                ):
+                    compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+                    logger.info(
+                        "DiffusionGemma on FLASHINFER: forcing PIECEWISE "
+                        "cudagraph mode; the grouped prefill partition is "
+                        "data-dependent and cannot be full-graph captured."
+                    )
                 logger.info(
                     "DiffusionGemma on FLASHINFER via unified per-request "
                     "causal grouping (NVFP4 VO-split active)."
                 )
             else:
                 raise ValueError(
-                    "FlashInfer does not support DiffusionGemma's mixed "
-                    "causal/bidirectional attention without the NVFP4 VO-split "
-                    "path. Use --attention-backend FLASH_ATTN or TRITON_ATTN "
-                    "instead."
+                    "FlashInfer supports DiffusionGemma's mixed "
+                    "causal/bidirectional attention only on the NVFP4 "
+                    "VO-split path (NVFP4 KV cache on CC 12.x with "
+                    "VLLM_NVFP4_KV_VOSPLIT). Use --attention-backend "
+                    "FLASH_ATTN or TRITON_ATTN instead."
                 )
         if attention_config.backend is None and not attention_config.use_non_causal:
             attention_config.use_non_causal = True

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -304,11 +304,25 @@ class DiffusionGemmaModelForBlockDiffusionConfig(VerifyAndUpdateConfig):
 
         attention_config = vllm_config.attention_config
         if attention_config.backend == AttentionBackendEnum.FLASHINFER:
-            raise ValueError(
-                "FlashInfer does not support DiffusionGemma's mixed "
-                "causal/bidirectional attention. Use --attention-backend "
-                "FLASH_ATTN or TRITON_ATTN instead."
-            )
+            import vllm.envs as envs
+
+            if envs.VLLM_NVFP4_KV_VOSPLIT:
+                # The unified FlashInfer prefill grouping (FIPrefillGroup, keyed
+                # by ``(is_mm, causal)``) serves DiffusionGemma's mixed
+                # causal/bidirectional batches (encoder=causal, denoise=
+                # non-causal), including the D=512 NVFP4 VO-split path. Allowed
+                # when the NVFP4 VO-split path is enabled.
+                logger.info(
+                    "DiffusionGemma on FLASHINFER via unified per-request "
+                    "causal grouping (NVFP4 VO-split active)."
+                )
+            else:
+                raise ValueError(
+                    "FlashInfer does not support DiffusionGemma's mixed "
+                    "causal/bidirectional attention without the NVFP4 VO-split "
+                    "path. Use --attention-backend FLASH_ATTN or TRITON_ATTN "
+                    "instead."
+                )
         if attention_config.backend is None and not attention_config.use_non_causal:
             attention_config.use_non_causal = True
             logger.info(

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -467,29 +467,60 @@ def _nvfp4_split_data_scale(
     return data, scale
 
 
-def nvfp4_kv_cache_split_views(kv_cache: torch.Tensor) -> tuple[tuple, tuple]:
+def _nvfp4_global_split_views(kv_cache: torch.Tensor) -> tuple[tuple, tuple]:
+    """Contiguous [all-data | all-SF] split for the FlashInfer FA2 nvfp4 path.
+
+    The FA2 paged nvfp4 kernel derives the scale-factor stride as
+    ``data_stride / 8`` (it does not read the SF tensor's own strides), so the
+    data and scale regions must each be contiguous with that exact 8:1 ratio at
+    every dim.  We therefore lay the page buffer out as one contiguous data
+    region followed by one contiguous SF region (rather than the trtllm-gen
+    per-page ``[data|scale]`` interleave).  Slicing K/V from dim 1 preserves the
+    8:1 ratio on each side (both skip the other side's region by the same
+    factor).  Requires a contiguous (NHD) ``kv_cache``.
+    """
+    full = kv_cache.shape[-1]
+    data_dim = full * 8 // 9
+    scale_dim = full - data_dim
+    flat = kv_cache.reshape(-1)
+    if kv_cache.dim() == 4:
+        nb, d1, d2 = kv_cache.shape[:3]
+        dc = nb * d1 * d2 * data_dim
+        data = flat[:dc].view(nb, d1, d2, data_dim)
+        scale = flat[dc:].view(nb, d1, d2, scale_dim).view(torch.float8_e4m3fn)
+        return (data,), (scale,)
+    nb, two, d1, d2 = kv_cache.shape[:4]
+    dc = nb * two * d1 * d2 * data_dim
+    data = flat[:dc].view(nb, two, d1, d2, data_dim)
+    scale = flat[dc:].view(nb, two, d1, d2, scale_dim).view(torch.float8_e4m3fn)
+    return (data[:, 0], data[:, 1]), (scale[:, 0], scale[:, 1])
+
+
+def nvfp4_kv_cache_split_views(
+    kv_cache: torch.Tensor, contiguous_sf_layout: bool = False
+) -> tuple[tuple, tuple]:
     """Split an NVFP4 KV cache tensor into data and scale views.
 
     Accepts either a 5D tensor ``(num_pages, 2, dim_2, dim_3, full_dim)``
     or a 4D single-side tensor ``(num_pages, dim_2, dim_3, full_dim)``.
 
-    Per-page layout: [K_data | K_scale | V_data | V_scale].
-    Each KV side is self-contained (data followed by its scale), so the
-    5D case simply splits each side independently.
+    Two physical layouts are supported, selected by ``contiguous_sf_layout``:
 
-    The returned views are in the same dim order as the input (NHD or
-    HND), so callers get views matching whichever order they passed in.
+    * ``False`` (default, trtllm-gen / sm100f): per-page ``[data|scale]`` — each
+      KV side is self-contained (data followed by its scale) within its page.
+    * ``True`` (FlashInfer FA2 / sm120/sm121): contiguous ``[all-data|all-SF]``
+      — required because the FA2 nvfp4 kernel derives the SF stride as
+      ``data_stride/8``.  See :func:`_nvfp4_global_split_views`.
 
-    Args:
-        kv_cache: 5D or 4D uint8 tensor where the last dimension is
-            ``full_dim = data_dim + scale_dim = 9 * head_size / 16``.
+    The returned views are in the same dim order as the input (NHD or HND).
 
     Returns:
-        For 5D input:
-            ``(k_data, v_data), (k_scale, v_scale)``
-        For 4D input (single KV side):
-            ``(data,), (scale,)``
+        For 5D input: ``(k_data, v_data), (k_scale, v_scale)``.
+        For 4D input (single KV side): ``(data,), (scale,)``.
     """
+    if contiguous_sf_layout:
+        return _nvfp4_global_split_views(kv_cache)
+
     if kv_cache.dim() == 4:
         data, scale = _nvfp4_split_data_scale(kv_cache)
         return (data,), (scale,)

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -522,16 +522,29 @@ class FlashInferBackend(AttentionBackend):
 
 
 @dataclass
-class FIPrefillMMGroup:
-    """One partition of an mm-prefix prefill batch (Gemma 3 / Gemma 4
-    multimodal: requests whose image-token span intersects the current
-    query window need span-level bidirectional masking; plain requests
-    stay causal)."""
+class FIPrefillGroup:
+    """One partition of a prefill batch whose requests do not all share the
+    same attention semantics. The group key is the per-request tuple
+    ``(is_mm, causal)``, subsuming two structurally parallel mechanisms:
+
+    * mm-prefix (Gemma 3 / Gemma 4 multimodal): requests whose image-token
+      span intersects the query window need span-level bidirectional
+      masking; plain requests stay causal.
+    * per-request causal (DiffusionGemma): encoder/commit requests are
+      causal, denoise requests are bidirectional, mixed within a batch.
+    * composed mm x causal (multimodal DiffusionGemma): requests group by
+      BOTH keys; each group's wrapper carries the right causal flag AND
+      the right packed mask.
+
+    The attention semantics are baked into ``wrapper`` at plan() time, so
+    the dataclass only needs the wrapper plus this group's gather index."""
 
     wrapper: BatchPrefillWithPagedKVCacheWrapper
-    """Planned for exactly this group's requests: causal=True for the
-    plain group, packed custom mask ((causal AND sliding-window) OR
-    span-bidirectional) for the mm group."""
+    """Planned for exactly this group's requests. Plain-causal groups plan
+    causal=True with the layer-group window; non-causal groups plan
+    causal=False; mm groups plan a packed custom mask ((base AND
+    sliding-window) OR span-bidirectional) with the chosen causal base
+    folded into the mask, window_left=-1."""
 
     token_indices: torch.Tensor
     """Rows of the prefill query/output owned by this group: GPU int64,
@@ -547,10 +560,12 @@ class FIPrefill:
 
     wrapper: BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper
 
-    mm_groups: list[FIPrefillMMGroup] | None = None
-    """mm-prefix wrapper grouping when image-token spans intersect the
-    query window of at least one prefill request; None on the scalar
-    causal fast path (no mm requests => byte-identical legacy path)."""
+    prefill_groups: list[FIPrefillGroup] | None = None
+    """Per-semantics wrapper grouping when the prefill batch mixes
+    attention semantics -- image-token spans intersect the query window of
+    at least one request (mm-prefix) and/or ``CommonAttentionMetadata.causal``
+    is a per-request tensor (DiffusionGemma). None on the scalar-causal
+    no-mm fast path (=> byte-identical legacy single-wrapper path)."""
 
 
 @dataclass
@@ -668,9 +683,20 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self._noncausal_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = (
             None  # Wrapper for non-causal prefill (DFlash)
         )
-        # Second prefill wrapper for mm-prefix custom-mask requests
-        # (Gemma 3 / Gemma 4 multimodal image spans); lazily created.
-        self._mm_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = None
+        # Secondary persistent prefill wrappers for the grouped-prefill path
+        # (FIPrefillGroup). Each group key that is NOT plain-causal (which
+        # reuses self._prefill_wrapper) gets its own wrapper, since every
+        # group plans once and all run in the same step. Keyed by
+        # (is_mm, causal); every wrapper is built nvfp4-aware (so the FA2/
+        # trtllm-gen backend + VO split apply identically), unlike the
+        # backend="auto" DFlash _noncausal_prefill_wrapper which rejects nvfp4.
+        #   (True,  True ) mm spans, causal base   -> packed custom mask
+        #   (True,  False) mm spans, non-causal    -> packed custom mask
+        #   (False, False) plain non-causal (DiffusionGemma denoise)
+        # The (False, True) plain-causal key uses self._prefill_wrapper.
+        self._grouped_prefill_wrappers: dict[
+            tuple[bool, bool], BatchPrefillWithPagedKVCacheWrapper
+        ] = {}
         self._decode_wrapper = None  # Wrapper for decode (general shape)
 
         if envs.VLLM_BATCH_INVARIANT:
@@ -1003,24 +1029,36 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         assert self._prefill_wrapper is not None
         return self._prefill_wrapper
 
-    def _get_mm_prefill_wrapper(self) -> BatchPrefillWithPagedKVCacheWrapper:
-        # Second paged prefill wrapper for the mm-prefix custom-mask group.
-        # Built the same way as the plain prefill wrapper (the VO split and
-        # NVFP4 jit module are applied at plan()/run() time, not here);
-        # only reachable on the mm-prefix path, which rejects DCP.
-        if self._mm_prefill_wrapper is None:
+    def _get_group_prefill_wrapper(
+        self, is_mm: bool, causal: bool
+    ) -> BatchPrefillWithPagedKVCacheWrapper:
+        # Persistent prefill wrapper for one (is_mm, causal) group key of the
+        # grouped prefill path (FIPrefillGroup). The plain-causal key reuses
+        # the primary self._prefill_wrapper (so the legacy single-wrapper plan
+        # is untouched when only one group exists); every other key -- including
+        # plain non-causal -- gets its own lazily-built wrapper from the SAME
+        # nvfp4-aware construction (the VO split + NVFP4 jit module are applied
+        # at plan()/run() time). Only reachable on the grouped path (no DCP).
+        if not is_mm and causal:
+            wrapper = self._get_prefill_wrapper()
+            assert isinstance(wrapper, BatchPrefillWithPagedKVCacheWrapper)
+            return wrapper
+        key = (is_mm, causal)
+        wrapper = self._grouped_prefill_wrappers.get(key)
+        if wrapper is None:
             if self.use_fa2_nvfp4_kv:
                 backend = "fa2"
             elif self.is_kvcache_nvfp4:
                 backend = "trtllm-gen"
             else:
                 backend = "auto"
-            self._mm_prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
+            wrapper = BatchPrefillWithPagedKVCacheWrapper(
                 self._get_workspace_buffer(),
                 get_kv_cache_layout(),
                 backend=backend,
             )
-        return self._mm_prefill_wrapper
+            self._grouped_prefill_wrappers[key] = wrapper
+        return wrapper
 
     def _get_decode_wrapper(self, batch_size: int, use_cudagraph: bool = False):
         if use_cudagraph:
@@ -1177,25 +1215,41 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         qo_lens: list[int],
         kv_lens: list[int],
         span_lists: list[list[tuple[int, int]]],
+        causal_base: bool = True,
     ) -> torch.Tensor:
         """Boolean (qo_len x kv_len)-per-request mask, flattened row-major
         and concatenated in group order; FlashInfer's plan() bit-packs it
         per request (segment_packbits). Composition matches the Triton /
         FlexAttention mm-prefix contract:
-        (causal AND sliding-window) OR (q in span AND kv in span),
+        (base AND sliding-window) OR (q in span AND kv in span),
         with query rows end-aligned to the KV sequence. The mm wrapper is
         planned with window_left=-1 because the mask already carries the
         sliding window; spans must OVERRIDE it (FlashInfer's in-kernel SW
-        would AND it instead)."""
+        would AND it instead).
+
+        ``base`` is the causal lower-triangle when ``causal_base`` is True
+        (the autoregressive mm ladder) and the all-attend matrix when False
+        (composed mm x non-causal: a DiffusionGemma denoise request that
+        also carries image spans -- text region bidirectional, spans stay
+        bidirectional). The sliding-window AND still applies to the base in
+        both cases; spans OR over it unchanged."""
         masks = []
         for qo_len, kv_len, spans in zip(qo_lens, kv_lens, span_lists):
             q_abs = torch.arange(
                 kv_len - qo_len, kv_len, device=self.device, dtype=torch.int32
             )
             k_abs = torch.arange(kv_len, device=self.device, dtype=torch.int32)
-            mask = k_abs[None, :] <= q_abs[:, None]
-            if self.window_left >= 0:
-                mask &= (q_abs[:, None] - k_abs[None, :]) <= self.window_left
+            if causal_base:
+                mask = k_abs[None, :] <= q_abs[:, None]
+                if self.window_left >= 0:
+                    mask &= (q_abs[:, None] - k_abs[None, :]) <= self.window_left
+            else:
+                mask = torch.ones(
+                    (qo_len, kv_len), device=self.device, dtype=torch.bool
+                )
+                if self.window_left >= 0:
+                    # Non-causal base: symmetric window around the query.
+                    mask &= (q_abs[:, None] - k_abs[None, :]).abs() <= self.window_left
             for start, end in spans:
                 q_in = (q_abs >= start) & (q_abs <= end)
                 k_in = (k_abs >= start) & (k_abs <= end)
@@ -1203,38 +1257,71 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             masks.append(mask.reshape(-1))
         return torch.cat(masks)
 
-    def _plan_prefill_mm_groups(
+    def _plan_prefill_groups(
         self,
-        prefill_mm_spans: list[list[tuple[int, int]]],
+        prefill_mm_spans: list[list[tuple[int, int]]] | None,
+        causal_prefill_cpu: torch.Tensor | None,
         qo_indptr_prefill_cpu: torch.Tensor,
         paged_kv_indptr_prefill_cpu: torch.Tensor,
         paged_kv_last_page_len_prefill_cpu: torch.Tensor,
         paged_kv_indices: torch.Tensor,
         seq_lens_prefill_cpu: torch.Tensor,
         o_dtype: torch.dtype,
-    ) -> list[FIPrefillMMGroup]:
-        """Plan one prefill wrapper per partition of an mm-prefix batch:
-        requests with image spans intersecting the query window run on a
-        custom-mask wrapper; the rest stay on the fast causal wrapper.
+    ) -> list[FIPrefillGroup]:
+        """Plan one prefill wrapper per distinct attention-semantics
+        partition of the batch, keyed by the per-request tuple
+        ``(is_mm, causal)``:
 
-        Each request's tokens and KV pages are contiguous ranges of the
-        batch-level arrays, so a group is fully described by per-request
-        deltas of the indptr arrays plus gathered index subranges
-        (indptr/last_page_len slicing on CPU, paged_kv_indices on GPU).
-        plan(custom_mask=...) requires the FlashInfer-side mask_indptr
-        device fix because the mask lives on GPU while the indptr arrays
-        stay on CPU.
+        * ``is_mm`` is True when the request has an image-token span that
+          intersects its query window (mm-prefix); the mm group plans a
+          packed custom mask. Source: ``prefill_mm_spans`` (None => all
+          is_mm=False).
+        * ``causal`` is the per-request causal flag (DiffusionGemma:
+          encoder/commit causal, denoise bidirectional). Source:
+          ``causal_prefill_cpu`` (None => scalar-causal batch, all causal).
+
+        Subsumes mm-only (is_mm varies), causal-only (causal varies), and
+        composed mm x causal. Each request's tokens and KV pages are
+        contiguous ranges of the batch-level arrays, so a group is fully
+        described by per-request indptr deltas plus gathered index subranges.
+        plan(custom_mask=...) requires the FlashInfer-side mask_indptr device
+        fix because the mask lives on GPU while the indptr arrays stay on CPU.
         """
-        is_mm = torch.tensor([bool(s) for s in prefill_mm_spans])
+        num_prefills = int(qo_indptr_prefill_cpu.numel()) - 1
+        is_mm = [
+            bool(prefill_mm_spans[i]) if prefill_mm_spans is not None else False
+            for i in range(num_prefills)
+        ]
+        if causal_prefill_cpu is not None:
+            is_causal = [bool(causal_prefill_cpu[i]) for i in range(num_prefills)]
+        else:
+            is_causal = [True] * num_prefills
+        keys = [(is_mm[i], is_causal[i]) for i in range(num_prefills)]
+
         qo_lens_cpu = qo_indptr_prefill_cpu[1:] - qo_indptr_prefill_cpu[:-1]
         # paged_kv_indptr is NOT rebased to 0 (its offsets index the full
         # paged_kv_indices array), so deltas are taken before regrouping.
         kv_page_counts_cpu = (
             paged_kv_indptr_prefill_cpu[1:] - paged_kv_indptr_prefill_cpu[:-1]
         )
-        groups: list[FIPrefillMMGroup] = []
-        for group_mm in (False, True):
-            req_indices = (is_mm if group_mm else ~is_mm).nonzero(as_tuple=True)[0]
+        groups: list[FIPrefillGroup] = []
+        # Deterministic key order: plain-causal first (so a degenerate
+        # single-group batch reuses the primary wrapper exactly as the
+        # mm-only path did), then the rest.
+        for group_mm, group_causal in (
+            (False, True),
+            (False, False),
+            (True, True),
+            (True, False),
+        ):
+            req_indices = torch.tensor(
+                [
+                    i
+                    for i in range(num_prefills)
+                    if keys[i] == (group_mm, group_causal)
+                ],
+                dtype=torch.int64,
+            )
             if req_indices.numel() == 0:
                 continue
             group_qo_indptr = torch.zeros(req_indices.numel() + 1, dtype=torch.int32)
@@ -1266,25 +1353,24 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             group_kv_indices = torch.index_select(
                 paged_kv_indices, 0, page_gather_cpu.to(self.device)
             )
+            wrapper = self._get_group_prefill_wrapper(group_mm, group_causal)
             if group_mm:
-                wrapper = self._get_mm_prefill_wrapper()
+                # The packed mask carries the group's causal base AND the
+                # sliding window AND the span bidirectionality wholesale, so
+                # the wrapper plans causal=False, window_left=-1 regardless.
+                assert prefill_mm_spans is not None
                 custom_mask = self._build_mm_prefix_custom_mask(
                     [int(qo_lens_cpu[i]) for i in req_indices.tolist()],
                     [int(seq_lens_prefill_cpu[i]) for i in req_indices.tolist()],
                     [prefill_mm_spans[i] for i in req_indices.tolist()],
+                    causal_base=group_causal,
                 )
-                # The mask carries causal/SW/span composition wholesale.
-                group_causal = False
-                group_window_left = -1
+                plan_causal = False
+                plan_window_left = -1
             else:
-                maybe_wrapper = self._get_prefill_wrapper()
-                assert isinstance(
-                    maybe_wrapper, BatchPrefillWithPagedKVCacheWrapper
-                )
-                wrapper = maybe_wrapper
                 custom_mask = None
-                group_causal = True
-                group_window_left = self.window_left
+                plan_causal = group_causal
+                plan_window_left = self.window_left
             wrapper.plan(
                 qo_indptr=group_qo_indptr,
                 paged_kv_indptr=group_kv_indptr,
@@ -1299,10 +1385,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 # impl runs each group's wrapper once per V slice.
                 head_dim_vo=self.head_dim // self.vo_split,
                 page_size=self.page_size,
-                causal=group_causal,
+                causal=plan_causal,
                 custom_mask=custom_mask,
                 sm_scale=self.sm_scale,
-                window_left=group_window_left,
+                window_left=plan_window_left,
                 logits_soft_cap=self.logits_soft_cap,
                 q_data_type=self.q_data_type,
                 kv_data_type=self.kv_cache_dtype,
@@ -1313,7 +1399,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             wrapper.vllm_prefill_fixed_split_size = self.prefill_fixed_split_size
             wrapper.vllm_disable_split_kv = self.disable_split_kv
             groups.append(
-                FIPrefillMMGroup(
+                FIPrefillGroup(
                     wrapper=wrapper,
                     token_indices=token_indices_cpu.to(self.device),
                     num_tokens=int(token_indices_cpu.numel()),
@@ -1330,7 +1416,15 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         causal = common_attn_metadata.causal
-        if causal:
+        # DiffusionGemma passes a per-request causal tensor (encoder/commit
+        # causal, denoise bidirectional, mixed within a batch). For dispatch it
+        # behaves like the non-causal whole-batch path (all FI-native prefill,
+        # no TRTLLM/decode); the per-request flags are consumed by the grouped
+        # planner. Collapse to a scalar False for the decisions below -- the
+        # legacy scalar-bool ``causal`` path is unchanged.
+        per_request_causal = isinstance(causal, torch.Tensor) and num_reqs > 0
+        causal_dispatch = False if per_request_causal else causal
+        if causal_dispatch:
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
                 split_decodes_and_prefills(
                     common_attn_metadata,
@@ -1340,7 +1434,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             )
         else:
             # FlashInfer decode/TRTLLM paths cannot express non-causal
-            # query-query attention, so DFlash runs as native prefill.
+            # query-query attention, so DFlash / DiffusionGemma run as native
+            # prefill.
             num_decodes = 0
             num_prefills = num_reqs
             num_decode_tokens = 0
@@ -1363,7 +1458,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         prefill_force_trtllm = (
             True if page_size >= 128 else self.attention_config.use_trtllm_attention
         )
-        prefill_use_trtllm = causal and use_trtllm_attention(
+        prefill_use_trtllm = causal_dispatch and use_trtllm_attention(
             self.num_qo_heads,
             self.num_kv_heads,
             num_prefill_tokens,
@@ -1377,14 +1472,16 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             has_spec=uses_spec_reorder,
         )
         decode_use_trtllm = (
-            causal and self.use_trtllm_decode_attention and self.dcp_world_size <= 1
+            causal_dispatch
+            and self.use_trtllm_decode_attention
+            and self.dcp_world_size <= 1
         )
 
-        if not causal and self.use_dcp:
+        if not causal_dispatch and self.use_dcp:
             raise NotImplementedError(
                 "FlashInfer non-causal prefill is not supported with DCP yet."
             )
-        if not causal and self.use_trtllm_decode_attention:
+        if not causal_dispatch and self.use_trtllm_decode_attention:
             logger.warning_once(
                 "Using FlashInfer for draft model non-causal attention; TRTLLM "
                 "can still be used for target model causal attention."
@@ -1400,7 +1497,16 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             if prefill_mm_spans is not None:
                 prefill_use_trtllm = False
 
-        all_uses_trtllm = causal and (
+        if per_request_causal and (
+            use_cascade or self.use_dcp or self.reorder_batch_threshold > 1
+        ):
+            raise NotImplementedError(
+                "Per-request causal flags (DiffusionGemma) require the "
+                "FlashInfer-native prefill pathway (no cascade, DCP, or "
+                "spec-decode batch reordering)."
+            )
+
+        all_uses_trtllm = causal_dispatch and (
             (num_prefills == 0 or prefill_use_trtllm)
             and (num_decodes == 0 or decode_use_trtllm)
         )
@@ -1599,7 +1705,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     max_seq_len=max_seq_len,
                 )
             else:
-                prefill_wrapper = self._get_prefill_wrapper(causal=attn_metadata.causal)
+                # Per-request causal (DiffusionGemma) makes attn_metadata.causal
+                # a tensor; the grouped planner overrides this wrapper anyway, so
+                # fetch the primary causal wrapper as a placeholder (avoids the
+                # tensor truth-check and the nvfp4 non-causal raise).
+                prefill_wrapper = self._get_prefill_wrapper(
+                    causal=True if per_request_causal else attn_metadata.causal
+                )
                 # Slicing CPU buffers that are only needed for FI native prefills
                 paged_kv_last_page_len_prefill_cpu = self.paged_kv_last_page_len.cpu[
                     prefill_start:num_reqs
@@ -1609,7 +1721,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     prefill_start : num_reqs + 1
                 ]
                 assert paged_kv_indptr_prefill_cpu.shape[0] == num_prefills + 1
-                mm_groups: list[FIPrefillMMGroup] | None = None
+                prefill_groups: list[FIPrefillGroup] | None = None
                 if self.use_dcp:
                     assert isinstance(prefill_wrapper, BatchDCPPrefillWrapper)
                     prefill_wrapper.plan(
@@ -1641,10 +1753,21 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     o_dtype = (
                         FP8_DTYPE if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv) else self.model_config.dtype
                     )
-                    if prefill_mm_spans is not None:
+                    if prefill_mm_spans is not None or per_request_causal:
                         assert seq_lens_cpu is not None
-                        mm_groups = self._plan_prefill_mm_groups(
+                        # The .cpu() sync on the causal tensor is acceptable
+                        # here -- the scalar path's plan() consumes CPU arrays
+                        # in this same spot anyway.
+                        causal_prefill_cpu = (
+                            common_attn_metadata.causal[prefill_start:num_reqs]
+                            .cpu()
+                            .bool()
+                            if per_request_causal
+                            else None
+                        )
+                        prefill_groups = self._plan_prefill_groups(
                             prefill_mm_spans,
+                            causal_prefill_cpu,
                             qo_indptr_prefill_cpu,
                             paged_kv_indptr_prefill_cpu,
                             paged_kv_last_page_len_prefill_cpu,
@@ -1652,9 +1775,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                             seq_lens_cpu[prefill_start:num_reqs],
                             o_dtype,
                         )
-                        # The impl's forward dispatches on mm_groups; this
+                        # The impl's forward dispatches on prefill_groups; this
                         # field only feeds its isinstance/identity asserts.
-                        prefill_wrapper = mm_groups[0].wrapper
+                        prefill_wrapper = prefill_groups[0].wrapper
                     else:
                         prefill_wrapper.plan(
                             qo_indptr=qo_indptr_prefill_cpu,
@@ -1682,7 +1805,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                             disable_split_kv=self.disable_split_kv,
                         )
                 attn_metadata.prefill = FIPrefill(
-                    wrapper=prefill_wrapper, mm_groups=mm_groups
+                    wrapper=prefill_wrapper, prefill_groups=prefill_groups
                 )
 
         ## DECODE PATHWAY
@@ -2115,22 +2238,25 @@ class FlashInferImpl(AttentionImpl):
                     assert isinstance(
                         prefill_wrapper, BatchPrefillWithPagedKVCacheWrapper
                     )
-                    mm_groups = attn_metadata.prefill.mm_groups
+                    prefill_groups = attn_metadata.prefill.prefill_groups
                     assert prefill_wrapper._logits_soft_cap == (
                         self.logits_soft_cap or 0.0
                     )
                     assert prefill_wrapper._sm_scale == self.scale
-                    if mm_groups is None:
+                    if prefill_groups is None:
+                        # Legacy fast path: single scalar-causal wrapper.
                         assert prefill_wrapper._window_left == self.window_left
                         assert prefill_wrapper._causal == attn_metadata.causal
                     else:
-                        # The mm group's wrapper carries the sliding window
-                        # and causality inside its packed custom mask
-                        # (planned non-causal, window_left=-1); the plain
-                        # group keeps the scalar-causal plan.
-                        for group in mm_groups:
+                        # Grouped prefill. Each group's wrapper carries its own
+                        # semantics from plan() time: masked (mm) groups fold
+                        # causal base + sliding window + spans into the packed
+                        # mask (planned non-causal, window_left=-1); unmasked
+                        # groups plan the layer-group window and their per-group
+                        # causal flag (True for plain causal, False for a
+                        # DiffusionGemma non-causal denoise group).
+                        for group in prefill_groups:
                             if group.wrapper._custom_mask_buf is None:
-                                assert group.wrapper._causal
                                 assert (
                                     group.wrapper._window_left == self.window_left
                                 )
@@ -2157,16 +2283,17 @@ class FlashInferImpl(AttentionImpl):
                     else:
                         out_prefill = output[num_decode_tokens:]
 
-                    if mm_groups is not None:
-                        # mm-prefix grouping: each partition runs its own
-                        # planned wrapper (plain causal vs packed custom
-                        # mask) over a gathered copy of its query rows,
-                        # then scatters back. Gather/scatter is by token
-                        # index because the groups may interleave within
-                        # the batch.
+                    if prefill_groups is not None:
+                        # Grouped prefill: each attention-semantics partition
+                        # (plain causal, plain non-causal, or a packed
+                        # custom-mask mm group) runs its own planned wrapper
+                        # over a gathered copy of its query rows, then scatters
+                        # back. Gather/scatter is by token index because the
+                        # groups interleave within the batch. The VO-split
+                        # branch is taken per group as on the single path.
                         if self.is_kvcache_nvfp4:
                             assert isinstance(kv_cache_permute, tuple)
-                        for group in mm_groups:
+                        for group in prefill_groups:
                             group_query = torch.index_select(
                                 prefill_query, 0, group.token_indices
                             )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -648,17 +648,26 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # Cannot use self.kv_cache_spec.dtype here because kv_cache_spec
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype == "nvfp4"
+            self.use_fa2_nvfp4_kv = False
             if self.is_kvcache_nvfp4:
-                # trtllm-gen FP4 FMHA kernels only exist for sm100f (sm_100/sm_103).
-                # Fail fast at init rather than crashing on the first request.
-                if not current_platform.is_device_capability_family(100):
-                    raise ValueError(
-                        "--kv-cache-dtype nvfp4 requires sm100f, "
-                        "please try a different dtype or remove"
+                if current_platform.is_device_capability_family(120):
+                    # Consumer Blackwell (sm120/sm121): no trtllm-gen FP4 FMHA,
+                    # so route NVFP4 KV through FlashInfer's FA2 paged reader.
+                    # The cache stores packed uint8 fp4 data; scale factors are a
+                    # separate contiguous tensor (see contiguous_sf_layout).
+                    self.use_fa2_nvfp4_kv = True
+                    self.kv_cache_dtype = FlashInferBackend.get_dtype_for_flashinfer(
+                        "nvfp4"
                     )
-                # For NVFP4, kv_cache_dtype stays as the string "nvfp4"
-                # which is passed to FlashInferImpl
-                self.kv_cache_dtype = self.cache_dtype
+                elif current_platform.is_device_capability_family(100):
+                    # sm100f trtllm-gen: kv_cache_dtype stays the string "nvfp4"
+                    # which is passed to FlashInferImpl.
+                    self.kv_cache_dtype = self.cache_dtype
+                else:
+                    raise ValueError(
+                        "--kv-cache-dtype nvfp4 requires sm100f (datacenter "
+                        "Blackwell) or sm120/sm121 (consumer Blackwell)"
+                    )
             else:
                 self.kv_cache_dtype = FlashInferBackend.get_dtype_for_flashinfer(
                     self.cache_dtype
@@ -666,6 +675,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         else:
             self.cache_dtype = "auto"
             self.is_kvcache_nvfp4 = False
+            self.use_fa2_nvfp4_kv = False
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
 
@@ -685,11 +695,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             can_use_trtllm
             and not vllm_config.attention_config.disable_flashinfer_q_quantization
         ):
-            if self.is_kvcache_nvfp4:
-                # NVFP4 KV cache uses FP8 quantized queries
+            if self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv:
+                # trtllm-gen NVFP4 KV uses FP8 queries; the FA2 paged
+                # path (sm12x) uses model-dtype queries.
                 self.q_data_type = FlashInferBackend.get_dtype_for_flashinfer(
                     "fp8_e4m3"
                 )
+            elif self.is_kvcache_nvfp4:
+                self.q_data_type = self.model_config.dtype
             else:
                 self.q_data_type = self.kv_cache_dtype
         else:
@@ -824,9 +837,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     dcp_a2a=self.dcp_a2a,
                 )
             else:
-                # NVFP4 KV cache requires the trtllm-gen backend inside
-                # the wrapper; fa2/fa3 do not support nvfp4.
-                backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+                # NVFP4 KV: FlashInfer FA2 paged reader on consumer Blackwell
+                # (sm120/sm121); trtllm-gen on sm100f.
+                if self.use_fa2_nvfp4_kv:
+                    backend = "fa2"
+                elif self.is_kvcache_nvfp4:
+                    backend = "trtllm-gen"
+                else:
+                    backend = "auto"
                 self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
                     self._get_workspace_buffer(),
                     get_kv_cache_layout(),
@@ -850,9 +868,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 paged_kv_indptr = None
                 paged_kv_indices = None
                 paged_kv_last_page_len = None
-            # NVFP4 KV cache requires the trtllm-gen backend inside
-            # the wrapper; fa2/fa3 do not support nvfp4.
-            backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+            # NVFP4 KV: FlashInfer FA2 paged reader on consumer Blackwell
+            # (sm120/sm121); trtllm-gen on sm100f.
+            if self.use_fa2_nvfp4_kv:
+                backend = "fa2"
+            elif self.is_kvcache_nvfp4:
+                backend = "trtllm-gen"
+            else:
+                backend = "auto"
             decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
                 self._get_workspace_buffer(),
                 get_kv_cache_layout(),
@@ -1245,7 +1268,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     # use FP8 o_data_type so the wrapper matches the
                     # FP8 output buffer allocated in forward().
                     o_dtype = (
-                        FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
+                        FP8_DTYPE if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv) else self.model_config.dtype
                     )
                     prefill_wrapper.plan(
                         qo_indptr=qo_indptr_prefill_cpu,
@@ -1300,7 +1323,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 # use FP8 o_data_type so the wrapper matches the
                 # FP8 output buffer allocated in forward().
                 o_dtype = (
-                    FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
+                    FP8_DTYPE if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv) else self.model_config.dtype
                 )
                 fast_plan_decode(
                     decode_wrapper,
@@ -1370,6 +1393,10 @@ class FlashInferImpl(AttentionImpl):
         )
         self.kv_cache_dtype = kv_cache_dtype
         self.is_kvcache_nvfp4 = kv_cache_dtype == "nvfp4"
+        self.use_fa2_nvfp4_kv = (
+            self.is_kvcache_nvfp4
+            and current_platform.is_device_capability_family(120)
+        )
         self.fp4_data_dim = head_size // 2 if self.is_kvcache_nvfp4 else 0
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
@@ -1584,7 +1611,7 @@ class FlashInferImpl(AttentionImpl):
         nvfp4_kv_block_scales = None
         if self.is_kvcache_nvfp4:
             nvfp4_kv_data, nvfp4_kv_block_scales = nvfp4_kv_cache_split_views(
-                kv_cache_permute
+                kv_cache_permute, contiguous_sf_layout=self.use_fa2_nvfp4_kv
             )
 
         use_dcp = self.dcp_world_size > 1
@@ -1643,7 +1670,9 @@ class FlashInferImpl(AttentionImpl):
                     # Use a pre-allocated FP8 buffer and dequantize
                     # afterwards.
                     needs_fp8_out_prefill = (
-                        self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                        self.is_kvcache_nvfp4
+                        and output.dtype != FP8_DTYPE
+                        and not self.use_fa2_nvfp4_kv
                     )
                     if needs_fp8_out_prefill:
                         out_prefill = self._nvfp4_fp8_out[:num_prefill_tokens]
@@ -1696,7 +1725,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_prefill_tokens]
 
@@ -1785,7 +1818,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out_decode = self._nvfp4_fp8_out[:num_decode_tokens]
                 else:
@@ -1869,7 +1906,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_decode_tokens]
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -83,6 +83,58 @@ FP4_DTYPE = torch.uint8
 
 logger = init_logger(__name__)
 
+
+def _vllm_nvfp4_kv_vosplit_requested() -> bool:
+    """VLLM_NVFP4_KV_VOSPLIT opts head_size > 256 NVFP4 layers into the FA2
+    two-pass VO split (Gemma 4 global D=512 full-attention layers).
+
+    Default-on (see vllm/envs.py); only an explicit "0" disables it. The
+    model-config routing (vllm/model_executor/models/config.py) gates the
+    Gemma 4 -> FLASHINFER decision on the same flag, so the backend must
+    honor it here too."""
+    return bool(envs.VLLM_NVFP4_KV_VOSPLIT)
+
+
+def _vo_split_factor(head_size: int, is_fa2_nvfp4: bool) -> int:
+    """Number of VO passes for the FlashInfer FA2 path.
+
+    The FA2 nvfp4 kernel trait guard rejects HEAD_DIM_VO > 256 (the
+    per-thread output-accumulator fragments do not fit the register
+    budget), but HEAD_DIM_QK=512 is fine, and attention decomposes
+    EXACTLY along the VO dimension: S = Q @ K^T and the softmax are
+    identical per pass, and O = [P @ V_left | P @ V_right] concatenates
+    with no LSE merge. So a Gemma 4 full-attention head (Q=K=V=512 wide;
+    the cache stores V at 512) runs as ``ceil(head_size/256)`` passes of
+    ``(head_dim_qk=512, head_dim_vo=256)``, each over a head-dim slice of
+    the 512-wide V cache (and, for NVFP4, of its per-16-element scale
+    factors).
+
+    The split is dtype-independent (the guard counts only accumulator
+    fragments). For NVFP4 it additionally requires the contiguous
+    ``[all-data | all-SF]`` cache layout (``contiguous_sf_layout=True`` in
+    ``nvfp4_kv_cache_split_views``) so each chunk's data and scale factors
+    are contiguous and slice cleanly along the head dim; the trtllm-gen
+    per-page swizzle does not commute with head-dim slicing.
+    """
+    if head_size <= 256:
+        return 1
+    if is_fa2_nvfp4 and not _vllm_nvfp4_kv_vosplit_requested():
+        raise ValueError(
+            f"NVFP4 KV with head_size={head_size} on the SM12x FA2 path "
+            "needs the two-pass VO split (the FA2 kernel caps HEAD_DIM_VO "
+            "at 256). Set VLLM_NVFP4_KV_VOSPLIT=1 to enable it, or keep "
+            "these layers on a different KV dtype."
+        )
+    split = -(-head_size // 256)  # ceil(head_size / 256)
+    if head_size % split != 0 or (is_fa2_nvfp4 and (head_size // split) % 16 != 0):
+        raise ValueError(
+            "The VO split needs head_size divisible into <=256-wide chunks"
+            f"{' of whole 16-element scale blocks' if is_fa2_nvfp4 else ''}; "
+            f"got head_size={head_size}."
+        )
+    return split
+
+
 trtllm_gen_workspace_buffer = None
 
 
@@ -450,6 +502,13 @@ class FlashInferBackend(AttentionBackend):
         return supports_trtllm_attention()
 
     @classmethod
+    def supports_mm_prefix(cls) -> bool:
+        # Text-mode is fully correct (no image spans to mask). Span-level
+        # bidirectional masking for image inputs is the separate mm-prefix
+        # concern; for NVFP4-KV text serving this gate must not reject FA2.
+        return True
+
+    @classmethod
     def get_required_kv_cache_layout(cls) -> KVCacheLayoutType | None:
         capability = current_platform.get_device_capability()
         if capability is not None and capability.major == 10:
@@ -641,6 +700,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         self.num_kv_heads = self.kv_cache_spec.num_kv_heads
         self.head_dim = self.kv_cache_spec.head_size
+        # Gemma 4 full-attention is SYMMETRIC: Q=K=V=512-wide per head (the
+        # KV cache stores V at 512). There is no native 256-wide V. The FA2
+        # nvfp4 kernel caps HEAD_DIM_VO at 256, so a 512-wide V/O is run as
+        # ceil(head_size/256) two-pass VO-split chunks: each pass uses
+        # head_dim_qk=full head_size, head_dim_vo=head_size//vo_split, over a
+        # head-dim slice of the 512-wide V cache; the per-pass outputs
+        # concatenate exactly (identical S/softmax, no LSE merge).
+        # vo_split == 1 for head_size <= 256 (ordinary single-pass).
         self.page_size = self.kv_cache_spec.block_size
 
         if self.kv_cache_spec.kv_quant_mode != KVQuantMode.NONE:
@@ -712,6 +779,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # This allows us to use AttentionCGSupport.UNIFORM_BATCH mode.
         self.use_trtllm_decode_attention = can_use_trtllm
         self._init_reorder_batch_threshold(1, supports_spec_as_decode=can_use_trtllm)
+
+        # Two-pass VO split for head_size > 256 (Gemma 4 full-attention,
+        # head_dim_qk=512). vo_split == 1 leaves all existing paths
+        # untouched.
+        self.vo_split = _vo_split_factor(self.head_dim, self.use_fa2_nvfp4_kv)
+        if self.vo_split > 1:
+            # BatchDecodeWithPagedKVCacheWrapper.plan() has no head_dim_vo,
+            # so route every request through the VO-split-planned prefill
+            # wrapper: threshold 0 classifies nothing as decode, and a
+            # causal qo_len==1 prefill computes exactly what decode would.
+            self.reorder_batch_threshold = 0
+            logger.info_once(
+                "FA2 VO split (%s KV): head_size %d runs as %d passes of "
+                "head_dim_vo=%d; decode requests use the prefill wrapper.",
+                self.cache_dtype,
+                self.head_dim,
+                self.vo_split,
+                self.head_dim // self.vo_split,
+            )
 
         self._cascade_wrapper = None  # Wrapper for cascade attention
 
@@ -1278,6 +1364,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         num_qo_heads=self.num_qo_heads,
                         num_kv_heads=self.num_kv_heads,
                         head_dim_qk=self.head_dim,
+                        # == head_dim_qk unless the VO split is active; then
+                        # each pass plans head_dim_vo=head_size//vo_split (256
+                        # for Gemma 4 512-wide heads) and the impl runs the
+                        # wrapper once per V slice (_run_vo_split_prefill).
+                        head_dim_vo=self.head_dim // self.vo_split,
                         page_size=self.page_size,
                         causal=attn_metadata.causal,
                         sm_scale=self.sm_scale,
@@ -1398,6 +1489,11 @@ class FlashInferImpl(AttentionImpl):
             and current_platform.is_device_capability_family(120)
         )
         self.fp4_data_dim = head_size // 2 if self.is_kvcache_nvfp4 else 0
+        # Two-pass VO split factor for head_size > 256 (Gemma 4 D=512); 1
+        # otherwise. Must match the builder's vo_split: the wrapper is
+        # planned with head_dim_vo = head_size // vo_split, so the impl must
+        # run it once per V slice when vo_split > 1.
+        self.vo_split = _vo_split_factor(head_size, self.use_fa2_nvfp4_kv)
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
 
@@ -1464,6 +1560,69 @@ class FlashInferImpl(AttentionImpl):
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         if self.sinks is not None and self.sinks.dtype != torch.float32:
             self.sinks = self.sinks.to(torch.float32)
+
+    def _run_vo_split_prefill(
+        self,
+        wrapper: BatchPrefillWithPagedKVCacheWrapper,
+        query: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, torch.Tensor],
+        kv_sf: tuple[torch.Tensor, torch.Tensor] | None,
+        out: torch.Tensor,
+        *,
+        k_scale: float,
+        v_scale: float,
+    ) -> None:
+        """Multi-pass FA2 prefill run for head_size > 256 (Gemma 4 D=512).
+
+        The wrapper is planned with head_dim_vo = head_size // vo_split, and
+        each pass consumes a head-dim slice of V (and, for NVFP4, of the V
+        scale factors): S = Q @ K^T and the softmax are recomputed
+        identically per pass, so the per-pass outputs concatenate exactly
+        along the head dim with no LSE merge. narrow() keeps the full
+        tensor's strides, which the FA2 path requires.
+
+        NVFP4 V slicing relies on the contiguous ``[all-data | all-SF]``
+        cache layout (``contiguous_sf_layout=True``): the V data view's last
+        dim is ``head_size // 2`` packed e2m1 bytes and the V scale view's
+        last dim is ``head_size // 16`` fp8 scales, both contiguous along the
+        head dim, so chunk ``i`` is data[i*chunk//2 : ...] and
+        scale[i*chunk//16 : ...].
+        """
+        split = self.vo_split
+        head_chunk = self.head_size // split
+        k_cache, v_cache = kv_cache
+        if self.is_kvcache_nvfp4:
+            assert kv_sf is not None
+            k_sf, v_sf = kv_sf
+            data_step = head_chunk // 2  # packed e2m1, 2 elements per byte
+            sf_step = head_chunk // 16  # one fp8 scale per 16 elements
+        else:
+            k_sf = v_sf = None
+            data_step = head_chunk
+            sf_step = 0
+        for i in range(split):
+            v_cache_i = v_cache.narrow(-1, i * data_step, data_step)
+            kv_sf_i = (
+                (k_sf, v_sf.narrow(-1, i * sf_step, sf_step))
+                if v_sf is not None
+                else None
+            )
+            # The kernel needs a contiguous output; write into a chunk
+            # buffer and copy into the head-dim slice of the full output.
+            out_i = torch.empty(
+                (*out.shape[:-1], head_chunk),
+                dtype=out.dtype,
+                device=out.device,
+            )
+            wrapper.run(
+                query,
+                (k_cache, v_cache_i),
+                k_scale=k_scale,
+                v_scale=v_scale,
+                out=out_i,
+                kv_cache_sf=kv_sf_i,
+            )
+            out.narrow(-1, i * head_chunk, head_chunk).copy_(out_i)
 
     def forward(
         self,
@@ -1679,14 +1838,32 @@ class FlashInferImpl(AttentionImpl):
                     else:
                         out_prefill = output[num_decode_tokens:]
 
-                    prefill_wrapper.run(
-                        prefill_query,
-                        kv_cache_permute,
-                        k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
-                        out=out_prefill,
-                        kv_cache_sf=kv_cache_sf,
-                    )
+                    if self.vo_split > 1:
+                        # head_size > 256: run ceil(head_size/256) passes,
+                        # each over a head-dim slice of the 512-wide V cache,
+                        # and concatenate the per-pass outputs. The wrapper is
+                        # planned with head_dim_vo = head_size // vo_split.
+                        if self.is_kvcache_nvfp4:
+                            assert isinstance(kv_cache_permute, tuple)
+                            assert isinstance(kv_cache_sf, tuple)
+                        self._run_vo_split_prefill(
+                            prefill_wrapper,
+                            prefill_query,
+                            kv_cache_permute,
+                            kv_cache_sf,
+                            out_prefill,
+                            k_scale=layer._k_scale_float,
+                            v_scale=layer._v_scale_float,
+                        )
+                    else:
+                        prefill_wrapper.run(
+                            prefill_query,
+                            kv_cache_permute,
+                            k_scale=layer._k_scale_float,
+                            v_scale=layer._v_scale_float,
+                            out=out_prefill,
+                            kv_cache_sf=kv_cache_sf,
+                        )
 
                     if needs_fp8_out_prefill:
                         output[
@@ -1803,6 +1980,16 @@ class FlashInferImpl(AttentionImpl):
         if num_decode_tokens > 0:
             decode_query = query[:num_decode_tokens]
             assert decode_query.shape[0] == num_decode_tokens
+
+            # The VO split routes every request (including would-be decodes)
+            # through the prefill wrapper (builder sets reorder_batch_threshold
+            # = 0), because BatchDecodeWithPagedKVCacheWrapper.plan() has no
+            # head_dim_vo. So no decode tokens should reach this block.
+            assert self.vo_split == 1, (
+                "FA2 VO split routes decodes through the prefill wrapper; "
+                f"unexpected {num_decode_tokens} decode tokens with "
+                f"vo_split={self.vo_split}."
+            )
 
             if not decode_use_trtllm:
                 assert isinstance(attn_metadata.decode, FIDecode)

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -503,10 +503,13 @@ class FlashInferBackend(AttentionBackend):
 
     @classmethod
     def supports_mm_prefix(cls) -> bool:
-        # Text-mode is fully correct (no image spans to mask). Span-level
-        # bidirectional masking for image inputs is the separate mm-prefix
-        # concern; for NVFP4-KV text serving this gate must not reject FA2.
-        return True
+        """mm-prefix LMs (Gemma 3 / Gemma 4 multimodal: image-token spans
+        attend bidirectionally) are served via FA2 packed custom masks on
+        the FI-native prefill path. Decode is untouched: spans live in the
+        prompt, so decode queries are strictly causal. Knob-gated and
+        default-on; set VLLM_FLASHINFER_MM_PREFIX=0 to route mm-prefix
+        models away from FlashInfer instead (e.g. for debugging)."""
+        return envs.VLLM_FLASHINFER_MM_PREFIX
 
     @classmethod
     def get_required_kv_cache_layout(cls) -> KVCacheLayoutType | None:
@@ -519,10 +522,35 @@ class FlashInferBackend(AttentionBackend):
 
 
 @dataclass
+class FIPrefillMMGroup:
+    """One partition of an mm-prefix prefill batch (Gemma 3 / Gemma 4
+    multimodal: requests whose image-token span intersects the current
+    query window need span-level bidirectional masking; plain requests
+    stay causal)."""
+
+    wrapper: BatchPrefillWithPagedKVCacheWrapper
+    """Planned for exactly this group's requests: causal=True for the
+    plain group, packed custom mask ((causal AND sliding-window) OR
+    span-bidirectional) for the mm group."""
+
+    token_indices: torch.Tensor
+    """Rows of the prefill query/output owned by this group: GPU int64,
+    the concatenation of per-request token ranges from query_start_loc.
+    Needed because the groups may interleave within the batch."""
+
+    num_tokens: int
+
+
+@dataclass
 class FIPrefill:
     """Metadata for the native FlashInfer prefill pathway (non-TRTLLM)."""
 
     wrapper: BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper
+
+    mm_groups: list[FIPrefillMMGroup] | None = None
+    """mm-prefix wrapper grouping when image-token spans intersect the
+    query window of at least one prefill request; None on the scalar
+    causal fast path (no mm requests => byte-identical legacy path)."""
 
 
 @dataclass
@@ -640,6 +668,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self._noncausal_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = (
             None  # Wrapper for non-causal prefill (DFlash)
         )
+        # Second prefill wrapper for mm-prefix custom-mask requests
+        # (Gemma 3 / Gemma 4 multimodal image spans); lazily created.
+        self._mm_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = None
         self._decode_wrapper = None  # Wrapper for decode (general shape)
 
         if envs.VLLM_BATCH_INVARIANT:
@@ -816,6 +847,39 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 "sinks, please use trtllm on blackwell or flash attention on "
                 "earlier GPUs."
             )
+
+        # mm-prefix (PrefixLM) span-level bidirectional masking for this
+        # layer group. Gemma4 with use_bidirectional_attention='vision'
+        # applies bidirectional image spans ONLY to sliding_attention
+        # layers (full-attention layers stay plain causal: the static
+        # equivalent of gemma4_mm._clear_mm_prefix_for_full_attn_layers,
+        # decided here at build time because FlashInfer bakes masks into
+        # wrapper plans). Gemma3 applies the spans to all layers.
+        self.mm_prefix_enabled = (
+            envs.VLLM_FLASHINFER_MM_PREFIX
+            and self.model_config is not None
+            and self.model_config.is_mm_prefix_lm
+        )
+        if self.mm_prefix_enabled:
+            bidi_mode = getattr(
+                self.model_config.hf_text_config,
+                "use_bidirectional_attention",
+                None,
+            )
+            if bidi_mode == "vision" and self.window_left < 0:
+                self.mm_prefix_enabled = False
+            if self.use_dcp:
+                raise NotImplementedError(
+                    "FlashInfer mm-prefix custom masks are not wired for "
+                    "DCP; unset VLLM_FLASHINFER_MM_PREFIX or disable DCP."
+                )
+        if self.mm_prefix_enabled:
+            logger.info_once(
+                "FlashInfer mm-prefix: image-token spans of multimodal "
+                "requests run with FA2 packed custom masks on a second "
+                "prefill wrapper (layer group window_left=%d).",
+                self.window_left,
+            )
         # Preparing persistent buffers
         # Since we do not have explicit synchronization in ModelRunnerV2, we do not pin
         # reused CPU buffers to avoid a race condition between step N async copies to
@@ -939,6 +1003,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         assert self._prefill_wrapper is not None
         return self._prefill_wrapper
 
+    def _get_mm_prefill_wrapper(self) -> BatchPrefillWithPagedKVCacheWrapper:
+        # Second paged prefill wrapper for the mm-prefix custom-mask group.
+        # Built the same way as the plain prefill wrapper (the VO split and
+        # NVFP4 jit module are applied at plan()/run() time, not here);
+        # only reachable on the mm-prefix path, which rejects DCP.
+        if self._mm_prefill_wrapper is None:
+            if self.use_fa2_nvfp4_kv:
+                backend = "fa2"
+            elif self.is_kvcache_nvfp4:
+                backend = "trtllm-gen"
+            else:
+                backend = "auto"
+            self._mm_prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
+                self._get_workspace_buffer(),
+                get_kv_cache_layout(),
+                backend=backend,
+            )
+        return self._mm_prefill_wrapper
+
     def _get_decode_wrapper(self, batch_size: int, use_cudagraph: bool = False):
         if use_cudagraph:
             decode_wrapper = self._decode_wrappers_cudagraph.get(batch_size, None)
@@ -1048,6 +1131,196 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         )
         return paged_kv_indices
 
+    def _mm_prefix_prefill_spans(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_decodes: int,
+        num_prefills: int,
+    ) -> list[list[tuple[int, int]]] | None:
+        """Per-prefill-request image spans that intersect the query window.
+
+        Spans are document positions, inclusive [start, end] (the
+        mm_req_doc_ranges convention shared with the Triton/FlexAttention
+        mm-prefix paths; valid iff start < end). A span fully inside the
+        computed context needs nothing: K/V projections are mask-independent
+        and the in-window queries are text, i.e. causal. vLLM forces
+        --disable-chunked-mm-input for mm-prefix models, so spans do not
+        straddle the window boundary in practice; partial overlaps are
+        still handled correctly by the absolute-position mask.
+
+        Returns None when no prefill request has an intersecting span
+        (the scalar-causal fast path stays byte-identical).
+        """
+        mm_ranges = common_attn_metadata.mm_req_doc_ranges
+        if not mm_ranges:
+            return None
+        qo_indptr_cpu = common_attn_metadata.query_start_loc_cpu
+        seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+        span_lists: list[list[tuple[int, int]]] = []
+        any_spans = False
+        for j in range(num_prefills):
+            req_idx = num_decodes + j
+            kv_len = int(seq_lens_cpu[req_idx])
+            qo_len = int(qo_indptr_cpu[req_idx + 1] - qo_indptr_cpu[req_idx])
+            context_len = kv_len - qo_len
+            spans = [
+                (int(s), int(e))
+                for s, e in mm_ranges.get(req_idx, [])
+                if s < e and e >= context_len and s < kv_len
+            ]
+            any_spans = any_spans or bool(spans)
+            span_lists.append(spans)
+        return span_lists if any_spans else None
+
+    def _build_mm_prefix_custom_mask(
+        self,
+        qo_lens: list[int],
+        kv_lens: list[int],
+        span_lists: list[list[tuple[int, int]]],
+    ) -> torch.Tensor:
+        """Boolean (qo_len x kv_len)-per-request mask, flattened row-major
+        and concatenated in group order; FlashInfer's plan() bit-packs it
+        per request (segment_packbits). Composition matches the Triton /
+        FlexAttention mm-prefix contract:
+        (causal AND sliding-window) OR (q in span AND kv in span),
+        with query rows end-aligned to the KV sequence. The mm wrapper is
+        planned with window_left=-1 because the mask already carries the
+        sliding window; spans must OVERRIDE it (FlashInfer's in-kernel SW
+        would AND it instead)."""
+        masks = []
+        for qo_len, kv_len, spans in zip(qo_lens, kv_lens, span_lists):
+            q_abs = torch.arange(
+                kv_len - qo_len, kv_len, device=self.device, dtype=torch.int32
+            )
+            k_abs = torch.arange(kv_len, device=self.device, dtype=torch.int32)
+            mask = k_abs[None, :] <= q_abs[:, None]
+            if self.window_left >= 0:
+                mask &= (q_abs[:, None] - k_abs[None, :]) <= self.window_left
+            for start, end in spans:
+                q_in = (q_abs >= start) & (q_abs <= end)
+                k_in = (k_abs >= start) & (k_abs <= end)
+                mask |= q_in[:, None] & k_in[None, :]
+            masks.append(mask.reshape(-1))
+        return torch.cat(masks)
+
+    def _plan_prefill_mm_groups(
+        self,
+        prefill_mm_spans: list[list[tuple[int, int]]],
+        qo_indptr_prefill_cpu: torch.Tensor,
+        paged_kv_indptr_prefill_cpu: torch.Tensor,
+        paged_kv_last_page_len_prefill_cpu: torch.Tensor,
+        paged_kv_indices: torch.Tensor,
+        seq_lens_prefill_cpu: torch.Tensor,
+        o_dtype: torch.dtype,
+    ) -> list[FIPrefillMMGroup]:
+        """Plan one prefill wrapper per partition of an mm-prefix batch:
+        requests with image spans intersecting the query window run on a
+        custom-mask wrapper; the rest stay on the fast causal wrapper.
+
+        Each request's tokens and KV pages are contiguous ranges of the
+        batch-level arrays, so a group is fully described by per-request
+        deltas of the indptr arrays plus gathered index subranges
+        (indptr/last_page_len slicing on CPU, paged_kv_indices on GPU).
+        plan(custom_mask=...) requires the FlashInfer-side mask_indptr
+        device fix because the mask lives on GPU while the indptr arrays
+        stay on CPU.
+        """
+        is_mm = torch.tensor([bool(s) for s in prefill_mm_spans])
+        qo_lens_cpu = qo_indptr_prefill_cpu[1:] - qo_indptr_prefill_cpu[:-1]
+        # paged_kv_indptr is NOT rebased to 0 (its offsets index the full
+        # paged_kv_indices array), so deltas are taken before regrouping.
+        kv_page_counts_cpu = (
+            paged_kv_indptr_prefill_cpu[1:] - paged_kv_indptr_prefill_cpu[:-1]
+        )
+        groups: list[FIPrefillMMGroup] = []
+        for group_mm in (False, True):
+            req_indices = (is_mm if group_mm else ~is_mm).nonzero(as_tuple=True)[0]
+            if req_indices.numel() == 0:
+                continue
+            group_qo_indptr = torch.zeros(req_indices.numel() + 1, dtype=torch.int32)
+            torch.cumsum(qo_lens_cpu[req_indices], dim=0, out=group_qo_indptr[1:])
+            group_kv_indptr = torch.zeros(req_indices.numel() + 1, dtype=torch.int32)
+            torch.cumsum(
+                kv_page_counts_cpu[req_indices], dim=0, out=group_kv_indptr[1:]
+            )
+            token_indices_cpu = torch.cat(
+                [
+                    torch.arange(
+                        int(qo_indptr_prefill_cpu[i]),
+                        int(qo_indptr_prefill_cpu[i + 1]),
+                        dtype=torch.int64,
+                    )
+                    for i in req_indices.tolist()
+                ]
+            )
+            page_gather_cpu = torch.cat(
+                [
+                    torch.arange(
+                        int(paged_kv_indptr_prefill_cpu[i]),
+                        int(paged_kv_indptr_prefill_cpu[i + 1]),
+                        dtype=torch.int64,
+                    )
+                    for i in req_indices.tolist()
+                ]
+            )
+            group_kv_indices = torch.index_select(
+                paged_kv_indices, 0, page_gather_cpu.to(self.device)
+            )
+            if group_mm:
+                wrapper = self._get_mm_prefill_wrapper()
+                custom_mask = self._build_mm_prefix_custom_mask(
+                    [int(qo_lens_cpu[i]) for i in req_indices.tolist()],
+                    [int(seq_lens_prefill_cpu[i]) for i in req_indices.tolist()],
+                    [prefill_mm_spans[i] for i in req_indices.tolist()],
+                )
+                # The mask carries causal/SW/span composition wholesale.
+                group_causal = False
+                group_window_left = -1
+            else:
+                maybe_wrapper = self._get_prefill_wrapper()
+                assert isinstance(
+                    maybe_wrapper, BatchPrefillWithPagedKVCacheWrapper
+                )
+                wrapper = maybe_wrapper
+                custom_mask = None
+                group_causal = True
+                group_window_left = self.window_left
+            wrapper.plan(
+                qo_indptr=group_qo_indptr,
+                paged_kv_indptr=group_kv_indptr,
+                paged_kv_indices=group_kv_indices,
+                paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu[
+                    req_indices
+                ],
+                num_qo_heads=self.num_qo_heads,
+                num_kv_heads=self.num_kv_heads,
+                head_dim_qk=self.head_dim,
+                # == head_dim_qk unless the VO split is active; then the
+                # impl runs each group's wrapper once per V slice.
+                head_dim_vo=self.head_dim // self.vo_split,
+                page_size=self.page_size,
+                causal=group_causal,
+                custom_mask=custom_mask,
+                sm_scale=self.sm_scale,
+                window_left=group_window_left,
+                logits_soft_cap=self.logits_soft_cap,
+                q_data_type=self.q_data_type,
+                kv_data_type=self.kv_cache_dtype,
+                o_data_type=o_dtype,
+                fixed_split_size=self.prefill_fixed_split_size,
+                disable_split_kv=self.disable_split_kv,
+            )
+            wrapper.vllm_prefill_fixed_split_size = self.prefill_fixed_split_size
+            wrapper.vllm_disable_split_kv = self.disable_split_kv
+            groups.append(
+                FIPrefillMMGroup(
+                    wrapper=wrapper,
+                    token_indices=token_indices_cpu.to(self.device),
+                    num_tokens=int(token_indices_cpu.numel()),
+                )
+            )
+        return groups
+
     def build(
         self,
         common_prefix_len: int,
@@ -1116,6 +1389,17 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 "Using FlashInfer for draft model non-causal attention; TRTLLM "
                 "can still be used for target model causal attention."
             )
+        # mm-prefix: prefill requests whose image span intersects the
+        # query window need the FI-native custom-mask path (TRTLLM has no
+        # custom masks). Decode stays causal: spans live in the prompt.
+        prefill_mm_spans: list[list[tuple[int, int]]] | None = None
+        if self.mm_prefix_enabled and num_prefills > 0:
+            prefill_mm_spans = self._mm_prefix_prefill_spans(
+                common_attn_metadata, num_decodes, num_prefills
+            )
+            if prefill_mm_spans is not None:
+                prefill_use_trtllm = False
+
         all_uses_trtllm = causal and (
             (num_prefills == 0 or prefill_use_trtllm)
             and (num_decodes == 0 or decode_use_trtllm)
@@ -1325,6 +1609,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     prefill_start : num_reqs + 1
                 ]
                 assert paged_kv_indptr_prefill_cpu.shape[0] == num_prefills + 1
+                mm_groups: list[FIPrefillMMGroup] | None = None
                 if self.use_dcp:
                     assert isinstance(prefill_wrapper, BatchDCPPrefillWrapper)
                     prefill_wrapper.plan(
@@ -1356,31 +1641,49 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     o_dtype = (
                         FP8_DTYPE if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv) else self.model_config.dtype
                     )
-                    prefill_wrapper.plan(
-                        qo_indptr=qo_indptr_prefill_cpu,
-                        paged_kv_indptr=paged_kv_indptr_prefill_cpu,
-                        paged_kv_indices=paged_kv_indices,
-                        paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu,
-                        num_qo_heads=self.num_qo_heads,
-                        num_kv_heads=self.num_kv_heads,
-                        head_dim_qk=self.head_dim,
-                        # == head_dim_qk unless the VO split is active; then
-                        # each pass plans head_dim_vo=head_size//vo_split (256
-                        # for Gemma 4 512-wide heads) and the impl runs the
-                        # wrapper once per V slice (_run_vo_split_prefill).
-                        head_dim_vo=self.head_dim // self.vo_split,
-                        page_size=self.page_size,
-                        causal=attn_metadata.causal,
-                        sm_scale=self.sm_scale,
-                        window_left=self.window_left,
-                        logits_soft_cap=self.logits_soft_cap,
-                        q_data_type=self.q_data_type,
-                        kv_data_type=self.kv_cache_dtype,
-                        o_data_type=o_dtype,
-                        fixed_split_size=self.prefill_fixed_split_size,
-                        disable_split_kv=self.disable_split_kv,
-                    )
-                attn_metadata.prefill = FIPrefill(wrapper=prefill_wrapper)
+                    if prefill_mm_spans is not None:
+                        assert seq_lens_cpu is not None
+                        mm_groups = self._plan_prefill_mm_groups(
+                            prefill_mm_spans,
+                            qo_indptr_prefill_cpu,
+                            paged_kv_indptr_prefill_cpu,
+                            paged_kv_last_page_len_prefill_cpu,
+                            paged_kv_indices,
+                            seq_lens_cpu[prefill_start:num_reqs],
+                            o_dtype,
+                        )
+                        # The impl's forward dispatches on mm_groups; this
+                        # field only feeds its isinstance/identity asserts.
+                        prefill_wrapper = mm_groups[0].wrapper
+                    else:
+                        prefill_wrapper.plan(
+                            qo_indptr=qo_indptr_prefill_cpu,
+                            paged_kv_indptr=paged_kv_indptr_prefill_cpu,
+                            paged_kv_indices=paged_kv_indices,
+                            paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu,
+                            num_qo_heads=self.num_qo_heads,
+                            num_kv_heads=self.num_kv_heads,
+                            head_dim_qk=self.head_dim,
+                            # == head_dim_qk unless the VO split is active;
+                            # then each pass plans head_dim_vo=head_size//
+                            # vo_split (256 for Gemma 4 512-wide heads) and
+                            # the impl runs the wrapper once per V slice
+                            # (_run_vo_split_prefill).
+                            head_dim_vo=self.head_dim // self.vo_split,
+                            page_size=self.page_size,
+                            causal=attn_metadata.causal,
+                            sm_scale=self.sm_scale,
+                            window_left=self.window_left,
+                            logits_soft_cap=self.logits_soft_cap,
+                            q_data_type=self.q_data_type,
+                            kv_data_type=self.kv_cache_dtype,
+                            o_data_type=o_dtype,
+                            fixed_split_size=self.prefill_fixed_split_size,
+                            disable_split_kv=self.disable_split_kv,
+                        )
+                attn_metadata.prefill = FIPrefill(
+                    wrapper=prefill_wrapper, mm_groups=mm_groups
+                )
 
         ## DECODE PATHWAY
         if num_decodes > 0:
@@ -1812,12 +2115,28 @@ class FlashInferImpl(AttentionImpl):
                     assert isinstance(
                         prefill_wrapper, BatchPrefillWithPagedKVCacheWrapper
                     )
-                    assert prefill_wrapper._window_left == self.window_left
+                    mm_groups = attn_metadata.prefill.mm_groups
                     assert prefill_wrapper._logits_soft_cap == (
                         self.logits_soft_cap or 0.0
                     )
                     assert prefill_wrapper._sm_scale == self.scale
-                    assert prefill_wrapper._causal == attn_metadata.causal
+                    if mm_groups is None:
+                        assert prefill_wrapper._window_left == self.window_left
+                        assert prefill_wrapper._causal == attn_metadata.causal
+                    else:
+                        # The mm group's wrapper carries the sliding window
+                        # and causality inside its packed custom mask
+                        # (planned non-causal, window_left=-1); the plain
+                        # group keeps the scalar-causal plan.
+                        for group in mm_groups:
+                            if group.wrapper._custom_mask_buf is None:
+                                assert group.wrapper._causal
+                                assert (
+                                    group.wrapper._window_left == self.window_left
+                                )
+                            else:
+                                assert not group.wrapper._causal
+                                assert group.wrapper._window_left == -1
 
                     if self.is_kvcache_nvfp4:
                         kv_cache_permute = nvfp4_kv_data
@@ -1838,7 +2157,47 @@ class FlashInferImpl(AttentionImpl):
                     else:
                         out_prefill = output[num_decode_tokens:]
 
-                    if self.vo_split > 1:
+                    if mm_groups is not None:
+                        # mm-prefix grouping: each partition runs its own
+                        # planned wrapper (plain causal vs packed custom
+                        # mask) over a gathered copy of its query rows,
+                        # then scatters back. Gather/scatter is by token
+                        # index because the groups may interleave within
+                        # the batch.
+                        if self.is_kvcache_nvfp4:
+                            assert isinstance(kv_cache_permute, tuple)
+                        for group in mm_groups:
+                            group_query = torch.index_select(
+                                prefill_query, 0, group.token_indices
+                            )
+                            group_out = torch.empty(
+                                (group.num_tokens, *out_prefill.shape[1:]),
+                                dtype=out_prefill.dtype,
+                                device=out_prefill.device,
+                            )
+                            if self.vo_split > 1:
+                                self._run_vo_split_prefill(
+                                    group.wrapper,
+                                    group_query,
+                                    kv_cache_permute,
+                                    kv_cache_sf,
+                                    group_out,
+                                    k_scale=layer._k_scale_float,
+                                    v_scale=layer._v_scale_float,
+                                )
+                            else:
+                                group.wrapper.run(
+                                    group_query,
+                                    kv_cache_permute,
+                                    k_scale=layer._k_scale_float,
+                                    v_scale=layer._v_scale_float,
+                                    out=group_out,
+                                    kv_cache_sf=kv_cache_sf,
+                                )
+                            out_prefill.index_copy_(
+                                0, group.token_indices, group_out
+                            )
+                    elif self.vo_split > 1:
                         # head_size > 256: run ceil(head_size/256) passes,
                         # each over a head-dim slice of the 512-wide V cache,
                         # and concatenate the per-pass outputs. The wrapper is

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -494,6 +494,11 @@ class FlashInferBackend(AttentionBackend):
     @classmethod
     def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
         if kv_cache_dtype is not None and kv_cache_dtype.startswith("nvfp4"):
+            # Consumer Blackwell (sm120/sm121): NVFP4 KV is served through
+            # the FlashInfer FA2 paged reader (uint8 fp4 cache), no
+            # trtllm-gen requirement. Mirrors the builder __init__ gate.
+            if current_platform.is_device_capability_family(120):
+                return True
             return (
                 current_platform.is_device_capability_family(100)
                 and supports_trtllm_attention(is_prefill=True)
@@ -776,20 +781,34 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # Cannot use self.kv_cache_spec.dtype here because kv_cache_spec
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype.startswith("nvfp4")
+            self.use_fa2_nvfp4_kv = False
             if self.is_kvcache_nvfp4:
-                if (
+                if current_platform.is_device_capability_family(120):
+                    # Consumer Blackwell (sm120/sm121): no trtllm-gen FP4 FMHA,
+                    # so route NVFP4 KV through FlashInfer's FA2 paged reader.
+                    # The cache stores packed uint8 fp4 data; the per-side
+                    # [data | scale] regions are read back as views with
+                    # explicit strides (nvfp4_split_data_scale).
+                    self.use_fa2_nvfp4_kv = True
+                    self.kv_cache_dtype = FlashInferBackend.get_dtype_for_flashinfer(
+                        "nvfp4"
+                    )
+                elif (
                     force_use_trtllm_attention() is False
                     or not supports_trtllm_attention(is_prefill=True)
                     or not supports_trtllm_attention(is_prefill=False)
                 ):
                     raise ValueError(
                         f"--kv-cache-dtype {self.cache_dtype} requires the "
-                        "SM100 trtllm-gen "
-                        "FlashInfer path."
+                        "SM100 trtllm-gen FlashInfer path or consumer "
+                        "Blackwell (sm120/sm121)."
                     )
-                # The scale search only affects the store kernel. FlashInfer
-                # reads both variants using the same NVFP4 layout.
-                self.kv_cache_dtype = "nvfp4"
+                else:
+                    # sm100 trtllm-gen. The scale search only affects the
+                    # store kernel; FlashInfer reads both nvfp4 variants
+                    # using the same NVFP4 layout, so normalize to "nvfp4"
+                    # for FlashInferImpl.
+                    self.kv_cache_dtype = "nvfp4"
             else:
                 self.kv_cache_dtype = FlashInferBackend.get_dtype_for_flashinfer(
                     self.cache_dtype
@@ -797,6 +816,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         else:
             self.cache_dtype = "auto"
             self.is_kvcache_nvfp4 = False
+            self.use_fa2_nvfp4_kv = False
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
 
@@ -969,6 +989,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 return FlashInferBackend.get_dtype_for_flashinfer(cache_dtype)
             return self.model_config.dtype
         if cache_dtype.startswith("nvfp4"):
+            if current_platform.is_device_capability_family(120):
+                # The FA2 paged nvfp4 reader (consumer Blackwell) consumes
+                # model-dtype queries; FP8-Q is a trtllm-gen-only contract.
+                return self.model_config.dtype
             return FlashInferBackend.get_dtype_for_flashinfer("fp8_e4m3")
         return self.kv_cache_spec.dtype
 
@@ -1185,9 +1209,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         window_left=self.window_left,
                     )
                 else:
-                    # NVFP4 KV cache requires the trtllm-gen backend inside
-                    # the wrapper; fa2/fa3 do not support nvfp4.
-                    backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+                    # NVFP4 KV: FlashInfer FA2 paged reader on consumer
+                    # Blackwell (sm120/sm121); trtllm-gen on sm100f.
+                    if self.use_fa2_nvfp4_kv:
+                        backend = "fa2"
+                    elif self.is_kvcache_nvfp4:
+                        backend = "trtllm-gen"
+                    else:
+                        backend = "auto"
                     self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
                         self._get_workspace_buffer(),
                         get_flashinfer_layout_string(self.kv_cache_layout),
@@ -1211,9 +1240,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 paged_kv_indptr = None
                 paged_kv_indices = None
                 paged_kv_last_page_len = None
-            # NVFP4 KV cache requires the trtllm-gen backend inside
-            # the wrapper; fa2/fa3 do not support nvfp4.
-            backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+            # NVFP4 KV: FlashInfer FA2 paged reader on consumer Blackwell
+            # (sm120/sm121); trtllm-gen on sm100f.
+            if self.use_fa2_nvfp4_kv:
+                backend = "fa2"
+            elif self.is_kvcache_nvfp4:
+                backend = "trtllm-gen"
+            else:
+                backend = "auto"
             decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
                 self._get_workspace_buffer(),
                 get_flashinfer_layout_string(self.kv_cache_layout),
@@ -1647,7 +1681,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     # use FP8 o_data_type so the wrapper matches the
                     # FP8 output buffer allocated in forward().
                     o_dtype = (
-                        FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
+                        FP8_DTYPE
+                        if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv)
+                        else self.model_config.dtype
                     )
                     prefill_wrapper.plan(
                         qo_indptr=qo_indptr_prefill_cpu,
@@ -1736,7 +1772,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 # use FP8 o_data_type so the wrapper matches the
                 # FP8 output buffer allocated in forward().
                 o_dtype = (
-                    FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
+                    FP8_DTYPE
+                    if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv)
+                    else self.model_config.dtype
                 )
                 paged_kv_indptr_cpu = self.paged_kv_indptr.cpu[: num_input_tokens + 1]
                 paged_kv_last_page_len_cpu = self.paged_kv_last_page_len.cpu[
@@ -1827,6 +1865,9 @@ class FlashInferImpl(AttentionImpl):
         self.cache_dtype = kv_cache_dtype
         self.is_kvcache_nvfp4 = kv_cache_dtype.startswith("nvfp4")
         self.kv_cache_dtype = "nvfp4" if self.is_kvcache_nvfp4 else kv_cache_dtype
+        self.use_fa2_nvfp4_kv = (
+            self.is_kvcache_nvfp4 and current_platform.is_device_capability_family(120)
+        )
         self.fp4_data_dim = head_size // 2 if self.is_kvcache_nvfp4 else 0
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
@@ -2209,7 +2250,9 @@ class FlashInferImpl(AttentionImpl):
                     # Use a pre-allocated FP8 buffer and dequantize
                     # afterwards.
                     needs_fp8_out_prefill = (
-                        self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                        self.is_kvcache_nvfp4
+                        and output.dtype != FP8_DTYPE
+                        and not self.use_fa2_nvfp4_kv
                     )
                     if needs_fp8_out_prefill:
                         out_prefill = self._nvfp4_fp8_out[:num_prefill_tokens]
@@ -2276,7 +2319,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_prefill_tokens]
 
@@ -2384,7 +2431,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out_decode = self._nvfp4_fp8_out[:num_decode_tokens]
                 else:
@@ -2514,7 +2565,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_decode_tokens]
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -129,11 +129,22 @@ def _vo_split_factor(head_size: int, is_fa2_nvfp4: bool) -> int:
     conditions in FlashInfer's FA2 prefill are the 1-byte-KV shared-smem
     specialisation, which excludes FP4 outright; 16-bit and FP8 KV reach
     the CTA_TILE_Q=32 configuration that handles HEAD_DIM_VO >= 512
-    directly. Splitting those would be a behaviour change for models this
-    path was never meant to touch: it forces
-    ``reorder_batch_threshold = 0``, routing decode through the
-    per-step-planned prefill wrapper and giving up the decode CUDA-graph
-    path. So bf16 and FP8 keep ``head_dim_vo = head_size``.
+    directly, so both run a 512-wide head unsplit.
+
+    Splitting them is not merely redundant. Measured on a GB10 (sm121)
+    with Gemma 4 E2B (``global_head_dim`` 512) and the backend pinned to
+    FlashInfer:
+
+    * bf16 KV cannot use the split at all. The ``(head_dim_qk=512,
+      head_dim_vo=256)`` pass exceeds the 99 KiB shared-memory budget per
+      block even at ``cta_tile_q=16``, so FA2 raises and the engine dies
+      during startup profiling. Unsplit, the same model serves correctly.
+    * FP8 KV can use the split -- it *is* the 1-byte specialisation -- but
+      pays a second pass and forces ``reorder_batch_threshold = 0``, which
+      routes decode through the per-step-planned prefill wrapper and gives
+      up the decode CUDA-graph path.
+
+    So bf16 and FP8 keep ``head_dim_vo = head_size``.
 
     NVFP4 additionally requires linear (non-swizzled) V scale factors,
     which the sm12x cache writer stores, so the V data and scale views
@@ -1040,7 +1051,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self.use_xqa = (
             self.flashinfer_trtllm_api_decode_kernel == FlashInferDecodeKernel.XQA
         )
-        )
         # Adaptive verification trims drafts on device, so decode query lengths
         # must come from the device qo_indptr; only trtllm-gen supports that
         # (the selector already rejects the other configurations).
@@ -1244,6 +1254,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # wired for uniform multi-token capture. Advertise single-token only
         # rather than promising UNIFORM_BATCH the decode route cannot honour.
         cache_config = vllm_config.cache_config
+        # Upstream's SM90 XQA work (#50439) dropped the shared sm12x local this
+        # used to borrow, so derive it here.
+        is_sm12x = current_platform.is_device_capability_family(120)
         if (
             is_sm12x
             and cache_config is not None

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -125,15 +125,24 @@ def _vo_split_factor(head_size: int, is_fa2_nvfp4: bool) -> int:
     the 512-wide V cache (and, for NVFP4, of its per-16-element scale
     factors).
 
-    The split is dtype-independent (the guard counts only accumulator
-    fragments). For NVFP4 it additionally requires linear (non-swizzled)
-    V scale factors, which the sm12x cache writer stores, so the V data
-    and scale views slice cleanly along the head dim; the trtllm-gen
-    4-token V-scale swizzle does not commute with head-dim slicing.
+    The split exists for the NVFP4 path only. The HEAD_DIM_VO <= 256
+    conditions in FlashInfer's FA2 prefill are the 1-byte-KV shared-smem
+    specialisation, which excludes FP4 outright; 16-bit and FP8 KV reach
+    the CTA_TILE_Q=32 configuration that handles HEAD_DIM_VO >= 512
+    directly. Splitting those would be a behaviour change for models this
+    path was never meant to touch: it forces
+    ``reorder_batch_threshold = 0``, routing decode through the
+    per-step-planned prefill wrapper and giving up the decode CUDA-graph
+    path. So bf16 and FP8 keep ``head_dim_vo = head_size``.
+
+    NVFP4 additionally requires linear (non-swizzled) V scale factors,
+    which the sm12x cache writer stores, so the V data and scale views
+    slice cleanly along the head dim; the trtllm-gen 4-token V-scale
+    swizzle does not commute with head-dim slicing.
     """
-    if head_size <= 256:
+    if head_size <= 256 or not is_fa2_nvfp4:
         return 1
-    if is_fa2_nvfp4 and not _vllm_nvfp4_kv_vosplit_requested():
+    if not _vllm_nvfp4_kv_vosplit_requested():
         raise ValueError(
             f"NVFP4 KV with head_size={head_size} on the SM12x FA2 path "
             "needs the two-pass VO split (the FA2 kernel caps HEAD_DIM_VO "
@@ -141,7 +150,7 @@ def _vo_split_factor(head_size: int, is_fa2_nvfp4: bool) -> int:
             "these layers on a different KV dtype."
         )
     split = -(-head_size // 256)  # ceil(head_size / 256)
-    if head_size % split != 0 or (is_fa2_nvfp4 and (head_size // split) % 16 != 0):
+    if head_size % split != 0 or (head_size // split) % 16 != 0:
         raise ValueError(
             "The VO split needs head_size divisible into <=256-wide chunks"
             f"{' of whole 16-element scale blocks' if is_fa2_nvfp4 else ''}; "
@@ -1234,24 +1243,23 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # dedicated-XQA API rejects the packed fp4 cache), and that path is not
         # wired for uniform multi-token capture. Advertise single-token only
         # rather than promising UNIFORM_BATCH the decode route cannot honour.
-        # head_size > 256 (Gemma 4 global layers) runs the two-pass VO split:
-        # the builder sets reorder_batch_threshold = 0, so every request,
-        # decode included, goes through the per-step-planned prefill wrapper,
-        # which has no cudagraph buffers. A FULL decode graph captured around
-        # it replays stale plan data and produces garbage. _vo_split_factor()
-        # keys on head_size alone, so this holds for bf16 and FP8 KV as well as
-        # NVFP4 -- refuse capture whenever the split is in play and let the
-        # runner fall back to PIECEWISE.
-        for spec in iter_layer_specs(kv_cache_spec):
-            if isinstance(spec, AttentionSpec) and spec.head_size > 256:
-                return AttentionCGSupport.NEVER
-
         cache_config = vllm_config.cache_config
         if (
             is_sm12x
             and cache_config is not None
             and cache_config.cache_dtype.startswith("nvfp4")
         ):
+            # head_size > 256 (Gemma 4 global layers) runs the two-pass VO
+            # split, and only NVFP4 does -- see _vo_split_factor(). The builder
+            # then sets reorder_batch_threshold = 0, so every request, decode
+            # included, goes through the per-step-planned prefill wrapper,
+            # which has no cudagraph buffers: a FULL decode graph captured
+            # around it replays stale plan data and produces garbage. Refuse
+            # capture for these groups and let the runner fall back to
+            # PIECEWISE.
+            for spec in iter_layer_specs(kv_cache_spec):
+                if isinstance(spec, AttentionSpec) and spec.head_size > 256:
+                    return AttentionCGSupport.NEVER
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
 
         kv_specs = iter_layer_specs(kv_cache_spec)

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -612,6 +612,27 @@ class FlashInferBackend(AttentionBackend):
             # The trtllm-gen kernels consume head-major block interiors; the L/B
             # nesting outside the block is immaterial to them.
             return (KVCacheLayout.LBHNC, KVCacheLayout.BLHNC)
+        # NVFP4 KV on consumer Blackwell (sm120/sm121, FA2 path): each K/V
+        # side of the cache packs [data | scale] regions carved out of the
+        # side's byte range (reshape_and_cache_nvfp4 writes the scales at
+        # side_base + num_heads * block_size * data_dim;
+        # nvfp4_split_data_scale reads them back with derived strides).
+        # That carve is only byte-coherent when each side's heads own one
+        # contiguous region per page, i.e. a head-major (HND) block interior.
+        # Under NHD the K and V head rows interleave within each token and
+        # the side-region offsets land inside the other side's data ->
+        # silent KV corruption. This hook has no dtype parameter, so read
+        # the ambient vllm config (same pattern as
+        # get_kv_connector_cache_layout); if the hook grows a dtype-aware
+        # signature, this decision moves into it.
+        if capability is not None and capability.major == 12:
+            vllm_config = get_current_vllm_config_or_none()
+            if (
+                vllm_config is not None
+                and vllm_config.cache_config is not None
+                and vllm_config.cache_config.cache_dtype.startswith("nvfp4")
+            ):
+                return (KVCacheLayout.LBHNC, KVCacheLayout.BLHNC)
         return super().supported_kv_cache_layouts()
 
     forward_includes_kv_cache_update: bool = False
@@ -916,6 +937,24 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.use_fa2_nvfp4_kv = False
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
+
+        if self.is_kvcache_nvfp4 and not (
+            self.kv_cache_layout.is_block_compact
+            and self.kv_cache_layout.is_block_contiguous
+        ):
+            # The NVFP4 per-side [data | scale] carve (reshape_and_cache_nvfp4
+            # writes scales at side_base + num_heads * block_size * data_dim;
+            # nvfp4_split_data_scale reads them back with derived strides) is
+            # only byte-coherent when each page's [H, N, C] bytes form one
+            # contiguous head-major run. Test the resolved layout itself, not
+            # its FlashInfer nickname: BHLNC also reports "HND" but is neither
+            # block-compact nor block-contiguous, and would silently corrupt
+            # the cache. See FlashInferBackend.supported_kv_cache_layouts.
+            raise ValueError(
+                "NVFP4 KV cache requires a block-compact, head-major KV cache "
+                f"layout; resolved layout is {self.kv_cache_layout.name!r}. "
+                "Unset VLLM_KV_CACHE_LAYOUT or set it to 'HND' (LBHNC)."
+            )
 
         # Compute per-phase Q dtype.  On SM90 (XQA decode), the prefill and
         # decode phases require different Q dtypes when the KV cache is FP8

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1235,6 +1235,16 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             and cache_config is not None
             and cache_config.cache_dtype.startswith("nvfp4")
         ):
+            # head_size > 256 (Gemma 4 global layers) runs the two-pass VO
+            # split: the builder sets reorder_batch_threshold = 0 and every
+            # request, decode included, goes through the per-step-planned
+            # prefill wrapper, which has no cudagraph buffers. A FULL decode
+            # graph captured around it replays stale plan data and produces
+            # garbage, so refuse capture for these groups (the runner falls
+            # back to PIECEWISE for the model).
+            for spec in iter_layer_specs(kv_cache_spec):
+                if isinstance(spec, AttentionSpec) and spec.head_size > 256:
+                    return AttentionCGSupport.NEVER
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
 
         kv_specs = iter_layer_specs(kv_cache_spec)

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -99,6 +99,57 @@ FP4_DTYPE = torch.uint8
 
 logger = init_logger(__name__)
 
+
+def _vllm_nvfp4_kv_vosplit_requested() -> bool:
+    """VLLM_NVFP4_KV_VOSPLIT opts head_size > 256 NVFP4 layers into the FA2
+    two-pass VO split (Gemma 4 global D=512 full-attention layers).
+
+    Default-on (see vllm/envs.py); only an explicit "0" disables it. The
+    model-config routing (vllm/model_executor/models/config.py) gates the
+    Gemma 4 -> FLASHINFER decision on the same flag, so the backend must
+    honor it here too."""
+    return bool(envs.VLLM_NVFP4_KV_VOSPLIT)
+
+
+def _vo_split_factor(head_size: int, is_fa2_nvfp4: bool) -> int:
+    """Number of VO passes for the FlashInfer FA2 path.
+
+    The FA2 nvfp4 kernel trait guard rejects HEAD_DIM_VO > 256 (the
+    per-thread output-accumulator fragments do not fit the register
+    budget), but HEAD_DIM_QK=512 is fine, and attention decomposes
+    EXACTLY along the VO dimension: S = Q @ K^T and the softmax are
+    identical per pass, and O = [P @ V_left | P @ V_right] concatenates
+    with no LSE merge. So a Gemma 4 full-attention head (Q=K=V=512 wide;
+    the cache stores V at 512) runs as ``ceil(head_size/256)`` passes of
+    ``(head_dim_qk=512, head_dim_vo=256)``, each over a head-dim slice of
+    the 512-wide V cache (and, for NVFP4, of its per-16-element scale
+    factors).
+
+    The split is dtype-independent (the guard counts only accumulator
+    fragments). For NVFP4 it additionally requires linear (non-swizzled)
+    V scale factors, which the sm12x cache writer stores, so the V data
+    and scale views slice cleanly along the head dim; the trtllm-gen
+    4-token V-scale swizzle does not commute with head-dim slicing.
+    """
+    if head_size <= 256:
+        return 1
+    if is_fa2_nvfp4 and not _vllm_nvfp4_kv_vosplit_requested():
+        raise ValueError(
+            f"NVFP4 KV with head_size={head_size} on the SM12x FA2 path "
+            "needs the two-pass VO split (the FA2 kernel caps HEAD_DIM_VO "
+            "at 256). Set VLLM_NVFP4_KV_VOSPLIT=1 to enable it, or keep "
+            "these layers on a different KV dtype."
+        )
+    split = -(-head_size // 256)  # ceil(head_size / 256)
+    if head_size % split != 0 or (is_fa2_nvfp4 and (head_size // split) % 16 != 0):
+        raise ValueError(
+            "The VO split needs head_size divisible into <=256-wide chunks"
+            f"{' of whole 16-element scale blocks' if is_fa2_nvfp4 else ''}; "
+            f"got head_size={head_size}."
+        )
+    return split
+
+
 trtllm_workspace_buffer = None
 
 
@@ -545,6 +596,13 @@ class FlashInferBackend(AttentionBackend):
         ) and supports_trtllm_attention(is_prefill=True)
 
     @classmethod
+    def supports_mm_prefix(cls) -> bool:
+        # Text-mode is fully correct (no image spans to mask). Span-level
+        # bidirectional masking for image inputs is the separate mm-prefix
+        # concern; for NVFP4-KV text serving this gate must not reject FA2.
+        return True
+
+    @classmethod
     def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...] | None:
         capability = current_platform.get_device_capability()
         if capability is not None and capability.major == 10:
@@ -774,6 +832,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         self.num_kv_heads = self.kv_cache_spec.num_kv_heads
         self.head_dim = self.kv_cache_spec.head_size
+        # Gemma 4 full-attention is SYMMETRIC: Q=K=V=512-wide per head (the
+        # KV cache stores V at 512). There is no native 256-wide V. The FA2
+        # nvfp4 kernel caps HEAD_DIM_VO at 256, so a 512-wide V/O is run as
+        # ceil(head_size/256) two-pass VO-split chunks: each pass uses
+        # head_dim_qk=full head_size, head_dim_vo=head_size//vo_split, over a
+        # head-dim slice of the 512-wide V cache; the per-pass outputs
+        # concatenate exactly (identical S/softmax, no LSE merge).
+        # vo_split == 1 for head_size <= 256 (ordinary single-pass).
         self.page_size = self.kv_cache_spec.block_size
 
         if self.kv_cache_spec.kv_quant_mode != KVQuantMode.NONE:
@@ -900,6 +966,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # flash_attn_varlen_func's cp_world_size/cp_rank/cp_tot_seqused_k).
             supports_dcp_with_varlen=False,
         )
+
+        # Two-pass VO split for head_size > 256 (Gemma 4 full-attention,
+        # head_dim_qk=512). vo_split == 1 leaves all existing paths
+        # untouched.
+        self.vo_split = _vo_split_factor(self.head_dim, self.use_fa2_nvfp4_kv)
+        if self.vo_split > 1:
+            # BatchDecodeWithPagedKVCacheWrapper.plan() has no head_dim_vo,
+            # so route every request through the VO-split-planned prefill
+            # wrapper: threshold 0 classifies nothing as decode, and a
+            # causal qo_len==1 prefill computes exactly what decode would.
+            self.reorder_batch_threshold = 0
+            logger.info_once(
+                "FA2 VO split (%s KV): head_size %d runs as %d passes of "
+                "head_dim_vo=%d; decode requests use the prefill wrapper.",
+                self.cache_dtype,
+                self.head_dim,
+                self.vo_split,
+                self.head_dim // self.vo_split,
+            )
 
         self._cascade_wrapper = None  # Wrapper for cascade attention
 
@@ -1694,6 +1779,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         num_qo_heads=self.num_qo_heads,
                         num_kv_heads=self.num_kv_heads,
                         head_dim_qk=self.head_dim,
+                        # == head_dim_qk unless the VO split is active; then
+                        # each pass plans head_dim_vo=head_size//vo_split (256
+                        # for Gemma 4 512-wide heads) and the impl runs the
+                        # wrapper once per V slice (_run_vo_split_prefill).
+                        head_dim_vo=self.head_dim // self.vo_split,
                         page_size=self.page_size,
                         causal=attn_metadata.causal,
                         sm_scale=self.sm_scale,
@@ -1869,6 +1959,11 @@ class FlashInferImpl(AttentionImpl):
             self.is_kvcache_nvfp4 and current_platform.is_device_capability_family(120)
         )
         self.fp4_data_dim = head_size // 2 if self.is_kvcache_nvfp4 else 0
+        # Two-pass VO split factor for head_size > 256 (Gemma 4 D=512); 1
+        # otherwise. Must match the builder's vo_split: the wrapper is
+        # planned with head_dim_vo = head_size // vo_split, so the impl must
+        # run it once per V slice when vo_split > 1.
+        self.vo_split = _vo_split_factor(head_size, self.use_fa2_nvfp4_kv)
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
 
@@ -2000,6 +2095,71 @@ class FlashInferImpl(AttentionImpl):
             return query_quantized.view(num_tokens, num_heads, head_size)
 
         return query
+
+    def _run_vo_split_prefill(
+        self,
+        wrapper: BatchPrefillWithPagedKVCacheWrapper,
+        query: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, torch.Tensor],
+        kv_sf: tuple[torch.Tensor, torch.Tensor] | None,
+        out: torch.Tensor,
+        *,
+        q_scale: float,
+        k_scale: float,
+        v_scale: float,
+    ) -> None:
+        """Multi-pass FA2 prefill run for head_size > 256 (Gemma 4 D=512).
+
+        The wrapper is planned with head_dim_vo = head_size // vo_split, and
+        each pass consumes a head-dim slice of V (and, for NVFP4, of the V
+        scale factors): S = Q @ K^T and the softmax are recomputed
+        identically per pass, so the per-pass outputs concatenate exactly
+        along the head dim with no LSE merge. narrow() keeps the full
+        tensor's strides, which the FA2 path requires.
+
+        NVFP4 V slicing relies on the linear (non-swizzled) V scale layout
+        the sm12x cache writer stores: the V data view's last dim is
+        ``head_size // 2`` packed e2m1 bytes and the V scale view's last
+        dim is ``head_size // 16`` fp8 scales, both contiguous along the
+        head dim, so chunk ``i`` is data[i*chunk//2 : ...] and
+        scale[i*chunk//16 : ...].
+        """
+        split = self.vo_split
+        head_chunk = self.head_size // split
+        k_cache, v_cache = kv_cache
+        if self.is_kvcache_nvfp4:
+            assert kv_sf is not None
+            k_sf, v_sf = kv_sf
+            data_step = head_chunk // 2  # packed e2m1, 2 elements per byte
+            sf_step = head_chunk // 16  # one fp8 scale per 16 elements
+        else:
+            k_sf = v_sf = None
+            data_step = head_chunk
+            sf_step = 0
+        for i in range(split):
+            v_cache_i = v_cache.narrow(-1, i * data_step, data_step)
+            kv_sf_i = (
+                (k_sf, v_sf.narrow(-1, i * sf_step, sf_step))
+                if v_sf is not None
+                else None
+            )
+            # The kernel needs a contiguous output; write into a chunk
+            # buffer and copy into the head-dim slice of the full output.
+            out_i = torch.empty(
+                (*out.shape[:-1], head_chunk),
+                dtype=out.dtype,
+                device=out.device,
+            )
+            wrapper.run(
+                query,
+                (k_cache, v_cache_i),
+                q_scale=q_scale,
+                k_scale=k_scale,
+                v_scale=v_scale,
+                out=out_i,
+                kv_cache_sf=kv_sf_i,
+            )
+            out.narrow(-1, i * head_chunk, head_chunk).copy_(out_i)
 
     def forward(
         self,
@@ -2271,6 +2431,24 @@ class FlashInferImpl(AttentionImpl):
                             v_scale=layer._v_scale_float,
                             out=out_prefill,
                         )
+                    elif self.vo_split > 1:
+                        # head_size > 256: run ceil(head_size/256) passes,
+                        # each over a head-dim slice of the 512-wide V cache,
+                        # and concatenate the per-pass outputs. The wrapper is
+                        # planned with head_dim_vo = head_size // vo_split.
+                        if self.is_kvcache_nvfp4:
+                            assert isinstance(kv_cache_for_fi, tuple)
+                            assert isinstance(kv_cache_sf, tuple)
+                        self._run_vo_split_prefill(
+                            prefill_wrapper,
+                            prefill_query,
+                            kv_cache_for_fi,
+                            kv_cache_sf,
+                            out_prefill,
+                            q_scale=layer._q_scale_float,
+                            k_scale=layer._k_scale_float,
+                            v_scale=layer._v_scale_float,
+                        )
                     else:
                         prefill_wrapper.run(
                             prefill_query,
@@ -2407,6 +2585,16 @@ class FlashInferImpl(AttentionImpl):
                     decode_query_tokens = attn_metadata.num_decodes
             decode_query = query_padded[:decode_query_tokens]
             assert decode_query.shape[0] == decode_query_tokens
+
+            # The VO split routes every request (including would-be decodes)
+            # through the prefill wrapper (builder sets reorder_batch_threshold
+            # = 0), because BatchDecodeWithPagedKVCacheWrapper.plan() has no
+            # head_dim_vo. So no decode tokens should reach this block.
+            assert self.vo_split == 1, (
+                "FA2 VO split routes decodes through the prefill wrapper; "
+                f"unexpected {num_decode_tokens} decode tokens with "
+                f"vo_split={self.vo_split}."
+            )
 
             # Convert query to the expected dtype for decode if needed.
             decode_query = self.maybe_quant_query(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -659,7 +659,7 @@ class FlashInferBackend(AttentionBackend):
 
 
 @dataclass
-class FIPrefillMMGroup:
+class FIPrefillGroup:
     """One partition of an mm-prefix prefill batch (Gemma 3 / Gemma 4
     multimodal: requests whose image-token span intersects the current
     query window need span-level bidirectional masking; plain requests
@@ -677,6 +677,22 @@ class FIPrefillMMGroup:
 
     num_tokens: int
 
+    is_mm: bool
+    """Whether this group's requests carry image spans needing bidirectional
+    masking. Part of the group key, not the plan."""
+
+    req_causal: bool
+    """The attention semantics this group's requests actually want. Part of
+    the group key, not the plan: a masked group encodes causality inside its
+    packed mask and is still planned causal=False."""
+
+    causal: bool
+    """The causal flag the wrapper was planned with. The impl asserts that
+    the plan is a valid ENCODING of (is_mm, req_causal) -- an unmasked group
+    must plan its own semantics directly, a masked group must plan
+    causal=False with the window disabled -- so a mis-planned wrapper is
+    caught rather than silently mis-attending."""
+
 
 @dataclass
 class FIPrefill:
@@ -684,7 +700,7 @@ class FIPrefill:
 
     wrapper: BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper
 
-    mm_groups: list[FIPrefillMMGroup] | None = None
+    prefill_groups: list[FIPrefillGroup] | None = None
     """mm-prefix wrapper grouping when image-token spans intersect the
     query window of at least one prefill request; None on the scalar
     causal fast path (no mm requests => byte-identical legacy path)."""
@@ -834,9 +850,16 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self._noncausal_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = (
             None  # Wrapper for non-causal prefill (DFlash)
         )
-        # Second prefill wrapper for mm-prefix custom-mask requests
-        # (Gemma 3 / Gemma 4 multimodal image spans); lazily created.
-        self._mm_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = None
+        # Secondary prefill wrappers for batches whose requests do not all
+        # share the same attention semantics, keyed by (is_mm, causal):
+        #   (True,  True )  mm spans, causal base    -> packed custom mask
+        #   (True,  False)  mm spans, non-causal     -> packed custom mask
+        #   (False, False)  plain non-causal (DiffusionGemma denoise)
+        # The (False, True) plain-causal key reuses self._prefill_wrapper, so
+        # the legacy scalar-causal no-mm path is untouched. Lazily created.
+        self._grouped_prefill_wrappers: dict[
+            tuple[bool, bool], BatchPrefillWithPagedKVCacheWrapper
+        ] = {}
         self._decode_wrapper = None  # Wrapper for decode (general shape)
 
         if envs.VLLM_BATCH_INVARIANT:
@@ -1492,24 +1515,39 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         assert self._prefill_wrapper is not None
         return self._prefill_wrapper
 
-    def _get_mm_prefill_wrapper(self) -> BatchPrefillWithPagedKVCacheWrapper:
-        # Second paged prefill wrapper for the mm-prefix custom-mask group.
-        # Built the same way as the plain prefill wrapper (the VO split and
-        # NVFP4 jit module are applied at plan()/run() time, not here);
-        # only reachable on the mm-prefix path, which rejects DCP.
-        if self._mm_prefill_wrapper is None:
+    def _get_group_prefill_wrapper(
+        self, is_mm: bool, causal: bool
+    ) -> BatchPrefillWithPagedKVCacheWrapper:
+        # Paged prefill wrapper for one (is_mm, causal) partition. Built the
+        # same way as the plain prefill wrapper (the VO split and NVFP4 jit
+        # module are applied at plan()/run() time, not here); only reachable
+        # on the grouped path, which rejects DCP, cascade and sinks.
+        #
+        # Note this deliberately does NOT go through
+        # _get_prefill_wrapper(causal=False): that builds a backend="auto"
+        # wrapper and rejects NVFP4 outright. Every grouped wrapper is
+        # nvfp4-aware, which is what lets a DiffusionGemma denoise group run
+        # the sm12x FA2 VO-split path.
+        if not is_mm and causal:
+            wrapper = self._get_prefill_wrapper()
+            assert isinstance(wrapper, BatchPrefillWithPagedKVCacheWrapper)
+            return wrapper
+        key = (is_mm, causal)
+        wrapper = self._grouped_prefill_wrappers.get(key)
+        if wrapper is None:
             if self.use_fa2_nvfp4_kv:
                 backend = "fa2"
             elif self.is_kvcache_nvfp4:
                 backend = "trtllm-gen"
             else:
                 backend = "auto"
-            self._mm_prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
+            wrapper = BatchPrefillWithPagedKVCacheWrapper(
                 self._get_workspace_buffer(),
                 get_flashinfer_layout_string(self.kv_cache_layout),
                 backend=backend,
             )
-        return self._mm_prefill_wrapper
+            self._grouped_prefill_wrappers[key] = wrapper
+        return wrapper
 
     def _get_decode_wrapper(self, batch_size: int, use_cudagraph: bool = False):
         if use_cudagraph:
@@ -1671,6 +1709,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         qo_lens: list[int],
         kv_lens: list[int],
         span_lists: list[list[tuple[int, int]]],
+        causal_base: bool = True,
     ) -> torch.Tensor:
         """Boolean (qo_len x kv_len)-per-request mask, flattened row-major
         and concatenated in group order; FlashInfer's plan() bit-packs it
@@ -1687,9 +1726,20 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 kv_len - qo_len, kv_len, device=self.device, dtype=torch.int32
             )
             k_abs = torch.arange(kv_len, device=self.device, dtype=torch.int32)
-            mask = k_abs[None, :] <= q_abs[:, None]
-            if self.window_left >= 0:
-                mask &= (q_abs[:, None] - k_abs[None, :]) <= self.window_left
+            if causal_base:
+                mask = k_abs[None, :] <= q_abs[:, None]
+                if self.window_left >= 0:
+                    mask &= (q_abs[:, None] - k_abs[None, :]) <= self.window_left
+            else:
+                # Non-causal base (DiffusionGemma denoise): every KV position
+                # is visible, and a sliding window becomes symmetric around
+                # the query -- the same rule FlashAttention applies in
+                # _maybe_symmetrize_window() for tensor/False causal.
+                mask = torch.ones(
+                    (qo_len, kv_len), device=self.device, dtype=torch.bool
+                )
+                if self.window_left >= 0:
+                    mask &= (q_abs[:, None] - k_abs[None, :]).abs() <= self.window_left
             for start, end in spans:
                 q_in = (q_abs >= start) & (q_abs <= end)
                 k_in = (k_abs >= start) & (k_abs <= end)
@@ -1697,19 +1747,22 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             masks.append(mask.reshape(-1))
         return torch.cat(masks)
 
-    def _plan_prefill_mm_groups(
+    def _plan_prefill_groups(
         self,
-        prefill_mm_spans: list[list[tuple[int, int]]],
+        prefill_mm_spans: list[list[tuple[int, int]]] | None,
+        causal_prefill_cpu: torch.Tensor | None,
         qo_indptr_prefill_cpu: torch.Tensor,
         paged_kv_indptr_prefill_cpu: torch.Tensor,
         paged_kv_last_page_len_prefill_cpu: torch.Tensor,
         paged_kv_indices: torch.Tensor,
         seq_lens_prefill_cpu: torch.Tensor,
         o_dtype: torch.dtype,
-    ) -> list[FIPrefillMMGroup]:
-        """Plan one prefill wrapper per partition of an mm-prefix batch:
+    ) -> list[FIPrefillGroup]:
+        """Plan one prefill wrapper per ``(is_mm, causal)`` partition of a
+        prefill batch whose requests do not all share attention semantics:
         requests with image spans intersecting the query window run on a
-        custom-mask wrapper; the rest stay on the fast causal wrapper.
+        custom-mask wrapper, DiffusionGemma denoise requests run non-causal,
+        and plain causal requests stay on the fast primary wrapper.
 
         Each request's tokens and KV pages are contiguous ranges of the
         batch-level arrays, so a group is fully described by per-request
@@ -1719,18 +1772,40 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         device fix because the mask lives on GPU while the indptr arrays
         stay on CPU.
         """
-        is_mm = torch.tensor([bool(s) for s in prefill_mm_spans])
+        num_prefill_reqs = qo_indptr_prefill_cpu.numel() - 1
+        is_mm_list = (
+            [bool(sp) for sp in prefill_mm_spans]
+            if prefill_mm_spans is not None
+            else [False] * num_prefill_reqs
+        )
+        causal_list = (
+            [bool(c) for c in causal_prefill_cpu.tolist()]
+            if causal_prefill_cpu is not None
+            else [True] * num_prefill_reqs
+        )
         qo_lens_cpu = qo_indptr_prefill_cpu[1:] - qo_indptr_prefill_cpu[:-1]
         # paged_kv_indptr is NOT rebased to 0 (its offsets index the full
         # paged_kv_indices array), so deltas are taken before regrouping.
         kv_page_counts_cpu = (
             paged_kv_indptr_prefill_cpu[1:] - paged_kv_indptr_prefill_cpu[:-1]
         )
-        groups: list[FIPrefillMMGroup] = []
-        for group_mm in (False, True):
-            req_indices = (is_mm if group_mm else ~is_mm).nonzero(as_tuple=True)[0]
-            if req_indices.numel() == 0:
+        groups: list[FIPrefillGroup] = []
+        # Plain-causal first: groups[0].wrapper is then the primary wrapper in
+        # the common case, matching the ungrouped path's metadata.
+        for group_mm, group_causal in (
+            (False, True),
+            (False, False),
+            (True, True),
+            (True, False),
+        ):
+            members = [
+                i
+                for i in range(num_prefill_reqs)
+                if is_mm_list[i] == group_mm and causal_list[i] == group_causal
+            ]
+            if not members:
                 continue
+            req_indices = torch.tensor(members, dtype=torch.int64)
             group_qo_indptr = torch.zeros(req_indices.numel() + 1, dtype=torch.int32)
             torch.cumsum(qo_lens_cpu[req_indices], dim=0, out=group_qo_indptr[1:])
             group_kv_indptr = torch.zeros(req_indices.numel() + 1, dtype=torch.int32)
@@ -1760,23 +1835,51 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             group_kv_indices = torch.index_select(
                 paged_kv_indices, 0, page_gather_cpu.to(self.device)
             )
+            wrapper = self._get_group_prefill_wrapper(group_mm, group_causal)
             if group_mm:
-                wrapper = self._get_mm_prefill_wrapper()
+                assert prefill_mm_spans is not None
                 custom_mask = self._build_mm_prefix_custom_mask(
                     [int(qo_lens_cpu[i]) for i in req_indices.tolist()],
                     [int(seq_lens_prefill_cpu[i]) for i in req_indices.tolist()],
                     [prefill_mm_spans[i] for i in req_indices.tolist()],
+                    causal_base=group_causal,
                 )
-                # The mask carries causal/SW/span composition wholesale.
-                group_causal = False
-                group_window_left = -1
+                # The mask carries causal/SW/span composition wholesale, so
+                # the plan itself is non-causal with the window disabled.
+                plan_causal = False
+                plan_window_left = -1
+            elif not group_causal and self.window_left >= 0:
+                # FlashInfer's window_left is a LEFT bound only (kv_idx +
+                # qo_len + window_left >= kv_len + q_idx), so planning a
+                # non-causal group with it would leave future context
+                # unbounded. A non-causal request wants a SYMMETRIC window,
+                # the same rule FlashAttention applies in
+                # _maybe_symmetrize_window(); carry it in a spanless custom
+                # mask and disable the in-kernel window.
+                custom_mask = self._build_mm_prefix_custom_mask(
+                    [int(qo_lens_cpu[i]) for i in req_indices.tolist()],
+                    [int(seq_lens_prefill_cpu[i]) for i in req_indices.tolist()],
+                    [[] for _ in req_indices.tolist()],
+                    causal_base=False,
+                )
+                plan_causal = False
+                plan_window_left = -1
             else:
-                maybe_wrapper = self._get_prefill_wrapper()
-                assert isinstance(maybe_wrapper, BatchPrefillWithPagedKVCacheWrapper)
-                wrapper = maybe_wrapper
                 custom_mask = None
-                group_causal = True
-                group_window_left = self.window_left
+                plan_causal = group_causal
+                plan_window_left = self.window_left
+            if custom_mask is not None and getattr(wrapper, "_backend", None) == (
+                "trtllm-gen"
+            ):
+                # trtllm-gen's paged_run ignores the packed mask and treats
+                # mask_mode==CUSTOM as plain causal, which would silently run
+                # this group with the wrong attention. Only the FA2 reader
+                # honours custom masks.
+                raise NotImplementedError(
+                    "FlashInfer custom-mask prefill groups (mm-prefix or "
+                    "per-request causal) require the FA2 paged reader; the "
+                    "trtllm-gen backend ignores packed masks."
+                )
             wrapper.plan(
                 qo_indptr=group_qo_indptr,
                 paged_kv_indptr=group_kv_indptr,
@@ -1789,10 +1892,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 # impl runs each group's wrapper once per V slice.
                 head_dim_vo=self.head_dim // self.vo_split,
                 page_size=self.page_size,
-                causal=group_causal,
+                causal=plan_causal,
                 custom_mask=custom_mask,
                 sm_scale=self.sm_scale,
-                window_left=group_window_left,
+                window_left=plan_window_left,
                 logits_soft_cap=self.logits_soft_cap,
                 q_data_type=self.q_data_type_prefill,
                 kv_data_type=self.kv_cache_dtype,
@@ -1803,10 +1906,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             wrapper.vllm_prefill_fixed_split_size = self.prefill_fixed_split_size
             wrapper.vllm_disable_split_kv = self.disable_split_kv
             groups.append(
-                FIPrefillMMGroup(
+                FIPrefillGroup(
                     wrapper=wrapper,
                     token_indices=token_indices_cpu.to(self.device),
                     num_tokens=int(token_indices_cpu.numel()),
+                    is_mm=group_mm,
+                    req_causal=group_causal,
+                    causal=plan_causal,
                 )
             )
         return groups
@@ -1820,7 +1926,53 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         causal = common_attn_metadata.causal
-        route_decode = causal or self.use_xqa
+        # DiffusionGemma hands over a per-request causal tensor (encoder /
+        # commit causal, denoise bidirectional, mixed within one batch). For
+        # dispatch the batch behaves like the non-causal whole-batch case --
+        # all FI-native prefill, no TRTLLM, no decode split -- and the
+        # per-request flags are consumed by the grouped planner instead.
+        # Collapsing to a scalar also keeps every boolean site below from
+        # doing a truth-test on a multi-element tensor.
+        per_request_causal = isinstance(causal, torch.Tensor)
+        causal_dispatch = False if per_request_causal else causal
+        if per_request_causal and self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv:
+            # The config gate only sees an explicitly-requested backend;
+            # FlashInfer can still be auto-selected. Refuse here, where the
+            # resolved backend is actually known: a non-causal group needs
+            # the FA2 paged reader, and trtllm-gen would ignore its mask.
+            raise NotImplementedError(
+                "Per-request causal flags (DiffusionGemma) with an NVFP4 KV "
+                "cache require the sm12x FlashInfer FA2 paged reader."
+            )
+        if (
+            per_request_causal
+            and self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+        ):
+            # The grouped prefill partition is data-dependent Python control
+            # flow, so a full graph would bake in one batch's partition and
+            # replay it against another. The DiffusionGemma config gate forces
+            # PIECEWISE, but it only sees an explicitly requested backend --
+            # FlashInfer can still be auto-selected, so enforce it here too,
+            # where the resolved mode is known.
+            raise NotImplementedError(
+                "Per-request causal flags (DiffusionGemma) are not supported "
+                "under full CUDA graphs; the grouped prefill partition is "
+                "data-dependent. Use --cudagraph-mode PIECEWISE."
+            )
+        if per_request_causal and (
+            self.use_dcp or self.has_sinks or self.reorder_batch_threshold > 1
+        ):
+            raise NotImplementedError(
+                "Per-request causal flags (DiffusionGemma) require the "
+                "FlashInfer-native prefill pathway: no DCP, attention sinks, "
+                "or speculative batch reordering."
+            )
+        # Mixed causality must not split decodes off the batch: a decode row
+        # planned scalar-causal would attend with the wrong mask. Force the
+        # whole batch through the grouped prefill path.
+        route_decode = (not per_request_causal) and (
+            causal_dispatch or self.use_xqa
+        )
         if route_decode:
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
                 split_decodes_and_prefills(
@@ -1847,12 +1999,18 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # - Prefill (FI native or TRTLLM)
         # - Decode (FI native, XQA, or trtllm-gen)
         use_cascade = common_prefix_len > 0
+        if per_request_causal and use_cascade:
+            raise NotImplementedError(
+                "Per-request causal flags (DiffusionGemma) are not supported "
+                "with cascade attention; the shared-prefix wrapper is planned "
+                "with a single causal flag for the whole batch."
+            )
         uses_spec_reorder = self.reorder_batch_threshold > 1
         # Page sizes >= 128 must use trtllm-gen; force it for prefill too.
         prefill_force_trtllm = (
             True if page_size >= 128 else self.attention_config.use_trtllm_attention
         )
-        prefill_use_trtllm = causal and use_trtllm_attention(
+        prefill_use_trtllm = causal_dispatch and use_trtllm_attention(
             self.num_qo_heads,
             self.num_kv_heads,
             num_prefill_tokens,
@@ -1866,14 +2024,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             has_spec=uses_spec_reorder,
         )
         decode_with_flashinfer_trtllm_api = self.use_trtllm_decode_attention and (
-            causal or self.use_xqa
+            causal_dispatch or self.use_xqa
         )
 
-        if not causal and self.use_dcp:
+        if not causal_dispatch and self.use_dcp:
             raise NotImplementedError(
                 "FlashInfer non-causal prefill is not supported with DCP yet."
             )
-        if not causal and self.use_trtllm_decode_attention:
+        if not causal_dispatch and self.use_trtllm_decode_attention:
             logger.warning_once(
                 "Using FlashInfer for draft model non-causal attention; TRTLLM "
                 "can still be used for target model causal attention."
@@ -1889,7 +2047,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             if prefill_mm_spans is not None:
                 prefill_use_trtllm = False
 
-        all_uses_trtllm = causal and (
+        all_uses_trtllm = causal_dispatch and (
             (num_prefills == 0 or prefill_use_trtllm)
             and (num_decodes == 0 or decode_with_flashinfer_trtllm_api)
         )
@@ -1928,7 +2086,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             num_decode_tokens=num_decode_tokens,
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
-            causal=causal,
+            # The collapsed scalar: FlashInferMetadata.causal is typed bool,
+            # and the per-request tensor is consumed by the grouped planner.
+            causal=causal_dispatch,
             use_cascade=use_cascade,
             prefill=None,
             decode=None,
@@ -2107,7 +2267,15 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     max_seq_len=max_seq_len,
                 )
             else:
-                prefill_wrapper = self._get_prefill_wrapper(causal=attn_metadata.causal)
+                # Placeholder only: overwritten by prefill_groups[0].wrapper
+                # when the grouped planner runs. Ask for the causal wrapper on
+                # the grouped path -- attn_metadata.causal is the collapsed
+                # scalar False there, and _get_prefill_wrapper(causal=False)
+                # rejects NVFP4 outright, which would kill the very config
+                # this stack exists to enable.
+                prefill_wrapper = self._get_prefill_wrapper(
+                    causal=True if per_request_causal else attn_metadata.causal
+                )
                 # Slicing CPU buffers that are only needed for FI native prefills
                 paged_kv_last_page_len_prefill_cpu = self.paged_kv_last_page_len.cpu[
                     prefill_start:num_reqs
@@ -2139,7 +2307,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 )
                 if PIN_MEMORY:
                     kv_lens_prefill_cpu = kv_lens_prefill_cpu.pin_memory()
-                mm_groups: list[FIPrefillMMGroup] | None = None
+                prefill_groups: list[FIPrefillGroup] | None = None
                 if self.use_dcp:
                     assert isinstance(prefill_wrapper, BatchDCPPrefillWrapper)
                     prefill_wrapper.plan(
@@ -2174,10 +2342,17 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv)
                         else self.model_config.dtype
                     )
-                    if prefill_mm_spans is not None:
+                    if prefill_mm_spans is not None or per_request_causal:
                         assert seq_lens_cpu is not None
-                        mm_groups = self._plan_prefill_mm_groups(
+                        causal_prefill_cpu = None
+                        if per_request_causal:
+                            with gpu_sync_allowed():
+                                causal_prefill_cpu = causal[
+                                    prefill_start:num_reqs
+                                ].cpu()
+                        prefill_groups = self._plan_prefill_groups(
                             prefill_mm_spans,
+                            causal_prefill_cpu,
                             qo_indptr_prefill_cpu,
                             paged_kv_indptr_prefill_cpu,
                             paged_kv_last_page_len_prefill_cpu,
@@ -2185,9 +2360,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                             seq_lens_cpu[prefill_start:num_reqs],
                             o_dtype,
                         )
-                        # The impl's forward dispatches on mm_groups; this
+                        # The impl's forward dispatches on prefill_groups; this
                         # field only feeds its isinstance/identity asserts.
-                        prefill_wrapper = mm_groups[0].wrapper
+                        prefill_wrapper = prefill_groups[0].wrapper
                     else:
                         prefill_wrapper.plan(
                             qo_indptr=qo_indptr_prefill_cpu,
@@ -2216,7 +2391,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                             disable_split_kv=self.disable_split_kv,
                         )
                 attn_metadata.prefill = FIPrefill(
-                    wrapper=prefill_wrapper, mm_groups=mm_groups
+                    wrapper=prefill_wrapper, prefill_groups=prefill_groups
                 )
 
         ## DECODE PATHWAY
@@ -2240,7 +2415,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         q_len_per_req,
                         ragged_q_lens,
                         num_decodes,
-                        bool(causal),
+                        bool(causal_dispatch),
                     )
                 elif self.use_trtllm_gen_varlen_decode:
                     # CPU lens are only an upper bound, device qo_indptr is
@@ -2818,26 +2993,40 @@ class FlashInferImpl(AttentionImpl):
                     assert isinstance(
                         prefill_wrapper, BatchPrefillWithPagedKVCacheWrapper
                     )
-                    mm_groups = attn_metadata.prefill.mm_groups
+                    prefill_groups = attn_metadata.prefill.prefill_groups
                     assert prefill_wrapper._logits_soft_cap == (
                         self.logits_soft_cap or 0.0
                     )
                     assert prefill_wrapper._sm_scale == self.scale
-                    if mm_groups is None:
+                    if prefill_groups is None:
                         assert prefill_wrapper._window_left == self.window_left
                         assert prefill_wrapper._causal == attn_metadata.causal
+                        # attn_metadata.causal is the collapsed scalar; the
+                        # per-request tensor only ever reaches the grouped path.
                     else:
                         # The mm group's wrapper carries the sliding window
                         # and causality inside its packed custom mask
                         # (planned non-causal, window_left=-1); the plain
                         # group keeps the scalar-causal plan.
-                        for group in mm_groups:
+                        for group in prefill_groups:
+                            assert group.wrapper._causal == group.causal
                             if group.wrapper._custom_mask_buf is None:
-                                assert group.wrapper._causal
-                                assert group.wrapper._window_left == self.window_left
+                                # Unmasked: the plan must carry the group's
+                                # own semantics directly, and an unmasked
+                                # non-causal group is only sound with the
+                                # in-kernel (left-only) window disabled.
+                                assert group.causal == group.req_causal
+                                assert not group.is_mm
+                                assert group.wrapper._window_left == (
+                                    self.window_left if group.req_causal else -1
+                                )
                             else:
-                                assert not group.wrapper._causal
+                                # Masked: causality and the window live in the
+                                # packed mask, so the plan is always
+                                # non-causal with the window disabled.
+                                assert not group.causal
                                 assert group.wrapper._window_left == -1
+                                assert group.is_mm or not group.req_causal
 
                     if self.is_kvcache_nvfp4:
                         kv_cache_for_fi = nvfp4_kv_data
@@ -2860,16 +3049,17 @@ class FlashInferImpl(AttentionImpl):
                     else:
                         out_prefill = output[num_decode_tokens:]
 
-                    if mm_groups is not None:
-                        # mm-prefix grouping: each partition runs its own
-                        # planned wrapper (plain causal vs packed custom
-                        # mask) over a gathered copy of its query rows,
-                        # then scatters back. Gather/scatter is by token
-                        # index because the groups may interleave within
-                        # the batch.
+                    if prefill_groups is not None:
+                        # Prefill grouping: each (is_mm, causal) partition
+                        # runs its own planned wrapper (plain causal, plain
+                        # non-causal, or packed custom mask) over a gathered
+                        # copy of its query rows, then scatters back.
+                        # Gather/scatter is by token index because the groups
+                        # may interleave within the batch.
                         if self.is_kvcache_nvfp4:
                             assert isinstance(kv_cache_for_fi, tuple)
-                        for group in mm_groups:
+                            assert isinstance(kv_cache_sf, tuple)
+                        for group in prefill_groups:
                             group_query = torch.index_select(
                                 prefill_query, 0, group.token_indices
                             )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1131,12 +1131,17 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             )
             if bidi_mode == "vision" and self.window_left < 0:
                 self.mm_prefix_enabled = False
-            if self.use_dcp:
+            # Re-check the flag: the line above turns mm-prefix off for this
+            # layer group, and the rejections below only apply while it is on.
+            # Without this a Gemma 4 full-attention group would refuse to start
+            # under DCP or attention sinks, pointing at a flag that no longer
+            # affects it.
+            if self.mm_prefix_enabled and self.use_dcp:
                 raise NotImplementedError(
                     "FlashInfer mm-prefix custom masks are not wired for "
                     "DCP; unset VLLM_FLASHINFER_MM_PREFIX or disable DCP."
                 )
-            if self.has_sinks:
+            if self.mm_prefix_enabled and self.has_sinks:
                 # The mm-prefix groups drive their own planned wrappers via
                 # the plain run() signature, which cannot pass the sink
                 # tensor. Reject the combination here rather than silently
@@ -1229,22 +1234,24 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # dedicated-XQA API rejects the packed fp4 cache), and that path is not
         # wired for uniform multi-token capture. Advertise single-token only
         # rather than promising UNIFORM_BATCH the decode route cannot honour.
+        # head_size > 256 (Gemma 4 global layers) runs the two-pass VO split:
+        # the builder sets reorder_batch_threshold = 0, so every request,
+        # decode included, goes through the per-step-planned prefill wrapper,
+        # which has no cudagraph buffers. A FULL decode graph captured around
+        # it replays stale plan data and produces garbage. _vo_split_factor()
+        # keys on head_size alone, so this holds for bf16 and FP8 KV as well as
+        # NVFP4 -- refuse capture whenever the split is in play and let the
+        # runner fall back to PIECEWISE.
+        for spec in iter_layer_specs(kv_cache_spec):
+            if isinstance(spec, AttentionSpec) and spec.head_size > 256:
+                return AttentionCGSupport.NEVER
+
         cache_config = vllm_config.cache_config
         if (
             is_sm12x
             and cache_config is not None
             and cache_config.cache_dtype.startswith("nvfp4")
         ):
-            # head_size > 256 (Gemma 4 global layers) runs the two-pass VO
-            # split: the builder sets reorder_batch_threshold = 0 and every
-            # request, decode included, goes through the per-step-planned
-            # prefill wrapper, which has no cudagraph buffers. A FULL decode
-            # graph captured around it replays stale plan data and produces
-            # garbage, so refuse capture for these groups (the runner falls
-            # back to PIECEWISE for the model).
-            for spec in iter_layer_specs(kv_cache_spec):
-                if isinstance(spec, AttentionSpec) and spec.head_size > 256:
-                    return AttentionCGSupport.NEVER
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
 
         kv_specs = iter_layer_specs(kv_cache_spec)
@@ -1616,7 +1623,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         if not mm_ranges:
             return None
         qo_indptr_cpu = common_attn_metadata.query_start_loc_cpu
-        seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+        # seq_lens_cpu is a deprecated property that lazily runs
+        # seq_lens.to("cpu"). build() calls this helper before its own guarded
+        # access, so without this the mm-prefix path forces an unguarded sync
+        # (and raises under VLLM_GPU_SYNC_CHECK=error).
+        with gpu_sync_allowed():
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu
         span_lists: list[list[tuple[int, int]]] = []
         any_spans = False
         for j in range(num_prefills):

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -2357,7 +2357,12 @@ class FlashInferImpl(AttentionImpl):
         self.o_sf_scale: float | None = None
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
-        if self.is_kvcache_nvfp4 and vllm_config is not None:
+        # The sm12x FA2 path writes into `output` directly and never reads this.
+        if (
+            self.is_kvcache_nvfp4
+            and vllm_config is not None
+            and not self.use_fa2_nvfp4_kv
+        ):
             max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
             self._nvfp4_fp8_out = torch.empty(
                 (max_num_tokens, num_heads, head_size),

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -597,10 +597,13 @@ class FlashInferBackend(AttentionBackend):
 
     @classmethod
     def supports_mm_prefix(cls) -> bool:
-        # Text-mode is fully correct (no image spans to mask). Span-level
-        # bidirectional masking for image inputs is the separate mm-prefix
-        # concern; for NVFP4-KV text serving this gate must not reject FA2.
-        return True
+        """mm-prefix LMs (Gemma 3 / Gemma 4 multimodal: image-token spans
+        attend bidirectionally) are served via FA2 packed custom masks on
+        the FI-native prefill path. Decode is untouched: spans live in the
+        prompt, so decode queries are strictly causal. Knob-gated and
+        default-on; set VLLM_FLASHINFER_MM_PREFIX=0 to route mm-prefix
+        models away from FlashInfer instead (e.g. for debugging)."""
+        return envs.VLLM_FLASHINFER_MM_PREFIX
 
     @classmethod
     def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...] | None:
@@ -615,10 +618,35 @@ class FlashInferBackend(AttentionBackend):
 
 
 @dataclass
+class FIPrefillMMGroup:
+    """One partition of an mm-prefix prefill batch (Gemma 3 / Gemma 4
+    multimodal: requests whose image-token span intersects the current
+    query window need span-level bidirectional masking; plain requests
+    stay causal)."""
+
+    wrapper: BatchPrefillWithPagedKVCacheWrapper
+    """Planned for exactly this group's requests: causal=True for the
+    plain group, packed custom mask ((causal AND sliding-window) OR
+    span-bidirectional) for the mm group."""
+
+    token_indices: torch.Tensor
+    """Rows of the prefill query/output owned by this group: GPU int64,
+    the concatenation of per-request token ranges from query_start_loc.
+    Needed because the groups may interleave within the batch."""
+
+    num_tokens: int
+
+
+@dataclass
 class FIPrefill:
     """Metadata for the native FlashInfer prefill pathway (non-TRTLLM)."""
 
     wrapper: BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper
+
+    mm_groups: list[FIPrefillMMGroup] | None = None
+    """mm-prefix wrapper grouping when image-token spans intersect the
+    query window of at least one prefill request; None on the scalar
+    causal fast path (no mm requests => byte-identical legacy path)."""
 
 
 @dataclass
@@ -765,6 +793,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self._noncausal_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = (
             None  # Wrapper for non-causal prefill (DFlash)
         )
+        # Second prefill wrapper for mm-prefix custom-mask requests
+        # (Gemma 3 / Gemma 4 multimodal image spans); lazily created.
+        self._mm_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = None
         self._decode_wrapper = None  # Wrapper for decode (general shape)
 
         if envs.VLLM_BATCH_INVARIANT:
@@ -1020,6 +1051,48 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.kv_cache_dtype,
             arch,
         )
+
+        # mm-prefix (PrefixLM) span-level bidirectional masking for this
+        # layer group. Gemma4 with use_bidirectional_attention='vision'
+        # applies bidirectional image spans ONLY to sliding_attention
+        # layers (full-attention layers stay plain causal: the static
+        # equivalent of gemma4_mm._clear_mm_prefix_for_full_attn_layers,
+        # decided here at build time because FlashInfer bakes masks into
+        # wrapper plans). Gemma3 applies the spans to all layers.
+        self.mm_prefix_enabled = (
+            envs.VLLM_FLASHINFER_MM_PREFIX
+            and self.model_config is not None
+            and self.model_config.is_mm_prefix_lm
+        )
+        if self.mm_prefix_enabled:
+            bidi_mode = getattr(
+                self.model_config.hf_text_config,
+                "use_bidirectional_attention",
+                None,
+            )
+            if bidi_mode == "vision" and self.window_left < 0:
+                self.mm_prefix_enabled = False
+            if self.use_dcp:
+                raise NotImplementedError(
+                    "FlashInfer mm-prefix custom masks are not wired for "
+                    "DCP; unset VLLM_FLASHINFER_MM_PREFIX or disable DCP."
+                )
+            if self.has_sinks:
+                # The mm-prefix groups drive their own planned wrappers via
+                # the plain run() signature, which cannot pass the sink
+                # tensor. Reject the combination here rather than silently
+                # dropping sinks at the FFI boundary.
+                raise NotImplementedError(
+                    "FlashInfer mm-prefix custom masks are not wired for "
+                    "attention sinks; unset VLLM_FLASHINFER_MM_PREFIX."
+                )
+        if self.mm_prefix_enabled:
+            logger.info_once(
+                "FlashInfer mm-prefix: image-token spans of multimodal "
+                "requests run with FA2 packed custom masks on a second "
+                "prefill wrapper (layer group window_left=%d).",
+                self.window_left,
+            )
         # Preparing persistent buffers
         self.paged_kv_indptr = CpuGpuBuffer(
             max_num_reqs + 1, dtype=torch.int32, device=self.device, pin_memory=False
@@ -1310,6 +1383,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         assert self._prefill_wrapper is not None
         return self._prefill_wrapper
 
+    def _get_mm_prefill_wrapper(self) -> BatchPrefillWithPagedKVCacheWrapper:
+        # Second paged prefill wrapper for the mm-prefix custom-mask group.
+        # Built the same way as the plain prefill wrapper (the VO split and
+        # NVFP4 jit module are applied at plan()/run() time, not here);
+        # only reachable on the mm-prefix path, which rejects DCP.
+        if self._mm_prefill_wrapper is None:
+            if self.use_fa2_nvfp4_kv:
+                backend = "fa2"
+            elif self.is_kvcache_nvfp4:
+                backend = "trtllm-gen"
+            else:
+                backend = "auto"
+            self._mm_prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
+                self._get_workspace_buffer(),
+                get_flashinfer_layout_string(self.kv_cache_layout),
+                backend=backend,
+            )
+        return self._mm_prefill_wrapper
+
     def _get_decode_wrapper(self, batch_size: int, use_cudagraph: bool = False):
         if use_cudagraph:
             decode_wrapper = self._decode_wrappers_cudagraph.get(batch_size, None)
@@ -1419,6 +1511,192 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         )
         return paged_kv_indices
 
+    def _mm_prefix_prefill_spans(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_decodes: int,
+        num_prefills: int,
+    ) -> list[list[tuple[int, int]]] | None:
+        """Per-prefill-request image spans that intersect the query window.
+
+        Spans are document positions, inclusive [start, end] (the
+        mm_req_doc_ranges convention shared with the Triton/FlexAttention
+        mm-prefix paths; valid iff start < end). A span fully inside the
+        computed context needs nothing: K/V projections are mask-independent
+        and the in-window queries are text, i.e. causal. vLLM forces
+        --disable-chunked-mm-input for mm-prefix models, so spans do not
+        straddle the window boundary in practice; partial overlaps are
+        still handled correctly by the absolute-position mask.
+
+        Returns None when no prefill request has an intersecting span
+        (the scalar-causal fast path stays byte-identical).
+        """
+        mm_ranges = common_attn_metadata.mm_req_doc_ranges
+        if not mm_ranges:
+            return None
+        qo_indptr_cpu = common_attn_metadata.query_start_loc_cpu
+        seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+        span_lists: list[list[tuple[int, int]]] = []
+        any_spans = False
+        for j in range(num_prefills):
+            req_idx = num_decodes + j
+            kv_len = int(seq_lens_cpu[req_idx])
+            qo_len = int(qo_indptr_cpu[req_idx + 1] - qo_indptr_cpu[req_idx])
+            context_len = kv_len - qo_len
+            spans = [
+                (int(s), int(e))
+                for s, e in mm_ranges.get(req_idx, [])
+                if s < e and e >= context_len and s < kv_len
+            ]
+            any_spans = any_spans or bool(spans)
+            span_lists.append(spans)
+        return span_lists if any_spans else None
+
+    def _build_mm_prefix_custom_mask(
+        self,
+        qo_lens: list[int],
+        kv_lens: list[int],
+        span_lists: list[list[tuple[int, int]]],
+    ) -> torch.Tensor:
+        """Boolean (qo_len x kv_len)-per-request mask, flattened row-major
+        and concatenated in group order; FlashInfer's plan() bit-packs it
+        per request (segment_packbits). Composition matches the Triton /
+        FlexAttention mm-prefix contract:
+        (causal AND sliding-window) OR (q in span AND kv in span),
+        with query rows end-aligned to the KV sequence. The mm wrapper is
+        planned with window_left=-1 because the mask already carries the
+        sliding window; spans must OVERRIDE it (FlashInfer's in-kernel SW
+        would AND it instead)."""
+        masks = []
+        for qo_len, kv_len, spans in zip(qo_lens, kv_lens, span_lists):
+            q_abs = torch.arange(
+                kv_len - qo_len, kv_len, device=self.device, dtype=torch.int32
+            )
+            k_abs = torch.arange(kv_len, device=self.device, dtype=torch.int32)
+            mask = k_abs[None, :] <= q_abs[:, None]
+            if self.window_left >= 0:
+                mask &= (q_abs[:, None] - k_abs[None, :]) <= self.window_left
+            for start, end in spans:
+                q_in = (q_abs >= start) & (q_abs <= end)
+                k_in = (k_abs >= start) & (k_abs <= end)
+                mask |= q_in[:, None] & k_in[None, :]
+            masks.append(mask.reshape(-1))
+        return torch.cat(masks)
+
+    def _plan_prefill_mm_groups(
+        self,
+        prefill_mm_spans: list[list[tuple[int, int]]],
+        qo_indptr_prefill_cpu: torch.Tensor,
+        paged_kv_indptr_prefill_cpu: torch.Tensor,
+        paged_kv_last_page_len_prefill_cpu: torch.Tensor,
+        paged_kv_indices: torch.Tensor,
+        seq_lens_prefill_cpu: torch.Tensor,
+        o_dtype: torch.dtype,
+    ) -> list[FIPrefillMMGroup]:
+        """Plan one prefill wrapper per partition of an mm-prefix batch:
+        requests with image spans intersecting the query window run on a
+        custom-mask wrapper; the rest stay on the fast causal wrapper.
+
+        Each request's tokens and KV pages are contiguous ranges of the
+        batch-level arrays, so a group is fully described by per-request
+        deltas of the indptr arrays plus gathered index subranges
+        (indptr/last_page_len slicing on CPU, paged_kv_indices on GPU).
+        plan(custom_mask=...) requires the FlashInfer-side mask_indptr
+        device fix because the mask lives on GPU while the indptr arrays
+        stay on CPU.
+        """
+        is_mm = torch.tensor([bool(s) for s in prefill_mm_spans])
+        qo_lens_cpu = qo_indptr_prefill_cpu[1:] - qo_indptr_prefill_cpu[:-1]
+        # paged_kv_indptr is NOT rebased to 0 (its offsets index the full
+        # paged_kv_indices array), so deltas are taken before regrouping.
+        kv_page_counts_cpu = (
+            paged_kv_indptr_prefill_cpu[1:] - paged_kv_indptr_prefill_cpu[:-1]
+        )
+        groups: list[FIPrefillMMGroup] = []
+        for group_mm in (False, True):
+            req_indices = (is_mm if group_mm else ~is_mm).nonzero(as_tuple=True)[0]
+            if req_indices.numel() == 0:
+                continue
+            group_qo_indptr = torch.zeros(req_indices.numel() + 1, dtype=torch.int32)
+            torch.cumsum(qo_lens_cpu[req_indices], dim=0, out=group_qo_indptr[1:])
+            group_kv_indptr = torch.zeros(req_indices.numel() + 1, dtype=torch.int32)
+            torch.cumsum(
+                kv_page_counts_cpu[req_indices], dim=0, out=group_kv_indptr[1:]
+            )
+            token_indices_cpu = torch.cat(
+                [
+                    torch.arange(
+                        int(qo_indptr_prefill_cpu[i]),
+                        int(qo_indptr_prefill_cpu[i + 1]),
+                        dtype=torch.int64,
+                    )
+                    for i in req_indices.tolist()
+                ]
+            )
+            page_gather_cpu = torch.cat(
+                [
+                    torch.arange(
+                        int(paged_kv_indptr_prefill_cpu[i]),
+                        int(paged_kv_indptr_prefill_cpu[i + 1]),
+                        dtype=torch.int64,
+                    )
+                    for i in req_indices.tolist()
+                ]
+            )
+            group_kv_indices = torch.index_select(
+                paged_kv_indices, 0, page_gather_cpu.to(self.device)
+            )
+            if group_mm:
+                wrapper = self._get_mm_prefill_wrapper()
+                custom_mask = self._build_mm_prefix_custom_mask(
+                    [int(qo_lens_cpu[i]) for i in req_indices.tolist()],
+                    [int(seq_lens_prefill_cpu[i]) for i in req_indices.tolist()],
+                    [prefill_mm_spans[i] for i in req_indices.tolist()],
+                )
+                # The mask carries causal/SW/span composition wholesale.
+                group_causal = False
+                group_window_left = -1
+            else:
+                maybe_wrapper = self._get_prefill_wrapper()
+                assert isinstance(maybe_wrapper, BatchPrefillWithPagedKVCacheWrapper)
+                wrapper = maybe_wrapper
+                custom_mask = None
+                group_causal = True
+                group_window_left = self.window_left
+            wrapper.plan(
+                qo_indptr=group_qo_indptr,
+                paged_kv_indptr=group_kv_indptr,
+                paged_kv_indices=group_kv_indices,
+                paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu[req_indices],
+                num_qo_heads=self.num_qo_heads,
+                num_kv_heads=self.num_kv_heads,
+                head_dim_qk=self.head_dim,
+                # == head_dim_qk unless the VO split is active; then the
+                # impl runs each group's wrapper once per V slice.
+                head_dim_vo=self.head_dim // self.vo_split,
+                page_size=self.page_size,
+                causal=group_causal,
+                custom_mask=custom_mask,
+                sm_scale=self.sm_scale,
+                window_left=group_window_left,
+                logits_soft_cap=self.logits_soft_cap,
+                q_data_type=self.q_data_type_prefill,
+                kv_data_type=self.kv_cache_dtype,
+                o_data_type=o_dtype,
+                fixed_split_size=self.prefill_fixed_split_size,
+                disable_split_kv=self.disable_split_kv,
+            )
+            wrapper.vllm_prefill_fixed_split_size = self.prefill_fixed_split_size
+            wrapper.vllm_disable_split_kv = self.disable_split_kv
+            groups.append(
+                FIPrefillMMGroup(
+                    wrapper=wrapper,
+                    token_indices=token_indices_cpu.to(self.device),
+                    num_tokens=int(token_indices_cpu.numel()),
+                )
+            )
+        return groups
+
     def build(
         self,
         common_prefix_len: int,
@@ -1486,6 +1764,17 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 "Using FlashInfer for draft model non-causal attention; TRTLLM "
                 "can still be used for target model causal attention."
             )
+        # mm-prefix: prefill requests whose image span intersects the
+        # query window need the FI-native custom-mask path (TRTLLM has no
+        # custom masks). Decode stays causal: spans live in the prompt.
+        prefill_mm_spans: list[list[tuple[int, int]]] | None = None
+        if self.mm_prefix_enabled and num_prefills > 0:
+            prefill_mm_spans = self._mm_prefix_prefill_spans(
+                common_attn_metadata, num_decodes, num_prefills
+            )
+            if prefill_mm_spans is not None:
+                prefill_use_trtllm = False
+
         all_uses_trtllm = causal and (
             (num_prefills == 0 or prefill_use_trtllm)
             and (num_decodes == 0 or decode_with_flashinfer_trtllm_api)
@@ -1736,6 +2025,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 )
                 if PIN_MEMORY:
                     kv_lens_prefill_cpu = kv_lens_prefill_cpu.pin_memory()
+                mm_groups: list[FIPrefillMMGroup] | None = None
                 if self.use_dcp:
                     assert isinstance(prefill_wrapper, BatchDCPPrefillWrapper)
                     prefill_wrapper.plan(
@@ -1770,32 +2060,50 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv)
                         else self.model_config.dtype
                     )
-                    prefill_wrapper.plan(
-                        qo_indptr=qo_indptr_prefill_cpu,
-                        paged_kv_indptr=paged_kv_indptr_prefill_cpu,
-                        paged_kv_indices=paged_kv_indices,
-                        paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu,
-                        seq_lens=kv_lens_prefill_cpu,
-                        num_qo_heads=self.num_qo_heads,
-                        num_kv_heads=self.num_kv_heads,
-                        head_dim_qk=self.head_dim,
-                        # == head_dim_qk unless the VO split is active; then
-                        # each pass plans head_dim_vo=head_size//vo_split (256
-                        # for Gemma 4 512-wide heads) and the impl runs the
-                        # wrapper once per V slice (_run_vo_split_prefill).
-                        head_dim_vo=self.head_dim // self.vo_split,
-                        page_size=self.page_size,
-                        causal=attn_metadata.causal,
-                        sm_scale=self.sm_scale,
-                        window_left=self.window_left,
-                        logits_soft_cap=self.logits_soft_cap,
-                        q_data_type=self.q_data_type_prefill,
-                        kv_data_type=self.kv_cache_dtype,
-                        o_data_type=o_dtype,
-                        fixed_split_size=self.prefill_fixed_split_size,
-                        disable_split_kv=self.disable_split_kv,
-                    )
-                attn_metadata.prefill = FIPrefill(wrapper=prefill_wrapper)
+                    if prefill_mm_spans is not None:
+                        assert seq_lens_cpu is not None
+                        mm_groups = self._plan_prefill_mm_groups(
+                            prefill_mm_spans,
+                            qo_indptr_prefill_cpu,
+                            paged_kv_indptr_prefill_cpu,
+                            paged_kv_last_page_len_prefill_cpu,
+                            paged_kv_indices,
+                            seq_lens_cpu[prefill_start:num_reqs],
+                            o_dtype,
+                        )
+                        # The impl's forward dispatches on mm_groups; this
+                        # field only feeds its isinstance/identity asserts.
+                        prefill_wrapper = mm_groups[0].wrapper
+                    else:
+                        prefill_wrapper.plan(
+                            qo_indptr=qo_indptr_prefill_cpu,
+                            paged_kv_indptr=paged_kv_indptr_prefill_cpu,
+                            paged_kv_indices=paged_kv_indices,
+                            paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu,
+                            seq_lens=kv_lens_prefill_cpu,
+                            num_qo_heads=self.num_qo_heads,
+                            num_kv_heads=self.num_kv_heads,
+                            head_dim_qk=self.head_dim,
+                            # == head_dim_qk unless the VO split is active;
+                            # then each pass plans head_dim_vo=head_size//
+                            # vo_split (256 for Gemma 4 512-wide heads) and
+                            # the impl runs the wrapper once per V slice
+                            # (_run_vo_split_prefill).
+                            head_dim_vo=self.head_dim // self.vo_split,
+                            page_size=self.page_size,
+                            causal=attn_metadata.causal,
+                            sm_scale=self.sm_scale,
+                            window_left=self.window_left,
+                            logits_soft_cap=self.logits_soft_cap,
+                            q_data_type=self.q_data_type_prefill,
+                            kv_data_type=self.kv_cache_dtype,
+                            o_data_type=o_dtype,
+                            fixed_split_size=self.prefill_fixed_split_size,
+                            disable_split_kv=self.disable_split_kv,
+                        )
+                attn_metadata.prefill = FIPrefill(
+                    wrapper=prefill_wrapper, mm_groups=mm_groups
+                )
 
         ## DECODE PATHWAY
         if num_decodes > 0:
@@ -2391,12 +2699,26 @@ class FlashInferImpl(AttentionImpl):
                     assert isinstance(
                         prefill_wrapper, BatchPrefillWithPagedKVCacheWrapper
                     )
-                    assert prefill_wrapper._window_left == self.window_left
+                    mm_groups = attn_metadata.prefill.mm_groups
                     assert prefill_wrapper._logits_soft_cap == (
                         self.logits_soft_cap or 0.0
                     )
                     assert prefill_wrapper._sm_scale == self.scale
-                    assert prefill_wrapper._causal == attn_metadata.causal
+                    if mm_groups is None:
+                        assert prefill_wrapper._window_left == self.window_left
+                        assert prefill_wrapper._causal == attn_metadata.causal
+                    else:
+                        # The mm group's wrapper carries the sliding window
+                        # and causality inside its packed custom mask
+                        # (planned non-causal, window_left=-1); the plain
+                        # group keeps the scalar-causal plan.
+                        for group in mm_groups:
+                            if group.wrapper._custom_mask_buf is None:
+                                assert group.wrapper._causal
+                                assert group.wrapper._window_left == self.window_left
+                            else:
+                                assert not group.wrapper._causal
+                                assert group.wrapper._window_left == -1
 
                     if self.is_kvcache_nvfp4:
                         kv_cache_for_fi = nvfp4_kv_data
@@ -2419,7 +2741,47 @@ class FlashInferImpl(AttentionImpl):
                     else:
                         out_prefill = output[num_decode_tokens:]
 
-                    if isinstance(
+                    if mm_groups is not None:
+                        # mm-prefix grouping: each partition runs its own
+                        # planned wrapper (plain causal vs packed custom
+                        # mask) over a gathered copy of its query rows,
+                        # then scatters back. Gather/scatter is by token
+                        # index because the groups may interleave within
+                        # the batch.
+                        if self.is_kvcache_nvfp4:
+                            assert isinstance(kv_cache_for_fi, tuple)
+                        for group in mm_groups:
+                            group_query = torch.index_select(
+                                prefill_query, 0, group.token_indices
+                            )
+                            group_out = torch.empty(
+                                (group.num_tokens, *out_prefill.shape[1:]),
+                                dtype=out_prefill.dtype,
+                                device=out_prefill.device,
+                            )
+                            if self.vo_split > 1:
+                                self._run_vo_split_prefill(
+                                    group.wrapper,
+                                    group_query,
+                                    kv_cache_for_fi,
+                                    kv_cache_sf,
+                                    group_out,
+                                    q_scale=layer._q_scale_float,
+                                    k_scale=layer._k_scale_float,
+                                    v_scale=layer._v_scale_float,
+                                )
+                            else:
+                                group.wrapper.run(
+                                    group_query,
+                                    kv_cache_for_fi,
+                                    q_scale=layer._q_scale_float,
+                                    k_scale=layer._k_scale_float,
+                                    v_scale=layer._v_scale_float,
+                                    out=group_out,
+                                    kv_cache_sf=kv_cache_sf,
+                                )
+                            out_prefill.index_copy_(0, group.token_indices, group_out)
+                    elif isinstance(
                         prefill_wrapper, BatchAttentionWithAttentionSinkWrapper
                     ):
                         assert self.sinks is not None

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1009,8 +1009,28 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             )
             self.use_trtllm_decode_attention = False
             self.flashinfer_trtllm_api_decode_kernel = None
+        if (
+            self.use_fa2_nvfp4_kv
+            and self.flashinfer_trtllm_api_decode_kernel is not None
+        ):
+            # NVFP4 KV on consumer Blackwell is served by the FlashInfer FA2
+            # paged reader; neither the XQA nor the trtllm-gen decode API
+            # accepts the packed fp4 cache (FlashInferImpl.forward asserts on
+            # it). Upstream selects XQA on sm12x regardless of KV dtype, so
+            # without this the engine cannot boot with --kv-cache-dtype nvfp4.
+            # The fa2 route is also what every sm12x measurement on this PR was
+            # taken on, and XQA benchmarked 0.7-1.2% slower at equal cudagraph
+            # mode (#49818), so nothing is lost.
+            logger.info_once(
+                "NVFP4 KV cache on consumer Blackwell uses the FlashInfer FA2 "
+                "paged decode path; disabling the %s decode API.",
+                self.flashinfer_trtllm_api_decode_kernel.value,
+            )
+            self.use_trtllm_decode_attention = False
+            self.flashinfer_trtllm_api_decode_kernel = None
         self.use_xqa = (
             self.flashinfer_trtllm_api_decode_kernel == FlashInferDecodeKernel.XQA
+        )
         )
         # Adaptive verification trims drafts on device, so decode query lengths
         # must come from the device qo_indptr; only trtllm-gen supports that
@@ -1203,6 +1223,18 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         """Get the cudagraph support level for FlashInfer attention."""
         # XQA lacks LSE for DCP; DCP also cannot graph variable-length trtllm-gen.
         if vllm_config.parallel_config.decode_context_parallel_size > 1:
+            return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
+
+        # NVFP4 KV on sm12x decodes through the FI-native FA2 path (the
+        # dedicated-XQA API rejects the packed fp4 cache), and that path is not
+        # wired for uniform multi-token capture. Advertise single-token only
+        # rather than promising UNIFORM_BATCH the decode route cannot honour.
+        cache_config = vllm_config.cache_config
+        if (
+            is_sm12x
+            and cache_config is not None
+            and cache_config.cache_dtype.startswith("nvfp4")
+        ):
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
 
         kv_specs = iter_layer_specs(kv_cache_spec)

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -106,8 +106,13 @@ class WorkerBase:
 
     def get_supported_kv_cache_layouts(self) -> list[str]:
         """Layout names every attention backend supports, most preferred first."""
-        backends = get_current_attn_backends(self.vllm_config)
-        return [layout.name for layout in get_supported_kv_cache_layouts(backends)]
+        # Backend capability hooks read the ambient config (e.g. FlashInfer's
+        # get_supported_kernel_block_sizes and supported_kv_cache_layouts), so
+        # install it for the duration of the query; this RPC is otherwise the
+        # one capability path that runs without it.
+        with set_current_vllm_config(self.vllm_config):
+            backends = get_current_attn_backends(self.vllm_config)
+            return [layout.name for layout in get_supported_kv_cache_layouts(backends)]
 
     def set_kv_cache_layout(self, kv_cache_layout: str) -> None:
         """Adopt the KV cache layout resolved by the engine core."""


### PR DESCRIPTION
## Summary

Adds NVFP4 KV-cache support for **DiffusionGemma** (`diffusiongemma-26B-A4B-it`)
on consumer Blackwell (sm120), building on the Gemma 3/4 NVFP4 KV work in #46329.

DiffusionGemma is a block-diffusion model whose attention mixes **causal**
(encoder/commit) and **non-causal** (denoise) batches per request, with the
Gemma-4 512-wide global heads (head_dim_qk=512 / head_dim_vo=256). Two commits:

1. **DiffusionGemma: allow FLASHINFER under NVFP4 VO-split** — routes DG to the
   FlashInfer FA2 VO-split backend when `VLLM_NVFP4_KV_VOSPLIT` is set (instead of
   the hard rejection), and auto-creates the `DiffusionConfig` from the HF config.
2. **FlashInfer: unify prefill grouping into `FIPrefillGroup`** — generalizes the
   multimodal mm-prefix prefill grouping and DG's per-request causal grouping into
   one structure keyed by `(is_mm, causal)`, so a batch can mix causal and
   bidirectional requests (and NVFP4 VO-split) in one FlashInfer plan.

## Stacking

This PR is **stacked on #46329** — the diff includes #46329's commits until it
merges; the DiffusionGemma-specific changes are the top two commits
(`DiffusionGemma: allow FLASHINFER…` and `FlashInfer: unify prefill grouping…`).
Depends on flashinfer#3684 (the VO-split kernel) like #46329 does.

## Calibration

DiffusionGemma's decoder reads the KV cache structurally
(`past_key_values.layers[i].keys`) rather than via `update()`, which surfaced two
calibration issues, both handled outside this PR:
- the crash fix in compressed-tensors (vllm-project/compressed-tensors#747), and
- the decoder-scale-tie for the silent zero-scale follow-on
  (vllm-project/llm-compressor#2853; our calibration ties the weight-shared
  encoder scale into the decoder layers).
Loading DG to calibrate also needs `transformers>=5.12` (llm-compressor#2845, merged).

## Validation

On sm120 (RTX PRO 6000), calibrated NVFP4 KV == bf16 for DiffusionGemma-26B-A4B:
coherent generation through DG's diffusion sampler + needle retrieval, matching
the bf16 baseline. The AR control (Gemma-4-26B-A4B) is also NVFP4 == bf16.

**sm120 only**: DG-26B is MoE, and Spark/sm121 is blocked by *upstream* MoE issues
(#46307 / flashinfer#3683), not by this KV path.

**Tests**: CPU unit tests for the VO-split factor and mm-prefix masking are in
#46329. I'm re-confirming the serving validation on the just-rebased branch and
will post results. AI assistance (Claude) was used; commits carry the
`Co-authored-by` trailer and a human ran the on-box validation.

## Duplicate-work check

Stacked on #46329; see the duplicate-work note there for the SM120 NVFP4 KV picture, including #50288 (ch2lab), which builds on that base rather than competing with it.

No open PR other than this one adds DiffusionGemma NVFP4 KV support, or the mixed causal / non-causal prefill grouping (`FIPrefillGroup`) that block-diffusion attention needs in a single FlashInfer plan.
