### PR TITLE
fix(logging): don't color DEBUG white (unreadable on light terminals)

### DIFF
--- a/vllm/logging_utils/formatter.py
+++ b/vllm/logging_utils/formatter.py
@@ -84,8 +84,10 @@ class ColoredFormatter(NewLineFormatter):
     """
 
     # ANSI color codes
+    # DEBUG intentionally left uncolored so it uses the terminal's default
+    # foreground -- a hardcoded white (\033[37m) is unreadable on light
+    # backgrounds.
     COLORS = {
-        "DEBUG": "\033[37m",  # White
         "INFO": "\033[32m",  # Green
         "WARNING": "\033[33m",  # Yellow
         "ERROR": "\033[31m",  # Red


### PR DESCRIPTION
DEBUG logs hardcode `\033[37m` (white), which is invisible on light-background terminals (#45920). Dropping it lets DEBUG use the terminal default foreground, readable on both light and dark. Other levels keep their colors.

Fixes #45920