### PR TITLE
[XPU][UT] Fix test failure by using platform-aware imports

### DIFF
--- a/tests/v1/worker/test_worker_memory_snapshot.py
+++ b/tests/v1/worker/test_worker_memory_snapshot.py
@@ -12,8 +12,14 @@ import torch
 
 from vllm.config import set_current_vllm_config
 from vllm.engine.arg_utils import EngineArgs
+from vllm.platforms import current_platform
 from vllm.utils.mem_utils import MemorySnapshot
-from vllm.v1.worker.gpu_worker import Worker, init_worker_distributed_environment
+
+if current_platform.is_xpu():
+    from vllm.v1.worker.xpu_worker import XPUWorker as Worker
+    from vllm.v1.worker.xpu_worker import init_worker_distributed_environment
+else:
+    from vllm.v1.worker.gpu_worker import Worker, init_worker_distributed_environment
 
 # Global queue to track operation order across processes
 _QUEUE: Queue | None = None
@@ -81,7 +87,9 @@ def worker_process(
 
         # Apply minimal patches to track operation order
         init_patch = patch(
-            "vllm.v1.worker.gpu_worker.init_worker_distributed_environment",
+            "vllm.v1.worker.xpu_worker.init_worker_distributed_environment"
+            if current_platform.is_xpu()
+            else "vllm.v1.worker.gpu_worker.init_worker_distributed_environment",
             side_effect=make_operation_tracker(
                 "init_distributed", original_init_worker
             ),


### PR DESCRIPTION
## Summary
This PR fixes an XPU UT failure by using platform-aware imports in the worker memory snapshot test.

## What changed

- Replace GPU-specific imports with platform-aware imports in `tests/v1/worker/test_worker_memory_snapshot.py`
- Allow the worker memory snapshot test to run on both XPU and CUDA/GPU environments

## Root cause
The test used device-specific imports that were not platform-aware. On XPU, this could take a GPU-specific code path and fail during device handling, typically surfacing as:

```text
RuntimeError: Not support device type: xpu
```
By switching to platform-aware imports, the test now uses the correct device backend for the current platform.

## Example to reproduce (without this PR)
ZE_AFFINITY_MASK=0,1 VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -sv tests/v1/worker/test_worker_memory_snapshot.py::test_init_distributed_is_called_before_memory_snapshot
