### PR TITLE
[HelionLinearBackend][3/N] Add HelionFP8ScaledMMLinearKernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,6 +468,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     list(APPEND VLLM_STABLE_EXT_SRC
       "csrc/libtorch_stable/cutlass_extensions/common.cpp"
       "csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_entry.cu"
+      "csrc/libtorch_stable/quantization/w8a8/helion/scaled_mm.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_quant_entry.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_scaled_mm_entry.cu"
       "csrc/libtorch_stable/quantization/awq/gemm_kernels.cu"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     list(APPEND VLLM_STABLE_EXT_SRC
       "csrc/libtorch_stable/cutlass_extensions/common.cpp"
       "csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_entry.cu"
+      "csrc/libtorch_stable/quantization/w8a8/helion/scaled_mm.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_quant_entry.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_scaled_mm_entry.cu"
       "csrc/libtorch_stable/quantization/awq/gemm_kernels.cu"

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -175,6 +175,19 @@ torch::stable::Tensor awq_dequantize(torch::stable::Tensor _kernel,
                                      int64_t split_k_iters, int64_t thx,
                                      int64_t thy);
 
+// Helion linear ops
+
+// Dispatches to the Helion scaled_mm when a.size(0) <= helion_threshold,
+// otherwise to cutlass_scaled_mm. The Helion branch re-enters Python through
+// the dispatcher (GIL acquisition + dispatch overhead), so only enable it for
+// a.size(0) values covered by the CUDA graph capture range, where the branch
+// is resolved at capture time and the re-entry cost is paid once, not per step.
+void helion_cutlass_hybrid_scaled_mm(
+    torch::stable::Tensor& out, torch::stable::Tensor const& a,
+    torch::stable::Tensor const& b, torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales,
+    std::optional<torch::stable::Tensor> const& bias, int64_t helion_threshold);
+
 // DSV3 fused A GEMM: conditionally compiled so declaration and impl
 // registration are in the source file (dsv3_fused_a_gemm.cu)
 

--- a/csrc/libtorch_stable/quantization/w8a8/helion/scaled_mm.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/helion/scaled_mm.cu
@@ -1,0 +1,31 @@
+#include <torch/csrc/stable/tensor.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/stableivalue_conversions.h>
+
+#include <array>
+
+#include "libtorch_stable/ops.h"
+
+void helion_cutlass_hybrid_scaled_mm(
+    torch::stable::Tensor& out, torch::stable::Tensor const& a,
+    torch::stable::Tensor const& b, torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales,
+    std::optional<torch::stable::Tensor> const& bias,
+    int64_t helion_threshold) {
+  if (a.size(0) <= helion_threshold) {
+    // The Helion scaled_mm is a Python custom op registered on the dispatcher
+    // as vllm_helion::scaled_mm. Re-enter the dispatcher to invoke it; the
+    // stack order must match its schema:
+    //   scaled_mm(Tensor(a0!) out, Tensor a, Tensor b, Tensor a_scales,
+    //             Tensor b_scales, Tensor? bias=None) -> ()
+    // out is mutated in place, so there is no return value to unpack.
+    using torch::stable::detail::from;
+    std::array<StableIValue, 6> stack{from(out),      from(a),
+                                      from(b),        from(a_scales),
+                                      from(b_scales), from(bias)};
+    TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+        "vllm_helion::scaled_mm", "", stack.data(), TORCH_ABI_VERSION));
+    return;
+  }
+  cutlass_scaled_mm(out, a, b, a_scales, b_scales, bias);
+}

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -118,6 +118,14 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "                  Tensor b, Tensor a_scales,"
       "                  Tensor b_scales, Tensor? bias) -> ()");
 
+  // Hybrid scaled_mm: dispatch to Helion when a.size(0) <= helion_threshold,
+  // otherwise to cutlass_scaled_mm.
+  ops.def(
+      "helion_cutlass_hybrid_scaled_mm(Tensor! out, Tensor a,"
+      "                  Tensor b, Tensor a_scales,"
+      "                  Tensor b_scales, Tensor? bias,"
+      "                  int helion_threshold) -> ()");
+
   // CUTLASS w8a8 GEMM, supporting asymmetric per-tensor or per-row/column
   // quantization.
   ops.def(
@@ -629,6 +637,8 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
 #ifndef USE_ROCM
   // CUTLASS scaled_mm ops
   ops.impl("cutlass_scaled_mm", TORCH_BOX(&cutlass_scaled_mm));
+  ops.impl("helion_cutlass_hybrid_scaled_mm",
+           TORCH_BOX(&helion_cutlass_hybrid_scaled_mm));
   ops.impl("cutlass_scaled_mm_azp", TORCH_BOX(&cutlass_scaled_mm_azp));
   ops.impl("cutlass_moe_mm", TORCH_BOX(&cutlass_moe_mm));
   ops.impl("get_cutlass_moe_mm_data", TORCH_BOX(&get_cutlass_moe_mm_data));

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -118,6 +118,14 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "                  Tensor b, Tensor a_scales,"
       "                  Tensor b_scales, Tensor? bias) -> ()");
 
+  // Hybrid scaled_mm: dispatch to Helion when a.size(0) <= helion_threshold,
+  // otherwise to cutlass_scaled_mm.
+  ops.def(
+      "helion_cutlass_hybrid_scaled_mm(Tensor! out, Tensor a,"
+      "                  Tensor b, Tensor a_scales,"
+      "                  Tensor b_scales, Tensor? bias,"
+      "                  int helion_threshold) -> ()");
+
   // CUTLASS w8a8 GEMM, supporting asymmetric per-tensor or per-row/column
   // quantization.
   ops.def(
@@ -723,6 +731,8 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
 #ifndef USE_ROCM
   // CUTLASS scaled_mm ops
   ops.impl("cutlass_scaled_mm", TORCH_BOX(&cutlass_scaled_mm));
+  ops.impl("helion_cutlass_hybrid_scaled_mm",
+           TORCH_BOX(&helion_cutlass_hybrid_scaled_mm));
   ops.impl("cutlass_scaled_mm_azp", TORCH_BOX(&cutlass_scaled_mm_azp));
   ops.impl("cutlass_moe_mm", TORCH_BOX(&cutlass_moe_mm));
   ops.impl("get_cutlass_moe_mm_data", TORCH_BOX(&get_cutlass_moe_mm_data));

--- a/scripts/autotune_helion_kernels.py
+++ b/scripts/autotune_helion_kernels.py
@@ -38,7 +38,10 @@ try:
         get_registered_kernels,
     )
     from vllm.kernels.helion.ops import import_all_kernels
-    from vllm.kernels.helion.utils import get_canonical_gpu_name
+    from vllm.kernels.helion.utils import (
+        get_config_gpu_name,
+        get_gpu_name,
+    )
     from vllm.logger import init_logger
     from vllm.utils.import_utils import has_helion
 except ImportError as e:
@@ -88,7 +91,6 @@ def check_requirements() -> bool:
 
 def autotune_kernel(
     kernel_name: str,
-    platform: str,
     config_manager: ConfigManager,
     force: bool = False,
     autotune_effort: str = "quick",
@@ -109,6 +111,8 @@ def autotune_kernel(
             failed=0,
             configs={},
         )
+
+    platform = get_config_gpu_name(kernel_wrapper.use_variant_config)
 
     try:
         with FakeTensorMode():
@@ -402,7 +406,7 @@ def main():
     if not check_requirements():
         sys.exit(1)
 
-    platform = get_canonical_gpu_name()
+    platform = get_gpu_name()
     logger.info("Detected GPU platform: %s", platform)
 
     config_manager = (
@@ -427,7 +431,7 @@ def main():
     results = {}
     for kernel_name in kernels_to_autotune:
         result = autotune_kernel(
-            kernel_name, platform, config_manager, args.force, args.autotune_effort
+            kernel_name, config_manager, args.force, args.autotune_effort
         )
         results[kernel_name] = result
 

--- a/tests/fusion/test_quant_activation_contract.py
+++ b/tests/fusion/test_quant_activation_contract.py
@@ -25,6 +25,9 @@ from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
 from vllm.model_executor.kernels.linear.scaled_mm.flashinfer import (
     FlashInferFP8ScaledMMLinearKernel,
 )
+from vllm.model_executor.kernels.linear.scaled_mm.helion import (
+    HelionFP8ScaledMMLinearKernel,
+)
 from vllm.model_executor.kernels.linear.scaled_mm.ScaledMMLinearKernel import (
     FP8ScaledMMLinearLayerConfig,
     Int8ScaledMMLinearKernel,
@@ -46,6 +49,7 @@ SUPPORTING = {
     CutlassFP8ScaledMMLinearKernel,
     FlashInferFP8ScaledMMLinearKernel,
     FlashInferCutlassNvFp4LinearKernel,
+    HelionFP8ScaledMMLinearKernel,
 }
 
 

--- a/tests/kernels/helion/helpers.py
+++ b/tests/kernels/helion/helpers.py
@@ -14,9 +14,9 @@ import helion
 from vllm.kernels.helion.case_key import CaseKey
 from vllm.kernels.helion.config_manager import ConfigManager
 from vllm.kernels.helion.register import register_kernel
-from vllm.kernels.helion.utils import get_canonical_gpu_name
+from vllm.kernels.helion.utils import get_config_gpu_name
 
-GPU_PLATFORM = get_canonical_gpu_name()
+GPU_PLATFORM = get_config_gpu_name(False)
 
 DEFAULT_CONFIGS: dict[CaseKey, helion.Config] = {
     CaseKey.default(): helion.Config(block_sizes=[32]),

--- a/tests/kernels/helion/test_pattern_matching.py
+++ b/tests/kernels/helion/test_pattern_matching.py
@@ -56,7 +56,7 @@ def _helion_mock_context():
             return_value=mock_config_manager,
         ),
         patch(
-            "vllm.kernels.helion.utils.get_canonical_gpu_name",
+            "vllm.kernels.helion.utils.get_config_gpu_name",
             return_value="nvidia_h200",
         ),
     ):

--- a/tests/kernels/helion/test_register.py
+++ b/tests/kernels/helion/test_register.py
@@ -110,7 +110,7 @@ def configured_kernel(sample_kernel, sample_configs, config_manager_with_test_co
             return_value=config_manager_with_test_configs,
         ),
         patch(
-            "vllm.kernels.helion.utils.get_canonical_gpu_name",
+            "vllm.kernels.helion.utils.get_config_gpu_name",
             return_value="nvidia_h200",
         ),
         patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -177,7 +177,7 @@ def create_configured_kernel_with_configs(
             return_value=mock_config_manager,
         ),
         patch(
-            "vllm.kernels.helion.utils.get_canonical_gpu_name",
+            "vllm.kernels.helion.utils.get_config_gpu_name",
             return_value=platform,
         ),
         patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -210,7 +210,7 @@ class TestConfiguredHelionKernel:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             pytest.raises(RuntimeError, match="No config picker registered"),
@@ -287,7 +287,7 @@ class TestConfiguredHelionKernel:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
         ):
@@ -331,7 +331,7 @@ class TestConfiguredHelionKernel:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
         ):
@@ -383,7 +383,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -418,7 +418,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -453,7 +453,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -491,7 +491,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -530,7 +530,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -575,7 +575,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -600,7 +600,7 @@ class TestHelionKernelWrapper:
     def test_init_eagerly_initializes_hop_path(self):
         """Test that register_kernel eagerly builds the configured kernel
         on the HOP path (no custom op registration needed)."""
