### PR TITLE
[Bugfix] Fix KV cache memory leak when all requests finish with connector

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -361,7 +361,10 @@ class InprocClient(EngineCoreClient):
         return self.engine_core.collective_rpc(method, timeout, args, kwargs)
 
     def dp_engines_running(self) -> bool:
-        return False
+        # Unfinished requests are already tracked by the output processor.
+        # Only check for finished requests with pending delayed KV connector
+        # frees (e.g. async store to external KV cache).
+        return self.engine_core.scheduler.has_finished_requests()
 
 
 @dataclass


### PR DESCRIPTION
fix: https://github.com/vllm-project/vllm/issues/46502
When a KV connector (e.g. MooncakeStore) returns delay_free_blocks=True for a finished request, the GPU blocks are held until the async store completes. However, InprocClient.dp_engines_running() always returned False, so the step loop exited immediately after the output processor cleared the request — without waiting for the async store to finish. GPU memory was leaked until the next round of requests triggered step().

Fix by delegating dp_engines_running() to scheduler.has_finished_requests(), which detects pending delayed KV connector frees. The output processor already tracks unfinished requests, so has_requests() is not needed here.
<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
