### PR TITLE
[Spec Decode] Add FlashInfer CuteDSL non-causal decode path for DFlash

### DIFF
--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -1017,3 +1017,80 @@ def test_non_causal_backend_correctness(
             causal=False,
             block_size=128,
         )
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
+@pytest.mark.parametrize(
+    "batch_spec_name",
+    [
+        # Uniform query lengths route through the CuteDSL decode kernel;
+        # mixed_small is non-uniform and must fall back to non-causal prefill.
+        "small_decode",
+        "small_prefill",
+        "medium_prefill",
+        "mixed_small",
+    ],
+)
+@pytest.mark.parametrize("model", ["meta-llama/Meta-Llama-3-8B"])
+def test_non_causal_cutedsl_decode_correctness(
+    default_vllm_config, batch_spec_name: str, model: str, monkeypatch
+):
+    """Test FlashInfer CuteDSL non-causal decode path (DFlash)."""
+    from vllm.utils.flashinfer import has_flashinfer_cutedsl_decode
+    from vllm.v1.attention.backends.flashinfer import FlashInferMetadataBuilder
+
+    if not current_platform.is_device_capability_family(100):
+        pytest.skip("CuteDSL decode requires SM100.")
+    if not has_flashinfer_cutedsl_decode():
+        pytest.skip("flashinfer CuteDSL paged decode wrapper is not available.")
+
+    import unittest.mock
+
+    def bidirectional_mask_mod(
+        b: torch.Tensor,
+        h: torch.Tensor,
+        q_idx: torch.Tensor,
+        kv_idx: torch.Tensor,
+        *,
+        context_len: int,
+    ):
+        return q_idx >= 0  # Always True
+
+    monkeypatch.setenv("VLLM_FLASHINFER_CUTEDSL_DECODE", "1")
+
+    # CuteDSL decode is gated off under full-decode CUDA graphs; force eager.
+    from vllm.config import CUDAGraphMode
+
+    orig_create_vllm_config = create_vllm_config
+
+    def eager_create_vllm_config(*args, **kwargs):
+        config = orig_create_vllm_config(*args, **kwargs)
+        config.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+        return config
+
+    monkeypatch.setattr(
+        "tests.v1.attention.test_attention_backends.create_vllm_config",
+        eager_create_vllm_config,
+    )
+
+    batch_spec = BATCH_SPECS[batch_spec_name]
+    uniform_q_len = len(set(batch_spec.query_lens)) == 1
+
+    with unittest.mock.patch.object(
+        FlashInferMetadataBuilder,
+        "_get_cutedsl_decode_wrapper",
+        autospec=True,
+        side_effect=FlashInferMetadataBuilder._get_cutedsl_decode_wrapper,
+    ) as spy:
+        _test_backend_correctness(
+            batch_spec,
+            model,
+            [AttentionBackendEnum.FLASHINFER],
+            bidirectional_mask_mod,
+            causal=False,
+        )
+
+    assert spy.called == uniform_q_len

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -1433,3 +1433,65 @@ def test_non_causal_backend_correctness(
             causal=False,
             block_size=128,
         )
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
+@pytest.mark.parametrize(
+    "batch_spec_name",
+    [
+        # Uniform query lengths route through the CuteDSL decode kernel;
+        # mixed_small is non-uniform and must fall back to non-causal prefill.
+        "small_decode",
+        "small_prefill",
+        "medium_prefill",
+        "mixed_small",
+    ],
+)
+@pytest.mark.parametrize("model", ["meta-llama/Meta-Llama-3-8B"])
+def test_non_causal_cutedsl_decode_correctness(
+    default_vllm_config, batch_spec_name: str, model: str, monkeypatch
+):
+    """Test FlashInfer CuteDSL non-causal decode path (DFlash)."""
+    from vllm.utils.flashinfer import has_flashinfer_cutedsl_decode
+    from vllm.v1.attention.backends.flashinfer import FlashInferMetadataBuilder
+
+    if not current_platform.is_device_capability_family(100):
+        pytest.skip("CuteDSL decode requires SM100.")
+    if not has_flashinfer_cutedsl_decode():
+        pytest.skip("flashinfer CuteDSL paged decode wrapper is not available.")
+
+    import unittest.mock
+
+    def bidirectional_mask_mod(
+        b: torch.Tensor,
+        h: torch.Tensor,
+        q_idx: torch.Tensor,
+        kv_idx: torch.Tensor,
+        *,
+        context_len: int,
+    ):
+        return q_idx >= 0  # Always True
+
+    monkeypatch.setenv("VLLM_FLASHINFER_CUTEDSL_DECODE", "1")
+
+    batch_spec = BATCH_SPECS[batch_spec_name]
+    uniform_q_len = len(set(batch_spec.query_lens)) == 1
+
+    with unittest.mock.patch.object(
+        FlashInferMetadataBuilder,
+        "_get_cutedsl_decode_wrapper",
+        autospec=True,
+        side_effect=FlashInferMetadataBuilder._get_cutedsl_decode_wrapper,
+    ) as spy:
+        _test_backend_correctness(
+            batch_spec,
+            model,
+            [AttentionBackendEnum.FLASHINFER],
+            bidirectional_mask_mod,
+            causal=False,
+        )
+
+    assert spy.called == uniform_q_len

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -198,6 +198,7 @@ if TYPE_CHECKING:
     VLLM_KIMI_K3_SHARD_SP_SHARED_EXPERT: bool = False
     VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: bool = True
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
+    VLLM_FLASHINFER_CUTEDSL_DECODE: bool = False
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
@@ -1547,6 +1548,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Allow use of FlashInfer MxInt4 MoE kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_INT4": lambda: bool(
         int(os.getenv("VLLM_USE_FLASHINFER_MOE_INT4", "0"))
