### PR TITLE
Mistral Large 3 EPLB Support

### DIFF
--- a/tests/distributed/test_eplb_after_rearrangement.py
+++ b/tests/distributed/test_eplb_after_rearrangement.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""CPU-only tests for the after_eplb_rearrangement hook.
+
+The GPU/distributed EPLB tests drive ``rearrange_expert_weights_inplace``
+directly and never go through ``EplbState``, so they never exercise the
+post-rearrangement hooks. These tests cover that gap: the dispatch wiring
+and the NVFP4 derived-scale refresh, both runnable without a GPU.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.distributed.eplb.eplb_state import _run_after_eplb_rearrangement_hooks
+
+
+class _RecordingQuantMethod:
+    def __init__(self):
+        self.calls: list[object] = []
+
+    def after_eplb_rearrangement(self, layer):
+        self.calls.append(layer)
+
+
+def _make_model(num_layers: int):
+    """Fake MixtureOfExperts whose moe_layers mimic MoERunner.
+
+    Like a real ``MoERunner``, each layer exposes ``routed_experts`` but has
+    no public ``quant_method`` attribute -- that lives on routed_experts.
+    """
+    moe_layers = []
+    for _ in range(num_layers):
+        routed_experts = SimpleNamespace(quant_method=_RecordingQuantMethod())
+        moe_layers.append(SimpleNamespace(routed_experts=routed_experts))
+    return SimpleNamespace(moe_layers=moe_layers)
+
+
+def test_hook_dispatches_via_routed_experts():
+    # Regression: the hook must reach quant_method through routed_experts and
+    # pass the routed_experts (a RoutedExperts) as the layer arg. A MoERunner
+    # has no public quant_method, so ``moe_layer.quant_method`` would raise.
+    model = _make_model(num_layers=3)
+
+    for moe_layer in model.moe_layers:
+        assert not hasattr(moe_layer, "quant_method")
+
+    _run_after_eplb_rearrangement_hooks(model)
+
+    for moe_layer in model.moe_layers:
+        routed_experts = moe_layer.routed_experts
+        assert routed_experts.quant_method.calls == [routed_experts]
+
+
+def test_nvfp4_after_eplb_rearrangement_refreshes_scale_2():
+    # after_eplb_rearrangement ignores self, so bypass the CUDA-dependent
+    # __init__ and drive the real method body against a fake RoutedExperts.
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w4a4_nvfp4 import (  # noqa: E501
+        CompressedTensorsW4A4Nvfp4MoEMethod,
+    )
+
+    method = object.__new__(CompressedTensorsW4A4Nvfp4MoEMethod)
+
+    num_experts = 4
+    torch.manual_seed(0)
+    layer = SimpleNamespace(
+        w13_weight_global_scale=torch.rand(num_experts, 2) + 0.5,
+        w2_weight_global_scale=torch.rand(num_experts) + 0.5,
+        w13_input_scale=torch.rand(num_experts) + 0.5,
+        w2_input_scale=torch.rand(num_experts) + 0.5,
+        w13_weight_scale_2=torch.zeros(num_experts),
+        w2_weight_scale_2=torch.zeros(num_experts),
+    )
+
+    method.after_eplb_rearrangement(layer)
+    torch.testing.assert_close(
+        layer.w13_weight_scale_2,
+        (1.0 / layer.w13_weight_global_scale[:, 0]) * layer.w13_input_scale,
+    )
+    torch.testing.assert_close(
+        layer.w2_weight_scale_2,
+        (1.0 / layer.w2_weight_global_scale) * layer.w2_input_scale,
+    )
+
+    # EPLB permutes the per-expert globals/inputs in place; the derived
+    # scale_2 (separate storage) must be re-derived to match.
+    scale_2_before = layer.w13_weight_scale_2.clone()
+    perm = torch.tensor([2, 0, 3, 1])
+    layer.w13_weight_global_scale = layer.w13_weight_global_scale[perm].contiguous()
+    layer.w2_weight_global_scale = layer.w2_weight_global_scale[perm].contiguous()
+    layer.w13_input_scale = layer.w13_input_scale[perm].contiguous()
+    layer.w2_input_scale = layer.w2_input_scale[perm].contiguous()
+
+    method.after_eplb_rearrangement(layer)
+    torch.testing.assert_close(layer.w13_weight_scale_2, scale_2_before[perm])

--- a/tests/distributed/test_eplb_after_rearrangement.py
+++ b/tests/distributed/test_eplb_after_rearrangement.py
@@ -1,96 +1,207 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""CPU-only tests for the after_eplb_rearrangement hook.
+"""GPU tests for the after_eplb_rearrangement hook on NVFP4 MoE."""
 
