### PR TITLE
[ROCm][P/D] MoRIIO toy proxy: support JSON Content-Type for OpenAI clients.

### DIFF
--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -327,6 +327,9 @@ async def handle_request(api: str, request: Request):
         session, decode_response = await decode_request_task
         stream_generator = stream_decode_response(session, decode_response, request_id)
         response = await make_response(stream_generator)
+        response.headers["Content-Type"] = decode_response.headers.get(
+            "Content-Type", "application/json"
+        )
         return response
     except Exception as e:
         logger.exception("An error occurred while handling the request: %s", e)


### PR DESCRIPTION


## Purpose

The Quart-based MoRIIO disaggregated toy proxy returns streamed responses with Quart's defaults via `make_response(stream_generator)` without setting a `Content-Type`. 

Quart defaults a streamed response to `text/html; charset=utf-8`, so even on a successful `200` the body is mislabeled.

**Reference Documentation from Quart:** 
https://quart.palletsprojects.com/en/stable/reference/source/quart.wrappers.response.html

This breaks OpenAI-compatible JSON clients. For example, `lm_eval` (`local-completions` backend) calls `response.json()`, which rejects the non-JSON mimetype and discards every response with the following error message: 

```
ContentTypeError(..., status=200, message="Attempt to decode JSON with unexpected mimetype: text/html; charset=utf-8", headers=<... 'Content-Type': 'text/html; charset=utf-8', 'Server': 'hypercorn-h11' ...>)
```

The result is `(no outputs)` for every request and no accuracy score, even though the prefill/decode disaggregation path itself works correctly. The MoRIIO proxy is the only one (Quart-based) that omits it.

This PR aims at supporting Content-Type (application/json) for MoRI IO toy proxy server and also matches with other toy proxies. 

## Changes

Files changed: 

* `examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py`

## Test Plan

* Run the following GSM8K lm_eval command in PD Disagg with MoRI IO toy proxy. 

```
lm_eval --model local-completions --tasks gsm8k \ --model_args model=<model>,base_url=http://127.0.0.1:<proxy_port>/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False
```