### PR TITLE
[Bugfix] Hybrid Mamba + KV connector: reconcile diverged per-group prefix hits instead of `max()`/trim

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -25,14 +25,17 @@ from vllm.multimodal.inputs import (
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
+from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.core.single_type_kv_cache_manager import register_all_kvcache_specs
 from vllm.v1.engine import FinishReason
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    MambaSpec,
 )
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
@@ -5246,3 +5249,207 @@ def test_async_load_reservation_prevents_wedge_e2e():
     assert b.status == RequestStatus.WAITING
     assert b.num_preemptions == 0
     assert b.request_id not in req_to_blocks
+
+
+def _create_hybrid_mamba_connector_scheduler(
+    matched_tokens: int,
+    block_size: int = 16,
+    num_blocks: int = 100,
+) -> Scheduler:
+    """FA + Mamba ("all" cache mode) hybrid scheduler with a MockKVConnector
+    that reports ``matched_tokens`` external tokens (issue #46453)."""
+    model_config = ModelConfig(
+        model="facebook/opt-125m",
+        trust_remote_code=True,
+        dtype="float16",
+        seed=42,
+        skip_tokenizer_init=True,
+    )
+    vllm_config = VllmConfig(
+        scheduler_config=SchedulerConfig(
+            max_num_seqs=4,
+            max_num_batched_tokens=8192,
+            max_model_len=8192,
+            enable_chunked_prefill=True,
+            is_encoder_decoder=False,
+            watermark=0.0,
+        ),
+        model_config=model_config,
+        cache_config=CacheConfig(
+            block_size=block_size,
+            enable_prefix_caching=True,
+            mamba_cache_mode="all",
+        ),
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="MockKVConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "matched_tokens": matched_tokens,
+                "is_async": False,
+            },
+        ),
+    )
+    vllm_config.cache_config.num_gpu_blocks = num_blocks
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["fa"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="all",
+                ),
+            ),
+        ],
+    )
+    register_all_kvcache_specs(vllm_config)
+    scheduler = Scheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        structured_output_manager=StructuredOutputManager(vllm_config),
+        block_size=block_size,
+        hash_block_size=block_size,
+        log_stats=True,
+    )
+    assert isinstance(scheduler.kv_cache_manager.coordinator, HybridKVCacheCoordinator)
+    return scheduler
+
+
+def _seed_hybrid_prefix(
+    scheduler: Scheduler, num_prefix_blocks: int, block_size: int
+) -> tuple[list[int], list[int]]:
+    """Cache a full ``num_prefix_blocks`` prefix in both groups (mamba "all"
+    mode caches every block's state), then free it so all blocks are evictable.
+    Returns the FA and Mamba block ids in sequence order."""
+    manager = scheduler.kv_cache_manager
+    [fill] = create_requests(
+        num_requests=1,
+        num_tokens=num_prefix_blocks * block_size,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["fill"],
+    )
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(fill)
+    blocks = manager.allocate_slots(
+        fill, fill.num_tokens, num_computed, computed_blocks
+    )
+    fa_ids = [b.block_id for b in blocks.blocks[0]]
+    mamba_ids = [b.block_id for b in blocks.blocks[1]]
+    manager.free(fill)
+    return fa_ids, mamba_ids
+
+
+@pytest.mark.parametrize(
+    "matched_tokens,expected_num_computed",
+    [
+        # ext == 0: nothing external backs the deeper Mamba hit, so the
+        # scheduler falls back to the convergent boundary every group agrees on
+        # (FA[0] + the resident state@0), NOT the over-reported FA/Mamba depth.
+        (0, 16),
+        # ext > 0: the connector supplies the prefix (incl. the Mamba state) up
+        # to num_computed = spine(32) + ext; each group's hit is trimmed there.
+        (16, 48),
+        (32, 64),
+    ],
+)
+def test_hybrid_per_group_hit_divergence_mamba_deeper(
+    matched_tokens: int, expected_num_computed: int
+):
+    """#46453: per-group prefix hits diverge with the FA prefix tail evicted
+    while a deeper Mamba state survives -> (FA=short, Mamba=deep). The scheduler
+    must admit the request at a boundary consistent for every group; it reports
+    the spine (FA) hit to the connector and reconciles once the external length
+    is known (ext==0 -> convergent re-query, ext>0 -> trim to num_computed)."""
+    block_size = 16
+    scheduler = _create_hybrid_mamba_connector_scheduler(matched_tokens, block_size)
+    manager = scheduler.kv_cache_manager
+    block_pool = manager.block_pool
+
+    # Seed FA[0..3] + mamba m0..m3, then evict the FA tail and the *middle*
+    # mamba states. FA reaches 2 blocks; the mamba hit only needs its deepest
+    # resident state (m3), so it reaches 4 blocks -> diverged (FA < Mamba).
+    fa_ids, mamba_ids = _seed_hybrid_prefix(scheduler, 4, block_size)
+    block_pool.evict_blocks({fa_ids[2], fa_ids[3], mamba_ids[1], mamba_ids[2]})
+
+    [replay] = create_requests(
+        num_requests=1,
+        num_tokens=5 * block_size,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["replay"],
+    )
+    _, per_group_hits = manager.coordinator.find_longest_cache_hit_per_group(
+        replay.block_hashes, replay.num_tokens - 1
+    )
+    assert per_group_hits == (2 * block_size, 4 * block_size)  # diverged
+
+    scheduler.add_request(replay)
+    output = scheduler.schedule()
+    num_scheduled = output.num_scheduled_tokens[replay.request_id]
+    assert replay.num_tokens - num_scheduled == expected_num_computed
+
+    if matched_tokens == 0:
+        # The convergent re-query (not a trim of the sparse Mamba list) must
+        # leave a real Mamba state at the resume boundary.
+        blocks = manager.get_blocks(replay.request_id).blocks
+        local_mamba = blocks[1][: expected_num_computed // block_size]
+        assert any(
+            b is not block_pool.null_block and b.block_hash is not None
+            for b in local_mamba
+        )
+
+
+def test_hybrid_per_group_hit_divergence_fa_deeper_no_external():
+    """The opposite divergence: the FA prefix survives deeper than the Mamba
+    state, and the connector returns no external match. Reporting the deep FA
+    hit as local would resume with no valid Mamba state at that boundary (silent
+    bad output). With ext==0 the scheduler must fall back to the convergent
+    boundary (16), where FA[0] and the resident state@0 agree."""
+    block_size = 16
+    scheduler = _create_hybrid_mamba_connector_scheduler(
+        matched_tokens=0, block_size=block_size
+    )
+    manager = scheduler.kv_cache_manager
+    block_pool = manager.block_pool
+
+    # Keep all FA blocks; evict every mamba state but m0. FA reaches 4 blocks,
+    # the mamba hit only reaches 1 block -> diverged (FA > Mamba).
+    _, mamba_ids = _seed_hybrid_prefix(scheduler, 4, block_size)
+    block_pool.evict_blocks({mamba_ids[1], mamba_ids[2], mamba_ids[3]})
+
+    [replay] = create_requests(
+        num_requests=1,
+        num_tokens=5 * block_size,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["replay"],
+    )
+    _, per_group_hits = manager.coordinator.find_longest_cache_hit_per_group(
+        replay.block_hashes, replay.num_tokens - 1
+    )
+    assert per_group_hits == (4 * block_size, 1 * block_size)  # FA deeper
+
+    scheduler.add_request(replay)
+    output = scheduler.schedule()
+    num_scheduled = output.num_scheduled_tokens[replay.request_id]
+    # Must resume at the convergent boundary (16), not the deep FA hit (64).
+    assert replay.num_tokens - num_scheduled == block_size
+
+    blocks = manager.get_blocks(replay.request_id).blocks
+    assert blocks[1][0] is not block_pool.null_block
+    assert blocks[1][0].block_hash is not None

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -636,6 +636,16 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             key=lambda g: not isinstance(g.spec, FullAttentionSpec)
         )
 