-The GPU/distributed EPLB tests drive ``rearrange_expert_weights_inplace``
-directly and never go through ``EplbState``, so they never exercise the
-post-rearrangement hooks. These tests cover that gap: the dispatch wiring
-and the NVFP4 derived-scale refresh, both runnable without a GPU.
-"""
-
+from collections.abc import Iterable
 from types import SimpleNamespace
 
+import pytest
 import torch
 
+from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.distributed.eplb.eplb_state import _run_after_eplb_rearrangement_hooks
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    RoutingMethodType,
+)
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w4a4_nvfp4 import (  # noqa: E501
+    CompressedTensorsW4A4Nvfp4MoEMethod,
+)
+from vllm.platforms import current_platform
+
+EPLB_NVFP4_BACKENDS = ["flashinfer_cutedsl", "flashinfer_trtllm"]
+
+NUM_EXPERTS = 8
+HIDDEN_SIZE = 128
+INTERMEDIATE_SIZE = 256
+EXPERT_PERMUTATION = [3, 0, 5, 1, 7, 2, 6, 4]
+
+DERIVED_SCALE_NAMES = (
+    "w13_weight_scale_2",
+    "w2_weight_scale_2",
+    "w13_input_scale",
+    "w2_input_scale",
+)
 
 
-class _RecordingQuantMethod:
-    def __init__(self):
-        self.calls: list[object] = []
+class _RoutedExpertsStub(torch.nn.Module):
+    """Minimal ``RoutedExperts`` stand-in for NVFP4 weight processing."""
 
-    def after_eplb_rearrangement(self, layer):
-        self.calls.append(layer)
+    def __init__(self, moe_config: FusedMoEConfig) -> None:
+        super().__init__()
+        self.moe_config = moe_config
+        self.activation = moe_config.activation
 
-
-def _make_model(num_layers: int):
-    """Fake MixtureOfExperts whose moe_layers mimic MoERunner.
-
-    Like a real ``MoERunner``, each layer exposes ``routed_experts`` but has
-    no public ``quant_method`` attribute -- that lives on routed_experts.
-    """
-    moe_layers = []
-    for _ in range(num_layers):
-        routed_experts = SimpleNamespace(quant_method=_RecordingQuantMethod())
-        moe_layers.append(SimpleNamespace(routed_experts=routed_experts))
-    return SimpleNamespace(moe_layers=moe_layers)
+    def _expert_routing_tables(
+        self,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+        return None
 
 
-def test_hook_dispatches_via_routed_experts():
-    # Regression: the hook must reach quant_method through routed_experts and
-    # pass the routed_experts (a RoutedExperts) as the layer arg. A MoERunner
-    # has no public quant_method, so ``moe_layer.quant_method`` would raise.
-    model = _make_model(num_layers=3)
+def _make_moe_config(backend: str) -> FusedMoEConfig:
+    parallel_config = FusedMoEParallelConfig(
+        tp_size=1,
+        pcp_size=1,
+        dp_size=1,
+        ep_size=1,
+        tp_rank=0,
+        pcp_rank=0,
+        dp_rank=0,
+        ep_rank=0,
+        sp_size=1,
+        use_ep=True,
+        all2all_backend="allgather_reducescatter",
+        enable_eplb=True,
+    )
+    return FusedMoEConfig(
+        num_experts=NUM_EXPERTS,
+        experts_per_token=2,
+        hidden_dim=HIDDEN_SIZE,
+        intermediate_size=INTERMEDIATE_SIZE,
+        num_local_experts=NUM_EXPERTS,
+        num_logical_experts=NUM_EXPERTS,
+        activation=MoEActivation.SILU,
+        device="cuda",
+        routing_method=RoutingMethodType.TopK,
+        moe_parallel_config=parallel_config,
+        in_dtype=torch.bfloat16,
+        moe_backend=backend,
+    )
 
-    for moe_layer in model.moe_layers:
+
+def _make_raw_weights(
+    device: torch.device, generator: torch.Generator
+) -> dict[str, torch.Tensor]:
+    """Random raw NVFP4 checkpoint tensors, indexable per-expert on dim 0."""
+    e, h, i = NUM_EXPERTS, HIDDEN_SIZE, INTERMEDIATE_SIZE
+
+    def packed(*shape: int) -> torch.Tensor:
+        return torch.randint(
+            0, 256, shape, dtype=torch.uint8, device=device, generator=generator
+        )
+
+    def block_scale(*shape: int) -> torch.Tensor:
+        return torch.randint(
+            0, 128, shape, dtype=torch.uint8, device=device, generator=generator
+        ).view(torch.float8_e4m3fn)
+
+    def global_scale(*shape: int) -> torch.Tensor:
+        return torch.rand(shape, device=device, generator=generator) + 0.5
+
+    return {
+        "w13_weight_packed": packed(e, 2 * i, h // 2),
+        "w2_weight_packed": packed(e, h, i // 2),
+        "w13_weight_scale": block_scale(e, 2 * i, h // 16),
+        "w2_weight_scale": block_scale(e, h, i // 16),
+        "w13_weight_global_scale": global_scale(e, 2),
+        "w2_weight_global_scale": global_scale(e),
+        "w13_input_global_scale": global_scale(e, 2),
+        "w2_input_global_scale": global_scale(e),
+    }
+
+
+def _build_processed_layer(
+    backend: str, raw: dict[str, torch.Tensor], device: torch.device
+) -> tuple[CompressedTensorsW4A4Nvfp4MoEMethod, _RoutedExpertsStub]:
+    """Create the method + layer, load ``raw`` and run the real
+    process_weights_after_loading (which builds the flashinfer kernel)."""
+    moe_config = _make_moe_config(backend)
+    method = CompressedTensorsW4A4Nvfp4MoEMethod(moe_config, "layer.0", use_a16=False)
+    layer = _RoutedExpertsStub(moe_config).to(device)
+    method.create_weights(
+        layer,
+        num_experts=NUM_EXPERTS,
+        hidden_size=HIDDEN_SIZE,
+        intermediate_size_per_partition=INTERMEDIATE_SIZE,
+        params_dtype=torch.bfloat16,
+        weight_loader=lambda *args, **kwargs: None,
+    )
+    layer = layer.to(device)
+    with torch.no_grad():
+        for name, value in raw.items():
+            getattr(layer, name).copy_(value)
+    method.process_weights_after_loading(layer)
+    return method, layer
+
+
+def _assert_tensors_equal(
+    actual: torch.Tensor, expected: torch.Tensor, name: str
+) -> None:
+    if actual.dtype == torch.float8_e4m3fn:
+        assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8)), name
+    elif actual.dtype == torch.uint8:
+        assert torch.equal(actual, expected), name
+    else:
+        torch.testing.assert_close(actual, expected, msg=lambda m: f"{name}: {m}")
+
+
+def _iter_derived_scales(
+    layer: _RoutedExpertsStub,
+) -> Iterable[tuple[str, torch.Tensor]]:
+    for name in DERIVED_SCALE_NAMES:
+        yield name, getattr(layer, name)
+
+
+@pytest.mark.parametrize("backend", EPLB_NVFP4_BACKENDS)
+def test_nvfp4_after_eplb_rearrangement_matches_reload(backend: str) -> None:
+    if not (
+        current_platform.is_cuda() and current_platform.is_device_capability_family(100)
+    ):
+        pytest.skip("NVFP4 CuteDSL/TRTLLM MoE backends require Blackwell (SM100).")
+
+    device = torch.device("cuda:0")
+    torch.accelerator.set_device_index(device)
+    perm = torch.tensor(EXPERT_PERMUTATION, device=device)
+
+    with set_current_vllm_config(VllmConfig()):
+        generator = torch.Generator(device=device).manual_seed(1234)
+        raw = _make_raw_weights(device, generator)
+        raw_permuted = {name: value[perm].contiguous() for name, value in raw.items()}
+
+        try:
+            method, routed_experts = _build_processed_layer(backend, raw, device)
+        except ValueError as exc:
+            pytest.skip(f"{backend} NVFP4 MoE backend unavailable: {exc}")
+        _, reloaded = _build_processed_layer(backend, raw_permuted, device)
+
+        before = {n: t.clone() for n, t in _iter_derived_scales(routed_experts)}
+        method.after_eplb_rearrangement(routed_experts)
+        for name, tensor in _iter_derived_scales(routed_experts):
+            _assert_tensors_equal(before[name], tensor, f"hook not a no-op: {name}")
+
+        # Simulate EPLB rearrangement.
+        with torch.no_grad():
+            for _, param in routed_experts.named_parameters():
+                param.copy_(param[perm])
+        # quant_method lives on the RoutedExperts; EplbState reaches it via
+        # moe_layer.routed_experts.quant_method (a MoERunner has no public one).
+        routed_experts.quant_method = method
+        assert not hasattr(MoERunner, "quant_method")
+        moe_layer = SimpleNamespace(routed_experts=routed_experts)
         assert not hasattr(moe_layer, "quant_method")
+        model = SimpleNamespace(moe_layers=[moe_layer])
+        _run_after_eplb_rearrangement_hooks(model)
 
-    _run_after_eplb_rearrangement_hooks(model)
-
-    for moe_layer in model.moe_layers:
-        routed_experts = moe_layer.routed_experts
-        assert routed_experts.quant_method.calls == [routed_experts]
-
-
-def test_nvfp4_after_eplb_rearrangement_refreshes_scale_2():
-    # after_eplb_rearrangement ignores self, so bypass the CUDA-dependent
-    # __init__ and drive the real method body against a fake RoutedExperts.
-    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w4a4_nvfp4 import (  # noqa: E501
-        CompressedTensorsW4A4Nvfp4MoEMethod,
-    )
-
-    method = object.__new__(CompressedTensorsW4A4Nvfp4MoEMethod)
-
-    num_experts = 4
-    torch.manual_seed(0)
-    layer = SimpleNamespace(
-        w13_weight_global_scale=torch.rand(num_experts, 2) + 0.5,
-        w2_weight_global_scale=torch.rand(num_experts) + 0.5,
-        w13_input_scale=torch.rand(num_experts) + 0.5,
-        w2_input_scale=torch.rand(num_experts) + 0.5,
-        w13_weight_scale_2=torch.zeros(num_experts),
-        w2_weight_scale_2=torch.zeros(num_experts),
-    )
-
-    method.after_eplb_rearrangement(layer)
-    torch.testing.assert_close(
-        layer.w13_weight_scale_2,
-        (1.0 / layer.w13_weight_global_scale[:, 0]) * layer.w13_input_scale,
-    )
-    torch.testing.assert_close(
-        layer.w2_weight_scale_2,
-        (1.0 / layer.w2_weight_global_scale) * layer.w2_input_scale,
-    )
-
-    # EPLB permutes the per-expert globals/inputs in place; the derived
-    # scale_2 (separate storage) must be re-derived to match.
-    scale_2_before = layer.w13_weight_scale_2.clone()
-    perm = torch.tensor([2, 0, 3, 1])
-    layer.w13_weight_global_scale = layer.w13_weight_global_scale[perm].contiguous()
-    layer.w2_weight_global_scale = layer.w2_weight_global_scale[perm].contiguous()
-    layer.w13_input_scale = layer.w13_input_scale[perm].contiguous()
-    layer.w2_input_scale = layer.w2_input_scale[perm].contiguous()
-
-    method.after_eplb_rearrangement(layer)
-    torch.testing.assert_close(layer.w13_weight_scale_2, scale_2_before[perm])
+        # After rearrangement, the state must equal what we would get by
+        # loading the permuted experts directly.
+        ref_params = dict(routed_experts.named_parameters())
+        new_params = dict(reloaded.named_parameters())
+        assert ref_params.keys() == new_params.keys()
+        for name in ref_params:
+            _assert_tensors_equal(ref_params[name], new_params[name], name)
+        for name, tensor in _iter_derived_scales(routed_experts):
+            _assert_tensors_equal(tensor, getattr(reloaded, name), name)

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -1279,9 +1279,13 @@ def _move_to_workspace(
         layer=result.layer_idx,
     )
 
+    # In async EPLB mode, post-rearrangement actions need to be performed
+    # per layer.
+    moe_layer = model_state.model.moe_layers[result.layer_idx]
+    moe_layer.quant_method.after_eplb_rearrangement(moe_layer)
+
     if result.layer_idx == model_state.model.num_moe_layers - 1:
         model_state.rebalanced = False
-        _run_after_eplb_rearrangement_hooks(model_state.model)
 
     # Reset pending_result before unblocking the async worker
     model_state.pending_result = None

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -1280,9 +1280,10 @@ def _move_to_workspace(
     )
 
     # In async EPLB mode, post-rearrangement actions need to be performed
-    # per layer.
-    moe_layer = model_state.model.moe_layers[result.layer_idx]
-    moe_layer.quant_method.after_eplb_rearrangement(moe_layer)
+    # per layer. quant_method and the rearranged Parameters live on
+    # routed_experts, not the MoERunner.
+    routed_experts = model_state.model.moe_layers[result.layer_idx].routed_experts
+    routed_experts.quant_method.after_eplb_rearrangement(routed_experts)
 
     if result.layer_idx == model_state.model.num_moe_layers - 1:
         model_state.rebalanced = False
@@ -1300,4 +1301,6 @@ def _run_after_eplb_rearrangement_hooks(model: MixtureOfExperts) -> None:
     rearrangement won't touch on its own.
     """
     for moe_layer in model.moe_layers:
