### PR TITLE
[Attention] Occupancy-gated 3D segmented decode for multi-query (diffusion-LM canvas) over long KV

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -39,7 +39,10 @@ from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
     triton_reshape_and_cache_flash,
     triton_reshape_and_cache_flash_per_token_head_quant,
 )
-from vllm.v1.attention.ops.triton_unified_attention import unified_attention
+from vllm.v1.attention.ops.triton_unified_attention import (
+    _ATTN_3D_MIN_KV_FOR_MULTI_Q,
+    unified_attention,
+)
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVQuantMode,
@@ -149,6 +152,12 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
 
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
         headdim_padded = next_power_of_2(self.headdim)
+        # 3D segmented-softmax scratch. The 1-query decode path needs one row per
+        # sequence (<= seq_threshold_3D); allocate that here, unchanged from the
+        # original 1-query design. Multi-query decode (max_seqlen_q > 1: diffusion-LM
+        # canvas, MTP/spec) needs more rows but is rarer, so its larger buffers are
+        # allocated lazily on first use (see _ensure_multi_query_segm_buffers),
+        # leaving 1-query-only models byte-for-byte unchanged.
         self.softmax_segm_output = torch.empty(
             (
                 self.seq_threshold_3D,
@@ -168,6 +177,43 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
             dtype=torch.float32,
             device=device,
+        )
+        # Larger buffers for multi-query decode, sized to the 2D-grid-under-fill
+        # bound under which the 3D path still wins. Allocated lazily (build()) so
+        # models that only ever do 1-query decode never pay for them.
+        sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+        self._mq_segm_rows = max(
+            self.seq_threshold_3D,
+            (sm_count // self.num_heads_kv + 1) * 32,
+        )
+        self._mq_headdim_padded = headdim_padded
+        self._mq_device = device
+        self._mq_segm_output = None
+        self._mq_segm_max = None
+        self._mq_segm_expsum = None
+
+    def _ensure_multi_query_segm_buffers(self):
+        # Allocate the larger multi-query segment buffers on first use. They are
+        # separate tensors from the 1-query buffers that the captured decode graph
+        # references, and are never reallocated, so CUDA-graph replay is unaffected.
+        if self._mq_segm_output is not None:
+            return
+        nq = self.num_heads_q
+        ns = self.num_par_softmax_segments
+        self._mq_segm_output = torch.empty(
+            (self._mq_segm_rows, nq, ns, self._mq_headdim_padded),
+            dtype=torch.float32,
+            device=self._mq_device,
+        )
+        self._mq_segm_max = torch.empty(
+            (self._mq_segm_rows, nq, ns),
+            dtype=torch.float32,
+            device=self._mq_device,
+        )
+        self._mq_segm_expsum = torch.empty(
+            (self._mq_segm_rows, nq, ns),
+            dtype=torch.float32,
+            device=self._mq_device,
         )
 
     def build_for_cudagraph_capture(
@@ -213,6 +259,18 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             suffix_kv_lens = None
             prefix_scheduler_metadata = None
 
+        # Multi-query decode over a long KV (diffusion-LM canvas / spec verify)
+        # can take the 3D path and needs the larger segment buffers; allocate
+        # them lazily so 1-query-only models keep the small ones.
+        segm_output = self.softmax_segm_output
+        segm_max = self.softmax_segm_max
+        segm_expsum = self.softmax_segm_expsum
+        if max_query_len > 1 and max_seq_len >= _ATTN_3D_MIN_KV_FOR_MULTI_Q:
+            self._ensure_multi_query_segm_buffers()
+            segm_output = self._mq_segm_output
+            segm_max = self._mq_segm_max
+            segm_expsum = self._mq_segm_expsum
+
         attn_metadata = TritonAttentionMetadata(
             num_actual_tokens=num_actual_tokens,
             max_query_len=max_query_len,
@@ -230,9 +288,9 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             prefix_scheduler_metadata=prefix_scheduler_metadata,
             seq_threshold_3D=self.seq_threshold_3D,
             num_par_softmax_segments=self.num_par_softmax_segments,
-            softmax_segm_output=self.softmax_segm_output,
-            softmax_segm_max=self.softmax_segm_max,
-            softmax_segm_expsum=self.softmax_segm_expsum,
+            softmax_segm_output=segm_output,
+            softmax_segm_max=segm_max,
+            softmax_segm_expsum=segm_expsum,
         )
 
         mm_ranges = common_attn_metadata.mm_req_doc_ranges

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -194,7 +194,16 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         # Larger buffers for multi-query decode, sized to the 2D-grid-under-fill
         # bound under which the 3D path still wins. Allocated lazily (build()) so
         # models that only ever do 1-query decode never pay for them.
-        sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+        # Platform-agnostic: TRITON_ATTN is also selected on XPU and ROCm, so
+        # this must not reach into torch.cuda. Platforms that do not implement
+        # num_compute_units report 0, which leaves the multi-query 3D gate below
+        # permanently closed and the behaviour identical to before this change.
+        try:
+            sm_count = current_platform.num_compute_units(
+                device.index if device.index is not None else 0
+            )
+        except NotImplementedError:
+            sm_count = 0
         self._mq_segm_rows = max(
             self.seq_threshold_3D,
             (sm_count // self.num_heads_kv + 1) * 32,

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -39,7 +39,10 @@ from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
     triton_reshape_and_cache_flash,
     triton_reshape_and_cache_flash_per_token_head_quant,
 )
-from vllm.v1.attention.ops.triton_unified_attention import unified_attention
+from vllm.v1.attention.ops.triton_unified_attention import (
+    _ATTN_3D_MIN_KV_FOR_MULTI_Q,
+    unified_attention,
+)
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVQuantMode,
@@ -153,6 +156,12 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
 
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
         headdim_padded = next_power_of_2(self.headdim)
+        # 3D segmented-softmax scratch. The 1-query decode path needs one row per
+        # sequence (<= seq_threshold_3D); allocate that here, unchanged from the
+        # original 1-query design. Multi-query decode (max_seqlen_q > 1: diffusion-LM
+        # canvas, MTP/spec) needs more rows but is rarer, so its larger buffers are
+        # allocated lazily on first use (see _ensure_multi_query_segm_buffers),
+        # leaving 1-query-only models byte-for-byte unchanged.
         self.softmax_segm_output = torch.empty(
             (
                 self.seq_threshold_3D,
@@ -181,6 +190,44 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
                 dtype=torch.int32,
                 device=device,
             )
+
+        # Larger buffers for multi-query decode, sized to the 2D-grid-under-fill
+        # bound under which the 3D path still wins. Allocated lazily (build()) so
+        # models that only ever do 1-query decode never pay for them.
+        sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+        self._mq_segm_rows = max(
+            self.seq_threshold_3D,
+            (sm_count // self.num_heads_kv + 1) * 32,
+        )
+        self._mq_headdim_padded = headdim_padded
+        self._mq_device = device
+        self._mq_segm_output = None
+        self._mq_segm_max = None
+        self._mq_segm_expsum = None
+
+    def _ensure_multi_query_segm_buffers(self):
+        # Allocate the larger multi-query segment buffers on first use. They are
+        # separate tensors from the 1-query buffers that the captured decode graph
+        # references, and are never reallocated, so CUDA-graph replay is unaffected.
+        if self._mq_segm_output is not None:
+            return
+        nq = self.num_heads_q
+        ns = self.num_par_softmax_segments
+        self._mq_segm_output = torch.empty(
+            (self._mq_segm_rows, nq, ns, self._mq_headdim_padded),
+            dtype=torch.float32,
+            device=self._mq_device,
+        )
+        self._mq_segm_max = torch.empty(
+            (self._mq_segm_rows, nq, ns),
+            dtype=torch.float32,
+            device=self._mq_device,
+        )
+        self._mq_segm_expsum = torch.empty(
+            (self._mq_segm_rows, nq, ns),
+            dtype=torch.float32,
+            device=self._mq_device,
+        )
 
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata
@@ -225,6 +272,18 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             suffix_kv_lens = None
             prefix_scheduler_metadata = None
 
+        # Multi-query decode over a long KV (diffusion-LM canvas / spec verify)
+        # can take the 3D path and needs the larger segment buffers; allocate
+        # them lazily so 1-query-only models keep the small ones.
+        segm_output = self.softmax_segm_output
+        segm_max = self.softmax_segm_max
+        segm_expsum = self.softmax_segm_expsum
+        if max_query_len > 1 and max_seq_len >= _ATTN_3D_MIN_KV_FOR_MULTI_Q:
+            self._ensure_multi_query_segm_buffers()
+            segm_output = self._mq_segm_output
+            segm_max = self._mq_segm_max
+            segm_expsum = self._mq_segm_expsum
+
         attn_metadata = TritonAttentionMetadata(
             num_actual_tokens=num_actual_tokens,
             max_query_len=max_query_len,
@@ -242,9 +301,9 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             prefix_scheduler_metadata=prefix_scheduler_metadata,
             seq_threshold_3D=self.seq_threshold_3D,
             num_par_softmax_segments=self.num_par_softmax_segments,
-            softmax_segm_output=self.softmax_segm_output,
-            softmax_segm_max=self.softmax_segm_max,
-            softmax_segm_expsum=self.softmax_segm_expsum,
+            softmax_segm_output=segm_output,
+            softmax_segm_max=segm_max,
+            softmax_segm_expsum=segm_expsum,
         )
 
         mm_ranges = common_attn_metadata.mm_req_doc_ranges

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -34,6 +34,32 @@ logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
 float8_info = torch.finfo(current_platform.fp8_dtype())
 
+# Minimum KV length at which multi-query decode (max_seqlen_q > 1) switches to
+# the 3D segmented attention path. Below this the single-pass 2D path already
+# saturates the GPU, so 3D's reduction overhead is not worth it.
+_ATTN_3D_MIN_KV_FOR_MULTI_Q = 8192
+
+# Multi-query decode uses the 3D segmented path while the 2D grid provides fewer
+# than this many CTAs per SM: with a long KV each 2D CTA serially reduces the
+# whole KV, and a couple of CTAs per SM is too few to hide that latency, so
+# splitting the reduction across segments wins. (Larger grids already have enough
+# CTAs to hide it and keep the 2D path.)
+_ATTN_3D_MULTI_Q_CTAS_PER_SM = 2
+
+# Cached SM count per device — used to decide when a 2D launch grid under-fills
+# the GPU. (MIN_LAUNCH_GRID_SIZE_2D is a conservative constant ~128; the true
+# occupancy bound is the device's SM count, e.g. 148 on B200.)
+_DEVICE_SM_COUNT: dict[int, int] = {}
+
+
+def _device_sm_count(device: torch.device) -> int:
+    idx = device.index if device.index is not None else torch.cuda.current_device()
+    if idx not in _DEVICE_SM_COUNT:
+        _DEVICE_SM_COUNT[idx] = torch.cuda.get_device_properties(
+            idx
+        ).multi_processor_count
+    return _DEVICE_SM_COUNT[idx]
+
 
 @triton.jit
 def _cast_kv_tile(data, Q, tensor_scale, KV_QUANT_MODE: tl.constexpr):
@@ -1018,6 +1044,32 @@ def unified_attention(
         or num_seqs > seq_threshold_3D
         or is_batch_invariant
     )
+    # Multi-query decode (max_seqlen_q > 1) was forced onto the 2D path above.
+    # That path launches a (total_num_q_blocks x num_kv_heads) grid; with few
+    # sequences over a long KV it under-occupies the GPU (e.g. a diffusion-LM
+    # bidirectional canvas, or MTP/speculative decode: one request, a few-hundred
+    # query rows, a 100k-token KV -> only ~100 CTAs). The 3D segmented
+    # (flash-decoding) path splits the long KV across NUM_PAR_SOFTMAX_SEGMENTS
+    # extra CTAs and reduces the partials, recovering occupancy. Output is
+    # identical (same online-softmax, different reduction tiling). Enable it for
+    # multi-query decode when the 2D grid (total_num_q_blocks * num_kv_heads)
+    # under-fills the GPU's SMs, gated on a long-enough KV (so short sequences,
+    # where 2D is already efficient, are untouched) and on the segm buffers being
+    # large enough to hold every query token (else fall back to 2D). Large
+    # multi-query batches that already saturate the SMs keep using the 2D path.
+    # Standard autoregressive decode has max_seqlen_q == 1 and is never affected.
+    if (
+        not use_3d
+        and softmax_segm_output is not None
+        and seq_threshold_3D is not None
+        and not is_batch_invariant
+        and max_seqlen_q > 1
+        and total_num_q_blocks * num_kv_heads
+        < _device_sm_count(q.device) * _ATTN_3D_MULTI_Q_CTAS_PER_SM
+        and max_seqlen_k >= _ATTN_3D_MIN_KV_FOR_MULTI_Q
+        and q.shape[0] <= softmax_segm_output.shape[0]
+    ):
+        use_3d = True
 
     # The kernel signature is the same for 2D and 3D — only the launch
     # grid + a handful of constexpr toggles differ.  Per-token-head scale

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -53,11 +53,15 @@ _DEVICE_SM_COUNT: dict[int, int] = {}
 
 
 def _device_sm_count(device: torch.device) -> int:
-    idx = device.index if device.index is not None else torch.cuda.current_device()
+    idx = device.index if device.index is not None else 0
     if idx not in _DEVICE_SM_COUNT:
-        _DEVICE_SM_COUNT[idx] = torch.cuda.get_device_properties(
-            idx
-        ).multi_processor_count
+        # num_compute_units is not itself cached, and this sits on the per-call
+        # attention path, so keep the memo. A platform that does not implement
+        # it reports 0, which keeps the multi-query 3D gate closed.
+        try:
+            _DEVICE_SM_COUNT[idx] = current_platform.num_compute_units(idx)
+        except NotImplementedError:
+            _DEVICE_SM_COUNT[idx] = 0
     return _DEVICE_SM_COUNT[idx]
 
 

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -34,6 +34,32 @@ logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
 float8_info = torch.finfo(current_platform.fp8_dtype())
 
+# Minimum KV length at which multi-query decode (max_seqlen_q > 1) switches to
+# the 3D segmented attention path. Below this the single-pass 2D path already
+# saturates the GPU, so 3D's reduction overhead is not worth it.
+_ATTN_3D_MIN_KV_FOR_MULTI_Q = 8192
+
+# Multi-query decode uses the 3D segmented path while the 2D grid provides fewer
+# than this many CTAs per SM: with a long KV each 2D CTA serially reduces the
+# whole KV, and a couple of CTAs per SM is too few to hide that latency, so
+# splitting the reduction across segments wins. (Larger grids already have enough
+# CTAs to hide it and keep the 2D path.)
+_ATTN_3D_MULTI_Q_CTAS_PER_SM = 2
+
+# Cached SM count per device — used to decide when a 2D launch grid under-fills
+# the GPU. (MIN_LAUNCH_GRID_SIZE_2D is a conservative constant ~128; the true
+# occupancy bound is the device's SM count, e.g. 148 on B200.)
+_DEVICE_SM_COUNT: dict[int, int] = {}
+
+
+def _device_sm_count(device: torch.device) -> int:
+    idx = device.index if device.index is not None else torch.cuda.current_device()
+    if idx not in _DEVICE_SM_COUNT:
+        _DEVICE_SM_COUNT[idx] = torch.cuda.get_device_properties(
+            idx
+        ).multi_processor_count
+    return _DEVICE_SM_COUNT[idx]
+
 
 @triton.jit
 def _cast_kv_tile(data, Q, tensor_scale, KV_QUANT_MODE: tl.constexpr):
@@ -1048,6 +1074,32 @@ def unified_attention(
         or num_seqs > seq_threshold_3D
         or is_batch_invariant
     )
+    # Multi-query decode (max_seqlen_q > 1) was forced onto the 2D path above.
+    # That path launches a (total_num_q_blocks x num_kv_heads) grid; with few
+    # sequences over a long KV it under-occupies the GPU (e.g. a diffusion-LM
+    # bidirectional canvas, or MTP/speculative decode: one request, a few-hundred
+    # query rows, a 100k-token KV -> only ~100 CTAs). The 3D segmented
+    # (flash-decoding) path splits the long KV across NUM_PAR_SOFTMAX_SEGMENTS
+    # extra CTAs and reduces the partials, recovering occupancy. Output is
+    # identical (same online-softmax, different reduction tiling). Enable it for
+    # multi-query decode when the 2D grid (total_num_q_blocks * num_kv_heads)
+    # under-fills the GPU's SMs, gated on a long-enough KV (so short sequences,
+    # where 2D is already efficient, are untouched) and on the segm buffers being
+    # large enough to hold every query token (else fall back to 2D). Large
+    # multi-query batches that already saturate the SMs keep using the 2D path.
+    # Standard autoregressive decode has max_seqlen_q == 1 and is never affected.
+    if (
+        not use_3d
+        and softmax_segm_output is not None
+        and seq_threshold_3D is not None
+        and not is_batch_invariant
+        and max_seqlen_q > 1
+        and total_num_q_blocks * num_kv_heads
+        < _device_sm_count(q.device) * _ATTN_3D_MULTI_Q_CTAS_PER_SM
+        and max_seqlen_k >= _ATTN_3D_MIN_KV_FOR_MULTI_Q
+        and q.shape[0] <= softmax_segm_output.shape[0]
+    ):
+        use_3d = True
 
     # The kernel signature is the same for 2D and 3D — only the launch
     # grid + a handful of constexpr toggles differ.  Per-token-head scale


### PR DESCRIPTION
## Purpose

> **Motivating case: diffusion *text* models (e.g. DiffusionGemma).** Unlike autoregressive LLMs that emit one token per step, diffusion LMs denoise a whole canvas of query tokens against the full context every decode step — so *every* decode forward pass is multi-query (`max_seqlen_q > 1`). They are the workload this PR is built for and the only one benchmarked here (all numbers below are DiffusionGemma‑26B‑A4B in NVFP4 on a single NVIDIA B200). The underlying fix is general to any multi-query decode, so speculative/MTP decode over long context is expected to benefit from the same mechanism, but that is not benchmarked in this PR.

The Triton unified-attention kernel only takes the 3D segmented (flash-decoding) path for **single-query** decode (`max_seqlen_q == 1`). Any **multi-query** decode (`max_seqlen_q > 1`) is unconditionally forced onto the 2D path:

```python
use_3d = not (
    ...
    or max_seqlen_q > 1          # <-- multi-query always 2D
    or num_seqs > seq_threshold_3D
    or is_batch_invariant
)
```

For multi-query decode over a **long KV with few sequences** this is a large amount of left-on-the-table parallelism. The motivating case is diffusion LMs (e.g. DiffusionGemma), which denoise a bidirectional canvas of a few hundred query rows against the full context every step — so every decode forward pass is multi-query. Speculative / MTP decode is the same shape (a handful of query rows, long KV). In that regime the 2D launch grid `total_num_q_blocks * num_kv_heads` is only on the order of ~100 CTAs (a few tens for the smaller layers), so most SMs sit idle while each CTA serially reduces the entire 100k-token KV.

This PR enables the **existing** 3D segmented path for multi-query decode when the 2D grid under-fills the SMs and the KV is long, recovering occupancy by splitting the KV reduction across `NUM_PAR_SOFTMAX_SEGMENTS` extra CTAs. It is a kernel-tiling change only — **the output is numerically identical to the 2D path** up to floating-point reduction-order noise (max `|3D − 2D|` ≈ `1.5e-5`, quantified below; same online softmax, different reduction tiling).

## Relationship to #44652 and #45450 (why this is not a duplicate)

#44652 and #45450 relax the same `max_seqlen_q > 1` gate, but both target **speculative-decode verify**, and **neither admits a diffusion-LM canvas**:

- **#44652** caps admission at `max_seqlen_q > MAX_SEQLEN_Q_3D_LIMIT (=16)`, so a 24–256-token canvas is still forced onto the 2D path.
- **#45450** keys admission to `decode_query_len = 1 + num_speculative_tokens` (plus sliding-window layers); with no speculative config (a diffusion model) that reduces to the original `max_seqlen_q > 1` — byte-for-byte upstream, by its own description — and its segment buffers stay `seq_threshold_3D`-sized, so a multi-row canvas never fits.

This PR is the **diffusion / occupancy-aware sibling**: same gate, different admission. Like #45450 it is **structural, not flag-gated** — autoregressive decode (`max_seqlen_q == 1`) hits exactly the original code path. What is unique here is the *admission policy*: it is the only one that (a) admits the 24–256-row diffusion canvas, and (b) keys admission to **2D-grid occupancy** (`grid < CTAS_PER_SM·SM_count`) and a **long-KV floor** (`max_seqlen_k ≥ 8192`), so it fires precisely when 2D leaves SMs idle over a long KV and never where 2D is already fast. The new branch only flips `use_3d` False→True **after** the existing gate, so it is *additive* and composes with #45450 (a one-line textual overlap; the lazy buffers below are sized independently per caller) rather than conflicting in logic. Happy to rebase on top of #45450, or combine, if it lands first.

## Changes

- **`triton_unified_attention.py`**: after the existing `use_3d` decision, add a structurally-gated branch that switches multi-query decode to the 3D path when (a) `max_seqlen_q > 1`, (b) the 2D grid `total_num_q_blocks * num_kv_heads` is below `CTAS_PER_SM (=2) × SM_count` (under-filled), (c) `max_seqlen_k >= 8192` (long KV — where split-KV pays off), and (d) the segmented-softmax buffers are large enough to hold every query token (else fall back to 2D). No new env var; admission is purely structural.
- **`triton_attn.py`**: keep the original one-row-per-sequence segmented-softmax scratch for the 1-query path unchanged, and allocate the larger multi-query buffers **lazily** — only on the first `build()` that sees `max_seqlen_q > 1` over a long KV — in tensors separate from the 1-query scratch. Models that only ever do 1-query decode keep the original buffers and allocate nothing extra. The runtime guard `q.shape[0] <= softmax_segm_output.shape[0]` keeps writes in-bounds and falls back to 2D otherwise.

## Safety / scope

- **Standard autoregressive decode (`max_seqlen_q == 1`) is never affected** — it does not enter the new branch and keeps the original (small) buffers, so existing single-query behavior is byte-for-byte unchanged. There is no env var or default to set.
- **Lossless.** The 3D path reuses the same kernel and online-softmax math; only the reduction tiling differs. Verified numerically (see below): max `|out_3D − out_2D|` ≈ `1.5e-5`, i.e. floating-point reduction-order noise, the same order as `|out_2D − fp32_reference|`.
- **Memory-safe.** The segm buffers are indexed by query-*token* index (`< q.shape[0]`, with the block tail mask-suppressed), and the firing condition guards `q.shape[0] <= buffer_rows`, so no shape that fires can write out of bounds.
- **CUDA-graph-safe.** Multi-query decode is non-uniform, so it runs in piecewise mode where attention is a splitting op excluded from the graph (FULL graphs only capture uniform 1-token decode). The lazily-allocated multi-query buffers are separate tensors from the 1-query scratch that the captured decode graph references, and are never reallocated, so graph replay is unaffected; the `use_3d` decision is re-evaluated eagerly every forward against the live shapes.

## Test Plan

**Benchmark scope (please read):** every number in this PR comes from a single model — [`nvidia/diffusiongemma-26B-A4B-it-NVFP4`](https://huggingface.co/nvidia/diffusiongemma-26B-A4B-it-NVFP4) — on **one NVIDIA B200** (148 SMs), vLLM **TRITON_ATTN** backend, `--max-model-len 131072`, fp8 KV cache. This is the motivating diffusion-LM workload; I have **not** benchmarked speculative/MTP or other models, though the mechanism applies to them.

1. **Numerical losslessness** — drive `unified_attention` directly on identical multi-query long-KV paged-attention inputs with the 3D path forced off vs on (by forcing the occupancy gate), plus an eager fp32 reference; assert the 2D path leaves the segm buffers untouched, the 3D path fires, and the two outputs agree to fp reduction-order tolerance. Swept 60 shapes (`n_kv∈{2,8}`, `head_dim∈{128,256}`, `q_len∈{8..256}`, `kv_len∈{8k,92k,131k}`, `n_seqs∈{1..16}`, causal both).
2. **Kernel-level latency** — CUDA-event-timed 2D vs 3D on the same shapes (exclusive GPU), to isolate the attention speedup from the diffusion denoising loop.
3. **End-to-end** — (a) decode-throughput A/B forcing the 2D vs 3D path on the same server/prompt across context lengths and concurrencies; (b) a functional run of the patched server to confirm 3D fires on the live model, the lazy multi-query buffers allocate on the first multi-query long-KV step, and output is coherent.

## Test Result

**Losslessness:** 60/60 shapes pass; max `|out_3D − out_2D| = 1.5e-5` (≤ the 2D-vs-fp32 error). 2D path provably never writes the segm buffers; 3D fires on the under-filled shapes.

**Kernel-level latency (median of 100 iters):**

| shape (n_q/n_kv/hd, q_len, kv_len, n_seqs) | 2D | 3D | speedup |
|---|---|---|---|
| 16/2/128, 24, 92k, 1 | 3894 µs | 534 µs | **7.30×** |
| 16/8/128, 24, 92k, 1 | 4341 µs | 626 µs | 6.94× |
| 16/2/128, 24, 131k, 1 | 5542 µs | 752 µs | **7.37×** |
| 16/2/128, 24, 92k, 2 | 4119 µs | 1081 µs | 3.81× |
| 16/2/128, 24, 92k, 4 | 4126 µs | 1675 µs | 2.46× |

3D is faster than 2D at every concurrency tested (the speedup shrinks as more sequences fill the grid, as expected).

**End-to-end decode throughput (single stream, prefix-cached prompt; 2D vs 3D path forced):**

| context | 2D | 3D | speedup |
|---|---|---|---|
| 16k | 343 tok/s | 514 tok/s | 1.50× |
| 92k | 61 tok/s | 100 tok/s | **1.64×** |
| 120k | 68 tok/s | 102 tok/s | 1.50× |

(End-to-end gain is smaller than the kernel gain because long-context decode is partly KV-bandwidth-bound and the diffusion denoising loop adds variance; short-context `< 8192` KV is excluded by the gate and unchanged.)

**Provenance of the numbers.** The kernel-latency A/B was re-measured on this exact revision (structural gate + lazy buffers). The end-to-end throughput figures are carried over from a functionally-equivalent earlier revision: steady-state decode runs the identical kernel path, and the lazy buffer allocation is a one-time event at `build()`, not per-step, so it does not affect decode throughput. The final revision was additionally confirmed end-to-end by a functional server run (3D fires on the live model, the multi-query buffers allocate on the first multi-query long-KV step, output coherent).

## Notes for reviewers

- The two thresholds — `8192` KV and `CTAS_PER_SM = 2` — are the knobs. They're chosen so the gate fires only when the 2D grid genuinely leaves SMs idle over a long KV; happy to adjust or wire them through config if preferred.
- Admission is fully structural (no env var). If you'd prefer it strictly opt-in initially, I can gate it behind a config field instead.
- **Scope is "any multi-query forward", not strictly decode.** The gate keys on `max_seqlen_q > 1` + grid under-fill + long KV, so a multi-query *prefill* chunk over a long cached KV that under-fills the grid is also admitted. That is intended and safe — the output is identical and the `q.shape[0] <= buffer_rows` guard keeps it in-bounds; the long-KV + occupancy thresholds keep short/cheap forwards on the 2D path. The diffusion-LM canvas and spec/MTP decode are simply the motivating workloads.

## Tests run

All on `nvidia/diffusiongemma-26B-A4B-it-NVFP4`, single B200, TRITON_ATTN backend (standalone driver scripts — no vLLM source change needed to run them; the 2D/3D path is forced via the kernel's occupancy gate). Commands (scripts available on request):

```bash
python micro_lossless.py      # 2D vs 3D vs eager-fp32 ref, 4 shapes
python micro_features.py      # Gemma feature path: softcap + SWA + fp8 KV, 14 cases
python robustness_sweep.py    # randomized 60-shape parity + crash sweep
python timing_micro.py        # CUDA-event 2D-vs-3D kernel latency (exclusive GPU)
bash   server_e2e.sh          # functional run vs a live vLLM server (3D fires, buffers allocate)
```

Results:

- 2D-vs-3D vs eager-fp32 reference, 4 shapes — max `|3D − 2D| = 7.6e-6` (3D firing confirmed; the 2D path provably never writes the segment buffers).
- 2D-vs-3D parity on the **full Gemma feature path** (logit soft-cap + sliding-window + fp8 KV-cache descales, and combinations), 14 cases — max `6.1e-5`.
- Randomized robustness sweep, 60 shapes (`n_kv ∈ {2,8}`, `head_dim ∈ {128,256}`, `q_len 8–256`, `kv_len 8k–131k`, `n_seqs 1–16`, causal both) — 0 failures / 0 crashes, max `1.5e-5`.
- Kernel-level 2D-vs-3D latency (CUDA-event, exclusive GPU): 7.3× @92k, 7.4× @131k single-stream; 3.8× / 2.5× at `n_seqs` 2 / 4.
- End-to-end decode A/B (2D vs 3D path forced, identical server + prompt): 1.50× / 1.64× / 1.50× at 16k / 92k / 120k single-stream.
- Patched-server functional run: the server loads and serves; the lazy multi-query segment buffers allocate on the first multi-query long-KV `build()`; the 3D multi-query branch fires on the live model (occupancy gate satisfied); output is coherent.

## Note on AI assistance

This change was developed with AI assistance. I (the submitter) have reviewed every changed line, understand the change end-to-end, and ran the tests above; I can defend and maintain it. Per the contribution guidelines I checked the open PRs first (#44652, #45450) and explained above why this is a materially different admission policy targeting a workload (the diffusion-LM canvas) that neither covers.

cc @jvlunteren (original kernel author) @LucasWilkinson @JartX — would appreciate your eyes on the threshold choices, and on whether you'd prefer this combined with #45450.