### PR TITLE
[ROCm] Gate AITER MoE GateMode.INTERLEAVE on the gu-interleaved weight layout

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -352,13 +352,13 @@ def rocm_aiter_fused_experts(
         )
 
         # https://github.com/ROCm/aiter/pull/3123 specialized the AITER stage1 GEMMs
-        # for interleaved vs separated gate and up weights.
-        # For gpt-oss i.e. use_mxfp4_w4a16=True, the weights are shuffled by
-        # `rocm_aiter_ops.shuffle_weight_a16w4` in `oracle/mxfp4.py`,
-        # which always sets `is_guinterleave=True`.
-        # Hence, we pass in GateMode.INTERLEAVE to match the weight shuffling.
+        # for interleaved vs separated gate and up weights. Only pass
+        # GateMode.INTERLEAVE when the weights were actually shuffled into the
+        # gate-up interleaved layout (gpt-oss); models that keep the separated
+        # layout (e.g. DeepSeek-V4) set `gu_interleaved=False` and must use the
+        # default SEPARATED mode.
         gate_mode = ""
-        if quant_config.use_mxfp4_w4a16:
+        if quant_config.use_mxfp4_w4a16 and getattr(w1, "gu_interleaved", True):
             try:
                 from aiter.ops.flydsl.moe_common import GateMode
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -705,6 +705,11 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         if self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16:
             layer.w13_weight.is_shuffled = True
             layer.w2_weight.is_shuffled = True
+            # This path keeps gate/up in the separated layout (unlike the
+            # gpt-oss gu-interleaved shuffle), so the AITER MoE dispatch must
+            # use GateMode.SEPARATED rather than INTERLEAVE.
+            layer.w13_weight.gu_interleaved = False
+            layer.w2_weight.gu_interleaved = False
 
         if w13_bias is not None and w2_bias is not None:
             replace_parameter(layer, "w13_bias", w13_bias)


### PR DESCRIPTION
#44893 passes `GateMode.INTERLEAVE` for every `use_mxfp4_w4a16` model, but only gpt-oss shuffles its weights into the gate-up interleaved layout. DeepSeek-V4 keeps the separated layout, so INTERLEAVE routes small-M decode to an a16w4 path with no kernel → `RuntimeError: Unsupported kernel config for moe heuristic dispatch`. This marks the separated path and gates INTERLEAVE on it; gpt-oss is unchanged.

**Not a duplicate:** #46122 takes the opposite approach (move DSV4 *onto* gu-interleave + `AITER_BF16_FP8_MOE_BOUND=0`); this keeps DSV4 on the working SEPARATED path with no env-var workaround.

**Test:** `pre-commit run --files <changed>` passes. The resulting SEPARATED routing serves + decodes DeepSeek-V4-Pro (TP8, gfx950) — gsm8k 5-shot 0.945 — whereas the default INTERLEAVE crashes at startup with the dispatch error above.

AI assistance (Claude) was used.