+    ),
+    # Route non-causal DFlash decode through the FlashInfer CuteDSL paged
+    # decode kernel (SM100, flashinfer>=0.6.15) instead of the prefill
+    # wrapper. Falls back automatically when unavailable.
+    "VLLM_FLASHINFER_CUTEDSL_DECODE": lambda: bool(
+        int(os.getenv("VLLM_FLASHINFER_CUTEDSL_DECODE", "0"))
     ),
     # Control the cache sized used by the xgrammar compiler. The default
     # of 512 MB should be enough for roughly 1000 JSON schemas.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -214,6 +214,7 @@ if TYPE_CHECKING:
     VLLM_KIMI_K3_GEMM_RS: bool = False
     VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: bool = True
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
+    VLLM_FLASHINFER_CUTEDSL_DECODE: bool = False
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
@@ -1625,6 +1626,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Allow use of FlashInfer MxInt4 MoE kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_INT4": lambda: bool(
         int(os.getenv("VLLM_USE_FLASHINFER_MOE_INT4", "0"))
+    ),
+    # Route non-causal DFlash decode through the FlashInfer CuteDSL paged
+    # decode kernel (SM100, flashinfer>=0.6.15) instead of the prefill
+    # wrapper. Falls back automatically when unavailable.
+    "VLLM_FLASHINFER_CUTEDSL_DECODE": lambda: bool(
+        int(os.getenv("VLLM_FLASHINFER_CUTEDSL_DECODE", "0"))
     ),
     # Control the cache sized used by the xgrammar compiler. The default
     # of 512 MB should be enough for roughly 1000 JSON schemas.

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -241,6 +241,15 @@ def has_flashinfer_cutedsl() -> bool:
 
 
 @functools.cache
+def has_flashinfer_cutedsl_decode() -> bool:
+    """Return ``True`` if the CuteDSL paged decode wrapper is available."""
+    if not has_flashinfer_cutedsl():
+        return False
+    mod = _get_submodule("flashinfer.cute_dsl.attention")
+    return mod is not None and hasattr(mod, "BatchDecodePagedCuteDSLWrapper")
+
+
+@functools.cache
 def has_flashinfer_trtllm_fused_moe() -> bool:
     """Return `True` if FlashInfer TRTLLM fused MoE is available."""
     if not has_flashinfer_moe():

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -433,6 +433,15 @@ def has_flashinfer_fused_kda_decode() -> bool:
 
 
 @functools.cache
