### PR TITLE
[CI] Add TORCH_NIGHTLY flag to run full CI against torch nightly

### DIFF
--- a/.buildkite/scripts/trigger-ci-build.sh
+++ b/.buildkite/scripts/trigger-ci-build.sh
@@ -23,6 +23,7 @@ NC='\033[0m' # No Color
 # Default configuration
 PIPELINE="ci"
 DRY_RUN=true
+TORCH_NIGHTLY=false
 
 usage() {
     cat <<EOF
@@ -34,12 +35,14 @@ Sets RUN_ALL=1 and NIGHTLY=1 environment variables.
 SAFETY: Dry-run by default. Use --execute to actually trigger a build.
 
 Options:
-    --execute       Actually trigger the build (default: dry-run)
-    --pipeline      Buildkite pipeline slug (default: ${PIPELINE})
-    --commit        Override commit SHA (default: current HEAD)
-    --branch        Override branch name (default: current branch)
-    --message       Custom build message (default: auto-generated)
-    --help          Show this help message
+    --execute        Actually trigger the build (default: dry-run)
+    --pipeline       Buildkite pipeline slug (default: ${PIPELINE})
+    --commit         Override commit SHA (default: current HEAD)
+    --branch         Override branch name (default: current branch)
+    --message        Custom build message (default: auto-generated)
+    --torch-nightly  Also build and run the full suite against torch nightly
+                     (sets TORCH_NIGHTLY=1)
+    --help           Show this help message
 
 Prerequisites:
     - bk CLI installed: brew tap buildkite/buildkite && brew install buildkite/buildkite/bk
@@ -49,6 +52,7 @@ Examples:
     $(basename "$0")                        # Dry-run, show what would happen
     $(basename "$0") --execute              # Actually trigger the build
     $(basename "$0") --pipeline ci-shadow   # Dry-run with different pipeline
+    $(basename "$0") --torch-nightly        # Dry-run a full torch-nightly run
 EOF
     exit 1
 }
@@ -95,6 +99,10 @@ while [[ $# -gt 0 ]]; do
         --message)
             MESSAGE="$2"
             shift 2
+            ;;
+        --torch-nightly)
+            TORCH_NIGHTLY=true
+            shift
             ;;
         --help|-h)
             usage
@@ -171,11 +179,17 @@ if [[ $(echo "$REMOTE_BRANCHES" | wc -l) -gt 5 ]]; then
 fi
 echo ""
 
+# Environment variables passed to the build.
+BUILD_ENV=("RUN_ALL=1" "NIGHTLY=1")
+if [[ "$TORCH_NIGHTLY" == true ]]; then
+    BUILD_ENV+=("TORCH_NIGHTLY=1")
+fi
+
 log_info "Pipeline: ${PIPELINE}"
 log_info "Branch: ${BRANCH}"
 log_info "Commit: ${COMMIT}"
 log_info "Message: ${MESSAGE}"
-log_info "Environment: RUN_ALL=1, NIGHTLY=1"
+log_info "Environment: ${BUILD_ENV[*]}"
 echo ""
 
 # Build the command
@@ -187,9 +201,10 @@ CMD=(bk build create
     --commit "${COMMIT}"
     --branch "${BRANCH}"
     --message "${MESSAGE}"
-    --env "RUN_ALL=1"
-    --env "NIGHTLY=1"
 )
+for env_var in "${BUILD_ENV[@]}"; do
+    CMD+=(--env "${env_var}")
+done
 
 if [[ "$DRY_RUN" == true ]]; then
     echo "=========================================="
@@ -210,8 +225,14 @@ if [[ "$DRY_RUN" == true ]]; then
     echo "    --commit '$(escape_for_shell "${COMMIT}")' \\"
     echo "    --branch '$(escape_for_shell "${BRANCH}")' \\"
     echo "    --message '$(escape_for_shell "${MESSAGE}")' \\"
