### PR TITLE
[ROCm][CI] Don't force emulation MoE backend on plain-FP8 gpt-oss test

### DIFF
--- a/tests/models/quantization/test_gpt_oss.py
+++ b/tests/models/quantization/test_gpt_oss.py
@@ -104,9 +104,11 @@ def test_gpt_oss_attention_quantization(
 
     model_args = EvaluationConfig(model_name).get_model_args(tp_size)
 
-    # Emulation backend on MI300, MI250 is opt-in
-    # following https://github.com/vllm-project/vllm/pull/45896
-    if not on_gfx950():
+    # Emulation backend on MI300, MI250 is opt-in for the MX-weight models
+    # (no native MX MoE kernel there), following
+    # https://github.com/vllm-project/vllm/pull/45896. Plain FP8 models run
+    # natively and have no FP8 emulation path, so don't force it on them.
+    if not on_gfx950() and "MXFP4" in model_name:
         model_args["moe_backend"] = "emulation"
 
     extra_run_kwargs = {


### PR DESCRIPTION
Plain FP8 has no emulation path, so map_fp8_backend rejects
  moe_backend='emulation' and engine init crashes. Scope the override to
  MXFP4-weight models only.
