### PR TITLE
[ROCm][Perf] Prefer ROCM_AITER_FA over ROCM_ATTN when AITER MHA is enabled

### DIFF
--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -80,11 +80,12 @@ def mock_on_mi3xx():
             "ROCM_AITER_UNIFIED_ATTN",
             AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN.get_path(),
         ),
-        # Test Case 6: VLLM_ROCM_USE_AITER=1
+        # Test Case 6: VLLM_ROCM_USE_AITER=1 -> AITER FlashAttention is
+        # preferred over the non-AITER ROCM_ATTN once AITER MHA is enabled.
         (
             {"VLLM_ROCM_USE_AITER": "1"},
             None,
-            AttentionBackendEnum.ROCM_ATTN.get_path(),
+            AttentionBackendEnum.ROCM_AITER_FA.get_path(),
         ),
         # Test Case 7: VLLM_ROCM_USE_AITER=1 + explicit TRITON_ATTN
         (
@@ -148,6 +149,70 @@ def test_standard_attention_backend_selection(
 
     backend_path = RocmPlatform.get_attn_backend_cls(
         selected_backend=backend_enum, attn_selector_config=attn_selector_config
+    )
+
+    assert backend_path == expected_backend_path
+
+
+@pytest.mark.parametrize(
+    "env_vars, expected_backend_path",
+    [
+        # AITER opt-in -> ROCM_AITER_FA wins over the non-AITER ROCM_ATTN.
+        (
+            {"VLLM_ROCM_USE_AITER": "1"},
+            AttentionBackendEnum.ROCM_AITER_FA.get_path(),
+        ),
+        # AITER on but MHA explicitly disabled -> fall back to ROCM_ATTN
+        # (ROCM_AITER_FA must not be promoted when is_mha_enabled() is False).
+        (
+            {"VLLM_ROCM_USE_AITER": "1", "VLLM_ROCM_USE_AITER_MHA": "0"},
+            AttentionBackendEnum.ROCM_ATTN.get_path(),
+        ),
+        # AITER fully disabled -> non-AITER ordering unchanged (ROCM_ATTN).
+        (
+            {},
+            AttentionBackendEnum.ROCM_ATTN.get_path(),
+        ),
+    ],
+)
+def test_aiter_fa_preferred_over_rocm_attn(
+    env_vars,
+    expected_backend_path,
+    mock_vllm_config,
+    mock_on_gfx9,
+    mock_on_mi3xx,
+    monkeypatch,
+):
+    """ROCM_AITER_FA must outrank ROCM_ATTN when AITER MHA is enabled.
+
+    Regression guard for the ROCm attention-backend priority order: with
+    VLLM_ROCM_USE_AITER=1 on CDNA3, auto-selection must pick ROCM_AITER_FA
+    (the AITER FlashAttention path) rather than the slower non-AITER ROCM_ATTN,
+    while leaving the non-AITER ordering unchanged when AITER (MHA) is off.
+    """
+    for key, value in env_vars.items():
+        monkeypatch.setenv(key, value)
+
+    import importlib
+
+    import vllm.envs as envs
+
+    importlib.reload(envs)
+
+    from vllm.platforms.rocm import RocmPlatform
+
+    attn_selector_config = AttentionSelectorConfig(
+        head_size=128,
+        dtype=torch.float16,
+        kv_cache_dtype="auto",
+        block_size=16,
+        use_mla=False,
+        has_sink=False,
+        use_sparse=False,
+    )
+
+    backend_path = RocmPlatform.get_attn_backend_cls(
+        selected_backend=None, attn_selector_config=attn_selector_config
     )
 
     assert backend_path == expected_backend_path

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -419,12 +419,13 @@ def _get_backend_priorities(
             ]
 
     backends = []
+    # Prefer AITER FlashAttention over ROCM_ATTN when AITER MHA is enabled.
+    if rocm_aiter_ops.is_mha_enabled():
+        backends.append(AttentionBackendEnum.ROCM_AITER_FA)
     # ROCM_ATTN uses (2, num_blocks, ...) KV cache layout which is
     # incompatible with KV connectors that require blocks-first layout.
     if not use_kv_connector:
         backends.append(AttentionBackendEnum.ROCM_ATTN)
-    if rocm_aiter_ops.is_mha_enabled():
-        backends.append(AttentionBackendEnum.ROCM_AITER_FA)
     if is_aiter_found_and_supported():
         backends.append(AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN)
     backends.append(AttentionBackendEnum.TRITON_ATTN)


### PR DESCRIPTION
## Purpose

Fixes #46596.

On CDNA (MI300X/MI325X/MI355X), `VLLM_ROCM_USE_AITER=1` for an MHA model still selected the non-AITER `ROCM_ATTN` for decode attention instead of `ROCM_AITER_FA`. In `_get_backend_priorities()`, `ROCM_ATTN` was listed before `ROCM_AITER_FA`, and selection takes the lowest-index valid backend — so `ROCM_ATTN` won even when the operator opted into AITER and `ROCM_AITER_FA` was valid. This contradicts the documented behavior and the [vLLM ROCm attention-backend blog](https://blog.vllm.ai/2026/02/27/rocm-attention-backend.html) ("with `VLLM_ROCM_USE_AITER=1`, vLLM selects `ROCM_AITER_FA` for MHA models").

## Change

Promote **only** `ROCM_AITER_FA` ahead of `ROCM_ATTN`, and **only** when `is_mha_enabled()` is true:
- `is_mha_enabled()` is gated on the env opt-in **and** gfx9 (`@if_aiter_supported`), so the order is unchanged on Radeon/RDNA and when `VLLM_ROCM_USE_AITER_MHA=0`.
- `ROCM_AITER_UNIFIED_ATTN` keeps its original position (after `ROCM_ATTN`).
- The KV-connector exclusion of `ROCM_ATTN` is preserved.

This is intentionally narrow — not "make AITER the global default" (that would regress Radeon; cf. closed #21805 / #21366). It only honors an explicit opt-in.

## Result (8x MI300X, Qwen3-VL-235B-A22B-Instruct-FP8, EAGLE3 SD, real MMMU)

SD decode TPOT (ms), default selection vs `ROCM_AITER_FA`:

| mc | v0.21 default | v0.21 AITER_FA | v0.23 default | v0.23 AITER_FA |
|----|------|------|------|------|
| 1  | 11.10 | **5.62** | 10.65 | **5.31** |
| 8  | 18.92 | **8.58** | 18.64 | **8.24** |
| 16 | 24.23 | **11.73** | 24.67 | **11.12** |

SD throughput ~doubles (e.g. mc=8: 390 → 808 tok/s on v0.21). Non-speculative baseline is unchanged within noise. Consistent with the blog's 2.8–4.6× TPOT / 2.7–4.4× throughput figures for `ROCM_AITER_FA` vs `ROCM_ATTN` on CDNA3.

## Test

Updated `tests/v1/attention/test_rocm_attention_backends_selection.py`:
- existing `VLLM_ROCM_USE_AITER=1` case now expects `ROCM_AITER_FA`;
- added `test_aiter_fa_preferred_over_rocm_attn` covering AITER-on (→ `ROCM_AITER_FA`), AITER-on + `MHA=0` (→ `ROCM_ATTN`), and AITER-off (→ `ROCM_ATTN`).

(ROCm-gated tests; require a ROCm host to execute.)
