### PR TITLE
[KVConnector] Add UcclP2pConnector for disaggregated prefill over UCCL P2P

### DIFF
--- a/analyze_uccl_p2p_logs.py
+++ b/analyze_uccl_p2p_logs.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Parse VLLM_UCCL_P2P_TIMING=1 logs and print micro-benchmark summary."""
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+
+TIMING_RE = re.compile(
+    r"\[uccl_p2p(?:_worker|_wrapper)?_timing\]\s+([^:]+):\s+([\d.]+)\s*us"
+)
+
+
+def percentile(sorted_vals, p):
+    n = len(sorted_vals)
+    idx = int(n * p)
+    idx = min(idx, n - 1)
+    return sorted_vals[idx]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Summarize UCCL P2P timing logs")
+    parser.add_argument("log_files", nargs="+", help="log files to parse")
+    parser.add_argument("--top", "-n", type=int, default=30)
+    args = parser.parse_args()
+
+    values = defaultdict(list)
+    for path in args.log_files:
+        try:
+            with open(path) as f:
+                for line in f:
+                    m = TIMING_RE.search(line)
+                    if m:
+                        values[m.group(1).strip()].append(float(m.group(2)))
+        except FileNotFoundError:
+            print(f"File not found: {path}", file=sys.stderr)
+            sys.exit(1)
+
+    if not values:
+        print("No [uccl_p2p_timing] lines found.")
+        return
+
+    rows = []
+    for label, vals in values.items():
+        s = sorted(vals)
+        n = len(vals)
+        p50 = percentile(s, 0.50)
+        p99 = percentile(s, 0.99)
+        mean = sum(vals) / n
+        rows.append((label, n, p50, p99, max(vals), mean))
+
+    # Sort by total estimated time (count * mean)
+    rows.sort(key=lambda x: x[1] * x[5], reverse=True)
+
+    print("| label | count | p50 (us) | p99 (us) | max (us) | mean (us) |")
+    print("|---|---:|---:|---:|---:|---:|")
+    for label, n, p50, p99, mx, mean in rows[: args.top]:
+        print(f"| {label} | {n} | {p50:.1f} | {p99:.1f} | {mx:.1f} | {mean:.1f} |")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -3,4 +3,6 @@ lmcache >= 0.3.9
 # until a fixed newer release is verified for runtime images.
 cupy-cuda13x < 14.1.0
 nixl >= 1.1.0 # Required for disaggregated prefill
+# Required for disaggregated prefill with UCCL P2P
+uccl-p2p >= 0.1.0
 mooncake-transfer-engine >= 0.3.8

--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -4,5 +4,6 @@ lmcache >= 0.3.9
 cupy-cuda13x < 14.1.0
 nixl >= 1.1.0 # Required for disaggregated prefill
 # Required for disaggregated prefill with UCCL P2P
-uccl-p2p >= 0.1.0
+# https://github.com/uccl-project/uccl/tree/main/p2p
+uccl >= 0.1.1
 mooncake-transfer-engine >= 0.3.8

--- a/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Connector selection (default: NixlConnector)
+CONNECTOR_NAME=${CONNECTOR_NAME:-NixlConnector}
+
 # Utility to run integration tests sequentially with varying TP configurations.
 SCRIPT="v1/kv_connector/nixl_integration/run_accuracy_test.sh"
 IMPORT_CANARY="v1/kv_connector/nixl_integration/test_nixl_imports.py"
 
-echo "=== Running NIXL import canary ==="
+echo "=== Running ${CONNECTOR_NAME} import canary ==="
 python3 -m pytest -s -x "${IMPORT_CANARY}"
 
 # Define test configurations

--- a/tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -xe
 
+# Connector selection (default: NixlConnector)
+CONNECTOR_NAME=${CONNECTOR_NAME:-NixlConnector}
+SIDE_CHANNEL_PREFIX=${SIDE_CHANNEL_PREFIX:-NIXL}
+
+# UCX is only needed by NIXL connector
+UCX_ENV=""
+if [[ "$CONNECTOR_NAME" == *"Nixl"* ]]; then
+    UCX_ENV="UCX_NET_DEVICES=all"
+fi
+
 # Parse command line arguments
 KV_BUFFER_DEVICE="cuda"  # Default to cuda
 ATTENTION_BACKEND=""  # Default to empty (use vllm default)
@@ -51,11 +61,11 @@ fi
 
 # Build the kv-transfer-config for P and D
 if [[ "$KV_BUFFER_DEVICE" == "cuda" ]]; then
-  KV_CONFIG_P='{"kv_connector":"NixlConnector","kv_role":"kv_producer"'${KV_CONFIG_HETERO_LAYOUT}${KV_EXTRA_CONFIG}'}'
-  KV_CONFIG_D='{"kv_connector":"NixlConnector","kv_role":"kv_consumer"'${KV_CONFIG_HETERO_LAYOUT}${KV_EXTRA_CONFIG}'}'
+  KV_CONFIG_P='{"kv_connector":"'"${CONNECTOR_NAME}"'","kv_role":"kv_producer"'${KV_CONFIG_HETERO_LAYOUT}${KV_EXTRA_CONFIG}'}'
+  KV_CONFIG_D='{"kv_connector":"'"${CONNECTOR_NAME}"'","kv_role":"kv_consumer"'${KV_CONFIG_HETERO_LAYOUT}${KV_EXTRA_CONFIG}'}'
 else
-  KV_CONFIG_P="{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\",\"kv_buffer_device\":\"$KV_BUFFER_DEVICE\""${KV_CONFIG_HETERO_LAYOUT}${KV_EXTRA_CONFIG}"}"
-  KV_CONFIG_D="{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\",\"kv_buffer_device\":\"$KV_BUFFER_DEVICE\""${KV_CONFIG_HETERO_LAYOUT}${KV_EXTRA_CONFIG}"}"
+  KV_CONFIG_P="{\"kv_connector\":\"${CONNECTOR_NAME}\",\"kv_role\":\"kv_producer\",\"kv_buffer_device\":\"$KV_BUFFER_DEVICE\""${KV_CONFIG_HETERO_LAYOUT}${KV_EXTRA_CONFIG}"}"
+  KV_CONFIG_D="{\"kv_connector\":\"${CONNECTOR_NAME}\",\"kv_role\":\"kv_consumer\",\"kv_buffer_device\":\"$KV_BUFFER_DEVICE\""${KV_CONFIG_HETERO_LAYOUT}${KV_EXTRA_CONFIG}"}"
 fi
 
 # Models to run
@@ -153,8 +163,8 @@ run_tests_for_model() {
     # Build the command with or without model-specific args
     BASE_CMD="CUDA_VISIBLE_DEVICES=$GPU_ID \
     VLLM_KV_CACHE_LAYOUT='HND' \
-    UCX_NET_DEVICES=all \
-    VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
+    $UCX_ENV \
+    VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
     vllm serve $model_name \
     --port $PORT \
     --enforce-eager \
@@ -202,8 +212,8 @@ run_tests_for_model() {
     # Build the command with or without model-specific args
     BASE_CMD="CUDA_VISIBLE_DEVICES=$GPU_ID \
     VLLM_KV_CACHE_LAYOUT=$DECODER_KV_LAYOUT \
-    UCX_NET_DEVICES=all \
-    VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
+    $UCX_ENV \
+    VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
     vllm serve $model_name \
     --port $PORT \
     --enforce-eager \

--- a/tests/v1/kv_connector/nixl_integration/run_edge_case_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_edge_case_test.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -xe
 
+# Connector selection (default: NixlConnector)
+CONNECTOR_NAME=${CONNECTOR_NAME:-NixlConnector}
+SIDE_CHANNEL_PREFIX=${SIDE_CHANNEL_PREFIX:-NIXL}
+
+# UCX is only needed by NIXL connector
+UCX_ENV=""
+if [[ "$CONNECTOR_NAME" == *"Nixl"* ]]; then
+    UCX_ENV="UCX_NET_DEVICES=all"
+fi
+
 # Parse command line arguments
 KV_BUFFER_DEVICE="cuda"  # Default to cuda
 PREFILL_GPU_ID=4         # Default GPU IDs
@@ -23,9 +33,9 @@ echo "Running edge case tests with kv_buffer_device=$KV_BUFFER_DEVICE (GPUs: $PR
 
 # Build the kv-transfer-config once
 if [[ "$KV_BUFFER_DEVICE" == "cuda" ]]; then
-  KV_CONFIG='{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+  KV_CONFIG='{"kv_connector":"'"${CONNECTOR_NAME}"'","kv_role":"kv_both"}'
 else
-  KV_CONFIG="{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"$KV_BUFFER_DEVICE\"}"
+  KV_CONFIG="{\"kv_connector\":\"${CONNECTOR_NAME}\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"$KV_BUFFER_DEVICE\"}"
 fi
 
 # Models to run
@@ -66,7 +76,10 @@ run_tests_for_model() {
   # Start prefill instance
   PREFILL_PORT=8001
 
-  BASE_CMD="CUDA_VISIBLE_DEVICES=$PREFILL_GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=5559 vllm serve $model_name \
+  BASE_CMD="CUDA_VISIBLE_DEVICES=$PREFILL_GPU_ID \
+  $UCX_ENV \
+  VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=5559 \
+  vllm serve $model_name \
   --port $PREFILL_PORT \
   --enforce-eager \
   --gpu-memory-utilization 0.2 \
@@ -80,7 +93,10 @@ run_tests_for_model() {
   DECODE_PORT=8002
 
   # Build the command with or without model-specific args
-  BASE_CMD="CUDA_VISIBLE_DEVICES=$DECODE_GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=6000 vllm serve $model_name \
+  BASE_CMD="CUDA_VISIBLE_DEVICES=$DECODE_GPU_ID \
+  $UCX_ENV \
+  VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=6000 \
+  vllm serve $model_name \
   --port $DECODE_PORT \
   --enforce-eager \
   --gpu-memory-utilization 0.2 \

--- a/tests/v1/kv_connector/nixl_integration/run_mamba_prefix_cache_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_mamba_prefix_cache_test.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -xe
 
+# Connector selection (default: NixlConnector)
+CONNECTOR_NAME=${CONNECTOR_NAME:-NixlConnector}
+SIDE_CHANNEL_PREFIX=${SIDE_CHANNEL_PREFIX:-NIXL}
+
 # E2E test: Mamba hybrid prefix cache hits in PD disaggregation.
 # Spins up a 1P1D setup with a Mamba hybrid model and verifies
 # repeated prompts yield non-zero D-side prefix cache hits.
@@ -12,7 +16,7 @@ GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION:-0.8}
 
 echo "Running Mamba prefix cache test (GPUs: P=$PREFILL_GPU_ID, D=$DECODE_GPU_ID, model=$MODEL)"
 
-KV_CONFIG='{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+KV_CONFIG='{"kv_connector":"'"${CONNECTOR_NAME}"'","kv_role":"kv_both"}'
 
 # Resolve repository root
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
@@ -41,7 +45,7 @@ PREFILL_PORT=8001
 CUDA_VISIBLE_DEVICES=$PREFILL_GPU_ID \
 VLLM_SSM_CONV_STATE_LAYOUT=DS \
 VLLM_KV_CACHE_LAYOUT=HND \
-VLLM_NIXL_SIDE_CHANNEL_PORT=5559 \
+VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=5559 \
 vllm serve $MODEL \
   --port $PREFILL_PORT \
   --enforce-eager \
@@ -58,7 +62,7 @@ DECODE_PORT=8002
 CUDA_VISIBLE_DEVICES=$DECODE_GPU_ID \
 VLLM_SSM_CONV_STATE_LAYOUT=DS \
 VLLM_KV_CACHE_LAYOUT=HND \
-VLLM_NIXL_SIDE_CHANNEL_PORT=6000 \
+VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=6000 \
 vllm serve $MODEL \
   --port $DECODE_PORT \
   --enforce-eager \

--- a/tests/v1/kv_connector/nixl_integration/run_multi_connector_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_multi_connector_accuracy_test.sh
@@ -23,6 +23,16 @@
 #   SKIP_NORMAL_LAYOUT       - set to 1 to skip the normal layout test
 set -xe
 
+# Connector selection (default: NixlConnector)
+CONNECTOR_NAME=${CONNECTOR_NAME:-NixlConnector}
+SIDE_CHANNEL_PREFIX=${SIDE_CHANNEL_PREFIX:-NIXL}
+
+# UCX is only needed by NIXL connector
+UCX_ENV=""
+if [[ "$CONNECTOR_NAME" == *"Nixl"* ]]; then
+    UCX_ENV="UCX_NET_DEVICES=all"
+fi
+
 # ── Configuration ────────────────────────────────────────────────────────
 
 MODEL_NAMES=${MODEL_NAMES:-}
@@ -48,7 +58,7 @@ KV_CONFIG_NORMAL='{
   "kv_role":"kv_both",
   "kv_connector_extra_config":{
     "connectors":[
-      {"kv_connector":"NixlConnector","kv_role":"kv_both"},
+      {"kv_connector":"'"${CONNECTOR_NAME}"'","kv_role":"kv_both"},
       {"kv_connector":"OffloadingConnector","kv_role":"kv_both",
        "kv_connector_extra_config":{"cpu_bytes_to_use":1000000000}}
     ]
@@ -63,7 +73,7 @@ KV_CONFIG_CROSS_LAYERS='{
   "kv_role":"kv_both",
   "kv_connector_extra_config":{
     "connectors":[
-      {"kv_connector":"NixlConnector","kv_role":"kv_both",
+      {"kv_connector":"'"${CONNECTOR_NAME}"'","kv_role":"kv_both",
        "kv_connector_extra_config":{"enable_cross_layers_blocks":"True"}},
       {"kv_connector":"OffloadingConnector","kv_role":"kv_both",
        "kv_connector_extra_config":{"cpu_bytes_to_use":1000000000}}
@@ -123,8 +133,8 @@ run_tests_for_model() {
   echo "Starting prefill instance on GPU $PREFILL_GPU, port $PREFILL_PORT"
   BASE_CMD="CUDA_VISIBLE_DEVICES=$PREFILL_GPU \
     VLLM_KV_CACHE_LAYOUT='HND' \
-    UCX_NET_DEVICES=all \
-    VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_SIDE_CHANNEL_PORT \
+    $UCX_ENV \
+    VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=$PREFILL_SIDE_CHANNEL_PORT \
     vllm serve $model_name \
     --port $PREFILL_PORT \
     --enforce-eager \
@@ -145,8 +155,8 @@ run_tests_for_model() {
   echo "Starting decode instance on GPU $DECODE_GPU, port $DECODE_PORT"
   BASE_CMD="CUDA_VISIBLE_DEVICES=$DECODE_GPU \
     VLLM_KV_CACHE_LAYOUT='HND' \
-    UCX_NET_DEVICES=all \
-    VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_SIDE_CHANNEL_PORT \
+    $UCX_ENV \
+    VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=$DECODE_SIDE_CHANNEL_PORT \
     vllm serve $model_name \
     --port $DECODE_PORT \
     --enforce-eager \

--- a/tests/v1/kv_connector/nixl_integration/run_multi_connector_edge_case_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_multi_connector_edge_case_test.sh
@@ -22,6 +22,16 @@
 #   VLLM_SERVE_EXTRA_ARGS    - comma-separated extra args for vllm serve
 set -xe
 
+# Connector selection (default: NixlConnector)
+CONNECTOR_NAME=${CONNECTOR_NAME:-NixlConnector}
+SIDE_CHANNEL_PREFIX=${SIDE_CHANNEL_PREFIX:-NIXL}
+
+# UCX is only needed by NIXL connector
+UCX_ENV=""
+if [[ "$CONNECTOR_NAME" == *"Nixl"* ]]; then
+    UCX_ENV="UCX_NET_DEVICES=all"
+fi
+
 # ── Configuration ────────────────────────────────────────────────────────
 
 MODEL_NAMES=${MODEL_NAMES:-}
@@ -45,7 +55,7 @@ KV_CONFIG='{
   "kv_role":"kv_both",
   "kv_connector_extra_config":{
     "connectors":[
-      {"kv_connector":"NixlConnector","kv_role":"kv_both"},
+      {"kv_connector":"'"${CONNECTOR_NAME}"'","kv_role":"kv_both"},
       {"kv_connector":"OffloadingConnector","kv_role":"kv_both",
        "kv_connector_extra_config":{"cpu_bytes_to_use":2147483648}}
     ]
@@ -93,8 +103,8 @@ run_tests_for_model() {
   echo "Starting prefill instance on GPU $PREFILL_GPU, port $PREFILL_PORT"
   BASE_CMD="CUDA_VISIBLE_DEVICES=$PREFILL_GPU \
     VLLM_KV_CACHE_LAYOUT='HND' \
-    UCX_NET_DEVICES=all \
-    VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_SIDE_CHANNEL_PORT \
+    $UCX_ENV \
+    VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=$PREFILL_SIDE_CHANNEL_PORT \
     vllm serve \"$model_name\" \
     --port $PREFILL_PORT \
     --enforce-eager \
@@ -116,8 +126,8 @@ run_tests_for_model() {
   echo "Starting decode instance on GPU $DECODE_GPU, port $DECODE_PORT"
   BASE_CMD="CUDA_VISIBLE_DEVICES=$DECODE_GPU \
     VLLM_KV_CACHE_LAYOUT='HND' \
-    UCX_NET_DEVICES=all \
-    VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_SIDE_CHANNEL_PORT \
+    $UCX_ENV \
+    VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=$DECODE_SIDE_CHANNEL_PORT \
     vllm serve \"$model_name\" \
     --port $DECODE_PORT \
     --enforce-eager \

--- a/tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh
@@ -30,6 +30,16 @@
 #   VLLM_SERVE_EXTRA_ARGS - comma-separated extra args for vllm serve
 set -ex
 
+# Connector selection (default: NixlConnector)
+CONNECTOR_NAME=${CONNECTOR_NAME:-NixlConnector}
+SIDE_CHANNEL_PREFIX=${SIDE_CHANNEL_PREFIX:-NIXL}
+
+# UCX is only needed by NIXL connector
+UCX_ENV=""
+if [[ "$CONNECTOR_NAME" == *"Nixl"* ]]; then
+    UCX_ENV="UCX_NET_DEVICES=all"
+fi
+
 # ── Model & spec decode config ──────────────────────────────────────────
 
 MODEL_NAME="${MODEL_NAME:-meta-llama/Llama-3.1-8B-Instruct}"
@@ -139,12 +149,12 @@ wait_for_nixl_side_channel() {
   local server_name=$4
   local deadline=120
   local elapsed=0
-  echo "Waiting for ${server_name} NIXL side channel on ${host}:${port}..."
+  echo "Waiting for ${server_name} ${SIDE_CHANNEL_PREFIX} side channel on ${host}:${port}..."
   while [ $elapsed -lt $deadline ]; do
     if ! ps -p "$server_pid" > /dev/null 2>&1; then
       local status=0
       wait "$server_pid" || status=$?
-      echo "FAIL: ${server_name} server process ${server_pid} exited with status ${status} before NIXL side channel ${host}:${port} became ready"
+      echo "FAIL: ${server_name} server process ${server_pid} exited with status ${status} before ${SIDE_CHANNEL_PREFIX} side channel ${host}:${port} became ready"
       exit 1
     fi
     if python3 "${GIT_ROOT}/tests/v1/kv_connector/nixl_integration/nixl_side_channel_probe.py" \
@@ -152,13 +162,13 @@ wait_for_nixl_side_channel() {
       --port "$port" \
       --timeout-ms 1000 > /dev/null 2>&1
     then
-      echo "${server_name} NIXL side channel on ${host}:${port} ready"
+      echo "${server_name} ${SIDE_CHANNEL_PREFIX} side channel on ${host}:${port} ready"
       return 0
     fi
     sleep 2
     elapsed=$((elapsed + 2))
   done
-  echo "FAIL: ${server_name} NIXL side channel ${host}:${port} did not start within ${deadline}s"
+  echo "FAIL: ${server_name} ${SIDE_CHANNEL_PREFIX} side channel ${host}:${port} did not start within ${deadline}s"
   exit 1
 }
 
@@ -193,16 +203,16 @@ run_test_for_device() {
   local kv_device=$1
 
   if [[ "$kv_device" == "cuda" ]]; then
-    local kv_config_p='{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
-    local kv_config_d='{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
+    local kv_config_p='{"kv_connector":"'"${CONNECTOR_NAME}"'","kv_role":"kv_producer"}'
+    local kv_config_d='{"kv_connector":"'"${CONNECTOR_NAME}"'","kv_role":"kv_consumer"}'
   else
-    local kv_config_p="{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\",\"kv_buffer_device\":\"${kv_device}\"}"
-    local kv_config_d="{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\",\"kv_buffer_device\":\"${kv_device}\"}"
+    local kv_config_p="{\"kv_connector\":\"${CONNECTOR_NAME}\",\"kv_role\":\"kv_producer\",\"kv_buffer_device\":\"${kv_device}\"}"
+    local kv_config_d="{\"kv_connector\":\"${CONNECTOR_NAME}\",\"kv_role\":\"kv_consumer\",\"kv_buffer_device\":\"${kv_device}\"}"
   fi
 
   echo ""
   echo "================================================================"
-  echo "NixlConnector PD + Spec Decode Acceptance Test (kv_buffer_device=${kv_device})"
+  echo "${CONNECTOR_NAME} PD + Spec Decode Acceptance Test (kv_buffer_device=${kv_device})"
   echo "================================================================"
   echo "Model:              ${MODEL_NAME}"
   echo "SD method:          ${SD_METHOD}"
@@ -212,7 +222,7 @@ run_test_for_device() {
   echo "Attention backend:  ${ATTENTION_BACKEND}"
   echo "GPU platform:       ${GPU_PLATFORM}"
   echo "Server host:        ${SERVER_HOST}"
-  echo "NIXL side channel:  ${NIXL_SIDE_CHANNEL_HOST}"
+  echo "${SIDE_CHANNEL_PREFIX} side channel:  ${NIXL_SIDE_CHANNEL_HOST}"
   echo "GPUs available:     ${ALL_GPUS[*]}"
   echo "================================================================"
 
@@ -239,10 +249,10 @@ run_test_for_device() {
     env \
     ${GPU_DEVICE_VAR}=$GPU_ID \
     VLLM_KV_CACHE_LAYOUT='HND' \
-    UCX_NET_DEVICES=all \
+    ${UCX_ENV} \
     ${VLLM_SSM_CONV_STATE_LAYOUT:+VLLM_SSM_CONV_STATE_LAYOUT=$VLLM_SSM_CONV_STATE_LAYOUT} \
-    VLLM_NIXL_SIDE_CHANNEL_HOST=$NIXL_SIDE_CHANNEL_HOST \
-    VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
+    VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_HOST=$NIXL_SIDE_CHANNEL_HOST \
+    VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
     vllm serve $MODEL_NAME \
       --port $PORT \
       --enforce-eager \
@@ -259,7 +269,9 @@ run_test_for_device() {
     PREFILL_HOSTS+=("$SERVER_HOST")
     PREFILL_PORTS+=("$PORT")
     wait_for_server "$PORT" "$SERVER_PID" "prefill"
-    wait_for_nixl_side_channel "$NIXL_SIDE_CHANNEL_HOST" "$SIDE_CHANNEL_PORT" "$SERVER_PID" "prefill"
+    if [[ "$CONNECTOR_NAME" == *"Nixl"* ]]; then
+      wait_for_nixl_side_channel "$NIXL_SIDE_CHANNEL_HOST" "$SIDE_CHANNEL_PORT" "$SERVER_PID" "prefill"
+    fi
   done
 
   # Start decode instances after prefill is ready.
@@ -278,10 +290,10 @@ run_test_for_device() {
     env \
     ${GPU_DEVICE_VAR}=$GPU_ID \
     VLLM_KV_CACHE_LAYOUT='HND' \
-    UCX_NET_DEVICES=all \
+    ${UCX_ENV} \
     ${VLLM_SSM_CONV_STATE_LAYOUT:+VLLM_SSM_CONV_STATE_LAYOUT=$VLLM_SSM_CONV_STATE_LAYOUT} \
-    VLLM_NIXL_SIDE_CHANNEL_HOST=$NIXL_SIDE_CHANNEL_HOST \
-    VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
+    VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_HOST=$NIXL_SIDE_CHANNEL_HOST \
+    VLLM_${SIDE_CHANNEL_PREFIX}_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT \
     vllm serve $MODEL_NAME \
       --port $PORT \
       --enforce-eager \
@@ -298,7 +310,9 @@ run_test_for_device() {
     DECODE_HOSTS+=("$SERVER_HOST")
     DECODE_PORTS+=("$PORT")
     wait_for_server "$PORT" "$SERVER_PID" "decode"
-    wait_for_nixl_side_channel "$NIXL_SIDE_CHANNEL_HOST" "$SIDE_CHANNEL_PORT" "$SERVER_PID" "decode"
+    if [[ "$CONNECTOR_NAME" == *"Nixl"* ]]; then
+      wait_for_nixl_side_channel "$NIXL_SIDE_CHANNEL_HOST" "$SIDE_CHANNEL_PORT" "$SERVER_PID" "decode"
+    fi
   done
 
   # Start proxy

--- a/tests/v1/kv_connector/nixl_integration/test_mamba_prefix_cache.py
+++ b/tests/v1/kv_connector/nixl_integration/test_mamba_prefix_cache.py
@@ -13,6 +13,8 @@ import openai
 import regex as re
 import requests
 
+TEST_CONNECTOR = os.environ.get("TEST_CONNECTOR", "nixl")
+
 PREFILL_HOST = os.getenv("PREFILL_HOST", "localhost")
 PREFILL_PORT = os.environ["PREFILL_PORT"]
 DECODE_HOST = os.getenv("DECODE_HOST", "localhost")
@@ -222,10 +224,10 @@ while len(PROMPT) < 23000:
 
 
 METRICS_OF_INTEREST = [
-    "vllm:nixl_bytes_transferred_sum",
-    "vllm:nixl_bytes_transferred_count",
-    "vllm:nixl_num_descriptors_sum",
-    "vllm:nixl_num_descriptors_count",
+    f"vllm:{TEST_CONNECTOR}_bytes_transferred_sum",
+    f"vllm:{TEST_CONNECTOR}_bytes_transferred_count",
+    f"vllm:{TEST_CONNECTOR}_num_descriptors_sum",
+    f"vllm:{TEST_CONNECTOR}_num_descriptors_count",
     "vllm:prefix_cache_hits",
     "vllm:prefix_cache_queries",
 ]
@@ -291,12 +293,12 @@ def test_mamba_prefix_cache_hit():
     print_metrics("D-side after req1", m_after_req1)
 
     transfer_req1 = (
-        m_after_req1["vllm:nixl_bytes_transferred_sum"]
-        - m_baseline["vllm:nixl_bytes_transferred_sum"]
+        m_after_req1[f"vllm:{TEST_CONNECTOR}_bytes_transferred_sum"]
+        - m_baseline[f"vllm:{TEST_CONNECTOR}_bytes_transferred_sum"]
     )
     descs_req1 = (
-        m_after_req1["vllm:nixl_num_descriptors_sum"]
-        - m_baseline["vllm:nixl_num_descriptors_sum"]
+        m_after_req1[f"vllm:{TEST_CONNECTOR}_num_descriptors_sum"]
+        - m_baseline[f"vllm:{TEST_CONNECTOR}_num_descriptors_sum"]
     )
     print(f"  Transfer: {transfer_req1 / 1e6:.2f} MB, {descs_req1:.0f} descs")
 
@@ -313,12 +315,12 @@ def test_mamba_prefix_cache_hit():
     print_metrics("D-side after req2", m_after_req2)
 
     transfer_req2 = (
-        m_after_req2["vllm:nixl_bytes_transferred_sum"]
-        - m_after_req1["vllm:nixl_bytes_transferred_sum"]
+        m_after_req2[f"vllm:{TEST_CONNECTOR}_bytes_transferred_sum"]
+        - m_after_req1[f"vllm:{TEST_CONNECTOR}_bytes_transferred_sum"]
     )
     descs_req2 = (
-        m_after_req2["vllm:nixl_num_descriptors_sum"]
-        - m_after_req1["vllm:nixl_num_descriptors_sum"]
+        m_after_req2[f"vllm:{TEST_CONNECTOR}_num_descriptors_sum"]
+        - m_after_req1[f"vllm:{TEST_CONNECTOR}_num_descriptors_sum"]
     )
     print(f"  Transfer: {transfer_req2 / 1e6:.2f} MB, {descs_req2:.0f} descs")
 

--- a/tests/v1/kv_connector/nixl_integration/test_multi_connector_edge_cases.py
+++ b/tests/v1/kv_connector/nixl_integration/test_multi_connector_edge_cases.py
@@ -19,6 +19,8 @@ import urllib.request
 import openai
 import regex as re
 
+TEST_CONNECTOR = os.environ.get("TEST_CONNECTOR", "nixl")
+
 # ── Server configuration from environment ─────────────────────────────────
 
 PREFILL_HOST = os.getenv("PREFILL_HOST", "localhost")
@@ -97,7 +99,9 @@ def _fetch_prefill_metrics() -> dict[str, float]:
     return _fetch_metrics(PREFILL_HOST, PREFILL_PORT)
 
 
-_NIXL_BYTES_RE = re.compile(r"vllm:nixl_bytes_transferred_sum\b.*?\s+([\d.eE+\-]+)")
+_NIXL_BYTES_RE = re.compile(
+    rf"vllm:{TEST_CONNECTOR}_bytes_transferred_sum\b.*?\s+([\d.eE+\-]+)"
+)
 
 
 def _fetch_nixl_bytes(host: str, port: str) -> float:

--- a/tests/v1/kv_connector/nixl_integration/test_nixl_imports.py
+++ b/tests/v1/kv_connector/nixl_integration/test_nixl_imports.py
@@ -4,12 +4,15 @@
 
 import importlib
 import importlib.metadata as metadata
+import os
 import pathlib
 import subprocess
 import sys
 
 import pytest
 import torch
+
+TEST_CONNECTOR = os.environ.get("TEST_CONNECTOR", "nixl")
 
 
 def _print_distribution_version(package_name: str) -> None:
@@ -20,6 +23,10 @@ def _print_distribution_version(package_name: str) -> None:
     print(f"{package_name}: {version}")
 
 
+@pytest.mark.skipif(
+    TEST_CONNECTOR != "nixl",
+    reason="NixlConnector import checks only run for nixl connector",
+)
 @pytest.mark.skipif(torch.version.cuda is None, reason="CUDA NIXL EP canary")
 def test_nixl_and_nixl_ep_imports() -> None:
     """Verify both core NIXL and the NIXL EP extension import successfully."""

--- a/tests/v1/kv_connector/unit/test_uccl_p2p_connector.py
+++ b/tests/v1/kv_connector/unit/test_uccl_p2p_connector.py
@@ -38,6 +38,7 @@ class FakeUcclP2pWrapper:
     def __init__(self, local_gpu_idx: int):
         self._md = b"fake_md"
         self._conn_ids: dict[str, int] = {}
+        self._conn_id_to_agent: dict[int, str] = {}
         self._counter = 0
 
     def get_agent_metadata(self) -> bytes:
@@ -64,8 +65,8 @@ class FakeUcclP2pWrapper:
             addr=addr,
             size=size,
             mr_id=base_desc.mr_id,
-            lkeys=list(base_desc.lkeys) if base_desc.lkeys is not None else [],
-            rkeys=list(base_desc.rkeys) if base_desc.rkeys is not None else [],
+            lkeys=base_desc.lkeys,
+            rkeys=base_desc.rkeys,
         )
 
     def add_remote_agent(
@@ -76,10 +77,13 @@ class FakeUcclP2pWrapper:
         self._counter += 1
         conn_id = self._counter
         self._conn_ids[agent_name] = conn_id
+        self._conn_id_to_agent[conn_id] = agent_name
         return agent_name
 
     def remove_remote_agent(self, agent_name: str) -> None:
-        self._conn_ids.pop(agent_name, None)
+        conn_id = self._conn_ids.pop(agent_name, None)
+        if conn_id is not None:
+            self._conn_id_to_agent.pop(conn_id, None)
 
     def make_prepped_xfer(
         self,

--- a/tests/v1/kv_connector/unit/test_uccl_p2p_connector.py
+++ b/tests/v1/kv_connector/unit/test_uccl_p2p_connector.py
@@ -59,6 +59,15 @@ class FakeUcclP2pWrapper:
     def deserialize_descs(self, serialized: bytes) -> list[Any]:
         return [FakeXferDesc()]
 
+    def copy_xfer_desc(self, base_desc: Any, addr: int, size: int) -> Any:
+        return FakeXferDesc(
+            addr=addr,
+            size=size,
+            mr_id=base_desc.mr_id,
+            lkeys=list(base_desc.lkeys) if base_desc.lkeys is not None else [],
+            rkeys=list(base_desc.rkeys) if base_desc.rkeys is not None else [],
+        )
+
     def add_remote_agent(
         self,
         agent_name: str,

--- a/tests/v1/kv_connector/unit/test_uccl_p2p_connector.py
+++ b/tests/v1/kv_connector/unit/test_uccl_p2p_connector.py
@@ -36,14 +36,12 @@ class FakeUcclP2pWrapper:
     """Stub that mimics the UcclP2pWrapper interface for smoke testing."""
 
     def __init__(self, local_gpu_idx: int):
-        self._data_md = b"fake_data_md"
-        self._notif_md = b"fake_notif_md"
-        self._data_conn_ids: dict[str, int] = {}
-        self._notif_conn_ids: dict[str, int] = {}
+        self._md = b"fake_md"
+        self._conn_ids: dict[str, int] = {}
         self._counter = 0
 
-    def get_agent_metadata(self) -> tuple[bytes, bytes]:
-        return (self._data_md, self._notif_md)
+    def get_agent_metadata(self) -> bytes:
+        return self._md
 
     def register_memory(self, tensor_list: list[torch.Tensor]) -> list[Any]:
         descs = [
@@ -64,18 +62,15 @@ class FakeUcclP2pWrapper:
     def add_remote_agent(
         self,
         agent_name: str,
-        data_endpoint_metadata: bytes,
-        notif_endpoint_metadata: bytes,
+        endpoint_metadata: bytes,
     ) -> str:
         self._counter += 1
         conn_id = self._counter
-        self._data_conn_ids[agent_name] = conn_id
-        self._notif_conn_ids[agent_name] = conn_id
+        self._conn_ids[agent_name] = conn_id
         return agent_name
 
     def remove_remote_agent(self, agent_name: str) -> None:
-        self._data_conn_ids.pop(agent_name, None)
-        self._notif_conn_ids.pop(agent_name, None)
+        self._conn_ids.pop(agent_name, None)
 
     def make_prepped_xfer(
         self,

--- a/tests/v1/kv_connector/unit/test_uccl_p2p_connector.py
+++ b/tests/v1/kv_connector/unit/test_uccl_p2p_connector.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Smoke test for the UCCL P2P connector using a fake wrapper."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from vllm.config import set_current_vllm_config
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p import (
+    UcclP2pConnector,
+    UcclP2pConnectorScheduler,
+    UcclP2pConnectorWorker,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.metadata import (
+    UcclP2pHandshakePayload,
+)
+
+from .utils import create_vllm_config, make_kv_cache_config
+
+
+@dataclass
+class FakeXferDesc:
+    """Minimal fake XferDesc matching the uccl.p2p interface."""
+
+    addr: int = 0
+    size: int = 0
+    mr_id: int = 0
+    lkeys: list[int] | None = None
+    rkeys: list[int] | None = None
+
+
+class FakeUcclP2pWrapper:
+    """Stub that mimics the UcclP2pWrapper interface for smoke testing."""
+
+    def __init__(self, local_gpu_idx: int):
+        self._data_md = b"fake_data_md"
+        self._notif_md = b"fake_notif_md"
+        self._data_conn_ids: dict[str, int] = {}
+        self._notif_conn_ids: dict[str, int] = {}
+        self._counter = 0
+
+    def get_agent_metadata(self) -> tuple[bytes, bytes]:
+        return (self._data_md, self._notif_md)
+
+    def register_memory(self, tensor_list: list[torch.Tensor]) -> list[Any]:
+        descs = [
+            FakeXferDesc(addr=t.data_ptr(), size=t.numel() * t.element_size())
+            for t in tensor_list
+        ]
+        return descs
+
+    def deregister_memory(self, desc_list: list[Any]) -> None:
+        pass
+
+    def get_serialized_descs(self, desc_list: list[Any]) -> bytes:
+        return b"fake_serialized"
+
+    def deserialize_descs(self, serialized: bytes) -> list[Any]:
+        return [FakeXferDesc()]
+
+    def add_remote_agent(
+        self,
+        agent_name: str,
+        data_endpoint_metadata: bytes,
+        notif_endpoint_metadata: bytes,
+    ) -> str:
+        self._counter += 1
+        conn_id = self._counter
+        self._data_conn_ids[agent_name] = conn_id
+        self._notif_conn_ids[agent_name] = conn_id
+        return agent_name
+
+    def remove_remote_agent(self, agent_name: str) -> None:
+        self._data_conn_ids.pop(agent_name, None)
+        self._notif_conn_ids.pop(agent_name, None)
+
+    def make_prepped_xfer(
+        self,
+        op_name: str,
+        local_descs: list[Any],
+        remote_descs: list[Any],
+        notif_msg: bytes | None = None,
+        agent_name: str | None = None,
+    ) -> int:
+        self._counter += 1
+        return self._counter
+
+    def transfer(self, transfer_id: int) -> None:
+        pass
+
+    def check_xfer_state(self, transfer_id: int) -> str:
+        return "DONE"
+
+    def release_xfer_handle(self, transfer_id: int) -> None:
+        pass
+
+    def release_dlist_handle(self, handle: Any) -> None:
+        pass
+
+    def get_xfer_telemetry(self, transfer_id: int) -> dict[str, Any]:
+        return {}
+
+    def send_notif(self, agent_name: str, notif_msg: bytes) -> None:
+        pass
+
+    def get_new_notifs(self) -> dict[str, list[bytes]]:
+        return {}
+
+    def shutdown(self) -> None:
+        pass
+
+
+def _monkeypatch_worker_init(monkeypatch):
+    """Replace the real UcclP2pWrapper with FakeUcclP2pWrapper."""
+    monkeypatch.setattr(
+        "vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.worker.UcclP2pWrapper",
+        FakeUcclP2pWrapper,
+    )
+    # Mock TP group functions for standalone testing.
+    monkeypatch.setattr(
+        "vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.worker"
+        ".get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.worker"
+        ".get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+
+
+def test_uccl_p2p_connector_worker_smoke(monkeypatch):
+    """Smoke test: UcclP2pConnector in WORKER role with fake wrapper."""
+    _monkeypatch_worker_init(monkeypatch)
+
+    vllm_config = create_vllm_config(
+        kv_connector="UcclP2pConnector",
+        kv_role="kv_consumer",
+        disable_hybrid_kv_cache_manager=True,
+    )
+    kv_cache_config = make_kv_cache_config(
+        block_size=vllm_config.cache_config.block_size,
+    )
+
+    with set_current_vllm_config(vllm_config):
+        conn = UcclP2pConnector(
+            vllm_config, KVConnectorRole.WORKER, kv_cache_config=kv_cache_config
+        )
+        assert conn.connector_worker is not None
+        assert isinstance(conn.connector_worker, UcclP2pConnectorWorker)
+
+        # Run register_kv_caches with a trivial tensor map.
+        fake_kv = {"layer0": torch.randn(100, 16, 4, 16, dtype=torch.float32)}
+        conn.register_kv_caches(fake_kv)
+
+        # Verify handshake metadata was produced.
+        md = conn.get_handshake_metadata()
+        assert md is not None
+        assert isinstance(md, UcclP2pHandshakePayload)
+        assert md.compatibility_hash
+        assert md.agent_metadata_bytes
+
+        # get_finished should return empty sets.
+        finished_sending, finished_recving = conn.get_finished(set())
+        assert finished_sending == set()
+        assert finished_recving == set()
+
+        conn.shutdown()
+
+
+def test_uccl_p2p_connector_scheduler_smoke(monkeypatch):
+    """Smoke test: UcclP2pConnector in SCHEDULER role."""
+    _monkeypatch_worker_init(monkeypatch)
+
+    vllm_config = create_vllm_config(
+        kv_connector="UcclP2pConnector",
+        kv_role="kv_consumer",
+        disable_hybrid_kv_cache_manager=True,
+    )
+    kv_cache_config = make_kv_cache_config(
+        block_size=vllm_config.cache_config.block_size,
+    )
+
+    with set_current_vllm_config(vllm_config):
+        conn = UcclP2pConnector(
+            vllm_config, KVConnectorRole.SCHEDULER, kv_cache_config=kv_cache_config
+        )
+        assert conn.connector_scheduler is not None
+        assert isinstance(conn.connector_scheduler, UcclP2pConnectorScheduler)
+        conn.shutdown()

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -180,6 +180,12 @@ KVConnectorFactory.register_connector(
 )
 
 KVConnectorFactory.register_connector(
+    "UcclP2pConnector",
+    "vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p",
+    "UcclP2pConnector",
+)
+
+KVConnectorFactory.register_connector(
     "MultiConnector",
     "vllm.distributed.kv_transfer.kv_connector.v1.multi_connector",
     "MultiConnector",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/__init__.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""UCCL_P2P KV-cache transfer connector (disaggregated prefill / decode)."""
