### PR TITLE
[Frontend][KV Connector] Plumb request session id to Mooncake worker

### DIFF
--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -13,7 +13,9 @@ use crate::routes::openai::utils::structured_outputs::convert_from_response_form
 use crate::routes::openai::utils::types::{
     ChatMessage, ContentPart, MessageContent, Tool, ToolChoice, ToolChoiceValue,
 };
-use crate::utils::{ResolvedRequestContext, convert_logit_bias, merge_kv_transfer_params};
+use crate::utils::{
+    ResolvedRequestContext, convert_logit_bias, merge_kv_transfer_params, merge_session_id,
+};
 
 /// Lowered chat request plus the public response metadata carried by every SSE
 /// chunk.
@@ -130,9 +132,9 @@ pub(super) fn prepare_chat_request(
             logprob_token_ids: None,
             structured_outputs,
             skip_reading_prefix_cache: None,
-            vllm_xargs: merge_kv_transfer_params(
-                request.vllm_xargs,
-                request.kv_transfer_params.as_ref(),
+            vllm_xargs: merge_session_id(
+                merge_kv_transfer_params(request.vllm_xargs, request.kv_transfer_params.as_ref()),
+                ctx.session_id.as_deref(),
             ),
         },
         chat_options: ChatOptions {
@@ -1030,6 +1032,65 @@ mod tests {
         )
         .expect("request is valid");
         assert_eq!(prepared.chat_request.data_parallel_rank, None);
+    }
+
+    #[test]
+    fn prepare_chat_request_threads_session_id_from_correlation_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Correlation-ID", "conv-abc".parse().unwrap());
+        let prepared = prepare_chat_request(
+            base_request(),
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            request_context(&headers, None),
+        )
+        .expect("request is valid");
+        let xargs = prepared.chat_request.sampling_params.vllm_xargs.unwrap();
+        assert_eq!(xargs.get("session_id"), Some(&json!("conv-abc")));
+    }
+
+    #[test]
+    fn prepare_chat_request_prefers_session_header_over_correlation() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Correlation-ID", "conv-abc".parse().unwrap());
+        headers.insert("X-Session-ID", "sess-1".parse().unwrap());
+        let prepared = prepare_chat_request(
+            base_request(),
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            request_context(&headers, None),
+        )
+        .expect("request is valid");
+        let xargs = prepared.chat_request.sampling_params.vllm_xargs.unwrap();
+        assert_eq!(xargs.get("session_id"), Some(&json!("sess-1")));
+    }
+
+    #[test]
+    fn prepare_chat_request_body_session_id_overrides_header() {
+        let mut request = base_request();
+        request.vllm_xargs = Some(HashMap::from([(
+            "session_id".to_string(),
+            json!("from-body"),
+        )]));
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Correlation-ID", "conv-abc".parse().unwrap());
+        let prepared = prepare_chat_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            request_context(&headers, None),
+        )
+        .expect("request is valid");
+        let xargs = prepared.chat_request.sampling_params.vllm_xargs.unwrap();
+        assert_eq!(xargs.get("session_id"), Some(&json!("from-body")));
+    }
+
+    #[test]
+    fn prepare_chat_request_leaves_session_id_absent_without_header() {
+        let prepared = prepare_chat_request(
+            base_request(),
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect("request is valid");
+        assert!(prepared.chat_request.sampling_params.vllm_xargs.is_none());
     }
 
     #[test]

--- a/rust/src/server/src/utils.rs
+++ b/rust/src/server/src/utils.rs
@@ -12,7 +12,10 @@ use crate::error::ApiError;
 pub struct ResolvedRequestContext {
     pub request_id: String,
     pub data_parallel_rank: Option<u32>,
+    pub session_id: Option<String>,
 }
+
+const SESSION_ID_HEADERS: [&str; 2] = ["X-Session-ID", "X-Correlation-ID"];
 
 /// Return the current Unix timestamp in seconds for OpenAI response objects.
 pub fn unix_timestamp() -> u64 {
@@ -41,6 +44,20 @@ pub fn merge_kv_transfer_params(
             // This is safe because we know that `kv_params` is already valid JSON.
             serde_json::to_value(kv_params).unwrap(),
         );
+    }
+    xargs
+}
+
+/// Inject the session id into `vllm_xargs["session_id"]`, mirroring the Python
+/// frontend. An explicit body value is preserved.
+pub fn merge_session_id(
+    mut xargs: Option<HashMap<String, Value>>,
+    session_id: Option<&str>,
+) -> Option<HashMap<String, Value>> {
+    if let Some(session_id) = session_id {
+        let map = xargs.get_or_insert_with(HashMap::new);
+        map.entry("session_id".to_string())
+            .or_insert_with(|| Value::String(session_id.to_owned()));
     }
     xargs
 }
