### PR TITLE
Superseded duplicate: add registry layer cache to x86 CUDA release image builds

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -143,8 +143,9 @@ steps:
           queue: cpu_queue_release
         commands:
           - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
+          - "bash .buildkite/scripts/setup-release-buildx.sh"
           - |
-            DOCKER_BUILDKIT=1 docker build \
+            docker buildx build \
               $(bash .buildkite/scripts/docker-build-metadata-args.sh) \
               --build-arg max_jobs=16 \
               --build-arg USE_SCCACHE=1 \
@@ -155,7 +156,10 @@ steps:
               --build-arg MOONCAKE_WHEEL_AARCH64="${MOONCAKE_WHEEL_AARCH64_2_35}" \
               --build-arg MOONCAKE_WHEEL_X86_64="${MOONCAKE_WHEEL_X86_64}" \
               --build-arg BUILD_BASE_IMAGE=nvidia/cuda:13.0.2-devel-ubuntu22.04 \
+              --cache-from type=registry,ref=936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:x86_64-cu130-ubuntu2204,mode=max \
+              --cache-to type=registry,ref=936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:x86_64-cu130-ubuntu2204,mode=max,compression=zstd \
               --target vllm-openai \
+              --load \
               --progress plain \
               -f docker/Dockerfile .
           - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT-$(uname -m)"
@@ -196,8 +200,9 @@ steps:
           queue: cpu_queue_release
         commands:
           - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
+          - "bash .buildkite/scripts/setup-release-buildx.sh"
           - |
-            DOCKER_BUILDKIT=1 docker build \
+            docker buildx build \
               $(bash .buildkite/scripts/docker-build-metadata-args.sh cu129) \
               --build-arg max_jobs=16 \
               --build-arg USE_SCCACHE=1 \
@@ -207,7 +212,10 @@ steps:
               --build-arg INSTALL_KV_CONNECTORS=true \
               --build-arg MOONCAKE_WHEEL_AARCH64="${MOONCAKE_WHEEL_AARCH64_2_35}" \
               --build-arg MOONCAKE_WHEEL_X86_64="${MOONCAKE_WHEEL_X86_64}" \
+              --cache-from type=registry,ref=936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:x86_64-cu129-ubuntu2204,mode=max \
+              --cache-to type=registry,ref=936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:x86_64-cu129-ubuntu2204,mode=max,compression=zstd \
               --target vllm-openai \
+              --load \
               --progress plain \
               -f docker/Dockerfile .
           - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT-$(uname -m)-cu129"
@@ -247,8 +255,9 @@ steps:
           queue: cpu_queue_release
         commands:
           - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
+          - "bash .buildkite/scripts/setup-release-buildx.sh"
           - |
-            DOCKER_BUILDKIT=1 docker build \
+            docker buildx build \
               $(bash .buildkite/scripts/docker-build-metadata-args.sh ubuntu2404) \
               --build-arg max_jobs=16 \
               --build-arg USE_SCCACHE=1 \
@@ -261,7 +270,10 @@ steps:
               --build-arg MOONCAKE_WHEEL_AARCH64="${MOONCAKE_WHEEL_AARCH64_2_39}" \
               --build-arg MOONCAKE_WHEEL_X86_64="${MOONCAKE_WHEEL_X86_64}" \
               --build-arg BUILD_BASE_IMAGE=nvidia/cuda:13.0.2-devel-ubuntu24.04 \
+              --cache-from type=registry,ref=936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:x86_64-cu130-ubuntu2404,mode=max \
+              --cache-to type=registry,ref=936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:x86_64-cu130-ubuntu2404,mode=max,compression=zstd \
               --target vllm-openai \
+              --load \
               --progress plain \
               -f docker/Dockerfile .
           - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT-$(uname -m)-ubuntu2404"
@@ -303,8 +315,9 @@ steps:
           queue: cpu_queue_release
         commands:
           - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
+          - "bash .buildkite/scripts/setup-release-buildx.sh"
           - |
-            DOCKER_BUILDKIT=1 docker build \
+            docker buildx build \
               $(bash .buildkite/scripts/docker-build-metadata-args.sh cu129-ubuntu2404) \
               --build-arg max_jobs=16 \
               --build-arg USE_SCCACHE=1 \
@@ -316,7 +329,10 @@ steps:
               --build-arg INSTALL_KV_CONNECTORS=true \
               --build-arg MOONCAKE_WHEEL_AARCH64="${MOONCAKE_WHEEL_AARCH64_2_39}" \
               --build-arg MOONCAKE_WHEEL_X86_64="${MOONCAKE_WHEEL_X86_64}" \