+
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.connector import (
+    UcclP2pConnector,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.metadata import (
+    UcclP2pAgentMetadata,
+    UcclP2pConnectorMetadata,
+    UcclP2pHandshakePayload,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.scheduler import (
+    UcclP2pConnectorScheduler,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.stats import (
+    UcclP2pKVConnectorStats,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.worker import (
+    UcclP2pConnectorWorker,
+)
+
+__all__ = [
+    "UcclP2pAgentMetadata",
+    "UcclP2pConnector",
+    "UcclP2pConnectorMetadata",
+    "UcclP2pConnectorScheduler",
+    "UcclP2pConnectorWorker",
+    "UcclP2pHandshakePayload",
+    "UcclP2pKVConnectorStats",
+]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/connector.py
@@ -1,0 +1,302 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""UcclP2pConnector – thin facade that delegates to scheduler / worker."""
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.utils import (
+    EngineId,
+    get_current_attn_backend,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    CopyBlocksOp,
+    KVConnectorBase_V1,
+    KVConnectorHandshakeMetadata,
+    KVConnectorMetadata,
+    KVConnectorRole,
+    SupportsHMA,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.metadata import (
+    UcclP2pConnectorMetadata,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.scheduler import (
+    UcclP2pConnectorScheduler,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.stats import (
+    UcclP2pKVConnectorStats,
+    UcclP2pPromMetrics,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.worker import (
+    UcclP2pConnectorWorker,
+)
+from vllm.forward_context import ForwardContext
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata
+from vllm.v1.attention.backends.utils import get_kv_cache_layout
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import MambaSpec
+from vllm.v1.outputs import KVConnectorOutput
+
+if TYPE_CHECKING:
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+class UcclP2pConnector(KVConnectorBase_V1, SupportsHMA):
+    @property
+    def prefer_cross_layer_blocks(self) -> bool:
+        if any(
+            [
+                isinstance(group.kv_cache_spec, MambaSpec)
+                for group in self.kv_cache_config.kv_cache_groups
+            ]
+        ):
+            # Hybrid SSM models do not yet support cross-layer layout
+            return False
+
+        backend = get_current_attn_backend(self._vllm_config)
+        if backend.get_name() not in (
+            "FLASH_ATTN",
+            "FLASHINFER",
+            "TRITON_ATTN",
+        ):
+            return False
+
+        # For now there is no benefit to run cross layers when backend
+        # does not support on HND
+        if get_kv_cache_layout() != "HND":
+            return False
+
+        extra_config = self.kv_transfer_config.kv_connector_extra_config
+        return (
+            str(extra_config.get("enable_cross_layers_blocks", "False")).lower()
+            == "true"
+        )
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        role: KVConnectorRole,
+        kv_cache_config: "KVCacheConfig",
+    ):
+        super().__init__(vllm_config, role, kv_cache_config)
+        assert vllm_config.kv_transfer_config is not None
+        assert vllm_config.kv_transfer_config.engine_id is not None
+
+        if vllm_config.kv_transfer_config.kv_role == "kv_both":
+            logger.warning_once(
+                "Using kv_role='kv_both' with UcclP2pConnector is deprecated "
+                "and will be removed in a future release. Please set "
+                "kv_role='kv_producer' for prefill instances and "
+                "kv_role='kv_consumer' for decode instances. "
+            )
+
+        self.kv_cache_config = kv_cache_config
+        self.engine_id: EngineId = vllm_config.kv_transfer_config.engine_id
+        self.kv_transfer_config = vllm_config.kv_transfer_config
+        if role == KVConnectorRole.SCHEDULER:
+            self.connector_scheduler: UcclP2pConnectorScheduler | None = (
+                UcclP2pConnectorScheduler(vllm_config, self.engine_id, kv_cache_config)
+            )
+            self.connector_worker: UcclP2pConnectorWorker | None = None
+        elif role == KVConnectorRole.WORKER:
+            self.connector_scheduler = None
+            self.connector_worker = UcclP2pConnectorWorker(
+                vllm_config, self.engine_id, kv_cache_config
+            )
+
+    ############################################################
+    # Class Methods
+    ############################################################
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config: VllmConfig):
+        if vllm_config.model_config is None:
+            logger.warning_once(
+                "Unable to detect current VLLM config. "
+                "Fallback to default kv cache layout."
+            )
+            return None
+        use_mla = vllm_config.model_config.use_mla
+        if use_mla:
+            # return None when we have mla
+            # as the layout should not matter in that case,
+            # which fallback to the default behavior.
+            return None
+        logger.info_once(
+            "UcclP2pConnector setting KV cache layout to HND "
+            "for better xfer performance."
+        )
+        return "HND"
+
+    ############################################################
+    # Scheduler Side Methods
+    ############################################################
+
+    def get_num_new_matched_tokens(
+        self, request: "Request", num_computed_tokens: int
+    ) -> tuple[int | None, bool]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.get_num_new_matched_tokens(
+            request, num_computed_tokens
+        )
+
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.update_state_after_alloc(
+            request, blocks, num_external_tokens
+        )
+
+    def build_connector_meta(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> KVConnectorMetadata:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.build_connector_meta(scheduler_output)
+
+    def on_new_request(self, request: "Request") -> None:
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.on_new_request(request)
+
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.update_connector_output(connector_output)
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished(request, (block_ids,))
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished(request, block_ids)
+
+    def set_xfer_handshake_metadata(
+        self, metadata: dict[int, KVConnectorHandshakeMetadata]
+    ) -> None:
+        """
+        Set the KV connector handshake metadata for this connector.
+
+        Args:
+            metadata (dict): the handshake metadata to set.
+        """
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.set_xfer_handshake_metadata(metadata)
+
+    ############################################################
+    # Worker Side Methods
+    ############################################################
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        assert self.connector_worker is not None
+        self.connector_worker.register_kv_caches(kv_caches)
+
+    def register_cross_layers_kv_cache(
+        self, kv_cache: torch.Tensor, attn_backend: type[AttentionBackend]
+    ):
+        assert self.connector_worker is not None
+        self.connector_worker.register_cross_layers_kv_caches(kv_cache)
+
+    def set_host_xfer_buffer_ops(self, copy_operation: CopyBlocksOp):
+        assert self.connector_worker is not None
+        self.connector_worker.set_host_xfer_buffer_ops(copy_operation)
+
+    def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
+        """Get the finished recving and sending requests."""
+        assert self.connector_worker is not None
+        return self.connector_worker.get_finished()
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """Get block IDs that failed to load via UCCL_P2P."""
+        assert self.connector_worker is not None
+        return self.connector_worker.get_block_ids_with_load_errors()
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        if self.connector_worker is None:
+            return None
+        return self.connector_worker.get_kv_connector_stats()
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> KVConnectorStats | None:
+        return (
+            UcclP2pKVConnectorStats(data=data)
+            if data is not None
+            else UcclP2pKVConnectorStats()
+        )
+
+    @classmethod
+    def build_prom_metrics(
+        cls,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> KVConnectorPromMetrics:
+        return UcclP2pPromMetrics(
+            vllm_config, metric_types, labelnames, per_engine_labelvalues
+        )
+
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
+        assert self.connector_worker is not None
+        assert isinstance(self._connector_metadata, UcclP2pConnectorMetadata)
+        self.connector_worker.start_load_kv(self._connector_metadata)
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        """UcclP2pConnector does not do layerwise saving."""
+        pass
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs,
+    ) -> None:
+        """UcclP2pConnector does not save explicitly."""
+        pass
+
+    def wait_for_save(self):
+        assert self.connector_worker is not None
+        assert isinstance(self._connector_metadata, UcclP2pConnectorMetadata)
+        if self.connector_worker.use_host_buffer and self.connector_worker.copy_blocks:
+            self.connector_worker.save_kv_to_host(self._connector_metadata)
+
+    def shutdown(self):
+        if self.connector_worker is not None:
+            self.connector_worker.shutdown()
+        if self.connector_scheduler is not None:
+            self.connector_scheduler.shutdown()
+
+    def get_handshake_metadata(self) -> KVConnectorHandshakeMetadata | None:
+        """
+        Get the KVConnector handshake metadata for this connector.
+        This metadata is used for out-of-band connector handshake
+        between P/D workers.
+
+        Returns:
+            KVConnectorHandshakeMetadata: the handshake metadata.
+            None if no handshake metadata is available.
+        """
+        assert self.connector_worker is not None
+        return self.connector_worker.xfer_handshake_metadata

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/metadata.py
@@ -41,8 +41,7 @@ UCCL_P2P_CONNECTOR_VERSION: int = 4
 @dataclass
 class UcclP2pAgentMetadata:
     engine_id: str
-    data_endpoint_metadata: bytes
-    notif_endpoint_metadata: bytes
+    endpoint_metadata: bytes
     serialized_xfer_descs: bytes
     kv_caches_base_addr: list[int]
     device_id: int

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/metadata.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Metadata dataclasses and helpers for the UCCL_P2P connector."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds, EngineId
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorHandshakeMetadata,
+    KVConnectorMetadata,
+)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+TransferHandle = int
+ReqId = str
+
+GET_META_MSG = b"get_meta_msg"
+#
+# UCCL_P2P Connector Version
+#
+# Increment this version whenever there is an incompatible change to:
+#   - UcclP2pAgentMetadata schema
+#   - kv_transfer_params schema or semantics
+#   - UCCL_P2P transfer protocol or wire format
+#   - KV cache memory layout or block organization
+#   - Any other change that breaks P/D interoperability
+#
+# Version History:
+#   1: Initial version with compatibility checking
+#   2: Add remote_request_id to kv_transfer_params
+#   3: Add physical_blocks_per_logical_kv_block to UcclP2pAgentMetadata
+#   4: Add KV block lease renewal through heartbeats
+#
+UCCL_P2P_CONNECTOR_VERSION: int = 4
+
+
+@dataclass
+class UcclP2pAgentMetadata:
+    engine_id: str
+    data_endpoint_metadata: bytes
+    notif_endpoint_metadata: bytes
+    serialized_xfer_descs: bytes
+    kv_caches_base_addr: list[int]
+    device_id: int
+    num_blocks: int
+    block_lens: list[int]
+    kv_cache_layout: str
+    block_size: int
+    ssm_sizes: tuple[int, int]
+    attn_backend_name: str
+    physical_blocks_per_logical_kv_block: int
+
+
+@dataclass
+class UcclP2pHandshakePayload(KVConnectorHandshakeMetadata):
+    """
+    Wrapper for UCCL_P2P handshake sent over the wire.
+
+    Enables two-phase decoding for graceful compatibility checking:
+    1. Decode UcclP2pHandshakePayload to get compatibility_hash
+    2. Compute local hash and compare
+    3. Only if hashes match, decode agent_metadata_bytes
+
+    This prevents decoder errors when UcclP2pAgentMetadata schema is
+    incompatible, allowing graceful failure with clear error message.
+    """
+
+    compatibility_hash: str
+    agent_metadata_bytes: bytes  # UcclP2pAgentMetadata encoded
+
+
+def compute_uccl_p2p_compatibility_hash(
+    vllm_config: VllmConfig, attn_backend_name: str, cross_layers_blocks: bool
+) -> str:
+    """
+    Compute compatibility hash for UCCL_P2P KV transfer.
+
+    Hash only the factors that affect whether two UCCL_P2P instances can
+    successfully transfer KV cache data.
+
+    Factors included:
+    - vLLM version and UCCL_P2P connector version
+    - Model architecture (name, dtype, KV heads, layers)
+    - KV cache format (dtype, sliding window)
+    - Attention backend
+
+    Note: Factors like tensor_parallel_size, block_size, and kv_cache_layout
+    are validated at runtime in _validate_remote_agent_handshake and are not
+    included in this hash to support heterogeneous deployments.
+
+    Note - the set of factors are likely to evolve significantly over
+    time to be more or less permissive.
+
+    Returns:
+        SHA-256 hex digest
+    """
+    from vllm import __version__ as vllm_version
+    from vllm.config.utils import hash_factors
+
+    model_config = vllm_config.model_config
+    cache_config = vllm_config.cache_config
+    is_hma_enabled = not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
+
+    factors = {
+        # Version compatibility
+        "vllm_version": vllm_version,
+        "uccl_p2p_connector_version": UCCL_P2P_CONNECTOR_VERSION,
+        # Model architecture - affects KV cache shape
+        "model": model_config.model,
+        "dtype": str(model_config.dtype),
+        "num_kv_heads": model_config.get_total_num_kv_heads(),
+        "head_size": model_config.get_head_size(),
+        "num_hidden_layers": model_config.get_total_num_hidden_layers(),
+        # Attention backend and KV cache dtype affect memory layout
+        "attn_backend_name": attn_backend_name,
+        "cache_dtype": str(cache_config.cache_dtype),
+        "cross_layers_blocks": cross_layers_blocks,
+        "is_hma_enabled": is_hma_enabled,
+    }
+
+    compat_hash = hash_factors(factors)
+    logger.debug(
+        "UCCL_P2P compatibility hash: %s (model=%s, dtype=%s, num_kv_heads=%d, "
+        "cache_dtype=%s, attn_backend=%s)",
+        compat_hash,
+        factors["model"],
+        factors["dtype"],
+        factors["num_kv_heads"],
+        factors["cache_dtype"],
+        attn_backend_name,
+    )
+    return compat_hash
+
+
+@dataclass
+class HeartbeatInfo:
+    """Heartbeat data for a single remote engine, sent from D worker to P."""
+
+    req_ids: set[ReqId]
+    host: str
+    port: int
+    tp_size: int
+
+
+@dataclass
+class RemoteMeta:
+    block_ids: BlockIds
+    host: str
+    port: int
+    engine_id: str
+    request_id: str
+
+
+@dataclass
+class ReqMeta:
+    local_block_ids: BlockIds
+    # To be used when logical block size does not match the kernel block size
+    local_physical_block_ids: BlockIds
+    tp_size: int
+    remote: RemoteMeta | None = None
+
+
+class UcclP2pConnectorMetadata(KVConnectorMetadata):
+    def __init__(self):
+        self.reqs_to_recv: dict[ReqId, ReqMeta] = {}
+        self.reqs_to_save: dict[ReqId, ReqMeta] = {}
+        self.reqs_to_send: dict[ReqId, float] = {}
+        self.reqs_in_batch: set[ReqId] = set()
+        self.reqs_not_processed: set[ReqId] = set()
+        # Heartbeat data grouped by remote engine, sent by D worker to P.
+        self.heartbeat_by_engine: dict[EngineId, HeartbeatInfo] = {}
+
+    def _add_new_req(
+        self,
+        local_block_ids: BlockIds,
+        kv_transfer_params: dict[str, Any],
+    ) -> ReqMeta:
+        return ReqMeta(
+            local_block_ids=local_block_ids,
+            local_physical_block_ids=local_block_ids,
+            # P workers don't need to receive tp_size from proxy here.
+            tp_size=kv_transfer_params.get("tp_size", 1),
+        )
+
+    def add_new_req_to_save(
+        self,
+        request_id: ReqId,
+        local_block_ids: BlockIds,
+        kv_transfer_params: dict[str, Any],
+    ):
+        self.reqs_to_save[request_id] = self._add_new_req(
+            local_block_ids, kv_transfer_params
+        )
+
+    def add_new_req_to_recv(
+        self,
+        request_id: ReqId,
+        local_block_ids: BlockIds,
+        kv_transfer_params: dict[str, Any],
+    ):
+        req = self._add_new_req(local_block_ids, kv_transfer_params)
+        req.remote = RemoteMeta(
+            block_ids=kv_transfer_params["remote_block_ids"],
+            engine_id=kv_transfer_params["remote_engine_id"],
+            request_id=kv_transfer_params["remote_request_id"],
+            host=kv_transfer_params["remote_host"],
+            port=kv_transfer_params["remote_port"],
+        )
+        self.reqs_to_recv[request_id] = req

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/scheduler.py
@@ -1,0 +1,674 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Scheduler-side logic for the UCCL_P2P connector."""
+
+import threading
+import time
+from typing import TYPE_CHECKING, Any
+
+import msgspec
+import zmq
+
+from vllm import envs
+from vllm.distributed.kv_transfer.kv_connector.utils import (
+    BlockIds,
+    EngineId,
+    yield_req_data,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorHandshakeMetadata,
+    KVConnectorMetadata,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.metadata import (
+    GET_META_MSG,
+    HeartbeatInfo,
+    ReqId,
+    UcclP2pConnectorMetadata,
+    UcclP2pHandshakePayload,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.utils import zmq_ctx
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils.math_utils import cdiv
+from vllm.utils.network_utils import make_zmq_path
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    MambaSpec,
+    SlidingWindowSpec,
+)
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.outputs import KVConnectorOutput
+    from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+class UcclP2pConnectorScheduler:
+    """Implementation of Scheduler side methods"""
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        engine_id: str,
+        kv_cache_config: "KVCacheConfig",
+    ):
+        self.vllm_config = vllm_config
+        self.block_size = vllm_config.cache_config.block_size
+        self.engine_id: EngineId = engine_id
+        self.kv_cache_config = kv_cache_config
+        self.side_channel_host = envs.VLLM_UCCL_P2P_SIDE_CHANNEL_HOST
+        self.side_channel_port = (
+            envs.VLLM_UCCL_P2P_SIDE_CHANNEL_PORT
+            + vllm_config.parallel_config.data_parallel_index
+        )
+        assert vllm_config.kv_transfer_config is not None
+        self._kv_lease_duration: int = (
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "kv_lease_duration", 30
+            )
+        )
+        # NOTE (NickLucche): For now we use a hardcoded value for a simpler interface.
+        self._heartbeat_interval = self._kv_lease_duration // 6
+        if current_platform.device_type == "cpu":
+            self.use_host_buffer = False
+        else:
+            self.use_host_buffer = (
+                vllm_config.kv_transfer_config.kv_buffer_device == "cpu"
+            )
+        self._is_hma_required = (
+            not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
+            # Also handle unlikely SW-only model case instead of checking num_groups>1.
+            and any(
+                not isinstance(g.kv_cache_spec, FullAttentionSpec)
+                for g in kv_cache_config.kv_cache_groups
+            )
+        )
+        self._has_mamba = any(
+            isinstance(g.kv_cache_spec, MambaSpec)
+            for g in kv_cache_config.kv_cache_groups
+        )
+
+        logger.info("Initializing UCCL_P2P Scheduler %s", engine_id)
+        if vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
+            logger.info("Hybrid Memory Allocator is enabled with UCCL_P2P")
+
+        # Background thread for handling new handshake requests.
+        self._uccl_p2p_handshake_listener_t: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+        # Requests that need to start recv/send.
+        # New requests are added by update_state_after_alloc in
+        # the scheduler. Used to make metadata passed to Worker.
+        self._reqs_need_recv: dict[ReqId, tuple[Request, BlockIds]] = {}
+        self._reqs_need_save: dict[ReqId, Request] = {}
+        # Reqs to send and their expiration time
+        self._reqs_need_send: dict[ReqId, float] = {}
+        self._reqs_in_batch: set[ReqId] = set()
+        # Reqs to remove from processed set because they're not to send after
+        # remote prefill or aborted.
+        self._reqs_not_processed: set[ReqId] = set()
+
+        # Heartbeat tracking: requests needing periodic lease-renewal heartbeats to
+        # remote P-side, stored as ready-to-send HeartbeatInfo grouped by remote engine
+        self._heartbeat_by_engine: dict[EngineId, HeartbeatInfo] = {}
+        # Reverse lookup: local req_id -> (engine_id, remote_req_id) for O(1) removal
+        self._heartbeat_req_engine: dict[ReqId, tuple[EngineId, ReqId]] = {}
+        self._last_heartbeat_time: float = 0.0
+
+        # Gather Sliding Window sizes for each kv cache group (if any) in number of
+        # blocks per KV cache group. This is used to clip the local attention window.
+        sw_sizes_tokens: list[tuple[int, int]] = [
+            (g.kv_cache_spec.sliding_window, g.kv_cache_spec.block_size)
+            if isinstance(g.kv_cache_spec, SlidingWindowSpec)
+            else (0, self.block_size)
+            for g in kv_cache_config.kv_cache_groups
+        ]
+        # cdiv(n_tokens, block_size) gives blocks/window; add 1 to conservatively
+        # account for boundary overlap eg window isn't fully aligned with blocks.
+        self.blocks_per_sw = [
+            cdiv(n_tokens, block_size) + 1 if n_tokens else 0
+            for n_tokens, block_size in sw_sizes_tokens
+        ]
+
+        # Threshold to decide whether to compute kv cache locally
+        # or pull from a remote node: minimum number of remote
+        # tokens to amortize the xfer latencies
+        self.kv_recompute_threshold: int = int(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "kv_recompute_threshold", 64
+            )
+        )
+
+        # Bi-directional KV transfer feature supports KV block
+        # transfers from D node to P node
+        self.is_bidirectional_kv_xfer_enabled = (
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "bidirectional_kv_xfer", False
+            )
+        )
+        self.decoder_kv_blocks_ttl = (
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "decoder_kv_blocks_ttl", 480
+            )
+        )
+
+        if self.is_bidirectional_kv_xfer_enabled and self.kv_recompute_threshold > 0:
+            logger.info(
+                "Bidirectional KV transfer is enabled and the kv "
+                "recompute threshold is set to %d tokens."
+                "KV blocks on D are released after a TTL of %d seconds.",
+                self.kv_recompute_threshold,
+                self.decoder_kv_blocks_ttl,
+            )
+
+    def shutdown(self):
+        self._stop_event.set()
+        if self._uccl_p2p_handshake_listener_t is not None:
+            self._uccl_p2p_handshake_listener_t.join()
+            self._uccl_p2p_handshake_listener_t = None
+
+    def on_new_request(self, request: "Request") -> None:
+        """Track a request that may need heartbeats."""
+        params = request.kv_transfer_params
+        # NOTE (NickLucche) This excludes request meant for P, ie heartbeats are
+        # effectively disabled for Bidirectional KV transfer.
+        if params is None or not params.get("do_remote_prefill"):
+            return
+        # Only track if all required remote fields are present.
+        remote_engine_id = params.get("remote_engine_id")
+        remote_request_id = params.get("remote_request_id")
+        host = params.get("remote_host")
+        port = params.get("remote_port")
+        tp_size = params.get("tp_size")
+        if (
+            remote_engine_id is None
+            or remote_request_id is None
+            or host is None
+            or port is None
+            or tp_size is None
+        ):
+            return
+        if remote_engine_id not in self._heartbeat_by_engine:
+            self._heartbeat_by_engine[remote_engine_id] = HeartbeatInfo(
+                req_ids=set(),
+                host=host,
+                port=port,
+                tp_size=tp_size,
+            )
+        self._heartbeat_by_engine[remote_engine_id].req_ids.add(remote_request_id)
+        self._heartbeat_req_engine[request.request_id] = (
+            remote_engine_id,
+            remote_request_id,
+        )
+
+    def _stop_heartbeat(self, req_id: ReqId) -> None:
+        """Remove *req_id* from heartbeat tracking (if tracked)."""
+        if key := self._heartbeat_req_engine.pop(req_id, None):
+            engine_id, remote_id = key
+            if info := self._heartbeat_by_engine.get(engine_id):
+                info.req_ids.discard(remote_id)
+                if not info.req_ids:
+                    # Clean up empty engines so we don't leak a key when remote dies.
+                    del self._heartbeat_by_engine[engine_id]
+
+    def get_sw_clipped_blocks(self, block_ids: BlockIds) -> BlockIds:
+        """
+        Clip the number of blocks to the sliding window size for each kv cache group
+        that employs SWA.
+        This is necessary because the KV Cache manager initially allocates blocks for
+        the entire sequence length, and successively cleans up blocks that are outside
+        the window prior to the `request_finished_all_groups` hook.
+        """
+        if len(block_ids) == 0 or not self._is_hma_required:
+            # No blocks to clip eg Full prefix cache hit or not a hybrid model.
+            return block_ids
+        # NOTE (NickLucche) This logic is currently handled at the connector level
+        # because offloading connectors might want to receive the whole sequence even
+        # for SWA groups. We will abstract this logic once the interface is more stable
+        assert len(block_ids) == len(self.blocks_per_sw), (
+            "Number of KV cache groups must match"
+        )
+        # For non-SWA groups, blocks_per_sw is 0 so we return all block_ids unchanged
+        return tuple(
+            [
+                blocks[-self.blocks_per_sw[i] :]
+                if self.blocks_per_sw[i] > 0
+                else blocks
+                for i, blocks in enumerate(block_ids)
+            ]
+        )
+
+    def set_xfer_handshake_metadata(
+        self, metadata: dict[int, KVConnectorHandshakeMetadata]
+    ) -> None:
+        """
+        Set the KV connector handshake metadata for this connector.
+
+        Args:
+            metadata (dict): the handshake metadata to set.
+        """
+        encoded_data: dict[int, bytes] = {}
+        encoder = msgspec.msgpack.Encoder()
+        for tp_rank, rank_metadata in metadata.items():
+            if not isinstance(rank_metadata, UcclP2pHandshakePayload):
+                raise ValueError(
+                    "UcclP2pConnectorScheduler expects UcclP2pHandshakePayload for "
+                    "handshake metadata."
+                )
+            encoded_data[tp_rank] = encoder.encode(rank_metadata)
+            logger.debug(
+                "Tp rank %d: encoded UcclP2pHandshakePayload size: %s bytes",
+                tp_rank,
+                str(len(encoded_data[tp_rank])),
+            )
+
+        # Only start the listener when we have metadata to serve.
+        if self._uccl_p2p_handshake_listener_t is None:
+            ready_event = threading.Event()
+            self._uccl_p2p_handshake_listener_t = threading.Thread(
+                target=self._uccl_p2p_handshake_listener,
+                args=(
+                    encoded_data,
+                    ready_event,
+                    self._stop_event,
+                    self.side_channel_host,
+                    self.side_channel_port,
+                ),
+                daemon=True,
+                name="uccl_p2p_handshake_listener",
+            )
+            self._uccl_p2p_handshake_listener_t.start()
+            ready_event.wait()  # Wait for listener ZMQ socket to be ready.
+
+    @staticmethod
+    def _uccl_p2p_handshake_listener(
+        encoded_data: dict[int, Any],
+        ready_event: threading.Event,
+        stop_event: threading.Event,
+        host: str,
+        port: int,
+    ):
+        """Background thread for getting new UCCL_P2P handshakes."""
+        # NOTE(rob): this is a simple implementation. We will move
+        # to a better approach via HTTP endpoint soon.
+
+        # Listen for new requests for metadata.
+        path = make_zmq_path("tcp", host, port)
+        logger.debug("Starting listening on path: %s", path)
+        with zmq_ctx(zmq.ROUTER, path) as sock:
+            sock.setsockopt(zmq.RCVTIMEO, 1000)
+            ready_event.set()
+            while True:
+                try:
+                    identity, _, msg = sock.recv_multipart()
+                except zmq.Again:
+                    if stop_event.is_set():
+                        break
+                    continue
+                # Decode the message which contains (GET_META_MSG, rank)
+                msg, target_tp_rank = msgspec.msgpack.decode(msg)
+                logger.debug(
+                    "Received message for tp rank %s",
+                    target_tp_rank,
+                )
+                if msg != GET_META_MSG:
+                    logger.warning("Connection listener got unexpected message %s", msg)
+                sock.send_multipart((identity, b"", encoded_data[target_tp_rank]))
+
+    def _mamba_prefill_token_count(self, num_prompt_tokens: int) -> int:
+        """D-side only. Returns N-1 for Mamba models since the decoder
+        always recomputes the last token and must start from h(N-1)."""
+        if self._has_mamba and num_prompt_tokens > 1:
+            return num_prompt_tokens - 1
+        return num_prompt_tokens
+
+    def _truncate_mamba_request_for_prefill(self, request: "Request") -> None:
+        """P-side only: drop the last prompt token so the prefiller computes
+        h(N-1) instead of h(N). The decoder recomputes the last token to
+        derive h(N) correctly.
+
+        Guarded by ``_p_side_truncated`` to avoid repeated truncation if the
+        request is preempted and rescheduled."""
+        params = request.kv_transfer_params
+        if (
+            params is not None
+            # Guard against repeated truncation after preemption/reschedule.
+            and not params.get("_p_side_truncated")
+            and request.num_prompt_tokens > 1
+        ):
+            if request.prompt_token_ids is not None:
+                request.prompt_token_ids.pop()
+            elif request.prompt_embeds is not None:
+                request.prompt_embeds = request.prompt_embeds[:-1]
+            else:
+                return
+
+            request._all_token_ids.pop()
+            request.num_prompt_tokens -= 1
+            request.max_tokens = 1
+            params["_p_side_truncated"] = True
+
+    def get_num_new_matched_tokens(
+        self, request: "Request", num_computed_tokens: int
+    ) -> tuple[int, bool]:
+        """
+        For remote prefill, pull all prompt blocks from remote
+        asynchronously relative to engine execution.
+
+        Args:
+            request (Request): the request object.
+            num_computed_tokens (int): the number of locally
+                computed tokens for this request
+        Returns:
+            * the number of tokens that can be loaded from the
+              external KV cache beyond what is already computed.
+            * true if the external KV cache tokens will be loaded
+              asynchronously (between scheduler steps).
+        """
+
+        params = request.kv_transfer_params
+        logger.debug(
+            "UCCL_P2PConnector get_num_new_matched_tokens: "
+            "num_computed_tokens=%s, kv_transfer_params=%s",
+            num_computed_tokens,
+            params,
+        )
+
+        if params is not None and params.get("do_remote_prefill"):
+            # Remote prefill: get all prompt blocks from remote.
+            token_ids = request.prompt_token_ids or []
+            actual = self._mamba_prefill_token_count(len(token_ids))
+            count = actual - num_computed_tokens
+            if count > 0:
+                return count, True
+
+        if params is not None and params.get("do_remote_decode") and self._has_mamba:
+            self._truncate_mamba_request_for_prefill(request)
+
+        if (
+            params is not None
+            and params.get("do_remote_decode")
+            and params.get("remote_block_ids")
+            and all(
+                p in params
+                for p in (
+                    "remote_engine_id",
+                    "remote_request_id",
+                    "remote_host",
+                    "remote_port",
+                )
+            )
+        ):
+            # Decode node has kv blocks for part of prefill request, so, provide them
+            # as an external token count to scheduler.
+            # The tokens will be loaded if not already present
+            # in the prefill node local cache
+            remote_num_tokens = params.get("remote_num_tokens") or 0
+            count = (
+                min(remote_num_tokens, request.num_prompt_tokens) - num_computed_tokens
+            )
+            if count > 0:
+                # Check kv_recompute_threshold: skip pull if
+                # remote tokens are below the threshold.
+                if (
+                    self.kv_recompute_threshold > 0
+                    and count < self.kv_recompute_threshold
+                ):
+                    logger.debug(
+                        "Skipping remote pull for %s: %d remote tokens < threshold %d",
+                        request.request_id,
+                        count,
+                        self.kv_recompute_threshold,
+                    )
+                    return 0, False
+                return count, True
+
+        # No remote prefill for this request.
+        return 0, False
+
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
+        params = request.kv_transfer_params
+        logger.debug(
+            "UCCL_P2PConnector update_state_after_alloc: "
+            "num_external_tokens=%s, kv_transfer_params=%s",
+            num_external_tokens,
+            params,
+        )
+
+        if not params:
+            return
+
+        if params.get("do_remote_decode") or (
+            params.get("do_remote_prefill") and self.is_bidirectional_kv_xfer_enabled
+        ):
+            self._reqs_in_batch.add(request.request_id)
+        if self.use_host_buffer and params.get("do_remote_decode"):
+            # NOTE: when accelerator is not directly supported by UcclP2p,
+            # prefilled blocks need to be saved to host memory before transfer.
+            self._reqs_need_save[request.request_id] = request
+        elif params.get("do_remote_prefill") or (
+            params.get("do_remote_decode")
+            and self.is_bidirectional_kv_xfer_enabled
+            and not params.get("_remote_blocks_processed")
+        ):
+            if params.get("remote_block_ids"):
+                if all(
+                    p in params
+                    for p in (
+                        "remote_engine_id",
+                        "remote_request_id",
+                        "remote_host",
+                        "remote_port",
+                    )
+                ):
+                    # If remote_blocks and num_external_tokens = 0, we have
+                    # a full prefix cache hit on the local node. We need to call
+                    # send_notif in _read_blocks to free the memory on the remote node.
+
+                    unhashed_local_block_ids: BlockIds = (
+                        blocks.get_unhashed_block_ids_all_groups()
+                        if num_external_tokens > 0
+                        else ()
+                    )
+                    local_block_ids = self.get_sw_clipped_blocks(
+                        unhashed_local_block_ids
+                    )
+
+                    # Get unhashed blocks to pull from remote. Mind that a full prefix
+                    # cache hit is indicated with an empty list.
+                    self._reqs_need_recv[request.request_id] = (
+                        request,
+                        local_block_ids,
+                    )
+
+                else:
+                    logger.warning(
+                        "Got invalid KVTransferParams: %s. This "
+                        "request will not utilize KVTransfer",
+                        params,
+                    )
+            else:
+                assert num_external_tokens == 0
+            # Only trigger 1 KV transfer per request.
+            params["do_remote_prefill"] = False
+            params["_remote_blocks_processed"] = True
+
+    def _build_save_meta(
+        self,
+        meta: UcclP2pConnectorMetadata,
+        scheduler_output: SchedulerOutput,
+    ) -> None:
+        # only called when use_host_buffer is True to build the save metadata
+
+        # NOTE: For the prefill side, there might be a chance that an early added
+        # request is a chunked prefill, so we need to check if new blocks are added
+        for req_id, new_block_id_groups, _ in yield_req_data(scheduler_output):
+            req_to_save = self._reqs_need_save.get(req_id)
+            if req_to_save is None or new_block_id_groups is None:
+                continue
+            req = req_to_save
+
+            assert req.kv_transfer_params is not None
+            clipped_block_id_groups = self.get_sw_clipped_blocks(new_block_id_groups)
+            meta.add_new_req_to_save(
+                request_id=req_id,
+                local_block_ids=clipped_block_id_groups,
+                kv_transfer_params=req.kv_transfer_params,
+            )
+            assert scheduler_output.num_scheduled_tokens is not None
+            num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
+            is_partial = (
+                req.num_computed_tokens + num_scheduled_tokens
+            ) < req.num_prompt_tokens
+            if not is_partial:
+                # For non-partial prefills, once new req_meta is scheduled, it
+                # can be removed from _reqs_need_save.
+                # For partial prefill case, we will retain the request in
+                # _reqs_need_save until all blocks are scheduled with req_meta.
+                # Therefore, only pop if `not is_partial`.
+                self._reqs_need_save.pop(req_id)
+
+    def build_connector_meta(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> KVConnectorMetadata:
+        meta = UcclP2pConnectorMetadata()
+
+        # Loop through scheduled reqs and convert to ReqMeta.
+        for req_id, (req, block_ids) in self._reqs_need_recv.items():
+            assert req.kv_transfer_params is not None
+            meta.add_new_req_to_recv(
+                request_id=req_id,
+                local_block_ids=block_ids,
+                kv_transfer_params=req.kv_transfer_params,
+            )
+
+        if self.use_host_buffer:
+            self._build_save_meta(meta, scheduler_output)
+
+        meta.reqs_to_send = self._reqs_need_send
+        meta.reqs_in_batch = self._reqs_in_batch
+        meta.reqs_not_processed = self._reqs_not_processed
+
+        # Package heartbeats, throttled by heartbeat_interval.
+        if self._heartbeat_by_engine:
+            now = time.perf_counter()
+            if now - self._last_heartbeat_time >= self._heartbeat_interval:
+                self._last_heartbeat_time = now
+                meta.heartbeat_by_engine = self._heartbeat_by_engine
+
+        # Clear the list once workers start the transfers
+        self._reqs_need_recv.clear()
+        self._reqs_in_batch = set()
+        self._reqs_not_processed = set()
+        self._reqs_need_send = {}
+
+        return meta
+
+    def update_connector_output(self, connector_output: "KVConnectorOutput") -> None:
+        """Stop heartbeating for requests whose KV transfer completed."""
+        for req_id in connector_output.finished_recving or ():
+            self._stop_heartbeat(req_id)
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: BlockIds,
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """
+        Once a request is finished, determine whether request blocks
+        should be freed now or will be sent asynchronously and freed later.
+        """
+        from vllm.v1.request import RequestStatus
+
+        params = request.kv_transfer_params
+        logger.debug(
+            "UCCL_P2PConnector request_finished(%s), request_status=%s, "
+            "kv_transfer_params=%s",
+            request.request_id,
+            request.status,
+            params,
+        )
+        if not params:
+            return False, None
+
+        is_p_node = bool(params.get("do_remote_decode"))
+        is_d_node = not is_p_node
+
+        # Stop heartbeating for aborted requests that never reached finished_recving:
+        # normal path cleans up in update_connector_output.
+        self._stop_heartbeat(request.request_id)
+
+        if params.get("do_remote_prefill"):
+            # If do_remote_prefill is still True when the request is finished,
+            # update_state_after_alloc must not have been called (the request
+            # must have been aborted before it was scheduled, e.g. via the
+            # abort_immediately path used to clean up KV-transfer requests
+            # rejected at the D-side serving layer).
+            # To avoid stranding the prefill blocks in the prefill instance,
+            # we must add empty block_ids to _reqs_need_recv so that our
+            # worker side will notify and free blocks in the prefill instance.
+            self._reqs_need_recv[request.request_id] = (request, [])
+            params["do_remote_prefill"] = False
+            return False, None
+
+        if is_d_node and not self.is_bidirectional_kv_xfer_enabled:
+            return False, None
+
+        if request.status not in (
+            RequestStatus.FINISHED_LENGTH_CAPPED,
+            RequestStatus.FINISHED_STOPPED,
+        ):
+            # Also include the case of a P/D Prefill request with immediate
+            # block free (eg abort). Stop tracking this request.
+            self._reqs_not_processed.add(request.request_id)
+            # Clear _reqs_need_save if a request is aborted as partial prefill.
+            self._reqs_need_save.pop(request.request_id, None)
+            return False, None
+
+        # TODO: check whether block_ids actually ever be 0. If not we could
+        # remove the conditional below
+        delay_free_blocks = any(len(group) > 0 for group in block_ids)
+        remote_num_tokens = 0
+        if delay_free_blocks:
+            # Prefill request on remote. It will be read from D upon completion
+            request_kv_blocks_ttl = self._kv_lease_duration
+            if is_d_node:
+                # For blocks pinned on D, use a simpler timeout for now instead of a
+                # lease mechanism as turn2 request is client-driven.
+                request_kv_blocks_ttl = self.decoder_kv_blocks_ttl
+            logger.debug(
+                "UCCL_P2PConnector request_finished(%s) waiting for %d seconds "
+                "before releasing blocks",
+                request.request_id,
+                request_kv_blocks_ttl,
+            )
+            self._reqs_need_send[request.request_id] = (
+                time.perf_counter() + request_kv_blocks_ttl
+            )
+            # NOTE HMA will "mark" empty/null blocks in groups with 0s (eg SWA ones),
+            # trimming down after allocating for the whole sequence length. Empty
+            # blocks are always at the start of the list.
+            # Here we "unpad" blocks to send the actual remote blocks to be read.
+            block_ids = self.get_sw_clipped_blocks(block_ids)
+
+            remote_num_tokens = request.num_computed_tokens
+
+        return delay_free_blocks, dict(
+            do_remote_prefill=is_p_node,
+            do_remote_decode=is_d_node,
+            remote_block_ids=block_ids,
+            remote_engine_id=self.engine_id,
+            remote_request_id=request.request_id,
+            remote_host=self.side_channel_host,
+            remote_port=self.side_channel_port,
+            tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
+            remote_num_tokens=remote_num_tokens,
+        )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/stats.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Stats and Prometheus metrics for the UCCL_P2P connector."""
+
+import copy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
+from vllm.v1.metrics.utils import create_metric_per_engine
+
+if TYPE_CHECKING:
+    from vllm.distributed.uccl_p2p_utils import uccl_p2pXferTelemetry
+
+
+@dataclass
+class UcclP2pKVConnectorStats(KVConnectorStats):
+    """Container for transfer performance metrics"""
+
+    def __post_init__(self):
+        if not self.data:
+            # Empty container init, no data is passed in.
+            self.reset()
+
+    def reset(self):
+        # Must be serializable
+        self.data: dict[str, list[float | int]] = {
+            "transfer_duration": [],
+            "post_duration": [],
+            "bytes_transferred": [],
+            "num_descriptors": [],
+            "num_failed_transfers": [],
+            "num_failed_notifications": [],
+            "num_kv_expired_reqs": [],
+        }
+
+    def record_transfer(self, res: "uccl_p2pXferTelemetry"):
+        # Keep metrics units consistent with rest of the code: time us->s
+        self.data["transfer_duration"].append(res.xferDuration / 1e6)
+        self.data["post_duration"].append(res.postDuration / 1e6)
+        self.data["bytes_transferred"].append(res.totalBytes)
+        self.data["num_descriptors"].append(res.descCount)
+
+    def record_failed_transfer(self):
+        """Record a failed UCCL_P2P transfer operation."""
+        self.data["num_failed_transfers"].append(1)
+
+    def record_failed_notification(self):
+        """Record a failed UCCL_P2P notification (send_notif)."""
+        self.data["num_failed_notifications"].append(1)
+
+    def record_kv_expired_req(self):
+        """Record a request that had its KV blocks expire."""
+        self.data["num_kv_expired_reqs"].append(1)
+
+    def clone_and_reset(self) -> "UcclP2pKVConnectorStats":
+        old = copy.copy(self)
+        self.reset()
+        return old
+
+    def is_empty(self) -> bool:
+        # Do not discard metrics update that are entirely failures related.
+        return (
+            self.num_successful_transfers == 0
+            and len(self.data["num_failed_transfers"]) == 0
+            and len(self.data["num_failed_notifications"]) == 0
+            and len(self.data["num_kv_expired_reqs"]) == 0
+        )
+
+    def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
+        if not other.is_empty():
+            for k, v in other.data.items():
+                accumulator = self.data[k]
+                assert isinstance(accumulator, list)
+                accumulator.extend(v)
+        return self
+
+    def reduce(self) -> dict[str, int | float]:
+        # Compute compact representative stats suitable for CLI logging
+        if self.num_successful_transfers == 0:
+            # CLI logging only reports successful transfers stats. If all requests in
+            # the interval were unsuccessful, Prom will report failures stats instead.
+            return {
+                "Num successful transfers": 0,
+                "Avg xfer time (ms)": 0,
+                "P90 xfer time (ms)": 0,
+                "Avg post time (ms)": 0,
+                "P90 post time (ms)": 0,
+                "Avg MB per transfer": 0,
+                "Throughput (MB/s)": 0,
+                "Avg number of descriptors": 0,
+            }
+
+        xfer_time = np.asarray(self.data["transfer_duration"])
+        post_time = np.asarray(self.data["post_duration"])
+        # Convert to MB for CLI logging.
+        mb = np.asarray(self.data["bytes_transferred"]) / 2**20
+        descs = np.asarray(self.data["num_descriptors"], dtype=np.uint32)
+        n = len(descs)
+        assert n == self.num_successful_transfers
+
+        total_mb = mb.sum()
+        avg_mb = total_mb / n
+
+        total_time_seconds = xfer_time.sum()
+        throughput_mb_s = total_mb / total_time_seconds
+
+        return {
+            "Num successful transfers": n,
+            "Avg xfer time (ms)": round(xfer_time.mean() * 1e3, 3),
+            "P90 xfer time (ms)": round(np.percentile(xfer_time, 90).item() * 1e3, 3),
+            "Avg post time (ms)": round(post_time.mean() * 1e3, 3),
+            "P90 post time (ms)": round(np.percentile(post_time, 90).item() * 1e3, 3),
+            "Avg MB per transfer": round(avg_mb, 3),
+            "Throughput (MB/s)": round(throughput_mb_s, 3),
+            "Avg number of descriptors": round(descs.mean(), 1),
+        }
+
+    @property
+    def num_successful_transfers(self) -> int:
+        return len(self.data["transfer_duration"])
+
+
+class UcclP2pPromMetrics(KVConnectorPromMetrics):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ):
+        super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
+
+        buckets = [
+            0.001,
+            0.005,
+            0.01,
+            0.025,
+            0.05,
+            0.075,
+            0.1,
+            0.2,
+            0.3,
+            0.5,
+            0.75,
+            1.0,
+            5.0,
+        ]
+        uccl_p2p_histogram_xfer_time = self._histogram_cls(
+            name="vllm:uccl_p2p_xfer_time_seconds",
+            documentation=(
+                "Histogram of transfer duration for UCCL_P2P KV Cache transfers."),
+            buckets=buckets[1:],
+            labelnames=labelnames,
+        )
+        self.uccl_p2p_histogram_xfer_time = create_metric_per_engine(
+            uccl_p2p_histogram_xfer_time, self.per_engine_labelvalues
+        )
+        uccl_p2p_histogram_post_time = self._histogram_cls(
+            name="vllm:uccl_p2p_post_time_seconds",
+            documentation="Histogram of transfer post time for UCCL_P2P KV"
+            " Cache transfers.",
+            buckets=buckets,
+            labelnames=labelnames,
+        )
+        self.uccl_p2p_histogram_post_time = create_metric_per_engine(
+            uccl_p2p_histogram_post_time, self.per_engine_labelvalues
+        )
+        # uniform 2kb to 16gb range
+        buckets = [2 ** (10 + i) for i in range(1, 25, 2)]
+        uccl_p2p_histogram_bytes_transferred = self._histogram_cls(
+            name="vllm:uccl_p2p_bytes_transferred",
+            documentation=(
+                "Histogram of bytes transferred per UCCL_P2P KV Cache transfers."),
+            buckets=buckets,
+            labelnames=labelnames,
+        )
+        self.uccl_p2p_histogram_bytes_transferred = create_metric_per_engine(
+            uccl_p2p_histogram_bytes_transferred, self.per_engine_labelvalues
+        )
+        buckets = [
+            10,
+            20,
+            30,
+            50,
+            75,
+            100,
+            200,
+            400,
+            1000,
+            2000,
+            4000,
+            10000,
+            20000,
+            50000,
+        ]
+        uccl_p2p_histogram_num_descriptors = self._histogram_cls(
+            name="vllm:uccl_p2p_num_descriptors",
+            documentation="Histogram of number of descriptors per UCCL_P2P"
+            "  KV Cache transfers.",
+            buckets=buckets,
+            labelnames=labelnames,
+        )
+        self.uccl_p2p_histogram_num_descriptors = create_metric_per_engine(
+            uccl_p2p_histogram_num_descriptors, self.per_engine_labelvalues
+        )
+        counter_uccl_p2p_num_failed_transfers = self._counter_cls(
+            name="vllm:uccl_p2p_num_failed_transfers",
+            documentation="Number of failed UCCL_P2P KV Cache transfers.",
+            labelnames=labelnames,
+        )
+        self.counter_uccl_p2p_num_failed_transfers = create_metric_per_engine(
+            counter_uccl_p2p_num_failed_transfers, self.per_engine_labelvalues
+        )
+        counter_uccl_p2p_num_failed_notifications = self._counter_cls(
+            name="vllm:uccl_p2p_num_failed_notifications",
+            documentation="Number of failed UCCL_P2P KV Cache notifications.",
+            labelnames=labelnames,
+        )
+        self.counter_uccl_p2p_num_failed_notifications = create_metric_per_engine(
+            counter_uccl_p2p_num_failed_notifications, self.per_engine_labelvalues
+        )
+
+        counter_uccl_p2p_num_kv_expired_reqs = self._counter_cls(
+            name="vllm:uccl_p2p_num_kv_expired_reqs",
+            documentation="Number of requests that had their KV expire. "
+            "NOTE: This metric is tracked on the P instance.",
+            labelnames=labelnames,
+        )
+        self.counter_uccl_p2p_num_kv_expired_reqs = create_metric_per_engine(
+            counter_uccl_p2p_num_kv_expired_reqs, self.per_engine_labelvalues
+        )
+
+    def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
+        for prom_obj, list_item_key in zip(
+            [
+                self.uccl_p2p_histogram_xfer_time,
+                self.uccl_p2p_histogram_post_time,
+                self.uccl_p2p_histogram_bytes_transferred,
+                self.uccl_p2p_histogram_num_descriptors,
+            ],
+            [
+                "transfer_duration",
+                "post_duration",
+                "bytes_transferred",
+                "num_descriptors",
+            ],
+        ):
+            for list_item in transfer_stats_data[list_item_key]:
+                prom_obj[engine_idx].observe(list_item)
+        for counter_obj, counter_item_key in zip(
+            [
+                self.counter_uccl_p2p_num_failed_transfers,
+                self.counter_uccl_p2p_num_failed_notifications,
+                self.counter_uccl_p2p_num_kv_expired_reqs,
+            ],
+            ["num_failed_transfers", "num_failed_notifications", "num_kv_expired_reqs"],
+        ):
+            for list_item in transfer_stats_data[counter_item_key]:
+                counter_obj[engine_idx].inc(list_item)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/tp_mapping.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/tp_mapping.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TP mapping computation for UCCL_P2P KV cache transfers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from vllm.distributed.kv_transfer.kv_connector.utils import (
+    BlockIds,
+    TransferTopology,
+)
+from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheSpec, MambaSpec
+
+# ======================================================================
+# Data structures
+# ======================================================================
+
+
+@dataclass(frozen=True)
+class ReadSpec:
+    """Specification for a single remote block read operation."""
+
+    remote_rank: int
+    local_block_ids: BlockIds
+    remote_block_ids: BlockIds
+
+
+def _is_attention_spec(spec_type: type[KVCacheSpec]) -> bool:
+    return issubclass(spec_type, AttentionSpec)
+
+
+def _is_ssm_spec(spec_type: type[KVCacheSpec]) -> bool:
+    return issubclass(spec_type, MambaSpec)
+
+
+@dataclass(frozen=True)
+class TPMapping:
+    """Complete local-to-remote TP mapping for one remote engine.
+
+    Generated once per remote engine during handshake.
+    """
+
+    # Remote TP ranks that this local rank reads from, per group.
+    # Position = local piece index.
+    source_ranks_per_group: tuple[tuple[int, ...], ...]
+
+    # Superset of all source ranks (union of all groups).
+    all_source_ranks: tuple[int, ...]
+
+    # Maps each source rank to its FA head slot index.
+    rank_to_attention_slot: dict[int, int]
+
+    # FA head offset factor for hetero-TP (D_TP > P_TP).
+    rank_offset_factor: int
+
+
+# ======================================================================
+# TP mapping computation
+# ======================================================================
+
+
+def compute_tp_mapping(
+    transfer_topology: TransferTopology,
+    remote_tp_size: int,
+    group_spec_types: tuple[type[KVCacheSpec], ...],
+) -> TPMapping:
+    """Build the complete local-to-remote TP mapping.
+
+    Computes source ranks, head slot assignments, and the rank offset
+    factor in a single pass.
+    """
+    tp_rank = transfer_topology.tp_rank
+    tp_size = transfer_topology.tp_size
+    total_num_kv_heads = transfer_topology.total_num_kv_heads
+    # --- Attention source ranks ---
+    if transfer_topology.is_mla or tp_size >= remote_tp_size:
+        # D (local TP) > P (remote TP): multiple local ranks read different chunks from
+        # *one* remote rank, corresponding to different kv heads.
+        # For MLA, we only need one remote since cache is duplicated. When P TP=k*TP k,
+        # this will spread mla ranks to read from remote k*tp_rank.
+        attn_ranks = [tp_rank * remote_tp_size // tp_size]
+    else:
+        # P (remote TP) > D (local TP): one local rank
+        # reads from multiple remote ranks.
+        # GQA dedup: when K < remote_tp_size, several remote ranks
+        # hold the same KV head.  np.unique keeps only the first
+        # rank per unique head so we don't issue redundant reads.
+        abs_tp = remote_tp_size // tp_size
+        start = tp_rank * abs_tp
+        heads = np.arange(start, start + abs_tp) * total_num_kv_heads // remote_tp_size
+        _, unique_idx = np.unique(heads, return_index=True)
+        attn_ranks = (start + np.sort(unique_idx)).tolist()
+
+    # --- SSM source ranks ---
+    has_ssm = any(_is_ssm_spec(t) for t in group_spec_types)
+    if has_ssm:
+        if tp_size < remote_tp_size:
+            abs_tp = remote_tp_size // tp_size
+            ssm_ranks = list(range(tp_rank * abs_tp, (tp_rank + 1) * abs_tp))
+        else:
+            ssm_ranks = list(attn_ranks)
+    else:
+        ssm_ranks = []
+
+    all_ranks = sorted(set(attn_ranks) | set(ssm_ranks))
+
+    # --- Per-group ordered source ranks ---
+    source_ranks_per_group = tuple(
+        tuple(ssm_ranks) if _is_ssm_spec(t) else tuple(attn_ranks)
+        for t in group_spec_types
+    )
+
+    # --- Attention head slots ---
+    head_to_slot: dict[int, int] = {}
+    for i, r in enumerate(attn_ranks):
+        head_to_slot[r * total_num_kv_heads // remote_tp_size] = i
+    rank_to_attention_slot = {
+        r: head_to_slot.get(r * total_num_kv_heads // remote_tp_size, 0)
+        for r in all_ranks
+    }
+
+    # --- Rank offset factor ---
+    if transfer_topology.is_mla or tp_size <= remote_tp_size:
+        # We don't index into remote for reading, no offset needed.
+        rank_offset_factor = 0
+    elif tp_size > total_num_kv_heads:
+        local_head = tp_rank * total_num_kv_heads // tp_size
+        p_start = attn_ranks[0] * total_num_kv_heads // remote_tp_size
+        rank_offset_factor = local_head - p_start
+    else:
+        # D TP > P TP: we index into remote to read different heads depending on rank.
+        rank_offset_factor = tp_rank % (tp_size // remote_tp_size)
+
+    return TPMapping(
+        source_ranks_per_group=source_ranks_per_group,
+        all_source_ranks=tuple(all_ranks),
+        rank_to_attention_slot=rank_to_attention_slot,
+        rank_offset_factor=rank_offset_factor,
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/uccl_p2p_wrapper.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/uccl_p2p_wrapper.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Thin wrapper around uccl.p2p.Endpoint for vLLM KV connector use."""
 
+import os
 import queue
 import threading
 import time
@@ -15,6 +16,15 @@ from vllm.distributed.uccl_p2p_utils import XferDesc as UcclP2pXferDesc
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+_UCCL_P2P_TIMING_ENABLED = os.environ.get("VLLM_UCCL_P2P_TIMING", "0") == "1"
+_UCCL_P2P_NOTIF_SPIN_US = int(os.environ.get("VLLM_UCCL_P2P_NOTIF_SPIN_US", "100"))
+_UCCL_P2P_NOTIF_SPIN_S = _UCCL_P2P_NOTIF_SPIN_US / 1e6
+
+
+def _timing(label: str, elapsed_us: float) -> None:
+    if _UCCL_P2P_TIMING_ENABLED:
+        logger.info("[uccl_p2p_timing] %s: %.1f us", label, elapsed_us)
 
 
 class UcclP2pWrapper:
@@ -43,6 +53,8 @@ class UcclP2pWrapper:
 
         # Agent name -> conn_id (shared by data transfers and notifications).
         self._conn_ids: dict[str, int] = {}
+        # Reverse lookup for notification delivery.
+        self._conn_id_to_agent: dict[int, str] = {}
 
         # Notification receive state.
         self._notif_queue: queue.Queue[tuple[str, bytes]] = queue.Queue()
@@ -52,22 +64,20 @@ class UcclP2pWrapper:
         )
         self._notif_recv_thread.start()
 
