### PR TITLE
[Bugfix] Balance MiniMax M3 reasoning markers in is_reasoning_end (#46042)

### DIFF
--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -459,3 +459,12 @@ def test_token_id_helpers_enabled_mode():
     assert parser.count_reasoning_tokens(open_reasoning_ids) == len(
         tokenizer.encode("abc")
     )
+
+
+def test_is_reasoning_end_ignores_paired_prompt_examples_with_thinking_enabled():
+    parser, tokenizer = make_parser(chat_template_kwargs={"thinking_mode": "enabled"})
+    prompt_ids = tokenizer.encode(
+        "Use <mm:think></mm:think> for reasoning.", add_special_tokens=False
+    )
+
+    assert not parser.is_reasoning_end(prompt_ids)

--- a/vllm/reasoning/minimax_m3_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m3_reasoning_parser.py
@@ -311,10 +311,23 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         return count
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
-        start_index = self._rfind_token_sequence(input_ids, self._start_token_ids)
-        end_index = self._rfind_token_sequence(input_ids, self._end_token_ids)
-        if end_index < 0:
-            return False
-        if start_index < 0:
-            return True
-        return end_index > start_index
+        depth = 1 if self._initial_in_reasoning else 0
+        saw_start = self._initial_in_reasoning
+        i = 0
+        while i < len(input_ids):
+            if tuple(input_ids[i : i + len(self._start_token_ids)]) == (
+                self._start_token_ids
+            ):
+                depth += 1
+                saw_start = True
+                i += len(self._start_token_ids)
+                continue
+            if tuple(input_ids[i : i + len(self._end_token_ids)]) == (
+                self._end_token_ids
+            ):
+                if depth > 0:
+                    depth -= 1
+                i += len(self._end_token_ids)
+                continue
+            i += 1
+        return depth == 0 and saw_start


### PR DESCRIPTION
## Purpose

Fixes #46042.

When `thinking_mode=enabled`, MiniMax M3 streaming leaked literal `<mm:think>` / `</mm:think>` into `delta.content` instead of routing text through `delta.reasoning`.

The prompt often contains a paired `<mm:think></mm:think>` example in the system message. `is_reasoning_end()` only compared the last start/end marker positions, so it treated that example as a completed reasoning block and initialized streaming with `reasoning_ended=True`.

This change tracks balanced marker depth (including the prefilled thinking state) so paired prompt examples no longer prematurely end the reasoning phase.

No open PR duplicates this fix. AI assistance was used; changes were reviewed before submission.

## Test Plan

- [x] Added regression test for paired prompt examples with `thinking_mode=enabled`
- [ ] `pytest tests/reasoning/test_minimax_m3_reasoning_parser.py -v` (blocked locally: test deps not installed)

## Test Result

Logic validated against the reported failure mode and existing parser expectations. Full pytest suite not run in this environment due to missing optional dependencies.


Made with [Cursor](https://cursor.com)