### PR TITLE
[ROCm] Remove erroneous inclusion of gptq_marlin as supported quant scheme on ROCm

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -453,7 +453,6 @@ class RocmPlatform(Platform):
         "auto_awq",
         "awq_marlin",  # will be overwritten with awq
         "gptq",
-        "gptq_marlin",
         "auto_gptq",
         "fp8",
         "deepseek_v4_fp8",


### PR DESCRIPTION

https://github.com/vllm-project/vllm/pull/38288 erroneously added gpt_marlin as a supported quantization scheme on ROCm. This is causing test failures like the following: https://buildkite.com/vllm/amd-ci/builds/9903/list?tab=output&jid=019ef8db-be68-43cb-ab67-e7a22f6a6a5c#L3836

Here we remove it. It will be added back in the future if we do indeed add support for gptq_marlin.