### PR TITLE
Fix gpt-oss-20b NVFP4 (ModelOpt) inference

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -815,6 +815,9 @@ def nvfp4_moe_quant_config(
     w2_bias: torch.Tensor | None = None,
     is_scale_swizzled: bool = True,
     gemm1_clamp_limit: float | None = None,
+    # Bug 3: clamped-SwiGLU (swigluoai) alpha/beta (clamp limit above).
+    gemm1_alpha: float | None = None,
+    gemm1_beta: float | None = None,
 ) -> FusedMoEQuantConfig:
     """
     Construct a quant config for mxfp4 activations and nvp4 weights.
@@ -834,6 +837,9 @@ def nvfp4_moe_quant_config(
         block_shape=None,
         is_scale_swizzled=is_scale_swizzled,
         gemm1_clamp_limit=gemm1_clamp_limit,
+        # Bug 3: clamped-SwiGLU (swigluoai) alpha/beta (clamp limit above).
+        gemm1_alpha=gemm1_alpha,
+        gemm1_beta=gemm1_beta,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -94,6 +94,25 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         # - skip input activation quantization (kernel applies scaling)
         self.use_deepseek_fp8_block_scale = quant_config.is_block_quantized
         self.max_capture_size = moe_config.max_capture_size
+
+        # Bug 3a: read the clamped-SwiGLU (swigluoai) constants from the quant
+        # config so the nvfp4 path gets them too. Upstream only set gemm1_alpha/
+        # gemm1_beta in the mxfp4 branch below, so nvfp4 swigluoai (gpt-oss) ran
+        # plain SwiGLU without the clamp. Other models leave these None.
+        self.gemm1_alpha: torch.Tensor | None = None
+        if quant_config.gemm1_alpha is not None:
+            self.gemm1_alpha = torch.tensor(
+                [quant_config.gemm1_alpha] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
+        self.gemm1_beta: torch.Tensor | None = None
+        if quant_config.gemm1_beta is not None:
+            self.gemm1_beta = torch.tensor(
+                [quant_config.gemm1_beta] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
         self.gemm1_clamp_limit: torch.Tensor | None = None
         if quant_config.gemm1_clamp_limit is not None:
             self.gemm1_clamp_limit = torch.tensor(
@@ -322,6 +341,22 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             # FlashInfer API requires weight to be long for nvfp4
             fc1_expert_weights = w1.view(torch.long)
             fc2_expert_weights = w2.view(torch.long)
+            if activation == MoEActivation.SWIGLUOAI:
+                # Bug 3b: pass the expert biases and clamped-SwiGLU params in the
+                # nvfp4 branch (previously only the mxfp4 branch did this).
+                fc1_expert_biases = self.w1_bias
+                fc2_expert_biases = self.w2_bias
+                swiglu_alpha = self.gemm1_alpha
+                swiglu_beta = self.gemm1_beta
+                swiglu_limit = self.gemm1_clamp_limit
+                # Bug 3c: GPT-OSS gate/up bias is interleaved ([g0,u0,...]);
+                # de-interleave to [up, gate] (odd then even) to match the w13
+                # weight reorder in prepare_nvfp4_moe_layer_for_fi_or_cutlass.
+                if fc1_expert_biases is not None:
+                    fc1_expert_biases = torch.cat(
+                        [fc1_expert_biases[..., 1::2], fc1_expert_biases[..., 0::2]],
+                        dim=-1,
+                    ).contiguous()
         elif self.weight_quant_dtype == "mxfp4":
             assert self.w1_scale is not None and self.w2_scale is not None
             assert w1.is_contiguous() and w2.is_contiguous()

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -418,6 +418,12 @@ def make_nvfp4_moe_quant_config(
     a13_scale: torch.Tensor,
     a2_scale: torch.Tensor,
     swiglu_limit: float | None = None,
+    # Bug 3: clamped-SwiGLU (swigluoai) alpha/beta (clamp limit above).
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
+    # Bug 1: per-expert biases.
+    w13_bias: torch.Tensor | None = None,
+    w2_bias: torch.Tensor | None = None,
 ) -> FusedMoEQuantConfig:
     if backend == NvFp4MoeBackend.MARLIN:
         return nvfp4_w4a16_moe_quant_config(
@@ -436,6 +442,12 @@ def make_nvfp4_moe_quant_config(
             w1_scale=w13_scale,
             w2_scale=w2_scale,
             gemm1_clamp_limit=swiglu_limit,
+            # Bug 3: clamped-SwiGLU (swigluoai) alpha/beta (clamp limit above).
+            gemm1_alpha=swiglu_alpha,
+            gemm1_beta=swiglu_beta,
+            # Bug 1: per-expert biases.
+            w1_bias=w13_bias,
+            w2_bias=w2_bias,
         )
 
     # Pass w13_scale_2 / w2_scale_2 directly as g1/g2_alphas.
@@ -460,6 +472,12 @@ def make_nvfp4_moe_quant_config(
             )
         ),
         gemm1_clamp_limit=swiglu_limit,
+        # Bug 3: clamped-SwiGLU (swigluoai) alpha/beta (clamp limit above).
+        gemm1_alpha=swiglu_alpha,
+        gemm1_beta=swiglu_beta,
+        # Bug 1: per-expert biases.
+        w1_bias=w13_bias,
+        w2_bias=w2_bias,
     )
 
 

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1548,6 +1548,30 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         )
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
+        # Bug 1: register expert biases. GPT-OSS has per-expert
+        # biases; without this, loading fails with KeyError: ...experts.w2_bias.
+        # Bias stays bf16 (not quantized) and is applied by the kernel. Only
+        # registered when the MoE layer declares biases, so bias-free models are
+        # unaffected.
+        if self.moe.has_bias:
+            w13_bias = torch.nn.Parameter(
+                torch.zeros(
+                    num_experts,
+                    w13_num_shards * intermediate_size_per_partition,
+                    dtype=torch.bfloat16,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w13_bias", w13_bias)
+            set_weight_attrs(w13_bias, extra_weight_attrs)
+
+            w2_bias = torch.nn.Parameter(
+                torch.zeros(num_experts, hidden_size, dtype=torch.bfloat16),
+                requires_grad=False,
+            )
+            layer.register_parameter("w2_bias", w2_bias)
+            set_weight_attrs(w2_bias, extra_weight_attrs)
+
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         """
         Convert NVFP4 MoE weights into kernel format and setup the kernel.