+def has_flashinfer_cutedsl_decode() -> bool:
+    """Return ``True`` if the CuteDSL paged decode wrapper is available."""
+    if not has_flashinfer_cutedsl():
+        return False
+    mod = _get_submodule("flashinfer.cute_dsl.attention")
+    return mod is not None and hasattr(mod, "BatchDecodePagedCuteDSLWrapper")
+
+
+@functools.cache
 def has_flashinfer_trtllm_fused_moe() -> bool:
     """Return `True` if FlashInfer TRTLLM fused MoE is available."""
     if not has_flashinfer_moe():

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -438,7 +438,19 @@ def has_flashinfer_cutedsl_decode() -> bool:
     if not has_flashinfer_cutedsl():
         return False
     mod = _get_submodule("flashinfer.cute_dsl.attention")
-    return mod is not None and hasattr(mod, "BatchDecodePagedCuteDSLWrapper")
+    if mod is None or not hasattr(mod, "BatchDecodePagedCuteDSLWrapper"):
+        return False
+    try:
+        from flashinfer.cute_dsl.availability import is_cute_dsl_arch_supported
+    except ImportError:
+        return False
+    capability = current_platform.get_device_capability()
+    if capability is None:
+        return False
+    try:
+        return bool(is_cute_dsl_arch_supported(capability.major, capability.minor))
+    except (RuntimeError, TypeError, ValueError):
+        return False
 
 
 @functools.cache

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -5,7 +5,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 import torch
@@ -41,6 +41,7 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.flashinfer import (
     can_use_trtllm_attention,
     force_use_trtllm_attention,
+    has_flashinfer_cutedsl_decode,
     supports_trtllm_attention,
     use_trtllm_attention,
 )
@@ -81,6 +82,11 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.utils import CpuGpuBuffer
+
+if TYPE_CHECKING:
+    # flashinfer>=0.6.15 only; imported lazily at runtime (see
+    # _get_cutedsl_decode_wrapper).
+    from flashinfer.cute_dsl.attention import BatchDecodePagedCuteDSLWrapper
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 FLASHINFER_PREFILL_WORKSPACE_BYTES_PER_ELEM = 16
@@ -576,6 +582,13 @@ class FlashInferTrtllmAPIDecode:
 
 
 @dataclass
+class CuteDSLDecode:
+    """Metadata for the CuteDSL non-causal decode pathway (DFlash)."""
+
+    wrapper: "BatchDecodePagedCuteDSLWrapper"
+
+
+@dataclass
 class FlashInferMetadata:
     num_actual_tokens: int
     """Total number of tokens in the batch (excluding padding)."""
@@ -600,7 +613,7 @@ class FlashInferMetadata:
     Will be `None` if `num_prefill_tokens == 0`.
     """
 
-    decode: FIDecode | FlashInferTrtllmAPIDecode | None
+    decode: FIDecode | FlashInferTrtllmAPIDecode | CuteDSLDecode | None
     """
     Holds the metadata for the decode portion of the batch.
     Will be `None` if `num_decode_tokens == 0`.
@@ -640,6 +653,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             None  # Wrapper for non-causal prefill (DFlash)
         )
         self._decode_wrapper = None  # Wrapper for decode (general shape)
+        # Wrapper for non-causal CuteDSL decode (DFlash); created lazily.
+        self._cutedsl_decode_wrapper: BatchDecodePagedCuteDSLWrapper | None = None
 
         if envs.VLLM_BATCH_INVARIANT:
             self.decode_fixed_split_size = 2048
@@ -665,6 +680,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             if speculative_config is not None
             else 0
         )
+        self.num_spec_tokens = num_spec_tokens
         self.enable_cuda_graph = (
             self.compilation_config.cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
         )
@@ -830,6 +846,30 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.kv_cache_dtype,
             arch,
         )
