### PR TITLE
[torch.compile] fix misleading docstrings in non-impacting config compute_hash (#39479 item 7)

### DIFF
--- a/vllm/config/device.py
+++ b/vllm/config/device.py
@@ -28,20 +28,8 @@ class DeviceConfig:
     `__post_init__`."""
 
     def compute_hash(self) -> str:
-        """
-        WARNING: Whenever a new field is added to this config,
-        ensure that it is included in the factors list if
-        it affects the computation graph.
-
-        Provide a hash that uniquely identifies all the configs
-        that affect the structure of the computation
-        graph from input ids/embeddings to the final hidden states,
-        excluding anything before input ids/embeddings and after
-        the final hidden states.
-        """
-        # no factors to consider.
-        # the device/platform information will be summarized
-        # by torch/vllm automatically.
+        """This config does not affect the computation graph.
+        Returns a hash of empty factors."""
         factors: list[Any] = []
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str

--- a/vllm/config/ec_transfer.py
+++ b/vllm/config/ec_transfer.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import hashlib
 import uuid
 from dataclasses import field
 from typing import Any, Literal, get_args
 
 from vllm.config.utils import config
+from vllm.utils.hashing import safe_hash
 
 ECProducer = Literal["ec_producer", "ec_both"]
 ECConsumer = Literal["ec_consumer", "ec_both"]
@@ -58,21 +58,10 @@ class ECTransferConfig:
     Only supported in V1."""
 
     def compute_hash(self) -> str:
-        """
-        WARNING: Whenever a new field is added to this config,
-        ensure that it is included in the factors list if
-        it affects the computation graph.
-
-        Provide a hash that uniquely identifies all the configs
-        that affect the structure of the computation
-        graph from input ids/embeddings to the final hidden states,
-        excluding anything before input ids/embeddings and after
-        the final hidden states.
-        """
-        # no factors to consider.
-        # this config will not affect the computation graph.
+        """This config does not affect the computation graph.
+        Returns a hash of empty factors."""
         factors: list[Any] = []
-        hash_str = hashlib.md5(str(factors).encode(), usedforsecurity=False).hexdigest()
+        hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 
     def __post_init__(self) -> None:

--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -72,19 +72,8 @@ class KVTransferConfig:
     'fail': immediately fail the request with an error finish reason (default)"""
 
     def compute_hash(self) -> str:
-        """
-        WARNING: Whenever a new field is added to this config,
-        ensure that it is included in the factors list if
-        it affects the computation graph.
-
-        Provide a hash that uniquely identifies all the configs
-        that affect the structure of the computation
-        graph from input ids/embeddings to the final hidden states,
-        excluding anything before input ids/embeddings and after
-        the final hidden states.
-        """
-        # no factors to consider.
-        # this config will not affect the computation graph.
+        """This config does not affect the computation graph.
+        Returns a hash of empty factors."""
         factors: list[Any] = []
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str

--- a/vllm/config/load.py
+++ b/vllm/config/load.py
@@ -114,19 +114,8 @@ class LoadConfig:
     """
 
     def compute_hash(self) -> str:
-        """
-        WARNING: Whenever a new field is added to this config,
-        ensure that it is included in the factors list if
-        it affects the computation graph.
-
-        Provide a hash that uniquely identifies all the configs
-        that affect the structure of the computation
-        graph from input ids/embeddings to the final hidden states,
-        excluding anything before input ids/embeddings and after
-        the final hidden states.
-        """
-        # no factors to consider.
-        # this config will not affect the computation graph.
+        """This config does not affect the computation graph.
+        Returns a hash of empty factors."""
         factors: list[Any] = []
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -97,19 +97,8 @@ class ObservabilityConfig:
         )
 
     def compute_hash(self) -> str:
-        """
-        WARNING: Whenever a new field is added to this config,
-        ensure that it is included in the factors list if
-        it affects the computation graph.
-
-        Provide a hash that uniquely identifies all the configs
-        that affect the structure of the computation
-        graph from input ids/embeddings to the final hidden states,
-        excluding anything before input ids/embeddings and after
-        the final hidden states.
-        """
-        # no factors to consider.
-        # this config will not affect the computation graph.
+        """This config does not affect the computation graph.
+        Returns a hash of empty factors."""
         factors: list[Any] = []
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str

--- a/vllm/config/pooler.py
+++ b/vllm/config/pooler.py
@@ -154,19 +154,8 @@ class PoolerConfig:
         return self.tok_pooling_type
 
     def compute_hash(self) -> str:
-        """
-        WARNING: Whenever a new field is added to this config,
-        ensure that it is included in the factors list if
-        it affects the computation graph.
-
-        Provide a hash that uniquely identifies all the configs
-        that affect the structure of the computation
-        graph from input ids/embeddings to the final hidden states,
-        excluding anything before input ids/embeddings and after
-        the final hidden states.
-        """
-        # no factors to consider.
-        # this config will not affect the computation graph.
+        """This config does not affect the computation graph.
+        Returns a hash of empty factors."""
         factors: list[Any] = []
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str

--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -105,19 +105,8 @@ class ProfilerConfig:
     """
 
     def compute_hash(self) -> str:
-        """
-        WARNING: Whenever a new field is added to this config,
-        ensure that it is included in the factors list if
-        it affects the computation graph.
-
-        Provide a hash that uniquely identifies all the configs
-        that affect the structure of the computation
-        graph from input ids/embeddings to the final hidden states,
-        excluding anything before input ids/embeddings and after
-        the final hidden states.
-        """
-        # no factors to consider.
-        # this config will not affect the computation graph.
+        """This config does not affect the computation graph.
+        Returns a hash of empty factors."""
         factors: list[Any] = []
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str

--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -42,19 +42,8 @@ class StructuredOutputsConfig:
     """Whether to use structured input for reasoning."""
 
     def compute_hash(self) -> str:
-        """
-        WARNING: Whenever a new field is added to this config,
-        ensure that it is included in the factors list if
-        it affects the computation graph.
-
-        Provide a hash that uniquely identifies all the configs
-        that affect the structure of the computation
-        graph from input ids/embeddings to the final hidden states,
-        excluding anything before input ids/embeddings and after
-        the final hidden states.
-        """
-        # no factors to consider.
-        # this config will not affect the computation graph.
+        """This config does not affect the computation graph.
+        Returns a hash of empty factors."""
         factors: list[Any] = []
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str


### PR DESCRIPTION
## Purpose
Fix misleading docstrings in 8 non-impacting config `compute_hash` methods  (addresses #39479 item 7). Also fixes `ECTransferConfig` using `hashlib.md5` instead of `safe_hash` for consistency

## Test Plan
pre-commit run ruff-check --all-files
pre-commit run mypy-3.12 --all-files --hook-stage manual
python -m pytest tests/config/test_config_utils.py -v

## Test Result
- ruff check: Passed
- mypy: Passed
- config tests: 20/20 passed

AI assistance was used (Claude Code Opus 4.6).