### PR TITLE
Withdrawn: FlashAttnMLA FP8 KV cache support

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -225,7 +225,7 @@ MLA decode backends are selected using the standard
 | `FLASHINFER_MLA_SPARSE_SM120` | bf16 | `auto`, `fp8`, `fp8_e4m3`, `fp8_ds_mla` | 64, 256 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | 12.x |
 | `FLASHMLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 64 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 9.x-10.x |
 | `FLASHMLA_SPARSE` | bf16 | `auto`, `bfloat16`, `fp8_ds_mla` | 64 | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | 9.x-10.x |
-| `FLASH_ATTN_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16` | %16 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 9.x |
+| `FLASH_ATTN_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | %16 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 9.x |
 | `FLASH_ATTN_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16` | 64 | Any | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | 9.x |
 | `ROCM_AITER_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %1 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 1, 64 | Any | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | N/A |

--- a/tests/kernels/attention/test_mla_cross_layer_kernel_equivalence.py
+++ b/tests/kernels/attention/test_mla_cross_layer_kernel_equivalence.py
@@ -421,6 +421,116 @@ def test_flashattn_mla_dense_decode_unified_slot_view():
     assert (out_ref - out_view).abs().max().item() == 0.0
 
 
+def test_flashattn_mla_dense_fp8_decode_unified_slot_view():
+    """FLASH_ATTN_MLA must read a standard fp8 unified-slot block-major
+    cache with bf16 queries and dispatch the FA3 MLA q_v kernel."""
+    try:
+        from vllm.vllm_flash_attn import flash_attn_varlen_func
+    except ImportError:
+        pytest.skip("vllm_flash_attn is not available")
+    from vllm.v1.attention.backends.fa_utils import flash_attn_supports_mla
+    from vllm.v1.attention.backends.mla.flashattn_mla import (
+        FlashAttnMLADecodeMetadata,
+        FlashAttnMLAImpl,
+    )
+
+    if not flash_attn_supports_mla():
+        pytest.skip("FA3 MLA requires a Hopper device")
+
+    torch.manual_seed(0)
+    dev = "cuda"
+    dt = torch.bfloat16
+    fp8_dt = torch.float8_e4m3fn
+    kv_lora_rank = 512
+    rope_dim = 64
+    entry = kv_lora_rank + rope_dim  # 576
+    h_q = 16
+    page = 64
+    num_blocks = 64
+    bs = 4
+    n_layers = 3
+    layer = 1
+
+    q_pe = torch.randn(bs, h_q, rope_dim, device=dev, dtype=dt) * 0.1
+    q_nope = torch.randn(bs, h_q, kv_lora_rank, device=dev, dtype=dt) * 0.1
+    kv_data = torch.randn(num_blocks, page, entry, device=dev, dtype=dt) * 0.1
+
+    k_scale = torch.tensor(0.5, device=dev, dtype=torch.float32)
+    fp8_kv_data = (kv_data / k_scale).to(fp8_dt)
+
+    # (A) contiguous per-layer reference.
+    cache_contiguous = fp8_kv_data.clone().contiguous()
+
+    # (B) unified slot: view one layer -> inflated stride(0), non-zero offset.
+    unified = (torch.randn(num_blocks, n_layers, page, entry, device=dev) * 0.1).to(
+        fp8_dt
+    )
+    unified[:, layer].copy_(fp8_kv_data)
+    cache_view = unified[:, layer]
+    assert not cache_view.is_contiguous()
+    assert cache_view.stride(0) == n_layers * page * entry
+
+    max_blk = num_blocks // bs
+    block_table = torch.arange(num_blocks, device=dev, dtype=torch.int32).view(
+        bs, max_blk
+    )
+    seq_lens = torch.full((bs,), max_blk * page, device=dev, dtype=torch.int32)
+    cu_seqlens_q = torch.arange(bs + 1, device=dev, dtype=torch.int32)
+
+    decode = FlashAttnMLADecodeMetadata(
+        block_table=block_table,
+        seq_lens=seq_lens,
+        query_start_loc=cu_seqlens_q,
+        max_query_len=1,
+        max_seq_len=int(seq_lens.max().item()),
+        scheduler_metadata=None,
+        max_num_splits=0,
+        dcp_tot_seq_lens=None,
+    )
+    attn_metadata = type("_AttnMetadata", (), {"decode": decode})()
+    layer_obj = type("_Layer", (), {"_k_scale": k_scale})()
+
+    impl = object.__new__(FlashAttnMLAImpl)
+    impl.kv_cache_dtype = "fp8"
+    impl.kv_lora_rank = kv_lora_rank
+    impl.qk_rope_head_dim = rope_dim
+    impl.num_kv_heads = 1
+    impl.scale = entry**-0.5
+    impl.need_to_return_lse_for_decode = False
+    impl.dcp_world_size = 1
+    impl.dcp_rank = 0
+
+    def run_ref(cache):
+        cache = cache.to(dt) * k_scale.to(dt)
+        kv_c_cache = cache[..., :kv_lora_rank]
+        k_pe_cache = cache[..., kv_lora_rank:]
+        out = flash_attn_varlen_func(
+            q=q_pe,
+            k=k_pe_cache.unsqueeze(-2),  # Add head dim of 1
+            v=kv_c_cache.unsqueeze(-2),  # Add head dim of 1
+            q_v=q_nope,
+            max_seqlen_q=1,
+            cu_seqlens_q=cu_seqlens_q,
+            max_seqlen_k=int(seq_lens.max().item()),
+            seqused_k=seq_lens,
+            block_table=block_table,
+            softmax_scale=entry**-0.5,
+            causal=True,
+            fa_version=3,
+        )
+        return out.clone().float()
+
+    def run_impl(cache):
+        out, _ = impl.forward_mqa((q_nope, q_pe), cache, attn_metadata, layer_obj)
+        return out.clone().float()
+
+    out_ref = run_ref(cache_contiguous)
+    out_view = run_impl(cache_view)
+    assert torch.isfinite(out_ref).all()
+    assert out_ref.abs().max().item() > 0.0
+    assert (out_ref - out_view).abs().max().item() == 0.0
+
+
 def test_flashmla_dense_fp8_decode_unified_slot_view():
     """FlashMLA dense fp8 decode (FLASHMLA backend with quantized KV cache)
     must read a unified-slot block-major view bit-identically to a contiguous

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -46,6 +46,8 @@ class FlashAttnMLABackend(MLACommonBackend):
         "auto",
         "float16",
         "bfloat16",
+        "fp8",
+        "fp8_e4m3",
     ]
 
     @staticmethod
@@ -185,7 +187,7 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
                 num_heads_kv=1,
                 headdim=self.mla_dims.qk_rope_head_dim,
                 cache_seqlens=seqlens,
-                qkv_dtype=self.kv_cache_spec.dtype,
+                qkv_dtype=self.q_data_type,
                 headdim_v=self.mla_dims.kv_lora_rank,
                 page_size=self.page_size,
                 cu_seqlens_q=cu_query_lens,
@@ -311,9 +313,7 @@ class FlashAttnMLAImpl(MLACommonImpl[FlashAttnMLAMetadata]):
             )
 
         if is_quantized_kv_cache(self.kv_cache_dtype):
-            raise NotImplementedError(
-                "FlashAttnMLA V1 with FP8 KV cache not yet supported"
-            )
+            self.supports_quant_query_input = False
 
     def forward_mqa(
         self,
@@ -333,7 +333,13 @@ class FlashAttnMLAImpl(MLACommonImpl[FlashAttnMLAMetadata]):
             )
 
         if is_quantized_kv_cache(self.kv_cache_dtype):
-            raise NotImplementedError("FP8 FlashAttention MLA not yet supported")
+            # FA3's MLA q_v path currently requires q/k/v to have the same
+            # fp16/bf16 dtype, so dequantize the standard fp8 MLA cache before
+            # dispatching to the FA3 MLA kernel. MLA stores kv_c and k_pe in
+            # one cache with one scale.
+            kv_c_and_k_pe_cache = kv_c_and_k_pe_cache.to(
+                q_pe.dtype
+            ) * layer._k_scale.to(q_pe.dtype)
 
         kv_c_cache = kv_c_and_k_pe_cache[..., : self.kv_lora_rank]
         k_pe_cache = kv_c_and_k_pe_cache[..., self.kv_lora_rank :]


### PR DESCRIPTION
Withdrawn.

This PR originally attempted to make `FLASH_ATTN_MLA` accept standard FP8 KV cache by dequantizing the cache before dispatching the existing FA3 MLA `q_v` kernel. That is only a correctness workaround, not real FP8 KV-cache support: it loses the memory-bandwidth benefit and adds extra work before attention.

True `FLASH_ATTN_MLA` FP8 support needs a fused low-level operator in the FA3/vllm-flash-attention path that consumes FP8 KV cache directly. The existing fused FP8 MLA decode path is the dedicated FlashMLA backend/extension (`flash_mla_with_kvcache_fp8`), not the FA3 `FLASH_ATTN_MLA` path.

For #46581, the correct short-term fix is to skip/filter the unsupported `(FLASH_ATTN_MLA, fp8)` test matrix cell until fused support exists.