### PR TITLE
[Model Runner V2][Spec Decode] Enable local argmax reduction for greedy drafting

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import CUDAGraphMode
+from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import (
@@ -22,6 +23,8 @@ from vllm.v1.worker.gpu.cudagraph_utils import (
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+
+logger = init_logger(__name__)
 
 
 class BaseSpeculator(ABC):
@@ -160,6 +163,18 @@ class DraftModelSpeculator(BaseSpeculator):
             ).keys()
         )
         self.draft_attn_layer_names = all_attn_layers - target_attn_layer_names
+
+        if self.use_local_argmax_reduction:
+            if not hasattr(self.model, "get_top_tokens"):
+                raise ValueError(
+                    "use_local_argmax_reduction is enabled but draft model "
+                    f"{self.model.__class__.__name__} does not implement "
+                    "get_top_tokens()."
+                )
+            logger.info(
+                "Using local argmax reduction for draft token generation "
+                "(communication: O(2*tp_size) vs O(vocab_size))."
+            )
 
     def set_attn(
         self,

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -95,6 +95,9 @@ class DraftModelSpeculator(BaseSpeculator):
         self.vocab_size = self.draft_model_config.get_vocab_size()
         self.dtype = vllm_config.model_config.dtype
         self.use_fp64_gumbel = vllm_config.model_config.use_fp64_gumbel
+        self.use_local_argmax_reduction: bool = (
+            self.speculative_config.use_local_argmax_reduction
+        )
 
         # DP configuration
         self.dp_size = vllm_config.parallel_config.data_parallel_size
@@ -221,6 +224,9 @@ class DraftModelSpeculator(BaseSpeculator):
         draft_step: torch.Tensor,
         draft_logits: torch.Tensor | None,
     ) -> torch.Tensor:
+        if self.use_local_argmax_reduction and draft_logits is None:
+            return self.model.get_top_tokens(hidden_states)
+
         logits = self.model.compute_logits(hidden_states)
         if draft_logits is not None:
             # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
@@ -236,8 +242,7 @@ class DraftModelSpeculator(BaseSpeculator):
                 output_processed_logits_col=draft_step,
                 use_fp64=self.use_fp64_gumbel,
             )
-        else:
-            return logits.argmax(dim=-1)
+        return logits.argmax(dim=-1)
 
     def _copy_request_inputs(
         self,


### PR DESCRIPTION
# Context
`use_local_argmax_reduction` is a speculative config property that is currently only supported in MRV1, but not MRV2. When enabled, this feature performs a local argmax of the draft model output logits on each TP rank, before all-gathering and argmaxing again to get the greedily sampled token. The benefit of this optimization is that for TP > 1, we avoid all-gathering and materializing the full logits across all ranks. This reduces network and memory overhead during draft model sample.

This optimization is particularly beneficial for draft model types that sample large numbers of draft tokens in a single forward pass, like DFlash. That was my main motiviation for enabling this optimization.

# This PR
The changes were straightforward. `DraftModelSpeculator` now gets `use_local_argmax_reduction` from the spec config, and stores it as a property value. Then during `sample_draft` (and when draft logits are not requested for rejection sampling, which is the majority case), it performs the local argmax via `get_top_tokens` if `use_local_argmax_reduction` is true. Otherwise, it falls back to the original behavior (compute_logits + argmax). All draft model speculators can now benefit from this optimization when the flag is enabled.

This mirrors the MRV1 logic [here](https://github.com/vllm-project/vllm/blob/556bc4e3a089378e9df2482659898192da18db15/vllm/v1/spec_decode/llm_base_proposer.py#L413-L414).

## Profile
Server command
```
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash \
  --tensor-parallel-size 4 \
  --trust-remote-code \
  --gpu-memory-utilization 0.95 \
  --max-num-seqs 64 \
  --max-model-len auto \
  --reasoning-parser mimo \
  --tool-call-parser mimo \
  --enable-auto-tool-choice \
  --generation-config vllm \
  --no-enable-prefix-caching \
  --speculative_config '{"method":"dflash","model":"<path_to_draft_model>","num_speculative_tokens":8,"attention_backend":"FLASH_ATTN"}' \
--profiler-config '{"profiler": "torch", "torch_profiler_dir": "~/dev/mimo/traces/"}'
```

Bench command
```
curl -X POST http://localhost:8000/start_profile
vllm-bench --backend openai-chat --base-url http://127.0.0.1:8000 --dataset-name hf --dataset-path philschmid/mt-bench --ignore-eos --request-rate inf --temperature 1.0 --num-warmups 0 --output-len 128 --max-concurrency 32 --num-prompts 32 --save-result --result-dir /tmp
curl -X POST http://localhost:8000/stop_profile
```

**Before**
<img width="922" height="236" alt="image" src="https://github.com/user-attachments/assets/2dd7b2ba-182b-4c6b-8f75-7f2d9bfae9f0" />

**After**
<img width="582" height="253" alt="image" src="https://github.com/user-attachments/assets/b6d41a03-47e0-4dd4-8f5c-951db6e74d15" />

## Benchmarks
**Before**
```
========================================================== Sweep Summary ==========================================================
Max Concurrency           Req/s      Tok/s  Total tok/s   SS req/s SS out tok/s P50 TTFT(ms) P50 TPOT(ms) P90 TTFT(ms) P90 TPOT(ms)
-------------------- ---------- ---------- ------------ ---------- ------------ ------------ ------------ ------------ ------------
concurrency=1              1.67     213.23       378.32       1.50        72.13        52.15         3.87        76.86         5.96
concurrency=2              2.29     293.03       508.11       2.20       102.05        66.81         5.13       223.83         8.13
concurrency=4              3.62     462.74       729.54       3.54       161.37        79.69         6.75       246.84        10.64
concurrency=8              5.51     704.64      1078.84       5.15       221.05       108.21         9.50       264.99        14.40
concurrency=16             8.03    1027.45      1589.28       7.70       323.57       233.09        13.21       283.47        20.57
concurrency=32             6.69     855.80      1317.98       6.23       262.42       407.47        33.52       581.61        49.65
concurrency=64             7.19     920.26      1411.65       6.70       281.01       638.60        63.69       688.11        92.06
===================================================================================================================================
```

**After**
```
========================================================== Sweep Summary ==========================================================
Max Concurrency           Req/s      Tok/s  Total tok/s   SS req/s SS out tok/s P50 TTFT(ms) P50 TPOT(ms) P90 TTFT(ms) P90 TPOT(ms)
-------------------- ---------- ---------- ------------ ---------- ------------ ------------ ------------ ------------ ------------
concurrency=1              1.83     234.64       416.30       1.65        73.51        52.16         3.85        75.45         5.29
concurrency=2              2.50     320.12       555.08       2.30       101.48        65.68         4.98       223.62         7.49
concurrency=4              3.73     477.94       753.51       3.66       164.06        78.22         6.91       231.00         9.97
concurrency=8              5.79     741.22      1134.85       5.52       238.68        98.95         9.23       255.56        12.65
concurrency=16             8.15    1043.11      1613.50       7.80       323.31       129.00        13.22       285.60        19.48
concurrency=32             6.79     869.62      1339.27       6.36       267.03       400.31        33.04       591.60        50.05
concurrency=64             7.41     947.97      1454.16       6.87       289.98       622.10        61.05       685.18        90.93
===================================================================================================================================
```

3–10% gains in Tok/s across the sweep, with the largest gains at low concurrency (~10% at c=1, ~9% at c=2) and modest gains (1–5%) at higher concurrency. That trend is expected because at higher concurrencies this optimization saves a smaller fraction of the decode step duration.