+
+        # Static gate for the CuteDSL non-causal decode path (DFlash). Scope is
+        # deliberately narrow for a correctness-first Phase 1: SM100 only,
+        # full-attention only (no SWA / logits soft cap / sinks), kv_data_type
+        # == q_data_type so non-quantized KV only, and no CUDA graph (the path
+        # is not graph-safe yet; see Phase 2). Anything else keeps the existing
+        # non-causal prefill fallback. Scope = "Standard DFlash".
+        self._use_cutedsl_decode = (
+            envs.VLLM_FLASHINFER_CUTEDSL_DECODE
+            and has_flashinfer_cutedsl_decode()
+            and current_platform.is_device_capability_family(100)
+            and not self.is_kvcache_nvfp4
+            and not self.use_dcp
+            and not self.has_sinks
+            and not self.enable_cuda_graph
+            and self.window_left == -1
+            and (self.logits_soft_cap or 0.0) == 0.0
+            and self.kv_cache_dtype == self.model_config.dtype
+            and self.head_dim % 64 == 0
+            and self.page_size in (8, 16, 32, 64)
+            and self.num_kv_heads > 0
+            and self.num_qo_heads % self.num_kv_heads == 0
+        )
+
         # Preparing persistent buffers
         # Since we do not have explicit synchronization in ModelRunnerV2, we do not pin
         # reused CPU buffers to avoid a race condition between step N async copies to
@@ -1050,6 +1090,16 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         return decode_wrapper
 
+    def _get_cutedsl_decode_wrapper(self) -> "BatchDecodePagedCuteDSLWrapper":
+        if self._cutedsl_decode_wrapper is None:
+            from flashinfer.cute_dsl.attention import BatchDecodePagedCuteDSLWrapper
+
+            # Shares the uint8 workspace; the wrapper reinterprets it as fp32.
+            self._cutedsl_decode_wrapper = BatchDecodePagedCuteDSLWrapper(
+                self._get_workspace_buffer()
+            )
+        return self._cutedsl_decode_wrapper
+
     def _get_cascade_wrapper(self):
         if self._cascade_wrapper is None:
             self._cascade_wrapper = MultiLevelCascadeAttentionWrapper(
@@ -1123,6 +1173,15 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         causal = common_attn_metadata.causal
+        # Non-causal DFlash uses the CuteDSL paged decode kernel when enabled
+        # and the batch has a uniform q_len per request; else falls back to the
+        # non-causal prefill wrapper below.
+        use_cutedsl_decode = (
+            not causal
+            and self._use_cutedsl_decode
+            and num_reqs > 0
+            and num_actual_tokens == num_reqs * common_attn_metadata.max_query_len
+        )
         if causal:
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
                 split_decodes_and_prefills(
@@ -1131,6 +1190,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     require_uniform=True,
                 )
             )
+        elif use_cutedsl_decode:
+            num_decodes = num_reqs
+            num_prefills = 0
+            num_decode_tokens = num_actual_tokens
+            num_prefill_tokens = 0
         else:
             # FlashInfer decode/TRTLLM paths cannot express non-causal
             # query-query attention, so DFlash runs as native prefill.
@@ -1470,6 +1534,30 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     seq_lens=seq_lens_decode,
                     max_seq_len=max_seq_len,
                 )
+            elif use_cutedsl_decode:
+                assert paged_kv_indices is not None
+                wrapper = self._get_cutedsl_decode_wrapper()
+                wrapper.plan(
+                    indptr=self.paged_kv_indptr.gpu[: num_reqs + 1],
+                    indices=paged_kv_indices,
+                    seq_lens=seq_lens[:num_decodes],
+                    num_qo_heads=self.num_qo_heads,
+                    num_kv_heads=self.num_kv_heads,
+                    head_dim=self.head_dim,
+                    page_size=self.page_size,
+                    q_data_type=self.q_data_type_decode,
+                    kv_data_type=self.kv_cache_dtype,
+                    sm_scale=self.sm_scale,
+                    # "auto" may resolve to atomic reduction, which requires a
+                    # zero-initialized out buffer (done in forward()). Atomic
+                    # summation order is non-deterministic, so batch-invariant
+                    # mode forces the deterministic kernel reduction.
+                    reduction="kernel" if envs.VLLM_BATCH_INVARIANT else "auto",
+                    q_len_per_req=num_decode_tokens // num_decodes,
+                    is_causal=False,
+                    max_kv_len=max_seq_len,
+                )
+                attn_metadata.decode = CuteDSLDecode(wrapper=wrapper)
             else:
                 assert seq_lens_cpu is not None
                 pure_decode = num_prefills == 0
@@ -1726,6 +1814,7 @@ class FlashInferImpl(AttentionImpl):
         decode_with_xqa = decode_kernel == FlashInferDecodeKernel.XQA
         decode_with_trtllm_gen = decode_kernel == FlashInferDecodeKernel.TRTLLM_GEN
         decode_with_flashinfer_trtllm_api = decode_with_xqa or decode_with_trtllm_gen
