### PR TITLE
[ROCm][CI] Skip the MoE Marlin tile-padding helper assertion

### DIFF
--- a/tests/kernels/quantization/test_marlin_tile_padding.py
+++ b/tests/kernels/quantization/test_marlin_tile_padding.py
@@ -664,6 +664,10 @@ def test_gptq_marlin_moe_padded_round_trip(shape, group_size):
     torch.testing.assert_close(marlin_out, ref, atol=5e-2, rtol=0)
 
 
+@pytest.mark.skipif(
+    current_platform.is_rocm(),
+    reason="MoE Marlin is not selected on ROCm.",
+)
 def test_check_moe_marlin_supports_layer_padding():
     from vllm.model_executor.layers.quantization.utils.marlin_utils import (
         check_moe_marlin_supports_layer,


### PR DESCRIPTION
Skip the MoE Marlin tile-padding helper assertion on ROCm, where production code intentionally keeps MoE Marlin disabled and falls back to ROCm/native MoE paths. `test_check_moe_marlin_supports_layer_padding` was added in #45703 with CUDA Marlin selection semantics, but the helper it exercises still returns `False` immediately on ROCm. The AMD kernel-quantization lane was already printing this failure on 6617db1bf, but the ROCm CI command wrapper allowed the job to pass. The newer CI branch now exits on the pytest failure, exposing the existing mismatch.

For now we are skipping this on ROCm so that we enable CI and later we might enable wider Marlin support.