@@ -1616,6 +1640,14 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             a13_scale=layer.w13_input_scale,
             a2_scale=layer.w2_input_scale,
             swiglu_limit=getattr(layer, "swiglu_limit", None),
+            # Bug 3: clamped-SwiGLU (swigluoai) alpha/beta, set on the layer by
+            # the model (gpt-oss). The values flow into the MoE quant config and
+            # on to the kernel.
+            swiglu_alpha=getattr(layer, "swiglu_alpha", None),
+            swiglu_beta=getattr(layer, "swiglu_beta", None),
+            # Bug 1: per-expert biases.
+            w13_bias=getattr(layer, "w13_bias", None),
+            w2_bias=getattr(layer, "w2_bias", None),
         )
 
     @property

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import torch
 
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     align_fp4_moe_weights_for_fi,
     align_trtllm_fp4_moe_hidden_dim_for_fi,
@@ -317,7 +318,18 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
             NvFp4MoeBackend.FLASHINFER_B12X,
         ]
     ):
-        w13, w13_scale = reorder_w1w3_to_w3w1(w13, w13_scale)
+        # Bug 3c: GPT-OSS stores gate/up INTERLEAVED ([g0,u0,g1,u1,...]); the FI
+        # kernels want them de-interleaved AND in [w3,w1] (up,gate) order. Both
+        # reduce to selecting odd (up) rows then even (gate) rows. Packing is on
+        # the last (hidden) dim, so reordering dim -2 rows is safe. The bias is
+        # reordered to match in experts.apply.
+        if layer.activation == MoEActivation.SWIGLUOAI:
+            w13 = torch.cat([w13[:, 1::2], w13[:, 0::2]], dim=-2).contiguous()
+            w13_scale = torch.cat(
+                [w13_scale[:, 1::2], w13_scale[:, 0::2]], dim=-2
+            ).contiguous()
+        else:
+            w13, w13_scale = reorder_w1w3_to_w3w1(w13, w13_scale)
 
     # For some FI kernels, the input scales are shared by all experts.
     if is_global_sf_supported_for_nvfp4_backend(backend):

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -199,6 +199,13 @@ class MLPBlock(torch.nn.Module):
             apply_router_weight_on_input=False,
             has_bias=True,
             activation="swigluoai",
