### PR TITLE
fix(security): Cap repetition_detection window to bound scheduler CPU…

### DIFF
--- a/tests/v1/core/test_repetition_detection.py
+++ b/tests/v1/core/test_repetition_detection.py
@@ -1,8 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from unittest.mock import MagicMock
+
 import pytest
 
-from vllm.sampling_params import RepetitionDetectionParams, SamplingParams
+from vllm.sampling_params import (
+    _MAX_ABSOLUTE_MIN_COUNT,
+    _MAX_ABSOLUTE_PATTERN_SIZE,
+    RepetitionDetectionParams,
+    SamplingParams,
+    VLLMValidationError,
+)
 from vllm.v1.core.sched.utils import check_sequence_repetition, check_stop
 from vllm.v1.request import Request, RequestStatus
 
@@ -288,3 +296,143 @@ class TestRepetitionDetectionIntegration:
         )
         request.append_output_token_ids([10, 20, 10, 20, 10, 20])
         assert not check_stop(request, max_model_len=1024)
+
+
+# ============================================================================
+# CAP / VALIDATION TESTS - server-side limits on repetition detection
+# ============================================================================
+
+
+def _mock_model_config(max_rep_cap: int = 2048) -> MagicMock:
+    """Minimal mock satisfying SamplingParams.verify() for cap tests."""
+    cfg = MagicMock()
+    cfg.max_logprobs = 20
+    cfg.get_vocab_size.return_value = 32000
+    cfg.max_repetition_detection_pattern_size = max_rep_cap
+    cfg.is_diffusion = False
+    cfg.logits_processors = None
+    return cfg
+
+
+class TestRepetitionDetectionCaps:
+    """Tests for server-side caps on repetition detection parameters."""
+
+    def test_max_pattern_size_exceeds_server_cap(self):
+        params = SamplingParams(
+            max_tokens=100,
+            repetition_detection=RepetitionDetectionParams(
+                max_pattern_size=4096,
+                min_pattern_size=1,
+                min_count=2,
+            ),
+        )
+        with pytest.raises(VLLMValidationError, match="exceeds the server"):
+            params._validate_repetition_detection(_mock_model_config(max_rep_cap=2048))
+
+    def test_max_pattern_size_within_server_cap(self):
+        params = SamplingParams(
+            max_tokens=100,
+            repetition_detection=RepetitionDetectionParams(
+                max_pattern_size=1024,
+                min_pattern_size=1,
+                min_count=2,
+            ),
+        )
+        params._validate_repetition_detection(_mock_model_config(max_rep_cap=2048))
+
+    def test_server_disabled_repetition_detection(self):
+        params = SamplingParams(
+            max_tokens=100,
+            repetition_detection=RepetitionDetectionParams(
+                max_pattern_size=5,
+                min_pattern_size=1,
+                min_count=2,
+            ),
+        )
+        with pytest.raises(VLLMValidationError, match="disabled"):
+            params._validate_repetition_detection(_mock_model_config(max_rep_cap=0))
+
+    def test_server_uncapped_repetition_detection(self):
+        params = SamplingParams(
+            max_tokens=100,
+            repetition_detection=RepetitionDetectionParams(
+                max_pattern_size=60000,
+                min_pattern_size=1,
+                min_count=2,
+            ),
+        )
+        params._validate_repetition_detection(_mock_model_config(max_rep_cap=-1))
+
+    def test_disabled_detection_skips_validation(self):
+        params = SamplingParams(max_tokens=100)
+        params._validate_repetition_detection(_mock_model_config(max_rep_cap=0))
+
+    def test_scan_work_budget_exceeded(self):
+        params = SamplingParams(
+            max_tokens=100,
+            repetition_detection=RepetitionDetectionParams(
+                max_pattern_size=2048,
+                min_pattern_size=1,
+                min_count=100,
+            ),
+        )
+        with pytest.raises(VLLMValidationError, match="scan work"):
+            params._validate_repetition_detection(_mock_model_config(max_rep_cap=2048))
+
+    def test_scan_work_budget_ok(self):
+        params = SamplingParams(
+            max_tokens=100,
+            repetition_detection=RepetitionDetectionParams(
+                max_pattern_size=2048,
+                min_pattern_size=1,
+                min_count=5,
+            ),
+        )
+        params._validate_repetition_detection(_mock_model_config(max_rep_cap=2048))
+
+
+class TestRepetitionDetectionAbsoluteCaps:
+    """Tests for hard absolute limits in RepetitionDetectionParams."""
+
+    def test_absolute_hard_cap_max_pattern_size(self):
+        with pytest.raises(ValueError, match="max_pattern_size must be"):
+            RepetitionDetectionParams(
+                max_pattern_size=_MAX_ABSOLUTE_PATTERN_SIZE + 1,
+                min_pattern_size=1,
+                min_count=2,
+            )
+
+    def test_absolute_hard_cap_min_count(self):
+        with pytest.raises(ValueError, match="min_count must be"):
+            RepetitionDetectionParams(
+                max_pattern_size=10,
+                min_pattern_size=1,
+                min_count=_MAX_ABSOLUTE_MIN_COUNT + 1,
+            )
+
+    def test_values_at_absolute_limit_accepted(self):
+        params = RepetitionDetectionParams(
+            max_pattern_size=_MAX_ABSOLUTE_PATTERN_SIZE,
+            min_pattern_size=1,
+            min_count=_MAX_ABSOLUTE_MIN_COUNT,
+        )
+        assert params.max_pattern_size == _MAX_ABSOLUTE_PATTERN_SIZE
+        assert params.min_count == _MAX_ABSOLUTE_MIN_COUNT
+
+    def test_normal_small_window_still_works(self):
+        token_ids = [1, 2, 3, 1, 2, 3, 1, 2, 3]
+        params = RepetitionDetectionParams(
+            max_pattern_size=5,
+            min_pattern_size=2,
+            min_count=3,
+        )
+        assert check_sequence_repetition(token_ids, params)
+
+    def test_scheduler_defense_rejects_oversized_window(self):
+        token_ids = list(range(200000))
+        params = RepetitionDetectionParams(
+            max_pattern_size=_MAX_ABSOLUTE_PATTERN_SIZE,
+            min_pattern_size=1,
+            min_count=_MAX_ABSOLUTE_MIN_COUNT,
+        )
+        assert not check_sequence_repetition(token_ids, params)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -218,6 +218,12 @@ class ModelConfig:
     specified in `SamplingParams`. The default value comes the default for the
     OpenAI Chat Completions API. -1 means no cap, i.e. all (output_length *
     vocab_size) logprobs are allowed to be returned and it may cause OOM."""
+    max_repetition_detection_pattern_size: int = 2048
+    """Maximum ``max_pattern_size`` a request may set in
+    ``repetition_detection``.  Limits scheduler CPU work per generated token.
+    0 disables the feature (rejects any non-zero max_pattern_size).
+    -1 removes the cap (up to the absolute hard limit in
+    RepetitionDetectionParams)."""
     logprobs_mode: LogprobsMode = "raw_logprobs"
     """Indicates the content returned in the logprobs and prompt_logprobs.
     Supported mode:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -528,6 +528,9 @@ class EngineArgs:
     long_prefill_token_threshold: int = SchedulerConfig.long_prefill_token_threshold
     max_num_seqs: int | None = None
     max_logprobs: int = ModelConfig.max_logprobs
