### PR TITLE
[Bugfix][Parser] Thread token IDs through non-streaming paths of parser engine

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -359,6 +359,10 @@ async def test_reasoning_tokens_counted_for_text_reasoning_model(monkeypatch):
         def get_vocab(self):
             return self._vocab
 
+        def decode(self, token_ids):
+            inv = {v: k for k, v in self._vocab.items()}
+            return "".join(inv.get(tid, f"[{tid}]") for tid in token_ids)
+
     # Force non-harmony, SimpleContext path
     monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
 

--- a/tests/parser/engine/conftest.py
+++ b/tests/parser/engine/conftest.py
@@ -8,6 +8,15 @@ import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
+from vllm.parser.abstract_parser import DelegatingParser
+from vllm.parser.engine.adapters import make_adapters
+from vllm.parser.engine.events import EventType
+from vllm.parser.engine.parser_engine import ParserEngine
+from vllm.parser.engine.parser_engine_config import (
+    ParserEngineConfig,
+    ParserState,
+    Transition,
+)
 
 
 @pytest.fixture()
@@ -38,3 +47,71 @@ def mock_request():
     req.tools = []
     req.tool_choice = "auto"
     return req
+
+
+# ── Shared test configs ──────────────────────────────────────────────
+
+VOCAB: dict[str, int] = {
+    "<think>": 200,
+    "</think>": 201,
+    "<tool_call>": 202,
+    "</tool_call>": 203,
+}
+
+
+def combined_config() -> ParserEngineConfig:
+    """Config with reasoning tags and tool-call tags."""
+    return ParserEngineConfig(
+        name="combined_test",
+        terminals={
+            "THINK_START": "<think>",
+            "THINK_END": "</think>",
+            "TOOL_START": "<tool_call>",
+            "TOOL_END": "</tool_call>",
+        },
+        token_id_terminals={
+            "THINK_START": "<think>",
+            "THINK_END": "</think>",
+            "TOOL_START": "<tool_call>",
+            "TOOL_END": "</tool_call>",
+        },
+        transitions={
+            (ParserState.REASONING, "THINK_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.REASONING_END,),
+            ),
+            (ParserState.CONTENT, "THINK_START"): Transition(
+                ParserState.REASONING,
+                (EventType.REASONING_START,),
+            ),
+            (ParserState.CONTENT, "TOOL_START"): Transition(
+                ParserState.TOOL_ARGS,
+                (EventType.TOOL_CALL_START,),
+            ),
+            (ParserState.TOOL_ARGS, "TOOL_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.TOOL_CALL_END,),
+            ),
+        },
+        initial_state=ParserState.REASONING,
+        content_events={
+            ParserState.CONTENT: EventType.TEXT_CHUNK,
+            ParserState.REASONING: EventType.REASONING_CHUNK,
+            ParserState.TOOL_ARGS: EventType.ARG_VALUE_CHUNK,
+        },
+    )
+
+
+class CombinedTestEngine(ParserEngine):
+    def __init__(self, tokenizer, tools=None, **kwargs):
+        super().__init__(
+            tokenizer, tools, parser_engine_config=combined_config(), **kwargs
+        )
+
+
+CombinedReasoningAdapter, CombinedToolAdapter = make_adapters(CombinedTestEngine)
+
+
+class CombinedDelegating(DelegatingParser):
+    reasoning_parser_cls = CombinedReasoningAdapter
+    tool_parser_cls = CombinedToolAdapter

--- a/tests/parser/engine/replay_harness.py
+++ b/tests/parser/engine/replay_harness.py
@@ -64,6 +64,10 @@ class MockTokenizer:
         "pad_token_id",
     )
 
+    eos_token_id: int | None
+    bos_token_id: int | None
+    pad_token_id: int | None
+
     def __init__(
         self,
         vocab: dict[str, int],
@@ -71,7 +75,11 @@ class MockTokenizer:
     ) -> None:
         self._vocab = vocab
         self._token_ids = [tid for tid, _ in tokens]
-        self._token_decode_map = {tid: text for tid, text in tokens}
+        # Seed decode map from vocab so any vocab token can be decoded
+        # even if it doesn't appear in the token stream (e.g. injected
+        # tokens from _preprocess_feed).
+        self._token_decode_map: dict[int, str] = {v: k for k, v in vocab.items()}
+        self._token_decode_map.update({tid: text for tid, text in tokens})
         self._special_ids = set(vocab.values())
         self.eos_token_id = None
         self.bos_token_id = None

--- a/tests/parser/engine/test_engine.py
+++ b/tests/parser/engine/test_engine.py
@@ -71,79 +71,6 @@ def _think_config() -> ParserEngineConfig:
     )
 
 
-class TestNonStreaming:
-    def test_plain_text(self):
-        engine = StreamingParserEngine(_hermes_config(), tokenizer=None)
-        events = engine.parse_complete("Hello, world!")
-        assert len(events) == 1
-        assert events[0].type == EventType.TEXT_CHUNK
-        assert events[0].value == "Hello, world!"
-
-    def test_single_tool_call(self):
-        engine = StreamingParserEngine(_hermes_config(), tokenizer=None)
-        text = (
-            '<tool_call>{"name": "get_weather",'
-            ' "arguments": {"city": "SF"}}'
-            "</tool_call>"
-        )
-        events = engine.parse_complete(text)
-
-        types = [e.type for e in events]
-        assert EventType.TOOL_CALL_START in types
-        assert EventType.TOOL_CALL_END in types
-        assert EventType.ARG_VALUE_CHUNK in types
-
-        arg_text = "".join(
-            e.value for e in events if e.type == EventType.ARG_VALUE_CHUNK
-        )
-        assert '"name": "get_weather"' in arg_text
-        assert '"city": "SF"' in arg_text
-
-    def test_text_then_tool_call(self):
-        engine = StreamingParserEngine(_hermes_config(), tokenizer=None)
-        text = 'Sure!<tool_call>{"name": "add"}</tool_call>'
-        events = engine.parse_complete(text)
-
-        types = [e.type for e in events]
-        assert types[0] == EventType.TEXT_CHUNK
-        assert events[0].value == "Sure!"
-        assert EventType.TOOL_CALL_START in types
-        assert EventType.TOOL_CALL_END in types
-
-    def test_multiple_tool_calls(self):
-        engine = StreamingParserEngine(_hermes_config(), tokenizer=None)
-        text = (
-            '<tool_call>{"name": "a"}</tool_call><tool_call>{"name": "b"}</tool_call>'
-        )
-        events = engine.parse_complete(text)
-
-        starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
-        ends = [e for e in events if e.type == EventType.TOOL_CALL_END]
-        assert len(starts) == 2
-        assert len(ends) == 2
-        assert starts[0].tool_index == 0
-        assert starts[1].tool_index == 1
-
-    def test_reasoning(self):
-        engine = StreamingParserEngine(_think_config(), tokenizer=None)
-        text = "<think>Let me think...</think>The answer is 42."
-        events = engine.parse_complete(text)
-
-        types = [e.type for e in events]
-        assert types[0] == EventType.REASONING_START
-        assert EventType.REASONING_CHUNK in types
-        assert EventType.REASONING_END in types
-        assert EventType.TEXT_CHUNK in types
-
-        reasoning = "".join(
-            e.value for e in events if e.type == EventType.REASONING_CHUNK
-        )
-        assert "Let me think..." in reasoning
-
-        content = "".join(e.value for e in events if e.type == EventType.TEXT_CHUNK)
-        assert "The answer is 42." in content
-
-
 class TestStreaming:
     @staticmethod
     def _feed_chars(
@@ -210,6 +137,31 @@ class TestStreaming:
         values = list(results.values())
         for v in values[1:]:
             assert v == values[0], f"Mismatch: {results}"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "<think>Let me think about this.</think>The answer is 42.",
+            "<think>hmm</think>short",
+        ],
+        ids=["long_reasoning", "short_reasoning"],
+    )
+    def test_reasoning_chunk_sizes_produce_same_content(self, text):
+        """Different chunk sizes must produce identical reasoning + content."""
+        results = {}
+        config = _think_config()
+        for chunk_size in [1, 2, 3, 5, 7, len(text)]:
+            engine = StreamingParserEngine(config, tokenizer=None)
+            events = self._feed_chunks(engine, text, chunk_size)
+            reasoning = "".join(
+                e.value for e in events if e.type == EventType.REASONING_CHUNK
+            )
+            content = "".join(e.value for e in events if e.type == EventType.TEXT_CHUNK)
+            results[chunk_size] = (reasoning, content)
+
+        first = results[1]
+        for cs, val in results.items():
+            assert val == first, f"chunk_size={cs} mismatch: {val} != {first}"
 
     def test_prefix_buffering_prevents_premature_emit(self):
         """Text like '<tool_' should be buffered, not emitted as content."""
@@ -786,7 +738,8 @@ class TestMultiCharTerminalInArgs:
     def test_newline_in_args_parsed_correctly(self):
         engine = StreamingParserEngine(self._newline_config(), tokenizer=None)
         text = '<tool_call>{"name": "f",\n"arguments": {"a": 1}}</tool_call>'
