### PR TITLE
[Perf][Multimodal] Avoid building a full timestamps list in video frame sampling

### DIFF
--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -885,7 +885,6 @@ class GLM46VVideoBackend(VideoBackend):
         extract_t = min(extract_t, cls._MAX_FRAME_COUNT_DYNAMIC)
 
         duration_per_frame = 1 / original_fps if original_fps > 0 else 0
-        timestamps = [i * duration_per_frame for i in range(total_frames_num)]
         max_second = int(duration) if duration else 0
 
         if total_frames_num < extract_t:
@@ -897,7 +896,7 @@ class GLM46VVideoBackend(VideoBackend):
             current_second = 0.0
             inv_fps = 1 / (temporal_patch_size * target_fps)
             for frame_index in range(total_frames_num):
-                if timestamps[frame_index] >= current_second:
+                if frame_index * duration_per_frame >= current_second:
                     current_second += inv_fps
                     frame_indices.append(frame_index)
                     if current_second >= max_second:
@@ -991,7 +990,6 @@ class GLMGAVideoBackend(VideoBackend):
         extract_t = min(extract_t, max_frames)
 
         duration_per_frame = 1 / original_fps
-        timestamps = [i * duration_per_frame for i in range(total_frames_num)]
 
         if total_frames_num < extract_t:
             frame_indices = [
@@ -1002,7 +1000,7 @@ class GLMGAVideoBackend(VideoBackend):
             current_second = 0.0
             inv_fps = 1 / target_fps
             for frame_index in range(total_frames_num):
-                if timestamps[frame_index] >= current_second:
+                if frame_index * duration_per_frame >= current_second:
                     current_second += inv_fps
                     frame_indices.append(frame_index)
                     if current_second >= duration - inv_fps:


### PR DESCRIPTION
## Purpose

The GLM-4V / GLM video frame-sampling backends (`GLM46VVideoBackend` and `GLMGAVideoBackend` in `vllm/multimodal/video.py`) build a Python list with one float timestamp **per source frame**:

```python
timestamps = [i * duration_per_frame for i in range(total_frames_num)]
```

and then only ever read it as `timestamps[frame_index]` inside the sampling loop.

Two issues:
1. The list is O(`total_frames_num`) to allocate, but is **never read** when the `total_frames_num < extract_t` branch is taken.
2. When it *is* read, `timestamps[frame_index]` is exactly `frame_index * duration_per_frame`, so it can be computed inline without materializing the list.

This PR drops the list and computes the timestamp inline. Behavior is identical; it just removes a per-video O(num_frames) allocation that is pure waste for long videos.

## Test Plan

- The change is a mechanical, value-preserving rewrite (`timestamps[frame_index]` -> `frame_index * duration_per_frame`).
- Existing multimodal/video tests.

## Test Result

`timestamps[frame_index] == frame_index * duration_per_frame` by construction, so frame indices returned are unchanged. The O(num_frames) list allocation is removed (and fully avoided in the `total_frames_num < extract_t` path where it was previously built but never used).
