### PR TITLE
Filter Pydantic-internal markers from validation error param

### DIFF
--- a/tests/entrypoints/serve/utils/test_server_utils.py
+++ b/tests/entrypoints/serve/utils/test_server_utils.py
@@ -15,9 +15,11 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi.exceptions import RequestValidationError
-from vllm.entrypoints.serve.utils.server_utils import validation_exception_handler
 
-from vllm.entrypoints.serve.utils.server_utils import clean_loc_for_param
+from vllm.entrypoints.serve.utils.server_utils import (
+    clean_loc_for_param,
+    validation_exception_handler,
+)
 
 
 def _fake_request(log_error_stack: bool = False) -> SimpleNamespace:
@@ -64,6 +66,7 @@ class TestValidationErrorParamFallback:
         body = json.loads(response.body)
 
         assert body["error"]["param"] is None
+
 
 class TestCleanLocForParam:
     """Guards against PR #1's naive dot-joined `loc` fallback leaking

--- a/tests/entrypoints/serve/utils/test_server_utils.py
+++ b/tests/entrypoints/serve/utils/test_server_utils.py
@@ -15,8 +15,9 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi.exceptions import RequestValidationError
-
 from vllm.entrypoints.serve.utils.server_utils import validation_exception_handler
+
+from vllm.entrypoints.serve.utils.server_utils import clean_loc_for_param
 
 
 def _fake_request(log_error_stack: bool = False) -> SimpleNamespace:
@@ -63,3 +64,36 @@ class TestValidationErrorParamFallback:
         body = json.loads(response.body)
 
         assert body["error"]["param"] is None
+
+class TestCleanLocForParam:
+    """Guards against PR #1's naive dot-joined `loc` fallback leaking
+    Pydantic-internal wrapper/union-branch markers into `param`, e.g.
+    'body.function-wrap[__log_extra_fields__()].prompt' instead of the
+    clean 'body.prompt' an API consumer would recognize.
+    """
+
+    @pytest.mark.parametrize(
+        "loc,expected",
+        [
+            (("body", "prompt"), "body.prompt"),
+            (("body", "messages", 2, "content"), "body.messages.2.content"),
+            (
+                ("body", "function-wrap[__log_extra_fields__()]", "prompt"),
+                "body.prompt",
+            ),
+            (("body", "stop", "str"), "body.stop"),
+            (("body", "stop", "list[str]"), "body.stop"),
+            (
+                ("body", "prompt", "list[constrained-int]"),
+                "body.prompt",
+            ),
+        ],
+    )
+    def test_strips_internal_markers(self, loc, expected):
+        assert clean_loc_for_param(loc) == expected
+
+    def test_all_internal_falls_back_to_raw_join(self):
+        """If every loc segment looks internal, fall back to the raw
+        dot-join rather than returning an empty string."""
+        loc = ("function-wrap[__log_extra_fields__()]",)
+        assert clean_loc_for_param(loc) == "function-wrap[__log_extra_fields__()]"

--- a/vllm/entrypoints/serve/utils/server_utils.py
+++ b/vllm/entrypoints/serve/utils/server_utils.py
@@ -3,7 +3,6 @@
 import asyncio
 import hashlib
 import json
-import re
 import secrets
 import uuid
 from argparse import Namespace
@@ -12,6 +11,7 @@ from contextlib import asynccontextmanager
 from http import HTTPStatus
 
 import pydantic
+import regex as re
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse

--- a/vllm/entrypoints/serve/utils/server_utils.py
+++ b/vllm/entrypoints/serve/utils/server_utils.py
@@ -412,6 +412,21 @@ async def http_exception_handler(req: Request, exc: HTTPException):
 
 _BRACKETED_INTERNAL_RE = re.compile(r"[\[\]{}()]")
 
+# NOTE: this list is pydantic-core's internal schema-kind vocabulary,
+# not a stable public API -- it can grow when pydantic-core adds new
+# wrapper/validator kinds. To refresh it after a pydantic upgrade:
+#   1. Fuzz the validation-error-prone endpoints (e.g. /tokenize,
+#      /v1/completions, /v1/chat/completions) with deliberately
+#      malformed values for union-typed and wrapped fields (e.g. `stop`,
+#      `prompt`), and inspect the raw `loc` tuples in the response.
+#   2. Any *unbracketed* segment that isn't a real field name or list
+#      index is a new internal marker -- add it here. Bracketed/
+#      parenthesized markers (e.g. "list[...]", "function-wrap[...]")
+#      are already caught structurally by _BRACKETED_INTERNAL_RE and
+#      don't need a list entry.
+#   3. pydantic-core's source (the `error.rs`/schema-kind definitions
+#      in the pydantic-core Rust crate) is the canonical reference if
+#      you want to check before it shows up in a live fuzz run.
 _INTERNAL_LOC_MARKERS = frozenset(
     {
         "function-wrap",

--- a/vllm/entrypoints/serve/utils/server_utils.py
+++ b/vllm/entrypoints/serve/utils/server_utils.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import json
+import re
 import secrets
 import uuid
 from argparse import Namespace
@@ -409,6 +410,66 @@ async def http_exception_handler(req: Request, exc: HTTPException):
     return JSONResponse(err.model_dump(), status_code=exc.status_code)
 
 
+_BRACKETED_INTERNAL_RE = re.compile(r"[\[\]{}()]")
+
+_INTERNAL_LOC_MARKERS = frozenset(
+    {
+        "function-wrap",
+        "function-after",
+        "function-before",
+        "function-plain",
+        "json-or-python",
+        "lax-or-strict",
+        "chain",
+        "default",
+        "nullable",
+        "tagged-union",
+        "union",
+        "call",
+        "arguments",
+        "is-instance",
+        "is-subclass",
+        "callable",
+        "str",
+        "int",
+        "float",
+        "bool",
+        "bytes",
+        "bytearray",
+        "list",
+        "tuple",
+        "dict",
+        "set",
+        "frozenset",
+        "complex",
+        "none",
+        "nonetype",
+    }
+)
+
+
+def _is_internal_loc_segment(segment: str) -> bool:
+    """True if `segment` is a Pydantic-internal wrapper/union-branch
+    marker rather than a user-meaningful field name or list index."""
+    if _BRACKETED_INTERNAL_RE.search(segment):
+        return True
+    return segment.lower() in _INTERNAL_LOC_MARKERS
+
+
+def clean_loc_for_param(loc: tuple) -> str:
+    """Join a Pydantic error `loc` tuple into a clean dotted `param`
+    path, dropping internal wrapper/union-branch markers that don't
+    correspond to a real field name an API consumer would recognize.
+
+    E.g. ('body', 'function-wrap[__log_extra_fields__()]', 'prompt')
+    -> "body.prompt", not "body.function-wrap[__log_extra_fields__()].prompt".
+    """
+    parts = [str(p) for p in loc if not _is_internal_loc_segment(str(p))]
+    if not parts:
+        return ".".join(str(p) for p in loc)
+    return ".".join(parts)
+
+
 async def validation_exception_handler(req: Request, exc: RequestValidationError):
     if req.app.state.args.log_error_stack:
         logger.exception(
@@ -431,7 +492,7 @@ async def validation_exception_handler(req: Request, exc: RequestValidationError
         first_error = errors[0]
         loc = first_error.get("loc") if isinstance(first_error, dict) else None
         if loc:
-            param = ".".join(str(part) for part in loc)
+            param = clean_loc_for_param(loc)
 
     exc_str = str(exc)
     errors_str = str(errors)


### PR DESCRIPTION
## Purpose

Follow-up to #46038 (param fallback for plain validation errors), scoped by the same fuzz run that surfaced the file-path leak fixed in #46415 (sanitize-validation-error-paths).

#46038 added a fallback in `validation_exception_handler` that joins the Pydantic error `loc` tuple with `.` to populate `param` for plain (non-`VLLMValidationError`) validation errors. For union-typed or internally-wrapped fields, this naive join leaks Pydantic-core's internal schema markers into `param`, e.g.:

- `body.stop.str` (union-branch type tag, for a field typed `str | list[str] | None`)
- `body.function-wrap[__log_extra_fields__()].prompt` (internal validator wrapper)

These expose Pydantic's internal type-discriminator/wrapper names instead of a clean field name an API consumer would recognize.

This PR adds `clean_loc_for_param()`, which filters `loc` tuple components before joining: it drops segments that are either bracketed/parenthesized (covers generic/wrapper syntax like `function-wrap[...]`, `list[constrained-int]`) or that exactly match a known set of bare pydantic-core internal markers (union-branch type tags like `str`/`list`, validator-wrapper kinds like `function-wrap`/`chain`, etc.), while keeping real field names and list indices intact.

Unrelated to and does not modify `sanitize_message` (the `message`-leak fix in #46415) — confirmed live that `message` content is unaffected by this change (see Test Result).

## Test Plan

Unit tests added in `tests/entrypoints/serve/utils/test_server_utils.py::TestCleanLocForParam`, covering:
- a plain field path (no-op, nothing to strip)
- a list index (kept — meaningful position info for the caller)
- the confirmed `function-wrap[__log_extra_fields__()]` repro
- the confirmed union-branch repro (a `str | list[str] | None` field failing on both branches)
- a list-wrapped constrained-type marker
- the pathological all-internal-segments case (falls back to the raw join rather than returning an empty `param`)

```bash
pytest tests/entrypoints/serve/utils/test_server_utils.py -v
ruff check vllm/entrypoints/serve/utils/server_utils.py
ruff format --check vllm/entrypoints/serve/utils/server_utils.py
```
## Test Result

`pytest`: 10 passed (3 pre-existing #46038 tests + 7 new). `ruff check` / `ruff format --check`: clean.

Before (main):
```json
"param": "body.function-wrap[__log_extra_fields__()].prompt"
"param": "body.stop.str"
```

After (this PR):
```json
"param": "body.prompt"
"param": "body.stop"
```

`message` field unchanged in both before/after responses on both requests, confirming this PR only affects `param`.

Note: in both before and after, `param` reflects only the first validation error when a request fails multiple checks (e.g. the `/tokenize` repro above also has a `messages`-required error not reflected in `param`). This is pre-existing behavior from #46038, not introduced by this PR.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>