### PR TITLE
[Bugfix] Skip PP sampled-token broadcast on KV producer

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -259,19 +259,28 @@ def test_select_common_block_size_uses_largest_shared_int():
 
 @pytest.mark.skip_global_cleanup
 @pytest.mark.parametrize(
-    ("world_size", "is_last_rank", "expected_calls"),
-    [(1, True, 0), (2, True, 0), (2, False, 1)],
+    ("world_size", "is_last_rank", "is_kv_producer", "expected_calls"),
+    [
+        (1, True, False, 0),
+        (2, True, False, 0),
+        (2, False, False, 1),
+        (2, False, True, 0),
+    ],
 )
 def test_sample_tokens_receives_pp_sampled_ids_only_on_non_last_rank(
     monkeypatch: pytest.MonkeyPatch,
     world_size: int,
     is_last_rank: bool,
+    is_kv_producer: bool,
     expected_calls: int,
 ):
     runner = GPUModelRunner.__new__(GPUModelRunner)
     runner.execute_model_state = None
     runner.kv_connector_output = None
     runner.use_async_scheduling = True
+    runner.vllm_config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(is_kv_producer=is_kv_producer)
+    )
     receive_calls = 0
 
     def receive_prev_sampled_token_ids():

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4435,11 +4435,21 @@ class GPUModelRunner(
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
+        pp = None
+        skip_pp_pd_broadcast = False
+        if self.use_async_scheduling:
+            pp = get_pp_group()
+            skip_pp_pd_broadcast = self._should_skip_pp_pd_broadcast(pp)
+
         if self.execute_model_state is None:
             kv_connector_output = self.kv_connector_output
             self.kv_connector_output = None
             # receive sampled token ids from the last PP rank.
-            if self.use_async_scheduling and not get_pp_group().is_last_rank:
+            if (
+                self.use_async_scheduling
+                and not pp.is_last_rank
+                and not skip_pp_pd_broadcast
+            ):
                 self._pp_receive_prev_sampled_token_ids_to_input_batch()
             # In case of PP with kv transfer, we need to pass through the
             # kv_connector_output
@@ -4474,11 +4484,15 @@ class GPUModelRunner(
             sampler_output.sampled_token_ids, scheduler_output
         )
         if self.use_async_scheduling:
-            pp = get_pp_group()
             # For torchrun external_launcher PP mode with broadcast_pp_output=True,
             # PP outputs have been broadcasted to all ranks at logits computation.
             # Therefore, here is no need to send sampled token ids again in this case.
-            if not self.broadcast_pp_output and pp.world_size > 1 and pp.is_last_rank:
+            if (
+                not self.broadcast_pp_output
+                and pp.world_size > 1
+                and pp.is_last_rank
+                and not skip_pp_pd_broadcast
+            ):
                 self._pp_broadcast_prev_sampled_token_ids(
                     sampler_output.sampled_token_ids
                 )
@@ -4692,6 +4706,16 @@ class GPUModelRunner(
             )
 
         return async_output
+
+    def _should_skip_pp_pd_broadcast(self, pp) -> bool:
+        kv_transfer_config = getattr(
+            getattr(self, "vllm_config", None), "kv_transfer_config", None
+        )
+        return (
+            pp.world_size > 1
+            and kv_transfer_config is not None
+            and kv_transfer_config.is_kv_producer
+        )
 
     def _pp_broadcast_prev_sampled_token_ids(
         self, sampled_token_ids: torch.Tensor


### PR DESCRIPTION
## Purpose

Fix a pipeline bubble in the `PP + async scheduling + disaggregated prefill` path for KV producer instances.

When a non-final PP rank has no `execute_model_state`, `sample_tokens()` only needs to return the KV connector output. However, the async PP path still tried to receive sampled token ids broadcast from the last PP rank. On a KV producer, those sampled token ids are not needed by the producer-side PD flow, so participating in this PP broadcast can make producer ranks wait unnecessarily and introduce a pipeline bubble.

This PR skips the sampled-token PP broadcast/receive when the current instance is a KV producer and PP world size is greater than 1. The normal PP async path is unchanged for non-KV-producer execution.

This follows the same fix strategy as vllm-project/vllm-ascend#10855.

## Test Plan

- Add unit coverage for the `sample_tokens()` early-return path to verify that a non-last PP rank still receives sampled token ids normally, but skips the receive when configured as a KV producer.
- Run focused local syntax/diff checks.

## Test Result

```bash
python3 -m py_compile vllm/v1/worker/gpu_model_runner.py tests/v1/worker/test_gpu_model_runner.py
```

Passed.

```bash
git diff --check
```

Passed.

I could not run pytest/ruff locally because the current environment does not have those Python modules installed (`No module named pytest`, `No module named ruff`).