+        decode_use_cutedsl = isinstance(attn_metadata.decode, CuteDSLDecode)
 
         # The attn+quant fusion happens when output_scale is provided.
         if output_scale is None:
@@ -2058,7 +2147,28 @@ class FlashInferImpl(AttentionImpl):
                 layer._q_scale,
             )
 
-            if not decode_with_flashinfer_trtllm_api:
+            if decode_use_cutedsl:
+                assert isinstance(attn_metadata.decode, CuteDSLDecode)
+                # CuteDSL paged decode expects k/v as
+                # [num_pages, page_size, num_kv_heads, head_dim]; an HND cache
+                # is passed as a transposed view (head_dim stays innermost).
+                k_cache = kv_cache_permute[:, 0]
+                v_cache = kv_cache_permute[:, 1]
+                if get_kv_cache_layout() == "HND":
+                    k_cache = k_cache.transpose(1, 2)
+                    v_cache = v_cache.transpose(1, 2)
+                # Atomic reduction accumulates into out; zero-init is required
+                # (no-op overhead for kernel/none reduction, which overwrite).
+                out = output[:num_decode_tokens]
+                out.zero_()
+                attn_metadata.decode.wrapper.run(
+                    decode_query,
+                    k_cache,
+                    v_cache,
+                    out=out,
+                    sm_scale=self.scale,
+                )
+            elif not decode_with_flashinfer_trtllm_api:
                 assert isinstance(attn_metadata.decode, FIDecode)
                 decode_wrapper = attn_metadata.decode.wrapper
                 assert decode_wrapper is not None

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1275,6 +1275,18 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         return decode_wrapper
 
+    @staticmethod
+    def _is_uniform_query_batch(common_attn_metadata: CommonAttentionMetadata) -> bool:
+        num_reqs = common_attn_metadata.num_reqs
+        qo_indptr_cpu = common_attn_metadata.query_start_loc_cpu
+        q_lens = qo_indptr_cpu[1 : num_reqs + 1] - qo_indptr_cpu[:num_reqs]
+        q_len = int(q_lens[0])
+        return (
+            q_len > 0
+            and bool((q_lens == q_len).all())
+            and q_len * num_reqs == common_attn_metadata.num_actual_tokens
+        )
+
     def _get_cutedsl_decode_wrapper(self) -> "BatchDecodePagedCuteDSLWrapper":
         if self._cutedsl_decode_wrapper is None:
             from flashinfer.cute_dsl.attention import BatchDecodePagedCuteDSLWrapper
@@ -1366,7 +1378,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             not causal
             and self._use_cutedsl_decode
             and num_reqs > 0
-            and num_actual_tokens == num_reqs * common_attn_metadata.max_query_len
+            and self._is_uniform_query_batch(common_attn_metadata)
         )
         route_decode = causal or self.use_xqa
         if route_decode:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -5,7 +5,7 @@
 from dataclasses import dataclass, replace
 from enum import Enum
 from functools import partial
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 import torch
@@ -44,6 +44,7 @@ from vllm.utils.flashinfer import (
     can_use_trtllm_attention,
     flashinfer_xqa_batch_decode_with_kv_cache,
     force_use_trtllm_attention,
+    has_flashinfer_cutedsl_decode,
     pin_host_range_buf,
     supports_trtllm_attention,
     use_trtllm_attention,
@@ -90,6 +91,11 @@ from vllm.v1.kv_cache_interface import (
     iter_layer_specs,
 )
 from vllm.v1.utils import CpuGpuBuffer
+
+if TYPE_CHECKING:
+    # flashinfer>=0.6.15 only; imported lazily at runtime (see
+    # _get_cutedsl_decode_wrapper).
+    from flashinfer.cute_dsl.attention import BatchDecodePagedCuteDSLWrapper
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 FLASHINFER_PREFILL_WORKSPACE_BYTES_PER_ELEM = 16
@@ -639,6 +645,13 @@ class FlashInferTrtllmAPIDecode:
 
 
 @dataclass
+class CuteDSLDecode:
+    """Metadata for the CuteDSL non-causal decode pathway (DFlash)."""
+
+    wrapper: "BatchDecodePagedCuteDSLWrapper"
+
+
+@dataclass
 class FlashInferMetadata:
     num_actual_tokens: int
     """Total number of tokens in the batch (excluding padding)."""
@@ -663,7 +676,7 @@ class FlashInferMetadata:
     Will be `None` if `num_prefill_tokens == 0`.
     """
 
-    decode: FIDecode | FlashInferTrtllmAPIDecode | None
+    decode: FIDecode | FlashInferTrtllmAPIDecode | CuteDSLDecode | None
     """
     Holds the metadata for the decode portion of the batch.
     Will be `None` if `num_decode_tokens == 0`.
@@ -703,6 +716,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             None  # Wrapper for non-causal prefill (DFlash)
         )
         self._decode_wrapper = None  # Wrapper for decode (general shape)
