### PR TITLE
[CI] Depend GPQA Eval DGX Spark job on arm64 image build

### DIFF
--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -226,6 +226,8 @@ steps:
   device: dgx-spark
   optional: true
   num_devices: 1
+  depends_on:
+  - arm64-image-build
   source_file_dependencies:
   - csrc/
   - vllm/model_executor/layers/quantization


### PR DESCRIPTION
DGX Spark is ARM, so the GPQA Eval job needs the arm64 CUDA image rather than the x86_64 `image-build` inherited from the group-level `depends_on`. The job-level `depends_on` overrides the group default, fixing the recurring nightly failure where the job runs before the arm64 image is ready.

AI assistance (Claude) was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)