-        # Small pinned CPU buffers used for notifications.
+        # Small pinned CPU buffer used for sending notifications.
         self._notif_buf_size = 256
         self._notif_send_buf = torch.zeros(
-            self._notif_buf_size, dtype=torch.uint8, pin_memory=True
-        )
-        self._notif_recv_buf = torch.zeros(
             self._notif_buf_size, dtype=torch.uint8, pin_memory=True
         )
         send_descs = self._ep.register_memory([self._notif_send_buf])
         if not send_descs:
             raise RuntimeError("UCCL P2P notification send buffer registration failed")
         self._notif_send_mr = send_descs[0].mr_id
-        recv_descs = self._ep.register_memory([self._notif_recv_buf])
-        if not recv_descs:
-            raise RuntimeError("UCCL P2P notification recv buffer registration failed")
-        self._notif_recv_mr = recv_descs[0].mr_id
+
+        # Per-connection receive buffers and async recv handles.
+        self._notif_recv_bufs: dict[int, torch.Tensor] = {}
+        self._notif_recv_mrs: dict[int, int] = {}
+        self._pending_recvs: dict[int, int] = {}
 
     # ------------------------------------------------------------------
     # Endpoint metadata
@@ -92,12 +102,32 @@ class UcclP2pWrapper:
         if not ok:
             raise RuntimeError(f"Failed to add UCCL P2P endpoint for {agent_name}")
         self._conn_ids[agent_name] = conn_id
+        self._conn_id_to_agent[conn_id] = agent_name
+
+        # Allocate a dedicated pinned receive buffer for this connection so
+        # multiple async recvs can be outstanding without overwriting a shared
+        # buffer.
+        recv_buf = torch.zeros(
+            self._notif_buf_size, dtype=torch.uint8, pin_memory=True
+        )
+        recv_descs = self._ep.register_memory([recv_buf])
+        if not recv_descs:
+            raise RuntimeError(
+                "UCCL P2P notification recv buffer registration failed for "
+                f"{agent_name}"
+            )
+        self._notif_recv_bufs[conn_id] = recv_buf
+        self._notif_recv_mrs[conn_id] = recv_descs[0].mr_id
 
         return agent_name
 
     def remove_remote_agent(self, agent_name: str) -> None:
         conn_id = self._conn_ids.pop(agent_name, None)
         if conn_id is not None:
+            self._conn_id_to_agent.pop(conn_id, None)
+            self._pending_recvs.pop(conn_id, None)
+            self._notif_recv_bufs.pop(conn_id, None)
+            self._notif_recv_mrs.pop(conn_id, None)
             self._ep.remove_remote_endpoint(conn_id)
 
     # ------------------------------------------------------------------
@@ -116,13 +146,16 @@ class UcclP2pWrapper:
         return self._ep.deserialize_descs(serialized)
 
     def copy_xfer_desc(self, base_desc: Any, addr: int, size: int) -> Any:
-        """Return a new XferDesc copying RDMA fields and overriding addr/size."""
+        """Return a new XferDesc sharing RDMA keys and overriding addr/size."""
         desc = UcclP2pXferDesc()
         desc.addr = addr
         desc.size = size
         desc.mr_id = base_desc.mr_id
-        desc.lkeys = list(base_desc.lkeys)
-        desc.rkeys = list(base_desc.rkeys)
+        # lkeys/rkeys are immutable for a registered memory region, so share
+        # the same list object across all per-block descriptors to avoid deep
+        # copy overhead during registration.
+        desc.lkeys = base_desc.lkeys
+        desc.rkeys = base_desc.rkeys
         return desc
 
     # ------------------------------------------------------------------
@@ -144,8 +177,13 @@ class UcclP2pWrapper:
         if agent_name is None:
             raise ValueError("agent_name is required for UCCL P2P transfer")
         conn_id = self._conn_ids[agent_name]
+        t0 = time.perf_counter()
         ok, transfer_id = self._ep.transfer(
             conn_id, op_name.lower(), local_descs, remote_descs
+        )
+        _timing(
+            f"transfer_{op_name.lower()}_n={len(local_descs)}",
+            (time.perf_counter() - t0) * 1e6,
         )
         if not ok:
             raise RuntimeError(f"Failed to start UCCL P2P {op_name} transfer")
@@ -156,7 +194,9 @@ class UcclP2pWrapper:
         pass
 
     def check_xfer_state(self, transfer_id: int) -> str:
+        t0 = time.perf_counter()
         ok, is_done = self._ep.poll_async(transfer_id)
+        _timing("poll_async", (time.perf_counter() - t0) * 1e6)
         if not ok:
             return "ERR"
         return "DONE" if is_done else "PROC"
@@ -179,9 +219,11 @@ class UcclP2pWrapper:
         self._notif_send_buf[:n].copy_(
             torch.frombuffer(notif_msg[:n], dtype=torch.uint8)
         )
+        t0 = time.perf_counter()
         ok = self._ep.send(
             conn_id, self._notif_send_mr, self._notif_send_buf.data_ptr(), n
         )
+        _timing("send_notif", (time.perf_counter() - t0) * 1e6)
         if not ok:
             raise RuntimeError(f"Failed to send UCCL P2P notification to {agent_name}")
 
@@ -199,27 +241,61 @@ class UcclP2pWrapper:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+    def _post_async_recv(self, conn_id: int) -> bool:
+        """Post an asynchronous recv for conn_id. Returns True on success."""
+        buf = self._notif_recv_bufs.get(conn_id)
+        mr = self._notif_recv_mrs.get(conn_id)
+        if buf is None or mr is None:
+            return False
+        t0 = time.perf_counter()
+        ok, handle = self._ep.recv_async(
+            conn_id, mr, buf.data_ptr(), self._notif_buf_size
+        )
+        _timing("recv_async_post", (time.perf_counter() - t0) * 1e6)
+        if ok:
+            self._pending_recvs[conn_id] = handle
+            return True
+        return False
+
+    def _drain_completed_recvs(self) -> bool:
+        """Poll all pending async recvs and enqueue completed messages.
+
+        Returns True if at least one message was received.
+        """
+        received = False
+        for conn_id, handle in list(self._pending_recvs.items()):
+            t0 = time.perf_counter()
+            ok, is_done = self._ep.poll_async(handle)
+            _timing("recv_async_poll", (time.perf_counter() - t0) * 1e6)
+            if ok and is_done:
+                buf = self._notif_recv_bufs[conn_id]
+                arr = buf.numpy()
+                msg = arr.tobytes().rstrip(b"\x00")
+                if msg:
+                    agent_name = self._conn_id_to_agent.get(conn_id)
+                    if agent_name is not None:
+                        self._notif_queue.put((agent_name, msg))
+                received = True
+                # Re-post a fresh recv for this connection.
+                self._pending_recvs.pop(conn_id, None)
+                self._post_async_recv(conn_id)
+            elif not ok:
+                self._pending_recvs.pop(conn_id, None)
+                self._post_async_recv(conn_id)
+        return received
+
     def _notif_recv_loop(self) -> None:
         while not self._notif_stop.is_set():
-            received = False
-            for agent_name, conn_id in list(self._conn_ids.items()):
-                try:
-                    ok = self._ep.recv(
-                        conn_id,
-                        self._notif_recv_mr,
-                        self._notif_recv_buf.data_ptr(),
-                        self._notif_buf_size,
-                    )
-                    if ok:
-                        arr = self._notif_recv_buf.numpy()
-                        msg = arr.tobytes().rstrip(b"\x00")
-                        if msg:
-                            self._notif_queue.put((agent_name, msg))
-                        received = True
-                except Exception as e:
-                    logger.debug("UCCL P2P recv error on %s: %s", agent_name, e)
-            if not received:
-                time.sleep(0.001)
+            # Ensure every known connection has an outstanding async recv.
+            for conn_id in self._notif_recv_bufs:
+                if conn_id not in self._pending_recvs:
+                    self._post_async_recv(conn_id)
+
+            if self._drain_completed_recvs():
+                continue
+
+            # No completions: short spin wait before polling again.
+            time.sleep(_UCCL_P2P_NOTIF_SPIN_S)
 
     def shutdown(self) -> None:
         self._notif_stop.set()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/uccl_p2p_wrapper.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/uccl_p2p_wrapper.py
@@ -11,6 +11,7 @@ from typing import Any
 import torch
 
 from vllm.distributed.uccl_p2p_utils import Endpoint as UcclP2pEndpoint
+from vllm.distributed.uccl_p2p_utils import XferDesc as UcclP2pXferDesc
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -113,6 +114,16 @@ class UcclP2pWrapper:
 
     def deserialize_descs(self, serialized: bytes) -> list[Any]:
         return self._ep.deserialize_descs(serialized)
+
+    def copy_xfer_desc(self, base_desc: Any, addr: int, size: int) -> Any:
+        """Return a new XferDesc copying RDMA fields and overriding addr/size."""
+        desc = UcclP2pXferDesc()
+        desc.addr = addr
+        desc.size = size
+        desc.mr_id = base_desc.mr_id
+        desc.lkeys = list(base_desc.lkeys)
+        desc.rkeys = list(base_desc.rkeys)
+        return desc
 
     # ------------------------------------------------------------------
     # Transfer

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/uccl_p2p_wrapper.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/uccl_p2p_wrapper.py
@@ -17,11 +17,12 @@ logger = init_logger(__name__)
 
 
 class UcclP2pWrapper:
-    """Wraps two uccl.p2p.Endpoint instances and exposes a NIXL-like API.
+    """Wraps a single uccl.p2p.Endpoint instance and exposes a NIXL-like API.
 
-    We keep two endpoints so that data transfers and small notifications do
-    not share the same UCCL connection.  Both endpoints run
-    ``start_passive_accept()`` so remote peers can connect to us.
+    A single endpoint safely supports a background blocking ``recv()`` thread
+    concurrent with the main thread calling ``register_memory()`` /
+    ``transfer()`` / ``poll_async()`` (only fine-grained ``shared_mutex`` on
+    conn/mr tables; ``poll`` is lock-free).
 
     The wrapper intentionally mimics the NixlWrapper interface used by the
     vLLM NIXL connector so that the higher-level connector logic can be reused
@@ -31,38 +32,38 @@ class UcclP2pWrapper:
     def __init__(self, local_gpu_idx: int):
         if UcclP2pEndpoint is None:
             raise RuntimeError(
-                "uccl.p2p is not available. Please install the UCCL P2P package.")
+                "uccl.p2p is not available. Please install the UCCL P2P package."
+            )
 
-        self._data_ep = UcclP2pEndpoint(local_gpu_idx)
-        self._notif_ep = UcclP2pEndpoint(local_gpu_idx)
-        self._data_ep.start_passive_accept()
-        self._notif_ep.start_passive_accept()
+        self._ep = UcclP2pEndpoint(local_gpu_idx)
+        self._ep.start_passive_accept()
 
-        self._data_metadata = self._data_ep.get_metadata()
-        self._notif_metadata = self._notif_ep.get_metadata()
+        self._metadata = self._ep.get_metadata()
 
-        # Agent name -> data conn_id and notification conn_id.
-        self._data_conn_ids: dict[str, int] = {}
-        self._notif_conn_ids: dict[str, int] = {}
+        # Agent name -> conn_id (shared by data transfers and notifications).
+        self._conn_ids: dict[str, int] = {}
 
         # Notification receive state.
         self._notif_queue: queue.Queue[tuple[str, bytes]] = queue.Queue()
         self._notif_stop = threading.Event()
         self._notif_recv_thread = threading.Thread(
-            target=self._notif_recv_loop, daemon=True, name="uccl_p2p_notif_recv")
+            target=self._notif_recv_loop, daemon=True, name="uccl_p2p_notif_recv"
+        )
         self._notif_recv_thread.start()
 
         # Small pinned CPU buffers used for notifications.
         self._notif_buf_size = 256
         self._notif_send_buf = torch.zeros(
-            self._notif_buf_size, dtype=torch.uint8, pin_memory=True)
+            self._notif_buf_size, dtype=torch.uint8, pin_memory=True
+        )
         self._notif_recv_buf = torch.zeros(
-            self._notif_buf_size, dtype=torch.uint8, pin_memory=True)
-        send_descs = self._notif_ep.register_memory([self._notif_send_buf])
+            self._notif_buf_size, dtype=torch.uint8, pin_memory=True
+        )
+        send_descs = self._ep.register_memory([self._notif_send_buf])
         if not send_descs:
             raise RuntimeError("UCCL P2P notification send buffer registration failed")
         self._notif_send_mr = send_descs[0].mr_id
-        recv_descs = self._notif_ep.register_memory([self._notif_recv_buf])
+        recv_descs = self._ep.register_memory([self._notif_recv_buf])
         if not recv_descs:
             raise RuntimeError("UCCL P2P notification recv buffer registration failed")
         self._notif_recv_mr = recv_descs[0].mr_id
@@ -70,9 +71,9 @@ class UcclP2pWrapper:
     # ------------------------------------------------------------------
     # Endpoint metadata
     # ------------------------------------------------------------------
-    def get_agent_metadata(self) -> tuple[bytes, bytes]:
-        """Return (data_endpoint_metadata, notification_endpoint_metadata)."""
-        return (self._data_metadata, self._notif_metadata)
+    def get_agent_metadata(self) -> bytes:
+        """Return the endpoint metadata bytes."""
+        return self._metadata
 
     # ------------------------------------------------------------------
     # Connection management
@@ -80,50 +81,38 @@ class UcclP2pWrapper:
     def add_remote_agent(
         self,
         agent_name: str,
-        data_endpoint_metadata: bytes,
-        notif_endpoint_metadata: bytes,
+        endpoint_metadata: bytes,
     ) -> str:
-        """Add a remote endpoint pair and return the agent name."""
-        if agent_name in self._data_conn_ids:
+        """Add a remote endpoint and return the agent name."""
+        if agent_name in self._conn_ids:
             return agent_name
 
-        ok, data_conn_id = self._data_ep.add_remote_endpoint(data_endpoint_metadata)
+        ok, conn_id = self._ep.add_remote_endpoint(endpoint_metadata)
         if not ok:
-            raise RuntimeError(
-                f"Failed to add UCCL P2P data endpoint for {agent_name}")
-        self._data_conn_ids[agent_name] = data_conn_id
-
-        ok, notif_conn_id = self._notif_ep.add_remote_endpoint(
-            notif_endpoint_metadata)
-        if not ok:
-            raise RuntimeError(
-                f"Failed to add UCCL P2P notification endpoint for {agent_name}")
-        self._notif_conn_ids[agent_name] = notif_conn_id
+            raise RuntimeError(f"Failed to add UCCL P2P endpoint for {agent_name}")
+        self._conn_ids[agent_name] = conn_id
 
         return agent_name
 
     def remove_remote_agent(self, agent_name: str) -> None:
-        data_conn_id = self._data_conn_ids.pop(agent_name, None)
-        if data_conn_id is not None:
-            self._data_ep.remove_remote_endpoint(data_conn_id)
-        notif_conn_id = self._notif_conn_ids.pop(agent_name, None)
-        if notif_conn_id is not None:
-            self._notif_ep.remove_remote_endpoint(notif_conn_id)
+        conn_id = self._conn_ids.pop(agent_name, None)
+        if conn_id is not None:
+            self._ep.remove_remote_endpoint(conn_id)
 
     # ------------------------------------------------------------------
     # Memory registration
     # ------------------------------------------------------------------
     def register_memory(self, tensor_list: list[torch.Tensor]) -> list[Any]:
-        return self._data_ep.register_memory(tensor_list)
+        return self._ep.register_memory(tensor_list)
 
     def deregister_memory(self, desc_list: list[Any]) -> None:
-        self._data_ep.deregister_memory(desc_list)
+        self._ep.deregister_memory(desc_list)
 
     def get_serialized_descs(self, desc_list: list[Any]) -> bytes:
