### PR TITLE
[Hardware][AMD][CI] Use Triton-based AITER MHA for LM Eval Qwen-3.5 Models Tests

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -2828,13 +2828,12 @@ steps:
     - uv pip install --system 'gpt-oss[eval]==0.0.5'
     - pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-gfx950.txt
 
-- label: LM Eval Qwen3-5 Models (B200-MI355) %N # TBD
-  timeout_in_minutes: 180
+- label: LM Eval Qwen3-5 Models (B200-MI355) # TBD
+  timeout_in_minutes: 120
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
   agent_pool: mi355_2
   num_gpus: 2
   optional: true
-  parallelism: 4
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/model_executor/models/qwen3_5.py
@@ -2849,7 +2848,7 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-qwen35-mi355.txt --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-qwen35-mi355.txt
 
 - label: LM Eval Small Models (2xB200-2xMI355) # TBD
   timeout_in_minutes: 180

--- a/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-AITER-TP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-AITER-TP2.yaml
@@ -3,7 +3,6 @@ accuracy_threshold: 0.89
 tolerance: 0.03
 num_questions: 1319
 num_fewshot: 5
-startup_max_wait_seconds: 3600
 server_args: >-
   --max-model-len 4096
   --tensor-parallel-size 2

--- a/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-AITER-TP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-AITER-TP2.yaml
@@ -11,3 +11,4 @@ server_args: >-
   --moe-backend aiter
 env:
   VLLM_ROCM_USE_AITER: "1"
+  ENABLE_CK: "0"  # Avoid AITER CK-based MHA JIT compilation to save time

--- a/vllm/v1/attention/ops/vit_attn_wrappers.py
+++ b/vllm/v1/attention/ops/vit_attn_wrappers.py
@@ -12,11 +12,12 @@ latencies by ~7% (see qwen2_5_vl for example usage)
 To use these ops, you must have a recent version of PyTorch installed (>= 2.4.0)
 """
 
+from typing import Any
+
 import einops
 import torch
 import torch.nn.functional as F
 
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 
@@ -32,9 +33,10 @@ def flash_attn_maxseqlen_wrapper(
     cu_seqlens: torch.Tensor | None = None,
     max_seqlen: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    kwargs = {}
+    kwargs: dict[str, Any] = {}
     if is_rocm_aiter:
-        flash_attn_varlen_func = rocm_aiter_ops.flash_attn_varlen_func
+        from aiter import flash_attn_varlen_func
+
         kwargs["window_size"] = (-1, -1)
     else:
         from vllm.v1.attention.backends.fa_utils import flash_attn_varlen_func

--- a/vllm/v1/attention/ops/vit_attn_wrappers.py
+++ b/vllm/v1/attention/ops/vit_attn_wrappers.py
@@ -16,6 +16,7 @@ import einops
 import torch
 import torch.nn.functional as F
 
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 
@@ -33,7 +34,8 @@ def flash_attn_maxseqlen_wrapper(
 ) -> torch.Tensor:
     kwargs = {}
     if is_rocm_aiter:
-        from aiter import flash_attn_varlen_func
+        flash_attn_varlen_func = rocm_aiter_ops.flash_attn_varlen_func
+        kwargs["window_size"] = (-1, -1)
     else:
         from vllm.v1.attention.backends.fa_utils import flash_attn_varlen_func
 


### PR DESCRIPTION


## Purpose
Use Triton-based (rather than CK-based) AITER MHA in the LM Eval Qwen-3.5 35B AITER test. This sidesteps the issue reported in https://github.com/vllm-project/vllm/pull/46520, and also reverts the changes made in that PR.

## Test Plan
`pytest -sv evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-qwen35-mi355.txt`
This is run as part of the LM Eval Qwen-3.5 Models test group on MI355 in AMD CI.

## Test Result
The test group passes.

cc @AndreasKaratzas 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

