### PR TITLE
[torch.compile] Extract reusable PassManager base class

### DIFF
--- a/tests/compile/passes/test_pass_manager.py
+++ b/tests/compile/passes/test_pass_manager.py
@@ -10,7 +10,7 @@ from vllm.compilation.passes.inductor_pass import (
     InductorPass,
     pass_context,
 )
-from vllm.compilation.passes.pass_manager import PostGradPassManager
+from vllm.compilation.passes.pass_manager import PassManager, PostGradPassManager
 from vllm.config import ModelConfig, VllmConfig
 from vllm.config.utils import Range
 
@@ -81,3 +81,37 @@ def test_pass_manager_uuid(callable):
         pass_manager3.configure(config2)
         pass_manager3.add(callable)
         assert uuid1 != pass_manager3.uuid()
+
+
+def test_post_grad_is_pass_manager():
+    """PostGradPassManager should be a thin subclass of the shared base."""
+    assert issubclass(PostGradPassManager, PassManager)
+
+
+def test_uuid_includes_always_on_passes():
+    """The post-grad uuid must hash the always-on utility passes that run in
+    __call__ (post_cleanup, ir_lowering, clone_elimination, post_cleanup,
+    fix_functionalization), not just the configurable `self.passes`. This pins
+    the contract that the base `_uuid_state` is extended by the subclass, so a
+    future refactor that drops the always-on passes from the cache key fails
+    here instead of silently reusing a stale Inductor cache entry."""
+    with pass_context(Range(start=1, end=8)):
+        config = VllmConfig(model_config=ModelConfig(dtype=torch.bfloat16))
+        pass_manager = PostGradPassManager()
+        pass_manager.configure(config)
+
+        full_uuid = pass_manager.uuid()
+        # The base-only state omits the always-on utility passes; the
+        # subclass uuid must differ from hashing that base state alone.
+        base_state = PassManager._uuid_state(pass_manager)
+        assert full_uuid != InductorPass.hash_dict(base_state)
+
+        # And the always-on pass UUIDs must each appear in the hashed state.
+        full_state = pass_manager._uuid_state()
+        for utility in (
+            pass_manager.post_cleanup,
+            pass_manager.ir_lowering,
+            pass_manager.clone_elimination,
+            pass_manager.fix_functionalization,
+        ):
+            assert utility.uuid() in full_state["passes"]

--- a/vllm/compilation/passes/pass_manager.py
+++ b/vllm/compilation/passes/pass_manager.py
@@ -83,7 +83,64 @@ def with_pattern_match_debug(fn: Callable[P, R]) -> Callable[P, R]:
     return wrapper
 
 
-class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
+class PassManager(CustomGraphPass):  # type: ignore[misc]
+    """
+    Base class for vLLM custom-graph pass managers.
+
+    Holds the machinery shared by every pass manager: an ordered list of
+    configurable `InductorPass`es, a helper to run them over an fx graph, and
+    UUID aggregation for the Inductor code cache (including torch<2.6 support
+    via pickling, see `.inductor_pass.CustomGraphPass`).
+
+    Subclasses are responsible for:
+    - populating `self.passes` and setting `self.pass_config` (e.g. in a
+      `configure` method),
+    - implementing `__call__` to run `self.passes` (typically via
+      `_run_passes`) plus any always-on passes, and
+    - extending `_uuid_state` with the UUIDs of those always-on passes so the
+      cache key reflects them.
+    """
+
+    def __init__(self) -> None:
+        self.passes: list[InductorPass] = []
+
+    def add(self, pass_: InductorPass) -> None:
+        assert isinstance(pass_, InductorPass)
+        self.passes.append(pass_)
+
+    def _run_passes(self, graph: fx.Graph) -> None:
+        """Run every configurable pass that applies to the current compile
+        range, advancing the dump index for each pass that runs."""
+        compile_range = get_pass_context().compile_range
+        for pass_ in self.passes:
+            if pass_.is_applicable_for_range(compile_range):
+                pass_(graph)
+                VllmInductorPass.dump_prefix += 1
+            else:
+                logger.debug("Skipping %s with compile range %s", pass_, compile_range)
+
+    def _uuid_state(self) -> dict[str, Any]:
+        """Build the dict hashed by `uuid`. Subclasses extend `state["passes"]`
+        with the UUIDs of any always-on passes they run in `__call__`."""
+        state: dict[str, Any] = {"pass_config": self.pass_config.compute_hash()}
+        passes = [pass_.uuid() for pass_ in self.passes]
+
+        # Include the compile range in the uuid to ensure that inductor
+        # recompiles the graph for the new dynamic compile range.
+        state["compile_range"] = str(get_pass_context().compile_range)
+        state["passes"] = passes
+        return state
+
+    def uuid(self) -> str:
+        """
+        The pass manager is set as a custom pass in the Inductor and affects
+        compilation caching. Its uuid depends on the UUIDs of all dependent
+        passes and the pass config. See InductorPass for more info.
+        """
+        return InductorPass.hash_dict(self._uuid_state())
+
+
+class PostGradPassManager(PassManager):  # type: ignore[misc]
     """
     The pass manager for post-grad passes.
     It handles configuration, adding custom passes, and running passes.
@@ -98,20 +155,11 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
     This way, all passes operate on a functionalized graph.
     """
 
