### PR TITLE
[ROCm][CI] Shard LM Eval Qwen3-5 Models (B200-MI355) in AMD CI

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -2819,12 +2819,13 @@ steps:
     - uv pip install --system 'gpt-oss[eval]==0.0.5'
     - pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-gfx950.txt
 
-- label: LM Eval Qwen3-5 Models (B200-MI355) # TBD
-  timeout_in_minutes: 120
+- label: LM Eval Qwen3-5 Models (B200-MI355) %N # TBD
+  timeout_in_minutes: 180
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
   agent_pool: mi355_2
   num_gpus: 2
   optional: true
+  parallelism: 3
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/model_executor/models/qwen3_5.py
@@ -2839,7 +2840,7 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-qwen35-mi355.txt
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-qwen35-mi355.txt --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
 - label: LM Eval Small Models (2xB200-2xMI355) # TBD
   timeout_in_minutes: 180

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -2825,7 +2825,7 @@ steps:
   agent_pool: mi355_2
   num_gpus: 2
   optional: true
-  parallelism: 3
+  parallelism: 4
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/model_executor/models/qwen3_5.py

--- a/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-AITER-TP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-AITER-TP2.yaml
@@ -3,6 +3,7 @@ accuracy_threshold: 0.89
 tolerance: 0.03
 num_questions: 1319
 num_fewshot: 5
+startup_max_wait_seconds: 3600
 server_args: >-
   --max-model-len 4096
   --tensor-parallel-size 2


### PR DESCRIPTION

` LM Eval Qwen3-5 Models (B200-MI355)` is a long running test group that is timing out in AMD CI after 2 hours. We need to extend the timeout, and I added sharding since it is such a long TG 

Example failure: https://buildkite.com/vllm/amd-ci/builds/9851/list?jid=019ef3b5-76ba-4b1a-b69a-5a7cb2468ef3&tab=output
