### PR TITLE
[Kernel][SM120] NVFP4 grouped MoE: pingpong schedule at large per-exp…

### DIFF
--- a/csrc/libtorch_stable/quantization/fp4/nvfp4_blockwise_moe_kernel.cu
+++ b/csrc/libtorch_stable/quantization/fp4/nvfp4_blockwise_moe_kernel.cu
@@ -18,6 +18,8 @@
 #include <torch/csrc/stable/tensor.h>
 #include "libtorch_stable/torch_utils.h"
 
+#include <type_traits>
+
 #include <cutlass/arch/arch.h>
 
 #include "libtorch_stable/cutlass_extensions/common.hpp"
@@ -403,6 +405,10 @@ void run_fp4_blockwise_scaled_group_mm_sm100(
   STD_TORCH_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
 }
 
+// UsePingpong selects the pingpong PtrArray schedule (faster at large per-expert
+// M / prefill); the default (false) keeps KernelScheduleAuto == cooperative
+// (faster at small M / decode). See the dispatch in run_fp4_blockwise_scaled_group_mm.
+template <bool UsePingpong = false>
 void run_fp4_blockwise_scaled_group_mm_sm120(
     torch::stable::Tensor& output, const torch::stable::Tensor& a,
     const torch::stable::Tensor& b, const torch::stable::Tensor& a_blockscale,
@@ -460,7 +466,10 @@ void run_fp4_blockwise_scaled_group_mm_sm120(
           LayoutB*, AlignmentB, ElementAccumulator, MmaTileShape, ClusterShape,
           cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
               sizeof(typename CollectiveEpilogue::SharedStorage))>,
-          cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+          std::conditional_t<
+              UsePingpong,
+              cutlass::gemm::KernelPtrArrayTmaWarpSpecializedPingpong,
+              cutlass::gemm::collective::KernelScheduleAuto>>::CollectiveOp;
 
   using GemmKernel =
       cutlass::gemm::kernel::GemmUniversal<ProblemShape, CollectiveMainloop,
@@ -611,9 +620,30 @@ void run_fp4_blockwise_scaled_group_mm(
   int32_t version_num = get_sm_version_num();
 #if defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120
   if (version_num >= 120 && version_num < 130) {
-    run_fp4_blockwise_scaled_group_mm_sm120(
-        output, a, b, a_blockscale, b_blockscales, alphas, problem_sizes,
-        expert_offsets, sf_offsets, M, N, K);
+    // Schedule selection: pingpong is faster at large per-expert M (prefill),
+    // cooperative (KernelScheduleAuto) at small per-expert M (decode). Measured on
+    // RTX PRO 6000 (sm120, NVFP4 grouped GEMM): pingpong is +6% at per-expert M=512,
+    // +13% at 1024, +19% at 2048; cooperative wins at <=256. Those are grouped-GEMM
+    // kernel deltas; the fused-MoE-op speedup is smaller (~+1-3% on sm120, diluted by
+    // routing/finalize). 512 is the conservative
+    // crossover (where pingpong first pulls ahead). Unlike the sm90/sm100 dispatchers
+    // (grouped_mm_c3x_sm{90,100}.cu) which key on total M, we use the average
+    // per-expert M (= total rows / num_experts): the grouped kernel tiles each
+    // expert's GEMM independently, so schedule efficiency is governed by per-expert M.
+    // This is the mean, so skewed routing may mispredict the schedule -- perf only,
+    // never a correctness issue.
+    int const num_experts = static_cast<int>(expert_offsets.size(0));
+    int const per_expert_m = num_experts > 0 ? M / num_experts : M;
+    constexpr int kPingpongMinPerExpertM = 512;
+    if (per_expert_m >= kPingpongMinPerExpertM) {
+      run_fp4_blockwise_scaled_group_mm_sm120<true>(
+          output, a, b, a_blockscale, b_blockscales, alphas, problem_sizes,
+          expert_offsets, sf_offsets, M, N, K);
+    } else {
+      run_fp4_blockwise_scaled_group_mm_sm120<false>(
+          output, a, b, a_blockscale, b_blockscales, alphas, problem_sizes,
+          expert_offsets, sf_offsets, M, N, K);
+    }
     return;
   }
 #endif


### PR DESCRIPTION
## Summary
The SM120 NVFP4 block-scaled **grouped** MoE GEMM (`run_fp4_blockwise_scaled_group_mm_sm120`
in `nvfp4_blockwise_moe_kernel.cu`) builds its mainloop with `KernelScheduleAuto`, which
resolves to the **cooperative** PtrArray warp-specialized schedule for every problem size.
On consumer Blackwell (SM120) the **pingpong** schedule is meaningfully faster at large
per-expert M (prefill), while cooperative stays better at small per-expert M (decode).

This adds a `template <bool UsePingpong>` to the function (only the mainloop `KernelSchedule`
changes, via `std::conditional_t`) and dispatches in `run_fp4_blockwise_scaled_group_mm` on
the average per-expert M (`M / num_experts`) with a threshold of 512 — pingpong at/above,
cooperative below. The `UsePingpong=false` path is bit-identical to the current behavior
(zero regression for decode). This mirrors the existing SM90/SM100 grouped-GEMM M-based
dispatch in `grouped_mm_c3x_sm{90,100}.cu`.

## Why this is not a duplicate
- #24968 ("[NVFP4] Enable MOE support for SM_120") is a stale draft on the old
  `csrc/quantization/` path (enablement, landed differently); it does not touch the schedule.
- #38957 is an unrelated CMake FP4-arch fix.
- No open PR changes the SM120 NVFP4 MoE kernel schedule.

## Measurements (RTX PRO 6000, SM120, CUDA 13)
Schedule A/B on the exact kernel this op builds (`KernelPtrArrayTmaWarpSpecialized`
cooperative vs pingpong), via CUTLASS example `79d_blackwell_geforce_nvfp4_grouped_gemm`,
N=2048, K=4096, 8 groups. The box has a co-tenant so I report the contention-robust best
(max TFLOPS over 12 reps):

| per-expert M | cooperative | pingpong | speedup |
|---:|---:|---:|---:|
| 128 | 580 | 563 | 0.97× (cooperative kept) |
| 256 | 682 | 606 | 0.89× (cooperative kept) |
| 512 | 862 | 917 | **+6%** |
| 1024 | 804 | 912 | **+13%** |
| 2048 | 741 | 879 | **+19%** |

(Tile shapes were swept too — `128×128×128` is optimal across M; only the *schedule* helps.)

## Test plan / results
```
pytest tests/kernels/moe/test_nvfp4_moe.py::test_cutlass_fp4_moe_no_graph
```
**18/18 PASS** on SM120, including a large-m case (m=4096, e=64, topk=8 → per-expert M=512)
that exercises the new pingpong path, verified against the `torch_moe` reference
(atol/rtol 1e-1). The `UsePingpong=false` (decode) path is unchanged → no small-M regression.
Built with `pip install --no-build-isolation -e .` on torch 2.11.0+cu130, arch `12.0a`.

## Notes
The 512 threshold is hardcoded, consistent with the SM90/SM100 M-dispatch convention (no env
knob). `M / num_experts` is the *average* per-expert M, so skewed routing can mispredict the
schedule — perf only, never a correctness issue.

This change was AI-assisted (Claude); it was benchmarked and verified on a real SM120 card.
