### PR TITLE
[Frontend][Anthropic] Support cache_salt in the Anthropic Messages API

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -16,6 +16,7 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from vllm.entrypoints.anthropic.protocol import (
     AnthropicMessagesRequest,
@@ -1420,3 +1421,33 @@ class TestMessagesFullConverter:
         assert len(result.content) == 1
         assert result.content[0].type == "text"
         assert result.content[0].text == ""
+
+
+class TestCacheSaltPassthrough:
+    """cache_salt on the Anthropic Messages API must flow into the underlying
+    ChatCompletionRequest, mirroring the OpenAI route. See #46688."""
+
+    _messages = [{"role": "user", "content": "hi"}]
+
+    def test_cache_salt_field_accepted(self):
+        req = _make_request(self._messages, cache_salt="my-salt")
+        assert req.cache_salt == "my-salt"
+
+    def test_cache_salt_defaults_to_none(self):
+        assert _make_request(self._messages).cache_salt is None
+
+    def test_cache_salt_passed_to_chat_request(self):
+        req = _make_request(self._messages, cache_salt="abc123")
+        chat_req = AnthropicServingMessages._build_base_request(req, self._messages)
+        assert chat_req.cache_salt == "abc123"
+
+    def test_no_cache_salt_passed_as_none(self):
+        req = _make_request(self._messages)
+        chat_req = AnthropicServingMessages._build_base_request(req, self._messages)
+        assert chat_req.cache_salt is None
+
+    def test_empty_cache_salt_rejected_at_request_validation(self):
+        # Rejected by the request model (FastAPI -> 422) rather than falling
+        # through to a 500 from the Messages router.
+        with pytest.raises(ValidationError):
+            _make_request(self._messages, cache_salt="")

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -144,6 +144,17 @@ class AnthropicMessagesRequest(BaseModel):
             "Will be accessible by the template."
         ),
     )
+    cache_salt: str | None = Field(
+        default=None,
+        description=(
+            "If specified, the prefix cache will be salted with the provided "
+            "string to prevent an attacker to guess prompts in multi-user "
+            "environments. The salt should be random, protected from "
+            "access by 3rd parties, and long enough to be "
+            "unpredictable (e.g., 43 characters base64-encoded, corresponding "
+            "to 256 bit). Mirrors the OpenAI-compatible Chat Completions API."
+        ),
+    )
 
     @field_validator("model")
     @classmethod
@@ -157,6 +168,17 @@ class AnthropicMessagesRequest(BaseModel):
     def validate_max_tokens(cls, v):
         if v <= 0:
             raise ValueError("max_tokens must be positive")
+        return v
+
+    @field_validator("cache_salt")
+    @classmethod
+    def validate_cache_salt(cls, v):
+        # Reject at request-validation time (HTTP 422) instead of letting the
+        # empty string fall through to the ChatCompletionRequest validator,
+        # which would surface as a 500 from the Messages router. Mirrors the
+        # OpenAI route's non-empty requirement.
+        if v is not None and (not isinstance(v, str) or not v):
+            raise ValueError("cache_salt must be a non-empty string if provided.")
         return v
 
 

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -492,6 +492,7 @@ class AnthropicServingMessages(OpenAIServingChat):
             top_k=anthropic_request.top_k,
             kv_transfer_params=anthropic_request.kv_transfer_params,
             chat_template_kwargs=anthropic_request.chat_template_kwargs,
+            cache_salt=anthropic_request.cache_salt,
         )
 
     @classmethod


### PR DESCRIPTION
## Summary

Fixes #46688.

`cache_salt` (explicit prefix-cache isolation) is available on the
OpenAI-compatible Completions / Chat Completions routes but not on the Anthropic
Messages API. Anthropic-schema clients currently have to switch to the OpenAI
format just to get deterministic cache isolation in multi-tenant setups.

## Change

- Add `cache_salt: str | None` to `AnthropicMessagesRequest`, alongside the
  existing vLLM-specific `kv_transfer_params` / `chat_template_kwargs` fields.
- Pass it through `_build_base_request` into the `ChatCompletionRequest`, which
  already plumbs `cache_salt` into the prefix-cache hash — so behavior matches
  the OpenAI route exactly (no engine-side changes needed).
- A field validator rejects an empty `cache_salt` at request-validation time
  (HTTP 422) instead of letting it fall through to a 500 from the Messages
  router, mirroring the OpenAI route's non-empty requirement.
- `count_tokens` is intentionally left untouched (it only renders/counts).

## Tests

`tests/entrypoints/anthropic/test_anthropic_messages_conversion.py`
(`TestCacheSaltPassthrough`): field accepted / defaults to `None`; passthrough
into the built `ChatCompletionRequest`; `None` stays `None`; empty string is
rejected with a `ValidationError`. All pass locally.