### PR TITLE
[Bugfix] Qwen2-Audio: override top-level tie_word_embeddings=False

### DIFF
--- a/vllm/model_executor/models/qwen2_audio.py
+++ b/vllm/model_executor/models/qwen2_audio.py
@@ -345,6 +345,15 @@ class Qwen2AudioForConditionalGeneration(nn.Module, SupportsMultiModal, Supports
         self.multimodal_config = multimodal_config
         self.quant_config = quant_config
 
+        # Qwen2AudioConfig defaults tie_word_embeddings=True at the top level,
+        # but the checkpoint ships an independent lm_head.weight (HF logs
+        # "both are present ... different values, so we will NOT tie them").
+        # On transformers v5, VllmConfig.with_hf_config propagates the top-level
+        # value onto text_config; without this override the language_model would
+        # alias lm_head to embed_tokens and skip loading the real lm_head weights
+        # from the checkpoint, producing garbage logits at generation time.
+        config.tie_word_embeddings = False
+
         with self._mark_tower_model(vllm_config, "audio"):
             self.audio_tower = Qwen2AudioEncoder(config.audio_config)
             self.multi_modal_projector = Qwen2AudioMultiModalProjector(


### PR DESCRIPTION
## Purpose

On `transformers >= 5.x`, `Qwen/Qwen2-Audio-7B-Instruct` in vLLM produces only `<|audio_bos|>` / `<|audio_eos|>` instead of text. Greedy decoding on a plain text prompt does the same. Caused by `lm_head` being aliased to `embed_tokens` and the real `lm_head.weight` being skipped at load time.

## Root cause

`Qwen2AudioConfig`'s HF default sets `tie_word_embeddings=True`, but the checkpoint ships an independent `lm_head.weight`. Transformers itself logs this at load:

> The tied weights mapping and config for this model specifies to tie `model.language_model.embed_tokens.weight` to `lm_head.weight`, but both are present in the checkpoints with different values, so we will NOT tie them.

On `transformers >= 5.0.0`, `VllmConfig.with_hf_config` (intentionally, per #38035) propagates the top-level `tie_word_embeddings` onto `text_config` for multimodal models. `Qwen2ForCausalLM` then takes that `True` and:

1. sets `self.lm_head = self.model.embed_tokens` (aliases in memory; `data_ptr` confirms),
2. passes `skip_prefixes=["lm_head."]` to `AutoWeightsLoader`, dropping the real ckpt weights.

The propagation rule itself is correct for most multimodal models; the bug is that Qwen2-Audio's *top-level* default doesn't match its actual checkpoint layout.

## Fix

Override `config.tie_word_embeddings = False` inside `Qwen2AudioForConditionalGeneration.__init__` before the language_model is created. This keeps `with_hf_config`'s propagation untouched and only affects models that own this config.

```python
self.config = config
self.multimodal_config = multimodal_config
self.quant_config = quant_config

# Qwen2AudioConfig defaults tie_word_embeddings=True at the top level,
# but the checkpoint ships an independent lm_head.weight ...
config.tie_word_embeddings = False
```

## Test Plan

`transformers==5.10.2`, 1 × NVIDIA H20:

```
pytest -xvs tests/samplers/test_beam_search.py::test_beam_search_passes_multimodal_data[2-64-half]
===== 1 passed in 199.59s =====
```

vLLM's transcription now matches the HF reference for both beams.

## Risk

Single-model change; no impact outside Qwen2-Audio. `with_hf_config`'s general propagation behavior is unchanged.

## History

This is the model-scoped follow-up to #46288 (closed). The earlier attempts (#46266, #46288) tried to gate `with_hf_config` on `text_config`'s existing value; @hmellor pointed out (#38035) that that signal isn't reliable, so the right fix lives in the model, not in `VllmConfig`. Related issue: #46250.
