### PR TITLE
[CI] Fix failing CUDA graph capture in Triton MOE

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
@@ -72,6 +72,11 @@ class Nvfp4QuantizationEmulationTritonExperts(TritonExperts):
     def expects_unquantized_inputs(self) -> bool:
         return True
 
+    @property
+    def a1_scale(self) -> torch.Tensor:
+        # Used in experts/triton_moe.py and passed to moe_kernel_quantize_input.
+        return self.a1_gscale
+
     @staticmethod
     def _supports_quant_scheme(
         weight_key: QuantKey | None,

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -245,7 +245,7 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
             lora_unquantized_hidden_states = hidden_states
             hidden_states, a1q_scale = moe_kernel_quantize_input(
                 hidden_states,
-                self.a1_scale or self.a1_gscale,
+                self.a1_scale,
                 self.quant_dtype,
                 self.per_act_token_quant,
                 self.block_shape,


### PR DESCRIPTION
## Purpose

Following a change in https://github.com/vllm-project/vllm/pull/46254 that used `self.a1_scale or self.a1_gscale` as `moe_kernel_quantize_input` argument in Triton MOE, graph capture started failing with:

```
(EngineCore pid=3325911)   File "/felmarty/repos/vllm/vllm/model_executor/layers/fused_moe/experts/triton_moe.py", line 248, in apply
(EngineCore pid=3325911)     self.a1_scale or self.a1_gscale,
(EngineCore pid=3325911)     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3325911) torch.AcceleratorError: HIP error: operation not permitted when stream is capturing
(EngineCore pid=3325911) Search for `hipErrorStreamCaptureUnsupported' in https://rocm.docs.amd.com/projects/HIP/en/latest/index.html for more information.
(EngineCore pid=3325911) HIP kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(EngineCore pid=3325911) For debugging consider passing AMD_SERIALIZE_KERNEL=3
(EngineCore pid=3325911) Compile with `TORCH_USE_HIP_DSA` to enable device-side assertions.
(EngineCore pid=3325911)
[rank0]:[W625 14:59:32.481659036 ProcessGroupNCCL.cpp:1554] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```

resulting in the test `CUDA_VISIBLE_DEVICES=0 pytest tests/models/quantization/test_gpt_oss.py -s -vvvvv -k "test_gpt_oss_attention_quantization and amd/gpt-oss-20b-MoE-Quant-W-MXFP4-A-FP8-KV-FP8-0.89-1"` to fail on MI300, including in the CI at https://buildkite.com/vllm/amd-ci/builds/9942/list?sid=019efbda-6d6f-47fd-905e-6e75327748f2&tab=output.

@AndreasKaratzas @mawong-amd Why was this regression not detected in the CI of https://github.com/vllm-project/vllm/pull/46254 ?

## Test Plan

- `CUDA_VISIBLE_DEVICES=0 pytest tests/models/quantization/test_gpt_oss.py -s -vvvvv -k "test_gpt_oss_attention_quantization and amd/gpt-oss-20b-MoE-Quant-W-MXFP4-A-FP8-KV-FP8-0.89-1"`
- `CUDA_VISIBLE_DEVICES=1 pytest tests/models/quantization/test_nvfp4.py -s -vvvvv -k "test_nvfp4_moe and nvidia"`
- `CUDA_VISIBLE_DEVICES=0 pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx.txt` using `Qwen3-30B-A3B-NVFP4.yaml`

## Test Result

All passing on MI300.