+        # Wrapper for non-causal CuteDSL decode (DFlash); created lazily.
+        self._cutedsl_decode_wrapper: BatchDecodePagedCuteDSLWrapper | None = None
 
         if envs.VLLM_BATCH_INVARIANT:
             self.decode_fixed_split_size = 2048
@@ -915,6 +930,30 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.kv_cache_dtype,
             arch,
         )
+
+        # Static gate for the CuteDSL non-causal decode path (DFlash). Scope is
+        # deliberately narrow for a correctness-first Phase 1: SM100 only,
+        # full-attention only (no SWA / logits soft cap / sinks), kv_data_type
+        # == q_data_type so non-quantized KV only. Anything else keeps the
+        # existing non-causal prefill fallback. Not gated on enable_cuda_graph:
+        # draft builders inherit it from the target, and non-causal capture is
+        # already excluded by get_cudagraph_support().
+        self._use_cutedsl_decode = (
+            envs.VLLM_FLASHINFER_CUTEDSL_DECODE
+            and has_flashinfer_cutedsl_decode()
+            and current_platform.is_device_capability_family(100)
+            and not self.is_kvcache_nvfp4
+            and not self.use_dcp
+            and not self.has_sinks
+            and self.window_left == -1
+            and (self.logits_soft_cap or 0.0) == 0.0
+            and self.kv_cache_dtype == self.model_config.dtype
+            and self.head_dim % 64 == 0
+            and self.page_size in (8, 16, 32, 64)
+            and self.num_kv_heads > 0
+            and self.num_qo_heads % self.num_kv_heads == 0
+        )
+
         # Preparing persistent buffers
         self.paged_kv_indptr = CpuGpuBuffer(
             max_num_reqs + 1, dtype=torch.int32, device=self.device, pin_memory=False
@@ -1236,6 +1275,16 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         return decode_wrapper
 
+    def _get_cutedsl_decode_wrapper(self) -> "BatchDecodePagedCuteDSLWrapper":
+        if self._cutedsl_decode_wrapper is None:
+            from flashinfer.cute_dsl.attention import BatchDecodePagedCuteDSLWrapper
+
+            # Shares the uint8 workspace; the wrapper reinterprets it as fp32.
+            self._cutedsl_decode_wrapper = BatchDecodePagedCuteDSLWrapper(
+                self._get_workspace_buffer()
+            )
+        return self._cutedsl_decode_wrapper
+
     def _get_cascade_wrapper(self):
         if self._cascade_wrapper is None:
             self._cascade_wrapper = MultiLevelCascadeAttentionWrapper(
@@ -1309,6 +1358,16 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         causal = common_attn_metadata.causal
+        # Non-causal DFlash uses the CuteDSL paged decode kernel when enabled
+        # and the batch has a uniform q_len per request; else falls back to the
+        # non-causal prefill wrapper below. XQA (SM90 / SM12x) handles
+        # non-causal decode itself, so it keeps the decode route.
+        use_cutedsl_decode = (
+            not causal
+            and self._use_cutedsl_decode
+            and num_reqs > 0
+            and num_actual_tokens == num_reqs * common_attn_metadata.max_query_len
+        )
         route_decode = causal or self.use_xqa
         if route_decode:
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
@@ -1318,6 +1377,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     require_uniform=not self.use_xqa,
                 )
             )