+        # Full-attention reference group for per-group lookups (None when the
+        # model has no full-attention layers). It bounds the GPU-resident
+        # reusable prefix reported to a KV connector; a group hitting deeper
+        # holds that prefix only in a sparse-retention (Mamba) state block
+        # (#46453).
+        first = self.attention_groups[0]
+        self.full_attention_group_id: int | None = (
+            first.group_ids[0] if isinstance(first.spec, FullAttentionSpec) else None
+        )
+
         # Propagate the eagle bit to each manager (default to ``use_eagle=False``).
         for group in self.attention_groups:
             if group.use_eagle:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -702,20 +702,21 @@ class Scheduler(SchedulerInterface):
                 num_external_computed_tokens = 0
                 load_kv_async = False
                 connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
+                hybrid_hits_diverged = False
 
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
                     # Get locally-cached tokens.
+                    coordinator = self.kv_cache_manager.coordinator
                     if (
                         self.connector is not None
                         and self.has_mamba_layers
-                        and isinstance(
-                            self.kv_cache_manager.coordinator,
-                            HybridKVCacheCoordinator,
-                        )
+                        and isinstance(coordinator, HybridKVCacheCoordinator)
+                        and coordinator.full_attention_group_id is not None
                     ):
+                        fa_group_id = coordinator.full_attention_group_id
                         computed, per_group_hits = (
-                            self.kv_cache_manager.coordinator.find_longest_cache_hit_per_group(
+                            coordinator.find_longest_cache_hit_per_group(
                                 request.block_hashes, request.num_tokens - 1
                             )
                         )
@@ -724,14 +725,18 @@ class Scheduler(SchedulerInterface):
                         )
                         # NOTE(ZhanqiuHu): For Mamba hybrid models,
                         # num_new_local_computed_tokens should be the FA hit
