### PR TITLE
[Core] Skip building unused per-step scheduler-output fields

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -175,11 +175,82 @@ def test_cached_request_data_resumed_all_token_ids_mrv1_only():
     assert req.request_id in cached.resumed_req_ids
     assert cached.all_token_ids[req.request_id] == list(req.all_token_ids)
 
-    # V2 model runner: all_token_ids is skipped entirely.
+    # V2 model runner: all_token_ids is skipped entirely; resumed_req_ids is
+    # still populated (consumed by scheduler-side KV connectors).
     scheduler.use_v2_model_runner = True
     cached = make_cached()
     assert req.request_id in cached.resumed_req_ids
     assert cached.all_token_ids == {}
+
+
+@pytest.mark.parametrize(
+    ("use_v2", "enable_logging", "profiler", "expected"),
+    [
+        (False, False, None, False),  # V1 runner always reads it
+        (True, False, None, True),  # V2, no consumer -> skip
+        (True, True, None, False),  # V2 + iteration-detail logging -> keep
+        (True, False, "torch", False),  # V2 + profiler -> keep
+    ],
+)
+def test_should_skip_num_output_tokens(use_v2, enable_logging, profiler, expected):
+    """The skip predicate fires only on V2 when neither consumer of
+    `num_output_tokens` (iteration-detail logging or a profiler) is active.
+
+    A V2 scheduler cannot be constructed without Triton, so the derivation is
+    covered here directly rather than through `create_scheduler`.
+    """
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    assert (
+        Scheduler._should_skip_num_output_tokens(use_v2, enable_logging, profiler)
+        is expected
+    )
+
+
+def test_cached_request_data_skips_num_output_tokens_when_guarded():
+    """`_make_cached_request_data` populates `num_output_tokens` in req order,
+    unless the skip guard is set, in which case it leaves the empty default
+    without disturbing the other per-request fields.
+    """
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+
+    scheduler = create_scheduler()
+    running, resumed = create_requests(num_requests=2, num_tokens=8)
+    running.append_output_token_ids([11, 12])
+    resumed.append_output_token_ids([21])
+
+    empty_blocks = KVCacheBlocks(blocks=((),))
+
+    def make_cached():
+        return scheduler._make_cached_request_data(
+            running_reqs=[running],
+            resumed_reqs=[resumed],
+            num_scheduled_tokens={running.request_id: 1, resumed.request_id: 1},
+            spec_decode_tokens={},
+            req_to_new_blocks={
+                running.request_id: empty_blocks,
+                resumed.request_id: empty_blocks,
+            },
+        )
+
+    # Guard off (the default): populated in req order.
+    assert not scheduler._skip_num_output_tokens
+    cached = make_cached()
+    assert cached.req_ids == [running.request_id, resumed.request_id]
+    assert cached.num_output_tokens == [
+        running.num_output_tokens + running.num_output_placeholders,
+        resumed.num_output_tokens + resumed.num_output_placeholders,
+    ]
+
+    # Guard on: empty default, other per-request fields unaffected.
+    scheduler._skip_num_output_tokens = True
+    cached = make_cached()
+    assert cached.num_output_tokens == []
+    assert cached.req_ids == [running.request_id, resumed.request_id]
+    assert cached.num_computed_tokens == [
+        running.num_computed_tokens,
+        resumed.num_computed_tokens,
+    ]
 
 
 def test_schedule_partial_requests():
@@ -5208,3 +5279,69 @@ def test_async_load_reservation_prevents_wedge_e2e():
     assert b.status == RequestStatus.WAITING
     assert b.num_preemptions == 0
     assert b.request_id not in req_to_blocks