@@ -86,9 +103,20 @@ pub fn resolve_request_context(
     let request_id_header = headers.get("X-Request-Id").and_then(|value| value.to_str().ok());
     let request_id = resolve_base_request_id(request_id_header, request_id);
 
+    // First present session header wins.
+    let session_id = SESSION_ID_HEADERS.iter().find_map(|name| {
+        headers
+            .get(*name)
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    });
+
     ResolvedRequestContext {
         request_id,
         data_parallel_rank,
+        session_id,
     }
 }
 

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -1200,6 +1200,78 @@ async def test_serving_chat_data_parallel_rank_extraction():
     assert mock_engine.generate.call_args.kwargs["data_parallel_rank"] is None
 
 
+@pytest.mark.asyncio
+async def test_serving_chat_session_id_header_extraction():
+    """Session/conversation id headers are captured into
+    sampling_params.extra_args["session_id"], with X-Session-ID taking
+    precedence over X-Correlation-ID."""
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    async def mock_generate(*args, **kwargs):
+        from vllm.outputs import CompletionOutput, RequestOutput
+
+        yield RequestOutput(
+            request_id="test-request",
+            prompt="test prompt",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="test response",
+                    token_ids=[4, 5, 6],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                    stop_reason=None,
+                )
+            ],
+            finished=True,
+        )
+
+    mock_engine.generate = AsyncMock(side_effect=mock_generate)
+    serving_chat = _build_serving_chat(mock_engine)
+
+    def _session_id_passed_to_engine() -> str | None:
+        # generate(engine_input, sampling_params, sub_request_id, ...)
+        sampling_params = mock_engine.generate.call_args.args[1]
+        extra_args = sampling_params.extra_args or {}
+        return extra_args.get("session_id")
+
+    req = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "what is 1+1?"}],
+    )
+
+    # X-Correlation-ID is captured.
+    raw = MagicMock()
+    raw.headers = {"X-Correlation-ID": "conv-abc"}
+    raw.state = MagicMock()
+    with suppress(Exception):
+        await serving_chat.create_chat_completion(req, raw)
+    assert _session_id_passed_to_engine() == "conv-abc"
+
+    # X-Session-ID wins when both are present.
+    raw_both = MagicMock()
+    raw_both.headers = {"X-Session-ID": "sess-1", "X-Correlation-ID": "conv-abc"}
+    raw_both.state = MagicMock()
+    with suppress(Exception):
+        await serving_chat.create_chat_completion(req, raw_both)
+    assert _session_id_passed_to_engine() == "sess-1"
+
+    # No header -> no session_id injected.
+    raw_none = MagicMock()
+    raw_none.headers = {}
+    raw_none.state = MagicMock()
+    with suppress(Exception):
+        await serving_chat.create_chat_completion(req, raw_none)
+    assert _session_id_passed_to_engine() is None
+
+
 async def _render_chat_prompt_token_ids(
     serving_chat: OpenAIServingChat,
     messages: list[dict[str, str]],

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -10,6 +10,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.scheduler import (
     MooncakeStoreScheduler,
+    _session_id_from_request,
 )
 
 
@@ -469,3 +470,46 @@ def test_full_external_hit_with_full_local_hit_skips_load():
     assert need_to_allocate == 0
     assert load_async is False
     assert "req-0" not in scheduler.load_specs
+
+
+def _request_with_extra_args(extra_args):
+    return SimpleNamespace(sampling_params=SimpleNamespace(extra_args=extra_args))
+
+
+def test_session_id_from_request_extracts_str():
+    request = _request_with_extra_args({"session_id": "conv-abc"})
+    assert _session_id_from_request(request) == "conv-abc"
+
+
+def test_session_id_from_request_missing_returns_none():
+    assert _session_id_from_request(SimpleNamespace(sampling_params=None)) is None
+    assert _session_id_from_request(_request_with_extra_args(None)) is None
+    assert _session_id_from_request(_request_with_extra_args({})) is None
+    assert _session_id_from_request(_request_with_extra_args({"other": "x"})) is None
+
+
+def test_session_id_from_request_non_str_ignored():
+    assert (
+        _session_id_from_request(_request_with_extra_args({"session_id": 123})) is None
+    )
+
+
+def test_from_request_tracker_propagates_session_id():
+    tracker = RequestTracker(
+        req_id="req-0",
+        token_len=48,
+        allocated_block_ids=([0, 1, 2],),
+        num_saved_tokens=0,
+        session_id="conv-abc",
+    )
+
+    req_meta = ReqMeta.from_request_tracker(
+        tracker,
+        block_size=16,
+        load_spec=None,
+        skip_save=False,
+        block_hashes=[b"h0", b"h1", b"h2"],
+    )
+
+    assert req_meta is not None
+    assert req_meta.session_id == "conv-abc"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -252,6 +252,8 @@ class RequestTracker:
     # For a fresh request this is len(prompt). For a resumed-from-preemption
     # request it includes previously-generated tokens, which are re-prefilled.
     prefill_end_tokens: int = 0
+    # Session/conversation id (e.g. from X-Correlation-ID), if provided.
+    session_id: str | None = None
 
     def reset(self) -> None:
         self.token_len = 0
@@ -294,6 +296,7 @@ class ReqMeta:
 
     token_ids: list[int] | None = None
     num_prompt_tokens: int | None = None
+    session_id: str | None = None
 
     @staticmethod
     def from_request_tracker(
@@ -354,6 +357,7 @@ class ReqMeta:
             is_last_chunk=is_last_chunk,
             token_ids=token_ids,
             num_prompt_tokens=tracker.prefill_end_tokens,
+            session_id=tracker.session_id,
         )
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -30,6 +30,16 @@ from vllm.v1.request import Request
 logger = init_logger(__name__)
 
 
+def _session_id_from_request(request: Request) -> str | None:
+    """Read the session id from ``sampling_params.extra_args``; None if unset."""
+    sampling_params = getattr(request, "sampling_params", None)
+    extra_args = getattr(sampling_params, "extra_args", None)
+    if not extra_args:
+        return None
+    session_id = extra_args.get("session_id")
+    return session_id if isinstance(session_id, str) else None
+
+
 def _new_req_prefill_tokens(request: NewRequestData) -> list[int]:
     """Tokens this prefill will compute KV for.
 
@@ -216,6 +226,7 @@ class MooncakeStoreScheduler:
                 num_saved_tokens=0,
                 token_ids=prefill_tokens[:num_tokens_to_compute],
                 prefill_end_tokens=len(prefill_tokens),
+                session_id=_session_id_from_request(request_real),
             )
             self._request_trackers[request.req_id] = request_tracker
 
@@ -267,6 +278,7 @@ class MooncakeStoreScheduler:
                         num_saved_tokens=0,
                         token_ids=prefill_tokens[:num_tokens_to_compute].copy(),
                         prefill_end_tokens=len(prefill_tokens),
+                        session_id=_session_id_from_request(request_real),
                     )
                     self._request_trackers[req_id] = request_tracker
 
@@ -340,6 +352,7 @@ class MooncakeStoreScheduler:
                     token_len=num_tokens_to_compute,
                     allocated_block_ids=block_ids,
                     num_saved_tokens=0,
+                    session_id=_session_id_from_request(unfinished_req),
                 )
                 self._request_trackers[request_id] = request_tracker
                 req_meta = ReqMeta.from_request_tracker(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -283,6 +283,8 @@ class OpenAIServingChat(OpenAIServing):
         # Extract data_parallel_rank from header (router can inject it)
         data_parallel_rank = self._get_data_parallel_rank(raw_request)
 
+        session_id = self._get_session_id(raw_request)
+
         # Schedule the request and get the result generator.
         max_model_len = self.model_config.max_model_len
         generators: list[AsyncGenerator[RequestOutput, None]] = []
@@ -318,6 +320,10 @@ class OpenAIServingChat(OpenAIServing):
                     max_tokens,
                     self.default_sampling_params,
                 )
+                if session_id is not None:
+                    if sampling_params.extra_args is None:
+                        sampling_params.extra_args = {}
+                    sampling_params.extra_args.setdefault("session_id", session_id)
 
             self._log_inputs(
                 sub_request_id,

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -40,6 +40,8 @@ logger = init_logger(__name__)
 RequestT = TypeVar("RequestT", bound=AnyRequest)
 _T = TypeVar("_T")
 
+SESSION_ID_HEADERS: tuple[str, ...] = ("X-Session-ID", "X-Correlation-ID")
+
 
 @dataclass(kw_only=True)
 class ServeContext(Generic[RequestT]):
@@ -157,6 +159,17 @@ class OpenAIServing(BaseServing, BeamSearchOnlineMixin):
             return int(rank_str)
         except ValueError:
             return None
+
+    @staticmethod
+    def _get_session_id(raw_request: Request | None) -> str | None:
+        """Resolve a session id from ``SESSION_ID_HEADERS`` (None if absent)."""
+        if raw_request is None:
+            return None
+        for header in SESSION_ID_HEADERS:
+            value = raw_request.headers.get(header)
+            if value:
+                return value
+        return None
 
     async def _with_kv_transfer_rejection_cleanup(
         self,


### PR DESCRIPTION
## Purpose

Lets the OpenAI-compatible frontend capture a logical **session/conversation id** from a request header and thread it down to the Mooncake store KV connector, so connectors can do session/cache-aware routing (e.g. co-locating a multi-turn conversation's prefixes).

Today a client can already pass arbitrary metadata via `vllm_xargs`/`extra_args` in the request body, but proxies/routers and benchmark clients commonly carry the session identity as an HTTP header (`X-Session-ID` / `X-Correlation-ID`), which vLLM currently drops. This PR reads that header and stashes it where connectors can see it.

Flow: `X-Session-ID` (falling back to `X-Correlation-ID`) → `sampling_params.extra_args["session_id"]` → engine `Request` → `RequestTracker` → `ReqMeta` (available to the Mooncake store worker).

### Changes
- **Frontend (Python):** new `SESSION_ID_HEADERS` + `OpenAIServing._get_session_id`; chat serving injects the captured id into `sampling_params.extra_args["session_id"]`. `X-Session-ID` takes precedence; an explicit body `vllm_xargs.session_id` is preserved and wins over the header.
- **Frontend (Rust):** mirror in the server — read the header into `ResolvedRequestContext.session_id` and inject via `vllm_xargs` (the same channel `kv_transfer_params` already uses), so it arrives as `extra_args["session_id"]` on the engine side.
- **Mooncake store connector:** carry `session_id` on `RequestTracker`/`ReqMeta` and populate it in `build_connector_meta` from the request.

## Test plan & results
- **Python unit:** `.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_serving_chat_session_id_header_extraction` → **17 passed** (new tests: header capture + precedence, `_session_id_from_request` edge cases, `RequestTracker`→`ReqMeta` propagation; existing scheduler tests still green).
- **Python lint:** `ruff check` + `ruff format --check` on all changed files → clean.
- **Rust:** `cargo test -p vllm-server session` → **4 passed** (header→`vllm_xargs` threading, `X-Session-ID` precedence, body-value wins, absent header); `cargo fmt -p vllm-server --check` → clean; `cargo build -p vllm-server` → ok.

adding debug logs and verified data plumbed through aiperf -> router -> vllm
```
(Worker_TP2_EP2 pid=611730) INFO 06-23 23:27:21 [worker.py:520] [session-debug] store thread req_id=chatcmpl-5d5198f7-b319-4817-a675-6e98b415bdb1-9cb07a92 session_id=f87405c9-9dc1-40e5-92c4-9a5aa698d6cf
(Worker_TP1_EP1 pid=611729) INFO 06-23 23:27:21 [worker.py:520] [session-debug] store thread req_id=chatcmpl-5d5198f7-b319-4817-a675-6e98b415bdb1-9cb07a92 session_id=f87405c9-9dc1-40e5-92c4-9a5aa698d6cf
(Worker_TP3_EP3 pid=611731) INFO 06-23 23:27:21 [worker.py:520] [session-debug] store thread req_id=chatcmpl-5d5198f7-b319-4817-a675-6e98b415bdb1-9cb07a92 session_id=f87405c9-9dc1-40e5-92c4-9a5aa698d6cf
(APIServer pid=610972) INFO:     127.0.0.1:42840 - "GET /metrics HTTP/1.1" 200 OK
(Worker_TP0_EP0 pid=611728) INFO 06-23 23:27:21 [worker.py:520] [session-debug] store thread req_id=chatcmpl-5d5198f7-b319-4817-a675-6e98b415bdb1-9cb07a92 session_id=f87405c9-9dc1-40e5-92c4-9a5aa698d6cf
(APIServer pid=610972) INFO:     127.0.0.1:42840 - "GET /metrics HTTP/1.1" 200 OK
(APIServer pid=610972) INFO 06-23 23:27:21 [serving.py:289] [session-debug] chat serving request_id=chatcmpl-05f027c6-fc3c-4650-b546-df9e3666c297 session_id=e3ab351b-ebef-44f6-86a6-55d7be03fd96
(APIServer pid=610972) INFO:     127.0.0.1:34310 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=610972) INFO:     127.0.0.1:42840 - "GET /metrics HTTP/1.1" 200 OK
(Worker_TP1_EP1 pid=611729) INFO 06-23 23:27:22 [worker.py:520] [session-debug] store thread req_id=chatcmpl-05f027c6-fc3c-4650-b546-df9e3666c297-b6016465 session_id=e3ab351b-ebef-44f6-86a6-55d7be03fd96
(Worker_TP3_EP3 pid=611731) INFO 06-23 23:27:22 [worker.py:520] [session-debug] store thread req_id=chatcmpl-05f027c6-fc3c-4650-b546-df9e3666c297-b6016465 session_id=e3ab351b-ebef-44f6-86a6-55d7be03fd96
(Worker_TP2_EP2 pid=611730) INFO 06-23 23:27:22 [worker.py:520] [session-debug] store thread req_id=chatcmpl-05f027c6-fc3c-4650-b546-df9e3666c297-b6016465 session_id=e3ab351b-ebef-44f6-86a6-55d7be03fd96
(Worker_TP0_EP0 pid=611728) INFO 06-23 23:27:22 [worker.py:520] [session-debug] store thread req_id=chatcmpl-05f027c6-fc3c-4650-b546-df9e3666c297-b6016465 session_id=e3ab351b-ebef-44f6-86a6-55d7be03fd96
```

## Notes
- This is a **draft** for review of the approach/scope.
- Not a duplicate: searched open `vllm-project/vllm` PRs for `X-Correlation-ID` / `X-Session-ID` / "session id header" — none plumb a session/correlation header into `extra_args`/the KV connector.
- AI assistance (Claude Code) was used; the submitter will review every line and run the full test suite before marking ready.