### PR TITLE
[Misc][PD] Disable bidirectional xfer mode for NixlPushConnector

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -30,6 +30,10 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
         kv_cache_config: "KVCacheConfig",
     ):
         super().__init__(vllm_config, engine_id, kv_cache_config)
+        if self.is_bidirectional_kv_xfer_enabled:
+            raise NotImplementedError(
+                "Bidirectional KV transfer is not supported for NIXL pull connector."
+            )
 
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -30,10 +30,6 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
         kv_cache_config: "KVCacheConfig",
     ):
         super().__init__(vllm_config, engine_id, kv_cache_config)
-        if self.is_bidirectional_kv_xfer_enabled:
-            raise NotImplementedError(
-                "Bidirectional KV transfer is not supported for NIXL pull connector."
-            )
 
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -67,6 +67,10 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
         kv_cache_config: KVCacheConfig,
     ):
         super().__init__(vllm_config, engine_id, kv_cache_config)
+        if self.is_bidirectional_kv_xfer_enabled:
+            raise NotImplementedError(
+                g"Bidirectional KV transfer is not supported for NIXL push connector."
+            )
 
         # D-side: registration data to pass to D workers via metadata on
         # the next ``build_connector_meta`` call.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -69,7 +69,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
         super().__init__(vllm_config, engine_id, kv_cache_config)
         if self.is_bidirectional_kv_xfer_enabled:
             raise NotImplementedError(
-                g"Bidirectional KV transfer is not supported for NIXL push connector."
+                "Bidirectional KV transfer is not supported for NIXL push connector."
             )
 
         # D-side: registration data to pass to D workers via metadata on


### PR DESCRIPTION
Bidirectional kv transfer with the newly added Push model is not supported, but there's no validation right now