### PR TITLE
[Bugfix] Exclude disagg P/D transfer tokens from cached_tokens (NixlConnector)

### DIFF
--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -288,3 +288,74 @@ def test_prompt_token_stats_full_external_transfer_recompute():
     assert stats.external_kv_transfer == 999
     assert stats.cached_tokens == 999
     assert stats.total == 1000
+
+
+def test_prefill_stats_disagg_transfer_excluded_from_cached():
+    """Disagg transfer tokens are not counted as cached_tokens (issue #43370)."""
+    stats = PromptTokenStats()
+
+    # Cold disagg request: all prompt tokens (minus the recompute token) are
+    # transferred from the remote prefiller, with no real prefix-cache hit.
+    prefill_stats = PrefillStats()
+    prefill_stats.set(
+        num_prompt_tokens=100,
+        num_local_cached_tokens=0,
+        num_external_cached_tokens=0,
+        num_disagg_transfer_tokens=99,
+    )
+    stats.update_from_output(prefill_stats)
+
+    # cached_tokens must be 0 for a cold request, not ~prompt_tokens.
+    assert stats.cached_tokens == 0
+    assert stats.local_cache_hit == 0
+    # external_kv_transfer stays inclusive for Prometheus continuity...
+    assert stats.external_kv_transfer == 99
+    # ...while disagg_transfer isolates the transfer-only subset.
+    assert stats.disagg_transfer == 99
+    assert stats.computed == 1
+    assert stats.total == 100
+
+
+def test_finalize_excludes_disagg_transfer_from_cache_creation():
+    """Transferred tokens must not count as cache-creation work.
+
+    Disagg transfer tokens land in the local prefix cache, so the
+    estimate passed to finalize() includes them. They are excluded from
+    num_cached_tokens by set(), and without the matching exclusion in
+    finalize() they would silently inflate num_cache_creation_tokens
+    (tokens computed and written, which a transfer is not).
+    """
+    prefill_stats = PrefillStats()
+    prefill_stats.set(
+        num_prompt_tokens=100,
+        num_local_cached_tokens=40,
+        num_external_cached_tokens=0,
+        num_disagg_transfer_tokens=50,
+    )
+    # After the step, the 40 prior hits, the 50 transferred tokens and the
+    # 10 locally computed tokens are all resident in the local cache.
+    prefill_stats.finalize(100)
+
+    # Only the 10 locally computed tokens are cache-creation work.
+    assert prefill_stats.num_cache_creation_tokens == 10
+
+
+def test_prefill_stats_local_cache_hit_still_counted_with_disagg():
+    """A real local prefix-cache hit is still reported even on a disagg worker."""
+    stats = PromptTokenStats()
+
+    prefill_stats = PrefillStats()
+    prefill_stats.set(
+        num_prompt_tokens=100,
+        num_local_cached_tokens=40,
+        num_external_cached_tokens=0,
+        num_disagg_transfer_tokens=50,
+    )
+    stats.update_from_output(prefill_stats)
+
+    # Local APC hits remain in cached_tokens; only the transfer is excluded.
+    assert stats.cached_tokens == 40
+    assert stats.local_cache_hit == 40
+    assert stats.disagg_transfer == 50
+    assert stats.computed == 10
+    assert stats.total == 100

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -193,6 +193,21 @@ class KVConnectorBase_V1(ABC):
         """
         return self._kv_transfer_config.is_kv_producer
 
+    @property
+    def is_disagg_prefill_transfer(self) -> bool:
+        """
+        Whether the tokens this connector reports via
+        get_num_new_matched_tokens are transferred from a disaggregated prefill
+        worker rather than served from a reusable KV cache.
+
+        Transfer tokens are moved from another engine for this request and are
+        not prefix-cache hits, so they must be excluded from the cached_tokens
+        reported in the API response (see #43370). Cache-store connectors (e.g.
+        LMCache, MooncakeStore) should leave this False, since their external
+        tokens are genuine cache hits. Defaults to False.
+        """
+        return False
+
     def __init__(
         self,
         vllm_config: "VllmConfig",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
@@ -160,6 +160,14 @@ class NixlBaseConnector(KVConnectorBase_V1, SupportsHMA):
     # Scheduler Side Methods
     ############################################################
 
+    @property
+    def is_disagg_prefill_transfer(self) -> bool:
+        # NIXL is purely a prefill/decode KV-transfer connector: every token it
+        # reports via get_num_new_matched_tokens is pulled/pushed from another
+        # engine for this request, never a reusable prefix-cache hit, so it is
+        # excluded from cached_tokens in the API response (see #43370).
+        return True
+
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int
     ) -> tuple[int | None, bool]:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -839,11 +839,26 @@ class Scheduler(SchedulerInterface):
                     # Track first scheduled prefill, not post-preemption repeat prefills
                     if request.prefill_stats and request.num_preemptions <= 0:
                         assert num_computed_tokens <= request.num_prompt_tokens
-                        request.prefill_stats.set(
-                            num_prompt_tokens=request.num_prompt_tokens,
-                            num_local_cached_tokens=num_new_local_computed_tokens,
-                            num_external_cached_tokens=num_external_computed_tokens,
-                        )
+                        if (
+                            self.connector is not None
+                            and self.connector.is_disagg_prefill_transfer
+                        ):
+                            # Tokens pulled from a remote prefill worker are a
+                            # transfer, not a prefix-cache hit. Route them to
+                            # num_disagg_transfer_tokens so they are excluded
+                            # from cached_tokens in the API response (#43370).
+                            request.prefill_stats.set(
+                                num_prompt_tokens=request.num_prompt_tokens,
+                                num_local_cached_tokens=num_new_local_computed_tokens,
+                                num_external_cached_tokens=0,
+                                num_disagg_transfer_tokens=num_external_computed_tokens,
+                            )
+                        else:
+                            request.prefill_stats.set(
+                                num_prompt_tokens=request.num_prompt_tokens,
+                                num_local_cached_tokens=num_new_local_computed_tokens,
+                                num_external_cached_tokens=num_external_computed_tokens,
+                            )
                 else:
                     # KVTransfer: WAITING reqs have num_computed_tokens > 0
                     # after async KV recvs are completed.

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -262,9 +262,13 @@ class PrefillStats:
     Fields:
         num_prompt_tokens: Total number of tokens to be prefilled.
         num_computed_tokens: Tokens to be prefilled locally (actual compute work).
-        num_cached_tokens: Tokens to be prefilled without actual compute work.
+        num_cached_tokens: APC cache hits (local + external); reported as
+            cached_tokens in the API response.
         num_local_cached_tokens: Tokens to be prefilled from local prefix cache.
-        num_external_cached_tokens: Tokens to be prefilled from external KV transfer.
+        num_external_cached_tokens: Tokens to be prefilled from an external KV
+            cache store (a genuine cache hit).
+        num_disagg_transfer_tokens: Tokens transferred from a disaggregated
+            prefill worker. Not a cache hit, so excluded from num_cached_tokens.
         num_cache_creation_tokens: Tokens computed and written to the prefix cache.
     """
 
