### PR TITLE
[Rust Frontend] Extract renderer fixture test utilities

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5722,6 +5722,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serial_test",
+ "strum",
  "subenum",
  "tempfile",
  "thiserror 2.0.18",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -79,6 +79,7 @@ serde_with = "3.18.0"
 serial_test = { version = "3.2.0", features = ["file_locks"] }
 sha2 = "0.10.9"
 socket2 = "0.6.3"
+strum = { version = "0.27.2", features = ["derive"] }
 subenum = "1.1.3"
 subtle = "2.6"
 task-local = "0.1.1"

--- a/rust/src/chat/Cargo.toml
+++ b/rust/src/chat/Cargo.toml
@@ -21,6 +21,7 @@ serde.workspace = true
 serde-json-fmt.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
+strum.workspace = true
 subenum.workspace = true
 thiserror.workspace = true
 thiserror-ext.workspace = true

--- a/rust/src/chat/src/multimodal.rs
+++ b/rust/src/chat/src/multimodal.rs
@@ -245,16 +245,15 @@ pub(crate) async fn finalize_rendered_prompt(
         return Ok((rendered.prompt, None));
     }
     let info = info.ok_or(Error::UnsupportedMultimodalRenderer)?;
-    let Prompt::Text(prompt) = rendered.prompt else {
-        bail_multimodal!("multimodal chat renderer must return a text prompt before expansion");
+    let mut prompt_token_ids = match rendered.prompt {
+        Prompt::Text(prompt) => info
+            .context
+            .tokenizer()
+            .encode(&prompt, request.add_special_tokens)
+            .map_err(|error| multimodal!("{error}"))?,
+        Prompt::TokenIds(token_ids) => token_ids,
     };
     let media_parts = extract_media_parts(request)?;
-
-    let mut prompt_token_ids = info
-        .context
-        .tokenizer()
-        .encode(&prompt, request.add_special_tokens)
-        .map_err(|error| multimodal!("{error}"))?;
     let prepared = info.prepare_multimodal(media_parts, &mut prompt_token_ids, model_dtype).await?;
 
     Ok((Prompt::TokenIds(prompt_token_ids), Some(prepared)))

--- a/rust/src/chat/src/renderer/deepseek_v32/tests.rs
+++ b/rust/src/chat/src/renderer/deepseek_v32/tests.rs
@@ -1,81 +1,17 @@
-use std::fs;
 use std::path::PathBuf;
 
 use expect_test::{ExpectFile, expect, expect_file};
-use serde::Deserialize;
 use serde_json::{Value, json};
 use thiserror_ext::AsReport;
 
 use super::DeepSeekV32ChatRenderer;
 use crate::error::Error;
 use crate::event::{AssistantContentBlock, AssistantToolCall};
+use crate::renderer::test_utils::{FixtureRequestOptions, fixture_chat_request};
 use crate::request::{
     ChatContentPart, ChatMessage, ChatRequest, ChatTool, ChatToolChoice, GenerationPromptMode,
 };
 use crate::{ChatRenderer, ChatRole};
-
-#[derive(Debug, Deserialize)]
-struct FixtureRequest {
-    #[serde(default)]
-    tools: Vec<FixtureTool>,
-    messages: Vec<FixtureMessage>,
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureTool {
-    function: FixtureToolFunction,
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureToolFunction {
-    name: String,
-    description: Option<String>,
-    parameters: Value,
-    #[serde(default)]
-    strict: Option<bool>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(tag = "role", rename_all = "snake_case")]
-enum FixtureMessage {
-    System {
-        content: String,
-    },
-    Developer {
-        content: String,
-        #[serde(default)]
-        tools: Vec<FixtureTool>,
-    },
-    User {
-        content: String,
-    },
-    Assistant {
-        #[serde(default)]
-        content: String,
-        #[serde(default)]
-        reasoning_content: String,
-        #[serde(default)]
-        tool_calls: Vec<FixtureToolCall>,
-    },
-    Tool {
-        content: String,
-        #[serde(default)]
-        tool_call_id: Option<String>,
-    },
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureToolCall {
-    #[serde(default)]
-    id: Option<String>,
-    function: FixtureToolCallFunction,
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureToolCallFunction {
-    name: String,
-    arguments: String,
-}
 
 fn render_request(request: &ChatRequest) -> String {
     DeepSeekV32ChatRenderer::new()
@@ -115,88 +51,14 @@ fn thinking_request(messages: Vec<ChatMessage>) -> ChatRequest {
 }
 
 fn fixture_request(input_name: &str) -> ChatRequest {
-    let fixture = fs::read_to_string(fixture_path(input_name)).unwrap();
-    let fixture: FixtureRequest = serde_json::from_str(&fixture).unwrap();
-    let mut request = ChatRequest {
-        request_id: "deepseek-v32-fixture".to_string(),
-        messages: fixture
-            .messages
-            .into_iter()
-            .enumerate()
-            .map(|(index, message)| match message {
-                FixtureMessage::System { content } => ChatMessage::system(content),
-                FixtureMessage::Developer { content, tools } => ChatMessage::developer(
-                    content,
-                    (!tools.is_empty()).then(|| to_chat_tools(&tools)),
-                ),
-                FixtureMessage::User { content } => ChatMessage::user(content),
-                FixtureMessage::Assistant {
-                    content,
-                    reasoning_content,
-                    tool_calls,
-                } => {
-                    let mut blocks = Vec::new();
-                    if !reasoning_content.is_empty() {
-                        blocks.push(AssistantContentBlock::Reasoning {
-                            text: reasoning_content,
-                        });
-                    }
-                    if !content.is_empty() {
-                        blocks.push(AssistantContentBlock::Text { text: content });
-                    }
-                    blocks.extend(tool_calls.into_iter().enumerate().map(
-                        |(tool_index, tool_call)| {
-                            AssistantContentBlock::ToolCall(AssistantToolCall {
-                                id: tool_call.id.unwrap_or_else(|| {
-                                    format!("fixture-tool-call-{index}-{tool_index}")
-                                }),
-                                name: tool_call.function.name,
-                                arguments: tool_call.function.arguments,
-                            })
-                        },
-                    ));
-                    ChatMessage::assistant_blocks(blocks)
-                }
-                FixtureMessage::Tool {
-                    content,
-                    tool_call_id,
-                } => ChatMessage::tool_response(
-                    content,
-                    tool_call_id.unwrap_or_else(|| format!("fixture-tool-response-{index}")),
-                ),
-            })
-            .collect(),
-        tools: to_chat_tools(&fixture.tools),
-        tool_choice: if fixture.tools.is_empty() {
-            ChatToolChoice::None
-        } else {
-            ChatToolChoice::Auto
-        },
-        ..ChatRequest::for_test()
-    };
-    if matches!(
-        request.messages.last().map(ChatMessage::role),
-        Some(ChatRole::Assistant)
-    ) {
-        request.chat_options.generation_prompt_mode = GenerationPromptMode::NoGenerationPrompt;
-    }
-    request
-        .chat_options
-        .template_kwargs
-        .insert("thinking".to_string(), Value::Bool(true));
-    request
+    fixture_chat_request(&fixture_path(input_name), deepseek_fixture_options())
 }
 
-fn to_chat_tools(tools: &[FixtureTool]) -> Vec<ChatTool> {
-    tools
-        .iter()
-        .map(|tool| ChatTool {
-            name: tool.function.name.clone(),
-            description: tool.function.description.clone(),
-            parameters: tool.function.parameters.clone(),
-            strict: tool.function.strict,
-        })
-        .collect()
+fn deepseek_fixture_options() -> FixtureRequestOptions {
+    FixtureRequestOptions {
+        enable_thinking: true,
+        no_generation_prompt_when_last_assistant: true,
+    }
 }
 
 fn fixture_path(name: &str) -> PathBuf {

--- a/rust/src/chat/src/renderer/deepseek_v4/tests.rs
+++ b/rust/src/chat/src/renderer/deepseek_v4/tests.rs
@@ -1,95 +1,13 @@
-use std::fs;
 use std::path::PathBuf;
 
 use expect_test::{ExpectFile, expect, expect_file};
-use serde::Deserialize;
 use serde_json::Value;
 
 use super::DeepSeekV4ChatRenderer;
+use crate::ChatRenderer;
 use crate::event::{AssistantContentBlock, AssistantToolCall};
-use crate::request::{
-    ChatMessage, ChatRequest, ChatTool, ChatToolChoice, GenerationPromptMode, ReasoningEffort,
-};
-use crate::{ChatRenderer, ChatRole};
-
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum FixtureFile {
-    WithTools(FixtureRequest),
-    MessagesOnly(Vec<FixtureMessage>),
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureRequest {
-    #[serde(default)]
-    tools: Vec<FixtureTool>,
-    messages: Vec<FixtureMessage>,
-}
-
-impl FixtureFile {
-    fn into_parts(self) -> (Vec<FixtureTool>, Vec<FixtureMessage>) {
-        match self {
-            Self::WithTools(req) => (req.tools, req.messages),
-            Self::MessagesOnly(messages) => (Vec::new(), messages),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureTool {
-    function: FixtureToolFunction,
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureToolFunction {
-    name: String,
-    description: Option<String>,
-    parameters: Value,
-    #[serde(default)]
-    strict: Option<bool>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(tag = "role", rename_all = "snake_case")]
-enum FixtureMessage {
-    System {
-        content: String,
-    },
-    Developer {
-        content: String,
-        #[serde(default)]
-        tools: Vec<FixtureTool>,
-    },
-    User {
-        content: String,
-    },
-    Assistant {
-        #[serde(default)]
-        content: String,
-        #[serde(default)]
-        reasoning_content: String,
-        #[serde(default)]
-        tool_calls: Vec<FixtureToolCall>,
-    },
-    Tool {
-        content: String,
-        #[serde(default)]
-        tool_call_id: Option<String>,
-    },
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureToolCall {
-    #[serde(default)]
-    id: Option<String>,
-    function: FixtureToolCallFunction,
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureToolCallFunction {
-    name: String,
-    arguments: String,
-}
+use crate::renderer::test_utils::{FixtureRequestOptions, fixture_chat_request};
+use crate::request::{ChatMessage, ChatRequest, GenerationPromptMode, ReasoningEffort};
 
 fn render_request(request: &ChatRequest) -> String {
     DeepSeekV4ChatRenderer::new()
@@ -101,88 +19,14 @@ fn render_request(request: &ChatRequest) -> String {
 }
 
 fn fixture_request(input_name: &str) -> ChatRequest {
-    let fixture = fs::read_to_string(fixture_path(input_name)).unwrap();
-    let fixture: FixtureFile = serde_json::from_str(&fixture).unwrap();
-    let (fixture_tools, fixture_messages) = fixture.into_parts();
-    let mut request = ChatRequest {
-        request_id: "deepseek-v4-fixture".to_string(),
-        messages: fixture_messages
-            .into_iter()
-            .enumerate()
-            .map(|(index, message)| match message {
-                FixtureMessage::System { content } => ChatMessage::system(content),
-                FixtureMessage::Developer { content, tools } => ChatMessage::developer(
-                    content,
-                    (!tools.is_empty()).then(|| to_chat_tools(&tools)),
-                ),
-                FixtureMessage::User { content } => ChatMessage::user(content),
-                FixtureMessage::Assistant {
-                    content,
-                    reasoning_content,
-                    tool_calls,
-                } => {
-                    let mut blocks = Vec::new();
-                    if !reasoning_content.is_empty() {
-                        blocks.push(AssistantContentBlock::Reasoning {
-                            text: reasoning_content,
-                        });
-                    }
-                    if !content.is_empty() {
-                        blocks.push(AssistantContentBlock::Text { text: content });
-                    }
-                    blocks.extend(tool_calls.into_iter().enumerate().map(
-                        |(tool_index, tool_call)| {
-                            AssistantContentBlock::ToolCall(AssistantToolCall {
-                                id: tool_call.id.unwrap_or_else(|| {
-                                    format!("fixture-tool-call-{index}-{tool_index}")
-                                }),
-                                name: tool_call.function.name,
-                                arguments: tool_call.function.arguments,
-                            })
-                        },
-                    ));
-                    ChatMessage::assistant_blocks(blocks)
-                }
-                FixtureMessage::Tool {
-                    content,
-                    tool_call_id,
-                } => ChatMessage::tool_response(
-                    content,
-                    tool_call_id.unwrap_or_else(|| format!("fixture-tool-response-{index}")),
-                ),
-            })
-            .collect(),
-        tools: to_chat_tools(&fixture_tools),
-        tool_choice: if fixture_tools.is_empty() {
-            ChatToolChoice::None
-        } else {
-            ChatToolChoice::Auto
-        },
-        ..ChatRequest::for_test()
-    };
-    if matches!(
-        request.messages.last().map(ChatMessage::role),
-        Some(ChatRole::Assistant)
-    ) {
-        request.chat_options.generation_prompt_mode = GenerationPromptMode::NoGenerationPrompt;
-    }
-    request
-        .chat_options
-        .template_kwargs
-        .insert("thinking".to_string(), Value::Bool(true));
-    request
+    fixture_chat_request(&fixture_path(input_name), deepseek_fixture_options())
 }
 
-fn to_chat_tools(tools: &[FixtureTool]) -> Vec<ChatTool> {
-    tools
-        .iter()
-        .map(|tool| ChatTool {
-            name: tool.function.name.clone(),
-            description: tool.function.description.clone(),
-            parameters: tool.function.parameters.clone(),
-            strict: tool.function.strict,
-        })
-        .collect()
+fn deepseek_fixture_options() -> FixtureRequestOptions {
+    FixtureRequestOptions {
+        enable_thinking: true,
+        no_generation_prompt_when_last_assistant: true,
+    }
 }
 
 fn fixture_path(name: &str) -> PathBuf {

--- a/rust/src/chat/src/renderer/mod.rs
+++ b/rust/src/chat/src/renderer/mod.rs
@@ -11,6 +11,8 @@ pub mod deepseek_v32;
 pub mod deepseek_v4;
 pub mod hf;
 mod selection;
+#[cfg(test)]
+mod test_utils;
 
 pub use deepseek_v4::DeepSeekV4ChatRenderer;
 pub use deepseek_v32::DeepSeekV32ChatRenderer;

--- a/rust/src/chat/src/renderer/selection.rs
+++ b/rust/src/chat/src/renderer/selection.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::str::FromStr;
 
+use itertools::Itertools;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use strum::{EnumIter, IntoEnumIterator};
 
@@ -25,13 +26,6 @@ impl RendererSelection {
     pub const DEEPSEEK_V32_LITERAL: &str = "deepseek_v32";
     pub const DEEPSEEK_V4_LITERAL: &str = "deepseek_v4";
     pub const HF_LITERAL: &str = "hf";
-
-    fn expected_literals() -> String {
-        Self::iter()
-            .map(|selection| selection.to_string())
-            .collect::<Vec<_>>()
-            .join(", ")
-    }
 
     /// Resolve the renderer selection using the given model type string, if
     /// it's `Auto`.
@@ -62,7 +56,7 @@ impl FromStr for RendererSelection {
         } else {
             Err(format!(
                 "unknown renderer `{value}` (expected one of: {})",
-                Self::expected_literals()
+                Self::iter().join(", ")
             ))
         }
     }
@@ -81,6 +75,8 @@ impl fmt::Display for RendererSelection {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr as _;
+
     use strum::IntoEnumIterator;
 
     use super::RendererSelection;
@@ -93,5 +89,14 @@ mod tests {
                 selection
             );
         }
+    }
+
+    #[test]
+    fn renderer_selection_expected_error_message() {
+        let err = RendererSelection::from_str("unknown").unwrap_err();
+        expect_test::expect![
+            "unknown renderer `unknown` (expected one of: auto, hf, deepseek_v32, deepseek_v4)"
+        ]
+        .assert_eq(&err);
     }
 }

--- a/rust/src/chat/src/renderer/selection.rs
+++ b/rust/src/chat/src/renderer/selection.rs
@@ -2,9 +2,12 @@ use std::fmt;
 use std::str::FromStr;
 
 use serde_with::{DeserializeFromStr, SerializeDisplay};
+use strum::{EnumIter, IntoEnumIterator};
 
 /// Specify which chat renderer implementation to use.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, DeserializeFromStr, SerializeDisplay)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, DeserializeFromStr, SerializeDisplay, EnumIter,
+)]
 pub enum RendererSelection {
     /// Use model-based auto-detection.
     #[default]
@@ -22,6 +25,13 @@ impl RendererSelection {
     pub const DEEPSEEK_V32_LITERAL: &str = "deepseek_v32";
     pub const DEEPSEEK_V4_LITERAL: &str = "deepseek_v4";
     pub const HF_LITERAL: &str = "hf";
+
+    fn expected_literals() -> String {
+        Self::iter()
+            .map(|selection| selection.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
 
     /// Resolve the renderer selection using the given model type string, if
     /// it's `Auto`.
@@ -51,7 +61,8 @@ impl FromStr for RendererSelection {
             Ok(Self::DeepSeekV4)
         } else {
             Err(format!(
-                "unknown renderer `{value}` (expected one of: auto, hf, deepseek_v32, deepseek_v4)"
+                "unknown renderer `{value}` (expected one of: {})",
+                Self::expected_literals()
             ))
         }
     }
@@ -70,36 +81,13 @@ impl fmt::Display for RendererSelection {
 
 #[cfg(test)]
 mod tests {
+    use strum::IntoEnumIterator;
+
     use super::RendererSelection;
 
     #[test]
-    fn renderer_selection_parses_known_values() {
-        assert_eq!(
-            "auto".parse::<RendererSelection>().unwrap(),
-            RendererSelection::Auto
-        );
-        assert_eq!(
-            "hf".parse::<RendererSelection>().unwrap(),
-            RendererSelection::Hf
-        );
-        assert_eq!(
-            "deepseek_v32".parse::<RendererSelection>().unwrap(),
-            RendererSelection::DeepSeekV32
-        );
-        assert_eq!(
-            "deepseek_v4".parse::<RendererSelection>().unwrap(),
-            RendererSelection::DeepSeekV4
-        );
-    }
-
-    #[test]
     fn renderer_selection_display_round_trips() {
-        for selection in [
-            RendererSelection::Auto,
-            RendererSelection::Hf,
-            RendererSelection::DeepSeekV32,
-            RendererSelection::DeepSeekV4,
-        ] {
+        for selection in RendererSelection::iter() {
             assert_eq!(
                 selection.to_string().parse::<RendererSelection>().unwrap(),
                 selection

--- a/rust/src/chat/src/renderer/test_utils.rs
+++ b/rust/src/chat/src/renderer/test_utils.rs
@@ -1,0 +1,239 @@
+use std::fs;
+use std::path::Path;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::event::{AssistantContentBlock, AssistantToolCall};
+use crate::request::{
+    ChatContent, ChatContentPart, ChatMessage, ChatRequest, ChatTool, ChatToolChoice,
+    GenerationPromptMode,
+};
+
+/// Options for constructing a [`ChatRequest`] from a fixture file.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FixtureRequestOptions {
+    /// Whether to set the template kwarg `[enable_]thinking=true`.
+    pub enable_thinking: bool,
+    /// Whether fixtures ending in an assistant message should omit the
+    /// trailing generation prompt.
+    pub no_generation_prompt_when_last_assistant: bool,
+}
+
+/// Read a fixture file from the given path and convert it into a [`ChatRequest`]
+/// using the provided options.
+pub(crate) fn fixture_chat_request(path: &Path, options: FixtureRequestOptions) -> ChatRequest {
+    let fixture = fs::read_to_string(path).unwrap();
+    let fixture: FixtureFile = serde_json::from_str(&fixture).unwrap();
+    fixture.into_request().into_chat_request(options)
+}
+
+/// Fixture file format for chat-renderer tests.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum FixtureFile {
+    WithRequest(FixtureRequest),
+    MessagesOnly(Vec<FixtureMessage>),
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct FixtureRequest {
+    #[serde(default)]
+    tools: Vec<FixtureTool>,
+    messages: Vec<FixtureMessage>,
+    add_generation_prompt: Option<bool>,
+}
+
+impl FixtureFile {
+    fn into_request(self) -> FixtureRequest {
+        match self {
+            Self::WithRequest(request) => request,
+            Self::MessagesOnly(messages) => FixtureRequest {
+                tools: Vec::new(),
+                messages,
+                add_generation_prompt: None,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "role", rename_all = "snake_case")]
+pub(crate) enum FixtureMessage {
+    System {
+        content: FixtureContent,
+    },
+    Developer {
+        content: FixtureContent,
+        #[serde(default)]
+        tools: Vec<FixtureTool>,
+    },
+    User {
+        content: FixtureContent,
+    },
+    Assistant {
+        #[serde(default)]
+        content: String,
+        #[serde(default)]
+        reasoning_content: String,
+        #[serde(default)]
+        tool_calls: Vec<FixtureToolCall>,
+    },
+    Tool {
+        content: FixtureContent,
+        #[serde(default)]
+        tool_call_id: Option<String>,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum FixtureContent {
+    Text(String),
+    Parts(Vec<FixtureContentPart>),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum FixtureContentPart {
+    Text { text: String },
+    ImageUrl { image_url: String },
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct FixtureTool {
+    function: FixtureToolFunction,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureToolFunction {
+    name: String,
+    description: Option<String>,
+    parameters: Value,
+    #[serde(default)]
+    strict: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct FixtureToolCall {
+    #[serde(default)]
+    id: Option<String>,
+    function: FixtureToolCallFunction,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureToolCallFunction {
+    name: String,
+    arguments: String,
+}
+
+impl FixtureRequest {
+    fn into_chat_request(self, options: FixtureRequestOptions) -> ChatRequest {
+        let mut request = ChatRequest {
+            request_id: "renderer-fixture".to_string(),
+            messages: self
+                .messages
+                .into_iter()
+                .enumerate()
+                .map(|(index, message)| fixture_message_to_chat_message(index, message))
+                .collect(),
+            tools: to_chat_tools(&self.tools),
+            tool_choice: if self.tools.is_empty() {
+                ChatToolChoice::None
+            } else {
+                ChatToolChoice::Auto
+            },
+            ..ChatRequest::for_test()
+        };
+
+        if options.no_generation_prompt_when_last_assistant
+            && matches!(request.messages.last(), Some(ChatMessage::Assistant { .. }))
+        {
+            request.chat_options.generation_prompt_mode = GenerationPromptMode::NoGenerationPrompt;
+        }
+        if self.add_generation_prompt == Some(false) {
+            request.chat_options.generation_prompt_mode = GenerationPromptMode::NoGenerationPrompt;
+        }
+        if options.enable_thinking {
+            for key in ["thinking", "enable_thinking"] {
+                request.chat_options.template_kwargs.insert(key.to_string(), Value::Bool(true));
+            }
+        }
+
+        request
+    }
+}
+
+fn fixture_message_to_chat_message(index: usize, message: FixtureMessage) -> ChatMessage {
+    match message {
+        FixtureMessage::System { content } => ChatMessage::system(to_chat_content(content)),
+        FixtureMessage::Developer { content, tools } => ChatMessage::developer(
+            to_chat_content(content),
+            (!tools.is_empty()).then(|| to_chat_tools(&tools)),
+        ),
+        FixtureMessage::User { content } => ChatMessage::user(to_chat_content(content)),
+        FixtureMessage::Assistant {
+            content,
+            reasoning_content,
+            tool_calls,
+        } => {
+            let mut blocks = Vec::new();
+            if !reasoning_content.is_empty() {
+                blocks.push(AssistantContentBlock::Reasoning {
+                    text: reasoning_content,
+                });
+            }
+            if !content.is_empty() {
+                blocks.push(AssistantContentBlock::Text { text: content });
+            }
+            blocks.extend(
+                tool_calls.into_iter().enumerate().map(|(tool_index, tool_call)| {
+                    AssistantContentBlock::ToolCall(AssistantToolCall {
+                        id: tool_call
+                            .id
+                            .unwrap_or_else(|| format!("fixture-tool-call-{index}-{tool_index}")),
+                        name: tool_call.function.name,
+                        arguments: tool_call.function.arguments,
+                    })
+                }),
+            );
+            ChatMessage::assistant_blocks(blocks)
+        }
+        FixtureMessage::Tool {
+            content,
+            tool_call_id,
+        } => ChatMessage::tool_response(
+            to_chat_content(content),
+            tool_call_id.unwrap_or_else(|| format!("fixture-tool-response-{index}")),
+        ),
+    }
+}
+
+fn to_chat_content(content: FixtureContent) -> ChatContent {
+    match content {
+        FixtureContent::Text(text) => ChatContent::Text(text),
+        FixtureContent::Parts(parts) => ChatContent::Parts(
+            parts
+                .into_iter()
+                .map(|part| match part {
+                    FixtureContentPart::Text { text } => ChatContentPart::text(text),
+                    FixtureContentPart::ImageUrl { image_url } => {
+                        ChatContentPart::image_url(image_url)
+                    }
+                })
+                .collect(),
+        ),
+    }
+}
+
+fn to_chat_tools(tools: &[FixtureTool]) -> Vec<ChatTool> {
+    tools
+        .iter()
+        .map(|tool| ChatTool {
+            name: tool.function.name.clone(),
+            description: tool.function.description.clone(),
+            parameters: tool.function.parameters.clone(),
+            strict: tool.function.strict,
+        })
+        .collect()
+}


### PR DESCRIPTION
## Purpose

Native Rust chat renderers currently maintain renderer-specific JSON fixture DTOs for snapshot tests. This PR extracts a shared fixture loader for renderer tests and migrates the existing DeepSeek V3.2/V4 fixture tests to it, so future native renderers can reuse the same fixture format.

It also makes two small renderer-facing improvements:
- Allow multimodal prompt finalization to consume already-tokenized `Prompt::TokenIds` inputs.
- Build `RendererSelection` roundtrip tests and error-message literals from the enum variants.

## Changes

- Add `renderer::test_utils` with a shared fixture request format for tools, developer messages, assistant tool calls, tool responses, text parts, image URL parts, and generation-prompt control.
- Migrate DeepSeek V3.2 and V4 renderer fixture tests to the shared fixture loader.
- Add `EnumIter` for `RendererSelection` and derive expected selection strings from the variants.
- Accept `Prompt::TokenIds` in multimodal `finalize_rendered_prompt` before placeholder expansion.

## Test Plan

- `cargo test -p vllm-chat --lib`

## Test Result

- Passed: 160 tests.
