### PR TITLE
Fix compact Sentence-Transformers pooling config parsing

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,7 @@ from vllm.config.vllm import (
     OptimizationLevel,
 )
 from vllm.platforms import current_platform
+from vllm.transformers_utils.config import get_pooling_config
 
 DEVICE_TYPE = current_platform.device_type
 
@@ -429,6 +430,53 @@ def test_get_pooling_config():
     assert model_config.pooler_config.use_activation
     assert model_config.pooler_config.seq_pooling_type == "MEAN"
     assert model_config.pooler_config.tok_pooling_type == "ALL"
+
+
+@pytest.mark.parametrize(
+    ("pooling_mode", "expected_pooling_type"),
+    [
+        ("cls", "CLS"),
+        ("mean", "MEAN"),
+        ("lasttoken", "LAST"),
+    ],
+)
+def test_get_pooling_config_from_compact_sentence_transformers_schema(
+    tmp_path, pooling_mode, expected_pooling_type
+):
+    pooling_dir = tmp_path / "1_Pooling"
+    pooling_dir.mkdir()
+    (tmp_path / "modules.json").write_text(
+        """
+        [
+            {
+                "path": "1_Pooling",
+                "type": "sentence_transformers.models.Pooling"
+            },
+            {
+                "path": "2_Normalize",
+                "type": "sentence_transformers.models.Normalize"
+            }
+        ]
+        """,
+        encoding="utf-8",
+    )
+    (pooling_dir / "config.json").write_text(
+        f"""
+        {{
+            "embedding_dimension": 384,
+            "pooling_mode": "{pooling_mode}",
+            "include_prompt": true
+        }}
+        """,
+        encoding="utf-8",
+    )
+
+    config = get_pooling_config(str(tmp_path))
+
+    assert config == {
+        "seq_pooling_type": expected_pooling_type,
+        "use_activation": True,
+    }
 
 
 @pytest.mark.skipif(

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -839,6 +839,15 @@ def get_pooling_config(
 
         config: dict[str, Any] = {"use_activation": normalize}
         for key, val in pooling_dict.items():
+            if key == "pooling_mode" and isinstance(val, str):
+                pooling_type = parse_pooling_type(val)
+                if pooling_type in SEQ_POOLING_TYPES:
+                    config["seq_pooling_type"] = pooling_type
+                elif pooling_type in TOK_POOLING_TYPES:
+                    config["tok_pooling_type"] = pooling_type
+                else:
+                    logger.debug("Skipping unsupported pooling mode: %r", val)
+
             if val is True:
                 pooling_type = parse_pooling_type(key)
                 if pooling_type in SEQ_POOLING_TYPES:
@@ -847,6 +856,13 @@ def get_pooling_config(
                     config["tok_pooling_type"] = pooling_type
                 else:
                     logger.debug("Skipping unrelated field: %r=%r", key, val)
+
+        if "seq_pooling_type" not in config and "tok_pooling_type" not in config:
+            logger.warning(
+                "Found pooling configuration for %s, but could not derive a "
+                "supported pooling type. Falling back to the architecture default.",
+                model,
+            )
 
         return config
 


### PR DESCRIPTION
Fixes #45995.

This teaches `get_pooling_config()` to parse the compact Sentence-Transformers `1_Pooling/config.json` schema introduced by newer `sentence-transformers` saves, e.g. `{"pooling_mode": "mean"}`. Previously vLLM only looked for verbose boolean keys such as `pooling_mode_mean_tokens`, so compact configs silently fell back to the architecture default pooler.

The patch:
- maps compact string `pooling_mode` through the existing `parse_pooling_type()` helper;
- keeps unsupported pooling modes non-fatal;
- emits a warning when a pooling config exists but no supported pooling type can be derived, avoiding a completely silent fallback;
- adds an offline local-layout regression test for compact `cls`, `mean`, and `lasttoken` configs.

Validation:
- `.venv/bin/python -m pytest tests/test_config.py::test_get_pooling_config_from_compact_sentence_transformers_schema -q` -> `3 passed`
- `uvx ruff check vllm/transformers_utils/config.py tests/test_config.py` -> `All checks passed!`
- `uvx ruff format --check vllm/transformers_utils/config.py tests/test_config.py` -> `2 files already formatted`
- `git diff --check` -> passed

Note: I also attempted the existing HF-backed `tests/test_config.py::test_get_pooling_config` locally. It could not complete in this environment because the configured proxy/mirror could not fetch/cache `sentence-transformers/all-MiniLM-L12-v2`; the new regression test is intentionally local-only to avoid that dependency.