@@ -273,6 +277,7 @@ class PrefillStats:
     num_cached_tokens: int = 0
     num_local_cached_tokens: int = 0
     num_external_cached_tokens: int = 0
+    num_disagg_transfer_tokens: int = 0
     num_cache_creation_tokens: int = 0
 
     def set(
@@ -280,20 +285,30 @@ class PrefillStats:
         num_prompt_tokens: int,
         num_local_cached_tokens: int,
         num_external_cached_tokens: int,
+        num_disagg_transfer_tokens: int = 0,
     ):
         num_cached_tokens = num_local_cached_tokens + num_external_cached_tokens
-        assert num_cached_tokens <= num_prompt_tokens
+        assert num_cached_tokens + num_disagg_transfer_tokens <= num_prompt_tokens
 
         self.num_prompt_tokens = num_prompt_tokens
-        self.num_computed_tokens = num_prompt_tokens - num_cached_tokens
+        self.num_computed_tokens = (
+            num_prompt_tokens - num_cached_tokens - num_disagg_transfer_tokens
+        )
         self.num_cached_tokens = num_cached_tokens
         self.num_local_cached_tokens = num_local_cached_tokens
         self.num_external_cached_tokens = num_external_cached_tokens
+        self.num_disagg_transfer_tokens = num_disagg_transfer_tokens
 
     def finalize(self, num_cached_tokens: int) -> None:
         assert num_cached_tokens >= 0
