### PR TITLE
[Frontend][Responses] Accept chat-completions image format on /v1/responses (#46631)

### DIFF
--- a/tests/entrypoints/multimodal/openai/responses/test_image.py
+++ b/tests/entrypoints/multimodal/openai/responses/test_image.py
@@ -115,21 +115,24 @@ async def test_single_chat_session_image_base64encoded(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
+@pytest.mark.parametrize("part_type", ["input_image", "image_url"])
 @pytest.mark.parametrize("raw_image_url", TEST_IMAGE_ASSETS)
 async def test_single_chat_session_image_chat_completions_format(
     client: openai.AsyncOpenAI,
     model_name: str,
+    part_type: str,
     raw_image_url: str,
     url_encoded_image: dict[str, str],
 ):
-    # #46631: accept chat-completions image shape (nested image_url, no detail)
+    # #46631: accept chat-completions image shapes (image_url type or
+    # input_image with nested image_url, no detail)
     content_text = "What's in this image?"
     messages = [
         {
             "role": "user",
             "content": [
                 {
-                    "type": "input_image",
+                    "type": part_type,
                     "image_url": {"url": url_encoded_image[raw_image_url]},
                 },
                 {"type": "input_text", "text": content_text},

--- a/tests/entrypoints/multimodal/openai/responses/test_image.py
+++ b/tests/entrypoints/multimodal/openai/responses/test_image.py
@@ -140,6 +140,11 @@ async def test_single_chat_session_image_chat_completions_format(
         model=model_name,
         input=messages,
     )
+    assert response.status == "completed"
+    assert len(response.output) >= 1
+    message = next((out for out in response.output if out.type == "message"), None)
+    assert message is not None
+    assert message.role == "assistant"
     assert len(response.output_text) > 0
 
 

--- a/tests/entrypoints/multimodal/openai/responses/test_image.py
+++ b/tests/entrypoints/multimodal/openai/responses/test_image.py
@@ -115,6 +115,36 @@ async def test_single_chat_session_image_base64encoded(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
+@pytest.mark.parametrize("raw_image_url", TEST_IMAGE_ASSETS)
+async def test_single_chat_session_image_chat_completions_format(
+    client: openai.AsyncOpenAI,
+    model_name: str,
+    raw_image_url: str,
+    url_encoded_image: dict[str, str],
+):
+    # #46631: accept chat-completions image shape (nested image_url, no detail)
+    content_text = "What's in this image?"
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": {"url": url_encoded_image[raw_image_url]},
+                },
+                {"type": "input_text", "text": content_text},
+            ],
+        }
+    ]
+    response = await client.responses.create(
+        model=model_name,
+        input=messages,
+    )
+    assert len(response.output_text) > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize(
     "image_urls",
     [TEST_IMAGE_ASSETS[:i] for i in range(2, len(TEST_IMAGE_ASSETS))],

--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
 from openai_harmony import (
     Message,
 )
@@ -11,8 +12,10 @@ from vllm.entrypoints.openai.responses.protocol import (
 )
 
 
-def test_input_image_accepts_chat_completions_format() -> None:
-    # Regression test for #46631: nested image_url + missing detail must be accepted.
+@pytest.mark.parametrize("part_type", ["input_image", "image_url"])
+def test_input_image_accepts_chat_completions_format(part_type: str) -> None:
+    # Regression test for #46631: chat-completions image parts (image_url type,
+    # nested image_url, missing detail) must be accepted.
     req = ResponsesRequest.model_validate(
         {
             "model": "test",
@@ -22,7 +25,7 @@ def test_input_image_accepts_chat_completions_format() -> None:
                     "content": [
                         {"type": "input_text", "text": "what is this?"},
                         {
-                            "type": "input_image",
+                            "type": part_type,
                             "image_url": {"url": "data:image/png;base64,AAAA"},
                         },
                     ],
@@ -31,7 +34,9 @@ def test_input_image_accepts_chat_completions_format() -> None:
         }
     )
     image_part = req.input[0]["content"][1]
-    # nested {"url": X} flattened to X; required `detail` defaulted to "auto".
+    # type normalized to input_image; nested {"url": X} flattened to X;
+    # required `detail` defaulted to "auto".
+    assert image_part["type"] == "input_image"
     assert image_part["image_url"] == "data:image/png;base64,AAAA"
     assert image_part["detail"] == "auto"
 

--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -12,8 +12,7 @@ from vllm.entrypoints.openai.responses.protocol import (
 
 
 def test_input_image_accepts_chat_completions_format() -> None:
-    # Regression test for #46631: /v1/responses must accept the chat-completions
-    # image format (nested image_url + missing `detail`), which previously failed.
+    # Regression test for #46631: nested image_url + missing detail must be accepted.
     req = ResponsesRequest.model_validate(
         {
             "model": "test",

--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -5,9 +5,36 @@ from openai_harmony import (
 )
 
 from vllm.entrypoints.openai.responses.protocol import (
+    ResponsesRequest,
     serialize_message,
     serialize_messages,
 )
+
+
+def test_input_image_accepts_chat_completions_format() -> None:
+    # Regression test for #46631: /v1/responses must accept the chat-completions
+    # image format (nested image_url + missing `detail`), which previously failed.
+    req = ResponsesRequest.model_validate(
+        {
+            "model": "test",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "what is this?"},
+                        {
+                            "type": "input_image",
+                            "image_url": {"url": "data:image/png;base64,AAAA"},
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+    image_part = req.input[0]["content"][1]
+    # nested {"url": X} flattened to X; required `detail` defaulted to "auto".
+    assert image_part["image_url"] == "data:image/png;base64,AAAA"
+    assert image_part["detail"] == "auto"
 
 
 def test_serialize_message() -> None:

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -134,12 +134,20 @@ ResponseInputOutputItem: TypeAlias = ResponseInputItemParam | ResponseOutputItem
 
 
 def _normalize_chat_completions_image_parts(content: list) -> list:
-    """Flatten chat-style ``input_image`` parts (nested ``image_url``, no
-    ``detail``) to the flat ResponseInputImageParam schema (#46631)."""
+    """Normalize chat-completions image parts to the flat
+    ResponseInputImageParam schema (#46631).
+
+    Accepts the chat-style ``image_url`` type, nested ``image_url``
+    (``{"url": ...}``), and a missing ``detail``.
+    """
     normalized = []
     for part in content:
-        if isinstance(part, dict) and part.get("type") == "input_image":
+        if isinstance(part, dict) and part.get("type") in (
+            "input_image",
+            "image_url",
+        ):
             part = dict(part)
+            part["type"] = "input_image"
             image_url = part.get("image_url")
             if isinstance(image_url, dict) and "url" in image_url:
                 part["image_url"] = image_url["url"]

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -133,6 +133,25 @@ ResponseInputOutputMessage: TypeAlias = (
 ResponseInputOutputItem: TypeAlias = ResponseInputItemParam | ResponseOutputItem
 
 
+def _normalize_chat_completions_image_parts(content: list) -> list:
+    """Flatten chat-completions ``input_image`` parts to the Responses schema.
+
+    Accepts the chat shape (nested ``image_url={"url": ...}`` and no ``detail``)
+    by flattening the URL and defaulting ``detail`` to ``"auto"``, since
+    ResponseInputImageParam requires a flat ``image_url`` string (#46631).
+    """
+    normalized = []
+    for part in content:
+        if isinstance(part, dict) and part.get("type") == "input_image":
+            part = dict(part)
+            image_url = part.get("image_url")
+            if isinstance(image_url, dict) and "url" in image_url:
+                part["image_url"] = image_url["url"]
+            part.setdefault("detail", "auto")
+        normalized.append(part)
+    return normalized
+
+
 class ResponsesRequest(OpenAIBaseModel):
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/responses/create
@@ -500,19 +519,12 @@ class ResponsesRequest(OpenAIBaseModel):
                 processed_input.append(item)
                 continue
 
-            # Accept chat-completions-style images (#46631): flatten
-            # image_url {"url": X} -> X and default the required `detail` to "auto".
-            if isinstance(item.get("content"), list):
-                content = []
-                for c in item["content"]:
-                    if isinstance(c, dict) and c.get("type") == "input_image":
-                        c = dict(c)
-                        image_url = c.get("image_url")
-                        if isinstance(image_url, dict) and "url" in image_url:
-                            c["image_url"] = image_url["url"]
-                        c.setdefault("detail", "auto")
-                    content.append(c)
-                item = {**item, "content": content}
+            content = item.get("content")
+            if isinstance(content, list):
+                item = {
+                    **item,
+                    "content": _normalize_chat_completions_image_parts(content),
+                }
 
             item_type = item.get("type")
 

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -500,6 +500,20 @@ class ResponsesRequest(OpenAIBaseModel):
                 processed_input.append(item)
                 continue
 
+            # Accept chat-completions-style images (#46631): flatten
+            # image_url {"url": X} -> X and default the required `detail` to "auto".
+            if isinstance(item.get("content"), list):
+                content = []
+                for c in item["content"]:
+                    if isinstance(c, dict) and c.get("type") == "input_image":
+                        c = dict(c)
+                        image_url = c.get("image_url")
+                        if isinstance(image_url, dict) and "url" in image_url:
+                            c["image_url"] = image_url["url"]
+                        c.setdefault("detail", "auto")
+                    content.append(c)
+                item = {**item, "content": content}
+
             item_type = item.get("type")
 
             if item_type == "function_call":

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -134,12 +134,8 @@ ResponseInputOutputItem: TypeAlias = ResponseInputItemParam | ResponseOutputItem
 
 
 def _normalize_chat_completions_image_parts(content: list) -> list:
-    """Flatten chat-completions ``input_image`` parts to the Responses schema.
-
-    Accepts the chat shape (nested ``image_url={"url": ...}`` and no ``detail``)
-    by flattening the URL and defaulting ``detail`` to ``"auto"``, since
-    ResponseInputImageParam requires a flat ``image_url`` string (#46631).
-    """
+    """Flatten chat-style ``input_image`` parts (nested ``image_url``, no
+    ``detail``) to the flat ResponseInputImageParam schema (#46631)."""
     normalized = []
     for part in content:
         if isinstance(part, dict) and part.get("type") == "input_image":


### PR DESCRIPTION
 
## Summary

Multimodal **image** inputs that work on `/v1/chat/completions` fail on `/v1/responses` (#46631).

Root cause: the Responses `input_image` schema (OpenAI `ResponseInputImageParam`) requires a **flat `image_url` string** and a **required `detail` field**, but a chat-completions-style image uses a **nested `image_url: {"url": ...}`** and omits `detail`. So an identical image payload validates on chat-completions but raises a large, opaque `ValidationError` on `/v1/responses`.

## Fix

Normalize chat-style image parts in the existing `input_item_parsing` validator:
- flatten `image_url: {"url": X}` → `X`
- default the required `detail` to `"auto"` (OpenAI's documented default)

so both endpoints accept the same multimodal format.

No open PR addresses #46631 (checked the issue timeline + keyword search).

## Test

CPU-only, no model/GPU needed (the failure is at request validation):

```
pytest tests/entrypoints/openai/responses/test_protocol.py   # 3 passed
```

New `test_input_image_accepts_chat_completions_format` reproduces the issue (nested `image_url` + missing `detail`) — it fails on `main` and passes with this fix; `ruff` clean.

> AI assistance was used to investigate and implement this change; the diff and tests were reviewed and run locally.

 