+    max_repetition_detection_pattern_size: int = (
+        ModelConfig.max_repetition_detection_pattern_size
+    )
     logprobs_mode: LogprobsMode = ModelConfig.logprobs_mode
     use_fp64_gumbel: bool = ModelConfig.use_fp64_gumbel
     disable_log_stats: bool = False
@@ -830,6 +833,10 @@ class EngineArgs:
             **model_kwargs["enable_return_routed_experts"],
         )
         model_group.add_argument("--max-logprobs", **model_kwargs["max_logprobs"])
+        model_group.add_argument(
+            "--max-repetition-detection-pattern-size",
+            **model_kwargs["max_repetition_detection_pattern_size"],
+        )
         model_group.add_argument("--logprobs-mode", **model_kwargs["logprobs_mode"])
         model_group.add_argument("--use-fp64-gumbel", **model_kwargs["use_fp64_gumbel"])
         model_group.add_argument(
@@ -1625,6 +1632,7 @@ class EngineArgs:
             enforce_eager=self.enforce_eager,
             enable_return_routed_experts=self.enable_return_routed_experts,
             max_logprobs=self.max_logprobs,
+            max_repetition_detection_pattern_size=self.max_repetition_detection_pattern_size,
             logprobs_mode=self.logprobs_mode,
             use_fp64_gumbel=self.use_fp64_gumbel,
             disable_sliding_window=self.disable_sliding_window,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -142,6 +142,10 @@ class StructuredOutputsParams:
         )
 
 
+_MAX_ABSOLUTE_PATTERN_SIZE = 65536
+_MAX_ABSOLUTE_MIN_COUNT = 1000
+
+
 @dataclass
 class RepetitionDetectionParams:
     """Parameters for detecting repetitive N-gram patterns in output tokens."""
