### PR TITLE
Update FA pin to have new FA2 not pull in dropout headers

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -39,7 +39,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG ed4b7342bc8f0489dd9b649d5288867e35fc6a32
+          GIT_TAG c3f5c9c141d40372bf26425d33a113436f1fd213
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn


### PR DESCRIPTION

## Purpose

As a part of #26946, step 1 of making the vllm fork of FA2 ABI stable by removing unused dropout headers (Philox/RNG). This PR updates the pin to the landed PR in vLLM's flash attention fork https://github.com/vllm-project/flash-attention/pull/153

## Test Plan
Run `pytest tests/kernels/attention/test_flash_attn.py -v -k "2-"` (the 2 is for the FA2 vs FA3 backend)

I also had Claude adapt the fork's sparse tests as vllm repo doesn't have those:

<details>

```
"""
One-off smoke/numerical test for the FA2 sparse ops.

Adapted from vllm-flash-attn/tests/test_vllm_flash_attn.py
(test_sparse_attention + test_sparse_attention_varlen), but imports from the
VENDORED package so it runs against the vllm build you already have:

    python /home/janeyx/repos/sparse_op_smoke.py

Exercises:
  - torch.ops._vllm_fa2_C.fwd_sparse        (via sparse_attn_func)
  - torch.ops._vllm_fa2_C.varlen_fwd_sparse (via sparse_attn_varlen_func)
"""

import math
import itertools

import torch
from einops import repeat

from vllm.vllm_flash_attn.flash_attn_interface import (
    sparse_attn_func,
    sparse_attn_varlen_func,
    flash_attn_varlen_func,
)

ATOL, RTOL = 2e-2, 1e-2
BLOCK_M = 64
BLOCK_N = 64


def ref_attn(q, k, v):
    """Full (non-causal, no-window) reference attention. Matches the fork's
    ref_attn for the default args used by test_sparse_attention.
    q,k,v: (b, s, h, d) -> (out (b,s,h,d), lse (b,h,s))."""
    qf, kf, vf = q.float(), k.float(), v.float()
    g = q.shape[2] // k.shape[2]
    kf = repeat(kf, "b s h d -> b s (h g) d", g=g)
    vf = repeat(vf, "b s h d -> b s (h g) d", g=g)
    d = q.shape[-1]
    scores = torch.einsum("bthd,bshd->bhts", qf / math.sqrt(d), kf)
    lse_ref = scores.logsumexp(dim=-1)
    attn = torch.softmax(scores, dim=-1).to(vf.dtype)
    out = torch.einsum("bhts,bshd->bthd", attn, vf)
    return out.to(q.dtype), lse_ref


def check(name, out, ref_out, lse, ref_lse):
    try:
        torch.testing.assert_close(out, ref_out, atol=ATOL, rtol=RTOL)
        torch.testing.assert_close(lse, ref_lse, atol=ATOL, rtol=RTOL)
        print(f"  PASS  {name}")
        return True
    except AssertionError as e:
        first = str(e).splitlines()[0]
        print(f"  FAIL  {name}  ({first})")
        return False


def run_dense_sparse():
    """fwd_sparse: sparse pattern covering the whole sequence == full attention."""
    print("== test_sparse_attention (fwd_sparse) ==")
    DTYPES = [torch.bfloat16, torch.float16]
    SEQ_LENS = [(1, 1024), (1023, 1023), (129, 129), (32, 32)]
    NUM_HEADS = [1, 2, 4]
    HEAD_SIZE = 128
    NNZ_S_LIST = [0, 1, 2, 7, 15]
    passed = total = skipped = 0
    for dtype, (sq, sk), nh, nnz_s in itertools.product(
        DTYPES, SEQ_LENS, NUM_HEADS, NNZ_S_LIST
    ):
        if nnz_s * BLOCK_N > sk:
            skipped += 1
            continue
        torch.cuda.manual_seed_all(0)
        b = 2
        q = torch.randn(b, sq, nh, HEAD_SIZE, dtype=dtype)
        k = torch.randn(b, sk, nh, HEAD_SIZE, dtype=dtype)
        v = torch.randn(b, sk, nh, HEAD_SIZE, dtype=dtype)
        num_rows = (sq + BLOCK_M - 1) // BLOCK_M
        nnz_v = sk - nnz_s * BLOCK_N
        block_count = torch.full(
            (b, nh, num_rows), nnz_s, dtype=torch.int32
        )
        column_count = torch.full(
            (b, nh, num_rows), nnz_v, dtype=torch.int32
        )
        block_offset = torch.tensor(
            [[i * BLOCK_N for i in range(nnz_s)]] * b * nh * num_rows,
            dtype=torch.int32,
        ).reshape(b, nh, num_rows, nnz_s)
        column_index = torch.tensor(
            [[nnz_s * BLOCK_N + i for i in range(nnz_v)]] * b * nh * num_rows,
            dtype=torch.int32,
        ).reshape(b, nh, num_rows, nnz_v)

        out, lse = sparse_attn_func(
            q, k, v,
            block_count, block_offset, column_count, column_index,
            return_softmax_lse=True,
        )
        ref_out, ref_lse = ref_attn(q, k, v)
        total += 1
        passed += check(
            f"dtype={dtype} seq=({sq},{sk}) heads={nh} NNZ_S={nnz_s}",
            out, ref_out, lse, ref_lse,
        )
    print(f"  -> {passed}/{total} passed ({skipped} param combos skipped)\n")
    return passed, total


def run_varlen_sparse():
    """varlen_fwd_sparse vs dense varlen reference (sparse pattern == full)."""
    print("== test_sparse_attention_varlen (varlen_fwd_sparse) ==")
    DTYPES = [torch.bfloat16, torch.float16]
    SEQ_LENS_LIST = [
        [(1024, 1328)],
        [(1024, 1328), (1, 2048)],
        [(1025, 2049), (2, 1281)],
    ]
    HEAD_SIZE = 128
    NNZ_S = 20
    NNZ_V = 2048
    num_heads = 1
    passed = total = 0
    for dtype, seq_lens in itertools.product(DTYPES, SEQ_LENS_LIST):
        torch.cuda.manual_seed_all(0)
        query_lens = [x[0] for x in seq_lens]
        kv_lens = [x[1] for x in seq_lens]
        query = torch.randn(sum(query_lens), num_heads, HEAD_SIZE, dtype=dtype)
        key = torch.randn(sum(kv_lens), num_heads, HEAD_SIZE, dtype=dtype)
        value = torch.randn_like(key)
        cu_q = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(0, dtype=torch.int32)
        cu_k = torch.tensor([0] + kv_lens, dtype=torch.int32).cumsum(0, dtype=torch.int32)
        max_q = max(query_lens)
        max_k = max(kv_lens)
        num_rows = (max_q + BLOCK_M - 1) // BLOCK_M
        bsz = len(query_lens)

        bc, cc, bo, ci = [], [], [], []
        for bi in range(bsz):
            bc.append(torch.full((num_heads, num_rows), NNZ_S, dtype=torch.int32))
            cols = kv_lens[bi] - NNZ_S * BLOCK_N
            cc.append(torch.full((num_heads, num_rows), cols, dtype=torch.int32))
            bo.append(torch.tensor(
                [[i * BLOCK_N for i in range(NNZ_S)]] * num_rows * num_heads,
                dtype=torch.int32).reshape(num_heads, num_rows, NNZ_S))
            ci.append(torch.tensor(
                [[NNZ_S * BLOCK_N + i for i in range(NNZ_V)]] * num_rows * num_heads,
                dtype=torch.int32).reshape(num_heads, num_rows, NNZ_V))
        block_count = torch.concat(bc).reshape(bsz, num_heads, num_rows)
        column_count = torch.concat(cc).reshape(bsz, num_heads, num_rows)
        block_offset = torch.concat(bo).reshape(bsz, num_heads, num_rows, NNZ_S)
        column_index = torch.concat(ci).reshape(bsz, num_heads, num_rows, NNZ_V)

        out, lse = sparse_attn_varlen_func(
            query, key, value,
            block_count, block_offset, column_count, column_index,
            cu_seqlens_q=cu_q, cu_seqlens_k=cu_k,
            max_seqlen_q=max_q, max_seqlen_k=max_k,
            return_softmax_lse=True,
        )
        ref_out, ref_lse = flash_attn_varlen_func(
            query, key, value,
            cu_seqlens_q=cu_q, cu_seqlens_k=cu_k,
            max_seqlen_q=max_q, max_seqlen_k=max_k,
            return_softmax_lse=True,
        )
        total += 1
        passed += check(
            f"dtype={dtype} seq_lens={seq_lens}",
            out, ref_out, lse, ref_lse,
        )
    print(f"  -> {passed}/{total} passed\n")
    return passed, total


def main():
    assert torch.cuda.is_available(), "needs a CUDA device"
    torch.set_default_device("cuda")

    # Sanity: the schemas must carry the (re-added) trailing `gen` arg.
    for op in ("fwd_sparse", "varlen_fwd_sparse"):
        schema = str(getattr(torch.ops._vllm_fa2_C, op).default._schema)
        assert "Tensor? gen)" in schema, f"{op} is missing the gen arg!"
        print(f"schema ok (gen present): {op}")
    print()

    p1, t1 = run_dense_sparse()
    p2, t2 = run_varlen_sparse()
    print(f"TOTAL: {p1 + p2}/{t1 + t2} passed")
    raise SystemExit(0 if (p1 + p2) == (t1 + t2) else 1)


if __name__ == "__main__":
    main()
```