+        elif use_cutedsl_decode:
+            num_decodes = num_reqs
+            num_prefills = 0
+            num_decode_tokens = num_actual_tokens
+            num_prefill_tokens = 0
         else:
             num_decodes = 0
             num_prefills = num_reqs
@@ -1716,6 +1780,32 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         qo_indptr[: num_decodes + 1] if self.use_dcp else None
                     ),
                 )
+            elif use_cutedsl_decode:
+                assert paged_kv_indices is not None
+                wrapper = self._get_cutedsl_decode_wrapper()
+                wrapper.plan(
+                    indptr=self.paged_kv_indptr.gpu[: num_reqs + 1],
+                    indices=paged_kv_indices,
+                    seq_lens=seq_lens[:num_decodes],
+                    num_qo_heads=self.num_qo_heads,
+                    num_kv_heads=self.num_kv_heads,
+                    head_dim=self.head_dim,
+                    page_size=self.page_size,
+                    q_data_type=self.q_data_type_decode,
+                    kv_data_type=self.kv_cache_dtype,
+                    sm_scale=self.sm_scale,
+                    # "auto" may resolve to atomic reduction, which requires a
+                    # zero-initialized out buffer (done in forward()). Atomic
+                    # summation order is non-deterministic, so batch-invariant
+                    # mode forces the deterministic kernel reduction.
+                    reduction="kernel" if envs.VLLM_BATCH_INVARIANT else "auto",
+                    q_len_per_req=num_decode_tokens // num_decodes,
+                    # Dense mask; window_right defaults to 0 (causal).
+                    window_left=None,
+                    window_right=None,
+                    max_kv_len=max_seq_len,
+                )
+                attn_metadata.decode = CuteDSLDecode(wrapper=wrapper)
             else:
                 assert seq_lens_cpu is not None
                 pure_decode = num_prefills == 0
@@ -2008,6 +2098,7 @@ class FlashInferImpl(AttentionImpl):
         decode_with_xqa = decode_kernel == FlashInferDecodeKernel.XQA
         decode_with_trtllm_gen = decode_kernel == FlashInferDecodeKernel.TRTLLM_GEN
         decode_with_flashinfer_trtllm_api = decode_with_xqa or decode_with_trtllm_gen
+        decode_use_cutedsl = isinstance(attn_metadata.decode, CuteDSLDecode)
 
         # The attn+quant fusion happens when output_scale is provided.
         if output_scale is None:
@@ -2368,7 +2459,24 @@ class FlashInferImpl(AttentionImpl):
                 layer._q_scale,
             )
 
-            if not decode_with_flashinfer_trtllm_api:
+            if decode_use_cutedsl:
+                assert isinstance(attn_metadata.decode, CuteDSLDecode)
+                # K/V views are [num_pages, num_kv_heads, page_size, head_dim];
+                # the kernel wants page_size before heads (head_dim innermost).
+                k_cache = kv_cache_tuple[0].transpose(1, 2)
+                v_cache = kv_cache_tuple[1].transpose(1, 2)
+                # Atomic reduction accumulates into out; zero-init is required
+                # (no-op overhead for kernel/none reduction, which overwrite).
+                out = output[:num_decode_tokens]
+                out.zero_()
+                attn_metadata.decode.wrapper.run(
+                    decode_query,
+                    k_cache,
+                    v_cache,
+                    out=out,
+                    sm_scale=self.scale,
+                )
+            elif not decode_with_flashinfer_trtllm_api:
                 assert isinstance(attn_metadata.decode, FIDecode)
                 decode_wrapper = attn_metadata.decode.wrapper
                 assert decode_wrapper is not None


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

On SM100, FlashInfer serves non-causal DFlash draft queries through `BatchPrefillWithPagedKVCacheWrapper(causal=False)` because the decode/TRTLLM paths cannot express non-causal attention. FlashInfer's CuteDSL paged decode wrapper can (`q_len_per_req > 1`, dense mask), and it fits the DFlash decode shape exactly (uniform `1 + num_speculative_tokens` queries per request).