-        return self._data_ep.get_serialized_descs(desc_list)
+        return self._ep.get_serialized_descs(desc_list)
 
     def deserialize_descs(self, serialized: bytes) -> list[Any]:
-        return self._data_ep.deserialize_descs(serialized)
+        return self._ep.deserialize_descs(serialized)
 
     # ------------------------------------------------------------------
     # Transfer
@@ -143,9 +132,10 @@ class UcclP2pWrapper:
         """
         if agent_name is None:
             raise ValueError("agent_name is required for UCCL P2P transfer")
-        conn_id = self._data_conn_ids[agent_name]
-        ok, transfer_id = self._data_ep.transfer(
-            conn_id, op_name.lower(), local_descs, remote_descs)
+        conn_id = self._conn_ids[agent_name]
+        ok, transfer_id = self._ep.transfer(
+            conn_id, op_name.lower(), local_descs, remote_descs
+        )
         if not ok:
             raise RuntimeError(f"Failed to start UCCL P2P {op_name} transfer")
         return transfer_id
@@ -155,7 +145,7 @@ class UcclP2pWrapper:
         pass
 
     def check_xfer_state(self, transfer_id: int) -> str:
-        ok, is_done = self._data_ep.poll_async(transfer_id)
+        ok, is_done = self._ep.poll_async(transfer_id)
         if not ok:
             return "ERR"
         return "DONE" if is_done else "PROC"
@@ -173,13 +163,14 @@ class UcclP2pWrapper:
     # Notifications (emulated with UCCL P2P send/recv)
     # ------------------------------------------------------------------
     def send_notif(self, agent_name: str, notif_msg: bytes) -> None:
-        conn_id = self._notif_conn_ids[agent_name]
+        conn_id = self._conn_ids[agent_name]
         n = min(len(notif_msg), self._notif_buf_size)
         self._notif_send_buf[:n].copy_(
-            torch.frombuffer(notif_msg[:n], dtype=torch.uint8))
-        ok = self._notif_ep.send(
-            conn_id, self._notif_send_mr,
-            self._notif_send_buf.data_ptr(), n)
+            torch.frombuffer(notif_msg[:n], dtype=torch.uint8)
+        )
+        ok = self._ep.send(
+            conn_id, self._notif_send_mr, self._notif_send_buf.data_ptr(), n
+        )
         if not ok:
             raise RuntimeError(f"Failed to send UCCL P2P notification to {agent_name}")
 
@@ -200,11 +191,14 @@ class UcclP2pWrapper:
     def _notif_recv_loop(self) -> None:
         while not self._notif_stop.is_set():
             received = False
-            for agent_name, conn_id in list(self._notif_conn_ids.items()):
+            for agent_name, conn_id in list(self._conn_ids.items()):
                 try:
-                    ok = self._notif_ep.recv(
-                        conn_id, self._notif_recv_mr,
-                        self._notif_recv_buf.data_ptr(), self._notif_buf_size)
+                    ok = self._ep.recv(
+                        conn_id,
+                        self._notif_recv_mr,
+                        self._notif_recv_buf.data_ptr(),
+                        self._notif_buf_size,
+                    )
                     if ok:
                         arr = self._notif_recv_buf.numpy()
                         msg = arr.tobytes().rstrip(b"\x00")

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/uccl_p2p_wrapper.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/uccl_p2p_wrapper.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Thin wrapper around uccl.p2p.Endpoint for vLLM KV connector use."""
+
+import queue
+import threading
+import time
+from collections import defaultdict
+from typing import Any
+
+import torch
+
+from vllm.distributed.uccl_p2p_utils import Endpoint as UcclP2pEndpoint
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class UcclP2pWrapper:
+    """Wraps two uccl.p2p.Endpoint instances and exposes a NIXL-like API.
+
+    We keep two endpoints so that data transfers and small notifications do
+    not share the same UCCL connection.  Both endpoints run
+    ``start_passive_accept()`` so remote peers can connect to us.
+
+    The wrapper intentionally mimics the NixlWrapper interface used by the
+    vLLM NIXL connector so that the higher-level connector logic can be reused
+    with minimal changes.
+    """
+
+    def __init__(self, local_gpu_idx: int):
+        if UcclP2pEndpoint is None:
+            raise RuntimeError(
+                "uccl.p2p is not available. Please install the UCCL P2P package.")
+
+        self._data_ep = UcclP2pEndpoint(local_gpu_idx)
+        self._notif_ep = UcclP2pEndpoint(local_gpu_idx)
+        self._data_ep.start_passive_accept()
+        self._notif_ep.start_passive_accept()
+
+        self._data_metadata = self._data_ep.get_metadata()
+        self._notif_metadata = self._notif_ep.get_metadata()
+
+        # Agent name -> data conn_id and notification conn_id.
+        self._data_conn_ids: dict[str, int] = {}
+        self._notif_conn_ids: dict[str, int] = {}
+
+        # Notification receive state.
+        self._notif_queue: queue.Queue[tuple[str, bytes]] = queue.Queue()
+        self._notif_stop = threading.Event()
+        self._notif_recv_thread = threading.Thread(
+            target=self._notif_recv_loop, daemon=True, name="uccl_p2p_notif_recv")
+        self._notif_recv_thread.start()
+
+        # Small pinned CPU buffers used for notifications.
+        self._notif_buf_size = 256
+        self._notif_send_buf = torch.zeros(
+            self._notif_buf_size, dtype=torch.uint8, pin_memory=True)
+        self._notif_recv_buf = torch.zeros(
+            self._notif_buf_size, dtype=torch.uint8, pin_memory=True)
+        send_descs = self._notif_ep.register_memory([self._notif_send_buf])
+        if not send_descs:
+            raise RuntimeError("UCCL P2P notification send buffer registration failed")
+        self._notif_send_mr = send_descs[0].mr_id
+        recv_descs = self._notif_ep.register_memory([self._notif_recv_buf])
+        if not recv_descs:
+            raise RuntimeError("UCCL P2P notification recv buffer registration failed")
+        self._notif_recv_mr = recv_descs[0].mr_id
+
+    # ------------------------------------------------------------------
+    # Endpoint metadata
+    # ------------------------------------------------------------------
+    def get_agent_metadata(self) -> tuple[bytes, bytes]:
+        """Return (data_endpoint_metadata, notification_endpoint_metadata)."""
+        return (self._data_metadata, self._notif_metadata)
+
+    # ------------------------------------------------------------------
+    # Connection management
+    # ------------------------------------------------------------------
+    def add_remote_agent(
+        self,
+        agent_name: str,
+        data_endpoint_metadata: bytes,
+        notif_endpoint_metadata: bytes,
+    ) -> str:
+        """Add a remote endpoint pair and return the agent name."""
+        if agent_name in self._data_conn_ids:
+            return agent_name
+
+        ok, data_conn_id = self._data_ep.add_remote_endpoint(data_endpoint_metadata)
+        if not ok:
+            raise RuntimeError(
+                f"Failed to add UCCL P2P data endpoint for {agent_name}")
+        self._data_conn_ids[agent_name] = data_conn_id
+
+        ok, notif_conn_id = self._notif_ep.add_remote_endpoint(
+            notif_endpoint_metadata)
+        if not ok:
+            raise RuntimeError(
+                f"Failed to add UCCL P2P notification endpoint for {agent_name}")
+        self._notif_conn_ids[agent_name] = notif_conn_id
+
+        return agent_name
+
+    def remove_remote_agent(self, agent_name: str) -> None:
+        data_conn_id = self._data_conn_ids.pop(agent_name, None)
+        if data_conn_id is not None:
+            self._data_ep.remove_remote_endpoint(data_conn_id)
+        notif_conn_id = self._notif_conn_ids.pop(agent_name, None)
+        if notif_conn_id is not None:
+            self._notif_ep.remove_remote_endpoint(notif_conn_id)
+
+    # ------------------------------------------------------------------
+    # Memory registration
+    # ------------------------------------------------------------------
+    def register_memory(self, tensor_list: list[torch.Tensor]) -> list[Any]:
+        return self._data_ep.register_memory(tensor_list)
+
+    def deregister_memory(self, desc_list: list[Any]) -> None:
+        self._data_ep.deregister_memory(desc_list)
+
+    def get_serialized_descs(self, desc_list: list[Any]) -> bytes:
+        return self._data_ep.get_serialized_descs(desc_list)
+
+    def deserialize_descs(self, serialized: bytes) -> list[Any]:
+        return self._data_ep.deserialize_descs(serialized)
+
+    # ------------------------------------------------------------------
+    # Transfer
+    # ------------------------------------------------------------------
+    def make_prepped_xfer(
+        self,
+        op_name: str,
+        local_descs: list[Any],
+        remote_descs: list[Any],
+        notif_msg: bytes | None = None,
+        agent_name: str | None = None,
+    ) -> int:
+        """Start a transfer and return a transfer_id.
+
+        The transfer begins immediately.  Callers send any notification
+        separately via ``send_notif()``.
+        """
+        if agent_name is None:
+            raise ValueError("agent_name is required for UCCL P2P transfer")
+        conn_id = self._data_conn_ids[agent_name]
+        ok, transfer_id = self._data_ep.transfer(
+            conn_id, op_name.lower(), local_descs, remote_descs)
+        if not ok:
+            raise RuntimeError(f"Failed to start UCCL P2P {op_name} transfer")
+        return transfer_id
+
+    def transfer(self, transfer_id: int) -> None:
+        # UCCL P2P starts transfers immediately in ``transfer()``.
+        pass
+
+    def check_xfer_state(self, transfer_id: int) -> str:
+        ok, is_done = self._data_ep.poll_async(transfer_id)
+        if not ok:
+            return "ERR"
+        return "DONE" if is_done else "PROC"
+
+    def release_xfer_handle(self, transfer_id: int) -> None:
+        pass
+
+    def release_dlist_handle(self, handle: Any) -> None:
+        pass
+
+    def get_xfer_telemetry(self, transfer_id: int) -> dict[str, Any]:
+        return {}
+
+    # ------------------------------------------------------------------
+    # Notifications (emulated with UCCL P2P send/recv)
+    # ------------------------------------------------------------------
+    def send_notif(self, agent_name: str, notif_msg: bytes) -> None:
+        conn_id = self._notif_conn_ids[agent_name]
+        n = min(len(notif_msg), self._notif_buf_size)
+        self._notif_send_buf[:n].copy_(
+            torch.frombuffer(notif_msg[:n], dtype=torch.uint8))
+        ok = self._notif_ep.send(
+            conn_id, self._notif_send_mr,
+            self._notif_send_buf.data_ptr(), n)
+        if not ok:
+            raise RuntimeError(f"Failed to send UCCL P2P notification to {agent_name}")
+
+    def get_new_notifs(self) -> dict[str, list[bytes]]:
+        """Drain notification queue and return {agent_name: [messages]}."""
+        result: dict[str, list[bytes]] = defaultdict(list)
+        while not self._notif_queue.empty():
+            try:
+                agent_name, msg = self._notif_queue.get_nowait()
+                result[agent_name].append(msg)
+            except queue.Empty:
+                break
+        return dict(result)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _notif_recv_loop(self) -> None:
+        while not self._notif_stop.is_set():
+            received = False
+            for agent_name, conn_id in list(self._notif_conn_ids.items()):
+                try:
+                    ok = self._notif_ep.recv(
+                        conn_id, self._notif_recv_mr,
+                        self._notif_recv_buf.data_ptr(), self._notif_buf_size)
+                    if ok:
+                        arr = self._notif_recv_buf.numpy()
+                        msg = arr.tobytes().rstrip(b"\x00")
+                        if msg:
+                            self._notif_queue.put((agent_name, msg))
+                        received = True
+                except Exception as e:
+                    logger.debug("UCCL P2P recv error on %s: %s", agent_name, e)
+            if not received:
+                time.sleep(0.001)
+
+    def shutdown(self) -> None:
+        self._notif_stop.set()
+        self._notif_recv_thread.join(timeout=1.0)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/utils.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared constants, lazy imports and helpers for the UCCL_P2P connector."""
+
+import contextlib
+from collections.abc import Iterator
+from typing import Any
+
+import zmq
+
+from vllm.platforms import current_platform
+from vllm.utils.network_utils import make_zmq_socket
+from vllm.v1.kv_cache_interface import KVCacheSpec, UniformTypeKVCacheSpecs
+
+# Supported platforms and types of kv transfer buffer.
+# {device: tuple of supported kv buffer types}
+_UCCL_P2P_SUPPORTED_DEVICE = {
+    "cuda": (
+        "cuda",
+        "cpu",
+    ),
+    "tpu": ("cpu",),
+    "xpu": (
+        "cpu",
+        "xpu",
+    ),
+    "cpu": ("cpu",),
+}
+# support for oot platform by providing mapping in current_platform
+_supported_fn = current_platform.get_uccl_p2p_supported_devices
+if _supported_fn is not None and callable(_supported_fn):
+    _UCCL_P2P_SUPPORTED_DEVICE.update(_supported_fn())
+
+
+# TODO: merge with vllm.utils.network_utils.zmq_socket_ctx
+@contextlib.contextmanager
+def zmq_ctx(socket_type: Any, addr: str) -> Iterator[zmq.Socket]:
+    """Context manager for a ZMQ socket"""
+
+    if socket_type not in (zmq.ROUTER, zmq.REQ):
+        raise ValueError(f"Unexpected socket type: {socket_type}")
+
+    ctx: zmq.Context | None = None
+    try:
+        ctx = zmq.Context()  # type: ignore[attr-defined]
+        yield make_zmq_socket(
+            ctx=ctx, path=addr, socket_type=socket_type, bind=socket_type == zmq.ROUTER
+        )
+    finally:
+        if ctx is not None:
+            ctx.destroy(linger=0)
+
+
+def get_representative_spec_type(spec: KVCacheSpec) -> type[KVCacheSpec]:
+    if isinstance(spec, UniformTypeKVCacheSpecs):
+        # All inner specs are the same type; pick any.
+        inner = next(iter(spec.kv_cache_specs.values()))
+        return type(inner)
+    return type(spec)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/worker.py
@@ -1274,11 +1274,10 @@ class UcclP2pConnectorWorker:
         """Convert (addr, size, dev) tuples to per-block XferDesc objects.
 
         Each block is matched to the registered tensor whose address range
-        contains it.  The corresponding base XferDesc is shallow-copied and
-        its addr and size are set to the block's values.
+        contains it.  The corresponding base XferDesc is copied through the
+        UCCL P2P wrapper (``XferDesc`` is not pickleable / copyable) and its
+        addr and size are set to the block's values.
         """
-        import copy
-
         result: list[Any] = []
         for addr, block_size_val, dev in blocks_data:
             base_desc = None
@@ -1290,9 +1289,9 @@ class UcclP2pConnectorWorker:
                 raise RuntimeError(
                     f"Block at addr {addr} not found in registered tensors"
                 )
-            xfer_desc = copy.copy(base_desc)
-            xfer_desc.addr = addr
-            xfer_desc.size = block_size_val
+            xfer_desc = self.uccl_p2p_wrapper.copy_xfer_desc(
+                base_desc, addr, block_size_val
+            )
             result.append(xfer_desc)
         return result
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/worker.py
@@ -1055,11 +1055,10 @@ class UcclP2pConnectorWorker:
         )
 
         # After KV Caches registered, listen for new connections.
-        data_ep_md, notif_ep_md = self.uccl_p2p_wrapper.get_agent_metadata()
+        endpoint_md = self.uccl_p2p_wrapper.get_agent_metadata()
         agent_metadata = UcclP2pAgentMetadata(
             engine_id=self.engine_id,
-            data_endpoint_metadata=data_ep_md,
-            notif_endpoint_metadata=notif_ep_md,
+            endpoint_metadata=endpoint_md,
             serialized_xfer_descs=self._serialized_xfer_descs,
             device_id=self.device_id,
             kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][self.tp_rank],
@@ -1423,8 +1422,7 @@ class UcclP2pConnectorWorker:
 
         remote_agent_name = self.uccl_p2p_wrapper.add_remote_agent(
             f"{engine_id}_{remote_tp_rank}",
-            uccl_p2p_agent_meta.data_endpoint_metadata,
-            uccl_p2p_agent_meta.notif_endpoint_metadata,
+            uccl_p2p_agent_meta.endpoint_metadata,
         )
 
         # Create dst descs and xfer side handles. TP workers have same #blocks
@@ -1526,8 +1524,7 @@ class UcclP2pConnectorWorker:
         remote_base_addr_to_desc = dict(zip(remote_base_addrs, remote_base_descs))
         # Compute tensor sizes from block_lens and num_blocks.
         remote_tensor_sizes = [
-            bl * uccl_p2p_agent_meta.num_blocks
-            for bl in uccl_p2p_agent_meta.block_lens
+            bl * uccl_p2p_agent_meta.num_blocks for bl in uccl_p2p_agent_meta.block_lens
         ]
         remote_base_addr_to_size = dict(zip(remote_base_addrs, remote_tensor_sizes))
 
@@ -2025,7 +2022,8 @@ class UcclP2pConnectorWorker:
                             notif_msg, agent_name = notif_meta
                             try:
                                 self.uccl_p2p_wrapper.send_notif(
-                                    agent_name, notif_msg=notif_msg)
+                                    agent_name, notif_msg=notif_msg
+                                )
                             except Exception as e:
                                 self._log_failure(
                                     failure_type="notification_failed",
@@ -2108,7 +2106,8 @@ class UcclP2pConnectorWorker:
                 with self._handshake_lock:
                     if remote_engine_id not in self._remote_agents:
                         self._background_uccl_p2p_handshake(
-                            req_id, remote_engine_id, meta)
+                            req_id, remote_engine_id, meta
+                        )
                         continue
 
             # Handshake already completed, start async read xfer.
@@ -2230,9 +2229,7 @@ class UcclP2pConnectorWorker:
             else:
                 # Single read from remote, we write to the whole memory region.
                 # Also handle remote block size different from local block size.
-                local_xfer_descs = self.src_xfer_descs_by_block_size[
-                    remote_block_size
-                ]
+                local_xfer_descs = self.src_xfer_descs_by_block_size[remote_block_size]
 
             # Destination XferDesc list: remote_engine_id -> remote_rank -> list.
             remote_xfer_descs = self.dst_xfer_descs[meta.remote.engine_id][
@@ -2372,14 +2369,8 @@ class UcclP2pConnectorWorker:
         # Select per-block XferDesc objects by the computed indices.
         handle = None
         try:
-            local_descs = [
-                local_xfer_descs[int(i)]
-                for i in local_block_descs_ids
-            ]
-            remote_descs = [
-                remote_xfer_descs[int(i)]
-                for i in remote_block_descs_ids
-            ]
+            local_descs = [local_xfer_descs[int(i)] for i in local_block_descs_ids]
+            remote_descs = [remote_xfer_descs[int(i)] for i in remote_block_descs_ids]
             agent_name = self._remote_agents[dst_engine_id][remote_rank]
             transfer_id = self.uccl_p2p_wrapper.make_prepped_xfer(
                 "READ",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/worker.py
@@ -84,6 +84,13 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+_UCCL_P2P_TIMING_ENABLED = os.environ.get("VLLM_UCCL_P2P_TIMING", "0") == "1"
+
+
+def _timing(label: str, elapsed_us: float) -> None:
+    if _UCCL_P2P_TIMING_ENABLED:
+        logger.info("[uccl_p2p_worker_timing] %s: %.1f us", label, elapsed_us)
+
 
 class UcclP2pConnectorWorker:
     """Implementation of Worker side methods"""
@@ -817,6 +824,7 @@ class UcclP2pConnectorWorker:
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data in uccl_p2p."""
+        t0 = time.perf_counter()
         self.transfer_topo = TransferTopology(
             tp_rank=self.tp_rank,
             tp_size=self.world_size,
@@ -1081,6 +1089,7 @@ class UcclP2pConnectorWorker:
             compatibility_hash=self.compat_hash,
             agent_metadata_bytes=encoder.encode(agent_metadata),
         )
+        _timing("register_kv_caches", (time.perf_counter() - t0) * 1e6)
 
     def _build_mamba_local(
         self,
@@ -1387,6 +1396,7 @@ class UcclP2pConnectorWorker:
         For Mamba hetero-TP, both tp_ratio > 0 (D_TP > P_TP) and
         tp_ratio < 0 (P_TP > D_TP) are supported by the 3-read transfer.
         """  # noqa: E501
+        t0 = time.perf_counter()
         engine_id = uccl_p2p_agent_meta.engine_id
         # TODO re-evaluate refreshing for scaling/recovery
         if remote_tp_rank in self._remote_agents.get(engine_id, {}):
@@ -1541,6 +1551,7 @@ class UcclP2pConnectorWorker:
                 self.register_local_xfer_handler(uccl_p2p_agent_meta.block_size)[0]
             )
 
+        _timing("add_remote_agent", (time.perf_counter() - t0) * 1e6)
         return remote_agent_name
 
     def _validate_remote_agent_handshake(
@@ -1929,50 +1940,59 @@ class UcclP2pConnectorWorker:
         extending the lease on the referenced requests.
         """
         assert self.transfer_topo is not None
+        t0 = time.perf_counter()
         notified_req_ids: set[str] = set()
-        for notifs in self.uccl_p2p_wrapper.get_new_notifs().values():
-            for notif in notifs:
-                msg = notif.decode("utf-8")
+        notif_count = 0
+        try:
+            for notifs in self.uccl_p2p_wrapper.get_new_notifs().values():
+                for notif in notifs:
+                    notif_count += 1
+                    msg = notif.decode("utf-8")
 
-                # Handle heartbeat messages from D-side.
-                if msg.startswith("HB:"):
-                    self._handle_heartbeat(msg[3:])
-                    continue
+                    # Handle heartbeat messages from D-side.
+                    if msg.startswith("HB:"):
+                        self._handle_heartbeat(msg[3:])
+                        continue
 
-                req_id, tp_size = msg.rsplit(":", 1)
-                if (
-                    req_id not in self._reqs_to_send
-                    and req_id not in self._reqs_to_process
-                ):
-                    logger.error(
-                        "Potentially invalid KV blocks for "
-                        "unrecognized request %s were retrieved by "
-                        "a decode worker. They may have expired.",
-                        req_id,
+                    req_id, tp_size = msg.rsplit(":", 1)
+                    if (
+                        req_id not in self._reqs_to_send
+                        and req_id not in self._reqs_to_process
+                    ):
+                        logger.error(
+                            "Potentially invalid KV blocks for "
+                            "unrecognized request %s were retrieved by "
+                            "a decode worker. They may have expired.",
+                            req_id,
+                        )
+                        continue
+
+                    # NOTE: `tp_ratio` is the opposite when swapping local<>remote
+                    n_consumers = int(tp_size)
+                    tp_ratio = self.transfer_topo.tp_ratio(n_consumers)
+
+                    # Number of reads *per producer* to wait for.
+                    # When remote D TP > local P TP we expect `tp_ratio` reads.
+                    consumers_per_producer = (
+                        -tp_ratio if n_consumers > self.world_size else 1
                     )
-                    continue
 
-                # NOTE: `tp_ratio` is the opposite when swapping local<>remote
-                n_consumers = int(tp_size)
-                tp_ratio = self.transfer_topo.tp_ratio(n_consumers)
-
-                # Number of reads *per producer* to wait for.
-                # When remote D TP > local P TP we expect `tp_ratio` reads.
-                consumers_per_producer = (
-                    -tp_ratio if n_consumers > self.world_size else 1
-                )
-
-                self.consumer_notification_counts_by_req[req_id] += 1
-                # Wait all consumers (D) to be done reading before freeing.
-                if (
-                    self.consumer_notification_counts_by_req[req_id]
-                    == consumers_per_producer
-                ):
-                    notified_req_ids.add(req_id)
-                    del self.consumer_notification_counts_by_req[req_id]
-                    self._reqs_to_process.remove(req_id)
-                    self._reqs_to_send.pop(req_id, None)
-        return notified_req_ids
+                    self.consumer_notification_counts_by_req[req_id] += 1
+                    # Wait all consumers (D) to be done reading before freeing.
+                    if (
+                        self.consumer_notification_counts_by_req[req_id]
+                        == consumers_per_producer
+                    ):
+                        notified_req_ids.add(req_id)
+                        del self.consumer_notification_counts_by_req[req_id]
+                        self._reqs_to_process.remove(req_id)
+                        self._reqs_to_send.pop(req_id, None)
+            return notified_req_ids
+        finally:
+            _timing(
+                f"_get_new_notifs_count={notif_count}_done={len(notified_req_ids)}",
+                (time.perf_counter() - t0) * 1e6,
+            )
 
     def _handle_heartbeat(self, payload: str) -> None:
         """Extend leases for requests referenced in a heartbeat.
@@ -2003,60 +2023,71 @@ class UcclP2pConnectorWorker:
         Returns:
             set of req_ids that have all done xfers
         """
+        t0 = time.perf_counter()
         done_req_ids: set[str] = set()
-        for req_id, handles in list(transfers.items()):
-            in_progress = []
-            for handle in handles:
-                try:
-                    xfer_state = self.uccl_p2p_wrapper.check_xfer_state(handle)
-                    if xfer_state == "DONE":
-                        # Get telemetry from UCCL_P2P
-                        res = self.uccl_p2p_wrapper.get_xfer_telemetry(handle)
-                        self.xfer_stats.record_transfer(res)
-                        self.uccl_p2p_wrapper.release_xfer_handle(handle)
-                        # Send completion notification to remote agent
-                        # so P worker can release KV blocks promptly.
-                        notif_meta = self._recving_notif_meta.pop(handle, None)
-                        if notif_meta is not None:
-                            notif_msg, agent_name = notif_meta
-                            try:
-                                self.uccl_p2p_wrapper.send_notif(
-                                    agent_name, notif_msg=notif_msg
-                                )
-                            except Exception as e:
-                                self._log_failure(
-                                    failure_type="notification_failed",
-                                    msg="P worker blocks will be freed after timeout.",
-                                    req_id=req_id,
-                                    error=e,
-                                )
-                    elif xfer_state == "PROC":
-                        in_progress.append(handle)
-                        continue
-                    else:
+        polled = 0
+        try:
+            for req_id, handles in list(transfers.items()):
+                in_progress = []
+                for handle in handles:
+                    polled += 1
+                    try:
+                        xfer_state = self.uccl_p2p_wrapper.check_xfer_state(handle)
+                        if xfer_state == "DONE":
+                            # Get telemetry from UCCL_P2P
+                            res = self.uccl_p2p_wrapper.get_xfer_telemetry(handle)
+                            self.xfer_stats.record_transfer(res)
+                            self.uccl_p2p_wrapper.release_xfer_handle(handle)
+                            # Send completion notification to remote agent
+                            # so P worker can release KV blocks promptly.
+                            notif_meta = self._recving_notif_meta.pop(handle, None)
+                            if notif_meta is not None:
+                                notif_msg, agent_name = notif_meta
+                                try:
+                                    self.uccl_p2p_wrapper.send_notif(
+                                        agent_name, notif_msg=notif_msg
+                                    )
+                                except Exception as e:
+                                    self._log_failure(
+                                        failure_type="notification_failed",
+                                        msg=(
+                                    "P worker blocks will be freed after timeout."
+                                ),
+                                        req_id=req_id,
+                                        error=e,
+                                    )
+                        elif xfer_state == "PROC":
+                            in_progress.append(handle)
+                            continue
+                        else:
+                            self._log_failure(
+                                failure_type="transfer_failed",
+                                msg="Marking blocks as invalid",
+                                req_id=req_id,
+                                xfer_state=xfer_state,
+                            )
+                            self._handle_failed_transfer(req_id, handle)
+                    except Exception as e:
                         self._log_failure(
-                            failure_type="transfer_failed",
+                            failure_type="transfer_exception",
                             msg="Marking blocks as invalid",
                             req_id=req_id,
-                            xfer_state=xfer_state,
+                            error=e,
                         )
                         self._handle_failed_transfer(req_id, handle)
-                except Exception as e:
-                    self._log_failure(
-                        failure_type="transfer_exception",
-                        msg="Marking blocks as invalid",
-                        req_id=req_id,
-                        error=e,
-                    )
-                    self._handle_failed_transfer(req_id, handle)
 
-            if not in_progress:
-                # Only report request as completed when all transfers are done.
-                done_req_ids.add(req_id)
-                del transfers[req_id]
-            else:
-                transfers[req_id] = in_progress
-        return done_req_ids
+                if not in_progress:
+                    # Only report request as completed when all transfers are done.
+                    done_req_ids.add(req_id)
+                    del transfers[req_id]
+                else:
+                    transfers[req_id] = in_progress
+            return done_req_ids
+        finally:
+            _timing(
+                f"_pop_done_transfers_polled={polled}_done={len(done_req_ids)}",
+                (time.perf_counter() - t0) * 1e6,
+            )
 
     def _handle_failed_transfer(self, req_id: str, handle: int | None):
         """
@@ -2168,90 +2199,96 @@ class UcclP2pConnectorWorker:
                     )
 
     def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
-        assert meta.remote is not None and self.transfer_topo is not None
-        engine_id = meta.remote.engine_id
-        # Update last activity from this remote. Mind that cleanup is done on main
-        # thread (this one), so we don't race on this structure.
-        self._engine_last_active[engine_id] = time.perf_counter()
-        plan = self.tp_mappings[engine_id]
-        remote_info = self.transfer_topo.get_engine_info(engine_id)
-        tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+        t0 = time.perf_counter()
+        try:
+            assert meta.remote is not None and self.transfer_topo is not None
+            engine_id = meta.remote.engine_id
+            # Update last activity from this remote. Mind that cleanup is done on main
+            # thread (this one), so we don't race on this structure.
+            self._engine_last_active[engine_id] = time.perf_counter()
+            plan = self.tp_mappings[engine_id]
+            remote_info = self.transfer_topo.get_engine_info(engine_id)
+            tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
 
-        meta.remote.block_ids = self._logical_to_remote_kernel_block_ids(
-            meta.remote.block_ids,
-            remote_info.remote_physical_blocks_per_logical,
-        )
-        remote_block_ids = meta.remote.block_ids
-        local_block_ids = meta.local_physical_block_ids
-        num_groups = len(local_block_ids)
-        read_specs = [
-            ReadSpec(
-                remote_rank=rank,
-                local_block_ids=[
-                    list(local_block_ids[g])
-                    if rank in plan.source_ranks_per_group[g]
-                    else []
-                    for g in range(num_groups)
-                ],
-                remote_block_ids=[
-                    list(remote_block_ids[g])
-                    if rank in plan.source_ranks_per_group[g]
-                    else []
-                    for g in range(num_groups)
-                ],
+            meta.remote.block_ids = self._logical_to_remote_kernel_block_ids(
+                meta.remote.block_ids,
+                remote_info.remote_physical_blocks_per_logical,
             )
-            for rank in plan.all_source_ranks
-        ]
-
-        # D may have to perform multiple reads from different remote ranks.
-        # MLA opt: when P TP > D TP, only a single read is executed for
-        # the first remote rank (cache is duplicated)..
-        if self.use_mla and tp_ratio < 0:
-            assert len(read_specs) == 1
-
-        for i, spec in enumerate(read_specs):
-            remote_block_size = remote_info.remote_block_size
-            logger.debug(
-                "Remote agent %s available, calling _read_blocks"
-                " on remote rank %s with remote block size %s for req %s",
-                meta.remote.engine_id,
-                spec.remote_rank,
-                remote_block_size,
-                req_id,
-            )
-            # Get side XferDesc lists (instead of NIXL dlist handles).
-            if tp_ratio < 0 and not self.use_mla:
-                assert remote_block_size == self.block_size
-                # Remote tp_size > local tp_size: we must perform multiple
-                # reads. Get the memory chunk onto which we will write to.
-                local_xfer_descs = self.src_xfer_descs_by_tp_ratio[tp_ratio][i]
-            else:
-                # Single read from remote, we write to the whole memory region.
-                # Also handle remote block size different from local block size.
-                local_xfer_descs = self.src_xfer_descs_by_block_size[remote_block_size]
-
-            # Destination XferDesc list: remote_engine_id -> remote_rank -> list.
-            remote_xfer_descs = self.dst_xfer_descs[meta.remote.engine_id][
-                spec.remote_rank
+            remote_block_ids = meta.remote.block_ids
+            local_block_ids = meta.local_physical_block_ids
+            num_groups = len(local_block_ids)
+            read_specs = [
+                ReadSpec(
+                    remote_rank=rank,
+                    local_block_ids=[
+                        list(local_block_ids[g])
+                        if rank in plan.source_ranks_per_group[g]
+                        else []
+                        for g in range(num_groups)
+                    ],
+                    remote_block_ids=[
+                        list(remote_block_ids[g])
+                        if rank in plan.source_ranks_per_group[g]
+                        else []
+                        for g in range(num_groups)
+                    ],
+                )
+                for rank in plan.all_source_ranks
             ]
 
-            self._read_blocks(
-                read_spec=spec,
-                request_id=req_id,
-                dst_engine_id=meta.remote.engine_id,
-                remote_request_id=meta.remote.request_id,
-                local_xfer_descs=local_xfer_descs,
-                remote_xfer_descs=remote_xfer_descs,
-            )
+            # D may have to perform multiple reads from different remote ranks.
+            # MLA opt: when P TP > D TP, only a single read is executed for
+            # the first remote rank (cache is duplicated)..
+            if self.use_mla and tp_ratio < 0:
+                assert len(read_specs) == 1
 
-        if self.use_mla and tp_ratio < 0 and read_specs:
-            # ..but we still need to notify the other remote ranks that we
-            # have the blocks we need so they can update the request state.
-            notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
-            remote_agents = self._remote_agents[meta.remote.engine_id]
-            for rank_to_notify, agent in remote_agents.items():
-                if rank_to_notify != read_specs[0].remote_rank:
-                    self.uccl_p2p_wrapper.send_notif(agent, notif_msg=notif_id)
+            for i, spec in enumerate(read_specs):
+                remote_block_size = remote_info.remote_block_size
+                logger.debug(
+                    "Remote agent %s available, calling _read_blocks"
+                    " on remote rank %s with remote block size %s for req %s",
+                    meta.remote.engine_id,
+                    spec.remote_rank,
+                    remote_block_size,
+                    req_id,
+                )
+                # Get side XferDesc lists (instead of NIXL dlist handles).
+                if tp_ratio < 0 and not self.use_mla:
+                    assert remote_block_size == self.block_size
+                    # Remote tp_size > local tp_size: we must perform multiple
+                    # reads. Get the memory chunk onto which we will write to.
+                    local_xfer_descs = self.src_xfer_descs_by_tp_ratio[tp_ratio][i]
+                else:
+                    # Single read from remote, we write to the whole memory region.
+                    # Also handle remote block size different from local block size.
+                    local_xfer_descs = self.src_xfer_descs_by_block_size[
+                        remote_block_size
+                    ]
+
+                # Destination XferDesc list: remote_engine_id -> remote_rank -> list.
+                remote_xfer_descs = self.dst_xfer_descs[meta.remote.engine_id][
+                    spec.remote_rank
+                ]
+
+                self._read_blocks(
+                    read_spec=spec,
+                    request_id=req_id,
+                    dst_engine_id=meta.remote.engine_id,
+                    remote_request_id=meta.remote.request_id,
+                    local_xfer_descs=local_xfer_descs,
+                    remote_xfer_descs=remote_xfer_descs,
+                )
+
+            if self.use_mla and tp_ratio < 0 and read_specs:
+                # ..but we still need to notify the other remote ranks that we
+                # have the blocks we need so they can update the request state.
+                notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
+                remote_agents = self._remote_agents[meta.remote.engine_id]
+                for rank_to_notify, agent in remote_agents.items():
+                    if rank_to_notify != read_specs[0].remote_rank:
+                        self.uccl_p2p_wrapper.send_notif(agent, notif_msg=notif_id)
+        finally:
+            _timing(f"_read_blocks_for_req_{req_id}", (time.perf_counter() - t0) * 1e6)
 
     def _read_blocks(
         self,
@@ -2266,134 +2303,149 @@ class UcclP2pConnectorWorker:
         Post a READ point-to-point xfer request from a single local worker to
         a single remote worker.
         """
-        assert self.transfer_topo is not None
-        remote_rank = read_spec.remote_rank
-        local_block_ids = read_spec.local_block_ids
-        remote_block_ids = read_spec.remote_block_ids
+        t0 = time.perf_counter()
+        try:
+            assert self.transfer_topo is not None
+            remote_rank = read_spec.remote_rank
+            local_block_ids = read_spec.local_block_ids
+            remote_block_ids = read_spec.remote_block_ids
 
-        remote_info = self.transfer_topo.get_engine_info(dst_engine_id)
-        block_size_ratio = self.transfer_topo.block_size_ratio(
-            remote_info.remote_block_size
-        )
-        if block_size_ratio > 1:
-            # TODO (NickLucche) assume HMA is off. Change to handle multiple KV groups.
-            assert not self._is_hma_required
-            local_block_ids0 = local_block_ids[0] if local_block_ids else []
-            remote_block_ids0 = remote_block_ids[0]
-            local_block_ids_mapped = self.get_mapped_blocks(
-                np.asarray(local_block_ids0), block_size_ratio
-            ).tolist()
-            if len(local_block_ids_mapped) > len(remote_block_ids0):
-                # NOTE:
-                # get_mapped_blocks will always expand block_ids for n times.
-                # ex:
-                # prefill block_ids with block_size as 4:
-                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-                # Local decode block_ids with block_size as 16: [1, 2, 3]
-                # expanded decode block_ids with get_mapped_blocks from [1, 2, 3] to
-                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-                # Then we clip local to align with prefill
-                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] to
-                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-                local_block_ids_mapped = local_block_ids_mapped[
-                    : len(remote_block_ids0)
-                ]
-            local_block_ids = [local_block_ids_mapped] if local_block_ids_mapped else []
-            remote_block_ids = [remote_block_ids0]
-        # NOTE(rob): having the staging blocks be on the READER side is
-        # not going to work well (since we will have to call rearrange tensors).
-        # after we detect the txn is complete (which means we cannot make the
-        # read trxn async easily). If we want to make "READ" happen cleanly,
-        # then we will need to have the staging blocks on the remote side.
+            remote_info = self.transfer_topo.get_engine_info(dst_engine_id)
+            block_size_ratio = self.transfer_topo.block_size_ratio(
+                remote_info.remote_block_size
+            )
+            if block_size_ratio > 1:
+                # TODO (NickLucche) assume HMA is off. Change to handle
+                # multiple KV groups.
+                assert not self._is_hma_required
+                local_block_ids0 = local_block_ids[0] if local_block_ids else []
+                remote_block_ids0 = remote_block_ids[0]
+                local_block_ids_mapped = self.get_mapped_blocks(
+                    np.asarray(local_block_ids0), block_size_ratio
+                ).tolist()
+                if len(local_block_ids_mapped) > len(remote_block_ids0):
+                    # NOTE:
+                    # get_mapped_blocks will always expand block_ids for n times.
+                    # ex:
+                    # prefill block_ids with block_size as 4:
+                    # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                    # Local decode block_ids with block_size as 16: [1, 2, 3]
+                    # expanded decode block_ids with get_mapped_blocks from [1, 2, 3] to
+                    # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+                    # Then we clip local to align with prefill
+                    # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] to
+                    # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                    local_block_ids_mapped = local_block_ids_mapped[
+                        : len(remote_block_ids0)
+                    ]
+                if local_block_ids_mapped:
+                    local_block_ids = [local_block_ids_mapped]
+                else:
+                    local_block_ids = []
+                remote_block_ids = [remote_block_ids0]
+            # NOTE(rob): having the staging blocks be on the READER side is
+            # not going to work well (since we will have to call rearrange tensors).
+            # after we detect the txn is complete (which means we cannot make the
+            # read trxn async easily). If we want to make "READ" happen cleanly,
+            # then we will need to have the staging blocks on the remote side.
 