</details>

## Test Result

All FA2 tests passed. the failing ones are in FA3:
```
====================================================== short test summary info =======================================================
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads0-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads0-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads0-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads0-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads1-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads1-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads1-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads1-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads0-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads0-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads0-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads0-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads1-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads1-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads1-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads1-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads0-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads0-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads0-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads0-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads1-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads1-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads1-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads1-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads0-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads0-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads0-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads0-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads1-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads1-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads1-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads1-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
======================== 32 failed, 192 passed, 160 skipped, 256 deselected, 16 warnings in 135.94s (0:02:15) ========================
<sys>:0: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

Everything passed in my smoke tests.
```
(vllm-fa2-pt210) ➜  vllm-flash-attn git:(vllm-yank-dropout-fa2) python /home/janeyx/repos/sparse_op_smoke.py
schema ok (gen present): fwd_sparse
schema ok (gen present): varlen_fwd_sparse

== test_sparse_attention (fwd_sparse) ==
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=1 NNZ_S=0
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=1 NNZ_S=1
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=1 NNZ_S=2
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=1 NNZ_S=7
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=1 NNZ_S=15
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=2 NNZ_S=0
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=2 NNZ_S=1
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=2 NNZ_S=2
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=2 NNZ_S=7
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=2 NNZ_S=15
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=4 NNZ_S=0
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=4 NNZ_S=1
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=4 NNZ_S=2
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=4 NNZ_S=7
  PASS  dtype=torch.bfloat16 seq=(1,1024) heads=4 NNZ_S=15
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=1 NNZ_S=0
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=1 NNZ_S=1
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=1 NNZ_S=2
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=1 NNZ_S=7
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=1 NNZ_S=15
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=2 NNZ_S=0
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=2 NNZ_S=1
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=2 NNZ_S=2
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=2 NNZ_S=7
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=2 NNZ_S=15
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=4 NNZ_S=0
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=4 NNZ_S=1
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=4 NNZ_S=2
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=4 NNZ_S=7
  PASS  dtype=torch.bfloat16 seq=(1023,1023) heads=4 NNZ_S=15
  PASS  dtype=torch.bfloat16 seq=(129,129) heads=1 NNZ_S=0
  PASS  dtype=torch.bfloat16 seq=(129,129) heads=1 NNZ_S=1
  PASS  dtype=torch.bfloat16 seq=(129,129) heads=1 NNZ_S=2
  PASS  dtype=torch.bfloat16 seq=(129,129) heads=2 NNZ_S=0
  PASS  dtype=torch.bfloat16 seq=(129,129) heads=2 NNZ_S=1
  PASS  dtype=torch.bfloat16 seq=(129,129) heads=2 NNZ_S=2
  PASS  dtype=torch.bfloat16 seq=(129,129) heads=4 NNZ_S=0
  PASS  dtype=torch.bfloat16 seq=(129,129) heads=4 NNZ_S=1
  PASS  dtype=torch.bfloat16 seq=(129,129) heads=4 NNZ_S=2
  PASS  dtype=torch.bfloat16 seq=(32,32) heads=1 NNZ_S=0
  PASS  dtype=torch.bfloat16 seq=(32,32) heads=2 NNZ_S=0
  PASS  dtype=torch.bfloat16 seq=(32,32) heads=4 NNZ_S=0
  PASS  dtype=torch.float16 seq=(1,1024) heads=1 NNZ_S=0
  PASS  dtype=torch.float16 seq=(1,1024) heads=1 NNZ_S=1
  PASS  dtype=torch.float16 seq=(1,1024) heads=1 NNZ_S=2
  PASS  dtype=torch.float16 seq=(1,1024) heads=1 NNZ_S=7
  PASS  dtype=torch.float16 seq=(1,1024) heads=1 NNZ_S=15
  PASS  dtype=torch.float16 seq=(1,1024) heads=2 NNZ_S=0
  PASS  dtype=torch.float16 seq=(1,1024) heads=2 NNZ_S=1
  PASS  dtype=torch.float16 seq=(1,1024) heads=2 NNZ_S=2
  PASS  dtype=torch.float16 seq=(1,1024) heads=2 NNZ_S=7
  PASS  dtype=torch.float16 seq=(1,1024) heads=2 NNZ_S=15
  PASS  dtype=torch.float16 seq=(1,1024) heads=4 NNZ_S=0
  PASS  dtype=torch.float16 seq=(1,1024) heads=4 NNZ_S=1
  PASS  dtype=torch.float16 seq=(1,1024) heads=4 NNZ_S=2
  PASS  dtype=torch.float16 seq=(1,1024) heads=4 NNZ_S=7
  PASS  dtype=torch.float16 seq=(1,1024) heads=4 NNZ_S=15
  PASS  dtype=torch.float16 seq=(1023,1023) heads=1 NNZ_S=0
  PASS  dtype=torch.float16 seq=(1023,1023) heads=1 NNZ_S=1
  PASS  dtype=torch.float16 seq=(1023,1023) heads=1 NNZ_S=2
  PASS  dtype=torch.float16 seq=(1023,1023) heads=1 NNZ_S=7
  PASS  dtype=torch.float16 seq=(1023,1023) heads=1 NNZ_S=15
  PASS  dtype=torch.float16 seq=(1023,1023) heads=2 NNZ_S=0
  PASS  dtype=torch.float16 seq=(1023,1023) heads=2 NNZ_S=1
  PASS  dtype=torch.float16 seq=(1023,1023) heads=2 NNZ_S=2
  PASS  dtype=torch.float16 seq=(1023,1023) heads=2 NNZ_S=7
  PASS  dtype=torch.float16 seq=(1023,1023) heads=2 NNZ_S=15
  PASS  dtype=torch.float16 seq=(1023,1023) heads=4 NNZ_S=0
  PASS  dtype=torch.float16 seq=(1023,1023) heads=4 NNZ_S=1
  PASS  dtype=torch.float16 seq=(1023,1023) heads=4 NNZ_S=2
  PASS  dtype=torch.float16 seq=(1023,1023) heads=4 NNZ_S=7
  PASS  dtype=torch.float16 seq=(1023,1023) heads=4 NNZ_S=15
  PASS  dtype=torch.float16 seq=(129,129) heads=1 NNZ_S=0
  PASS  dtype=torch.float16 seq=(129,129) heads=1 NNZ_S=1
  PASS  dtype=torch.float16 seq=(129,129) heads=1 NNZ_S=2
  PASS  dtype=torch.float16 seq=(129,129) heads=2 NNZ_S=0
  PASS  dtype=torch.float16 seq=(129,129) heads=2 NNZ_S=1
  PASS  dtype=torch.float16 seq=(129,129) heads=2 NNZ_S=2
  PASS  dtype=torch.float16 seq=(129,129) heads=4 NNZ_S=0
  PASS  dtype=torch.float16 seq=(129,129) heads=4 NNZ_S=1
  PASS  dtype=torch.float16 seq=(129,129) heads=4 NNZ_S=2
  PASS  dtype=torch.float16 seq=(32,32) heads=1 NNZ_S=0
  PASS  dtype=torch.float16 seq=(32,32) heads=2 NNZ_S=0
  PASS  dtype=torch.float16 seq=(32,32) heads=4 NNZ_S=0
  -> 84/84 passed (36 param combos skipped)

== test_sparse_attention_varlen (varlen_fwd_sparse) ==
  PASS  dtype=torch.bfloat16 seq_lens=[(1024, 1328)]
  PASS  dtype=torch.bfloat16 seq_lens=[(1024, 1328), (1, 2048)]
  PASS  dtype=torch.bfloat16 seq_lens=[(1025, 2049), (2, 1281)]
  PASS  dtype=torch.float16 seq_lens=[(1024, 1328)]
  PASS  dtype=torch.float16 seq_lens=[(1024, 1328), (1, 2048)]
  PASS  dtype=torch.float16 seq_lens=[(1025, 2049), (2, 1281)]
  -> 6/6 passed

TOTAL: 90/90 passed
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

