### PR TITLE
[ROCm] Begin Deprecation Window for CUDA_VISIBLE_DEVICES on ROCm

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -119,6 +119,14 @@ def _sync_hip_cuda_env_vars():
     hip_val = os.environ.get("HIP_VISIBLE_DEVICES") or None
     cuda_val = os.environ.get("CUDA_VISIBLE_DEVICES") or None
 
+    if cuda_val is not None:
+        logger.warning_once(
+            "Using CUDA_VISIBLE_DEVICES on ROCm is deprecated and support "
+            "will be removed in vLLM v0.26.0. Please use HIP_VISIBLE_DEVICES "
+            "instead.",
+            scope="process",
+        )
+
     if hip_val is not None and cuda_val is not None:
         if hip_val != cuda_val:
             raise ValueError(


### PR DESCRIPTION

ROCm currently respects `CUDA_VISIBLE_DEVICES` in vLLM. This has been a recurring source of bugs, especially in distributed environments, e.g. when using Ray. Examples: https://github.com/vllm-project/vllm/pull/45998, https://github.com/vllm-project/vllm/pull/35069, https://github.com/vllm-project/vllm/pull/33305, https://github.com/vllm-project/vllm/pull/33308


Follow up: https://github.com/vllm-project/vllm/pull/39448