### PR TITLE
fix(rocm): fall back to cuda_ipc backend for NIXL on ROCm/AMD

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -252,8 +252,14 @@ class NixlBaseConnectorWorker:
             raise ValueError("kv_transfer_config must be set for NixlConnector")
         self.kv_transfer_config = vllm_config.kv_transfer_config
 
+        # On ROCm/AMD platforms the NIXL package ships without UCX support and
+        # only provides the `cuda_ipc` backend.  Fall back to `cuda_ipc` unless
+        # the user has explicitly set a backend via kv_connector_extra_config.
+        _default_nixl_backends = (
+            ["cuda_ipc"] if current_platform.is_rocm() else ["UCX"]
+        )
         self.nixl_backends = vllm_config.kv_transfer_config.get_from_extra_config(
-            "backends", ["UCX"]
+            "backends", _default_nixl_backends
         )
         kv_lease_duration: int = vllm_config.kv_transfer_config.get_from_extra_config(
             "kv_lease_duration", 30


### PR DESCRIPTION
## Summary

Fixes #29176 -- AMD CI failure in `bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh`.

## Root Cause

`NixlBaseConnectorWorker.__init__` defaults `nixl_backends` to `[UCX]` unconditionally. On ROCm/AMD the NIXL package is built **without UCX** -- only `cuda_ipc` is available -- so `nixl._api.register_memory(backends=[UCX])` raises `KeyError: 'UCX'` during `initialize_kv_cache`.

## Fix

Detect the ROCm platform via `current_platform.is_rocm()` and use `[cuda_ipc]` as the default NIXL backend on AMD hardware. The `[UCX]` default is preserved on NVIDIA/CUDA. Users may still override via `kv_connector_extra_config.backends`.

## Testing

- Python syntax verified (`ast.parse`)
- `current_platform.is_rocm()` confirmed at `vllm/platforms/interface.py:192`
- `current_platform` already imported in `base_worker.py` -- no new import needed
- NVIDIA/CUDA behavior unchanged; user overrides preserved on both platforms

CC @Alexei-V-Ivanov-AMD

Closes #29176