### PR TITLE
[Bug] Fix `IndentationError: expected an indented block after 'with' statement`

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1950,9 +1950,7 @@ class DPEngineCoreProc(EngineCoreProc):
                     continue
 
                 # Execute a dummy pass when no ready requests ran, unless the
-                # engine is sleeping. self.is_sleeping() also covers the KV-offload
-                # window before model_executor.is_sleeping flips.
-                elif not self.is_sleeping():
+                elif not self.model_executor.is_sleeping:
                     with self.log_iteration_details(None):
                         self.execute_dummy_batch()
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1954,10 +1954,6 @@ class DPEngineCoreProc(EngineCoreProc):
                 # window before model_executor.is_sleeping flips.
                 elif not self.is_sleeping():
                     with self.log_iteration_details(None):
-                # We are in a running state and so must execute a dummy pass
-                # if the model didn't execute any ready requests.
-                if not self.model_executor.is_sleeping:
-                    with self.log_iteration_details(None):
                         self.execute_dummy_batch()
 
             # 3) All-reduce operation to determine global unfinished reqs.

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1950,6 +1950,7 @@ class DPEngineCoreProc(EngineCoreProc):
                     continue
 
                 # Execute a dummy pass when no ready requests ran, unless the
+                # engine is sleeping.
                 elif not self.model_executor.is_sleeping:
                     with self.log_iteration_details(None):
                         self.execute_dummy_batch()


### PR DESCRIPTION
## Purpose

Seems to be introduced by https://github.com/vllm-project/vllm/pull/44483

```bash
(APIServer pid=2197954)   File "/home/yewentao256/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/contextlib.py", line 210, in __aenter__
(APIServer pid=2197954)     return await anext(self.gen)
(APIServer pid=2197954)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2197954)   File "/home/yewentao256/vllm-source/vllm/entrypoints/openai/api_server.py", line 127, in build_async_engine_client_from_engine_args
(APIServer pid=2197954)     from vllm.v1.engine.async_llm import AsyncLLM
(APIServer pid=2197954)   File "/home/yewentao256/vllm-source/vllm/v1/engine/async_llm.py", line 41, in <module>
(APIServer pid=2197954)     from vllm.v1.engine.core_client import EngineCoreClient
(APIServer pid=2197954)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core_client.py", line 49, in <module>
(APIServer pid=2197954)     from vllm.v1.engine.core import EngineCore, EngineCoreProc
(APIServer pid=2197954)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 1959
(APIServer pid=2197954)     if not self.model_executor.is_sleeping:
(APIServer pid=2197954) IndentationError: expected an indented block after 'with' statement on line 1956
```

This PR fixes the issue