### PR TITLE
[Bugfix] Use block_k for block-wise FP8 activation group_shape

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -70,7 +70,9 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
             self.cutlass_block_fp8_supported = cutlass_block_fp8_supported()
             self.use_aiter_and_is_supported = rocm_aiter_ops.is_linear_fp8_enabled()
             assert not self.is_static_input_scheme
-            self.act_q_group_shape = GroupShape(1, self.weight_block_size[0])
+            # Activations are grouped along the K (contraction) dim:
+            # block_k = weight_block_size[1].
+            self.act_q_group_shape = GroupShape(1, self.weight_block_size[1])
             self.weight_quant_key = create_fp8_quant_key(
                 static=True, group_shape=GroupShape(*self.weight_block_size)
             )

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -303,7 +303,10 @@ class Fp8LinearMethod(LinearMethodBase):
 
             self.activation_quant_key = create_fp8_quant_key(
                 static=self.act_q_static,
-                group_shape=GroupShape(1, self.weight_block_size[0]),
+                # Activations are grouped along the K (contraction) dim, which
+                # is blocked by block_k = weight_block_size[1] (see modelopt.py
+                # and the block GEMM scale-shape asserts in fp8_utils.py).
+                group_shape=GroupShape(1, self.weight_block_size[1]),
             )
             self.weight_quant_key = create_fp8_quant_key(
                 static=True, group_shape=GroupShape(*self.weight_block_size)

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -210,7 +210,9 @@ class Fp8PerBlockOnlineLinearMethod(_Fp8OnlineLinearBase):
         self.weight_block_size = [128, 128]
         self.activation_quant_key = create_fp8_quant_key(
             static=False,
-            group_shape=GroupShape(1, self.weight_block_size[0]),
+            # Activations are grouped along the K (contraction) dim:
+            # block_k = weight_block_size[1].
+            group_shape=GroupShape(1, self.weight_block_size[1]),
         )
         self.weight_quant_key = create_fp8_quant_key(
             static=True, group_shape=GroupShape(*self.weight_block_size)


### PR DESCRIPTION
## Purpose

For block-wise FP8, a linear layer computes `out = A @ Wᵀ`, contracting over the
**K dimension**. Both the activation `A` and the weight `W` are stored in FP8 with
scales laid out **along K** (one scale per `block_k`-sized chunk, not a single
scalar), so the GEMM accumulates K in tiles and applies one
`(activation_scale, weight_scale)` pair per tile — i.e. it factors the scales out
of the inner sum, which is only valid if **both** scales are constant across the
tile. That requires the activation and the weight to share the **same K group
size**: `block_k = weight_block_size[1]`, the K edge of the weight block. If the
two K groupings differ, a single accumulation tile would span more than one scale
on one operand and the result would be wrong.

Three call sites instead derived the activation group size from
`weight_block_size[0]` (which is **block_n**, the output/N edge, not the
contraction edge):

| File | Site |
|------|------|
| `vllm/model_executor/layers/quantization/fp8.py` | `Fp8LinearMethod.__init__` |
| `vllm/model_executor/layers/quantization/online/fp8.py` | `Fp8PerBlockOnlineLinearMethod.__init__` |
| `vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py` | `CompressedTensorsW8A8Fp8.__init__` |

This contradicts:

1. **The block GEMM contract** in `utils/fp8_utils.py`, whose scale-shape asserts
   require the activation scale to be grouped by `block_k`:
   ```python
   block_n, block_k = block_size[0], block_size[1]
   assert triton.cdiv(A.shape[-1], block_k) == As.shape[-1]   # activation scale along K
   assert triton.cdiv(N, block_n)          == Bs.shape[0]
   assert triton.cdiv(K, block_k)          == Bs.shape[1]
   ```
2. **`modelopt.py`**, which already does it correctly:
   ```python
   block_n, block_k = self._WEIGHT_BLOCK_SIZE
   activation = GroupShape(1, block_k)          # <- correct
   weight     = GroupShape(block_n, block_k)
   ```

### Why this is benign today (but still worth fixing)

- Every supported block config in practice is **square `[128, 128]`**, so
  `block_n == block_k` and `[0]`/`[1]` are numerically identical.
- The CUTLASS block kernel further hard-requires an activation group of
  `(1, 128)` (`can_implement` rejects anything else), so non-square blocks
  cannot currently reach a working path anyway.

It remains a **latent correctness bug** for any future non-square
`weight_block_size`, and it is an internal inconsistency with `modelopt.py`.
This PR aligns the three remaining sites with the correct `block_k` semantics
and adds a short clarifying comment at each site.

## Modifications

- Change activation `group_shape` from `GroupShape(1, weight_block_size[0])` to
  `GroupShape(1, weight_block_size[1])` in the three sites above.
- Add a one-line comment at each site noting that activations group along K
  (`block_k = weight_block_size[1]`).

Diff is 3 files, +10/-3.

## Test Plan

- `ruff check` on the three changed files — passes.
- No behavior change for existing models (all shipped block-FP8 checkpoints use
  square `[128, 128]`, so the emitted `group_shape` value is unchanged).
- Existing coverage only exercises square blocks, which is precisely why this was
  never caught:
  - `tests/kernels/quantization/test_block_fp8.py`: `BLOCK_SIZE = [[128, 128]]`
  - `tests/quantization/test_fp8.py`: `weight_block_size` ∈ `[None, [1, 1]]`
  - These are kernel-level GEMM tests and do not go through the
    `*LinearMethod.__init__` group-shape derivation that this PR fixes.

## Test Result

- Lint passes. Functionally equivalent on square-block models (the only ones
  currently supported end-to-end).