-        moe_layer.quant_method.after_eplb_rearrangement(moe_layer)
+        # quant_method and the rearranged Parameters live on routed_experts.
+        routed_experts = moe_layer.routed_experts
+        routed_experts.quant_method.after_eplb_rearrangement(routed_experts)

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -842,6 +842,7 @@ class EplbState:
                         eplb_model_state,
                         new_physical_to_logical_map=new_physical_to_logical_map,
                     )
+                    _run_after_eplb_rearrangement_hooks(eplb_model_state.model)
 
                 if is_main_rank:
                     assert start_event is not None
@@ -1280,7 +1281,19 @@ def _move_to_workspace(
 
     if result.layer_idx == model_state.model.num_moe_layers - 1:
         model_state.rebalanced = False
+        _run_after_eplb_rearrangement_hooks(model_state.model)
 
     # Reset pending_result before unblocking the async worker
     model_state.pending_result = None
     result.consumed_event.record()
+
+
+def _run_after_eplb_rearrangement_hooks(model: MixtureOfExperts) -> None:
+    """Invoke quant_method.after_eplb_rearrangement on every MoE layer.
+
+    Lets quant methods refresh derived per-expert state (e.g. fused
+    activation x weight scales for NVFP4) that EPLB's Parameter
+    rearrangement won't touch on its own.
+    """
+    for moe_layer in model.moe_layers:
+        moe_layer.quant_method.after_eplb_rearrangement(moe_layer)

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -293,20 +293,9 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             and not self.use_deepseek_fp8_block_scale
         ):
             # FP8 per-tensor path: use global alphas/scales; do not pass input_sf
-            if self.moe_config.moe_parallel_config.enable_eplb:
-                # Account for weight scale rearrangement with EPLB
-                # TODO (varun): This is wasteful recomputation on every step.
-                # Hook this computation to EPLB rearrangement directly.
-
-                assert self.w1_scale is not None and self.w2_scale is not None
-                assert self.a1_scale is not None and self.a2_scale is not None
-                # w13_weight_scale * w13_input_scale
-                g1_alphas = (self.w1_scale * self.a1_scale).squeeze()
-                # w2_weight_scale * w2_input_scale
-                g2_alphas = (self.w2_scale * self.a2_scale).squeeze()
-            else:
-                # Use precomputed g1_alphas, g2_alphas
-                g1_alphas, g2_alphas = self.g1_alphas, self.g2_alphas
+            # g1_alphas / g2_alphas are kept fresh by Fp8MoEMethod
+            # .after_eplb_rearrangement after each EPLB expert reorder.
+            g1_alphas, g2_alphas = self.g1_alphas, self.g2_alphas
 
             quant_scales = [
                 g1_alphas,  # w13_weight_scale * w13_input_scale

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -293,10 +293,25 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             and not self.use_deepseek_fp8_block_scale
         ):
             # FP8 per-tensor path: use global alphas/scales; do not pass input_sf
+            if self.moe_config.moe_parallel_config.enable_eplb:
+                # Account for weight scale rearrangement with EPLB
+                # TODO (varun): This is wasteful recomputation on every step.
+                # Hook this computation to EPLB rearrangement directly.
+
+                assert self.w1_scale is not None and self.w2_scale is not None
+                assert self.a1_scale is not None and self.a2_scale is not None
+                # w13_weight_scale * w13_input_scale
+                g1_alphas = (self.w1_scale * self.a1_scale).squeeze()
+                # w2_weight_scale * w2_input_scale
+                g2_alphas = (self.w2_scale * self.a2_scale).squeeze()
+            else:
+                # Use precomputed g1_alphas, g2_alphas
+                g1_alphas, g2_alphas = self.g1_alphas, self.g2_alphas
+
             quant_scales = [
-                self.g1_alphas,  # w13_weight_scale * w13_input_scale
+                g1_alphas,  # w13_weight_scale * w13_input_scale
                 self.a2_gscale,  # 1.0 / w2_input_scale
-                self.g2_alphas,  # w2_weight_scale * w2_input_scale
+                g2_alphas,  # w2_weight_scale * w2_input_scale
                 self.a1_scale,
             ]
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -160,8 +160,7 @@ class FusedMoEMethodBase(QuantizeMethodBase):
         self,
         layer: "RoutedExperts",  # type: ignore[name-defined] # noqa: F821
     ) -> None:
-        """Refresh any quant-method state that depends on the per-expert
-        ordering after EPLB has rearranged the registered Parameters.
+        """Refresh derived quant-method state after EPLB rearranges Parameters.
 
         EPLB moves registered expert Parameters in-place via P2P, but
         quant methods often hold *derived* per-expert tensors (e.g. the

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -156,6 +156,23 @@ class FusedMoEMethodBase(QuantizeMethodBase):
     def supports_eplb(self) -> bool:
         return False
 
+    def after_eplb_rearrangement(
+        self,
+        layer: "RoutedExperts",  # type: ignore[name-defined] # noqa: F821
+    ) -> None:
+        """Refresh any quant-method state that depends on the per-expert
+        ordering after EPLB has rearranged the registered Parameters.
+
+        EPLB moves registered expert Parameters in-place via P2P, but
+        quant methods often hold *derived* per-expert tensors (e.g. the
+        reciprocal of a global scale, with activation scales fused in)
+        that are separate tensors with their own storage. Those won't
+        be touched by the rearrangement. Override this to re-derive
+        them in place so kernel references stay in sync. Default no-op
+        for methods with no such derived state.
+        """
+        return
+
     @property
     def method_name(self) -> str:
         return self.__class__.__name__

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -162,13 +162,8 @@ class FusedMoEMethodBase(QuantizeMethodBase):
     ) -> None:
         """Refresh derived quant-method state after EPLB rearranges Parameters.
 
-        EPLB moves registered expert Parameters in-place via P2P, but
-        quant methods often hold *derived* per-expert tensors (e.g. the
-        reciprocal of a global scale, with activation scales fused in)
-        that are separate tensors with their own storage. Those won't
-        be touched by the rearrangement. Override this to re-derive
-        them in place so kernel references stay in sync. Default no-op
-        for methods with no such derived state.
+        Override when the method holds derived per-expert tensors (separate
+        storage) the in-place rearrangement won't update; default is a no-op.
         """
         return
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -32,12 +32,11 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
-# Backends whose weight layout is per-expert leading-dim contiguous,
-# so EPLB can safely rearrange them.
 _EPLB_SUPPORTED_NVFP4_BACKENDS = frozenset(
     {
         NvFp4MoeBackend.FLASHINFER_CUTEDSL,
         NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED,
+        NvFp4MoeBackend.FLASHINFER_TRTLLM,
     }
 )
 
@@ -326,8 +325,6 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         )
 
     def after_eplb_rearrangement(self, layer: RoutedExperts) -> None:
-        # w13/w2_weight_scale_2 are fused products derived from the
-        # globals EPLB just rearranged; re-derive them here to stay in sync.
         layer.w13_weight_scale_2.copy_(
             (1.0 / layer.w13_weight_global_scale[:, 0]) * layer.w13_input_scale
         )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -16,11 +16,23 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
     convert_to_nvfp4_moe_kernel_format,
     is_global_sf_supported_for_nvfp4_backend,
     make_nvfp4_moe_kernel,
     make_nvfp4_moe_quant_config,
     select_nvfp4_moe_backend,
