### PR TITLE
[Bugfix] Improve DCP error message with backend hint

### DIFF
--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -32,8 +32,8 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "Decode Context Parallelism (DCP) requires attention "
                     "implementations to return the softmax LSE during decode, "
                     f"but {layer_impl.__class__.__name__} does not. "
-                    "Try a different backend by setting "
-                    "--attention-backend or disable DCP."
+                    "Try a different backend using the VLLM_ATTENTION_BACKEND "
+                    "environment variable or --attention-backend CLI flag, or set --decode-context-parallel-size 1 to disable DCP."
                 )
 
             if pcp_size > 1:


### PR DESCRIPTION
Fixes #28407

  The previous error message for DCP incompatibility suggested using
  --attention-backend but didn't mention the VLLM_ATTENTION_BACKEND
  environment variable. This change adds both options and includes the
  flag to disable DCP for clarity.