-        events = engine.parse_complete(text)
+        events = engine.feed(text, [])
+        events.extend(engine.finish())
 
         arg_text = "".join(
             e.value for e in events if e.type == EventType.ARG_VALUE_CHUNK
@@ -815,7 +768,8 @@ class TestSkipToolParsing:
         engine.skip_tool_parsing = True
 
         text = '<tool_call>{"name": "f"}</tool_call>'
-        events = engine.parse_complete(text)
+        events = engine.feed(text, [])
+        events.extend(engine.finish())
 
         types = [e.type for e in events]
         assert EventType.TOOL_CALL_START not in types

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -14,7 +14,13 @@ from unittest.mock import MagicMock
 import pytest
 import regex as re
 
-from tests.parser.engine.conftest import make_mock_tokenizer
+from tests.parser.engine.conftest import (
+    VOCAB,
+    CombinedDelegating,
+    CombinedReasoningAdapter,
+    combined_config,
+    make_mock_tokenizer,
+)
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
     ChatCompletionToolsParam,
@@ -33,58 +39,6 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
-
-# ── Shared test configs ──────────────────────────────────────────────
-
-_VOCAB: dict[str, int] = {
-    "<think>": 200,
-    "</think>": 201,
-    "<tool_call>": 202,
-    "</tool_call>": 203,
-}
-
-
-def _combined_config() -> ParserEngineConfig:
-    """Config with reasoning tags and tool-call tags."""
-    return ParserEngineConfig(
-        name="combined_test",
-        terminals={
-            "THINK_START": "<think>",
-            "THINK_END": "</think>",
-            "TOOL_START": "<tool_call>",
-            "TOOL_END": "</tool_call>",
-        },
-        token_id_terminals={
-            "THINK_START": "<think>",
-            "THINK_END": "</think>",
-            "TOOL_START": "<tool_call>",
-            "TOOL_END": "</tool_call>",
-        },
-        transitions={
-            (ParserState.REASONING, "THINK_END"): Transition(
-                ParserState.CONTENT,
-                (EventType.REASONING_END,),
-            ),
-            (ParserState.CONTENT, "THINK_START"): Transition(
-                ParserState.REASONING,
-                (EventType.REASONING_START,),
-            ),
-            (ParserState.CONTENT, "TOOL_START"): Transition(
-                ParserState.TOOL_ARGS,
-                (EventType.TOOL_CALL_START,),
-            ),
-            (ParserState.TOOL_ARGS, "TOOL_END"): Transition(
-                ParserState.CONTENT,
-                (EventType.TOOL_CALL_END,),
-            ),
-        },
-        initial_state=ParserState.REASONING,
-        content_events={
-            ParserState.CONTENT: EventType.TEXT_CHUNK,
-            ParserState.REASONING: EventType.REASONING_CHUNK,
-            ParserState.TOOL_ARGS: EventType.ARG_VALUE_CHUNK,
-        },
-    )
 
 
 def _hermes_config() -> ParserEngineConfig:
@@ -120,8 +74,8 @@ def _make_engine(
     config: ParserEngineConfig | None = None,
     tools: list | None = None,
 ) -> ParserEngine:
-    tokenizer = make_mock_tokenizer(_VOCAB)
-    cfg = config or _combined_config()
+    tokenizer = make_mock_tokenizer(VOCAB)
+    cfg = config or combined_config()
     return ParserEngine(
         tokenizer,
         tools=tools,
@@ -809,12 +763,12 @@ class TestEngineBasedPath:
         assert len(result.tool_calls) > 0
 
 
-# ── TestParseTokenIdPassthrough ────────────────────────────────────
+# ── TestNonStreamingTokenIds ───────────────────────────────────────
 
 
-class TestParseTokenIdPassthrough:
-    """parse() must forward model_output_token_ids to _single_pass_parse
-    so that token-ID-based strict terminal matching is active."""
+class TestNonStreamingTokenIds:
+    """Non-streaming extract methods must accept token IDs so that
+    token-ID-based strict terminal matching is active."""
 
     def test_literal_tool_tag_in_content_preserved_with_token_ids(self, mock_request):
         engine = _make_engine(_hermes_config())
@@ -870,23 +824,53 @@ class TestParseTokenIdPassthrough:
         assert len(tool_calls) == 1
         assert tool_calls[0].name == "g"
 
-
-# ── TestAdapterFinishOnStreamEnd ────────────────────────────────────
-
-
-class _CombinedTestEngine(ParserEngine):
-    def __init__(self, tokenizer, tools=None, **kwargs):
-        super().__init__(
-            tokenizer, tools, parser_engine_config=_combined_config(), **kwargs
+    def test_parse_multiple_tool_calls(self, mock_request):
+        engine = _make_engine(_hermes_config())
+        text = (
+            '<tool_call>{"name": "a", "arguments": {}}</tool_call>'
+            '<tool_call>{"name": "b", "arguments": {}}</tool_call>'
         )
 
+        _, content, tool_calls = engine.parse(text, mock_request)
 
-_CombinedReasoningAdapter, _CombinedToolAdapter = make_adapters(_CombinedTestEngine)
+        assert tool_calls is not None
+        assert len(tool_calls) == 2
+        assert tool_calls[0].name == "a"
+        assert tool_calls[1].name == "b"
+
+    def test_extract_tool_calls_uses_pending_token_ids(self, mock_request):
+        """extract_tool_calls() must consume pending token IDs so that
+        token-ID-based strict terminal matching is active."""
+        engine = _make_engine(_hermes_config())
+        text = (
+            "Use <tool_call> to call tools."
+            '<tool_call>{"name": "f", "arguments": {"a": 1}}</tool_call>'
+        )
+        token_ids = [
+            65,
+            66,
+            67,
+            68,
+            69,
+            70,
+            71,  # "Use <tool_call> to call tools."
+            202,  # real <tool_call>
+            72,
+            73,
+            74,  # '{"name": "f", ...}'
+            203,  # real </tool_call>
+        ]
+
+        result = engine.extract_tool_calls_with_token_ids(text, mock_request, token_ids)
+
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "f"
+        assert result.content is not None
+        assert "<tool_call>" in result.content
 
 
-class _CombinedDelegating(DelegatingParser):
-    reasoning_parser_cls = _CombinedReasoningAdapter
-    tool_parser_cls = _CombinedToolAdapter
+# ── TestAdapterFinishOnStreamEnd ────────────────────────────────────
 
 
 def _make_delegating_request():
@@ -908,8 +892,8 @@ class TestAdapterFinishOnStreamEnd:
     def test_lexer_buffer_flushed_on_finished(self):
         """Text buffered as a potential terminal prefix must be emitted
         as content when the stream ends."""
-        tokenizer = make_mock_tokenizer(_VOCAB)
-        parser = _CombinedDelegating(tokenizer)
+        tokenizer = make_mock_tokenizer(VOCAB)
+        parser = CombinedDelegating(tokenizer)
         request = _make_delegating_request()
 
         # Feed reasoning then content with a trailing '<' that looks like
@@ -926,8 +910,8 @@ class TestAdapterFinishOnStreamEnd:
     def test_args_buffer_flushed_on_finished(self):
         """Pending arg buffer text must be emitted when stream ends
         mid-tool-call (closing brace held back in buffer)."""
-        tokenizer = make_mock_tokenizer(_VOCAB)
-        parser = _CombinedDelegating(tokenizer)
+        tokenizer = make_mock_tokenizer(VOCAB)
+        parser = CombinedDelegating(tokenizer)
         request = _make_delegating_request()
 
         parser.parse_delta("</think>", [201], request, finished=False)
@@ -948,7 +932,7 @@ class TestAdapterFinishOnStreamEnd:
 class _ReasoningOnlyDelegating(DelegatingParser):
     """DelegatingParser with reasoning adapter but NO tool adapter."""
 
-    reasoning_parser_cls = _CombinedReasoningAdapter
+    reasoning_parser_cls = CombinedReasoningAdapter
     tool_parser_cls = None
 
 
@@ -963,7 +947,7 @@ class TestReasoningOnlyEndTokenLeak:
     """
 
     def test_think_end_not_leaked_as_content(self):
-        tokenizer = make_mock_tokenizer(_VOCAB)
+        tokenizer = make_mock_tokenizer(VOCAB)
         parser = _ReasoningOnlyDelegating(tokenizer)
         request = _make_delegating_request()
 
@@ -1002,7 +986,7 @@ class TestReasoningOnlyEndTokenLeak:
 
     def test_streaming_content_matches_non_streaming(self):
         """Concatenated streaming content must match extract_reasoning."""
-        tokenizer = make_mock_tokenizer(_VOCAB)
+        tokenizer = make_mock_tokenizer(VOCAB)
         # No <think> in input: the combined config starts in REASONING
         # state, so all text before </think> is reasoning.
         full_text = "reasoning</think>\n\nHello!"
@@ -1039,7 +1023,7 @@ class TestReasoningOnlyEndTokenLeak:
 
     def test_multi_token_delta_preserves_content_after_think_end(self):
         """Content after </think> in the same delta must not be lost."""
-        tokenizer = make_mock_tokenizer(_VOCAB)
+        tokenizer = make_mock_tokenizer(VOCAB)
         parser = _ReasoningOnlyDelegating(tokenizer)
         request = _make_delegating_request()
 
@@ -1071,6 +1055,96 @@ class TestReasoningOnlyEndTokenLeak:
         assert "Hi!" in d2.content
 
 
+# ── TestStreamingNonStreamingParity ──────────────────────────────────
+
+
+class TestStreamingNonStreamingParity:
+    """parse() and streamed parse_delta() must produce identical results."""
+
+    @staticmethod
+    def _accumulate(delta, reasoning_parts, content_parts, tool_call_deltas):
+        if delta:
+            if delta.reasoning:
+                reasoning_parts.append(delta.reasoning)
+            if delta.content:
+                content_parts.append(delta.content)
+            if delta.tool_calls:
+                tool_call_deltas.extend(delta.tool_calls)
+
+    @pytest.mark.parametrize(
+        "config_fn, text",
+        [
+            (_hermes_config, "Hello, world!"),
+            (
+                _hermes_config,
+                '<tool_call>{"name": "get_weather", '
+                '"arguments": {"city": "SF"}}</tool_call>',
+            ),
+            (
+                _hermes_config,
+                'Sure!<tool_call>{"name": "add", "arguments": {}}</tool_call>',
+            ),
+            (
+                _hermes_config,
+                '<tool_call>{"name": "a", "arguments": {}}'
+                "</tool_call>"
+                '<tool_call>{"name": "b", "arguments": {}}'
+                "</tool_call>",
+            ),
+            (
+                combined_config,
+                "<think>Let me think...</think>The answer is 42.",
+            ),
+            (
+                combined_config,
+                "<think>Let me think</think>"
+                '<tool_call>{"name": "get_weather", '
+                '"arguments": {"city": "SF"}}</tool_call>',
+            ),
+        ],
+        ids=[
+            "plain_text",
+            "single_tool_call",
+            "text_then_tool_call",
+            "multiple_tool_calls",
+            "reasoning_and_content",
+            "reasoning_and_tool_call",
+        ],
+    )
+    def test_parity(self, config_fn, text, mock_request):
+        config = config_fn()
+
+        # Non-streaming
+        ns_engine = _make_engine(config)
+        reasoning_ns, content_ns, tools_ns = ns_engine.parse(text, mock_request)
+
+        # Streaming — feed char by char
+        s_engine = _make_engine(config)
+        s_engine.initialize_streaming()
+        reasoning_parts: list[str] = []
+        content_parts: list[str] = []
+        tool_call_deltas: list[DeltaToolCall] = []
+        for ch in text:
+            delta = s_engine.parse_delta(ch, [], mock_request, finished=False)
+            self._accumulate(delta, reasoning_parts, content_parts, tool_call_deltas)
+        final = s_engine.parse_delta("", [], mock_request, finished=True)
+        self._accumulate(final, reasoning_parts, content_parts, tool_call_deltas)
+
+        reasoning_s = "".join(reasoning_parts) or None
+        content_s = "".join(content_parts) or None
+
+        assert reasoning_s == reasoning_ns
+        assert content_s == content_ns
+
+        tool_names_ns = sorted(tc.name for tc in tools_ns) if tools_ns else []
+        tool_names_s = sorted(
+            tc.function.name
+            for tc in tool_call_deltas
+            if tc.function and tc.function.name
+        )
+        assert tool_names_s == tool_names_ns
+
+
 # ── TestToolAdapterForwardsKwargs ──────────────────────────────────
 
 
@@ -1099,6 +1173,47 @@ class TestToolAdapterForwardsKwargs:
         )
         engine = adapter._parser_engine
         assert engine.parser_engine_config.initial_state == expected_state
+
+    def test_extract_tool_calls_with_token_ids_delegates(self, mock_request):
+        """ToolAdapter must forward token_ids to the underlying engine."""
+        tokenizer = make_mock_tokenizer(VOCAB)
+
+        class _HermesEngine(ParserEngine):
+            def __init__(self, tok, tools=None, **kw):
+                kw.setdefault("parser_engine_config", _hermes_config())
+                super().__init__(tok, tools, **kw)
+
+        _, ToolAdapter = make_adapters(_HermesEngine)
+        adapter = ToolAdapter(tokenizer, tools=None)
+
+        text = (
+            "Use <tool_call> to call tools."
+            '<tool_call>{"name": "f", "arguments": {"a": 1}}</tool_call>'
+        )
+        token_ids = [
+            65,
+            66,
+            67,
+            68,
+            69,
+            70,
+            71,  # "Use <tool_call> to call tools."
+            202,  # real <tool_call>
+            72,
+            73,
+            74,  # '{"name": "f", ...}'
+            203,  # real </tool_call>
+        ]
+
+        result = adapter.extract_tool_calls_with_token_ids(
+            text, mock_request, token_ids
+        )
+
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "f"
+        assert result.content is not None
+        assert "<tool_call>" in result.content
 
 
 # ── TestExtractContentIdsNoEmptyReturn ─────────────────────────────

--- a/tests/parser/engine/test_structural_token_drop.py
+++ b/tests/parser/engine/test_structural_token_drop.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for structural token (BOS/EOS/PAD) drop behavior.
+
+Verifies that tokens in STRUCTURAL_DROP_TOKENS are correctly filtered
+in streaming (parse_delta) and non-streaming (parse) paths for both
+direct ParserEngine and DelegatingParser wiring.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.parser.engine.replay_harness import (
+    CHUNK_SIZES,
+    MockTokenizer,
+    collect_output,
+    replay_streaming,
+)
+from vllm.parser.abstract_parser import DelegatingParser
+from vllm.parser.engine.adapters import make_adapters
+from vllm.parser.engine.events import EventType
+from vllm.parser.engine.parser_engine import ParserEngine
+from vllm.parser.engine.parser_engine_config import (
+    ParserEngineConfig,
+    ParserState,
+    Transition,
+)
+
+BOS_ID = 1
+BOS_TEXT = "<bos>"
+
+THINK_END_ID = 51
+
+_VOCAB: dict[str, int] = {
+    "<think>": 50,
+    "</think>": THINK_END_ID,
+    BOS_TEXT: BOS_ID,
+}
+
+_THINK_CONFIG = ParserEngineConfig(
+    name="think_test",
+    terminals={
+        "THINK_START": "<think>",
+        "THINK_END": "</think>",
+    },
+    transitions={
+        (ParserState.REASONING, "THINK_END"): Transition(
+            ParserState.CONTENT,
+            (EventType.REASONING_END,),
+        ),
+    },
+    initial_state=ParserState.REASONING,
+)
+
+# Token sequence: reasoning → </think> → content with <bos> mid-stream
+_TOKENS: list[tuple[int, str]] = [
+    (100, "Let "),
+    (101, "me "),
+    (102, "think."),
+    (THINK_END_ID, "</think>"),
+    (103, "Hello "),
+    (BOS_ID, BOS_TEXT),
+    (104, "world"),
+]
+
+_FULL_TEXT = "".join(text for _, text in _TOKENS)
+_TOKEN_IDS = [tid for tid, _ in _TOKENS]
+
+
+def _make_tokenizer() -> MockTokenizer:
+    tok = MockTokenizer(vocab=_VOCAB, tokens=_TOKENS)
+    tok.bos_token_id = BOS_ID
+    return tok
+
+
+class _ThinkParser(ParserEngine):
+    def __init__(self, tokenizer, tools=None, **kwargs):
+        super().__init__(tokenizer, tools, parser_engine_config=_THINK_CONFIG, **kwargs)
+
+
+_ThinkReasoningAdapter, _ThinkToolAdapter = make_adapters(_ThinkParser)
+
+
+class _ThinkDelegating(DelegatingParser):
+    reasoning_parser_cls = _ThinkReasoningAdapter
+    tool_parser_cls = _ThinkToolAdapter
+
+
+class TestDirectParser:
+    @pytest.mark.parametrize("chunk_size", CHUNK_SIZES, ids=lambda c: f"chunk={c}")
+    def test_streaming_drops_bos(self, chunk_size):
+        tokenizer = _make_tokenizer()
+        parser = _ThinkParser(tokenizer, None)
+
+        deltas = replay_streaming(
+            parser, _TOKENS, chunk_size=chunk_size, finished_on_last=True
+        )
+        output = collect_output(deltas)
+
+        assert output.content == "Hello world"
+        assert output.reasoning == "Let me think."
+
+    def test_parse_drops_bos(self, mock_request):
+        tokenizer = _make_tokenizer()
+        parser = _ThinkParser(tokenizer, None)
+        reasoning, content, _tool_calls = parser.parse(
+            _FULL_TEXT, mock_request, model_output_token_ids=_TOKEN_IDS
+        )
+
+        assert content == "Hello world"
+        assert reasoning == "Let me think."
+
+
+class TestDelegatingParser:
+    @pytest.mark.parametrize("chunk_size", CHUNK_SIZES, ids=lambda c: f"chunk={c}")
+    def test_streaming_drops_bos(self, chunk_size):
+        tokenizer = _make_tokenizer()
+        parser = _ThinkDelegating(tokenizer, None)
+
+        deltas = replay_streaming(
+            parser, _TOKENS, chunk_size=chunk_size, finished_on_last=True
+        )
+        output = collect_output(deltas)
+
+        assert output.content == "Hello world"
+        assert output.reasoning == "Let me think."
+
+    def test_parse_drops_bos(self, mock_request):
+        tokenizer = _make_tokenizer()
+        parser = _ThinkDelegating(tokenizer, None)
+        reasoning, content, _tool_calls = parser.parse(
+            _FULL_TEXT, mock_request, model_output_token_ids=_TOKEN_IDS
+        )
+
+        assert content == "Hello world"
+        assert reasoning == "Let me think."
+
+
+# ── EOS / PAD token drop ────────────────────────────────────────────
+
+EOS_ID = 2
+EOS_TEXT = "<eos>"
+PAD_ID = 3
+PAD_TEXT = "<pad>"
+
+_VOCAB_EOS_PAD: dict[str, int] = {
+    **_VOCAB,
+    EOS_TEXT: EOS_ID,
+    PAD_TEXT: PAD_ID,
+}
+
+_TOKENS_WITH_EOS: list[tuple[int, str]] = [
+    (100, "Let "),
+    (101, "me "),
+    (102, "think."),
+    (THINK_END_ID, "</think>"),
+    (103, "Hello "),
+    (104, "world"),
+    (EOS_ID, EOS_TEXT),
+]
+
+_TOKENS_WITH_PAD: list[tuple[int, str]] = [
+    (100, "Let "),
+    (PAD_ID, PAD_TEXT),
+    (101, "me "),
+    (102, "think."),
+    (THINK_END_ID, "</think>"),
+    (103, "Hello "),
+    (PAD_ID, PAD_TEXT),
+    (104, "world"),
+]
+
+_TOKENS_WITH_ALL: list[tuple[int, str]] = [
+    (BOS_ID, BOS_TEXT),
+    (100, "Let "),
+    (PAD_ID, PAD_TEXT),
+    (101, "me "),
+    (102, "think."),
+    (THINK_END_ID, "</think>"),
+    (103, "Hello "),
+    (BOS_ID, BOS_TEXT),
+    (104, "world"),
+    (EOS_ID, EOS_TEXT),
+]
+
+
+_STRUCTURAL_DROP_CASES = [
+    pytest.param(
+        _TOKENS_WITH_EOS,
+        {"eos_token_id": EOS_ID},
+        id="eos",
+    ),
+    pytest.param(
+        _TOKENS_WITH_PAD,
+        {"pad_token_id": PAD_ID},
+        id="pad",
+    ),
+    pytest.param(
+        _TOKENS_WITH_ALL,
+        {"bos_token_id": BOS_ID, "eos_token_id": EOS_ID, "pad_token_id": PAD_ID},
+        id="bos+eos+pad",
+    ),
+]
+
+
+def _make_drop_parser(tokens, id_overrides):
+    tok = MockTokenizer(vocab=_VOCAB_EOS_PAD, tokens=tokens)
+    for attr, value in id_overrides.items():
+        setattr(tok, attr, value)
+    return _ThinkParser(tok, None), tokens
+
+
+class TestStructuralTokenDrop:
+    @pytest.mark.parametrize("tokens,id_overrides", _STRUCTURAL_DROP_CASES)
+    @pytest.mark.parametrize("chunk_size", CHUNK_SIZES, ids=lambda c: f"chunk={c}")
+    def test_streaming_drops(self, chunk_size, tokens, id_overrides):
+        parser, tokens = _make_drop_parser(tokens, id_overrides)
+        deltas = replay_streaming(
+            parser, tokens, chunk_size=chunk_size, finished_on_last=True
+        )
+        output = collect_output(deltas)
+        assert output.content == "Hello world"
+        assert output.reasoning == "Let me think."
+
+    @pytest.mark.parametrize("tokens,id_overrides", _STRUCTURAL_DROP_CASES)
+    def test_parse_drops(self, mock_request, tokens, id_overrides):
+        parser, tokens = _make_drop_parser(tokens, id_overrides)
+        full_text = "".join(text for _, text in tokens)
+        token_ids = [tid for tid, _ in tokens]
+        reasoning, content, _ = parser.parse(
+            full_text, mock_request, model_output_token_ids=token_ids
+        )
+        assert content == "Hello world"
+        assert reasoning == "Let me think."
+
+
+# ── Text/token ID consistency edge cases ─────────────────────────────
+
+
+class TestTokenIdEdgeCases:
+    def test_empty_text_with_structural_token_ids(self, mock_request):
+        """Empty text with BOS token ID should not crash."""
+        tokenizer = _make_tokenizer()
+        parser = _ThinkParser(tokenizer, None)
+        reasoning, content, _ = parser.parse(
+            "", mock_request, model_output_token_ids=[BOS_ID]
+        )
+        assert reasoning is None
+        assert content is None
+
+    def test_text_without_token_ids_backward_compat(self, mock_request):
+        """Text-only path (no token IDs) must still parse correctly."""
+        tokenizer = _make_tokenizer()
+        parser = _ThinkParser(tokenizer, None)
+        text = "Let me think.</think>Hello world"
+        reasoning, content, _ = parser.parse(
+            text, mock_request, model_output_token_ids=()
+        )
+        assert reasoning == "Let me think."
+        assert content == "Hello world"
+
+    def test_drop_token_id_present_but_text_already_stripped(self, mock_request):
+        """Token IDs contain BOS but text doesn't — no corruption."""
+        tokenizer = _make_tokenizer()
+        parser = _ThinkParser(tokenizer, None)
+        text_without_bos = "Let me think.</think>Hello world"
+        ids_with_bos = [BOS_ID, 100, 101, 102, THINK_END_ID, 103, 104]
+
+        reasoning, content, _ = parser.parse(
+            text_without_bos, mock_request, model_output_token_ids=ids_with_bos
+        )
+        assert reasoning == "Let me think."
+        assert content == "Hello world"

--- a/tests/parser/test_parse.py
+++ b/tests/parser/test_parse.py
@@ -3,7 +3,9 @@
 
 import json
 import os
+from contextlib import contextmanager
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -11,11 +13,20 @@ _STRICT_TOOL_CALLING_ENV = "VLLM_ENFORCE_STRICT_TOOL_CALLING"
 _STRICT_TOOL_CALLING_ENV_VALUE = os.environ.get(_STRICT_TOOL_CALLING_ENV)
 os.environ[_STRICT_TOOL_CALLING_ENV] = "0"
 
+from tests.parser.engine.conftest import (  # noqa: E402
+    VOCAB,
+    CombinedDelegating,
+    make_mock_tokenizer,
+)
+from tests.parser.engine.replay_harness import MockTokenizer  # noqa: E402
 from vllm.entrypoints.openai.chat_completion.protocol import (  # noqa: E402
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest  # noqa: E402
 from vllm.parser.abstract_parser import DelegatingParser  # noqa: E402
+from vllm.parser.engine.adapters import make_adapters  # noqa: E402
+from vllm.parser.gemma4 import Gemma4Parser  # noqa: E402
+from vllm.parser.qwen3 import Qwen3Parser  # noqa: E402
 from vllm.parser.utils import count_history_tool_calls  # noqa: E402
 from vllm.reasoning.basic_parsers import (  # noqa: E402
     BaseThinkingReasoningParser,
@@ -427,3 +438,282 @@ def test_parse_auto_tools_no_calls_returns_none(tokenizer):
     assert reasoning is None
     assert content == PLAIN_TEXT
     assert tool_calls is None
+
+
+# ── Token ID forwarding tests ────────────────────────────────────────
+
+
+def _make_engine_delegating_parser():
+    return CombinedDelegating(make_mock_tokenizer(VOCAB))
+
+
+@contextmanager
+def _spy_feed(engine):
+    calls: list[tuple[str, list[int]]] = []
+    original = engine._feed
+
+    def _spy(text, tids):
+        calls.append((text, list(tids)))
+        return original(text, tids)
+
+    with patch.object(engine, "_feed", side_effect=_spy):
+        yield calls
+
+
+def test_parse_forwards_token_ids_to_engine_reasoning():
+    parser = _make_engine_delegating_parser()
+    request = make_request()
+    model_output = "<think>thoughts</think>content"
+    token_ids = [200, 10, 11, 201, 12, 13]
+
+    with _spy_feed(parser._reasoning_parser._parser_engine) as feed_calls:
+        parser.parse(model_output, request, model_output_token_ids=token_ids)
+
+    assert len(feed_calls) == 1
+    assert feed_calls[0][1] == token_ids
+
+
+def test_parse_forwards_token_ids_to_engine_tool_calls():
+    parser = _make_engine_delegating_parser()
+    request = make_request(tools=TOOLS)
+    model_output = (
+        '<tool_call>\n{"name": "get_weather", '
+        '"arguments": {"city": "Dallas"}}\n</tool_call>'
+    )
+    token_ids = [202, 30, 31, 32, 203]
+
+    with _spy_feed(parser._tool_parser._parser_engine) as feed_calls:
+        parser.parse(
+            model_output,
+            request,
+            enable_auto_tools=True,
+            model_output_token_ids=token_ids,
+        )
+
+    assert len(feed_calls) == 1
+    assert feed_calls[0][1] == token_ids
+
+
+def test_parse_does_not_forward_token_ids_to_non_engine_reasoning(
+    tokenizer,
+):
+    parser = make_parser(tokenizer, reasoning=True, tool=True)
+    request = make_request(tools=TOOLS)
+    token_ids = [1, 2, 3, 4, 5]
+
+    reasoning, content, tool_calls = parser.parse(
+        MODEL_OUTPUT,
+        request,
+        enable_auto_tools=True,
+        model_output_token_ids=token_ids,
+    )
+    assert reasoning is not None
+    assert "let me think about this" in reasoning
+
+
+def test_parse_threads_token_ids_end_to_end():
+    parser = _make_engine_delegating_parser()
+    request = make_request(tools=TOOLS)
+    model_output = (
+        "<think>thoughts</think>"
+        '<tool_call>\n{"name": "get_weather", '
+        '"arguments": {"city": "Dallas"}}\n</tool_call>'
+    )
+    token_ids = [200, 10, 11, 201, 202, 30, 31, 32, 203]
+
+    with (
+        _spy_feed(parser._reasoning_parser._parser_engine) as r_calls,
+        _spy_feed(parser._tool_parser._parser_engine) as t_calls,
+    ):
+        reasoning, content, tool_calls = parser.parse(
+            model_output,
+            request,
+            enable_auto_tools=True,
+            model_output_token_ids=token_ids,
+        )
+
+    assert reasoning is not None
+    assert "thoughts" in reasoning
+
+    assert len(r_calls) == 1
+    assert r_calls[0][1] == token_ids
+
+    assert len(t_calls) == 1
+    assert t_calls[0][1] == [202, 30, 31, 32, 203]
+
+
+# ── DelegatingParser tests with real engine-based parsers ────────────
+
+
+Qwen3ReasoningAdapter, Qwen3ToolAdapter = make_adapters(Qwen3Parser)
+Gemma4ReasoningAdapter, Gemma4ToolAdapter = make_adapters(Gemma4Parser)
+
+# -- Qwen3 fixtures --
+
+_QWEN3_VOCAB: dict[str, int] = {
+    "<think>": 200,
+    "</think>": 201,
+    "<tool_call>": 202,
+    "</tool_call>": 203,
+}
+
+_QWEN3_REASONING_TOOL_TOKENS: list[tuple[int, str]] = [
+    (200, "<think>"),
+    (10, "I need "),
+    (11, "the weather."),
+    (201, "</think>"),
+    (13, "\n"),
+    (202, "<tool_call>"),
+    (14, "\n"),
+    (15, "<function=get_weather>"),
+    (16, "\n"),
+    (17, "<parameter=city>"),
+    (18, "Dallas"),
+    (19, "</parameter>"),
+    (20, "\n"),
+    (21, "</function>"),
+    (22, "\n"),
+    (203, "</tool_call>"),
+]
+
+
+def _qwen3_delegating(tokens=None, vocab=None, **kwargs):
+    class Qwen3Delegating(DelegatingParser):
+        reasoning_parser_cls = Qwen3ReasoningAdapter
+        tool_parser_cls = Qwen3ToolAdapter
+
+    tokens = tokens or _QWEN3_REASONING_TOOL_TOKENS
+    vocab = vocab or dict(_QWEN3_VOCAB)
+    tok = MockTokenizer(vocab=vocab, tokens=tokens)
+    return Qwen3Delegating(tok, **kwargs)
+
+
+@pytest.mark.parametrize("with_token_ids", [True, False], ids=["with_ids", "no_ids"])
+def test_qwen3_parse_reasoning_and_tools(with_token_ids):
+    parser = _qwen3_delegating()
+    tokens = _QWEN3_REASONING_TOOL_TOKENS
+    text = "".join(t for _, t in tokens)
+    ids = [tid for tid, _ in tokens] if with_token_ids else None
+    request = make_request(tools=TOOLS)
+
+    reasoning, content, tool_calls = parser.parse(
+        text, request, enable_auto_tools=True, model_output_token_ids=ids
+    )
+
+    assert reasoning == "I need the weather."
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "get_weather"
+    assert json.loads(tool_calls[0].arguments) == {"city": "Dallas"}
+
+
+def test_qwen3_parse_thinking_disabled_with_token_ids():
+    tokens: list[tuple[int, str]] = [
+        (30, "Here is the answer."),
+        (13, "\n"),
+        (202, "<tool_call>"),
+        (14, "\n"),
+        (15, "<function=get_weather>"),
+        (16, "\n"),
+        (17, "<parameter=city>"),
+        (18, "Dallas"),
+        (19, "</parameter>"),
+        (20, "\n"),
+        (21, "</function>"),
+        (22, "\n"),
+        (203, "</tool_call>"),
+    ]
+    parser = _qwen3_delegating(
+        tokens=tokens,
+        chat_template_kwargs={"enable_thinking": False},
+    )
+    text = "".join(t for _, t in tokens)
+    ids = [tid for tid, _ in tokens]
+    request = make_request(tools=TOOLS)
+
+    reasoning, content, tool_calls = parser.parse(
+        text, request, enable_auto_tools=True, model_output_token_ids=ids
+    )
+
+    assert reasoning is None
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "get_weather"
+
+
+# -- Gemma4 fixtures --
+
+_GEMMA4_VOCAB: dict[str, int] = {
+    "<|channel>": 50,
+    "<channel|>": 51,
+    "<|tool_call>": 48,
+    "<tool_call|>": 49,
+    '<|"|>': 52,
+}
+
+_GEMMA4_REASONING_TOOL_TOKENS: list[tuple[int, str]] = [
+    (50, "<|channel>"),
+    (60, "thought\n"),
+    (61, "The user wants weather."),
+    (51, "<channel|>"),
+    (48, "<|tool_call>"),
+    (62, "call:get_weather"),
+    (63, "{"),
+    (64, "city:"),
+    (52, '<|"|>'),
+    (65, "Dallas"),
+    (52, '<|"|>'),
+    (66, "}"),
+    (49, "<tool_call|>"),
+]
+
+
+def _gemma4_delegating(tokens=None, vocab=None, **kwargs):
+    class Gemma4Delegating(DelegatingParser):
+        reasoning_parser_cls = Gemma4ReasoningAdapter
+        tool_parser_cls = Gemma4ToolAdapter
+
+    tokens = tokens or _GEMMA4_REASONING_TOOL_TOKENS
+    vocab = vocab or dict(_GEMMA4_VOCAB)
+    tok = MockTokenizer(vocab=vocab, tokens=tokens)
+    return Gemma4Delegating(tok, **kwargs)
+
+
+@pytest.mark.parametrize("with_token_ids", [True, False], ids=["with_ids", "no_ids"])
+def test_gemma4_parse_reasoning_and_tools(with_token_ids):
+    parser = _gemma4_delegating()
+    tokens = _GEMMA4_REASONING_TOOL_TOKENS
+    text = "".join(t for _, t in tokens)
+    ids = [tid for tid, _ in tokens] if with_token_ids else None
+    request = make_request(tools=TOOLS)
+
+    reasoning, content, tool_calls = parser.parse(
+        text, request, enable_auto_tools=True, model_output_token_ids=ids
+    )
+
+    assert reasoning == "The user wants weather."
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "get_weather"
+    assert json.loads(tool_calls[0].arguments) == {"city": "Dallas"}
+
+
+def test_gemma4_bare_thought_injection_with_token_ids():
+    """Gemma4 _preprocess_feed injects <|channel> when model omits it."""
+    tokens: list[tuple[int, str]] = [
+        (60, "thought\n"),
+        (61, "Reasoning here."),
+        (51, "<channel|>"),
+        (70, "Final answer"),
+    ]
+    parser = _gemma4_delegating(tokens=tokens)
+    text = "".join(t for _, t in tokens)
+    ids = [tid for tid, _ in tokens]
+    request = make_request()
+
+    reasoning, content, tool_calls = parser.parse(
+        text, request, model_output_token_ids=ids
+    )
+
+    assert reasoning == "Reasoning here."
+    assert content == "Final answer"

--- a/tests/reasoning/test_gemma4_reasoning_parser.py
+++ b/tests/reasoning/test_gemma4_reasoning_parser.py
@@ -262,6 +262,42 @@ def test_gemma4_adjust_request(generic_tokenizer):
     assert result is request
 
 
+NONSTREAMING_CASES = [
+    (case.values[1], case.id)
+    for case in TEST_CASES
+    if case.values[0] is False  # streaming=False
+]
+
+
+@pytest.mark.parametrize(
+    "param_dict",
+    [pytest.param(d, id=name) for d, name in NONSTREAMING_CASES],
+)
+def test_gemma4_reasoning_with_token_ids(
+    param_dict: dict,
+    generic_tokenizer,
+):
+    """Non-streaming extraction with token IDs via extract_reasoning_with_token_ids.
+
+    Verifies that passing token IDs (as DelegatingParser.parse() does)
+    produces the same result as the text-only path.
+    """
+    output = param_dict["output"]
+    output_tokens = gemma4_encode_output(generic_tokenizer, output)
+
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        generic_tokenizer
+    )
+
+    request = ChatCompletionRequest(messages=[], model="test-model")
+    reasoning, content = parser.extract_reasoning_with_token_ids(
+        model_output=output, request=request, token_ids=output_tokens
+    )
+
+    assert reasoning == param_dict["reasoning"]
+    assert content == param_dict["content"]
+
+
 def test_gemma4_previous_turn_reasoning_is_reasoning_end(generic_tokenizer):
     output = (
         "<|channel>thought\n1st thought<channel|>1st content<turn|>\n"

--- a/tests/reasoning/test_glm4_moe_reasoning_parser.py
+++ b/tests/reasoning/test_glm4_moe_reasoning_parser.py
@@ -4,7 +4,10 @@
 import pytest
 from transformers import AutoTokenizer
 
+from tests.parser.engine.replay_harness import MockTokenizer
 from tests.reasoning.utils import run_reasoning_extraction
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.glm47_moe import Glm47MoeParser
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 
 parser_name = "glm45"
@@ -227,3 +230,37 @@ def test_is_reasoning_end_full_prompt(
     token_ids = glm45_tokenizer.convert_tokens_to_ids(tokens)
     check_is_reasoning_end = parser.is_reasoning_end(token_ids)
     assert check_is_reasoning_end == is_reasoning_end
+
+
+def test_extract_reasoning_with_token_ids_forwards_ids():
+    """Verify token_ids are forwarded (not dropped) to the engine."""
+    vocab: dict[str, int] = {
+        "<think>": 10,
+        "</think>": 11,
+        "<tool_call>": 20,
+        "</tool_call>": 21,
+        "<arg_key>": 30,
+        "</arg_key>": 31,
+        "<arg_value>": 32,
+        "</arg_value>": 33,
+    }
+    tokens: list[tuple[int, str]] = [
+        (10, "<think>"),
+        (99, "reasoning"),
+        (11, ""),  # empty text: tests token-ID-only terminal detection
+        (100, "content"),
+    ]
+    tok = MockTokenizer(vocab=vocab, tokens=tokens)
+    parser = Glm47MoeParser(tok)
+
+    text = "".join(t for _, t in tokens)
+    ids = [tid for tid, _ in tokens]
+
+    reasoning, content = parser.extract_reasoning_with_token_ids(
+        model_output=text,
+        request=ChatCompletionRequest(messages=[], model="test-model"),
+        token_ids=ids,
+    )
+
+    assert reasoning == "reasoning"
+    assert content == "content"

--- a/tests/reasoning/test_nemotron_v3_reasoning_parser.py
+++ b/tests/reasoning/test_nemotron_v3_reasoning_parser.py
@@ -6,10 +6,12 @@ from typing import TypedDict
 import pytest
 import regex as re
 
+from tests.parser.engine.replay_harness import MockTokenizer
 from tests.reasoning.utils import run_reasoning_extraction
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.parser.abstract_parser import DelegatingParser
 from vllm.parser.engine.registered_adapters import NemotronV3ParserReasoningAdapter
+from vllm.parser.nemotron_v3 import NemotronV3Parser
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 
 parser_name = "nemotron_v3"
@@ -290,3 +292,37 @@ def test_nemotron_v3_streaming_no_promotion_without_opt_in(
 
     assert reasoning == "4"
     assert content == ""
+
+
+def test_extract_reasoning_with_token_ids_forwards_ids():
+    """Verify token_ids are forwarded (not dropped) to the engine."""
+    vocab: dict[str, int] = {
+        "<think>": 1,
+        "</think>": 2,
+        "<tool_call>": 3,
+        "</tool_call>": 4,
+    }
+    tokens: list[tuple[int, str]] = [
+        (1, "<think>"),
+        (99, "reasoning"),
+        (2, ""),
+        (100, "content"),
+    ]
+    tok = MockTokenizer(vocab=vocab, tokens=tokens)
+    parser = NemotronV3Parser(tok)
+
+    text = "".join(t for _, t in tokens)
+    ids = [tid for tid, _ in tokens]
+
+    reasoning, content = parser.extract_reasoning_with_token_ids(
+        model_output=text,
+        request=ChatCompletionRequest(
+            model="test-model",
+            messages=[],
+            chat_template_kwargs={"force_nonempty_content": True},
+        ),
+        token_ids=ids,
+    )
+
+    assert reasoning == "reasoning"
+    assert content == "content"

--- a/tests/reasoning/test_qwen3_reasoning_parser.py
+++ b/tests/reasoning/test_qwen3_reasoning_parser.py
@@ -4,12 +4,14 @@
 import pytest
 from transformers import AutoTokenizer
 
+from tests.parser.engine.replay_harness import MockTokenizer
 from tests.reasoning.utils import (
     StreamingReasoningReconstructor,
     run_reasoning_extraction,
     run_reasoning_extraction_streaming,
 )
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.qwen3 import Qwen3Parser
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 
 parser_name = "qwen3"
@@ -326,6 +328,42 @@ def test_reasoning_streaming_multi_token_deltas(
     assert (reconstructor.other_content or None) == expected_content
 
 
+NONSTREAMING_CASES = [
+    (case.values[1], case.id)
+    for case in TEST_CASES
+    if case.values[0] is False  # streaming=False
+]
+
+
+@pytest.mark.parametrize(
+    "param_dict",
+    [pytest.param(d, id=name) for d, name in NONSTREAMING_CASES],
+)
+def test_reasoning_with_token_ids(
+    param_dict: dict,
+    qwen3_tokenizer,
+):
+    """Non-streaming extraction with token IDs via extract_reasoning_with_token_ids.
+
+    Verifies that passing token IDs (as DelegatingParser.parse() does)
+    produces the same result as the text-only path.
+    """
+    output = param_dict["output"]
+    token_ids = qwen3_tokenizer.encode(output, add_special_tokens=False)
+
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        qwen3_tokenizer
+    )
+
+    request = ChatCompletionRequest(messages=[], model="test-model")
+    reasoning, content = parser.extract_reasoning_with_token_ids(
+        model_output=output, request=request, token_ids=token_ids
+    )
+
+    assert reasoning == param_dict["reasoning"]
+    assert content == param_dict["content"]
+
+
 # --- Tests for enable_thinking=False (thinking explicitly disabled) ---
 
 
@@ -373,3 +411,33 @@ def test_reasoning_thinking_disabled(
 
     assert reasoning == expected_reasoning
     assert content == expected_content
+
+
+def test_extract_reasoning_with_token_ids_forwards_ids():
+    """Verify token_ids are forwarded (not dropped) to the engine."""
+    vocab: dict[str, int] = {
+        "<think>": 200,
+        "</think>": 201,
+        "<tool_call>": 202,
+        "</tool_call>": 203,
+    }
+    tokens: list[tuple[int, str]] = [
+        (200, "<think>"),
+        (10, "reasoning"),
+        (201, ""),
+        (11, "content"),
+    ]
+    tok = MockTokenizer(vocab=vocab, tokens=tokens)
+    parser = Qwen3Parser(tok)
+
+    text = "".join(t for _, t in tokens)
+    ids = [tid for tid, _ in tokens]
+
+    reasoning, content = parser.extract_reasoning_with_token_ids(
+        model_output=text,
+        request=ChatCompletionRequest(messages=[], model="test-model"),
+        token_ids=ids,
+    )
+
+    assert reasoning == "reasoning"
+    assert content == "content"

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -267,6 +267,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                     reasoning, content, _ = parser.parse(
                         output.text,
                         request=request,  # type: ignore[arg-type]
+                        model_output_token_ids=output.token_ids,
                     )
                     if not request.include_reasoning:
                         reasoning = None

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -346,6 +346,7 @@ class ParsableContext(ConversationContext):
                 completion.text,
                 self.request,
                 enable_auto_tools=self.enable_auto_tools,
+                model_output_token_ids=completion.token_ids,
             )
             self.response_messages.extend(
                 build_response_output_items(

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1063,6 +1063,7 @@ class OpenAIServingResponses(OpenAIServing):
                 final_output.text,
                 request,
                 enable_auto_tools=self.enable_auto_tools,
+                model_output_token_ids=final_output.token_ids,
             )
             return build_response_output_items(
                 reasoning=reasoning,

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -27,6 +27,10 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
+from vllm.parser.engine.adapters import (
+    ParserEngineReasoningAdapter,
+    ParserEngineToolAdapter,
+)
 from vllm.parser.metrics import record_tool_parser_invocation
 from vllm.parser.utils import count_history_tool_calls
 from vllm.reasoning.abs_reasoning_parsers import ReasoningParser
@@ -387,8 +391,20 @@ class DelegatingParser(Parser):
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> tuple[str | None, str | None]:
+        return self.extract_reasoning_with_token_ids(model_output, request)
+
+    def extract_reasoning_with_token_ids(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        token_ids: Sequence[int] = (),
+    ) -> tuple[str | None, str | None]:
         if self._reasoning_parser is None:
             return None, model_output
+        if isinstance(self._reasoning_parser, ParserEngineReasoningAdapter):
+            return self._reasoning_parser.extract_reasoning_with_token_ids(
+                model_output, request, token_ids
+            )
         return self._reasoning_parser.extract_reasoning(model_output, request)
 
     def _get_function_name(
@@ -419,6 +435,7 @@ class DelegatingParser(Parser):
         content: str | None,
         request: ChatCompletionRequest | ResponsesRequest,
         enable_auto_tools: bool = False,
+        token_ids: Sequence[int] = (),
     ) -> tuple[list[FunctionCall] | None, str | None]:
         tool_parser = self._tool_parser
         if tool_parser is None:
@@ -472,9 +489,10 @@ class DelegatingParser(Parser):
         elif is_auto_tool_choice:
             # Automatic Tool Call Parsing (also used as fallback for
             # required/named when supports_required_and_named=False)
-            tool_call_info = self.extract_tool_calls(
+            tool_call_info = self.extract_tool_calls_with_token_ids(
                 content if content is not None else "",
                 request=request,
+                token_ids=token_ids,
             )
             if tool_call_info is not None and tool_call_info.tools_called:
                 tool_calls.extend(
@@ -568,6 +586,14 @@ class DelegatingParser(Parser):
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> ExtractedToolCallInformation:
+        return self.extract_tool_calls_with_token_ids(model_output, request)
+
+    def extract_tool_calls_with_token_ids(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        token_ids: Sequence[int] = (),
+    ) -> ExtractedToolCallInformation:
         if self._tool_parser is None:
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
@@ -575,10 +601,17 @@ class DelegatingParser(Parser):
         result = None
         is_tool_called: bool | Exception = False
         try:
-            result = self._tool_parser.extract_tool_calls(
-                model_output,
-                request=request,  # type: ignore[arg-type]
-            )
+            if isinstance(self._tool_parser, ParserEngineToolAdapter):
+                result = self._tool_parser.extract_tool_calls_with_token_ids(
+                    model_output,
+                    request=request,  # type: ignore[arg-type]
+                    token_ids=token_ids,
+                )
+            else:
+                result = self._tool_parser.extract_tool_calls(
+                    model_output,
+                    request=request,  # type: ignore[arg-type]
+                )
             is_tool_called = bool(result.tools_called)
         except Exception as e:
             is_tool_called = e
@@ -776,11 +809,20 @@ class DelegatingParser(Parser):
         model_output_token_ids: Sequence[int] = (),
     ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
         self._initialize_history_tool_call_cnt(request)
-        reasoning, content = self.extract_reasoning(model_output, request)
+        token_ids = model_output_token_ids or ()
+
+        reasoning, content = self.extract_reasoning_with_token_ids(
+            model_output, request, token_ids
+        )
+
+        content_token_ids = (
+            self.extract_content_ids(list(token_ids)) if token_ids else []
+        )
         tool_calls, content = self._extract_tool_calls(
             content=content,
             request=request,
             enable_auto_tools=enable_auto_tools,
+            token_ids=content_token_ids,
         )
         return reasoning, content, tool_calls
 

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -387,7 +387,21 @@ class DelegatingParser(Parser):
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> tuple[str | None, str | None]:
-        return self.extract_reasoning_with_token_ids(model_output, request)
+        return self._do_extract_reasoning(model_output, request)
+
+    def _do_extract_reasoning(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        token_ids: Sequence[int] = (),
+    ) -> tuple[str | None, str | None]:
+        if self._reasoning_parser is None:
+            return None, model_output
+        if hasattr(self._reasoning_parser, "extract_reasoning_with_token_ids"):
+            return self._reasoning_parser.extract_reasoning_with_token_ids(
+                model_output, request, token_ids
+            )
+        return self._reasoning_parser.extract_reasoning(model_output, request)
 
     def extract_reasoning_with_token_ids(
         self,
@@ -400,11 +414,7 @@ class DelegatingParser(Parser):
             if type(self).extract_reasoning is not DelegatingParser.extract_reasoning:
                 return self.extract_reasoning(model_output, request)
             return None, model_output
-        if hasattr(self._reasoning_parser, "extract_reasoning_with_token_ids"):
-            return self._reasoning_parser.extract_reasoning_with_token_ids(
-                model_output, request, token_ids
-            )
-        return self._reasoning_parser.extract_reasoning(model_output, request)
+        return self._do_extract_reasoning(model_output, request, token_ids)
 
     def _get_function_name(
         self, request: ChatCompletionRequest | ResponsesRequest
@@ -580,14 +590,7 @@ class DelegatingParser(Parser):
             delta_token_ids,
         )
 
-    def extract_tool_calls(
-        self,
-        model_output: str,
-        request: ChatCompletionRequest | ResponsesRequest,
-    ) -> ExtractedToolCallInformation:
-        return self.extract_tool_calls_with_token_ids(model_output, request)
-
-    def extract_tool_calls_with_token_ids(
+    def _do_extract_tool_calls_non_streaming(
         self,
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
@@ -622,6 +625,23 @@ class DelegatingParser(Parser):
                 request=request,
             )
         return result
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> ExtractedToolCallInformation:
+        return self._do_extract_tool_calls_non_streaming(model_output, request)
+
+    def extract_tool_calls_with_token_ids(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        token_ids: Sequence[int] = (),
+    ) -> ExtractedToolCallInformation:
+        return self._do_extract_tool_calls_non_streaming(
+            model_output, request, token_ids
+        )
 
     def extract_tool_calls_streaming(
         self,

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -604,7 +604,7 @@ class DelegatingParser(Parser):
             if isinstance(self._tool_parser, ParserEngineToolAdapter):
                 result = self._tool_parser.extract_tool_calls_with_token_ids(
                     model_output,
-                    request=request,  # type: ignore[arg-type]
+                    request=request,
                     token_ids=token_ids,
                 )
             else:

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -396,6 +396,9 @@ class DelegatingParser(Parser):
         token_ids: Sequence[int] = (),
     ) -> tuple[str | None, str | None]:
         if self._reasoning_parser is None:
+            # Subclass overrides extract_reasoning directly (not via delegate)
+            if type(self).extract_reasoning is not DelegatingParser.extract_reasoning:
+                return self.extract_reasoning(model_output, request)
             return None, model_output
         if hasattr(self._reasoning_parser, "extract_reasoning_with_token_ids"):
             return self._reasoning_parser.extract_reasoning_with_token_ids(

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -27,10 +27,6 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
-from vllm.parser.engine.adapters import (
-    ParserEngineReasoningAdapter,
-    ParserEngineToolAdapter,
-)
 from vllm.parser.metrics import record_tool_parser_invocation
 from vllm.parser.utils import count_history_tool_calls
 from vllm.reasoning.abs_reasoning_parsers import ReasoningParser
@@ -401,7 +397,7 @@ class DelegatingParser(Parser):
     ) -> tuple[str | None, str | None]:
         if self._reasoning_parser is None:
             return None, model_output
-        if isinstance(self._reasoning_parser, ParserEngineReasoningAdapter):
+        if hasattr(self._reasoning_parser, "extract_reasoning_with_token_ids"):
             return self._reasoning_parser.extract_reasoning_with_token_ids(
                 model_output, request, token_ids
             )
@@ -601,7 +597,7 @@ class DelegatingParser(Parser):
         result = None
         is_tool_called: bool | Exception = False
         try:
-            if isinstance(self._tool_parser, ParserEngineToolAdapter):
+            if hasattr(self._tool_parser, "extract_tool_calls_with_token_ids"):
                 result = self._tool_parser.extract_tool_calls_with_token_ids(
                     model_output,
                     request=request,

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -173,7 +173,7 @@ class ParserEngineToolAdapter(ToolParser):
     def extract_tool_calls(
         self,
         model_output: str,
-        request: ChatCompletionRequest,
+        request: ChatCompletionRequest | ResponsesRequest,
     ) -> ExtractedToolCallInformation:
         return self._parser_engine.extract_tool_calls_from_content(
             model_output,
@@ -183,7 +183,7 @@ class ParserEngineToolAdapter(ToolParser):
     def extract_tool_calls_with_token_ids(
         self,
         model_output: str,
-        request: ChatCompletionRequest,
+        request: ChatCompletionRequest | ResponsesRequest,
         token_ids: Sequence[int] = (),
     ) -> ExtractedToolCallInformation:
         return self._parser_engine.extract_tool_calls_from_content(

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -72,7 +72,23 @@ class ParserEngineReasoningAdapter(ReasoningParser):
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> tuple[str | None, str | None]:
         with self._skip_tool_parsing():
-            return self._parser_engine.extract_reasoning(model_output, request)
+            return self._parser_engine.extract_reasoning(
+                model_output,
+                request,
+            )
+
+    def extract_reasoning_with_token_ids(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        token_ids: Sequence[int] = (),
+    ) -> tuple[str | None, str | None]:
+        with self._skip_tool_parsing():
+            return self._parser_engine.extract_reasoning_with_token_ids(
+                model_output,
+                request,
+                token_ids,
+            )
 
     def extract_reasoning_streaming(
         self,
@@ -160,7 +176,20 @@ class ParserEngineToolAdapter(ToolParser):
         request: ChatCompletionRequest,
     ) -> ExtractedToolCallInformation:
         return self._parser_engine.extract_tool_calls_from_content(
-            model_output, request
+            model_output,
+            request,
+        )
+
+    def extract_tool_calls_with_token_ids(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+        token_ids: Sequence[int] = (),
+    ) -> ExtractedToolCallInformation:
+        return self._parser_engine.extract_tool_calls_from_content(
+            model_output,
+            request,
+            token_ids,
         )
 
     def extract_tool_calls_streaming(

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -554,7 +554,7 @@ class ParserEngine(Parser):
     def extract_tool_calls_from_content(
         self,
         content: str,
-        request: ChatCompletionRequest,
+        request: ChatCompletionRequest | ResponsesRequest,
         token_ids: Sequence[int] = (),
     ) -> ExtractedToolCallInformation:
         """Extract tool calls from reasoning-stripped content.

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -477,8 +477,16 @@ class ParserEngine(Parser):
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> tuple[str | None, str | None]:
+        return self.extract_reasoning_with_token_ids(model_output, request)
+
+    def extract_reasoning_with_token_ids(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        token_ids: Sequence[int] = (),
+    ) -> tuple[str | None, str | None]:
         self._reset()
-        events = self._feed(model_output, [])
+        events = self._feed(model_output, token_ids)
         events.extend(self._engine.finish())
 
         reasoning_parts: list[str] = []
@@ -521,6 +529,14 @@ class ParserEngine(Parser):
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> ExtractedToolCallInformation:
+        return self.extract_tool_calls_with_token_ids(model_output, request)
+
+    def extract_tool_calls_with_token_ids(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        token_ids: Sequence[int] = (),
+    ) -> ExtractedToolCallInformation:
         self._reset()
         self._streaming_initialized = True
         result = self.extract_tool_calls_streaming(
@@ -528,8 +544,8 @@ class ParserEngine(Parser):
             current_text=model_output,
             delta_text=model_output,
             previous_token_ids=[],
-            current_token_ids=[],
-            delta_token_ids=[],
+            current_token_ids=token_ids,
+            delta_token_ids=token_ids,
             request=request,
         )
         finish_delta = self.finish_streaming()
@@ -539,6 +555,7 @@ class ParserEngine(Parser):
         self,
         content: str,
         request: ChatCompletionRequest,
+        token_ids: Sequence[int] = (),
     ) -> ExtractedToolCallInformation:
         """Extract tool calls from reasoning-stripped content.
 
@@ -549,7 +566,7 @@ class ParserEngine(Parser):
         self._check_skip_tool_parsing(request)
         _, parsed_content, tool_call_info = self._single_pass_parse(
             content,
-            [],
+            token_ids,
             initial_state=ParserState.CONTENT,
         )
         if parsed_content is not None and tool_call_info.content is None:

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -217,12 +217,6 @@ class StreamingParserEngine:
 
         return events
 
-    def parse_complete(self, text: str) -> list[SemanticEvent]:
-        token_ids: list[int] = []
-        events = self.feed(text, token_ids)
-        events.extend(self.finish())
-        return events
-
     def _process_lex_tokens(self, tokens: list[LexToken]) -> list[SemanticEvent]:
         events: list[SemanticEvent] = []
         strict = self._token_id_terminal_names if self._ever_had_token_ids else None

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -598,12 +598,15 @@ class Gemma4Parser(ParserEngine):
         delta.reasoning = self._reasoning_text
         return delta
 
-    def extract_reasoning(
+    def extract_reasoning_with_token_ids(
         self,
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
+        token_ids: Sequence[int] = (),
     ) -> tuple[str | None, str | None]:
-        reasoning, content = super().extract_reasoning(model_output, request)
+        reasoning, content = super().extract_reasoning_with_token_ids(
+            model_output, request, token_ids
+        )
         if reasoning:
             if reasoning.startswith(_GEMMA4_THOUGHT_PREFIX):
                 reasoning = reasoning[len(_GEMMA4_THOUGHT_PREFIX) :]

--- a/vllm/parser/glm47_moe.py
+++ b/vllm/parser/glm47_moe.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import functools
 import json
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -216,11 +217,14 @@ class Glm47MoeParser(ParserEngine):
             return input_ids
         return super().extract_content_ids(input_ids)
 
-    def extract_reasoning(
+    def extract_reasoning_with_token_ids(
         self,
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
+        token_ids: Sequence[int] = (),
     ) -> tuple[str | None, str | None]:
         if not self.thinking_enabled:
             return None, model_output
-        return super().extract_reasoning(model_output, request)
+        return super().extract_reasoning_with_token_ids(
+            model_output, request, token_ids
+        )

--- a/vllm/parser/nemotron_v3.py
+++ b/vllm/parser/nemotron_v3.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from vllm.parser.qwen3 import Qwen3Parser, qwen3_config
@@ -98,12 +99,15 @@ class NemotronV3Parser(Qwen3Parser):
             return None
         return "".join(self._streamed_reasoning) or None
 
-    def extract_reasoning(
+    def extract_reasoning_with_token_ids(
         self,
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
+        token_ids: Sequence[int] = (),
     ) -> tuple[str | None, str | None]:
-        reasoning, content = super().extract_reasoning(model_output, request)
+        reasoning, content = super().extract_reasoning_with_token_ids(
+            model_output, request, token_ids
+        )
 
         if self._should_force_content(request) and (
             content is None or not content.strip()

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import functools
 import json
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -235,14 +236,17 @@ class Qwen3Parser(ParserEngine):
         self._tool_call_token_id: int | None = vocab.get(self.TOOL_START)
         self._tool_call_end_token_id: int | None = vocab.get(self.TOOL_END)
 
-    def extract_reasoning(
+    def extract_reasoning_with_token_ids(
         self,
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
+        token_ids: Sequence[int] = (),
     ) -> tuple[str | None, str | None]:
         if not self.thinking_enabled:
             return None, model_output
-        return super().extract_reasoning(model_output, request)
+        return super().extract_reasoning_with_token_ids(
+            model_output, request, token_ids
+        )
 
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
         if super().is_reasoning_end(input_ids):


### PR DESCRIPTION
## Purpose

Non-streaming paths in the new parser engine did not use token IDs, so token-ID-based strict terminal matching (as opposed to text that might happen to look like a special token) only worked for the streaming path. The non-streaming path was always falling back to text-based matching. This also means special token dropping by ID only happened for the streaming paths. That was ok for the current set of models, but needed to be fixed before moving DeepSeek v3 and v4 models to the new parser engine because its `bos` token at id 0 is more commonly emitted by the model and needs to be stripped by the parser so the client does not see it.
    
New `extract_tool_calls_with_token_ids` and `extract_reasoning_with_token_ids` non-streaming methods are defined on `DelegatingParser`, not on the legacy `ReasoningParser` or `ToolParser` base classes, to avoid expanding the public API of the old or new parsers. `DelegatingParser` dispatches intelligently so engine-based parsers get token IDs and legacy parsers fall back to text-only methods.

Minor changes were made in the serving layer to fix a couple of places that were not passing the token ids into the `parse(...)` calls for non-streaming Responses and batch Chat Completions.
    
This also removes the unused `StreamingParserEngine.parse_complete()` method that was attracting incorrect usage from contributors, as that was just a test helper. The official non-streaming entrypoint into the new Parsers `parse(...)`, already defined in abstract_parser.py.

## Test Plan

### Unit Tests

```
pytest -v \
    tests/entrypoints/openai/responses/test_parsable_context_unit.py \
    tests/entrypoints/openai/responses/test_serving_responses.py \
    tests/entrypoints/unit_tests \
    tests/parser/engine/ \
    tests/parser/test_parse.py \
    tests/reasoning/test_gemma4_reasoning_parser.py \
    tests/reasoning/test_glm4_moe_reasoning_parser.py \
    tests/reasoning/test_nemotron_v3_reasoning_parser.py \
    tests/reasoning/test_qwen3_reasoning_parser.py \
    tests/tool_parsers/test_gemma4_tool_parser.py \
    tests/tool_parsers/test_glm4_moe_tool_parser.py \
    tests/tool_parsers/test_qwen3coder_tool_parser.py
```

## Test Result

### Unit Tests

```
2972 passed, 1 skipped, 17 warnings
```

