### PR TITLE
Support `srt` response format for audio transcription 

### DIFF
--- a/tests/entrypoints/speech_to_text/transcription/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/speech_to_text/transcription/test_transcription_validation_whisper.py
@@ -10,6 +10,7 @@ import numpy as np
 import openai
 import pytest
 import pytest_asyncio
+import regex as re
 import soundfile as sf
 
 from tests.utils import RemoteOpenAIServer
@@ -307,6 +308,43 @@ async def test_audio_with_timestamp(mary_had_lamb, whisper_client):
     assert len(transcription.segments) > 0
     assert transcription.segments[0].avg_logprob is not None
     assert transcription.segments[0].compression_ratio is not None
+
+
+@pytest.mark.asyncio
+async def test_audio_response_format_srt(mary_had_lamb, whisper_client):
+    """srt format returns subtitle text built from segment timestamps."""
+    # The OpenAI client returns srt as a raw string, not a parsed object.
+    transcription = await whisper_client.audio.transcriptions.create(
+        model=MODEL_NAME,
+        file=mary_had_lamb,
+        language="en",
+        response_format="srt",
+        temperature=0.0,
+    )
+    assert isinstance(transcription, str)
+    # First cue is numbered "1" and is followed by a timestamp line.
+    assert transcription.startswith("1\n")
+    assert "-->" in transcription
+    # Cue timing uses the SRT "HH:MM:SS,mmm --> HH:MM:SS,mmm" format.
+    assert re.search(
+        r"\d{2}:\d{2}:\d{2},\d{3} --> \d{2}:\d{2}:\d{2},\d{3}", transcription
+    )
+    assert "Mary had a little lamb" in transcription
+
+
+@pytest.mark.asyncio
+async def test_srt_streaming_raises(mary_had_lamb, whisper_client):
+    """srt format does not support streaming and should raise a 400."""
+    with pytest.raises(openai.BadRequestError):
+        await whisper_client.audio.transcriptions.create(
+            model=MODEL_NAME,
+            file=mary_had_lamb,
+            language="en",
+            response_format="srt",
+            temperature=0.0,
+            stream=True,
+            timeout=30,
+        )
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -75,6 +75,9 @@ ResponseType: TypeAlias = (
 
 logger = init_logger(__name__)
 
+# Formats require Whisper style segment timestamps.
+_SEGMENT_TIMESTAMP_FORMATS = frozenset({"verbose_json", "srt", "vtt"})
+
 
 def asr_inter_chunk_separator(
     language: str | None, no_space_languages: Set[str]
@@ -85,6 +88,28 @@ def asr_inter_chunk_separator(
     separator; others use a single ASCII space.
     """
     return "" if language and language.lower() in no_space_languages else " "
+
+
+# formatting verbose json start,end time to SRT timing format
+def _format_srt_time(seconds: float) -> str:
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    ms = int(round((seconds % 1) * 1000))
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+# converting segments into SRT format
+def _to_srt(segments: list[SpeechToTextSegment], response_format: str) -> str:
+    lines = []
+    for seg in segments:
+        lines.append(str(seg.id + 1))
+        lines.append(f"{_format_srt_time(seg.start)} --> {_format_srt_time(seg.end)}")
+        lines.append(seg.text.strip())
+
+        # blank line separator
+        lines.append("")
+    return "\n".join(lines)
 
 
 class OpenAISpeechToText(OpenAIServing):
@@ -293,7 +318,7 @@ class OpenAISpeechToText(OpenAIServing):
             prompt = self.model_cls.get_generation_prompt(stt_params)
 
             parsed_prompt: DictPrompt
-            if request.response_format == "verbose_json":
+            if request.response_format in _SEGMENT_TIMESTAMP_FORMATS:
                 parsed_prompt = parse_enc_dec_prompt(prompt)
                 parsed_prompt = self._preprocess_verbose_prompt(parsed_prompt)
             else:
@@ -417,7 +442,7 @@ class OpenAISpeechToText(OpenAIServing):
         raw_request: Request,
         response_class: type[ResponseType],
         stream_generator_method: Callable[..., AsyncGenerator[str, None]],
-    ) -> T | V | AsyncGenerator[str, None] | ErrorResponse:
+    ) -> T | V | str | AsyncGenerator[str, None] | ErrorResponse:
         """Base method for speech-to-text operations like transcription and
         translation."""
         if request.stream and request.use_beam_search:
@@ -438,23 +463,24 @@ class OpenAISpeechToText(OpenAIServing):
         if self.engine_client.errored:
             raise self.engine_client.dead_error
 
-        if request.response_format not in ["text", "json", "verbose_json"]:
+        if request.response_format not in ["text", "json", "verbose_json", "srt"]:
             return self.create_error_response(
                 "Currently only support response_format: "
-                "`text`, `json` or `verbose_json`"
+                "`text`, `json` or `verbose_json` or `srt`"
             )
 
         if (
-            request.response_format == "verbose_json"
+            request.response_format in _SEGMENT_TIMESTAMP_FORMATS
             and not self.model_cls.supports_segment_timestamp
         ):
             return self.create_error_response(
-                f"Currently do not support verbose_json for {request.model}"
+                f"Currently do not support {request.response_format} "
+                f"for {request.model}"
             )
 
-        if request.response_format == "verbose_json" and request.stream:
+        if request.response_format in _SEGMENT_TIMESTAMP_FORMATS and request.stream:
             return self.create_error_response(
-                "verbose_json format doesn't support streaming case"
+                f"{request.response_format} format doesn't support streaming case"
             )
         request_id = f"{self.task_type}-{self._base_request_id(raw_request)}"
 
@@ -501,7 +527,7 @@ class OpenAISpeechToText(OpenAIServing):
                 self.default_sampling_params,
             )
 
-        if request.response_format == "verbose_json":
+        if request.response_format in _SEGMENT_TIMESTAMP_FORMATS:
             sampling_params.logprobs = 1
 
         engine_request_ids = [
@@ -589,7 +615,7 @@ class OpenAISpeechToText(OpenAIServing):
                 start_time = (
                     float(idx * chunk_size_in_s) if chunk_size_in_s is not None else 0.0
                 )
-                if request.response_format == "verbose_json":
+                if request.response_format in _SEGMENT_TIMESTAMP_FORMATS:
                     assert op.outputs[0].logprobs
                     segments: list[SpeechToTextSegment] = self._get_verbose_segments(
                         tokens=tuple(op.outputs[0].token_ids),
@@ -613,6 +639,10 @@ class OpenAISpeechToText(OpenAIServing):
             ]
             text_parts = [text for text_part in chunk_text_parts for text in text_part]
             text = separator.join(text_parts)
+
+            if request.response_format == "srt":
+                return _to_srt(total_segments, request.response_format)
+
             if self.task_type == "transcribe":
                 final_response: ResponseType
                 # add usage in TranscriptionResponse.

--- a/vllm/entrypoints/speech_to_text/transcription/api_router.py
+++ b/vllm/entrypoints/speech_to_text/transcription/api_router.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 from typing import Annotated
 
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.serve.utils.api_utils import (
@@ -57,5 +57,8 @@ async def create_transcriptions(
 
     elif isinstance(generator, TranscriptionResponseVariant):
         return JSONResponse(content=generator.model_dump())
+
+    elif isinstance(generator, str):
+        return PlainTextResponse(content=generator)
 
     return StreamingResponse(content=generator, media_type="text/event-stream")


### PR DESCRIPTION
## Purpose

Adds support for the `srt` (SubRip subtitle) `response_format` on the
OpenAI-compatible audio endpoints:

- `POST /v1/audio/transcriptions` 

Previously these endpoints rejected `srt` with a `400`:

> `Currently only support response_format: \`text\`, \`json\` or \`verbose_json\``

even though `srt`/`vtt` were already listed in the `AudioResponseFormat`
type alias. This PR makes `srt` functional by reusing the existing
`verbose_json` segment-timestamp pipeline and rendering the resulting
segments into a standard SubRip string (sequential index, `HH:MM:SS,mmm
--> HH:MM:SS,mmm` cue timing, text, blank-line separator).

### What changed
- `vllm/entrypoints/speech_to_text/base/serving.py`
  - Added a `_SEGMENT_TIMESTAMP_FORMATS = {"verbose_json", "srt"}` set and
    routed the timestamp-prompt preprocessing, `logprobs=1`, and segment
    extraction through it so `srt` reuses the same Whisper-style segment
    logic as `verbose_json`.
  - Added module-level `_format_srt_time` / `_to_srt` helpers and return
    the SRT body as plain text for `response_format="srt"`.
  - Allowed `srt` in request validation; `srt` requires a
    segment-timestamp-capable model and does not support streaming
    (both return a clear `400`).
  - Return `srt` output though `PlainTextResponse` (raw subtitle text rather
    than a JSON object) in `entrypoints/speech_to_text/transcription/api_router.py`.

### Notes
- `srt` is only valid for segment-timestamp models (e.g. Whisper);
  non-timestamp models return a `400` rather than erroring out.
- `vtt` is a natural follow-up using the same machinery (only the
  millisecond separator and a `WEBVTT` header) and can be added in
  a subsequent PR.
- **AI assistance (Claude) was used for writing cases** while developing this change. The
  submitter has reviewed every test case and run the tests below.
- Not a duplicate: searched open PRs for `srt` / audio `response_format`
  and found no existing PR adding this.

## Test Plan

Added two tests to
`tests/entrypoints/speech_to_text/transcription/test_transcription_validation_whisper.py`
(which runs against `openai/whisper-large-v3-turbo`):

- `test_audio_response_format_srt` - asserts the response is raw text,
  the first cue is numbered `1`, contains `-->`, and matches the SRT
  timestamp pattern `\d{2}:\d{2}:\d{2},\d{3} --> \d{2}:\d{2}:\d{2},\d{3}`.
- `test_srt_streaming_raises` - asserts `srt` + `stream=True` returns a
  `400`.

```bash
pytest tests/entrypoints/speech_to_text/transcription/test_transcription_validation_whisper.py -k "srt" -v
```

## Test Result

**Before** - `srt` requests were rejected with a `400`:

```text
--- Testing SRT Format ---
SRT request failed: Error code: 400 - {'error': {'message': 'Currently only support response_format: `text`, `json` or `verbose_json`', 'type': 'BadRequestError', 'param': None, 'code': 400}}
```

**After** - `srt` returns a valid SubRip body:

```
client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")

print("Sending processed audio.wav to Whisper for transcription...")
with open("audio.wav", "rb") as audio_file:
    transcription = client.audio.transcriptions.create(
        model="openai/whisper-tiny",
        file=audio_file,
        response_format="srt"
    )
```

```text
1
00:00:00,000 --> 00:00:20,000
Oh, you think darkness is your ally. Are you merely adopted the dark? I was born in it. More lit by it. I didn't see the light until I was already a man, but then it was nothing to me, but brightened.
```

Comparing `verbose_json` and `srt` on the same audio confirms the SRT output
faithfully reflects the model's segments:

```text
verbose_json → 1 segment (id: 0, start: 0.0, end: 20.0)
srt          → 1 cue     (00:00:00,000 --> 00:00:20,000)
```

**Automated tests:**

```text
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-8.4.2, pluggy-1.6.0 -- /usr/bin/python3
collected 19 items / 17 deselected / 2 selected

tests/entrypoints/speech_to_text/transcription/test_transcription_validation_whisper.py::test_audio_response_format_srt[default] PASSED [ 50%]
tests/entrypoints/speech_to_text/transcription/test_transcription_validation_whisper.py::test_srt_streaming_raises[default] PASSED [100%]

================= 2 passed, 17 deselected in 129.02s (0:02:09) =================
```