### PR TITLE
[ROCm][CI] Relax fused layernorm quant test tolerances for one-ULP outliers

### DIFF
--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 
 import vllm._custom_ops as ops
-from tests.kernels.utils import opcheck
+from tests.kernels.utils import fp8_ulp_distance, opcheck
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
@@ -254,12 +254,16 @@ def test_rms_norm(
     # Per-block bf16 scales: allow a small relative tolerance for a few groups
     # whose abs-max flips by one ULP between the fused and reference paths. The
     # per-token and fp32 paths stay strict.
-    relax_block = group_size is not None and dtype == torch.bfloat16
+    relax_block_rocm = (
+        group_size is not None
+        and dtype == torch.bfloat16
+        and current_platform.is_rocm()
+    )
 
     def scales_close(rtol: float, atol: float) -> bool:
         if torch.allclose(ref_scales, ops_scales, rtol=rtol, atol=atol):
             return True
-        return relax_block and torch.allclose(
+        return relax_block_rocm and torch.allclose(
             ref_scales, ops_scales, rtol=1e-2, atol=atol
         )
 
@@ -273,25 +277,27 @@ def test_rms_norm(
         b = ops_out.to(dtype=torch.float32)
         ok = torch.allclose(a, b, atol=1e-6)
         if not ok:
-            # fallback: compare dequantized values with relaxed tolerance
-            if group_size is None:
-                a_deq = a * ref_scales.view(-1, 1)
-                b_deq = b * ops_scales.view(-1, 1)
+            if relax_block_rocm:
+                # ULP-flipped group scale can cross an E4M3 tie; tolerate a
+                # bounded count of isolated fp8 outliers.
+                ulp = fp8_ulp_distance(ref_out, ops_out)
+                max_outliers = ulp.numel() // 100_000 + 8
+                ok = int((ulp > 0).sum().item()) <= max_outliers
             else:
-                a_deq = a * ref_scales.repeat_interleave(group_size[1], dim=1)
-                b_deq = b * ops_scales.repeat_interleave(group_size[1], dim=1)
-            # NOTE: It is possible that some future test cases trigger this
-            # max diff due to precision issues. If such an error is
-            # encountered, it's recommended to inspect the differences between
-            # all corresponding elements from each tensor (e.g. by looping over
-            # them) and checking how many the max diff error shows up on (just
-            # a few bad elements should still be considered acceptable).
-            close = torch.isclose(a_deq, b_deq, rtol=5e-2, atol=5e-2)
-            # Per-block bf16: tolerate a few isolated outliers where a ULP-flipped
-            # group scale pushes its abs-max element into an adjacent quant
-            # bucket; require an exact match everywhere else.
-            max_outliers = (close.numel() // 100_000 + 8) if relax_block else 0
-            ok = int((~close).sum().item()) <= max_outliers
+                # CUDA (& non-bf16): compare dequantized values with relaxed tolerance.
+                if group_size is None:
+                    a_deq = a * ref_scales.view(-1, 1)
+                    b_deq = b * ops_scales.view(-1, 1)
+                else:
+                    a_deq = a * ref_scales.repeat_interleave(group_size[1], dim=1)
+                    b_deq = b * ops_scales.repeat_interleave(group_size[1], dim=1)
+                # NOTE: It is possible that some future test cases trigger this
+                # max diff due to precision issues. If such an error is
+                # encountered, it's recommended to inspect the differences between
+                # all corresponding elements from each tensor (e.g. by looping over
+                # them) and checking how many the max diff error shows up on (just
+                # a few bad elements should still be considered acceptable).
+                ok = torch.allclose(a_deq, b_deq, rtol=5e-2, atol=5e-2)
         assert ok
     if add_residual:
         assert torch.allclose(ref_residual, ops_residual)

--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -250,12 +250,25 @@ def test_rms_norm(
 
     assert ref_out.dtype == quant_dtype
     assert ops_out.dtype == quant_dtype
+
+    # Per-block bf16 scales: allow a small relative tolerance for a few groups
+    # whose abs-max flips by one ULP between the fused and reference paths. The
+    # per-token and fp32 paths stay strict.
+    relax_block = group_size is not None and dtype == torch.bfloat16
+
+    def scales_close(rtol: float, atol: float) -> bool:
+        if torch.allclose(ref_scales, ops_scales, rtol=rtol, atol=atol):
+            return True
+        return relax_block and torch.allclose(
+            ref_scales, ops_scales, rtol=1e-2, atol=atol
+        )
+
     if quant_dtype == torch.int8:
-        assert torch.allclose(ref_scales, ops_scales, atol=1e-6)
+        assert scales_close(rtol=1e-5, atol=1e-6)
         # big atol to account for round-off errors.
         assert torch.allclose(ref_out, ops_out, atol=1)
     else:
-        assert torch.allclose(ref_scales, ops_scales)
+        assert scales_close(rtol=1e-5, atol=1e-8)
         a = ref_out.to(dtype=torch.float32)
         b = ops_out.to(dtype=torch.float32)
         ok = torch.allclose(a, b, atol=1e-6)
@@ -273,7 +286,12 @@ def test_rms_norm(
             # all corresponding elements from each tensor (e.g. by looping over
             # them) and checking how many the max diff error shows up on (just
             # a few bad elements should still be considered acceptable).
-            ok = torch.allclose(a_deq, b_deq, rtol=5e-2, atol=5e-2)
+            close = torch.isclose(a_deq, b_deq, rtol=5e-2, atol=5e-2)
+            # Per-block bf16: tolerate a few isolated outliers where a ULP-flipped
+            # group scale pushes its abs-max element into an adjacent quant
+            # bucket; require an exact match everywhere else.
+            max_outliers = (close.numel() // 100_000 + 8) if relax_block else 0
+            ok = int((~close).sum().item()) <= max_outliers
         assert ok
     if add_residual:
         assert torch.allclose(ref_residual, ops_residual)

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from tests.kernels.quant_utils import FP8_DTYPE
-from tests.kernels.utils import opcheck
+from tests.kernels.utils import fp8_ulp_distance, opcheck
 from vllm import ir
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm
 from vllm.platforms import current_platform
@@ -204,19 +204,22 @@ def test_fused_rms_norm_quant(
             (out_quant_fused, x, weight, quant_scale_t, 1e-6),
         )
 
-    # Tolerate a tiny number of FP8 tie-boundary outliers between the fused and
-    # unfused paths (one-ULP diffs from FMA contraction on ROCm/HIP) while
-    # requiring an exact match everywhere else.
-    a = out_quant.to(dtype=torch.float32)
-    b = out_quant_fused.to(dtype=torch.float32)
-    close = torch.isclose(a, b, atol=1e-3, rtol=1e-3)
-    max_outliers = close.numel() // 100_000 + 8
-    num_outliers = int((~close).sum().item())
-    assert num_outliers <= max_outliers, (
-        f"FP8 quant mismatch: {num_outliers} elements differ "
-        f"(allowed {max_outliers}); greatest abs diff "
-        f"{(a - b).abs().max().item()}"
-    )
+    if current_platform.is_rocm():
+        # Fused and unfused FP8 paths can land on opposite sides of an E4M3 tie;
+        # tolerate a tiny number of isolated fp8 outliers on ROCm.
+        ulp = fp8_ulp_distance(out_quant, out_quant_fused)
+        max_outliers = ulp.numel() // 100_000 + 8
+        num_outliers = int((ulp > 0).sum().item())
+        assert num_outliers <= max_outliers, (
+            f"FP8 quant mismatch: {num_outliers} fp8 outliers (allowed {max_outliers})"
+        )
+    else:
+        torch.testing.assert_close(
+            out_quant.to(dtype=torch.float32),
+            out_quant_fused.to(dtype=torch.float32),
+            atol=1e-3,
+            rtol=1e-3,
+        )
 
 
 @torch.inference_mode()

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -204,11 +204,18 @@ def test_fused_rms_norm_quant(
             (out_quant_fused, x, weight, quant_scale_t, 1e-6),
         )
 
-    torch.testing.assert_close(
-        out_quant.to(dtype=torch.float32),
-        out_quant_fused.to(dtype=torch.float32),
-        atol=1e-3,
-        rtol=1e-3,
+    # Tolerate a tiny number of FP8 tie-boundary outliers between the fused and
+    # unfused paths (one-ULP diffs from FMA contraction on ROCm/HIP) while
+    # requiring an exact match everywhere else.
+    a = out_quant.to(dtype=torch.float32)
+    b = out_quant_fused.to(dtype=torch.float32)
+    close = torch.isclose(a, b, atol=1e-3, rtol=1e-3)
+    max_outliers = close.numel() // 100_000 + 8
+    num_outliers = int((~close).sum().item())
+    assert num_outliers <= max_outliers, (
+        f"FP8 quant mismatch: {num_outliers} elements differ "
+        f"(allowed {max_outliers}); greatest abs diff "
+        f"{(a - b).abs().max().item()}"
     )
 
 

--- a/tests/kernels/test_fused_deepseek_v4_qnorm_rope_kv_insert.py
+++ b/tests/kernels/test_fused_deepseek_v4_qnorm_rope_kv_insert.py
@@ -19,6 +19,7 @@ The kernel is imported via
 import pytest
 import torch
 
+from tests.kernels.utils import bf16_ulp_distance, fp8_ulp_distance
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     get_fp8_min_max,
 )
@@ -160,35 +161,6 @@ def _call_fused(
     )
 
 
-def _bf16_ulp_distance(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-    """Representable-step distance between two bf16 tensors.
-
-    Reinterprets the bf16 bit patterns under the IEEE-754 total ordering so
-    that adjacent representable values differ by exactly 1.
-    """
-
-    def key(t: torch.Tensor) -> torch.Tensor:
-        u = t.contiguous().view(torch.int16).to(torch.int64) & 0xFFFF
-        return torch.where(u >= 0x8000, 0xFFFF - u, u + 0x8000)
-
-    return (key(a) - key(b)).abs()
-
-
-def _fp8_ulp_distance(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-    """Representable-step distance between two 8-bit fp8 tensors.
-
-    Reinterprets the fp8 bytes under a sign-magnitude total ordering so that
-    adjacent representable values differ by exactly 1. Inputs must already share
-    the same fp8 encoding (e.g. both FP8_STORE_DTYPE).
-    """
-
-    def key(t: torch.Tensor) -> torch.Tensor:
-        u = t.contiguous().view(torch.uint8).to(torch.int64)
-        return torch.where(u >= 0x80, 0xFF - u, u + 0x80)
-
-    return (key(a) - key(b)).abs()
-
-
 def _as_stored_fp8(t: torch.Tensor) -> torch.Tensor:
     """Reinterpret a float8_e4m3fn-typed kernel output under the real (FNUZ on
     gfx942) encoding the kernel actually wrote, without touching the bytes."""
@@ -235,7 +207,7 @@ def _assert_kv_cache_parity(
         rec_fused[:, :NOPE_DIM], rec_ref[:, :NOPE_DIM], rtol=0, atol=0
     )
     max_ulp = int(
-        _bf16_ulp_distance(rec_fused[:, NOPE_DIM:], rec_ref[:, NOPE_DIM:]).max().item()
+        bf16_ulp_distance(rec_fused[:, NOPE_DIM:], rec_ref[:, NOPE_DIM:]).max().item()
     )
     assert max_ulp <= 1, f"RoPE bf16 region differs by {max_ulp} ULP (>1)"
 
@@ -709,7 +681,7 @@ def test_full_cache_per_tensor_fp8_matches_reference(
     # reduction and RoPE rotation can land the kernel and the torch reference on
     # opposite sides of an fp8 round-to-nearest tie, so allow <=1 fp8 ULP.
     q_fused = _as_stored_fp8(q_fp8_fused)
-    q_max_ulp = int(_fp8_ulp_distance(q_fused, q_fp8_ref).max().item())
+    q_max_ulp = int(fp8_ulp_distance(q_fused, q_fp8_ref).max().item())
     assert q_max_ulp <= 1, f"Q fp8 differs by {q_max_ulp} ULP (>1)"
 
     # K-cache NoPE region [0, NOPE_DIM) is a deterministic per-tensor fp8 quant
@@ -723,7 +695,7 @@ def test_full_cache_per_tensor_fp8_matches_reference(
         atol=0,
     )
     k_max_ulp = int(
-        _fp8_ulp_distance(k_fused[..., NOPE_DIM:], k_cache_ref[..., NOPE_DIM:])
+        fp8_ulp_distance(k_fused[..., NOPE_DIM:], k_cache_ref[..., NOPE_DIM:])
         .max()
         .item()
     )

--- a/tests/kernels/utils.py
+++ b/tests/kernels/utils.py
@@ -809,6 +809,35 @@ def fp8_allclose(
     )
 
 
+def bf16_ulp_distance(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Representable-step distance between two bf16 tensors.
+
+    Reinterprets the bf16 bit patterns under the IEEE-754 total ordering so
+    that adjacent representable values differ by exactly 1.
+    """
+
+    def key(t: torch.Tensor) -> torch.Tensor:
+        u = t.contiguous().view(torch.int16).to(torch.int64) & 0xFFFF
+        return torch.where(u >= 0x8000, 0xFFFF - u, u + 0x8000)
+
+    return (key(a) - key(b)).abs()
+
+
+def fp8_ulp_distance(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Representable-step distance between two 8-bit fp8 tensors.
+
+    Reinterprets the fp8 bytes under a sign-magnitude total ordering so that
+    adjacent representable values differ by exactly 1. Inputs must already share
+    the same fp8 encoding (e.g. both FP8_STORE_DTYPE).
+    """
+
+    def key(t: torch.Tensor) -> torch.Tensor:
+        u = t.contiguous().view(torch.uint8).to(torch.int64)
+        return torch.where(u >= 0x80, 0xFF - u, u + 0x80)
+
+    return (key(a) - key(b)).abs()
+
+
 # Marlin MoE test utils
 
 


### PR DESCRIPTION
The fused RMSNorm+quant kernels compute the normalized intermediate and quantization in one pass, while the reference path runs a native fp32 RMS norm followed by a separate quant kernel. The differing fp32 reduction order (and FMA contraction in the x * s_variance * w chain on HIP) occasionally flips a single group's bf16 abs-max by one ULP, or pushes an element across an E4M3 tie boundary into the adjacent quant bucket. Impact is tiny and isolated (e.g. 1 group out of 16k–32k; 2 elements out of ~3M, one FP8 ULP), with everything else bit-exact. This is an expected cross-platform precision artifact, not a kernel bug.

- `test_fused_quant_layernorm.py`: per-block bf16 scale check allows a small relative tolerance (rtol=1e-2, ~one bf16 ULP) on a few groups; fp8 dequant fallback tolerates a bounded count of isolated outliers. Per-token and fp32 paths stay strict.
- `test_layernorm.py`: replaces the bit-exact assert_close(atol/rtol=1e-3) with an outlier-tolerant check (numel//100k + 8 allowed) that still requires an exact match everywhere else.

Fixes the following tests. ([reference buidkite test fail link](https://buildkite.com/vllm/amd-ci/builds/9790/list?sid=019eee8f-10a9-4710-85d0-db0925c65c7b&tab=output))

`kernels/core/test_fused_quant_layernorm.py::test_rms_norm`
`kernels/core/test_layernorm.py::test_fused_rms_norm_quant`