-    def __init__(self) -> None:
-        self.passes: list[InductorPass] = []
-
     @with_pattern_match_debug
     def __call__(self, graph: fx.Graph) -> None:
         VllmInductorPass.dump_prefix = 0  # reset dump index
 
-        compile_range = get_pass_context().compile_range
-        for pass_ in self.passes:
-            if pass_.is_applicable_for_range(compile_range):
-                pass_(graph)
-                VllmInductorPass.dump_prefix += 1
-            else:
-                logger.debug("Skipping %s with compile range %s", pass_, compile_range)
+        self._run_passes(graph)
 
         # perform the first post-cleanup before IR lowering to clean up fusion artifacts
         # and make sure no dead IR ops are lowered.
@@ -199,30 +247,17 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
             self.post_cleanup = PostCleanupPass(config)
             self.fix_functionalization = FixFunctionalizationPass(config)
 
-    def add(self, pass_: InductorPass) -> None:
-        assert isinstance(pass_, InductorPass)
-        self.passes.append(pass_)
+    def _uuid_state(self) -> dict[str, Any]:
+        state = super()._uuid_state()
 
-    def uuid(self) -> str:
-        """
-        The PostGradPassManager is set as a custom pass in the Inductor and
-        affects compilation caching. Its uuid depends on the UUIDs of all
-        dependent passes and the pass config. See InductorPass for more info.
-        """
-        passes = []
-
-        state: dict[str, Any] = {"pass_config": self.pass_config.compute_hash()}
-        for pass_ in self.passes:
-            passes.append(pass_.uuid())
-
-        passes.append(self.post_cleanup.uuid())
-        passes.append(self.ir_lowering.uuid())
-        passes.append(self.clone_elimination.uuid())
-        passes.append(self.post_cleanup.uuid())
-        passes.append(self.fix_functionalization.uuid())
-
-        # Include the compile range in the uuid to ensure that inductor
-        # recompiles the graph for the new dynamic compile range.
-        state["compile_range"] = str(get_pass_context().compile_range)
-        state["passes"] = passes
-        return InductorPass.hash_dict(state)
+        # The always-on utility passes run in __call__ after self.passes, in
+        # this order. Append them so the cache key reflects them. Kept
+        # identical to the previous flat uuid() to avoid invalidating caches.
+        state["passes"] += [
+            self.post_cleanup.uuid(),
+            self.ir_lowering.uuid(),
+            self.clone_elimination.uuid(),
+            self.post_cleanup.uuid(),
+            self.fix_functionalization.uuid(),
+        ]
+        return state


### PR DESCRIPTION
Towards #39356.

## Summary

First step toward proper `PassManager` infrastructure: extract the generic machinery out of `PostGradPassManager` into a reusable `PassManager` base class (a `CustomGraphPass` subclass), leaving `PostGradPassManager` as a thin subclass.

The base now owns:
- the ordered `self.passes: list[InductorPass]` and `add()`
- `_run_passes()` — the compile-range-aware run loop (with `dump_prefix` bookkeeping)
- `uuid()` / `_uuid_state()` — the Inductor code-cache key aggregation

`PostGradPassManager` keeps only what is post-grad-specific:
- `configure()` (the flag-driven pass list)
- `__call__` ordering (configurable passes via `_run_passes`, then the always-on tail `post_cleanup → ir_lowering → clone_elimination → post_cleanup → fix_functionalization`)
- a `_uuid_state()` override that appends those always-on passes to the cache key

## No behavior change / cache-safe

This is a pure extraction. The `uuid()` output is **preserved byte-for-byte** for any given config, so it does **not** invalidate existing Inductor caches — the hashed dict (`pass_config`, `compile_range`, and the `passes` list in the same order, including the always-on tail) is identical to the previous flat implementation.

## Tests

- Existing `test_pass_manager_uuid` continues to pass.
- Added `test_post_grad_is_pass_manager` (subclass relationship) and `test_uuid_includes_always_on_passes` (pins that the always-on utility passes stay in the cache key, so a future refactor that drops them fails loudly instead of silently reusing a stale cache entry).

## Open questions for @ProExpertProg

1. Does this base/subclass split match the direction you had in mind for #39356? Happy to restructure.
2. Should the base live in `pass_manager.py` (as here) or its own module so OOT backends can import it without pulling post-grad specifics?
3. Should the always-on utility passes eventually become regular (default-on) entries in `self.passes` so they are CLI-disableable? That would change `uuid()` ordering (a one-time cache-hash bump) — I kept them out of scope here to keep this PR a behavior-preserving extraction.

Draft while I confirm the direction.