### PR TITLE
[Frontend][Responses] Accept chat-style nested image_url on input_image

### DIFF
--- a/tests/tool_use/test_responses_request_validations.py
+++ b/tests/tool_use/test_responses_request_validations.py
@@ -182,3 +182,41 @@ def test_responses_request_empty_tools_named_tool_choice():
                 "tool_choice": NAMED_TOOL_CHOICE,
             }
         )
+
+
+# https://github.com/vllm-project/vllm/issues/46631
+IMAGE_URL = "https://example.com/image.png"
+
+
+def _input_image_message(image_url):
+    return {
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "What is this?"},
+                    {"type": "input_image", "image_url": image_url, "detail": "auto"},
+                ],
+            }
+        ],
+        "model": "test-model",
+    }
+
+
+def _image_url_of(request):
+    # The validated input_image content part is a TypedDict (plain dict).
+    part = request.input[0]["content"][1]
+    return part["image_url"]
+
+
+def test_responses_request_input_image_flat_url():
+    # The Responses-native flat string form is accepted unchanged.
+    request = ResponsesRequest.model_validate(_input_image_message(IMAGE_URL))
+    assert _image_url_of(request) == IMAGE_URL
+
+
+def test_responses_request_input_image_nested_url_coerced():
+    # chat-completions-style nested {"url": ...} is coerced to the flat string
+    # instead of failing strict validation with an opaque error (#46631).
+    request = ResponsesRequest.model_validate(_input_image_message({"url": IMAGE_URL}))
+    assert _image_url_of(request) == IMAGE_URL

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -133,6 +133,29 @@ ResponseInputOutputMessage: TypeAlias = (
 ResponseInputOutputItem: TypeAlias = ResponseInputItemParam | ResponseOutputItem
 
 
+def _coerce_input_image_url(part: Any) -> Any:
+    """Normalize a chat-completions-style nested ``image_url`` to the flat
+    string the Responses API expects.
+
+    The Responses ``input_image`` content part defines ``image_url`` as a flat
+    string, whereas chat-completions ``image_url`` is a nested
+    ``{"url": ...}`` object. Clients that reuse chat-completions formatting send
+    the nested form, which otherwise fails strict validation. Coerce it here so
+    both shapes are accepted; non-``input_image`` parts are returned unchanged.
+
+    See https://github.com/vllm-project/vllm/issues/46631.
+    """
+    if (
+        isinstance(part, dict)
+        and part.get("type") == "input_image"
+        and isinstance(part.get("image_url"), dict)
+    ):
+        url = part["image_url"].get("url")
+        if isinstance(url, str):
+            return {**part, "image_url": url}
+    return part
+
+
 class ResponsesRequest(OpenAIBaseModel):
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/responses/create
@@ -523,6 +546,24 @@ class ResponsesRequest(OpenAIBaseModel):
                         "leaving for Pydantic validation"
                     )
                     processed_input.append(item)
+
+            elif item.get("role") not in (None, "assistant"):
+                # User/system/developer messages (role present and not
+                # assistant; ``type`` is optional and often omitted): normalize
+                # chat-completions-style nested image_url ({"url": ...}) on
+                # input_image content parts to the flat string the Responses
+                # API schema expects. Clients reusing chat-completions image
+                # formatting otherwise fail strict validation with an opaque
+                # 400 that also echoes the entire (possibly multi-MB base64)
+                # image back to the user.
+                # See https://github.com/vllm-project/vllm/issues/46631.
+                content = item.get("content")
+                if isinstance(content, list):
+                    item = {
+                        **item,
+                        "content": [_coerce_input_image_url(c) for c in content],
+                    }
+                processed_input.append(item)
 
             elif item_type == "message" and item.get("role") == "assistant":
                 content = item.get("content")


### PR DESCRIPTION
Closes #46631.

## Problem

The Responses API `input_image` content part defines `image_url` as a **flat string**, whereas chat-completions `image_url` is a **nested `{"url": ...}` object**. Clients that reuse chat-completions image formatting send the nested form to `/v1/responses`:

```json
{"type": "input_image", "image_url": {"url": "data:image/png;base64,..."}}
```

This fails strict request validation. Worse, because the failure happens during FastAPI body validation (before the handler runs), the resulting HTTP 400 has an opaque `loc=('body','input','str')` message **and echoes the entire (often multi-MB base64) image back to the user**.

The same image input works on `/v1/chat/completions`, hence the reported asymmetry.

## Fix

Normalize the nested `{"url": ...}` form to the flat string in the existing `input_item_parsing` before-validator, for user/system/developer messages. Both shapes are now accepted; the native flat form and non-`input_image` parts are unchanged.

The coercion is scoped to a small helper (`_coerce_input_image_url`) and only triggers when `image_url` is a dict containing a string `url` — anything else is left for normal validation.

## Testing

Added CPU-only unit tests in `tests/tool_use/test_responses_request_validations.py` (no model/GPU needed):
- flat string form validates unchanged
- nested `{"url": ...}` form is coerced to the flat string

Verified on a main-aligned nightly build (`0.23.1rc1.dev415+gdda3aca47`): both forms now validate to the same flat `image_url`, and the full file passes (`19 passed`). `ruff check` + `ruff format` clean.

## Open question for maintainers

This takes the **lenient-coercion** approach (accept the chat-style nested form). The alternative is to **reject with a clearer error** (and stop FastAPI echoing the base64 blob) while staying strictly OpenAI-Responses-conformant. The base64-dump-in-error is a defect worth fixing either way — happy to switch to the strict-error approach if that is preferred. Marking as draft pending that decision.