### PR TITLE
[CPU] Fix shared-memory all-reduce deadlock across nodes

### DIFF
--- a/vllm/distributed/device_communicators/cpu_communicator.py
+++ b/vllm/distributed/device_communicators/cpu_communicator.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+import socket
 from typing import Any
 
 import torch
@@ -239,7 +240,14 @@ class _CPUSHMDistributed:
     def make_group_name(communicator: CpuCommunicator) -> str:
         instance_identifier = os.environ["VLLM_DIST_IDENT"]
         unique_name = communicator.unique_name
-        instance_identifier = f"{instance_identifier}-{unique_name}"
+        # Shared memory is node-local, so ranks on different hosts must not agree
+        # on a single SHM group name. VLLM_DIST_IDENT is broadcast (identical on
+        # every rank), so without the hostname the consistency check in
+        # _all_group_ranks_share_shm_group_name() always passes and the SHM
+        # all-reduce is selected even across nodes -- where it deadlocks, each host
+        # operating on its own segment. Including the hostname makes ranks on
+        # different hosts disagree, so they fall back to torch.distributed.
+        instance_identifier = f"{instance_identifier}-{socket.gethostname()}-{unique_name}"
         group_ranks = [str(rank) for rank in communicator.ranks]
         shm_group_identifier = f"[{'-'.join(group_ranks)}]"
         return f"{instance_identifier}-{shm_group_identifier}-cpushm"


### PR DESCRIPTION
## Purpose

Fix a deadlock in CPU tensor parallelism **across nodes**.

`CpuCommunicator` selects the shared-memory all-reduce when
`_all_group_ranks_share_shm_group_name()` finds all ranks agreeing on
`_CPUSHMDistributed.make_group_name()`. That name is built from
`VLLM_DIST_IDENT`, the group's `unique_name`, and the rank list — none of which
distinguish *which host* a rank runs on. `VLLM_DIST_IDENT` is broadcast, so it is
identical on every rank; the consistency check therefore **always passes**, even
when ranks are on different hosts.

Shared memory is node-local. On a multi-node TP job each host then operates on
its own segment, and the first collective hangs forever: the cluster forms, every
rank loads the model, and it deadlocks at the profile-run all-reduce with no
error.

```python
# vllm/distributed/device_communicators/cpu_communicator.py
def make_group_name(communicator):
    instance_identifier = os.environ["VLLM_DIST_IDENT"]   # broadcast -> same on all ranks
    unique_name = communicator.unique_name                # same on all ranks
    ...                                                    # ranks list -> same on all ranks
    # -> identical name on every node -> SHM wrongly selected across nodes
```

## Fix

Include `socket.gethostname()` in the SHM group name. Ranks on different hosts now
produce different names, so the consistency check fails and the group falls back
to `torch.distributed` (gloo), which works across nodes. Ranks on the same host
produce the same name and keep using shared memory — no change to the single-node
path.

## Test Plan / Result

- **Single node, TP=2 (CPU):** still selects SHM (no `CPU SHM communicator
  disabled` log) and generates coherent output. No regression.
- **Two nodes, TP=2 (CPU):** previously hung at the first all-reduce; with the fix
  the group falls back to gloo, init completes, and inference is correct.
- Unit check of `make_group_name`: identical hostname → identical name (SHM kept);
  differing hostnames → differing names (gloo fallback).
