### PR TITLE
tests(v1): add enforce_eager=True to test_spec_decode_logprobs

### DIFF
--- a/tests/v1/sample/test_logprobs.py
+++ b/tests/v1/sample/test_logprobs.py
@@ -1128,6 +1128,9 @@ def test_spec_decode_logprobs(
         enable_chunked_prefill=True,
         max_num_batched_tokens=32,
         enable_prefix_caching=False,
+        # Use eager mode as documented in the docstring — avoids non-determinism
+        # from compiled CUDA/ROCm kernels that would mask spec-decode divergence.
+        enforce_eager=True,
         **GPU_DETERMINISM_KWARGS,
     )
 


### PR DESCRIPTION
## Summary

Closes #46657

The docstring for `test_spec_decode_logprobs` states:

> Both base and spec-decode models are run in eager mode to control for infrastructure differences (e.g., CUDA graph capture differences).

However, `enforce_eager=True` was never actually passed in `llm_kwargs`. Without it the LLM defaults to compiled CUDA/ROCm kernels which introduce non-determinism, causing logprob mismatches that are unrelated to spec-decode correctness and make the test non-deterministic.

## Change

Added `enforce_eager=True` to the `llm_kwargs` dict in `test_spec_decode_logprobs` to match the documented intent.

## Why this is not a duplicate

Searched open PRs referencing #46657 — no existing PR addresses this.

```bash
gh pr list --repo vllm-project/vllm --state open --search "46657 in:body"
```

Returns no results.

## Test commands run

This is a GPU-only test requiring an H100/A100 with spec-decode support. The change is a one-line flag addition matching the docstring intent; no local GPU was available to run the full test. The fix is logically equivalent to what the docstring describes.

## AI assistance

This PR was developed with AI assistance (Claude). The submitting human has reviewed every changed line and understands the fix end-to-end.