+
+
+def _advance_one_decode_step(scheduler, requests):
+    """Schedule once and feed back a sampled token for every request."""
+    output = scheduler.schedule()
+    req_ids = [r.request_id for r in requests]
+    model_runner_output = ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={rid: i for i, rid in enumerate(req_ids)},
+        sampled_token_ids=[[0]] * len(requests),
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_runner_output)
+    return output
+
+
+def test_num_common_prefix_blocks_skipped_when_cascade_disabled():
+    """When cascade attention is disabled (the default), the scheduler must
+    not walk the shared prefix and must emit the zero-filled default, even
+    when running requests share a long prefix with real shared blocks."""
+    scheduler = create_scheduler(enable_prefix_caching=True, block_size=16)
+    assert scheduler.cascade_attn_enabled is False
+    num_groups = len(scheduler.kv_cache_config.kv_cache_groups)
+
+    # 4 identical 128-token prompts -> 8 fully-shared blocks once allocated.
+    requests = create_requests(num_requests=4, num_tokens=128, same_prompt=True)
+    for request in requests:
+        scheduler.add_request(request)
+
+    output = _advance_one_decode_step(scheduler, requests)
+    assert output.num_common_prefix_blocks == [0] * num_groups
+
+    output = scheduler.schedule()
+    assert output.num_common_prefix_blocks == [0] * num_groups
+    # Sanity: a direct manager call proves shared blocks really exist, so the
+    # zero result above is the guard short-circuiting, not an empty cache.
+    direct = scheduler.kv_cache_manager.get_num_common_prefix_blocks(
+        scheduler.running[0].request_id
+    )
+    assert any(v > 0 for v in direct)
+
+
+def test_num_common_prefix_blocks_computed_when_cascade_enabled():
+    """When cascade attention is enabled, the field must still be computed and
+    match the KV cache manager's value."""
+    scheduler = create_scheduler(enable_prefix_caching=True, block_size=16)
+    # Platforms such as CPU force-disable cascade attention in config; set the
+    # guard flag directly to exercise the computed path independent of platform.
+    scheduler.cascade_attn_enabled = True
+    num_groups = len(scheduler.kv_cache_config.kv_cache_groups)
+
+    requests = create_requests(num_requests=4, num_tokens=128, same_prompt=True)
+    for request in requests:
+        scheduler.add_request(request)
+
+    _advance_one_decode_step(scheduler, requests)
+    output = scheduler.schedule()
+
+    expected = scheduler.kv_cache_manager.get_num_common_prefix_blocks(
+        scheduler.running[0].request_id
+    )
+    assert len(output.num_common_prefix_blocks) == num_groups
+    assert output.num_common_prefix_blocks == expected
+    assert any(v > 0 for v in output.num_common_prefix_blocks)

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -60,6 +60,7 @@ def create_scheduler(
     use_ec_connector: bool = False,
     ec_role: str | None = None,
     use_v2_model_runner: bool | None = None,
+    disable_cascade_attn: bool = True,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -80,6 +81,7 @@ def create_scheduler(
         dtype="float16",
         seed=42,
         skip_tokenizer_init=skip_tokenizer_init,
+        disable_cascade_attn=disable_cascade_attn,
     )
     if max_model_len is None:
         max_model_len = max_num_batched_tokens

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -93,6 +93,11 @@ class Scheduler(SchedulerInterface):
             )
         self.structured_output_manager = structured_output_manager
         self.is_encoder_decoder = vllm_config.model_config.is_encoder_decoder
+        # Cascade attention is the only consumer of num_common_prefix_blocks
+        # (see GPUModelRunner._compute_cascade_attn_prefix_lens). When it is
+        # disabled, skip the per-step common-prefix walk entirely. Mirrors the
+        # consumer's gate: cascade_attn_enabled = not disable_cascade_attn.
+        self.cascade_attn_enabled = not vllm_config.model_config.disable_cascade_attn
 
         # include_finished_set controls whether a separate set of finished
         # request ids should be included in the EngineCoreOutputs returned
@@ -273,6 +278,11 @@ class Scheduler(SchedulerInterface):
 
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
+        self._skip_num_output_tokens = self._should_skip_num_output_tokens(
+            self.use_v2_model_runner,
+            self.observability_config.enable_logging_iteration_details,
+            vllm_config.profiler_config.profiler,
+        )
         # Scheduler iteration counter. Drives the V2+PP+async decode-throttle
         # cadence (`next_decode_eligible_step`).
         self.current_step = 0
@@ -1026,8 +1036,11 @@ class Scheduler(SchedulerInterface):
         # Get the longest common prefix among all requests in the running queue.
         # This can be potentially used for cascade attention.
         num_common_prefix_blocks = [0] * len(self.kv_cache_config.kv_cache_groups)
