### PR TITLE
[Bugfix][CPU] Avoid embedding padded runner token ids

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -887,6 +887,40 @@ def test_apply_sparse_weight_patches_updates_only_selected_entries():
     assert torch.equal(runner.get_model().weight.data, expected)
 
 
+def test_preprocess_clears_padded_input_ids_before_embedding(monkeypatch):
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True),
+    )
+    runner = object.__new__(GPUModelRunner)
+    runner.model_config = SimpleNamespace(is_encoder_decoder=False)
+    runner.supports_mm_inputs = False
+    runner.enable_prompt_embeds = False
+    runner.uses_mrope = False
+    runner.uses_xdrope_dim = 0
+    runner.is_pooling_model = False
+    runner.input_ids = SimpleNamespace(
+        gpu=torch.tensor([10, 11, 92544, 92545], dtype=torch.int32)
+    )
+    runner.positions = torch.empty(4, dtype=torch.int64)
+    scheduler_output = SimpleNamespace(
+        total_num_scheduled_tokens=2,
+        scheduled_encoder_inputs={},
+    )
+
+    embedding = torch.nn.Embedding(92544, 1)
+    with pytest.raises(IndexError):
+        embedding(runner.input_ids.gpu.long())
+
+    input_ids, *_ = GPUModelRunner._preprocess(
+        runner, scheduler_output, num_input_tokens=4
+    )
+
+    assert input_ids.tolist() == [10, 11, 0, 0]
+    embedding(input_ids.long())
+
+
 def test_apply_sparse_weight_patches_rejects_mismatched_lengths():
     class DummyModel(nn.Module):
         def __init__(self):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3436,6 +3436,16 @@ class GPUModelRunner(
         inputs_embeds = self.inputs_embeds.gpu[:num_tokens]
         return input_ids, inputs_embeds
 
+    def _clear_padded_input_ids(
+        self,
+        num_scheduled_tokens: int,
+        num_input_tokens: int,
+    ) -> None:
+        # Padded slots are not real scheduled tokens, but some forward paths
+        # still slice input_ids to the padded size. Keep those ids embed-safe.
+        if num_input_tokens > num_scheduled_tokens:
+            self.input_ids.gpu[num_scheduled_tokens:num_input_tokens].zero_()
+
     def _preprocess(
         self,
         scheduler_output: "SchedulerOutput",
@@ -3540,6 +3550,7 @@ class GPUModelRunner(
             # While it is possible to use embeddings as input just like the
             # multimodal models, it is not desirable for performance since
             # then the embedding layer is not included in the CUDA graph.
+            self._clear_padded_input_ids(num_scheduled_tokens, num_input_tokens)
             input_ids = self.input_ids.gpu[:num_input_tokens]
             inputs_embeds = None
             model_kwargs = self._init_model_kwargs()


### PR DESCRIPTION
## Purpose

Fixes #46470.

The v1 model runner can execute a text-only forward pass with `num_input_tokens` padded beyond the number of scheduled tokens. Those padded slots are not real tokens, but the text-only path still slices `input_ids` to the padded size before model execution. If a padded slot contains an out-of-range token id, models with compact embedding tables can fail in `F.embedding` with `IndexError`.

This PR clears padded text-path `input_ids` to token id `0` before those padded ids can reach the model. The scheduled token ids are unchanged. `CPUModelRunner` in `vllm/v1/worker/cpu_model_runner.py` subclasses the v1 `GPUModelRunner` and does not override `_preprocess`, so the same path is used by the CPU runner without adding model-specific InternLM2 handling.

## Duplicate-work check

I searched open PRs for #46470 and for the InternLM2 CPU embedding failure wording and did not find an existing PR for this issue.

## Test Plan

```bash
python -m py_compile vllm/v1/worker/gpu_model_runner.py tests/v1/worker/test_gpu_model_runner.py
uvx ruff check vllm/v1/worker/gpu_model_runner.py tests/v1/worker/test_gpu_model_runner.py
git diff --check
uv run --no-project --python /home/foadad/micromamba/envs/foad/bin/python python -m pytest tests/v1/worker/test_gpu_model_runner.py::test_preprocess_clears_padded_input_ids_before_embedding -q
```

## Test Result

```text
ruff: All checks passed
pytest: 1 passed
```

Not tested: full InternLM2 CPU `lm_eval` reproduction from the issue.

AI assistance was used to inspect the issue, identify the padded-token path, draft the patch/test, and review the PR text. I reviewed the changed lines and validation output.
