### PR TITLE
[ROCm][DSV4][Kernel] Add gfx950 HIP compressor path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1325,6 +1325,19 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
       "csrc/rocm/moe_q_gemm_rdna3.cu")
   endif()
 
+  # DeepSeek-V4 fused compressors are gfx950 (CDNA4)-only because they use
+  # native FP8/FP4 conversion builtins. Only compile and register them when
+  # gfx950 is among the requested ROCm targets.
+  set(VLLM_ROCM_HAS_GFX950 OFF)
+  if(VLLM_GPU_ARCHES MATCHES "gfx950")
+    set(VLLM_ROCM_HAS_GFX950 ON)
+    list(APPEND VLLM_ROCM_EXT_SRC
+      "csrc/rocm/dsv4_csa_compress.cu"
+      "csrc/rocm/dsv4_hca_compress.cu"
+      "csrc/rocm/dsv4_indexer_compress.cu"
+      "csrc/rocm/dsv4_compress_ops.cu")
+  endif()
+
   define_extension_target(
     _rocm_C
     DESTINATION vllm
@@ -1337,6 +1350,10 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
 
   if(VLLM_ROCM_HAS_GFX1100)
     target_compile_definitions(_rocm_C PRIVATE VLLM_ROCM_GFX1100)
+  endif()
+
+  if(VLLM_ROCM_HAS_GFX950)
+    target_compile_definitions(_rocm_C PRIVATE VLLM_ROCM_GFX950)
   endif()
 endif()
 

--- a/benchmarks/kernels/benchmark_dsv4_compress.py
+++ b/benchmarks/kernels/benchmark_dsv4_compress.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark DeepSeek-V4 ROCm gfx950 compressor kernels."""
+
+from dataclasses import dataclass
+
+import torch
+from tabulate import tabulate
+
+from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
+    compress_norm_rope_store_triton,
+)
+from vllm.models.deepseek_v4.common.ops.save_partial_states import (
+    save_partial_states,
+)
+from vllm.triton_utils import triton
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+KV_BLOCK_SIZE = 16
+RMS_EPS = 1e-6
+SEED = 2026
+
+
+@dataclass(frozen=True)
+class ShapeConfig:
+    name: str
+    head_dim: int
+    rope_head_dim: int
+    ratio: int
+    overlap: bool
+    state_block_size: int
+    quant_format: str
+
+    @property
+    def state_width(self) -> int:
+        return (2 if self.overlap else 1) * self.head_dim
+
+    @property
+    def coff(self) -> int:
+        return 2 if self.overlap else 1
+
+    @property
+    def token_stride(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return self.head_dim
+        if self.quant_format == "indexer_mxfp4":
+            return self.head_dim // 2
+        return self.head_dim + self.rope_head_dim
+
+    @property
+    def scale_dim(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return 4
+        if self.quant_format == "indexer_mxfp4":
+            return self.head_dim // 32
+        return (self.head_dim - self.rope_head_dim) // 64 + 1
+
+    @property
+    def quant_block(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return self.head_dim
+        if self.quant_format == "indexer_mxfp4":
+            return 32
+        return 64
+
+
+SHAPES = (
+    ShapeConfig("csa_main", 512, 64, 4, True, 4, "csa"),
+    ShapeConfig("hca_main", 512, 64, 128, False, 8, "hca"),
+    ShapeConfig("indexer_fp8", 128, 64, 4, True, 4, "indexer_fp8"),
+    ShapeConfig("indexer_mxfp4", 128, 64, 4, True, 4, "indexer_mxfp4"),
+)
+SCENARIOS = (
+    "decode_boundary",
+    "prefill_256",
+    "prefill_1024",
+    "prefill_4096",
+    "prefill_32768",
+)
+
+
+class KVCacheMetadata:
+    def __init__(self, slot_mapping: torch.Tensor):
+        self.slot_mapping = slot_mapping
+
+
+@dataclass
+class BenchmarkInput:
+    name: str
+    shape: ShapeConfig
+    positions: torch.Tensor
+    token_to_req_indices: torch.Tensor
+    slot_mapping: torch.Tensor
+    block_table: torch.Tensor
+    kv_slot_mapping: torch.Tensor
+    state_cache_fp32: torch.Tensor
+    state_cache_bf16: torch.Tensor
+    ape: torch.Tensor
+    cos_sin_cache: torch.Tensor
+    rms_weight: torch.Tensor
+    num_tokens: int
+    num_kv_blocks: int
+    kv_block_bytes: int
+
+    def new_kv_cache(self) -> torch.Tensor:
+        return torch.zeros(
+            self.num_kv_blocks,
+            KV_BLOCK_SIZE,
+            self.kv_block_bytes,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+
+    def common_kwargs(self, kv_cache: torch.Tensor) -> dict:
+        shape = self.shape
+        return dict(
+            num_actual=self.num_tokens,
+            token_to_req_indices=self.token_to_req_indices,
+            positions=self.positions,
+            slot_mapping=self.slot_mapping,
+            block_table=self.block_table,
+            block_size=shape.state_block_size,
+            state_width=shape.state_width,
+            cos_sin_cache=self.cos_sin_cache,
+            kv_cache=kv_cache,
+            k_cache_metadata=KVCacheMetadata(self.kv_slot_mapping),
+            pdl_kwargs={},
+            head_dim=shape.head_dim,
+            rope_head_dim=shape.rope_head_dim,
+            compress_ratio=shape.ratio,
+            overlap=shape.overlap,
+            use_fp4_cache=shape.quant_format == "indexer_mxfp4",
+            rms_norm_weight=self.rms_weight,
+            rms_norm_eps=RMS_EPS,
+            quant_block=shape.quant_block,
+            token_stride=shape.token_stride,
+            scale_dim=shape.scale_dim,
+        )
+
+
+def _scenario(
+    shape: ShapeConfig,
+    name: str,
+) -> tuple[list[int], list[int], list[int]]:
+    if name == "decode_boundary":
+        positions, req_indices, slots = [], [], []
+        context_len = 4096
+        for req_idx, max_position in enumerate([127, 255, 383, 511]):
+            for position in range(max_position + 1):
+                positions.append(position)
+                req_indices.append(req_idx)
+                slots.append(req_idx * context_len + position)
+        return positions, req_indices, slots
+
+    seq_len = int(name.removeprefix("prefill_"))
+    positions = list(range(seq_len))
+    return positions, [0] * seq_len, positions
+
+
+def _kv_slot_mapping(positions: list[int], ratio: int) -> list[int]:
+    kv_slots = []
+    next_slot = 0
+    for position in positions:
+        if (position + 1) % ratio == 0:
+            kv_slots.append(next_slot)
+            next_slot += 1
+        else:
+            kv_slots.append(-1)
+    return kv_slots
+
+
+def _block_table(
+    positions: list[int],
+    token_to_req: list[int],
+    slot_mapping: list[int],
+    block_size: int,
+) -> torch.Tensor:
+    num_reqs = max(token_to_req) + 1
+    num_blocks = max(positions) // block_size + 2
+    table = torch.zeros(num_reqs, num_blocks, dtype=torch.int32, device="cuda")
+    for req_idx, position, slot in zip(token_to_req, positions, slot_mapping):
+        table[req_idx, position // block_size] = slot // block_size
+    return table
+
+
+def _cos_sin_cache(max_position: int, rope_head_dim: int) -> torch.Tensor:
+    inv_freq = 1.0 / (
+        10000
+        ** (
+            torch.arange(0, rope_head_dim, 2, dtype=torch.float32, device="cuda")
+            / rope_head_dim
+        )
+    )
+    freqs = torch.outer(
+        torch.arange(max_position + 1, dtype=torch.float32, device="cuda"),
+        inv_freq,
+    )
+    return torch.cat([freqs.cos(), freqs.sin()], dim=-1)
+
+
+def build_input(shape: ShapeConfig, scenario: str) -> BenchmarkInput:
+    positions, token_to_req, slot_mapping = _scenario(shape, scenario)
+    num_tokens = len(positions)
+    kv_slot_mapping = _kv_slot_mapping(positions, shape.ratio)
+
+    generator = torch.Generator(device="cuda").manual_seed(SEED + num_tokens)
+    kv = torch.randn(
+        num_tokens,
+        shape.coff * shape.head_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    score = torch.randn_like(kv)
+    ape = torch.randn(
+        shape.ratio,
+        shape.coff * shape.head_dim,
+        dtype=torch.float32,
+        device="cuda",
+        generator=generator,
+    )
+    rms_weight = torch.rand(
+        shape.head_dim,
+        dtype=torch.float32,
+        device="cuda",
+        generator=generator,
+    ).to(torch.bfloat16)
+
+    positions_t = torch.tensor(positions, dtype=torch.int64, device="cuda")
+    token_to_req_t = torch.tensor(token_to_req, dtype=torch.int32, device="cuda")
+    slot_mapping_t = torch.tensor(slot_mapping, dtype=torch.int64, device="cuda")
+    kv_slot_mapping_t = torch.tensor(kv_slot_mapping, dtype=torch.int64, device="cuda")
+
+    max_slot = max(slot_mapping)
+    state_shape = (
+        max_slot // shape.state_block_size + 4,
+        shape.state_block_size,
+        2 * shape.state_width,
+    )
+    state_cache_fp32 = torch.zeros(state_shape, dtype=torch.float32, device="cuda")
+    state_cache_bf16 = torch.zeros(state_shape, dtype=torch.bfloat16, device="cuda")
+    save_partial_states(
+        kv=kv,
+        score=score,
+        ape=ape,
+        positions=positions_t,
+        state_cache=state_cache_fp32,
+        slot_mapping=slot_mapping_t,
+        block_size=shape.state_block_size,
+        state_width=shape.state_width,
+        compress_ratio=shape.ratio,
+    )
+    save_partial_states(
+        kv=kv,
+        score=score,
+        ape=None,
+        positions=positions_t,
+        state_cache=state_cache_bf16,
+        slot_mapping=slot_mapping_t,
+        block_size=shape.state_block_size,
+        state_width=shape.state_width,
+        compress_ratio=shape.ratio,
+    )
+
+    num_compressed_tokens = sum(slot >= 0 for slot in kv_slot_mapping)
+    return BenchmarkInput(
+        name=scenario,
+        shape=shape,
+        positions=positions_t,
+        token_to_req_indices=token_to_req_t,
+        slot_mapping=slot_mapping_t,
+        block_table=_block_table(
+            positions, token_to_req, slot_mapping, shape.state_block_size
+        ),
+        kv_slot_mapping=kv_slot_mapping_t,
+        state_cache_fp32=state_cache_fp32,
+        state_cache_bf16=state_cache_bf16,
+        ape=ape,
+        cos_sin_cache=_cos_sin_cache(max(positions), shape.rope_head_dim),
+        rms_weight=rms_weight,
+        num_tokens=num_tokens,
+        num_kv_blocks=num_compressed_tokens // KV_BLOCK_SIZE + 4,
+        kv_block_bytes=shape.token_stride + shape.scale_dim,
+    )
+
+
+def hip_available() -> bool:
+    try:
+        import vllm._rocm_C  # noqa: F401
+
+        return hasattr(torch.ops._rocm_C, "dsv4_csa_compress")
+    except Exception:
+        return False
+
+
+def run_triton(inputs: BenchmarkInput, kv_cache: torch.Tensor) -> None:
+    compress_norm_rope_store_triton(
+        state_cache=inputs.state_cache_fp32,
+        **inputs.common_kwargs(kv_cache),
+    )
+
+
+def run_hip(inputs: BenchmarkInput, kv_cache: torch.Tensor) -> None:
+    shape = inputs.shape
+    common = (
+        inputs.state_cache_bf16,
+        inputs.num_tokens,
+        inputs.ape,
+        inputs.token_to_req_indices,
+        inputs.positions,
+        inputs.slot_mapping,
+        inputs.block_table,
+        shape.state_block_size,
+        inputs.rms_weight.to(torch.float32),
+        RMS_EPS,
+        inputs.cos_sin_cache,
+        kv_cache,
+        inputs.kv_slot_mapping,
+        kv_cache.shape[1],
+        shape.scale_dim,
+    )
+    if shape.head_dim == 128:
+        torch.ops._rocm_C.dsv4_indexer_compress(
+            *common, shape.quant_format == "indexer_mxfp4"
+        )
+    elif shape.ratio == 128:
+        plan_capacity = (
+            inputs.num_tokens // shape.ratio + inputs.block_table.shape[0] + 2
+        )
+        plan_scratch = torch.empty(plan_capacity, dtype=torch.int32, device="cuda")
+        counter_scratch = torch.empty(1, dtype=torch.int32, device="cuda")
+        torch.ops._rocm_C.dsv4_hca_compress(
+            *common,
+            plan_scratch,
+            counter_scratch,
+        )
+    else:
+        torch.ops._rocm_C.dsv4_csa_compress(*common)
+
+
+def do_bench_us(fn) -> tuple[float, float, float]:
+    ms, min_ms, max_ms = triton.testing.do_bench(
+        fn,
+        quantiles=[0.5, 0.2, 0.8],
+    )
+    return 1000 * ms, 1000 * min_ms, 1000 * max_ms
+
+
+def benchmark_one(inputs: BenchmarkInput) -> tuple[str, str, str, str, str]:
+    hip_cache = inputs.new_kv_cache()
+    hip_us, _, _ = do_bench_us(lambda: run_hip(inputs, hip_cache))
+
+    if inputs.shape.quant_format == "indexer_mxfp4":
+        return inputs.shape.name, inputs.name, "n/a", f"{hip_us:.1f}", "n/a"
+
+    triton_cache = inputs.new_kv_cache()
+    triton_us, _, _ = do_bench_us(lambda: run_triton(inputs, triton_cache))
+    return (
+        inputs.shape.name,
+        inputs.name,
+        f"{triton_us:.1f}",
+        f"{hip_us:.1f}",
+        f"{hip_us / triton_us:.3f}",
+    )
+
+
+def parse_args():
+    parser = FlexibleArgumentParser(
+        description="Benchmark DeepSeek-V4 ROCm gfx950 compressor kernels."
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    parse_args()
+    torch.set_default_device("cuda")
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA/HIP device is not available")
+    if not hip_available():
+        raise SystemExit("dsv4 compressor ops are not registered in _rocm_C")
+
+    rows = []
+    for shape in SHAPES:
+        for scenario in SCENARIOS:
+            row = benchmark_one(build_input(shape, scenario))
+            rows.append(row)
+
+    print(
+        tabulate(
+            rows,
+            headers=["shape", "scenario", "triton (us)", "hip (us)", "hip/triton"],
+            tablefmt="github",
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/rocm/dsv4_compress_common.cuh
+++ b/csrc/rocm/dsv4_compress_common.cuh
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+/**
+ * Shared device code for the DeepSeek-V4 fused compressors (gfx950 / CDNA4).
+ *
+ * The CSA (ratio=4) and HCA (ratio=128) compressors share the entire output
+ * half — RMSNorm → GPT-J RoPE → native FP8 E4M3 + UE8M0 scale → packed store —
+ * over a head_dim=512 row (8 dims/lane). That writer lives here as
+ * ``dsv4::write_output_512`` (the only difference between the two is the RoPE
+ * compressed-position mask, passed as ``ratio``). ``dsv4::warp_reduce_sum`` is
+ * shared by all three compressors (CSA / HCA / indexer).
+ *
+ * The native FP8 cvt builtin is CDNA4-only, so the writer body compiles only for
+ * the gfx950 device pass (and the host pass for symbol parity); on other device
+ * passes it is an empty stub. See dsv4_*_compress.cu for the per-shape kernels.
+ */
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+#include <cmath>
+#include <cstdint>
+
+// Defined only when the device pass targets gfx950 (CDNA4). Mirrors the
+// __HIP__RDNA3__ pattern in q_gemm_rdna3.cu.
+#if defined(__HIPCC__) && defined(__gfx950__)
+  #define DSV4_GFX950
+#endif
+
+#if defined(DSV4_GFX950) || !defined(__HIP_DEVICE_COMPILE__)
+  #define DSV4_COMPILE_GFX950_BODY 1
+#endif
+
+namespace dsv4 {
+
+template <typename... Args>
+__host__ __device__ __forceinline__ void ignore_unused(const Args&...) {}
+
+constexpr int WARP_SIZE = 64;     // AMD wavefront
+constexpr int HEAD_SIZE = 512;    // CSA / HCA head_dim
+constexpr int ROPE_HEAD_DIM = 64;
+constexpr int NOPE_HEAD_DIM = HEAD_SIZE - ROPE_HEAD_DIM;       // 448
+constexpr int QUANT_BLOCK = 64;
+constexpr int N_NOPE_BLOCKS = NOPE_HEAD_DIM / QUANT_BLOCK;     // 7
+constexpr int TOKEN_STRIDE = NOPE_HEAD_DIM + ROPE_HEAD_DIM * 2;  // 576
+constexpr int DIMS_PER_LANE = HEAD_SIZE / WARP_SIZE;          // 8
+constexpr float FP8_MAX = 448.0f;
+constexpr float INV_FP8_MAX = 1.0f / FP8_MAX;
+
+// Warp-level sum reduction (64-lane wavefront).
+__device__ __forceinline__ float warp_reduce_sum(float val) {
+    #pragma unroll
+    for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+        val += __shfl_xor(val, offset);
+    }
+    return val;
+}
+
+__device__ __forceinline__ float load_rms_norm_weight(
+    const float* __restrict__ rms_norm_weight,
+    int idx
+) {
+    return rms_norm_weight[idx];
+}
+
+__device__ __forceinline__ float load_rms_norm_weight(
+    const __hip_bfloat16* __restrict__ rms_norm_weight,
+    int idx
+) {
+    return __bfloat162float(rms_norm_weight[idx]);
+}
+
+// head_dim=512 output half, shared by CSA and HCA. Must be called by all 64
+// lanes of a single wave; comp[] holds that wave's 8 dims/lane (512 total).
+// RMSNorm (warp_reduce) + GPT-J RoPE + native FP8 E4M3 + UE8M0 scale + paged
+// scatter. ``ratio`` selects the RoPE compressed-position mask (4 for CSA, 128
+// for HCA).
+template <typename WeightT>
+__device__ __forceinline__ void write_output_512(
+    float comp[DIMS_PER_LANE], int lane_id, int dim_base,
+    int64_t position, int64_t kv_slot_idx, int ratio,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache, int32_t kv_cache_block_size,
+    int64_t kv_block_stride, int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX950_BODY)
+    // RMSNorm: wave-local single warp_reduce_sum (no barrier, no LDS).
+    float sq = 0.0f;
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) sq += comp[d] * comp[d];
+    float variance = warp_reduce_sum(sq) / HEAD_SIZE;
+    float rrms = rsqrtf(variance + rms_norm_eps);
+
+    float normed[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        float w = load_rms_norm_weight(rms_norm_weight, dim_base + d);
+        normed[d] = comp[d] * rrms * w;
+    }
+
+    int64_t kv_blk_idx = kv_slot_idx / kv_cache_block_size;
+    int64_t kv_pos = kv_slot_idx % kv_cache_block_size;
+    uint8_t* cache_block = kv_cache + kv_blk_idx * kv_block_stride;
+    uint8_t* fp8_ptr = cache_block + kv_pos * TOKEN_STRIDE;
+    uint8_t* scale_ptr = cache_block + kv_cache_block_size * TOKEN_STRIDE
+                       + kv_pos * scale_dim;
+
+    // BF16 roundtrip for parity with the fused Triton path.
+    float quant[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        quant[d] = __bfloat162float(__float2bfloat16(normed[d]));
+    }
+
+    // NOPE: each lane owns 8 dims = 1/8 of a 64-dim quant block. absmax over the
+    // aligned 8-lane group (xor 4,2,1), native E4M3 pack (2 f32 -> 2 fp8/call),
+    // one dwordx2 store of the 8 contiguous NOPE bytes; one UE8M0 byte per block.
+    if (dim_base < NOPE_HEAD_DIM) {
+        float local_max = 0.0f;
+        #pragma unroll
+        for (int d = 0; d < DIMS_PER_LANE; d++) {
+            local_max = fmaxf(local_max, fabsf(quant[d]));
+        }
+        float rmax = local_max;
+        rmax = fmaxf(rmax, __shfl_xor(rmax, 4));
+        rmax = fmaxf(rmax, __shfl_xor(rmax, 2));
+        rmax = fmaxf(rmax, __shfl_xor(rmax, 1));
+        float blk_max = fmaxf(rmax, 1e-4f);
+
+        float raw_scale = blk_max * INV_FP8_MAX;
+        float exponent = ceilf(log2f(raw_scale));
+        float inv_scale = exp2f(-exponent);
+        int enc_scale = (int)(exponent + 127.0f);
+        enc_scale = max(0, min(255, enc_scale));
+
+        uint32_t words[2];
+        #pragma unroll
+        for (int p = 0; p < 2; p++) {
+            int b = p * 4;
+            int w = 0;
+            w = __builtin_amdgcn_cvt_pk_fp8_f32(quant[b]   * inv_scale,
+                                                quant[b+1] * inv_scale, w, false);
+            w = __builtin_amdgcn_cvt_pk_fp8_f32(quant[b+2] * inv_scale,
+                                                quant[b+3] * inv_scale, w, true);
+            words[p] = (uint32_t)w;
+        }
+        *reinterpret_cast<uint64_t*>(fp8_ptr + dim_base) =
+            (uint64_t)words[0] | ((uint64_t)words[1] << 32);
+
+        int qb = dim_base / QUANT_BLOCK;
+        if ((lane_id % 8) == 0 && qb < N_NOPE_BLOCKS) {
+            scale_ptr[qb] = (uint8_t)enc_scale;
+        }
+    }
+
+    if (lane_id == 0) {
+        scale_ptr[N_NOPE_BLOCKS] = 0;  // padding scale
+    }
+
+    // ROPE: GPT-J interleaved rotation + bf16 store for dims [NOPE, HEAD_SIZE).
+    if (dim_base >= NOPE_HEAD_DIM) {
+        __hip_bfloat16* bf16_out =
+            reinterpret_cast<__hip_bfloat16*>(fp8_ptr + NOPE_HEAD_DIM);
+        int64_t comp_pos = position & (~(int64_t)(ratio - 1));  // (pos/ratio)*ratio
+        const float* cs = cos_sin_cache + comp_pos * cos_sin_stride;
+        #pragma unroll
+        for (int d = 0; d < DIMS_PER_LANE; d += 2) {
+            int rope_local = (dim_base - NOPE_HEAD_DIM) + d;
+            int cs_idx = rope_local / 2;
+            float cos_v = cs[cs_idx];
+            float sin_v = cs[ROPE_HEAD_DIM / 2 + cs_idx];
+            float e = normed[d], o = normed[d + 1];
+            bf16_out[rope_local]     = __float2bfloat16(e * cos_v - o * sin_v);
+            bf16_out[rope_local + 1] = __float2bfloat16(o * cos_v + e * sin_v);
+        }
+    }
+#else
+    ignore_unused(comp, lane_id, dim_base, position, kv_slot_idx, ratio,
+                  rms_norm_weight, rms_norm_eps, cos_sin_cache, cos_sin_stride,
+                  kv_cache, kv_cache_block_size, kv_block_stride, scale_dim);
+#endif  // DSV4_COMPILE_GFX950_BODY
+}
+
+}  // namespace dsv4

--- a/csrc/rocm/dsv4_compress_ops.cu
+++ b/csrc/rocm/dsv4_compress_ops.cu
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+/**
+ * Torch op wrappers for the fused DeepSeek-V4 compressor kernels (gfx950 only).
+ *
+ * The device kernels + C-ABI launchers live in
+ * csrc/rocm/dsv4_{csa,hca,indexer}_compress.cu. These host-only wrappers adapt
+ * the model's tensor-level call (see vllm/models/deepseek_v4/compressor.py) to
+ * the launchers. Registered into _rocm_C from torch_bindings.cpp under
+ * VLLM_ROCM_GFX950.
+ */
+
+#include <torch/all.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include "rocm/ops.h"
+
+#ifdef VLLM_ROCM_GFX950
+
+extern "C" void launch_csa_compress(
+    int num_tokens,
+    const void* state_cache, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    void* stream);
+
+extern "C" void launch_hca_compress_plan(
+    int num_tokens, int nw_select,
+    const void* state_cache, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    int32_t* plan, int32_t* counter, int plan_capacity, void* stream);
+
+extern "C" void launch_indexer_compress(
+    int num_tokens, int use_fp4_cache,
+    const void* state_cache, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    void* stream);
+
+namespace {
+bool is_supported_rms_weight_dtype(const torch::Tensor& w) {
+  return w.dtype() == torch::kBFloat16 || w.dtype() == torch::kFloat32;
+}
+}  // namespace
+
+void dsv4_csa_compress(torch::Tensor state_cache, int64_t num_actual,
+                       torch::Tensor ape, torch::Tensor token_to_req_indices,
+                       torch::Tensor positions, torch::Tensor slot_mapping,
+                       torch::Tensor block_table, int64_t block_size,
+                       torch::Tensor rms_norm_weight, double rms_norm_eps,
+                       torch::Tensor cos_sin_cache, torch::Tensor kv_cache,
+                       torch::Tensor kv_slot_mapping,
+                       int64_t kv_cache_block_size, int64_t scale_dim) {
+  TORCH_CHECK(state_cache.dtype() == torch::kBFloat16, "state_cache must be bf16");
+  TORCH_CHECK(ape.dtype() == torch::kFloat32, "ape must be fp32");
+  TORCH_CHECK(is_supported_rms_weight_dtype(rms_norm_weight),
+              "rms_norm_weight must be bf16 or fp32");
+  TORCH_CHECK(ape.size(0) == 4, "CSA expects RAW ape [4, 2*head_dim]");
+  if (num_actual == 0) return;
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(state_cache));
+  bool rms_norm_weight_is_bf16 = rms_norm_weight.dtype() == torch::kBFloat16;
+  launch_csa_compress(
+      static_cast<int>(num_actual), state_cache.data_ptr(),
+      state_cache.stride(0), state_cache.stride(1), ape.data_ptr<float>(),
+      ape.stride(0), token_to_req_indices.data_ptr<int32_t>(),
+      positions.data_ptr<int64_t>(), slot_mapping.data_ptr<int64_t>(),
+      block_table.data_ptr<int32_t>(), block_table.stride(0),
+      static_cast<int32_t>(block_size), rms_norm_weight.data_ptr(),
+      rms_norm_weight_is_bf16, static_cast<float>(rms_norm_eps),
+      cos_sin_cache.data_ptr<float>(),
+      cos_sin_cache.stride(0), kv_cache.data_ptr<uint8_t>(),
+      kv_slot_mapping.data_ptr<int64_t>(),
+      static_cast<int32_t>(kv_cache_block_size), kv_cache.stride(0),
+      static_cast<int32_t>(scale_dim),
+      at::cuda::getCurrentCUDAStream().stream());
+}
+
+void dsv4_hca_compress(torch::Tensor state_cache, int64_t num_actual,
+                       torch::Tensor ape, torch::Tensor token_to_req_indices,
+                       torch::Tensor positions, torch::Tensor slot_mapping,
+                       torch::Tensor block_table, int64_t block_size,
+                       torch::Tensor rms_norm_weight, double rms_norm_eps,
+                       torch::Tensor cos_sin_cache, torch::Tensor kv_cache,
+                       torch::Tensor kv_slot_mapping,
+                       int64_t kv_cache_block_size, int64_t scale_dim,
+                       torch::Tensor plan_scratch,
+                       torch::Tensor counter_scratch) {
+  TORCH_CHECK(state_cache.dtype() == torch::kBFloat16, "state_cache must be bf16");
+  TORCH_CHECK(ape.dtype() == torch::kFloat32, "ape must be fp32");
+  TORCH_CHECK(is_supported_rms_weight_dtype(rms_norm_weight),
+              "rms_norm_weight must be bf16 or fp32");
+  TORCH_CHECK(plan_scratch.dtype() == torch::kInt32,
+              "plan_scratch must be int32");
+  TORCH_CHECK(counter_scratch.dtype() == torch::kInt32,
+              "counter_scratch must be int32");
+  TORCH_CHECK(ape.size(0) == 128, "HCA expects RAW ape [128, head_dim]");
+  if (num_actual == 0) return;
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(state_cache));
+  bool rms_norm_weight_is_bf16 = rms_norm_weight.dtype() == torch::kBFloat16;
+
+  // Compact-plan scratch: safe upper bound on boundary count.
+  int64_t num_reqs = block_table.size(0);
+  int plan_capacity = static_cast<int>(num_actual / 128 + num_reqs + 2);
+  TORCH_CHECK(plan_scratch.device() == state_cache.device(),
+              "plan_scratch must be on the same device as state_cache");
+  TORCH_CHECK(counter_scratch.device() == state_cache.device(),
+              "counter_scratch must be on the same device as state_cache");
+  TORCH_CHECK(plan_scratch.numel() >= plan_capacity,
+              "plan_scratch is too small for HCA compact plan");
+  TORCH_CHECK(counter_scratch.numel() >= 1,
+              "counter_scratch must have at least one element");
+
+  launch_hca_compress_plan(
+      static_cast<int>(num_actual), /*nw_select=*/0, state_cache.data_ptr(),
+      state_cache.stride(0), state_cache.stride(1), ape.data_ptr<float>(),
+      ape.stride(0), token_to_req_indices.data_ptr<int32_t>(),
+      positions.data_ptr<int64_t>(), slot_mapping.data_ptr<int64_t>(),
+      block_table.data_ptr<int32_t>(), block_table.stride(0),
+      static_cast<int32_t>(block_size), rms_norm_weight.data_ptr(),
+      rms_norm_weight_is_bf16, static_cast<float>(rms_norm_eps),
+      cos_sin_cache.data_ptr<float>(),
+      cos_sin_cache.stride(0), kv_cache.data_ptr<uint8_t>(),
+      kv_slot_mapping.data_ptr<int64_t>(),
+      static_cast<int32_t>(kv_cache_block_size), kv_cache.stride(0),
+      static_cast<int32_t>(scale_dim), plan_scratch.data_ptr<int32_t>(),
+      counter_scratch.data_ptr<int32_t>(), plan_capacity,
+      at::cuda::getCurrentCUDAStream().stream());
+}
+
+void dsv4_indexer_compress(torch::Tensor state_cache, int64_t num_actual,
+                           torch::Tensor ape,
+                           torch::Tensor token_to_req_indices,
+                           torch::Tensor positions, torch::Tensor slot_mapping,
+                           torch::Tensor block_table, int64_t block_size,
+                           torch::Tensor rms_norm_weight, double rms_norm_eps,
+                           torch::Tensor cos_sin_cache, torch::Tensor kv_cache,
+                           torch::Tensor kv_slot_mapping,
+                           int64_t kv_cache_block_size, int64_t scale_dim,
+                           bool use_fp4_cache) {
+  TORCH_CHECK(state_cache.dtype() == torch::kBFloat16, "state_cache must be bf16");
+  TORCH_CHECK(ape.dtype() == torch::kFloat32, "ape must be fp32");
+  TORCH_CHECK(is_supported_rms_weight_dtype(rms_norm_weight),
+              "rms_norm_weight must be bf16 or fp32");
+  TORCH_CHECK(ape.size(0) == 4 && ape.size(1) == 256,
+              "indexer expects RAW ape [4, 256]");
+  if (num_actual == 0) return;
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(state_cache));
+  bool rms_norm_weight_is_bf16 = rms_norm_weight.dtype() == torch::kBFloat16;
+  launch_indexer_compress(
+      static_cast<int>(num_actual), use_fp4_cache ? 1 : 0, state_cache.data_ptr(),
+      state_cache.stride(0), state_cache.stride(1), ape.data_ptr<float>(),
+      ape.stride(0), token_to_req_indices.data_ptr<int32_t>(),
+      positions.data_ptr<int64_t>(), slot_mapping.data_ptr<int64_t>(),
+      block_table.data_ptr<int32_t>(), block_table.stride(0),
+      static_cast<int32_t>(block_size), rms_norm_weight.data_ptr(),
+      rms_norm_weight_is_bf16, static_cast<float>(rms_norm_eps),
+      cos_sin_cache.data_ptr<float>(),
+      cos_sin_cache.stride(0), kv_cache.data_ptr<uint8_t>(),
+      kv_slot_mapping.data_ptr<int64_t>(),
+      static_cast<int32_t>(kv_cache_block_size), kv_cache.stride(0),
+      static_cast<int32_t>(scale_dim),
+      at::cuda::getCurrentCUDAStream().stream());
+}
+
+#endif  // VLLM_ROCM_GFX950

--- a/csrc/rocm/dsv4_csa_compress.cu
+++ b/csrc/rocm/dsv4_csa_compress.cu
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+/**
+ * HIP CSA Compressor Kernel - DeepSeek-V4 Ratio=4 Specialized BF16 Fast Path
+ *
+ * Fully fused, plan-free kernel for gfx950 (CDNA4 / MI350):
+ *   - wave-per-boundary mapping (each wave owns one token, 8 dims/lane);
+ *     RMSNorm variance is a single warp_reduce_sum -> NO __syncthreads, NO LDS.
+ *   - single fused load pass + online softmax (kv and score read together).
+ *     (A two-pass max-then-exp form halves the transcendentals but adds a
+ *     second score load pass; benchmarked -14% at 32k prefill because this
+ *     kernel is load/bandwidth-bound at scale, not exp-bound. Kept single-pass.)
+ *   - on-device boundary derivation: launched per-TOKEN, non-boundary waves
+ *     return immediately, so there is NO host plan / no positions[].item() syncs.
+ *   - raw APE [4, 2*HEAD_SIZE] read directly (no host-side expansion).
+ * 128-bit vectorized loads; native v_cvt_pk_fp8_f32 E4M3 quant; 79 VGPR /
+ * 0 spill -> 6 waves/SIMD.
+ *
+ * Built into the _rocm_C extension for all VLLM_GPU_ARCHES. The native FP8 cvt
+ * builtin exists only on gfx950 (CDNA4), so the kernel BODY is compiled only for
+ * the gfx950 device pass (and the host pass for symbol parity); on other device
+ * passes it is an empty stub. The host launcher always compiles, and the Python
+ * dispatcher only routes to this op on gfx950.
+ */
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+#include <cmath>
+#include <cstdint>
+
+#include "dsv4_compress_common.cuh"
+using namespace dsv4;  // HEAD_SIZE, WARP_SIZE, DIMS_PER_LANE, warp_reduce_sum, write_output_512, ...
+
+// CSA-specific config (ratio=4, overlap). Shared 512-dim constants + the output
+// writer live in dsv4_compress_common.cuh.
+[[maybe_unused]] constexpr int K_POOL = 8;
+[[maybe_unused]] constexpr int STATE_WIDTH = 1024;  // overlap mode: 2 * HEAD_SIZE
+[[maybe_unused]] constexpr int BLOCK_SIZE = 256;    // 4 waves
+
+// (An XCD-locality block remap was tried here to capture the K_POOL overlap
+// reuse -- adjacent boundaries share 4 of 8 rows. It only lifted 32k L2 hit
+// 30%->32% and REGRESSED device time -8%: the default sequential block order is
+// already HBM-streaming friendly, and intra-XCD concurrency evicts the shared
+// rows faster than the reuse distance, so static swizzle loses streaming
+// locality without capturing reuse. Reverted. The overlap reuse needs explicit
+// per-wave load-union, not scheduling alone.)
+
+// ============================================================================
+// Kernel: fully fused, plan-free, wave-per-boundary
+// ============================================================================
+// block = 256 threads = 4 waves; each wave maps to ONE token and owns 8
+// contiguous hidden dims (64 lanes * 8 = 512). The boundary is derived
+// on-device; non-boundary waves return immediately. grid = ceil(num_tokens/4).
+template <typename WeightT>
+__global__ void csa_compress_kernel(
+    int num_tokens,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0,
+    int64_t state_stride1,
+    const float* __restrict__ ape,          // RAW [4, 2*HEAD_SIZE] fp32
+    int64_t ape_stride,                      // = ape.stride(0) (e.g. 1024)
+    const int32_t* __restrict__ token_to_req_indices,
+    const int64_t* __restrict__ positions,
+    const int64_t* __restrict__ slot_mapping,
+    const int32_t* __restrict__ block_table,
+    int64_t block_table_stride,
+    int32_t block_size,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache,
+    int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache,
+    const int64_t* __restrict__ kv_slot_mapping,
+    int32_t kv_cache_block_size,
+    int64_t kv_block_stride,
+    int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX950_BODY)
+    int wave_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int token_idx = blockIdx.x * (BLOCK_SIZE / WARP_SIZE) + wave_id;
+    if (token_idx >= num_tokens) return;
+
+    // On-device boundary derivation (replaces the host plan).
+    int64_t kv_slot_idx = kv_slot_mapping[token_idx];
+    int64_t position = positions[token_idx];
+    if (((position + 1) & 3) != 0 || kv_slot_idx < 0) return;  // not a boundary
+    int64_t slot_id = slot_mapping[token_idx];
+    if (slot_id < 0) return;
+
+    int32_t req_idx = token_to_req_indices[token_idx];
+    int64_t start_pos = position - (K_POOL - 1);
+    int dim_base = lane_id * DIMS_PER_LANE;  // 0,8,...,504
+
+    // Phase 1: resolve row base pointers (wave-uniform -> SGPR; gather batches).
+    const __hip_bfloat16* row_ptrs[K_POOL];
+    bool valid_k[K_POOL];
+    #pragma unroll
+    for (int k = 0; k < K_POOL; k++) {
+        int64_t pos_k = start_pos + k;
+        if (pos_k < 0) {
+            valid_k[k] = false;
+            row_ptrs[k] = nullptr;
+            continue;
+        }
+        valid_k[k] = true;
+        int64_t blk_idx = pos_k / block_size;
+        int64_t blk_off = pos_k % block_size;
+        int32_t blk_num = block_table[req_idx * block_table_stride + blk_idx];
+        int head_offset = (k >= 4) ? HEAD_SIZE : 0;
+        row_ptrs[k] = state_cache + blk_num * state_stride0
+                    + blk_off * state_stride1 + head_offset;
+    }
+
+    // Online softmax: single fused pass loading score AND kv per k. APE is read
+    // straight from raw [4, 1024]: expanded[k] = ape[k&3, (k>=4?HEAD:0) + d].
+    float m[DIMS_PER_LANE], l[DIMS_PER_LANE], acc[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        m[d] = -INFINITY; l[d] = 0.0f; acc[d] = 0.0f;
+    }
+    #pragma unroll
+    for (int k = 0; k < K_POOL; k++) {
+        if (!valid_k[k]) continue;  // exp(-inf) contributes nothing
+        union { float4 v; __hip_bfloat16 h[8]; } us, uk;
+        us.v = *reinterpret_cast<const float4*>(row_ptrs[k] + STATE_WIDTH + dim_base);
+        uk.v = *reinterpret_cast<const float4*>(row_ptrs[k] + dim_base);
+        const float* ape_ptr = ape + (int64_t)(k & 3) * ape_stride
+                             + ((k >= 4) ? HEAD_SIZE : 0) + dim_base;
+        #pragma unroll
+        for (int d = 0; d < DIMS_PER_LANE; d++) {
+            float s = __bfloat162float(us.h[d]) + ape_ptr[d];
+            float kvv = __bfloat162float(uk.h[d]);
+            float new_m = fmaxf(m[d], s);
+            float corr = __expf(m[d] - new_m);   // 0 on first valid k (m=-inf)
+            float p = __expf(s - new_m);
+            l[d] = l[d] * corr + p;
+            acc[d] = acc[d] * corr + p * kvv;
+            m[d] = new_m;
+        }
+    }
+    float comp[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) comp[d] = acc[d] / l[d];
+
+    // Shared head_dim=512 output half (RMSNorm + GPT-J RoPE + FP8 + store).
+    // ratio=4 selects the CSA RoPE compressed-position mask.
+    write_output_512(comp, lane_id, dim_base, position, kv_slot_idx, /*ratio=*/4,
+                     rms_norm_weight, rms_norm_eps,
+                     cos_sin_cache, cos_sin_stride, kv_cache, kv_cache_block_size,
+                     kv_block_stride, scale_dim);
+#else
+    dsv4::ignore_unused(num_tokens, state_cache, state_stride0, state_stride1,
+                        ape, ape_stride, token_to_req_indices, positions,
+                        slot_mapping, block_table, block_table_stride,
+                        block_size, rms_norm_weight, rms_norm_eps,
+                        cos_sin_cache, cos_sin_stride, kv_cache,
+                        kv_slot_mapping, kv_cache_block_size, kv_block_stride,
+                        scale_dim);
+#endif  // DSV4_COMPILE_GFX950_BODY
+}
+
+// ============================================================================
+// Launcher
+// ============================================================================
+
+extern "C" void launch_csa_compress(
+    int num_tokens,
+    const void* state_cache_ptr, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices,
+    const int64_t* positions,
+    const int64_t* slot_mapping,
+    const int32_t* block_table, int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    void* stream_ptr
+) {
+    if (num_tokens == 0) return;
+
+    const __hip_bfloat16* state_cache = reinterpret_cast<const __hip_bfloat16*>(state_cache_ptr);
+    hipStream_t stream = reinterpret_cast<hipStream_t>(stream_ptr);
+
+    constexpr int WAVES_PER_BLOCK = BLOCK_SIZE / WARP_SIZE;  // 4
+    int num_blocks = (num_tokens + WAVES_PER_BLOCK - 1) / WAVES_PER_BLOCK;
+    dim3 grid(num_blocks);
+    dim3 block(BLOCK_SIZE);
+
+    #define CSA_FWD_ARGS \
+        num_tokens, state_cache, state_stride0, state_stride1, \
+        ape_raw, ape_stride, token_to_req_indices, positions, slot_mapping, \
+        block_table, block_table_stride, block_size, rms_norm_weight_t, \
+        rms_norm_eps, cos_sin_cache, cos_sin_stride, kv_cache, kv_slot_mapping, \
+        kv_cache_block_size, kv_block_stride, scale_dim
+
+    if (rms_norm_weight_is_bf16) {
+        const __hip_bfloat16* rms_norm_weight_t =
+            reinterpret_cast<const __hip_bfloat16*>(rms_norm_weight);
+        hipLaunchKernelGGL((csa_compress_kernel<__hip_bfloat16>),
+                           grid, block, 0, stream, CSA_FWD_ARGS);
+    } else {
+        const float* rms_norm_weight_t =
+            reinterpret_cast<const float*>(rms_norm_weight);
+        hipLaunchKernelGGL((csa_compress_kernel<float>),
+                           grid, block, 0, stream, CSA_FWD_ARGS);
+    }
+    #undef CSA_FWD_ARGS
+}

--- a/csrc/rocm/dsv4_hca_compress.cu
+++ b/csrc/rocm/dsv4_hca_compress.cu
@@ -1,0 +1,577 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+/**
+ * HIP HCA Compressor Kernel - DeepSeek-V4 Ratio=128 Main Path (BF16 state)
+ *
+ * HCA differs from CSA (ratio=4) in the front half only:
+ *   - ratio = 128, K_POOL = 128 (NO overlap, coff=1) -> each boundary
+ *     softmax-weight-sums 128 state rows (vs 8 for CSA).
+ *   - state_width = HEAD_SIZE = 512 (single region; no k>=4 head offset).
+ *   - boundary: (position + 1) % 128 == 0; window = [position-127, position]
+ *     (always >= 0, so no padding mask is needed).
+ *   - APE is raw [128, HEAD_SIZE] fp32; expanded[k] = ape[k, d].
+ *   - state-cache page size (block_size) is 8 (vs 4 for CSA).
+ * The output half (RMSNorm warp_reduce, native v_cvt_pk_fp8_f32 E4M3 + UE8M0
+ * scale + GPT-J bf16 RoPE, packed dwordx2 store) is identical to CSA and is
+ * factored into hca_write_output() (called by one full wave).
+ *
+ * Two kernels:
+ *   v0  hca_compress_kernel        - wave-per-boundary, K=128 serial.
+ *       Good when boundaries are dense enough to fill the machine (huge N);
+ *       4 tokens/block, no LDS.
+ *   v1  hca_compress_ksplit_kernel<NW>  - block-per-boundary, K split across
+ *       NW waves + LDS cross-wave online-softmax reduce. Lifts occupancy when
+ *       boundaries are sparse (ratio=128 -> always sparse at small/mid N).
+ * launch_hca_compress() auto-dispatches NW by estimated boundary count.
+ *
+ * Built into the _rocm_C extension for all VLLM_GPU_ARCHES. The native FP8 cvt
+ * builtin (in hca_write_output) exists only on gfx950 (CDNA4), so that helper's
+ * BODY is compiled only for the gfx950 device pass (and the host pass for symbol
+ * parity); on other device passes it is an empty stub. Everything else (the
+ * kernels, build_plan, launchers) always compiles, and the Python dispatcher
+ * only routes to this op on gfx950.
+ */
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+#include <cmath>
+#include <cstdint>
+
+#include "dsv4_compress_common.cuh"
+using namespace dsv4;  // HEAD_SIZE, WARP_SIZE, DIMS_PER_LANE, warp_reduce_sum, write_output_512, ...
+
+// HCA-specific config (ratio=128, no overlap). Shared 512-dim constants + the
+// output writer live in dsv4_compress_common.cuh.
+[[maybe_unused]] constexpr int RATIO = 128;
+[[maybe_unused]] constexpr int K_POOL = RATIO;          // no overlap -> K_POOL == ratio
+[[maybe_unused]] constexpr int STATE_WIDTH = HEAD_SIZE; // no overlap: kv | score each HEAD_SIZE
+[[maybe_unused]] constexpr int V0_BLOCK_SIZE = 256;     // v0: 4 waves (4 tokens/block)
+
+// Per-(k) online-softmax update of one lane's 8 dims, reading row k of the
+// state cache + APE. Used by both kernels.
+__device__ __forceinline__ void hca_softmax_step(
+    int k, int64_t start_pos, int32_t req_idx,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const int32_t* __restrict__ block_table, int64_t block_table_stride,
+    int32_t block_size, const float* __restrict__ ape, int64_t ape_stride,
+    int dim_base, float m[DIMS_PER_LANE], float l[DIMS_PER_LANE],
+    float acc[DIMS_PER_LANE]
+) {
+#if defined(DSV4_COMPILE_GFX950_BODY)
+    int64_t pos_k = start_pos + k;
+    if (pos_k < 0) return;  // dead for HCA (boundary position >= 127)
+    int64_t blk_idx = pos_k / block_size;
+    int64_t blk_off = pos_k % block_size;
+    int32_t blk_num = block_table[req_idx * block_table_stride + blk_idx];
+    const __hip_bfloat16* row = state_cache + blk_num * state_stride0
+                              + blk_off * state_stride1;
+    union { float4 v; __hip_bfloat16 h[8]; } us, uk;
+    us.v = *reinterpret_cast<const float4*>(row + STATE_WIDTH + dim_base);
+    uk.v = *reinterpret_cast<const float4*>(row + dim_base);
+    const float* ape_ptr = ape + (int64_t)k * ape_stride + dim_base;
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        float s = __bfloat162float(us.h[d]) + ape_ptr[d];
+        float kvv = __bfloat162float(uk.h[d]);
+        float new_m = fmaxf(m[d], s);
+        float corr = __expf(m[d] - new_m);
+        float p = __expf(s - new_m);
+        l[d] = l[d] * corr + p;
+        acc[d] = acc[d] * corr + p * kvv;
+        m[d] = new_m;
+    }
+#else
+    dsv4::ignore_unused(k, start_pos, req_idx, state_cache, state_stride0,
+                        state_stride1, block_table, block_table_stride,
+                        block_size, ape, ape_stride, dim_base, m, l, acc);
+#endif  // DSV4_COMPILE_GFX950_BODY
+}
+
+// ============================================================================
+// v0: wave-per-boundary, K=128 serial. grid = ceil(num_tokens / 4).
+// ============================================================================
+template <typename WeightT>
+__global__ void hca_compress_kernel(
+    int num_tokens,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* __restrict__ ape, int64_t ape_stride,
+    const int32_t* __restrict__ token_to_req_indices,
+    const int64_t* __restrict__ positions,
+    const int64_t* __restrict__ slot_mapping,
+    const int32_t* __restrict__ block_table, int64_t block_table_stride,
+    int32_t block_size,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache, const int64_t* __restrict__ kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX950_BODY)
+    int wave_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int token_idx = blockIdx.x * (V0_BLOCK_SIZE / WARP_SIZE) + wave_id;
+    if (token_idx >= num_tokens) return;
+
+    int64_t kv_slot_idx = kv_slot_mapping[token_idx];
+    int64_t position = positions[token_idx];
+    if (((position + 1) & (RATIO - 1)) != 0 || kv_slot_idx < 0) return;
+    if (slot_mapping[token_idx] < 0) return;
+
+    int32_t req_idx = token_to_req_indices[token_idx];
+    int64_t start_pos = position - (K_POOL - 1);
+    int dim_base = lane_id * DIMS_PER_LANE;
+
+    float m[DIMS_PER_LANE], l[DIMS_PER_LANE], acc[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) { m[d] = -INFINITY; l[d] = 0.0f; acc[d] = 0.0f; }
+    for (int k = 0; k < K_POOL; k++) {
+        hca_softmax_step(k, start_pos, req_idx, state_cache, state_stride0,
+                         state_stride1, block_table, block_table_stride,
+                         block_size, ape, ape_stride, dim_base, m, l, acc);
+    }
+    float comp[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) comp[d] = acc[d] / l[d];
+
+    write_output_512(comp, lane_id, dim_base, position, kv_slot_idx, RATIO,
+                     rms_norm_weight, rms_norm_eps,
+                     cos_sin_cache, cos_sin_stride, kv_cache,
+                     kv_cache_block_size, kv_block_stride, scale_dim);
+#else
+    dsv4::ignore_unused(num_tokens, state_cache, state_stride0, state_stride1,
+                        ape, ape_stride, token_to_req_indices, positions,
+                        slot_mapping, block_table, block_table_stride,
+                        block_size, rms_norm_weight, rms_norm_eps,
+                        cos_sin_cache, cos_sin_stride, kv_cache,
+                        kv_slot_mapping, kv_cache_block_size, kv_block_stride,
+                        scale_dim);
+#endif  // DSV4_COMPILE_GFX950_BODY
+}
+
+// K-split body: NW waves split the 128 rows, LDS cross-wave online-softmax
+// reduce, wave 0 writes output. Called uniformly by all block threads for a
+// resolved boundary (token_idx/position/kv_slot_idx already known valid).
+//
+// (A dim-tiled merge to halve the LDS — NW*256*3 over 2 passes instead of
+// NW*512*3 — was tried to lift occupancy from the 48KB-LDS-locked 2 waves/SIMD
+// toward 4. It REGRESSED 5-37%: VGPR rose 118->130 (comp[] lives across passes)
+// capping occupancy at 3, and the extra barriers serialized the merge and hurt
+// large-N throughput. The 2-waves/SIMD occupancy was not the real limiter —
+// large N is bandwidth-bound (~45% peak), small N is boundary-count-bound.
+// Reverted; single-pass merge below.)
+template <int NW, typename WeightT>
+__device__ __forceinline__ void hca_ksplit_body(
+    int token_idx, int64_t position, int64_t kv_slot_idx,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* __restrict__ ape, int64_t ape_stride,
+    const int32_t* __restrict__ token_to_req_indices,
+    const int32_t* __restrict__ block_table, int64_t block_table_stride,
+    int32_t block_size,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX950_BODY)
+    constexpr int K_PER_WAVE = K_POOL / NW;
+    int wid = threadIdx.x / WARP_SIZE;     // 0..NW-1
+    int lane_id = threadIdx.x % WARP_SIZE; // 0..63
+    int dim_base = lane_id * DIMS_PER_LANE;
+    int32_t req_idx = token_to_req_indices[token_idx];
+    int64_t start_pos = position - (K_POOL - 1);
+
+    float m[DIMS_PER_LANE], l[DIMS_PER_LANE], acc[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) { m[d] = -INFINITY; l[d] = 0.0f; acc[d] = 0.0f; }
+    int k0 = wid * K_PER_WAVE;
+    #pragma unroll
+    for (int kk = 0; kk < K_PER_WAVE; kk++) {
+        hca_softmax_step(k0 + kk, start_pos, req_idx, state_cache, state_stride0,
+                         state_stride1, block_table, block_table_stride,
+                         block_size, ape, ape_stride, dim_base, m, l, acc);
+    }
+
+    __shared__ float sm[NW * HEAD_SIZE];
+    __shared__ float sl[NW * HEAD_SIZE];
+    __shared__ float sa[NW * HEAD_SIZE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        int idx = wid * HEAD_SIZE + dim_base + d;
+        sm[idx] = m[d]; sl[idx] = l[d]; sa[idx] = acc[d];
+    }
+    __syncthreads();
+    if (wid != 0) return;  // only wave 0 reduces + writes output
+
+    float comp[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        int dd = dim_base + d;
+        float mg = -INFINITY;
+        #pragma unroll
+        for (int w = 0; w < NW; w++) mg = fmaxf(mg, sm[w * HEAD_SIZE + dd]);
+        float ls = 0.0f, as = 0.0f;
+        #pragma unroll
+        for (int w = 0; w < NW; w++) {
+            float sc = __expf(sm[w * HEAD_SIZE + dd] - mg);
+            ls += sl[w * HEAD_SIZE + dd] * sc;
+            as += sa[w * HEAD_SIZE + dd] * sc;
+        }
+        comp[d] = as / ls;
+    }
+    write_output_512(comp, lane_id, dim_base, position, kv_slot_idx, RATIO,
+                     rms_norm_weight, rms_norm_eps,
+                     cos_sin_cache, cos_sin_stride, kv_cache,
+                     kv_cache_block_size, kv_block_stride, scale_dim);
+#else
+    dsv4::ignore_unused(token_idx, position, kv_slot_idx, state_cache,
+                        state_stride0, state_stride1, ape, ape_stride,
+                        token_to_req_indices, block_table, block_table_stride,
+                        block_size, rms_norm_weight, rms_norm_eps,
+                        cos_sin_cache, cos_sin_stride, kv_cache,
+                        kv_cache_block_size, kv_block_stride, scale_dim);
+#endif  // DSV4_COMPILE_GFX950_BODY
+}
+
+// ----------------------------------------------------------------------------
+// v1: plan-free. grid = num_tokens; block-per-token; non-boundary blocks bail.
+// ----------------------------------------------------------------------------
+template <int NW, typename WeightT>
+__global__ void __launch_bounds__(WARP_SIZE * NW)
+hca_compress_ksplit_kernel(
+    int num_tokens,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* __restrict__ ape, int64_t ape_stride,
+    const int32_t* __restrict__ token_to_req_indices,
+    const int64_t* __restrict__ positions,
+    const int64_t* __restrict__ slot_mapping,
+    const int32_t* __restrict__ block_table, int64_t block_table_stride,
+    int32_t block_size,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache, const int64_t* __restrict__ kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX950_BODY)
+    int token_idx = blockIdx.x;
+    if (token_idx >= num_tokens) return;
+    int64_t kv_slot_idx = kv_slot_mapping[token_idx];
+    int64_t position = positions[token_idx];
+    if (((position + 1) & (RATIO - 1)) != 0 || kv_slot_idx < 0) return;
+    if (slot_mapping[token_idx] < 0) return;
+    hca_ksplit_body<NW, WeightT>(token_idx, position, kv_slot_idx, state_cache,
+        state_stride0, state_stride1, ape, ape_stride, token_to_req_indices,
+        block_table, block_table_stride, block_size, rms_norm_weight,
+        rms_norm_eps, cos_sin_cache, cos_sin_stride, kv_cache, kv_cache_block_size,
+        kv_block_stride, scale_dim);
+#else
+    dsv4::ignore_unused(num_tokens, state_cache, state_stride0, state_stride1,
+                        ape, ape_stride, token_to_req_indices, positions,
+                        slot_mapping, block_table, block_table_stride,
+                        block_size, rms_norm_weight, rms_norm_eps,
+                        cos_sin_cache, cos_sin_stride, kv_cache,
+                        kv_slot_mapping, kv_cache_block_size, kv_block_stride,
+                        scale_dim);
+#endif  // DSV4_COMPILE_GFX950_BODY
+}
+
+// ============================================================================
+// v2: compact plan. A prep kernel atomically compacts boundary token indices
+// into plan[]; the compress kernel launches grid = plan_capacity (host upper
+// bound) and bails on sentinel rows -> no num_tokens-sized wasted launches.
+// ============================================================================
+extern "C" __global__ void hca_build_plan_kernel(
+    int num_tokens,
+    const int64_t* __restrict__ positions,
+    const int64_t* __restrict__ slot_mapping,
+    const int64_t* __restrict__ kv_slot_mapping,
+    int32_t* __restrict__ plan,        // [plan_capacity] init to -1
+    int32_t* __restrict__ counter      // [1] init to 0
+) {
+#if defined(DSV4_COMPILE_GFX950_BODY)
+    int t = blockIdx.x * blockDim.x + threadIdx.x;
+    if (t >= num_tokens) return;
+    int64_t kv_slot = kv_slot_mapping[t];
+    int64_t pos = positions[t];
+    if (((pos + 1) & (RATIO - 1)) != 0 || kv_slot < 0) return;
+    if (slot_mapping[t] < 0) return;
+    int slot = atomicAdd(counter, 1);
+    plan[slot] = t;  // plan_capacity is a safe upper bound -> no overflow
+#else
+    dsv4::ignore_unused(num_tokens, positions, slot_mapping, kv_slot_mapping,
+                        plan, counter);
+#endif  // DSV4_COMPILE_GFX950_BODY
+}
+
+template <int NW, typename WeightT>
+__global__ void __launch_bounds__(WARP_SIZE * NW)
+hca_compress_plan_ksplit_kernel(
+    const int32_t* __restrict__ plan,  // [plan_capacity]; -1 = sentinel
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* __restrict__ ape, int64_t ape_stride,
+    const int32_t* __restrict__ token_to_req_indices,
+    const int64_t* __restrict__ positions,
+    const int32_t* __restrict__ block_table, int64_t block_table_stride,
+    int32_t block_size,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache, const int64_t* __restrict__ kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX950_BODY)
+    int token_idx = plan[blockIdx.x];
+    if (token_idx < 0) return;  // sentinel padding row
+    int64_t position = positions[token_idx];
+    int64_t kv_slot_idx = kv_slot_mapping[token_idx];
+    hca_ksplit_body<NW, WeightT>(token_idx, position, kv_slot_idx, state_cache,
+        state_stride0, state_stride1, ape, ape_stride, token_to_req_indices,
+        block_table, block_table_stride, block_size, rms_norm_weight,
+        rms_norm_eps, cos_sin_cache, cos_sin_stride, kv_cache,
+        kv_cache_block_size, kv_block_stride, scale_dim);
+#else
+    dsv4::ignore_unused(plan, state_cache, state_stride0, state_stride1, ape,
+                        ape_stride, token_to_req_indices, positions,
+                        block_table, block_table_stride, block_size,
+                        rms_norm_weight, rms_norm_eps, cos_sin_cache,
+                        cos_sin_stride, kv_cache, kv_slot_mapping,
+                        kv_cache_block_size, kv_block_stride, scale_dim);
+#endif  // DSV4_COMPILE_GFX950_BODY
+}
+
+// ============================================================================
+// Launchers
+// ============================================================================
+
+template <int NW, typename WeightT>
+static void ksplit_launch(
+    int num_tokens, const __hip_bfloat16* state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* ape, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const WeightT* rms_norm_weight,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    hipStream_t stream
+) {
+    dim3 grid(num_tokens);
+    dim3 block(WARP_SIZE * NW);
+    hipLaunchKernelGGL(
+        (hca_compress_ksplit_kernel<NW, WeightT>), grid, block, 0, stream,
+        num_tokens, state_cache, state_stride0, state_stride1,
+        ape, ape_stride, token_to_req_indices, positions, slot_mapping,
+        block_table, block_table_stride, block_size,
+        rms_norm_weight, rms_norm_eps,
+        cos_sin_cache, cos_sin_stride,
+        kv_cache, kv_slot_mapping, kv_cache_block_size, kv_block_stride, scale_dim);
+}
+
+template <typename WeightT>
+static void v0_launch(
+    int num_tokens, const __hip_bfloat16* state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* ape, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const WeightT* rms_norm_weight,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    hipStream_t stream
+) {
+    int num_blocks = (num_tokens + (V0_BLOCK_SIZE / WARP_SIZE) - 1) / (V0_BLOCK_SIZE / WARP_SIZE);
+    hipLaunchKernelGGL(
+        (hca_compress_kernel<WeightT>), dim3(num_blocks), dim3(V0_BLOCK_SIZE), 0, stream,
+        num_tokens, state_cache, state_stride0, state_stride1,
+        ape, ape_stride, token_to_req_indices, positions, slot_mapping,
+        block_table, block_table_stride, block_size,
+        rms_norm_weight, rms_norm_eps,
+        cos_sin_cache, cos_sin_stride,
+        kv_cache, kv_slot_mapping, kv_cache_block_size, kv_block_stride, scale_dim);
+}
+
+template <int NW, typename WeightT>
+static void plan_ksplit_launch(
+    int plan_capacity, const int32_t* plan, const __hip_bfloat16* state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* ape, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int32_t* block_table, int64_t block_table_stride, int32_t block_size,
+    const WeightT* rms_norm_weight,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    hipStream_t stream
+) {
+    hipLaunchKernelGGL(
+        (hca_compress_plan_ksplit_kernel<NW, WeightT>),
+        dim3(plan_capacity), dim3(WARP_SIZE * NW),
+        0, stream, plan, state_cache, state_stride0, state_stride1,
+        ape, ape_stride, token_to_req_indices, positions,
+        block_table, block_table_stride, block_size,
+        rms_norm_weight, rms_norm_eps,
+        cos_sin_cache, cos_sin_stride,
+        kv_cache, kv_slot_mapping, kv_cache_block_size, kv_block_stride, scale_dim);
+}
+
+#define HCA_FWD_ARGS \
+    state_cache, state_stride0, state_stride1, ape_raw, ape_stride, \
+    token_to_req_indices, positions, slot_mapping, block_table, \
+    block_table_stride, block_size, rms_norm_weight_t, rms_norm_eps, \
+    cos_sin_cache, cos_sin_stride, kv_cache, kv_slot_mapping, \
+    kv_cache_block_size, kv_block_stride, scale_dim, stream
+
+#define HCA_PLAN_ARGS \
+    state_cache, state_stride0, state_stride1, ape_raw, ape_stride, \
+    token_to_req_indices, positions, block_table, block_table_stride, block_size, \
+    rms_norm_weight_t, rms_norm_eps, cos_sin_cache, cos_sin_stride, kv_cache, \
+    kv_slot_mapping, kv_cache_block_size, kv_block_stride, scale_dim, stream
+
+// nw_select: explicit NW override (0 = auto by estimated boundary count).
+extern "C" void launch_hca_compress_nw(
+    int num_tokens, int nw_select,
+    const void* state_cache_ptr, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    void* stream_ptr
+) {
+    if (num_tokens == 0) return;
+    const __hip_bfloat16* state_cache =
+        reinterpret_cast<const __hip_bfloat16*>(state_cache_ptr);
+    hipStream_t stream = reinterpret_cast<hipStream_t>(stream_ptr);
+
+    int nw = nw_select;
+    if (nw == 0) {
+        // Auto: estimate boundaries ~= num_tokens / RATIO. Tuned on MI350 graph
+        // timing (v1 K-split). Few boundaries -> NW=8 (max blocks for occupancy);
+        // more boundaries -> NW=4 (48KB LDS at NW=8 caps occupancy to 1 block/CU,
+        // 24KB at NW=4 allows 2). NW=4 wins from ~128 boundaries up through the
+        // tested range (256); revisit NW=2/1 with much larger N (machine saturates).
+        int est = num_tokens / RATIO;
+        nw = (est <= 64) ? 8 : 4;
+    }
+    if (rms_norm_weight_is_bf16) {
+        const __hip_bfloat16* rms_norm_weight_t =
+            reinterpret_cast<const __hip_bfloat16*>(rms_norm_weight);
+        switch (nw) {
+            case 8: ksplit_launch<8>(num_tokens, HCA_FWD_ARGS); break;
+            case 4: ksplit_launch<4>(num_tokens, HCA_FWD_ARGS); break;
+            case 2: ksplit_launch<2>(num_tokens, HCA_FWD_ARGS); break;
+            default: v0_launch(num_tokens, HCA_FWD_ARGS); break;  // nw == 1
+        }
+    } else {
+        const float* rms_norm_weight_t =
+            reinterpret_cast<const float*>(rms_norm_weight);
+        switch (nw) {
+            case 8: ksplit_launch<8>(num_tokens, HCA_FWD_ARGS); break;
+            case 4: ksplit_launch<4>(num_tokens, HCA_FWD_ARGS); break;
+            case 2: ksplit_launch<2>(num_tokens, HCA_FWD_ARGS); break;
+            default: v0_launch(num_tokens, HCA_FWD_ARGS); break;  // nw == 1
+        }
+    }
+}
+
+// Default entry (used by the torch binding): auto NW dispatch.
+extern "C" void launch_hca_compress(
+    int num_tokens,
+    const void* state_cache_ptr, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    void* stream_ptr
+) {
+    launch_hca_compress_nw(
+        num_tokens, 0, state_cache_ptr, state_stride0, state_stride1,
+        ape_raw, ape_stride, token_to_req_indices, positions, slot_mapping,
+        block_table, block_table_stride, block_size, rms_norm_weight,
+        rms_norm_weight_is_bf16, rms_norm_eps, cos_sin_cache, cos_sin_stride,
+        kv_cache, kv_slot_mapping,
+        kv_cache_block_size, kv_block_stride, scale_dim, stream_ptr);
+}
+
+// v2: compact-plan path. Caller pre-allocates scratch: plan[plan_capacity] i32
+// and counter[1] i32 (sized plan_capacity >= num_tokens/RATIO + num_reqs).
+// Two memsets + build_plan + compact compress launch (grid = plan_capacity);
+// all graph-capturable. nw_select: 0 = auto.
+extern "C" void launch_hca_compress_plan(
+    int num_tokens, int nw_select,
+    const void* state_cache_ptr, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    int32_t* plan, int32_t* counter, int plan_capacity,
+    void* stream_ptr
+) {
+    if (num_tokens == 0) return;
+    const __hip_bfloat16* state_cache =
+        reinterpret_cast<const __hip_bfloat16*>(state_cache_ptr);
+    hipStream_t stream = reinterpret_cast<hipStream_t>(stream_ptr);
+
+    (void)hipMemsetAsync(counter, 0, sizeof(int32_t), stream);
+    (void)hipMemsetAsync(plan, 0xFF, (size_t)plan_capacity * sizeof(int32_t), stream);  // -1
+    int prep_blocks = (num_tokens + 255) / 256;
+    hipLaunchKernelGGL(hca_build_plan_kernel, dim3(prep_blocks), dim3(256), 0, stream,
+                       num_tokens, positions, slot_mapping, kv_slot_mapping, plan, counter);
+
+    // Auto NW (compact-plan path). Swept on MI350 graph timing: with the compact
+    // grid (~num_compress blocks), NW=8 wins all the way to ~512 boundaries
+    // (its 48KB LDS caps occupancy to 1 block/CU, but there are few blocks so it
+    // doesn't bite, and the higher per-boundary parallelism dominates); NW=4
+    // takes over at ~1024+ boundaries. (This differs from the plan-FREE v1
+    // optimum, est<=64, because there NW=8 also paid num_tokens-block + LDS
+    // overhead.) Crossover ~640 boundaries.
+    int nw = nw_select;
+    if (nw == 0) { int est = num_tokens / RATIO; nw = (est <= 640) ? 8 : 4; }
+    if (rms_norm_weight_is_bf16) {
+        const __hip_bfloat16* rms_norm_weight_t =
+            reinterpret_cast<const __hip_bfloat16*>(rms_norm_weight);
+        switch (nw) {
+            case 8: plan_ksplit_launch<8>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            case 4: plan_ksplit_launch<4>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            case 2: plan_ksplit_launch<2>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            default: plan_ksplit_launch<1>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+        }
+    } else {
+        const float* rms_norm_weight_t =
+            reinterpret_cast<const float*>(rms_norm_weight);
+        switch (nw) {
+            case 8: plan_ksplit_launch<8>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            case 4: plan_ksplit_launch<4>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            case 2: plan_ksplit_launch<2>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            default: plan_ksplit_launch<1>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+        }
+    }
+}

--- a/csrc/rocm/dsv4_indexer_compress.cu
+++ b/csrc/rocm/dsv4_indexer_compress.cu
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+/**
+ * HIP Indexer Compressor Kernel - DeepSeek-V4 head_dim=128 (FP8 + MXFP4)
+ *
+ * The indexer's compressor is CSA geometry (ratio=4, overlap, K_POOL=8) at
+ * head_dim=128. The compress -> softmax -> weighted-sum -> RMSNorm -> RoPE
+ * front-end is shared; only the quant tail differs. Two compile-time
+ * specializations (template<QFMT>), selected at launch by use_fp4_cache, mirror
+ * vLLM's two Triton kernels (_fused_kv_compress_norm_rope_insert_indexer_attn /
+ * ..._indexer_mxfp4_attn). Both are the byte-exact targets.
+ *
+ *   QFMT_FP8  : whole 128-dim post-RoPE row -> FP8 + single ue8m0 scale (fp32).
+ *               token_stride=128, scale_dim=4 (1 fp32). native v_cvt_pk_fp8_f32.
+ *   QFMT_MXFP4: even/odd pairs -> E2M1 nibbles, per-32 ue8m0 block scale.
+ *               token_stride=64, scale_dim=4 (4 ue8m0 bytes). native
+ *               v_cvt_scalef32_pk_fp4_f32.
+ *
+ * Mapping = M1 (CSA port): wave-per-token, 64 lanes * 2 dims = 128. RMSNorm /
+ * FP8 absmax are wave-local warp reductions; MXFP4 block absmax is a 16-lane
+ * subgroup reduction. No LDS, no __syncthreads. Plan-free: launched per-token,
+ * non-boundary waves return. (P3: M1 is at max occupancy / latency-bound;
+ * thread-per-token is infeasible (per-dim softmax state). See PLAN_INDEXER.md.)
+ *
+ * Built into the _rocm_C extension for all VLLM_GPU_ARCHES. The native FP8 /
+ * FP4 cvt builtins exist only on gfx950 (CDNA4), so the kernel BODY is compiled
+ * only for the gfx950 device pass (and the host pass for symbol parity); on
+ * other device passes it is an empty stub. The host launcher always compiles,
+ * and the Python dispatcher only routes to this op on gfx950.
+ */
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+#include <cmath>
+#include <cstdint>
+
+#include "dsv4_compress_common.cuh"  // DSV4_GFX950, dsv4::warp_reduce_sum
+
+// Constants for DeepSeek-V4 indexer config (ratio=4, overlap, head_dim=128)
+[[maybe_unused]] constexpr int K_POOL = 8;
+[[maybe_unused]] constexpr int HEAD_SIZE = 128;
+[[maybe_unused]] constexpr int ROPE_HEAD_DIM = 64;
+[[maybe_unused]] constexpr int NOPE_HEAD_DIM = HEAD_SIZE - ROPE_HEAD_DIM;  // 64
+[[maybe_unused]] constexpr int STATE_WIDTH = 256;   // overlap: coff*head_dim = 2*128
+
+[[maybe_unused]] constexpr int BLOCK_SIZE = 256;  // 4 waves
+[[maybe_unused]] constexpr int WARP_SIZE = 64;    // AMD wavefront
+[[maybe_unused]] constexpr int DIMS_PER_LANE = HEAD_SIZE / WARP_SIZE;  // 2
+
+[[maybe_unused]] constexpr float FP8_MAX = 448.0f;
+[[maybe_unused]] constexpr float INV_FP8_MAX = 1.0f / FP8_MAX;
+[[maybe_unused]] constexpr float FP4_MAX = 6.0f;          // E2M1 max
+[[maybe_unused]] constexpr float INV_FP4_MAX = 1.0f / FP4_MAX;
+
+// Quant-format specializations.
+[[maybe_unused]] constexpr int QFMT_FP8 = 0;
+[[maybe_unused]] constexpr int QFMT_MXFP4 = 1;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+// warp_reduce_sum comes from dsv4_compress_common.cuh (dsv4::warp_reduce_sum).
+__device__ __forceinline__ float warp_reduce_max(float val) {
+    #pragma unroll
+    for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+        val = fmaxf(val, __shfl_xor(val, offset));
+    }
+    return val;
+}
+
+// Max over a 16-lane subgroup (one MXFP4 block = 16 pairs = 16 consecutive lanes).
+__device__ __forceinline__ float subgroup16_reduce_max(float val) {
+    #pragma unroll
+    for (int offset = 8; offset > 0; offset /= 2) {
+        val = fmaxf(val, __shfl_xor(val, offset));
+    }
+    return val;
+}
+
+// ============================================================================
+// Kernel: fully fused, plan-free, wave-per-token (M1), templated quant tail
+// ============================================================================
+template <int QFMT, typename WeightT>
+__global__ void indexer_compress_kernel(
+    int num_tokens,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0,
+    int64_t state_stride1,
+    const float* __restrict__ ape,          // RAW [4, 2*HEAD_SIZE=256] fp32
+    int64_t ape_stride,                      // = ape.stride(0) (e.g. 256)
+    const int32_t* __restrict__ token_to_req_indices,
+    const int64_t* __restrict__ positions,
+    const int64_t* __restrict__ slot_mapping,
+    const int32_t* __restrict__ block_table,
+    int64_t block_table_stride,
+    int32_t block_size,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache,
+    int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache,
+    const int64_t* __restrict__ kv_slot_mapping,
+    int32_t kv_cache_block_size,
+    int64_t kv_block_stride,
+    int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX950_BODY)
+    // Per-token byte stride: FP8 = all 128 bytes; MXFP4 = 64 packed nibbles.
+    constexpr int TOKEN_STRIDE = (QFMT == QFMT_MXFP4) ? HEAD_SIZE / 2 : HEAD_SIZE;
+
+    int wave_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int token_idx = blockIdx.x * (BLOCK_SIZE / WARP_SIZE) + wave_id;
+    if (token_idx >= num_tokens) return;
+
+    // On-device boundary derivation (ratio=4): (position+1) % 4 == 0.
+    int64_t kv_slot_idx = kv_slot_mapping[token_idx];
+    int64_t position = positions[token_idx];
+    if (((position + 1) & 3) != 0 || kv_slot_idx < 0) return;  // not a boundary
+    int64_t slot_id = slot_mapping[token_idx];
+    if (slot_id < 0) return;
+
+    int32_t req_idx = token_to_req_indices[token_idx];
+    int64_t start_pos = position - (K_POOL - 1);
+    int dim_base = lane_id * DIMS_PER_LANE;  // 0,2,...,126; pair index == lane_id
+
+    // ── Phase 1: resolve K_POOL row base pointers (overlap second half @ k>=4) ─
+    const __hip_bfloat16* row_ptrs[K_POOL];
+    bool valid_k[K_POOL];
+    #pragma unroll
+    for (int k = 0; k < K_POOL; k++) {
+        int64_t pos_k = start_pos + k;
+        if (pos_k < 0) {
+            valid_k[k] = false;
+            row_ptrs[k] = nullptr;
+            continue;
+        }
+        valid_k[k] = true;
+        int64_t blk_idx = pos_k / block_size;
+        int64_t blk_off = pos_k % block_size;
+        int32_t blk_num = block_table[req_idx * block_table_stride + blk_idx];
+        int head_offset = (k >= 4) ? HEAD_SIZE : 0;
+        row_ptrs[k] = state_cache + blk_num * state_stride0
+                    + blk_off * state_stride1 + head_offset;
+    }
+
+    // ── Online softmax (per-dim over K_POOL); APE from raw [4,256] ────────────
+    float m[DIMS_PER_LANE], l[DIMS_PER_LANE], acc[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        m[d] = -INFINITY; l[d] = 0.0f; acc[d] = 0.0f;
+    }
+    #pragma unroll
+    for (int k = 0; k < K_POOL; k++) {
+        if (!valid_k[k]) continue;  // exp(-inf) contributes nothing
+        union { float v; __hip_bfloat16 h[2]; } us, uk;
+        us.v = *reinterpret_cast<const float*>(row_ptrs[k] + STATE_WIDTH + dim_base);
+        uk.v = *reinterpret_cast<const float*>(row_ptrs[k] + dim_base);
+        const float* ape_ptr = ape + (int64_t)(k & 3) * ape_stride
+                             + ((k >= 4) ? HEAD_SIZE : 0) + dim_base;
+        #pragma unroll
+        for (int d = 0; d < DIMS_PER_LANE; d++) {
+            float s = __bfloat162float(us.h[d]) + ape_ptr[d];
+            float kvv = __bfloat162float(uk.h[d]);
+            float new_m = fmaxf(m[d], s);
+            float corr = __expf(m[d] - new_m);   // 0 on first valid k (m=-inf)
+            float p = __expf(s - new_m);
+            l[d] = l[d] * corr + p;
+            acc[d] = acc[d] * corr + p * kvv;
+            m[d] = new_m;
+        }
+    }
+    float comp[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) comp[d] = acc[d] / l[d];
+
+    // ── RMSNorm: full-wave warp_reduce_sum over all 128 dims ──────────────────
+    float sq = 0.0f;
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) sq += comp[d] * comp[d];
+    float variance = dsv4::warp_reduce_sum(sq) / HEAD_SIZE;
+    float rrms = rsqrtf(variance + rms_norm_eps);
+
+    float normed[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        float w = dsv4::load_rms_norm_weight(rms_norm_weight, dim_base + d);
+        normed[d] = comp[d] * rrms * w;
+    }
+
+    // ── GPT-J RoPE on last ROPE_HEAD_DIM dims; result[0]=new_even,1=new_odd ───
+    float result[DIMS_PER_LANE];
+    if (dim_base < NOPE_HEAD_DIM) {
+        #pragma unroll
+        for (int d = 0; d < DIMS_PER_LANE; d++) result[d] = normed[d];
+    } else {
+        int rope_local = dim_base - NOPE_HEAD_DIM;   // 0,2,...,62
+        int cs_idx = rope_local / 2;
+        int64_t comp_pos = position & (~3LL);         // (position//4)*4
+        const float* cs = cos_sin_cache + comp_pos * cos_sin_stride;
+        float cos_v = cs[cs_idx];
+        float sin_v = cs[ROPE_HEAD_DIM / 2 + cs_idx];
+        float e = normed[0], o = normed[1];           // one pair per lane
+        result[0] = e * cos_v - o * sin_v;            // new_even
+        result[1] = o * cos_v + e * sin_v;            // new_odd
+    }
+    // bf16 roundtrip the whole row for parity with the reference.
+    float q[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        q[d] = __bfloat162float(__float2bfloat16(result[d]));
+    }
+
+    // ── Output addressing ─────────────────────────────────────────────────────
+    int64_t kv_blk_idx = kv_slot_idx / kv_cache_block_size;
+    int64_t kv_pos = kv_slot_idx % kv_cache_block_size;
+    uint8_t* cache_block = kv_cache + kv_blk_idx * kv_block_stride;
+    uint8_t* val_ptr = cache_block + kv_pos * TOKEN_STRIDE;
+    uint8_t* scale_ptr = cache_block + kv_cache_block_size * TOKEN_STRIDE
+                       + kv_pos * scale_dim;
+
+    if constexpr (QFMT == QFMT_FP8) {
+        // Single-block FP8 ue8m0: absmax over the WHOLE 128-dim row.
+        float lmax = 0.0f;
+        #pragma unroll
+        for (int d = 0; d < DIMS_PER_LANE; d++) lmax = fmaxf(lmax, fabsf(q[d]));
+        float blk_max = fmaxf(warp_reduce_max(lmax), 1e-4f);
+        float exponent = ceilf(log2f(blk_max * INV_FP8_MAX));
+        float inv_scale = exp2f(-exponent);
+
+        // Native E4M3 pack: 2 f32 -> 2 fp8 (low 16 bits), one uint16 store.
+        // dim_base = lane*2 -> val_ptr+dim_base is 2-byte aligned & contiguous.
+        int w = 0;
+        w = __builtin_amdgcn_cvt_pk_fp8_f32(q[0] * inv_scale, q[1] * inv_scale, w, false);
+        *reinterpret_cast<uint16_t*>(val_ptr + dim_base) = (uint16_t)(w & 0xFFFF);
+
+        // Single fp32 scale per token (value = 2^exponent), one writer.
+        if (lane_id == 0) {
+            *reinterpret_cast<float*>(scale_ptr) = exp2f(exponent);
+        }
+    } else {  // QFMT_MXFP4
+        // Per-32-element block ue8m0; pair index == lane, block = lane / 16.
+        // amax over the block (max of |new_even|,|new_odd| across 16 lanes).
+        float lmax = fmaxf(fabsf(q[0]), fabsf(q[1]));
+        float amax = fmaxf(subgroup16_reduce_max(lmax), FP4_MAX * exp2f(-126.0f));
+        float log2r = ceilf(log2f(amax * INV_FP4_MAX));
+        log2r = fminf(fmaxf(log2r, -127.0f), 127.0f);
+        float inv_scale = exp2f(-log2r);
+
+        // Native E2M1 pack: (even,odd) -> 2 nibbles (1 byte). Pre-scale by
+        // inv_scale and pass scale=1.0 to mirror Triton's
+        // _fp32x2_to_fp4x2(even*inv_scale, odd*inv_scale).
+        uint32_t packed = 0;
+        packed = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(
+            packed, q[0] * inv_scale, q[1] * inv_scale, 1.0f, 0);
+        val_ptr[lane_id] = (uint8_t)(packed & 0xFF);
+
+        // ue8m0 block scale byte (one writer per 16-lane block).
+        if ((lane_id & 15) == 0) {
+            scale_ptr[lane_id >> 4] = (uint8_t)((int)(log2r + 127.0f));
+        }
+    }
+#else
+    dsv4::ignore_unused(num_tokens, state_cache, state_stride0, state_stride1,
+                        ape, ape_stride, token_to_req_indices, positions,
+                        slot_mapping, block_table, block_table_stride,
+                        block_size, rms_norm_weight, rms_norm_eps,
+                        cos_sin_cache, cos_sin_stride, kv_cache,
+                        kv_slot_mapping, kv_cache_block_size, kv_block_stride,
+                        scale_dim);
+#endif  // DSV4_COMPILE_GFX950_BODY
+}
+
+// ============================================================================
+// Launcher
+// ============================================================================
+extern "C" void launch_indexer_compress(
+    int num_tokens,
+    int use_fp4_cache,
+    const void* state_cache_ptr, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices,
+    const int64_t* positions,
+    const int64_t* slot_mapping,
+    const int32_t* block_table, int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    void* stream_ptr
+) {
+    if (num_tokens == 0) return;
+
+    const __hip_bfloat16* state_cache =
+        reinterpret_cast<const __hip_bfloat16*>(state_cache_ptr);
+    hipStream_t stream = reinterpret_cast<hipStream_t>(stream_ptr);
+
+    constexpr int WAVES_PER_BLOCK = BLOCK_SIZE / WARP_SIZE;  // 4
+    int num_blocks = (num_tokens + WAVES_PER_BLOCK - 1) / WAVES_PER_BLOCK;
+    dim3 grid(num_blocks);
+    dim3 block(BLOCK_SIZE);
+
+    #define IDX_FWD_ARGS \
+        num_tokens, state_cache, state_stride0, state_stride1, \
+        ape_raw, ape_stride, token_to_req_indices, positions, slot_mapping, \
+        block_table, block_table_stride, block_size, \
+        rms_norm_weight_t, rms_norm_eps, cos_sin_cache, cos_sin_stride, \
+        kv_cache, kv_slot_mapping, kv_cache_block_size, kv_block_stride, scale_dim
+
+    // Parens around the templated kernel name: hipLaunchKernelGGL macro would
+    // otherwise split the template args on the comma.
+    if (rms_norm_weight_is_bf16) {
+        const __hip_bfloat16* rms_norm_weight_t =
+            reinterpret_cast<const __hip_bfloat16*>(rms_norm_weight);
+        if (use_fp4_cache) {
+            hipLaunchKernelGGL((indexer_compress_kernel<QFMT_MXFP4, __hip_bfloat16>),
+                               grid, block, 0, stream, IDX_FWD_ARGS);
+        } else {
+            hipLaunchKernelGGL((indexer_compress_kernel<QFMT_FP8, __hip_bfloat16>),
+                               grid, block, 0, stream, IDX_FWD_ARGS);
+        }
+    } else {
+        const float* rms_norm_weight_t =
+            reinterpret_cast<const float*>(rms_norm_weight);
+        if (use_fp4_cache) {
+            hipLaunchKernelGGL((indexer_compress_kernel<QFMT_MXFP4, float>),
+                               grid, block, 0, stream, IDX_FWD_ARGS);
+        } else {
+            hipLaunchKernelGGL((indexer_compress_kernel<QFMT_FP8, float>),
+                               grid, block, 0, stream, IDX_FWD_ARGS);
+        }
+    }
+    #undef IDX_FWD_ARGS
+}

--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -36,6 +36,39 @@ void moe_gptq_gemm_rdna3(torch::Tensor a, torch::Tensor c,
                          int64_t block_size_m, bool mul_topk_weight,
                          int64_t output_topk);
 
+// DeepSeek-V4 fused compressors (gfx950 / CDNA4 only). Impls in
+// csrc/rocm/dsv4_compress_ops.cpp + dsv4_{csa,hca,indexer}_compress.cu.
+void dsv4_csa_compress(torch::Tensor state_cache, int64_t num_actual,
+                       torch::Tensor ape, torch::Tensor token_to_req_indices,
+                       torch::Tensor positions, torch::Tensor slot_mapping,
+                       torch::Tensor block_table, int64_t block_size,
+                       torch::Tensor rms_norm_weight, double rms_norm_eps,
+                       torch::Tensor cos_sin_cache, torch::Tensor kv_cache,
+                       torch::Tensor kv_slot_mapping,
+                       int64_t kv_cache_block_size, int64_t scale_dim);
+
+void dsv4_hca_compress(torch::Tensor state_cache, int64_t num_actual,
+                       torch::Tensor ape, torch::Tensor token_to_req_indices,
+                       torch::Tensor positions, torch::Tensor slot_mapping,
+                       torch::Tensor block_table, int64_t block_size,
+                       torch::Tensor rms_norm_weight, double rms_norm_eps,
+                       torch::Tensor cos_sin_cache, torch::Tensor kv_cache,
+                       torch::Tensor kv_slot_mapping,
+                       int64_t kv_cache_block_size, int64_t scale_dim,
+                       torch::Tensor plan_scratch,
+                       torch::Tensor counter_scratch);
+
+void dsv4_indexer_compress(torch::Tensor state_cache, int64_t num_actual,
+                           torch::Tensor ape,
+                           torch::Tensor token_to_req_indices,
+                           torch::Tensor positions, torch::Tensor slot_mapping,
+                           torch::Tensor block_table, int64_t block_size,
+                           torch::Tensor rms_norm_weight, double rms_norm_eps,
+                           torch::Tensor cos_sin_cache, torch::Tensor kv_cache,
+                           torch::Tensor kv_slot_mapping,
+                           int64_t kv_cache_block_size, int64_t scale_dim,
+                           bool use_fp4_cache);
+
 void paged_attention(
     torch::Tensor& out, torch::Tensor& exp_sums, torch::Tensor& max_logits,
     torch::Tensor& tmp_out, torch::Tensor& query, torch::Tensor& key_cache,

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -61,6 +61,36 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
   rocm_ops.impl("moe_gptq_gemm_rdna3", torch::kCUDA, &moe_gptq_gemm_rdna3);
 #endif
 
+#ifdef VLLM_ROCM_GFX950
+  // DeepSeek-V4 fused compressors (gfx950 / CDNA4). kv_cache is written in place.
+  rocm_ops.def(
+      "dsv4_csa_compress(Tensor state_cache, int num_actual, Tensor ape, "
+      "Tensor token_to_req_indices, Tensor positions, Tensor slot_mapping, "
+      "Tensor block_table, int block_size, Tensor rms_norm_weight, "
+      "float rms_norm_eps, Tensor cos_sin_cache, Tensor! kv_cache, "
+      "Tensor kv_slot_mapping, int kv_cache_block_size, int scale_dim) -> ()");
+  rocm_ops.impl("dsv4_csa_compress", torch::kCUDA, &dsv4_csa_compress);
+
+  rocm_ops.def(
+      "dsv4_hca_compress(Tensor state_cache, int num_actual, Tensor ape, "
+      "Tensor token_to_req_indices, Tensor positions, Tensor slot_mapping, "
+      "Tensor block_table, int block_size, Tensor rms_norm_weight, "
+      "float rms_norm_eps, Tensor cos_sin_cache, Tensor! kv_cache, "
+      "Tensor kv_slot_mapping, int kv_cache_block_size, int scale_dim, "
+      "Tensor plan_scratch, Tensor counter_scratch) -> ()");
+  rocm_ops.impl("dsv4_hca_compress", torch::kCUDA, &dsv4_hca_compress);
+
+  rocm_ops.def(
+      "dsv4_indexer_compress(Tensor state_cache, int num_actual, Tensor ape, "
+      "Tensor token_to_req_indices, Tensor positions, Tensor slot_mapping, "
+      "Tensor block_table, int block_size, Tensor rms_norm_weight, "
+      "float rms_norm_eps, Tensor cos_sin_cache, Tensor! kv_cache, "
+      "Tensor kv_slot_mapping, int kv_cache_block_size, int scale_dim, "
+      "bool use_fp4_cache) -> ()");
+  rocm_ops.impl("dsv4_indexer_compress", torch::kCUDA,
+                &dsv4_indexer_compress);
+#endif
+
   // Custom attention op
   // Compute the attention between an input query and the cached
   // keys/values using PagedAttention.

--- a/tests/kernels/attention/dsv4_compress_utils.py
+++ b/tests/kernels/attention/dsv4_compress_utils.py
@@ -1,0 +1,800 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared scaffolding for the DeepSeek-V4 fused compressor kernel tests.
+
+The fused HIP compressors (CSA head=512/ratio=4, HCA head=512/ratio=128,
+indexer head=128/ratio=4 with FP8 + MXFP4) are built into ``_rocm_C`` for
+gfx950 (CDNA4) and exposed as ``torch.ops._rocm_C.dsv4_{csa,hca,indexer}_compress``.
+The vLLM Triton FP32 path (``common/ops/fused_compress_quant_cache.py``) is the
+byte-exact oracle for the FP8 outputs; the indexer MXFP4 tail is checked against
+a faithful torch reference (the Triton MXFP4 kernel uses NVIDIA PTX and cannot
+run on AMD).
+
+This module is pure test/benchmark scaffolding — it is NOT collected by pytest
+(no ``test_`` prefix) and is not imported by any production code. It builds, for
+one scenario and one shape, the full input set (positions, slot mapping, APE,
+RoPE cache, RMS weight, block table) and the populated FP32 / BF16 state caches
+the compressor backends consume, plus the Triton/HIP runners, dequant + compare
+helpers, and the MXFP4 torch oracle.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import torch
+
+# ── fixed test geometry (matches the production cache layout) ────────────────
+KV_BLOCK_SIZE = 16
+RMS_EPS = 1e-6
+FP8_MAX = 448.0
+SEED = 2026
+
+# head=512 (CSA/HCA) packed-cache layout.
+H512_TOKEN_STRIDE = 576
+H512_NOPE = 448
+H512_SCALE_DIM = 8
+H512_N_NOPE_BLOCKS = 7
+H512_QUANT_BLOCK = 64
+
+# E2M1 decode LUT (OCP MXFP4): index = 4-bit code, low nibble=even / high=odd.
+E2M1_LUT = torch.tensor(
+    [
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        -0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ],
+    dtype=torch.float32,
+)
+
+
+def detect_gfx950() -> bool:
+    """True iff running on gfx950 (CDNA4). Safe to call on any platform.
+
+    The fused HIP compressors are CDNA4-only and built into ``_rocm_C`` only
+    when gfx950 is among the target archs; the correctness tests skip otherwise.
+    """
+    try:
+        from vllm.models.deepseek_v4.amd.ops.hip_compress_dispatch import (
+            hip_compressor_runtime_available,
+        )
+
+        return hip_compressor_runtime_available()
+    except Exception:
+        return False
+
+
+# =============================================================================
+# Shape config
+# =============================================================================
+
+
+@dataclass
+class ShapeConfig:
+    label: str
+    head_dim: int
+    rope_head_dim: int
+    ratio: int
+    overlap: bool
+    # State-cache page size (tokens per block). CSA(ratio=4)=4, HCA(ratio=128)=8
+    # to match CompressorStateCache.block_size in compressor.py.
+    state_block_size: int = 4
+    # Quant tail / cache layout. "csa": nope(FP8 per-64 ue8m0)+rope(bf16), the
+    # head=512 path. "indexer_fp8": whole head_dim FP8 + single fp32 scale.
+    # "indexer_mxfp4": E2M1 nibbles (head_dim//2 bytes) + ue8m0 per 32 (P4).
+    quant_format: str = "csa"
+
+    @property
+    def nope_dim(self) -> int:
+        return self.head_dim - self.rope_head_dim
+
+    @property
+    def token_stride(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return self.head_dim  # all FP8, single scale
+        if self.quant_format == "indexer_mxfp4":
+            return self.head_dim // 2  # 2 E2M1 nibbles/byte
+        return self.nope_dim + self.rope_head_dim * 2
+
+    @property
+    def scale_dim(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return 4  # one float32 scale
+        if self.quant_format == "indexer_mxfp4":
+            return self.head_dim // 32  # one ue8m0 byte per 32-elem block
+        return self.nope_dim // 64 + 1
+
+    @property
+    def quant_block(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return self.head_dim  # single block (128)
+        if self.quant_format == "indexer_mxfp4":
+            return 32
+        return 64
+
+    @property
+    def state_width(self) -> int:
+        return (2 if self.overlap else 1) * self.head_dim
+
+    @property
+    def k_pool(self) -> int:
+        return (2 if self.overlap else 1) * self.ratio
+
+    @property
+    def coff(self) -> int:
+        return 2 if self.overlap else 1
+
+
+CSA_MAIN = ShapeConfig("csa_main", 512, 64, 4, True)
+HCA_MAIN = ShapeConfig("hca_main", 512, 64, 128, False, state_block_size=8)
+# Indexer compressor = CSA geometry (ratio=4, overlap) at head_dim=128.
+INDEXER_FP8 = ShapeConfig("indexer_fp8", 128, 64, 4, True, quant_format="indexer_fp8")
+INDEXER_MXFP4 = ShapeConfig(
+    "indexer_mxfp4", 128, 64, 4, True, quant_format="indexer_mxfp4"
+)
+
+# Shapes whose FP8 output is byte-exact-comparable to the Triton oracle.
+BYTE_EXACT_SHAPES = [CSA_MAIN, HCA_MAIN, INDEXER_FP8]
+
+
+class MockMetadata:
+    def __init__(self, slot_mapping: torch.Tensor):
+        self.slot_mapping = slot_mapping
+
+
+# =============================================================================
+# Compressor context: all inputs + populated state caches for one scenario
+# =============================================================================
+
+
+@dataclass
+class CompressorContext:
+    name: str
+    desc: str
+    shape: ShapeConfig
+    positions: list[int]
+    token_to_req: list[int]
+    slot_mapping: list[int]
+    kv_slot_mapping: list[int]
+    max_position: int
+
+    # Filled by build()
+    num_tokens: int = 0
+    num_compress: int = 0
+    ape: torch.Tensor = None
+    cos_sin_cache: torch.Tensor = None
+    rms_weight: torch.Tensor = None
+    block_table: torch.Tensor = None
+    max_state_blocks: int = 0
+    total_kv_blocks: int = 0
+    bytes_per_block: int = 0
+    _raw: dict = field(default_factory=dict)
+    state_cache_fp32: torch.Tensor = None
+    state_cache_bf16: torch.Tensor = None
+    positions_t: torch.Tensor = None
+    token_to_req_t: torch.Tensor = None
+    slot_mapping_t: torch.Tensor = None
+    kv_slot_mapping_t: torch.Tensor = None
+
+    def build(self) -> CompressorContext:
+        shape = self.shape
+        self.num_tokens = len(self.positions)
+        self.num_compress = sum(1 for k in self.kv_slot_mapping if k >= 0)
+        bs = max(self.token_to_req) + 1 if self.token_to_req else 1
+
+        g = torch.Generator(device="cuda").manual_seed(SEED + self.num_tokens)
+        kv_raw = (
+            torch.randn(
+                self.num_tokens,
+                shape.coff * shape.head_dim,
+                dtype=torch.bfloat16,
+                generator=g,
+            )
+            * 0.5
+        )
+        score_raw = (
+            torch.randn(
+                self.num_tokens,
+                shape.coff * shape.head_dim,
+                dtype=torch.bfloat16,
+                generator=g,
+            )
+            * 0.5
+        )
+        self.ape = (
+            torch.randn(
+                shape.ratio,
+                shape.coff * shape.head_dim,
+                dtype=torch.float32,
+                generator=g,
+            )
+            * 0.1
+        )
+        self._raw = {"kv": kv_raw, "score": score_raw}
+
+        self.positions_t = torch.tensor(self.positions, dtype=torch.int64)
+        self.token_to_req_t = torch.tensor(self.token_to_req, dtype=torch.int32)
+        self.slot_mapping_t = torch.tensor(self.slot_mapping, dtype=torch.int64)
+        self.kv_slot_mapping_t = torch.tensor(self.kv_slot_mapping, dtype=torch.int64)
+
+        # Build block_table directly from the actual slot_mapping so it is
+        # correct for any slot layout (sparse per-request or packed). Kernels
+        # index it as block_table[req, position // state_block_size] and expect
+        # the physical state-cache block where save_partial_states wrote that
+        # token, i.e. slot // state_block_size.
+        sbs = shape.state_block_size
+        max_slot = max((s for s in self.slot_mapping if s >= 0), default=0)
+        max_state_blocks = (max_slot // sbs) + 4
+        max_lblk = 0
+        for pos, slot in zip(self.positions, self.slot_mapping):
+            if slot >= 0:
+                max_lblk = max(max_lblk, pos // sbs)
+        max_blocks_per_seq = max_lblk + 2
+        block_table = torch.zeros(bs, max_blocks_per_seq, dtype=torch.int32)
+        for req, pos, slot in zip(self.token_to_req, self.positions, self.slot_mapping):
+            if slot < 0:
+                continue
+            block_table[req, pos // sbs] = slot // sbs
+        self.block_table = block_table
+        self.max_state_blocks = max_state_blocks
+
+        self.rms_weight = (
+            torch.rand(shape.head_dim, dtype=torch.float32, generator=g) * 0.5 + 0.5
+        ).to(torch.bfloat16)
+
+        max_cos_pos = self.max_position + 1
+        inv_freq = 1.0 / (
+            10000
+            ** (
+                torch.arange(0, shape.rope_head_dim, 2, dtype=torch.float32)
+                / shape.rope_head_dim
+            )
+        )
+        freqs = torch.outer(torch.arange(max_cos_pos, dtype=torch.float32), inv_freq)
+        self.cos_sin_cache = torch.cat([freqs.cos(), freqs.sin()], dim=-1)
+
+        self.total_kv_blocks = (self.num_compress // KV_BLOCK_SIZE) + 4
+        self.bytes_per_block = (
+            KV_BLOCK_SIZE * shape.token_stride + KV_BLOCK_SIZE * shape.scale_dim
+        )
+
+        self._populate_state_caches()
+        return self
+
+    def _populate_state_caches(self):
+        from vllm.models.deepseek_v4.common.ops.save_partial_states import (
+            save_partial_states,
+        )
+
+        shape = self.shape
+        sbs = shape.state_block_size
+        self.state_cache_fp32 = torch.zeros(
+            self.max_state_blocks, sbs, 2 * shape.state_width, dtype=torch.float32
+        )
+        save_partial_states(
+            kv=self._raw["kv"],
+            score=self._raw["score"],
+            ape=self.ape,
+            positions=self.positions_t,
+            state_cache=self.state_cache_fp32,
+            slot_mapping=self.slot_mapping_t,
+            block_size=sbs,
+            state_width=shape.state_width,
+            compress_ratio=shape.ratio,
+        )
+        self.state_cache_bf16 = torch.zeros(
+            self.max_state_blocks, sbs, 2 * shape.state_width, dtype=torch.bfloat16
+        )
+        save_partial_states(
+            kv=self._raw["kv"],
+            score=self._raw["score"],
+            ape=None,
+            positions=self.positions_t,
+            state_cache=self.state_cache_bf16,
+            slot_mapping=self.slot_mapping_t,
+            block_size=sbs,
+            state_width=shape.state_width,
+            compress_ratio=shape.ratio,
+        )
+
+    def new_kv_cache(self) -> tuple[torch.Tensor, torch.Tensor]:
+        kv = torch.zeros(self.total_kv_blocks, self.bytes_per_block, dtype=torch.uint8)
+        return kv, kv.view(self.total_kv_blocks, KV_BLOCK_SIZE, -1)
+
+    def generic_kwargs(self) -> dict:
+        return dict(
+            num_actual=self.num_tokens,
+            token_to_req_indices=self.token_to_req_t,
+            positions=self.positions_t,
+            slot_mapping=self.slot_mapping_t,
+            block_table=self.block_table,
+            block_size=self.shape.state_block_size,
+            state_width=self.shape.state_width,
+            cos_sin_cache=self.cos_sin_cache,
+            k_cache_metadata=MockMetadata(self.kv_slot_mapping_t),
+            pdl_kwargs={},
+            head_dim=self.shape.head_dim,
+            rope_head_dim=self.shape.rope_head_dim,
+            compress_ratio=self.shape.ratio,
+            overlap=self.shape.overlap,
+            use_fp4_cache=(self.shape.quant_format == "indexer_mxfp4"),
+            rms_norm_weight=self.rms_weight,
+            rms_norm_eps=RMS_EPS,
+            quant_block=self.shape.quant_block,
+            token_stride=self.shape.token_stride,
+            scale_dim=self.shape.scale_dim,
+        )
+
+
+# =============================================================================
+# Scenario builders — boundary every ``ratio`` positions, shared across shapes
+# =============================================================================
+
+
+def _mk(shape, name, pos, t2r, slot, max_pos) -> CompressorContext:
+    kvs, b = [], 0
+    for p in pos:
+        if (p + 1) % shape.ratio == 0:
+            kvs.append(b)
+            b += 1
+        else:
+            kvs.append(-1)
+    return CompressorContext(name, name, shape, pos, t2r, slot, kvs, max_pos)
+
+
+def _prefill(shape, name, seqlen):
+    return _mk(
+        shape, name, list(range(seqlen)), [0] * seqlen, list(range(seqlen)), seqlen
+    )
+
+
+def _chunked(shape, name, offset, length):
+    pos = list(range(offset, offset + length))
+    return _mk(shape, name, pos, [0] * length, list(pos), offset + length)
+
+
+def _multi(shape, name, lengths):
+    P, T, S = [], [], []
+    ml = max(lengths)
+    for bi, L in enumerate(lengths):
+        for p in range(L):
+            P.append(p)
+            T.append(bi)
+            S.append(bi * ml + p)
+    return _mk(shape, name, P, T, S, ml)
+
+
+def _decode(shape, name, positions, ctx_len=4096):
+    P, T, S = [], [], []
+    for bi, mp in enumerate(positions):
+        for p in range(mp + 1):
+            P.append(p)
+            T.append(bi)
+            S.append(bi * ctx_len + p)
+    return _mk(shape, name, P, T, S, ctx_len)
+
+
+def _padded(shape, name, seqlen, num_pad):
+    pos = list(range(seqlen)) + [0] * num_pad
+    t2r = [0] * (seqlen + num_pad)
+    slot = list(range(seqlen)) + [-1] * num_pad
+    return _mk(shape, name, pos, t2r, slot, seqlen)
+
+
+def all_scenarios(shape) -> list[CompressorContext]:
+    """Canonical scenario set, valid for every supported ratio.
+
+    Boundary decode positions (127/255/383/511) are multiples of 128 - 1, so
+    they land exactly on a boundary for ratio=4 and ratio=128 alike; the mixed
+    set deliberately includes a non-boundary tail. Chunked offsets exercise the
+    look-back window synthesis in :func:`build_shared_input`.
+    """
+    s = []
+    s.append(_decode(shape, "decode_boundary", [127, 255, 383, 511]))
+    s.append(_decode(shape, "decode_mixed", [127, 255, 200, 383]))
+    for seqlen in [128, 256, 512, 1024, 4096, 16384, 32768]:
+        s.append(_prefill(shape, f"prefill_{seqlen}", seqlen))
+    for seqlen in [257, 1025, 4097]:  # tails (extra non-boundary tokens)
+        s.append(_prefill(shape, f"prefill_tail_{seqlen}", seqlen))
+    s.append(_chunked(shape, "chunked_100", 100, 1024))  # offset -> look-back
+    s.append(_chunked(shape, "chunked_4096", 4096, 4096))
+    s.append(_multi(shape, "multi_2", [256, 512]))
+    s.append(_multi(shape, "multi_3", [257, 1024, 384]))
+    s.append(_padded(shape, "padded", 256, 4))
+    return s
+
+
+# Scenario names are shape-independent (the builder only varies boundary phase).
+SCENARIO_NAMES = [c.name for c in all_scenarios(CSA_MAIN)]
+
+
+def build_scenario(shape, name) -> CompressorContext:
+    """Return the single scenario ``name`` for ``shape`` (un-built)."""
+    for c in all_scenarios(shape):
+        if c.name == name:
+            return c
+    raise KeyError(f"unknown scenario {name!r}; available: {SCENARIO_NAMES}")
+
+
+# =============================================================================
+# Shared input: BF16 authoritative; FP32 = bf16.float() + APE in the score half
+# =============================================================================
+
+
+def build_shared_input(ctx: CompressorContext) -> None:
+    """Rebuild ctx's state caches so Triton and HIP see identical data.
+
+    The BF16 state cache (no APE) is authoritative — HIP reads it and adds APE
+    in-kernel. The FP32 cache is exactly ``bf16.float()`` with APE added into its
+    score region (matching Triton's APE-fused semantics), so both backends read
+    the same kv/score/APE values and any difference is kernel arithmetic + FP8
+    quantization, never input mismatch.
+
+    Chunked scenarios (first present position m > 0) have boundaries whose
+    look-back window [m-(k_pool-1) .. m-1] reaches the previous chunk; those
+    tokens are synthesized here (same save_partial_states layout, slot ==
+    position) so the comparison is well-defined. No-op for sequences starting at
+    position 0 (prefill / decode).
+    """
+    from vllm.models.deepseek_v4.common.ops.save_partial_states import (
+        save_partial_states,
+    )
+
+    shape = ctx.shape
+    sw = shape.state_width
+    ratio = shape.ratio
+    sbs = shape.state_block_size
+
+    window_depth = (2 if shape.overlap else 1) * ratio - 1
+    req_min, present = {}, set()
+    for r, p, sl in zip(ctx.token_to_req, ctx.positions, ctx.slot_mapping):
+        if sl < 0:
+            continue
+        present.add((r, p))
+        req_min[r] = min(req_min.get(r, p), p)
+    lb_pos, lb_slot, lb_req = [], [], []
+    for r, mn in req_min.items():
+        for p in range(max(0, mn - window_depth), mn):
+            if (r, p) in present:
+                continue
+            lb_pos.append(p)
+            lb_slot.append(p)
+            lb_req.append(r)
+
+    bf16 = torch.zeros(ctx.max_state_blocks, sbs, 2 * sw, dtype=torch.bfloat16)
+    save_partial_states(
+        kv=ctx._raw["kv"],
+        score=ctx._raw["score"],
+        ape=None,
+        positions=ctx.positions_t,
+        state_cache=bf16,
+        slot_mapping=ctx.slot_mapping_t,
+        block_size=sbs,
+        state_width=sw,
+        compress_ratio=ratio,
+    )
+    if lb_pos:
+        g = torch.Generator(device="cuda").manual_seed(20240611 + ctx.num_tokens)
+        n_lb = len(lb_pos)
+        lb_kv = (
+            torch.randn(
+                n_lb, shape.coff * shape.head_dim, dtype=torch.bfloat16, generator=g
+            )
+            * 0.5
+        )
+        lb_score = (
+            torch.randn(
+                n_lb, shape.coff * shape.head_dim, dtype=torch.bfloat16, generator=g
+            )
+            * 0.5
+        )
+        save_partial_states(
+            kv=lb_kv,
+            score=lb_score,
+            ape=None,
+            positions=torch.tensor(lb_pos, dtype=torch.int64),
+            state_cache=bf16,
+            slot_mapping=torch.tensor(lb_slot, dtype=torch.int64),
+            block_size=sbs,
+            state_width=sw,
+            compress_ratio=ratio,
+        )
+        for r, p, sl in zip(lb_req, lb_pos, lb_slot):
+            ctx.block_table[r, p // sbs] = sl // sbs
+    ctx.state_cache_bf16 = bf16
+
+    fp32 = bf16.float()
+    ape = ctx.ape  # [ratio, 2*head_dim] fp32 (== sw)
+    for p, sl in list(zip(ctx.positions, ctx.slot_mapping)) + list(
+        zip(lb_pos, lb_slot)
+    ):
+        if sl < 0:
+            continue
+        blk, off = sl // sbs, sl % sbs
+        fp32[blk, off, sw : 2 * sw] += ape[p % ratio]
+    ctx.state_cache_fp32 = fp32
+
+
+# =============================================================================
+# Backend runners
+# =============================================================================
+
+
+def hip_available() -> bool:
+    """True iff the AOT dsv4 compressor ops are registered in _rocm_C."""
+    try:
+        import vllm._rocm_C  # noqa: F401
+
+        return hasattr(torch.ops._rocm_C, "dsv4_csa_compress")
+    except Exception:
+        return False
+
+
+def run_triton(ctx, kv_3d) -> None:
+    """vLLM Triton FP32 reference (byte-exact oracle for the FP8 output)."""
+    from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
+        compress_norm_rope_store_triton,
+    )
+
+    compress_norm_rope_store_triton(
+        state_cache=ctx.state_cache_fp32, kv_cache=kv_3d, **ctx.generic_kwargs()
+    )
+
+
+def run_hip(ctx, kv_3d) -> None:
+    """Dispatch to the AOT _rocm_C op matching ctx.shape (positional schema)."""
+    s = ctx.shape
+    common = (
+        ctx.state_cache_bf16,
+        ctx.num_tokens,
+        ctx.ape,
+        ctx.token_to_req_t,
+        ctx.positions_t,
+        ctx.slot_mapping_t,
+        ctx.block_table,
+        s.state_block_size,
+        ctx.rms_weight.to(torch.float32),
+        RMS_EPS,
+        ctx.cos_sin_cache,
+        kv_3d,
+        ctx.kv_slot_mapping_t,
+        kv_3d.shape[1],
+        s.scale_dim,
+    )
+    if s.head_dim == 128:  # indexer (FP8 or MXFP4)
+        torch.ops._rocm_C.dsv4_indexer_compress(
+            *common, s.quant_format == "indexer_mxfp4"
+        )
+    elif s.ratio == 128:  # HCA
+        plan_capacity = ctx.num_tokens // s.ratio + ctx.block_table.shape[0] + 2
+        plan_scratch = torch.empty(
+            plan_capacity, dtype=torch.int32, device=ctx.state_cache_bf16.device
+        )
+        counter_scratch = torch.empty(
+            1, dtype=torch.int32, device=ctx.state_cache_bf16.device
+        )
+        torch.ops._rocm_C.dsv4_hca_compress(*common, plan_scratch, counter_scratch)
+    else:  # CSA
+        torch.ops._rocm_C.dsv4_csa_compress(*common)
+
+
+# =============================================================================
+# Dequantization (vLLM cache format -> normed row) + compare
+# =============================================================================
+
+
+def _dequant_h512(buf, ci):
+    """head=512: NOPE 448 FP8 * per-64 ue8m0 + ROPE 64 bf16 -> normed [512]."""
+    soff = KV_BLOCK_SIZE * H512_TOKEN_STRIDE
+    blk, p = ci // KV_BLOCK_SIZE, ci % KV_BLOCK_SIZE
+    base = p * H512_TOKEN_STRIDE
+    fp8 = buf[blk][base : base + H512_NOPE].view(torch.float8_e4m3fn).float()
+    sc = buf[blk][
+        soff + p * H512_SCALE_DIM : soff + p * H512_SCALE_DIM + H512_N_NOPE_BLOCKS
+    ]
+    out = torch.zeros(512)
+    for nb in range(H512_N_NOPE_BLOCKS):
+        e = sc[nb].int().item() - 127
+        out[nb * H512_QUANT_BLOCK : (nb + 1) * H512_QUANT_BLOCK] = fp8[
+            nb * H512_QUANT_BLOCK : (nb + 1) * H512_QUANT_BLOCK
+        ] * (2.0**e)
+    out[H512_NOPE:] = (
+        buf[blk][base + H512_NOPE : base + H512_TOKEN_STRIDE]
+        .view(torch.bfloat16)
+        .float()
+    )
+    return out
+
+
+def _dequant_indexer_fp8(buf, ci):
+    """indexer FP8: whole 128-dim row FP8 * single fp32 scale -> [128]."""
+    ts, sd = 128, 4
+    soff = KV_BLOCK_SIZE * ts
+    blk, p = ci // KV_BLOCK_SIZE, ci % KV_BLOCK_SIZE
+    base = p * ts
+    fp8 = buf[blk][base : base + 128].view(torch.float8_e4m3fn).float()
+    scale = buf[blk][soff + p * sd : soff + p * sd + 4].view(torch.float32)
+    return fp8 * scale
+
+
+def _dequant_indexer_mxfp4(buf, ci):
+    """indexer MXFP4: E2M1 nibbles * per-32 ue8m0 scale -> [128]."""
+    ts, sd = 64, 4  # 64 packed bytes, 4 ue8m0 bytes
+    soff = KV_BLOCK_SIZE * ts
+    blk, p = ci // KV_BLOCK_SIZE, ci % KV_BLOCK_SIZE
+    base = p * ts
+    packed = buf[blk][base : base + ts].long()  # [64] uint8
+    sc = buf[blk][soff + p * sd : soff + p * sd + sd].long()  # [4] ue8m0
+    low = packed & 0xF  # even
+    high = (packed >> 4) & 0xF  # odd
+    scale = (2.0 ** (sc.float() - 127.0)).repeat_interleave(ts // sd)  # [64]
+    lut = E2M1_LUT.to(packed.device)
+    even = lut[low] * scale
+    odd = lut[high] * scale
+    return torch.stack([even, odd], dim=1).reshape(128)
+
+
+def _dequant_row(buf, ci, shape):
+    if shape.quant_format == "indexer_fp8":
+        return _dequant_indexer_fp8(buf, ci)
+    if shape.quant_format == "indexer_mxfp4":
+        return _dequant_indexer_mxfp4(buf, ci)
+    return _dequant_h512(buf, ci)
+
+
+def compare_to_triton(ref, hip, ctx) -> tuple:
+    """Compare a HIP packed cache against the Triton reference.
+
+    Returns ``(aligned, detail)``. ``aligned`` means reference-equivalent: the
+    dequantized output matches within FP8/bf16 tolerance.
+
+    The tolerance is region-aware, matching what the kernels actually emit:
+
+    * head=512 (CSA/HCA): the NOPE half is FP8-quantized, so a single element
+      may round to an adjacent FP8 code (a ~2^-4 step) when Triton and HIP pick
+      different RNE ties at a boundary — reference-equivalent, caught by the
+      *mean*, not the max. The ROPE half is bf16 (high precision), so its *max*
+      diff must stay tiny. Hence ``nope_mean`` and ``rope_max`` are thresholded
+      separately. A per-element max over the FP8 NOPE region would flag exactly
+      those harmless RNE ties (this is why an earlier whole-row max check failed
+      large prefills despite byte% == 100).
+    * indexer (head=128): whole-row mean (the FP8 single-scale / MXFP4 path is
+      checked the same way, max being dominated by FP8 RNE ties).
+    """
+    shape = ctx.shape
+    nc = ctx.num_compress
+    byte_pct = (
+        ref.view(torch.uint8).int() == hip.view(torch.uint8).int()
+    ).float().mean().item() * 100
+    if shape.head_dim == 512:
+        nope_mean, rope_max = 0.0, 0.0
+        for ci in range(nc):
+            d = (_dequant_h512(ref, ci) - _dequant_h512(hip, ci)).abs()
+            nope_mean = max(nope_mean, d[:H512_NOPE].mean().item())
+            rope_max = max(rope_max, d[H512_NOPE:].max().item())
+        aligned = nope_mean < 5e-2 and rope_max < 5e-2
+        detail = (
+            f"byte%={byte_pct:.2f} nope_mean={nope_mean:.5f} rope_max={rope_max:.4f}"
+        )
+    else:
+        dmean = 0.0
+        for ci in range(nc):
+            d = (_dequant_row(ref, ci, shape) - _dequant_row(hip, ci, shape)).abs()
+            dmean = max(dmean, d.mean().item())
+        aligned = dmean < 1e-2
+        detail = f"byte%={byte_pct:.2f} dmean={dmean:.5f}"
+    return aligned, detail
+
+
+# =============================================================================
+# Indexer MXFP4 torch oracle (Triton MXFP4 uses NVIDIA PTX, can't run on AMD)
+# =============================================================================
+
+
+def _torch_indexer_row(ctx, P, r) -> torch.Tensor:
+    """Reproduce the HIP front-end in torch: read the SAME bf16 state cache HIP
+    reads, add APE in-kernel-style, per-dim softmax over the 8 overlap positions,
+    weighted sum, RMSNorm, GPT-J RoPE -> true fp32 post-RoPE row [128]."""
+    sbs = ctx.shape.state_block_size
+    state = ctx.state_cache_bf16.float()
+    HEAD, SW = 128, 256
+    ape = ctx.ape
+    kv_l, sc_l, valid = [], [], []
+    for k in range(8):
+        pk = P - 7 + k
+        ho = 128 if k >= 4 else 0
+        if pk < 0:
+            valid.append(False)
+            kv_l.append(torch.zeros(HEAD))
+            sc_l.append(torch.zeros(HEAD))
+            continue
+        valid.append(True)
+        blk = int(ctx.block_table[r, pk // sbs].item())
+        off = pk % sbs
+        kv_l.append(state[blk, off, ho : ho + HEAD])
+        sc_l.append(
+            state[blk, off, SW + ho : SW + ho + HEAD] + ape[k % 4, ho : ho + HEAD]
+        )
+    KV = torch.stack(kv_l)  # [8,128]
+    SC = torch.stack(sc_l)
+    mask = torch.tensor(valid, device=KV.device).view(8, 1)
+    SC = torch.where(mask, SC, torch.full_like(SC, -float("inf")))
+    w = torch.softmax(SC, dim=0)  # per-dim over 8
+    comp = (w * KV).sum(0)  # [128]
+    var = (comp * comp).mean()
+    normed = comp * torch.rsqrt(var + RMS_EPS) * ctx.rms_weight.float()
+    cs = ctx.cos_sin_cache[(P // 4) * 4]  # [64]: 32 cos + 32 sin
+    out = normed.clone()
+    idx = torch.arange(32, device=out.device)
+    e = normed[64::2]
+    o = normed[65::2]  # rope pairs (dims 64..127)
+    cos_v = cs[idx]
+    sin_v = cs[32 + idx]
+    out[64::2] = e * cos_v - o * sin_v
+    out[65::2] = o * cos_v + e * sin_v
+    return out
+
+
+def _torch_mxfp4_dequant(row: torch.Tensor) -> torch.Tensor:
+    """Reference MXFP4 quant+dequant of one fp32 post-RoPE row [128].
+
+    Mirrors the Triton _quantize_mxfp4_pair math (per-32 block ue8m0 scale =
+    2^ceil(log2(amax/6)), E2M1 round-to-nearest, even->low / odd->high nibble).
+    """
+    HEAD = 128
+    mag = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], device=row.device)
+    odd_pen = torch.tensor([0.0, 1, 0, 1, 0, 1, 0, 1], device=row.device) * 1e-6
+    even = row[0::2].bfloat16().float()  # [64]
+    odd = row[1::2].bfloat16().float()
+    out = torch.zeros(HEAD, device=row.device)
+
+    def _q(x, log2r):
+        s = x.sign()
+        xs = (x.abs() * (2.0**-log2r)).unsqueeze(-1)
+        idx = ((xs - mag).abs() + odd_pen).argmin(-1)
+        return s * mag[idx] * (2.0**log2r)
+
+    for b in range(4):  # 4 blocks of 16 pairs (32 elems)
+        e = even[b * 16 : (b + 1) * 16]
+        o = odd[b * 16 : (b + 1) * 16]
+        amax = max(e.abs().max().item(), o.abs().max().item(), 6.0 * 2**-126)
+        log2r = min(max(math.ceil(math.log2(amax / 6.0)), -127), 127)
+        out[b * 32 : b * 32 + 32 : 2] = _q(e, log2r)
+        out[b * 32 + 1 : b * 32 + 32 : 2] = _q(o, log2r)
+    return out
+
+
+def mxfp4_oracle_diff(ctx, hip_cpu, max_check=512) -> float:
+    """Max per-boundary mean |HIP MXFP4 - torch front-end + RNE MXFP4|.
+
+    The front-end is per-token in python; it is independently proven by the FP8
+    byte-exact test, so a bounded sample (``max_check`` boundaries) suffices to
+    catch quant-tail bugs.
+    """
+    nc = ctx.num_compress
+    bnd = [
+        (p, r)
+        for p, r, ks in zip(ctx.positions, ctx.token_to_req, ctx.kv_slot_mapping)
+        if ks >= 0
+    ]
+    dmean = 0.0
+    for ci in range(min(nc, max_check)):
+        P, r = bnd[ci]
+        exp = _torch_mxfp4_dequant(_torch_indexer_row(ctx, P, r))
+        act = _dequant_indexer_mxfp4(hip_cpu, ci).cuda()
+        dmean = max(dmean, (exp - act).abs().mean().item())
+    return dmean

--- a/tests/kernels/attention/test_dsv4_compress.py
+++ b/tests/kernels/attention/test_dsv4_compress.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness of the DeepSeek-V4 fused HIP compressors (gfx950 / CDNA4).
+
+Three kernels share one front-end (RMSNorm + GPT-J RoPE over a softmax-pooled
+window) and differ only in the quant tail / cache layout:
+
+  * CSA          head_dim=512, ratio=4    NOPE 448 FP8 + ROPE 64 bf16 + ue8m0
+  * HCA          head_dim=512, ratio=128  (same packed layout, wider window)
+  * indexer FP8  head_dim=128, ratio=4    whole-row FP8 + single fp32 scale
+  * indexer MXFP4 head_dim=128, ratio=4   E2M1 nibbles + per-32 ue8m0
+
+The vLLM Triton FP32 path is the byte-exact oracle for the FP8 outputs. The
+MXFP4 tail is checked against a faithful torch front-end + RNE MXFP4 reference
+(the Triton MXFP4 kernel uses NVIDIA PTX and cannot run on AMD).
+
+gfx950-only: the kernels use native FP8/FP4 cvt builtins and are built into
+_rocm_C only when gfx950 is a target arch. Skipped on every other platform.
+"""
+
+import pytest
+import torch
+
+from tests.kernels.attention.dsv4_compress_utils import (
+    BYTE_EXACT_SHAPES,
+    INDEXER_MXFP4,
+    SCENARIO_NAMES,
+    build_scenario,
+    build_shared_input,
+    compare_to_triton,
+    detect_gfx950,
+    hip_available,
+    mxfp4_oracle_diff,
+    run_hip,
+    run_triton,
+)
+
+pytestmark = pytest.mark.skipif(
+    not detect_gfx950(), reason="DSV4 fused compressor requires gfx950 (CDNA4)"
+)
+
+
+@pytest.fixture(autouse=True)
+def _default_cuda_device():
+    """The scenario/state-cache builders create CUDA tensors via the default
+    device; pin it here (only runs on gfx950, where CUDA is present)."""
+    torch.set_default_device("cuda")
+    yield
+    torch.set_default_device("cpu")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_ops():
+    assert hip_available(), "dsv4 compressor ops not registered in _rocm_C on gfx950"
+
+
+@pytest.mark.parametrize("shape", BYTE_EXACT_SHAPES, ids=lambda s: s.label)
+@pytest.mark.parametrize("scenario", SCENARIO_NAMES)
+def test_compress_matches_triton(shape, scenario):
+    """HIP packed cache is reference-equivalent to the Triton FP32 oracle."""
+    ctx = build_scenario(shape, scenario)
+    ctx.build()
+    build_shared_input(ctx)
+
+    ref_flat, ref_3d = ctx.new_kv_cache()
+    run_triton(ctx, ref_3d)
+    torch.cuda.synchronize()
+
+    hip_flat, hip_3d = ctx.new_kv_cache()
+    run_hip(ctx, hip_3d)
+    torch.cuda.synchronize()
+
+    aligned, detail = compare_to_triton(ref_flat.cpu(), hip_flat.cpu(), ctx)
+    assert aligned, (
+        f"{shape.label}/{scenario}: {detail} (expected reference-equivalent)"
+    )
+
+
+@pytest.mark.parametrize("scenario", SCENARIO_NAMES)
+def test_indexer_mxfp4_matches_torch_oracle(scenario):
+    """HIP MXFP4 tail matches a faithful torch front-end + RNE MXFP4 reference."""
+    ctx = build_scenario(INDEXER_MXFP4, scenario)
+    ctx.build()
+    build_shared_input(ctx)
+
+    hip_flat, hip_3d = ctx.new_kv_cache()
+    run_hip(ctx, hip_3d)
+    torch.cuda.synchronize()
+
+    dmean = mxfp4_oracle_diff(ctx, hip_flat.cpu())
+    assert dmean < 1e-2, (
+        f"indexer_mxfp4/{scenario}: dmean={dmean:.5f} "
+        f"(expected FP4 RNE-tie reference-equivalent)"
+    )

--- a/tests/kernels/attention/test_dsv4_compress_arch_guard.py
+++ b/tests/kernels/attention/test_dsv4_compress_arch_guard.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Arch-gating contract for the AOT DeepSeek-V4 compressor ops.
+
+Platform-agnostic — runs on any host (including non-ROCm CI). It asserts that
+``hip_compressor_supported`` is True exactly when the device is gfx950 (CDNA4)
+with the _rocm_C ops built in, and always False otherwise (wrong arch, an
+unsupported/default-disabled shape, or a non-uint8 cache layout). The model
+relies on this gate to choose between the HIP op and the Triton fallback.
+"""
+
+import pytest
+import torch
+
+from tests.kernels.attention.dsv4_compress_utils import detect_gfx950
+from vllm.models.deepseek_v4.amd.ops.hip_compress_dispatch import (
+    ALL_HIP_COMPRESSOR_SHAPES,
+    DEFAULT_HIP_COMPRESSOR_SHAPES,
+    hip_compressor_supported,
+    parse_hip_compressor_modes,
+)
+
+
+def test_parse_hip_compressor_modes():
+    assert parse_hip_compressor_modes(None) == frozenset()
+    assert parse_hip_compressor_modes("0") == frozenset()
+    assert parse_hip_compressor_modes("false") == frozenset()
+    assert parse_hip_compressor_modes("1") == frozenset({"csa", "hca"})
+    assert parse_hip_compressor_modes("true") == frozenset({"csa", "hca"})
+    assert parse_hip_compressor_modes("csa,indexer") == frozenset({"csa", "indexer"})
+
+    with pytest.raises(ValueError, match="VLLM_ROCM_DSV4_HIP_COMPRESSOR"):
+        parse_hip_compressor_modes("csa,unknown")
+
+
+def test_compressor_gated_on_gfx950():
+    on = detect_gfx950()
+    if on:
+        import vllm._rocm_C  # noqa: F401  (ensure the ops are registered)
+
+    u8 = torch.empty(1, 16, dtype=torch.uint8)
+
+    assert (128, 4) not in DEFAULT_HIP_COMPRESSOR_SHAPES
+    assert (128, 4) in ALL_HIP_COMPRESSOR_SHAPES
+
+    # Default enabled mode supports CSA/HCA iff on gfx950.
+    for head_dim, ratio in DEFAULT_HIP_COMPRESSOR_SHAPES:
+        assert hip_compressor_supported(head_dim, ratio, u8) == on
+
+    # Indexer is HIP-supported only when explicitly included by the caller.
+    assert not hip_compressor_supported(128, 4, u8)
+    assert (
+        hip_compressor_supported(128, 4, u8, allowed_shapes=ALL_HIP_COMPRESSOR_SHAPES)
+        == on
+    )
+
+    # Unsupported (head_dim, compress_ratio) -> never supported.
+    assert not hip_compressor_supported(256, 4, u8)
+    # Non-uint8 (e.g. FlashInfer full-cache) layout -> never supported.
+    bf16 = torch.empty(1, 16, dtype=torch.bfloat16)
+    assert not hip_compressor_supported(512, 4, bf16)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -117,6 +117,7 @@ if TYPE_CHECKING:
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
     VLLM_ROCM_USE_AITER: bool = False
+    VLLM_ROCM_DSV4_HIP_COMPRESSOR: str = "False"
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
     VLLM_ROCM_USE_AITER_LINEAR_HIPBMM: bool = False
@@ -1129,6 +1130,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ROCM_USE_AITER": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER", "False").lower() in ("true", "1")
     ),
+    # DeepSeek-V4 fused HIP compressor modes (experimental ROCm gfx950 path).
+    # false/0 disables; true/1 enables csa+hca; list values may include indexer.
+    "VLLM_ROCM_DSV4_HIP_COMPRESSOR": lambda: os.getenv(
+        "VLLM_ROCM_DSV4_HIP_COMPRESSOR", "False"
+    ),
     # Whether to use aiter paged attention.
     # By default is disabled.
     "VLLM_ROCM_USE_AITER_PAGED_ATTN": lambda: (
@@ -1580,10 +1586,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS", "1")
     ),
     # Enforce function parameter schemas in structural-tag based tool calling.
-    "VLLM_ENFORCE_STRICT_TOOL_CALLING": lambda: os.getenv(
-        "VLLM_ENFORCE_STRICT_TOOL_CALLING", "True"
-    ).lower()
-    in ("true", "1"),
+    "VLLM_ENFORCE_STRICT_TOOL_CALLING": lambda: (
+        os.getenv("VLLM_ENFORCE_STRICT_TOOL_CALLING", "True").lower() in ("true", "1")
+    ),
     # Control the max chunk bytes (in MB) for the rpc message queue.
     # Object larger than this threshold will be broadcast to worker
     # processes via zmq.

--- a/vllm/models/deepseek_v4/amd/ops/__init__.py
+++ b/vllm/models/deepseek_v4/amd/ops/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""AMD DeepSeek-V4 fused compressor adapter (gfx950 / CDNA4).
+
+The fused compressor kernels (CSA / HCA / indexer) are built into the _rocm_C
+extension from ``csrc/rocm/dsv4_*_compress.cu`` and exposed as
+``torch.ops._rocm_C.dsv4_{csa,hca,indexer}_compress`` (gfx950 only).
+
+  - ``hip_compress_dispatch.py`` : the adapter ``compress_norm_rope_store_hip``
+    + ``hip_compressor_supported`` used by ``compressor.py`` (opt-in via
+    ``VLLM_ROCM_DSV4_HIP_COMPRESSOR``).
+
+Correctness tests and the DVFS-robust micro-benchmark live with the rest of the
+kernel suite, not in this package:
+  - ``tests/kernels/attention/test_dsv4_compress.py``           (byte-exact)
+  - ``tests/kernels/attention/test_dsv4_compress_arch_guard.py`` (gating)
+  - ``tests/kernels/attention/dsv4_compress_utils.py``          (scaffolding)
+  - ``benchmarks/kernels/benchmark_dsv4_compress.py``           (perf)
+"""

--- a/vllm/models/deepseek_v4/amd/ops/hip_compress_dispatch.py
+++ b/vllm/models/deepseek_v4/amd/ops/hip_compress_dispatch.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Opt-in adapter for the fused HIP DeepSeek-V4 compressors (gfx950 / CDNA4).
+
+Bridges the model's ``compress_norm_rope_store_fn(...)`` call site
+(``compressor.py``) to the AOT ``torch.ops._rocm_C.dsv4_*`` ops, dispatching by
+``(head_dim, compress_ratio)``:
+
+    (512, 4)   -> dsv4_csa_compress
+    (512, 128) -> dsv4_hca_compress
+    (128, 4)   -> dsv4_indexer_compress   (FP8 or MXFP4 via use_fp4_cache)
+
+These kernels read a **bf16** state cache and add APE in-kernel, emit the legacy
+paged UE8M0 / packed layout (``kv_cache`` dtype uint8), and are CDNA4-only — they
+are built into ``_rocm_C`` only when gfx950 is among the target archs
+(VLLM_ROCM_GFX950). ``hip_compressor_supported`` enforces every precondition.
+The default enabled mode includes CSA/HCA; HIP indexer exists for explicit
+opt-in and focused testing, but defaults to Triton.
+"""
+
+from typing import Any, Literal, cast
+
+import torch
+
+from vllm import envs
+
+CompressorKind = Literal["csa", "hca", "indexer"]
+
+HIP_COMPRESSOR_SHAPES_BY_KIND: dict[CompressorKind, tuple[int, int]] = {
+    "csa": (512, 4),
+    "hca": (512, 128),
+    "indexer": (128, 4),
+}
+DEFAULT_HIP_COMPRESSOR_KINDS: frozenset[CompressorKind] = frozenset({"csa", "hca"})
+DEFAULT_HIP_COMPRESSOR_SHAPES = frozenset({(512, 4), (512, 128)})
+ALL_HIP_COMPRESSOR_SHAPES = DEFAULT_HIP_COMPRESSOR_SHAPES | frozenset({(128, 4)})
+SUPPORTED_SHAPES = ALL_HIP_COMPRESSOR_SHAPES
+
+
+def parse_hip_compressor_modes(value: str | None) -> frozenset[CompressorKind]:
+    """Parse VLLM_ROCM_DSV4_HIP_COMPRESSOR as bool-compatible modes."""
+    if value is None:
+        return frozenset()
+
+    normalized = value.strip().lower()
+    if normalized in ("", "0", "false"):
+        return frozenset()
+    if normalized in ("1", "true"):
+        return DEFAULT_HIP_COMPRESSOR_KINDS
+
+    allowed = set(HIP_COMPRESSOR_SHAPES_BY_KIND)
+    modes = {part.strip() for part in normalized.split(",")}
+    if not modes or "" in modes or not modes <= allowed:
+        allowed_values = ", ".join(sorted(allowed))
+        raise ValueError(
+            "VLLM_ROCM_DSV4_HIP_COMPRESSOR must be one of 0/false, "
+            "1/true, or a comma-separated list containing: "
+            f"{allowed_values}."
+        )
+    return frozenset(cast(CompressorKind, mode) for mode in modes)
+
+
+def selected_hip_compressor_kinds() -> frozenset[CompressorKind]:
+    return parse_hip_compressor_modes(envs.VLLM_ROCM_DSV4_HIP_COMPRESSOR)
+
+
+def selected_hip_compressor_shapes() -> frozenset[tuple[int, int]]:
+    return frozenset(
+        HIP_COMPRESSOR_SHAPES_BY_KIND[kind] for kind in selected_hip_compressor_kinds()
+    )
+
+
+def classify_compressor(head_dim: int, compress_ratio: int) -> CompressorKind | None:
+    for kind, shape in HIP_COMPRESSOR_SHAPES_BY_KIND.items():
+        if shape == (head_dim, compress_ratio):
+            return kind
+    return None
+
+
+def hip_compressor_selected(head_dim: int, compress_ratio: int) -> bool:
+    kind = classify_compressor(head_dim, compress_ratio)
+    return kind in selected_hip_compressor_kinds()
+
+
+def hip_compressor_runtime_available() -> bool:
+    """Return whether this ROCm process can use gfx950-only compressor kernels."""
+    try:
+        from vllm.platforms.rocm import on_gfx950
+
+        return on_gfx950()
+    except Exception:
+        return False
+
+
+def _aot_op(head_dim: int, compress_ratio: int):
+    """The torch.ops._rocm_C op for this shape, or None if not registered.
+
+    The op is registered only when _rocm_C was built with VLLM_ROCM_GFX950.
+    """
+    rocm_C = getattr(torch.ops, "_rocm_C", None)
+    if rocm_C is None:
+        return None
+    if head_dim == 512 and compress_ratio == 4:
+        return getattr(rocm_C, "dsv4_csa_compress", None)
+    if head_dim == 512 and compress_ratio == 128:
+        return getattr(rocm_C, "dsv4_hca_compress", None)
+    if head_dim == 128 and compress_ratio == 4:
+        return getattr(rocm_C, "dsv4_indexer_compress", None)
+    return None
+
+
+def hip_compressor_supported(
+    head_dim: int,
+    compress_ratio: int,
+    kv_cache: torch.Tensor,
+    allowed_shapes: frozenset[tuple[int, int]] | None = None,
+) -> bool:
+    """True iff the fused HIP compressor can serve this configuration.
+
+    Checks (all required): the caller-selected HIP mode includes this shape,
+    gfx950 (CDNA4), the bf16 state-cache path (so APE is added in-kernel), the
+    legacy paged uint8 cache layout (the kernels do not emit FlashInfer
+    full-cache rows), and that the matching AOT op is actually registered (i.e.
+    _rocm_C was built with VLLM_ROCM_GFX950). The caller has already checked the
+    opt-in flag + is_rocm().
+    """
+    if allowed_shapes is None:
+        allowed_shapes = DEFAULT_HIP_COMPRESSOR_SHAPES
+    if (head_dim, compress_ratio) not in allowed_shapes:
+        return False
+    if kv_cache.dtype != torch.uint8:
+        return False
+    if not hip_compressor_runtime_available():
+        return False
+    return _aot_op(head_dim, compress_ratio) is not None
+
+
+def compress_norm_rope_store_hip(
+    *,
+    state_cache: torch.Tensor,
+    num_actual: int,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    state_width: int,
+    cos_sin_cache: torch.Tensor,
+    kv_cache: torch.Tensor,
+    k_cache_metadata: Any,
+    pdl_kwargs: dict,
+    head_dim: int,
+    rope_head_dim: int,
+    compress_ratio: int,
+    overlap: bool,
+    use_fp4_cache: bool,
+    rms_norm_weight: torch.Tensor,
+    rms_norm_eps: float,
+    quant_block: int,
+    token_stride: int,
+    scale_dim: int,
+    ape: torch.Tensor,
+    use_bf16_state_cache: bool = True,
+    hca_plan_scratch: torch.Tensor | None = None,
+    hca_counter_scratch: torch.Tensor | None = None,
+    **_ignored: Any,
+) -> None:
+    """Dispatch one fused HIP compressor launch (signature mirrors the model's
+    ``compress_norm_rope_store_fn``). Assumes ``hip_compressor_supported`` already
+    returned True for this configuration."""
+    if num_actual == 0:
+        return
+
+    op = _aot_op(head_dim, compress_ratio)
+    if op is None:
+        raise RuntimeError(
+            f"HIP compressor op unavailable for (head_dim={head_dim}, "
+            f"compress_ratio={compress_ratio}); was _rocm_C built with "
+            f"VLLM_ROCM_GFX950?"
+        )
+
+    # Positional args, matching the TORCH_LIBRARY schema in
+    # csrc/rocm/torch_bindings.cpp. kv_cache is written in place.
+    args = [
+        state_cache,
+        num_actual,
+        ape,  # RAW APE; expanded / added on-device
+        token_to_req_indices,
+        positions,
+        slot_mapping,
+        block_table,
+        block_size,
+        rms_norm_weight,
+        rms_norm_eps,
+        cos_sin_cache,
+        kv_cache,
+        k_cache_metadata.slot_mapping,
+        kv_cache.shape[1],  # kv_cache_block_size
+        scale_dim,
+    ]
+    if head_dim == 128 and compress_ratio == 4:
+        args.append(use_fp4_cache)
+    elif head_dim == 512 and compress_ratio == 128:
+        if hca_plan_scratch is None or hca_counter_scratch is None:
+            raise RuntimeError(
+                "HCA HIP compressor requires reusable plan/counter scratch buffers."
+            )
+        args.extend([hca_plan_scratch, hca_counter_scratch])
+    op(*args)

--- a/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
@@ -51,12 +51,30 @@ def compress_norm_rope_store_triton(
     quant_block: int,
     token_stride: int,
     scale_dim: int,
+    ape: torch.Tensor | None = None,
+    use_bf16_state_cache: bool = False,
 ) -> None:
     """Shared triton launcher for the fused compress+norm+RoPE+insert path.
 
     Picks one of the three kernels in this module based on ``head_dim`` and
     ``use_fp4_cache``. Identical launch signature for all three.
+
+    Args:
+        ape: APE tensor [compress_ratio, coff*head_dim]. Required when
+            use_bf16_state_cache=True.
+        use_bf16_state_cache: If True, add APE inside the compress kernel
+            instead of reading fused score+ape.
     """
+    if use_bf16_state_cache:
+        # Triton has no in-kernel APE path; the bf16 state cache is served by
+        # the fused HIP compressor on gfx950.
+        raise NotImplementedError(
+            "use_bf16_state_cache=True is not implemented for Triton kernels. "
+            "Use the fused HIP compressor on gfx950: "
+            "VLLM_ROCM_DSV4_HIP_COMPRESSOR=1 for CSA/HCA, or include "
+            "indexer explicitly for HIP indexer."
+        )
+
     if head_dim == 512:
         kernel = _fused_kv_compress_norm_rope_insert_sparse_attn
         num_warps = 4

--- a/vllm/models/deepseek_v4/common/ops/save_partial_states.py
+++ b/vllm/models/deepseek_v4/common/ops/save_partial_states.py
@@ -5,11 +5,13 @@ import torch
 
 from vllm.triton_utils import tl, triton
 
+_DUMMY_APE_CACHE: dict[torch.device, torch.Tensor] = {}
+
 
 def save_partial_states(
     kv: torch.Tensor,
     score: torch.Tensor,
-    ape: torch.Tensor,
+    ape: torch.Tensor | None,
     positions: torch.Tensor,
     state_cache: torch.Tensor,
     slot_mapping: torch.Tensor,
@@ -17,13 +19,29 @@ def save_partial_states(
     state_width: int,
     compress_ratio: int,
     pdl_kwargs: dict | None = None,
+    dummy_ape: torch.Tensor | None = None,
 ) -> None:
-    """Write packed [kv, score+ape] partial states into the compressor cache.
+    """Write packed [kv, score(+ape)] partial states into the compressor cache.
 
     One program per token; pads (slot_id == -1) are skipped.
+
+    Args:
+        ape: If None, stores raw score without APE addition (bf16 state_cache mode).
+             APE will be added inside the compress kernel instead.
+        dummy_ape: Reusable placeholder used only to satisfy the Triton kernel
+             signature when ape is None. It is not read when SKIP_APE=True.
     """
     num_actual = slot_mapping.shape[0]
     head_size = kv.shape[-1]
+    skip_ape = ape is None
+    if skip_ape:
+        if dummy_ape is None:
+            dummy_ape = _DUMMY_APE_CACHE.get(kv.device)
+            if dummy_ape is None:
+                dummy_ape = torch.empty(1, 1, dtype=torch.float32, device=kv.device)
+                _DUMMY_APE_CACHE[kv.device] = dummy_ape
+        ape = dummy_ape
+
     _save_partial_states_kernel[(num_actual,)](
         kv,
         kv.stride(0),
@@ -41,6 +59,7 @@ def save_partial_states(
         TRITON_BLOCK_SIZE=triton.next_power_of_2(head_size),
         STATE_WIDTH=state_width,
         COMPRESS_RATIO=compress_ratio,
+        SKIP_APE=skip_ape,
         **(pdl_kwargs or {}),
     )
 
@@ -64,6 +83,7 @@ def _save_partial_states_kernel(
     # state_cache last dim packs [kv_state, score_state], each STATE_WIDTH wide.
     STATE_WIDTH: tl.constexpr,
     COMPRESS_RATIO: tl.constexpr,
+    SKIP_APE: tl.constexpr,
 ):
     token_idx = tl.program_id(0)
     slot_id = tl.load(slot_mapping_ptr + token_idx)
@@ -89,13 +109,15 @@ def _save_partial_states_kernel(
     kv = tl.load(kv_ptr + token_idx * kv_stride + block, mask=mask)
     tl.store(base_ptr + block, kv, mask=mask)
 
-    # Fused: score += ape[position % compress_ratio]
-    position = tl.load(positions_ptr + token_idx)
-    ape_row = position % COMPRESS_RATIO
-    ape = tl.load(ape_ptr + ape_row * ape_stride + block, mask=mask)
     score = tl.load(score_ptr + token_idx * score_stride + block, mask=mask)
-    tl.store(
-        base_ptr + STATE_WIDTH + block,
-        score + ape,
-        mask=mask,
-    )
+    if SKIP_APE:
+        # BF16 state_cache mode: store raw score without APE.
+        # APE will be added inside the compress kernel.
+        tl.store(base_ptr + STATE_WIDTH + block, score, mask=mask)
+    else:
+        # FP32 state_cache mode: fuse APE addition here.
+        # score += ape[position % compress_ratio]
+        position = tl.load(positions_ptr + token_idx)
+        ape_row = position % COMPRESS_RATIO
+        ape = tl.load(ape_ptr + ape_row * ape_stride + block, mask=mask)
+        tl.store(base_ptr + STATE_WIDTH + block, score + ape, mask=mask)

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -9,6 +9,7 @@ from torch import nn
 
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import MergedColumnParallelLinear
@@ -32,6 +33,8 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     SlidingWindowMLASpec,
 )
+
+logger = init_logger(__name__)
 
 
 class CompressorBackend(AttentionBackend):
@@ -136,7 +139,7 @@ class CompressorStateCache(torch.nn.Module, AttentionLayerBase):
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
 
-        assert self.dtype == torch.float32
+        assert self.dtype in (torch.float32, torch.bfloat16)
         assert compress_ratio in [4, 128]
         coff = 1 + (compress_ratio == 4)
         self.sliding_window = coff * compress_ratio
@@ -211,20 +214,64 @@ class DeepseekCompressor(nn.Module):
         self.rms_norm_eps = config.rms_norm_eps
         self.device = current_platform.device_type
         self.max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+        self.max_num_batched_tokens = (
+            vllm_config.scheduler_config.max_num_batched_tokens
+        )
         self.max_model_len = vllm_config.model_config.max_model_len
 
         self.overlap = compress_ratio == 4
         self.coff = 1 + self.overlap
+        self.use_hip_compressor = False
+        self.use_bf16_state_cache = False
+        if current_platform.is_rocm():
+            from .amd.ops.hip_compress_dispatch import (
+                hip_compressor_runtime_available,
+                hip_compressor_selected,
+            )
 
-        state_dtype = torch.float32
+            selected_hip_compressor = hip_compressor_selected(
+                self.head_dim, self.compress_ratio
+            )
+            self.use_hip_compressor = (
+                selected_hip_compressor and hip_compressor_runtime_available()
+            )
+            self.use_bf16_state_cache = self.use_hip_compressor
+            if selected_hip_compressor and not self.use_hip_compressor:
+                logger.warning_once(
+                    "VLLM_ROCM_DSV4_HIP_COMPRESSOR selected this compressor, "
+                    "but the fused HIP path is only available on gfx950. "
+                    "Falling back to Triton."
+                )
+
+        state_dtype = torch.bfloat16 if self.use_bf16_state_cache else torch.float32
         self.ape = nn.Parameter(
             torch.empty(
                 (compress_ratio, self.coff * self.head_dim),
-                dtype=state_dtype,
+                dtype=torch.float32,
                 device=self.device,
             ),
             requires_grad=False,
         )
+        if (
+            self.use_hip_compressor
+            and self.head_dim == 512
+            and self.compress_ratio == 128
+        ):
+            hca_plan_capacity = (
+                self.max_num_batched_tokens // self.compress_ratio
+                + self.max_num_reqs
+                + 2
+            )
+            self.register_buffer(
+                "_hca_plan_scratch",
+                torch.empty(hca_plan_capacity, dtype=torch.int32, device=self.device),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_hca_counter_scratch",
+                torch.empty(1, dtype=torch.int32, device=self.device),
+                persistent=False,
+            )
 
         self.fused_wkv_wgate = MergedColumnParallelLinear(
             self.hidden_size,
@@ -309,16 +356,19 @@ class DeepseekCompressor(nn.Module):
             else {"launch_pdl": False}
         )
 
-        # Store the KV and score (with fused APE addition) in the state.
+        # Store the KV and score in the state cache.
         # NOTE: PDL is disabled — both this kernel and the compress kernels
         # below depend on preceding kernel outputs (kv/score from the cublas
         # GEMM; state_cache from this kernel) but neither emits/waits on PDL
         # grid dependency primitives, so launch_pdl=True caused a
         # read-after-write race and non-deterministic output.
+        #
+        # When use_bf16_state_cache=True, store raw score without APE. The HIP
+        # compressor adds APE in-kernel while preserving fp32 precision.
         save_partial_states(
             kv=kv,
             score=score,
-            ape=self.ape,
+            ape=None if self.use_bf16_state_cache else self.ape,
             positions=positions,
             state_cache=state_cache,
             slot_mapping=slot_mapping,
@@ -353,6 +403,7 @@ class DeepseekCompressor(nn.Module):
         # cutedsl (head=512) accepts the full-cache flags; triton (indexer/AMD)
         # does not, so the two callables have different signatures.
         compress_norm_rope_store_fn: Any
+        using_hip_compressor = False
         if current_platform.is_cuda() and self.head_dim == 512:
             from .nvidia.ops.sparse_attn_compress_cutedsl import (
                 compress_norm_rope_store_cutedsl,
@@ -367,10 +418,43 @@ class DeepseekCompressor(nn.Module):
                 store_full_fp8=store_full_fp8,
                 fp8_scale=fp8_scale,
             )
+        elif current_platform.is_rocm() and self.use_hip_compressor:
+            from .amd.ops.hip_compress_dispatch import (
+                compress_norm_rope_store_hip,
+                hip_compressor_supported,
+                selected_hip_compressor_shapes,
+            )
+
+            if hip_compressor_supported(
+                self.head_dim,
+                self.compress_ratio,
+                kv_cache,
+                allowed_shapes=selected_hip_compressor_shapes(),
+            ):
+                compress_norm_rope_store_fn = compress_norm_rope_store_hip
+                using_hip_compressor = True
+            else:
+                raise RuntimeError(
+                    "VLLM_ROCM_DSV4_HIP_COMPRESSOR selected a fused HIP "
+                    "compressor, but it is unavailable for this configuration "
+                    "(requires gfx950, a registered _rocm_C op, a supported "
+                    "(head_dim, compress_ratio), and the uint8 paged cache "
+                    "layout). Triton cannot serve the bf16-state-cache path. "
+                    "Use a gfx950 build with the paged uint8 cache layout or "
+                    "disable VLLM_ROCM_DSV4_HIP_COMPRESSOR."
+                )
+            extra_kwargs = {}
         else:
             # Indexer path (head_dim == 128) or non-CUDA GPUs (AMD, XPU, etc.).
             compress_norm_rope_store_fn = compress_norm_rope_store_triton
             extra_kwargs = {}
+
+        if self.use_bf16_state_cache:
+            extra_kwargs["ape"] = self.ape
+            extra_kwargs["use_bf16_state_cache"] = True
+        if using_hip_compressor and self.head_dim == 512 and self.compress_ratio == 128:
+            extra_kwargs["hca_plan_scratch"] = self._hca_plan_scratch
+            extra_kwargs["hca_counter_scratch"] = self._hca_counter_scratch
 
         compress_norm_rope_store_fn(
             state_cache=state_cache,


### PR DESCRIPTION
## Purpose

This PR adds an opt-in HIP compressor path for DeepSeek-V4 on ROCm gfx950/CDNA4.

The new path fuses the DeepSeek-V4 compressor -> RMSNorm -> RoPE -> quantize -> KV-cache-store sequence into `_rocm_C` HIP kernels for the CSA, HCA, and indexer compressors. This targets long-prefill DeepSeek-V4 workloads where compressor/cache construction contributes to TTFT.

The feature is disabled by default. Users can enable the HIP compressor set with:

```bash
VLLM_ROCM_DSV4_HIP_COMPRESSOR=1 # enables CSA + HCA.
VLLM_ROCM_DSV4_HIP_COMPRESSOR=csa,hca,indexer # enable CSA + HCA + indexer.
```

Non-gfx950 systems and unsupported cache layouts keep the existing Triton compressor path.

## Test result

### Single kernel benchmark

Command:

```bash
python benchmarks/kernels/benchmark_dsv4_compress.py
```

| shape         | scenario        | triton (us)   |   hip (us) | hip/triton   |
|---------------|-----------------|---------------|------------|--------------|
| csa_main      | decode_boundary | 23.6          |       19.1 | 0.810        |
| csa_main      | prefill_256     | 23.9          |       18.2 | 0.762        |
| csa_main      | prefill_1024    | 24.0          |       18.5 | 0.769        |
| csa_main      | prefill_4096    | 28.8          |       21.1 | 0.733        |
| csa_main      | prefill_32768   | 171.7         |       69.3 | 0.404        |
| hca_main      | decode_boundary | 124.0         |       38.3 | 0.309        |
| hca_main      | prefill_256     | 88.8          |       39.5 | 0.445        |
| hca_main      | prefill_1024    | 81.0          |       39.5 | 0.487        |
| hca_main      | prefill_4096    | 236.4         |       39.6 | 0.168        |
| hca_main      | prefill_32768   | 1883.4        |       47.5 | 0.025        |
| indexer_fp8   | decode_boundary | 22.9          |       16.2 | 0.705        |
| indexer_fp8   | prefill_256     | 23.1          |       16.2 | 0.702        |
| indexer_fp8   | prefill_1024    | 23.2          |       16.3 | 0.703        |
| indexer_fp8   | prefill_4096    | 23.6          |       18.4 | 0.778        |
| indexer_fp8   | prefill_32768   | 43.6          |       38.1 | 0.874        |
| indexer_mxfp4 | decode_boundary | n/a           |       16.3 | n/a          |
| indexer_mxfp4 | prefill_256     | n/a           |       16.2 | n/a          |
| indexer_mxfp4 | prefill_1024    | n/a           |       16.3 | n/a          |
| indexer_mxfp4 | prefill_4096    | n/a           |       18.4 | n/a          |
| indexer_mxfp4 | prefill_32768   | n/a           |       37.8 | n/a          |


```markdown
The HIP kernels are faster than the Triton compressor reference for CSA, HCA, and indexer FP8 in the standalone kernel benchmark. HCA shows the largest gain, especially for long-prefill scenarios. The indexer MXFP4 path is HIP-only in this benchmark because the Triton MXFP4 reference uses NVIDIA-specific PTX.
```


### Fixed-length long-prefill e2e benchmark

All runs use `OSL=1`, `max_concurrency=1`, `num_prompts=16`,
`random-range-ratio=0.0`, and seed 221.

| ISL | Variant | Completed | Failed | Duration (s) | Total tok/s | Mean TTFT (ms) | Median TTFT (ms) |
|---:|---|---:|---:|---:|---:|---:|---:|
| 32K | Baseline | 16 | 0 | 132.15 | 3967.48 | 8258.96 | 8769.85 |
| 32K | HIP | 16 | 0 | 125.12 | 4190.51 | 7819.50 | 8327.75 |
| 64K | Baseline | 16 | 0 | 268.23 | 3909.26 | 16764.16 | 17857.33 |
| 64K | HIP | 16 | 0 | 267.35 | 3922.12 | 16709.15 | 17809.51 |
| 102K | Baseline | 16 | 0 | 487.17 | 3363.14 | 30447.64 | 32580.50 |
| 102K | HIP | 16 | 0 | 443.91 | 3690.90 | 27743.81 | 29570.70 |

| ISL | Duration | Total tok/s | Mean TTFT | Median TTFT |
|---:|---:|---:|---:|---:|
| 32K | -5.32% | +5.62% | -5.32% | -5.04% |
| 64K | -0.33% | +0.33% | -0.33% | -0.27% |
| 102K | -8.88% | +9.75% | -8.88% | -9.24% |

64K was roughly neutral (+0.33% total throughput), while 32K and 102K showed clear gains. All fixed-length e2e runs completed with 0 failed requests.

The e2e server used DP=8 with expert parallel, AITER MoE, and FULL_AND_PIECEWISE cudagraph compilation, so the measurements include scheduler and communication effects beyond the compressor kernels.

### GSM8K test

HIP compressor enabled (`VLLM_ROCM_DSV4_HIP_COMPRESSOR=1`):
`local-chat-completions ({'model': 'deepseek-ai/DeepSeek-V4-Pro', 'base_url': 'http://127.0.0.1:19090/v1/chat/completions', 'api_key': 'EMPTY', 'max_retries': 5, 'num_concurrent': 128, 'tokenized_requests': False}), gen_kwargs: ({'max_tokens': 5376, 'temperature': 0, 'top_p': 1}), num_fewshot: 20, batch_size: 1`
| Task | Version | Filter | n-shot | Metric | Value | Stderr |
|---|---:|---|---:|---|---:|---:|
| gsm8k | 3 | flexible-extract | 20 | exact_match | TODO | TODO |
| gsm8k | 3 | strict-match | 20 | exact_match | TODO | TODO |