### PR TITLE
[ROCm][Bugfix] Fix HIP fork re-init in multimodal offline examples

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1374,8 +1374,11 @@ steps:
     - python3 basic/offline_inference/score.py
     # Multi-modal models
     - python3 generate/multimodal/audio_language_offline.py --seed 0
-    - python3 generate/multimodal/vision_language_offline.py --seed 0
-    - python3 generate/multimodal/vision_language_multi_image_offline.py --seed 0
+    # These two examples import transformers before vllm, so on ROCm the HIP context
+    # is initialized in the parent before vllm sets this guard, poisoning fork. Set it
+    # inline to keep torch.cuda.is_available() fork-safe (see vllm/env_override.py).
+    - PYTORCH_NVML_BASED_CUDA_CHECK=1 python3 generate/multimodal/vision_language_offline.py --seed 0
+    - PYTORCH_NVML_BASED_CUDA_CHECK=1 python3 generate/multimodal/vision_language_multi_image_offline.py --seed 0
     - python3 generate/multimodal/encoder_decoder_multimodal_offline.py --model-type whisper --seed 0
     # Pooling models
     - python3 pooling/embed/vision_embedding_offline.py --seed 0
@@ -1817,7 +1820,10 @@ steps:
   - pytest -v -s tests/models/test_transformers.py
   - pytest -v -s tests/models/multimodal/test_mapping.py
   - python3 examples/basic/offline_inference/chat.py
-  - python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
+  # This example imports transformers before vllm, so on ROCm the HIP context is
+  # initialized in the parent before vllm sets this guard, poisoning fork. Set it
+  # inline to keep torch.cuda.is_available() fork-safe (see vllm/env_override.py).
+  - PYTORCH_NVML_BASED_CUDA_CHECK=1 python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
   - VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper
 
 #-------------------------------------------------------  mi300 · quantization  --------------------------------------------------------#
@@ -2893,8 +2899,11 @@ steps:
   - python3 basic/offline_inference/score.py
   # Multi-modal models
   - python3 generate/multimodal/audio_language_offline.py --seed 0
-  - python3 generate/multimodal/vision_language_offline.py --seed 0
-  - python3 generate/multimodal/vision_language_multi_image_offline.py --seed 0
+  # These two examples import transformers before vllm, so on ROCm the HIP context
+  # is initialized in the parent before vllm sets this guard, poisoning fork. Set it
+  # inline to keep torch.cuda.is_available() fork-safe (see vllm/env_override.py).
+  - PYTORCH_NVML_BASED_CUDA_CHECK=1 python3 generate/multimodal/vision_language_offline.py --seed 0
+  - PYTORCH_NVML_BASED_CUDA_CHECK=1 python3 generate/multimodal/vision_language_multi_image_offline.py --seed 0
   - python3 generate/multimodal/encoder_decoder_multimodal_offline.py --model-type whisper --seed 0
   # Pooling models
   - python3 pooling/embed/vision_embedding_offline.py --seed 0


### PR DESCRIPTION
## Purpose

The AMD/ROCm "Examples" CI step (`.buildkite/test-amd.yaml`, mi300 and mi355) fails with:

```
RuntimeError: Cannot re-initialize CUDA in forked subprocess.
```

`vision_language_offline.py` and `vision_language_multi_image_offline.py` import `transformers` before `vllm`. On ROCm, importing `transformers` calls `torch.cuda.is_available()`, which (default path) runs `cuInit` and creates a HIP context in the parent process ~@~T bb
efore `vllm` sets `PYTORCH_NVML_BASED_CUDA_CHECK=1` in `vllm/env_override.py`. That context poisons the default fork-based `EngineCore` launch.

**Fix:** set `PYTORCH_NVML_BASED_CUDA_CHECK=1` inline on just those two commands (the same value `import vllm` sets globally), routing the check through NVML so no context is created. Matches the existing inline `ENV=val ...` convention in this file; no example source changes.

## Test Plan

On MI300 (gfx942), run the two affected commands with the env var, and as a control without it:

```bash
cd examples
PYTORCH_NVML_BASED_CUDA_CHECK=1 python3 generate/multimodal/vision_language_offline.py --seed 0
PYTORCH_NVML_BASED_CUDA_CHECK=1 python3 generate/multimodal/vision_language_multi_image_offline.py --seed 0
```

## Test Result

- Without the env var: `RuntimeError: Cannot re-initialize CUDA in forked subprocess` (exit 1).
- With the env var: both exit 0 with valid generations.