+        # Disagg transfer tokens are written to the local cache but not
+        # computed here, so they are neither cached_tokens (see set()) nor
+        # cache-creation work.
         self.num_cache_creation_tokens = max(
-            0, min(num_cached_tokens, self.num_prompt_tokens) - self.num_cached_tokens
+            0,
+            min(num_cached_tokens, self.num_prompt_tokens)
+            - self.num_cached_tokens
+            - self.num_disagg_transfer_tokens,
         )
 
 
@@ -304,13 +319,16 @@ class PromptTokenStats:
     Fields:
         computed: Tokens prefilled locally (actual compute work).
         local_cache_hit: Tokens from local prefix cache.
-        external_kv_transfer: Tokens from external KV transfer.
+        external_kv_transfer: Tokens from external KV transfer (cache store or
+            disagg prefill worker). Preserved for Prometheus metric continuity.
+        disagg_transfer: Tokens transferred from a disagg prefill worker;
+            a subset of external_kv_transfer, excluded from cached_tokens.
         cached_tokens: Tokens skipped during prefill (from scheduler).
         total: Total prompt tokens.
 
     Invariants:
         computed + local_cache_hit + external_kv_transfer = total
-        local_cache_hit + external_kv_transfer = cached_tokens
+        local_cache_hit + (external_kv_transfer - disagg_transfer) = cached_tokens
     """
 
     ALL_SOURCES: tuple[str, ...] = (
@@ -322,6 +340,7 @@ class PromptTokenStats:
     computed: int = 0
     local_cache_hit: int = 0
     external_kv_transfer: int = 0
+    disagg_transfer: int = 0
     cached_tokens: int = 0
     total: int = 0
 
@@ -332,7 +351,14 @@ class PromptTokenStats:
         self.total += prefill_stats.num_prompt_tokens
 
         self.local_cache_hit += prefill_stats.num_local_cached_tokens
-        self.external_kv_transfer += prefill_stats.num_external_cached_tokens
+        # external_kv_transfer keeps both cache-store hits and disagg transfers
+        # so the existing Prometheus metric is unchanged; disagg_transfer tracks
+        # the transfer-only subset that is excluded from cached_tokens.
+        self.external_kv_transfer += (
+            prefill_stats.num_external_cached_tokens
+            + prefill_stats.num_disagg_transfer_tokens
+        )
+        self.disagg_transfer += prefill_stats.num_disagg_transfer_tokens
 
     def get_by_source(self, source: str) -> int:
         """Get token count by source label."""


### PR DESCRIPTION
# [Bugfix] Exclude disagg P/D transfer tokens from `cached_tokens` (NixlConnector)

## Purpose

Fixes #43370.

In disaggregated prefill/decode mode, `usage.prompt_tokens_details.cached_tokens`
is inflated to nearly `prompt_tokens - 1` on **every** request — including cold
requests with a unique prompt that cannot have a prefix-cache hit.

**Root cause.** On the decode worker, the KV connector's
`get_num_new_matched_tokens()` returns the number of prompt tokens that will be
**transferred from the remote prefill worker**. The scheduler passed that value
into `PrefillStats.set(num_external_cached_tokens=...)`, where it flows into the
OpenAI-style `cached_tokens` field. This conflates two different things:

- **KV cache hits** — tokens served from a reusable prefix cache (local APC or an
  external cache store). These *should* count as `cached_tokens`.
- **Disagg transfer tokens** — tokens *moved* from a prefill engine for this
  request. These are not a cache hit and should *not* count as `cached_tokens`.

This is the same bug previously addressed in #43460 (closed unmerged after
`P2pNcclConnector` was removed in #44854). This PR re-implements the fix on the
surviving connector path (`NixlConnector`). Note #43346 fixed the *Prometheus*
`iteration_tokens_total` path; this PR fixes the separate *API response* path
(`PrefillStats` → `RequestOutput` → serving layer), which is still broken on main.

## Approach

- Add `PrefillStats.num_disagg_transfer_tokens`, tracked separately from cache
  hits and excluded from `num_cached_tokens` / `num_computed_tokens`.
- Add `PromptTokenStats.disagg_transfer`. `external_kv_transfer` continues to
  include disagg transfers so the existing Prometheus metric is unchanged;
  `disagg_transfer` isolates the transfer-only subset that is excluded from
  `cached_tokens`. New invariant:
  `local_cache_hit + (external_kv_transfer - disagg_transfer) = cached_tokens`.
- Add `KVConnectorBase_V1.is_disagg_prefill_transfer` (property, default `False`).
  In the scheduler, when the active connector reports `True`, route external
  matched tokens into `num_disagg_transfer_tokens` instead of
  `num_external_cached_tokens`.
- Override the property to `True` on `NixlBaseConnector` (covers pull and push):
  NIXL is purely a P/D transfer connector, so every token it reports via
  `get_num_new_matched_tokens` is a transfer, never a reusable cache hit.

Cache-store connectors (LMCache, MooncakeStore, etc.) keep the default `False`,
so their genuine external cache hits are still reported as `cached_tokens`.

## Scope / follow-ups

- This PR fixes **NixlConnector** only. Mooncake is intentionally out of scope:
  it can act as either a transfer connector or a cache store depending on
  configuration, so it needs a per-request signal rather than a static `True`.
  Tracked as a follow-up.

## Test Plan

Unit:
```bash
pytest tests/v1/metrics/test_stats.py -v
```
Two new tests: (1) a cold disagg request reports `cached_tokens == 0`;
(2) a request with a real local prefix-cache hit still reports it while the
transfer portion is excluded.

E2E (single node, 2 GPUs, NixlConnector): prefill on GPU 0 (`kv_producer`),
decode on GPU 1 (`kv_consumer`), both with `--enable-prompt-tokens-details`,
behind the disagg proxy. Send a cold unique prompt, then resend it.

## Test Result

Unit tests — `pytest tests/v1/metrics/test_stats.py -q` → **12 passed** (2 new + 10
existing, no regressions).

Direct before/after on the patched `PrefillStats`/`PromptTokenStats`, simulating a
cold disagg request (100 prompt tokens, 99 transferred from the prefiller, no real
cache hit):

```
BUG (old path):  cached_tokens = 99   <- inflated
FIX (new path):  cached_tokens = 0    <- correct for a cold request
```

E2E on 2× NVIDIA T4 (single node, NixlConnector, prefill GPU 0 / decode GPU 1)
with `Qwen/Qwen2.5-0.5B-Instruct`, behind `disagg_proxy_demo.py`:

| Request | `prompt_tokens` | `cached_tokens` (after fix) | Expected |
|---|---|---|---|
| Cold (unique prompt) | 39 | **0** | 0 (was ~38 = `prompt_tokens - 1` before fix) |
| Warm (resent, real local prefix-cache hit) | 39 | 32 | > 0 — genuine hit still reported (block-aligned: 2×16 cached, last partial block recomputed) |

The cold request no longer reports transferred tokens as cached, while a real
prefix-cache hit on resend is still reported correctly.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] Purpose of the PR + linked issue (#43370)
- [x] Test plan (commands)
- [x] Test results (before/after) — unit + 2-engine NIXL E2E
- [ ] Documentation update (n/a)
</details>