@@ -170,6 +174,18 @@ class RepetitionDetectionParams:
                 "max_pattern_size, min_pattern_size must be >=0, "
                 "with min_pattern_size <= max_pattern_size. "
                 "Set both to 0 to disable repetitive pattern detection."
+            )
+        if self.max_pattern_size > _MAX_ABSOLUTE_PATTERN_SIZE:
+            raise ValueError(
+                f"max_pattern_size must be at most "
+                f"{_MAX_ABSOLUTE_PATTERN_SIZE}, "
+                f"got {self.max_pattern_size}."
+            )
+        if self.min_count > _MAX_ABSOLUTE_MIN_COUNT:
+            raise ValueError(
+                f"min_count must be at most "
+                f"{_MAX_ABSOLUTE_MIN_COUNT}, "
+                f"got {self.min_count}."
             )
         if self.max_pattern_size > 0 and self.min_count < 2:
             raise ValueError(
@@ -729,6 +745,7 @@ class SamplingParams(
         self._validate_structured_outputs(
             model_config, structured_outputs_config, tokenizer
         )
+        self._validate_repetition_detection(model_config)
 
     def _validate_logprobs(self, model_config: ModelConfig) -> None:
         max_logprobs = model_config.max_logprobs
@@ -844,6 +861,47 @@ class SamplingParams(
                     parameter="allowed_token_ids",
                     value=invalid_token_ids,
                 )
+
+    def _validate_repetition_detection(self, model_config: ModelConfig) -> None:
+        rd = self.repetition_detection
+        if rd is None or rd.max_pattern_size == 0:
+            return
+
+        cap = model_config.max_repetition_detection_pattern_size
+        if cap == 0:
+            raise VLLMValidationError(
+                "The server has disabled repetition detection "
+                "(--max-repetition-detection-pattern-size 0). "
+                "Set max_pattern_size to 0 or remove "
+                "repetition_detection from the request.",
+                parameter="repetition_detection.max_pattern_size",
+                value=rd.max_pattern_size,
+            )
+
+        if cap > 0 and rd.max_pattern_size > cap:
+            raise VLLMValidationError(
+                f"Requested max_pattern_size of "
+                f"{rd.max_pattern_size}, which exceeds the server "
+                f"limit of {cap}. Reduce max_pattern_size or ask "
+                f"the operator to raise "
+                f"--max-repetition-detection-pattern-size.",
+                parameter="repetition_detection.max_pattern_size",
+                value=rd.max_pattern_size,
+            )
+
+        effective_cap = cap if cap > 0 else _MAX_ABSOLUTE_PATTERN_SIZE
+        work_budget = effective_cap * 10
+        scan_work = rd.max_pattern_size * rd.min_count
+        if scan_work > work_budget:
+            raise VLLMValidationError(
+                f"Repetition detection scan work "
+                f"(max_pattern_size={rd.max_pattern_size} * "
+                f"min_count={rd.min_count} = {scan_work}) exceeds "
+                f"the budget of {work_budget}. Reduce "
+                f"max_pattern_size or min_count.",
+                parameter="repetition_detection",
+                value=scan_work,
+            )
 
     def _validate_spec_decode(
         self,

--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -3,7 +3,10 @@
 import contextlib
 from collections.abc import Sequence
 
-from vllm.sampling_params import RepetitionDetectionParams
+from vllm.sampling_params import (
+    _MAX_ABSOLUTE_PATTERN_SIZE,
+    RepetitionDetectionParams,
+)
 from vllm.v1.request import Request, RequestStatus
 
 
@@ -44,6 +47,13 @@ def check_sequence_repetition(
         min_pattern_size = 1
 
     if max_pattern_size <= 0 or min_count < 2 or min_pattern_size > max_pattern_size:
+        return False
+
+    if max_pattern_size > _MAX_ABSOLUTE_PATTERN_SIZE:
+        return False
+
+    scan_work = (max_pattern_size - min_pattern_size + 1) * min_count
+    if scan_work > _MAX_ABSOLUTE_PATTERN_SIZE * 10:
         return False
 
     for pattern_len in range(


### PR DESCRIPTION
Add server-side operator-configurable limit on repetition_detection.max_pattern_size (--max-repetition-detection-pattern-size, default 2048) to prevent unbounded scheduler suffix-scan amplification (CWE-400/CWE-770).
- Add max_repetition_detection_pattern_size to ModelConfig and EngineArgs
- Add absolute hard caps in RepetitionDetectionParams (65536 / 1000)
- Add _validate_repetition_detection() with scan-work budget in verify()
- Add defense-in-depth checks in check_sequence_repetition()
- Add regression tests for all cap/validation paths