-        from vllm.kernels.helion.utils import get_canonical_gpu_name
+        from vllm.kernels.helion.utils import get_config_gpu_name
 
         configs: dict[CaseKey, helion.Config] = {
             CaseKey.default(): helion.Config(block_sizes=[4, 4])
@@ -608,8 +608,8 @@ class TestHelionKernelWrapper:
         with (
             dummy_kernel_registry(configs=configs) as register,
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
-                wraps=get_canonical_gpu_name,
+                "vllm.kernels.helion.utils.get_config_gpu_name",
+                wraps=get_config_gpu_name,
             ) as mock_gpu,
         ):
             wrapper = register(
@@ -620,8 +620,8 @@ class TestHelionKernelWrapper:
             assert wrapper._configured_kernel is not None
 
         with patch(
-            "vllm.kernels.helion.utils.get_canonical_gpu_name",
-            side_effect=AssertionError("get_canonical_gpu_name called during __call__"),
+            "vllm.kernels.helion.utils.get_config_gpu_name",
+            side_effect=AssertionError("get_config_gpu_name called during __call__"),
         ):
             x = torch.randn(4, 4, device="cuda")
             y = torch.randn(4, 4, device="cuda")
@@ -635,13 +635,13 @@ class TestHelionKernelWrapper:
     def test_init_eagerly_initializes(self):
         """Test that register_kernel eagerly loads configs and detects GPU
         during construction so __call__ needs no further initialization."""
-        from vllm.kernels.helion.utils import get_canonical_gpu_name
+        from vllm.kernels.helion.utils import get_config_gpu_name
 
         with (
             dummy_kernel_registry() as register,
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
-                wraps=get_canonical_gpu_name,
+                "vllm.kernels.helion.utils.get_config_gpu_name",
+                wraps=get_config_gpu_name,
             ) as mock_gpu,
         ):
             wrapper = register(
@@ -678,7 +678,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch.object(torch.ops, "vllm_helion", mock_namespace),
@@ -732,7 +732,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch.object(torch.ops, "vllm_helion", mock_namespace),
@@ -937,7 +937,7 @@ class TestKernelRegistry:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,

--- a/tests/kernels/helion/test_scaled_mm.py
+++ b/tests/kernels/helion/test_scaled_mm.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the scaled_mm helion kernel
+
+Run `pytest tests/kernels/helion/test_scaled_mm.py`.
+"""
+
+from typing import Any
+
+import pytest
+import torch
+
+from tests.kernels.helion.utils import skip_if_platform_unsupported
+from vllm.kernels.helion.case_key import CaseKey
+from vllm.kernels.helion.config_manager import ConfigManager
+from vllm.kernels.helion.ops.scaled_mm import (
+    _pick_cache,
+    baseline,
+    pick_config,
+    scaled_mm,
+)
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_helion
+from vllm.utils.torch_utils import set_random_seed
+
+if not has_helion():
+    pytest.skip(
+        "Helion is not installed. Install with: pip install vllm[helion]",
+        allow_module_level=True,
+    )
+
+
+def _generate_input(M: int, K: int, N: int) -> tuple[Any, ...]:
+    in_dtype = current_platform.fp8_dtype()
+    a = torch.randn(M, K, dtype=torch.float32, device="cuda").to(in_dtype)
+    b = torch.randn(N, K, dtype=torch.float32, device="cuda").to(in_dtype)
+    b = b.t()
+    scale_a = torch.randn(M, 1, dtype=torch.float32, device="cuda")
+    scale_b = torch.randn(N, 1, dtype=torch.float32, device="cuda")
+    bias = torch.randn(N, dtype=torch.bfloat16, device="cuda")
+    out_dtype = torch.bfloat16
+
+    args = (a, b, scale_a, scale_b, out_dtype, bias)
+    return args
+
+
+@pytest.fixture(autouse=True)
+def reset_config_manager_singleton():
+    ConfigManager.reset_instance()
+    ConfigManager()
+    yield
+    ConfigManager.reset_instance()
+
+
+class TestScaledMmConfigPicker:
+    def setup_method(self):
+        _pick_cache.clear()
+
+    def test_config_picker_exact_match(self):
+        config_keys = [
+            CaseKey({"K": 2048, "N": 4096, "M": 16}),
+            CaseKey({"K": 4096, "N": 6144, "M": 16}),
+        ]
+
+        args = _generate_input(16, 4096, 6144)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey({"K": 4096, "N": 6144, "M": 16})
+
+    def test_config_picker_closest_match(self):
+        config_keys = [
+            CaseKey({"K": 2048, "N": 4096, "M": 16}),
+            CaseKey({"K": 2048, "N": 4096, "M": 32}),
+            CaseKey({"K": 2048, "N": 6144, "M": 16}),
+            CaseKey({"K": 2048, "N": 6144, "M": 32}),
+            CaseKey({"K": 4096, "N": 4096, "M": 16}),
+            CaseKey({"K": 4096, "N": 4096, "M": 32}),
+            CaseKey({"K": 4096, "N": 6144, "M": 16}),
+            CaseKey({"K": 4096, "N": 6144, "M": 32}),
+        ]
+
+        args = _generate_input(20, 3000, 500)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey({"K": 2048, "N": 4096, "M": 32})
+
+    def test_config_picker_no_configs(self):
+        config_keys: list[dict] = []
+
+        args = _generate_input(16, 4096, 4096)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key is None
+
+    def test_config_picker_fallback_to_largest(self):
+        config_keys = [
+            CaseKey({"K": 2048, "N": 4096, "M": 16}),
+            CaseKey({"K": 2048, "N": 4096, "M": 32}),
+            CaseKey({"K": 2048, "N": 6144, "M": 16}),
+            CaseKey({"K": 2048, "N": 6144, "M": 32}),
+            CaseKey({"K": 4096, "N": 4096, "M": 16}),
+            CaseKey({"K": 4096, "N": 4096, "M": 32}),
+            CaseKey({"K": 4096, "N": 6144, "M": 16}),
+            CaseKey({"K": 4096, "N": 6144, "M": 32}),
+        ]
+
+        args = _generate_input(64, 8192, 7000)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey({"K": 4096, "N": 6144, "M": 32})
+
+
+def _get_8bit_types():
+    types = [torch.int8]
+    if current_platform.supports_fp8():
+        types.append(current_platform.fp8_dtype())
+    return types
+
+
+MNK_FACTORS = [
+    (1, 256, 128),
+    (33, 256, 496),
+    (64, 971, 1024),
+    (64, 20486, 128),
+    (512, 256, 496),
+    (512, 20486, 1024),
+]
+
+
+class TestScaledMmCorrectness:
+    @pytest.mark.parametrize("M,N,K", MNK_FACTORS)
+    @pytest.mark.parametrize("out_dtype", [torch.bfloat16])
+    @pytest.mark.parametrize("in_dtype", _get_8bit_types())
+    @pytest.mark.parametrize("use_scalar_scale_a", [True, False])
+    @pytest.mark.parametrize("use_scalar_scale_b", [True, False])
+    @pytest.mark.parametrize("use_bias", [True, False])
+    def test_scaled_mm(
+        self,
+        M,
+        N,
+        K,
+        in_dtype,
+        out_dtype,
+        use_scalar_scale_a,
+        use_scalar_scale_b,
+        use_bias,
+    ):
+        skip_if_platform_unsupported("scaled_mm")
+        is_floating_point_type = lambda t: torch.tensor(
+            [1, 1], dtype=t
+        ).is_floating_point()
+
+        set_random_seed(0)
+
+        # NOTE: There are cases, where if the matrix is large enough, an output
+        # like 65504.4 can be produced, and can easily turn into inf when
+        # multiplied when using float16/bfloat16.  This means one function, e.g.,
+        # testing function, and another function, e.g. golden function, can
+        # produce a non-inf value while the other produces an inf value, and
+        # will cause assert_close/allclose to fail, even though if overflow
+        # wouldn't have occurred, the values would have been "close."
+        #
+        # So, the values here are kept small enough to avoid this situation.
+        if is_floating_point_type(in_dtype):
+            a = (0.25 * torch.rand((M, K), dtype=torch.float32, device="cuda")).to(
+                in_dtype
+            )
+            b = (0.25 * torch.rand((N, K), dtype=torch.float32, device="cuda")).to(
+                in_dtype
+            )
+        else:
+            a = torch.randint(-32, 32, (M, K), dtype=in_dtype, device="cuda")
+            b = torch.randint(-32, 32, (N, K), dtype=in_dtype, device="cuda")
+
+        b = b.T
+
+        if use_scalar_scale_a:
+            scale_a = torch.rand((1, 1), device=a.device)
+        else:
+            scale_a = 0.25 * torch.rand((M, 1), device=a.device)
+
+        if use_scalar_scale_b:
+            scale_b = torch.rand((1, 1), device=b.device)
+        else:
+            scale_b = 0.25 * torch.rand((N, 1), device=b.device)
+
+        bias = None
+        if use_bias:
+            bias = torch.rand((N,), device=a.device, dtype=out_dtype)
+
+        c_check = scaled_mm(a, b, scale_a, scale_b, out_dtype, bias)
+
+        c_actual = baseline(a, b, scale_a, scale_b, out_dtype, bias)
+
+        torch.testing.assert_close(c_check, c_actual, rtol=1e-1, atol=1e-1)
+
+
+class TestScaledMmIntegration:
+    def test_kernel_registration_integration(self):
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        assert "scaled_mm" in registered_kernels
+
+        kernel_wrapper = registered_kernels["scaled_mm"]
+        assert kernel_wrapper.op_name == "scaled_mm"
+        assert kernel_wrapper._config_picker is not None
+        assert kernel_wrapper._mutates_args is None
+
+    def test_fake_impl_functionality(self):
+        skip_if_platform_unsupported("scaled_mm")
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        kernel_wrapper = registered_kernels["scaled_mm"]
+        fake_impl = kernel_wrapper._fake_impl
+
+        a, b, scale_a, scale_b, out_dtype, bias = _generate_input(16, 4096, 4096)
+        fake_output = fake_impl(a, b, scale_a, scale_b, out_dtype, bias)
+
+        assert fake_output.shape[0] == a.shape[0]
+        assert fake_output.shape[1] == b.shape[1]
+        assert fake_output.dtype == out_dtype
+        assert fake_output.device == a.device

--- a/tests/kernels/helion/test_scaled_mm.py
+++ b/tests/kernels/helion/test_scaled_mm.py
@@ -30,18 +30,20 @@ if not has_helion():
     )
 
 
-def _generate_input(M: int, K: int, N: int) -> tuple[Any, ...]:
+def _generate_input(M: int, K: int, N: int, has_bias: bool = False) -> tuple[Any, ...]:
     in_dtype = current_platform.fp8_dtype()
     a = torch.randn(M, K, dtype=torch.float32, device="cuda").to(in_dtype)
     b = torch.randn(N, K, dtype=torch.float32, device="cuda").to(in_dtype)
     b = b.t()
+    c = torch.empty((M, N), dtype=torch.bfloat16, device=a.device)
     scale_a = torch.randn(M, 1, dtype=torch.float32, device="cuda")
     scale_b = torch.randn(N, 1, dtype=torch.float32, device="cuda")
-    bias = torch.randn(N, dtype=torch.bfloat16, device="cuda")
-    out_dtype = torch.bfloat16
 
-    args = (a, b, scale_a, scale_b, out_dtype, bias)
-    return args
+    if has_bias:
+        bias = torch.randn(N, dtype=torch.bfloat16, device="cuda")
+        return c, a, b, scale_a, scale_b, bias
+
+    return c, a, b, scale_a, scale_b
 
 
 @pytest.fixture(autouse=True)
@@ -60,9 +62,10 @@ class TestScaledMmConfigPicker:
         config_keys = [
             CaseKey({"K": 2048, "N": 4096, "M": 16}),
             CaseKey({"K": 4096, "N": 6144, "M": 16}),
+            CaseKey({"K": 4096, "N": 4096, "M": 16}),
         ]
 
-        args = _generate_input(16, 4096, 6144)
+        args = _generate_input(16, 4096, 6144, True)
         selected_key = pick_config(args, config_keys)
         assert selected_key == CaseKey({"K": 4096, "N": 6144, "M": 16})
 
@@ -78,7 +81,7 @@ class TestScaledMmConfigPicker:
             CaseKey({"K": 4096, "N": 6144, "M": 32}),
         ]
 
-        args = _generate_input(20, 3000, 500)
+        args = _generate_input(20, 3000, 500, False)
         selected_key = pick_config(args, config_keys)
         assert selected_key == CaseKey({"K": 2048, "N": 4096, "M": 32})
 
@@ -101,7 +104,7 @@ class TestScaledMmConfigPicker:
             CaseKey({"K": 4096, "N": 6144, "M": 32}),
         ]
 
-        args = _generate_input(64, 8192, 7000)
+        args = _generate_input(64, 8192, 7000, False)
         selected_key = pick_config(args, config_keys)
         assert selected_key == CaseKey({"K": 4096, "N": 6144, "M": 32})
 
@@ -184,9 +187,11 @@ class TestScaledMmCorrectness:
         if use_bias:
             bias = torch.rand((N,), device=a.device, dtype=out_dtype)
 
-        c_check = scaled_mm(a, b, scale_a, scale_b, out_dtype, bias)
+        c_check = torch.empty((M, N), dtype=out_dtype, device=a.device)
+        c_actual = torch.empty((M, N), dtype=out_dtype, device=a.device)
 
-        c_actual = baseline(a, b, scale_a, scale_b, out_dtype, bias)
+        scaled_mm(c_check, a, b, scale_a, scale_b, bias)
+        baseline(c_actual, a, b, scale_a, scale_b, bias)
 
         torch.testing.assert_close(c_check, c_actual, rtol=1e-1, atol=1e-1)
 
@@ -201,7 +206,7 @@ class TestScaledMmIntegration:
         kernel_wrapper = registered_kernels["scaled_mm"]
         assert kernel_wrapper.op_name == "scaled_mm"
         assert kernel_wrapper._config_picker is not None
-        assert kernel_wrapper._mutates_args is None
+        assert kernel_wrapper._mutates_args == ["out"]
 
     def test_fake_impl_functionality(self):
         skip_if_platform_unsupported("scaled_mm")
@@ -211,10 +216,5 @@ class TestScaledMmIntegration:
         kernel_wrapper = registered_kernels["scaled_mm"]
         fake_impl = kernel_wrapper._fake_impl
 
-        a, b, scale_a, scale_b, out_dtype, bias = _generate_input(16, 4096, 4096)
-        fake_output = fake_impl(a, b, scale_a, scale_b, out_dtype, bias)
-
-        assert fake_output.shape[0] == a.shape[0]
-        assert fake_output.shape[1] == b.shape[1]
-        assert fake_output.dtype == out_dtype
-        assert fake_output.device == a.device
+        args = _generate_input(16, 4096, 4096)
+        assert fake_impl(*args) is None

--- a/tests/kernels/helion/test_scaled_mm.py
+++ b/tests/kernels/helion/test_scaled_mm.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 
 from tests.kernels.helion.utils import skip_if_platform_unsupported
+from tests.kernels.utils import opcheck
 from vllm.kernels.helion.case_key import CaseKey
 from vllm.kernels.helion.config_manager import ConfigManager
 from vllm.kernels.helion.ops.scaled_mm import (
@@ -218,3 +219,16 @@ class TestScaledMmIntegration:
 
         args = _generate_input(16, 4096, 4096)
         assert fake_impl(*args) is None
+
+    def test_customop_opcheck(self):
+        skip_if_platform_unsupported("scaled_mm")
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        kernel_wrapper = registered_kernels["scaled_mm"]
+
+        # opcheck if registered as custom op
+        if hasattr(torch.ops.vllm_helion, kernel_wrapper.op_name):
+            fn = getattr(torch.ops.vllm_helion, kernel_wrapper.op_name)
+            args = _generate_input(16, 4096, 4096)
+            opcheck(fn, args)

--- a/tests/kernels/helion/test_scaled_mm.py
+++ b/tests/kernels/helion/test_scaled_mm.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the scaled_mm helion kernel
+
+Run `pytest tests/kernels/helion/test_scaled_mm.py`.
+"""
+
+from typing import Any
+
+import pytest
+import torch
+
+from tests.kernels.helion.utils import skip_if_platform_unsupported
+from tests.kernels.utils import opcheck
+from vllm.kernels.helion.case_key import CaseKey
+from vllm.kernels.helion.config_manager import ConfigManager
+from vllm.kernels.helion.ops.scaled_mm import (
+    _pick_cache,
+    baseline,
+    pick_config,
+    scaled_mm,
+)
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_helion
+from vllm.utils.torch_utils import set_random_seed
+
+if not has_helion():
+    pytest.skip(
+        "Helion is not installed. Install with: pip install vllm[helion]",
+        allow_module_level=True,
+    )
+
+
+def _generate_input(
+    M: int,
+    K: int,
+    N: int,
+    has_bias: bool = False,
+    in_dtype: torch.dtype | None = None,
+) -> tuple[Any, ...]:
+    if in_dtype is None:
+        in_dtype = current_platform.fp8_dtype()
+    if in_dtype.is_floating_point:
+        a = torch.randn(M, K, dtype=torch.float32, device="cuda").to(in_dtype)
+        b = torch.randn(N, K, dtype=torch.float32, device="cuda").to(in_dtype)
+    else:
+        a = torch.randint(-32, 32, (M, K), dtype=in_dtype, device="cuda")
+        b = torch.randint(-32, 32, (N, K), dtype=in_dtype, device="cuda")
+    b = b.t()
+    c = torch.empty((M, N), dtype=torch.bfloat16, device=a.device)
+    scale_a = torch.randn(M, 1, dtype=torch.float32, device="cuda")
+    scale_b = torch.randn(N, 1, dtype=torch.float32, device="cuda")
+
+    if has_bias:
+        bias = torch.randn(N, dtype=torch.bfloat16, device="cuda")
+        return c, a, b, scale_a, scale_b, bias
+
+    return c, a, b, scale_a, scale_b
+
+
+@pytest.fixture(autouse=True)
+def reset_config_manager_singleton():
+    ConfigManager.reset_instance()
+    ConfigManager()
+    yield
+    ConfigManager.reset_instance()
+
+
+class TestScaledMmConfigPicker:
+    def setup_method(self):
+        _pick_cache.clear()
+        self.fp8 = str(current_platform.fp8_dtype())
+        self.int8 = str(torch.int8)
+
+    def test_config_picker_exact_match(self):
+        config_keys = [
+            CaseKey({"K": 2048, "N": 4096, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 4096, "M": 16, "in_dtype": self.fp8}),
+        ]
+
+        args = _generate_input(16, 4096, 6144, True)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey(
+            {"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}
+        )
+
+    def test_config_picker_closest_match(self):
+        config_keys = [
+            CaseKey({"K": 2048, "N": 4096, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 4096, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 6144, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 4096, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 4096, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 6144, "M": 32, "in_dtype": self.fp8}),
+        ]
+
+        args = _generate_input(20, 3000, 500, False)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey(
+            {"K": 2048, "N": 4096, "M": 32, "in_dtype": self.fp8}
+        )
+
+    def test_config_picker_matches_in_dtype(self):
+        config_keys = [
+            CaseKey({"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 4096, "M": 16, "in_dtype": self.int8}),
+        ]
+
+        args = _generate_input(16, 4096, 6144, in_dtype=torch.int8)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey(
+            {"K": 2048, "N": 4096, "M": 16, "in_dtype": self.int8}
+        )
+
+    def test_config_picker_no_configs(self):
+        config_keys: list[dict] = []
+
+        args = _generate_input(16, 4096, 4096)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key is None
+
+    def test_config_picker_no_matching_in_dtype(self):
+        config_keys = [
+            CaseKey({"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+        ]
+
+        args = _generate_input(16, 4096, 6144, in_dtype=torch.int8)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key is None
+
+    def test_config_picker_fallback_to_largest(self):
+        config_keys = [
+            CaseKey({"K": 2048, "N": 4096, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 4096, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 6144, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 4096, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 4096, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 6144, "M": 32, "in_dtype": self.fp8}),
+        ]
+
+        args = _generate_input(64, 8192, 7000, False)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey(
+            {"K": 4096, "N": 6144, "M": 32, "in_dtype": self.fp8}
+        )
+
+
+def _get_8bit_types():
+    types = [torch.int8]
+    if current_platform.supports_fp8():
+        types.append(current_platform.fp8_dtype())
+    return types
+
+
+MNK_FACTORS = [
+    (1, 256, 128),
+    (33, 256, 496),
+    (64, 971, 1024),
+    (64, 20486, 128),
+    (512, 256, 496),
+    (512, 20486, 1024),
+]
+
+
+class TestScaledMmCorrectness:
+    @pytest.mark.parametrize("M,N,K", MNK_FACTORS)
+    @pytest.mark.parametrize("out_dtype", [torch.bfloat16])
+    @pytest.mark.parametrize("in_dtype", _get_8bit_types())
+    @pytest.mark.parametrize("use_scalar_scale_a", [True, False])
+    @pytest.mark.parametrize("use_scalar_scale_b", [True, False])
+    @pytest.mark.parametrize("use_bias", [True, False])
+    def test_scaled_mm(
+        self,
+        M,
+        N,
+        K,
+        in_dtype,
+        out_dtype,
+        use_scalar_scale_a,
+        use_scalar_scale_b,
+        use_bias,
+    ):
+        skip_if_platform_unsupported("scaled_mm")
+        is_floating_point_type = lambda t: torch.tensor(
+            [1, 1], dtype=t
+        ).is_floating_point()
+
+        set_random_seed(0)
+
+        # NOTE: There are cases, where if the matrix is large enough, an output
+        # like 65504.4 can be produced, and can easily turn into inf when
+        # multiplied when using float16/bfloat16.  This means one function, e.g.,
+        # testing function, and another function, e.g. golden function, can
+        # produce a non-inf value while the other produces an inf value, and
+        # will cause assert_close/allclose to fail, even though if overflow
+        # wouldn't have occurred, the values would have been "close."
+        #
+        # So, the values here are kept small enough to avoid this situation.
+        if is_floating_point_type(in_dtype):
+            a = (0.25 * torch.rand((M, K), dtype=torch.float32, device="cuda")).to(
+                in_dtype
+            )
+            b = (0.25 * torch.rand((N, K), dtype=torch.float32, device="cuda")).to(
+                in_dtype
+            )
+        else:
+            a = torch.randint(-32, 32, (M, K), dtype=in_dtype, device="cuda")
+            b = torch.randint(-32, 32, (N, K), dtype=in_dtype, device="cuda")
+
+        b = b.T
+
+        if use_scalar_scale_a:
+            scale_a = torch.rand((1, 1), device=a.device)
+        else:
+            scale_a = 0.25 * torch.rand((M, 1), device=a.device)
+
+        if use_scalar_scale_b:
+            scale_b = torch.rand((1, 1), device=b.device)
+        else:
+            scale_b = 0.25 * torch.rand((N, 1), device=b.device)
+
+        bias = None
+        if use_bias:
+            bias = torch.rand((N,), device=a.device, dtype=out_dtype)
+
+        c_check = torch.empty((M, N), dtype=out_dtype, device=a.device)
+        c_actual = torch.empty((M, N), dtype=out_dtype, device=a.device)
+
+        scaled_mm(c_check, a, b, scale_a, scale_b, bias)
+        baseline(c_actual, a, b, scale_a, scale_b, bias)
+
+        torch.testing.assert_close(c_check, c_actual, rtol=1e-1, atol=1e-1)
+
+
+class TestScaledMmIntegration:
+    def test_kernel_registration_integration(self):
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        assert "scaled_mm" in registered_kernels
+
+        kernel_wrapper = registered_kernels["scaled_mm"]
+        assert kernel_wrapper.op_name == "scaled_mm"
+        assert kernel_wrapper._config_picker is not None
+        assert kernel_wrapper._mutates_args == ["out"]
+
+    def test_fake_impl_functionality(self):
+        skip_if_platform_unsupported("scaled_mm")
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        kernel_wrapper = registered_kernels["scaled_mm"]
+        fake_impl = kernel_wrapper._fake_impl
+
+        args = _generate_input(16, 4096, 4096)
+        assert fake_impl(*args) is None
+
+    def test_customop_opcheck(self):
+        skip_if_platform_unsupported("scaled_mm")
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        kernel_wrapper = registered_kernels["scaled_mm"]
+
+        # opcheck if registered as custom op
+        if hasattr(torch.ops.vllm_helion, kernel_wrapper.op_name):
+            fn = getattr(torch.ops.vllm_helion, kernel_wrapper.op_name)
+            args = _generate_input(16, 4096, 4096)
+            opcheck(fn, args)

--- a/tests/kernels/helion/test_scaled_mm.py
+++ b/tests/kernels/helion/test_scaled_mm.py
@@ -236,6 +236,43 @@ class TestScaledMmCorrectness:
 
         torch.testing.assert_close(c_check, c_actual, rtol=1e-1, atol=1e-1)
 
+    # N and K are multiples of 16 to satisfy cutlass_scaled_mm's alignment
+    # requirements (c.stride(0) and b.stride(1) must be 16-element aligned).
+    @pytest.mark.parametrize("N,K", [(256, 128), (496, 256)])
+    @pytest.mark.parametrize("use_bias", [True, False])
+    # threshold picks the branch: M(=8) <= threshold -> Helion, else -> cutlass.
+    @pytest.mark.parametrize("threshold", [16, 4])
+    def test_helion_cutlass_hybrid_scaled_mm(self, N, K, use_bias, threshold):
+        skip_if_platform_unsupported("scaled_mm")
+        if not current_platform.supports_fp8():
+            pytest.skip("Platform does not support FP8")
+        cap = current_platform.get_device_capability()
+        assert cap is not None
+        if not torch.ops._C.cutlass_scaled_mm_supports_fp8(cap.to_int()):
+            pytest.skip("CUTLASS scaled_mm does not support FP8 on this platform")
+
+        set_random_seed(0)
+        M = 8
+        in_dtype = current_platform.fp8_dtype()
+        out_dtype = torch.bfloat16
+
+        a = (0.25 * torch.rand((M, K), dtype=torch.float32, device="cuda")).to(in_dtype)
+        b = (0.25 * torch.rand((N, K), dtype=torch.float32, device="cuda")).to(in_dtype)
+        b = b.T
+        scale_a = 0.25 * torch.rand((M, 1), device=a.device)
+        scale_b = 0.25 * torch.rand((N, 1), device=b.device)
+        bias = torch.rand((N,), device=a.device, dtype=out_dtype) if use_bias else None
+
+        c_check = torch.empty((M, N), dtype=out_dtype, device=a.device)
+        c_actual = torch.empty((M, N), dtype=out_dtype, device=a.device)
+
+        torch.ops._C.helion_cutlass_hybrid_scaled_mm(
+            c_check, a, b, scale_a, scale_b, bias, threshold
+        )
+        baseline(c_actual, a, b, scale_a, scale_b, bias)
+
+        torch.testing.assert_close(c_check, c_actual, rtol=1e-1, atol=1e-1)
+
 
 class TestScaledMmIntegration:
     def test_kernel_registration_integration(self):
@@ -272,3 +309,8 @@ class TestScaledMmIntegration:
             fn = getattr(torch.ops.vllm_helion, kernel_wrapper.op_name)
             args = _generate_input(16, 4096, 4096)
             opcheck(fn, args)
+
+        # opcheck for the hybrid c++ kernel
+        args = _generate_input(16, 4096, 4096, True)
+        args += (8,)
+        opcheck(torch.ops._C.helion_cutlass_hybrid_scaled_mm, args)

--- a/tests/kernels/helion/test_scaled_mm.py
+++ b/tests/kernels/helion/test_scaled_mm.py
@@ -31,10 +31,21 @@ if not has_helion():
     )
 
 
-def _generate_input(M: int, K: int, N: int, has_bias: bool = False) -> tuple[Any, ...]:
-    in_dtype = current_platform.fp8_dtype()
-    a = torch.randn(M, K, dtype=torch.float32, device="cuda").to(in_dtype)
-    b = torch.randn(N, K, dtype=torch.float32, device="cuda").to(in_dtype)
+def _generate_input(
+    M: int,
+    K: int,
+    N: int,
+    has_bias: bool = False,
+    in_dtype: torch.dtype | None = None,
+) -> tuple[Any, ...]:
+    if in_dtype is None:
+        in_dtype = current_platform.fp8_dtype()
+    if in_dtype.is_floating_point:
+        a = torch.randn(M, K, dtype=torch.float32, device="cuda").to(in_dtype)
+        b = torch.randn(N, K, dtype=torch.float32, device="cuda").to(in_dtype)
+    else:
+        a = torch.randint(-32, 32, (M, K), dtype=in_dtype, device="cuda")
+        b = torch.randint(-32, 32, (N, K), dtype=in_dtype, device="cuda")
     b = b.t()
     c = torch.empty((M, N), dtype=torch.bfloat16, device=a.device)
     scale_a = torch.randn(M, 1, dtype=torch.float32, device="cuda")
@@ -58,33 +69,51 @@ def reset_config_manager_singleton():
 class TestScaledMmConfigPicker:
     def setup_method(self):
         _pick_cache.clear()
+        self.fp8 = str(current_platform.fp8_dtype())
+        self.int8 = str(torch.int8)
 
     def test_config_picker_exact_match(self):
         config_keys = [
-            CaseKey({"K": 2048, "N": 4096, "M": 16}),
-            CaseKey({"K": 4096, "N": 6144, "M": 16}),
-            CaseKey({"K": 4096, "N": 4096, "M": 16}),
+            CaseKey({"K": 2048, "N": 4096, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 4096, "M": 16, "in_dtype": self.fp8}),
         ]
 
         args = _generate_input(16, 4096, 6144, True)
         selected_key = pick_config(args, config_keys)
-        assert selected_key == CaseKey({"K": 4096, "N": 6144, "M": 16})
+        assert selected_key == CaseKey(
+            {"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}
+        )
 
     def test_config_picker_closest_match(self):
         config_keys = [
-            CaseKey({"K": 2048, "N": 4096, "M": 16}),
-            CaseKey({"K": 2048, "N": 4096, "M": 32}),
-            CaseKey({"K": 2048, "N": 6144, "M": 16}),
-            CaseKey({"K": 2048, "N": 6144, "M": 32}),
-            CaseKey({"K": 4096, "N": 4096, "M": 16}),
-            CaseKey({"K": 4096, "N": 4096, "M": 32}),
-            CaseKey({"K": 4096, "N": 6144, "M": 16}),
-            CaseKey({"K": 4096, "N": 6144, "M": 32}),
+            CaseKey({"K": 2048, "N": 4096, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 4096, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 6144, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 4096, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 4096, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 6144, "M": 32, "in_dtype": self.fp8}),
         ]
 
         args = _generate_input(20, 3000, 500, False)
         selected_key = pick_config(args, config_keys)
-        assert selected_key == CaseKey({"K": 2048, "N": 4096, "M": 32})
+        assert selected_key == CaseKey(
+            {"K": 2048, "N": 4096, "M": 32, "in_dtype": self.fp8}
+        )
+
+    def test_config_picker_matches_in_dtype(self):
+        config_keys = [
+            CaseKey({"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 4096, "M": 16, "in_dtype": self.int8}),
+        ]
+
+        args = _generate_input(16, 4096, 6144, in_dtype=torch.int8)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey(
+            {"K": 2048, "N": 4096, "M": 16, "in_dtype": self.int8}
+        )
 
     def test_config_picker_no_configs(self):
         config_keys: list[dict] = []
@@ -93,21 +122,32 @@ class TestScaledMmConfigPicker:
         selected_key = pick_config(args, config_keys)
         assert selected_key is None
 
+    def test_config_picker_no_matching_in_dtype(self):
+        config_keys = [
+            CaseKey({"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+        ]
+
+        args = _generate_input(16, 4096, 6144, in_dtype=torch.int8)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key is None
+
     def test_config_picker_fallback_to_largest(self):
         config_keys = [
-            CaseKey({"K": 2048, "N": 4096, "M": 16}),
-            CaseKey({"K": 2048, "N": 4096, "M": 32}),
-            CaseKey({"K": 2048, "N": 6144, "M": 16}),
-            CaseKey({"K": 2048, "N": 6144, "M": 32}),
-            CaseKey({"K": 4096, "N": 4096, "M": 16}),
-            CaseKey({"K": 4096, "N": 4096, "M": 32}),
-            CaseKey({"K": 4096, "N": 6144, "M": 16}),
-            CaseKey({"K": 4096, "N": 6144, "M": 32}),
+            CaseKey({"K": 2048, "N": 4096, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 4096, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 2048, "N": 6144, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 4096, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 4096, "M": 32, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 6144, "M": 16, "in_dtype": self.fp8}),
+            CaseKey({"K": 4096, "N": 6144, "M": 32, "in_dtype": self.fp8}),
         ]
 
         args = _generate_input(64, 8192, 7000, False)
         selected_key = pick_config(args, config_keys)
-        assert selected_key == CaseKey({"K": 4096, "N": 6144, "M": 32})
+        assert selected_key == CaseKey(
+            {"K": 4096, "N": 6144, "M": 32, "in_dtype": self.fp8}
+        )
 
 
 def _get_8bit_types():

--- a/tests/kernels/helion/test_silu_mul_fp8.py
+++ b/tests/kernels/helion/test_silu_mul_fp8.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from tests.kernels.helion.utils import skip_if_platform_unsupported
 from vllm.utils.import_utils import has_helion
 
 if not has_helion():
@@ -21,28 +22,6 @@ from vllm.kernels.helion.ops.silu_mul_fp8 import (
     silu_mul_fp8,
     silu_mul_fp8_baseline,
 )
-
-
-def skip_if_platform_unsupported():
-    try:
-        from vllm.kernels.helion.utils import get_canonical_gpu_name
-
-        if not torch.cuda.is_available():
-            pytest.skip("CUDA not available")
-
-        platform = get_canonical_gpu_name()
-
-        try:
-            config_manager = ConfigManager.get_instance()
-        except RuntimeError:
-            config_manager = ConfigManager()
-
-        configs = config_manager.get_platform_configs("silu_mul_fp8", platform)
-        if len(configs) == 0:
-            pytest.skip("Current GPU platform not supported for silu_mul_fp8 kernel")
-
-    except (ImportError, RuntimeError, KeyError):
-        pytest.skip("Error detecting platform support for silu_mul_fp8 kernel")
 
 
 @pytest.fixture(autouse=True)
@@ -155,7 +134,7 @@ class TestSiluMulFp8Correctness:
     @pytest.mark.parametrize("intermediate_size", [2048, 3000, 3500, 4096, 5000])
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_silu_mul_fp8_correctness(self, batch_size, intermediate_size, dtype):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
 
         input_size = 2 * intermediate_size
         input_tensor = torch.randn(batch_size, input_size, dtype=dtype, device="cuda")
@@ -181,7 +160,7 @@ class TestSiluMulFp8Correctness:
         )
 
     def test_silu_mul_fp8_shape_inference(self):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
         batch_size, input_size = 32, 8192
         intermediate_size = input_size // 2
 
@@ -197,7 +176,7 @@ class TestSiluMulFp8Correctness:
         assert output.dtype == torch.float8_e4m3fn
 
     def test_silu_mul_fp8_scale_variations(self):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
         batch_size, input_size = 16, 4096
 
         input_tensor = torch.randn(
@@ -235,7 +214,7 @@ class TestSiluMulFp8Correctness:
         ],
     )
     def test_silu_mul_fp8_various_shapes(self, shape):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
 
         input_tensor = torch.randn(*shape, dtype=torch.bfloat16, device="cuda")
         scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
@@ -276,7 +255,7 @@ class TestSiluMulFp8PytorchReference:
     @pytest.mark.parametrize("intermediate_size", [1024, 2048, 4096])
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_silu_mul_fp8_vs_pytorch(self, batch_size, intermediate_size, dtype):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
 
         input_tensor = torch.randn(
             batch_size, 2 * intermediate_size, dtype=dtype, device="cuda"
@@ -313,7 +292,7 @@ class TestSiluMulFp8PytorchReference:
         ],
     )
     def test_silu_mul_fp8_multidim_vs_pytorch(self, shape):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
 
         input_tensor = torch.randn(*shape, dtype=torch.bfloat16, device="cuda")
         scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
@@ -347,7 +326,7 @@ class TestSiluMulFp8Integration:
         assert kernel_wrapper._config_picker is not None
 
     def test_fake_impl_functionality(self):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
         from vllm.kernels.helion.register import get_registered_kernels
 
         input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cuda")

--- a/tests/kernels/helion/test_utils.py
+++ b/tests/kernels/helion/test_utils.py
@@ -2,9 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit tests for Helion utility functions."""
 
+from unittest.mock import patch
+
 import pytest
 
-from vllm.kernels.helion.utils import canonicalize_gpu_name
+from vllm.kernels.helion.utils import (
+    canonicalize_gpu_name,
+    get_config_gpu_name,
+)
 
 
 @pytest.mark.parametrize(
@@ -31,3 +36,12 @@ def test_canonicalize_gpu_name_rejects_empty(invalid_name):
     """Test that empty or whitespace-only names are rejected."""
     with pytest.raises(ValueError, match="cannot be empty"):
         canonicalize_gpu_name(invalid_name)
+
+
+def test_get_config_gpu_name():
+    with patch(
+        "vllm.kernels.helion.utils.get_gpu_name",
+        return_value="NVIDIA H100 PCIe",
+    ):
+        assert get_config_gpu_name(True) == "nvidia_h100_pcie"
+        assert get_config_gpu_name(False) == "nvidia_h100"

--- a/tests/kernels/helion/utils.py
+++ b/tests/kernels/helion/utils.py
@@ -6,16 +6,18 @@ import pytest
 import torch
 
 from vllm.kernels.helion.config_manager import ConfigManager
+from vllm.kernels.helion.register import get_kernel_by_name
 
 
 def skip_if_platform_unsupported(op_name: str):
     try:
-        from vllm.kernels.helion.utils import get_canonical_gpu_name
+        from vllm.kernels.helion.utils import get_config_gpu_name
 
         if not torch.cuda.is_available():
             pytest.skip("CUDA not available")
 
-        platform = get_canonical_gpu_name()
+        kernel = get_kernel_by_name(op_name)
+        platform = get_config_gpu_name(kernel.use_variant_config)
 
         try:
             config_manager = ConfigManager.get_instance()

--- a/tests/model_executor/kernels/linear/test_helion_linear_backend.py
+++ b/tests/model_executor/kernels/linear/test_helion_linear_backend.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Helion linear backends.
+
+Run `pytest tests/model_executor/kernels/linear/test_helion_linear_backend.py`.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    pytest.skip(
+        "Helion is not installed. Install with: pip install vllm[helion]",
+        allow_module_level=True,
+    )
+
+from tests.kernels.helion.utils import skip_if_platform_unsupported
+from tests.kernels.utils import to_fp8
+from vllm.config import CUDAGraphMode
+from vllm.kernels.helion.case_key import CaseKey
+from vllm.kernels.helion.ops.scaled_mm import baseline
+from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
+    CutlassFP8ScaledMMLinearKernel,
+)
+from vllm.model_executor.kernels.linear.scaled_mm.helion import (
+    HelionFP8ScaledMMLinearKernel,
+)
+from vllm.model_executor.kernels.linear.scaled_mm.ScaledMMLinearKernel import (
+    FP8ScaledMMLinearLayerConfig,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8StaticTensorSym,
+)
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+
+def _make_fp8_config(K: int, N: int) -> FP8ScaledMMLinearLayerConfig:
+    # weight_shape is (N, K) == (output_size, input_size); can_implement
+    # unpacks it as ``N, K = c.weight_shape``.
+    return FP8ScaledMMLinearLayerConfig(
+        weight_quant_key=kFp8StaticTensorSym,
+        activation_quant_key=kFp8StaticTensorSym,
+        weight_shape=(N, K),
+        input_dtype=current_platform.fp8_dtype(),
+        out_dtype=torch.bfloat16,
+    )
+
+
+@contextmanager
+def _patch_can_implement_env(
+    config_keys: list[CaseKey],
+    capture_sizes: list[int],
+    max_capture_size: int,
+    disabled: bool = False,
+    disabled_reason: str | None = None,
+):
+    """Patch the globals ``can_implement`` reads: the scaled_mm wrapper and
+    the current vLLM compilation config."""
+    mock_scaled_mm = MagicMock()
+    mock_scaled_mm._disabled = disabled
+    mock_scaled_mm._disabled_reason = disabled_reason
+    mock_scaled_mm.get_configured_op.return_value.configs = {
+        key: None for key in config_keys
+    }
+
+    mock_compilation = MagicMock()
+    mock_compilation.max_cudagraph_capture_size = max_capture_size
+    mock_compilation.cudagraph_capture_sizes = capture_sizes
+    mock_vllm_config = MagicMock()
+    mock_vllm_config.compilation_config = mock_compilation
+
+    with (
+        patch(
+            "vllm.kernels.helion.ops.scaled_mm.scaled_mm",
+            mock_scaled_mm,
+        ),
+        patch(
+            "vllm.model_executor.kernels.linear.scaled_mm.helion"
+            ".get_current_vllm_config",
+            return_value=mock_vllm_config,
+        ),
+    ):
+        yield
+
+
+@contextmanager
+def _patch_is_supported_env(
+    cudagraph_mode: CUDAGraphMode = CUDAGraphMode.FULL,
+    max_capture_size: int = 128,
+):
+    """Patch the platform gates ``is_supported`` checks so it reaches the
+    later branches on any host."""
+    mock_compilation = MagicMock()
+    mock_compilation.cudagraph_mode = cudagraph_mode
+    mock_compilation.max_cudagraph_capture_size = max_capture_size
+    mock_vllm_config = MagicMock()
+    mock_vllm_config.compilation_config = mock_compilation
+
+    helion = "vllm.model_executor.kernels.linear.scaled_mm.helion"
+    with (
+        patch(f"{helion}.has_helion", return_value=True),
+        patch(f"{helion}.current_platform.is_cuda", return_value=True),
+        patch(f"{helion}.current_platform.is_device_capability", return_value=True),
+        patch(f"{helion}.get_current_vllm_config", return_value=mock_vllm_config),
+    ):
+        yield
+
+
+class TestHelionFP8ScaledMMLinearKernel:
+    # M values Helion is dispatched for are cudagraph_capture_sizes capped at
+    # HELION_SCALED_MM_MAX_NUM_TOKENS (=32).
+    CAPTURE_SIZES = [1, 2, 4, 8, 16, 24, 32, 64, 128]
+    COVERED_M = [1, 2, 4, 8, 16, 24, 32]
+
+    def _keys_for(self, K: int, N: int, m_values: list[int]) -> list[CaseKey]:
+        in_dtype = str(current_platform.fp8_dtype())
+        return [
+            CaseKey({"K": K, "N": N, "M": m, "in_dtype": in_dtype}) for m in m_values
+        ]
+
+    @pytest.mark.cpu_test
+    def test_is_supported(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("VLLM_BATCH_INVARIANT", "0")
+        with _patch_is_supported_env():
+            is_supported, reason = HelionFP8ScaledMMLinearKernel.is_supported()
+        assert is_supported, reason
+        assert reason is None
+
+    @pytest.mark.cpu_test
+    def test_not_supported_without_helion(self):
+        helion = "vllm.model_executor.kernels.linear.scaled_mm.helion"
+        with patch(f"{helion}.has_helion", return_value=False):
+            is_supported, reason = HelionFP8ScaledMMLinearKernel.is_supported()
+        assert not is_supported
+        assert reason is not None
+        assert "helion" in reason
+
+    @pytest.mark.cpu_test
+    def test_not_supported_on_non_cuda(self):
+        helion = "vllm.model_executor.kernels.linear.scaled_mm.helion"
+        with (
+            patch(f"{helion}.has_helion", return_value=True),
+            patch(f"{helion}.current_platform.is_cuda", return_value=False),
+        ):
+            is_supported, reason = HelionFP8ScaledMMLinearKernel.is_supported()
+        assert not is_supported
+        assert reason is not None
+        assert "CUDA" in reason
+
+    @pytest.mark.cpu_test
+    def test_not_supported_on_non_sm90(self):
+        helion = "vllm.model_executor.kernels.linear.scaled_mm.helion"
+        with (
+            patch(f"{helion}.has_helion", return_value=True),
+            patch(f"{helion}.current_platform.is_cuda", return_value=True),
+            patch(
+                f"{helion}.current_platform.is_device_capability", return_value=False
+            ),
+        ):
+            is_supported, reason = HelionFP8ScaledMMLinearKernel.is_supported()
+        assert not is_supported
+        assert reason is not None
+        assert "SM90" in reason
+
+    @pytest.mark.cpu_test
+    def test_not_supported_for_batch_invariant(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+        with _patch_is_supported_env():
+            is_supported, reason = HelionFP8ScaledMMLinearKernel.is_supported()
+        assert not is_supported
+        assert reason is not None
+        assert "batch invariant" in reason
+
+    @pytest.mark.cpu_test
+    def test_not_supported_without_cuda_graph(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("VLLM_BATCH_INVARIANT", "0")
+        with _patch_is_supported_env(cudagraph_mode=CUDAGraphMode.NONE):
+            is_supported, reason = HelionFP8ScaledMMLinearKernel.is_supported()
+        assert not is_supported
+        assert reason is not None
+        assert "CUDA Graph" in reason
+
+    @pytest.mark.cpu_test
+    def test_can_implement(self):
+        K, N = 4096, 6144
+        keys = self._keys_for(K, N, self.COVERED_M)
+        with _patch_can_implement_env(keys, self.CAPTURE_SIZES, 128):
+            can_impl, reason = HelionFP8ScaledMMLinearKernel.can_implement(
+                _make_fp8_config(K, N)
+            )
+        assert can_impl, reason
+        assert reason is None
+
+    @pytest.mark.cpu_test
+    def test_cannot_implement_missing_one_m_config(self):
+        K, N = 4096, 6144
+        # Drop M=16 so coverage is incomplete.
+        keys = self._keys_for(K, N, [m for m in self.COVERED_M if m != 16])
+        with _patch_can_implement_env(keys, self.CAPTURE_SIZES, 128):
+            can_impl, reason = HelionFP8ScaledMMLinearKernel.can_implement(
+                _make_fp8_config(K, N)
+            )
+        assert not can_impl
+        assert reason is not None
+        assert "no pre-tuned config" in reason
+        assert "16" in reason
+
+    @pytest.mark.cpu_test
+    def test_cannot_implement_missing_config_for_other_shape(self):
+        # Configs exist, but for a different (K, N) than the layer needs.
+        keys = self._keys_for(2048, 2048, self.COVERED_M)
+        with _patch_can_implement_env(keys, self.CAPTURE_SIZES, 128):
+            can_impl, reason = HelionFP8ScaledMMLinearKernel.can_implement(
+                _make_fp8_config(4096, 6144)
+            )
+        assert not can_impl
+        assert reason is not None
+        assert "K=4096" in reason and "N=6144" in reason
+
+    @pytest.mark.cpu_test
+    def test_can_implement_m_sizes_capped_by_helion_max(self):
+        # Configs only for M <= 8, but capture sizes go up to 128. With
+        # max_cudagraph_capture_size=8 the covered M range is [1, 2, 4, 8].
+        K, N = 4096, 6144
+        keys = self._keys_for(K, N, [1, 2, 4, 8])
+        with _patch_can_implement_env(keys, [1, 2, 4, 8], 8):
+            can_impl, reason = HelionFP8ScaledMMLinearKernel.can_implement(
+                _make_fp8_config(K, N)
+            )
+        assert can_impl, reason
+
+    @pytest.mark.cpu_test
+    def test_cannot_implement_disabled_op(self):
+        with _patch_can_implement_env(
+            [], [1, 2, 4], 4, disabled=True, disabled_reason="no configs for platform"
+        ):
+            can_impl, reason = HelionFP8ScaledMMLinearKernel.can_implement(
+                _make_fp8_config(4096, 6144)
+            )
+        assert not can_impl
+        assert reason is not None
+        assert "disabled" in reason
+        assert "no configs for platform" in reason
+
+    @pytest.mark.cpu_test
+    def test_can_implement_skip_config_check_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("VLLM_HELION_LINEAR_SKIP_CONFIG_CHECK", "1")
+        K, N = 4096, 6144
+        # No matching configs, but the env var bypasses the coverage check.
+        with _patch_can_implement_env([], self.CAPTURE_SIZES, 128):
+            can_impl, reason = HelionFP8ScaledMMLinearKernel.can_implement(
+                _make_fp8_config(K, N)
+            )
+        assert can_impl, reason
+
+    @staticmethod
+    def _make_apply_kernel(
+        logical_output_size: int, helion_max_num_tokens: int
+    ) -> HelionFP8ScaledMMLinearKernel:
+        kernel = object.__new__(HelionFP8ScaledMMLinearKernel)
+        fallback = object.__new__(CutlassFP8ScaledMMLinearKernel)
+        fallback.logical_output_size = logical_output_size
+        kernel.fallback = fallback
+        kernel.helion_max_num_tokens = helion_max_num_tokens
+        return kernel
+
+    def _run_apply_scaled_mm(
+        self, M: int, N: int, K: int, use_bias: bool, helion_max_num_tokens: int
+    ) -> None:
+        skip_if_platform_unsupported("scaled_mm")
+        if not current_platform.supports_fp8():
+            pytest.skip("Platform does not support FP8")
+        cap = current_platform.get_device_capability()
+        assert cap is not None
+        if not torch.ops._C.cutlass_scaled_mm_supports_fp8(cap.to_int()):
+            pytest.skip("CUTLASS scaled_mm does not support FP8 on this platform")
+
+        set_random_seed(0)
+        in_dtype = current_platform.fp8_dtype()
+        out_dtype = torch.bfloat16
+
+        a = to_fp8(0.25 * torch.randn((M, K), device="cuda")).to(in_dtype)
+        b = to_fp8(0.25 * torch.randn((N, K), device="cuda")).to(in_dtype).t()
+        scale_a = 0.25 * torch.rand((M, 1), device="cuda", dtype=torch.float32)
+        scale_b = 0.25 * torch.rand((N, 1), device="cuda", dtype=torch.float32)
+        bias = torch.rand((N,), device="cuda", dtype=out_dtype) if use_bias else None
+
+        # baseline uses the original, unpadded operands.
+        baseline_out = torch.empty((M, N), dtype=out_dtype, device="cuda")
+        baseline(baseline_out, a, b, scale_a, scale_b, bias)
+
+        # process_weights_after_loading pads the weight (and per-channel weight
+        # scale) up to 16-element alignment; mirror that here.
+        pad_k = (16 - K % 16) % 16
+        pad_n = (16 - N % 16) % 16
+        if pad_k > 0 or pad_n > 0:
+            b = torch.nn.functional.pad(b.t().contiguous(), (0, pad_k, 0, pad_n)).t()
+            if pad_n > 0:
+                scale_b = torch.nn.functional.pad(scale_b, (0, 0, 0, pad_n), value=1.0)
+
+        kernel = self._make_apply_kernel(
+            logical_output_size=N, helion_max_num_tokens=helion_max_num_tokens
+        )
+        out = kernel.apply_scaled_mm(
+            A=a,
+            B=b,
+            out_dtype=out_dtype,
+            As=scale_a,
+            Bs=scale_b,
+            bias=bias,
+            output_shape=[M, N],
+        )
+
+        assert out.shape == (M, N)
+        torch.testing.assert_close(out, baseline_out, rtol=1e-1, atol=1e-1)
+
+    @pytest.mark.skipif(
+        not current_platform.is_cuda(), reason="apply_scaled_mm requires CUDA"
+    )
+    @pytest.mark.parametrize("M", [4, 32])
+    @pytest.mark.parametrize("N,K", [(256, 128), (496, 256)])
+    @pytest.mark.parametrize("use_bias", [True, False])
+    def test_apply_scaled_mm_aligned(self, M, N, K, use_bias):
+        self._run_apply_scaled_mm(M, N, K, use_bias, helion_max_num_tokens=16)
+
+    @pytest.mark.skipif(
+        not current_platform.is_cuda(), reason="apply_scaled_mm requires CUDA"
+    )
+    @pytest.mark.parametrize("M", [4, 32])
+    @pytest.mark.parametrize("N,K", [(255, 513), (100, 200), (1280, 342)])
+    @pytest.mark.parametrize("use_bias", [True, False])
+    def test_apply_scaled_mm_padded(self, M, N, K, use_bias):
+        self._run_apply_scaled_mm(M, N, K, use_bias, helion_max_num_tokens=16)
+
+    @pytest.mark.skipif(
+        not current_platform.is_cuda(), reason="apply_scaled_mm requires CUDA"
+    )
+    @pytest.mark.parametrize("M", [4, 32])
+    @pytest.mark.parametrize("N,K", [(255, 513), (100, 200)])
+    @pytest.mark.parametrize("use_bias", [True, False])
+    def test_apply_scaled_mm_triton_fallback(self, M, N, K, use_bias):
+        skip_if_platform_unsupported("scaled_mm")
+        if not current_platform.supports_fp8():
+            pytest.skip("Platform does not support FP8")
+
+        set_random_seed(0)
+        in_dtype = current_platform.fp8_dtype()
+        out_dtype = torch.bfloat16
+
+        a = to_fp8(0.25 * torch.randn((M, K), device="cuda")).to(in_dtype)
+        b = to_fp8(0.25 * torch.randn((N, K), device="cuda")).to(in_dtype).t()
+        scale_a = 0.25 * torch.rand((M, 1), device="cuda", dtype=torch.float32)
+        scale_b = 0.25 * torch.rand((N, 1), device="cuda", dtype=torch.float32)
+        bias = torch.rand((N,), device="cuda", dtype=out_dtype) if use_bias else None
+
+        baseline_out = torch.empty((M, N), dtype=out_dtype, device="cuda")
+        baseline(baseline_out, a, b, scale_a, scale_b, bias)
+
+        # B is left unpadded (K/N not 16-aligned) -> triton_scaled_mm branch.
+        kernel = self._make_apply_kernel(
+            logical_output_size=N, helion_max_num_tokens=16
+        )
+        out = kernel.apply_scaled_mm(
+            A=a,
+            B=b,
+            out_dtype=out_dtype,
+            As=scale_a,
+            Bs=scale_b,
+            bias=bias,
+            output_shape=[M, N],
+        )
+
+        assert out.shape == (M, N)
+        torch.testing.assert_close(out, baseline_out, rtol=1e-1, atol=1e-1)

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -159,6 +159,7 @@ LinearBackend = Literal[
     "emulation",
     "xpu",
     "xpu_woq",
+    "helion",
 ]
 
 

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -204,6 +204,7 @@ LinearBackend = Literal[
     "emulation",
     "xpu",
     "xpu_woq",
+    "helion",
 ]
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1069,6 +1069,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.environ.get("VLLM_TEST_FORCE_FP8_MARLIN", "0").strip().lower()
         in ("1", "true")
     ),
+    # If set, skips the pre-tuned config coverage check for Helion linear
+    # backends, allowing them to run even when no config exactly covers the
+    # layer's shapes. The kernel's config picker falls back to the closest
+    # available config.
+    "VLLM_HELION_LINEAR_SKIP_CONFIG_CHECK": lambda: (
+        os.environ.get("VLLM_HELION_LINEAR_SKIP_CONFIG_CHECK", "0").strip().lower()
+        in ("1", "true")
+    ),
     "VLLM_TEST_FORCE_LOAD_FORMAT": lambda: os.getenv(
         "VLLM_TEST_FORCE_LOAD_FORMAT", "dummy"
     ),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1096,6 +1096,20 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.environ.get("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "0").strip().lower()
         in ("1", "true")
     ),
+    # If set, forces FP8 Marlin to be used for FP8 quantization regardless
+    # of the hardware support for FP8 compute.
+    "VLLM_TEST_FORCE_FP8_MARLIN": lambda: (
+        os.environ.get("VLLM_TEST_FORCE_FP8_MARLIN", "0").strip().lower()
+        in ("1", "true")
+    ),
+    # If set, skips the pre-tuned config coverage check for Helion linear
+    # backends, allowing them to run even when no config exactly covers the
+    # layer's shapes. The kernel's config picker falls back to the closest
+    # available config.
+    "VLLM_HELION_LINEAR_SKIP_CONFIG_CHECK": lambda: (
+        os.environ.get("VLLM_HELION_LINEAR_SKIP_CONFIG_CHECK", "0").strip().lower()
+        in ("1", "true")
+    ),
     "VLLM_TEST_FORCE_LOAD_FORMAT": lambda: os.getenv(
         "VLLM_TEST_FORCE_LOAD_FORMAT", "dummy"
     ),

--- a/vllm/kernels/helion/__init__.py
+++ b/vllm/kernels/helion/__init__.py
@@ -16,7 +16,7 @@ from vllm.kernels.helion.register import (
     register_kernel,
     vllm_helion_lib,
 )
-from vllm.kernels.helion.utils import canonicalize_gpu_name, get_canonical_gpu_name
+from vllm.kernels.helion.utils import canonicalize_gpu_name, get_config_gpu_name
 
 __all__ = [
     # Config management
@@ -33,5 +33,5 @@ __all__ = [
     "vllm_helion_lib",
     # Utilities
     "canonicalize_gpu_name",
-    "get_canonical_gpu_name",
+    "get_config_gpu_name",
 ]

--- a/vllm/kernels/helion/configs/scaled_mm/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/scaled_mm/nvidia_h100.json
@@ -1,0 +1,5769 @@
+[
+  {
+    "key": {
+      "K": 2048,
+      "N": 4096,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        8,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        4,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null
+      ],
+      "range_flattens": [
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "",
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 4,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 2048,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 8,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        4,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        true
+      ],
+      "range_flattens": [
+        false,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "last",
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 4,
+      "maxnreg": 256
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        4,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null
+      ],
+      "range_flattens": [
+        true,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 2,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "last",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "first",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "",
+        "last",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 4096,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "first",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 2048,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "",
+        "last",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "last",
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "first",
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "last",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "first",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 4096,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 2048,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "last",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first",
+        "last",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "last",
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first",
+        "first",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        32,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "",
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        32,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 4096,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "first",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 2048,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "first",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "last",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        32,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last",
+        "last",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "last",
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first",
+        "last",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "last",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "last",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "first",
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 4096,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 2048,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "last",
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        32,
+        128
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "first",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first",
+        "first",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first",
+        "first",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last",
+        "first",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 4096,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 2048,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "first",
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "first",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "last",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        32,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        false
+      ],
+      "range_flattens": [
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 32,
+      "maxnreg": 256
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "last",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        1,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        false,
+        null
+      ],
+      "range_flattens": [
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "last",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 4,
+      "maxnreg": 256
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 4096,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 2048,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "first",
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "last",
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "last",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last",
+        "",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "last",
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "first",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 64
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 4096,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last",
+        "first",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 2048,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "last",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last",
+        "first",
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "",
+        "last",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "",
+        "first",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "last",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        128,
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        64,
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "last",
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        128,
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null
+      ],
+      "range_flattens": [
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 2,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 128
+    },
+    "config": {
+      "block_sizes": [
+        128,
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  }
+]

--- a/vllm/kernels/helion/configs/scaled_mm/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/scaled_mm/nvidia_h100.json
@@ -7,57 +7,58 @@
     },
     "config": {
       "block_sizes": [
-        1,
-        8,
-        128
+        16,
+        64,
+        256
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
-        4,
-        4
+        0,
+        1
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        true,
-        null
+        null,
+        false
       ],
       "range_flattens": [
-        false,
-        null
+        null,
+        false
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
-        "first",
         "",
         "last",
         "",
-        "first"
+        "",
+        "",
+        "",
+        "first",
+        ""
       ],
-      "num_warps": 1,
-      "num_stages": 8,
+      "num_warps": 4,
+      "num_stages": 5,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
         "pointer",
         "tensor_descriptor"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 4,
-      "maxnreg": 128
+      "pid_type": "flat"
     }
   },
   {
@@ -68,57 +69,58 @@
     },
     "config": {
       "block_sizes": [
-        1,
         16,
+        64,
         256
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "l2_groupings": [
-        16
+        2
       ],
       "range_unroll_factors": [
         0,
-        1
+        2
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
         null,
         false
       ],
       "range_flattens": [
         null,
-        null
+        true
       ],
       "load_eviction_policies": [
-        "",
+        "first",
         "last",
+        "",
         "first",
         "",
-        "",
         "last",
-        ""
+        "last",
+        "first"
       ],
-      "num_warps": 2,
-      "num_stages": 4,
+      "num_warps": 4,
+      "num_stages": 6,
       "indexing": [
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 8,
-      "maxnreg": 128
+      "pid_type": "flat"
     }
   },
   {
@@ -131,16 +133,16 @@
       "block_sizes": [
         1,
         16,
-        256
+        512
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0,
@@ -157,28 +159,30 @@
         null
       ],
       "load_eviction_policies": [
+        "first",
         "last",
         "last",
-        "last",
-        "last",
-        "last",
+        "first",
+        "",
+        "first",
         "",
         ""
       ],
       "num_warps": 2,
-      "num_stages": 3,
+      "num_stages": 1,
       "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
-      "pid_type": "xyz"
+      "pid_type": "flat"
     }
   },
   {
@@ -189,69 +193,8 @@
     },
     "config": {
       "block_sizes": [
-        1,
         16,
-        512
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        4,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_multi_buffers": [
-        true,
-        true
-      ],
-      "range_flattens": [
-        false,
-        false
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "first",
-        "last",
-        "",
-        "first",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 4,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "persistent_interleaved",
-      "num_sm_multiplier": 4,
-      "maxnreg": 256
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 6144,
-      "M": 1
-    },
-    "config": {
-      "block_sizes": [
-        1,
-        16,
+        64,
         256
       ],
       "loop_orders": [
@@ -261,7 +204,7 @@
         ]
       ],
       "l2_groupings": [
-        8
+        4
       ],
       "range_unroll_factors": [
         0,
@@ -278,25 +221,89 @@
         true
       ],
       "load_eviction_policies": [
+        "last",
         "first",
-        "last",
-        "last",
         "",
         "first",
         "first",
+        "last",
+        "last",
         "last"
       ],
-      "num_warps": 1,
-      "num_stages": 5,
+      "num_warps": 4,
+      "num_stages": 8,
       "indexing": [
+        "pointer",
+        "pointer",
         "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
         "pointer",
         "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -310,8 +317,8 @@
     },
     "config": {
       "block_sizes": [
-        1,
         16,
+        64,
         256
       ],
       "loop_orders": [
@@ -321,35 +328,38 @@
         ]
       ],
       "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        4,
         4
       ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        true,
-        null
+        null,
+        false
       ],
       "range_flattens": [
-        true,
+        null,
         true
       ],
       "load_eviction_policies": [
-        "",
         "last",
         "first",
         "",
-        "",
-        "",
-        "first"
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 6,
+      "num_warps": 4,
+      "num_stages": 8,
       "indexing": [
         "pointer",
         "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor",
@@ -358,9 +368,7 @@
         "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_interleaved",
-      "num_sm_multiplier": 2,
-      "maxnreg": 128
+      "pid_type": "flat"
     }
   },
   {
@@ -373,67 +381,7 @@
       "block_sizes": [
         1,
         16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "last",
-        "",
-        "first",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 3,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 12288,
-      "N": 4096,
-      "M": 1
-    },
-    "config": {
-      "block_sizes": [
-        1,
-        16,
-        256
+        512
       ],
       "loop_orders": [
         [
@@ -452,31 +400,95 @@
       "range_num_stages": [],
       "range_multi_buffers": [
         null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
         false
       ],
       "range_flattens": [
         null,
-        false
+        true
       ],
       "load_eviction_policies": [
         "last",
+        "first",
         "",
         "first",
         "first",
         "last",
         "last",
-        "first"
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 5,
+      "num_warps": 4,
+      "num_stages": 8,
       "indexing": [
         "pointer",
         "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "atomic_indexing": [],
@@ -488,6 +500,378 @@
       "K": 5120,
       "N": 10240,
       "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 4096,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 2048,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 2
     },
     "config": {
       "block_sizes": [
@@ -512,6 +896,502 @@
       "range_num_stages": [],
       "range_multi_buffers": [
         null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "first",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "first",
+        "first",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "first",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
         false
       ],
       "range_flattens": [
@@ -523,6 +1403,503 @@
         "first",
         "last",
         "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 4096,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 2048,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first",
+        "first",
+        "first",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last",
+        "first",
+        "last",
         "first",
         "",
         "last"
@@ -530,1332 +1907,13 @@
       "num_warps": 2,
       "num_stages": 1,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 5120,
-      "M": 1
-    },
-    "config": {
-      "block_sizes": [
-        4,
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "last",
-        "",
-        "last",
-        "last",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 51200,
-      "M": 1
-    },
-    "config": {
-      "block_sizes": [
-        1,
-        64,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first",
-        "first",
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 25600,
-      "N": 5120,
-      "M": 1
-    },
-    "config": {
-      "block_sizes": [
-        1,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0,
-        3
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "first",
-        "first",
-        "",
-        "last",
-        "last",
-        "last",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 4096,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        2,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "last",
-        "first",
-        "",
-        "first",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 2048,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        2,
-        16,
-        512
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "last",
-        "first",
-        "last",
-        "",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 12288,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        2,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "last",
-        "last",
-        "last",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 6144,
-      "N": 2048,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "first",
-        "last",
-        "last",
-        "",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 6144,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        2,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "first",
-        "first",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 4096,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        4,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 24576,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        2,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "first",
-        "first",
-        "first",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 12288,
-      "N": 4096,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        2,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first",
-        "",
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 10240,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        2,
-        16,
-        512
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        3
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 5120,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        8,
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "first",
-        "last",
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 51200,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        2,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "first",
-        "first",
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 25600,
-      "N": 5120,
-      "M": 2
-    },
-    "config": {
-      "block_sizes": [
-        2,
-        64,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "",
-        "last",
-        "first",
-        "",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 4096,
-      "M": 4
-    },
-    "config": {
-      "block_sizes": [
-        4,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "first",
-        "first",
-        "first",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 2048,
-      "M": 4
-    },
-    "config": {
-      "block_sizes": [
-        4,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "first",
-        "first",
-        "first",
-        "last",
-        "first",
-        "last",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 12288,
-      "M": 4
-    },
-    "config": {
-      "block_sizes": [
-        4,
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "first",
-        "last",
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 6144,
-      "N": 2048,
-      "M": 4
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "first",
-        "last",
-        "last",
-        "",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 6144,
-      "M": 4
-    },
-    "config": {
-      "block_sizes": [
-        4,
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "last",
-        "",
-        "last",
-        "last",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 4096,
-      "M": 4
-    },
-    "config": {
-      "block_sizes": [
-        4,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "first",
-        "first",
-        "last",
-        "first",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 24576,
-      "M": 4
-    },
-    "config": {
-      "block_sizes": [
-        4,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "first",
-        "",
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
         "tensor_descriptor",
         "pointer"
       ],
@@ -1871,18 +1929,18 @@
     },
     "config": {
       "block_sizes": [
-        4,
-        32,
-        512
+        16,
+        64,
+        256
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0,
@@ -1899,28 +1957,30 @@
         true
       ],
       "load_eviction_policies": [
-        "first",
         "last",
         "first",
         "",
-        "",
+        "first",
+        "first",
         "last",
-        ""
+        "last",
+        "last"
       ],
       "num_warps": 4,
-      "num_stages": 5,
+      "num_stages": 8,
       "indexing": [
+        "pointer",
+        "pointer",
         "tensor_descriptor",
         "pointer",
         "pointer",
+        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
         "tensor_descriptor",
         "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "xyz"
+      "pid_type": "flat"
     }
   },
   {
@@ -1931,14 +1991,76 @@
     },
     "config": {
       "block_sizes": [
-        4,
         16,
+        64,
         256
       ],
       "loop_orders": [
         [
           0,
           1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "last",
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
         ]
       ],
       "l2_groupings": [
@@ -1952,95 +2074,37 @@
       "range_num_stages": [],
       "range_multi_buffers": [
         null,
-        null
+        false
       ],
       "range_flattens": [
         null,
         true
       ],
       "load_eviction_policies": [
+        "first",
+        "last",
+        "",
         "",
         "",
         "last",
-        "",
-        "first",
-        "first",
+        "last",
         "first"
       ],
-      "num_warps": 2,
-      "num_stages": 4,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 5120,
-      "M": 4
-    },
-    "config": {
-      "block_sizes": [
-        4,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 7,
+      "num_warps": 4,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "xyz"
+      "pid_type": "flat"
     }
   },
   {
@@ -2051,22 +2115,22 @@
     },
     "config": {
       "block_sizes": [
-        4,
-        32,
+        16,
+        64,
         256
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0,
-        4
+        2
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
@@ -2079,25 +2143,27 @@
         true
       ],
       "load_eviction_policies": [
-        "last",
-        "last",
+        "first",
         "last",
         "",
         "",
         "",
-        "last"
+        "last",
+        "last",
+        "first"
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 4,
+      "num_stages": 6,
       "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
         "pointer",
         "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -2111,188 +2177,8 @@
     },
     "config": {
       "block_sizes": [
-        4,
-        32,
-        1024
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "first",
-        "",
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 3,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 4096,
-      "M": 8
-    },
-    "config": {
-      "block_sizes": [
-        8,
         16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 2048,
-      "M": 8
-    },
-    "config": {
-      "block_sizes": [
-        8,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "last",
-        "",
-        "first",
-        "first",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 12288,
-      "M": 8
-    },
-    "config": {
-      "block_sizes": [
-        8,
-        16,
+        64,
         256
       ],
       "loop_orders": [
@@ -2306,37 +2192,39 @@
       ],
       "range_unroll_factors": [
         0,
-        4
+        2
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
       "range_multi_buffers": [
         null,
-        null
+        false
       ],
       "range_flattens": [
         null,
-        null
+        true
       ],
       "load_eviction_policies": [
-        "",
+        "first",
+        "last",
         "",
         "",
         "",
         "last",
         "last",
-        ""
+        "first"
       ],
-      "num_warps": 2,
-      "num_stages": 3,
+      "num_warps": 4,
+      "num_stages": 6,
       "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
         "pointer",
         "pointer",
         "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
@@ -2345,8 +2233,132 @@
   },
   {
     "key": {
-      "K": 6144,
+      "K": 2048,
+      "N": 4096,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
       "N": 2048,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
       "M": 8
     },
     "config": {
@@ -2366,7 +2378,7 @@
       ],
       "range_unroll_factors": [
         0,
-        0
+        3
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
@@ -2376,31 +2388,95 @@
       ],
       "range_flattens": [
         null,
-        false
+        null
       ],
       "load_eviction_policies": [
         "first",
-        "",
         "last",
+        "",
         "first",
         "",
+        "",
         "last",
-        "first"
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 4,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "xyz"
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
     }
   },
   {
@@ -2411,9 +2487,133 @@
     },
     "config": {
       "block_sizes": [
-        8,
         16,
-        128
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        32,
+        256
       ],
       "loop_orders": [
         [
@@ -2436,117 +2636,121 @@
       ],
       "range_flattens": [
         null,
-        true
+        false
       ],
       "load_eviction_policies": [
         "last",
+        "",
         "last",
         "first",
         "last",
+        "first",
         "",
-        "last",
-        ""
+        "last"
       ],
-      "num_warps": 1,
-      "num_stages": 6,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "pointer",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "xyz"
+      "pid_type": "flat"
     }
   },
   {
     "key": {
-      "K": 4096,
+      "K": 12288,
       "N": 4096,
       "M": 8
     },
     "config": {
       "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
         8,
-        32,
+        16,
         512
       ],
       "loop_orders": [
         [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "last",
-        "last",
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 4,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "xyz"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 24576,
-      "M": 8
-    },
-    "config": {
-      "block_sizes": [
-        8,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
           1,
           0
         ]
       ],
       "l2_groupings": [
-        32
+        2
       ],
       "range_unroll_factors": [
         0,
-        4
+        3
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
@@ -2556,146 +2760,28 @@
       ],
       "range_flattens": [
         null,
-        true
+        null
       ],
       "load_eviction_policies": [
-        "last",
         "first",
-        "first",
-        "last",
         "last",
         "",
-        "first"
+        "first",
+        "",
+        "",
+        "last",
+        "last"
       ],
       "num_warps": 2,
       "num_stages": 1,
       "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer",
         "pointer",
         "tensor_descriptor",
         "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 12288,
-      "N": 4096,
-      "M": 8
-    },
-    "config": {
-      "block_sizes": [
-        8,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "last",
-        "",
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 10240,
-      "M": 8
-    },
-    "config": {
-      "block_sizes": [
-        8,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0,
-        3
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "first",
-        "last",
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
@@ -2711,14 +2797,14 @@
     },
     "config": {
       "block_sizes": [
-        8,
         16,
-        128
+        64,
+        256
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "l2_groupings": [
@@ -2739,28 +2825,30 @@
         true
       ],
       "load_eviction_policies": [
-        "last",
-        "last",
         "first",
         "last",
         "",
+        "",
+        "",
         "last",
-        ""
+        "last",
+        "first"
       ],
-      "num_warps": 1,
+      "num_warps": 4,
       "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "xyz"
+      "pid_type": "flat"
     }
   },
   {
@@ -2771,7 +2859,7 @@
     },
     "config": {
       "block_sizes": [
-        8,
+        16,
         64,
         256
       ],
@@ -2782,33 +2870,34 @@
         ]
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0,
-        3
+        2
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
       "range_multi_buffers": [
         null,
-        true
+        false
       ],
       "range_flattens": [
         null,
-        null
+        true
       ],
       "load_eviction_policies": [
-        "",
-        "last",
         "first",
         "last",
+        "",
+        "",
+        "",
         "last",
         "last",
-        ""
+        "first"
       ],
-      "num_warps": 8,
-      "num_stages": 5,
+      "num_warps": 4,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
@@ -2816,7 +2905,8 @@
         "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
@@ -2831,22 +2921,22 @@
     },
     "config": {
       "block_sizes": [
-        8,
-        32,
+        16,
+        64,
         256
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0,
-        3
+        2
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
@@ -2856,31 +2946,33 @@
       ],
       "range_flattens": [
         null,
-        false
+        true
       ],
       "load_eviction_policies": [
         "first",
-        "first",
-        "first",
-        "first",
+        "last",
         "",
-        "first",
+        "",
+        "",
+        "last",
+        "last",
         "first"
       ],
-      "num_warps": 2,
-      "num_stages": 7,
+      "num_warps": 4,
+      "num_stages": 6,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "xyz"
+      "pid_type": "flat"
     }
   },
   {
@@ -2891,18 +2983,18 @@
     },
     "config": {
       "block_sizes": [
+        16,
         64,
-        32,
         256
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0,
@@ -2912,30 +3004,32 @@
       "range_num_stages": [],
       "range_multi_buffers": [
         null,
-        true
+        false
       ],
       "range_flattens": [
         null,
-        false
+        true
       ],
       "load_eviction_policies": [
-        "",
-        "",
         "first",
+        "last",
         "",
         "",
-        "first",
-        "last"
+        "",
+        "last",
+        "last",
+        "first"
       ],
       "num_warps": 4,
-      "num_stages": 7,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -2951,8 +3045,8 @@
     },
     "config": {
       "block_sizes": [
-        64,
         16,
+        64,
         256
       ],
       "loop_orders": [
@@ -2966,7 +3060,7 @@
       ],
       "range_unroll_factors": [
         0,
-        0
+        2
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
@@ -2976,25 +3070,27 @@
       ],
       "range_flattens": [
         null,
-        false
+        true
       ],
       "load_eviction_policies": [
-        "last",
         "first",
-        "first",
-        "last",
         "last",
         "",
+        "",
+        "",
+        "last",
+        "last",
         "first"
       ],
       "num_warps": 4,
-      "num_stages": 8,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
@@ -3012,8 +3108,8 @@
     "config": {
       "block_sizes": [
         16,
-        32,
-        128
+        64,
+        256
       ],
       "loop_orders": [
         [
@@ -3026,36 +3122,38 @@
       ],
       "range_unroll_factors": [
         0,
-        4
+        1
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
       "range_multi_buffers": [
         null,
-        true
+        false
       ],
       "range_flattens": [
         null,
         false
       ],
       "load_eviction_policies": [
-        "",
         "first",
         "last",
-        "first",
+        "",
+        "",
+        "",
         "",
         "first",
         ""
       ],
       "num_warps": 4,
-      "num_stages": 5,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -3071,67 +3169,7 @@
     },
     "config": {
       "block_sizes": [
-        64,
         16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "first",
-        "",
-        "last",
-        "last",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 6144,
-      "M": 16
-    },
-    "config": {
-      "block_sizes": [
-        64,
         64,
         256
       ],
@@ -3142,7 +3180,7 @@
         ]
       ],
       "l2_groupings": [
-        2
+        4
       ],
       "range_unroll_factors": [
         0,
@@ -3161,20 +3199,84 @@
       "load_eviction_policies": [
         "last",
         "first",
-        "first",
-        "first",
         "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
         "last",
         "first"
       ],
       "num_warps": 4,
-      "num_stages": 5,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
@@ -3191,18 +3293,18 @@
     },
     "config": {
       "block_sizes": [
+        16,
         64,
-        32,
         256
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0,
@@ -3212,30 +3314,32 @@
       "range_num_stages": [],
       "range_multi_buffers": [
         null,
-        true
+        false
       ],
       "range_flattens": [
         null,
-        false
+        true
       ],
       "load_eviction_policies": [
-        "",
-        "",
         "first",
+        "last",
         "",
         "",
-        "first",
-        "last"
+        "",
+        "last",
+        "last",
+        "first"
       ],
       "num_warps": 4,
-      "num_stages": 7,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -3266,7 +3370,7 @@
       ],
       "range_unroll_factors": [
         0,
-        4
+        2
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
@@ -3279,22 +3383,24 @@
         true
       ],
       "load_eviction_policies": [
-        "",
-        "first",
-        "first",
         "first",
         "last",
-        "first",
+        "",
+        "",
+        "",
+        "last",
+        "last",
         "first"
       ],
       "num_warps": 4,
-      "num_stages": 1,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
@@ -3311,8 +3417,8 @@
     },
     "config": {
       "block_sizes": [
+        16,
         64,
-        32,
         256
       ],
       "loop_orders": [
@@ -3322,41 +3428,43 @@
         ]
       ],
       "l2_groupings": [
-        16
+        4
       ],
       "range_unroll_factors": [
         0,
-        2
+        1
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
       "range_multi_buffers": [
         null,
-        true
+        false
       ],
       "range_flattens": [
         null,
-        false
+        true
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "last",
         "first",
         "",
-        "",
         "first",
+        "first",
+        "last",
+        "last",
         "last"
       ],
       "num_warps": 4,
-      "num_stages": 7,
+      "num_stages": 8,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "atomic_indexing": [],
@@ -3372,21 +3480,21 @@
     "config": {
       "block_sizes": [
         16,
-        16,
+        64,
         256
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0,
-        4
+        2
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
@@ -3396,27 +3504,29 @@
       ],
       "range_flattens": [
         null,
-        null
+        true
       ],
       "load_eviction_policies": [
         "first",
-        "",
-        "first",
-        "first",
-        "first",
         "last",
-        "first"
+        "",
+        "",
+        "",
+        "last",
+        "",
+        "last"
       ],
-      "num_warps": 2,
+      "num_warps": 4,
       "num_stages": 4,
       "indexing": [
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
@@ -3431,22 +3541,22 @@
     },
     "config": {
       "block_sizes": [
-        64,
+        16,
         64,
         256
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0,
-        0
+        2
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
@@ -3456,25 +3566,27 @@
       ],
       "range_flattens": [
         null,
-        null
+        true
       ],
       "load_eviction_policies": [
-        "last",
         "first",
         "last",
-        "first",
-        "first",
+        "",
+        "",
+        "",
         "last",
-        "last"
+        "last",
+        "first"
       ],
       "num_warps": 4,
       "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
@@ -3492,7 +3604,7 @@
     "config": {
       "block_sizes": [
         16,
-        32,
+        64,
         256
       ],
       "loop_orders": [
@@ -3502,41 +3614,43 @@
         ]
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0,
-        4
+        2
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
       "range_multi_buffers": [
         null,
-        null
+        false
       ],
       "range_flattens": [
         null,
-        null
+        true
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
         "first",
         "last",
-        ""
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 4,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
@@ -3553,7 +3667,7 @@
       "block_sizes": [
         16,
         64,
-        1024
+        256
       ],
       "loop_orders": [
         [
@@ -3566,7 +3680,7 @@
       ],
       "range_unroll_factors": [
         0,
-        3
+        2
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
@@ -3576,19 +3690,20 @@
       ],
       "range_flattens": [
         null,
-        false
+        true
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        "last",
-        "",
-        "last",
         "first",
-        "last"
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
       ],
       "num_warps": 4,
-      "num_stages": 3,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
@@ -3596,6 +3711,7 @@
         "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -3607,251 +3723,11 @@
     "key": {
       "K": 2048,
       "N": 4096,
-      "M": 32
+      "M": 24
     },
     "config": {
       "block_sizes": [
-        64,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first",
-        "",
-        "",
-        "first",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 2048,
-      "M": 32
-    },
-    "config": {
-      "block_sizes": [
-        64,
         16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "first",
-        "",
-        "last",
-        "last",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 12288,
-      "M": 32
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "first",
-        "first",
-        "first",
-        "",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 6144,
-      "N": 2048,
-      "M": 32
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "first",
-        "",
-        "last",
-        "last",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 6144,
-      "M": 32
-    },
-    "config": {
-      "block_sizes": [
-        64,
         64,
         256
       ],
@@ -3859,1808 +3735,6 @@
         [
           0,
           1
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "first",
-        "first",
-        "",
-        "last",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 4096,
-      "M": 32
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first",
-        "",
-        "",
-        "first",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 24576,
-      "M": 32
-    },
-    "config": {
-      "block_sizes": [
-        32,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0,
-        3
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "first",
-        "last",
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 12288,
-      "N": 4096,
-      "M": 32
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first",
-        "",
-        "",
-        "first",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 10240,
-      "M": 32
-    },
-    "config": {
-      "block_sizes": [
-        32,
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "last",
-        "first",
-        "last",
-        "first",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 5120,
-      "M": 32
-    },
-    "config": {
-      "block_sizes": [
-        32,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_multi_buffers": [
-        true,
-        false
-      ],
-      "range_flattens": [
-        false,
-        true
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "first",
-        "last",
-        "last",
-        "last",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 32,
-      "maxnreg": 256
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 51200,
-      "M": 32
-    },
-    "config": {
-      "block_sizes": [
-        32,
-        128,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0,
-        3
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "first",
-        "last",
-        "",
-        "last",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 25600,
-      "N": 5120,
-      "M": 32
-    },
-    "config": {
-      "block_sizes": [
-        32,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        1,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_multi_buffers": [
-        false,
-        null
-      ],
-      "range_flattens": [
-        false,
-        true
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last",
-        "last",
-        "",
-        "last",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 4,
-      "maxnreg": 256
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 4096,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0,
-        3
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "first",
-        "last",
-        "last",
-        "first",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 2048,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "last",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 12288,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "first",
-        "first",
-        "first",
-        "",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 6144,
-      "N": 2048,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "first",
-        "last",
-        "last",
-        "",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 6144,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "last",
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 4096,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "first",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 24576,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "first",
-        "last",
-        "",
-        "first",
-        "last",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 12288,
-      "N": 4096,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "last",
-        "last",
-        "first",
-        "",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 10240,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        128,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "",
-        "first",
-        "",
-        "last",
-        "last"
-      ],
-      "num_warps": 8,
-      "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 5120,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        64,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "first",
-        "first",
-        "",
-        "last",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 51200,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        128,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "last",
-        "first",
-        "first",
-        "",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 25600,
-      "N": 5120,
-      "M": 64
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        64,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "",
-        "last",
-        "first",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 4096,
-      "M": 128
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        64,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "last",
-        "first",
-        "first",
-        "last",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 2048,
-      "M": 128
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first",
-        "last",
-        "",
-        "first",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 2048,
-      "N": 12288,
-      "M": 128
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "last",
-        "first",
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 6144,
-      "N": 2048,
-      "M": 128
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        false
-      ],
-      "load_eviction_policies": [
-        "first",
-        "first",
-        "last",
-        "first",
-        "",
-        "first",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 6144,
-      "M": 128
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 4096,
-      "M": 128
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "first",
-        "first",
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 4096,
-      "N": 24576,
-      "M": 128
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0,
-        1
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "",
-        "first",
-        "last",
-        "last",
-        "first"
-      ],
-      "num_warps": 8,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 12288,
-      "N": 4096,
-      "M": 128
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        true
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "last",
-        "last",
-        "",
-        "last",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 10240,
-      "M": 128
-    },
-    "config": {
-      "block_sizes": [
-        128,
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0,
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "",
-        "first",
-        "last",
-        "first",
-        "first"
-      ],
-      "num_warps": 8,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 5120,
-      "M": 128
-    },
-    "config": {
-      "block_sizes": [
-        64,
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0,
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        null
-      ],
-      "range_flattens": [
-        null,
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "first",
-        "last",
-        "",
-        "first",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 5120,
-      "N": 51200,
-      "M": 128
-    },
-    "config": {
-      "block_sizes": [
-        128,
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
         ]
       ],
       "l2_groupings": [
@@ -5671,52 +3745,177 @@
         2
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        true,
-        null
+        null,
+        false
       ],
       "range_flattens": [
-        false,
+        null,
         true
       ],
       "load_eviction_policies": [
-        "last",
-        "first",
         "",
         "last",
-        "first",
-        "first",
-        "first"
+        "",
+        "last",
+        "",
+        "last",
+        "",
+        "last"
       ],
-      "num_warps": 8,
-      "num_stages": 3,
+      "num_warps": 4,
+      "num_stages": 6,
       "indexing": [
-        "pointer",
-        "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 2,
-      "maxnreg": 128
+      "pid_type": "flat"
     }
   },
   {
     "key": {
-      "K": 25600,
-      "N": 5120,
-      "M": 128
+      "K": 2048,
+      "N": 2048,
+      "M": 24
     },
     "config": {
       "block_sizes": [
-        128,
+        16,
         64,
-        128
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 24
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first",
+        "",
+        "first",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 24
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
       ],
       "loop_orders": [
         [
@@ -5725,7 +3924,193 @@
         ]
       ],
       "l2_groupings": [
-        16
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 24
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 24
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "last",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 24
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
       ],
       "range_unroll_factors": [
         0,
@@ -5739,9 +4124,444 @@
       ],
       "range_flattens": [
         null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 24
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
         null
       ],
       "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 24
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "first",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 24
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 24
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first",
+        "last",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 24
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last",
+        "first",
+        "last",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 4096,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 2048,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
         "last",
         "",
         "",
@@ -5751,15 +4571,1070 @@
         "first"
       ],
       "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 12288,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 6144,
+      "N": 2048,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
       "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 24576,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "",
+        "last",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
       "indexing": [
         "tensor_descriptor",
         "pointer",
-        "pointer",
         "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12288,
+      "N": 4096,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first",
+        "last",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 1
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 2
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 4
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 8
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 16
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 24
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "",
+        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 32
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "atomic_indexing": [],

--- a/vllm/kernels/helion/configs/scaled_mm/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/scaled_mm/nvidia_h100.json
@@ -3,7 +3,8 @@
     "key": {
       "K": 2048,
       "N": 4096,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -65,7 +66,8 @@
     "key": {
       "K": 2048,
       "N": 2048,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -127,7 +129,8 @@
     "key": {
       "K": 2048,
       "N": 12288,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -189,7 +192,8 @@
     "key": {
       "K": 6144,
       "N": 2048,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -251,7 +255,8 @@
     "key": {
       "K": 4096,
       "N": 6144,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -313,7 +318,8 @@
     "key": {
       "K": 4096,
       "N": 4096,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -375,7 +381,8 @@
     "key": {
       "K": 4096,
       "N": 24576,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -437,7 +444,8 @@
     "key": {
       "K": 12288,
       "N": 4096,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -499,7 +507,8 @@
     "key": {
       "K": 5120,
       "N": 10240,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -561,7 +570,8 @@
     "key": {
       "K": 5120,
       "N": 5120,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -623,7 +633,8 @@
     "key": {
       "K": 5120,
       "N": 51200,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -685,7 +696,8 @@
     "key": {
       "K": 25600,
       "N": 5120,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -747,7 +759,8 @@
     "key": {
       "K": 2048,
       "N": 4096,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -809,7 +822,8 @@
     "key": {
       "K": 2048,
       "N": 2048,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -871,7 +885,8 @@
     "key": {
       "K": 2048,
       "N": 12288,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -933,7 +948,8 @@
     "key": {
       "K": 6144,
       "N": 2048,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -995,7 +1011,8 @@
     "key": {
       "K": 4096,
       "N": 6144,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1057,7 +1074,8 @@
     "key": {
       "K": 4096,
       "N": 4096,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1119,7 +1137,8 @@
     "key": {
       "K": 4096,
       "N": 24576,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1181,7 +1200,8 @@
     "key": {
       "K": 12288,
       "N": 4096,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1243,7 +1263,8 @@
     "key": {
       "K": 5120,
       "N": 10240,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1305,7 +1326,8 @@
     "key": {
       "K": 5120,
       "N": 5120,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1367,7 +1389,8 @@
     "key": {
       "K": 5120,
       "N": 51200,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1429,7 +1452,8 @@
     "key": {
       "K": 25600,
       "N": 5120,
-      "M": 2
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1491,7 +1515,8 @@
     "key": {
       "K": 2048,
       "N": 4096,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1553,7 +1578,8 @@
     "key": {
       "K": 2048,
       "N": 2048,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1615,7 +1641,8 @@
     "key": {
       "K": 2048,
       "N": 12288,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1677,7 +1704,8 @@
     "key": {
       "K": 6144,
       "N": 2048,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1739,7 +1767,8 @@
     "key": {
       "K": 4096,
       "N": 6144,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1801,7 +1830,8 @@
     "key": {
       "K": 4096,
       "N": 4096,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1863,7 +1893,8 @@
     "key": {
       "K": 4096,
       "N": 24576,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1925,7 +1956,8 @@
     "key": {
       "K": 12288,
       "N": 4096,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -1987,7 +2019,8 @@
     "key": {
       "K": 5120,
       "N": 10240,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2049,7 +2082,8 @@
     "key": {
       "K": 5120,
       "N": 5120,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2111,7 +2145,8 @@
     "key": {
       "K": 5120,
       "N": 51200,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2173,7 +2208,8 @@
     "key": {
       "K": 25600,
       "N": 5120,
-      "M": 4
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2235,7 +2271,8 @@
     "key": {
       "K": 2048,
       "N": 4096,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2297,7 +2334,8 @@
     "key": {
       "K": 2048,
       "N": 2048,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2359,7 +2397,8 @@
     "key": {
       "K": 2048,
       "N": 12288,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2421,7 +2460,8 @@
     "key": {
       "K": 6144,
       "N": 2048,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2483,7 +2523,8 @@
     "key": {
       "K": 4096,
       "N": 6144,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2545,7 +2586,8 @@
     "key": {
       "K": 4096,
       "N": 4096,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2607,7 +2649,8 @@
     "key": {
       "K": 4096,
       "N": 24576,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2669,7 +2712,8 @@
     "key": {
       "K": 12288,
       "N": 4096,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2731,7 +2775,8 @@
     "key": {
       "K": 5120,
       "N": 10240,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2793,7 +2838,8 @@
     "key": {
       "K": 5120,
       "N": 5120,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2855,7 +2901,8 @@
     "key": {
       "K": 5120,
       "N": 51200,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2917,7 +2964,8 @@
     "key": {
       "K": 25600,
       "N": 5120,
-      "M": 8
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -2979,7 +3027,8 @@
     "key": {
       "K": 2048,
       "N": 4096,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3041,7 +3090,8 @@
     "key": {
       "K": 2048,
       "N": 2048,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3103,7 +3153,8 @@
     "key": {
       "K": 2048,
       "N": 12288,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3165,7 +3216,8 @@
     "key": {
       "K": 6144,
       "N": 2048,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3227,7 +3279,8 @@
     "key": {
       "K": 4096,
       "N": 6144,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3289,7 +3342,8 @@
     "key": {
       "K": 4096,
       "N": 4096,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3351,7 +3405,8 @@
     "key": {
       "K": 4096,
       "N": 24576,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3413,7 +3468,8 @@
     "key": {
       "K": 12288,
       "N": 4096,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3475,7 +3531,8 @@
     "key": {
       "K": 5120,
       "N": 10240,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3537,7 +3594,8 @@
     "key": {
       "K": 5120,
       "N": 5120,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3552,7 +3610,7 @@
         ]
       ],
       "l2_groupings": [
-        1
+        2
       ],
       "range_unroll_factors": [
         0,
@@ -3572,7 +3630,7 @@
         "first",
         "last",
         "",
-        "",
+        "first",
         "",
         "last",
         "last",
@@ -3582,7 +3640,7 @@
       "num_stages": 6,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
@@ -3599,7 +3657,8 @@
     "key": {
       "K": 5120,
       "N": 51200,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3661,7 +3720,8 @@
     "key": {
       "K": 25600,
       "N": 5120,
-      "M": 16
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3723,7 +3783,8 @@
     "key": {
       "K": 2048,
       "N": 4096,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3785,7 +3846,8 @@
     "key": {
       "K": 2048,
       "N": 2048,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3847,7 +3909,8 @@
     "key": {
       "K": 2048,
       "N": 12288,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3909,7 +3972,8 @@
     "key": {
       "K": 6144,
       "N": 2048,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -3971,7 +4035,8 @@
     "key": {
       "K": 4096,
       "N": 6144,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4033,7 +4098,8 @@
     "key": {
       "K": 4096,
       "N": 4096,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4095,7 +4161,8 @@
     "key": {
       "K": 4096,
       "N": 24576,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4157,7 +4224,8 @@
     "key": {
       "K": 12288,
       "N": 4096,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4219,7 +4287,8 @@
     "key": {
       "K": 5120,
       "N": 10240,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4281,7 +4350,8 @@
     "key": {
       "K": 5120,
       "N": 5120,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4300,40 +4370,40 @@
       ],
       "range_unroll_factors": [
         0,
-        0
+        4
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
       "range_multi_buffers": [
         null,
-        false
+        null
       ],
       "range_flattens": [
         null,
         null
       ],
       "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "first",
-        "first",
         "first",
         "last",
-        "first"
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last"
       ],
       "num_warps": 4,
-      "num_stages": 6,
+      "num_stages": 7,
       "indexing": [
         "tensor_descriptor",
         "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -4343,7 +4413,8 @@
     "key": {
       "K": 5120,
       "N": 51200,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4405,7 +4476,8 @@
     "key": {
       "K": 25600,
       "N": 5120,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4467,7 +4539,8 @@
     "key": {
       "K": 2048,
       "N": 4096,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4529,7 +4602,8 @@
     "key": {
       "K": 2048,
       "N": 2048,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4591,7 +4665,8 @@
     "key": {
       "K": 2048,
       "N": 12288,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4653,7 +4728,8 @@
     "key": {
       "K": 6144,
       "N": 2048,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4715,7 +4791,8 @@
     "key": {
       "K": 4096,
       "N": 6144,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4777,7 +4854,8 @@
     "key": {
       "K": 4096,
       "N": 4096,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4839,7 +4917,8 @@
     "key": {
       "K": 4096,
       "N": 24576,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4901,7 +4980,8 @@
     "key": {
       "K": 12288,
       "N": 4096,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -4963,7 +5043,8 @@
     "key": {
       "K": 5120,
       "N": 10240,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -5025,7 +5106,8 @@
     "key": {
       "K": 5120,
       "N": 5120,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -5087,7 +5169,8 @@
     "key": {
       "K": 5120,
       "N": 51200,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -5149,7 +5232,8 @@
     "key": {
       "K": 25600,
       "N": 5120,
-      "M": 32
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -5211,7 +5295,134 @@
     "key": {
       "K": 8192,
       "N": 5120,
-      "M": 1
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -5273,7 +5484,8 @@
     "key": {
       "K": 8192,
       "N": 5120,
-      "M": 2
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -5335,7 +5547,8 @@
     "key": {
       "K": 8192,
       "N": 5120,
-      "M": 4
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -5354,7 +5567,7 @@
       ],
       "range_unroll_factors": [
         0,
-        2
+        0
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
@@ -5364,26 +5577,26 @@
       ],
       "range_flattens": [
         null,
-        true
+        null
       ],
       "load_eviction_policies": [
+        "",
         "first",
         "last",
+        "first",
         "",
         "",
-        "",
-        "last",
         "last",
         "first"
       ],
       "num_warps": 4,
-      "num_stages": 6,
+      "num_stages": 7,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
-        "pointer",
         "tensor_descriptor",
         "pointer",
         "pointer",
@@ -5397,135 +5610,1335 @@
     "key": {
       "K": 8192,
       "N": 5120,
-      "M": 8
-    },
-    "config": {
-      "block_sizes": [
-        16,
-        64,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 8192,
-      "N": 5120,
-      "M": 16
-    },
-    "config": {
-      "block_sizes": [
-        16,
-        64,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0,
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null,
-        false
-      ],
-      "range_flattens": [
-        null,
-        true
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "K": 8192,
-      "N": 5120,
-      "M": 24
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
         32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "last",
+        "first",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "first",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "last",
+        "first",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 7168,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "first",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 34816,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 17408,
+      "N": 5120,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 6144,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first",
+        "",
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "",
+        "first",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 65536,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 32768,
+      "N": 5120,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first",
+        "first",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last",
+        "last",
+        "last",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 7168,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last",
+        "last",
+        "last",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 34816,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 17408,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
         64,
         512
       ],
@@ -5540,7 +6953,70 @@
       ],
       "range_unroll_factors": [
         0,
-        0
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "",
+        "last",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
       ],
       "range_warp_specializes": [],
       "range_num_stages": [],
@@ -5550,25 +7026,907 @@
       ],
       "range_flattens": [
         null,
-        null
+        false
       ],
       "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
         "first",
         "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
         "last",
+        "first",
         "",
-        "",
+        "first",
+        "first",
         "last",
         "last",
         "last"
       ],
       "num_warps": 4,
-      "num_stages": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 6144,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 65536,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 32768,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 7168,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
       "indexing": [
         "pointer",
         "tensor_descriptor",
         "pointer",
+        "pointer",
         "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 34816,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 17408,
+      "N": 5120,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer",
         "pointer",
         "pointer",
@@ -5581,9 +7939,3272 @@
   },
   {
     "key": {
-      "K": 8192,
+      "K": 5120,
+      "N": 6144,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
       "N": 5120,
-      "M": 32
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 65536,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 32768,
+      "N": 5120,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 7168,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 34816,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last",
+        "first",
+        "last",
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 17408,
+      "N": 5120,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last",
+        "first",
+        "last",
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 6144,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 65536,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "last",
+        "",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 32768,
+      "N": 5120,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 7168,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 34816,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 17408,
+      "N": 5120,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 6144,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 65536,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 32768,
+      "N": 5120,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "last",
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 7168,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "last",
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 34816,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 17408,
+      "N": 5120,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "last",
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 6144,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "last",
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 65536,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "last",
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 32768,
+      "N": 5120,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "last",
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "",
+        "last",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 7168,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 34816,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 17408,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 6144,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
     },
     "config": {
       "block_sizes": [
@@ -5636,6 +11257,12461 @@
         "pointer",
         "pointer",
         "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 65536,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "last",
+        "",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 32768,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "last",
+        "",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 3072,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 5120,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 32768,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 16384,
+      "N": 5120,
+      "M": 1,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "first",
+        "",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "first",
+        "",
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 3072,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 32768,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 16384,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 3072,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 32768,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 16384,
+      "N": 5120,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 3072,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 32768,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 16384,
+      "N": 5120,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 3072,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 5120,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 32768,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 16384,
+      "N": 5120,
+      "M": 16,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "",
+        "first",
+        "last",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "last",
+        "",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "",
+        "",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 3072,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 5120,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 32768,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 16384,
+      "N": 5120,
+      "M": 24,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "first",
+        "last",
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "last",
+        "",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "first",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "",
+        "",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 3072,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 32768,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 16384,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "first",
+        "",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 5120,
+      "M": 4,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2048,
+      "N": 5120,
+      "M": 8,
+      "in_dtype": "torch.float8_e4m3fn"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "",
+        "first",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "",
+        "first",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "",
+        "first",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "first",
+        "first",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "last",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        64,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "",
+        "last",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last",
+        "first",
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        64,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "last",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "first",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first",
+        "last",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last",
+        "first",
+        "last",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 6144,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 4096,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 10240,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 51200,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 25600,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "first",
+        "first",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "first",
+        "first",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "",
+        "last",
+        "last",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "last",
+        "first",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "last",
+        "first",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "first",
+        "first",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first",
+        "last",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first",
+        "last",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "",
+        "",
+        "first",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first",
+        "last",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        "last",
+        "",
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last",
+        "last",
+        "last",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "first",
+        "",
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "first",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 6144,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 2560,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 2560,
+      "N": 19456,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "",
+        "last",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 9728,
+      "N": 2560,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "last",
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 28672,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 4096,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first",
+        "first",
+        "first",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "",
+        "last",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 1,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        2,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 2,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "xyz"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 4,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "first",
+        "",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        "",
+        "",
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 8,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "",
+        "last",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 16,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "",
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "last",
+        "",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "",
+        "first",
+        "",
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "",
+        "",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 24,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "",
+        "",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 5120,
+      "N": 25600,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "first",
+        "last",
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 12800,
+      "N": 5120,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first",
+        "",
+        "first",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 4096,
+      "N": 8192,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "first",
+        "",
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 8192,
+      "N": 28672,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "K": 14336,
+      "N": 8192,
+      "M": 32,
+      "in_dtype": "torch.int8"
+    },
+    "config": {
+      "block_sizes": [
+        32,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "",
+        "",
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"

--- a/vllm/kernels/helion/configs/scaled_mm/nvidia_h100_80gb_hbm3.json
+++ b/vllm/kernels/helion/configs/scaled_mm/nvidia_h100_80gb_hbm3.json
@@ -1,0 +1,72 @@
+[
+  {
+    "key": {},
+    "config": {
+      "block_sizes": [
+        16,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1,
+          2
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1,
+      "swap_ab": false
+    }
+  }
+]

--- a/vllm/kernels/helion/ops/scaled_mm.py
+++ b/vllm/kernels/helion/ops/scaled_mm.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+from itertools import product
+from typing import Any
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.kernels.helion.case_key import CaseKey
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    raise ImportError(
+        "Helion kernel requires helion to be installed. "
+        "Install it with: pip install helion"
+    )
+
+import helion
+import helion.language as hl
+
+from vllm.kernels.helion.register import register_kernel
+
+logger = init_logger(__name__)
+
+
+def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
+    # TODO(xiaohongchen1991): it is difficult for kernel author to cover
+    # all input property combination. Currently, dtypes are fixed. We need
+    # optimization to bucket/skip some combinations
+    m_size_list = [1, 2, 4, 8, 16, 32, 64, 128]
+    b_shape_list = [
+        # Qwen3-1.7B
+        # TP=1
+        (2048, 4096),
+        (2048, 2048),
+        (2048, 12288),
+        (6144, 2048),
+        # Qwen3-8B
+        # TP=1
+        (4096, 6144),
+        (4096, 4096),
+        (4096, 24576),
+        (12288, 4096),
+        # Qwen3-32B
+        # TP=1
+        (5120, 10240),
+        (5120, 5120),
+        (5120, 51200),
+        (25600, 5120),
+    ]
+
+    in_dtype: torch.dtype = current_platform.fp8_dtype()
+    scale_dtype: torch.dtype = torch.float32
+    out_dtype: torch.dtype = torch.bfloat16
+    inputs = {}
+    for M, (K, N) in product(m_size_list, b_shape_list):
+        scale = 1.0 / math.sqrt(K)
+        a = (scale * (0.5 + torch.rand(M, K, dtype=torch.float32, device="cuda"))).to(
+            in_dtype
+        )
+        b = (scale * (0.5 + torch.rand(N, K, dtype=torch.float32, device="cuda"))).to(
+            in_dtype
+        )
+        b = b.t()
+        scale_a = 0.5 + torch.rand((M, 1), dtype=scale_dtype, device="cuda")
+        scale_b = 0.5 + torch.rand((N, 1), dtype=scale_dtype, device="cuda")
+        bias = 0.5 * (torch.rand(N, dtype=out_dtype, device="cuda") - 0.5)
+
+        config_key = CaseKey(
+            {
+                "K": K,
+                "N": N,
+                "M": M,
+            }
+        )
+        inputs[config_key] = (a, b, scale_a, scale_b, out_dtype, bias)
+
+    return inputs
+
+
+_pick_cache: dict[tuple[int, int, int], CaseKey | None] = {}
+
+
+def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | None:
+    """Pick the best pre-tuned config for the given input shape.
+    Selection strategy:
+      1. Find the closest K among available configs
+         (exact match preferred).
+      2. Find the closest N among available configs
+         (exact match preferred).
+      3. Among the M values tuned for that K and N, pick
+         the smallest M >= the input's M. If the input is
+         larger than all available Ms, fall back to the largest.
+    """
+
+    if not config_keys:
+        return None
+
+    a, b, *_ = args
+    M, K = a.shape
+    N = b.shape[1]
+
+    cache_key = (M, K, N)
+    cached = _pick_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    configs: dict[int, dict[int, list[int]]] = {}
+    for key in config_keys:
+        if key.is_default():
+            continue
+        configs.setdefault(key["K"], {}).setdefault(key["N"], []).append(key["M"])
+
+    if not configs:
+        return None
+
+    best_K = min(configs, key=lambda s: abs(s - K))
+    best_N = min(configs[best_K], key=lambda s: abs(s - N))
+    available_M = sorted(configs[best_K][best_N])
+    best_M = next((m for m in available_M if m >= M), available_M[-1])
+
+    result = CaseKey(
+        {
+            "K": best_K,
+            "N": best_N,
+            "M": best_M,
+        }
+    )
+    _pick_cache[cache_key] = result
+    return result
+
+
+def fake_impl(
+    a: torch.Tensor,  # [M, K]
+    b: torch.Tensor,  # [K, N]
+    scale_a: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
+    scale_b: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
+    out_dtype: torch.dtype,
+    bias: torch.Tensor | None = None,  # [N]
+) -> torch.Tensor:
+    M = a.shape[0]
+    N = b.shape[1]
+    c = torch.empty((M, N), dtype=out_dtype, device=a.device)
+    return c
+
+
+def baseline(
+    a: torch.Tensor,  # [M, K]
+    b: torch.Tensor,  # [K, N]
+    scale_a: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
+    scale_b: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
+    out_dtype: torch.dtype,
+    bias: torch.Tensor | None = None,  # [N]
+) -> torch.Tensor:
+    return ops.cutlass_scaled_mm(
+        a, b, out_dtype=out_dtype, scale_a=scale_a, scale_b=scale_b, bias=bias
+    )
+
+
+# Overwrite autotune_baseline_atol and autotune_baseline_rtol
+# if too many configs failed due to baseline check during autotuning
+@register_kernel(
+    config_picker=pick_config,
+    input_generator=generate_inputs,
+    fake_impl=fake_impl,
+    helion_settings=helion.Settings(
+        autotune_baseline_fn=baseline,
+        ignore_warnings=[helion.exc.TensorOperationInWrapper],
+    ),
+)  # type: ignore[misc]
+def scaled_mm(
+    a: torch.Tensor,  # [M, K]
+    b: torch.Tensor,  # [K, N]
+    scale_a: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
+    scale_b: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
+    out_dtype: torch.dtype,
+    bias: torch.Tensor | None = None,  # [N]
+) -> torch.Tensor:
+    M, K = a.shape
+    N = b.shape[1]
+    hl.specialize(K)
+    hl.specialize(N)
+
+    assert N > 0 and K > 0 and M > 0
+    assert b.shape[0] == K
+    assert a.dtype == b.dtype
+    assert a.stride(1) == 1
+    assert b.stride(0) == 1
+
+    scale_a = scale_a.reshape(-1, 1) if scale_a.dim() <= 1 else scale_a
+    scale_b = scale_b.reshape(-1, 1) if scale_b.dim() <= 1 else scale_b
+
+    assert scale_a.dtype == scale_b.dtype and scale_a.is_floating_point()
+    assert scale_a.shape[1] == 1 and (scale_a.shape[0] == 1 or scale_a.shape[0] == M)
+    assert scale_b.shape[1] == 1 and (scale_b.shape[0] == 1 or scale_b.shape[0] == N)
+    hl.specialize(scale_b.shape[1])
+    assert out_dtype.is_floating_point
+
+    if bias is not None:
+        assert bias.numel() == N and bias.dtype == out_dtype
+
+    c = torch.empty((M, N), dtype=out_dtype, device=a.device)
+    acc_dtype = torch.float32 if a.is_floating_point() else torch.int32
+
+    for tile_m, tile_n in hl.tile([M, N]):
+        acc = hl.zeros([tile_m, tile_n], acc_dtype)
+        for tile_k in hl.tile(K):
+            acc = hl.dot(
+                a[tile_m, tile_k],
+                b[tile_k, tile_n],
+                acc=acc,
+                out_dtype=acc_dtype,
+            )
+
+        acc = acc.to(torch.float32)
+        if scale_a.shape[0] == M:
+            scale_a_blk = scale_a[tile_m, :]
+        else:
+            scale_a_blk = scale_a[0, 0].expand(tile_m.block_size, 1)
+        acc = scale_a_blk * acc
+
+        if scale_b.shape[0] == N:
+            scale_b_blk = scale_b[tile_n, :]
+        else:
+            scale_b_blk = scale_b[0, 0].expand(tile_n.block_size, 1)
+        acc = scale_b_blk.T * acc
+
+        c_blk = acc.to(out_dtype)
+
+        if bias is not None:
+            c_blk += bias[tile_n]
+
+        c[tile_m, tile_n] = c_blk
+
+    return c

--- a/vllm/kernels/helion/ops/scaled_mm.py
+++ b/vllm/kernels/helion/ops/scaled_mm.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import torch
 
-from vllm import _custom_ops as ops
 from vllm.kernels.helion.case_key import CaseKey
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -28,30 +27,32 @@ logger = init_logger(__name__)
 
 
 def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
-    # TODO(xiaohongchen1991): it is difficult for kernel author to cover
-    # all input property combination. Currently, dtypes are fixed. We need
-    # optimization to bucket/skip some combinations
-    m_size_list = [1, 2, 4, 8, 16, 32, 64, 128]
+    # The Helion linear kernel is autotuned per shape.
+    # m_size_list follows cudagraph_capture_sizes pattern:
+    # [1, 2, 4] + range(8, 256, 8) + range(256, max_graph_size + 1, 16),
+    # but is capped here to cover only small M values.
+    m_size_list = [1, 2, 4, 8, 16, 24, 32]
     b_shape_list = [
-        # Qwen3-1.7B
+        # qwen3-1.7B
         # TP=1
         (2048, 4096),
         (2048, 2048),
         (2048, 12288),
         (6144, 2048),
-        # Qwen3-8B
+        # qwen3-8B
         # TP=1
         (4096, 6144),
         (4096, 4096),
         (4096, 24576),
         (12288, 4096),
-        # Qwen3-32B
+        # qwen3-32B
         # TP=1
         (5120, 10240),
-        (5120, 5120),
+        (8192, 5120),
         (5120, 51200),
         (25600, 5120),
     ]
+    has_bias = False
 
     in_dtype: torch.dtype = current_platform.fp8_dtype()
     scale_dtype: torch.dtype = torch.float32
@@ -66,18 +67,18 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
             in_dtype
         )
         b = b.t()
-        scale_a = 0.5 + torch.rand((M, 1), dtype=scale_dtype, device="cuda")
-        scale_b = 0.5 + torch.rand((N, 1), dtype=scale_dtype, device="cuda")
-        bias = 0.5 * (torch.rand(N, dtype=out_dtype, device="cuda") - 0.5)
-
-        config_key = CaseKey(
-            {
-                "K": K,
-                "N": N,
-                "M": M,
-            }
+        out = torch.empty((M, N), dtype=out_dtype, device=a.device)
+        a_scales = 0.5 + torch.rand((1, M), dtype=scale_dtype, device="cuda")
+        a_scales = a_scales.t()
+        b_scales = 0.5 + torch.rand((N, 1), dtype=scale_dtype, device="cuda")
+        bias = (
+            0.5 * (torch.rand(N, dtype=out_dtype, device="cuda") - 0.5)
+            if has_bias
+            else None
         )
-        inputs[config_key] = (a, b, scale_a, scale_b, out_dtype, bias)
+
+        config_key = CaseKey({"K": K, "N": N, "M": M})
+        inputs[config_key] = (out, a, b, a_scales, b_scales, bias)
 
     return inputs
 
@@ -87,35 +88,33 @@ _pick_cache: dict[tuple[int, int, int], CaseKey | None] = {}
 
 def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | None:
     """Pick the best pre-tuned config for the given input shape.
-    Selection strategy:
-      1. Find the closest K among available configs
-         (exact match preferred).
-      2. Find the closest N among available configs
-         (exact match preferred).
-      3. Among the M values tuned for that K and N, pick
-         the smallest M >= the input's M. If the input is
-         larger than all available Ms, fall back to the largest.
+
+    K/N are picked by closest match. M is bucketed to the smallest tuned
+    M >= runtime M.
     """
 
     if not config_keys:
         return None
 
-    a, b, *_ = args
+    out, a, b, *_ = args
+
     M, K = a.shape
     N = b.shape[1]
 
     cache_key = (M, K, N)
-    cached = _pick_cache.get(cache_key)
-    if cached is not None:
-        return cached
+    if cache_key in _pick_cache:
+        return _pick_cache[cache_key]
 
     configs: dict[int, dict[int, list[int]]] = {}
     for key in config_keys:
         if key.is_default():
             continue
-        configs.setdefault(key["K"], {}).setdefault(key["N"], []).append(key["M"])
+
+        if all(k in key for k in ("K", "N", "M")):
+            configs.setdefault(key["K"], {}).setdefault(key["N"], []).append(key["M"])
 
     if not configs:
+        _pick_cache[cache_key] = None
         return None
 
     best_K = min(configs, key=lambda s: abs(s - K))
@@ -135,51 +134,68 @@ def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | 
 
 
 def fake_impl(
+    out: torch.Tensor,  # [M, N]
     a: torch.Tensor,  # [M, K]
     b: torch.Tensor,  # [K, N]
-    scale_a: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
-    scale_b: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
-    out_dtype: torch.dtype,
+    a_scales: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
+    b_scales: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
     bias: torch.Tensor | None = None,  # [N]
-) -> torch.Tensor:
-    M = a.shape[0]
-    N = b.shape[1]
-    c = torch.empty((M, N), dtype=out_dtype, device=a.device)
-    return c
+) -> None:
+    return
 
 
 def baseline(
+    out: torch.Tensor,  # [M, N]
     a: torch.Tensor,  # [M, K]
     b: torch.Tensor,  # [K, N]
-    scale_a: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
-    scale_b: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
-    out_dtype: torch.dtype,
+    a_scales: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
+    b_scales: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
     bias: torch.Tensor | None = None,  # [N]
-) -> torch.Tensor:
-    return ops.cutlass_scaled_mm(
-        a, b, out_dtype=out_dtype, scale_a=scale_a, scale_b=scale_b, bias=bias
-    )
+) -> None:
+    c = torch.mm(a.to(torch.float32), b.to(torch.float32))
+    c = a_scales * c
+    c = b_scales.T * c
+    c = c.to(out.dtype)
+    if bias is not None:
+        c = c + bias
+
+    out.copy_(c)
 
 
-# Overwrite autotune_baseline_atol and autotune_baseline_rtol
-# if too many configs failed due to baseline check during autotuning
+# TODO(xiaohongchen1991):
+# 1. Remove ProcessGroupNameNotFound from ignore_warning after fix for
+# https://github.com/pytorch/helion/issues/3024 is available in vLLM
+# 2. Conditionally use SwapAB trick when the fix for
+# https://github.com/pytorch/helion/issues/3044 is available in vLLM
+
+
+# Quantized GEMM kernels can have relatively large numerical differences
+# from the baseline.
+# Override autotune_baseline_atol and autotune_baseline_rtol to prevent
+# excessive config failures from baseline accuracy checks during autotuning.
 @register_kernel(
+    mutates_args=["out"],
     config_picker=pick_config,
     input_generator=generate_inputs,
     fake_impl=fake_impl,
     helion_settings=helion.Settings(
         autotune_baseline_fn=baseline,
-        ignore_warnings=[helion.exc.TensorOperationInWrapper],
+        autotune_baseline_atol=1e-1,
+        autotune_baseline_rtol=1e-1,
+        ignore_warnings=[
+            helion.exc.TensorOperationInWrapper,
+            helion.exc.ProcessGroupNameNotFound,
+        ],
     ),
 )  # type: ignore[misc]
 def scaled_mm(
+    out: torch.Tensor,  # [M, N]
     a: torch.Tensor,  # [M, K]
     b: torch.Tensor,  # [K, N]
-    scale_a: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
-    scale_b: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
-    out_dtype: torch.dtype,
+    a_scales: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
+    b_scales: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
     bias: torch.Tensor | None = None,  # [N]
-) -> torch.Tensor:
+) -> None:
     M, K = a.shape
     N = b.shape[1]
     hl.specialize(K)
@@ -191,49 +207,50 @@ def scaled_mm(
     assert a.stride(1) == 1
     assert b.stride(0) == 1
 
-    scale_a = scale_a.reshape(-1, 1) if scale_a.dim() <= 1 else scale_a
-    scale_b = scale_b.reshape(-1, 1) if scale_b.dim() <= 1 else scale_b
+    a_scales = a_scales.reshape(-1, 1) if a_scales.dim() <= 1 else a_scales
+    b_scales = b_scales.reshape(-1, 1) if b_scales.dim() <= 1 else b_scales
 
-    assert scale_a.dtype == scale_b.dtype and scale_a.is_floating_point()
-    assert scale_a.shape[1] == 1 and (scale_a.shape[0] == 1 or scale_a.shape[0] == M)
-    assert scale_b.shape[1] == 1 and (scale_b.shape[0] == 1 or scale_b.shape[0] == N)
-    hl.specialize(scale_b.shape[1])
+    assert a_scales.dtype == b_scales.dtype and a_scales.is_floating_point()
+    assert a_scales.shape[1] == 1 and (a_scales.shape[0] == 1 or a_scales.shape[0] == M)
+    assert b_scales.shape[1] == 1 and (b_scales.shape[0] == 1 or b_scales.shape[0] == N)
+    hl.specialize(b_scales.shape[1])
+
+    out_dtype = out.dtype
     assert out_dtype.is_floating_point
-
     if bias is not None:
         assert bias.numel() == N and bias.dtype == out_dtype
 
-    c = torch.empty((M, N), dtype=out_dtype, device=a.device)
     acc_dtype = torch.float32 if a.is_floating_point() else torch.int32
 
     for tile_m, tile_n in hl.tile([M, N]):
-        acc = hl.zeros([tile_m, tile_n], acc_dtype)
+        acc = hl.zeros([tile_n, tile_m], acc_dtype)
         for tile_k in hl.tile(K):
+            a_blk = hl.load(a, [tile_m.index[None, :], tile_k.index[:, None]])
+            b_blk = hl.load(b, [tile_k.index[None, :], tile_n.index[:, None]])
             acc = hl.dot(
-                a[tile_m, tile_k],
-                b[tile_k, tile_n],
+                b_blk,
+                a_blk,
                 acc=acc,
                 out_dtype=acc_dtype,
             )
 
-        acc = acc.to(torch.float32)
-        if scale_a.shape[0] == M:
-            scale_a_blk = scale_a[tile_m, :]
-        else:
-            scale_a_blk = scale_a[0, 0].expand(tile_m.block_size, 1)
-        acc = scale_a_blk * acc
+        acc = acc.t().to(torch.float32)
 
-        if scale_b.shape[0] == N:
-            scale_b_blk = scale_b[tile_n, :]
+        if a_scales.shape[0] == M:
+            a_scales_blk = a_scales[tile_m, :]
         else:
-            scale_b_blk = scale_b[0, 0].expand(tile_n.block_size, 1)
-        acc = scale_b_blk.T * acc
+            a_scales_blk = a_scales[0, 0].expand(tile_m.block_size, 1)
+        acc = a_scales_blk * acc
 
-        c_blk = acc.to(out_dtype)
+        if b_scales.shape[0] == N:
+            b_scales_blk = b_scales[tile_n, :]
+        else:
+            b_scales_blk = b_scales[0, 0].expand(tile_n.block_size, 1)
+        acc = b_scales_blk.T * acc
+
+        out_blk = acc.to(out_dtype)
 
         if bias is not None:
-            c_blk += bias[tile_n]
+            out_blk += bias[tile_n]
 
-        c[tile_m, tile_n] = c_blk
-
-    return c
+        out[tile_m, tile_n] = out_blk

--- a/vllm/kernels/helion/ops/scaled_mm.py
+++ b/vllm/kernels/helion/ops/scaled_mm.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+from itertools import product
+from typing import Any
+
+import torch
+
+from vllm.kernels.helion.case_key import CaseKey
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    raise ImportError(
+        "Helion kernel requires helion to be installed. "
+        "Install it with: pip install helion"
+    )
+
+import helion
+import helion.language as hl
+from helion.autotuner import BooleanFragment, PowerOfTwoFragment
+
+from vllm.kernels.helion.register import register_kernel
+
+logger = init_logger(__name__)
+
+
+def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
+    # The Helion linear kernel is autotuned per shape.
+    # m_size_list follows cudagraph_capture_sizes pattern:
+    # [1, 2, 4] + range(8, 256, 8) + range(256, max_graph_size + 1, 16),
+    # but is capped here to cover only small M values.
+    m_size_list = [1, 2, 4, 8, 16, 24, 32]
+
+    fp8: torch.dtype = current_platform.fp8_dtype()
+    int8: torch.dtype = torch.int8
+
+    # Each entry maps a (K, N) weight shape to a single input dtype.
+    # Update this list to match your workload.
+    b_shape_dtype_list: list[tuple[tuple[int, int], torch.dtype]] = [
+        # Qwen3.8-27B shapes with TP=1,
+        # used as example placeholders.
+        ((5120, 14336), fp8),
+        ((6144, 5120), fp8),
+        ((5120, 16384), fp8),
+        ((5120, 34816), fp8),
+        ((17408, 5120), fp8),
+        ((5120, 14336), int8),
+        ((6144, 5120), int8),
+        ((5120, 16384), int8),
+        ((5120, 34816), int8),
+        ((17408, 5120), int8),
+    ]
+
+    has_bias = False
+
+    scale_dtype: torch.dtype = torch.float32
+    out_dtype: torch.dtype = torch.bfloat16
+    inputs = {}
+    for M, ((K, N), in_dtype) in product(m_size_list, b_shape_dtype_list):
+        scale = 1.0 / math.sqrt(K)
+        if in_dtype.is_floating_point:
+            a = (
+                scale * (0.5 + torch.rand(M, K, dtype=torch.float32, device="cuda"))
+            ).to(in_dtype)
+            b = (
+                scale * (0.5 + torch.rand(N, K, dtype=torch.float32, device="cuda"))
+            ).to(in_dtype)
+        else:
+            a = torch.randint(-4, 32, (M, K), dtype=in_dtype, device="cuda")
+            b = torch.randint(-4, 32, (N, K), dtype=in_dtype, device="cuda")
+        b = b.t()
+        out = torch.empty((M, N), dtype=out_dtype, device=a.device)
+        a_scales = 0.5 + torch.rand((1, M), dtype=scale_dtype, device="cuda")
+        a_scales = a_scales.t()
+        b_scales = 0.5 + torch.rand((N, 1), dtype=scale_dtype, device="cuda")
+        bias = (
+            0.5 * (torch.rand(N, dtype=out_dtype, device="cuda") - 0.5)
+            if has_bias
+            else None
+        )
+
+        config_key = CaseKey({"K": K, "N": N, "M": M, "in_dtype": str(in_dtype)})
+        inputs[config_key] = (out, a, b, a_scales, b_scales, bias)
+
+    return inputs
+
+
+_pick_cache: dict[tuple[int, int, int, str], CaseKey | None] = {}
+
+
+def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | None:
+    """Pick the best pre-tuned config for the given input shape.
+
+    Configs are matched within the runtime input dtype. K/N are picked by
+    closest match. M is bucketed to the smallest tuned M >= runtime M.
+    """
+
+    if not config_keys:
+        return None
+
+    out, a, b, *_ = args
+
+    M, K = a.shape
+    N = b.shape[1]
+    in_dtype = str(a.dtype)
+
+    cache_key = (M, K, N, in_dtype)
+    if cache_key in _pick_cache:
+        return _pick_cache[cache_key]
+
+    configs: dict[int, dict[int, list[int]]] = {}
+    for key in config_keys:
+        if key.is_default():
+            continue
+
+        if all(k in key for k in ("K", "N", "M", "in_dtype")):
+            if "in_dtype" not in key or key["in_dtype"] != in_dtype:
+                continue
+            configs.setdefault(key["K"], {}).setdefault(key["N"], []).append(key["M"])
+
+    if not configs:
+        _pick_cache[cache_key] = None
+        return None
+
+    best_K = min(configs, key=lambda s: abs(s - K))
+    best_N = min(configs[best_K], key=lambda s: abs(s - N))
+    available_M = sorted(configs[best_K][best_N])
+    best_M = next((m for m in available_M if m >= M), available_M[-1])
+
+    result = CaseKey(
+        {
+            "K": best_K,
+            "N": best_N,
+            "M": best_M,
+            "in_dtype": in_dtype,
+        }
+    )
+    _pick_cache[cache_key] = result
+    return result
+
+
+def fake_impl(
+    out: torch.Tensor,  # [M, N]
+    a: torch.Tensor,  # [M, K]
+    b: torch.Tensor,  # [K, N]
+    a_scales: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
+    b_scales: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
+    bias: torch.Tensor | None = None,  # [N]
+) -> None:
+    return
+
+
+def baseline(
+    out: torch.Tensor,  # [M, N]
+    a: torch.Tensor,  # [M, K]
+    b: torch.Tensor,  # [K, N]
+    a_scales: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
+    b_scales: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
+    bias: torch.Tensor | None = None,  # [N]
+) -> None:
+    c = torch.mm(a.to(torch.float32), b.to(torch.float32))
+    c = a_scales * c
+    c = b_scales.T * c
+    c = c.to(out.dtype)
+    if bias is not None:
+        c = c + bias
+
+    out.copy_(c)
+
+
+# Quantized GEMM kernels can have relatively large numerical differences
+# from the baseline.
+# Override autotune_baseline_atol and autotune_baseline_rtol to prevent
+# excessive config failures from baseline accuracy checks during autotuning.
+@register_kernel(
+    mutates_args=["out"],
+    config_picker=pick_config,
+    input_generator=generate_inputs,
+    fake_impl=fake_impl,
+    use_variant_config=True,
+    helion_settings=helion.Settings(
+        autotune_baseline_fn=baseline,
+        autotune_baseline_atol=1e-1,
+        autotune_baseline_rtol=1e-1,
+        ignore_warnings=[
+            helion.exc.TensorOperationInWrapper,
+            helion.exc.ProcessGroupNameNotFound,
+        ],
+    ),
+)
+def scaled_mm(
+    out: torch.Tensor,  # [M, N]
+    a: torch.Tensor,  # [M, K]
+    b: torch.Tensor,  # [K, N]
+    a_scales: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
+    b_scales: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
+    bias: torch.Tensor | None = None,  # [N]
+) -> None:
+    M, K = a.shape
+    N = b.shape[1]
+    hl.specialize(K)
+    hl.specialize(N)
+
+    assert N > 0 and K > 0 and M > 0
+    assert b.shape[0] == K
+    assert a.dtype == b.dtype
+    assert a.stride(1) == 1
+    assert b.stride(0) == 1
+
+    a_scales = a_scales.reshape(-1, 1) if a_scales.dim() <= 1 else a_scales
+    b_scales = b_scales.reshape(-1, 1) if b_scales.dim() <= 1 else b_scales
+
+    assert a_scales.dtype == b_scales.dtype and a_scales.is_floating_point()
+    assert a_scales.shape[1] == 1 and (a_scales.shape[0] == 1 or a_scales.shape[0] == M)
+    assert b_scales.shape[1] == 1 and (b_scales.shape[0] == 1 or b_scales.shape[0] == N)
+    hl.specialize(b_scales.shape[1])
+
+    out_dtype = out.dtype
+    assert out_dtype.is_floating_point
+    if bias is not None:
+        assert bias.numel() == N and bias.dtype == out_dtype
+
+    acc_dtype = torch.float32 if a.is_floating_point() else torch.int32
+
+    split_k = hl.register_tunable("split_k", PowerOfTwoFragment(1, 256))
+    k_block_size = helion.next_power_of_2(helion.cdiv(K, split_k))
+    if split_k > 1:
+        out.zero_()
+
+    swap_ab = hl.register_tunable("swap_ab", BooleanFragment())
+
+    for tile_m, tile_n, outer_k in hl.tile(
+        [M, N, K], block_size=[None, None, k_block_size]
+    ):
+        acc = hl.zeros([tile_m, tile_n], acc_dtype)
+        acc_t = acc.t()
+        for tile_k in hl.tile(outer_k.begin, outer_k.end):
+            if swap_ab:
+                a_blk = hl.load(a, [tile_m.index[None, :], tile_k.index[:, None]])
+                b_blk = hl.load(b, [tile_k.index[None, :], tile_n.index[:, None]])
+                acc_t = hl.dot(
+                    b_blk,
+                    a_blk,
+                    acc=acc_t,
+                    out_dtype=acc_dtype,
+                )
+            else:
+                acc = hl.dot(
+                    a[tile_m, tile_k],
+                    b[tile_k, tile_n],
+                    acc=acc,
+                    out_dtype=acc_dtype,
+                )
+
+        if swap_ab:  # noqa: SIM108
+            acc = acc_t.t().to(torch.float32)
+        else:
+            acc = acc.to(torch.float32)
+
+        if a_scales.shape[0] == M:
+            a_scales_blk = a_scales[tile_m, :]
+        else:
+            a_scales_blk = a_scales[0, 0].expand(tile_m.block_size, 1)
+        acc = a_scales_blk * acc
+
+        if b_scales.shape[0] == N:
+            b_scales_blk = b_scales[tile_n, :]
+        else:
+            b_scales_blk = b_scales[0, 0].expand(tile_n.block_size, 1)
+        acc = b_scales_blk.T * acc
+
+        out_blk = acc.to(out_dtype)
+
+        if bias is not None:  # noqa: SIM102
+            if outer_k.begin == 0:
+                out_blk += bias[tile_n]
+
+        if split_k == 1:
+            out[tile_m, tile_n] = out_blk
+        else:
+            hl.atomic_add(out, [tile_m, tile_n], out_blk)

--- a/vllm/kernels/helion/ops/scaled_mm.py
+++ b/vllm/kernels/helion/ops/scaled_mm.py
@@ -32,40 +32,106 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
     # [1, 2, 4] + range(8, 256, 8) + range(256, max_graph_size + 1, 16),
     # but is capped here to cover only small M values.
     m_size_list = [1, 2, 4, 8, 16, 24, 32]
-    b_shape_list = [
+
+    fp8: torch.dtype = current_platform.fp8_dtype()
+    int8: torch.dtype = torch.int8
+
+    # Each entry maps a (K, N) weight shape to a single input dtype.
+    b_shape_dtype_list: list[tuple[tuple[int, int], torch.dtype]] = [
         # qwen3-1.7B
         # TP=1
-        (2048, 4096),
-        (2048, 2048),
-        (2048, 12288),
-        (6144, 2048),
+        ((2048, 4096), fp8),
+        ((2048, 2048), fp8),
+        ((2048, 12288), fp8),
+        ((6144, 2048), fp8),
+        # qwen3-4B
+        # TP=1
+        ((2560, 6144), fp8),
+        ((4096, 2560), fp8),
+        ((2560, 19456), fp8),
+        ((9728, 2560), fp8),
+        ((2560, 6144), int8),
+        ((4096, 2560), int8),
+        ((2560, 19456), int8),
+        ((9728, 2560), int8),
         # qwen3-8B
         # TP=1
-        (4096, 6144),
-        (4096, 4096),
-        (4096, 24576),
-        (12288, 4096),
+        ((4096, 6144), fp8),
+        ((4096, 4096), fp8),
+        ((4096, 24576), fp8),
+        ((12288, 4096), fp8),
+        # qwen3-14B
+        # TP=1
+        ((5120, 7168), fp8),
+        ((5120, 5120), fp8),
+        ((5120, 34816), fp8),
+        ((17408, 5120), fp8),
         # qwen3-32B
         # TP=1
-        (5120, 10240),
-        (8192, 5120),
-        (5120, 51200),
-        (25600, 5120),
+        ((5120, 10240), fp8),
+        ((8192, 5120), fp8),
+        ((5120, 51200), fp8),
+        ((25600, 5120), fp8),
+        ((5120, 10240), int8),
+        ((8192, 5120), int8),
+        ((5120, 51200), int8),
+        ((25600, 5120), int8),
+        # TP=2
+        ((5120, 5120), fp8),
+        ((4096, 5120), fp8),
+        ((5120, 25600), fp8),
+        ((12800, 5120), fp8),
+        ((5120, 5120), int8),
+        ((4096, 5120), int8),
+        ((5120, 25600), int8),
+        ((12800, 5120), int8),
+        # llama3.1-8B
+        # TP=1
+        ((4096, 28672), fp8),
+        ((14336, 4096), fp8),
+        ((4096, 6144), int8),
+        ((4096, 4096), int8),
+        ((4096, 28672), int8),
+        ((14336, 4096), int8),
+        # llama3.3-70B
+        # TP=2
+        ((8192, 5120), fp8),
+        ((4096, 8192), fp8),
+        ((8192, 28672), fp8),
+        ((14336, 8192), fp8),
+        ((8192, 5120), int8),
+        ((4096, 8192), int8),
+        ((8192, 28672), int8),
+        ((14336, 8192), int8),
+        # mistral-24B
+        # TP=1
+        ((5120, 6144), fp8),
+        ((4096, 5120), fp8),
+        ((5120, 65536), fp8),
+        ((32768, 5120), fp8),
+        # TP=2
+        ((5120, 3072), fp8),
+        ((2048, 5120), fp8),
+        ((5120, 32768), fp8),
+        ((16384, 5120), fp8),
     ]
     has_bias = False
 
-    in_dtype: torch.dtype = current_platform.fp8_dtype()
     scale_dtype: torch.dtype = torch.float32
     out_dtype: torch.dtype = torch.bfloat16
     inputs = {}
-    for M, (K, N) in product(m_size_list, b_shape_list):
+    for M, ((K, N), in_dtype) in product(m_size_list, b_shape_dtype_list):
         scale = 1.0 / math.sqrt(K)
-        a = (scale * (0.5 + torch.rand(M, K, dtype=torch.float32, device="cuda"))).to(
-            in_dtype
-        )
-        b = (scale * (0.5 + torch.rand(N, K, dtype=torch.float32, device="cuda"))).to(
-            in_dtype
-        )
+        if in_dtype.is_floating_point:
+            a = (
+                scale * (0.5 + torch.rand(M, K, dtype=torch.float32, device="cuda"))
+            ).to(in_dtype)
+            b = (
+                scale * (0.5 + torch.rand(N, K, dtype=torch.float32, device="cuda"))
+            ).to(in_dtype)
+        else:
+            a = torch.randint(-32, 32, (M, K), dtype=in_dtype, device="cuda")
+            b = torch.randint(-32, 32, (N, K), dtype=in_dtype, device="cuda")
         b = b.t()
         out = torch.empty((M, N), dtype=out_dtype, device=a.device)
         a_scales = 0.5 + torch.rand((1, M), dtype=scale_dtype, device="cuda")
@@ -77,20 +143,20 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
             else None
         )
 
-        config_key = CaseKey({"K": K, "N": N, "M": M})
+        config_key = CaseKey({"K": K, "N": N, "M": M, "in_dtype": str(in_dtype)})
         inputs[config_key] = (out, a, b, a_scales, b_scales, bias)
 
     return inputs
 
 
-_pick_cache: dict[tuple[int, int, int], CaseKey | None] = {}
+_pick_cache: dict[tuple[int, int, int, str], CaseKey | None] = {}
 
 
 def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | None:
     """Pick the best pre-tuned config for the given input shape.
 
-    K/N are picked by closest match. M is bucketed to the smallest tuned
-    M >= runtime M.
+    Configs are matched within the runtime input dtype. K/N are picked by
+    closest match. M is bucketed to the smallest tuned M >= runtime M.
     """
 
     if not config_keys:
@@ -100,8 +166,9 @@ def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | 
 
     M, K = a.shape
     N = b.shape[1]
+    in_dtype = str(a.dtype)
 
-    cache_key = (M, K, N)
+    cache_key = (M, K, N, in_dtype)
     if cache_key in _pick_cache:
         return _pick_cache[cache_key]
 
@@ -110,7 +177,9 @@ def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | 
         if key.is_default():
             continue
 
-        if all(k in key for k in ("K", "N", "M")):
+        if all(k in key for k in ("K", "N", "M", "in_dtype")):
+            if "in_dtype" not in key or key["in_dtype"] != in_dtype:
+                continue
             configs.setdefault(key["K"], {}).setdefault(key["N"], []).append(key["M"])
 
     if not configs:
@@ -127,6 +196,7 @@ def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | 
             "K": best_K,
             "N": best_N,
             "M": best_M,
+            "in_dtype": in_dtype,
         }
     )
     _pick_cache[cache_key] = result

--- a/vllm/kernels/helion/register.py
+++ b/vllm/kernels/helion/register.py
@@ -152,11 +152,13 @@ class ConfiguredHelionKernel:
         config_picker: ConfigPicker | None,
         raw_kernel_func: Callable,
         helion_settings: helion.Settings | None = None,
+        use_variant_config: bool = False,
     ):
         self.op_name = op_name
         self.config_picker = config_picker
         self.raw_kernel_func = raw_kernel_func
         self.helion_settings = helion_settings
+        self.use_variant_config = use_variant_config
         self._decorated_kernel = self._create_decorated_kernel()
 
     def __call__(self, *args, **kwargs):
@@ -218,9 +220,9 @@ class ConfiguredHelionKernel:
 
     def _load_platform_configs(self) -> None:
         from vllm.kernels.helion.config_manager import ConfigManager
-        from vllm.kernels.helion.utils import get_canonical_gpu_name
+        from vllm.kernels.helion.utils import get_config_gpu_name
 
-        self.platform = get_canonical_gpu_name()
+        self.platform = get_config_gpu_name(self.use_variant_config)
         config_manager = ConfigManager()
         self.configs = config_manager.get_platform_configs(self.op_name, self.platform)
 
@@ -263,6 +265,7 @@ class HelionKernelWrapper:
         mutates_args: list[str] | None = None,
         helion_settings: helion.Settings | None = None,
         input_generator: (Callable[[], dict[CaseKey, tuple[Any, ...]]] | None) = None,
+        use_variant_config: bool = False,
     ):
         # Validate helion_settings doesn't conflict with our custom autotuner
         validate_helion_settings(helion_settings, op_name)
@@ -274,6 +277,7 @@ class HelionKernelWrapper:
         self._config_picker = config_picker
         self._input_generator = input_generator
         self._mutates_args = mutates_args
+        self.use_variant_config = use_variant_config
         self._configured_kernel: ConfiguredHelionKernel | None = None
         # TODO(@gmagogsfm): Remove this disable flag once integrated with vLLM IR,
         # which handles op enablement/disablement.
@@ -346,6 +350,7 @@ class HelionKernelWrapper:
                 config_picker=self._config_picker,
                 raw_kernel_func=self.raw_kernel_func,
                 helion_settings=self.helion_settings,
+                use_variant_config=self.use_variant_config,
             )
         return self._configured_kernel
 
@@ -407,6 +412,7 @@ def register_kernel(
     mutates_args: list[str] | None = None,
     helion_settings: helion.Settings | None = None,
     input_generator: (Callable[[], dict[CaseKey, tuple[Any, ...]]] | None) = None,
+    use_variant_config: bool = False,
 ) -> Callable[[Callable], HelionKernelWrapper]:
     """Register a Helion kernel with pre-tuned config selection.
 
@@ -434,6 +440,12 @@ def register_kernel(
                         "4096": (torch.randn(4096, device="cuda"), 0.5),
                         "8192": (torch.randn(8192, device="cuda"), 0.5),
                     }
+
+        use_variant_config: Optional. When ``True``, configs are
+            looked up by the variant-specific GPU name (e.g.
+            ``nvidia_h100_pcie``) instead of the canonical name shared by all
+            variants (e.g. ``nvidia_h100``). Defaults to ``False``, which
+            preserves the canonical-name lookup used by most kernels.
     """
 
     def decorator(kernel_func: Callable) -> HelionKernelWrapper:
@@ -461,6 +473,7 @@ def register_kernel(
             mutates_args=mutates_args,
             helion_settings=helion_settings,
             input_generator=input_generator,
+            use_variant_config=use_variant_config,
         )
 
         _REGISTERED_KERNELS[final_op_name] = kernel_wrapper

--- a/vllm/kernels/helion/utils.py
+++ b/vllm/kernels/helion/utils.py
@@ -59,6 +59,19 @@ def get_gpu_name(device_id: int | None = None) -> str:
     return current_platform.get_device_name(device_id)
 
 
+def normalize_gpu_name(name: str) -> str:
+    """
+    Normalize a GPU name to lowercase underscore form, preserving variant
+    suffixes (i.e. without applying _GPU_NAME_ALIASES).
+
+    e.g., "NVIDIA H100 80GB HBM3" -> "nvidia_h100_80gb_hbm3"
+          "NVIDIA A100-SXM4-80GB" -> "nvidia_a100_sxm4_80gb"
+    """
+    if not name or not name.strip():
+        raise ValueError("GPU name cannot be empty")
+    return re.sub(r"[\s/-]+", "_", name.lower())
+
+
 def canonicalize_gpu_name(name: str) -> str:
     """
     Canonicalize GPU name for use as a platform identifier.
@@ -69,16 +82,15 @@ def canonicalize_gpu_name(name: str) -> str:
           "NVIDIA A100-SXM4-80GB" -> "nvidia_a100"
           "AMD Instinct MI300X"   -> "amd_instinct_mi300x"
     """
-    if not name or not name.strip():
-        raise ValueError("GPU name cannot be empty")
-    name = re.sub(r"[\s/-]+", "_", name.lower())
-    if name in _GPU_NAME_ALIASES:
-        return _GPU_NAME_ALIASES[name]
-    return name
+    name = normalize_gpu_name(name)
+    return _GPU_NAME_ALIASES.get(name, name)
 
 
-def get_canonical_gpu_name(device_id: int | None = None) -> str:
-    return canonicalize_gpu_name(get_gpu_name(device_id))
+def get_config_gpu_name(keep_variant: bool, device_id: int | None = None) -> str:
+    if keep_variant:
+        return normalize_gpu_name(get_gpu_name(device_id))
+    else:
+        return canonicalize_gpu_name(get_gpu_name(device_id))
 
 
 def get_fp8_dtype() -> torch.dtype:

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -166,6 +166,9 @@ from vllm.model_executor.kernels.linear.scaled_mm.flashinfer import (
     FlashInferFp8DeepGEMMDynamicBlockScaledKernel,
     FlashInferFP8ScaledMMLinearKernel,
 )
+from vllm.model_executor.kernels.linear.scaled_mm.helion import (
+    HelionFP8ScaledMMLinearKernel,
+)
 from vllm.model_executor.kernels.linear.scaled_mm.humming import (
     HummingFP8ScaledMMLinearKernel,
     HummingInt8ScaledMMLinearKernel,
@@ -261,6 +264,9 @@ _LINEAR_BACKEND_KERNEL_MAP: dict[str, set[type]] = {
         TritonFp8BlockScaledMMKernel,
         TritonW4A16LinearKernel,
     },
+    "helion": {
+        HelionFP8ScaledMMLinearKernel,
+    },
     "deep_gemm": {
         DeepGemmFp8BlockScaledMMKernel,
     },
@@ -327,6 +333,7 @@ _POSSIBLE_FP8_KERNELS: dict[PlatformEnum, list[type[FP8ScaledMMLinearKernel]]] =
         MarlinFP8ScaledMMLinearKernel,
         FlashInferFP8ScaledMMLinearKernel,
         CutlassFP8ScaledMMLinearKernel,
+        HelionFP8ScaledMMLinearKernel,
         PerTensorTorchFP8ScaledMMLinearKernel,
         ChannelWiseTorchFP8ScaledMMLinearKernel,
         HummingFP8ScaledMMLinearKernel,
@@ -1050,6 +1057,7 @@ __all__ = [
     "AiterInt8ScaledMMLinearKernel",
     "CPUInt8ScaledMMLinearKernel",
     "CutlassFP8ScaledMMLinearKernel",
+    "HelionFP8ScaledMMLinearKernel",
     "CutlassInt8ScaledMMLinearKernel",
     "FlashInferFP8ScaledMMLinearKernel",
     "ChannelWiseTorchFP8ScaledMMLinearKernel",

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -193,6 +193,9 @@ from vllm.model_executor.kernels.linear.scaled_mm.flashinfer import (
     FlashInferFp8DeepGEMMDynamicBlockScaledKernel,
     FlashInferFP8ScaledMMLinearKernel,
 )
+from vllm.model_executor.kernels.linear.scaled_mm.helion import (
+    HelionFP8ScaledMMLinearKernel,
+)
 from vllm.model_executor.kernels.linear.scaled_mm.humming import (
     HummingFP8ScaledMMLinearKernel,
     HummingInt8ScaledMMLinearKernel,
@@ -297,6 +300,9 @@ _LINEAR_BACKEND_KERNEL_MAP: dict[str, set[type]] = {
         TritonFp8BlockScaledMMKernel,
         TritonW4A16LinearKernel,
     },
+    "helion": {
+        HelionFP8ScaledMMLinearKernel,
+    },
     "deep_gemm": {
         DeepGemmFp8BlockScaledMMKernel,
     },
@@ -398,6 +404,7 @@ _POSSIBLE_FP8_KERNELS: dict[PlatformEnum, list[type[FP8ScaledMMLinearKernel]]] =
     PlatformEnum.CUDA: [
         FlashInferFP8ScaledMMLinearKernel,
         CutlassFP8ScaledMMLinearKernel,
+        HelionFP8ScaledMMLinearKernel,
         B12xTensorFP8ScaledMMLinearKernel,
         PerTensorTorchFP8ScaledMMLinearKernel,
         ChannelWiseTorchFP8ScaledMMLinearKernel,
@@ -1177,6 +1184,7 @@ __all__ = [
     "AiterInt8ScaledMMLinearKernel",
     "CPUInt8ScaledMMLinearKernel",
     "CutlassFP8ScaledMMLinearKernel",
+    "HelionFP8ScaledMMLinearKernel",
     "CutlassInt8ScaledMMLinearKernel",
     "FlashInferFP8ScaledMMLinearKernel",
     "ChannelWiseTorchFP8ScaledMMLinearKernel",

--- a/vllm/model_executor/kernels/linear/scaled_mm/helion.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/helion.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Sequence
+
+import torch
+
+import vllm.envs as envs
+from vllm.config import (
+    CUDAGraphMode,
+    get_current_vllm_config,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kFp8StaticTensorSym,
+)
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_helion
+
+from .cutlass import CutlassFP8ScaledMMLinearKernel
+from .ScaledMMLinearKernel import (
+    FP8ScaledMMLinearKernel,
+    FP8ScaledMMLinearLayerConfig,
+)
+
+# TODO(xiaohongchen1991):
+# Currently, Helion linear backend is only supported on Hopper.
+# The same threshold may not apply for other hardware types.
+# Need to generalize this threshold later on when supporting more hardwares.
+HELION_SCALED_MM_MAX_NUM_TOKENS = 32
+
+
+class HelionFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
+    """
+    Hybrid Helion / Cutlass FP8 scaled_mm kernel
+
+    Dispatches between Helion and CUTLASS based on the input batch size (M):
+    - Small batches: Use Helion.
+    - Large batches: use CUTLASS.
+
+    Restricting Helion to small batches:
+    - reduces autotuning time and config space
+    - avoids requiring large max_cudagraph_capture_size to cover all batch sizes
+    - focuses Helion on the batch sizes where it provides the most benefit.
+    """
+
+    def __init__(
+        self, c: FP8ScaledMMLinearLayerConfig, layer_param_names: Sequence[str]
+    ) -> None:
+        super().__init__(c, layer_param_names)
+        self.fallback: CutlassFP8ScaledMMLinearKernel = CutlassFP8ScaledMMLinearKernel(
+            c, layer_param_names
+        )
+        vllm_config = get_current_vllm_config().compilation_config
+        self.helion_max_num_tokens = min(
+            vllm_config.max_cudagraph_capture_size,
+            HELION_SCALED_MM_MAX_NUM_TOKENS,
+        )
+
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if not has_helion():
+            return False, "requires helion to be installed"
+
+        if not current_platform.is_cuda():
+            return False, "requires CUDA"
+
+        # TODO(xiaohongchen1991): support blackwell hardwares when CuteDSL
+        # backend supported by Helion
+        if not current_platform.is_device_capability(90):
+            return (
+                False,
+                "is only supported on SM90 (Hopper) architecture",
+            )
+
+        if envs.VLLM_BATCH_INVARIANT:
+            return False, "is not supported for batch invariant execution."
+
+        # Require CUDA graph capture and reply for Helion kernel
+        vllm_config = get_current_vllm_config()
+        compilation_config = vllm_config.compilation_config
+        if (
+            compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+            or compilation_config.max_cudagraph_capture_size == 0
+        ):
+            return False, "requires enabling CUDA Graph mode"
+
+        return True, None
+
+    @classmethod
+    def can_implement(cls, c: FP8ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:
+        # can_implement is called after is_supported.
+        # Place Helion kernel checks here to avoid unnecessary kernel registration
+        from vllm.kernels.helion.ops.scaled_mm import scaled_mm
+
+        # Helion kernel is disabled if no config exists for the hardware used.
+        if scaled_mm._disabled:
+            return False, f"op is disabled. {scaled_mm._disabled_reason}"
+
+        # Enable Helion only if pre-tuned configs cover all input shapes.
+        # (K, N) come from the weight; M ranges over the small-batch sizes
+        # Helion is dispatched for: cudagraph_capture_sizes capped by the
+        # Helion max (larger M falls back to CUTLASS).
+        N, K = c.weight_shape
+        in_dtype = str(current_platform.fp8_dtype())
+        compilation_config = get_current_vllm_config().compilation_config
+        helion_max_num_tokens = min(
+            compilation_config.max_cudagraph_capture_size,
+            HELION_SCALED_MM_MAX_NUM_TOKENS,
+        )
+        m_sizes = [
+            m
+            for m in compilation_config.cudagraph_capture_sizes
+            if m <= helion_max_num_tokens
+        ]
+
+        # Allow forcing Helion even without exact config coverage; pick_config
+        # falls back to the closest available config.
+        if envs.VLLM_HELION_LINEAR_SKIP_CONFIG_CHECK:
+            return True, None
+
+        configs = scaled_mm.get_configured_op().configs
+        tuned = {
+            (key["K"], key["N"], key["M"])
+            for key in configs
+            if not key.is_default()
+            and {"K", "N", "M", "in_dtype"} <= key.keys()
+            and key["in_dtype"] == in_dtype
+        }
+        missing = [M for M in m_sizes if (K, N, M) not in tuned]
+        # TODO(xiaohongchen1991): update the message to include the
+        # instruction to run autotune for the missing shapes.
+        if missing:
+            return (
+                False,
+                f"has no pre-tuned config for weight shape (K={K}, N={N}) "
+                f"with in_dtype={in_dtype} at M={missing}. Set "
+                f"VLLM_HELION_LINEAR_SKIP_CONFIG_CHECK=1 to run anyway with "
+                f"the closest available config",
+            )
+
+        return True, None
+
+    def input_quant_key(self) -> QuantKey | None:
+        """Only static per-tensor activation quantization is supported for external
+        quantization."""
+        if self.config.activation_quant_key == kFp8StaticTensorSym:
+            return kFp8StaticTensorSym
+        return None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self.fallback.process_weights_after_loading(layer)
+
+    def apply_scaled_mm(
+        self,
+        *,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        out_dtype: torch.dtype,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+        bias: torch.Tensor | None,
+        output_shape: list,
+    ) -> torch.Tensor:
+        padded_k, padded_n = B.shape
+        output_size = self.fallback.logical_output_size
+        assert output_size is not None
+        pad_k = padded_k - A.shape[1]
+        pad_n = padded_n - output_size
+
+        if pad_k > 0:
+            A = self.fallback._pad_to_alignment(A, dim=1, alignment=16)
+        if pad_n > 0 and bias is not None:
+            bias = self.fallback._pad_to_alignment(bias, dim=0, alignment=16)
+
+        cutlass_compatible_b = padded_k % 16 == 0 and padded_n % 16 == 0
+        if not cutlass_compatible_b:
+            from vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm import (  # noqa
+                triton_scaled_mm,
+            )
+
+            output = triton_scaled_mm(A, B, As, Bs, out_dtype, bias)
+        else:
+            output = torch.empty(
+                (A.shape[0], B.shape[1]), dtype=out_dtype, device=A.device
+            )
+
+            torch.ops._C.helion_cutlass_hybrid_scaled_mm(
+                output, A, B, As, Bs, bias, self.helion_max_num_tokens
+            )
+
+        if pad_n > 0:
+            output = output[..., :output_size].contiguous()
+
+        return output.view(*output_shape[:-1], output_size)

--- a/vllm/model_executor/kernels/linear/scaled_mm/helion.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/helion.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Sequence
+
+import torch
+
+import vllm.envs as envs
+from vllm.config import (
+    CUDAGraphMode,
+    get_current_vllm_config,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kFp8StaticTensorSym,
+)
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_helion
+
+from .cutlass import CutlassFP8ScaledMMLinearKernel
+from .ScaledMMLinearKernel import (
+    FP8ScaledMMLinearKernel,
+    FP8ScaledMMLinearLayerConfig,
+)
+
+logger = init_logger(__name__)
+
+# TODO(xiaohongchen1991):
+# Currently, Helion linear backend is only supported on Hopper.
+# The same threshold may not apply for other hardware types.
+# Need to generalize this threshold later on when supporting more hardwares.
+HELION_SCALED_MM_MAX_NUM_TOKENS = 32
+
+
+class HelionFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
+    """
+    Hybrid Helion / Cutlass FP8 scaled_mm kernel
+
+    Dispatches between Helion and CUTLASS based on the input batch size (M):
+    - Small batches: Use Helion.
+    - Large batches: use CUTLASS.
+
+    Restricting Helion to small batches:
+    - reduces autotuning time and config space
+    - avoids requiring large max_cudagraph_capture_size to cover all batch sizes
+    - focuses Helion on the batch sizes where it provides the most benefit.
+    """
+
+    def __init__(
+        self, c: FP8ScaledMMLinearLayerConfig, layer_param_names: Sequence[str]
+    ) -> None:
+        super().__init__(c, layer_param_names)
+        self.fallback: CutlassFP8ScaledMMLinearKernel = CutlassFP8ScaledMMLinearKernel(
+            c, layer_param_names
+        )
+        vllm_config = get_current_vllm_config().compilation_config
+        self.helion_max_num_tokens = min(
+            vllm_config.max_cudagraph_capture_size,
+            HELION_SCALED_MM_MAX_NUM_TOKENS,
+        )
+
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if not has_helion():
+            return False, "requires helion to be installed"
+
+        if not current_platform.is_cuda():
+            return False, "requires CUDA"
+
+        # TODO(xiaohongchen1991): support blackwell hardwares when CuteDSL
+        # backend supported by Helion
+        if not current_platform.is_device_capability(90):
+            return (
+                False,
+                "is only supported on SM90 (Hopper) architecture",
+            )
+
+        if envs.VLLM_BATCH_INVARIANT:
+            return False, "is not supported for batch invariant execution."
+
+        # Require CUDA graph capture and reply for Helion kernel
+        vllm_config = get_current_vllm_config()
+        compilation_config = vllm_config.compilation_config
+        if (
+            compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+            or compilation_config.max_cudagraph_capture_size == 0
+        ):
+            return False, "requires enabling CUDA Graph mode"
+
+        return True, None
+
+    @classmethod
+    def can_implement(cls, c: FP8ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:
+        # can_implement is called after is_supported.
+        # Place Helion kernel checks here to avoid unnecessary kernel registration
+        from vllm.kernels.helion.ops.scaled_mm import scaled_mm
+
+        # Helion kernel is disabled if no config exists for the hardware used.
+        if scaled_mm._disabled:
+            return False, f"op is disabled. {scaled_mm._disabled_reason}"
+
+        # Enable Helion only if pre-tuned configs cover all input shapes.
+        # (K, N) come from the weight; M ranges over the small-batch sizes
+        # Helion is dispatched for: cudagraph_capture_sizes capped by the
+        # Helion max (larger M falls back to CUTLASS).
+        N, K = c.weight_shape
+        in_dtype = str(current_platform.fp8_dtype())
+        compilation_config = get_current_vllm_config().compilation_config
+        helion_max_num_tokens = min(
+            compilation_config.max_cudagraph_capture_size,
+            HELION_SCALED_MM_MAX_NUM_TOKENS,
+        )
+        m_sizes = [
+            m
+            for m in compilation_config.cudagraph_capture_sizes
+            if m <= helion_max_num_tokens
+        ]
+
+        configs = scaled_mm.get_configured_op().configs
+        tuned = {
+            (key["K"], key["N"], key["M"])
+            for key in configs
+            if not key.is_default()
+            and {"K", "N", "M", "in_dtype"} <= key.keys()
+            and key["in_dtype"] == in_dtype
+        }
+        missing = [M for M in m_sizes if (K, N, M) not in tuned]
+
+        # Allow forcing Helion even without exact config coverage; pick_config
+        # falls back to the closest available config.
+        if envs.VLLM_HELION_LINEAR_SKIP_CONFIG_CHECK:
+            if missing:
+                logger.warning(
+                    "Helion scaled_mm has no pre-tuned config for weight shape "
+                    "(K=%s, N=%s) with in_dtype=%s at M=%s. Running anyway with "
+                    "the closest available config.",
+                    K,
+                    N,
+                    in_dtype,
+                    missing,
+                )
+            return True, None
+
+        if missing:
+            return (
+                False,
+                f"has no pre-tuned config for weight shape (K={K}, N={N}) "
+                f"with in_dtype={in_dtype} at M={missing}. Set "
+                f"VLLM_HELION_LINEAR_SKIP_CONFIG_CHECK=1 to run anyway with "
+                f"the closest available config",
+            )
+
+        return True, None
+
+    def input_quant_key(self) -> QuantKey | None:
+        """Only static per-tensor activation quantization is supported for external
+        quantization."""
+        if self.config.activation_quant_key == kFp8StaticTensorSym:
+            return kFp8StaticTensorSym
+        return None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self.fallback.process_weights_after_loading(layer)
+
+    def apply_scaled_mm(
+        self,
+        *,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        out_dtype: torch.dtype,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+        bias: torch.Tensor | None,
+        output_shape: list,
+    ) -> torch.Tensor:
+        padded_k, padded_n = B.shape
+        output_size = self.fallback.logical_output_size
+        assert output_size is not None
+        pad_k = padded_k - A.shape[1]
+        pad_n = padded_n - output_size
+
+        if pad_k > 0:
+            A = self.fallback._pad_to_alignment(A, dim=1, alignment=16)
+        if pad_n > 0 and bias is not None:
+            bias = self.fallback._pad_to_alignment(bias, dim=0, alignment=16)
+
+        cutlass_compatible_b = padded_k % 16 == 0 and padded_n % 16 == 0
+        if not cutlass_compatible_b:
+            from vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm import (  # noqa
+                triton_scaled_mm,
+            )
+
+            output = triton_scaled_mm(A, B, As, Bs, out_dtype, bias)
+        else:
+            output = torch.empty(
+                (A.shape[0], B.shape[1]), dtype=out_dtype, device=A.device
+            )
+
+            torch.ops._C.helion_cutlass_hybrid_scaled_mm(
+                output, A, B, As, Bs, bias, self.helion_max_num_tokens
+            )
+
+        if pad_n > 0:
+            output = output[..., :output_size].contiguous()
+
+        return output.view(*output_shape[:-1], output_size)


### PR DESCRIPTION
## Purpose
As described in the RFC, https://github.com/vllm-project/vllm/issues/46526, This PR introduces HelionFP8ScaledMMLinearKernel. The PR is stacked on top of https://github.com/vllm-project/vllm/pull/48889. 

### How it works
```
  ┌─ Is "HelionFP8ScaledMMLinearKernel" in VLLM_DISABLED_KERNELS? ─── YES ─▶ NOT Helion
  ▼ NO
  │
  ├─ is_supported():
  │   ├─ helion installed?                                 ── NO ─▶ NOT Helion ("requires helion")
  │   ├─ current_platform.is_cuda()?                        ── NO ─▶ NOT Helion ("requires CUDA")
  │   ├─ device_capability == 90 (Hopper SM90 EXACTLY)?     ── NO ─▶ NOT Helion (SM89/SM100/etc. rejected)
  │   └─ cudagraph_mode != NONE AND
  │      max_cudagraph_capture_size != 0?                   ── NO ─▶ NOT Helion ("requires CUDA Graph")
  │
  ▼ is_supported() = True
  │
  └─ can_implement(config):    [called AFTER is_supported]
      ├─ scaled_mm helion op enabled for this hardware?     ── NO ─▶ NOT Helion (op disabled, no HW config)
      │    (scaled_mm._disabled)
      │
      ├─ VLLM_HELION_LINEAR_SKIP_CONFIG_CHECK == 1?
      │    └─ YES ─▶ ✅ USE HELION (closest available config; skip coverage check)
      │
      └─ NO ─▶ pre-tuned config coverage check:
           Is there a pre-tuned config (K, N, M) for EVERY input shape?
           (K, N from weight_shape)
             ├─ NO                   ─▶ NOT Helion
             └─ YES (full coverage)  ─▶ ✅ USE HELION


  [RUNTIME DISPATCH]  (only reached once ✅ USE HELION above; inside apply_scaled_mm
                       → torch.ops._C.helion_cutlass_hybrid_scaled_mm)

  Given the selected kernel, per-call dispatch on batch size M:
      helion_max = self.helion_max_num_tokens
                 = min(max_cudagraph_capture_size, 32)   [HELION_SCALED_MM_MAX_NUM_TOKENS]

      ┌─ M <= helion_max ? ── YES ─▶ runs the HELION kernel
      └─ M >  helion_max ? ── YES ─▶ falls back to the CUTLASS kernel
```

## Test Plan
- Add/update unit test to cover the HelionFP8ScaledMMLinearKernel
- Run end-2-end perf benchmark 
- Run accuracy benchmark

## Test Result
### Environment
Python: 3.12.13
Pytorch: 2.11.0
Cuda: 13.0
Helion: 1.1.4 + commit from https://github.com/pytorch/helion/pull/3452
GPU: NVIDIA H100 80GB HBM3

### Unit test
All new/updated unit tests passed

### Performance benchmark
**Benchmark Setup**

Models used:
- AzatAI/Qwen3.8-27B-FP8-dynamic
- RedHatAI/Qwen3-1.7B-FP8-dynamic
- RedHatAI/Qwen3-4B-FP8-dynamic
- RedHatAI/Qwen3-8B-FP8-dynamic
- RedHatAI/Qwen3-14B-FP8-dynamic
- RedHatAI/Qwen3-32B-FP8-dynamic

Server startup:
```
python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/Qwen3-8B-FP8-dynamic --max-num-seqs 32 --tensor-parallel-size 1 --no-enable-prefix-caching --linear-backend helion
```

Baseline (using CUTLASS):
```
python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/Qwen3-8B-FP8-dynamic --max-num-seqs 32 --tensor-parallel-size 1 --no-enable-prefix-caching
```

Benchmark setup:

Clean L2 cache first. See https://github.com/vllm-project/vllm/issues/48518.

Then use vllm bench serve.
```
#!/usr/bin/env bash                                                                                                      
set -euo pipefail

MODEL="RedHatAI/Qwen3-8B-FP8-dynamic"
DATASET="ShareGPT_V3_unfiltered_cleaned_split.json"

for concurrency in 32 24 16 8 4 2 1; do
    warmups=$((concurrency * 8))
    prompts=$((concurrency * 128))

    echo "============================================================"
    echo "Running benchmark"
    echo "  max-concurrency = ${concurrency}"
    echo "  num-warmups     = ${warmups}"
    echo "  num-prompts     = ${prompts}"
    echo "============================================================"

    vllm bench serve \
        --backend vllm \
        --model "${MODEL}" \
        --endpoint /v1/completions \
        --dataset-name sharegpt \
        --dataset-path "${DATASET}" \
        --max-concurrency "${concurrency}" \
        --num-warmups "${warmups}" \
        --ignore-eos \
        --num-prompts "${prompts}"

    echo
done
```

**Results**
<img width="1774" height="887" alt="fp8_perf" src="https://github.com/user-attachments/assets/3f038c00-45c4-449e-aa4c-466e346d4144" />


### Accuracy benchmark
**AzatAI/Qwen3.8-27B-FP8-dynamic**

Helion
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7316|±  |0.0122|
|     |       |strict-match    |     5|exact_match|↑  |0.7051|±  |0.0126|

default
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7346|±  |0.0122|
|     |       |strict-match    |     5|exact_match|↑  |0.7127|±  |0.0125|

**RedHatAI/Qwen3-1.7B-FP8-dynamic**

Helion
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6687|±  | 0.013|
|     |       |strict-match    |     5|exact_match|↑  |0.6634|±  | 0.013|

Default
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6755|±  |0.0129|
|     |       |strict-match    |     5|exact_match|↑  |0.6755|±  |0.0129|


**RedHatAI/Qwen3-8B-FP8-dynamic**
Helion
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8795|±  | 0.009|
|     |       |strict-match    |     5|exact_match|↑  |0.8779|±  | 0.009|

Default
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8795|±  |0.0090|
|     |       |strict-match    |     5|exact_match|↑  |0.8741|±  |0.0091|


**RedHatAI/Qwen3-32B-FP8-dynamic**

Helion
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6315|±  |0.0133|
|     |       |strict-match    |     5|exact_match|↑  |0.7437|±  |0.0120|

Default
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6323|±  |0.0133|
|     |       |strict-match    |     5|exact_match|↑  |0.7498|±  |0.0119|

## Other information
### Startup time
We do observe extra startup time after enabling Helion linear backend. On the H100 VM we used, the extra overhead from Helion kernel compiling (for 28 kernels) is around 18s. Issue is tracked in https://github.com/pytorch/helion/issues/3118. Need to optimize this before enabling this linear backend by default. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helion as a supported linear backend for FP8 scaled matrix multiplication on compatible NVIDIA Hopper GPUs.
  * Added hybrid Helion/CUTLASS execution, selecting optimized paths for eligible workloads and falling back when needed.
  * Added support for optional bias, scaling, padding handling, and CUDA Graph-compatible execution.
  * Added GPU-specific kernel configurations and autotuning support.
  * Added environment controls for FP8 Marlin selection and bypassing Helion configuration checks.

* **Bug Fixes**
  * Improved GPU variant detection and configuration selection for Helion kernels.

* **Tests**
  * Expanded coverage for scaled matrix multiplication, backend selection, numerical correctness, fallbacks, and platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->