### PR TITLE
[M3] Enable FlashInfer A2A for Minimax-M3-MXFP8

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -133,6 +133,8 @@ class TrtLlmFp8ExpertsModular(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsModular):
             not moe_parallel_config.use_all2all_kernels
             or moe_parallel_config.use_ag_rs_all2all_kernels
             or moe_parallel_config.use_deepep_v2_kernels
+            or moe_parallel_config.use_fi_nvl_one_sided_kernels
+            or moe_parallel_config.use_fi_nvl_two_sided_kernels
         ) and not moe_parallel_config.enable_eplb
 
     @staticmethod

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -12,6 +12,7 @@ from vllm.config.parallel import ExpertPlacementStrategy
 from vllm.distributed import (
     get_ep_group,
     get_pcp_group,
+    get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_reduce,
 )
 from vllm.distributed.eplb.eplb_state import EplbLayerState
@@ -422,15 +423,6 @@ class MoERunner(MoERunnerInterface):
         * If we have SP (TP=N, DP=M, EP), there is a separate AG step handled
           in the model.
         """
-        # A combine kernel that already reduces the fused output is
-        # incompatible with deferring the all-reduce (reduce_results=False,
-        # e.g. fusing it into a subsequent GemmaRMSNorm): the deferred
-        # all-reduce would double-reduce the fused output.
-        assert not (self._fused_output_is_reduced and not self.reduce_results), (
-            "reduce_results=False is incompatible with a combine kernel that "
-            "already reduces the fused output (e.g. DeepEP/Mori/NIXL/"
-            "FlashInfer-NVLink all2all backends)."
-        )
         if (
             shared_output is not None
             and not self.moe_config.is_sequence_parallel
@@ -463,6 +455,19 @@ class MoERunner(MoERunnerInterface):
             states = tensor_model_parallel_all_reduce(states)
 
         return states[..., :trunc_size] if trunc_size is not None else states
+
+    def _validate_reduction_config(self) -> None:
+        if get_tensor_model_parallel_world_size() == 1:
+            return
+        # A combine kernel that already reduces the fused output is
+        # incompatible with deferring the all-reduce (reduce_results=False,
+        # e.g. fusing it into a subsequent GemmaRMSNorm): the deferred
+        # all-reduce would double-reduce the fused output.
+        assert not (self._fused_output_is_reduced and not self.reduce_results), (
+            "reduce_results=False is incompatible with a combine kernel that "
+            "already reduces the fused output within the TP group (e.g. "
+            "DeepEP/Mori/NIXL/FlashInfer-NVLink all2all backends)."
+        )
 
     def _encode_layer_name(self) -> str | LayerName:
         if _USE_LAYERNAME:
@@ -662,6 +667,7 @@ class MoERunner(MoERunnerInterface):
         1. pytorch cannot handle union types in custom op signatures so
            _moe_forward and _moe_forward_shared must be split.
         """
+        self._validate_reduction_config()
 
         # Apply transform for routed experts (e.g., latent projection
         # for latent MoE)


### PR DESCRIPTION
## Purpose

- Add FlashInfer 1-sided and 2-sided backends as supported parallel config for TRTLLM FP8 MoE
- Only do `assert not (self._fused_output_is_reduced and not self.reduce_results)` when the model TP>1

More on the 2nd point.
- Right now to enable allreduce+norm fusion in TP/TEP scenarios, there is an additional `reduce_results` flag to determine whether to defer TP-allreduce (only applicable for Minimax-M3).
- There is a sanity check `assert not (self._fused_output_is_reduced and not self.reduce_results)` to guard against double-reduction. However, in DEP scenarios, `tensor_model_parallel_all_reduce()` is a no-op, so it doesn't matter if `self._fused_output_is_reduced` is true or not -> we shouldn't need to do the validation
- Currently only `MoEPrepareAndFinalizeNaiveDPEPModular` (perform A2A combine within the DP group only, not across the TP group) and `MoEPrepareAndFinalizeNoDPEPModular` (no A2A at all) have `output_is_reduced=False`. I suppose this only matters when there is both TP+DP+EP enabled, which is very rare?

## Test Plan

AIME25 (4 epochs): 0.8917 exact match, 0.9333 pass@4

Prefill-only benchmark, 8k-1, concurrency 16, DEP4 on GB200

A2A backend | TPGS | TTFT
---|---|---
`allgather_reducescatter` | 20166 | 1.52 ms
`flashinfer_nvlink_one_sided` | 19850 | 1.48 ms

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

