### PR TITLE
Fix write-after-write hazard in xpu KV RoPE triton kernel

### DIFF
--- a/vllm/models/deepseek_v4/xpu/xpu_qnorm_rope_kv_fp8_insert.py
+++ b/vllm/models/deepseek_v4/xpu/xpu_qnorm_rope_kv_fp8_insert.py
@@ -88,10 +88,13 @@ def _xpu_qnorm_rope_kernel(
         kv_base = kv_ptr + token_idx * HEAD_DIM
         kv_out_base = kv_out_ptr + token_idx * HEAD_DIM
 
-        # Copy full KV unchanged first
+        # Copy only the NoPE portion; the RoPE region is written exclusively
+        # by the rotated stores below. Masking avoids a write-after-write
+        # hazard on the overlapping RoPE addresses (matches the Q branch).
         offs = tl.arange(0, HEAD_DIM)
         kv_full = tl.load(kv_base + offs)
-        tl.store(kv_out_base + offs, kv_full)
+        nope_mask = offs < NOPE_DIM
+        tl.store(kv_out_base + offs, kv_full, mask=nope_mask)
 
         # GPT-J interleaved RoPE on the last ROPE_DIM dimensions
         even_offs = NOPE_DIM + rope_pair_idx * 2


### PR DESCRIPTION
The KV branch of `_xpu_qnorm_rope_kernel` copied all HEAD_DIM elements into the output, then overwrote the RoPE region with the rotated values. These stores target overlapping addresses with no ordering guarantee, so on XPU the RoPE positions were non-deterministic run-to-run, making greedy decode unstable.

Mask the full copy to the NoPE region so the RoPE region is written only by the rotated stores, matching the Q branch.

gsm8k increase to 88 on deepseek v4 flash model