-        # NOTE(rob): according to nvidia the staging blocks are used to
-        # saturate IB with heterogeneous TP sizes.
+            # NOTE(rob): according to nvidia the staging blocks are used to
+            # saturate IB with heterogeneous TP sizes.
 
-        # Number of D TP workers that will read from dst P. Propagate info
-        # on notification so that dst worker can wait before freeing blocks.
-        notif_id = f"{remote_request_id}:{self.world_size}".encode()
+            # Number of D TP workers that will read from dst P. Propagate info
+            # on notification so that dst worker can wait before freeing blocks.
+            notif_id = f"{remote_request_id}:{self.world_size}".encode()
 
-        # Full prefix cache hit: do not need to read remote blocks,
-        # just notify P worker that we have the blocks we need.
-        if len(local_block_ids) == 0:
-            # A full prefix cache hit is indicated with an empty list.
-            agent_name = self._remote_agents[dst_engine_id][remote_rank]
+            # Full prefix cache hit: do not need to read remote blocks,
+            # just notify P worker that we have the blocks we need.
+            if len(local_block_ids) == 0:
+                # A full prefix cache hit is indicated with an empty list.
+                agent_name = self._remote_agents[dst_engine_id][remote_rank]
+                try:
+                    self.uccl_p2p_wrapper.send_notif(agent_name, notif_msg=notif_id)
+                except Exception as e:
+                    self._log_failure(
+                        failure_type="notification_failed",
+                        msg="P worker blocks will be freed after timeout. "
+                        "This may indicate network issues.",
+                        req_id=request_id,
+                        error=e,
+                        dst_engine_id=dst_engine_id,
+                        remote_rank=remote_rank,
+                        remote_agent_name=agent_name,
+                    )
+                    self.xfer_stats.record_failed_notification()
+                return
+
+            assert (
+                len(remote_block_ids)
+                == len(local_block_ids)
+                == len(self.kv_cache_config.kv_cache_groups)
+            )
+            remote_physical_per_logical = remote_info.remote_physical_blocks_per_logical
+            local_block_ids, remote_block_ids = self._apply_prefix_caching(
+                local_block_ids, remote_block_ids, remote_physical_per_logical
+            )
+
+            # NOTE (nicolo) With homogeneous TP, each TP worker loads KV from
+            # corresponding rank. With heterogeneous TP, fixing D>P, the D tp
+            # workers will issue xfers to parts of the P worker remote kv caches.
+
+            # Get descs ids.
+            remote_block_descs_ids = self._compute_desc_ids(
+                block_ids=remote_block_ids,
+                dst_num_blocks=self.dst_num_blocks[dst_engine_id],
+                block_size_ratio=None,
+                physical_blocks_per_logical=remote_info.remote_physical_blocks_per_logical,
+            )
+            local_block_descs_ids = self._compute_desc_ids(
+                block_ids=local_block_ids,
+                dst_num_blocks=self.dst_num_blocks[self.engine_id],
+                block_size_ratio=block_size_ratio,
+                physical_blocks_per_logical=self._physical_blocks_per_logical_kv_block,
+            )
+
+            assert len(local_block_descs_ids) == len(remote_block_descs_ids)
+
+            # Prepare transfer with UcclP2p.
+            # Select per-block XferDesc objects by the computed indices.
+            handle = None
             try:
-                self.uccl_p2p_wrapper.send_notif(agent_name, notif_msg=notif_id)
+                local_descs = [
+                    local_xfer_descs[int(i)] for i in local_block_descs_ids
+                ]
+                remote_descs = [
+                    remote_xfer_descs[int(i)] for i in remote_block_descs_ids
+                ]
+                agent_name = self._remote_agents[dst_engine_id][remote_rank]
+                transfer_id = self.uccl_p2p_wrapper.make_prepped_xfer(
+                    "READ",
+                    local_descs,
+                    remote_descs,
+                    notif_msg=notif_id,
+                    agent_name=agent_name,
+                )
+
+                # Transfer starts immediately in UCCL P2P.
+                # Use transfer_id to check completion in future step().
+                self._recving_transfers[request_id].append(transfer_id)
+                self._recving_notif_meta[transfer_id] = (notif_id, agent_name)
             except Exception as e:
+                # mark all (logical) blocks for this request as invalid
                 self._log_failure(
-                    failure_type="notification_failed",
-                    msg="P worker blocks will be freed after timeout. "
-                    "This may indicate network issues.",
+                    failure_type="transfer_setup_failed",
                     req_id=request_id,
+                    msg="Marking blocks as invalid",
                     error=e,
                     dst_engine_id=dst_engine_id,
                     remote_rank=remote_rank,
-                    remote_agent_name=agent_name,
                 )
