### PR TITLE
[Bugfix] Enable DSML structural tag for DeepSeek-V4 with auto + non-strict tools

### DIFF
--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -346,3 +346,17 @@ def test_get_function_parameters_relaxes_function_strict_false():
     )
 
     assert _get_function_parameters(function) is True
+
+
+def test_deepseek_v4_auto_non_strict_gets_structural_tag(
+    sample_tools: list[ChatCompletionToolsParam],
+):
+    # auto + non-strict must still constrain DSML for DeepSeek-V4 so malformed
+    # tool calls don't leak into content / drop as empty responses (#40801).
+    tag = get_model_structural_tag(
+        model="deepseek_v4",
+        tools=sample_tools,
+        tool_choice="auto",
+        reasoning=True,
+    )
+    assert isinstance(tag, StructuralTag)

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -107,7 +107,12 @@ def get_model_structural_tag(
         return None
 
     if tool_choice == "auto" and not _any_tool_strict(tools):
-        return None
+        # DeepSeek-V4: keep DSML grammar guidance on for auto + non-strict so
+        # the model is constrained to valid DSML when it attempts a tool call.
+        # Without this, malformed DSML leaks into content or is dropped as an
+        # empty response (see #40801).
+        if model != "deepseek_v4":
+            return None
 
     dumped_tools = [_dump_tool_for_xgrammar(tool) for tool in tools]
     dumped_tool_choice = _dump_tool_choice_for_xgrammar(tool_choice)


### PR DESCRIPTION
## Purpose

Fixes the intermittent DSML fragment leakage / empty tool-call responses for DeepSeek-V4 with `tool_choice="auto"` + non-strict tools (#40801).

Since #45600, `get_model_structural_tag()` returns `None` for `tool_choice="auto"` without any strict tool. Most OpenAI-compatible agentic clients (e.g. opencode) send `auto` + non-strict tools, so DeepSeek-V4 never gets a structural tag and the model is not constrained to valid DSML during generation. When the model emits partial/malformed DSML, `DeepSeekV4ToolParser` cannot extract it — `｜DSML｜` fragments leak into `content` (non-streaming) or are dropped to an empty response with `finish_reason="stop"` (streaming). The parser-level fix #40806 can't help here because it can only extract well-formed DSML; the malformation originates at generation time.

## Changes

- `get_model_structural_tag()`: for `deepseek_v4`, do not skip the structural tag for `auto` + non-strict. xgrammar's `deepseek_v4` builtin returns a `TriggeredTagsFormat` that allows free text/reasoning and constrains DSML to valid grammar **only when the model triggers `<｜DSML｜tool_calls>`** — so it does not force a tool call and does not over-constrain generation (the concern from #45600).
- Test: assert `get_model_structural_tag("deepseek_v4", non-strict tools, "auto")` returns a `StructuralTag`.

## Test Plan

```
pytest tests/tool_parsers/test_structural_tag_registry.py -k deepseek_v4
```

Verified on a DeepSeek-V4-Flash-NVFP4 deployment: tool calls extract cleanly with no DSML leakage, and an agentic workload (opencode subagents, many sequential tool calls) runs without the empty-response/leak failures.

## Tradeoff

Re-introduces per-request xgrammar compilation for DSv4 `auto` requests (minor perf cost). Hardcoding `deepseek_v4` is the minimal change; happy to generalize (model opt-in set / launch flag) if maintainers prefer.

Fixes #40801.

Refs: #45600 · #40806 · #45862 · #45877
