### PR TITLE
[Core] Add scheduler-orchestrated worker transfers for multi-node KV cache tiering

### DIFF
--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -55,7 +55,8 @@ vllm serve <model> \
           "type": "fs",
           "root_dir": "/mnt/kv_cache",
           "n_read_threads": 32,
-          "n_write_threads": 16
+          "n_write_threads": 16,
+          "worker_transfers": false
         }
       ]
     }
@@ -91,8 +92,21 @@ The filesystem tier (`type: "fs"`) writes blocks to a directory on local storage
 | `root_dir` | yes | — | Base directory; vLLM creates subdirectories beneath it (see [On-Disk Layout](#on-disk-layout)). |
 | `n_read_threads` | no | `16` | Read-priority I/O threads (load path). |
 | `n_write_threads` | no | `16` | Write-priority I/O threads (store path). |
+| `worker_transfers` | no | `false` | When `true`, the scheduler still owns lookup, promotion, and lifecycle decisions, but workers copy their rank-local CPU shard to/from the shared filesystem. Use this for multi-node TP setups where a scheduler process cannot directly read every worker's local CPU mmap. |
 
 Each thread group prefers its own queue but pulls from the other when its primary queue is empty, so a write-heavy or read-heavy burst won't leave the off-priority queue waiting. Size the totals to your storage's effective concurrency.
+
+When `worker_transfers` is enabled, a filesystem lookup is reported as a hit
+only after every rank's file exists. Promotion remains scheduler-orchestrated:
+the scheduler allocates CPU slots and sends workers typed transfer specs, and
+each worker reads only its own rank slice from the shared filesystem.
+
+!!! warning
+    `root_dir` must resolve to the same shared filesystem from every worker
+    process when `worker_transfers` is enabled. Node-local paths such as
+    `~/.cache/vllm/...` are not sufficient in multi-node deployments because
+    the scheduler must be able to observe every rank's files before committing
+    a store.
 
 #### On-Disk Layout
 

--- a/tests/v1/kv_connector/unit/offloading_connector/test_worker.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_worker.py
@@ -6,6 +6,10 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    OffloadingConnectorMetadata,
+    TransferJob,
+)
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -104,6 +108,94 @@ def _make_worker(kv_cache_config: KVCacheConfig):
     worker.worker = MagicMock()
 
     return worker, spec
+
+
+def test_register_kv_caches_shared_layers_with_different_offsets():
+    layer_a = "model.layers.0.self_attn"
+    layer_b = "model.layers.1.self_attn"
+    kv_cache_spec = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=DTYPE,
+    )
+    page_size = kv_cache_spec.page_size_bytes
+
+    base = torch.empty(2 * NUM_BLOCKS * page_size, dtype=torch.uint8)
+    kv_caches = {
+        layer_a: base.as_strided((NUM_BLOCKS, page_size), (page_size, 1)),
+        layer_b: base.as_strided(
+            (NUM_BLOCKS, page_size),
+            (page_size, 1),
+            storage_offset=NUM_BLOCKS * page_size,
+        ),
+    }
+
+    kv_cache_config = KVCacheConfig(
+        num_blocks=NUM_BLOCKS,
+        kv_cache_tensors=[
+            KVCacheTensor(
+                size=2 * page_size * NUM_BLOCKS,
+                shared_by=[layer_a, layer_b],
+            ),
+        ],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                layer_names=[layer_a, layer_b],
+                kv_cache_spec=kv_cache_spec,
+            )
+        ],
+    )
+
+    worker, spec = _make_worker(kv_cache_config)
+    worker.register_kv_caches(kv_caches)
+
+    canonical = spec.get_worker.call_args[0][0]
+    assert isinstance(canonical, CanonicalKVCaches)
+    assert len(canonical.tensors) == 2
+    assert canonical.tensors[0].tensor.stride() == (page_size, 1)
+    assert canonical.tensors[1].tensor.stride() == (page_size, 1)
+    assert canonical.tensors[0].tensor.storage_offset() == 0
+    assert canonical.tensors[1].tensor.storage_offset() == NUM_BLOCKS * page_size
+    assert canonical.group_data_refs == [
+        [
+            CanonicalKVCacheRef(tensor_idx=0, page_size_bytes=page_size),
+            CanonicalKVCacheRef(tensor_idx=1, page_size_bytes=page_size),
+        ]
+    ]
+
+
+def test_worker_transfer_submit_failure_reports_failed_metadata():
+    from vllm.distributed.kv_transfer.kv_connector.v1.offloading.worker import (
+        OffloadingConnectorWorker,
+    )
+
+    spec = MagicMock(spec=OffloadingSpec)
+    worker = OffloadingConnectorWorker(spec=spec)
+    worker.worker = MagicMock()
+    worker.worker.submit_transfer.return_value = False
+
+    src_spec = MagicMock()
+    dst_spec = MagicMock()
+    metadata = OffloadingConnectorMetadata(
+        load_jobs={},
+        store_jobs={},
+        worker_transfer_jobs={
+            42: TransferJob(
+                req_id="req",
+                src_spec=src_spec,
+                dst_spec=dst_spec,
+            )
+        },
+    )
+
+    worker.start_kv_transfers(metadata)
+
+    worker.worker.submit_transfer.assert_called_once_with(42, src_spec, dst_spec)
+    result = worker.build_connector_worker_meta()
+    assert result is not None
+    assert result.completed_jobs == {42: 1}
+    assert result.failed_jobs == {42: 1}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_connector/unit/offloading_connector/test_worker_metadata.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_worker_metadata.py
@@ -34,6 +34,20 @@ def test_aggregate_multiple_workers():
     assert result.completed_jobs == {42: 3, 43: 2, 7: 2, 8: 2}
 
 
