### PR TITLE
[Bugfix] Parse compact sentence-transformers pooling_mode (>=5.4.0)

### DIFF
--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -6,8 +6,10 @@ only get the `eos_token_id` from the tokenizer as defined by
 `BaseRenderer.get_eos_token_id`.
 """
 
+from unittest.mock import patch
+
 from vllm.tokenizers import get_tokenizer
-from vllm.transformers_utils.config import try_get_generation_config
+from vllm.transformers_utils.config import get_pooling_config, try_get_generation_config
 
 
 def test_get_llama3_eos_token():
@@ -30,3 +32,24 @@ def test_get_blip2_eos_token():
     generation_config = try_get_generation_config(model_name, trust_remote_code=False)
     assert generation_config is not None
     assert generation_config.eos_token_id == 50118
+
+
+@patch("vllm.transformers_utils.config.file_or_path_exists", return_value=True)
+@patch(
+    "vllm.transformers_utils.config.get_hf_file_to_dict",
+    side_effect=lambda name, *_args, **_kwargs: {
+        "modules.json": [
+            {"type": "sentence_transformers.models.Pooling", "path": "1_Pooling"},
+        ],
+        "1_Pooling/config.json": {
+            "embedding_dimension": 384,
+            "pooling_mode": "mean",
+            "include_prompt": True,
+        },
+    }.get(name),
+)
+def test_get_pooling_config_compact_schema(_mock_hf, _mock_exists):
+    get_pooling_config.cache_clear()
+    config = get_pooling_config("dummy-model")
+    assert config is not None
+    assert config["seq_pooling_type"] == "MEAN"

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -869,6 +869,13 @@ def get_pooling_config(
         logger.info("Found pooling configuration.")
 
         config: dict[str, Any] = {"use_activation": normalize}
+        compact_mode = pooling_dict.get("pooling_mode")
+        if isinstance(compact_mode, str):
+            pooling_type = parse_pooling_type(compact_mode)
+            if pooling_type in SEQ_POOLING_TYPES:
+                config["seq_pooling_type"] = pooling_type
+            elif pooling_type in TOK_POOLING_TYPES:
+                config["tok_pooling_type"] = pooling_type
         for key, val in pooling_dict.items():
             if val is True:
                 pooling_type = parse_pooling_type(key)


### PR DESCRIPTION
Fixes #45995

sentence-transformers >= 5.4.0 writes `1_Pooling/config.json` with `"pooling_mode": "mean"` instead of boolean flags like `pooling_mode_mean_tokens: true`. `get_pooling_config()` only parsed keys whose value was `True`, so compact configs produced no pooling type and vLLM silently used the architecture-default pooler — wrong embeddings for mean-pooled BERT-style models.

Parse the compact `pooling_mode` string via the existing `parse_pooling_type()` before the legacy boolean loop.