### PR TITLE
[Kernel][MoE] Allow FlashInfer MXINT4 MoE for gated SiLU

### DIFF
--- a/tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py
+++ b/tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py
@@ -5,8 +5,12 @@
 import pytest
 import torch
 
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
     fused_marlin_moe,
+)
+from vllm.model_executor.layers.fused_moe.experts.trtllm_mxint4_moe import (
+    TrtLlmMxint4ExpertsMonolithic,
 )
 from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
     grouped_topk,
@@ -75,6 +79,14 @@ __all__ = [
     "mxint4_quantize_moe_weights",
     "marlin_quantize_moe_weights",
 ]
+
+
+def test_trtllm_mxint4_activation_supports_vllm_gated_silu():
+    assert TrtLlmMxint4ExpertsMonolithic._supports_activation(MoEActivation.SILU)
+    assert TrtLlmMxint4ExpertsMonolithic._supports_activation(MoEActivation.SWIGLUOAI)
+    assert not TrtLlmMxint4ExpertsMonolithic._supports_activation(
+        MoEActivation.RELU2_NO_MUL
+    )
 
 
 def marlin_quantize_moe_weights(

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxint4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxint4_moe.py
@@ -68,8 +68,10 @@ class TrtLlmMxint4ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        # FlashInfer MxInt4 uses a fused SwiGLU activation.
-        return activation == MoEActivation.SWIGLUOAI
+        # FlashInfer MxInt4 names the standard gated SiLU path "SwiGLU".
+        # In vLLM MoE configs that maps to SILU/silu_and_mul; SWIGLUOAI is
+        # kept as an alias for consistency with other FlashInfer backends.
+        return activation in (MoEActivation.SILU, MoEActivation.SWIGLUOAI)
 
     @staticmethod
     def _supports_parallel_config(


### PR DESCRIPTION


## Purpose

`TrtLlmMxint4ExpertsMonolithic` currently rejects `MoEActivation.SILU`, so vLLM does not select the FlashInfer TRT-LLM MXINT4 MoE backend for Kimi-K2.5-style gated-SiLU MoE layers.

The underlying FlashInfer `trtllm_mxint4_block_scale_moe` path supports the standard gated SiLU computation. This PR updates the Python-side activation support predicate to accept `MoEActivation.SILU` in addition to the existing `MoEActivation.SWIGLUOAI` alias.

This is a backend selection / capability metadata fix only. No GPU kernel code is changed.

## Changes

- Allow `TrtLlmMxint4ExpertsMonolithic._supports_activation()` to accept:
    - `MoEActivation.SILU`
    - `MoEActivation.SWIGLUOAI`
- Add a regression test covering the MXINT4 activation support predicate.
- Keep unrelated activations rejected, e.g. `MoEActivation.RELU2_NO_MUL`.


## Test Plan

### Unit test

python3 -m pytest \
    tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py::test_trtllm_mxint4_activation_supports_vllm_gated_silu \
    -q

### End-to-end runtime validation

export VLLM_LOGGING_LEVEL=DEBUG
export VLLM_USE_FLASHINFER_MOE_INT4=1
export PYTHONNOUSERSITE=1


vllm serve models/Kimi-K2.5 \
  --served-model-name moonshotai/Kimi-K2.5 \
  --host 0.0.0.0 \
  --port 8888 \
  --gpu-memory-utilization 0.95 \
  --tensor-parallel-size 8 \
  --max-model-len 10240 \
  --max-num-seqs 16 \
  --reasoning-parser kimi_k2 \
  --tool-call-parser kimi_k2 \
  --compilation_config.pass_config.fuse_allreduce_rms true \
  --trust-remote-code \
  --no-enable-prefix-caching


## Test Result

Unit test passed.

### End-to-end runtime validation

vLLM selected the intended backend:

Using 'FLASHINFER_TRTLLM' WNA16 MoE backend.

GSM8K flexible: 0.9727, strict: 0.9727


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

