### PR TITLE
[Bugfix][Rust Frontend] Reject min_tokens above max_tokens

### DIFF
--- a/rust/src/chat/src/error.rs
+++ b/rust/src/chat/src/error.rs
@@ -74,6 +74,17 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+impl Error {
+    /// Whether this error represents invalid user request parameters.
+    pub fn is_request_validation_error(&self) -> bool {
+        match self {
+            Self::PromptTooLong { .. } => true,
+            Self::Text(error) => error.is_request_validation_error(),
+            _ => false,
+        }
+    }
+}
+
 /// Format the available-parser suffix used in user-facing error messages.
 fn available_parser_hint(available_names: &[String]) -> String {
     if available_names.is_empty() {

--- a/rust/src/server/src/error.rs
+++ b/rust/src/server/src/error.rs
@@ -103,6 +103,7 @@ fn is_request_validation_error(error: &vllm_text::Error) -> bool {
             | vllm_text::Error::EmptyPromptTokenIds { .. }
             | vllm_text::Error::Logprobs(_)
             | vllm_text::Error::TokenIds(_)
+            | vllm_text::Error::MinTokensExceedsMaxTokens { .. }
             | vllm_text::Error::InvalidThinkingTokenBudget
             // An empty tokenized prompt detected later, at request prepare
             // time, surfaces through the transparent Llm wrapper.
@@ -138,6 +139,22 @@ mod tests {
         let response = api_error.to_error_response();
         assert_eq!(response.error.error_type, "invalid_request_error");
         assert!(response.error.message.contains("thinking_token_budget"));
+    }
+
+    #[test]
+    fn min_tokens_above_max_tokens_maps_to_invalid_request() {
+        let api_error = text_submit_error(
+            "failed to submit completion request",
+            vllm_text::Error::MinTokensExceedsMaxTokens {
+                min_tokens: 5,
+                max_tokens: 4,
+            },
+        );
+        assert_eq!(api_error.status_code(), StatusCode::BAD_REQUEST);
+        let response = api_error.to_error_response();
+        assert_eq!(response.error.error_type, "invalid_request_error");
+        assert!(response.error.message.contains("min_tokens=5"));
+        assert!(response.error.message.contains("max_tokens=4"));
     }
 
     #[test]

--- a/rust/src/server/src/error.rs
+++ b/rust/src/server/src/error.rs
@@ -78,7 +78,7 @@ impl IntoResponse for ApiError {
 /// the client's fault and map to HTTP 400, mirroring the Python frontend.
 /// Everything else stays an internal 500.
 pub fn text_submit_error(context: &'static str, error: vllm_text::Error) -> ApiError {
-    if is_request_validation_error(&error) {
+    if error.is_request_validation_error() {
         return invalid_request!("{error}");
     }
     server_error!("{}: {}", context, error.to_report_string())
@@ -87,28 +87,10 @@ pub fn text_submit_error(context: &'static str, error: vllm_text::Error) -> ApiE
 /// Like [`text_submit_error`], for the chat pipeline (which both wraps the
 /// text errors and raises its own prompt-length variant).
 pub fn chat_submit_error(context: &'static str, error: vllm_chat::Error) -> ApiError {
-    match &error {
-        vllm_chat::Error::PromptTooLong { .. } => invalid_request!("{error}"),
-        vllm_chat::Error::Text(text_error) if is_request_validation_error(text_error) => {
-            invalid_request!("{error}")
-        }
-        _ => server_error!("{}: {}", context, error.to_report_string()),
+    if error.is_request_validation_error() {
+        return invalid_request!("{error}");
     }
-}
-
-fn is_request_validation_error(error: &vllm_text::Error) -> bool {
-    matches!(
-        error,
-        vllm_text::Error::PromptTooLong { .. }
-            | vllm_text::Error::EmptyPromptTokenIds { .. }
-            | vllm_text::Error::Logprobs(_)
-            | vllm_text::Error::TokenIds(_)
-            | vllm_text::Error::MinTokensExceedsMaxTokens { .. }
-            | vllm_text::Error::InvalidThinkingTokenBudget
-            // An empty tokenized prompt detected later, at request prepare
-            // time, surfaces through the transparent Llm wrapper.
-            | vllm_text::Error::Llm(vllm_llm::Error::EmptyPromptTokenIds { .. })
-    )
+    server_error!("{}: {}", context, error.to_report_string())
 }
 
 #[cfg(test)]

--- a/rust/src/server/src/grpc/mod.rs
+++ b/rust/src/server/src/grpc/mod.rs
@@ -155,22 +155,9 @@ impl pb::generate_server::Generate for GenerateServiceImpl {
 
 fn text_error_to_status(error: vllm_text::Error) -> Status {
     let message = error.to_report_string();
-    if is_text_request_validation_error(&error) {
+    if error.is_request_validation_error() {
         Status::invalid_argument(message)
     } else {
         Status::internal(message)
     }
-}
-
-fn is_text_request_validation_error(error: &vllm_text::Error) -> bool {
-    matches!(
-        error,
-        vllm_text::Error::PromptTooLong { .. }
-            | vllm_text::Error::EmptyPromptTokenIds { .. }
-            | vllm_text::Error::Logprobs(_)
-            | vllm_text::Error::TokenIds(_)
-            | vllm_text::Error::MinTokensExceedsMaxTokens { .. }
-            | vllm_text::Error::InvalidThinkingTokenBudget
-            | vllm_text::Error::Llm(vllm_llm::Error::EmptyPromptTokenIds { .. })
-    )
 }

--- a/rust/src/server/src/grpc/mod.rs
+++ b/rust/src/server/src/grpc/mod.rs
@@ -56,12 +56,9 @@ impl pb::generate_server::Generate for GenerateServiceImpl {
         info!(%request_id, "grpc generate (unary)");
 
         let stream = self.state.chat.text().generate(text_request).await;
-        let stream = stream.map_err(|e| Status::internal(e.to_report_string()))?;
+        let stream = stream.map_err(text_error_to_status)?;
 
-        let collected = stream
-            .collect_output()
-            .await
-            .map_err(|e| Status::internal(e.to_report_string()))?;
+        let collected = stream.collect_output().await.map_err(text_error_to_status)?;
 
         // Build the single aggregated response.
         let prompt_info = convert::to_prompt_info(
@@ -104,7 +101,7 @@ impl pb::generate_server::Generate for GenerateServiceImpl {
         info!(%request_id, "grpc generate (stream)");
 
         let stream = self.state.chat.text().generate(text_request).await;
-        let stream = stream.map_err(|e| Status::internal(e.to_report_string()))?;
+        let stream = stream.map_err(text_error_to_status)?;
 
         let (tx, rx) = mpsc::channel(32);
 
@@ -112,7 +109,7 @@ impl pb::generate_server::Generate for GenerateServiceImpl {
             futures::pin_mut!(stream);
             while let Some(event) = stream.next().await {
                 let response = match event {
-                    Err(e) => Err(Status::internal(e.to_report_string())),
+                    Err(e) => Err(text_error_to_status(e)),
                     Ok(DecodedTextEvent::Start {
                         prompt_token_ids,
                         prompt_logprobs,
@@ -154,4 +151,26 @@ impl pb::generate_server::Generate for GenerateServiceImpl {
         let response_stream = ReceiverStream::new(rx);
         Ok(Response::new(Box::pin(response_stream)))
     }
+}
+
+fn text_error_to_status(error: vllm_text::Error) -> Status {
+    let message = error.to_report_string();
+    if is_text_request_validation_error(&error) {
+        Status::invalid_argument(message)
+    } else {
+        Status::internal(message)
+    }
+}
+
+fn is_text_request_validation_error(error: &vllm_text::Error) -> bool {
+    matches!(
+        error,
+        vllm_text::Error::PromptTooLong { .. }
+            | vllm_text::Error::EmptyPromptTokenIds { .. }
+            | vllm_text::Error::Logprobs(_)
+            | vllm_text::Error::TokenIds(_)
+            | vllm_text::Error::MinTokensExceedsMaxTokens { .. }
+            | vllm_text::Error::InvalidThinkingTokenBudget
+            | vllm_text::Error::Llm(vllm_llm::Error::EmptyPromptTokenIds { .. })
+    )
 }

--- a/rust/src/server/src/grpc/tests.rs
+++ b/rust/src/server/src/grpc/tests.rs
@@ -427,6 +427,34 @@ async fn unary_generate_missing_prompt_returns_invalid_argument() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn unary_generate_min_tokens_above_max_tokens_returns_invalid_argument() {
+    let (mut client, server_task, _engine_task) =
+        grpc_test_server(b"engine-grpc-min-above-max", default_stream_output_specs()).await;
+
+    let status = client
+        .generate(pb::GenerateRequest {
+            request_id: "test-min-above-max".to_string(),
+            model: "test-model".to_string(),
+            prompt: Some(pb::generate_request::Prompt::Text("hi".to_string())),
+            stopping: Some(pb::StoppingCriteria {
+                max_new_tokens: 4,
+                min_new_tokens: 5,
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect_err("should fail when min_new_tokens exceeds max_new_tokens");
+
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    assert!(status.message().contains("min_tokens=5"));
+    assert!(status.message().contains("max_tokens=4"));
+
+    server_task.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn streaming_generate_yields_incremental_responses() {
     let (mut client, server_task, engine_task) =
         grpc_test_server(b"engine-grpc-stream", default_stream_output_specs()).await;
@@ -509,6 +537,37 @@ async fn streaming_generate_missing_prompt_returns_invalid_argument() {
         .expect_err("should fail without prompt");
 
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
+
+    server_task.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn streaming_generate_min_tokens_above_max_tokens_returns_invalid_argument() {
+    let (mut client, server_task, _engine_task) = grpc_test_server(
+        b"engine-grpc-stream-min-above-max",
+        default_stream_output_specs(),
+    )
+    .await;
+
+    let status = client
+        .generate_stream(pb::GenerateRequest {
+            request_id: "test-stream-min-above-max".to_string(),
+            model: "test-model".to_string(),
+            prompt: Some(pb::generate_request::Prompt::Text("hi".to_string())),
+            stopping: Some(pb::StoppingCriteria {
+                max_new_tokens: 4,
+                min_new_tokens: 5,
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect_err("should fail when min_new_tokens exceeds max_new_tokens");
+
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    assert!(status.message().contains("min_tokens=5"));
+    assert!(status.message().contains("max_tokens=4"));
 
     server_task.abort();
 }

--- a/rust/src/text/src/error.rs
+++ b/rust/src/text/src/error.rs
@@ -37,6 +37,24 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+impl Error {
+    /// Whether this error represents invalid user request parameters.
+    pub fn is_request_validation_error(&self) -> bool {
+        match self {
+            Self::PromptTooLong { .. }
+            | Self::EmptyPromptTokenIds { .. }
+            | Self::Logprobs(_)
+            | Self::TokenIds(_)
+            | Self::MinTokensExceedsMaxTokens { .. }
+            | Self::InvalidThinkingTokenBudget
+            // An empty tokenized prompt detected later, at request prepare
+            // time, surfaces through the transparent Llm wrapper.
+            | Self::Llm(LlmError::EmptyPromptTokenIds { .. }) => true,
+            _ => false,
+        }
+    }
+}
+
 impl From<vllm_tokenizer::TokenizerError> for Error {
     fn from(error: vllm_tokenizer::TokenizerError) -> Self {
         Self::Tokenizer(error.0)

--- a/rust/src/text/src/error.rs
+++ b/rust/src/text/src/error.rs
@@ -20,6 +20,11 @@ pub enum Error {
     Logprobs(#[from] LogprobsError),
     #[error(transparent)]
     TokenIds(#[from] TokenIdsError),
+    #[error(
+        "`min_tokens` must be less than or equal to `max_tokens`, \
+         got min_tokens={min_tokens}, max_tokens={max_tokens}"
+    )]
+    MinTokensExceedsMaxTokens { min_tokens: u32, max_tokens: u32 },
     #[error("`thinking_token_budget` must be a non-negative integer or -1 for unlimited.")]
     InvalidThinkingTokenBudget,
     #[error("text request stream `{request_id}` closed before terminal output")]

--- a/rust/src/text/src/lower.rs
+++ b/rust/src/text/src/lower.rs
@@ -128,6 +128,12 @@ pub fn lower_sampling_params(
         prompt_len,
     )?;
     let min_tokens = min_tokens.unwrap_or(0);
+    if min_tokens > max_tokens {
+        return Err(Error::MinTokensExceedsMaxTokens {
+            min_tokens,
+            max_tokens,
+        });
+    }
     let thinking_token_budget = normalize_thinking_token_budget(thinking_token_budget)?;
     let frequency_penalty = frequency_penalty.unwrap_or(0.0);
     let presence_penalty = presence_penalty.unwrap_or(0.0);
@@ -411,6 +417,27 @@ mod tests {
         assert!(matches!(
             lower(Some(-2)),
             Err(Error::InvalidThinkingTokenBudget)
+        ));
+    }
+
+    #[test]
+    fn lower_sampling_params_rejects_min_tokens_above_resolved_max_tokens() {
+        let error = lower_sampling_params_with_limits(
+            SamplingParams {
+                max_tokens: Some(4),
+                min_tokens: Some(5),
+                ..SamplingParams::default()
+            },
+            sample_sampling_limits(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::MinTokensExceedsMaxTokens {
+                min_tokens: 5,
+                max_tokens: 4,
+            }
         ));
     }
 


### PR DESCRIPTION



## Purpose

  Rust frontend request paths did not consistently reject `min_tokens > max_tokens`.

 Python `SamplingParams` already treats this combination as invalid, and the Rust chat completions request type had a route-level check. However, other Rust paths such as `/v1/completions` and `/generate` could still reach the shared text lowering layer with an impossible sampling configuration:
  - `max_tokens=4`: generate at most 4 tokens
  - `min_tokens=5`: do not allow stop/EOS behavior before 5 tokens

  This PR adds the validation to the shared Rust text lowering layer so all paths using it reject the invalid combination
  consistently.

## Test Plan

## Test Result

```
cargo test -p vllm-text lower_sampling_params_rejects_min_tokens_above_resolved_max_tokens
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running unittests src/lib.rs (target/debug/deps/vllm_text-b895ba6e49a8f640)

running 1 test
test lower::tests::lower_sampling_params_rejects_min_tokens_above_resolved_max_tokens ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 62 filtered out; finished in 0.00s

cargo test -p vllm-server \
                                                         min_tokens_above_max_tokens_maps_to_invalid_request
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running unittests src/lib.rs (target/debug/deps/vllm_server-31f0666f24a09e8a)

running 1 test
test error::tests::min_tokens_above_max_tokens_maps_to_invalid_request ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 265 filtered out; finished in 0.00s

e.g.

curl -i -sS http://127.0.0.1:18081/v1/completions \
                   -H 'Content-Type: application/json' \
                   -d '{
                     "model": "m",
                     "prompt": "Hello",
                     "max_tokens": 4,
                     "min_tokens": 5,
                     "temperature": 0
                   }'
HTTP/1.1 400 Bad Request
content-type: application/json
content-length: 173
date: Thu, 25 Jun 2026 15:04:16 GMT

{"error":{"message":"`min_tokens` must be less than or equal to `max_tokens`, got min_tokens=5, max_tokens=4","type":"invalid_request_error","code":"invalid_request_error"}}⏎
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

