### PR TITLE
[CI] Build macOS arm64 CPU wheels via GitHub-hosted runners

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -76,6 +76,23 @@ steps:
         env:
           DOCKER_BUILDKIT: "1"
 
+      - label: "Build wheel - macOS arm64 - CPU"
+        depends_on: ~
+        id: build-wheel-macos-arm64-cpu
+        agents:
+          queue: cpu_queue_release
+        timeout_in_minutes: 90
+        commands:
+          # Built on a GitHub-hosted Apple Silicon runner (no macOS BK agent);
+          # the wheel is downloaded into artifacts/dist for the normal upload.
+          - "bash .buildkite/scripts/build-macos-wheel-via-gha.sh"
+          - "VLLM_WHEEL_PLATFORM=macos bash .buildkite/scripts/upload-nightly-wheels.sh"
+          - 'bash .buildkite/scripts/annotate-build-artifact.sh "$$BUILDKITE_LABEL" "s3://vllm-wheels/$$BUILDKITE_COMMIT/$(cd artifacts/dist && echo *.whl)"'
+        env:
+          # GitHub token with actions:read+write, provisioned to release agents
+          # via ci-infra (AWS Secrets Manager). Adjust to the real secret name.
+          GH_TOKEN: "$${GITHUB_WHEEL_DISPATCH_TOKEN}"
+
       - label: "Build wheel - x86_64 - CUDA 12.9"
         depends_on: ~
         id: build-wheel-x86-cuda-12-9

