### PR TITLE
[Bugfix][TurboQuant] Add continuation guard to fast-path to prevent prefix K/V loss under prefix caching

### DIFF
--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -612,10 +612,31 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
     ) -> torch.Tensor:
         N, Hq, D = query.shape
 
+        # Count continuation requests to guard the fast path.
+        # max_query_len == max_seq_len alone is NOT sufficient: a batch can
+        # contain a long first-chunk prefill (q_len == seq_len) alongside
+        # shorter continuation requests (q_len < seq_len, prefix cache hit).
+        # In that case max_q == max_s still holds, but flash_attn_varlen
+        # with cu_seqlens_k=query_start_loc would cause continuation
+        # requests to attend only to their new tokens, LOSING the cached
+        # prefix K/V.  We compute the continuation count from CPU tensors
+        # (no GPU sync) and use it as a guard.
+        _n_continuation = 0
+        if (attn_metadata.query_start_loc_cpu is not None
+                and attn_metadata.seq_lens_cpu is not None):
+            _qsl = attn_metadata.query_start_loc_cpu.tolist()
+            _sl = attn_metadata.seq_lens_cpu.tolist()
+            for _i in range(min(len(_sl), len(_qsl) - 1)):
+                _ql = _qsl[_i + 1] - _qsl[_i]
+                if _ql != _sl[_i]:
+                    _n_continuation += 1
+
         # Fast path: use flash_attn for first-chunk prefills (all K/V in batch).
-        # max_query_len == max_seq_len means no request has prior cached KV.
-        # Both are Python ints — no GPU sync.
-        if _HAS_FLASH_ATTN and attn_metadata.max_query_len == attn_metadata.max_seq_len:
+        # Guarded: only fires when NO continuation requests exist in the batch.
+        # Both max values are Python ints — no GPU sync.
+        if (_HAS_FLASH_ATTN
+                and attn_metadata.max_query_len == attn_metadata.max_seq_len
+                and _n_continuation == 0):
             return self._flash_attn_varlen(
                 q=query,
                 k=key,

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -612,31 +612,31 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
     ) -> torch.Tensor:
         N, Hq, D = query.shape
 
-        # Count continuation requests to guard the fast path.
-        # max_query_len == max_seq_len alone is NOT sufficient: a batch can
-        # contain a long first-chunk prefill (q_len == seq_len) alongside
-        # shorter continuation requests (q_len < seq_len, prefix cache hit).
-        # In that case max_q == max_s still holds, but flash_attn_varlen
-        # with cu_seqlens_k=query_start_loc would cause continuation
-        # requests to attend only to their new tokens, LOSING the cached
-        # prefix K/V.  We compute the continuation count from CPU tensors
-        # (no GPU sync) and use it as a guard.
-        _n_continuation = 0
+        # Guard the fast path: it is only valid when NO continuation requests
+        # exist in the batch.  max_query_len == max_seq_len alone is NOT
+        # sufficient — a long first-chunk prefill (q_len == seq_len) can
+        # coexist with shorter continuation requests (q_len < seq_len, prefix
+        # cache hit), causing flash_attn_varlen with cu_seqlens_k=
+        # query_start_loc to LOSE the cached prefix K/V for continuations.
+        #
+        # Vectorized check on CPU tensors: diff() computes all query lengths,
+        # ne() + any() short-circuits on the first mismatch.  .item() on a
+        # CPU scalar tensor is a host read — no GPU sync.
+        _has_continuation = False
         if (attn_metadata.query_start_loc_cpu is not None
                 and attn_metadata.seq_lens_cpu is not None):
-            _qsl = attn_metadata.query_start_loc_cpu.tolist()
-            _sl = attn_metadata.seq_lens_cpu.tolist()
-            for _i in range(min(len(_sl), len(_qsl) - 1)):
-                _ql = _qsl[_i + 1] - _qsl[_i]
-                if _ql != _sl[_i]:
-                    _n_continuation += 1
+            _qsl = attn_metadata.query_start_loc_cpu
+            _sl = attn_metadata.seq_lens_cpu
+            _has_continuation = (
+                (_qsl[1:len(_sl) + 1] - _qsl[:len(_sl)]) != _sl
+            ).any().item()
 
         # Fast path: use flash_attn for first-chunk prefills (all K/V in batch).
         # Guarded: only fires when NO continuation requests exist in the batch.
         # Both max values are Python ints — no GPU sync.
         if (_HAS_FLASH_ATTN
                 and attn_metadata.max_query_len == attn_metadata.max_seq_len
-                and _n_continuation == 0):
+                and not _has_continuation):
             return self._flash_attn_varlen(
                 q=query,
                 k=key,

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -623,20 +623,24 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         # ne() + any() short-circuits on the first mismatch.  .item() on a
         # CPU scalar tensor is a host read — no GPU sync.
         _has_continuation = False
-        if (attn_metadata.query_start_loc_cpu is not None
-                and attn_metadata.seq_lens_cpu is not None):
+        if (
+            attn_metadata.query_start_loc_cpu is not None
+            and attn_metadata.seq_lens_cpu is not None
+        ):
             _qsl = attn_metadata.query_start_loc_cpu
             _sl = attn_metadata.seq_lens_cpu
             _has_continuation = (
-                (_qsl[1:len(_sl) + 1] - _qsl[:len(_sl)]) != _sl
-            ).any().item()
+                ((_qsl[1 : len(_sl) + 1] - _qsl[: len(_sl)]) != _sl).any().item()
+            )
 
         # Fast path: use flash_attn for first-chunk prefills (all K/V in batch).
         # Guarded: only fires when NO continuation requests exist in the batch.
         # Both max values are Python ints — no GPU sync.