-                self.xfer_stats.record_failed_notification()
-            return
-
-        assert (
-            len(remote_block_ids)
-            == len(local_block_ids)
-            == len(self.kv_cache_config.kv_cache_groups)
-        )
-        remote_physical_per_logical = remote_info.remote_physical_blocks_per_logical
-        local_block_ids, remote_block_ids = self._apply_prefix_caching(
-            local_block_ids, remote_block_ids, remote_physical_per_logical
-        )
-
-        # NOTE (nicolo) With homogeneous TP, each TP worker loads KV from
-        # corresponding rank. With heterogeneous TP, fixing D>P, the D tp
-        # workers will issue xfers to parts of the P worker remote kv caches.
-
-        # Get descs ids.
-        remote_block_descs_ids = self._compute_desc_ids(
-            block_ids=remote_block_ids,
-            dst_num_blocks=self.dst_num_blocks[dst_engine_id],
-            block_size_ratio=None,
-            physical_blocks_per_logical=remote_info.remote_physical_blocks_per_logical,
-        )
-        local_block_descs_ids = self._compute_desc_ids(
-            block_ids=local_block_ids,
-            dst_num_blocks=self.dst_num_blocks[self.engine_id],
-            block_size_ratio=block_size_ratio,
-            physical_blocks_per_logical=self._physical_blocks_per_logical_kv_block,
-        )
-
-        assert len(local_block_descs_ids) == len(remote_block_descs_ids)
-
-        # Prepare transfer with UcclP2p.
-        # Select per-block XferDesc objects by the computed indices.
-        handle = None
-        try:
-            local_descs = [local_xfer_descs[int(i)] for i in local_block_descs_ids]
-            remote_descs = [remote_xfer_descs[int(i)] for i in remote_block_descs_ids]
-            agent_name = self._remote_agents[dst_engine_id][remote_rank]
-            transfer_id = self.uccl_p2p_wrapper.make_prepped_xfer(
-                "READ",
-                local_descs,
-                remote_descs,
-                notif_msg=notif_id,
-                agent_name=agent_name,
+                self._handle_failed_transfer(request_id, handle)
+        finally:
+            _timing(
+                f"_read_blocks_n={len(getattr(read_spec, 'local_block_ids', []))}",
+                (time.perf_counter() - t0) * 1e6,
             )
-
-            # Transfer starts immediately in UCCL P2P.
-            # Use transfer_id to check completion in future step().
-            self._recving_transfers[request_id].append(transfer_id)
-            self._recving_notif_meta[transfer_id] = (notif_id, agent_name)
-        except Exception as e:
-            # mark all (logical) blocks for this request as invalid
-            self._log_failure(
-                failure_type="transfer_setup_failed",
-                req_id=request_id,
-                msg="Marking blocks as invalid",
-                error=e,
-                dst_engine_id=dst_engine_id,
-                remote_rank=remote_rank,
-            )
-            self._handle_failed_transfer(request_id, handle)
 
     def get_mapped_blocks(
         self, block_ids: np.ndarray, block_size_ratio: int

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/worker.py
@@ -1708,22 +1708,30 @@ class UcclP2pConnectorWorker:
         assert self.use_host_buffer
         assert self.copy_blocks is not None
 
-        local_block_ids = meta.local_physical_block_ids
-        # TODO (NickLucche) D2H<>H2D ops could benefit from coalescing io across groups
-        for group_block_ids in local_block_ids:
-            self.copy_blocks(
-                self.host_xfer_buffers,
-                self.device_kv_caches,
-                group_block_ids,
-                group_block_ids,
-                "h2d",
-            )
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "synced recved kv of request[%s] to device kv buffer,"
-                "local_block_ids: %s. ",
-                req_id,
-                ",".join(map(str, local_block_ids)),
+        t0 = time.perf_counter()
+        try:
+            local_block_ids = meta.local_physical_block_ids
+            # TODO (NickLucche) D2H<>H2D ops could benefit from coalescing io
+            # across groups.
+            for group_block_ids in local_block_ids:
+                self.copy_blocks(
+                    self.host_xfer_buffers,
+                    self.device_kv_caches,
+                    group_block_ids,
+                    group_block_ids,
+                    "h2d",
+                )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "synced recved kv of request[%s] to device kv buffer,"
+                    "local_block_ids: %s. ",
+                    req_id,
+                    ",".join(map(str, local_block_ids)),
+                )
+        finally:
+            _timing(
+                f"sync_recved_kv_to_device_req={req_id}_groups={len(meta.local_physical_block_ids)}",
+                (time.perf_counter() - t0) * 1e6,
             )
 
     def save_kv_to_host(self, metadata: UcclP2pConnectorMetadata):
@@ -1731,26 +1739,33 @@ class UcclP2pConnectorWorker:
         assert self.use_host_buffer
         assert self.copy_blocks is not None
 
-        for req_id, meta in metadata.reqs_to_save.items():
-            meta.local_physical_block_ids = self._logical_to_kernel_block_ids(
-                meta.local_block_ids
+        t0 = time.perf_counter()
+        try:
+            for req_id, meta in metadata.reqs_to_save.items():
+                meta.local_physical_block_ids = self._logical_to_kernel_block_ids(
+                    meta.local_block_ids
+                )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "save_load_kv for request[%s] to host xfer buffer."
+                        "local_block_ids: %s. ",
+                        req_id,
+                        ",".join(map(str, meta.local_physical_block_ids)),
+                    )
+                # blocking
+                for group_block_ids in meta.local_physical_block_ids:
+                    self.copy_blocks(
+                        self.device_kv_caches,
+                        self.host_xfer_buffers,
+                        group_block_ids,
+                        group_block_ids,
+                        "d2h",
+                    )
+        finally:
+            _timing(
+                f"save_kv_to_host_reqs={len(metadata.reqs_to_save)}",
+                (time.perf_counter() - t0) * 1e6,
             )
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(
-                    "save_load_kv for request[%s] to host xfer buffer."
-                    "local_block_ids: %s. ",
-                    req_id,
-                    ",".join(map(str, meta.local_physical_block_ids)),
-                )
-            # blocking
-            for group_block_ids in meta.local_physical_block_ids:
-                self.copy_blocks(
-                    self.device_kv_caches,
-                    self.host_xfer_buffers,
-                    group_block_ids,
-                    group_block_ids,
-                    "d2h",
-                )
 
     def post_process_device_kv_on_receive(
         self,
@@ -1839,96 +1854,102 @@ class UcclP2pConnectorWorker:
         to track which workers are done.
         """
         assert self.transfer_topo is not None
-        done_sending = self._get_new_notifs()
-        done_recving = self._pop_done_transfers(self._recving_transfers)
+        t0 = time.perf_counter()
+        try:
+            done_sending = self._get_new_notifs()
+            done_recving = self._pop_done_transfers(self._recving_transfers)
 
-        # Drain queue of requests where handshake or transfer setup failed.
-        failed_recv_reqs = set[ReqId]()
-        while not self._failed_recv_reqs.empty():
-            try:
-                failed_recv_reqs.add(self._failed_recv_reqs.get_nowait())
-            except queue.Empty:
-                break
+            # Drain queue of requests where handshake or transfer setup failed.
+            failed_recv_reqs = set[ReqId]()
+            while not self._failed_recv_reqs.empty():
+                try:
+                    failed_recv_reqs.add(self._failed_recv_reqs.get_nowait())
+                except queue.Empty:
+                    break
 
-        # Add failed requests to done_recving for scheduler tracking
-        # (blocks are already marked invalid, scheduler will handle recompute)
-        done_recving.update(failed_recv_reqs)
+            # Add failed requests to done_recving for scheduler tracking
+            # (blocks are already marked invalid, scheduler will handle recompute)
+            done_recving.update(failed_recv_reqs)
 
-        if len(done_sending) > 0 or len(done_recving) > 0:
-            logger.debug(
-                "Rank %s, get_finished: %s requests done sending "
-                "and %s requests done recving (%s failed)",
-                self.tp_rank,
-                len(done_sending),
-                len(done_recving),
-                len(failed_recv_reqs),
-            )
+            if len(done_sending) > 0 or len(done_recving) > 0:
+                logger.debug(
+                    "Rank %s, get_finished: %s requests done sending "
+                    "and %s requests done recving (%s failed)",
+                    self.tp_rank,
+                    len(done_sending),
+                    len(done_recving),
+                    len(failed_recv_reqs),
+                )
 
-        block_ids_for_blocksize_post_process = defaultdict(list)
-        block_ids_for_heterogeneous_attn_post_process = list[list[int]]()
-        for req_id in done_recving:
-            # clean up metadata for completed requests
-            meta = self._recving_metadata.pop(req_id, None)
-            assert meta is not None, f"{req_id} not found in recving_metadata list"
+            block_ids_for_blocksize_post_process = defaultdict(list)
+            block_ids_for_heterogeneous_attn_post_process = list[list[int]]()
+            for req_id in done_recving:
+                # clean up metadata for completed requests
+                meta = self._recving_metadata.pop(req_id, None)
+                assert meta is not None, f"{req_id} not found in recving_metadata list"
 
-            # Skip KV sync and post-processing for failed requests
-            if req_id in failed_recv_reqs:
+                # Skip KV sync and post-processing for failed requests
+                if req_id in failed_recv_reqs:
+                    logger.warning(
+                        "Skipping KV post-processing for failed request %s",
+                        req_id,
+                    )
+                    continue
+
+                assert meta.remote is not None
+                if self.use_host_buffer:
+                    self.sync_recved_kv_to_device(req_id, meta)
+
+                # post processing for heteroblocksize
+                remote_info = self.transfer_topo.get_engine_info(meta.remote.engine_id)
+                block_size_ratio = self.transfer_topo.block_size_ratio(
+                    remote_info.remote_block_size
+                )
+                if not self.use_mla and (
+                    block_size_ratio > 1 or self.enable_permute_local_kv
+                ):
+                    assert not self._is_hma_required
+                    block_ids_for_blocksize_post_process[block_size_ratio].append(
+                        meta.local_physical_block_ids[0]
+                    )
+                # post processing for heterogeneous attention
+                if self.enable_heterogeneous_attn_post_process:
+                    block_ids_for_heterogeneous_attn_post_process.append(
+                        meta.local_physical_block_ids[0]
+                    )
+            for (
+                block_size_ratio,
+                block_ids_list,
+            ) in block_ids_for_blocksize_post_process.items():
+                self.post_process_device_kv_on_receive(block_size_ratio, block_ids_list)
+
+            for block_ids in block_ids_for_heterogeneous_attn_post_process:
+                self.post_process_device_kv_on_receive_heterogeneous_attn(block_ids)
+
+            # Handle timeout to avoid stranding blocks on remote.
+            now = time.perf_counter()
+            while self._reqs_to_send:
+                req_id, expires = next(iter(self._reqs_to_send.items()))
+                # Sorted dict, oldest requests are put first so we can exit early.
+                if now < expires:
+                    break
+                count = self.consumer_notification_counts_by_req.pop(req_id, 0)
+                self.xfer_stats.record_kv_expired_req()
                 logger.warning(
-                    "Skipping KV post-processing for failed request %s",
+                    "Releasing expired KV blocks for request %s which were "
+                    "retrieved by %d remote worker(s) before lease expired.",
                     req_id,
+                    count,
                 )
-                continue
+                self._reqs_to_send.pop(req_id, None)
+                self._reqs_to_process.discard(req_id)
 
-            assert meta.remote is not None
-            if self.use_host_buffer:
-                self.sync_recved_kv_to_device(req_id, meta)
-
-            # post processing for heteroblocksize
-            remote_info = self.transfer_topo.get_engine_info(meta.remote.engine_id)
-            block_size_ratio = self.transfer_topo.block_size_ratio(
-                remote_info.remote_block_size
+            return done_sending, done_recving
+        finally:
+            _timing(
+                f"get_finished_send={len(done_sending)}_recv={len(done_recving)}",
+                (time.perf_counter() - t0) * 1e6,
             )
-            if not self.use_mla and (
-                block_size_ratio > 1 or self.enable_permute_local_kv
-            ):
-                assert not self._is_hma_required
-                block_ids_for_blocksize_post_process[block_size_ratio].append(
-                    meta.local_physical_block_ids[0]
-                )
-            # post processing for heterogeneous attention
-            if self.enable_heterogeneous_attn_post_process:
-                block_ids_for_heterogeneous_attn_post_process.append(
-                    meta.local_physical_block_ids[0]
-                )
-        for (
-            block_size_ratio,
-            block_ids_list,
-        ) in block_ids_for_blocksize_post_process.items():
-            self.post_process_device_kv_on_receive(block_size_ratio, block_ids_list)
-
-        for block_ids in block_ids_for_heterogeneous_attn_post_process:
-            self.post_process_device_kv_on_receive_heterogeneous_attn(block_ids)
-
-        # Handle timeout to avoid stranding blocks on remote.
-        now = time.perf_counter()
-        while self._reqs_to_send:
-            req_id, expires = next(iter(self._reqs_to_send.items()))
-            # Sorted dict, oldest requests are put first so we can exit early.
-            if now < expires:
-                break
-            count = self.consumer_notification_counts_by_req.pop(req_id, 0)
-            self.xfer_stats.record_kv_expired_req()
-            logger.warning(
-                "Releasing expired KV blocks for request %s which were "
-                "retrieved by %d remote worker(s) before lease expired.",
-                req_id,
-                count,
-            )
-            self._reqs_to_process.remove(req_id)
-            del self._reqs_to_send[req_id]
-            done_sending.add(req_id)
-
-        return done_sending, done_recving
 
     def _get_new_notifs(self) -> set[str]:
         """
@@ -2113,90 +2134,112 @@ class UcclP2pConnectorWorker:
         Start loading by triggering non-blocking uccl_p2p_xfer.
         We check for these trnxs to complete in each step().
         """
-        for req_id, meta in metadata.reqs_to_recv.items():
-            meta.local_physical_block_ids = self._logical_to_kernel_block_ids(
-                meta.local_block_ids
+        t0 = time.perf_counter()
+        try:
+            for req_id, meta in metadata.reqs_to_recv.items():
+                meta.local_physical_block_ids = self._logical_to_kernel_block_ids(
+                    meta.local_block_ids
+                )
+                assert meta.remote is not None
+                # Remote block IDs are kept logical here; expanded in
+                # _read_blocks_for_req using the remote engine's phys ratio.
+                remote_engine_id = meta.remote.engine_id
+                logger.debug(
+                    "start_load_kv for request %s from remote engine %s. "
+                    "Num local_block_ids: %s. Num remote_block_ids: %s. ",
+                    req_id,
+                    remote_engine_id,
+                    len(meta.local_physical_block_ids),
+                    len(meta.remote.block_ids),
+                )
+                # always store metadata for failure recovery
+                self._recving_metadata[req_id] = meta
+                if remote_engine_id not in self._remote_agents:
+                    # Initiate handshake with remote engine to exchange metadata.
+                    with self._handshake_lock:
+                        if remote_engine_id not in self._remote_agents:
+                            self._background_uccl_p2p_handshake(
+                                req_id, remote_engine_id, meta
+                            )
+                            continue
+
+                # Handshake already completed, start async read xfer.
+                self._read_blocks_for_req(req_id, meta)
+
+            # Start transfers for requests whose handshakes have now finished.
+            while not self._ready_requests.empty():
+                self._read_blocks_for_req(*self._ready_requests.get_nowait())
+
+            # Keep around the requests that have been part of a batch. This is
+            # needed because async scheduling pushes the misalignment between the
+            # moment in which requests expiration is set (P side) and the moment in
+            # which blocks are read from D. As P can now more easily lag behind D
+            # while processing the next batch, we make sure to only set an
+            # expiration for requests that have not been read from D yet.
+            for req_id in metadata.reqs_in_batch:
+                self._reqs_to_process.add(req_id)
+
+            # Remove all requests that are not to be processed (eg aborted).
+            for req_id in metadata.reqs_not_processed:
+                self._reqs_to_process.discard(req_id)
+                # We should never get an abort after setting an expiry timer
+                assert req_id not in self._reqs_to_send
+
+            # Add to requests that are waiting to be read and track expiration.
+            for req_id, expiration_time in metadata.reqs_to_send.items():
+                if req_id in self._reqs_to_process:
+                    self._reqs_to_send[req_id] = expiration_time
+
+            # Send heartbeats to P-side engines to keep KV blocks alive while
+            # requests sit in the D scheduler WAITING queue.
+            self._send_heartbeats(metadata)
+        finally:
+            _timing(
+                f"start_load_kv_reqs={len(metadata.reqs_to_recv)}",
+                (time.perf_counter() - t0) * 1e6,
             )
-            assert meta.remote is not None
-            # Remote block IDs are kept logical here; expanded in
-            # _read_blocks_for_req using the remote engine's phys ratio.
-            remote_engine_id = meta.remote.engine_id
-            logger.debug(
-                "start_load_kv for request %s from remote engine %s. "
-                "Num local_block_ids: %s. Num remote_block_ids: %s. ",
-                req_id,
-                remote_engine_id,
-                len(meta.local_physical_block_ids),
-                len(meta.remote.block_ids),
-            )
-            # always store metadata for failure recovery
-            self._recving_metadata[req_id] = meta
-            if remote_engine_id not in self._remote_agents:
-                # Initiate handshake with remote engine to exchange metadata.
-                with self._handshake_lock:
-                    if remote_engine_id not in self._remote_agents:
-                        self._background_uccl_p2p_handshake(
-                            req_id, remote_engine_id, meta
-                        )
-                        continue
-
-            # Handshake already completed, start async read xfer.
-            self._read_blocks_for_req(req_id, meta)
-
-        # Start transfers for requests whose handshakes have now finished.
-        while not self._ready_requests.empty():
-            self._read_blocks_for_req(*self._ready_requests.get_nowait())
-
-        # Keep around the requests that have been part of a batch. This is
-        # needed because async scheduling pushes the misalignment between the
-        # moment in which requests expiration is set (P side) and the moment in
-        # which blocks are read from D. As P can now more easily lag behind D
-        # while processing the next batch, we make sure to only set an
-        # expiration for requests that have not been read from D yet.
-        for req_id in metadata.reqs_in_batch:
-            self._reqs_to_process.add(req_id)
-
-        # Remove all requests that are not to be processed (eg aborted).
-        for req_id in metadata.reqs_not_processed:
-            self._reqs_to_process.discard(req_id)
-            # We should never get an abort after setting an expiry timer
-            assert req_id not in self._reqs_to_send
-
-        # Add to requests that are waiting to be read and track expiration.
-        for req_id, expiration_time in metadata.reqs_to_send.items():
-            if req_id in self._reqs_to_process:
-                self._reqs_to_send[req_id] = expiration_time
-
-        # Send heartbeats to P-side engines to keep KV blocks alive while
-        # requests sit in the D scheduler WAITING queue.
-        self._send_heartbeats(metadata)
 
     def _send_heartbeats(self, metadata: UcclP2pConnectorMetadata) -> None:
         """
         Send heartbeat notifications to remote engines, extending lease on KV blocks.
         """
-        for engine_id, hb_info in metadata.heartbeat_by_engine.items():
-            # Proactive handshake (this request may still be in waiting queue) so
-            # the **next** heartbeat for this remote can go through.
-            if (
-                self._ensure_handshake(
-                    engine_id, hb_info.host, hb_info.port, hb_info.tp_size
-                )
-                is not None
-            ):
-                continue  # handshake is still pending
-
-            # Build the heartbeat message: "HB:req1,req2,..."
-            hb_msg = ("HB:" + ",".join(hb_info.req_ids)).encode()
-            for agent_name in self._remote_agents[engine_id].values():
-                try:
-                    self.uccl_p2p_wrapper.send_notif(agent_name, notif_msg=hb_msg)
-                except Exception:
-                    logger.debug(
-                        "Failed to send heartbeat to engine %s",
-                        engine_id,
-                        exc_info=True,
+        t0 = time.perf_counter()
+        try:
+            for engine_id, hb_info in metadata.heartbeat_by_engine.items():
+                # Proactive handshake (this request may still be in waiting queue) so
+                # the **next** heartbeat for this remote can go through.
+                if (
+                    self._ensure_handshake(
+                        engine_id, hb_info.host, hb_info.port, hb_info.tp_size
                     )
+                    is not None
+                ):
+                    continue  # handshake is still pending
+
+                remote_agents = self._remote_agents.get(engine_id)
+                if not remote_agents:
+                    continue
+
+                # Send heartbeat to all remote agents for this engine.
+                hb_msg = (
+                    "HB:" + ",".join(metadata.reqs_to_send.keys())
+                ).encode()
+                for agent_name in remote_agents.values():
+                    try:
+                        self.uccl_p2p_wrapper.send_notif(
+                            agent_name, notif_msg=hb_msg
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Failed to send heartbeat to engine %s",
+                            engine_id,
+                            exc_info=True,
+                        )
+        finally:
+            _timing(
+                f"_send_heartbeats_engines={len(metadata.heartbeat_by_engine)}",
+                (time.perf_counter() - t0) * 1e6,
+            )
 
     def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
         t0 = time.perf_counter()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/uccl_p2p/worker.py
@@ -1,0 +1,2710 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Worker-side logic for the UCCL_P2P connector."""
+
+import logging
+import os
+import queue
+import threading
+import time
+from collections import defaultdict
+from collections.abc import Iterator
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any, cast
+
+import msgspec
+import numpy as np
+import torch
+import zmq
+
+from vllm.distributed.kv_transfer.kv_connector.utils import (
+    BlockIds,
+    EngineId,
+    EngineTransferInfo,
+    TransferTopology,
+    get_current_attn_backends,
+    kv_postprocess_blksize_and_layout_on_receive,
+    kv_postprocess_blksize_on_receive,
+    kv_postprocess_layout_on_receive,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import CopyBlocksOp
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import (
+    MambaConvSplitInfo,
+    derive_mamba_conv_split,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.metadata import (
+    GET_META_MSG,
+    ReqId,
+    ReqMeta,
+    TransferHandle,
+    UcclP2pAgentMetadata,
+    UcclP2pConnectorMetadata,
+    UcclP2pHandshakePayload,
+    compute_uccl_p2p_compatibility_hash,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.stats import (
+    UcclP2pKVConnectorStats,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.tp_mapping import (
+    ReadSpec,
+    TPMapping,
+    _is_attention_spec,
+    _is_ssm_spec,
+    compute_tp_mapping,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.uccl_p2p_wrapper import (
+    UcclP2pWrapper,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.uccl_p2p.utils import (
+    _UCCL_P2P_SUPPORTED_DEVICE,
+    get_representative_spec_type,
+    zmq_ctx,
+)
+from vllm.distributed.parallel_state import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils.network_utils import make_zmq_path
+from vllm.v1.attention.backends.utils import get_kv_cache_layout
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.worker.block_table import BlockTable
+from vllm.v1.worker.utils import select_common_block_size
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+
+logger = init_logger(__name__)
+
+
+class UcclP2pConnectorWorker:
+    """Implementation of Worker side methods"""
+
+    def _compute_desc_ids(
+        self,
+        block_ids: BlockIds,
+        dst_num_blocks: int,
+        block_size_ratio: float | None,
+        physical_blocks_per_logical: int,
+    ) -> np.ndarray:
+        """Compute UCCL_P2P descriptor IDs for given block IDs."""
+        num_fa_regions = self.num_regions
+        num_ssm_regions = len(self.block_len_per_layer) * 4 if self._has_mamba else 0
+
+        num_blocks = dst_num_blocks
+        if block_size_ratio is not None:
+            num_blocks = int(num_blocks * block_size_ratio)
+        num_fa_descs = num_fa_regions * num_blocks
+
+        # All-attention fast path: single vectorized broadcast.
+        if num_ssm_regions == 0:
+            # NOTE (NickLucche) With HMA, every kv group has the same number of layers
+            # and layers from different groups share the same kv tensor.
+            # eg block_ids=[[1, 2], [3]]->blocks [1, 2] need to be
+            # read across all regions, same for [3], but group0-group1 blocks will
+            # always differ (different areas). Therefore we can just flatten the
+            # block_ids and compute the descs ids for all groups at once.
+            block_arr = np.concatenate(block_ids)[None, :]
+            region_ids = np.arange(num_fa_regions)[:, None]
+            return (region_ids * num_blocks + block_arr).flatten()
+
+        # Compute desc ids per group using the right stride: FA descs have
+        # num_blocks entries per region (kernel granularity), SSM descs have
+        # logical_blocks entries per region (no kernel splitting).
+        logical_blocks = num_blocks // physical_blocks_per_logical
+        all_descs: list[np.ndarray] = []
+        for i, group in enumerate(block_ids):
+            group_arr = np.asarray(group)
+            if _is_attention_spec(self._group_spec_types[i]):
+                fa_region_ids = np.arange(num_fa_regions)[:, None]
+                all_descs.append(
+                    (fa_region_ids * num_blocks + group_arr[None, :]).flatten()
+                )
+            elif _is_ssm_spec(self._group_spec_types[i]):
+                # NOTE (NickLucche) SSM and Attention block regions can
+                # be exchanged arbitrarily by manager.  Therefore, descs
+                # are laid out as:
+                #   [descs_fa (all regions) | descs_ssm (all regions)].
+                # num_fa_descs offset must be computed per-engine since
+                # P and D can have different num_blocks (and thus
+                # different FA desc counts).
+                ssm_region_ids = np.arange(num_ssm_regions)[:, None]
+                all_descs.append(
+                    (
+                        ssm_region_ids * logical_blocks
+                        + group_arr[None, :]
+                        + num_fa_descs
+                    ).flatten()
+                )
+            else:
+                raise ValueError(
+                    f"Unknown spec type {self._group_spec_types[i]} at index {i}"
+                )
+
+        return np.concatenate(all_descs)
+
+    def _build_local_splits_from_plan(
+        self,
+        plan: TPMapping,
+        src_blocks_data: list[tuple[int, int, int]],
+        num_fa_descs: int,
+    ) -> Iterator[list[tuple[int, int, int]]]:
+        """Build split handle data for P_TP > D_TP scenario.
+
+        num_fa_descs is the boundary between FA and SSM descriptors.
+        Split counts are derived from source_ranks_per_group lengths.
+        FA uses rank_to_attention_slot for the slot offset;
+        SSM uses the rank's positional index.
+        """
+        fa_idx = next(
+            i for i, t in enumerate(self._group_spec_types) if _is_attention_spec(t)
+        )
+        fa_num_splits = len(plan.source_ranks_per_group[fa_idx])
+
+        has_ssm_descs = num_fa_descs < len(src_blocks_data)
+        ssm_idx = next(
+            (i for i, t in enumerate(self._group_spec_types) if _is_ssm_spec(t)),
+            None,
+        )
+        ssm_num_splits = (
+            len(plan.source_ranks_per_group[ssm_idx])
+            if has_ssm_descs and ssm_idx is not None
+            else 0
+        )
+
+        # Per-FA-descriptor replicate flag, in _build_fa_local emission order.
+        fa_desc_replicated = self._fa_desc_replicated(num_fa_descs)
+
+        for p_idx, p_rank in enumerate(plan.all_source_ranks):
+            fa_slot = plan.rank_to_attention_slot.get(p_rank, 0)
+
+            handle: list[tuple[int, int, int]] = []
+            for j, (addr, local_len, dev) in enumerate(src_blocks_data):
+                if j < num_fa_descs:
+                    if fa_desc_replicated[j]:
+                        # REPLICATE (MLA): whole block written on every rank.
+                        handle.append((addr, local_len, dev))
+                    else:
+                        # SPLIT (full-attn): this rank's head slice.
+                        chunk = local_len // fa_num_splits
+                        handle.append((addr + fa_slot * chunk, chunk, dev))
+                else:
+                    chunk = local_len // ssm_num_splits
+                    handle.append((addr + p_idx * chunk, chunk, dev))
+            yield handle
+
+    def _fa_desc_replicated(self, num_fa_descs: int) -> list[bool]:
+        """Per-FA-descriptor replicate flag, in _build_fa_local emission order
+        (region-major; K then optional V per region). Length ``num_fa_descs``.
+        """
+        assert self.transfer_topo is not None
+        n_regions = len(self.block_len_per_layer)
+        # Unset only when the worker is built directly in unit tests; a real
+        # model always registers regions (no-KV-cache crashes long before here).
+        # Fall back to all-SPLIT to preserve the pre-per-region behavior.
+        if n_regions == 0 or self.num_regions == 0:
+            return [False] * num_fa_descs
+        # Descriptors (blocks) per stream; all streams share the same count.
+        nblk = num_fa_descs // self.num_regions
+        virtually_split = self.transfer_topo.virtually_split_kv_in_blocks
+        flags: list[bool] = []
+        for i in range(n_regions):
+            replicated = self._is_region_replicated(i)
+            # REPLICATE (MLA) is key-only -> 1 stream; SPLIT emits K and V
+            # (2 streams) under the virtually-split layout.
+            num_streams = 1 if replicated or not virtually_split else 2
+            flags.extend([replicated] * (num_streams * nblk))
+        assert len(flags) == num_fa_descs, (
+            f"FA desc flags {len(flags)} != num_fa_descs {num_fa_descs}"
+        )
+        return flags
+
+    def _is_region_replicated(self, region_idx: int) -> bool:
+        """Whether region ``region_idx`` is transferred REPLICATE vs SPLIT.
+
+        REPLICATE (MLA): identical on every rank, whole block read from one
+        rank at offset 0, key-only. SPLIT (full-attn): head-sharded across TP.
+        Defaults to SPLIT when the per-region map is unset (e.g. tests that set
+        block_len_per_layer without register_kv_caches).
+        """
+        return region_idx < len(self._region_is_mla) and self._region_is_mla[region_idx]
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        engine_id: str,
+        kv_cache_config: "KVCacheConfig",
+    ):
+        uccl_p2p_wrapper_cls = UcclP2pWrapper
+        if uccl_p2p_wrapper_cls is None:
+            logger.error("UCCL_P2P is not available")
+            raise RuntimeError("UCCL_P2P is not available")
+        logger.info("Initializing UCCL_P2P wrapper")
+        logger.info("Initializing UCCL_P2P worker %s", engine_id)
+
+        # Config.
+        self.vllm_config = vllm_config
+        # mypy will complain on re-assignment otherwise.
+        self.block_size: int = cast(int, vllm_config.cache_config.block_size)
+
+        if vllm_config.kv_transfer_config is None:
+            raise ValueError("kv_transfer_config must be set for UcclP2pConnector")
+        self.kv_transfer_config = vllm_config.kv_transfer_config
+
+        kv_lease_duration: int = vllm_config.kv_transfer_config.get_from_extra_config(
+            "kv_lease_duration", 30
+        )
+        # NOTE (NickLucche): For now we use a hardcoded value for a simpler interface.
+        self._lease_extension = kv_lease_duration * 2 // 3
+
+        self._is_hma_required = (
+            not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
+            and any(
+                not isinstance(g.kv_cache_spec, FullAttentionSpec)
+                for g in kv_cache_config.kv_cache_groups
+            )
+        )
+        self.kv_cache_config = kv_cache_config
+        self._layer_specs = {
+            layer: group.kv_cache_spec
+            for group in kv_cache_config.kv_cache_groups
+            for layer in group.layer_names
+        }
+        self.hma_group_size = len(kv_cache_config.kv_cache_tensors)
+
+        # ---- Model state (derived from model config) ----
+        mamba_ssm_size = (0, 0)
+        # Conv state sub-projection decomposition (None when no Mamba).
+        # The 3-read transfer requires DS (dim, state_len) conv layout so
+        # that x/B/C sub-projections are contiguous in memory.
+        self._conv_decomp: MambaConvSplitInfo | None = None
+        self._has_mamba = any(
+            isinstance(g.kv_cache_spec, MambaSpec)
+            for g in kv_cache_config.kv_cache_groups
+        )
+        if self._has_mamba:
+            assert self._is_hma_required
+            from vllm.model_executor.layers.mamba.mamba_utils import (
+                is_conv_state_dim_first,
+            )
+
+            assert is_conv_state_dim_first(), (
+                "3-read Mamba conv transfer requires DS conv state layout. "
+                "Set VLLM_SSM_CONV_STATE_LAYOUT=DS"
+            )
+            mamba_spec = next(
+                spec
+                for spec in self._layer_specs.values()
+                if isinstance(spec, MambaSpec)
+            )
+            self._conv_decomp = derive_mamba_conv_split(
+                mamba_spec,
+                vllm_config.parallel_config.tensor_parallel_size,
+            )
+            mamba_ssm_size = self._conv_decomp.ssm_sizes
+        self._mamba_ssm_size = mamba_ssm_size
+
+        # Agent – UCCL P2P wrapper uses a per-GPU endpoint pair.
+        self.uccl_p2p_wrapper = UcclP2pWrapper(local_gpu_idx=0)
+        # Map of engine_id -> {rank0: agent_name0, rank1: agent_name1..}.
+        self._remote_agents: dict[EngineId, dict[int, str]] = defaultdict(dict)
+
+        # Metadata.
+        self.engine_id: EngineId = engine_id
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.world_size = get_tensor_model_parallel_world_size()
+
+        self.num_blocks = kv_cache_config.num_blocks
+        self.enable_permute_local_kv = False
+        self.enable_heterogeneous_attn_post_process = False
+
+        # KV Caches and uccl_p2p tracking data.
+        self.device_type = current_platform.device_type
+        self.kv_buffer_device: str = vllm_config.kv_transfer_config.kv_buffer_device
+        if self.device_type not in _UCCL_P2P_SUPPORTED_DEVICE:
+            raise RuntimeError(f"{self.device_type} is not supported.")
+        elif self.kv_buffer_device not in _UCCL_P2P_SUPPORTED_DEVICE[self.device_type]:
+            raise RuntimeError(
+                f"{self.device_type} with {self.kv_buffer_device} kv_buffer "
+                "is not supported."
+            )
+        self.device_kv_caches: dict[str, torch.Tensor] = {}
+
+        # cpu kv buffer for xfer
+        # used when device memory can not be registered under uccl_p2p
+        self.host_xfer_buffers: dict[str, torch.Tensor] = {}
+        if self.device_type == "cpu":
+            self.use_host_buffer = False
+        else:
+            self.use_host_buffer = self.kv_buffer_device == "cpu"
+
+        # reserve different cores for start_load_kv() from model_forward()
+        if self.device_type == "cpu":
+            numa_core_list = current_platform.discover_numa_topology()
+            # setup one last core in each numa for kv transfer.
+            rsv_cores_for_kv = [
+                max(each_numa_core_list) for each_numa_core_list in numa_core_list
+            ]
+
+            if rsv_cores_for_kv:
+                if not hasattr(os, "sched_setaffinity"):
+                    raise NotImplementedError(
+                        "os.sched_setaffinity is not available on this platform"
+                    )
+                os.sched_setaffinity(0, rsv_cores_for_kv)
+
+        # Note: host xfer buffer ops when use_host_buffer is True
+        self.copy_blocks: CopyBlocksOp | None = None
+
+        # Map of engine_id -> kv_caches_base_addr. For TP case, each local
+        self.device_id: int = 0
+        # Current rank may pull from multiple remote TP workers.
+        # EngineId, dict[int, list[int]] -> engine_id, tp_rank, base_addr_for_layer
+        self.kv_caches_base_addr = defaultdict[EngineId, dict[int, list[int]]](dict)
+
+        # Number of UCCL_P2P regions. Currently one region per cache
+        # (so 1 per layer for MLA, otherwise 2 per layer)
+        self.num_regions = 0
+
+        # Per-block XferDesc lists for local src data.  Keyed by block_size.
+        self.src_xfer_descs_by_block_size: dict[int, list[Any]] = {}
+        # Populated dynamically during handshake based on remote configuration.
+        # Keep track of descs at different tp_ratio values.
+        # tp_ratio -> list of desc lists
+        self.src_xfer_descs_by_tp_ratio: dict[int, list[list[Any]]] = {}
+        # Map of engine_id -> {tp_rank: list of per-block XferDesc objects}.
+        self.dst_xfer_descs = defaultdict[EngineId, dict[int, list[Any]]](dict)
+
+        # Map of engine_id -> num_blocks. All ranks in the same deployment will
+        # have the same number of blocks.
+        self.dst_num_blocks: dict[EngineId, int] = {}
+
+        # In progress transfers.
+        # [req_id -> list[handle]]
+        self._recving_metadata: dict[ReqId, ReqMeta] = {}
+        self._recving_transfers = defaultdict[ReqId, list[TransferHandle]](list)
+        # Maps transfer_id -> (notif_msg, agent_name) so that
+        # completion notifications can be sent when the transfer finishes.
+        self._recving_notif_meta: dict[int, tuple[bytes, str]] = {}
+        # Track the expiration time of requests that are waiting to be sent.
+        self._reqs_to_send: dict[ReqId, float] = {}
+        # Set of requests that have been part of a batch, regardless of status.
+        self._reqs_to_process: set[ReqId] = set()
+
+        # Invalid blocks from failed UCCL_P2P operations
+        # (thread-safe queue of block ids)
+        self._invalid_block_ids: queue.Queue[set[int]] = queue.Queue()
+        # requests that skipped transfer (handshake or transfer failures)
+        # Uses Queue for thread-safe cross-thread coordination with the
+        # background handshake thread, matching the _ready_requests pattern.
+        self._failed_recv_reqs: queue.Queue[ReqId] = queue.Queue()
+
+        # Handshake metadata of this worker for UCCL_P2P transfers.
+        self.xfer_handshake_metadata: UcclP2pHandshakePayload | None = None
+        # Background thread for initializing new UCCL_P2P handshakes.
+        self._handshake_initiation_executor = ThreadPoolExecutor(
+            # UCCL_P2P is not guaranteed to be thread-safe, limit 1 worker.
+            max_workers=1,
+            thread_name_prefix="vllm-uccl_p2p-handshake-initiator",
+        )
+        self._ready_requests = queue.Queue[tuple[ReqId, ReqMeta]]()
+        self._handshake_futures: dict[EngineId, Future[dict[int, str]]] = {}
+        # Protects _handshake_futures and _remote_agents.
+        self._handshake_lock = threading.RLock()
+
+        # TTL-based eviction of stale remote engine state.
+        self._engine_last_active: dict[EngineId, float] = {}
+        self._engine_ttl: float = vllm_config.kv_transfer_config.get_from_extra_config(
+            "engine_ttl", 3600.0
+        )
+
+        self.block_size = vllm_config.cache_config.block_size
+        self.model_config = vllm_config.model_config
+
+        self.use_mla = self.model_config.use_mla
+
+        # Get the attention backend from the first layer
+        # NOTE (NickLucche) models with multiple backends are not supported yet
+        self.attn_backends = get_current_attn_backends(vllm_config)
+        self.backend_name = self.attn_backends[0].get_name()
+
+        self.kv_cache_layout = get_kv_cache_layout()
+        self.host_buffer_kv_cache_layout = self.kv_cache_layout
+        logger.info(
+            "Detected attention backend(s) %s",
+            [backend.get_name() for backend in self.attn_backends],
+        )
+        logger.info("Detected kv cache layout %s", self.kv_cache_layout)
+
+        # lazy initialized in register_kv_caches
+        self.compat_hash: str | None = None
+        self.transfer_topo: TransferTopology | None = None
+
+        # With heterogeneous TP, P must wait for all assigned D TP workers to
+        # finish reading before safely freeing the blocks.
+        self.consumer_notification_counts_by_req = defaultdict[ReqId, int](int)
+        self.xfer_stats = UcclP2pKVConnectorStats()
+
+        self._physical_blocks_per_logical_kv_block = 1
+        self._sync_block_size_with_kernel()
+
+        # Unwrap UniformTypeKVCacheSpecs to get the representative spec type
+        self._group_spec_types = tuple(
+            get_representative_spec_type(g.kv_cache_spec)
+            for g in self.kv_cache_config.kv_cache_groups
+        )
+
+        # Per-region MLA flag, 1:1 with block_len_per_layer. True -> REPLICATE
+        # (MLA), False -> SPLIT (head-sharded full-attn). Mixed only for models
+        # combining both (e.g. GQA main + MLA Eagle-3 draft).
+        self._region_is_mla = list[bool]()
+
+        # Enable different block lengths for different layers *only* when MLA is used.
+        # This is not used for SSM layers, which use the counterpart `mamba_ssm_size`.
+        self.block_len_per_layer = list[int]()
+
+        # Per-engine TP mappings. Generated during handshake.
+        self.tp_mappings: dict[EngineId, TPMapping] = {}
+
+        self.enforce_compat_hash = self.kv_transfer_config.get_from_extra_config(
+            "enforce_handshake_compat", True
+        )
+
+    def _sync_block_size_with_kernel(self) -> None:
+        backends = get_current_attn_backends(self.vllm_config)
+        kernel_block_size = select_common_block_size(self.block_size, backends)
+        # Number of blocks not accounting for kernel block mismatches
+        self._logical_num_blocks = self.num_blocks
+        if self.block_size != kernel_block_size:
+            logger.info_once(
+                "User-specified logical block size (%s) does not match"
+                " physical kernel block size (%s). Using the latter.",
+                self.block_size,
+                kernel_block_size,
+            )
+            assert self.block_size > kernel_block_size
+            self._physical_blocks_per_logical_kv_block = (
+                self.block_size // kernel_block_size
+            )
+            self.block_size = kernel_block_size
+            self.num_blocks *= self._physical_blocks_per_logical_kv_block
+
+    def _uccl_p2p_handshake(
+        self,
+        host: str,
+        port: int,
+        remote_tp_size: int,
+        expected_engine_id: str,
+    ) -> dict[int, str]:
+        """Do a UCCL_P2P handshake with a remote instance."""
+
+        # the first time we connect to a remote agent.
+        # be careful, the handshake happens in a background thread.
+        # it does not have an active cuda context until any cuda runtime
+        # call is made. when UCX fails to find a valid cuda context, it will
+        # disable any cuda ipc communication, essentially disabling any NVLink
+        # communication.
+        # when we are using device buffers, we need to set the device
+        # explicitly to make sure the handshake background thread has a valid
+        # cuda context.
+        if not self.use_host_buffer:
+            current_platform.set_device(self.device_id)
+
+        # When target instance TP > local TP, we need to perform multiple
+        # handshakes. Do it in a single background job for simplicity.
+        # Regardless, only handshake with the remote TP rank(s) that current
+        # local rank will read from. Note that With homogeneous TP,
+        # this happens to be the same single rank_i.
+        assert self.transfer_topo is not None
+        p_remote_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
+        remote_rank_to_agent_name = {}
+        path = make_zmq_path("tcp", host, port)
+
+        with zmq_ctx(zmq.REQ, path) as sock:
+            for remote_rank in p_remote_ranks:
+                logger.debug(
+                    "Querying metadata on path: %s at remote tp rank %s",
+                    path,
+                    remote_rank,
+                )
+
+                start_time = time.perf_counter()
+                # Send query for the request.
+                msg = msgspec.msgpack.encode((GET_META_MSG, remote_rank))
+                # Set receive timeout to 5 seconds to avoid hanging on dead server
+                sock.setsockopt(zmq.RCVTIMEO, 5000)  # milliseconds
+                sock.send(msg)
+                handshake_bytes = sock.recv()
+
+                # Decode handshake payload to get compatibility hash
+                handshake_decoder = msgspec.msgpack.Decoder(UcclP2pHandshakePayload)
+                try:
+                    handshake_payload = handshake_decoder.decode(handshake_bytes)
+                except (msgspec.DecodeError, msgspec.ValidationError) as e:
+                    raise RuntimeError(
+                        "Failed to decode UcclP2pHandshakePayload. This likely "
+                        f"indicates an incompatibility between connector version. "
+                        f"Error: {e}"
+                    ) from e
+
+                got_metadata_time = time.perf_counter()
+                logger.debug(
+                    "UCCL_P2P handshake: get metadata took: %s",
+                    got_metadata_time - start_time,
+                )
+
+                # Check compatibility hash BEFORE decoding agent metadata
+                assert self.compat_hash is not None
+                if (
+                    self.enforce_compat_hash
+                    and handshake_payload.compatibility_hash != self.compat_hash
+                ):
+                    raise RuntimeError(
+                        f"UCCL_P2P compatibility hash mismatch. "
+                        f"Local: {self.compat_hash}, "
+                        f"Remote: {handshake_payload.compatibility_hash}. "
+                        f"Prefill and decode instances have incompatible "
+                        f"configurations. This may be due to: different vLLM versions,"
+                        f" models, dtypes, KV cache layouts, attention backends, etc. "
+                        f"Both instances must use identical configurations."
+                        f"Disable this check using "
+                        f'--kv-transfer-config \'{{"kv_connector_extra_config": '
+                        f'{{"enforce_handshake_compat": false}}}}\''
+                    )
+
+                logger.info(
+                    "UCCL_P2P compatibility check passed (hash: %s)",
+                    handshake_payload.compatibility_hash,
+                )
+
+                # Decode agent metadata
+                metadata_decoder = msgspec.msgpack.Decoder(UcclP2pAgentMetadata)
+                try:
+                    metadata = metadata_decoder.decode(
+                        handshake_payload.agent_metadata_bytes
+                    )
+                except (msgspec.DecodeError, msgspec.ValidationError) as e:
+                    # This should not happen if hash matched
+                    raise RuntimeError(
+                        f"Failed to decode UcclP2pAgentMetadata. Error: {e}"
+                    ) from e
+
+                # Ensure engine id matches.
+                if metadata.engine_id != expected_engine_id:
+                    raise RuntimeError(
+                        f"Remote UCCL_P2P agent engine ID mismatch. "
+                        f"Expected {expected_engine_id},"
+                        f"received {metadata.engine_id}."
+                    )
+
+                # Register Remote agent.
+                remote_agent_name = self.add_remote_agent(
+                    metadata, remote_rank, remote_tp_size
+                )
+                setup_agent_time = time.perf_counter()
+                logger.debug(
+                    "UCCL_P2P handshake: add agent took: %s",
+                    setup_agent_time - got_metadata_time,
+                )
+                remote_rank_to_agent_name[remote_rank] = remote_agent_name
+        return remote_rank_to_agent_name
+
+    def initialize_host_xfer_buffer(self, kv_caches: dict[str, torch.Tensor]) -> None:
+        """
+        Initialize transfer buffer in CPU mem for accelerators
+        NOT directly supported by UCCL_P2P (e.g., tpu)
+        """
+        xfer_buffers: dict[str, torch.Tensor] = {}
+        inv_order = [0, 1, 3, 2, 4]
+        try:
+            for layer_name, kv_cache in kv_caches.items():
+                kv_shape = kv_cache.shape
+                kv_dtype = kv_cache.dtype
+                permute_shape = False
+                if (
+                    self.kv_cache_layout == "NHD"
+                    and self.vllm_config.kv_transfer_config is not None
+                    and self.vllm_config.kv_transfer_config.enable_permute_local_kv
+                ):
+                    logger.info_once(
+                        "'enable_permute_local_kv' flag is enabled while "
+                        "device KV Layout is NHD. Init host buffer with"
+                        " HND to better support Decode/Prefill TP_ratio > 1."
+                    )
+                    # Since NHD will not support Decode/Prefill TP_ratio > 1,
+                    # we can leverage host_buffer for permute
+                    self.host_buffer_kv_cache_layout = "HND"
+                    kv_shape = (
+                        tuple(kv_shape[i] for i in inv_order)
+                        if not self.use_mla
+                        else kv_shape
+                    )
+                    permute_shape = not self.use_mla
+
+                xfer_buffers[layer_name] = torch.empty(
+                    kv_shape, dtype=kv_dtype, device="cpu"
+                )
+                if permute_shape:
+                    xfer_buffers[layer_name] = xfer_buffers[layer_name].permute(
+                        inv_order
+                    )
+        except MemoryError as e:
+            logger.error("UCCL_P2PConnectorWorker gets %s.", e)
+            raise
+
+        self.host_xfer_buffers = xfer_buffers
+
+    def set_host_xfer_buffer_ops(self, copy_operation: CopyBlocksOp):
+        """Assign copy (d2h, h2d) operations when host buffer is used."""
+        # Set a no-op if the host buffer is not cpu.
+        if self.kv_buffer_device != "cpu":
+            return
+        # Set a no-op if self.device_type is 'cpu'.
+        if self.device_type == "cpu":
+            return
+        assert self.use_host_buffer
+        self.copy_blocks = copy_operation
+
+    def _log_failure(
+        self,
+        failure_type: str,
+        req_id: str | None,
+        msg: str = "",
+        error: Exception | None = None,
+        meta: ReqMeta | None = None,
+        **extra_context,
+    ):
+        """Log transfer failure with structured context for easier debugging."""
+        context: dict[str, Any] = {
+            "failure_type": failure_type,
+            "request_id": req_id,
+            "engine_id": self.engine_id,
+        }
+        if meta is None and req_id is not None:
+            # Try to get metadata from in progress transfers when not provided
+            meta = self._recving_metadata.get(req_id)
+
+        if meta and meta.remote:
+            context.update(
+                {
+                    "remote_engine_id": meta.remote.engine_id,
+                    "remote_request_id": meta.remote.request_id,
+                    "remote_host": meta.remote.host,
+                    "remote_port": meta.remote.port,
+                    "num_local_blocks": sum(
+                        len(group) for group in meta.local_block_ids
+                    ),
+                    "num_remote_blocks": sum(
+                        len(group) for group in meta.remote.block_ids
+                    ),
+                    "local_block_ids_sample": meta.local_block_ids[0][:10]
+                    if meta.local_block_ids
+                    else [],
+                }
+            )
+
+        context.update(extra_context)
+        if msg:
+            failure_type = f"{failure_type}. {msg}"
+
+        logger.error(
+            "UCCL_P2P transfer failure: %s | Context: %s",
+            failure_type,
+            context,
+            exc_info=error is not None,
+            stacklevel=2,
+        )
+
+    def _ensure_handshake(
+        self,
+        engine_id: EngineId,
+        host: str,
+        port: int,
+        tp_size: int,
+    ) -> Future[dict[int, str]] | None:
+        """
+        Ensure a handshake is in-flight (or already done) for *engine_id*.
+
+        Returns the ``Future`` if a handshake is pending (or was just
+        started), or ``None`` if the handshake already completed
+        successfully.  Callers can attach per-request callbacks to the
+        returned future.
+        Failures to handshake are logged and the request is marked as failed.
+        """
+        self._evict_stale_engines()
+        with self._handshake_lock:
+            if engine_id in self._remote_agents:
+                return None
+            fut = self._handshake_futures.get(engine_id)
+            if fut is not None:
+                return fut
+            fut = self._handshake_initiation_executor.submit(
+                self._uccl_p2p_handshake,
+                host,
+                port,
+                tp_size,
+                engine_id,
+            )
+            self._handshake_futures[engine_id] = fut
+
+            def done_callback(f: Future[dict[int, str]], eid=engine_id):
+                with self._handshake_lock:
+                    del self._handshake_futures[eid]
+                    try:
+                        self._remote_agents[eid] = f.result()
+                        self._engine_last_active[eid] = time.perf_counter()
+                    except Exception as e:
+                        self._log_failure(
+                            failure_type="handshake_setup_failed",
+                            req_id=None,
+                            error=e,
+                            remote_engine_id=eid,
+                        )
+
+            fut.add_done_callback(done_callback)
+            return fut
+
+    def _background_uccl_p2p_handshake(
+        self, req_id: str, remote_engine_id: EngineId, meta: ReqMeta
+    ):
+        # Do UCCL_P2P handshake in background and add to _ready_requests when done.
+        assert meta.remote is not None
+        fut = self._ensure_handshake(
+            remote_engine_id,
+            meta.remote.host,
+            meta.remote.port,
+            meta.tp_size,
+        )
+        if fut is None:
+            # Already handshaked — only happens if caller does not pre-check.
+            self._ready_requests.put((req_id, meta))
+            return
+
+        # Check handshake success before proceeding with request.
+        def request_ready(f: Future[Any], entry=(req_id, meta)):
+            try:
+                f.result()
+                self._ready_requests.put(entry)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="handshake_failed",
+                    req_id=req_id,
+                    error=e,
+                    meta=meta,
+                )
+                self._handle_failed_transfer(req_id, None)
+
+        fut.add_done_callback(request_ready)
+
+    def register_cross_layers_kv_caches(self, kv_cache: torch.Tensor) -> None:
+        """Register a cross-layers KV cache tensor with UCCL_P2P.
+
+        `use_uniform_kv_cache()` guarantees a single KV cache group whose
+        layers all share the same `AttentionSpec`, so any layer name from
+        `_layer_specs` yields the correct per-layer spec for `page_size_bytes`.
+        """
+        first_layer = next(iter(self._layer_specs))
+        # Forwarding a real layer name rather than a synthetic key
+        self.register_kv_caches({first_layer: kv_cache})
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        """Register the KV Cache data in uccl_p2p."""
+        self.transfer_topo = TransferTopology(
+            tp_rank=self.tp_rank,
+            tp_size=self.world_size,
+            block_size=self.block_size,
+            engine_id=self.engine_id,
+            is_mla=self.use_mla,
+            total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
+            attn_backends=self.attn_backends,
+            # SSM States come in tuples (ssm, conv)
+            tensor_shape=next(iter(kv_caches.values())).shape
+            if not self._has_mamba
+            else None,
+            is_mamba=self._has_mamba,
+        )
+        self.compat_hash = compute_uccl_p2p_compatibility_hash(
+            self.vllm_config, self.backend_name, self.transfer_topo.cross_layers_blocks
+        )
+
+        if self.use_host_buffer:
+            self.initialize_host_xfer_buffer(kv_caches=kv_caches)
+            assert len(self.host_xfer_buffers) == len(kv_caches), (
+                f"host_buffer: {len(self.host_xfer_buffers)}, "
+                f"kv_caches: {len(kv_caches)}"
+            )
+            xfer_buffers = self.host_xfer_buffers
+        else:
+            xfer_buffers = kv_caches
+            assert not self.host_xfer_buffers, (
+                "host_xfer_buffer should not be initialized when "
+                f"kv_buffer_device is {self.kv_buffer_device}"
+            )
+
+        logger.info(
+            "Registering KV_Caches. use_mla: %s, kv_buffer_device: %s, "
+            "use_host_buffer: %s",
+            self.use_mla,
+            self.kv_buffer_device,
+            self.use_host_buffer,
+        )
+
+        caches_data = []
+        # With hybrid allocator, layers can share a kv cache tensor
+        seen_base_addresses = []
+        # Collect the actual tensors for UCCL P2P memory registration.
+        tensors_to_register: list[torch.Tensor] = []
+        _local_tensor_sizes: list[int] = []
+
+        # Note(tms): I modified this from the original region setup code.
+        # K and V are now in different regions. Advantage is that we can
+        # elegantly support MLA and any cases where the K and V tensors
+        # are non-contiguous (it's not locally guaranteed that they will be)
+        # Disadvantage is that the encoded UcclP2pAgentMetadata is now larger
+        # (roughly 8KB vs 5KB).
+        # Conversely for FlashInfer, K and V are registered in the same region
+        # to better exploit the memory layout (ie num_blocks is the first dim).
+        tensor_size_bytes = None
+
+        for layer_name, cache_or_caches in xfer_buffers.items():
+            # NOTE (NickLucche) Hybrid SSM models assume a layout that is similar to
+            # that of FI, with block laid out as in `get_backend_aware_kv_block_len`.
+            # However, physical page_size may differ when kernel requires a specific
+            # block size. This leads to SSM and FA layers having different num_blocks.
+            # `_physical_blocks_per_logical_kv_block` ratio is used to adjust for this.
+            layer_spec = self._layer_specs.get(layer_name)
+            if layer_spec is None:
+                logger.debug(
+                    "Skipping layer %s as no KVCache spec is present. "
+                    "This is likely because the layer is sharing its KV cache",
+                    layer_name,
+                )
+                continue
+            if isinstance(layer_spec, UniformTypeKVCacheSpecs):
+                # MLA DSv32 Indexer case: UniformTypeKVCacheSpecs merges kv_cache_specs
+                layer_spec = layer_spec.kv_cache_specs[layer_name]
+            cache_list = self.transfer_topo.get_transfer_cache_regions(
+                cache_or_caches, layer_spec
+            )
+            # `layer_spec.page_size_bytes` only accounts for logical page_size, that is
+            # the page_size assuming constant `self._logical_num_blocks`.
+            physical_page_size = (
+                layer_spec.page_size_bytes
+                if isinstance(layer_spec, MambaSpec)
+                else layer_spec.page_size_bytes
+                // self._physical_blocks_per_logical_kv_block
+            )
+            # For when registering multiple tensors eg K/V in separate regions.
+            physical_page_size = physical_page_size // len(cache_list)
+            if self.transfer_topo._cross_layers_blocks:
+                # When cross-layers blocks are used, multiply by number of layers
+                physical_page_size = physical_page_size * len(
+                    self.kv_cache_config.kv_cache_tensors
+                )
+            num_blocks = (
+                self._logical_num_blocks
+                if isinstance(layer_spec, MambaSpec)
+                else self.num_blocks
+            )
+            # `page_size` accounts for physical blocks, st KVCache is always
+            # [`num_blocks` * `page_size`]
+            curr_tensor_size_bytes = num_blocks * physical_page_size
+
+            # TODO (NickLucche) we could eventually unify how we handle FA/FI regions,
+            # registering a single tensor for both K/V and splitting logically like FI.
+            for cache in cache_list:
+                base_addr = cache.data_ptr()
+                if base_addr in seen_base_addresses:
+                    # NOTE (NickLucche) HMA employs memory pooling to share tensors
+                    # across groups. This results in skipping all tensors but the ones
+                    # pointed to by group0. Also, generally we will have more blocks
+                    # per tensor but fewer regions.
+                    logger.debug("Skipping %s because it's already seen", layer_name)
+                    continue
+                logger.debug(
+                    "Registering layer %s with cache shape: %s", layer_name, cache.shape
+                )
+                seen_base_addresses.append(base_addr)
+                # Only record non-Mamba page sizes.
+                if isinstance(layer_spec, MambaSpec):
+                    self.block_len_per_layer.append(
+                        physical_page_size // self._physical_blocks_per_logical_kv_block
+                    )
+                else:
+                    self.block_len_per_layer.append(physical_page_size)
+                is_mla_region = isinstance(layer_spec, MLAAttentionSpec)
+                self._region_is_mla.append(is_mla_region)
+
+                # HeteroTP cannot transfer differently-sized regions, so every
+                # non-MLA region in a group must share one tensor size (this also
+                # holds for Mamba-like models). The sole exception is the DeepSeek
+                # MLA indexer, which sits in a UniformTypeKVCacheSpecs group at a
+                # different size; MLA regions are therefore exempt.
+                if not is_mla_region:
+                    if tensor_size_bytes is None:
+                        tensor_size_bytes = curr_tensor_size_bytes
+                    assert tensor_size_bytes == curr_tensor_size_bytes, (
+                        "All non-MLA kv cache tensors must have the same size"
+                    )
+
+                if cache.shape[0] != num_blocks:
+                    raise AssertionError(
+                        "All kv cache tensors must have the same number of "
+                        f"blocks; layer={layer_name}, "
+                        f"expected_num_blocks={num_blocks}, "
+                        f"cache_shape={tuple(cache.shape)}, "
+                        f"cache_stride={tuple(cache.stride())}, "
+                        f"layer_spec={type(layer_spec).__name__}, "
+                        f"backend={self.backend_name}, "
+                        "all_backends="
+                        f"{[backend.get_name() for backend in self.attn_backends]}, "
+                        f"kv_cache_layout={self.kv_cache_layout}, "
+                        "blocks_first="
+                        f"{self.transfer_topo.is_kv_layout_blocks_first}"
+                    )
+
+                # Need to make sure the device ID is non-negative for UCCL_P2P,
+                # Torch uses -1 to indicate CPU tensors.
+                self.device_id = max(cache.get_device(), 0)
+                caches_data.append(
+                    (base_addr, curr_tensor_size_bytes, self.device_id, "")
+                )
+                tensors_to_register.append(cache)
+                _local_tensor_sizes.append(curr_tensor_size_bytes)
+
+        logger.debug(
+            "Different block lengths collected: %s", set(self.block_len_per_layer)
+        )
+        assert (
+            len(self.block_len_per_layer)
+            == len(seen_base_addresses)
+            == len(self._region_is_mla)
+        )
+
+        self.kv_caches_base_addr[self.engine_id][self.tp_rank] = seen_base_addresses
+        self.num_regions = len(caches_data)
+
+        if self.transfer_topo.virtually_split_kv_in_blocks:
+            # NOTE (NickLucche) When FlashInfer is used, memory is registered
+            # with joint KV for each block. This minimizes the overhead in
+            # registerMem allowing faster descs queries. In order to be able to
+            # split on kv_heads dim as required by heterogeneous TP, one must
+            # be able to index K/V separately. Hence we double the number
+            # of 'virtual' regions here and halve `block_len` below.
+            # Similarly for Mamba layers, we register SSM+Conv as a single region and
+            # then duplicate it logically to be able to index SSM/Conv separately.
+            # Exception: key-only REPLICATE regions (MLA) have no V half, so
+            # they contribute a single desc stream and are not doubled.
+            self.num_regions = sum(
+                1 if self._is_region_replicated(i) else 2
+                for i in range(len(self._region_is_mla))
+            )
+
+        # Total local FA descriptors (boundary between FA and mamba descs).
+        self.num_descs = self.num_regions * self.num_blocks
+
+        # Register the KV cache tensors with UCCL P2P.
+        logger.debug("Registering %d tensors with UCCL P2P", len(tensors_to_register))
+        self._base_xfer_descs = self.uccl_p2p_wrapper.register_memory(
+            tensors_to_register
+        )
+        self._serialized_xfer_descs = self.uccl_p2p_wrapper.get_serialized_descs(
+            self._base_xfer_descs
+        )
+        logger.debug(
+            "Done registering %d tensors as UCCL P2P memory",
+            len(tensors_to_register),
+        )
+        # Map base addresses to their XferDesc and tensor size for later
+        # per-block desc construction.
+        self._base_addr_to_xfer_desc: dict[int, Any] = dict(
+            zip(seen_base_addresses, self._base_xfer_descs)
+        )
+        self._base_addr_to_tensor_size: dict[int, int] = dict(
+            zip(seen_base_addresses, _local_tensor_sizes)
+        )
+
+        self.device_kv_caches = kv_caches
+        self.dst_num_blocks[self.engine_id] = self.num_blocks
+
+        if self._has_mamba:
+            logger.info(
+                "Hybrid SSM registration: num_blocks=%s, "
+                "logical_num_blocks=%s, ratio=%s, num_regions=%s, "
+                "num_descs=%s, mamba_ssm_size=%s, block_len_per_layer=%s",
+                self.num_blocks,
+                self._logical_num_blocks,
+                self._physical_blocks_per_logical_kv_block,
+                self.num_regions,
+                self.num_descs,
+                self._mamba_ssm_size,
+                set(self.block_len_per_layer),
+            )
+
+        # Register local/src descr for UCCL_P2P xfer.
+        self.src_xfer_descs_by_block_size[self.block_size], self.src_blocks_data = (
+            self.register_local_xfer_handler(self.block_size)
+        )
+
+        # After KV Caches registered, listen for new connections.
+        data_ep_md, notif_ep_md = self.uccl_p2p_wrapper.get_agent_metadata()
+        agent_metadata = UcclP2pAgentMetadata(
+            engine_id=self.engine_id,
+            data_endpoint_metadata=data_ep_md,
+            notif_endpoint_metadata=notif_ep_md,
+            serialized_xfer_descs=self._serialized_xfer_descs,
+            device_id=self.device_id,
+            kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][self.tp_rank],
+            num_blocks=self.num_blocks,
+            block_lens=self.block_len_per_layer,
+            kv_cache_layout=self.kv_cache_layout
+            if not self.use_host_buffer
+            else self.host_buffer_kv_cache_layout,
+            block_size=self.block_size,
+            ssm_sizes=self._mamba_ssm_size,
+            attn_backend_name=self.backend_name,
+            physical_blocks_per_logical_kv_block=(
+                self._physical_blocks_per_logical_kv_block
+            ),
+        )
+        # Wrap metadata in payload with hash for defensive decoding
+        assert self.compat_hash is not None
+        encoder = msgspec.msgpack.Encoder()
+        self.xfer_handshake_metadata = UcclP2pHandshakePayload(
+            compatibility_hash=self.compat_hash,
+            agent_metadata_bytes=encoder.encode(agent_metadata),
+        )
+
+    def _build_mamba_local(
+        self,
+        base_addresses: list[int],
+        block_size_ratio: int,
+    ) -> list[tuple[int, int, int]]:
+        """Build 4 desc regions (x, B, C, ssm) per layer for local mamba
+        blocks, enabling the 3-read transfer with DS conv layout."""
+        assert block_size_ratio == 1, (
+            "Mamba 3-read transfer with block_size_ratio != 1 is not tested. "
+            f"Got block_size_ratio={block_size_ratio}."
+        )
+        assert self._conv_decomp is not None
+        conv_offsets = self._conv_decomp.local_conv_offsets
+        conv_size, ssm_size = self._mamba_ssm_size
+        num_blocks = self._logical_num_blocks * block_size_ratio
+        physical_per_logical = self._physical_blocks_per_logical_kv_block
+
+        result: list[tuple[int, int, int]] = []
+        for i, base_addr in enumerate(base_addresses):
+            # Jump one page_size, but ssm page_size may be bigger when kernel
+            # locks block size to a specific value (physical_per_logical scale).
+            page_stride = (
+                self.block_len_per_layer[i] // block_size_ratio * physical_per_logical
+            )
+            for off, sz in conv_offsets:
+                for blk in range(num_blocks):
+                    result.append(
+                        (base_addr + blk * page_stride + off, sz, self.device_id)
+                    )
+            # SSM temporal state follows the conv state.
+            for blk in range(num_blocks):
+                result.append(
+                    (
+                        base_addr + blk * page_stride + conv_size,
+                        ssm_size,
+                        self.device_id,
+                    )
+                )
+        return result
+
+    def _build_mamba_remote(
+        self,
+        uccl_p2p_agent_meta: UcclP2pAgentMetadata,
+        tp_ratio: int,
+        transfer_info: EngineTransferInfo,
+    ) -> list[tuple[int, int, int]]:
+        """Build 4 remote desc regions (proj0, proj1, proj2, ssm) per layer
+        for the 3-read transfer.  For hetero-TP, each D rank reads only its
+        sub-projection slice from the P rank."""
+        assert self._conv_decomp is not None
+        effective_ratio = max(tp_ratio, 1)
+        # Mamba conv state is always TP-sharded, even when attention KV
+        # is replicated (num_kv_heads < tp_size).
+        local_offset = self.tp_rank % effective_ratio
+        conv_size_remote = uccl_p2p_agent_meta.ssm_sizes[0]
+
+        conv_offsets = self._conv_decomp.remote_conv_offsets(local_offset, tp_ratio)
+        if tp_ratio >= 1:
+            ssm_read_size = self._mamba_ssm_size[1]
+        else:
+            ssm_read_size = uccl_p2p_agent_meta.ssm_sizes[1]
+
+        remote_physical_per_logical = transfer_info.remote_physical_blocks_per_logical
+        num_blocks = uccl_p2p_agent_meta.num_blocks // remote_physical_per_logical
+        device_id = uccl_p2p_agent_meta.device_id
+
+        result: list[tuple[int, int, int]] = []
+        # NOTE (ZhanqiuHu): use per-layer block_lens[i], not [0], in case
+        # block lengths vary across layers (e.g. MLA).
+        for i, base_addr in enumerate(uccl_p2p_agent_meta.kv_caches_base_addr):
+            block_len = uccl_p2p_agent_meta.block_lens[i]
+            page_stride = block_len * remote_physical_per_logical
+            for off, sz in conv_offsets:
+                for blk in range(num_blocks):
+                    result.append((base_addr + blk * page_stride + off, sz, device_id))
+            # SSM temporal state is also TP-sharded on the heads dimension.
+            for blk in range(num_blocks):
+                ssm_addr = (
+                    base_addr
+                    + blk * page_stride
+                    + conv_size_remote
+                    + local_offset * ssm_read_size
+                )
+                result.append((ssm_addr, ssm_read_size, device_id))
+        return result
+
+    def _build_fa_local(
+        self,
+        base_addresses: list[int],
+        block_size_ratio: int,
+    ) -> list[tuple[int, int, int]]:
+        """Build local FA descriptors for all layers."""
+        assert self.transfer_topo is not None
+        num_blocks = self.num_blocks * block_size_ratio
+        result: list[tuple[int, int, int]] = []
+        for i, base_addr in enumerate(base_addresses):
+            kv_block_len = (
+                self.get_backend_aware_kv_block_len(
+                    layer_idx=i, first_split=True, mamba_view=False
+                )
+                // block_size_ratio
+            )
+            page_stride = self.block_len_per_layer[i] // block_size_ratio
+            for block_id in range(num_blocks):
+                block_offset = block_id * page_stride
+                addr = base_addr + block_offset
+                result.append((addr, kv_block_len, self.device_id))
+
+            if (
+                self.transfer_topo.virtually_split_kv_in_blocks
+                and not self._is_region_replicated(i)
+            ):
+                # Separate and interleave K/V regions to maintain the same
+                # descs ordering. This is needed for selecting contiguous heads
+                # when split across TP ranks. (Skipped for key-only REPLICATE.)
+                second_split = self.get_backend_aware_kv_block_len(
+                    layer_idx=i, first_split=False, mamba_view=False
+                )
+                for block_id in range(num_blocks):
+                    block_offset = block_id * page_stride
+                    addr = base_addr + block_offset
+                    v_addr = addr + kv_block_len
+                    result.append((v_addr, second_split, self.device_id))
+        return result
+
+    def _build_fa_remote(
+        self,
+        plan: TPMapping,
+        uccl_p2p_agent_meta: UcclP2pAgentMetadata,
+        block_size_ratio: int,
+    ) -> list[tuple[int, int, int]]:
+        """Build remote FA descriptors for all layers."""
+        assert self.transfer_topo is not None
+        fa_group_idx = next(
+            i for i, t in enumerate(self._group_spec_types) if _is_attention_spec(t)
+        )
+        # SPLIT regions read their head slice from this many remote ranks at a
+        # per-rank offset; REPLICATE regions read the whole block once.
+        split_reads = len(plan.source_ranks_per_group[fa_group_idx])
+        num_blocks = uccl_p2p_agent_meta.num_blocks
+        result: list[tuple[int, int, int]] = []
+        for i, base_addr in enumerate(uccl_p2p_agent_meta.kv_caches_base_addr):
+            replicated = self._is_region_replicated(i)
+            # Read our whole local region size from remote..
+            local_block_len = self.get_backend_aware_kv_block_len(
+                layer_idx=i, first_split=True, mamba_view=False
+            )
+            remote_kv_block_len = local_block_len // block_size_ratio
+            if block_size_ratio > 1:
+                # ..using remote kv_block_len as transfer unit
+                local_block_len = remote_kv_block_len
+
+            # REPLICATE reads the whole block once at offset 0; SPLIT gathers
+            # its head slice from `split_reads` remote ranks at a per-rank offset.
+            num_reads = 1 if replicated else split_reads
+            rank_offset = (
+                0 if replicated else plan.rank_offset_factor * remote_kv_block_len
+            )
+            local_block_len = local_block_len // num_reads
+
+            page_size = uccl_p2p_agent_meta.block_lens[i]
+            for block_id in range(num_blocks):
+                block_offset = block_id * page_size
+                # For each block, grab the kv heads chunk belonging to current local
+                # tp rank of size local_block_len.
+                addr = base_addr + block_offset + rank_offset
+                result.append((addr, local_block_len, uccl_p2p_agent_meta.device_id))
+
+            emits_v = self.transfer_topo.virtually_split_kv_in_blocks and not replicated
+            if emits_v:
+                # With FlashInfer index V separately to allow head splitting.
+                second_split = self.get_backend_aware_kv_block_len(
+                    layer_idx=i, first_split=False, mamba_view=False
+                )
+                second_split = second_split // num_reads
+                for block_id in range(num_blocks):
+                    block_offset = block_id * page_size
+                    addr = base_addr + block_offset + rank_offset
+                    # Hop over the first split of remote page, K, to read V.
+                    v_addr = addr + uccl_p2p_agent_meta.block_lens[i] // 2
+                    result.append((v_addr, second_split, uccl_p2p_agent_meta.device_id))
+        return result
+
+    def _blocks_data_to_xfer_descs(
+        self,
+        blocks_data: list[tuple[int, int, int]],
+        base_addr_to_desc: dict[int, Any],
+        base_addr_to_tensor_size: dict[int, int],
+    ) -> list[Any]:
+        """Convert (addr, size, dev) tuples to per-block XferDesc objects.
+
+        Each block is matched to the registered tensor whose address range
+        contains it.  The corresponding base XferDesc is shallow-copied and
+        its addr and size are set to the block's values.
+        """
+        import copy
+
+        result: list[Any] = []
+        for addr, block_size_val, dev in blocks_data:
+            base_desc = None
+            for base_addr, tensor_size_val in base_addr_to_tensor_size.items():
+                if base_addr <= addr < base_addr + tensor_size_val:
+                    base_desc = base_addr_to_desc.get(base_addr)
+                    break
+            if base_desc is None:
+                raise RuntimeError(
+                    f"Block at addr {addr} not found in registered tensors"
+                )
+            xfer_desc = copy.copy(base_desc)
+            xfer_desc.addr = addr
+            xfer_desc.size = block_size_val
+            result.append(xfer_desc)
+        return result
+
+    def register_local_xfer_handler(
+        self,
+        block_size: int,
+    ) -> tuple[list[Any], list[tuple[int, int, int]]]:
+        """
+        Function used for register local xfer handler with local block_size or
+        Remote block_size.
+
+        When local block_size is same as remote block_size, we use local block_size
+        to register local_xfer_handler during init.
+
+        When remote block size is less than local block size, we need to use
+        register another local_xfer_handler using remote block len to ensure
+        data copy correctness.
+        """
+        assert self.transfer_topo is not None
+        block_size_ratio = self.block_size // block_size
+        local_base_addresses = self.kv_caches_base_addr[self.engine_id][self.tp_rank]
+
+        blocks_data = self._build_fa_local(local_base_addresses, block_size_ratio)
+        logger.debug(
+            "Created %s blocks for src engine %s and rank %s on device id %s",
+            len(blocks_data),
+            self.engine_id,
+            self.tp_rank,
+            self.device_id,
+        )
+        if self._has_mamba:
+            assert self.num_descs == len(blocks_data)
+            logger.debug("Registering local Mamba descriptors (4 regions/layer)")
+            blocks_data.extend(
+                self._build_mamba_local(local_base_addresses, block_size_ratio)
+            )
+
+        # Build per-block XferDesc objects from the local base descs.
+        # Blocks are keyed by the local engine's registered memory.
+        xfer_descs = self._blocks_data_to_xfer_descs(
+            blocks_data,
+            self._base_addr_to_xfer_desc,
+            self._base_addr_to_tensor_size,
+        )
+        return xfer_descs, blocks_data
+
+    def add_remote_agent(
+        self,
+        uccl_p2p_agent_meta: UcclP2pAgentMetadata,
+        remote_tp_rank: int = 0,
+        remote_tp_size: int = 1,
+    ) -> str:
+        """
+        Add the remote UCCL_P2P agent and prepare the descriptors for reading cache
+        blocks from remote.
+
+        In particular, handle both homogeneous and heterogeneous TP. The former
+        requires local rank_i to read from remote rank_i.
+        The latter, in the case of D.world_size < P.world_size, requires that a
+        local (D) TP worker reads from multiple remote (P) TP workers.
+        Conversely, assuming D.world_size > P.world_size, two or more local TP
+        workers will read from a single remote TP worker.
+
+        Here's an example for the last case described above (non-MLA):
+
+        rank_offset     p_remote_tp_rank
+        (kv split no)
+        --------------------------------
+            0                 0      Worker0  ---- 1st half of KV ----> Worker0  [ KV Cache ]
+                                                                        /
+            1                 0      Worker1  ---- 2nd half of KV -----/
+
+            0                 1      Worker2  ---- 1st half of KV ----> Worker1  [ KV Cache ]
+                                                                        /
+            1                 1      Worker3  ---- 2nd half of KV -----/
+
+
+                                Decoder TP workers                     Prefix TP workers
+                                  (world_size=4)                         (world_size=2)
+                                                 tp_ratio = 4 // 2 = 2
+
+        Considering the KV Caches, if P-Worker_i has cache size [2, num_blocksP, kv_heads, block_size, head_dim]
+        then D-Worker_j has [2, num_blocksD, kv_heads//tp_ratio, block_size, head_dim]. Mind the "HND" layout format.
+        Assuming num_blocksD >= num_blocksP, D-Worker0 reads from P-Worker0 by preparing the kv_heads//tp_ratio
+        first heads from all the slots of all the blocks. D-Worker1 will do the same, but reading the second split
+        along the kv_heads dimension, and so forth until "tp_ratio" D TP workers have pulled from P-Worker0.
+
+        Note that the above will also hold true for the homogeneous TP case, where tp_ratio evaluates to 1.
+
+        Regarding MLA case, the cache is replicated across TP workers so the rank_offset will just always be 0
+        so that the whole cache is shared by "tp_ratio" D TP workers.
+
+        For Mamba hetero-TP, both tp_ratio > 0 (D_TP > P_TP) and
+        tp_ratio < 0 (P_TP > D_TP) are supported by the 3-read transfer.
+        """  # noqa: E501
+        engine_id = uccl_p2p_agent_meta.engine_id
+        # TODO re-evaluate refreshing for scaling/recovery
+        if remote_tp_rank in self._remote_agents.get(engine_id, {}):
+            logger.debug(
+                "Remote agent with engine_id %s and rank"
+                "%s already exchanged metadata, skip handshake.",
+                engine_id,
+                remote_tp_rank,
+            )
+            return self._remote_agents[engine_id][remote_tp_rank]
+
+        ### Register remote engine in TransferTopology (idempotent).
+        assert self.transfer_topo is not None
+        transfer_topo = self.transfer_topo
+        physical_blocks_per_logical = (
+            uccl_p2p_agent_meta.physical_blocks_per_logical_kv_block
+        )
+        transfer_info = EngineTransferInfo(
+            remote_tp_size=remote_tp_size,
+            remote_block_size=uccl_p2p_agent_meta.block_size,
+            remote_block_len=uccl_p2p_agent_meta.block_lens[0],
+            remote_physical_blocks_per_logical=physical_blocks_per_logical,
+        )
+        transfer_topo.register_remote_engine(engine_id, transfer_info)
+        logger.info("Transfer plan: %s", transfer_topo.describe(engine_id))
+
+        self.tp_mappings[engine_id] = compute_tp_mapping(
+            transfer_topology=transfer_topo,
+            remote_tp_size=remote_tp_size,
+            group_spec_types=self._group_spec_types,
+        )
+
+        remote_agent_name = self.uccl_p2p_wrapper.add_remote_agent(
+            f"{engine_id}_{remote_tp_rank}",
+            uccl_p2p_agent_meta.data_endpoint_metadata,
+            uccl_p2p_agent_meta.notif_endpoint_metadata,
+        )
+
+        # Create dst descs and xfer side handles. TP workers have same #blocks
+        # so we only register once per engine_id.
+        # Example:
+        # block_size_ratio > 1:
+        # remote:               | 0| 1| 2| 3| 4| 5| 6| 7| 8| 9|10|11|12|
+        # local origin:|          0|          1|          8|         12|
+        # local mapped:| 0| 1| 2| 3| 4| 5| 6| 7| 8| 9|10|11|12|13|14|15|
+        remote_block_size = uccl_p2p_agent_meta.block_size
+        block_size_ratio = transfer_topo.block_size_ratio(remote_block_size)
+
+        if engine_id not in self.dst_num_blocks:
+            self.dst_num_blocks[engine_id] = uccl_p2p_agent_meta.num_blocks
+
+        # Keep track of remote agent kv caches base addresses.
+        self.kv_caches_base_addr[engine_id][remote_tp_rank] = (
+            uccl_p2p_agent_meta.kv_caches_base_addr
+        )
+        self._validate_remote_agent_handshake(uccl_p2p_agent_meta, remote_tp_size)
+
+        # This is 1 when P and D `--tensor-parallel-size` match. Otherwise,
+        # this is the ratio between the two sizes.
+        tp_ratio = transfer_topo.tp_ratio(remote_tp_size)
+
+        logger.debug(
+            "Registering remote agent (%s, rank %s) memory regions with tp_ratio %s",
+            engine_id,
+            remote_tp_rank,
+            tp_ratio,
+        )
+
+        plan = self.tp_mappings[engine_id]
+
+        ### (Optional) Register local agent memory regions. MLA is not split.
+        if (
+            tp_ratio < 0
+            and not self.use_mla
+            and tp_ratio not in self.src_xfer_descs_by_tp_ratio
+        ):
+            # Remote tp_size > local tp_size: read from multiple remote ranks.
+            # Logically "split" own regions into |tp_ratio| chunks. Mind that
+            # we only do this once per remote tp_size (replica-friendly).
+            self.src_xfer_descs_by_tp_ratio[tp_ratio] = []
+
+            for handle_data in self._build_local_splits_from_plan(
+                plan,
+                self.src_blocks_data,
+                self.num_descs,
+            ):
+                xfer_descs = self._blocks_data_to_xfer_descs(
+                    handle_data,
+                    self._base_addr_to_xfer_desc,
+                    self._base_addr_to_tensor_size,
+                )
+                self.src_xfer_descs_by_tp_ratio[tp_ratio].append(xfer_descs)
+
+        ### Register remote agent memory regions
+        # With homogeneous TP, D pulls the whole kv cache from corresponding rank. With
+        # heterogeneous TP, prepare the descriptors by splitting the P KV cache along
+        # kv_head dim, of D worker's kv_head size (D>P).
+        # Eg. PTP1 DTP2 => P0 KV:[block0-KV_0 | block0-KV_1..].
+
+        # Register all remote blocks, but only the corresponding kv heads.
+        blocks_data = self._build_fa_remote(
+            plan,
+            uccl_p2p_agent_meta,
+            block_size_ratio,
+        )
+        logger.debug(
+            "Created %s blocks for dst engine %s with remote rank %s and local rank %s",
+            len(blocks_data),
+            engine_id,
+            remote_tp_rank,
+            self.tp_rank,
+        )
+        if self._has_mamba:
+            logger.debug(
+                "Registering remote Mamba blocks for engine %s rank %s",
+                engine_id,
+                remote_tp_rank,
+            )
+            blocks_data.extend(
+                self._build_mamba_remote(
+                    uccl_p2p_agent_meta,
+                    tp_ratio,
+                    transfer_info,
+                )
+            )
+
+        # Register with UCCL_P2P.
+        # Deserialize the remote agent's base XferDescs and build per-block
+        # descs from the remote blocks_data.
+        remote_base_descs = self.uccl_p2p_wrapper.deserialize_descs(
+            uccl_p2p_agent_meta.serialized_xfer_descs
+        )
+        remote_base_addrs = uccl_p2p_agent_meta.kv_caches_base_addr
+        assert len(remote_base_descs) == len(remote_base_addrs)
+        remote_base_addr_to_desc = dict(zip(remote_base_addrs, remote_base_descs))
+        # Compute tensor sizes from block_lens and num_blocks.
+        remote_tensor_sizes = [
+            bl * uccl_p2p_agent_meta.num_blocks
+            for bl in uccl_p2p_agent_meta.block_lens
+        ]
+        remote_base_addr_to_size = dict(zip(remote_base_addrs, remote_tensor_sizes))
+
+        xfer_descs = self._blocks_data_to_xfer_descs(
+            blocks_data,
+            remote_base_addr_to_desc,
+            remote_base_addr_to_size,
+        )
+        self.dst_xfer_descs[engine_id][remote_tp_rank] = xfer_descs
+
+        if block_size_ratio > 1:
+            # when prefill with smaller block_size, we need to init a
+            # new handler with same block_len to match
+            self.src_xfer_descs_by_block_size[uccl_p2p_agent_meta.block_size] = (
+                self.register_local_xfer_handler(uccl_p2p_agent_meta.block_size)[0]
+            )
+
+        return remote_agent_name
+
+    def _validate_remote_agent_handshake(
+        self, uccl_p2p_agent_meta: UcclP2pAgentMetadata, remote_tp_size: int
+    ):
+        """
+        Validate the remote agent handshake metadata ensuring the
+        invariants hold true.
+        """
+        remote_engine_id = uccl_p2p_agent_meta.engine_id
+
+        assert self.transfer_topo is not None
+        remote_info = self.transfer_topo.get_engine_info(remote_engine_id)
+        assert remote_info.remote_tp_size == remote_tp_size
+
+        tp_ratio = self.transfer_topo.tp_ratio(remote_tp_size)
+        block_size_ratio = self.transfer_topo.block_size_ratio(
+            uccl_p2p_agent_meta.block_size
+        )
+        # num_kv_heads > tp_size with P_TP > D_TP not supported for non-mamba.
+        # Mamba models can have replicated FA KV with tp_ratio < 0.
+        # MLA models do not need to handle kv replication.
+        if not self.use_mla and not self._has_mamba:
+            assert not (
+                tp_ratio < 0 and self.transfer_topo.is_kv_replicated(remote_engine_id)
+            )
+
+        remote_physical_per_logical = (
+            uccl_p2p_agent_meta.physical_blocks_per_logical_kv_block
+        )
+        if (
+            self._has_mamba
+            and remote_physical_per_logical
+            != self._physical_blocks_per_logical_kv_block
+            and self.vllm_config.cache_config.enable_prefix_caching
+        ):
+            raise RuntimeError(
+                "Prefix caching with heterogeneous physical_blocks_per_logical "
+                "is not supported for Mamba hybrid models. "
+                f"Local: {self._physical_blocks_per_logical_kv_block}, "
+                f"Remote: {remote_physical_per_logical}. "
+                "Disable prefix caching with --no-enable-prefix-caching."
+            )
+
+        if self._is_hma_required:
+            assert block_size_ratio == 1, (
+                "HMA does not support different remote block size yet"
+            )
+        kv_cache_layout = (
+            self.kv_cache_layout
+            if not self.use_host_buffer
+            else self.host_buffer_kv_cache_layout
+        )
+        if not self.use_mla and uccl_p2p_agent_meta.kv_cache_layout != kv_cache_layout:
+            if (
+                self.kv_transfer_config.enable_permute_local_kv
+                and uccl_p2p_agent_meta.kv_cache_layout == "HND"
+            ):
+                logger.info(
+                    "Remote is HND and local is NHD, enabled additional permute "
+                    "on local device KV."
+                )
+                assert not self._is_hma_required, (
+                    "HMA does not support block size post processing"
+                )
+                self.enable_permute_local_kv = True
+            else:
+                raise RuntimeError(
+                    "Heterogeneous TP expects same kv_cache_layout. "
+                    "Or enable experimental feature to use HND to NHD support by "
+                    "setting 'enable_permute_local_kv'=True in --kv-transfer-config."
+                )
+        # if remote_agent used attn is not same as local,
+        # hint heterogenuous attn post process
+        if (
+            uccl_p2p_agent_meta.attn_backend_name != self.backend_name
+            and self.backend_name in ["CPU_ATTN"]
+        ):
+            if self._is_hma_required:
+                raise RuntimeError(
+                    "heterogeneous attn post process is not supported with HMA"
+                )
+            logger.info(
+                "[Experimental] CPU_ATTN backend is used, "
+                "hint heterogeneous attn post process"
+            )
+            self.enable_heterogeneous_attn_post_process = True
+
+        # Heterogeneous TP requires head-splitting, which only works with
+        # HND layout. MLA and replicated-KV cases don't split on heads.
+        # Mamba doesn't support heterogeneous TP.
+        if (
+            abs(tp_ratio) != 1
+            and not self.use_mla
+            and not self.transfer_topo.is_kv_replicated(remote_engine_id)
+            and kv_cache_layout != "HND"
+            and not self.enable_permute_local_kv
+        ):
+            raise RuntimeError(
+                "Heterogeneous TP head-dimension splitting requires contiguous heads. "
+                "Use HND layout on the prefill side."
+            )
+
+        # Per-region block_len validation enforcing the P/D invariant.
+        # REPLICATE regions (MLA, or a whole-model MLA / replicated-KV transfer)
+        # only allow the number of blocks to differ; SPLIT regions scale with
+        # tp_ratio. Mamba uses the ssm_sizes counterpart, so skip block_len here.
+        if not self._has_mamba:
+            n_local_layers = len(self.block_len_per_layer)
+            n_remote_layers = len(uccl_p2p_agent_meta.block_lens)
+            assert n_local_layers == n_remote_layers, (
+                "Number of KV layers must match between prefill and decode"
+            )
+            model_replicated = self.use_mla or self.transfer_topo.is_kv_replicated(
+                remote_engine_id
+            )
+            for i, local_len in enumerate(self.block_len_per_layer):
+                replicated = model_replicated or self._is_region_replicated(i)
+                remote_len = uccl_p2p_agent_meta.block_lens[i]
+                if replicated:
+                    # Whole block copied; only the number of blocks may differ.
+                    assert local_len // block_size_ratio == remote_len, (
+                        "KV cache sizes must match between P and D when "
+                        f"replicated (region {i}: local={local_len}, "
+                        f"remote={remote_len}, bsr={block_size_ratio})."
+                    )
+                elif tp_ratio > 0:
+                    # D_TP >= P_TP: remote holds tp_ratio x local heads.
+                    assert remote_len == (local_len * tp_ratio) // block_size_ratio, (
+                        f"SPLIT region {i}: remote P KV block_len {remote_len} "
+                        f"must equal local {local_len} * tp_ratio {tp_ratio} "
+                        f"// block_size_ratio {block_size_ratio}."
+                    )
+                else:
+                    # P_TP > D_TP: local holds |tp_ratio| x remote heads.
+                    assert block_size_ratio == 1, (
+                        "Different local/remote block sizes are not supported "
+                        "when P TP > D TP."
+                    )
+                    assert remote_len == local_len // (-tp_ratio), (
+                        f"SPLIT region {i}: remote P KV block_len {remote_len} "
+                        f"must equal local {local_len} // |tp_ratio| {-tp_ratio}."
+                    )
+
+        # TP workers that handhshake with same remote have same #blocks.
+        remote_num_blocks = uccl_p2p_agent_meta.num_blocks
+        assert self.dst_num_blocks[remote_engine_id] == remote_num_blocks
+        # Same number of regions/~layers.
+        n_remote_base_addrs = len(uccl_p2p_agent_meta.kv_caches_base_addr)
+        assert n_remote_base_addrs == len(self.block_len_per_layer)
+
+    def sync_recved_kv_to_device(self, req_id: str, meta: ReqMeta):
+        """copy recved kv from host buffer to device."""
+        assert self.use_host_buffer
+        assert self.copy_blocks is not None
+
+        local_block_ids = meta.local_physical_block_ids
+        # TODO (NickLucche) D2H<>H2D ops could benefit from coalescing io across groups
+        for group_block_ids in local_block_ids:
+            self.copy_blocks(
+                self.host_xfer_buffers,
+                self.device_kv_caches,
+                group_block_ids,
+                group_block_ids,
+                "h2d",
+            )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "synced recved kv of request[%s] to device kv buffer,"
+                "local_block_ids: %s. ",
+                req_id,
+                ",".join(map(str, local_block_ids)),
+            )
+
+    def save_kv_to_host(self, metadata: UcclP2pConnectorMetadata):
+        """copy kv from device to host buffer."""
+        assert self.use_host_buffer
+        assert self.copy_blocks is not None
+
+        for req_id, meta in metadata.reqs_to_save.items():
+            meta.local_physical_block_ids = self._logical_to_kernel_block_ids(
+                meta.local_block_ids
+            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "save_load_kv for request[%s] to host xfer buffer."
+                    "local_block_ids: %s. ",
+                    req_id,
+                    ",".join(map(str, meta.local_physical_block_ids)),
+                )
+            # blocking
+            for group_block_ids in meta.local_physical_block_ids:
+                self.copy_blocks(
+                    self.device_kv_caches,
+                    self.host_xfer_buffers,
+                    group_block_ids,
+                    group_block_ids,
+                    "d2h",
+                )
+
+    def post_process_device_kv_on_receive(
+        self,
+        block_size_ratio: int,
+        block_ids_list: list[list[int]],
+    ):
+        """
+        Post process device kv cache after receiving from remote.
+
+        3 types of post processing supported:
+            * kv_cache_postprocess_layout => convert from HND to NHD
+            * kv_cache_postprocess_blksize => convert from small block size
+              to large block size
+            * kv_cache_postprocess_blksize_and_layout => convert from small
+              block size to large block size and convert from HND to NHD
+
+        """
+        if len(self.device_kv_caches) == 0:
+            return
+        assert block_size_ratio >= 1, "Only nP < nD supported currently."
+        assert self.transfer_topo is not None
+        if self.enable_permute_local_kv and block_size_ratio > 1:
+            logger.debug(
+                "Post-processing device kv cache on receive by converting "
+                "block_size with %sx bigger and permuting layout from HND"
+                " to NHD.",
+                block_size_ratio,
+            )
+        elif self.enable_permute_local_kv:
+            logger.debug(
+                "Post-processing device kv cache on receive by permuting layout"
+                "from HND to NHD."
+            )
+        else:
+            logger.debug(
+                "Post-processing device kv cache on receive by converting "
+                "block_size with %sx bigger.",
+                block_size_ratio,
+            )
+
+        split_k_and_v = self.transfer_topo.split_k_and_v
+
+        for block_ids in block_ids_list:
+            indices = torch.tensor(block_ids, device=self.device_type, dtype=torch.long)
+
+            for _, cache_or_caches in self.device_kv_caches.items():
+                cache_list = cache_or_caches if split_k_and_v else [cache_or_caches]
+                for cache in cache_list:
+                    if self.enable_permute_local_kv and block_size_ratio > 1:
+                        kv_postprocess_blksize_and_layout_on_receive(
+                            cache, indices, block_size_ratio
+                        )
+                    elif self.enable_permute_local_kv:
+                        kv_postprocess_layout_on_receive(cache, indices)
+                    else:
+                        kv_postprocess_blksize_on_receive(
+                            cache, indices, block_size_ratio
+                        )
+
+    def post_process_device_kv_on_receive_heterogeneous_attn(
+        self, block_ids: list[int]
+    ):
+        """
+        Post process device kv cache after receiving from remote
+        for heterogeneous attention.
+        """
+        assert self.enable_heterogeneous_attn_post_process
+
+        indices = torch.tensor(block_ids, device=self.device_type, dtype=torch.long)
+
+        for _, cache_or_caches in self.device_kv_caches.items():
+            blocks_to_update = cache_or_caches.index_select(1, indices)
+            current_platform.pack_kv_cache(
+                key=blocks_to_update[0],
+                value=blocks_to_update[1],
+                key_cache=cache_or_caches[0],
+                value_cache=cache_or_caches[1],
+                block_ids=block_ids,
+                indices=indices,
+            )
+
+    def get_finished(self) -> tuple[set[str], set[str]]:
+        """
+        Get requests that are done sending or recving on this specific worker.
+        The scheduler process (via the MultiprocExecutor) will use this output
+        to track which workers are done.
+        """
+        assert self.transfer_topo is not None
+        done_sending = self._get_new_notifs()
+        done_recving = self._pop_done_transfers(self._recving_transfers)
+
+        # Drain queue of requests where handshake or transfer setup failed.
+        failed_recv_reqs = set[ReqId]()
+        while not self._failed_recv_reqs.empty():
+            try:
+                failed_recv_reqs.add(self._failed_recv_reqs.get_nowait())
+            except queue.Empty:
+                break
+
+        # Add failed requests to done_recving for scheduler tracking
+        # (blocks are already marked invalid, scheduler will handle recompute)
+        done_recving.update(failed_recv_reqs)
+
+        if len(done_sending) > 0 or len(done_recving) > 0:
+            logger.debug(
+                "Rank %s, get_finished: %s requests done sending "
+                "and %s requests done recving (%s failed)",
+                self.tp_rank,
+                len(done_sending),
+                len(done_recving),
+                len(failed_recv_reqs),
+            )
+
+        block_ids_for_blocksize_post_process = defaultdict(list)
+        block_ids_for_heterogeneous_attn_post_process = list[list[int]]()
+        for req_id in done_recving:
+            # clean up metadata for completed requests
+            meta = self._recving_metadata.pop(req_id, None)
+            assert meta is not None, f"{req_id} not found in recving_metadata list"
+
+            # Skip KV sync and post-processing for failed requests
+            if req_id in failed_recv_reqs:
+                logger.warning(
+                    "Skipping KV post-processing for failed request %s",
+                    req_id,
+                )
+                continue
+
+            assert meta.remote is not None
+            if self.use_host_buffer:
+                self.sync_recved_kv_to_device(req_id, meta)
+
+            # post processing for heteroblocksize
+            remote_info = self.transfer_topo.get_engine_info(meta.remote.engine_id)
+            block_size_ratio = self.transfer_topo.block_size_ratio(
+                remote_info.remote_block_size
+            )
+            if not self.use_mla and (
+                block_size_ratio > 1 or self.enable_permute_local_kv
+            ):
+                assert not self._is_hma_required
+                block_ids_for_blocksize_post_process[block_size_ratio].append(
+                    meta.local_physical_block_ids[0]
+                )
+            # post processing for heterogeneous attention
+            if self.enable_heterogeneous_attn_post_process:
+                block_ids_for_heterogeneous_attn_post_process.append(
+                    meta.local_physical_block_ids[0]
+                )
+        for (
+            block_size_ratio,
+            block_ids_list,
+        ) in block_ids_for_blocksize_post_process.items():
+            self.post_process_device_kv_on_receive(block_size_ratio, block_ids_list)
+
+        for block_ids in block_ids_for_heterogeneous_attn_post_process:
+            self.post_process_device_kv_on_receive_heterogeneous_attn(block_ids)
+
+        # Handle timeout to avoid stranding blocks on remote.
+        now = time.perf_counter()
+        while self._reqs_to_send:
+            req_id, expires = next(iter(self._reqs_to_send.items()))
+            # Sorted dict, oldest requests are put first so we can exit early.
+            if now < expires:
+                break
+            count = self.consumer_notification_counts_by_req.pop(req_id, 0)
+            self.xfer_stats.record_kv_expired_req()
+            logger.warning(
+                "Releasing expired KV blocks for request %s which were "
+                "retrieved by %d remote worker(s) before lease expired.",
+                req_id,
+                count,
+            )
+            self._reqs_to_process.remove(req_id)
+            del self._reqs_to_send[req_id]
+            done_sending.add(req_id)
+
+        return done_sending, done_recving
+
+    def _get_new_notifs(self) -> set[str]:
+        """
+        Get req_ids which got a remote xfer message. When multiple consumers
+        are reading from the same producer (heterogeneous TP scenario), wait
+        for all consumers to be done pulling.
+
+        Also handles heartbeat notifications ("HB:req1,req2,...") by
+        extending the lease on the referenced requests.
+        """
+        assert self.transfer_topo is not None
+        notified_req_ids: set[str] = set()
+        for notifs in self.uccl_p2p_wrapper.get_new_notifs().values():
+            for notif in notifs:
+                msg = notif.decode("utf-8")
+
+                # Handle heartbeat messages from D-side.
+                if msg.startswith("HB:"):
+                    self._handle_heartbeat(msg[3:])
+                    continue
+
+                req_id, tp_size = msg.rsplit(":", 1)
+                if (
+                    req_id not in self._reqs_to_send
+                    and req_id not in self._reqs_to_process
+                ):
+                    logger.error(
+                        "Potentially invalid KV blocks for "
+                        "unrecognized request %s were retrieved by "
+                        "a decode worker. They may have expired.",
+                        req_id,
+                    )
+                    continue
+
+                # NOTE: `tp_ratio` is the opposite when swapping local<>remote
+                n_consumers = int(tp_size)
+                tp_ratio = self.transfer_topo.tp_ratio(n_consumers)
+
+                # Number of reads *per producer* to wait for.
+                # When remote D TP > local P TP we expect `tp_ratio` reads.
+                consumers_per_producer = (
+                    -tp_ratio if n_consumers > self.world_size else 1
+                )
+
+                self.consumer_notification_counts_by_req[req_id] += 1
+                # Wait all consumers (D) to be done reading before freeing.
+                if (
+                    self.consumer_notification_counts_by_req[req_id]
+                    == consumers_per_producer
+                ):
+                    notified_req_ids.add(req_id)
+                    del self.consumer_notification_counts_by_req[req_id]
+                    self._reqs_to_process.remove(req_id)
+                    self._reqs_to_send.pop(req_id, None)
+        return notified_req_ids
+
+    def _handle_heartbeat(self, payload: str) -> None:
+        """Extend leases for requests referenced in a heartbeat.
+
+        Args:
+            payload: comma-separated P-side request IDs, e.g.
+                     "req_abc,req_def".
+        """
+        new_expiry = time.perf_counter() + self._lease_extension
+        for req_id in payload.split(","):
+            if req_id in self._reqs_to_send:
+                old = self._reqs_to_send[req_id]
+                self._reqs_to_send[req_id] = max(old, new_expiry)
+                logger.debug(
+                    "Heartbeat extended lease for request %s "
+                    "by %ds (old_expiry=%.1f, new_expiry=%.1f)",
+                    req_id,
+                    self._lease_extension,
+                    old,
+                    new_expiry,
+                )
+
+    def _pop_done_transfers(self, transfers: dict[str, list[int]]) -> set[str]:
+        """
+        Pop completed xfers by checking for DONE state.
+        Args:
+            transfers: dict of req_id -> list[running_xfer]
+        Returns:
+            set of req_ids that have all done xfers
+        """
+        done_req_ids: set[str] = set()
+        for req_id, handles in list(transfers.items()):
+            in_progress = []
+            for handle in handles:
+                try:
+                    xfer_state = self.uccl_p2p_wrapper.check_xfer_state(handle)
+                    if xfer_state == "DONE":
+                        # Get telemetry from UCCL_P2P
+                        res = self.uccl_p2p_wrapper.get_xfer_telemetry(handle)
+                        self.xfer_stats.record_transfer(res)
+                        self.uccl_p2p_wrapper.release_xfer_handle(handle)
+                        # Send completion notification to remote agent
+                        # so P worker can release KV blocks promptly.
+                        notif_meta = self._recving_notif_meta.pop(handle, None)
+                        if notif_meta is not None:
+                            notif_msg, agent_name = notif_meta
+                            try:
+                                self.uccl_p2p_wrapper.send_notif(
+                                    agent_name, notif_msg=notif_msg)
+                            except Exception as e:
+                                self._log_failure(
+                                    failure_type="notification_failed",
+                                    msg="P worker blocks will be freed after timeout.",
+                                    req_id=req_id,
+                                    error=e,
+                                )
+                    elif xfer_state == "PROC":
+                        in_progress.append(handle)
+                        continue
+                    else:
+                        self._log_failure(
+                            failure_type="transfer_failed",
+                            msg="Marking blocks as invalid",
+                            req_id=req_id,
+                            xfer_state=xfer_state,
+                        )
+                        self._handle_failed_transfer(req_id, handle)
+                except Exception as e:
+                    self._log_failure(
+                        failure_type="transfer_exception",
+                        msg="Marking blocks as invalid",
+                        req_id=req_id,
+                        error=e,
+                    )
+                    self._handle_failed_transfer(req_id, handle)
+
+            if not in_progress:
+                # Only report request as completed when all transfers are done.
+                done_req_ids.add(req_id)
+                del transfers[req_id]
+            else:
+                transfers[req_id] = in_progress
+        return done_req_ids
+
+    def _handle_failed_transfer(self, req_id: str, handle: int | None):
+        """
+        Handle a failed transfer by marking all (logical) blocks as invalid and
+        recording the failure.
+
+        Args:
+            req_id: The request ID.
+            handle: The transfer handle.
+        """
+        # Use .get() here as the metadata cleanup is handled by get_finished()
+        # TODO (NickLucche) handle failed transfer for HMA.
+        if (meta := self._recving_metadata.get(req_id)) and not self._is_hma_required:
+            self._invalid_block_ids.put(set(meta.local_block_ids[0]))
+        self._failed_recv_reqs.put(req_id)
+        if handle is not None:
+            self.uccl_p2p_wrapper.release_xfer_handle(handle)
+            self._recving_notif_meta.pop(handle, None)
+        self.xfer_stats.record_failed_transfer()
+
+    def start_load_kv(self, metadata: UcclP2pConnectorMetadata):
+        """
+        Start loading by triggering non-blocking uccl_p2p_xfer.
+        We check for these trnxs to complete in each step().
+        """
+        for req_id, meta in metadata.reqs_to_recv.items():
+            meta.local_physical_block_ids = self._logical_to_kernel_block_ids(
+                meta.local_block_ids
+            )
+            assert meta.remote is not None
+            # Remote block IDs are kept logical here; expanded in
+            # _read_blocks_for_req using the remote engine's phys ratio.
+            remote_engine_id = meta.remote.engine_id
+            logger.debug(
+                "start_load_kv for request %s from remote engine %s. "
+                "Num local_block_ids: %s. Num remote_block_ids: %s. ",
+                req_id,
+                remote_engine_id,
+                len(meta.local_physical_block_ids),
+                len(meta.remote.block_ids),
+            )
+            # always store metadata for failure recovery
+            self._recving_metadata[req_id] = meta
+            if remote_engine_id not in self._remote_agents:
+                # Initiate handshake with remote engine to exchange metadata.
+                with self._handshake_lock:
+                    if remote_engine_id not in self._remote_agents:
+                        self._background_uccl_p2p_handshake(
+                            req_id, remote_engine_id, meta)
+                        continue
+
+            # Handshake already completed, start async read xfer.
+            self._read_blocks_for_req(req_id, meta)
+
+        # Start transfers for requests whose handshakes have now finished.
+        while not self._ready_requests.empty():
+            self._read_blocks_for_req(*self._ready_requests.get_nowait())
+
+        # Keep around the requests that have been part of a batch. This is
+        # needed because async scheduling pushes the misalignment between the
+        # moment in which requests expiration is set (P side) and the moment in
+        # which blocks are read from D. As P can now more easily lag behind D
+        # while processing the next batch, we make sure to only set an
+        # expiration for requests that have not been read from D yet.
+        for req_id in metadata.reqs_in_batch:
+            self._reqs_to_process.add(req_id)
+
+        # Remove all requests that are not to be processed (eg aborted).
+        for req_id in metadata.reqs_not_processed:
+            self._reqs_to_process.discard(req_id)
+            # We should never get an abort after setting an expiry timer
+            assert req_id not in self._reqs_to_send
+
+        # Add to requests that are waiting to be read and track expiration.
+        for req_id, expiration_time in metadata.reqs_to_send.items():
+            if req_id in self._reqs_to_process:
+                self._reqs_to_send[req_id] = expiration_time
+
+        # Send heartbeats to P-side engines to keep KV blocks alive while
+        # requests sit in the D scheduler WAITING queue.
+        self._send_heartbeats(metadata)
+
+    def _send_heartbeats(self, metadata: UcclP2pConnectorMetadata) -> None:
+        """
+        Send heartbeat notifications to remote engines, extending lease on KV blocks.
+        """
+        for engine_id, hb_info in metadata.heartbeat_by_engine.items():
+            # Proactive handshake (this request may still be in waiting queue) so
+            # the **next** heartbeat for this remote can go through.
+            if (
+                self._ensure_handshake(
+                    engine_id, hb_info.host, hb_info.port, hb_info.tp_size
+                )
+                is not None
+            ):
+                continue  # handshake is still pending
+
+            # Build the heartbeat message: "HB:req1,req2,..."
+            hb_msg = ("HB:" + ",".join(hb_info.req_ids)).encode()
+            for agent_name in self._remote_agents[engine_id].values():
+                try:
+                    self.uccl_p2p_wrapper.send_notif(agent_name, notif_msg=hb_msg)
+                except Exception:
+                    logger.debug(
+                        "Failed to send heartbeat to engine %s",
+                        engine_id,
+                        exc_info=True,
+                    )
+
+    def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
+        assert meta.remote is not None and self.transfer_topo is not None
+        engine_id = meta.remote.engine_id
+        # Update last activity from this remote. Mind that cleanup is done on main
+        # thread (this one), so we don't race on this structure.
+        self._engine_last_active[engine_id] = time.perf_counter()
+        plan = self.tp_mappings[engine_id]
+        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+
+        meta.remote.block_ids = self._logical_to_remote_kernel_block_ids(
+            meta.remote.block_ids,
+            remote_info.remote_physical_blocks_per_logical,
+        )
+        remote_block_ids = meta.remote.block_ids
+        local_block_ids = meta.local_physical_block_ids
+        num_groups = len(local_block_ids)
+        read_specs = [
+            ReadSpec(
+                remote_rank=rank,
+                local_block_ids=[
+                    list(local_block_ids[g])
+                    if rank in plan.source_ranks_per_group[g]
+                    else []
+                    for g in range(num_groups)
+                ],
+                remote_block_ids=[
+                    list(remote_block_ids[g])
+                    if rank in plan.source_ranks_per_group[g]
+                    else []
+                    for g in range(num_groups)
+                ],
+            )
+            for rank in plan.all_source_ranks
+        ]
+
+        # D may have to perform multiple reads from different remote ranks.
+        # MLA opt: when P TP > D TP, only a single read is executed for
+        # the first remote rank (cache is duplicated)..
+        if self.use_mla and tp_ratio < 0:
+            assert len(read_specs) == 1
+
+        for i, spec in enumerate(read_specs):
+            remote_block_size = remote_info.remote_block_size
+            logger.debug(
+                "Remote agent %s available, calling _read_blocks"
+                " on remote rank %s with remote block size %s for req %s",
+                meta.remote.engine_id,
+                spec.remote_rank,
+                remote_block_size,
+                req_id,
+            )
+            # Get side XferDesc lists (instead of NIXL dlist handles).
+            if tp_ratio < 0 and not self.use_mla:
+                assert remote_block_size == self.block_size
+                # Remote tp_size > local tp_size: we must perform multiple
+                # reads. Get the memory chunk onto which we will write to.
+                local_xfer_descs = self.src_xfer_descs_by_tp_ratio[tp_ratio][i]
+            else:
+                # Single read from remote, we write to the whole memory region.
+                # Also handle remote block size different from local block size.
+                local_xfer_descs = self.src_xfer_descs_by_block_size[
+                    remote_block_size
+                ]
+
+            # Destination XferDesc list: remote_engine_id -> remote_rank -> list.
+            remote_xfer_descs = self.dst_xfer_descs[meta.remote.engine_id][
+                spec.remote_rank
+            ]
+
+            self._read_blocks(
+                read_spec=spec,
+                request_id=req_id,
+                dst_engine_id=meta.remote.engine_id,
+                remote_request_id=meta.remote.request_id,
+                local_xfer_descs=local_xfer_descs,
+                remote_xfer_descs=remote_xfer_descs,
+            )
+
+        if self.use_mla and tp_ratio < 0 and read_specs:
+            # ..but we still need to notify the other remote ranks that we
+            # have the blocks we need so they can update the request state.
+            notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
+            remote_agents = self._remote_agents[meta.remote.engine_id]
+            for rank_to_notify, agent in remote_agents.items():
+                if rank_to_notify != read_specs[0].remote_rank:
+                    self.uccl_p2p_wrapper.send_notif(agent, notif_msg=notif_id)
+
+    def _read_blocks(
+        self,
+        read_spec: ReadSpec,
+        dst_engine_id: str,
+        request_id: str,
+        remote_request_id: str,
+        local_xfer_descs: list[Any],
+        remote_xfer_descs: list[Any],
+    ):
+        """
+        Post a READ point-to-point xfer request from a single local worker to
+        a single remote worker.
+        """
+        assert self.transfer_topo is not None
+        remote_rank = read_spec.remote_rank
+        local_block_ids = read_spec.local_block_ids
+        remote_block_ids = read_spec.remote_block_ids
+
+        remote_info = self.transfer_topo.get_engine_info(dst_engine_id)
+        block_size_ratio = self.transfer_topo.block_size_ratio(
+            remote_info.remote_block_size
+        )
+        if block_size_ratio > 1:
+            # TODO (NickLucche) assume HMA is off. Change to handle multiple KV groups.
+            assert not self._is_hma_required
+            local_block_ids0 = local_block_ids[0] if local_block_ids else []
+            remote_block_ids0 = remote_block_ids[0]
+            local_block_ids_mapped = self.get_mapped_blocks(
+                np.asarray(local_block_ids0), block_size_ratio
+            ).tolist()
+            if len(local_block_ids_mapped) > len(remote_block_ids0):
+                # NOTE:
+                # get_mapped_blocks will always expand block_ids for n times.
+                # ex:
+                # prefill block_ids with block_size as 4:
+                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                # Local decode block_ids with block_size as 16: [1, 2, 3]
+                # expanded decode block_ids with get_mapped_blocks from [1, 2, 3] to
+                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+                # Then we clip local to align with prefill
+                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] to
+                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                local_block_ids_mapped = local_block_ids_mapped[
+                    : len(remote_block_ids0)
+                ]
+            local_block_ids = [local_block_ids_mapped] if local_block_ids_mapped else []
+            remote_block_ids = [remote_block_ids0]
+        # NOTE(rob): having the staging blocks be on the READER side is
+        # not going to work well (since we will have to call rearrange tensors).
+        # after we detect the txn is complete (which means we cannot make the
+        # read trxn async easily). If we want to make "READ" happen cleanly,
+        # then we will need to have the staging blocks on the remote side.
+
+        # NOTE(rob): according to nvidia the staging blocks are used to
+        # saturate IB with heterogeneous TP sizes.
+
+        # Number of D TP workers that will read from dst P. Propagate info
+        # on notification so that dst worker can wait before freeing blocks.
+        notif_id = f"{remote_request_id}:{self.world_size}".encode()
+
+        # Full prefix cache hit: do not need to read remote blocks,
+        # just notify P worker that we have the blocks we need.
+        if len(local_block_ids) == 0:
+            # A full prefix cache hit is indicated with an empty list.
+            agent_name = self._remote_agents[dst_engine_id][remote_rank]
+            try:
+                self.uccl_p2p_wrapper.send_notif(agent_name, notif_msg=notif_id)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="notification_failed",
+                    msg="P worker blocks will be freed after timeout. "
+                    "This may indicate network issues.",
+                    req_id=request_id,
+                    error=e,
+                    dst_engine_id=dst_engine_id,
+                    remote_rank=remote_rank,
+                    remote_agent_name=agent_name,
+                )
+                self.xfer_stats.record_failed_notification()
+            return
+
+        assert (
+            len(remote_block_ids)
+            == len(local_block_ids)
+            == len(self.kv_cache_config.kv_cache_groups)
+        )
+        remote_physical_per_logical = remote_info.remote_physical_blocks_per_logical
+        local_block_ids, remote_block_ids = self._apply_prefix_caching(
+            local_block_ids, remote_block_ids, remote_physical_per_logical
+        )
+
+        # NOTE (nicolo) With homogeneous TP, each TP worker loads KV from
+        # corresponding rank. With heterogeneous TP, fixing D>P, the D tp
+        # workers will issue xfers to parts of the P worker remote kv caches.
+
+        # Get descs ids.
+        remote_block_descs_ids = self._compute_desc_ids(
+            block_ids=remote_block_ids,
+            dst_num_blocks=self.dst_num_blocks[dst_engine_id],
+            block_size_ratio=None,
+            physical_blocks_per_logical=remote_info.remote_physical_blocks_per_logical,
+        )
+        local_block_descs_ids = self._compute_desc_ids(
+            block_ids=local_block_ids,
+            dst_num_blocks=self.dst_num_blocks[self.engine_id],
+            block_size_ratio=block_size_ratio,
+            physical_blocks_per_logical=self._physical_blocks_per_logical_kv_block,
+        )
+
+        assert len(local_block_descs_ids) == len(remote_block_descs_ids)
+
+        # Prepare transfer with UcclP2p.
+        # Select per-block XferDesc objects by the computed indices.
+        handle = None
+        try:
+            local_descs = [
+                local_xfer_descs[int(i)]
+                for i in local_block_descs_ids
+            ]
+            remote_descs = [
+                remote_xfer_descs[int(i)]
+                for i in remote_block_descs_ids
+            ]
+            agent_name = self._remote_agents[dst_engine_id][remote_rank]
+            transfer_id = self.uccl_p2p_wrapper.make_prepped_xfer(
+                "READ",
+                local_descs,
+                remote_descs,
+                notif_msg=notif_id,
+                agent_name=agent_name,
+            )
+
+            # Transfer starts immediately in UCCL P2P.
+            # Use transfer_id to check completion in future step().
+            self._recving_transfers[request_id].append(transfer_id)
+            self._recving_notif_meta[transfer_id] = (notif_id, agent_name)
+        except Exception as e:
+            # mark all (logical) blocks for this request as invalid
+            self._log_failure(
+                failure_type="transfer_setup_failed",
+                req_id=request_id,
+                msg="Marking blocks as invalid",
+                error=e,
+                dst_engine_id=dst_engine_id,
+                remote_rank=remote_rank,
+            )
+            self._handle_failed_transfer(request_id, handle)
+
+    def get_mapped_blocks(
+        self, block_ids: np.ndarray, block_size_ratio: int
+    ) -> np.ndarray:
+        """
+          Calculates the new set of block IDs by mapping every element
+          in the (potentially sparse) input array.
+          Example: block_ids=[0, 2], block_size_ratio=2
+        get_mapped_blocks    0     1     [2     3]     4     5
+              # remote is |h0-b0|h1-b0||h0-b1|h1-b1||h0-b1|h1-b1||
+              # local is  |h0-b0......||h1-b0......||h2-b0........
+        local_block_ids         0           [1]           2
+        """
+        if block_ids.size == 0:
+            return np.array([], dtype=np.int64)
+
+        start_ids = block_ids * block_size_ratio
+        offsets = np.arange(block_size_ratio)
+        mapped_2d = start_ids[:, None] + offsets[None, :]
+
+        return mapped_2d.flatten().astype(np.int64)
+
+    def _logical_to_kernel_block_ids(self, block_ids: BlockIds) -> BlockIds:
+        """
+        Convert logical block ids to kernel physical block ids.
+        This is required when the logical block size (the one set by the user)
+        does not match the one required by the attn backend.
+        """
+        if self._physical_blocks_per_logical_kv_block == 1:
+            # Noop when physical and logical block sizes are the same
+            return block_ids
+        block_arange = np.arange(0, self._physical_blocks_per_logical_kv_block).reshape(
+            1, -1
+        )
+        # Mamba blocks have no logical<>physical discrepancy
+        group_specs = self.kv_cache_config.kv_cache_groups
+        return [
+            BlockTable.map_to_kernel_blocks(
+                np.array(group),
+                self._physical_blocks_per_logical_kv_block,
+                block_arange,
+            ).tolist()
+            if not isinstance(group_specs[i].kv_cache_spec, MambaSpec)
+            else group
+            for i, group in enumerate(block_ids)
+        ]
+
+    def _apply_prefix_caching(
+        self,
+        local_block_ids: BlockIds,
+        remote_block_ids: BlockIds,
+        remote_physical_per_logical: int,
+    ) -> tuple[BlockIds, list]:
+        """Apply prefix caching by trimming local/remote block ID lists.
+
+        For non-Mamba models: end-trim remote to match local count, so that
+        already-cached prefix blocks are skipped in the transfer.
+
+        For Mamba hybrid (prefix caching not yet supported): front-trim both
+        to the minimum count to handle kernel block count discrepancies from
+        logical block rounding in heterogeneous TP.
+        """
+        # Partial prefix cache hit: just read uncomputed blocks.
+        # Skip mamba groups — their blocks represent full state (conv+ssm),
+        # not per-token data, so trimming would corrupt the transfer.
+        remote_block_ids = list(remote_block_ids)
+        if not self._has_mamba:
+            for i, remote_group in enumerate(remote_block_ids):
+                num_local_blocks = len(local_block_ids[i])
+                assert num_local_blocks <= len(remote_group)
+                if num_local_blocks < len(remote_group):
+                    remote_block_ids[i] = remote_group[-num_local_blocks:]
+        else:
+            # (NOTE: ZhanqiuHu) Mamba hybrid: no prefix caching support so far.HeteroTP
+            # can cause different kernel block counts due to logical block rounding.
+            # Example: 640 prompt tokens, kernel_block_size=64
+            #   remote physical_per_logical=10, local physical_per_logical=6
+            #   remote logical ids from kv_transfer_params = [0]
+            #   local logical ids allocated = [0, 1]
+            #   remote kernel blocks: [0..9]  (1*10=10)
+            #   local kernel blocks:  [0..11] (2*6=12)
+            #   actual data blocks = ceil(640/64) = 10, trim both to 10
+            # Vice versa (remote physical_per_logical=6, local=10):
+            #   remote logical ids = [0, 1], local logical ids = [0]
+            #   remote kernel blocks: [0..11] (2*6=12)
+            #   local kernel blocks:  [0..9]  (1*10=10)
+            #   actual data blocks = ceil(640/64) = 10, trim both to 10
+            local_block_ids = list(local_block_ids)
+            for i, remote_group in enumerate(remote_block_ids):
+                num_local_blocks = len(local_block_ids[i])
+                num_remote_blocks = len(remote_group)
+                if (
+                    _is_ssm_spec(self._group_spec_types[i])
+                    and num_local_blocks < num_remote_blocks
+                ):
+                    # NOTE (NickLucche): With prefix caching on SSM, (remote) blocks
+                    # prior to the last one are placeholders (null blocks). Mind that
+                    # this doesn't really impact transfer, as we only still care about
+                    # the last "block", the full in-place state.
+                    assert num_local_blocks == 1, "SSM can only have one local block"
+                    remote_block_ids[i] = remote_group[-num_local_blocks:]
+                elif (
+                    self._physical_blocks_per_logical_kv_block
+                    == remote_physical_per_logical
+                    and num_local_blocks < num_remote_blocks
+                ):
+                    # Partial prefix cache hit for FA group.
+                    remote_block_ids[i] = remote_group[-num_local_blocks:]
+                else:
+                    # TODO Handle prefix caching with different block_sizes
+                    max_padding = max(
+                        self._physical_blocks_per_logical_kv_block,
+                        remote_physical_per_logical,
+                    )
+                    assert abs(num_local_blocks - num_remote_blocks) < max_padding, (
+                        f"Group {i}: |{num_local_blocks} - "
+                        f"{num_remote_blocks}| >= {max_padding}"
+                    )
+                    num_blocks = min(num_local_blocks, num_remote_blocks)
+                    local_block_ids[i] = local_block_ids[i][:num_blocks]
+                    remote_block_ids[i] = remote_group[:num_blocks]
+        return local_block_ids, remote_block_ids
+
+    def _logical_to_remote_kernel_block_ids(
+        self, block_ids: BlockIds, remote_physical_per_logical: int
+    ) -> BlockIds:
+        """Map logical block IDs to physical kernel block IDs on the remote.
+
+        Args:
+            block_ids: per-group lists of logical block IDs.
+            remote_physical_per_logical: remote engine's physical blocks
+                per logical block.
+
+        Returns:
+            Same structure with FA groups expanded (each logical block L
+            becomes kernel blocks [L*remote_physical_per_logical, ..
+            L*remote_physical_per_logical +
+            remote_physical_per_logical - 1]).
+            Mamba groups are passed through unchanged.
+        """
+        if remote_physical_per_logical == 1:
+            return block_ids
+        remote_arange = np.arange(remote_physical_per_logical).reshape(1, -1)
+        group_specs = self.kv_cache_config.kv_cache_groups
+        result = [
+            BlockTable.map_to_kernel_blocks(
+                np.array(group),
+                remote_physical_per_logical,
+                remote_arange,
+            ).tolist()
+            if not isinstance(group_specs[i].kv_cache_spec, MambaSpec)
+            else group
+            for i, group in enumerate(block_ids)
+        ]
+        return result
+
+    def get_backend_aware_kv_block_len(
+        self, layer_idx: int, first_split: bool = True, mamba_view: bool = False
+    ) -> int:
+        """
+        Get the block length for one K/V element (K and V have the same size).
+
+        For FA and other backends, this is equal to the length of the whole
+        block, as K and V are in separate regions.
+        For FlashInfer, this is half the length of the whole block, as K and V
+        share the same region.
+        Similarly, for SSM-based models, state and conv are interleaved, but crucially
+        the their size differs.
+        Reference diagram:
+                            KVCacheTensor (Shared)
+                               /       \\
+                              /         \\
+                             /           \\
+        Attention (FlashInfer) View      Mamba View
+                  |                          |
+                  |                          |
+           +-------------------+         +-------------------+
+           | KVCacheTensor     |         | KVCacheTensor      |
+           |                   |         |                    |
+           |<----- page ------>|         |<----- page ------->|
+           |       size        |         |       size         |
+           |  Key 0  |  Val 0  |         |Conv 0  |   SSM 0   |
+           |  Key 1  |  Val 1  |         |Conv 1  |   SSM 1   |
+           |   ...   |   ...   |         |  ...   |    ...    |
+           | Key N-2 | Val N-2 |         |Conv N-2|   SSM N-2 |
+           | Key N-1 | Val N-1 |         |Conv N-1|   SSM N-1 |
+           +-------------------+         +--------------------+
+           |1st_split-2nd_split|         |1st_split-2nd_split |
+        """
+        assert self.transfer_topo is not None
+        virtually_split = self.transfer_topo.virtually_split_kv_in_blocks
+        if virtually_split and mamba_view:
+            block_len = self._mamba_ssm_size[not first_split]
+        else:
+            # Per-descriptor block length: a SPLIT region (full-attn under the
+            # virtually-split layout) emits separate K and V and uses
+            # block_len//2; REPLICATE (MLA, key-only) and non-split layouts use
+            # the whole block.
+            half_block = virtually_split and not self._is_region_replicated(layer_idx)
+            block_len = self.block_len_per_layer[layer_idx] // (2 if half_block else 1)
+        return block_len
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        """
+        Get the KV transfer stats for the connector.
+        """
+        # Clear stats for next iteration
+        if not self.xfer_stats.is_empty():
+            return self.xfer_stats.clone_and_reset()
+        return None
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """
+        Return and clear the set of block IDs that failed to load.
+
+        This is called by the scheduler to identify blocks that need
+        to be retried after a UCCL_P2P transfer failure.
+        """
+        # Drain the queue (thread-safe, no lock needed).
+        result: set[int] = set()
+        while not self._invalid_block_ids.empty():
+            try:
+                result.update(self._invalid_block_ids.get_nowait())
+            except queue.Empty:
+                break
+        return result
+
+    def _evict_stale_engines(self) -> None:
+        """Scan for and evict remote engines that have exceeded their TTL.
+
+        Called from the main thread in when a new remote engine appears.
+        We can only go OOM as we discover and register a new remote, therefore we make
+        sure we clean up stale engine data structures before then. This invariant
+        prevents us from using background threads, though memory usage is not guaranteed
+        to be "optimal" until a new handshake is performed.
+
+        Engines with active transfers or pending handshakes cannot be stale:
+        - Active transfers touch _engine_last_active in start_load_kv.
+        - Pending handshakes don't have an _engine_last_active entry yet
+        """
+        # NOTE (NickLucche): This does NOT currently prevent OOMing if a huge number
+        # of remote engines is registered all at once (adding a background cleanup
+        # thread wouldnt help either).
+        # If that scenario is plausible, we can follow up with an LRU eviction policy.
+        if self._engine_ttl <= 0:
+            return
+
+        now = time.perf_counter()
+        for eid, last_active in list(self._engine_last_active.items()):
+            if now - last_active > self._engine_ttl:
+                self._cleanup_remote_engine(eid)
+
+    def _cleanup_remote_engine(
+        self, engine_id: EngineId, *, log_eviction: bool = True
+    ) -> None:
+        """Remove all state for a single remote engine.
+
+        Releases UCCL_P2P resources (dlist handles, remote agents) and clears
+        all per-engine data structures. Used by both TTL eviction and
+        shutdown.
+        """
+        assert engine_id in self._remote_agents
+
+        # Clean up per-engine XferDesc lists (no-op: lists are just Python objects).
+        self.dst_xfer_descs.pop(engine_id, None)
+        for agent_name in self._remote_agents.pop(engine_id).values():
+            self.uccl_p2p_wrapper.remove_remote_agent(agent_name)
+
+        del self.kv_caches_base_addr[engine_id]
+        del self.dst_num_blocks[engine_id]
+        del self.tp_mappings[engine_id]
+        if self.transfer_topo is not None:
+            self.transfer_topo.unregister_remote_engine(engine_id)
+
+        last_active = self._engine_last_active.pop(engine_id)
+        if log_eviction:
+            logger.info(
+                "Evicted stale remote engine %s (inactive for %.1fs).",
+                engine_id,
+                time.perf_counter() - last_active,
+            )
+
+    def __del__(self):
+        self.shutdown()
+
+    def shutdown(self):
+        """Shutdown the connector worker."""
+        if not hasattr(self, "_handshake_initiation_executor"):
+            # error happens during init, no need to shutdown
+            return
+        self._handshake_initiation_executor.shutdown(wait=False)
+        for handles in self._recving_transfers.values():
+            for handle in handles:
+                self.uccl_p2p_wrapper.release_xfer_handle(handle)
+        self._recving_transfers.clear()
+        self._recving_notif_meta.clear()
+        # Local XferDesc lists are just Python objects; clear them.
+        self.src_xfer_descs_by_block_size.clear()
+        self.src_xfer_descs_by_tp_ratio.clear()
+        for engine_id in list(self._remote_agents):
+            self._cleanup_remote_engine(engine_id, log_eviction=False)
+        if hasattr(self, "_base_xfer_descs") and self._base_xfer_descs:
+            self.uccl_p2p_wrapper.deregister_memory(self._base_xfer_descs)
+            self._base_xfer_descs = []

