### PR TITLE
[Perf][V1] Apply min-p in log-space to avoid a redundant softmax

### DIFF
--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -103,15 +103,24 @@ class MinPLogitsProcessor(LogitsProcessor):
         if not self.min_p_count:
             return logits
 
-        # Convert logits to probability distribution
-        probability_values = torch.nn.functional.softmax(logits, dim=-1)
-        # Calculate maximum probabilities per sequence
-        max_probabilities = torch.amax(probability_values, dim=-1, keepdim=True)
-        # Adjust min_p
-        adjusted_min_p = max_probabilities.mul_(self.min_p)
-        # Identify valid tokens using threshold comparison
-        invalid_token_mask = probability_values < adjusted_min_p
-        # Apply mask using boolean indexing
+        # Apply min-p directly in log-space to avoid a full-vocab softmax.
+        #
+        # min-p masks tokens whose probability is below ``min_p * max_prob``.
+        # Because softmax is monotonic and uses the same per-row normalizer,
+        # this is equivalent to masking tokens whose logit is below
+        # ``log(min_p) + max_logit``:
+        #
+        #   p_i < min_p * max_j p_j
+        #     <=> exp(logit_i) < min_p * exp(max_j logit_j)
+        #     <=> logit_i < log(min_p) + max_j logit_j
+        #
+        # This replaces the softmax (exp + sum + div over the vocab) with a
+        # cheaper amax reduction plus a small log, producing an identical mask.
+        # For ``min_p == 0`` the threshold becomes ``-inf`` so nothing is
+        # masked, matching the previous behavior.
+        max_logits = torch.amax(logits, dim=-1, keepdim=True)
+        min_p_thresholds = max_logits.add_(torch.log(self.min_p))
+        invalid_token_mask = logits < min_p_thresholds
         logits.masked_fill_(invalid_token_mask, -float("inf"))
         return logits
 


### PR DESCRIPTION
## Purpose

The min-p logits processor masks tokens whose probability is below `min_p * max_prob`. It currently runs a **full-vocab `softmax` every decode step** (whenever any request in the batch sets `min_p`) purely to derive that mask.

This softmax is unnecessary. Because `softmax` is monotonic and shares the same per-row normalizer, masking on probabilities is equivalent to masking directly on logits:

```
p_i < min_p * max_j p_j
  <=> exp(logit_i) < min_p * exp(max_j logit_j)
  <=> logit_i      < log(min_p) + max_j logit_j
```

So we can replace the `softmax` (exp + sum + div over the vocab) with a cheaper `amax` reduction plus a small `log`, producing a **bitwise-identical mask**. For `min_p == 0` the threshold becomes `-inf`, so nothing is masked — matching the previous behavior (and the per-row `min_p == 0` entries used for requests in a mixed batch that don't enable min-p).

## Test Plan

- Correctness: existing `tests/v1/logits_processors/test_correctness.py` (the `MinPLogitsProcessor` cases) exercises the masking semantics (dominant token never masked; non-dominant tokens masked when `min_p > 0`; nothing masked when `min_p == 0`).
- Equivalence: a standalone script compares the old softmax-based mask against the new log-space mask elementwise over randomized batches (varying batch size, vocab size, and per-row `min_p` including `0`).
- Microbenchmark of the `apply()` op on an RTX 4090 (fp32).

## Test Result

Equivalence — 200 randomized mixed batches, **0 mismatches** (elementwise-identical output logits), and `min_p == 0` confirmed to mask nothing.

Microbenchmark of `MinPLogitsProcessor.apply` (RTX 4090, fp32, all rows min-p active):

| batch | vocab | before | after | speedup |
|------:|------:|-------:|------:|--------:|
| 16  | 152k | 72 µs   | 38 µs   | 1.90x |
| 64  | 152k | 419 µs  | 280 µs  | 1.50x |
| 256 | 152k | 2816 µs | 1853 µs | 1.52x |
| 256 | 128k | 2278 µs | 1533 µs | 1.49x |

No change to behavior for requests that do not set `min_p` (early `return` on `min_p_count == 0` is unchanged).
