### PR TITLE
[CI][Bugfix] Spawn engine in mm cache sleep test to fix ROCm HIP error

### DIFF
--- a/tests/multimodal/test_cache.py
+++ b/tests/multimodal/test_cache.py
@@ -32,6 +32,8 @@ from vllm.multimodal.inputs import (
 from vllm.multimodal.processing import PromptInsertion
 from vllm.utils.mem_constants import GiB_bytes, MiB_bytes
 
+from ..utils import create_new_process_for_each_test
+
 pytestmark = pytest.mark.cpu_test
 
 
@@ -559,6 +561,7 @@ _SLEEP_VISION_PROMPT = (
 )
 
 
+@create_new_process_for_each_test()
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="sleep mode regression requires a CUDA GPU",


### PR DESCRIPTION
## Purpose

`tests/multimodal/test_cache.py::test_sleep_wake_preserves_mm_cache_consistency` (added in #43001 as a regression test for #42995) fails on ROCm CI with:

```
torch.AcceleratorError: HIP error: invalid argument
  ... in current_platform.mem_get_info(device) -> cudaMemGetInfo(device)
  EngineCore failed to start.
RuntimeError: Engine core initialization failed.
```

Root cause: the test instantiates an `LLM`, which launches `EngineCore` via the default `VLLM_WORKER_MULTIPROC_METHOD=fork` start method. When the test runs after other tests in the same process (it is collected into the `cpu_test` multimodal CI step, where ~185 tests run first), the parent process already holds a live HIP context. The forked child inherits an invalid HIP context, so `init_device` -> `mem_get_info` fails immediately. Run in isolation the test passes, because no prior HIP context exists.

Fix: wrap the test in `create_new_process_for_each_test()`, which defaults to **spawn** on ROCm/XPU and **fork** on CUDA. This matches the existing sleep-mode tests in `tests/basic_correctness/test_mem.py`. NVIDIA behavior is unchanged (still fork).

This is not a duplicate: issue #42995 is closed, and no open PR addresses this ROCm test failure (the only PR referencing #42995, #44543, is unrelated audio+video cache work).

AI assistance (Claude) was used to investigate and implement this change. The diff is 3 lines and has been reviewed line-by-line.

## Test Plan

Exact CI command for the failing step (`.buildkite/test-amd.yaml`, "Async Engine, Inputs, Utils, Worker" / multimodal `cpu_test` lane):

```bash
pytest -v -s -m 'cpu_test' multimodal
```

Run on a ROCm gfx90a (MI250-class) machine, which matches the failing CI lane (`amdgfx90anightly`, `amdmi250`).

## Test Result

Before (on the current `main`):

```
FAILED multimodal/test_cache.py::test_sleep_wake_preserves_mm_cache_consistency
1 failed, 185 passed, 1 skipped, 190 deselected, 22 warnings
```

After (with this change):

```
186 passed, 1 skipped, 190 deselected, 21 warnings in 308.48s
```

Same `190 deselected` confirms identical test selection; the failure is resolved and no other tests regressed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