+              --cache-from type=registry,ref=936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:x86_64-cu129-ubuntu2404,mode=max \
+              --cache-to type=registry,ref=936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:x86_64-cu129-ubuntu2404,mode=max,compression=zstd \
               --target vllm-openai \
+              --load \
               --progress plain \
               -f docker/Dockerfile .
           - "docker push public.ecr.aws/q9t5s3a7/vllm-release-repo:$BUILDKITE_COMMIT-$(uname -m)-cu129-ubuntu2404"

--- a/.buildkite/scripts/setup-release-buildx.sh
+++ b/.buildkite/scripts/setup-release-buildx.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Set up a registry-cache-capable buildx builder for CUDA release image builds.
+#
+# Release jobs historically used classic `docker build`, which only supports
+# inline cache (mode=min) and cannot cache the intermediate csrc-build compile
+# layer -- the expensive part. To reuse layers across releases/nightlies we need
+# a buildkit-backed builder that can export a mode=max registry cache.
+#
+# This mirrors .buildkite/image_build/image_build.sh: prefer the warm-AMI
+# standalone buildkitd (remote driver) when its socket is present; otherwise
+# fall back to a docker-container builder. The default `docker` driver cannot
+# export registry cache, so we never fall back to it here.
+#
+# Also logs in to the private ECR that hosts the release BuildKit cache
+# (vllm-release-cache); the release queues are granted read/write by ci-infra.
+set -euo pipefail
+
+CACHE_REGISTRY="936637512419.dkr.ecr.us-east-1.amazonaws.com"
+BUILDKIT_SOCKET="/run/buildkit/buildkitd.sock"
+
+echo "--- :docker: Logging in to private ECR for release cache"
+aws ecr get-login-password --region us-east-1 \
+    | docker login --username AWS --password-stdin "${CACHE_REGISTRY}"
+
+echo "--- :buildkite: Selecting buildx builder"
+if [[ -S "${BUILDKIT_SOCKET}" ]]; then
+    echo "Found warm-AMI buildkitd at ${BUILDKIT_SOCKET}; using remote driver"
+    docker buildx use baked-vllm-builder 2>/dev/null \
+        || docker buildx create --name baked-vllm-builder --driver remote --use "unix://${BUILDKIT_SOCKET}"
+else
+    echo "No buildkitd socket; using a docker-container builder (cold cache)"
+    docker buildx use release-cache-builder 2>/dev/null \
+        || docker buildx create --name release-cache-builder --driver docker-container --use
+fi
+docker buildx inspect --bootstrap


### PR DESCRIPTION
## Summary

Release image builds used classic `docker build` with only sccache — no BuildKit layer cache — so every release/nightly recompiled the CUDA `csrc` from scratch (~60 min). CI image builds avoid this with a `mode=max` registry layer cache on the warm-AMI buildkitd; this gives the **x86 CUDA release images** the same.

## What changed

- The 4 x86 CUDA release image jobs (`cpu_queue_release`) now build with `docker buildx build` against the warm-AMI `baked-vllm-builder` and import/export a per-variant `mode=max` registry cache:
  - `vllm-release-cache:x86_64-cu130-ubuntu2204`
  - `vllm-release-cache:x86_64-cu129-ubuntu2204`
  - `vllm-release-cache:x86_64-cu130-ubuntu2404`
  - `vllm-release-cache:x86_64-cu129-ubuntu2404`
- `--load` keeps the existing build-then-`docker push` flow unchanged.
- A small helper, `.buildkite/scripts/setup-release-buildx.sh`, selects a cache-capable builder (remote buildkitd if its socket is present, else a `docker-container` builder) and logs in to the cache registry — mirroring `.buildkite/image_build/image_build.sh`.

## Scope / what's intentionally left out

- **arm64**: the `arm64_cpu_queue_release` agents don't run the warm-AMI buildkitd, so the 4 aarch64 jobs stay on classic `docker build` for now. arm64 parity needs a separate arm64 build AMI with the same BuildKit service (follow-up infra).
- **CPU / ROCm**: unchanged. ROCm already has its own caching.
- The wheel-build jobs are untouched (separate concern; they use the manylinux base, not the runtime base the images use).

## Dependency

Requires **ci-infra#394**, which creates the private ECR repo `936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache` (14-day lifecycle) and grants the release queues read/write. Merge that first.

## Testing

YAML validated (`yaml.safe_load`). The buildx + builder-selection + `--load` pattern mirrors the existing, proven `image_build.sh` CI path. I could not run a CUDA build locally (no Docker/GPU in my environment), so the end-to-end caching needs validation on a release/nightly CI run — first run for each variant is cold (populates the cache), subsequent runs should skip the compile.
