### PR TITLE
[Rust Frontend] Add Jamba tool parser

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -286,7 +286,7 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, granite4, hermes, hy_v3, internlm, kimi_k2, llama3_json, llama4_json, minimax_m2, minimax_m3, mistral, phi4_mini_json, qwen3_coder, qwen3_xml)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, granite4, hermes, hy_v3, internlm, jamba, kimi_k2, llama3_json, llama4_json, minimax_m2, minimax_m3, mistral, phi4_mini_json, qwen3_coder, qwen3_xml)"].assert_eq(&error.to_report_string());
     }
 
     #[test]

--- a/rust/src/chat/src/parser/tool/mod.rs
+++ b/rust/src/chat/src/parser/tool/mod.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 pub use vllm_tool_parser::{
     DeepSeekV3ToolParser, DeepSeekV4ToolParser, DeepSeekV31ToolParser, DeepSeekV32ToolParser,
     Gemma4ToolParser, Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser, HermesToolParser,
-    HyV3ToolParser, Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser,
+    HyV3ToolParser, Internlm2ToolParser, JambaToolParser, KimiK2ToolParser, Llama3JsonToolParser,
     MinimaxM2ToolParser, MinimaxM3ToolParser, MistralToolParser, Phi4MiniJsonToolParser,
     Qwen3CoderToolParser, Qwen3XmlToolParser, ToolCallDelta, ToolParser, ToolParserError,
     ToolParserOutput,
@@ -29,6 +29,7 @@ pub mod names {
     // Matches the Python CLI name `--tool-call-parser internlm`, which Python
     // also routes to `Internlm2ToolParser` despite the version-agnostic name.
     pub const INTERNLM: &str = "internlm";
+    pub const JAMBA: &str = "jamba";
     pub const KIMI_K2: &str = "kimi_k2";
     pub const LLAMA3_JSON: &str = "llama3_json";
     pub const LLAMA4_JSON: &str = "llama4_json";
@@ -71,6 +72,7 @@ impl ToolParserFactory {
             .register_parser::<HermesToolParser>(names::HERMES)
             .register_parser::<HyV3ToolParser>(names::HY_V3)
             .register_parser::<Internlm2ToolParser>(names::INTERNLM)
+            .register_parser::<JambaToolParser>(names::JAMBA)
             .register_parser::<KimiK2ToolParser>(names::KIMI_K2)
             .register_parser::<Llama3JsonToolParser>(names::LLAMA3_JSON)
             .register_parser::<Llama3JsonToolParser>(names::LLAMA4_JSON)
@@ -97,6 +99,7 @@ impl ToolParserFactory {
             // vllm/model_executor/models/registry.py:146), or `Intern-S1` /
             // `Intern-S1-Pro` (separate intern-s1 parser, see PR #40115).
             .register_pattern("internlm2", names::INTERNLM)
+            .register_pattern("jamba", names::JAMBA)
             .register_pattern("llama-4", names::LLAMA4_JSON)
             .register_pattern("llama-3.2", names::LLAMA3_JSON)
             .register_pattern("llama-3.1", names::LLAMA3_JSON)

--- a/rust/src/tool-parser/src/json/jamba.rs
+++ b/rust/src/tool-parser/src/json/jamba.rs
@@ -1,0 +1,313 @@
+use super::{JsonToolCallConfig, JsonToolCallParser, JsonToolCallWhitespace};
+use crate::{Result, Tool, ToolParser, ToolParserOutput};
+
+const JAMBA_CONFIG: JsonToolCallConfig = JsonToolCallConfig {
+    parser_name: "Jamba",
+    start_marker: "<tool_calls>[",
+    end_marker: "]</tool_calls>",
+    marker_whitespace: JsonToolCallWhitespace::Optional,
+    delimiter: Some(","),
+    name_key: "name",
+    arguments_key: &["arguments"],
+};
+
+/// Tool parser for Jamba special-token wrapped JSON-array tool calls.
+///
+/// Example tool call content:
+///
+/// ```text
+/// <tool_calls>[
+///     {"name": "get_current_weather", "arguments": {"city": "Dallas"}}
+/// ]</tool_calls>
+/// ```
+///
+/// Jamba wraps a JSON array of `{"name", "arguments"}` objects between the
+/// `<tool_calls>` and `</tool_calls>` special tokens. The array's opening `[`
+/// and closing `]` are folded into the start and end markers so the shared
+/// JSON tool-call core can stream each array element as one tool call, the same
+/// way the Mistral parser handles `[TOOL_CALLS] [...]`.
+///
+/// Arguments are already OpenAI-style JSON text, so they are streamed as raw
+/// argument deltas without schema conversion or JSON normalization.
+///
+/// # Divergences from the Python reference
+///
+/// This Rust port intentionally diverges from
+/// `vllm/tool_parsers/jamba_tool_parser.py` in these user-visible ways:
+///
+/// - **Arguments bytes are forwarded verbatim.** Python re-serializes each
+///   `arguments` object with `json.dumps(...)`, which can reorder keys and
+///   normalize spacing; this parser streams the raw JSON object text the model
+///   emitted, matching the other JSON parsers in this crate (Mistral, Hermes).
+/// - **End-marker bytes inside JSON string values are preserved.** Python
+///   slices on `split("<tool_calls>")[-1].split("</tool_calls>")[0]`, which
+///   truncates regardless of JSON context; this parser scans matched braces and
+///   quotes so a literal `]</tool_calls>` inside an arguments string is
+///   forwarded intact.
+/// - **Truncated tool calls error rather than silently dropping.** Python's
+///   streaming wrapper swallows mid-stream errors with
+///   `except Exception: return None`; this parser returns an
+///   `incomplete Jamba tool call` error from `finish()`, matching the other
+///   JSON parsers and Python's non-streaming `json.loads` behavior.
+///
+/// # Known unaddressed divergences (TODO)
+///
+/// These stem from shared `JsonToolCallParser` core limitations also documented
+/// on the InternLM2 parser, and would require non-local core changes that would
+/// affect Hermes / Llama / Mistral / Qwen as well:
+///
+/// - **Arguments value type.** The shared core requires the `arguments` value to
+///   be a JSON object (`take_json_object` rejects anything not starting with
+///   `{`). Python's `json.dumps` round-trips `null`, arrays, strings, and numbers
+///   verbatim, so a model emitting `"arguments":null` hard-fails here.
+/// - **Field order independence.** The header parser requires the JSON keys in
+///   the order `name` then `arguments`. Python's `json.loads` + dict access is
+///   order-independent, so a model emitting `{"arguments":{...},"name":"foo"}`
+///   parses in Python but fails here.
+pub struct JambaToolParser {
+    inner: JsonToolCallParser,
+}
+
+impl JambaToolParser {
+    /// Create a Jamba tool parser.
+    fn new(_tools: &[Tool]) -> Self {
+        Self {
+            inner: JsonToolCallParser::new(JAMBA_CONFIG),
+        }
+    }
+}
+
+impl ToolParser for JambaToolParser {
+    /// Create a boxed Jamba tool parser.
+    fn create(tools: &[Tool]) -> Result<Box<dyn ToolParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tools)))
+    }
+
+    /// Preserve special-token markers while decoding, since `<tool_calls>` and
+    /// `</tool_calls>` are tokenizer special tokens in Jamba models (the Python
+    /// parser sets `skip_special_tokens = False` for the same reason).
+    fn preserve_special_tokens(&self) -> bool {
+        true
+    }
+
+    /// Feed one decoded text chunk through the Jamba parser.
+    fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+        self.inner.parse_into(chunk, output)
+    }
+
+    /// Flush any buffered partial state at end of stream.
+    fn finish(&mut self) -> Result<ToolParserOutput> {
+        self.inner.finish()
+    }
+
+    /// Clear parser state and return currently uncommitted buffered text.
+    fn reset(&mut self) -> String {
+        self.inner.reset()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+    use thiserror_ext::AsReport;
+
+    use super::JambaToolParser;
+    use crate::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::{ToolParser, ToolParserOutput, ToolParserTestExt as _};
+
+    fn build_tool_call(function_name: &str, arguments: &str) -> String {
+        format!(r#"{{"name":"{function_name}","arguments":{arguments}}}"#)
+    }
+
+    fn build_tool_calls(tool_calls: &[String]) -> String {
+        format!("<tool_calls>[{}]</tool_calls>", tool_calls.join(","))
+    }
+
+    #[test]
+    fn jamba_parse_complete_without_tool_call_keeps_text() {
+        let mut parser = JambaToolParser::new(&test_tools());
+        let output = parser.parse_complete("This is a test").unwrap();
+
+        assert_eq!(output.normal_text, "This is a test");
+        assert!(output.calls.is_empty());
+    }
+
+    #[test]
+    fn jamba_parse_complete_extracts_single_tool_call() {
+        let mut parser = JambaToolParser::new(&test_tools());
+        let arguments = r#"{"city":"Dallas","state":"TX","unit":"fahrenheit"}"#;
+        let output = parser
+            .parse_complete(&build_tool_calls(&[build_tool_call(
+                "get_current_weather",
+                arguments,
+            )]))
+            .unwrap();
+
+        assert!(output.normal_text.is_empty());
+        assert_eq!(output.calls.len(), 1);
+        assert_eq!(output.calls[0].tool_index, 0);
+        assert_eq!(output.calls[0].name.as_deref(), Some("get_current_weather"));
+        assert_eq!(output.calls[0].arguments, arguments);
+    }
+
+    #[test]
+    fn jamba_parse_complete_preserves_leading_content() {
+        let mut parser = JambaToolParser::new(&test_tools());
+        let arguments = r#"{"city":"Dallas"}"#;
+        let output = parser
+            .parse_complete(&format!(
+                "Sure! let me call the tool for you.{}",
+                build_tool_calls(&[build_tool_call("get_current_weather", arguments)])
+            ))
+            .unwrap();
+
+        assert_eq!(output.normal_text, "Sure! let me call the tool for you.");
+        assert_eq!(output.calls.len(), 1);
+        assert_eq!(output.calls[0].name.as_deref(), Some("get_current_weather"));
+        assert_eq!(output.calls[0].arguments, arguments);
+    }
+
+    #[test]
+    fn jamba_parse_complete_extracts_pretty_multiple_tool_calls() {
+        let mut parser = JambaToolParser::new(&test_tools());
+        let output = parser
+            .parse_complete(
+                "<tool_calls>[\n    {\"name\": \"get_current_weather\", \"arguments\": {\"city\": \"Dallas\", \"state\": \"TX\"}},\n    {\"name\": \"get_current_weather\", \"arguments\": {\"city\": \"Orlando\", \"state\": \"FL\"}}\n]</tool_calls>",
+            )
+            .unwrap();
+
+        expect![[r#"
+            ToolParserOutput {
+                normal_text: "",
+                calls: [
+                    ToolCallDelta {
+                        tool_index: 0,
+                        name: Some(
+                            "get_current_weather",
+                        ),
+                        arguments: "{\"city\": \"Dallas\", \"state\": \"TX\"}",
+                    },
+                    ToolCallDelta {
+                        tool_index: 1,
+                        name: Some(
+                            "get_current_weather",
+                        ),
+                        arguments: "{\"city\": \"Orlando\", \"state\": \"FL\"}",
+                    },
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&output);
+    }
+
+    #[test]
+    fn jamba_does_not_validate_or_normalize_arguments() {
+        let mut parser = JambaToolParser::new(&test_tools());
+        let arguments = r#"{"location":"Tokyo",}"#;
+        let output = parser
+            .parse_complete(&build_tool_calls(&[build_tool_call(
+                "get_weather",
+                arguments,
+            )]))
+            .unwrap();
+
+        assert_eq!(output.calls[0].arguments, arguments);
+    }
+
+    #[test]
+    fn jamba_streaming_emits_argument_deltas() {
+        let mut parser = JambaToolParser::new(&test_tools());
+        let chunks = [
+            "preface <tool",
+            "_calls>[{\"name\":\"get_weather\",\"arguments\":",
+            "{\"location\":",
+            "\"Beijing\"",
+            "}",
+            "}]</tool_calls> suffix",
+        ];
+
+        let mut output = ToolParserOutput::default();
+        let mut observed_arguments = Vec::new();
+        for chunk in chunks {
+            let next = parser.parse_chunk(chunk).unwrap();
+            observed_arguments.extend(
+                next.calls
+                    .iter()
+                    .filter(|call| call.name.is_none())
+                    .map(|call| call.arguments.clone()),
+            );
+            output.append(next);
+        }
+        output.append(parser.finish().unwrap());
+
+        assert_eq!(observed_arguments, ["{\"location\":", "\"Beijing\"", "}"]);
+        assert_eq!(output.normal_text, "preface  suffix");
+        assert_eq!(
+            output.coalesce_calls().calls[0].arguments,
+            r#"{"location":"Beijing"}"#
+        );
+    }
+
+    #[test]
+    fn jamba_streaming_handles_split_markers() {
+        let input = format!(
+            "hello {}",
+            build_tool_calls(&[build_tool_call("get_weather", r#"{"location":"Tokyo"}"#)])
+        );
+        let chunks = split_by_chars(&input, 5);
+        let mut parser = JambaToolParser::new(&test_tools());
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        assert_eq!(output.normal_text, "hello ");
+        assert_eq!(output.calls.len(), 1);
+        assert_eq!(output.calls[0].arguments, r#"{"location":"Tokyo"}"#);
+    }
+
+    #[test]
+    fn jamba_keeps_end_marker_literal_inside_json_string() {
+        let mut parser = JambaToolParser::new(&test_tools());
+        let arguments = r#"{"text":"literal ]</tool_calls> inside"}"#;
+        let output = parser
+            .parse_complete(&build_tool_calls(&[build_tool_call("echo", arguments)]))
+            .unwrap();
+
+        assert_eq!(output.calls.len(), 1);
+        assert_eq!(output.calls[0].arguments, arguments);
+    }
+
+    #[test]
+    fn jamba_finish_fails_incomplete_tool_call() {
+        let mut parser = JambaToolParser::new(&test_tools());
+        parser
+            .parse_chunk(r#"<tool_calls>[{"name":"get_weather","arguments":{"location""#)
+            .unwrap();
+
+        let error = parser.finish().unwrap_err();
+
+        expect!["tool parser parsing failed: incomplete Jamba tool call"]
+            .assert_eq(&error.to_report_string());
+    }
+
+    #[test]
+    fn jamba_malformed_field_order_fails_fast() {
+        let mut parser = JambaToolParser::new(&test_tools());
+        let error = parser
+            .parse_chunk(r#"<tool_calls>[{"arguments":{},"name":"get_weather"}]</tool_calls>"#)
+            .unwrap_err();
+
+        expect![[r#"
+            tool parser parsing failed: invalid Jamba
+            expected `name`"#]]
+        .assert_eq(&error.to_report_string());
+    }
+
+    #[test]
+    fn jamba_preserve_special_tokens_is_true() {
+        let parser = JambaToolParser::new(&test_tools());
+        assert!(parser.preserve_special_tokens());
+    }
+}

--- a/rust/src/tool-parser/src/json/mod.rs
+++ b/rust/src/tool-parser/src/json/mod.rs
@@ -3,6 +3,7 @@
 pub use granite4::Granite4ToolParser;
 pub use hermes::HermesToolParser;
 pub use internlm2::Internlm2ToolParser;
+pub use jamba::JambaToolParser;
 pub use llama::Llama3JsonToolParser;
 pub use mistral::MistralToolParser;
 pub use phi4mini::Phi4MiniJsonToolParser;
@@ -11,6 +12,7 @@ pub use qwen::Qwen3XmlToolParser;
 mod granite4;
 mod hermes;
 mod internlm2;
+mod jamba;
 mod llama;
 mod mistral;
 mod phi4mini;

--- a/rust/src/tool-parser/src/lib.rs
+++ b/rust/src/tool-parser/src/lib.rs
@@ -26,8 +26,8 @@ pub use gemma4::Gemma4ToolParser;
 pub use glm_xml::{Glm45MoeToolParser, Glm47MoeToolParser};
 pub use hy_v3::HyV3ToolParser;
 pub use json::{
-    Granite4ToolParser, HermesToolParser, Internlm2ToolParser, Llama3JsonToolParser,
-    MistralToolParser, Phi4MiniJsonToolParser, Qwen3XmlToolParser,
+    Granite4ToolParser, HermesToolParser, Internlm2ToolParser, JambaToolParser,
+    Llama3JsonToolParser, MistralToolParser, Phi4MiniJsonToolParser, Qwen3XmlToolParser,
 };
 pub use kimi_k2::KimiK2ToolParser;
 pub use minimax_m2::MinimaxM2ToolParser;


### PR DESCRIPTION
## Purpose

Adds the **Jamba** tool-call parser to the Rust frontend, contributing to the Rust Frontend Feature Parity effort (#44280). The Python frontend already ships `jamba_tool_parser.py`; this brings the same model family to the Rust frontend so `--tool-call-parser jamba` (and Jamba model auto-detection) works there too.

Jamba emits tool calls as a JSON array wrapped in the `<tool_calls>` / `</tool_calls>` special tokens:

```text
<tool_calls>[
    {"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX"}}
]</tool_calls>
```

This is structurally the same shape the Mistral parser already handles (`[TOOL_CALLS] [...]`), so the new parser folds the array brackets into the start/end markers and reuses the shared `JsonToolCallParser` core rather than adding bespoke parsing. It overrides `preserve_special_tokens()` to return `true`, because `<tool_calls>` / `</tool_calls>` are tokenizer special tokens (the Python parser sets `skip_special_tokens=False` for the same reason).

Wiring:
- `vllm-tool-parser`: new `json/jamba.rs` (`JambaToolParser`), exported from the crate.
- `vllm-chat`: registered under the `jamba` parser name and a `jamba` model pattern.

Behavioral divergences from the Python reference (arguments forwarded verbatim instead of re-serialized, JSON-aware end-marker handling, and erroring on truncated calls instead of silently dropping them) are documented in the module doc comment, consistent with the existing InternLM2 and Mistral Rust parsers.

## Test Plan

`cargo test`, `cargo fmt --check`, and `cargo clippy -- -D warnings` for the `vllm-tool-parser` and `vllm-chat` crates.

## Test Result

- `vllm-tool-parser`: 303 passed (11 new Jamba tests covering single, parallel, and streaming tool calls; split markers; leading content; a literal `]</tool_calls>` inside a JSON string argument; malformed field order; and incomplete-call errors).
- `vllm-chat`: 166 passed (registry now lists `jamba`).
- `cargo fmt --check`: clean. `cargo clippy -- -D warnings`: clean.