-        with record_function_or_nullcontext("schedule: get_num_common_prefix_blocks"):
-            if self.running:
+        # Only consumed by cascade attention; skip the walk when disabled.
+        if self.cascade_attn_enabled and self.running:
+            with record_function_or_nullcontext(
+                "schedule: get_num_common_prefix_blocks"
+            ):
                 any_request_id = self.running[0].request_id
                 num_common_prefix_blocks = (
                     self.kv_cache_manager.get_num_common_prefix_blocks(any_request_id)
@@ -1242,6 +1255,24 @@ class Scheduler(SchedulerInterface):
         if self.log_stats:
             session.record_event(EngineCoreEventType.QUEUED)
 
+    @staticmethod
+    def _should_skip_num_output_tokens(
+        use_v2_model_runner: bool,
+        enable_logging_iteration_details: bool,
+        profiler: str | None,
+    ) -> bool:
+        """Whether to skip building `CachedRequestData.num_output_tokens`.
+
+        It is read directly by the V1 model runner; on V2 it is read only by
+        `compute_iteration_details`, which runs under iteration-detail logging
+        or a profiler. Skip building it when no consumer is active.
+        """
+        return (
+            use_v2_model_runner
+            and not enable_logging_iteration_details
+            and profiler is None
+        )
+
     def _make_cached_request_data(
         self,
         running_reqs: list[Request],
@@ -1287,9 +1318,10 @@ class Scheduler(SchedulerInterface):
                 req_to_new_blocks[req_id].get_block_ids(allow_none=True)
             )
             num_computed_tokens.append(req.num_computed_tokens)
-            num_output_tokens.append(
-                req.num_output_tokens + req.num_output_placeholders
-            )
+            if not self._skip_num_output_tokens:
+                num_output_tokens.append(
+                    req.num_output_tokens + req.num_output_placeholders
+                )
 
         return CachedRequestData(
             req_ids=req_ids,


### PR DESCRIPTION
## What
Skip two per-step scheduler products when their consumer is inactive:

1. **`CachedRequestData.num_output_tokens`** — a direct follow-up to #45840 (which skipped
   `all_token_ids` for the V2 runner). The field is read directly by the V1 runner; on the V2
   runner it is read only via `compute_iteration_details` (`is_context_phase`), which runs only
   under iteration-detail logging or an active profiler. Skip building it on V2 when neither is
   active (`_should_skip_num_output_tokens`). Left as its correctly-typed empty default otherwise.
2. **`SchedulerOutput.num_common_prefix_blocks`** — same underlying principle (don't do per-step
   scheduler work whose consumer is inactive), via a different gate: cascade attention. The value
   is consumed in exactly one place — `GPUModelRunner._compute_cascade_attn_prefix_lens` — under
   `if self.cascade_attn_enabled and not use_ubatching`. Cascade attention is **disabled by
   default** (#36318 made it opt-in for numerical safety), and CPU/XPU runners hardcode it off, so
   the per-step `get_num_common_prefix_blocks` walk is pure waste in the default configuration.
   Guard it on `cascade_attn_enabled` (derived once at init); keep the existing zero default.

## Why this is not a duplicate
- No open PR touches the scheduler-side construction of either field. The open cascade PR #44397
  changes the kernel-side heuristic (`fa_utils.py`/`flash_attn.py`), not the scheduler. The
  `num_output_tokens` trim has no prior PR. The `new_block_ids` host-leak is owned by #44490.

## Behavior preservation
- `num_common_prefix_blocks`: the producer guard (`cascade_attn_enabled`) is strictly weaker than
  the consumer's (`cascade_attn_enabled and not use_ubatching`), so the field is always present
  when read. Identical when cascade is enabled. `disable_cascade_attn` is resolved before the
  scheduler is constructed and is immutable after.
- `num_output_tokens`: V1 always builds it (byte-identical). The two V2 readers
  (`gpu_worker.annotate_profile`, `engine/core.log_iteration_details`) are gated by exactly the
  two flags the skip predicate checks; a profiler cannot be enabled at runtime unless configured
  at init (`Worker.profile` raises otherwise), so there is no window where a reader sees an empty
  list.

## Test plan
```
python -m pytest tests/v1/core/test_scheduler.py
```
117 passed locally (CPU backend). New/updated tests:
- `test_should_skip_num_output_tokens` — parametrized over the skip predicate (V1; V2 no-consumer;
  V2 + logging; V2 + profiler).
- `test_cached_request_data_skips_num_output_tokens_when_guarded` — `_make_cached_request_data`
  honors the guard without disturbing other fields.
- `test_num_common_prefix_blocks_skipped_when_cascade_disabled` / `..._computed_when_cascade_enabled`
  — skip emits the zero default even when shared blocks exist (verified via a direct manager call);
  enabled path matches the manager's value.

`ruff check` + `ruff format` clean.

## Microbenchmark (CPU, single thread)
- `num_common_prefix_blocks`: ~3.46 µs/step removed at 64 reqs × 1024-token shared prefix; scales
  with shared-prefix length × fan-out, on the single-threaded scheduler critical path.
- `num_output_tokens` (V2): ~139 B/step @ N=64, ~715 B/step @ N=256 removed from the per-step
  broadcast to every worker (≈5.7 MB / 1k steps at TP=8, N=256).

---
*AI assistance was used in developing this change (Claude). I have reviewed every changed line,
understand and can defend the change, and ran the tests above.*