+            # Bug 3: gpt-oss uses clamped SwiGLU. Setting these on the layer
+            # routes the MoE to a clamp-capable backend and threads the constants
+            # through to the kernel (needed for the nvfp4 path; mxfp4 already
+            # hardcodes the same values).
+            swiglu_alpha=1.702,
+            swiglu_beta=1.0,
+            swiglu_limit=7.0,
             is_sequence_parallel=self.is_sequence_parallel,
         )
 
@@ -988,6 +995,20 @@ class GptOssModel(nn.Module, EagleModelMixin):
             if is_pp_missing_parameter(name, self):
                 continue
 
+            # Bug 2b: load the per-tensor scales. ModelOpt
+            # exports a single global scalar for the fused experts; broadcast
+            # it across the per-expert parameter. (Must precede the
+            # ".w13_weight"/".w2_weight" substring checks below, since
+            # "w13_weight_scale_2" contains "w13_weight".)
+            if name.endswith("_weight_scale_2") or name.endswith("_input_scale"):
+                param = params_dict[name]
+                if weight.numel() == 1:
+                    param.data.fill_(weight.reshape(-1)[0].to(param.dtype))
+                else:
+                    param.data.copy_(weight.to(param.dtype).reshape(param.shape))
+                loaded_params.add(name)
+                continue
+
             if ".w13_weight" in name:
                 # Handle MLP gate and up projection weights
                 # Extract gate and up projection parts
@@ -1169,6 +1190,16 @@ class GptOssForCausalLM(
             ".down_proj.weight_scale": ".w2_weight_scale",
             ".down_proj.bias": ".w2_bias",
             ".down_proj.input_scale": ".w2_input_scale",
+            # Bug 2a: map ModelOpt's underscore scale-key names
+            # (without these, the scales silently fail to load). NOTE: longer
+            # suffixes must precede shorter ones so e.g. _weight_scale_2 is not
+            # shadowed by _weight_scale.
+            ".gate_up_proj_weight_scale_2": ".w13_weight_scale_2",
+            ".down_proj_weight_scale_2": ".w2_weight_scale_2",
+            ".gate_up_proj_weight_scale": ".w13_weight_scale",
+            ".down_proj_weight_scale": ".w2_weight_scale",
+            ".gate_up_proj_input_scale": ".w13_input_scale",
+            ".down_proj_input_scale": ".w2_input_scale",
         },
     )
 


### PR DESCRIPTION
**Summary:**

Fixes https://github.com/vllm-project/vllm/issues/46641. Marked as draft currently to label each bug fix with comments. Happy to break PR into smaller fixes.

**Details:**

Fixes for each bug (numbered according to https://github.com/vllm-project/vllm/issues/46641):

1   modelopt.py: register w13_bias/w2_bias for the NVFP4 MoE (GPT-OSS has
    expert biases) and thread bias + clamped-SwiGLU params into the quant
    config; previously loading failed with KeyError: ...experts.w2_bias.

2a  gpt_oss.py: map ModelOpt's underscore scale keys (gate_up_proj_weight_
    scale/_2/_input_scale, down_proj_*) so the scales actually load
    (previously silently dropped -> NaN logits -> "!!!!" output).

2b  gpt_oss.py: broadcast ModelOpt's scalar per-tensor scales
    (weight_scale_2/input_scale) to the per-expert parameters.

3a  flashinfer_cutlass_moe.py: set the clamped-SwiGLU constants for any
    swigluoai activation, not just mxfp4.

3b  flashinfer_cutlass_moe.py: pass expert biases + swiglu params in the
    nvfp4 apply branch (previously only the mxfp4 branch did).

3c  flashinfer_fp4_moe.py / cutlass apply: GPT-OSS gate/up is interleaved;
    de-interleave (odd-then-even) the w13 weight/scale and the bias for the
    FlashInfer kernels. flashinfer_utils.py: map SWIGLUOAI -> Swiglu (the
    clamp params make it the OAI variant).

4   trtllm_nvfp4_moe.py: exclude SWIGLUOAI from the TRTLLM backend (its
    Gemm2 kernel has no working variant for GPT-OSS); the oracle falls
    through to FLASHINFER_CUTLASS, which works.

**Test Plan:**

Validated end-to-end: gpt-oss-20b NVFP4 now runs via the cutlass backend with output matching bf16. See https://github.com/vllm-project/vllm/issues/46641 for more details.