--- a/vllm/distributed/uccl_p2p_utils.py
+++ b/vllm/distributed/uccl_p2p_utils.py
@@ -11,11 +11,13 @@ logger = init_logger(__name__)
 
 # declaration for static analyzers
 Endpoint: Any
+XferDesc: Any
 
 
 def _load_uccl_p2p_attr(name: str) -> Any:
     attr_name = {
         "Endpoint": "Endpoint",
+        "XferDesc": "XferDesc",
     }[name]
 
     try:
@@ -47,5 +49,6 @@ def is_uccl_p2p_available() -> bool:
 
 __all__ = [
     "Endpoint",
+    "XferDesc",
     "is_uccl_p2p_available",
 ]

--- a/vllm/distributed/uccl_p2p_utils.py
+++ b/vllm/distributed/uccl_p2p_utils.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib
+import importlib.util
+from typing import Any
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# declaration for static analyzers
+Endpoint: Any
+
+
+def _load_uccl_p2p_attr(name: str) -> Any:
+    attr_name = {
+        "Endpoint": "Endpoint",
+    }[name]
+
+    try:
+        module = importlib.import_module("uccl.p2p")
+    except ImportError:
+        logger.warning_once("uccl.p2p is not available")
+        value = None
+    else:
+        value = getattr(module, attr_name, None)
+        if value is None:
+            logger.warning_once("uccl.p2p is not available")
+        else:
+            logger.info_once("uccl.p2p is available")
+
+    globals()[name] = value
+    return value
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        return _load_uccl_p2p_attr(name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def is_uccl_p2p_available() -> bool:
+    """Lightweight check for uccl.p2p package without importing it."""
+    return importlib.util.find_spec("uccl.p2p") is not None
+
+
+__all__ = [
+    "Endpoint",
+    "is_uccl_p2p_available",
+]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -193,6 +193,8 @@ if TYPE_CHECKING:
     VLLM_DISABLE_REQUEST_ID_RANDOMIZATION: bool = False
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5600
+    VLLM_UCCL_P2P_SIDE_CHANNEL_HOST: str = "localhost"
+    VLLM_UCCL_P2P_SIDE_CHANNEL_PORT: int = 5700
     VLLM_MOONCAKE_BOOTSTRAP_PORT: int = 8998
     VLLM_MOONCAKE_STORE_TIER_LOG: bool = False
     VLLM_MOONCAKE_DISK_STAGING_USABLE_RATIO: float = 0.9
@@ -1475,6 +1477,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_NIXL_SIDE_CHANNEL_PORT": lambda: int(
         os.getenv("VLLM_NIXL_SIDE_CHANNEL_PORT", "5600")
     ),