-        if (_HAS_FLASH_ATTN
-                and attn_metadata.max_query_len == attn_metadata.max_seq_len
-                and not _has_continuation):
+        if (
+            _HAS_FLASH_ATTN
+            and attn_metadata.max_query_len == attn_metadata.max_seq_len
+            and not _has_continuation
+        ):
             return self._flash_attn_varlen(
                 q=query,
                 k=key,


### PR DESCRIPTION
## Purpose

Fixes #46460.

TurboQuant's `_prefill_attention` fast-path incorrectly triggers when a batch contains continuation requests (prefix cache hit) alongside first-chunk prefills, causing continuation requests to lose cached prefix K/V and produce hallucinated outputs.

## Root Cause

The fast-path condition `max_query_len == max_seq_len` assumes this implies "no continuation requests in batch". This is insufficient: a long first-chunk prefill (`q_len == seq_len`) can coexist with shorter continuation requests (`q_len < seq_len`, prefix cache hit), and the max values still match. When the fast-path fires, `flash_attn_varlen` is called with `cu_seqlens_k=query_start_loc`, causing continuation requests to attend only to their new tokens and **lose the cached prefix K/V**.

## Symptom

On C-Eval full (52 subjects) with Qwen3-8B, `turboquant_4bit_nc`, `--enable-prefix-caching`, `--max-num-seqs 512`: **47–75 hallucinations** out of 52 subjects. Hallucinations disappear with prefix caching OFF, small batch, or subset tests.

## Fix

Add a continuation guard using the CPU-resident metadata fields (`query_start_loc_cpu`, `seq_lens_cpu`) already populated by `TurboQuantMetadataBuilder` (added in PR #41434). The guard uses a vectorized check — `diff` + `ne` + `any` on CPU tensors — with `.item()` on a CPU scalar (no GPU sync):

```python
_has_continuation = False
if (attn_metadata.query_start_loc_cpu is not None
        and attn_metadata.seq_lens_cpu is not None):
    _qsl = attn_metadata.query_start_loc_cpu
    _sl = attn_metadata.seq_lens_cpu
    _has_continuation = (
        (_qsl[1:len(_sl) + 1] - _qsl[:len(_sl)]) != _sl
    ).any().item()

if (_HAS_FLASH_ATTN
        and attn_metadata.max_query_len == attn_metadata.max_seq_len
        and not _has_continuation):
    return self._flash_attn_varlen(...)
```

When any continuation request exists in the batch, the fast-path is skipped and execution falls through to the per-request loop which correctly handles both first-chunk and continuation paths.

## Duplicate-work check

Searched open PRs and issues for `turboquant fast path`, `continuation guard`, `prefix loss`, `max_query_len max_seq_len`, `hallucination`. No existing PR or issue covers this bug. Closest PRs have different scope:

- **#43747** — fixes `.tolist()` CUDA graph capture crash, not fast-path logic
- **#40914** — fixes K+1 spec-verify routing, different code path
- **#41434** — added the CPU metadata fields this fix relies on, but did not change the fast-path condition

## Why this matters

Any user running TurboQuant with `--enable-prefix-caching` and diverse batch sizes is at risk of silent correctness degradation — the model produces plausible but wrong outputs without any error or warning. This is a correctness bug, not a crash.

## Related

- #46460 — this fix
- #40069 — TurboQuant/HIGGS tracking issue

## Test plan

```bash
.venv/bin/python -m pytest tests/quantization/test_turboquant.py -q
```

Expected: all existing tests pass.

Manual validation:
```bash
vllm serve Qwen/Qwen3-8B \
  --kv-cache-dtype turboquant_4bit_nc \
  --enable-prefix-caching \
  --max-num-seqs 512

# Send diverse prompts with overlapping prefixes
# With fix: no hallucinations
# Without fix: ~10% of requests produce hallucinated outputs
```

- [x] Duplicate-work check performed
- [x] Test plan included
- [ ] Test results on GPU (to be filled by submitter)