### PR TITLE
[Bugfix][Frontend] Fix reasoning-end detection to check prompt tail only

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2127,3 +2127,49 @@ async def test_streaming_n_gt1_independent_tool_parsers():
             f"Choice {choice_idx}: expected finish_reason='tool_calls', "
             f"got '{reasons[0]}'"
         )
+
+
+class TestPromptEndsReasoning:
+    """Unit tests for OpenAIServingChat._prompt_ends_reasoning.
+
+    The helper must inspect only the *tail* of the prompt so that an
+    end-of-reasoning token that appeared in an earlier turn (e.g. a
+    few-shot example) doesn't incorrectly signal that reasoning is done.
+    """
+
+    class _DummyParser:
+        """Minimal Parser stand-in: is_reasoning_end fires on a specific token id."""
+
+        def __init__(self, end_token_id: int):
+            self.end_token_id = end_token_id
+            self.reasoning_parser = True  # non-None so the calling code proceeds
+
+        def is_reasoning_end(self, input_ids: list[int]) -> bool:
+            return self.end_token_id in input_ids
+
+    def test_only_checks_tail(self):
+        """end-of-reasoning token in the *middle* of the prompt → False."""
+        parser = self._DummyParser(end_token_id=99)
+        assert not OpenAIServingChat._prompt_ends_reasoning(
+            parser,  # type: ignore[arg-type]
+            [1, 99, 2],
+        )
+
+    def test_tail_token_returns_true(self):
+        """end-of-reasoning token as the *last* prompt token → True."""
+        parser = self._DummyParser(end_token_id=99)
+        assert OpenAIServingChat._prompt_ends_reasoning(
+            parser,  # type: ignore[arg-type]
+            [1, 2, 99],
+        )
+
+    def test_empty_prompt_returns_false(self):
+        parser = self._DummyParser(end_token_id=99)
+        assert not OpenAIServingChat._prompt_ends_reasoning(
+            parser,  # type: ignore[arg-type]
+            [],
+        )
+        assert not OpenAIServingChat._prompt_ends_reasoning(
+            parser,  # type: ignore[arg-type]
+            None,
+        )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -346,7 +346,9 @@ class OpenAIServingChat(OpenAIServing):
                     # non-reasoning outputs.
                     reasoning_ended = True
                 elif parser is not None and parser.reasoning_parser is not None:
-                    reasoning_ended = parser.is_reasoning_end(prompt_token_ids or [])
+                    reasoning_ended = self._prompt_ends_reasoning(
+                        parser, prompt_token_ids
+                    )
                 else:
                     reasoning_ended = None
 
@@ -395,6 +397,22 @@ class OpenAIServingChat(OpenAIServing):
             parser=parser,
             mm_token_counts=mm_token_counts,
         )
+
+    @staticmethod
+    def _prompt_ends_reasoning(
+        parser: Parser,
+        prompt_token_ids: GenericSequence[int] | None,
+    ) -> bool:
+        """Return True only if the *last* token of the prompt is the reasoning-end token.
+
+        Checking the full prompt would return True whenever the end-of-reasoning token
+        appeared *anywhere* in the prompt (e.g. in a few-shot example or an earlier
+        assistant turn), causing subsequent generations to skip the reasoning phase even
+        though the assistant turn hasn't started reasoning yet.
+        """
+        if not prompt_token_ids:
+            return False
+        return parser.is_reasoning_end(as_list(prompt_token_ids)[-1:])
 
     def get_chat_request_role(self, request: ChatCompletionRequest) -> str:
         if request.add_generation_prompt:


### PR DESCRIPTION
## Summary

Closes the root issue described in #45891 (rebased onto current main after test-file reorganisation).

### Problem

`OpenAIServingChat._create_chat_completion` (non-streaming path) passed the **entire** `prompt_token_ids` list to `parser.is_reasoning_end`:

```python
elif parser is not None and parser.reasoning_parser is not None:
    reasoning_ended = parser.is_reasoning_end(prompt_token_ids or [])
```

If the end-of-reasoning token appeared *anywhere* in the prompt — e.g. in a few-shot example turn or an earlier `<|im_end|>` marker — the check returned `True` and subsequent generations skipped the reasoning phase even though the current assistant turn had not yet ended reasoning.

### Fix

Introduce a small `_prompt_ends_reasoning` static helper that passes only the **last token** of the prompt to `is_reasoning_end`:

```python
@staticmethod
def _prompt_ends_reasoning(
    parser: Parser,
    prompt_token_ids: GenericSequence[int] | None,
) -> bool:
    if not prompt_token_ids:
        return False
    return parser.is_reasoning_end(as_list(prompt_token_ids)[-1:])
```

Checking only the tail matches the actual intent: *does the prompt terminate with an end-of-reasoning marker?*

### Test plan

- [ ] `TestPromptEndsReasoning.test_only_checks_tail` — end-of-reasoning token in the middle of the prompt → `False`
- [ ] `TestPromptEndsReasoning.test_tail_token_returns_true` — end-of-reasoning token as the last token → `True`
- [ ] `TestPromptEndsReasoning.test_empty_prompt_returns_false` — empty / `None` prompt → `False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)