--- a/.buildkite/scripts/build-macos-wheel-via-gha.sh
+++ b/.buildkite/scripts/build-macos-wheel-via-gha.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Build the macOS arm64 CPU wheel on a GitHub-hosted Apple Silicon runner.
+#
+# vLLM's Buildkite fleet has no macOS agents, and macOS wheels cannot be
+# cross-compiled from Linux. This dispatches the macos-wheel.yml GitHub Actions
+# workflow (which runs on macos-latest), waits for it, and downloads the wheel
+# into artifacts/dist/ so the normal upload-nightly-wheels.sh path can take it
+# from here -- the macOS wheel flows through the release pipeline like any other.
+#
+# Requires the `gh` CLI and GH_TOKEN with actions:read+write on the repo.
+
+set -euo pipefail
+
+REPO="${MACOS_WHEEL_REPO:-vllm-project/vllm}"
+WORKFLOW="${MACOS_WHEEL_WORKFLOW:-macos-wheel.yml}"
+SHA="${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is not set}"
+# Unique handle, set as the workflow run-name, so we can find the run we just
+# dispatched (gh workflow run does not return a run id).
+BK_ID="${BUILDKITE_BUILD_ID:-manual-${SHA}}"
+RUN_NAME="macos-wheel ${BK_ID}"
+
+echo "Dispatching ${WORKFLOW} on ${REPO} for ${SHA} (bk_id=${BK_ID})"
+gh workflow run "${WORKFLOW}" --repo "${REPO}" -f sha="${SHA}" -f bk_id="${BK_ID}"
+
+# Dispatch is async; poll for the run with our unique run-name to appear.
+RUN_ID=""
+for _ in $(seq 1 30); do
+  RUN_ID="$(gh run list --repo "${REPO}" --workflow "${WORKFLOW}" \
+    --json databaseId,name \
+    -q "[.[] | select(.name == \"${RUN_NAME}\")][0].databaseId")"
+  if [[ -n "${RUN_ID}" && "${RUN_ID}" != "null" ]]; then
+    break
+  fi
+  sleep 10
+done
+if [[ -z "${RUN_ID}" || "${RUN_ID}" == "null" ]]; then
+  echo "ERROR: could not locate dispatched run named '${RUN_NAME}'" >&2
+  exit 1
+fi
+echo "Dispatched run ${RUN_ID}: https://github.com/${REPO}/actions/runs/${RUN_ID}"
+
+# Block until the run finishes; non-zero exit if it failed.
+gh run watch "${RUN_ID}" --repo "${REPO}" --exit-status
+
+# Place the wheel where upload-nightly-wheels.sh expects it (artifacts/dist/*.whl).
+mkdir -p artifacts/dist
+gh run download "${RUN_ID}" --repo "${REPO}" -n macos-wheel -D artifacts/dist
+echo "Downloaded wheel(s):"
+ls -l artifacts/dist/*.whl

--- a/.buildkite/scripts/upload-nightly-wheels.sh
+++ b/.buildkite/scripts/upload-nightly-wheels.sh
@@ -6,8 +6,14 @@ set -ex
 # manylinux platform tag with auditwheel.
 # Index generation is handled separately by generate-and-upload-nightly-index.sh.
 
-# shellcheck source=lib/manylinux.sh
-source .buildkite/scripts/lib/manylinux.sh
+# macOS wheels already carry a valid macosx_*_arm64 platform tag and auditwheel
+# is Linux-only, so skip the manylinux retag (and its Docker helper) for them.
+WHEEL_PLATFORM="${VLLM_WHEEL_PLATFORM:-linux}"
+
+if [[ "$WHEEL_PLATFORM" == "linux" ]]; then
+  # shellcheck source=lib/manylinux.sh
+  source .buildkite/scripts/lib/manylinux.sh
+fi
 
 BUCKET="vllm-wheels"
 SUBPATH=$BUILDKITE_COMMIT
@@ -27,8 +33,10 @@ wheel="${wheel_files[0]}"
 
 # ========= detect manylinux tag and rename ==========
 
-wheel="$(apply_manylinux_tag "$wheel")"
-echo "Renamed wheel to: $wheel"
+if [[ "$WHEEL_PLATFORM" == "linux" ]]; then
+  wheel="$(apply_manylinux_tag "$wheel")"
+  echo "Renamed wheel to: $wheel"
+fi
 
 # Extract the version from the wheel
 version=$(unzip -p "$wheel" '**/METADATA' | grep '^Version: ' | cut -d' ' -f2)

--- a/.github/workflows/macos-wheel.yml
+++ b/.github/workflows/macos-wheel.yml
@@ -1,0 +1,57 @@
+name: Build macOS arm64 CPU wheel
+run-name: "macos-wheel ${{ inputs.bk_id }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to build"
+        required: true
+      bk_id:
+        description: "Buildkite correlation id (used for run-name lookup)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-latest  # native Apple Silicon, free for public repos
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6.0.1
+        with:
+          ref: "${{ inputs.sha }}"
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install protoc
+        # Required by the Rust frontend's vllm-server build script (prost/tonic).
+        run: brew install protobuf
+
+      - name: Build wheel
+        env:
+          VLLM_TARGET_DEVICE: cpu
+          # Fail loudly if the Rust frontend can't build, rather than shipping
+          # a wheel that silently dropped it.
+          VLLM_REQUIRE_RUST_FRONTEND: "1"
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
+          # Force an arm64-only build and matching wheel tag. uv's CPython is a
+          # universal2 build, so without these the wheel is tagged universal2
+          # while the binaries are arm64-only, and pip would install it on
+          # Intel Macs where import fails.
+          ARCHFLAGS: "-arch arm64"
+          _PYTHON_HOST_PLATFORM: "macosx-11.0-arm64"
+          CMAKE_BUILD_PARALLEL_LEVEL: "4"
+        run: |
+          uv venv
+          uv pip install -r requirements/build/cpu.txt --index-strategy unsafe-best-match
+          uv build --wheel --no-build-isolation -o dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-wheel
+          path: dist/*.whl
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Builds and publishes **macOS Apple Silicon (arm64) CPU wheels** to `wheels.vllm.ai`, alongside the existing Linux CPU wheels.

This unblocks the long-standing problem behind #35428 and #37216: vLLM's Buildkite fleet has **no macOS agent**, and macOS wheels **cannot be cross-compiled from Linux**. The insight here is that we don't need a macOS Buildkite agent at all — GitHub-hosted Apple Silicon runners (`macos-latest`, free for public repos) provide the macOS build environment, and the Buildkite release pipeline drives them:

```
release-pipeline.yaml step (cpu_queue_release, Linux agent)
  └─ build-macos-wheel-via-gha.sh
       ├─ gh workflow run macos-wheel.yml        # dispatch
       ├─ find run by "macos-wheel <bk_id>"       # run-name correlation
       ├─ gh run watch --exit-status              # block; fail if build fails
       └─ gh run download → artifacts/dist/       # pull wheel back
  └─ VLLM_WHEEL_PLATFORM=macos upload-nightly-wheels.sh   # skips Linux-only auditwheel
  └─ annotate-build-artifact.sh → s3://vllm-wheels/$COMMIT/
  → existing index step globs the commit prefix and picks it up
```

The macOS wheel flows through the release pipeline like any other wheel, and is triggered by Buildkite (not on `push`).

## Not a duplicate

Supersedes my earlier #35428 (closed) and #37216 with a materially different approach: instead of needing a macOS Buildkite agent/queue, it builds on GitHub-hosted runners and bridges from Buildkite. The `upload-nightly-wheels.sh` change here is a clean platform gate rather than the runtime script-patching hack flagged in #35428.

## What this needs to go live (CI infra)

Two small agent-side items, neither in this diff:
1. A **GitHub token** with `actions:read+write` on `vllm-project/vllm`, provisioned to `cpu_queue_release` agents. The pipeline step reads `GITHUB_WHEEL_DISPATCH_TOKEN` — **placeholder name, please adjust** to the real secret. (The token is required: artifact *metadata* is anonymously readable but artifact *bytes* return HTTP 401 without auth, and `workflow_dispatch` is a write op.)
2. The **`gh` CLI** available on the agent (or I can rewrite the bridge in plain `curl`).

Also: `macos-wheel.yml` must land on `main` before it's dispatchable (`workflow_dispatch` workflows register from the default branch). It is inert until dispatched.

## Testing

Validated end-to-end on my fork (`mgoin/vllm`), all via `workflow_dispatch`:

- **Workflow builds the wheel** on `macos-latest` (~8 min), 4 green runs.
- **Wheel is correct**: filename + `WHEEL` `Tag:` both `cp312-cp312-macosx_11_0_arm64` (not `universal2`); `file` on the binaries confirms thin arm64.
- **Rust frontend included**: `vllm/vllm-rs` (22.9 MB, arm64) present. An early run silently dropped it because `protoc` was missing and `build_rust` treats the frontend as optional — fixed with `brew install protobuf` + `VLLM_REQUIRE_RUST_FRONTEND=1` (now a hard failure if it can't build).
- **Bridge script** (`build-macos-wheel-via-gha.sh`) run end-to-end against the fork using a real token: dispatch → correlate by `bk_id` → watch to green → download into `artifacts/dist/`, exit 0.
- **Upload gate**: `VLLM_WHEEL_PLATFORM=macos bash upload-nightly-wheels.sh` traced with stubbed `aws`/`docker` — skips the manylinux/auditwheel path and its Docker helper entirely, leaves the wheel untouched, reaches `aws s3 cp` to the commit prefix.

Not testable without the production agent: the provisioned token, `gh` on the agent, and the real S3 upload.

## AI assistance

This change was developed with AI assistance (Claude). I have reviewed every line and run the tests above.
