### PR TITLE
[Perf][LoRA] Replace O(n) list.index() with a dict in convert_mapping

### DIFF
--- a/vllm/lora/punica_wrapper/utils.py
+++ b/vllm/lora/punica_wrapper/utils.py
@@ -92,14 +92,22 @@ def convert_mapping(
     embedding_indices = index_mapping_indices.copy()
     lora_indices = index_mapping_indices.copy()
 
+    # Build a reverse lookup (LoRA id -> index) once instead of repeatedly
+    # calling list.index(), which is an O(num_loras) linear scan performed for
+    # every prompt token and every batch token on each step.
+    lora_id_to_index = {
+        lora_id: index
+        for index, lora_id in enumerate(lora_index_to_id)
+        if lora_id is not None
+    }
+
     prompt_mapping: list[int] = [
-        lora_index_to_id.index(x) if x > 0 else -1 for x in mapping.prompt_mapping
+        lora_id_to_index[x] if x > 0 else -1 for x in mapping.prompt_mapping
     ]
     lora_idx = None
     for i in range(len(index_mapping_indices)):
-        # TODO index can be slow. optimize
         lora_idx = (
-            lora_index_to_id.index(index_mapping_indices[i])
+            lora_id_to_index[index_mapping_indices[i]]
             if index_mapping_indices[i] > 0
             else -1
         )


### PR DESCRIPTION
## Purpose

`convert_mapping` (in `vllm/lora/punica_wrapper/utils.py`) builds the per-token LoRA index lists by calling `lora_index_to_id.index(...)` for **every prompt token and every batch token**:

```python
prompt_mapping = [lora_index_to_id.index(x) if x > 0 else -1 for x in mapping.prompt_mapping]
...
for i in range(len(index_mapping_indices)):
    # TODO index can be slow. optimize
    lora_idx = lora_index_to_id.index(index_mapping_indices[i]) if index_mapping_indices[i] > 0 else -1
```

Each `list.index()` is an O(`num_loras`) linear scan, so the construction is **O(num_tokens × num_loras)** every time LoRA metadata is rebuilt — which is on the per-forward path via `update_metadata`. The code already flagged this with a `# TODO index can be slow. optimize`.

This PR builds a reverse `{lora_id: index}` map once and uses dict lookups, making the construction O(num_tokens). The output is unchanged.

## Test Plan

- Correctness: compare the new dict-based construction against the original `list.index()` version elementwise over randomized mappings (varying `max_loras` and token counts).
- CPU microbenchmark of the mapping construction.
- Existing LoRA tests under `tests/lora/`.

## Test Result

Output is **identical** to the previous implementation across all randomized configs.

CPU microbenchmark of the mapping construction (pure Python, no GPU involved):

| max_loras | tokens | before | after | speedup |
|----------:|-------:|-------:|------:|--------:|
| 64 | 1024 | 275 µs | 42 µs | 6.5x |
| 32 | 1024 | 164 µs | 42 µs | 4.0x |
| 16 | 1024 | 107 µs | 42 µs | 2.5x |
| 64 | 256  | 70 µs  | 11 µs | 6.2x |

The speedup grows with `max_loras`, since that is the length of the list being linearly scanned. Behavior is unchanged for the non-LoRA case.