-    echo "    --env 'RUN_ALL=1' \\"
-    echo "    --env 'NIGHTLY=1'"
+    last_idx=$(( ${#BUILD_ENV[@]} - 1 ))
+    for i in "${!BUILD_ENV[@]}"; do
+        if [[ $i -eq $last_idx ]]; then
+            echo "    --env '$(escape_for_shell "${BUILD_ENV[$i]}")'"
+        else
+            echo "    --env '$(escape_for_shell "${BUILD_ENV[$i]}")' \\"
+        fi
+    done
     echo ""
     echo "=========================================="
     echo -e "${YELLOW}To actually trigger this build, run:${NC}"

--- a/docs/contributing/ci/update_pytorch_version.md
+++ b/docs/contributing/ci/update_pytorch_version.md
@@ -93,6 +93,23 @@ To address this, manually trigger a build on Buildkite to accomplish two objecti
 <img width="60%" alt="Buildkite new build popup" src="https://github.com/user-attachments/assets/3b07f71b-bb18-4ca3-aeaf-da0fe79d315f" />
 </p>
 
+You can also trigger this build from the command line with
+[`.buildkite/scripts/trigger-ci-build.sh`](../../../.buildkite/scripts/trigger-ci-build.sh)
+(dry-run by default; pass `--execute` to actually trigger it).
+
+## Test against PyTorch nightly
+
+The steps above test against a specific PyTorch RC/stable wheel pinned in the
+requirements files. To instead build and run the **full** CI suite against the
+latest PyTorch **nightly** wheels, set the `TORCH_NIGHTLY=1` environment
+variable on the build (or apply the `ready-torch-nightly` label to the PR).
+This runs the entire test suite in the `vLLM Against PyTorch Nightly` group
+against a torch-nightly image, in addition to the regular pinned-torch run.
+
+This differs from `NIGHTLY=1`, which only runs the curated subset of steps
+tagged with `mirror.torch_nightly`. Use `trigger-ci-build.sh --torch-nightly`
+to trigger it from the command line.
+
 ## Update all the different vLLM platforms
 
 Rather than attempting to update all vLLM platforms in a single pull request, it's more manageable


### PR DESCRIPTION
## Purpose

Today `NIGHTLY=1` only runs a **curated subset** of CI steps (those tagged `mirror: {torch_nightly: {}}`) against the torch-nightly image. There is no way to run the **full** CI suite against torch nightly.

This PR adds the **`TORCH_NIGHTLY`** flag, which builds and runs the *entire* test suite against torch nightly — in addition to the regular pinned-torch run — giving a complete "vLLM vs torch nightly" signal on demand. It is triggered by the build env var `TORCH_NIGHTLY=1` or the `ready-torch-nightly` PR label.

This is the vLLM-repo half of the change; the pipeline-generator support is in **vllm-project/ci-infra#382**.

### Changes here
- `.buildkite/scripts/trigger-ci-build.sh`: add `--torch-nightly` to pass `TORCH_NIGHTLY=1` to the triggered build.
- `docs/contributing/ci/update_pytorch_version.md`: document the flag and how it differs from `NIGHTLY=1`.

| Flag | Coverage |
|------|----------|
| `NIGHTLY=1` | full pinned-torch suite + curated nightly subset |
| `TORCH_NIGHTLY=1` | full pinned-torch suite + **full** nightly suite |

## Not a duplicate
No open PR adds a full-suite torch-nightly flag. Searched open PRs for `TORCH_NIGHTLY` / `torch-nightly` and for `trigger-ci-build` — the matches are unrelated (RC version bumps like #45082, model/bugfix PRs). This is net-new CI plumbing.

## Test Plan
- `bash -n .buildkite/scripts/trigger-ci-build.sh` — passes.
- Verified the dry-run output renders both `--env` modes correctly (with and without `--torch-nightly`), including correct line-continuation in the printed command.
- Generator behavior is covered by a unit test in the companion ci-infra PR (`tests/pipeline_generator/test_step.py`, 6 passed) asserting an untagged step runs unblocked in the nightly group under `TORCH_NIGHTLY=1`.

## BC-breaking?
No — additive flag; default behavior is unchanged.

AI assistance was used to author this change.
