### PR TITLE
[Bugfix] Add CPU fallback for mamba batch memcpy

### DIFF
--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -18,6 +18,7 @@ from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec, MambaSpe
 from vllm.v1.worker.mamba_utils import (
     MambaCopyBuffers,
     MambaSpecDecodeGPUContext,
+    batch_memcpy,
     collect_mamba_copy_meta,
     do_mamba_copy_block,
     preprocess_mamba,
@@ -30,6 +31,32 @@ _COPY_FUNCS: tuple[MambaStateCopyFunc, ...] = (
     get_conv_copy_spec,
     get_temporal_copy_spec,
 )
+
+
+@pytest.mark.skip_global_cleanup
+@torch.inference_mode()
+def test_batch_memcpy_falls_back_for_non_launchable_kernel(monkeypatch):
+    """batch_memcpy should work when Triton launch syntax is unavailable."""
+    from vllm.v1.worker import mamba_utils
+
+    def plain_memcpy_kernel(src_ptrs, dst_ptrs, sizes, BLOCK_SIZE=None):
+        raise AssertionError("plain kernel should not be launched with [grid]")
+
+    monkeypatch.setattr(mamba_utils, "batch_memcpy_kernel", plain_memcpy_kernel)
+
+    srcs = [
+        torch.arange(64, dtype=torch.float32),
+        torch.arange(17, dtype=torch.float32),
+    ]
+    dsts = [torch.zeros_like(src) for src in srcs]
+    src_ptrs = torch.tensor([src.data_ptr() for src in srcs], dtype=torch.uint64)
+    dst_ptrs = torch.tensor([dst.data_ptr() for dst in dsts], dtype=torch.uint64)
+    sizes = torch.tensor([src.nbytes for src in srcs], dtype=torch.int64)
+
+    batch_memcpy(src_ptrs, dst_ptrs, sizes)
+
+    for src, dst in zip(srcs, dsts):
+        torch.testing.assert_close(dst, src)
 
 
 def postprocess_mamba(

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import ctypes
 import dataclasses
 import itertools
 from collections.abc import Callable
@@ -215,6 +216,20 @@ def batch_memcpy(src_ptrs, dst_ptrs, sizes):
     batch = src_ptrs.shape[0]
     assert dst_ptrs.shape[0] == batch
     assert sizes.shape[0] == batch
+
+    if not hasattr(batch_memcpy_kernel, "__getitem__"):
+        if src_ptrs.device.type != "cpu" or dst_ptrs.device.type != "cpu":
+            raise RuntimeError(
+                "batch_memcpy CPU fallback requires CPU pointer tensors when "
+                "Triton launch syntax is unavailable."
+            )
+        for src, dst, size in zip(
+            src_ptrs.cpu().tolist(),
+            dst_ptrs.cpu().tolist(),
+            sizes.cpu().tolist(),
+        ):
+            ctypes.memmove(int(dst), int(src), int(size))
+        return
 
     grid = (batch,)
     BLOCK_SIZE = 1024


### PR DESCRIPTION
## Purpose

Fixes #46693.

`mamba_utils.batch_memcpy` currently assumes `batch_memcpy_kernel` always supports Triton-style launch syntax via `batch_memcpy_kernel[grid](...)`. On CPU/macOS paths where Triton is unavailable, the kernel can be a plain Python function, which crashes Qwen3.5/GDN Mamba align preprocessing with `TypeError: 'function' object is not subscriptable` once a request crosses a Mamba block boundary.

This PR adds a guarded CPU fallback in `batch_memcpy`: when the kernel is not launchable and the pointer tensors are CPU tensors, it copies each `(src, dst, size)` with `ctypes.memmove`. The existing Triton / CPU `_FuncWrapper` launch path is unchanged.

Duplicate-work check: I checked #46693 comments, searched open PRs for `46693 in:body`, `batch_memcpy mamba cpu triton`, and `Qwen3.5 mamba align CPU`. I found related broader Mamba-align PRs, but no open PR specifically fixing the non-launchable `batch_memcpy_kernel[grid]` CPU fallback crash.

AI assistance was used to prepare this patch; I reviewed the changed lines and ran the tests below.

## Test Plan

- `.venv/bin/python -m pytest tests/v1/worker/test_mamba_utils.py::test_batch_memcpy_falls_back_for_non_launchable_kernel -q`
- `.venv/bin/python -m ruff check vllm/v1/worker/mamba_utils.py tests/v1/worker/test_mamba_utils.py`
- `.venv/bin/python -m py_compile vllm/v1/worker/mamba_utils.py tests/v1/worker/test_mamba_utils.py && git diff --check`

I also attempted:

- `.venv/bin/python -m pytest tests/kernels/mamba/cpu/test_cpu_gdn_ops.py::test_batch_memcpy_cpu_fallback tests/v1/worker/test_mamba_utils.py::test_batch_memcpy_falls_back_for_non_launchable_kernel -q`

On this macOS arm64 machine, `tests/kernels/mamba/cpu/test_cpu_gdn_ops.py` is module-skipped / has no collector for the selected test, so this command exits with pytest code 4 while reporting the module as skipped. The new worker test is run separately above and passes.

## Test Result

```text
$ .venv/bin/python -m pytest tests/v1/worker/test_mamba_utils.py::test_batch_memcpy_falls_back_for_non_launchable_kernel -q
.                                                                        [100%]
1 passed, 17 warnings in 0.15s
```

```text
$ .venv/bin/python -m ruff check vllm/v1/worker/mamba_utils.py tests/v1/worker/test_mamba_utils.py
All checks passed!
```

```text
$ .venv/bin/python -m py_compile vllm/v1/worker/mamba_utils.py tests/v1/worker/test_mamba_utils.py && git diff --check
# no output
```
