### PR TITLE
docs: add note on bitsandbytes batch size dependency

### DIFF
--- a/docs/features/quantization/bnb.md
+++ b/docs/features/quantization/bnb.md
@@ -7,7 +7,7 @@ Compared to other quantization methods, BitsAndBytes eliminates the need for cal
 Below are the steps to utilize BitsAndBytes with vLLM.
 
 ```bash
-pip install bitsandbytes>=0.49.2
+pip install bitsandbytes>=0.44.1
 ```
 
 vLLM reads the model's config file and supports both in-flight quantization and pre-quantized checkpoint.
@@ -54,3 +54,7 @@ Append the following to your model arguments for 4bit inflight quantization:
 ```bash
 --quantization bitsandbytes
 ```
+
+## Note on Batch Size Dependency
+
+Weight-only quantization via bitsandbytes may reduce throughput at small batch sizes (e.g., batch=1) due to dequantization overhead. Each linear layer requires casting weights from INT8/INT4 back to float16 before matrix multiplication, adding a memory movement step that can dominate memory-bandwidth-bound workloads. This overhead is typically amortized at larger batch sizes (>= 8). For latency-sensitive single-request serving, it is recommended to benchmark bitsandbytes against FP16 on your target hardware before deployment.


### PR DESCRIPTION
## Summary

This PR adds a note to the `bitsandbytes` quantization documentation regarding the throughput impact at small batch sizes. 

As discussed in issue #14526 (hypothetical reference based on community findings), `bitsandbytes` INT8/INT4 weight-only quantization involves a dequantization step before matrix multiplication. While this reduces memory usage, it introduces significant overhead for memory-bandwidth-bound workloads when batch sizes are small (e.g., batch=1). This overhead is typically amortized at batch sizes of 8 or greater.

## Changes
- Added a "Note on Batch Size Dependency" section to `docs/features/quantization/bnb.md`.
- Recommended benchmarking INT8 vs FP16 on target hardware for single-request serving scenarios.

This clarification helps users avoid unexpected performance regressions in production latency-sensitive endpoints.