### PR TITLE
[Bugfix][Model]Guard MiniMax-M2 fused rms_norm workspace initialization on CUDA

### DIFF
--- a/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
+++ b/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
@@ -294,7 +294,11 @@ class MiniMaxText01RMSNormTP(CustomOp):
         self.variance_epsilon = eps
 
         self.workspace = None
-        if _MINIMAX_FUSED_AR_RMS_QK is not None and self.tp_world > 1:
+        if (
+            _MINIMAX_FUSED_AR_RMS_QK is not None
+            and self.tp_world > 1
+            and torch.cuda.is_available()
+        ):
             from .lamport_workspace import (
                 get_allreduce_workspace,
             )


### PR DESCRIPTION
**Bug Description**
`MiniMaxText01RMSNormTP.__init__` unconditionally imports `lamport_workspace` when the fused allreduce+RMSNorm op is available and TP > 1. `lamport_workspace.py` depends on `cuda.bindings` / `cudart `at module level, causing an immediate **ModuleNotFoundError** on non-CUDA platforms (e.g. Intel XPU):
<img width="2007" height="149" alt="image" src="https://github.com/user-attachments/assets/6a3e29c0-9781-4b1b-b49f-f60c84c9e569" />

**Fix**
Add `torch.cuda.is_available()` to the guard condition before importing lamport_workspace. On non-CUDA platforms, workspace stays None and the model falls back to the Triton/eager allreduce + RMSNorm path.

**Impact**
CUDA: No behavior change. The Lamport workspace is initialized as before.
Non-CUDA (XPU, etc.): Model loads successfully and uses the fallback path.