### PR TITLE
[ROCm][Bugfix] Actionable error for desc_act GPTQ models requiring fp16

### DIFF
--- a/tests/compile/fullgraph/test_full_graph.py
+++ b/tests/compile/fullgraph/test_full_graph.py
@@ -45,10 +45,16 @@ def models_list(*, all: bool = True, keywords: list[str] | None = None):
             )
 
         if is_quant_method_supported("gptq_marlin"):
+            # This checkpoint uses activation reordering (desc_act=True). On
+            # ROCm the only g_idx-capable mixed-precision kernel (Exllama)
+            # requires float16 activations, so pin the dtype there.
+            gptq_marlin_kwargs: dict[str, Any] = {"quantization": "gptq_marlin"}
+            if current_platform.is_rocm():
+                gptq_marlin_kwargs["dtype"] = torch.float16
             TEST_MODELS.append(
                 (
                     "TheBloke/TinyLlama-1.1B-Chat-v1.0-GPTQ",
-                    {"quantization": "gptq_marlin"},
+                    gptq_marlin_kwargs,
                 )
             )
 

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -712,6 +712,24 @@ def choose_mp_linear_kernel(
                 f" {kernel.__name__} cannot implement due to: {failure_reason}"
             )
 
+    # On ROCm, the only mixed-precision kernel that supports activation
+    # reordering (desc_act / g_idx) is Exllama, which requires float16
+    # activations. A model run in bfloat16 therefore has no viable kernel and
+    # fails with an opaque list of rejections. Surface an actionable hint.
+    if (
+        current_platform.is_rocm()
+        and config.has_g_idx
+        and config.act_type != torch.float16
+    ):
+        raise ValueError(
+            "Failed to find a kernel that can implement the WNA16 linear "
+            "layer. On ROCm, quantized models with activation reordering "
+            "(desc_act=True) require float16 activations; the current dtype "
+            f"is {config.act_type}. Re-run with dtype='float16' "
+            '(e.g. --dtype float16 or LLM(..., dtype="float16")). '
+            "Reasons: \n" + "\n".join(failure_reasons)
+        )
+
     raise ValueError(
         "Failed to find a kernel that can implement the "
         "WNA16 linear layer. Reasons: \n" + "\n".join(failure_reasons)


### PR DESCRIPTION
## Purpose

On ROCm, loading a GPTQ checkpoint that uses activation reordering
(`desc_act=True`) in its default `bfloat16` fails at engine init with an
opaque wall of kernel rejections:

```
ValueError: Failed to find a kernel that can implement the WNA16 linear layer. Reasons:
  TritonW4A16LinearKernel cannot implement due to: Activation reordering (g_idx) is not supported
  ConchLinearKernel cannot implement due to: Activation reordering (g_idx) is not supported
```

Root cause: on ROCm the only mixed-precision kernel that supports `g_idx`
is `ExllamaLinearKernel`, which requires **float16** activations
(`exllama.py`: `act_type != torch.float16 -> reject`). In bf16 it silently
drops out, leaving no viable kernel. On CUDA this works because Marlin
handles `g_idx`+bf16; Marlin is not available for this path on ROCm.

This PR raises an actionable error pointing the user to `dtype='float16'`
when (and only when) the failure is specifically this ROCm + g_idx +
non-fp16 case, instead of the generic rejection list. It also pins the
dtype for the `desc_act` `gptq_marlin` model in the full-graph compile
test on ROCm, mirroring the existing FP8 entry.

This is not a duplicate: searched open PRs for WNA16 / gptq / desc_act /
ROCm; the closest (#46236) raises an actionable error for a *different*
condition (group-size/TP mismatch). No open PR addresses the
desc_act/fp16 case.

AI assistance (Claude) was used to investigate and draft this change; all
changed lines were reviewed by the submitter.

## Test Plan

```bash
# gfx942 (MI300), ROCm 7.2.3
pytest -v tests/compile/fullgraph/test_full_graph.py -k "GPTQ"
# manual: load the desc_act model in bf16 (expect actionable error) and
# fp16 (expect success)
```

## Test Result

- `pytest ... -k "GPTQ"` -> **4 passed** (TinyLlama v0.3 gptq and v1.0
  gptq_marlin, each x2 compile modes); previously the v1.0 (desc_act)
  cases failed at engine init with the `Failed to find a kernel` error.
- bf16 load now raises the actionable error: `... require float16
  activations; the current dtype is torch.bfloat16. Re-run with
  dtype='float16' ...`
- fp16 load selects `ExllamaLinearKernel` and generates correctly
  (`'Paris, and it is the most popular...'`).
- `pre-commit` (ruff, ruff-format, mypy, SPDX) clean.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>