This PR adds a `CuteDSLDecode` dispatch mode to the FlashInfer backend (tracker #46105 item):

- `VLLM_FLASHINFER_CUTEDSL_DECODE`, default off.
- Static gate: SM100, full attention (no SWA / soft cap / sinks), `kv_data_type == q_data_type`, page size in {8, 16, 32, 64}.
- Per-batch gate: non-causal with uniform query length; otherwise the existing non-causal prefill path.
- CUDA graphs are already excluded for this case by `get_cudagraph_support()` (non-causal on SM100 reports `UNIFORM_SINGLE_TOKEN_DECODE`), so no extra gate is needed.

Scope: draft layers that reach the builder with `causal=False`, i.e. `full_attention` layers (standard DFlash, and the full layer of hybrid drafters). Sliding-window layers are causal in vLLM and keep the decode route, so the published DFlash2 checkpoints are unaffected. SM90 / SM12x are unaffected (XQA).

Requires flashinfer >= 0.6.15 (flashinfer-ai/flashinfer#3717 boundary-mask fix); `main` pins 0.6.18.post1. Plans with `window_left=None, window_right=None` since `is_causal` is deprecated (flashinfer-ai/flashinfer#3794).

## Test Plan

```bash
pytest tests/v1/attention/test_attention_backends.py -k cutedsl -v
pytest tests/v1/attention/test_attention_backends.py -k "non_causal or causal_backend_correctness" -v
```

E2E: Qwen3-8B + `z-lab/Qwen3-8B-DFlash-b16`, V2 runner, FlashInfer target and draft, flag off/on. Note for reproducing: the draft does not inherit the target backend, so pass `"attention_backend": "FLASHINFER"` in `--speculative-config`; with default `max_num_seqs` startup hits #56443 (fix in #56448, unrelated), `--max-num-seqs 64` avoids it.

## Test Result

B200, torch 2.13.0+cu130, flashinfer 0.6.18.post1, `main` d43bb2f37f + this PR.

Unit: 14/14 (CuteDSL cases route through the kernel and match the SDPA reference; the non-uniform case falls back; existing non-causal and causal tests pass with the flag off and on). Run with `Qwen/Qwen3-8B` as a same-shape stand-in since this machine has no token for the gated model.

Kernel microbench, CuteDSL (`reduction="auto"`) vs `BatchPrefillWithPagedKVCacheWrapper(causal=False)`, q_len_per_req=17, GQA 32/8, head_dim 128, page 16, bf16, median of 50:

| batch | kv_len | prefill (ms) | cutedsl (ms) | speedup |
|---|---|---|---|---|
| 1 | 512 | 0.028 | **0.017** | 1.68x |
| 1 | 2048 | 0.029 | 0.030 | 0.99x |
| 1 | 8192 | 0.041 | **0.035** | 1.16x |
| 8 | 2048 | 0.062 | **0.039** | 1.60x |
| 16 | 8192 | 0.272 | **0.157** | 1.73x |
| 32 | 8192 | 0.476 | **0.294** | 1.62x |

Deterministic `"kernel"` reduction (used under `VLLM_BATCH_INVARIANT`) is 1.0-1.5x, i.e. never slower than prefill. Max abs diff vs prefill: 2e-3.

E2E, num_spec_tokens=16, 12 prompts x 512 tokens, temperature 0, 3 timed runs:

| config | CuteDSL builds / non-causal builds | acceptance length | tok/s |
|---|---|---|---|
| off, FULL graphs | 0 / 259 | 2.2946 | 3194-3224 |
| on, FULL graphs | 259 / 259 | 2.2951 | **3260-3272** |
| off, eager | 0 / 261 | 2.3004 | 2311-2346 |
| on, eager | 263 / 263 | 2.2905 | **2435-2454** |

Every non-causal draft batch takes the CuteDSL path with the target on full CUDA graphs (the V2 default). Outputs are deterministic run-to-run; on vs off, 9/12 (graphs) and 4/12 (eager) outputs are bitwise identical and the rest diverge after token 406, well inside the spread between graph and eager runs of the same config.

Known caveat: the CuteDSL kernel is JIT-compiled on the first real request (`jit_monitor` warning), same as the existing Triton DFlash kernels.

## Follow-ups

- CUDA-graph support for this path, so non-causal drafters on SM100 stop running eagerly (a FlashAttention draft with full graphs runs the same E2E at 3576-3588 tok/s).
- Precompile the CuteDSL variants in `cutedsl_warmup`.
- Relax the SWA / sinks gate using flashinfer#3794 once verified.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
