### PR TITLE
[Docker] Remove redundant flashinfer download-cubin step

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -898,13 +898,6 @@ RUN --mount=type=cache,target=/opt/uv/cache \
         fi; \
     fi
 
-# Download FlashInfer precompiled cubins AFTER all pip installs are done.
-# This must run after the vLLM wheel and EP kernels installs above, because
-# those can reinstall/touch flashinfer packages. Downloading cubins earlier
-# (in the flashinfer-jit-cache layer) causes ~2.5 GB of layer duplication
-# when a later pip install overwrites flashinfer package files.
-RUN flashinfer show-config && flashinfer download-cubin
-
 # CUDA image changed from /usr/local/nvidia to /usr/local/cuda in 12.8 but will
 # return to /usr/local/nvidia in 13.0 to allow container providers to mount drivers
 # consistently from the host (see https://github.com/vllm-project/vllm/issues/18859).


### PR DESCRIPTION
## Summary

The `flashinfer-cubin` wheel — a default CUDA dep in `requirements/cuda.txt` since #37233 — already ships all precompiled cubins into the package directory that FlashInfer's runtime loader reads from (`jit/env.py:_get_cubin_dir` resolves to the package dir when `flashinfer-cubin` is installed). The `flashinfer download-cubin` step in `vllm-base` re-downloads the same files from NVIDIA's artifactory **unconditionally** (`download_artifacts()` has no skip-if-present check), and since #41134 moved it below the per-commit wheel-install layer, that download re-runs on every build (~10 min, ~half the image-build job). This removes the redundant step.

## Validation

Inspected the shipped nightly image (`vllm/vllm-openai@sha256:14469ba3…`):

- `flashinfer_cubin` wheel ships **15,558 `.cubin` files (1.8 GB)** — all listed in the wheel `RECORD`, i.e. provided by `pip install`, not the download step.
- With **`--network=none` and `FLASHINFER_NO_DOWNLOAD=1`**, the runtime loader (`get_artifact`) resolves cubins from disk with checksum verification passing (8/8 sampled). The image needs no network for cubins at runtime.
- `download-cubin` still re-fetched all ~15.6k artifacts in build #73639 despite the wheel already providing them — confirming pure redundancy.
- Compared the full required artifact set against the wheel: **0 missing** — all 15,558 cubins, all 34 unique `.h` headers (incl. the `trtllmGen_*_export/*.h` JIT include paths), and all 7 `checksums.txt` are shipped by the wheel.

Anything genuinely not bundled is JIT-fetched by FlashInfer on first use, the same as for any `pip install flashinfer-cubin` user who never runs `download-cubin`.

## Relation to #46465

Alternative to #46465, which keeps the download and caches it via a dedicated BuildKit stage (+53 net lines). Since the wheel already provides the cubins, the download isn't needed at all — this just deletes it (−7 lines). One of the two should land, not both.

## Notes

AI assistance (Claude) was used to investigate and prepare this change; I reviewed every line and am accountable for it.
