### PR TITLE
[FS Offloading] Move FSAsyncLookup into a subprocess 

### DIFF
--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -104,11 +104,14 @@ def lookup_and_wait(
         tier.lookup(k, ctx)
     tier.on_schedule_end()
     deadline = time.monotonic() + timeout
+    latest: list[bool | None] = [None] * len(keys)
     while time.monotonic() < deadline:
-        if not tier._lookup_manager._pending_results.empty():
+        latest = [tier.lookup(k, ctx) for k in keys]
+        if all(v is not None for v in latest):
             break
         time.sleep(0.01)
-    return [tier.lookup(k, ctx) for k in keys]
+    assert all(v is not None for v in latest), "lookup results did not resolve in time"
+    return [bool(v) for v in latest]
 
 
 def _page_aligned_zero_tensor(

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -107,6 +107,7 @@ def lookup_and_wait(
     latest: list[bool | None] = [None] * len(keys)
     while time.monotonic() < deadline:
         latest = [tier.lookup(k, ctx) for k in keys]
+        tier.on_schedule_end()  # attempt result drain
         if all(v is not None for v in latest):
             break
         time.sleep(0.01)

--- a/vllm/v1/kv_offload/tiering/async_lookup.py
+++ b/vllm/v1/kv_offload/tiering/async_lookup.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-Async lookup managers for secondary-tier existence checks.
+AsyncLookupManager: per-tier async lookup manager for secondary tier
+existence checks.
 
 Each secondary tier that wants non-blocking lookups composes its own
 AsyncLookupManager instance internally.  The manager maintains lookup
@@ -35,7 +36,7 @@ import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import cast
 
 from typing_extensions import override
 
@@ -78,9 +79,6 @@ class BaseAsyncLookupManager(ABC):
         tier_type: str,
     ) -> None:
         self._tier_type = tier_type
-        # Concrete subclasses provide queue implementations (thread/process).
-        self._lookup_queue: Any
-        self._pending_results: Any
 
         # key → LookupState; scheduler-owned, no lock needed.
         self._lookup_state: dict[OffloadKey, LookupState] = {}
@@ -92,41 +90,6 @@ class BaseAsyncLookupManager(ABC):
         self._lookup_batch: list[tuple[OffloadKey, ReqContext]] = []
 
         self._need_to_drain: bool = False
-
-    @staticmethod
-    def execute_lookup_batch(
-        pending: LookupBatch,
-        tier_type: str,
-        batch_lookup: Callable[[list[OffloadKey], ReqContext], Iterable[bool]],
-    ) -> LookupResults:
-        """Resolve one queued lookup batch grouped by request id."""
-        batches: dict[str, tuple[ReqContext, list[OffloadKey]]] = {}
-        for key, req_context in pending:
-            req_id = req_context.req_id
-            if req_id not in batches:
-                batches[req_id] = (req_context, [])
-            batches[req_id][1].append(key)
-
-        if not batches:
-            return []
-
-        results: LookupResults = []
-        for req_context, keys in batches.values():
-            try:
-                hits = batch_lookup(keys, req_context)
-            except Exception as exc:
-                logger.warning(
-                    "batch_lookup failed on tier %s for %d keys: %s",
-                    tier_type,
-                    len(keys),
-                    exc,
-                )
-                hits = (False for _ in keys)
-
-            for key, hit in zip(keys, hits):
-                results.append((key, hit))
-
-        return results
 
     # ------------------------------------------------------------------
     # Scheduler-thread API
@@ -164,7 +127,7 @@ class BaseAsyncLookupManager(ABC):
         """
         self._need_to_drain = True
         if self._lookup_batch:
-            self._send_lookup_batch(self._lookup_batch)
+            self.send_lookup_batch(self._lookup_batch)
             self._lookup_batch = []
 
     def drain_results(self) -> None:
@@ -173,7 +136,7 @@ class BaseAsyncLookupManager(ABC):
         Called from lookup() before checking state.
         """
         while True:
-            batch = self._try_recv_result_batch()
+            batch = self.try_recv_result_batch()
             if batch is None:
                 break
             for key, result in batch:
@@ -194,18 +157,50 @@ class BaseAsyncLookupManager(ABC):
                 del self._lookup_state[key]
 
     @abstractmethod
+    def send_lookup_batch(self, batch: LookupBatch) -> None: ...
+
+    @abstractmethod
+    def try_recv_result_batch(self) -> LookupResults | None: ...
+
+    @abstractmethod
     def shutdown(self) -> None:
         """Stop the background worker."""
         ...
 
-    def _send_lookup_batch(self, batch: LookupBatch) -> None:
-        self._lookup_queue.put(batch)
+    @staticmethod
+    def execute_lookup_batch(
+        pending: LookupBatch,
+        tier_type: str,
+        batch_lookup: Callable[[list[OffloadKey], ReqContext], Iterable[bool]],
+    ) -> LookupResults:
+        """Resolve one queued lookup batch grouped by request id."""
+        batches: dict[str, tuple[ReqContext, list[OffloadKey]]] = {}
+        for key, req_context in pending:
+            req_id = req_context.req_id
+            if req_id not in batches:
+                batches[req_id] = (req_context, [])
+            batches[req_id][1].append(key)
 
-    def _try_recv_result_batch(self) -> LookupResults | None:
-        try:
-            return cast(LookupResults, self._pending_results.get_nowait())
-        except queue.Empty:
-            return None
+        if not batches:
+            return []
+
+        results: LookupResults = []
+        for req_context, keys in batches.values():
+            try:
+                hits = batch_lookup(keys, req_context)
+            except Exception as exc:
+                logger.warning(
+                    "batch_lookup failed on tier %s for %d keys: %s",
+                    tier_type,
+                    len(keys),
+                    exc,
+                )
+                hits = (False for _ in keys)
+
+            for key, hit in zip(keys, hits):
+                results.append((key, hit))
+
+        return results
 
 
 class AsyncLookupManager(BaseAsyncLookupManager, ABC):
@@ -239,6 +234,17 @@ class AsyncLookupManager(BaseAsyncLookupManager, ABC):
     def shutdown(self) -> None:
         self._lookup_queue.put(None)  # unblock _worker from _lookup_queue.get()
         self._thread.join()
+
+    @override
+    def send_lookup_batch(self, batch: LookupBatch) -> None:
+        self._lookup_queue.put(batch)
+
+    @override
+    def try_recv_result_batch(self) -> LookupResults | None:
+        try:
+            return cast(LookupResults, self._pending_results.get_nowait())
+        except queue.Empty:
+            return None
 
     def _worker(self) -> None:
         while True:

--- a/vllm/v1/kv_offload/tiering/async_lookup.py
+++ b/vllm/v1/kv_offload/tiering/async_lookup.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-AsyncLookupManager: per-tier async lookup manager for secondary tier
-existence checks.
+Async lookup managers for secondary-tier existence checks.
 
 Each secondary tier that wants non-blocking lookups composes its own
 AsyncLookupManager instance internally.  The manager maintains lookup
-state and uses a background thread to execute batch_lookup() calls.
+state while a concrete runtime strategy (thread/process) executes lookups.
 
 Locking design
 --------------
@@ -16,16 +15,16 @@ There is no explicit lock.  Thread safety is achieved by ownership:
   thread.  lookup(), flush(), and cleanup() read and write them directly.
 
 * _lookup_queue is written by the scheduler (flush → put_nowait, one item
-  per step) and read by the background thread (get).  queue.Queue is
-  thread-safe.
+  per step) and read by the background worker (get).  Queue primitives are
+  thread/process-safe.
 
-* _pending_results is written by the background thread (put) and read by
+* _pending_results is written by the background worker (put) and read by
   the scheduler (get_nowait inside drain_results).  queue.SimpleQueue is
-  thread-safe by design.
+  thread-safe by design and multiprocessing.Queue is process-safe.
 
 lookup() accumulates new keys in _lookup_batch without touching the queue.
 flush() is called once per step from the tier's on_schedule_end(), posting
-the entire batch as a single queue item so the background thread sees one
+the entire batch as a single queue item so the background worker sees one
 batch per step.
 drain_results() is called before any lookup() calls in the same step, so
 lookup() is a pure OrderedDict operation.
@@ -34,8 +33,11 @@ lookup() is a pure OrderedDict operation.
 import queue
 import threading
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from typing import Any, cast
+
+from typing_extensions import override
 
 from vllm.logger import init_logger
 from vllm.v1.kv_offload.base import OffloadKey, ReqContext
@@ -49,17 +51,20 @@ class LookupState:
     request_ids: set[str] = field(default_factory=set)  # requests asking for the lookup
 
 
-class AsyncLookupManager(ABC):
+LookupBatch = list[tuple[OffloadKey, ReqContext]]
+LookupResults = list[tuple[OffloadKey, bool]]
+
+
+class BaseAsyncLookupManager(ABC):
     """
     Per-tier async lookup manager for secondary tier existence checks.
 
     Each secondary tier that wants non-blocking lookups composes its own
     AsyncLookupManager instance internally. The manager maintains lookup
-    state (cache, queue) and uses a background thread to execute the actual
-    batch_lookup() calls.
+    state (cache, queue) and lets subclasses decide the worker runtime
+    strategy (thread vs process).
 
-    Subclasses implement only batch_lookup() — all queue management,
-    state tracking, and result delivery is provided by this base class.
+    Subclasses provide queue transport and worker lifecycle.
 
     The owning tier delegates its lookup(), on_schedule_end(), and
     on_request_finished() to this manager:
@@ -73,6 +78,9 @@ class AsyncLookupManager(ABC):
         tier_type: str,
     ) -> None:
         self._tier_type = tier_type
+        # Concrete subclasses provide queue implementations (thread/process).
+        self._lookup_queue: Any
+        self._pending_results: Any
 
         # key → LookupState; scheduler-owned, no lock needed.
         self._lookup_state: dict[OffloadKey, LookupState] = {}
@@ -83,40 +91,42 @@ class AsyncLookupManager(ABC):
         # Flushed as one queue item per step by flush().
         self._lookup_batch: list[tuple[OffloadKey, ReqContext]] = []
 
-        # Scheduler → worker: one full step's batch per item.
-        # None is used as a shutdown sentinel.
-        self._lookup_queue: queue.SimpleQueue[
-            list[tuple[OffloadKey, ReqContext]] | None
-        ] = queue.SimpleQueue()
-
-        # Worker → scheduler: completed result batches.
-        # Each item is a list of (key, found) pairs.
-        # SimpleQueue is explicitly thread-safe for one writer / one reader.
-        self._pending_results: queue.SimpleQueue[list[tuple[OffloadKey, bool]]] = (
-            queue.SimpleQueue()
-        )
         self._need_to_drain: bool = False
 
-        self._thread = threading.Thread(
-            target=self._worker,
-            name=f"vllm_offloading_lookup_{tier_type}",
-            daemon=True,
-        )
-        self._thread.start()
+    @staticmethod
+    def execute_lookup_batch(
+        pending: LookupBatch,
+        tier_type: str,
+        batch_lookup: Callable[[list[OffloadKey], ReqContext], Iterable[bool]],
+    ) -> LookupResults:
+        """Resolve one queued lookup batch grouped by request id."""
+        batches: dict[str, tuple[ReqContext, list[OffloadKey]]] = {}
+        for key, req_context in pending:
+            req_id = req_context.req_id
+            if req_id not in batches:
+                batches[req_id] = (req_context, [])
+            batches[req_id][1].append(key)
 
-    @abstractmethod
-    def batch_lookup(
-        self, keys: list[OffloadKey], req_context: ReqContext
-    ) -> Iterable[bool]:
-        """
-        Check whether a batch of blocks exist in this tier.
+        if not batches:
+            return []
 
-        Called from the worker thread — must be synchronous and must not
-        touch the primary tier or scheduler state.
+        results: LookupResults = []
+        for req_context, keys in batches.values():
+            try:
+                hits = batch_lookup(keys, req_context)
+            except Exception as exc:
+                logger.warning(
+                    "batch_lookup failed on tier %s for %d keys: %s",
+                    tier_type,
+                    len(keys),
+                    exc,
+                )
+                hits = (False for _ in keys)
 
-        Returns a list parallel to keys: True if present, False if not.
-        """
-        ...
+            for key, hit in zip(keys, hits):
+                results.append((key, hit))
+
+        return results
 
     # ------------------------------------------------------------------
     # Scheduler-thread API
@@ -145,7 +155,7 @@ class AsyncLookupManager(ABC):
         return state.result
 
     def flush(self) -> None:
-        """Post this step's accumulated keys to the worker thread.
+        """Post this step's accumulated keys to the worker.
 
         Called once per step from on_schedule_end() after all lookup() calls
         are done. The worker receives the full batch and processes it during
@@ -154,7 +164,7 @@ class AsyncLookupManager(ABC):
         """
         self._need_to_drain = True
         if self._lookup_batch:
-            self._lookup_queue.put(self._lookup_batch)
+            self._send_lookup_batch(self._lookup_batch)
             self._lookup_batch = []
 
     def drain_results(self) -> None:
@@ -163,9 +173,8 @@ class AsyncLookupManager(ABC):
         Called from lookup() before checking state.
         """
         while True:
-            try:
-                batch = self._pending_results.get_nowait()
-            except queue.Empty:
+            batch = self._try_recv_result_batch()
+            if batch is None:
                 break
             for key, result in batch:
                 state = self._lookup_state.get(key)
@@ -184,48 +193,62 @@ class AsyncLookupManager(ABC):
             if not state.request_ids:
                 del self._lookup_state[key]
 
+    @abstractmethod
     def shutdown(self) -> None:
-        """Stop the worker thread."""
+        """Stop the background worker."""
+        ...
+
+    def _send_lookup_batch(self, batch: LookupBatch) -> None:
+        self._lookup_queue.put(batch)
+
+    def _try_recv_result_batch(self) -> LookupResults | None:
+        try:
+            return cast(LookupResults, self._pending_results.get_nowait())
+        except queue.Empty:
+            return None
+
+
+class AsyncLookupManager(BaseAsyncLookupManager, ABC):
+    """Thread-backed async lookup manager."""
+
+    def __init__(self, tier_type: str) -> None:
+        super().__init__(tier_type=tier_type)
+        # Scheduler → worker: one full step's batch per item.
+        # None is used as a shutdown sentinel.
+        self._lookup_queue: queue.SimpleQueue[LookupBatch | None] = queue.SimpleQueue()
+
+        # Worker → scheduler: completed result batches.
+        # SimpleQueue is explicitly thread-safe for one writer / one reader.
+        self._pending_results: queue.SimpleQueue[LookupResults] = queue.SimpleQueue()
+
+        self._thread = threading.Thread(
+            target=self._worker,
+            name=f"vllm_offloading_lookup_{tier_type}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    @abstractmethod
+    def batch_lookup(
+        self, keys: list[OffloadKey], req_context: ReqContext
+    ) -> Iterable[bool]:
+        """Check whether a batch of blocks exist in this tier."""
+        ...
+
+    @override
+    def shutdown(self) -> None:
         self._lookup_queue.put(None)  # unblock _worker from _lookup_queue.get()
         self._thread.join()
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
 
     def _worker(self) -> None:
         while True:
             pending = self._lookup_queue.get()
             if pending is None:
                 break
-
-            # Group by req_id.
-            batches: dict[str, tuple[ReqContext, list[OffloadKey]]] = {}
-            for key, req_context in pending:
-                req_id = req_context.req_id
-                if req_id not in batches:
-                    batches[req_id] = (req_context, [])
-                batches[req_id][1].append(key)
-
-            if not batches:
-                continue
-
-            results: list[tuple[OffloadKey, bool]] = []
-            for req_context, keys in batches.values():
-                try:
-                    hits = self.batch_lookup(keys, req_context)
-                except Exception as exc:
-                    logger.warning(
-                        "batch_lookup failed on tier %s for %d keys: %s",
-                        self._tier_type,
-                        len(keys),
-                        exc,
-                    )
-                    hits = (False for _ in keys)
-
-                for key, hit in zip(keys, hits):
-                    results.append((key, hit))
-
-            # Post the entire batch as one item — no lock needed.
+            results = self.execute_lookup_batch(
+                pending,
+                self._tier_type,
+                self.batch_lookup,
+            )
             if results:
                 self._pending_results.put(results)

--- a/vllm/v1/kv_offload/tiering/fs/io_process.py
+++ b/vllm/v1/kv_offload/tiering/fs/io_process.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FS lookup subprocess transport using vLLM MessageQueue."""
+
+import contextlib
+import os
+from multiprocessing.connection import Connection
+from multiprocessing.process import BaseProcess
+from typing import TYPE_CHECKING, cast
+
+from vllm.distributed.device_communicators.shm_broadcast import Handle, MessageQueue
+from vllm.logger import init_logger
+from vllm.utils.system_utils import get_mp_context
+from vllm.v1.kv_offload.base import OffloadKey, ReqContext
+from vllm.v1.kv_offload.file_mapper import FileMapper
+from vllm.v1.kv_offload.tiering.async_lookup import (
+    BaseAsyncLookupManager,
+    LookupBatch,
+    LookupResults,
+)
+
+if TYPE_CHECKING:
+    import multiprocessing
+
+logger = init_logger(__name__)
+
+_READY_TIMEOUT_S = 30.0
+
+
+class FsIoProcess:
+    """Owns the filesystem lookup subprocess and MessageQueue channels."""
+
+    def __init__(self, tier_type: str, file_mapper: FileMapper):
+        ctx = get_mp_context()
+        ready_reader, ready_writer = ctx.Pipe(duplex=False)
+        self._ready_reader: Connection = ready_reader
+
+        # Scheduler writer -> process reader.
+        self._request_queue = MessageQueue(n_reader=1, n_local_reader=1)
+        self._result_queue: MessageQueue | None = None
+        self._shutting_down = False
+
+        self._process: BaseProcess = ctx.Process(
+            target=_fs_lookup_worker_main,
+            kwargs={
+                "tier_type": tier_type,
+                "file_mapper": file_mapper,
+                "request_handle": self._request_queue.export_handle(),
+                "ready_pipe": ready_writer,
+            },
+            name=f"vllm_offloading_lookup_{tier_type}",
+            daemon=True,
+        )
+        self._process.start()
+        ready_writer.close()
+
+        try:
+            self._wait_for_startup_handshake()
+        except Exception:
+            self.shutdown()
+            raise
+
+    def _wait_for_startup_handshake(self) -> None:
+        if not self._ready_reader.poll(_READY_TIMEOUT_S):
+            raise RuntimeError(
+                "Timed out waiting for fs lookup process result queue handle"
+            )
+
+        message = self._ready_reader.recv()
+        if not isinstance(message, dict) or "result_handle" not in message:
+            raise RuntimeError(f"Unexpected fs lookup startup message: {message!r}")
+        result_handle = cast(Handle, message["result_handle"])
+        self._result_queue = MessageQueue.create_from_handle(result_handle, rank=0)
+
+        # MessageQueue readiness is collective: parent and child must both call.
+        self._request_queue.wait_until_ready()
+        self._result_queue.wait_until_ready()
+
+        if not self._ready_reader.poll(_READY_TIMEOUT_S):
+            raise RuntimeError("Timed out waiting for fs lookup process ready signal")
+        ready_signal = self._ready_reader.recv()
+        if ready_signal != "READY":
+            raise RuntimeError(f"Unexpected fs lookup ready signal: {ready_signal!r}")
+
+    def enqueue_lookup_batch(self, batch: LookupBatch) -> None:
+        self._request_queue.enqueue(batch)
+
+    def dequeue_lookup_results_nowait(self) -> LookupResults | None:
+        assert self._result_queue is not None
+        try:
+            return cast(LookupResults, self._result_queue.dequeue(timeout=0))
+        except TimeoutError:
+            return None
+
+    def shutdown(self) -> None:
+        if self._shutting_down:
+            return
+        self._shutting_down = True
+        with contextlib.suppress(Exception):
+            self._request_queue.enqueue(None)
+
+        self._process.join(timeout=5)
+        if self._process.is_alive():
+            self._process.terminate()
+            self._process.join(timeout=1)
+
+        if self._result_queue is not None:
+            self._result_queue.shutdown()
+        self._request_queue.shutdown()
+        self._ready_reader.close()
+
+
+def _fs_lookup_worker_main(
+    tier_type: str,
+    file_mapper: FileMapper,
+    request_handle: Handle,
+    ready_pipe: "multiprocessing.connection.Connection",
+) -> None:
+    request_reader = MessageQueue.create_from_handle(request_handle, rank=0)
+    result_writer = MessageQueue(n_reader=1, n_local_reader=1)
+    try:
+        ready_pipe.send({"result_handle": result_writer.export_handle()})
+
+        request_reader.wait_until_ready()
+        result_writer.wait_until_ready()
+        ready_pipe.send("READY")
+        ready_pipe.close()
+
+        def _batch_lookup(
+            keys: list[OffloadKey], req_context: ReqContext
+        ) -> list[bool]:
+            del req_context
+            return [os.path.exists(file_mapper.get_file_name(key)) for key in keys]
+
+        while True:
+            pending = cast(LookupBatch | None, request_reader.dequeue(indefinite=True))
+            if pending is None:
+                break
+            results = BaseAsyncLookupManager.execute_lookup_batch(
+                pending,
+                tier_type,
+                _batch_lookup,
+            )
+            if results:
+                result_writer.enqueue(results)
+    finally:
+        request_reader.shutdown()
+        result_writer.shutdown()
+        with contextlib.suppress(Exception):
+            ready_pipe.close()

--- a/vllm/v1/kv_offload/tiering/fs/io_process.py
+++ b/vllm/v1/kv_offload/tiering/fs/io_process.py
@@ -129,7 +129,6 @@ def _fs_lookup_worker_main(
         def _batch_lookup(
             keys: list[OffloadKey], req_context: ReqContext
         ) -> list[bool]:
-            del req_context
             return [os.path.exists(file_mapper.get_file_name(key)) for key in keys]
 
         while True:

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -26,7 +26,11 @@ from typing_extensions import override
 from vllm.logger import init_logger
 from vllm.v1.kv_offload.base import OffloadKey, ReqContext
 from vllm.v1.kv_offload.file_mapper import FileMapper
-from vllm.v1.kv_offload.tiering.async_lookup import AsyncLookupManager
+from vllm.v1.kv_offload.tiering.async_lookup import (
+    BaseAsyncLookupManager,
+    LookupBatch,
+    LookupResults,
+)
 from vllm.v1.kv_offload.tiering.base import (
     JobMetadata,
     JobResult,
@@ -34,6 +38,7 @@ from vllm.v1.kv_offload.tiering.base import (
     SecondaryTierManager,
 )
 from vllm.v1.kv_offload.tiering.fs.io import load_block, store_block
+from vllm.v1.kv_offload.tiering.fs.io_process import FsIoProcess
 from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
 
 if TYPE_CHECKING:
@@ -42,21 +47,28 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-class FsAsyncLookupManager(AsyncLookupManager):
-    """Async lookup manager for FileSystemTierManager."""
+class FsAsyncLookupManager(BaseAsyncLookupManager):
+    """Async lookup manager that routes FS lookup batches through FsIoProcess."""
 
     def __init__(
         self,
-        tier: "FileSystemTierManager",
+        io_process: FsIoProcess,
         tier_type: str,
     ) -> None:
         super().__init__(tier_type=tier_type)
-        self._tier = tier
+        self._io_process = io_process
 
-    def batch_lookup(
-        self, keys: list[OffloadKey], req_context: ReqContext
-    ) -> Iterable[bool]:
-        return (os.path.exists(self._tier.file_mapper.get_file_name(k)) for k in keys)
+    @override
+    def shutdown(self) -> None:
+        self._io_process.shutdown()
+
+    @override
+    def _send_lookup_batch(self, batch: LookupBatch) -> None:
+        self._io_process.enqueue_lookup_batch(batch)
+
+    @override
+    def _try_recv_result_batch(self) -> LookupResults | None:
+        return self._io_process.dequeue_lookup_results_nowait()
 
 
 class FileSystemTierManager(SecondaryTierManager):
@@ -130,7 +142,14 @@ class FileSystemTierManager(SecondaryTierManager):
             thread_name_prefix="vllm_kv_py_fs",
         )
 
-        self._lookup_manager = FsAsyncLookupManager(tier=self, tier_type=self.tier_type)
+        self._io_process = FsIoProcess(
+            tier_type=self.tier_type,
+            file_mapper=self.file_mapper,
+        )
+        self._lookup_manager = FsAsyncLookupManager(
+            io_process=self._io_process,
+            tier_type=self.tier_type,
+        )
 
     @override
     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -63,11 +63,11 @@ class FsAsyncLookupManager(BaseAsyncLookupManager):
         self._io_process.shutdown()
 
     @override
-    def _send_lookup_batch(self, batch: LookupBatch) -> None:
+    def send_lookup_batch(self, batch: LookupBatch) -> None:
         self._io_process.enqueue_lookup_batch(batch)
 
     @override
-    def _try_recv_result_batch(self) -> LookupResults | None:
+    def try_recv_result_batch(self) -> LookupResults | None:
         return self._io_process.dequeue_lookup_results_nowait()
 
 


### PR DESCRIPTION
## Purpose
TieredOffloading with FS tier on `main` yields poor performance. This is mostly due to lookup delays triggered by the FSAsyncLookupManager. 
We find that the thread backed FSAsyncLookup is severely impacted by the GIL. 

<img width="2082" height="1182" alt="wall_32" src="https://github.com/user-attachments/assets/eca1c743-44c7-476a-9442-65593fc849ac" />

PR https://github.com/vllm-project/vllm/pull/45765 Introduced a timeout for this as a stop-gap. This PR attempts to remove the GIL contention by moving the core part of FSAsyncLookup into a subprocess. 

Changes: 
 - Introduce `FsIoProcess`. This class, 
    - Creates a process 
    - Destroys the process
    - Uses MessageQueue from vLLM infrastructure for communication. 
    - Passes batch lookup commands to the process
    - Retrieves lookup results from the process
  Note that only the core batch lookup (group by requests + os.path.exists) is executed in the subprocess. All other functionality still lives in the main/scheduler thread. 
  
- Refactor `AsyncLookupManager`. 
  - Introduce `BaseAsyncLookupManager`. This class is responsible for, 
     - All the lifecycle logic (create lookup_batch, flush, drain) as exists in main. 
     - introduce 2 new abstract methods, 
        - send_lookup_batch, 
        - try_recv_result_batch
  - Redefine `AsyncLookupManager` to be thread-backed, like in main, and specialize `send_lookup_batch` and `try_recv_result_batch` to simply write and read from a `SimpleQueue`.
  - Redefine `FSAsyncLookupManager` to interface with `FsIoProcess`

Additionally `FsIOProcess` can be expanded to handle `load_blocks`, `store_blocks` in the future.

## Test Plan

## Test Result
