### PR TITLE
[Hardware][AMD][CI] Move Metrics, Tracing (2 GPUs) & make optional

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -2240,7 +2240,7 @@ steps:
   - pytest -v -s tests/distributed/test_packed_tensor.py
 
 - label: Metrics, Tracing (2 GPUs) # TBD
-  timeout_in_minutes: 180
+  timeout_in_minutes: 20
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
   agent_pool: mi300_2
   optional: true

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -252,9 +252,10 @@ steps:
   - pytest -v -s v1/tracing
   mirror:
     amd:
-      device: mi300_2
+      device: mi325_2
       depends_on:
       - image-build-amd
+      optional: true
 
 - label: Python-only Installation
   key: python-only-installation


### PR DESCRIPTION

## Purpose
Move the Metrics, Tracing (2 GPUs) test group to MI325 and make optional for investigation purposes, as we're seeing an unusually high rate of CPU-side segfaults on this test group currently.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