+)
+
+# Backends for which we've verified EPLB rearrangement preserves the
+# layout the kernel expects (registered Parameters are per-expert
+# leading-dim contiguous, derived scales get refreshed in the
+# after_eplb_rearrangement hook).
+_EPLB_SUPPORTED_NVFP4_BACKENDS = frozenset(
+    {
+        NvFp4MoeBackend.FLASHINFER_CUTEDSL,
+        NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED,
+    }
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
     CompressedTensorsMoEMethod,
@@ -54,6 +66,15 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         self.use_global_sf = is_global_sf_supported_for_nvfp4_backend(
             self.nvfp4_backend
         )
+
+    @property
+    def supports_eplb(self) -> bool:
+        # Online / static rearrangement is wired up only for the
+        # CuteDSL backends. Other NVFP4 backends still need their
+        # post-process layout (e.g. TRTLLM weight pre-shuffle, Marlin
+        # repacking) audited for per-expert leading-dim contiguity
+        # before EPLB can rearrange them safely.
+        return self.nvfp4_backend in _EPLB_SUPPORTED_NVFP4_BACKENDS
 
     def create_weights(
         self,
@@ -221,9 +242,35 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         )
 
         replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w13_weight_scale", w13_scale)
         replace_parameter(layer, "w2_weight", w2)
-        replace_parameter(layer, "w2_weight_scale", w2_scale)
+
+        if self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
+            # flashinfer's convert_sf_to_mma_layout returns a strided
+            # permuted view (shape (32, 4, m_t, 4, k_t, E)) of contiguous
+            # storage laid out as (E, m_t, k_t, 32, 4, 4). EPLB needs a
+            # per-expert leading-dim contiguous view to slice/move
+            # individual experts. The MMA view's permute is
+            # (3, 4, 1, 5, 2, 0); its inverse is (5, 2, 4, 0, 1, 3),
+            # which lands on the underlying (E, ...) contiguous layout
+            # while sharing storage. Register that as the Parameter and
+            # stash the MMA view on the layer as a plain tensor
+            # attribute for the kernel to consume via
+            # get_fused_moe_quant_config.
+            w13_scale_eplb_view = w13_scale.permute(5, 2, 4, 0, 1, 3)
+            w2_scale_eplb_view = w2_scale.permute(5, 2, 4, 0, 1, 3)
+            assert w13_scale_eplb_view.is_contiguous(), (
+                "Expected the inverse-permuted scale view to be contiguous; "
+                "flashinfer's convert_sf_to_mma_layout storage layout may "
+                "have changed."
+            )
+            assert w2_scale_eplb_view.is_contiguous()
+            layer.w13_weight_scale_mma_view = w13_scale
+            layer.w2_weight_scale_mma_view = w2_scale
+            replace_parameter(layer, "w13_weight_scale", w13_scale_eplb_view)
+            replace_parameter(layer, "w2_weight_scale", w2_scale_eplb_view)
+        else:
+            replace_parameter(layer, "w13_weight_scale", w13_scale)
+            replace_parameter(layer, "w2_weight_scale", w2_scale)
         layer.w13_weight_scale_2 = w13_scale_2
         layer.w2_weight_scale_2 = w2_scale_2
         layer.w13_input_scale = a13_scale
@@ -252,16 +299,48 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         )
 
     def get_fused_moe_quant_config(self, layer: torch.nn.Module) -> FusedMoEQuantConfig:
+        if self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
+            # Kernel consumes the strided MMA-layout view; the
+            # registered Parameter is the E-leading view of the same
+            # storage so EPLB can rearrange per-expert. Both alias the
+            # same memory -- updates from either propagate.
+            w13_scale = layer.w13_weight_scale_mma_view
+            w2_scale = layer.w2_weight_scale_mma_view
+        else:
+            w13_scale = layer.w13_weight_scale
+            w2_scale = layer.w2_weight_scale
         return make_nvfp4_moe_quant_config(
             backend=self.nvfp4_backend,
-            w13_scale=layer.w13_weight_scale,
-            w2_scale=layer.w2_weight_scale,
+            w13_scale=w13_scale,
+            w2_scale=w2_scale,
             w13_scale_2=layer.w13_weight_scale_2,
             w2_scale_2=layer.w2_weight_scale_2,
             a13_scale=layer.w13_input_scale,
             a2_scale=layer.w2_input_scale,
             swiglu_limit=getattr(layer, "swiglu_limit", None),
             layer=layer,
+        )
+
+    def after_eplb_rearrangement(self, layer: RoutedExperts) -> None:
+        if self.nvfp4_backend not in _EPLB_SUPPORTED_NVFP4_BACKENDS:
+            return
+        # EPLB moves the registered Parameters (w13_weight,
+        # w13_weight_scale, w13_weight_global_scale, w13_input_global_scale,
+        # and their w2 counterparts) per-expert. But the kernel-facing
+        # derived tensor layer.w13_weight_scale_2 holds the fused
+        # product (1 / w13_weight_global_scale) * w13_input_scale (see
+        # FlashInferCuteDSLExperts.process_weights_after_loading, which
+        # does the .mul_ in place). Its storage is independent of
+        # w13_weight_global_scale, so it doesn't get rearranged with the
+        # globals. Re-derive it in place so the kernel's captured
+        # references stay in sync. ``w13_input_scale`` is a max-broadcast
+        # scalar -- invariant under expert permutation, no refresh
+        # needed.
+        layer.w13_weight_scale_2.copy_(
+            (1.0 / layer.w13_weight_global_scale[:, 0]) * layer.w13_input_scale
+        )
+        layer.w2_weight_scale_2.copy_(
+            (1.0 / layer.w2_weight_global_scale) * layer.w2_input_scale
         )
 
     def apply_monolithic(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -23,6 +23,14 @@ from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
     make_nvfp4_moe_quant_config,
     select_nvfp4_moe_backend,
 )
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
+    CompressedTensorsMoEMethod,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kNvfp4Dynamic,
+    kNvfp4Static,
+)
+from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
 # Backends for which we've verified EPLB rearrangement preserves the
 # layout the kernel expects (registered Parameters are per-expert
@@ -34,14 +42,6 @@ _EPLB_SUPPORTED_NVFP4_BACKENDS = frozenset(
         NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED,
     }
 )
-from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
-    CompressedTensorsMoEMethod,
-)
-from vllm.model_executor.layers.quantization.utils.quant_utils import (
-    kNvfp4Dynamic,
-    kNvfp4Static,
-)
-from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
 logger = init_logger(__name__)
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -244,7 +244,10 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         replace_parameter(layer, "w13_weight", w13)
         replace_parameter(layer, "w2_weight", w2)
 
-        if self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
+        if (
+            self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL
+            and self.moe.moe_parallel_config.enable_eplb
+        ):
             # flashinfer's convert_sf_to_mma_layout returns a strided
             # permuted view (shape (32, 4, m_t, 4, k_t, E)) of contiguous
             # storage laid out as (E, m_t, k_t, 32, 4, 4). EPLB needs a
@@ -263,7 +266,11 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
                 "flashinfer's convert_sf_to_mma_layout storage layout may "
                 "have changed."
             )
-            assert w2_scale_eplb_view.is_contiguous()
+            assert w2_scale_eplb_view.is_contiguous(), (
+                "Expected the inverse-permuted w2 scale view to be contiguous; "
+                "flashinfer's convert_sf_to_mma_layout storage layout may "
+                "have changed."
+            )
             layer.w13_weight_scale_mma_view = w13_scale
             layer.w2_weight_scale_mma_view = w2_scale
             replace_parameter(layer, "w13_weight_scale", w13_scale_eplb_view)
@@ -299,11 +306,13 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         )
 
     def get_fused_moe_quant_config(self, layer: torch.nn.Module) -> FusedMoEQuantConfig:
-        if self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
-            # Kernel consumes the strided MMA-layout view; the
-            # registered Parameter is the E-leading view of the same
-            # storage so EPLB can rearrange per-expert. Both alias the
-            # same memory -- updates from either propagate.
+        if (
+            self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL
+            and self.moe.moe_parallel_config.enable_eplb
+        ):
+            # When EPLB is enabled the registered Parameter is the E-leading
+            # contiguous view (for per-expert slicing); the kernel needs the
+            # strided MMA-layout view stashed alongside it.
             w13_scale = layer.w13_weight_scale_mma_view
             w2_scale = layer.w2_weight_scale_mma_view
         else:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -32,10 +32,8 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