+    # IP address used for UCCL P2P handshake between remote agents.
+    "VLLM_UCCL_P2P_SIDE_CHANNEL_HOST": lambda: os.getenv(
+        "VLLM_UCCL_P2P_SIDE_CHANNEL_HOST", "localhost"
+    ),
+    # Port used for UCCL P2P handshake between remote agents.
+    "VLLM_UCCL_P2P_SIDE_CHANNEL_PORT": lambda: int(
+        os.getenv("VLLM_UCCL_P2P_SIDE_CHANNEL_PORT", "5700")
+    ),
     # Port used for Mooncake handshake between remote agents.
     "VLLM_MOONCAKE_BOOTSTRAP_PORT": lambda: int(
         os.getenv("VLLM_MOONCAKE_BOOTSTRAP_PORT", "8998")
@@ -1972,6 +1982,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_DP_MASTER_IP",
         "VLLM_DP_MASTER_PORT",
         "VLLM_NIXL_SIDE_CHANNEL_HOST",
+        "VLLM_UCCL_P2P_SIDE_CHANNEL_HOST",
         "VLLM_RANDOMIZE_DP_DUMMY_INPUTS",
         "VLLM_CI_USE_S3",
         "VLLM_MODEL_REDIRECT_PATH",


### PR DESCRIPTION
## Purpose
This PR adds a new KV transfer connector, UcclP2pConnector, that enables disaggregated prefill/decode serving over the UCCL P2P RDMA transport. UCCL P2P is a lightweight, SM-free peer-to-peer transfer engine designed for modern high-bandwidth RDMA NICs. The connector is modeled after the existing NixlConnector and reuses the same scheduler/worker architecture, while replacing the transport layer with uccl.p2p.Endpoint. This gives vLLM users an additional backend choice for KV cache transfer alongside NixlConnector and MooncakeConnector.

UCCL provides a unified abstraction over vendor-specific collective primitives (NCCL, RCCL). Crucially, for point-to-point (P2P) operations, the dominant traffic pattern in context migration, UCCL implements a host-resident software transport stack. By managing transport logic on the CPU rather than relying solely on hardware offload, the backend enables fine-grained flow splitting (packet spraying) and adaptive congestion control strategies that are difficult to achieve with traditional hardware network stacks. UCCL currently supports native RDMA, IPC, TCP and GPUDirect TCP-X transport. In large-scale evaluations, such as those in llm-d, UCCL has demonstrated superior scalability and sustained performance advantages over UCX (https://llm-d.ai/blog/llm-d-v0.5-sustaining-performance-at-scale). Furthermore, while NIXL already supports the UCCL P2P backend, the NIXL software abstraction layer itself introduces certain performance overhead. By directly utilizing uccl.p2p.Endpoint, this connector bypasses these intermediate layers to deliver superior end-to-end transfer performance.

## Test Plan
1. Unit tests
   ```bash
   python -m pytest tests/v1/kv_connector/unit/test_uccl_p2p_connector.py -q

2. Integration tests on real RDMA hardware (manual, in progress)
- Deploy prefill instance on one H200 node and decode instance on another.
- Run vllm bench serve against the disaggregated proxy.
- Compare UcclP2pConnector against NixlConnector using the same benchmark parameters.

## Test Result
1. Unit tests
   2 passed
2. Integration / e2e
   UCCL P2P endpoint initialization and KV cache registration succeed on H200 + ConnectX-7 RDMA.

### UCCL P2P
```bash
export VLLM_USE_FLASHINFER_SAMPLER=0
export VLLM_HOST_IP=<ip1>
export VLLM_UCCL_P2P_SIDE_CHANNEL_HOST=<ip1>
export VLLM_UCCL_P2P_SIDE_CHANNEL_PORT=5700
export VLLM_KV_CACHE_LAYOUT=HND

vllm serve ~/models/qwen2.5-32b-instruct \
  --port 8100 \
  --enforce-eager \
  --gpu-memory-utilization 0.8 \
  --kv-transfer-config '{"kv_connector":"UcclP2pConnector","kv_role":"kv_producer"}'
```

```bash
export VLLM_USE_FLASHINFER_SAMPLER=0
export VLLM_HOST_IP=<ip2>
export VLLM_UCCL_P2P_SIDE_CHANNEL_HOST=<ip2>
export VLLM_UCCL_P2P_SIDE_CHANNEL_PORT=5700
export VLLM_KV_CACHE_LAYOUT=HND

vllm serve ~/nfs/jinyao/models/qwen2.5-32b-instruct \
  --port 8200 \
  --enforce-eager \
  --gpu-memory-utilization 0.8 \
  --kv-transfer-config '{"kv_connector":"UcclP2pConnector","kv_role":"kv_consumer"}'
```

```bash
python examples/disaggregated/disaggregated_serving/disagg_proxy_demo.py \
  --model ~/models/qwen2.5-32b-instruct \
  --prefill <ip1>:8100 \
  --decode <ip2>:8200 \
  --port 8000
```

```bash
vllm bench serve   --model ~/models/qwen2.5-32b-instruct   --tokenizer ~/models/qwen2.5-32b-instruct   --dataset-name random   --num-prompts 200   --max-concurrency 20   --input-len 1024   --output-len 256   --port 8000

============ Serving Benchmark Result ============
Successful requests:                     200       
Failed requests:                         0         
Maximum request concurrency:             20        
Benchmark duration (s):                  360.75    
Total input tokens:                      204800    
Total generated tokens:                  51200     
Request throughput (req/s):              0.55      
Output token throughput (tok/s):         141.93    
Peak output token throughput (tok/s):    200.00    
Peak concurrent requests:                39.00     
Total token throughput (tok/s):          709.63    
---------------Time to First Token----------------
Mean TTFT (ms):                          2379.60   
Median TTFT (ms):                        1438.99   
P99 TTFT (ms):                           12575.99  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          131.44    
Median TPOT (ms):                        131.38    
P99 TPOT (ms):                           139.90    
---------------Inter-token Latency----------------
Mean ITL (ms):                           131.45    
Median ITL (ms):                         130.70    
P99 ITL (ms):                            204.52    
==================================================
```

```bash
vllm bench serve   --model ~/models/qwen2.5-32b-instruct   --tokenizer ~/models/qwen2.5-32b-instruct   --dataset-name random   --num-prompts 200   --request-rate 10   --input-len 512   --output-len 128   --port 8000

============ Serving Benchmark Result ============
Successful requests:                     200       
Failed requests:                         0         
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  59.80     
Total input tokens:                      102400    
Total generated tokens:                  25600     
Request throughput (req/s):              3.34      
Output token throughput (tok/s):         428.09    
Peak output token throughput (tok/s):    732.00    
Peak concurrent requests:                198.00    
Total token throughput (tok/s):          2140.43   
---------------Time to First Token----------------
Mean TTFT (ms):                          7968.05   
Median TTFT (ms):                        10458.52  
P99 TTFT (ms):                           22666.03  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          147.48    
Median TPOT (ms):                        146.44    
P99 TPOT (ms):                           215.53    
---------------Inter-token Latency----------------
Mean ITL (ms):                           147.48    
Median ITL (ms):                         143.29    
P99 ITL (ms):                            281.24    
==================================================
```

### NIXL
```bash
export VLLM_USE_FLASHINFER_SAMPLER=0
export VLLM_HOST_IP=<ip1>
export VLLM_NIXL_SIDE_CHANNEL_HOST=<ip1>
export VLLM_NIXL_SIDE_CHANNEL_PORT=5600
export VLLM_KV_CACHE_LAYOUT=HND
export UCX_NET_DEVICES=all

vllm serve ~/nfs/jinyao/models/qwen2.5-32b-instruct \
  --port 8100 \
  --enforce-eager \
  --gpu-memory-utilization 0.8 \
  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
```

```bash
export VLLM_USE_FLASHINFER_SAMPLER=0
export VLLM_HOST_IP=<ip2>
export VLLM_NIXL_SIDE_CHANNEL_HOST=<ip2>
export VLLM_NIXL_SIDE_CHANNEL_PORT=5600
export VLLM_KV_CACHE_LAYOUT=HND
export UCX_NET_DEVICES=all

vllm serve ~/nfs/jinyao/models/qwen2.5-32b-instruct \
  --port 8200 \
  --enforce-eager \
  --gpu-memory-utilization 0.8 \
  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
```

```bash
python examples/disaggregated/disaggregated_serving/disagg_proxy_demo.py \
  --model ~/models/qwen2.5-32b-instruct \
  --prefill <ip1>:8100 \
  --decode <ip2>:8200 \
  --port 8000
```

```bash
vllm bench serve   --model /home/uccl/nfs/jinyao/models/qwen2.5-32b-instruct   --tokenizer ~/nfs/jinyao/models/qwen2.5-32b-instruct   --dataset-name random   --num-prompts 200   --max-concurrency 20   --input-len 1024   --output-len 256   --port 8000

============ Serving Benchmark Result ============
Successful requests:                     200       
Failed requests:                         0         
Maximum request concurrency:             20        
Benchmark duration (s):                  199.10    
Total input tokens:                      204800    
Total generated tokens:                  51200     
Request throughput (req/s):              1.00      
Output token throughput (tok/s):         257.16    
Peak output token throughput (tok/s):    400.00    
Peak concurrent requests:                40.00     
Total token throughput (tok/s):          1285.78   
---------------Time to First Token----------------
Mean TTFT (ms):                          1669.96   
Median TTFT (ms):                        1548.33   
P99 TTFT (ms):                           4096.71   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          71.21     
Median TPOT (ms):                        72.46     
P99 TPOT (ms):                           99.03     
---------------Inter-token Latency----------------
Mean ITL (ms):                           71.21     
Median ITL (ms):                         64.66     
P99 ITL (ms):                            141.44    
==================================================
```

```bash
vllm bench serve   --model /home/uccl/nfs/jinyao/models/qwen2.5-32b-instruct   --tokenizer ~/nfs/jinyao/models/qwen2.5-32b-instruct   --dataset-name random   --num-prompts 200   --request-rate 10   --input-len 512   --output-len 128   --port 8000

============ Serving Benchmark Result ============
Successful requests:                     200       
Failed requests:                         0         
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  40.54     
Total input tokens:                      102400    
Total generated tokens:                  25600     
Request throughput (req/s):              4.93      
Output token throughput (tok/s):         631.50    
Peak output token throughput (tok/s):    1308.00   
Peak concurrent requests:                173.00    
Total token throughput (tok/s):          3157.52   
---------------Time to First Token----------------
Mean TTFT (ms):                          5053.55   
Median TTFT (ms):                        6412.73   
P99 TTFT (ms):                           13310.20  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          104.42    
Median TPOT (ms):                        105.48    
P99 TPOT (ms):                           155.91    
---------------Inter-token Latency----------------
Mean ITL (ms):                           104.42    
Median ITL (ms):                         101.09    
P99 ITL (ms):                            264.84    
==================================================
```

The current performance doesn't quite meet expectations. I will continue to optimize it.