### PR TITLE
Fix duplicated logging when loading a corrupt or partial video

### DIFF
--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -274,7 +274,7 @@ class OpenCVVideoBackendMixin:
 
             if not ok:
                 if is_target_frame:
-                    logger.warning(
+                    logger.debug(
                         "Failed to grab frame %d during video loading.",
                         idx,
                     )
@@ -305,7 +305,7 @@ class OpenCVVideoBackendMixin:
                             idx - recovered_idx,
                         )
                 elif is_target_frame:
-                    logger.warning(
+                    logger.debug(
                         "Failed to retrieve frame %d during video loading.",
                         idx,
                     )
@@ -313,7 +313,7 @@ class OpenCVVideoBackendMixin:
 
         # Log any remaining failed frames
         for failed_idx in failed_frames_idx:
-            logger.warning(
+            logger.debug(
                 "Frame %d could not be recovered (end of video).",
                 failed_idx,
             )
@@ -343,9 +343,9 @@ class OpenCVVideoBackendMixin:
         for idx in range(max_frame_idx + 1):
             ok = cap.grab()
             if not ok:
-                # Frame is broken/unreadable, log warning
+                # Frame is broken/unreadable, skip it
                 if idx in frame_indices:
-                    logger.warning(
+                    logger.debug(
                         "Failed to grab frame %d during video loading. "
                         "This frame will be skipped.",
                         idx,
@@ -359,7 +359,7 @@ class OpenCVVideoBackendMixin:
                     i += 1
                 else:
                     # retrieve() failed even though grab() succeeded
-                    logger.warning(
+                    logger.debug(
                         "Failed to retrieve frame %d during video loading. "
                         "This frame will be skipped.",
                         idx,


### PR DESCRIPTION
## Purpose
Loading a corrupt/partial video logged one WARNING per broken frame in
OpenCVVideoBackend, duplicating the single summary line. Demote the per-frame
messages to debug; keep the summary at warning. Verbosity-only.

## AI assistance
Prepared with AI assistance (Claude); reviewed by submitter.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [v] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [v] The test plan, such as providing test command. - not required
- [v] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

