### PR TITLE
[Rust Frontend] Raise frontend JSON body limit

### DIFF
--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -17,12 +17,15 @@ mod world_size;
 use std::sync::Arc;
 
 use axum::Router;
+use axum::extract::DefaultBodyLimit;
 use axum::middleware::{from_fn, from_fn_with_state};
 use axum::routing::{get, post};
 use tower_http::trace::TraceLayer;
 
 use crate::middleware;
 use crate::state::AppState;
+
+const DEFAULT_JSON_BODY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
 
 fn server_dev_mode_enabled() -> bool {
     std::env::var("VLLM_SERVER_DEV_MODE")
@@ -108,6 +111,7 @@ fn build_router_with_options(
     let enable_api_key_auth = state.has_api_keys();
     let mut router = router
         .with_state(state.clone())
+        .layer(DefaultBodyLimit::max(DEFAULT_JSON_BODY_LIMIT_BYTES))
         .layer(middleware::request_runtime_layer(state.clone()))
         .layer(from_fn_with_state(
             state.clone(),

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -3512,6 +3512,46 @@ async fn non_stream_chat_completions_still_succeed() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn chat_completions_accepts_request_body_larger_than_axum_default() {
+    let (chat, engine_task) = test_chat_with_engine_outputs(
+        b"engine-openai-chat-large-body",
+        default_stream_output_specs(),
+    )
+    .await;
+    let mut app = build_router(Arc::new(AppState::new(
+        vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()],
+        chat,
+    )));
+
+    let large_template_arg = "a".repeat(2 * 1024 * 1024);
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "stream": false,
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "chat_template_kwargs": {"large": large_template_arg}
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    engine_task.await.expect("mock engine task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn non_stream_completions_still_succeed() {
     let ipc = IpcNamespace::new().expect("create ipc namespace");
     let handshake_address = ipc.handshake_endpoint();


### PR DESCRIPTION
## Summary
The Rust frontend OpenAI routes use Axum's JSON extractor, which has a 2 MiB default request body limit. Large valid requests from 1M context length support models can be rejected before validation with `Failed to buffer the request body: length limit exceeded`.

This raises the router JSON body limit and adds a regression test for a request larger than Axum's default.

## Duplicate Check
Searched open PRs and issues for `DefaultBodyLimit`, `request body limit`, and `Failed to buffer the request body`; no existing fix was found.

## Tests
- `cargo test -p vllm-server chat_completions_accepts_request_body_larger_than_axum_default`

AI assistance was used to prepare this change.