### PR TITLE
[ROCm][Perf][Bugfix] DSv4 indexer: use platform FP8 dtype (fnuz) for Q-quant on gfx942

### DIFF
--- a/vllm/models/deepseek_v4/common/ops/fused_indexer_q.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_indexer_q.py
@@ -3,6 +3,7 @@
 
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.import_utils import has_cutedsl
 
@@ -88,6 +89,8 @@ def _fused_indexer_q_rope_quant_kernel(
     index_weights_head_scale,
     index_weights_out_ptr,
     index_weights_out_stride,
+    FP8_MAX: tl.constexpr = 448.0,
+    USE_FNUZ: tl.constexpr = False,
 ):
     # Layout matches the unfused reference (DeepseekV4ScalingRotaryEmbedding
     # + per_token_group_quant_fp8): GPT-J interleaved RoPE applied to the
@@ -128,26 +131,28 @@ def _fused_indexer_q_rope_quant_kernel(
         nope_offset = tl.arange(0, INDEX_Q_NOPE_DIM)
         x_nope = tl.load(base_ptr + nope_offset).to(tl.float32)
         amax = tl.maximum(amax, tl.max(tl.abs(x_nope)))
-    index_q_scale = tl.div_rn(tl.maximum(amax, 1e-4), 448.0)
+    index_q_scale = tl.div_rn(tl.maximum(amax, 1e-4), FP8_MAX)
     index_q_scale = tl.math.exp2(tl.math.ceil(tl.math.log2(index_q_scale)))
 
-    # Store quantized values to index_q_fp8
+    # Store quantized values to index_q_fp8. FNUZ (e4m3fnuz) on gfx942, OCP
+    # (e4m3fn) elsewhere -- matches the K cache.
+    fp8_dtype = tl.float8e4b8 if USE_FNUZ else tl.float8e4nv
     fp8_base_ptr = (
         index_q_fp8_ptr + tok_idx * index_q_fp8_stride0 + head_idx * index_q_fp8_stride1
     )
     if INDEX_Q_NOPE_DIM > 0:
         tl.store(
             fp8_base_ptr + nope_offset,
-            tl.div_rn(x_nope, index_q_scale).to(tl.float8e4nv),
+            tl.div_rn(x_nope, index_q_scale).to(fp8_dtype),
         )
     fp8_rot_base = fp8_base_ptr + INDEX_Q_NOPE_DIM
     tl.store(
         fp8_rot_base + half_offset * 2,
-        tl.div_rn(r_even, index_q_scale).to(tl.float8e4nv),
+        tl.div_rn(r_even, index_q_scale).to(fp8_dtype),
     )
     tl.store(
         fp8_rot_base + half_offset * 2 + 1,
-        tl.div_rn(r_odd, index_q_scale).to(tl.float8e4nv),
+        tl.div_rn(r_odd, index_q_scale).to(fp8_dtype),
     )
 
     # FP8 weight-fold contract:
@@ -299,8 +304,9 @@ def fused_indexer_q_rope_quant(
     Weight-fold semantics (important — the two paths differ):
 
     FP8 path (use_fp4=False, default):
-        q_fp8      : (T, H, HEAD_DIM) float8_e4m3fn, per-token-per-head
-                     scalar scale (NOT stored — folded into weights below)
+        q_fp8      : (T, H, HEAD_DIM) platform fp8 (e4m3fnuz on gfx942,
+                     e4m3fn elsewhere); per-token-per-head scalar scale
+                     (NOT stored — folded into weights below)
         weights_out = weights * q_scale * softmax_scale * head_scale
         Rationale: a single per-token q_scale is a scalar the downstream FP8
         logits kernel would otherwise multiply in. Folding it into `weights`
@@ -397,7 +403,10 @@ def fused_indexer_q_rope_quant(
             index_q_scale.view(torch.int32).squeeze(-1),
         ), index_weights_out
 
-    index_q_fp8 = torch.empty_like(index_q, dtype=torch.float8_e4m3fn)
+    fp8_dtype = current_platform.fp8_dtype()
+    use_fnuz = fp8_dtype == torch.float8_e4m3fnuz
+    fp8_max = 224.0 if use_fnuz else 448.0
+    index_q_fp8 = torch.empty_like(index_q, dtype=fp8_dtype)
     if has_cutedsl():
         # lazily import, otherwise some tests fail due to CUDA driver init failure.
         from vllm.models.deepseek_v4.nvidia.ops.fused_indexer_q_cutedsl import (
@@ -433,6 +442,8 @@ def fused_indexer_q_rope_quant(
             index_weights_head_scale,
             index_weights_out,
             index_weights_out.stride(0),
+            FP8_MAX=fp8_max,
+            USE_FNUZ=use_fnuz,
             num_warps=1,  # TODO: Tune this
         )
     return index_q_fp8, index_weights_out


### PR DESCRIPTION
## Motivation

On gfx942 the DeepSeek-V4 Flash indexer quantizes Q and K to different FP8 types. K already uses the platform type (e4m3fnuz on gfx942, via current_platform.fp8_dtype()), but the fused RoPE+quant kernel in fused_indexer_q.py hardcodes Q to e4m3fn. The FP8 logits kernel then gets fnuz K with fn Q and falls back to a mixed-dtype path on every call. This change derives Q's type from current_platform.fp8_dtype() as well, so on gfx942 both are fnuz and the logits kernel runs its native fnuz/fnuz path.

This is gfx942-specific by design. is_fp8_fnuz() is true only for gfx94x, so on gfx950 the platform type is OCP e4m3fn and Q/K are already fn/fn. Nothing changes there, and the NVIDIA cutedsl and MXFP4 paths are untouched (the two new kernel constexprs are defaulted).

The fnuz quant max is set to 224.0 to match get_fp8_min_max() in quant_utils.py, the value the K cache already uses.

## Results

End to end serving of DeepSeek-V4 Flash (TP4, gfx942 / MI300), mean TTFT, prefill-heavy (OSL=27, concurrency 4):
| ISL    | OSL | main (mixed fp8 q=fn / k=fnuz) | This PR (fnuz q/k) | Speedup |
|--------|-----|-------------------------------|--------------------|---------|
| 8,192  | 27  | 3283 ms                       | 1260 ms            | 2.6x    |
| 32,768 | 27  | 39744 ms                      | 5350 ms            | 7.4x    |

Bonus correctness check: the existing kernel test tests/kernels/test_fused_indexer_q_rope_quant.py matches the unfused reference bit for bit on 9 of 10 gfx942 shapes. The one miss is 3 of 8,380,416 values at float32 / 1023 tokens, from fused vs unfused RoPE rounding at FP8 boundaries, not a dtype or scale error.

## Note

The same indexer dtype handling was included in the larger ROCm enablement PRs #41601 and #42033, both stalled on rebase since May. This is a minimal, standalone version of just that fix for the gfx942 path; main as of today still hardcodes Q to e4m3fn.


<details>
<summary>Repro: serve + bench commands (DeepSeek-V4 Flash, TP4, gfx942)</summary>

Serve (4x MI325):

```bash
HIP_VISIBLE_DEVICES=0,1,2,3 VLLM_ROCM_USE_AITER=1 \
vllm serve deepseek-ai/DeepSeek-V4-Flash \
  --tensor-parallel-size 4 \
  --gpu-memory-utilization 0.85 \
  --kv-cache-dtype fp8_e4m3 \
  --block-size 256 \
  --max-model-len 132096 \
  --max-num-batched-tokens 16384 \
  --max-num-seqs 156 \
  --async-scheduling \
  --no-enable-prefix-caching \
  --tokenizer-mode deepseek_v4 \
  --reasoning-parser deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --disable-log-stats \
  --host 0.0.0.0 --port 8000
  
  vllm bench serve --backend vllm \
  --model deepseek-ai/DeepSeek-V4-Flash \
  --host localhost --port 8000 \
  --dataset-name random --ignore-eos --trust-remote-code \
  --seed 5678 \
  --random-input-len 8192 \
  --random-output-len 27 \
  --max-concurrency 4 --num-prompts 12 --num-warmups 4

# 32K ISL: same command with --random-input-len 32768