+def test_aggregate_failed_jobs():
+    meta1 = OffloadingWorkerMetadata()
+    meta1.mark_completed(42, success=False)
+    meta2 = OffloadingWorkerMetadata()
+    meta2.mark_completed(42, success=True)
+    meta3 = OffloadingWorkerMetadata()
+    meta3.mark_completed(7, success=False)
+
+    result = meta1.aggregate(meta2).aggregate(meta3)
+
+    assert result.completed_jobs == {42: 2, 7: 1}
+    assert result.failed_jobs == {42: 1, 7: 1}
+
+
 def test_aggregate_transfer_stats():
     meta1 = OffloadingWorkerMetadata(
         transfer_stats=TransferStats(

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -24,11 +24,14 @@ from vllm.v1.kv_offload.base import (
     ReqContext,
     make_offload_key,
 )
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
 from vllm.v1.kv_offload.tiering.base import JobMetadata
+from vllm.v1.kv_offload.tiering.fs.common import FileSystemLoadStoreSpec
 from vllm.v1.kv_offload.tiering.fs.manager import (
     FileSystemTierManager,
 )
 from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+from vllm.v1.kv_offload.tiering.fs.worker import FileSystemWorkerTransferHandler
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -47,6 +50,7 @@ _MOCK_VLLM_CONFIG.parallel_config.pipeline_parallel_size = 1
 _MOCK_VLLM_CONFIG.parallel_config.prefill_context_parallel_size = 1
 _MOCK_VLLM_CONFIG.parallel_config.decode_context_parallel_size = 1
 _MOCK_VLLM_CONFIG.parallel_config.rank = 0
+_MOCK_VLLM_CONFIG.parallel_config.world_size = 1
 
 _MOCK_KV_CACHE_CONFIG = MagicMock()
 _MOCK_KV_CACHE_CONFIG.kv_cache_groups = []
@@ -55,6 +59,27 @@ _MOCK_OFFLOADING_SPEC = MagicMock()
 _MOCK_OFFLOADING_SPEC.vllm_config = _MOCK_VLLM_CONFIG
 _MOCK_OFFLOADING_SPEC.kv_cache_config = _MOCK_KV_CACHE_CONFIG
 _MOCK_OFFLOADING_SPEC.block_size_factor = 1
+
+
+def _make_offloading_spec(world_size: int = 1, rank: int = 0):
+    vllm_config = MagicMock()
+    vllm_config.instance_id = "test-instance"
+    vllm_config.model_config.model = "test-model"
+    vllm_config.cache_config.block_size = 16
+    vllm_config.cache_config.cache_dtype = "torch.float32"
+    vllm_config.parallel_config.tensor_parallel_size = world_size
+    vllm_config.parallel_config.pipeline_parallel_size = 1
+    vllm_config.parallel_config.prefill_context_parallel_size = 1
+    vllm_config.parallel_config.decode_context_parallel_size = 1
+    vllm_config.parallel_config.rank = rank
+    vllm_config.parallel_config.world_size = world_size
+    vllm_config.use_v2_model_runner = False
+
+    offloading_spec = MagicMock()
+    offloading_spec.vllm_config = vllm_config
+    offloading_spec.kv_cache_config = _MOCK_KV_CACHE_CONFIG
+    offloading_spec.block_size_factor = 1
+    return offloading_spec
 
 
 def key(n: int) -> OffloadKey:
@@ -184,6 +209,397 @@ def test_store_creates_file_and_lookup_succeeds(fs_tier):
     assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
     dest = tier.file_mapper.get_file_name(key(1))
     assert os.path.exists(dest), f"Expected file at {dest}"
+
+
+def test_worker_store_commit_creates_visible_file(tmp_path):
+    tensor = _page_aligned_zero_tensor(1, mmap.PAGESIZE)
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=memoryview(tensor.numpy()),
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        worker_transfers=True,
+    )
+    try:
+        job = make_job(11, [key(1)], [0])
+        src_spec, dst_spec = tier.build_worker_store_transfer(job)
+
+        assert tier.uses_worker_transfers()
+        assert isinstance(src_spec, CPULoadStoreSpec)
+        assert isinstance(dst_spec, FileSystemLoadStoreSpec)
+        assert dst_spec.temp_file_paths is not None
+        final_path = dst_spec.file_paths[0]
+        temp_path = dst_spec.temp_file_paths[0]
+
+        os.makedirs(os.path.dirname(temp_path), exist_ok=True)
+        with open(temp_path, "wb") as f:
+            f.write(bytes([7]) * dst_spec.block_size)
+
+        assert not os.path.exists(final_path)
+        tier.complete_worker_store(job, success=True)
+
+        assert os.path.exists(final_path)
+        assert not os.path.exists(temp_path)
+        assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
+    finally:
+        tier.shutdown()
+
+
+@pytest.mark.parametrize("use_c_ext", [True, False])
+def test_worker_transfer_lookup_requires_all_rank_files(
+    tmp_path, monkeypatch, use_c_ext
+):
+    import vllm.v1.kv_offload.tiering.fs.manager as mgr_mod
+
+    if use_c_ext and not mgr_mod._HAS_BATCH_LOOKUP_C:
+        pytest.skip("fs_io_C extension not built")
+    monkeypatch.setattr(mgr_mod, "_HAS_BATCH_LOOKUP_C", use_c_ext)
+
+    tensor = _page_aligned_zero_tensor(1, mmap.PAGESIZE)
+    tier = FileSystemTierManager(
+        offloading_spec=_make_offloading_spec(world_size=2),
+        primary_kv_view=memoryview(tensor.numpy()),
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        worker_transfers=True,
+    )
+    try:
+        missing_rank_key = key(1)
+        complete_key = key(2)
+        _, missing_rank_spec = tier.build_worker_store_transfer(
+            make_job(21, [missing_rank_key], [0])
+        )
+        _, complete_spec = tier.build_worker_store_transfer(
+            make_job(22, [complete_key], [0])
+        )
+
+        for path in [missing_rank_spec.file_paths[0], *complete_spec.file_paths]:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "wb") as f:
+                f.write(bytes([3]) * missing_rank_spec.block_size)
+
+        assert lookup_and_wait(tier, [missing_rank_key, complete_key]) == [
+            LookupResult.MISS,
+            LookupResult.HIT,
+        ]
+    finally:
+        tier.shutdown()
+
+
+def test_worker_store_commit_missing_rank_temp_is_discarded(tmp_path):
+    tensor = _page_aligned_zero_tensor(1, mmap.PAGESIZE)
+    tier = FileSystemTierManager(
+        offloading_spec=_make_offloading_spec(world_size=2),
+        primary_kv_view=memoryview(tensor.numpy()),
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        worker_transfers=True,
+    )
+    try:
+        stored_key = key(1)
+        job = make_job(31, [stored_key], [0])
+        _, dst_spec = tier.build_worker_store_transfer(job)
+        assert dst_spec.temp_file_paths is not None
+
+        rank0_temp = dst_spec.temp_file_paths[0]
+        os.makedirs(os.path.dirname(rank0_temp), exist_ok=True)
+        with open(rank0_temp, "wb") as f:
+            f.write(bytes([7]) * dst_spec.block_size)
+
+        tier.complete_worker_store(job, success=True)
+
+        assert not os.path.exists(rank0_temp)
+        assert all(not os.path.exists(path) for path in dst_spec.file_paths)
+        assert lookup_and_wait(tier, [stored_key]) == [LookupResult.MISS]
+    finally:
+        tier.shutdown()
+
+
+def test_filesystem_worker_handler_store_and_load_rank_slice(tmp_path):
+    store_t0 = torch.arange(0, 8, dtype=torch.int8).view(2, 4)
+    store_t1 = torch.arange(10, 18, dtype=torch.int8).view(2, 4)
+    handler = FileSystemWorkerTransferHandler(
+        [store_t0, store_t1], rank=0, n_read_threads=1, n_write_threads=1
+    )
+    final_path = str(tmp_path / "block.bin")
+    temp_path = str(tmp_path / "block.tmp")
+    try:
+        assert handler.submit_store(
+            1,
+            CPULoadStoreSpec([1]),
+            FileSystemLoadStoreSpec(
+                file_paths=[final_path],
+                temp_file_paths=[temp_path],
+                block_size=8,
+            ),
+        )
+        handler.wait()
+        results = handler.get_finished()
+        assert len(results) == 1
+        assert results[0].job_id == 1
+        assert results[0].success
+        assert os.path.exists(temp_path)
+        assert (tmp_path / "block.tmp").read_bytes() == bytes(
+            store_t0[1].tolist() + store_t1[1].tolist()
+        )
+        os.replace(temp_path, final_path)
+
+        load_t0 = torch.zeros((2, 4), dtype=torch.int8)
+        load_t1 = torch.zeros((2, 4), dtype=torch.int8)
+        load_handler = FileSystemWorkerTransferHandler(
+            [load_t0, load_t1], rank=0, n_read_threads=1, n_write_threads=1
+        )
+        try:
+            assert load_handler.submit_load(
+                2,
+                FileSystemLoadStoreSpec(file_paths=[final_path], block_size=8),
+                CPULoadStoreSpec([0]),
+            )
+            load_handler.wait()
+            results = load_handler.get_finished()
+            assert len(results) == 1
+            assert results[0].job_id == 2
+            assert results[0].success
+            assert torch.equal(load_t0[0], store_t0[1])
+            assert torch.equal(load_t1[0], store_t1[1])
+        finally:
+            load_handler.shutdown()
+    finally:
+        handler.shutdown()
+
+
+def test_filesystem_worker_handler_loads_global_rank_slice(tmp_path):
+    rank_payload = bytes(range(20, 28))
+    rank1_file = tmp_path / "rank1.bin"
+    rank1_file.write_bytes(bytes(8) + rank_payload)
+
+    load_t0 = torch.zeros((1, 4), dtype=torch.int8)
+    load_t1 = torch.zeros((1, 4), dtype=torch.int8)
+    handler = FileSystemWorkerTransferHandler(
+        [load_t0, load_t1], rank=1, n_read_threads=1, n_write_threads=1
+    )
+    try:
+        assert handler.submit_load(
+            7,
+            FileSystemLoadStoreSpec(
+                file_paths=[str(tmp_path / "rank0.bin"), str(rank1_file)],
+                block_size=16,
+                num_ranks=2,
+            ),
+            CPULoadStoreSpec([0]),
+        )
+        handler.wait()
+        results = handler.get_finished()
+        assert len(results) == 1
+        assert results[0].job_id == 7
+        assert results[0].success
+        assert bytes(load_t0[0].tolist() + load_t1[0].tolist()) == rank_payload
+    finally:
+        handler.shutdown()
+
+
+def test_worker_transfer_store_then_load_all_rank_slices(tmp_path):
+    manager_tensor = _page_aligned_zero_tensor(1, mmap.PAGESIZE)
+    tier = FileSystemTierManager(
+        offloading_spec=_make_offloading_spec(world_size=2),
+        primary_kv_view=memoryview(manager_tensor.numpy()),
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        worker_transfers=True,
+    )
+
+    rank0_src0 = torch.arange(0, 8, dtype=torch.int8).view(2, 4)
+    rank0_src1 = torch.arange(10, 18, dtype=torch.int8).view(2, 4)
+    rank1_src0 = torch.arange(20, 28, dtype=torch.int8).view(2, 4)
+    rank1_src1 = torch.arange(30, 38, dtype=torch.int8).view(2, 4)
+    store_rank0 = FileSystemWorkerTransferHandler(
+        [rank0_src0, rank0_src1], rank=0, n_read_threads=1, n_write_threads=1
+    )
+    store_rank1 = FileSystemWorkerTransferHandler(
+        [rank1_src0, rank1_src1], rank=1, n_read_threads=1, n_write_threads=1
+    )
+
+    try:
+        stored_key = key(71)
+        store_job = make_job(71, [stored_key], [1])
+        store_src, store_dst = tier.build_worker_store_transfer(store_job)
+
+        assert store_rank0.submit_store(71, store_src, store_dst)
+        assert store_rank1.submit_store(71, store_src, store_dst)
+        store_rank0.wait()
+        store_rank1.wait()
+        assert [r.success for r in store_rank0.get_finished()] == [True]
+        assert [r.success for r in store_rank1.get_finished()] == [True]
+
+        tier.complete_worker_store(store_job, success=True)
+        assert all(os.path.exists(path) for path in store_dst.file_paths)
+
+        rank0_dst0 = torch.zeros((1, 4), dtype=torch.int8)
+        rank0_dst1 = torch.zeros((1, 4), dtype=torch.int8)
+        rank1_dst0 = torch.zeros((1, 4), dtype=torch.int8)
+        rank1_dst1 = torch.zeros((1, 4), dtype=torch.int8)
+        load_rank0 = FileSystemWorkerTransferHandler(
+            [rank0_dst0, rank0_dst1], rank=0, n_read_threads=1, n_write_threads=1
+        )
+        load_rank1 = FileSystemWorkerTransferHandler(
+            [rank1_dst0, rank1_dst1], rank=1, n_read_threads=1, n_write_threads=1
+        )
+        try:
+            load_job = make_job(72, [stored_key], [0], is_promotion=True)
+            load_src, load_dst = tier.build_worker_load_transfer(load_job)
+
+            assert load_rank0.submit_load(72, load_src, load_dst)
+            assert load_rank1.submit_load(72, load_src, load_dst)
+            load_rank0.wait()
+            load_rank1.wait()
+            assert [r.success for r in load_rank0.get_finished()] == [True]
+            assert [r.success for r in load_rank1.get_finished()] == [True]
+
+            assert torch.equal(rank0_dst0[0], rank0_src0[1])
+            assert torch.equal(rank0_dst1[0], rank0_src1[1])
+            assert torch.equal(rank1_dst0[0], rank1_src0[1])
+            assert torch.equal(rank1_dst1[0], rank1_src1[1])
+        finally:
+            load_rank0.shutdown()
+            load_rank1.shutdown()
+    finally:
+        store_rank0.shutdown()
+        store_rank1.shutdown()
+        tier.shutdown()
+
+
+def test_filesystem_worker_handler_wait_cleans_flushed_store_temp(tmp_path):
+    tensor = torch.arange(0, 8, dtype=torch.int8).view(2, 4)
+    handler = FileSystemWorkerTransferHandler(
+        [tensor], rank=0, n_read_threads=1, n_write_threads=1
+    )
+    final_path = str(tmp_path / "block.bin")
+    temp_path = str(tmp_path / "block.tmp")
+    try:
+        assert handler.submit_store(
+            8,
+            CPULoadStoreSpec([1]),
+            FileSystemLoadStoreSpec(
+                file_paths=[final_path],
+                temp_file_paths=[temp_path],
+                block_size=4,
+            ),
+        )
+        handler.wait({8})
+        assert not os.path.exists(temp_path)
+        results = handler.get_finished()
+        assert len(results) == 1
+        assert results[0].job_id == 8
+        assert results[0].success
+    finally:
+        handler.shutdown()
+
+
+def test_filesystem_worker_handler_uses_global_rank_for_path_slice(tmp_path):
+    store_t0 = torch.arange(0, 8, dtype=torch.int8).view(2, 4)
+    store_t1 = torch.arange(10, 18, dtype=torch.int8).view(2, 4)
+    handler = FileSystemWorkerTransferHandler(
+        [store_t0, store_t1], rank=1, n_read_threads=1, n_write_threads=1
+    )
+    rank0_final = str(tmp_path / "rank0.bin")
+    rank1_final = str(tmp_path / "rank1.bin")
+    rank0_temp = str(tmp_path / "rank0.tmp")
+    rank1_temp = str(tmp_path / "rank1.tmp")
+    try:
+        assert handler.submit_store(
+            3,
+            CPULoadStoreSpec([1]),
+            FileSystemLoadStoreSpec(
+                file_paths=[rank0_final, rank1_final],
+                temp_file_paths=[rank0_temp, rank1_temp],
+                block_size=16,
+                num_ranks=2,
+            ),
+        )
+        handler.wait()
+        results = handler.get_finished()
+        assert len(results) == 1
+        assert results[0].job_id == 3
+        assert results[0].success
+        assert not os.path.exists(rank0_temp)
+        assert os.path.exists(rank1_temp)
+        assert (tmp_path / "rank1.tmp").read_bytes() == (
+            bytes(8) + bytes(store_t0[1].tolist() + store_t1[1].tolist())
+        )
+    finally:
+        handler.shutdown()
+
+
+def test_filesystem_worker_handler_rejects_rank_out_of_range(tmp_path):
+    tensor = torch.zeros((1, 4), dtype=torch.int8)
+    handler = FileSystemWorkerTransferHandler(
+        [tensor], rank=2, n_read_threads=1, n_write_threads=1
+    )
+    try:
+        with pytest.raises(ValueError, match="outside num_ranks"):
+            handler.submit_store(
+                4,
+                CPULoadStoreSpec([0]),
+                FileSystemLoadStoreSpec(
+                    file_paths=[
+                        str(tmp_path / "rank0.bin"),
+                        str(tmp_path / "rank1.bin"),
+                    ],
+                    temp_file_paths=[
+                        str(tmp_path / "rank0.tmp"),
+                        str(tmp_path / "rank1.tmp"),
+                    ],
+                    block_size=8,
+                    num_ranks=2,
+                ),
+            )
+    finally:
+        handler.shutdown()
+
+
+def test_filesystem_worker_handler_rejects_uneven_rank_paths(tmp_path):
+    tensor = torch.zeros((1, 4), dtype=torch.int8)
+    handler = FileSystemWorkerTransferHandler(
+        [tensor], rank=1, n_read_threads=1, n_write_threads=1
+    )
+    try:
+        with pytest.raises(ValueError, match="Cannot split"):
+            handler.submit_load(
+                5,
+                FileSystemLoadStoreSpec(
+                    file_paths=[
+                        str(tmp_path / "rank0.bin"),
+                        str(tmp_path / "rank1.bin"),
+                        str(tmp_path / "extra.bin"),
+                    ],
+                    block_size=8,
+                    num_ranks=2,
+                ),
+                CPULoadStoreSpec([0]),
+            )
+    finally:
+        handler.shutdown()
+
+
+def test_filesystem_worker_handler_rejects_invalid_num_ranks(tmp_path):
+    tensor = torch.zeros((1, 4), dtype=torch.int8)
+    handler = FileSystemWorkerTransferHandler(
+        [tensor], rank=0, n_read_threads=1, n_write_threads=1
+    )
+    try:
+        with pytest.raises(ValueError, match="Invalid num_ranks"):
+            handler.submit_store(
+                6,
+                CPULoadStoreSpec([0]),
+                FileSystemLoadStoreSpec(
+                    file_paths=[str(tmp_path / "rank0.bin")],
+                    temp_file_paths=[str(tmp_path / "rank0.tmp")],
+                    block_size=4,
+                    num_ranks=0,
+                ),
+            )
+    finally:
+        handler.shutdown()
 
 
 def test_store_then_load_roundtrip(fs_tier):

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -21,6 +21,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
 )
 from vllm.v1.kv_offload.base import (
+    LoadStoreSpec,
     LookupResult,
     OffloadingCounterMetadata,
     OffloadKey,
@@ -29,6 +30,7 @@ from vllm.v1.kv_offload.base import (
     RequestOffloadingContext,
     make_offload_key,
 )
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
 from vllm.v1.kv_offload.tiering.base import (
     JobMetadata,
     JobResult,
@@ -115,6 +117,71 @@ class MetricsSecondaryTierManager(SecondaryTierManager):
         stats = self.stats
         self.stats = None
         return stats
+
+
+class DummyWorkerLoadStoreSpec(LoadStoreSpec):
+    @staticmethod
+    def medium() -> str:
+        return "dummy_worker"
+
+
+class WorkerTransferSecondaryTierManager(SecondaryTierManager):
+    """Test tier whose data copies must be executed by workers."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.lookup_hits: set[OffloadKey] = set()
+        self.worker_store_jobs: list[JobMetadata] = []
+        self.worker_load_jobs: list[JobMetadata] = []
+        self.completed_worker_stores: list[tuple[JobMetadata, bool]] = []
+        self.completed_worker_loads: list[tuple[JobMetadata, bool]] = []
+
+    def lookup(self, key: OffloadKey, req_context: ReqContext) -> LookupResult:
+        return LookupResult.HIT if key in self.lookup_hits else LookupResult.MISS
+
+    def submit_store(self, job_metadata: JobMetadata) -> None:
+        raise AssertionError("worker-transfer tier should not use submit_store")
+
+    def submit_load(self, job_metadata: JobMetadata) -> None:
+        raise AssertionError("worker-transfer tier should not use submit_load")
+
+    def get_finished_jobs(self) -> Iterable[JobResult]:
+        return ()
+
+    def drain_jobs(self) -> None:
+        return
+
+    def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
+        return RequestOffloadingContext()
+
+    def uses_worker_transfers(self) -> bool:
+        return True
+
+    def build_worker_store_transfer(
+        self, job_metadata: JobMetadata
+    ) -> tuple[LoadStoreSpec, LoadStoreSpec]:
+        self.worker_store_jobs.append(job_metadata)
+        return (
+            CPULoadStoreSpec([int(b) for b in job_metadata.block_ids]),
+            DummyWorkerLoadStoreSpec(),
+        )
+
+    def build_worker_load_transfer(
+        self, job_metadata: JobMetadata
+    ) -> tuple[LoadStoreSpec, LoadStoreSpec]:
+        self.worker_load_jobs.append(job_metadata)
+        return (
+            DummyWorkerLoadStoreSpec(),
+            CPULoadStoreSpec([int(b) for b in job_metadata.block_ids]),
+        )
+
+    def complete_worker_store(
+        self, job_metadata: JobMetadata, success: bool
+    ) -> None:
+        self.completed_worker_stores.append((job_metadata, success))
+
+    def complete_worker_load(self, job_metadata: JobMetadata, success: bool) -> None:
+        self.completed_worker_loads.append((job_metadata, success))
 
 
 def test_tiering_spec_collects_secondary_metric_definitions(monkeypatch):
@@ -336,6 +403,151 @@ class TestTieringOffloadingManager:
         # All completed jobs have been drained
         assert len(self.secondary_tier1.completed_jobs) == 0
         assert len(self.secondary_tier2.completed_jobs) == 0
+
+    def test_worker_transfer_cascade_is_scheduler_orchestrated(self):
+        mock_region = _mock_mmap_region(5)
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=5, mmap_region=mock_region
+        )
+        worker_tier = WorkerTransferSecondaryTierManager(
+            offloading_spec=_MOCK_OFFLOADING_SPEC,
+            primary_kv_view=mock_region.create_kv_memoryview(),
+            tier_type="worker_test",
+        )
+        manager = TieringOffloadingManager(
+            primary_tier=primary_tier,
+            secondary_tiers=[worker_tier],
+        )
+        manager.on_new_request(_CTX)
+
+        blocks = to_keys(range(2))
+        assert manager.prepare_store(blocks, _CTX) is not None
+        manager.complete_store(blocks, _CTX, success=True)
+
+        # The secondary transfer is queued for the connector instead of being
+        # submitted on the scheduler thread.
+        assert worker_tier.worker_store_jobs == []
+        assert manager.has_pending_work()
+        for block_hash in blocks:
+            block = primary_tier._policy.get(block_hash)
+            assert block.ref_cnt == 1
+
+        job_ids = iter([123])
+        worker_jobs = manager.pop_worker_transfer_jobs(lambda: next(job_ids))
+
+        assert set(worker_jobs) == {123}
+        assert isinstance(worker_jobs[123].src_spec, CPULoadStoreSpec)
+        assert isinstance(worker_jobs[123].dst_spec, DummyWorkerLoadStoreSpec)
+        assert [job.job_id for job in worker_tier.worker_store_jobs] == [123]
+
+        manager.complete_worker_transfer(123, success=True)
+
+        assert worker_tier.completed_worker_stores == [
+            (worker_tier.worker_store_jobs[0], True)
+        ]
+        for block_hash in blocks:
+            block = primary_tier._policy.get(block_hash)
+            assert block.ref_cnt == 0
+
+    def test_worker_transfer_job_id_skips_scheduler_side_secondary_jobs(self):
+        mock_region = _mock_mmap_region(5)
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=5, mmap_region=mock_region
+        )
+        mock_view = mock_region.create_kv_memoryview()
+        scheduler_tier = ExampleSecondaryTierManager(
+            offloading_spec=_MOCK_OFFLOADING_SPEC,
+            primary_kv_view=mock_view,
+            tier_type="example",
+        )
+        worker_tier = WorkerTransferSecondaryTierManager(
+            offloading_spec=_MOCK_OFFLOADING_SPEC,
+            primary_kv_view=mock_view,
+            tier_type="worker_test",
+        )
+        manager = TieringOffloadingManager(
+            primary_tier=primary_tier,
+            secondary_tiers=[scheduler_tier, worker_tier],
+        )
+        manager.on_new_request(_CTX)
+
+        blocks = to_keys(range(2))
+        assert manager.prepare_store(blocks, _CTX) is not None
+        manager.complete_store(blocks, _CTX, success=True)
+
+        assert [job.job_id for job in scheduler_tier.completed_jobs] == [0]
+        job_ids = iter([0, 1])
+        worker_jobs = manager.pop_worker_transfer_jobs(lambda: next(job_ids))
+
+        assert set(worker_jobs) == {1}
+        assert [job.job_id for job in worker_tier.worker_store_jobs] == [1]
+        assert manager._job_id_counter == 2
+
+    def test_worker_transfer_failure_is_reported_to_tier(self):
+        mock_region = _mock_mmap_region(5)
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=5, mmap_region=mock_region
+        )
+        worker_tier = WorkerTransferSecondaryTierManager(
+            offloading_spec=_MOCK_OFFLOADING_SPEC,
+            primary_kv_view=mock_region.create_kv_memoryview(),
+            tier_type="worker_test",
+        )
+        manager = TieringOffloadingManager(
+            primary_tier=primary_tier,
+            secondary_tiers=[worker_tier],
+        )
+        manager.on_new_request(_CTX)
+
+        blocks = to_keys(range(2))
+        assert manager.prepare_store(blocks, _CTX) is not None
+        manager.complete_store(blocks, _CTX, success=True)
+        worker_jobs = manager.pop_worker_transfer_jobs(lambda: 124)
+
+        assert set(worker_jobs) == {124}
+        manager.complete_worker_transfer(124, success=False)
+
+        assert worker_tier.completed_worker_stores == [
+            (worker_tier.worker_store_jobs[0], False)
+        ]
+        for block_hash in blocks:
+            block = primary_tier._policy.get(block_hash)
+            assert block.ref_cnt == 0
+
+    def test_worker_transfer_promotion_is_scheduler_orchestrated(self):
+        mock_region = _mock_mmap_region(5)
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=5, mmap_region=mock_region
+        )
+        worker_tier = WorkerTransferSecondaryTierManager(
+            offloading_spec=_MOCK_OFFLOADING_SPEC,
+            primary_kv_view=mock_region.create_kv_memoryview(),
+            tier_type="worker_test",
+        )
+        manager = TieringOffloadingManager(
+            primary_tier=primary_tier,
+            secondary_tiers=[worker_tier],
+        )
+        manager.on_new_request(_CTX)
+
+        block = to_keys([99])[0]
+        worker_tier.lookup_hits.add(block)
+
+        assert manager.lookup(block, _CTX) is LookupResult.RETRY
+        manager.on_schedule_end()
+        worker_jobs = manager.pop_worker_transfer_jobs(lambda: 125)
+
+        assert set(worker_jobs) == {125}
+        assert isinstance(worker_jobs[125].src_spec, DummyWorkerLoadStoreSpec)
+        assert isinstance(worker_jobs[125].dst_spec, CPULoadStoreSpec)
+        assert [job.job_id for job in worker_tier.worker_load_jobs] == [125]
+
+        manager.complete_worker_transfer(125, success=True)
+
+        assert worker_tier.completed_worker_loads == [
+            (worker_tier.worker_load_jobs[0], True)
+        ]
+        assert primary_tier.lookup(block, _CTX) is LookupResult.HIT
 
     def test_lookup_from_primary(self, manager_setup):
         """Test lookup when blocks are in primary tier."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/common.py
@@ -69,6 +69,7 @@ class OffloadingConnectorMetadata(KVConnectorMetadata):
     # Keyed by scheduler-assigned job IDs.
     load_jobs: dict[int, TransferJob]
     store_jobs: dict[int, TransferJob]
+    worker_transfer_jobs: dict[int, TransferJob] = field(default_factory=dict)
     jobs_to_flush: set[int] | None = None
 
 
@@ -83,11 +84,14 @@ class OffloadingWorkerMetadata(KVConnectorWorkerMetadata):
     """
 
     completed_jobs: dict[int, int] = field(default_factory=dict)
+    failed_jobs: dict[int, int] = field(default_factory=dict)
     transfer_stats: TransferStats = field(default_factory=TransferStats)
 
-    def mark_completed(self, job_id: int) -> None:
+    def mark_completed(self, job_id: int, success: bool = True) -> None:
         """Record a transfer job completion from this worker."""
         self.completed_jobs[job_id] = 1
+        if not success:
+            self.failed_jobs[job_id] = 1
 
     def aggregate(
         self, other: "KVConnectorWorkerMetadata"
@@ -97,8 +101,12 @@ class OffloadingWorkerMetadata(KVConnectorWorkerMetadata):
         merged = dict(self.completed_jobs)
         for job_id, v in other.completed_jobs.items():
             merged[job_id] = merged.get(job_id, 0) + v
+        failed = dict(self.failed_jobs)
+        for job_id, v in other.failed_jobs.items():
+            failed[job_id] = failed.get(job_id, 0) + v
 
         return OffloadingWorkerMetadata(
             completed_jobs=merged,
+            failed_jobs=failed,
             transfer_stats=self.transfer_stats.aggregate(other.transfer_stats),
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -61,12 +61,16 @@ class TransferJobStatus:
     # Offload keys this job covers; passed to manager.complete_*().
     keys: set[OffloadKey]
     is_store: bool
+    failed_count: int = 0
     # Store src block IDs whose ref_cnt protects them while the request
     # runs. Only registered in _block_id_to_pending_jobs on request_finished.
     non_sliding_window_block_ids: list[int] | None = None
     # Store src block IDs that may be freed before the request finishes.
     # Registered in _block_id_to_pending_jobs at store creation time.
     sliding_window_block_ids: list[int] | None = None
+    # True for scheduler-orchestrated secondary-tier transfers executed by
+    # workers. These jobs are not request-blocking GPU transfers.
+    is_worker_transfer: bool = False
 
 
 class GroupOffloadConfig(NamedTuple):
@@ -1052,9 +1056,31 @@ class OffloadingConnectorScheduler:
                 for jid in self._block_id_to_pending_jobs[bid]
             )
 
+        worker_transfer_jobs: dict[int, TransferJob] = {}
+        pop_worker_transfer_jobs = getattr(
+            self.manager, "pop_worker_transfer_jobs", None
+        )
+        if pop_worker_transfer_jobs is not None:
+            for job_id, job in pop_worker_transfer_jobs(
+                self._generate_job_id
+            ).items():
+                worker_transfer_jobs[job_id] = TransferJob(
+                    req_id=job.req_id,
+                    src_spec=job.src_spec,
+                    dst_spec=job.dst_spec,
+                )
+                self._jobs[job_id] = TransferJobStatus(
+                    req_id=job.req_id,
+                    pending_count=self.config.num_workers,
+                    keys=set(),
+                    is_store=False,
+                    is_worker_transfer=True,
+                )
+
         meta = OffloadingConnectorMetadata(
             load_jobs=self._current_batch_load_jobs,
             store_jobs=self._build_store_jobs(scheduler_output),
+            worker_transfer_jobs=worker_transfer_jobs,
             jobs_to_flush=self._current_batch_jobs_to_flush,
         )
         self._current_batch_load_jobs = {}
@@ -1126,14 +1152,28 @@ class OffloadingConnectorScheduler:
                 continue
             job_status = self._jobs[job_id]
             job_status.pending_count -= count
+            job_status.failed_count += meta.failed_jobs.get(job_id, 0)
             if job_status.pending_count > 0:
                 continue
             assert job_status.pending_count == 0
 
+            if job_status.is_worker_transfer:
+                complete_worker_transfer = getattr(
+                    self.manager, "complete_worker_transfer"
+                )
+                complete_worker_transfer(job_id, job_status.failed_count == 0)
+                del self._jobs[job_id]
+                continue
+
             req_status = self._req_status[job_status.req_id]
             if job_status.is_store:
-                self.manager.complete_store(job_status.keys, req_status.req_context)
+                self.manager.complete_store(
+                    job_status.keys,
+                    req_status.req_context,
+                    success=job_status.failed_count == 0,
+                )
             else:
+                assert job_status.failed_count == 0
                 self.manager.complete_load(job_status.keys, req_status.req_context)
                 if self._blocks_being_loaded:
                     self._blocks_being_loaded.difference_update(job_status.keys)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -165,7 +165,35 @@ class OffloadingConnectorWorker:
             return
 
         block_tensors: list[CanonicalKVCacheTensor] = []
+        block_tensor_indices: dict[tuple, int] = {}
         block_data_refs: dict[str, list[CanonicalKVCacheRef]] = defaultdict(list)
+
+        def get_canonical_tensor_idx(
+            tensor: torch.Tensor, page_size: int
+        ) -> int:
+            tensor_key = (
+                tensor.untyped_storage().data_ptr(),
+                tensor.storage_offset(),
+                tuple(tensor.shape),
+                tuple(tensor.stride()),
+                tensor.dtype,
+                tensor.device,
+                page_size,
+            )
+            tensor_idx = block_tensor_indices.get(tensor_key)
+            if tensor_idx is not None:
+                return tensor_idx
+
+            block_tensors.append(
+                CanonicalKVCacheTensor(
+                    tensor=tensor,
+                    page_size_bytes=page_size,
+                )
+            )
+            tensor_idx = len(block_tensors) - 1
+            block_tensor_indices[tensor_key] = tensor_idx
+            return tensor_idx
+
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
             # Filter to layers that were actually processed above.
             # Packed KV allocation emits KVCacheTensor entries for
@@ -178,31 +206,14 @@ class OffloadingConnectorWorker:
             if not tensor_layer_names:
                 continue
 
-            # verify all layers in the group reference the exact same tensors
-            assert len({len(tensors_per_block[n]) for n in tensor_layer_names}) == 1
-            assert (
-                len({tensors_per_block[n][0].data_ptr() for n in tensor_layer_names})
-                == 1
-            )
-            assert (
-                len({tensors_per_block[n][0].stride() for n in tensor_layer_names}) == 1
-            )
-
-            # pick the first layer to represent the group
-            first_layer_name = tensor_layer_names[0]
-            for tensor in tensors_per_block[first_layer_name]:
-                block_tensors.append(
-                    CanonicalKVCacheTensor(
-                        tensor=tensor,
-                        page_size_bytes=page_size_bytes[first_layer_name],
+            for layer_name in tensor_layer_names:
+                for tensor in tensors_per_block[layer_name]:
+                    tensor_idx = get_canonical_tensor_idx(
+                        tensor, page_size_bytes[layer_name]
                     )
-                )
-
-                curr_tensor_idx = len(block_tensors) - 1
-                for layer_name in tensor_layer_names:
                     block_data_refs[layer_name].append(
                         CanonicalKVCacheRef(
-                            tensor_idx=curr_tensor_idx,
+                            tensor_idx=tensor_idx,
                             page_size_bytes=(unpadded_page_size_bytes[layer_name]),
                         )
                     )
@@ -291,6 +302,20 @@ class OffloadingConnectorWorker:
             success = self.worker.submit_load(job_id, entry.src_spec, entry.dst_spec)
             assert success
 
+        for job_id, entry in metadata.worker_transfer_jobs.items():
+            logger.debug(
+                "Submitting worker transfer job %d for req %s: %s -> %s",
+                job_id,
+                entry.req_id,
+                entry.src_spec.medium(),
+                entry.dst_spec.medium(),
+            )
+            success = self.worker.submit_transfer(
+                job_id, entry.src_spec, entry.dst_spec
+            )
+            if not success:
+                self._connector_worker_meta.mark_completed(job_id, success=False)
+
     def prepare_store_kv(self, metadata: OffloadingConnectorMetadata):
         for job_id, entry in metadata.store_jobs.items():
             # NOTE(orozery): defer the store to the beginning of the next
@@ -314,9 +339,7 @@ class OffloadingConnectorWorker:
         assert self.worker is not None
         finished_recving: set[str] = set()
         for transfer_result in self.worker.get_finished():
-            # we currently do not support job failures
             job_id = transfer_result.job_id
-            assert transfer_result.success
             is_load = job_id in self._load_jobs
             if (
                 transfer_result.transfer_time is not None
@@ -331,9 +354,11 @@ class OffloadingConnectorWorker:
                     transfer_result.transfer_time,
                 )
 
-            self._connector_worker_meta.mark_completed(job_id)
+            self._connector_worker_meta.mark_completed(
+                job_id, transfer_result.success
+            )
             req_id = self._load_jobs.pop(job_id, None)
-            if req_id is not None:
+            if req_id is not None and transfer_result.success:
                 finished_recving.add(req_id)
 
         return set(), finished_recving

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -464,6 +464,23 @@ class OffloadingWorker(ABC):
     ) -> bool:
         """Async offloaded medium -> GPU."""
 
+    def submit_transfer(
+        self, job_id: int, src_spec: LoadStoreSpec, dst_spec: LoadStoreSpec
+    ) -> bool:
+        """Async transfer between two non-GPU offloaded media.
+
+        Implementations can override this for worker-executed secondary-tier
+        copies. The default keeps the historical GPU-facing API behavior.
+        """
+        if isinstance(src_spec, GPULoadStoreSpec):
+            return self.submit_store(job_id, src_spec, dst_spec)
+        if isinstance(dst_spec, GPULoadStoreSpec):
+            return self.submit_load(job_id, src_spec, dst_spec)
+        raise NotImplementedError(
+            f"Unsupported worker transfer {src_spec.medium()} -> "
+            f"{dst_spec.medium()}"
+        )
+
     @abstractmethod
     def get_finished(self) -> list[TransferResult]: ...
 

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -23,11 +23,14 @@ from vllm.v1.kv_offload.base import (
     OffloadingWorker,
     TransferResult,
 )
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
     THRESHOLD_BYTES,
     swap_blocks_batch,
 )
+from vllm.v1.kv_offload.tiering.fs.common import FileSystemLoadStoreSpec
+from vllm.v1.kv_offload.tiering.fs.worker import FileSystemWorkerTransferHandler
 
 logger = init_logger(__name__)
 
@@ -479,14 +482,18 @@ class CPUOffloadingWorker(OffloadingWorker):
         block_size_factor: int,
         num_cpu_blocks: int,
         mmap_region: SharedOffloadRegion | None = None,
+        parallel_rank: int | None = None,
     ):
         pin_memory = PIN_MEMORY
         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
+        self._mmap_region = mmap_region
+        self._parallel_rank = parallel_rank
+        self._fs_transfer_handler: FileSystemWorkerTransferHandler | None = None
         if mmap_region is not None and pin_memory:
             pin_mmap_region(mmap_region)
 
         gpu_tensors: list[torch.Tensor] = []
-        cpu_tensors: list[torch.Tensor] = []
+        self.cpu_tensors: list[torch.Tensor] = []
         for kv_cache_tensor in kv_caches.tensors:
             gpu_page_size_bytes = kv_cache_tensor.page_size_bytes
             gpu_tensor = kv_cache_tensor.tensor.view(torch.int8).view(
@@ -513,11 +520,11 @@ class CPUOffloadingWorker(OffloadingWorker):
                 )
 
             gpu_tensors.append(gpu_tensor)
-            cpu_tensors.append(cpu_tensor)
+            self.cpu_tensors.append(cpu_tensor)
 
         self._store_handler = SingleDirectionOffloadingHandler(
             gpu_tensors=gpu_tensors,
-            cpu_tensors=cpu_tensors,
+            cpu_tensors=self.cpu_tensors,
             block_size_factor=block_size_factor,
             kv_cache_groups_data_refs=kv_caches.group_data_refs,
             gpu_to_cpu=True,
@@ -526,11 +533,29 @@ class CPUOffloadingWorker(OffloadingWorker):
 
         self._load_handler = SingleDirectionOffloadingHandler(
             gpu_tensors=gpu_tensors,
-            cpu_tensors=cpu_tensors,
+            cpu_tensors=self.cpu_tensors,
             block_size_factor=block_size_factor,
             kv_cache_groups_data_refs=kv_caches.group_data_refs,
             gpu_to_cpu=False,
         )
+
+    def _get_fs_transfer_handler(self) -> FileSystemWorkerTransferHandler:
+        if self._fs_transfer_handler is None:
+            rank = (
+                self._parallel_rank
+                if self._parallel_rank is not None
+                else self._mmap_region.rank if self._mmap_region is not None else None
+            )
+            if self._mmap_region is None or rank is None:
+                raise RuntimeError(
+                    "Filesystem worker transfers require a ranked shared "
+                    "CPU offload region."
+                )
+            self._fs_transfer_handler = FileSystemWorkerTransferHandler(
+                cpu_tensors=self.cpu_tensors,
+                rank=rank,
+            )
+        return self._fs_transfer_handler
 
     def submit_store(
         self, job_id: int, src_spec: GPULoadStoreSpec, dst_spec: LoadStoreSpec
@@ -544,13 +569,38 @@ class CPUOffloadingWorker(OffloadingWorker):
         """Async CPU -> GPU."""
         return self._load_handler.transfer_async(job_id, src_spec, dst_spec)
 
+    def submit_transfer(
+        self, job_id: int, src_spec: LoadStoreSpec, dst_spec: LoadStoreSpec
+    ) -> bool:
+        if isinstance(src_spec, CPULoadStoreSpec) and isinstance(
+            dst_spec, FileSystemLoadStoreSpec
+        ):
+            return self._get_fs_transfer_handler().submit_store(
+                job_id, src_spec, dst_spec
+            )
+        if isinstance(src_spec, FileSystemLoadStoreSpec) and isinstance(
+            dst_spec, CPULoadStoreSpec
+        ):
+            return self._get_fs_transfer_handler().submit_load(
+                job_id, src_spec, dst_spec
+            )
+        return super().submit_transfer(job_id, src_spec, dst_spec)
+
     def get_finished(self) -> list[TransferResult]:
-        return self._store_handler.get_finished() + self._load_handler.get_finished()
+        results = self._store_handler.get_finished() + self._load_handler.get_finished()
+        if self._fs_transfer_handler is not None:
+            results += self._fs_transfer_handler.get_finished()
+        return results
 
     def wait(self, job_ids: set[int]) -> None:
         self._store_handler.wait(job_ids)
         self._load_handler.wait(job_ids)
+        if self._fs_transfer_handler is not None:
+            self._fs_transfer_handler.wait(job_ids)
 
     def shutdown(self) -> None:
+        if self._fs_transfer_handler is not None:
+            self._fs_transfer_handler.shutdown()
+            self._fs_transfer_handler = None
         self._store_handler.shutdown()
         self._load_handler.shutdown()

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -7,7 +7,7 @@ from typing_extensions import override
 from vllm.config import VllmConfig
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import round_up
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
 from vllm.v1.kv_offload.base import (
     CanonicalKVCaches,
     OffloadingCounterMetadata,
@@ -75,6 +75,10 @@ class CPUOffloadingSpec(OffloadingSpec):
                 if is_packed
                 else sum(t.size for t in kv_cache_config.kv_cache_tensors)
             )
+            total_gpu_kv_bytes = max(
+                total_gpu_kv_bytes,
+                self._get_per_layer_gpu_kv_bytes(kv_cache_config),
+            )
             kv_bytes_per_block = (
                 total_gpu_kv_bytes // kv_cache_config.num_blocks
             ) * world_size
@@ -104,6 +108,27 @@ class CPUOffloadingSpec(OffloadingSpec):
         self._worker: CPUOffloadingWorker | None = None
 
         self.eviction_policy: str = self.extra_config.get("eviction_policy", "lru")
+
+    @staticmethod
+    def _get_per_layer_gpu_kv_bytes(kv_cache_config: KVCacheConfig) -> int:
+        """Return a conservative per-layer KV byte upper bound.
+
+        KVCacheTensor entries can share storage across layers, but canonical
+        offloading tensors are split whenever their concrete tensor views differ
+        in stride or offset. This upper bound keeps CPU offload rows large
+        enough for those split views.
+        """
+        total_page_bytes = 0
+        for group in kv_cache_config.kv_cache_groups:
+            group_spec = group.kv_cache_spec
+            if isinstance(group_spec, UniformTypeKVCacheSpecs):
+                per_layer_specs = group_spec.kv_cache_specs
+            else:
+                per_layer_specs = {}
+            for layer_name in group.layer_names:
+                layer_spec = per_layer_specs.get(layer_name, group_spec)
+                total_page_bytes += layer_spec.page_size_bytes
+        return total_page_bytes * kv_cache_config.num_blocks
 
     @override
     def get_manager(self) -> OffloadingManager:

--- a/vllm/v1/kv_offload/file_mapper.py
+++ b/vllm/v1/kv_offload/file_mapper.py
@@ -109,13 +109,14 @@ class FileMapper:
             parallel_agnostic=parallel_agnostic,
         )
 
-    def get_file_name(self, key: OffloadKey) -> str:
+    def get_file_name(self, key: OffloadKey, rank: int | None = None) -> str:
         """Map an OffloadKey to <base>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash>.bin."""
         hash_hex = get_offload_block_hash(key).hex()
         group_idx = get_offload_group_idx(key)
+        file_rank = self.rank if rank is None else rank
         subfolder1, subfolder2 = hash_hex[:3], hash_hex[3:5]
         return (
-            f"{self.base_path}_r{self.rank}"
+            f"{self.base_path}_r{file_rank}"
             f"/{subfolder1}/{subfolder2}_g{group_idx}/{hash_hex}.bin"
         )
 

--- a/vllm/v1/kv_offload/tiering/base.py
+++ b/vllm/v1/kv_offload/tiering/base.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from vllm.v1.kv_offload.base import (
+    LoadStoreSpec,
     LookupResult,
     OffloadingMetricMetadata,
     OffloadKey,
@@ -46,6 +47,19 @@ class JobResult:
 
     job_id: JobId
     success: bool
+
+
+@dataclass
+class WorkerTransferSpec:
+    """A worker-executed secondary-tier transfer.
+
+    The scheduler still owns policy and lifetime decisions. This object only
+    describes the concrete source and destination a worker should copy between.
+    """
+
+    req_id: str
+    src_spec: LoadStoreSpec
+    dst_spec: LoadStoreSpec
 
 
 class SecondaryTierManager(ABC):
@@ -122,6 +136,41 @@ class SecondaryTierManager(ABC):
                           identifying the primary-tier slots to read from.
         """
         pass
+
+    def uses_worker_transfers(self) -> bool:
+        """Whether this tier wants primary<->secondary copies run by workers.
+
+        Scheduler-side tiers should keep the default and implement submit_*().
+        Multi-node tiers can return True so the scheduler only orchestrates the
+        transfer while workers perform the data copy from their local CPU shard.
+        """
+        return False
+
+    def build_worker_store_transfer(
+        self, job_metadata: JobMetadata
+    ) -> tuple[LoadStoreSpec, LoadStoreSpec]:
+        """Build worker source/destination specs for primary -> secondary."""
+        raise NotImplementedError
+
+    def build_worker_load_transfer(
+        self, job_metadata: JobMetadata
+    ) -> tuple[LoadStoreSpec, LoadStoreSpec]:
+        """Build worker source/destination specs for secondary -> primary."""
+        raise NotImplementedError
+
+    def complete_worker_store(
+        self, job_metadata: JobMetadata, success: bool
+    ) -> None:
+        """Finalize a worker-executed primary -> secondary transfer."""
+        return
+
+    def complete_worker_load(self, job_metadata: JobMetadata, success: bool) -> None:
+        """Finalize a worker-executed secondary -> primary transfer."""
+        return
+
+    def abort_worker_transfers(self) -> None:
+        """Drop tier-side bookkeeping for worker-executed transfers."""
+        return
 
     @abstractmethod
     def submit_load(self, job_metadata: JobMetadata) -> None:

--- a/vllm/v1/kv_offload/tiering/fs/common.py
+++ b/vllm/v1/kv_offload/tiering/fs/common.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+
+from typing_extensions import override
+
+from vllm.v1.kv_offload.base import LoadStoreSpec
+
+
+@dataclass
+class FileSystemLoadStoreSpec(LoadStoreSpec):
+    """Worker-visible filesystem transfer spec.
+
+    file_paths are the committed block files. temp_file_paths are present only
+    for stores; workers write temp files and the scheduler-side tier commits
+    them after every worker has reported completion.
+    """
+
+    file_paths: list[str]
+    block_size: int
+    temp_file_paths: list[str] | None = None
+    num_ranks: int = 1
+
+    @staticmethod
+    @override
+    def medium() -> str:
+        return "file_system"

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -32,6 +32,7 @@ from typing_extensions import override
 
 from vllm.logger import init_logger
 from vllm.v1.kv_offload.base import LookupResult, OffloadKey, ReqContext
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
 from vllm.v1.kv_offload.file_mapper import FileMapper
 from vllm.v1.kv_offload.tiering.async_lookup import AsyncLookupManager
 from vllm.v1.kv_offload.tiering.base import (
@@ -40,6 +41,7 @@ from vllm.v1.kv_offload.tiering.base import (
     RequestOffloadingContext,
     SecondaryTierManager,
 )
+from vllm.v1.kv_offload.tiering.fs.common import FileSystemLoadStoreSpec
 from vllm.v1.kv_offload.tiering.fs.io import load_block, store_block
 from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
 
@@ -63,11 +65,28 @@ class FsAsyncLookupManager(AsyncLookupManager):
     def batch_lookup(
         self, keys: list[OffloadKey], req_context: ReqContext
     ) -> Iterable[bool]:
-        paths = [self._tier.file_mapper.get_file_name(k) for k in keys]
+        if not self._tier.uses_worker_transfers():
+            paths = [self._tier.file_mapper.get_file_name(k) for k in keys]
+            return self._path_exists_batch(paths)
+
+        paths_by_key = [self._tier.get_lookup_paths(k) for k in keys]
+        flat_paths = [path for paths in paths_by_key for path in paths]
+        flat_results = self._path_exists_batch(flat_paths)
+
+        results = []
+        offset = 0
+        for paths in paths_by_key:
+            next_offset = offset + len(paths)
+            results.append(all(flat_results[offset:next_offset]))
+            offset = next_offset
+        return results
+
+    @staticmethod
+    def _path_exists_batch(paths: list[str]) -> list[bool]:
         if _HAS_BATCH_LOOKUP_C:
             # C extension: GIL released for the entire faccessat() batch.
             return batch_lookup_C(paths)
-        return (os.path.exists(p) for p in paths)
+        return [os.path.exists(p) for p in paths]
 
 
 class FileSystemTierManager(SecondaryTierManager):
@@ -99,6 +118,7 @@ class FileSystemTierManager(SecondaryTierManager):
         root_dir: str,
         n_read_threads: int = 16,
         n_write_threads: int = 16,
+        worker_transfers: bool = False,
     ):
         """
         Args:
@@ -109,6 +129,8 @@ class FileSystemTierManager(SecondaryTierManager):
             root_dir: Root directory for block files.
             n_read_threads: Number of read-priority I/O threads.
             n_write_threads: Number of write-priority I/O threads.
+            worker_transfers: If true, scheduler still owns policy/lookup but
+                workers execute CPU-shard <-> filesystem data copies.
         """
         super().__init__(offloading_spec, primary_kv_view, tier_type)
 
@@ -142,6 +164,8 @@ class FileSystemTierManager(SecondaryTierManager):
         )
 
         self._lookup_manager = FsAsyncLookupManager(tier=self, tier_type=self.tier_type)
+        self._worker_transfers = worker_transfers
+        self._worker_store_paths: dict[int, list[tuple[str, str]]] = {}
 
     @override
     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
@@ -153,6 +177,139 @@ class FileSystemTierManager(SecondaryTierManager):
         if result is None:
             return LookupResult.RETRY
         return LookupResult.HIT if result else LookupResult.MISS
+
+    @override
+    def uses_worker_transfers(self) -> bool:
+        return self._worker_transfers
+
+    def _get_num_ranks(self) -> int:
+        num_ranks = self._offloading_spec.vllm_config.parallel_config.world_size
+        if num_ranks <= 0:
+            raise ValueError(f"Invalid parallel world size: {num_ranks}")
+        return num_ranks
+
+    def _get_file_paths(self, keys, rank=None) -> list[str]:
+        return [self.file_mapper.get_file_name(k, rank=rank) for k in keys]
+
+    def get_lookup_paths(self, key: OffloadKey) -> list[str]:
+        if not self._worker_transfers:
+            return [self.file_mapper.get_file_name(key)]
+        return [
+            self.file_mapper.get_file_name(key, rank=rank)
+            for rank in range(self._get_num_ranks())
+        ]
+
+    def _get_temp_path(self, final_path: str, job_id: int) -> str:
+        instance_id = self._offloading_spec.vllm_config.instance_id
+        return f"{final_path}.{instance_id}.{job_id}.tmp"
+
+    @override
+    def build_worker_store_transfer(
+        self, job_metadata: JobMetadata
+    ) -> tuple[CPULoadStoreSpec, FileSystemLoadStoreSpec]:
+        num_ranks = self._get_num_ranks()
+        all_final: list[str] = []
+        all_temp: list[str] = []
+        for rank in range(num_ranks):
+            fp = self._get_file_paths(job_metadata.keys, rank=rank)
+            tp = [self._get_temp_path(p, job_metadata.job_id) for p in fp]
+            key = job_metadata.job_id
+            if key not in self._worker_store_paths:
+                self._worker_store_paths[key] = []
+            self._worker_store_paths[key].extend(zip(tp, fp))
+            all_final.extend(fp)
+            all_temp.extend(tp)
+        logger.debug(
+            "Built filesystem worker store transfer job %d: %d keys, %d ranks",
+            job_metadata.job_id,
+            len(job_metadata.keys),
+            num_ranks,
+        )
+        return CPULoadStoreSpec([int(b) for b in job_metadata.block_ids]), (
+            FileSystemLoadStoreSpec(
+                file_paths=all_final,
+                temp_file_paths=all_temp,
+                block_size=self._block_size,
+                num_ranks=num_ranks,
+            )
+        )
+
+    @override
+    def build_worker_load_transfer(
+        self, job_metadata: JobMetadata
+    ) -> tuple[FileSystemLoadStoreSpec, CPULoadStoreSpec]:
+        num_ranks = self._get_num_ranks()
+        all_final: list[str] = []
+        for rank in range(num_ranks):
+            fp = self._get_file_paths(job_metadata.keys, rank=rank)
+            all_final.extend(fp)
+        logger.debug(
+            "Built filesystem worker load transfer job %d: %d keys, %d ranks",
+            job_metadata.job_id,
+            len(job_metadata.keys),
+            num_ranks,
+        )
+        return (
+            FileSystemLoadStoreSpec(
+                file_paths=all_final,
+                block_size=self._block_size,
+                num_ranks=num_ranks,
+            ),
+            CPULoadStoreSpec([int(b) for b in job_metadata.block_ids]),
+        )
+
+    @override
+    def complete_worker_store(
+        self, job_metadata: JobMetadata, success: bool
+    ) -> None:
+        paths = self._worker_store_paths.pop(job_metadata.job_id, [])
+        if not success:
+            for temp_path, _ in paths:
+                try:
+                    os.remove(temp_path)
+                except FileNotFoundError:
+                    pass
+            return
+
+        missing_temp_paths = [
+            temp_path
+            for temp_path, final_path in paths
+            if not os.path.exists(final_path) and not os.path.exists(temp_path)
+        ]
+        if missing_temp_paths:
+            for temp_path, _ in paths:
+                try:
+                    os.remove(temp_path)
+                except FileNotFoundError:
+                    pass
+            logger.warning(
+                "Discarding incomplete worker filesystem store job %d: "
+                "missing %d temp file(s). Verify that root_dir is visible "
+                "from every worker when worker_transfers is enabled.",
+                job_metadata.job_id,
+                len(missing_temp_paths),
+            )
+            return
+
+        for temp_path, final_path in paths:
+            if os.path.exists(final_path):
+                try:
+                    os.remove(temp_path)
+                except FileNotFoundError:
+                    pass
+                continue
+            os.replace(temp_path, final_path)
+
+    @override
+    def abort_worker_transfers(self) -> None:
+        paths_by_job = self._worker_store_paths
+        self._worker_store_paths = {}
+        for paths in paths_by_job.values():
+            for temp_path, _ in paths:
+                try:
+                    os.remove(temp_path)
+                except FileNotFoundError:
+                    pass
 
     @override
     def submit_store(self, job_metadata: JobMetadata) -> None:

--- a/vllm/v1/kv_offload/tiering/fs/worker.py
+++ b/vllm/v1/kv_offload/tiering/fs/worker.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+import torch
+
+from vllm.logger import init_logger
+from vllm.v1.kv_offload.base import TransferResult
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+from vllm.v1.kv_offload.tiering.fs.common import FileSystemLoadStoreSpec
+from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+
+logger = init_logger(__name__)
+
+
+def _write_all_at(fd: int, view: memoryview, offset: int) -> None:
+    written = 0
+    while written < len(view):
+        n = os.pwrite(fd, view[written:], offset + written)
+        if n <= 0:
+            raise OSError("pwrite made no progress")
+        written += n
+
+
+def _read_exact_at(fd: int, view: memoryview, offset: int) -> None:
+    read = 0
+    while read < len(view):
+        chunk = os.pread(fd, len(view) - read, offset + read)
+        if not chunk:
+            raise OSError(
+                f"Short read: expected {len(view)} bytes, read {read}"
+            )
+        end = read + len(chunk)
+        view[read:end] = chunk
+        read = end
+
+
+class FileSystemWorkerTransferHandler:
+    """Worker-side CPU shard <-> filesystem transfer executor."""
+
+    def __init__(
+        self,
+        cpu_tensors: list[torch.Tensor],
+        rank: int,
+        n_read_threads: int = 4,
+        n_write_threads: int = 4,
+    ) -> None:
+        self._cpu_tensors = cpu_tensors
+        self._rank = rank
+        self._rank_size = sum(int(t.shape[1]) for t in cpu_tensors)
+        self._rank_offset = rank * self._rank_size
+        self._store_temp_paths: dict[int, list[str]] = {}
+        self._pool = DualQueueThreadPool(
+            n_read_threads,
+            n_write_threads,
+            thread_name_prefix="vllm_kv_worker_fs",
+        )
+
+    def _select_rank_paths(self, paths: list[str], num_ranks: int) -> list[str]:
+        if num_ranks <= 0:
+            raise ValueError(f"Invalid num_ranks={num_ranks}")
+        if self._rank < 0 or self._rank >= num_ranks:
+            raise ValueError(
+                f"Worker rank {self._rank} is outside num_ranks={num_ranks}"
+            )
+        if len(paths) % num_ranks != 0:
+            raise ValueError(
+                f"Cannot split {len(paths)} paths across {num_ranks} ranks"
+            )
+        per_rank = len(paths) // num_ranks
+        start = self._rank * per_rank
+        return paths[start : start + per_rank]
+
+    def submit_store(
+        self,
+        job_id: int,
+        src_spec: CPULoadStoreSpec,
+        dst_spec: FileSystemLoadStoreSpec,
+    ) -> bool:
+        if dst_spec.temp_file_paths is None:
+            raise ValueError("Filesystem worker stores require temp file paths")
+        # Select this rank's slice of the concatenated per-rank paths.
+        num_ranks: int = getattr(dst_spec, "num_ranks", 1)
+        my_final = self._select_rank_paths(dst_spec.file_paths, num_ranks)
+        my_temp = self._select_rank_paths(dst_spec.temp_file_paths, num_ranks)
+
+        if len(src_spec.block_ids) != len(my_final):
+            raise ValueError(
+                "CPU block count does not match filesystem path count: "
+                f"{len(src_spec.block_ids)} != {len(my_final)}"
+            )
+        if len(src_spec.block_ids) != len(my_temp):
+            raise ValueError(
+                "CPU block count does not match filesystem temp path count: "
+                f"{len(src_spec.block_ids)} != {len(my_temp)}"
+            )
+        self._store_temp_paths[job_id] = list(my_temp)
+
+        tasks = (
+            lambda bid=int(block_id), final_path=final_path, temp_path=temp_path: (
+                self._store_one(
+                    block_id=bid,
+                    final_path=final_path,
+                    temp_path=temp_path,
+                    block_size=dst_spec.block_size,
+                )
+            )
+            for block_id, final_path, temp_path in zip(
+                src_spec.block_ids, my_final, my_temp
+            )
+        )
+        self._pool.enqueue_store(job_id, len(src_spec.block_ids), tasks)
+        return True
+
+    def submit_load(
+        self,
+        job_id: int,
+        src_spec: FileSystemLoadStoreSpec,
+        dst_spec: CPULoadStoreSpec,
+    ) -> bool:
+        # Select this rank's slice of the concatenated per-rank paths.
+        num_ranks: int = getattr(src_spec, "num_ranks", 1)
+        my_files = self._select_rank_paths(src_spec.file_paths, num_ranks)
+
+        if len(my_files) != len(dst_spec.block_ids):
+            raise ValueError(
+                "Filesystem path count does not match CPU block count: "
+                f"{len(my_files)} != {len(dst_spec.block_ids)}"
+            )
+        tasks = (
+            lambda source_path=source_path, bid=int(block_id): self._load_one(
+                source_path=source_path,
+                block_id=bid,
+            )
+            for source_path, block_id in zip(my_files, dst_spec.block_ids)
+        )
+        self._pool.enqueue_load(job_id, len(dst_spec.block_ids), tasks)
+        return True
+
+    def _store_one(
+        self,
+        *,
+        block_id: int,
+        final_path: str,
+        temp_path: str,
+        block_size: int,
+    ) -> None:
+        if os.path.exists(final_path):
+            return
+
+        os.makedirs(os.path.dirname(temp_path), exist_ok=True)
+        flags = os.O_CREAT | os.O_EXCL | os.O_RDWR | os.O_TRUNC
+        fd = os.open(temp_path, flags, 0o644)
+        try:
+            os.ftruncate(fd, block_size)
+            offset = self._rank_offset
+            for tensor in self._cpu_tensors:
+                row = tensor[block_id].numpy()
+                view = memoryview(row).cast("B")
+                _write_all_at(fd, view, offset)
+                offset += len(view)
+        finally:
+            os.close(fd)
+
+    def _load_one(self, *, source_path: str, block_id: int) -> None:
+        fd = os.open(source_path, os.O_RDONLY)
+        try:
+            offset = self._rank_offset
+            for tensor in self._cpu_tensors:
+                row = tensor[block_id].numpy()
+                view = memoryview(row).cast("B")
+                _read_exact_at(fd, view, offset)
+                offset += len(view)
+        finally:
+            os.close(fd)
+
+    def get_finished(self) -> list[TransferResult]:
+        results: list[TransferResult] = []
+        for job_id, success in self._pool.get_finished():
+            if success:
+                self._store_temp_paths.pop(job_id, None)
+            else:
+                self._cleanup_store_temps({job_id})
+            results.append(
+                TransferResult(
+                    job_id=job_id,
+                    success=success,
+                    transfer_size=None,
+                    transfer_time=None,
+                )
+            )
+        return results
+
+    def _cleanup_store_temps(self, job_ids: set[int]) -> None:
+        for job_id in job_ids:
+            for temp_path in self._store_temp_paths.pop(job_id, []):
+                try:
+                    os.remove(temp_path)
+                except FileNotFoundError:
+                    pass
+
+    def wait(self, job_ids: set[int] | None = None) -> None:
+        self._pool.wait_idle()
+        if job_ids is not None:
+            self._cleanup_store_temps(job_ids)
+
+    def shutdown(self) -> None:
+        self._pool.shutdown(wait=True)

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -20,7 +20,7 @@ Key Design Principles:
    protecting blocks from eviction until complete_read() is called
 """
 
-from collections.abc import Collection, Iterable, Sequence
+from collections.abc import Callable, Collection, Iterable, Sequence
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -48,6 +48,7 @@ from vllm.v1.kv_offload.tiering.base import (
     JobId,
     JobMetadata,
     SecondaryTierManager,
+    WorkerTransferSpec,
 )
 
 logger = init_logger(__name__)
@@ -60,6 +61,17 @@ class PendingPromotion:
     req_context: ReqContext
     keys: list[OffloadKey] = field(default_factory=list)
     block_ids: list[int] = field(default_factory=list)
+
+
+@dataclass
+class PendingWorkerTransfer:
+    """A primary<->secondary transfer waiting for connector job IDs."""
+
+    tier: SecondaryTierManager
+    keys: Sequence[OffloadKey]
+    block_ids: np.ndarray
+    is_promotion: bool
+    req_context: ReqContext
 
 
 @dataclass(slots=True)
@@ -161,6 +173,8 @@ class TieringOffloadingManager(OffloadingManager):
         #   True:  secondary → primary (promotion)
         #   False: primary → secondary (cascade)
         self._transfer_jobs: dict[JobId, JobMetadata] = {}
+        self._worker_transfer_tiers: dict[JobId, SecondaryTierManager] = {}
+        self._pending_worker_transfers: list[PendingWorkerTransfer] = []
 
         # Pending promotion requests accumulated during lookup() calls; flushed
         # as one batched submit_load() per (tier, request) in on_schedule_end().
@@ -181,9 +195,22 @@ class TieringOffloadingManager(OffloadingManager):
 
     def _next_job_id(self) -> JobId:
         """Generate a unique job ID for async transfer tracking."""
+        while self._job_id_counter in self._transfer_jobs:
+            self._job_id_counter += 1
         job_id = self._job_id_counter
         self._job_id_counter += 1
         return job_id
+
+    def _reserve_worker_job_id(
+        self, allocate_job_id: Callable[[], JobId]
+    ) -> JobId:
+        """Reserve a connector-visible ID without colliding in manager state."""
+        while True:
+            job_id = allocate_job_id()
+            if job_id in self._transfer_jobs:
+                continue
+            self._job_id_counter = max(self._job_id_counter, job_id + 1)
+            return job_id
 
     def _maybe_process_finished_jobs(self):
         """
@@ -211,27 +238,134 @@ class TieringOffloadingManager(OffloadingManager):
         """
         for i, tier in enumerate(self.secondary_tiers):
             for completed_job in tier.get_finished_jobs():
-                job_id = completed_job.job_id
-                job_metadata = self._transfer_jobs.pop(job_id, None)
-                assert job_metadata is not None, (
-                    f"Finished job_id {job_id} from tier #{i}"
-                    f" ({tier.tier_type}) not in _transfer_jobs"
+                self._complete_secondary_transfer(
+                    completed_job.job_id,
+                    completed_job.success,
+                    tier,
+                    worker_transfer=False,
+                    tier_index=i,
                 )
 
-                if job_metadata.is_promotion:
-                    # secondary→primary transfer (promotion) completed.
-                    # Make blocks available in primary tier.
-                    self.primary_tier.complete_write(
-                        job_metadata.keys,
-                        job_metadata.req_context,
-                        completed_job.success,
-                    )
-                else:
-                    # primary→secondary transfer completed.
-                    # Decrement ref_cnt on primary blocks.
-                    self.primary_tier.complete_read(
-                        job_metadata.keys, job_metadata.req_context
-                    )
+    def _complete_secondary_transfer(
+        self,
+        job_id: JobId,
+        success: bool,
+        tier: SecondaryTierManager,
+        *,
+        worker_transfer: bool,
+        tier_index: int | None = None,
+    ) -> None:
+        job_metadata = self._transfer_jobs.pop(job_id, None)
+        tier_label = (
+            f"tier #{tier_index} ({tier.tier_type})"
+            if tier_index is not None
+            else f"tier ({tier.tier_type})"
+        )
+        assert job_metadata is not None, (
+            f"Finished job_id {job_id} from {tier_label} not in _transfer_jobs"
+        )
+
+        if job_metadata.is_promotion:
+            if worker_transfer:
+                tier.complete_worker_load(job_metadata, success)
+            # secondary→primary transfer (promotion) completed.
+            # Make blocks available in primary tier.
+            self.primary_tier.complete_write(
+                job_metadata.keys,
+                job_metadata.req_context,
+                success,
+            )
+        else:
+            if worker_transfer:
+                tier.complete_worker_store(job_metadata, success)
+            # primary→secondary transfer completed.
+            # Decrement ref_cnt on primary blocks.
+            self.primary_tier.complete_read(
+                job_metadata.keys, job_metadata.req_context
+            )
+
+    def _submit_secondary_transfer(
+        self,
+        tier: SecondaryTierManager,
+        keys: Sequence[OffloadKey],
+        block_ids: np.ndarray,
+        *,
+        is_promotion: bool,
+        req_context: ReqContext,
+    ) -> None:
+        if tier.uses_worker_transfers():
+            self._pending_worker_transfers.append(
+                PendingWorkerTransfer(
+                    tier=tier,
+                    keys=tuple(keys),
+                    block_ids=np.array(block_ids, dtype=np.int64),
+                    is_promotion=is_promotion,
+                    req_context=req_context,
+                )
+            )
+            return
+
+        job_id = self._next_job_id()
+        job_metadata = JobMetadata(
+            job_id=job_id,
+            keys=keys,
+            block_ids=np.array(block_ids, dtype=np.int64),
+            is_promotion=is_promotion,
+            req_context=req_context,
+        )
+        self._transfer_jobs[job_id] = job_metadata
+        if is_promotion:
+            tier.submit_load(job_metadata)
+        else:
+            tier.submit_store(job_metadata)
+
+    def pop_worker_transfer_jobs(
+        self, allocate_job_id: Callable[[], JobId]
+    ) -> dict[JobId, WorkerTransferSpec]:
+        """Return worker-executed secondary transfers queued by the manager."""
+        if not self._pending_worker_transfers:
+            return {}
+
+        jobs: dict[JobId, WorkerTransferSpec] = {}
+        for pending in self._pending_worker_transfers:
+            job_id = self._reserve_worker_job_id(allocate_job_id)
+            job_metadata = JobMetadata(
+                job_id=job_id,
+                keys=pending.keys,
+                block_ids=pending.block_ids,
+                is_promotion=pending.is_promotion,
+                req_context=pending.req_context,
+            )
+            if pending.is_promotion:
+                src_spec, dst_spec = pending.tier.build_worker_load_transfer(
+                    job_metadata
+                )
+            else:
+                src_spec, dst_spec = pending.tier.build_worker_store_transfer(
+                    job_metadata
+                )
+            self._transfer_jobs[job_id] = job_metadata
+            self._worker_transfer_tiers[job_id] = pending.tier
+            jobs[job_id] = WorkerTransferSpec(
+                req_id=pending.req_context.req_id,
+                src_spec=src_spec,
+                dst_spec=dst_spec,
+            )
+
+        self._pending_worker_transfers.clear()
+        return jobs
+
+    def complete_worker_transfer(self, job_id: JobId, success: bool) -> None:
+        tier = self._worker_transfer_tiers.pop(job_id)
+        logger.debug(
+            "Completing worker transfer job %d for tier %s: success=%s",
+            job_id,
+            tier.tier_type,
+            success,
+        )
+        self._complete_secondary_transfer(
+            job_id, success, tier, worker_transfer=True
+        )
 
     @override
     def lookup(self, key: OffloadKey, req_context: ReqContext) -> LookupResult:
@@ -338,16 +472,13 @@ class TieringOffloadingManager(OffloadingManager):
 
         for tier, pending_by_ctx in self._pending_load_submissions.items():
             for entry in pending_by_ctx.values():
-                job_id = self._next_job_id()
-                job_metadata = JobMetadata(
-                    job_id=job_id,
+                self._submit_secondary_transfer(
+                    tier,
                     keys=entry.keys,
                     block_ids=np.array(entry.block_ids, dtype=np.int64),
                     is_promotion=True,
                     req_context=entry.req_context,
                 )
-                self._transfer_jobs[job_id] = job_metadata
-                tier.submit_load(job_metadata)
 
         self._pending_load_submissions.clear()
 
@@ -481,17 +612,14 @@ class TieringOffloadingManager(OffloadingManager):
                 ready_keys, req_context
             )
 
-            job_id = self._next_job_id()
             assert isinstance(primary_blocks_spec, CPULoadStoreSpec)
-            job_metadata = JobMetadata(
-                job_id=job_id,
+            self._submit_secondary_transfer(
+                tier,
                 keys=ready_keys,
                 block_ids=primary_blocks_spec.block_ids,
                 is_promotion=False,
                 req_context=req_context,
             )
-            self._transfer_jobs[job_id] = job_metadata
-            tier.submit_store(job_metadata)
 
     @override
     def complete_store(
@@ -529,22 +657,14 @@ class TieringOffloadingManager(OffloadingManager):
             # secondary tier.
             for tier in self.secondary_tiers:
                 primary_blocks_spec = self.primary_tier.prepare_read(keys, req_context)
-
-                # Submit async store job: primary→secondary
-                job_id = self._next_job_id()
-
-                # Track this store job
                 assert isinstance(primary_blocks_spec, CPULoadStoreSpec)
-                job_metadata = JobMetadata(
-                    job_id=job_id,
+                self._submit_secondary_transfer(
+                    tier,
                     keys=keys,
                     block_ids=primary_blocks_spec.block_ids,
                     is_promotion=False,
                     req_context=req_context,
                 )
-                self._transfer_jobs[job_id] = job_metadata
-
-                tier.submit_store(job_metadata)
 
         # Note: The async transfers are now in flight. Their completion is
         # tracked via get_finished_jobs() / _maybe_process_finished_jobs().
@@ -621,8 +741,10 @@ class TieringOffloadingManager(OffloadingManager):
         # In-flight primary<->secondary transfers (pending promotions are
         # translated to transfer jobs in on_schedule_end), plus any work the
         # secondary tiers themselves still have outstanding.
-        return bool(self._transfer_jobs) or any(
-            tier.has_pending_work() for tier in self.secondary_tiers
+        return (
+            bool(self._transfer_jobs)
+            or bool(self._pending_worker_transfers)
+            or any(tier.has_pending_work() for tier in self.secondary_tiers)
         )
 
     @override
@@ -663,6 +785,11 @@ class TieringOffloadingManager(OffloadingManager):
         # reset below invalidates; their submit_load() has not yet been
         # called so no tier I/O is touching that memory.
         self._pending_load_submissions.clear()
+        self._pending_worker_transfers.clear()
+        self._worker_transfer_tiers.clear()
+        self._transfer_jobs.clear()
+        for tier in self.secondary_tiers:
+            tier.abort_worker_transfers()
 
         finished_req_ids = []
         for req_id, state in self._req_state.items():

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -32,8 +32,6 @@ Example configuration:
 """
 
 from typing import Any
-
-import torch
 from typing_extensions import override
 
 from vllm.config import VllmConfig
@@ -188,7 +186,7 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
 
     @override
     def create_worker(self, kv_caches: CanonicalKVCaches) -> CPUOffloadingWorker:
-        rank = torch.accelerator.current_device_index()
+        rank = self.vllm_config.parallel_config.rank
         worker_mmap = SharedOffloadRegion(
             instance_id=self.vllm_config.instance_id,
             num_blocks=self.num_blocks,
@@ -200,5 +198,6 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
             kv_caches=kv_caches,
             block_size_factor=self.block_size_factor,
             num_cpu_blocks=self.num_blocks,
+            parallel_rank=self.vllm_config.parallel_config.rank,
             mmap_region=worker_mmap,
         )


### PR DESCRIPTION
## Summary

This PR enables multi-node TP CPU-offloaded KV cache to write to and read back from a shared filesystem via a scheduler-orchestrated, worker-executed secondary-transfer path.

In the existing single-node offloading design, CPU KV cache shards are locally visible through the shared mmap region. In multi-node TP, each worker owns a rank-local CPU mmap slice, and the scheduler cannot directly access remote-node CPU shards. This PR extends tiering offload so the scheduler still owns policy, lookup, promotion, and lifecycle, while workers only execute typed transfer specs for rank-local CPU-shard <-> shared-filesystem copies.

It also hardens the multi-node path around explicit global-rank selection, worker-transfer failure propagation, partial-store cleanup, MoE/MTP canonical tensor layout handling, and compatibility with upstream #46713's filesystem C batch lookup.

## Design

**Scheduler owns policy and lifecycle.** `OffloadingConnectorScheduler` continues to decide when to offload, which blocks move to secondary tiers, and how lookup, promotion, eviction, reset, and completion are handled.

**Worker only executes transfer specs.** Workers receive typed `TransferSpec`s through connector metadata, execute data movement, and report completion/failure. A worker does not own a secondary tier, eviction policy, lookup policy, or promotion policy.

**Eager write-through is preserved.** The GPU -> CPU primary-store path remains eager. This PR does not add LRU write-back or worker-side eviction callbacks; worker-executed secondary stores are still triggered by scheduler-owned primary-store completion.

**Connector metadata remains generic.** The connector path uses `worker_transfer_jobs`; it does not expose `disk_*` or `fs_*` policy through the connector layer.

**Rank-aware shared-FS lookup/load remains scheduler-owned.** With `worker_transfers=True`, FS lookup reports a hit only when every rank file exists. Promotion is still initiated by scheduler-side lookup/promotion logic; workers only load their own rank-local slice from scheduler-provided file paths into scheduler-allocated CPU slots.

## Scope

This PR includes:

- A scheduler-orchestrated, worker-executed secondary transfer path carried through generic `worker_transfer_jobs` metadata and `OffloadingWorker.submit_transfer()`.
- Filesystem `TransferSpec`s and a worker handler for rank-local CPU-shard <-> shared-filesystem copies.
- `FileSystemTierManager` opt-in via `worker_transfers=True`.
- Rank-aware shared-FS lookup/load/promotion: lookup requires all rank files, scheduler creates promotion jobs, and workers load only their rank-local slice.
- Worker-transfer lifecycle handling: all-worker completion tracking, failure propagation, scheduler-side commit/discard, and reset/flush cleanup.
- Explicit global-rank path/mmap selection, CPU row-budget fixes, and canonical tensor layout handling needed by MoE/MTP views.
- Focused tests for worker transfer queueing/completion, all-rank FS lookup, FS store/load, partial-store cleanup, failure propagation, job-id handling, and shared-layer canonicalization with distinct storage offsets.
- Compatibility with upstream #46713's FS C batch lookup, including C/fallback coverage for worker-transfer lookup.

## Non-Duplication / AI Assistance

- Duplicate check performed with:
  - `gh issue view 46556 --repo vllm-project/vllm --comments`
  - `gh pr list --repo vllm-project/vllm --state open --search "46556 in:body"`
  - `gh pr list --repo vllm-project/vllm --state open --search "kv offload worker filesystem tiering multinode"`
  - `gh pr list --repo vllm-project/vllm --state open --search "OffloadingConnector filesystem"`
  - `gh pr list --repo vllm-project/vllm --state open --search "TieringOffloadingSpec fs"`
- No PR was found that directly solves multi-node TP CPU KV offloading with scheduler-orchestrated, worker-executed shared-FS transfers.
- Related but non-duplicating work includes #44193 (async/batched secondary-tier lookup), #46713 (FS batch lookup in C), #45765 (secondary-tier lookup timeout/backpressure), and #42285 (secondary tier implementation for PD disaggregation). Those PRs improve lookup scheduling/performance or related secondary-tier infrastructure; this PR adds the missing multi-node TP shared-FS data path with all-rank hit validation, scheduler-owned promotion, and worker-executed rank-local loads.
- AI assistance was used to help review, and test this change.

## Tests

- Current patch applies cleanly to latest upstream `main` at `a309d4fe6`.
- `git diff --check` passed.
- `python -m py_compile` passed for changed Python files checked locally.
- Targeted pytest in the rebuilt DGX test image passed: `61 passed, 2 skipped, 3 warnings`.
- DGX TP=2 shared-FS validation with `PYTHONHASHSEED=0` passed:
  - Write phase completed with HTTP 200, no actual Errors/Traceback/EngineDead, and no temp files.
  - Restart readback phase completed with HTTP 200, no actual Errors/Traceback/EngineDead, and no temp files.
  - Readback logs confirmed a scheduler-created FS -> CPU worker load job with `12 keys, 2 ranks`; rank0 and rank1 both submitted `file_system -> CPU`; scheduler completed the worker-transfer job with `success=True`.

## Follow-up

- Under the 1GB CPU primary-tier DGX stress setup, `cannot store blocks` warnings can appear while the primary tier is under pressure. The validated requests still completed successfully, shared-FS write/readback passed, and no temp files remained. This does not appear to be a correctness blocker for this PR; capacity tuning, shared-FS/NFS/disk throughput, and polling/backpressure behavior should be measured separately.