-# Backends for which we've verified EPLB rearrangement preserves the
-# layout the kernel expects (registered Parameters are per-expert
-# leading-dim contiguous, derived scales get refreshed in the
-# after_eplb_rearrangement hook).
+# Backends whose weight layout is per-expert leading-dim contiguous,
+# so EPLB can safely rearrange them.
 _EPLB_SUPPORTED_NVFP4_BACKENDS = frozenset(
     {
         NvFp4MoeBackend.FLASHINFER_CUTEDSL,
@@ -69,11 +67,8 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
 
     @property
     def supports_eplb(self) -> bool:
-        # Online / static rearrangement is wired up only for the
-        # CuteDSL backends. Other NVFP4 backends still need their
-        # post-process layout (e.g. TRTLLM weight pre-shuffle, Marlin
-        # repacking) audited for per-expert leading-dim contiguity
-        # before EPLB can rearrange them safely.
+        # Other NVFP4 backends still need their post-process layout audited
+        # for per-expert leading-dim contiguity before EPLB can use them.
         return self.nvfp4_backend in _EPLB_SUPPORTED_NVFP4_BACKENDS
 
     def create_weights(
@@ -217,6 +212,14 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
             )
         w13_weight_global_scale = layer.w13_weight_global_scale[:, 0].contiguous()
 
+        if self.moe.moe_parallel_config.enable_eplb:
+            # after_eplb_rearrangement() assumes this backend's layout is
+            # EPLB-safe; verify that here instead of trusting callers.
+            assert self.supports_eplb, (
+                f"EPLB rearrangement not verified for NVFP4 backend "
+                f"{self.nvfp4_backend}"
+            )
+
         # Shuffle weights into the NvFp4 kernel format.
         (
             w13,
@@ -248,17 +251,9 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
             self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL
             and self.moe.moe_parallel_config.enable_eplb
         ):
-            # flashinfer's convert_sf_to_mma_layout returns a strided
-            # permuted view (shape (32, 4, m_t, 4, k_t, E)) of contiguous
-            # storage laid out as (E, m_t, k_t, 32, 4, 4). EPLB needs a
-            # per-expert leading-dim contiguous view to slice/move
-            # individual experts. The MMA view's permute is
-            # (3, 4, 1, 5, 2, 0); its inverse is (5, 2, 4, 0, 1, 3),
-            # which lands on the underlying (E, ...) contiguous layout
-            # while sharing storage. Register that as the Parameter and
-            # stash the MMA view on the layer as a plain tensor
-            # attribute for the kernel to consume via
-            # get_fused_moe_quant_config.
+            # Register the per-expert contiguous inverse-permute of the MMA
+            # view so EPLB can slice experts; stash the MMA view itself for
+            # the kernel (see get_fused_moe_quant_config).
             w13_scale_eplb_view = w13_scale.permute(5, 2, 4, 0, 1, 3)
             w2_scale_eplb_view = w2_scale.permute(5, 2, 4, 0, 1, 3)
             assert w13_scale_eplb_view.is_contiguous(), (
@@ -331,20 +326,8 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         )
 
     def after_eplb_rearrangement(self, layer: RoutedExperts) -> None:
-        if self.nvfp4_backend not in _EPLB_SUPPORTED_NVFP4_BACKENDS:
-            return
-        # EPLB moves the registered Parameters (w13_weight,
-        # w13_weight_scale, w13_weight_global_scale, w13_input_global_scale,
-        # and their w2 counterparts) per-expert. But the kernel-facing
-        # derived tensor layer.w13_weight_scale_2 holds the fused
-        # product (1 / w13_weight_global_scale) * w13_input_scale (see
-        # FlashInferCuteDSLExperts.process_weights_after_loading, which
-        # does the .mul_ in place). Its storage is independent of
-        # w13_weight_global_scale, so it doesn't get rearranged with the
-        # globals. Re-derive it in place so the kernel's captured
-        # references stay in sync. ``w13_input_scale`` is a max-broadcast
-        # scalar -- invariant under expert permutation, no refresh
-        # needed.
+        # w13/w2_weight_scale_2 are fused products derived from the
+        # globals EPLB just rearranged; re-derive them here to stay in sync.
         layer.w13_weight_scale_2.copy_(
             (1.0 / layer.w13_weight_global_scale[:, 0]) * layer.w13_input_scale
         )

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -816,12 +816,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         a1_scale = layer.w13_input_scale
         a2_scale = layer.w2_input_scale
         assert a1_scale is not None and a2_scale is not None
-        self.moe_quant_config._w1.alpha_or_gscale.copy_(
-            (w1_scale * a1_scale).squeeze()
-        )
-        self.moe_quant_config._w2.alpha_or_gscale.copy_(
-            (w2_scale * a2_scale).squeeze()
-        )
+        w1_alpha = self.moe_quant_config._w1.alpha_or_gscale
+        w2_alpha = self.moe_quant_config._w2.alpha_or_gscale
+        assert w1_alpha is not None and w2_alpha is not None
+        w1_alpha.copy_((w1_scale * a1_scale).squeeze())
+        w2_alpha.copy_((w2_scale * a2_scale).squeeze())
 
     def apply_monolithic(
         self,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -807,10 +807,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         return True
 
     def after_eplb_rearrangement(self, layer: RoutedExperts) -> None:
-        # Only the FLASHINFER_CUTLASS per-tensor path precomputes g1_alphas /
-        # g2_alphas as fused (w_scale * a_scale) products. EPLB rearranges the
-        # registered w_scale Parameters in-place; refresh the fused products so
-        # the kernel doesn't read stale pre-rearrangement values.
+        # Refresh the fused (w_scale * a_scale) products EPLB just made
+        # stale by rearranging the registered w_scale Parameters in-place.
         if self.moe_quant_config is None or self.moe_quant_config.g1_alphas is None:
             return
         w1_scale = getattr(layer, f"w13_{self.weight_scale_name}")

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -806,6 +806,25 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     def supports_eplb(self) -> bool:
         return True
 
+    def after_eplb_rearrangement(self, layer: RoutedExperts) -> None:
+        # Only the FLASHINFER_CUTLASS per-tensor path precomputes g1_alphas /
+        # g2_alphas as fused (w_scale * a_scale) products. EPLB rearranges the
+        # registered w_scale Parameters in-place; refresh the fused products so
+        # the kernel doesn't read stale pre-rearrangement values.
+        if self.moe_quant_config is None or self.moe_quant_config.g1_alphas is None:
+            return
+        w1_scale = getattr(layer, f"w13_{self.weight_scale_name}")
+        w2_scale = getattr(layer, f"w2_{self.weight_scale_name}")
+        a1_scale = layer.w13_input_scale
+        a2_scale = layer.w2_input_scale
+        assert a1_scale is not None and a2_scale is not None
+        self.moe_quant_config._w1.alpha_or_gscale.copy_(
+            (w1_scale * a1_scale).squeeze()
+        )
+        self.moe_quant_config._w2.alpha_or_gscale.copy_(
+            (w2_scale * a2_scale).squeeze()
+        )
+
     def apply_monolithic(
         self,
         layer: RoutedExperts,

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -925,17 +925,18 @@ class MixtureOfExperts(Protocol):
 
 
 def get_mixture_of_experts_model(model: object) -> MixtureOfExperts | None:
-    """
-    Given an arbitrary model,
-     - if the model itself is a MixtureOfExperts, return the model directly.
-     - if the model is a multi-modal model, and its `language_model` is a
-       MixtureOfExperts, return the `language_model`.
-     - if neither, return None.
+    """Return the MixtureOfExperts contained within an arbitrary model.
 
-    :param model: Model being served.
-    :type model: object
-    :return: Return MixtureOfExperts instance contained within the model.
-    :rtype: MixtureOfExperts | None
+    - If the model itself is a MixtureOfExperts, return the model directly.
+    - If the model is a multi-modal model, and its `language_model` is a
+      MixtureOfExperts, return the `language_model`.
+    - If neither, return None.
+
+    Args:
+        model: Model being served.
+
+    Returns:
+        The MixtureOfExperts instance contained within the model, or None.
     """
 
     if is_mixture_of_experts(model):

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -5,7 +5,6 @@ import asyncio
 from collections.abc import (
     AsyncGenerator,
     Callable,
-    Iterable,
     Mapping,
     MutableSequence,
     Sequence,

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -881,7 +881,7 @@ class MixtureOfExperts(Protocol):
     num_redundant_experts: int
     """Number of redundant experts in this model."""
 
-    moe_layers: Iterable["MoERunner"]
+    moe_layers: Sequence["MoERunner"]
     """List of MoE layers in this model."""
 
     def set_eplb_state(

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -924,6 +924,36 @@ class MixtureOfExperts(Protocol):
     ) -> None: ...
 
 
+def get_mixture_of_experts_model(model: object) -> MixtureOfExperts | None:
+    """
+    Given an arbitrary model,
+     - if the model itself is a MixtureOfExperts, return the model directly.
+     - if the model is a multi-modal model, and its `language_model` is a
+       MixtureOfExperts, return the `language_model`.
+     - if neither, return None.
+
+    :param model: Model being served.
+    :type model: object
+    :return: Return MixtureOfExperts instance contained within the model.
+    :rtype: MixtureOfExperts | None
+    """
+
+    if is_mixture_of_experts(model):
+        return model
+
+    if isinstance(model, SupportsMultiModal):
+        try:
+            mm_language_model = model.get_language_model()
+            return (
+                mm_language_model if is_mixture_of_experts(mm_language_model) else None
+            )
+        except (NotImplementedError, AttributeError):
+            logger.info_once("Cannot fetch language_model from MultiModal model")
+            return None
+
+    return None
+
+
 def is_mixture_of_experts(model: object) -> TypeIs[MixtureOfExperts]:
     return (
         isinstance(model, MixtureOfExperts) and getattr(model, "num_moe_layers", 0) > 0

--- a/vllm/v1/worker/gpu/eplb_utils.py
+++ b/vllm/v1/worker/gpu/eplb_utils.py
@@ -13,6 +13,7 @@ from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import (
     SupportsMultiModal,
+    get_mixture_of_experts_model,
     is_mixture_of_experts,
 )
 
@@ -78,7 +79,8 @@ class EPLBController:
             return False
 
         draft_model = speculator.model
-        if not is_mixture_of_experts(draft_model):
+        draft_moe_model = get_mixture_of_experts_model(draft_model)
+        if draft_moe_model is None:
             return False
 
         assert not self.parallel_config.enable_elastic_ep, (
@@ -88,7 +90,7 @@ class EPLBController:
         assert speculative_config.draft_model_config is not None
         assert self.state is not None
         self.state.add_model(
-            draft_model,
+            draft_moe_model,
             speculative_config.draft_model_config,
         )
         speculator.set_eplb_state(self.state)
@@ -104,13 +106,15 @@ class EPLBController:
         if not self.parallel_config.enable_eplb or load_dummy_weights:
             return False
 
-        model = _unwrap_moe(model)
-        if not is_mixture_of_experts(model):
+        moe_model = get_mixture_of_experts_model(model)
+        if moe_model is None:
             return False
 
-        logger.info_once("EPLB is enabled for model %s.", model_config.model)
+        logger.info_once(
+            "EPLB is enabled for MoE part of model %s.", model_config.model
+        )
         assert self.state is not None
-        self.state.add_model(model, model_config)
+        self.state.add_model(moe_model, model_config)
         self._has_registered_models = True
         return True
 
@@ -154,11 +158,11 @@ class EPLBController:
         expanded_physical_to_logical: torch.Tensor,
         old_num_physical_experts: int,
     ) -> None:
-        model = _unwrap_moe(model)
-        assert is_mixture_of_experts(model)
+        moe_model = get_mixture_of_experts_model(model)
+        assert moe_model is not None
 
         self.state = EplbState.from_mapping(
-            model=model,
+            model=moe_model,
             model_config=model_config,
             device=self.device,
             parallel_config=self.parallel_config,

--- a/vllm/v1/worker/gpu/eplb_utils.py
+++ b/vllm/v1/worker/gpu/eplb_utils.py
@@ -12,22 +12,10 @@ from vllm.config import ModelConfig
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import (
-    SupportsMultiModal,
     get_mixture_of_experts_model,
-    is_mixture_of_experts,
 )
 
 logger = init_logger(__name__)
-
-
-def _unwrap_moe(model: nn.Module) -> nn.Module:
-    # VLM wrappers (e.g. KimiK25ForConditionalGeneration) hold the MoE
-    # language model under `.language_model` but don't implement
-    # MixtureOfExperts themselves. Mirror the V1 path
-    # (see vllm/v1/worker/gpu_model_runner.py, PR #39805).
-    if not is_mixture_of_experts(model) and isinstance(model, SupportsMultiModal):
-        return model.get_language_model()
-    return model
 
 
 def step_eplb_after(*, is_dummy: bool = False) -> Callable:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5273,13 +5273,7 @@ class GPUModelRunner(
                 # VLM models (e.g. KimiK25ForConditionalGeneration) wrap the
                 # actual MoE language model but don't implement
                 # MixtureOfExperts themselves.
-                moe_candidate = self.model
-                if not is_mixture_of_experts(moe_candidate) and isinstance(
-                    moe_candidate, SupportsMultiModal
-                ):
-                    moe_candidate = moe_candidate.get_language_model()
-                if is_mixture_of_experts(moe_candidate):
-                    self._moe_model = moe_candidate
+                self._moe_model = get_mixture_of_experts_model(self.model)
 
                 if (
                     self.parallel_config.enable_eplb

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -79,7 +79,7 @@ from vllm.model_executor.models.interfaces import (
     SupportsMRoPE,
     SupportsMultiModal,
     SupportsXDRoPE,
-    is_mixture_of_experts,
+    get_mixture_of_experts_model,
     supports_eagle3,
     supports_mrope,
     supports_multimodal_pruning,
@@ -3351,10 +3351,12 @@ class GPUModelRunner(
         expanded_physical_to_logical: torch.Tensor,
         old_num_physical_experts: int,
     ) -> None:
-        assert self._moe_model is not None
+        model = self.get_model()
+        moe_model = get_mixture_of_experts_model(model)
+        assert moe_model is not None
 
         self.eplb_state = EplbState.from_mapping(
-            model=self._moe_model,
+            model=moe_model,
             model_config=self.model_config,
             device=self.device,
             parallel_config=self.parallel_config,
@@ -5234,9 +5236,14 @@ class GPUModelRunner(
                     if hasattr(self.drafter, "load_model"):
                         self.drafter.load_model(self.model)
                     if (
-                        hasattr(self.drafter, "model")
-                        and is_mixture_of_experts(self.drafter.model)
-                        and self.parallel_config.enable_eplb
+                        self.parallel_config.enable_eplb
+                        and hasattr(self.drafter, "model")
+                        and (
+                            drafter_moe_model := get_mixture_of_experts_model(
+                                self.drafter.model
+                            )
+                        )
+                        is not None
                     ):
                         assert not self.parallel_config.enable_elastic_ep, (
                             "Elastic EP is not supported with drafter model."
@@ -5245,7 +5252,7 @@ class GPUModelRunner(
                         assert spec_config is not None
                         assert spec_config.draft_model_config is not None
                         logger.info_once(
-                            "EPLB is enabled for drafter model %s.",
+                            "EPLB is enabled for MoE part of drafter model %s.",
                             spec_config.draft_model_config.model,
                         )
                         if self.eplb_state is None:
@@ -5253,7 +5260,7 @@ class GPUModelRunner(
                                 self.parallel_config, self.device
                             )
                         self.eplb_state.add_model(
-                            self.drafter.model,
+                            drafter_moe_model,
                             spec_config.draft_model_config,
                         )
                         assert hasattr(self.drafter, "set_eplb_state")
@@ -5275,17 +5282,18 @@ class GPUModelRunner(
                     self._moe_model = moe_candidate
 
                 if (
-                    self._moe_model is not None
-                    and self.parallel_config.enable_eplb
+                    self.parallel_config.enable_eplb
                     and not load_dummy_weights
+                    and (moe_model := get_mixture_of_experts_model(self.model))
+                    is not None
                 ):
                     logger.info_once(
-                        "EPLB is enabled for model %s.",
+                        "EPLB is enabled for MoE part of model %s.",
                         self.model_config.model,
                     )
                     assert self.eplb_state is not None
                     self.eplb_state.add_model(
-                        self._moe_model,
+                        moe_model,
                         self.model_config,
                     )
                     eplb_models += 1
@@ -5325,8 +5333,8 @@ class GPUModelRunner(
         )  # Temporary hack for dynamic res video w/o support for bs>1 yet
 
         if (
-            self._moe_model is not None
-            and self.parallel_config.enable_eplb
+            self.parallel_config.enable_eplb
+            and get_mixture_of_experts_model(self.model) is not None
             and not load_dummy_weights
             and self.eplb_state is not None
             and self.eplb_state.is_async


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Resubmission of https://github.com/vllm-project/vllm/pull/41941, with added changes for
the NVFP4 path, in collaboration with @varun-sundar-rabindranath.

Two commits rebased on `vllm-project/vllm` main, enabling EPLB (Expert Parallelism Load
Balancing) for `Mistral-Large-3-675B-Instruct-2512-NVFP4` running on FlashInfer CuteDSL
backends.

### Commit 1 — Bugfix: MoE model unwrapping for EPLB (from @varun-sundar-rabindranath)

**Files:** `interfaces.py`, `eplb_utils.py`, `gpu_model_runner.py`,
`flashinfer_cutlass_moe.py`

#### Problem

EPLB registration and the EPLB step/setup paths operated on the raw top-level model
object. For VLM-wrapped MoE models (e.g. a multimodal model whose `.language_model` is
the actual MoE), `is_mixture_of_experts` returns `False` on the wrapper, so EPLB was
silently skipped or incorrectly asserted.

The `FlashInferCutlassMoEMethod` also incorrectly returned `supports_eplb = False`
unconditionally, blocking EPLB before it even reached registration.

#### Changes

**`vllm/model_executor/models/interfaces.py`**

Added `get_mixture_of_experts_model(model) -> MixtureOfExperts | None`: a single helper
that returns the `MixtureOfExperts` instance buried in an arbitrary model object. It
handles:
- Plain MoE models (returns `model` directly).
- `SupportsMultiModal` wrappers (returns `model.get_language_model()` if that is a MoE).
- Everything else (returns `None`).

This supersedes the ad-hoc `_unwrap_moe` + `is_mixture_of_experts` two-step that existed
in `eplb_utils.py` and `gpu_model_runner.py`.

**`vllm/v1/worker/gpu/eplb_utils.py`**

Replaced `_unwrap_moe(model)` / `is_mixture_of_experts(model)` calls in
`EPLBController.maybe_register_model` and `EPLBController.setup_from_mapping` with
`get_mixture_of_experts_model(model)`. The speculator registration path received the same
fix: it now passes the resolved MoE sub-model to `EplbState.add_model` instead of the
raw draft model.

**`vllm/v1/worker/gpu_model_runner.py`**

Replaced the two-step unwrap pattern in the load-model path with
`get_mixture_of_experts_model`. The EPLB registration condition and the async-EPLB guard
now use the helper directly rather than relying on `self._moe_model` being set first.
The drafter load call gained a `hasattr` guard (`if hasattr(self.drafter, "load_model")`)
for safety.

**`vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py`**

`FlashInferCutlassMoEMethod.supports_eplb` changed from unconditional `False` to `True`
for the CuteDSL and CuteDSL-Batched backends (the two backends that this PR validates).

### Commit 2 — EPLB weight rearrangement for NVFP4 CuteDSL MoE (Julien Debache)

**Files:** `eplb_state.py`, `fused_moe_method_base.py`,
`compressed_tensors_moe_w4a4_nvfp4.py`

#### Problem

Even after `supports_eplb` was unblocked, two things broke EPLB at runtime for NVFP4:

1. **Weight-scale layout**: `flashinfer.convert_sf_to_mma_layout` returns a strided,
   permuted view of shape `(32, 4, m_t, 4, k_t, E)` over storage laid out as
   `(E, m_t, k_t, 32, 4, 4)`. EPLB slices and moves per-expert chunks, which requires an
   expert-leading contiguous view. The MMA view is non-contiguous in the expert dimension,
   so EPLB writes went to wrong memory locations.

2. **Stale fused scale**: `FlashInferCuteDSLExperts.process_weights_after_loading` fuses
   `(1 / w_global_scale) * input_scale` into `layer.w13_weight_scale_2` (its own
   contiguous storage, not a view of the rearranged parameter). After EPLB reorders
   `w13_weight_global_scale`, the fused derivative becomes stale and the kernel reads the
   wrong per-expert scale.

#### Changes

**`vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py`**

- For the `FLASHINFER_CUTEDSL` backend: instead of registering the MMA-permuted scale
  view as the `Parameter`, register an E-leading contiguous view obtained via the inverse
  permute `(5, 2, 4, 0, 1, 3)`. The MMA view is stored as a plain tensor attribute
  (`layer.w13_weight_scale_mma`) for the kernel to consume through
  `get_fused_moe_quant_config`. Both views alias the same storage, so EPLB P2P writes to
  the registered `Parameter` are immediately visible to the kernel.
- For `FLASHINFER_CUTEDSL_BATCHED`: no permute trick needed — `swizzle_blockscale`
  already produces E-leading contiguous output.
- `supports_eplb` is now `True` only for these two backends. Other NVFP4 backends
  (TRTLLM, Marlin) have post-process layouts that still need auditing before they can opt
  in.
- Implements `after_eplb_rearrangement` to re-derive `w13_weight_scale_2` in-place
  via `.copy_()` after each rearrangement, keeping the fused product consistent with the
  new expert ordering. `input_scale` is a max-broadcast scalar invariant under
  permutation and does not need refreshing.

**`vllm/model_executor/layers/fused_moe/fused_moe_method_base.py`**

Added `after_eplb_rearrangement(self, layer)` hook to `FusedMoEMethodBase` with a no-op
default. Quant methods that maintain derived tensors (fused scales, repacked weights, etc.)
override this to refresh them after EPLB reorders experts.

**`vllm/distributed/eplb/eplb_state.py`**

`EplbState` now calls `method.after_eplb_rearrangement(layer)` after completing each
expert rearrangement, giving registered quant methods the opportunity to refresh stale
derived state.

## Test Plan

Validated end-to-end with `Mistral-Large-3-675B-Instruct-2512-NVFP4` on GB200, driving
EPLB (async, 8 redundant experts) on the FlashInfer CuteDSL backend paired with the
`deepep_high_throughput` all2all backend. A throughput benchmark and an MMLU-Pro accuracy
eval are run against the same live server.

<details>
<summary>Reproduction on GB200</summary>

The `Dockerfile` below allows overriding the vLLM installation of a nightly container with
the revision from this branch. It also installs DeepEP to have an efficient communication
backend to pair with CuteDSL (needs batched activation format).

```Dockerfile
ARG VLLM_IMAGE=vllm/vllm-openai:latest
FROM ${VLLM_IMAGE}

ARG VLLM_REPO
ARG VLLM_REVISION
ARG DEEPEP_REPO=https://github.com/deepseek-ai/DeepEP.git
ARG DEEPEP_REVISION
ARG TORCH_CUDA_ARCH_LIST=10.0+PTX

# Install git and the CUDA NVRTC dev headers needed to build DeepEP.
RUN apt-get update && \
    CUDA_VER=$(nvcc --version | grep -oE '[0-9]+\.[0-9]+' | tail -1 | tr '.' '-') && \
    apt-get install -y --no-install-recommends git cuda-nvrtc-dev-${CUDA_VER} libcusparse-dev-${CUDA_VER} libcusolver-dev-${CUDA_VER} cuda-driver-dev-${CUDA_VER} libcublas-dev-${CUDA_VER} && \
    rm -rf /var/lib/apt/lists/*

# Override vLLM Python source with the fork.
RUN git clone ${VLLM_REPO} /opt/vllm-src && \
    cd /opt/vllm-src && \
    git checkout ${VLLM_REVISION} && \
    git submodule update --init --recursive && \
    VLLM_USE_PRECOMPILED=1 pip install --no-deps .

# DeepEP runtime dependencies.
RUN pip install nvidia-nvshmem-cu13 nvidia-cuda-cccl && \
    pip install --no-deps --upgrade "nvidia-nccl-cu13>=2.30.4"

# DeepEP kernel build.
ENV TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}
RUN git clone ${DEEPEP_REPO} /opt/deepep && \
    cd /opt/deepep && \
    git checkout ${DEEPEP_REVISION} && \
    CCCL_INCLUDE=$(pip show nvidia-cuda-cccl | awk '/^Location:/{print $2}')/nvidia/cuda_cccl/include && \
    NVSHMEM_LIB=$(pip show nvidia-nvshmem-cu13 | awk '/^Location:/{print $2}')/nvidia/nvshmem/lib && \
    (cd "$NVSHMEM_LIB" && ln -sfn "$(ls libnvshmem_host.so.[0-9]* | head -1)" libnvshmem_host.so) && \
    CPATH="$CCCL_INCLUDE${CPATH:+:$CPATH}" \
    LIBRARY_PATH="/usr/local/cuda/lib64/stubs${LIBRARY_PATH:+:$LIBRARY_PATH}" \
    python3 setup.py install

ARG NEMO_EVALUATOR_REPO=https://github.com/NVIDIA-NeMo/evaluator.git
ARG NEMO_EVALUATOR_REVISION=main

# nemo-evaluator from source.
RUN git clone ${NEMO_EVALUATOR_REPO} /opt/nemo-evaluator && \
    cd /opt/nemo-evaluator && \
    git checkout ${NEMO_EVALUATOR_REVISION} && \
    pip install -e ".[all]"

```

Below, a one-click script to download the model, build the container, run a benchmark and eval:

```run.sh
#!/bin/bash
set -euo pipefail

VLLM_BASE_IMAGE="vllm/vllm-openai@sha256:df5f8edb3866c85ba7d7db427a07a6379839654951185c65528dfb0bc458ea24"
VLLM_REPO="https://github.com/jdebache/vllm.git"
VLLM_REVISION="29889693aad663c23d2da431114958b7d7fa2787"
DEEPEP_REVISION="d4f41e4e93"
IMAGE="vllm-deepep:${DEEPEP_REVISION}"

VLLM_CACHE_DIR="/tmp/vllm-cache"
FLASHINFER_CACHE_DIR="/tmp/flashinfer-cache"
AUTOTUNE_CACHE_DIR="/tmp/flashinfer-autotune-cache"
RESULTS_DIR="/tmp/results"
MODEL_URL="mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4"
MODEL_DIR="/raid/${MODEL_URL##*/}"

FRONTEND_PORT=8000
DP_RPC_PORT=13345
SERVER_CONTAINER="vllm-server-$$"

mkdir -p "$RESULTS_DIR"
mkdir -p "$VLLM_CACHE_DIR"
mkdir -p "$FLASHINFER_CACHE_DIR"
mkdir -p "$AUTOTUNE_CACHE_DIR"

# Build
echo "Building image $IMAGE..."
docker build \
    --build-arg VLLM_IMAGE="$VLLM_BASE_IMAGE" \
    --build-arg VLLM_REPO="$VLLM_REPO" \
    --build-arg VLLM_REVISION="$VLLM_REVISION" \
    --build-arg DEEPEP_REVISION="$DEEPEP_REVISION" \
    -t "$IMAGE" \
    -f Dockerfile \
    .

# Pre-stage model weights on fast local storage. hf download is resumable and
# idempotent, so we always run it: it only fetches missing/incomplete files.
echo "Downloading ${MODEL_URL} to ${MODEL_DIR}..."
docker run --rm -v /raid:/raid alpine mkdir -p "$MODEL_DIR"
docker run --rm \
    ${HF_TOKEN:+-e HF_TOKEN} \
    -v "/raid:/raid" \
    --entrypoint hf \
    "$IMAGE" download "${MODEL_URL}" --local-dir "${MODEL_DIR}"

WORKER_IP=$(hostname -I | awk '{print $1}')
WORKER_IFACE=$(ip -4 -o addr show | awk -v ip="$WORKER_IP" '$4 ~ "^"ip"/" {print $2; exit}')

# Serve
VLLM_CMD="vllm serve ${MODEL_DIR} \
  --host 0.0.0.0 --port ${FRONTEND_PORT} \
  --data-parallel-size 4 --data-parallel-size-local 4 \
  --data-parallel-rpc-port ${DP_RPC_PORT} \
  --data-parallel-address $(hostname) \
  --enable-expert-parallel \
  --all2all-backend deepep_high_throughput \
  --moe-backend flashinfer_cutedsl \
  --enable-eplb \
  --eplb-config.num_redundant_experts 8 \
  --eplb-config.use_async true \
  --eplb-config.log_balancedness true \
  --eplb-config.log_balancedness_interval 500 \
  --kv-cache-dtype fp8 \
  --max-num-batched-tokens 16384 --block-size 64 \
  --gpu-memory-utilization 0.9 --max-num-seqs 64 \
  --no-enable-log-requests --no-enable-prefix-caching \
  --load-format mistral --config-format mistral --tokenizer-mode mistral \
  --limit-mm-per-prompt '{\"image\":0}' \
  --tool-call-parser mistral --enable-auto-tool-choice"

echo "Starting vLLM server..."
docker run --rm \
    --name "$SERVER_CONTAINER" \
    --gpus all --network host --ipc host \
    -e VLLM_WORKER_MULTIPROC_METHOD=spawn \
    -e VLLM_HOST_IP="$WORKER_IP" \
    -e FLASHINFER_DISABLE_VERSION_CHECK=1 \
    -e NVIDIA_VISIBLE_DEVICES=all \
    -e VLLM_USE_FLASHINFER_MOE_FP4=1 \
    -e NVSHMEM_BOOTSTRAP_UID_SOCK_IFNAME="$WORKER_IFACE" \
    -e GLOO_SOCKET_IFNAME="$WORKER_IFACE" \
    -e NCCL_SOCKET_IFNAME="$WORKER_IFACE" \
    -e NCCL_CUMEM_ENABLE=1 \
    -e NCCL_MNNVL_ENABLE=1 \
    -e NCCL_NVLS_ENABLE=1 \
    -e VLLM_USE_NCCL_SYMM_MEM=1 \
    -e VLLM_RANDOMIZE_DP_DUMMY_INPUTS=1 \
    -e VLLM_ENGINE_READY_TIMEOUT_S=7200 \
    -e VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR="${AUTOTUNE_CACHE_DIR}" \
    ${HF_TOKEN:+-e HF_TOKEN} \
    -v "${RESULTS_DIR}:/results" \
    -v "${VLLM_CACHE_DIR}:/root/.cache/vllm" \
    -v "${FLASHINFER_CACHE_DIR}:/root/.cache/flashinfer" \
    -v "${AUTOTUNE_CACHE_DIR}:${AUTOTUNE_CACHE_DIR}" \
    -v "${MODEL_DIR}:${MODEL_DIR}" \
    --entrypoint /bin/bash \
    "$IMAGE" -c "$VLLM_CMD" > >(tee "${RESULTS_DIR}/server.log") 2>&1 &

SERVER_PID=$!
trap "docker stop $SERVER_CONTAINER 2>/dev/null || true; wait $SERVER_PID || true" EXIT

echo "Waiting for server to be ready..."
until curl -sf "http://localhost:${FRONTEND_PORT}/health"; do
    kill -0 $SERVER_PID 2>/dev/null || { echo "Server container exited early"; exit 1; }
    sleep 5
done
echo "Server ready."

# Benchmark
BENCH_CMD="vllm bench serve \
  --model ${MODEL_DIR} \
  --host localhost --port ${FRONTEND_PORT} \
  --dataset-name random \
  --random-input-len 2048 --random-output-len 256 \
  --num-prompts 1000 --max-concurrency 64 --num-warmups 128 \
  --ignore-eos --save-result \
  --result-filename /results/bench_isl2048_osl256_conc256.json \
  --ready-check-timeout-sec 300 \
  --tokenizer-mode mistral --trust-remote-code"

echo "Benchmarking (ISL=2048, OSL=256, concurrency=64)..."
docker run --rm \
    --network host \
    -v "${RESULTS_DIR}:/results" \
    -v "${MODEL_DIR}:${MODEL_DIR}" \
    --entrypoint /bin/bash \
    "$IMAGE" -c "$BENCH_CMD"

# Evaluate (small gsm8k accuracy smoke-test against the same running server)
EVAL_MAX_PROBLEMS=20
EVAL_CMD="nel eval run --bench gsm8k \
  --model-url http://localhost:${FRONTEND_PORT}/v1 \
  --model-id ${MODEL_DIR} \
  --api-key EMPTY \
  --max-problems ${EVAL_MAX_PROBLEMS} \
  --output-dir /results/eval_gsm8k"

# Evaluate (MMLU-Pro accuracy check against the same running server)
EVAL_MAX_PROBLEMS=200
EVAL_CMD="nel eval run --bench mmlu_pro \
  --model-url http://localhost:${FRONTEND_PORT}/v1 \
  --model-id ${MODEL_DIR} \
  --api-key EMPTY \
  --system-prompt 'Your final line must be exactly: Answer: X  where X is a single capital letter A-J. Do not use markdown, bold, asterisks, quotes, or any extra text on that line.' \
  --max-problems ${EVAL_MAX_PROBLEMS} \
  --output-dir /results/eval_mmlu_pro"

echo "Evaluating (mmlu_pro, ${EVAL_MAX_PROBLEMS} problems)..."
docker run --rm \
    --network host \
    -v "${RESULTS_DIR}:/results" \
    ${HF_TOKEN:+-e HF_TOKEN} \
    --entrypoint /bin/bash \
    "$IMAGE" -c "$EVAL_CMD"

echo "Done. Results in $RESULTS_DIR"

```

In the directory with both the `Dockerfile` and `run.sh` script, test out these changes with:
```
chmod +x run.sh
HF_TOKEN=XXXX ./run.sh
```

</details>

## Test Result

End-to-end run on GB200 with EPLB enabled (async, 8 redundant experts) on the FlashInfer
CuteDSL backend: the throughput benchmark and the MMLU-Pro accuracy eval both pass, with
no accuracy regression relative to the non-EPLB baseline. EPLB balancedness logging
confirms experts are being rearranged at runtime.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