-                        # length. This value is passed to the connector's
-                        # get_num_new_matched_tokens which computes:
-                        # external = total - local_computed.
+                        # length, passed to the connector's
+                        # get_num_new_matched_tokens (external = total - local).
                         # Using the FA hit skips re-transferring FA blocks
-                        # already cached on D-side. The Mamba state (always
-                        # the last block) is transferred unconditionally by
+                        # already cached on the D-side. The Mamba state (the last
+                        # block) is transferred unconditionally by
                         # _apply_prefix_caching in nixl/worker.py.
-                        num_new_local_computed_tokens = max(per_group_hits)
+                        num_new_local_computed_tokens = per_group_hits[fa_group_id]
+                        # A group hitting deeper than FA holds that prefix only
+                        # in a sparse-retention (Mamba) state block; the
+                        # divergence is reconciled once the external length is
+                        # known (see below).
+                        hybrid_hits_diverged = min(per_group_hits) < max(per_group_hits)
                         # The per-group lookup does not detect an uncached shared
                         # prefix, so there is no junction to pin in this path.
                         request.shared_prefix_boundary = 0
@@ -770,6 +775,56 @@ class Scheduler(SchedulerInterface):
                             continue
 
                         num_external_computed_tokens = ext_tokens
+
+                        # Reconcile the divergence now that ext_tokens is known.
+                        if hybrid_hits_diverged:
+                            num_computed = (
+                                num_new_local_computed_tokens
+                                + num_external_computed_tokens
+                            )
+                            if num_external_computed_tokens:
+                                # ext > 0: the connector supplies the prefix
+                                # (incl. the Mamba state) up to num_computed.
+                                # Trim each group's hit to that depth so a
+                                # surviving deeper state block can't drive
+                                # external allocation negative.
+                                groups = coordinator.kv_cache_config.kv_cache_groups
+                                for gid, group in enumerate(groups):
+                                    keep = (
+                                        num_computed // group.kv_cache_spec.block_size
+                                    )
+                                    del computed[gid][keep:]
+                                new_computed_blocks = (
+                                    self.kv_cache_manager.create_kv_cache_blocks(
+                                        computed
+                                    )
+                                )
+                            else:
+                                # ext == 0: nothing external backs the deeper
+                                # hits. Re-query the convergent hit (a boundary
+                                # all groups agree on, with a valid Mamba state
+                                # there); a plain trim would drop the sparse
+                                # Mamba state instead of re-finding it.
+                                (
+                                    computed,
+                                    num_new_local_computed_tokens,
+                                    num_uncached,
+                                ) = coordinator.find_longest_cache_hit(
+                                    request.block_hashes, request.num_tokens - 1
+                                )
+                                new_computed_blocks = (
+                                    self.kv_cache_manager.create_kv_cache_blocks(
+                                        computed
+                                    )
+                                )
+                                # Pin the junction where the lagging Mamba group
+                                # stops (Marconi-style APC), mirroring
+                                # get_computed_blocks().
+                                request.shared_prefix_boundary = (
+                                    num_new_local_computed_tokens + num_uncached
+                                    if num_uncached
+                                    else 0
+                                )
 
                         connector_prefix_cache_queries = (
                             request.num_tokens - num_new_local_computed_tokens


### PR DESCRIPTION

## Purpose

Fixes #46453 the hybrid (full-attention + Mamba) prefix-cache-hit divergence bug described:

- On `main` #44243, `num_new_local_computed_tokens = max(per_group_hits)` over-reports the local prefix when a request's FA prefix is evicted but a deeper Mamba state block survives, crashing the engine (or leaving dirty KV).
- PR #45804 switches to the dense `min` but trims the sparse Mamba per-group list, which drops the state block (silent correctness bug) and still crashes for some external-hit lengths.

This PR takes the spine (full-attention) `min` as the local hit and **reconciles the divergence after the external length is known**, choosing the correct operation per case. Scope is **Mamba hybrids only** (the FA "spine" + Mamba state layout).

## What changed

`vllm/v1/core/sched/scheduler.py`:

1. `__init__`: add `self._kv_spine_group_ids` — the full-attention backbone group ids of the hybrid model (the GPU-resident reusable prefix; the Mamba state is transferred separately by the connector). The hybrid per-group branch is gated on this being non-empty, so a no-spine layout falls back to the normal path.
2. Hybrid branch: the connector scalar is `min(per_group_hits over spine groups)`, not `max()`. `hybrid_hits_diverged` records whether any group hit a deeper prefix than the spine.
3. After `get_num_new_matched_tokens` returns the external length, when the hits diverged, reconcile at `num_computed = local + ext`:
   - **`ext == 0`** (connector supplies nothing): re-query the convergent `find_longest_cache_hit`, which re-finds the boundary every group agrees on, with a Mamba state valid there. A plain trim would only clamp to the dense `min` and drop the deeper state.
   - **`ext > 0`** (connector supplies the prefix incl. the Mamba state up to `num_computed`): trim every group's per-group list to `num_computed` so a surviving deeper-than-`num_computed` state block does not drive external allocation negative; the connector reloads the state at this depth.

`tests/v1/kv_connector/unit/test_hybrid_prefix_hit_divergence.py` (new): a scheduler-level regression test (no GPU) that builds a hybrid (FA + Mamba) `Scheduler` + `MockKVConnector`, seeds a prefix, evicts the FA tail and the middle Mamba states to force diverged per-group hits, then replays — parametrized over the connector returning {0, 1, 2} blocks beyond the spine hit.

## Why this design

The Mamba per-group hit is **sparse** — `find_longest_cache_hit_per_group` returns `[null]*i + [state@i]`, where the trailing block is the only real state. Trimming that list can only clamp it to the dense `min`; it cannot recover the boundary every group actually agrees on:

```
Mamba per-group hit:            [null, null, null, state@3]
trim to dense min 512:          [null, null]        <- claims 512 but state DROPPED
convergent re-query:            256 = [state@0]     <- the boundary all groups agree on
```

So trimming ≠ re-querying. The correct operation depends on whether the connector will reload the state:

- with `ext == 0` there is no external reload, so the local block set must itself carry a valid state at a consistent boundary → convergent re-query;
- with `ext > 0` the connector supplies the state at `num_computed`, so trimming the over-deep local state away is safe and avoids the negative external allocation that the no-trim path hits.

## Test plan

New regression test (scheduler-level, CPU-only, no GPU), parametrized over how many blocks the connector returns beyond the spine hit. It seeds a 4-block prefix, evicts `FA[2..3]` and the middle Mamba states (`m1`, `m2`; `m0`/`m3` stay pinned by the connector), then replays. It is a true regression test — it **passes on this fix** and **fails on upstream `main`**:

```
$ .venv/bin/python -m pytest \
      tests/v1/kv_connector/unit/test_hybrid_prefix_hit_divergence.py -v
test_hybrid_diverged_prefix_hit[0-256]  PASSED   # ext=0  -> num_computed 256  (convergent re-query: f0 + state@0)
test_hybrid_diverged_prefix_hit[1-768]  PASSED   # ext=256 -> num_computed 768 (trim; connector reloads state)
test_hybrid_diverged_prefix_hit[2-1024] PASSED   # ext=512 -> num_computed 1024 (trim; state@3 on boundary)
3 passed

# Same test against upstream main's max()-based scheduler:
3 failed   # [0]: over-reports local (1024); [1],[2]: AssertionError in admission
```

| case | upstream `main` | this fix |
|---|---|---|
| 0 blk (ext=0)   | over-reports local = 1024 (only `f0,f1` + `m0,m3` resident) | **OK** — convergent re-query to 256 (`f0` + `state@0`) |
| 1 blk (ext=256) | CRASH (`num_new_tokens > 0`)             | **OK** — trim to 768, connector reloads state |
| 2 blk (ext=512) | CRASH (`num_computed <= num_tokens`)     | **OK** — trim to 1024 |

A standalone runnable reproducer (`lihui/experiments/run_crash_hybrid_prefix_hit_divergence.py`) mirrors the same three cases and prints the prefix hit the scheduler commits.

Regression suite:

```
$ .venv/bin/python -m pytest tests/v1/core/test_scheduler.py \
      tests/v1/kv_connector/unit/test_hybrid_prefix_hit_divergence.py -q
1 failed, 114 passed
```

The single failure is `test_async_scheduling_pp_allows_rescheduling_with_output_placeholders`, which requires `pipeline_parallel_size=2` (2 GPUs); on a single-GPU box it fails independently of this change.

Lint (`ruff check` + `ruff format --check`, pin `v0.14.0`): clean on both changed files.

## Notes

- **Not a duplicate of #45804**: It trims the sparse state list (drops the Mamba state on `ext==0`); this PR re-queries on `ext==0` and only trims on `ext>0`. It is also narrower (Mamba-only) and addresses the silent-correctness case it does not.
- **Scope**: Mamba hybrids only. SWA/MLA state groups are out of scope here.

