### PR TITLE
fix: sanitize invalid speculative draft tokens

### DIFF
--- a/tests/v1/streaming_input/test_gpu_model_runner_v2_streaming.py
+++ b/tests/v1/streaming_input/test_gpu_model_runner_v2_streaming.py
@@ -20,6 +20,17 @@ pytestmark = pytest.mark.cpu_test
 
 
 @pytest.fixture
+def mock_model_runner_for_spec_token_sanitize():
+    runner = Mock(spec=GPUModelRunner)
+    runner.model_config = Mock()
+    runner.model_config.get_vocab_size.return_value = 32000
+    runner._sanitize_scheduled_spec_decode_tokens = (
+        GPUModelRunner._sanitize_scheduled_spec_decode_tokens.__get__(runner)
+    )
+    return runner
+
+
+@pytest.fixture
 def mock_model_runner_with_req_states():
     """Create a mock MRv2 GPUModelRunner with a real RequestState."""
 
@@ -62,6 +73,50 @@ def _make_scheduler_output(new_reqs):
         num_common_prefix_blocks=[],
         finished_req_ids=set(),
         free_encoder_mm_hashes=[],
+    )
+
+
+def test_sanitize_invalid_scheduled_spec_decode_tokens_drops_bad_drafts(
+    mock_model_runner_for_spec_token_sanitize,
+):
+    runner = mock_model_runner_for_spec_token_sanitize
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={"req-0": 2},
+        total_num_scheduled_tokens=2,
+        scheduled_spec_decode_tokens={"req-0": [-1]},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    sanitized = runner._sanitize_scheduled_spec_decode_tokens(scheduler_output)
+
+    assert sanitized.scheduled_spec_decode_tokens == {}
+    assert sanitized.num_scheduled_tokens == {"req-0": 1}
+    assert sanitized.total_num_scheduled_tokens == 1
+
+
+def test_sanitize_valid_scheduled_spec_decode_tokens_keeps_fast_path(
+    mock_model_runner_for_spec_token_sanitize,
+):
+    runner = mock_model_runner_for_spec_token_sanitize
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={"req-0": 2},
+        total_num_scheduled_tokens=2,
+        scheduled_spec_decode_tokens={"req-0": [1]},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    assert runner._sanitize_scheduled_spec_decode_tokens(scheduler_output) is (
+        scheduler_output
     )
 
 

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -238,57 +238,7 @@ def _make_mock_backend_for_kernel_block_size(
 
 
 def _make_kv_cache_spec() -> FullAttentionSpec:
-    return FullAttentionSpec(
-        block_size=1,
-        num_kv_heads=1,
-        head_size=1,
-        dtype="float16",
-    )
-
-
-def test_sanitize_invalid_scheduled_spec_decode_tokens_drops_bad_drafts(
-    model_runner: GPUModelRunner,
-):
-    scheduler_output = SchedulerOutput(
-        scheduled_new_reqs=[],
-        scheduled_cached_reqs=CachedRequestData.make_empty(),
-        num_scheduled_tokens={"req-0": 2},
-        total_num_scheduled_tokens=2,
-        scheduled_spec_decode_tokens={"req-0": [-1]},
-        scheduled_encoder_inputs={},
-        num_common_prefix_blocks=[],
-        finished_req_ids=set(),
-        free_encoder_mm_hashes=[],
-    )
-
-    sanitized = model_runner._sanitize_scheduled_spec_decode_tokens(
-        scheduler_output
-    )
-
-    assert sanitized.scheduled_spec_decode_tokens == {}
-    assert sanitized.num_scheduled_tokens == {"req-0": 1}
-    assert sanitized.total_num_scheduled_tokens == 1
-
-
-def test_sanitize_valid_scheduled_spec_decode_tokens_keeps_fast_path(
-    model_runner: GPUModelRunner,
-):
-    scheduler_output = SchedulerOutput(
-        scheduled_new_reqs=[],
-        scheduled_cached_reqs=CachedRequestData.make_empty(),
-        num_scheduled_tokens={"req-0": 2},
-        total_num_scheduled_tokens=2,
-        scheduled_spec_decode_tokens={"req-0": [1]},
-        scheduled_encoder_inputs={},
-        num_common_prefix_blocks=[],
-        finished_req_ids=set(),
-        free_encoder_mm_hashes=[],
-    )
-
-    assert (
-        model_runner._sanitize_scheduled_spec_decode_tokens(scheduler_output)
-        is scheduler_output
-    )
+    return FullAttentionSpec(block_size=1, num_kv_heads=1, head_size=1, dtype="float16")
 
 
 def test_select_common_block_size_prefers_manager_block_size():

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -238,7 +238,57 @@ def _make_mock_backend_for_kernel_block_size(
 
 
 def _make_kv_cache_spec() -> FullAttentionSpec:
-    return FullAttentionSpec(block_size=1, num_kv_heads=1, head_size=1, dtype="float16")
+    return FullAttentionSpec(
+        block_size=1,
+        num_kv_heads=1,
+        head_size=1,
+        dtype="float16",
+    )
+
+
+def test_sanitize_invalid_scheduled_spec_decode_tokens_drops_bad_drafts(
+    model_runner: GPUModelRunner,
+):
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={"req-0": 2},
+        total_num_scheduled_tokens=2,
+        scheduled_spec_decode_tokens={"req-0": [-1]},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    sanitized = model_runner._sanitize_scheduled_spec_decode_tokens(
+        scheduler_output
+    )
+
+    assert sanitized.scheduled_spec_decode_tokens == {}
+    assert sanitized.num_scheduled_tokens == {"req-0": 1}
+    assert sanitized.total_num_scheduled_tokens == 1
+
+
+def test_sanitize_valid_scheduled_spec_decode_tokens_keeps_fast_path(
+    model_runner: GPUModelRunner,
+):
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={"req-0": 2},
+        total_num_scheduled_tokens=2,
+        scheduled_spec_decode_tokens={"req-0": [1]},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    assert (
+        model_runner._sanitize_scheduled_spec_decode_tokens(scheduler_output)
+        is scheduler_output
+    )
 
 
 def test_select_common_block_size_prefers_manager_block_size():

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -857,8 +857,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         for req_id, token_ids in draft_tokens.items():
             if not any(
-                token_id < 0 or token_id >= vocab_size
-                for token_id in token_ids
+                token_id < 0 or token_id >= vocab_size for token_id in token_ids
             ):
                 continue
 
@@ -887,9 +886,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         return replace(
             scheduler_output,
             num_scheduled_tokens=sanitized_num_scheduled_tokens,
-            total_num_scheduled_tokens=sum(
-                sanitized_num_scheduled_tokens.values()
-            ),
+            total_num_scheduled_tokens=sum(sanitized_num_scheduled_tokens.values()),
             scheduled_spec_decode_tokens=sanitized_spec_tokens,
         )
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -21,6 +21,7 @@ import functools
 import gc
 import time
 from copy import deepcopy
+from dataclasses import replace
 from typing import Any, NamedTuple
 
 import numpy as np
@@ -842,6 +843,56 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             assert self.kv_block_zeroer is not None
             self.kv_block_zeroer.zero_block_ids(scheduler_output.new_block_ids_to_zero)
 
+    def _sanitize_scheduled_spec_decode_tokens(
+        self, scheduler_output: SchedulerOutput
+    ) -> SchedulerOutput:
+        draft_tokens = scheduler_output.scheduled_spec_decode_tokens
+        if not draft_tokens:
+            return scheduler_output
+
+        vocab_size = self.model_config.get_vocab_size()
+        sanitized_spec_tokens: dict[str, list[int]] | None = None
+        sanitized_num_scheduled_tokens: dict[str, int] | None = None
+        invalid_req_ids: list[str] = []
+
+        for req_id, token_ids in draft_tokens.items():
+            if not any(
+                token_id < 0 or token_id >= vocab_size
+                for token_id in token_ids
+            ):
+                continue
+
+            if sanitized_spec_tokens is None:
+                sanitized_spec_tokens = draft_tokens.copy()
+                sanitized_num_scheduled_tokens = (
+                    scheduler_output.num_scheduled_tokens.copy()
+                )
+
+            assert sanitized_num_scheduled_tokens is not None
+            sanitized_spec_tokens.pop(req_id, None)
+            sanitized_num_scheduled_tokens[req_id] = max(
+                1,
+                sanitized_num_scheduled_tokens[req_id] - len(token_ids),
+            )
+            invalid_req_ids.append(req_id)
+
+        if sanitized_spec_tokens is None or sanitized_num_scheduled_tokens is None:
+            return scheduler_output
+
+        logger.warning(
+            "Ignoring invalid speculative draft tokens for %d request(s): %s",
+            len(invalid_req_ids),
+            invalid_req_ids,
+        )
+        return replace(
+            scheduler_output,
+            num_scheduled_tokens=sanitized_num_scheduled_tokens,
+            total_num_scheduled_tokens=sum(
+                sanitized_num_scheduled_tokens.values()
+            ),
+            scheduled_spec_decode_tokens=sanitized_spec_tokens,
+        )
+
     def prepare_inputs(
         self, scheduler_output: SchedulerOutput, batch_desc: BatchExecutionDescriptor
     ) -> InputBatch:
@@ -1123,6 +1174,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.add_requests(scheduler_output)
             self.update_requests(scheduler_output)
             self.block_tables.apply_staged_writes()
+            scheduler_output = self._sanitize_scheduled_spec_decode_tokens(
+                scheduler_output
+            )
             if scheduler_output.total_num_scheduled_tokens == 0:
                 # No need to run the model.
                 empty_output = self.kv_connector.no_forward(scheduler_output)


### PR DESCRIPTION



## Purpose

This PR ignores invalid speculative draft token ids before batch preparation in the V1 GPU model runner
It is related to #46533, but it is not duplicate work. #46533 adds a rejection sampler guard when `-1` reaches the sampler. This patch handles an earlier point in the path: if `scheduled_spec_decode_tokens` already contains an invalid id, the runner now drops those draft tokens for that request and falls back to normal decode for that step, instead of letting the invalid draft affect batch shapes or input ids




It may not fix the root problem( the real root cause may be fixed by https://github.com/vllm-project/vllm/pull/46694 ? ), but this PR just a protection in case it happends ( invalid speculative token ) , stop it propogate into later code path. 



LOG


We've see `scheduled_spec_decode_tokens`  are all [-1]

example : `scheduled_spec_decode_tokens={chatcmpl-f38ada21-f2be-9670-b04d-1dd134073235-b608ae6b: [-1], chatcmpl-c3d2123d-5fe5-94c0-9918-fd690ffc678e-a50f52ea: [-1], chatcmpl-93083926-98ce-943a-bba3-aff25c3afbc0-9fd2badd: [-1], chatcmpl-5aa25120-c297-9e8c-b87c-fcfb7666f6f6-b9afb561: [-1], chatcmpl-c788b861-2f9b-99e8-8393-92722695908b-801d9e0f: [-1]},`


Log pieces : 
```
(EngineCore_DP1 pid=808) ERROR 06-24 03:42:29 [dump_input.py:79] Dumping scheduler output for model execution: SchedulerOutput(scheduled_new_reqs=[], scheduled_cached_reqs=CachedRequestData(req_ids=['chatcmpl-93083926-98ce-943a-bba3-aff25c3afbc0-9fd2badd', 'chatcmpl-f38ada21-f2be-9670-b04d-1dd134073235-b608ae6b', 'chatcmpl-c3d2123d-5fe5-94c0-9918-fd690ffc678e-a50f52ea', 'chatcmpl-5aa25120-c297-9e8c-b87c-fcfb7666f6f6-b9afb561', 'chatcmpl-c788b861-2f9b-99e8-8393-92722695908b-801d9e0f'],resumed_req_ids=set(),new_token_ids_lens=[],all_token_ids_lens={},new_block_ids=[None, None, None, None, None],num_computed_tokens=[28650, 17829, 1875, 79124, 76812],num_output_tokens=[28154, 17598, 1674, 5, 2]), num_scheduled_tokens={chatcmpl-c788b861-2f9b-99e8-8393-92722695908b-801d9e0f: 2, chatcmpl-93083926-98ce-943a-bba3-aff25c3afbc0-9fd2badd: 2, chatcmpl-f38ada21-f2be-9670-b04d-1dd134073235-b608ae6b: 2, chatcmpl-c3d2123d-5fe5-94c0-9918-fd690ffc678e-a50f52ea: 2, chatcmpl-5aa25120-c297-9e8c-b87c-fcfb7666f6f6-b9afb561: 2}, total_num_scheduled_tokens=10, scheduled_spec_decode_tokens={chatcmpl-f38ada21-f2be-9670-b04d-1dd134073235-b608ae6b: [-1], chatcmpl-c3d2123d-5fe5-94c0-9918-fd690ffc678e-a50f52ea: [-1], chatcmpl-93083926-98ce-943a-bba3-aff25c3afbc0-9fd2badd: [-1], chatcmpl-5aa25120-c297-9e8c-b87c-fcfb7666f6f6-b9afb561: [-1], chatcmpl-c788b861-2f9b-99e8-8393-92722695908b-801d9e0f: [-1]}, scheduled_encoder_inputs={}, num_common_prefix_blocks=[0], finished_req_ids=[], free_encoder_mm_hashes=[], preempted_req_ids=[], has_structured_output_requests=false, pending_structured_output_tokens=false, num_invalid_spec_tokens=null, kv_connector_metadata=NixlConnectorMetadata(reqs_to_recv={}, reqs_to_save={}, reqs_to_send={}, reqs_in_batch=[], reqs_not_processed=[], heartbeat_by_engine={}), ec_connector_metadata=null, new_block_ids_to_zero=null)
 (EngineCore_DP1 pid=808) ERROR 06-24 03:42:29 [dump_input.py:72] Dumping input data for V1 LLM engine (v0.23.0) with config: model='/mnt/model/zai-org/GLM5.1-NVFP4', speculative_config=SpeculativeConfig(method='mtp', model='/mnt/model/zai-org/GLM5.1-NVFP4', num_spec_tokens=1), tokenizer='/mnt/model/zai-org/GLM5.1-NVFP4', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=202752, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=8, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=modelopt_fp4, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=fp8_e4m3, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='glm45', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=public/glm-51, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::qwen_gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [1024], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto'),


 (EngineCore_DP5 pid=812) ERROR 06-24 03:42:29 [dump_input.py:79] Dumping scheduler output for model execution: SchedulerOutput(scheduled_new_reqs=[], scheduled_cached_reqs=CachedRequestData(req_ids=['chatcmpl-22258de6-b5da-99b6-b99a-bd5f9b82ed9a-9f04a460', 'chatcmpl-a72ecb0e-320b-90d0-ab47-c8f782765411-980047d7', 'chatcmpl-756231ba-4bea-9863-888c-7330a9e76e61-af5af6fb', 'chatcmpl-30f0cc0d-f172-9715-bced-180238301c55-90d51aa4'],resumed_req_ids=set(),new_token_ids_lens=[],all_token_ids_lens={},new_block_ids=[None, None, None, None],num_computed_tokens=[46059, 21317, 4165, 76840],num_output_tokens=[45691, 21094, 3235, 2]), num_scheduled_tokens={chatcmpl-756231ba-4bea-9863-888c-7330a9e76e61-af5af6fb: 2, chatcmpl-30f0cc0d-f172-9715-bced-180238301c55-90d51aa4: 2, chatcmpl-22258de6-b5da-99b6-b99a-bd5f9b82ed9a-9f04a460: 2, chatcmpl-a72ecb0e-320b-90d0-ab47-c8f782765411-980047d7: 2}, total_num_scheduled_tokens=8, scheduled_spec_decode_tokens={chatcmpl-756231ba-4bea-9863-888c-7330a9e76e61-af5af6fb: [-1], chatcmpl-22258de6-b5da-99b6-b99a-bd5f9b82ed9a-9f04a460: [-1], chatcmpl-a72ecb0e-320b-90d0-ab47-c8f782765411-980047d7: [-1], chatcmpl-30f0cc0d-f172-9715-bced-180238301c55-90d51aa4: [-1]}, scheduled_encoder_inputs={}, num_common_prefix_blocks=[0], finished_req_ids=[], free_encoder_mm_hashes=[], preempted_req_ids=[], has_structured_output_requests=false, pending_structured_output_tokens=false, num_invalid_spec_tokens=null, kv_connector_metadata=NixlConnectorMetadata(reqs_to_recv={}, reqs_to_save={}, reqs_to_send={}, reqs_in_batch=[], reqs_not_processed=[], heartbeat_by_engine={}), ec_connector_metadata=null, new_block_ids_to_zero=null)
 (EngineCore_DP5 pid=812) ERROR 06-24 03:42:29 [dump_input.py:72] Dumping input data for V1 LLM engine (v0.23.0) with config: model='/mnt/model/zai-org/GLM5.1-NVFP4', speculative_config=SpeculativeConfig(method='mtp', model='/mnt/model/zai-org/GLM5.1-NVFP4', num_spec_tokens=1), tokenizer='/mnt/model/zai-org/GLM5.1-NVFP4', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=202752, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=8, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=modelopt_fp4, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=fp8_e4m3, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='glm45', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=public/glm-51, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::qwen_gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [1024], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto'),




 (Worker_DP1_EP1 pid=7148) ERROR 06-24 03:42:29 [multiproc_executor.py:987] CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
 (Worker_DP1_EP1 pid=7148) ERROR 06-24 03:42:29 [multiproc_executor.py:987] Search for `cudaErrorAssert' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
 (Worker_DP1_EP1 pid=7148) ERROR 06-24 03:42:29 [multiproc_executor.py:987] torch.AcceleratorError: CUDA error: device-side assert triggered
 (Worker_DP1_EP1 pid=7148) ERROR 06-24 03:42:29 [multiproc_executor.py:987]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (Worker_DP1_EP1 pid=7148) ERROR 06-24 03:42:29 [multiproc_executor.py:987]     return out.copy_(x, non_blocking=True)
 (Worker_DP1_EP1 pid=7148) ERROR 06-24 03:42:29 [multiproc_executor.py:987]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu/buffer_utils.py", line 42, in async_copy_to_gpu
 (Worker_DP1_EP1 pid=7148) ERROR 06-24 03:42:29 [multiproc_executor.py:987]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (Worker_DP1_EP1 pid=7148) ERROR 06-24 03:42:29 [multiproc_executor.py:987]     idx_mapping = async_copy_to_gpu(idx_mapping_np, device=self.device)
 (Worker_DP1_EP1 pid=7148) ERROR 06-24 03:42:29 [multiproc_executor.py:987]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu/model_runner.py", line 833, in prepare_inputs

```



## Test Plan


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

