### PR TITLE
[Bugfix][Model] MiMo-V2: support TP > num_kv_heads for the fused FP8 QKV projection

### DIFF
--- a/tests/models/quantization/test_mimo_v2_qkv_shard.py
+++ b/tests/models/quantization/test_mimo_v2_qkv_shard.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit test for MiMo-V2 fused fp8 QKV sharding (_shard_fp8_qkv_proj).
+
+The Pro checkpoint stores the fused QKV as ``num_kv_heads`` block-fp8 stripes,
+one per KV head, each ordered ``[Q | K | V]``. This test builds such a
+checkpoint with a distinct, identifiable weight per head and verifies that
+``_shard_fp8_qkv_proj`` hands every TP rank exactly the heads it should own —
+for tp < num_kv_heads (groups merged), tp == num_kv_heads (plain chunk), and
+tp > num_kv_heads (KV heads replicated, Q heads sub-sharded).
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.models.mimo_v2 import _shard_fp8_qkv_proj
+
+# MiMo-V2.5-Pro attention shape.
+NUM_HEADS = 128
+NUM_KV = 8
+HEAD_DIM = 192  # qk head_dim
+V_HEAD_DIM = 128  # asymmetric v head_dim
+HIDDEN = 6144
+BLOCK = 128
+FP8 = torch.float8_e4m3fn
+
+Q_PER_GROUP = (NUM_HEADS // NUM_KV) * HEAD_DIM  # 3072
+ROWS_PER_GROUP = Q_PER_GROUP + HEAD_DIM + V_HEAD_DIM  # 3392
+
+
+def _head_block(seed: int, rows: int) -> torch.Tensor:
+    # Distinct unit-scale random matrix per head so heads are well separated
+    # under relative-L2 (~sqrt(2) apart), while a single fp8 round-trip is ~0.03.
+    g = torch.Generator().manual_seed(seed)
+    return torch.randn(rows, HIDDEN, generator=g)
+
+
+def _block_quant(w: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    # Block (128x128) fp8 quant matching the checkpoint export: per-block
+    # scale = amax / fp8_max (the dequant multiplier stored as weight_scale_inv);
+    # the final row/col block may be partial (the stripe is 3392 rows = 26.5
+    # blocks), which is exactly why scaled_quantize cannot build this.
+    rows, cols = w.shape
+    nr, nc = (rows + BLOCK - 1) // BLOCK, (cols + BLOCK - 1) // BLOCK
+    fp8_max = torch.finfo(FP8).max
+    wq = torch.zeros(rows, cols, dtype=torch.float32)
+    scale = torch.zeros(nr, nc, dtype=torch.float32)
+    for i in range(nr):
+        for j in range(nc):
+            r0, r1 = i * BLOCK, min((i + 1) * BLOCK, rows)
+            c0, c1 = j * BLOCK, min((j + 1) * BLOCK, cols)
+            blk = w[r0:r1, c0:c1]
+            s = blk.abs().max().clamp(min=1e-12) / fp8_max
+            scale[i, j] = s
+            wq[r0:r1, c0:c1] = blk / s
+    return wq.to(FP8), scale
+
+
+def _build_checkpoint():
+    """Return (w_full fp8, s_full) plus the float ground-truth head blocks.
+
+    Each stripe is quantized independently (as in the real checkpoint), so the
+    scale has ``ceil(ROWS_PER_GROUP / BLOCK) * NUM_KV`` rows.
+    """
+    src_q, src_k, src_v = {}, {}, {}
+    stripes_w, stripes_s = [], []
+    for g in range(NUM_KV):
+        rows = []
+        for j in range(NUM_HEADS // NUM_KV):
+            qh = g * (NUM_HEADS // NUM_KV) + j
+            src_q[qh] = _head_block(qh, HEAD_DIM)
+            rows.append(src_q[qh])
+        src_k[g] = _head_block(1000 + g, HEAD_DIM)
+        src_v[g] = _head_block(2000 + g, V_HEAD_DIM)
+        rows.append(src_k[g])
+        rows.append(src_v[g])
+        stripe = torch.cat(rows, dim=0)
+        w_g, s_g = _block_quant(stripe)
+        stripes_w.append(w_g)
+        stripes_s.append(s_g)
+    w_full = torch.cat(stripes_w, dim=0)
+    s_full = torch.cat(stripes_s, dim=0)
+    return w_full, s_full, src_q, src_k, src_v
+
+
+def _dequant(w_fp8: torch.Tensor, s: torch.Tensor) -> torch.Tensor:
+    se = s.repeat_interleave(BLOCK, 0).repeat_interleave(BLOCK, 1)
+    se = se[: w_fp8.shape[0], : w_fp8.shape[1]]
+    return w_fp8.to(torch.float32) * se
+
+
+def _best_match(block: torch.Tensor, src: dict) -> tuple[int, float]:
+    best_k, best_e = None, float("inf")
+    for k, ref in src.items():
+        e = (block - ref).norm().item() / ref.norm().item()
+        if e < best_e:
+            best_k, best_e = k, e
+    return best_k, best_e
+
+
+def _assert_heads(deq, off, rows, src, want_ids, kind, ctx):
+    """Assert each head-block at ``off`` matches its expected source head."""
+    tp_size, rank = ctx
+    for want in want_ids:
+        got, err = _best_match(deq[off : off + rows], src)
+        assert got == want and err < 0.1, (
+            f"tp{tp_size} r{rank} {kind} got {got} want {want} err {err:.3f}"
+        )
+        off += rows
+    return off
+
+
+def _expected_heads(tp_size: int, rank: int):
+    """Return (q_head_ids, k_head_ids, v_head_ids) this rank should own, in order."""
+    heads_per_group = NUM_HEADS // NUM_KV
+    if tp_size <= NUM_KV:
+        groups = range(rank * (NUM_KV // tp_size), (rank + 1) * (NUM_KV // tp_size))
+        q = [g * heads_per_group + j for g in groups for j in range(heads_per_group)]
+        k = list(groups)
+        v = list(groups)
+    else:
+        replicas = tp_size // NUM_KV
+        g = rank // replicas
+        sub = rank % replicas
+        q_per = heads_per_group // replicas
+        q = [g * heads_per_group + sub * q_per + j for j in range(q_per)]
+        k = [g]
+        v = [g]
+    return q, k, v
+
+
+@pytest.mark.parametrize("tp_size", [2, 4, 8, 16])
+def test_shard_fp8_qkv_proj_assigns_correct_heads(tp_size):
+    w_full, s_full, src_q, src_k, src_v = _build_checkpoint()
+
+    q_per_rank = NUM_HEADS // tp_size
+    kv_per_rank = max(1, NUM_KV // tp_size)
+    expected_rows = q_per_rank * HEAD_DIM + kv_per_rank * (HEAD_DIM + V_HEAD_DIM)
+
+    for rank in range(tp_size):
+        w_r, s_r = _shard_fp8_qkv_proj(
+            w_full,
+            s_full,
+            num_heads=NUM_HEADS,
+            num_kv_heads=NUM_KV,
+            head_dim=HEAD_DIM,
+            v_head_dim=V_HEAD_DIM,
+            tp_rank=rank,
+            tp_size=tp_size,
+        )
+        assert w_r.shape == (expected_rows, HIDDEN), (
+            f"tp={tp_size} rank={rank}: weight rows {w_r.shape[0]} != {expected_rows}"
+        )
+        deq = _dequant(w_r, s_r)
+        q_ids, k_ids, v_ids = _expected_heads(tp_size, rank)
+
+        ctx = (tp_size, rank)
+        off = _assert_heads(deq, 0, HEAD_DIM, src_q, q_ids, "Q", ctx)
+        off = _assert_heads(deq, off, HEAD_DIM, src_k, k_ids, "K", ctx)
+        off = _assert_heads(deq, off, V_HEAD_DIM, src_v, v_ids, "V", ctx)
+
+
+def test_shard_fp8_qkv_proj_replicates_kv_across_ranks():
+    """tp > num_kv_heads: ranks sharing a KV head get identical K/V but disjoint Q."""
+    tp_size = 16
+    w_full, s_full, *_ = _build_checkpoint()
+    # ranks 0 and 1 both own KV head 0.
+    outs = []
+    for rank in (0, 1):
+        w_r, s_r = _shard_fp8_qkv_proj(
+            w_full,
+            s_full,
+            num_heads=NUM_HEADS,
+            num_kv_heads=NUM_KV,
+            head_dim=HEAD_DIM,
+            v_head_dim=V_HEAD_DIM,
+            tp_rank=rank,
+            tp_size=tp_size,
+        )
+        outs.append(_dequant(w_r, s_r))
+    q_rows = (NUM_HEADS // tp_size) * HEAD_DIM
+    # K and V tail identical (replicated); Q heads disjoint (different slices).
+    torch.testing.assert_close(outs[0][q_rows:], outs[1][q_rows:])
+    assert not torch.allclose(outs[0][:q_rows], outs[1][:q_rows])

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -493,10 +493,55 @@ def _shard_fp8_qkv_proj(
     groups to float (dropping the block constraint), reorder the rows into the
     layout above (Q, K, and V then each span a whole number of blocks), and
     re-quantize to fp8.
+
+    When ``tp_size > num_kv_heads`` (more ranks than KV heads, the usual GQA
+    case at large TP) each KV head is shared by ``r = tp_size / num_kv_heads``
+    ranks. Such a rank owns ``1/r`` of its group's Q heads plus a *replicated*
+    copy of that group's single K and V head, i.e. ``[Q_sub | K | V]``. Because
+    a group's Q rows are block-aligned, ``Q_sub`` lands on whole blocks and the
+    K/V tail keeps its original blocks, so this rank's weight and scale are a
+    direct slice of the stored stripe -- no de-interleaving or re-quantization
+    (the per-rank row count is not a multiple of ``block``, so re-quantizing
+    would not be possible anyway).
     """
-    assert tp_size <= num_kv_heads and num_kv_heads % tp_size == 0, (
-        "TP size must evenly split the number of KV heads."
+    assert num_kv_heads % tp_size == 0 or tp_size % num_kv_heads == 0, (
+        "TP size and the number of KV heads must divide one another."
     )
+
+    q_rows_per_group = (num_heads // num_kv_heads) * head_dim
+    k_rows_per_group = head_dim
+    v_rows_per_group = v_head_dim
+    rows_per_group = q_rows_per_group + k_rows_per_group + v_rows_per_group
+    scale_rows_per_group = s_full.shape[0] // num_kv_heads
+
+    if tp_size > num_kv_heads:
+        # More TP ranks than KV heads: each KV head is replicated across
+        # ``replicas`` ranks, which split that group's Q heads between them.
+        # The rank's [Q_sub | K | V] is a direct slice of one stored stripe --
+        # Q_sub is a block-aligned sub-range of the group's Q rows and K/V are
+        # the stripe's tail (kept with their original blocks) -- so the fp8
+        # weight and its block scale can be sliced without re-quantizing.
+        replicas = tp_size // num_kv_heads
+        assert q_rows_per_group % replicas == 0, (
+            "Q heads per KV group must be divisible by tp_size / num_kv_heads."
+        )
+        q_rows_per_rank = q_rows_per_group // replicas
+        assert q_rows_per_group % block == 0 and q_rows_per_rank % block == 0, (
+            "Q rows per group and per rank must be multiples of the block size."
+        )
+        g_idx = tp_rank // replicas
+        sub = tp_rank % replicas
+        row0 = g_idx * rows_per_group
+        s0 = g_idx * scale_rows_per_group
+        q_blocks_per_rank = q_rows_per_rank // block
+        kv_block_start = q_rows_per_group // block
+        # Q sub-shard: a block-aligned slice of this group's Q weight and scale.
+        q_w = w_full[row0 + sub * q_rows_per_rank : row0 + (sub + 1) * q_rows_per_rank]
+        q_s = s_full[s0 + sub * q_blocks_per_rank : s0 + (sub + 1) * q_blocks_per_rank]
+        # Replicated K and V: the stripe's tail, kept with their original blocks.
+        kv_w = w_full[row0 + q_rows_per_group : row0 + rows_per_group]
+        kv_s = s_full[s0 + kv_block_start : s0 + scale_rows_per_group]
+        return torch.cat([q_w, kv_w], dim=0), torch.cat([q_s, kv_s], dim=0)
 
     kv_heads_per_rank = num_kv_heads // tp_size
     if kv_heads_per_rank == 1:
@@ -506,11 +551,6 @@ def _shard_fp8_qkv_proj(
         s = s_full.chunk(tp_size, dim=0)[tp_rank]
         return w, s
 
-    q_rows_per_group = (num_heads // num_kv_heads) * head_dim
-    k_rows_per_group = head_dim
-    v_rows_per_group = v_head_dim
-    rows_per_group = q_rows_per_group + k_rows_per_group + v_rows_per_group
-    scale_rows_per_group = s_full.shape[0] // num_kv_heads
     qs, ks, vs = [], [], []
     for g_idx in range(tp_rank * kv_heads_per_rank, (tp_rank + 1) * kv_heads_per_rank):
         row_start = g_idx * rows_per_group

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -492,10 +492,55 @@ def _shard_fp8_qkv_proj(
     groups to float (dropping the block constraint), reorder the rows into the
     layout above (Q, K, and V then each span a whole number of blocks), and
     re-quantize to fp8.
+
+    When ``tp_size > num_kv_heads`` (more ranks than KV heads, the usual GQA
+    case at large TP) each KV head is shared by ``r = tp_size / num_kv_heads``
+    ranks. Such a rank owns ``1/r`` of its group's Q heads plus a *replicated*
+    copy of that group's single K and V head, i.e. ``[Q_sub | K | V]``. Because
+    a group's Q rows are block-aligned, ``Q_sub`` lands on whole blocks and the
+    K/V tail keeps its original blocks, so this rank's weight and scale are a
+    direct slice of the stored stripe -- no de-interleaving or re-quantization
+    (the per-rank row count is not a multiple of ``block``, so re-quantizing
+    would not be possible anyway).
     """
-    assert tp_size <= num_kv_heads and num_kv_heads % tp_size == 0, (
-        "TP size must evenly split the number of KV heads."
+    assert num_kv_heads % tp_size == 0 or tp_size % num_kv_heads == 0, (
+        "TP size and the number of KV heads must divide one another."
     )
+
+    q_rows_per_group = (num_heads // num_kv_heads) * head_dim
+    k_rows_per_group = head_dim
+    v_rows_per_group = v_head_dim
+    rows_per_group = q_rows_per_group + k_rows_per_group + v_rows_per_group
+    scale_rows_per_group = s_full.shape[0] // num_kv_heads
+
+    if tp_size > num_kv_heads:
+        # More TP ranks than KV heads: each KV head is replicated across
+        # ``replicas`` ranks, which split that group's Q heads between them.
+        # The rank's [Q_sub | K | V] is a direct slice of one stored stripe --
+        # Q_sub is a block-aligned sub-range of the group's Q rows and K/V are
+        # the stripe's tail (kept with their original blocks) -- so the fp8
+        # weight and its block scale can be sliced without re-quantizing.
+        replicas = tp_size // num_kv_heads
+        assert q_rows_per_group % replicas == 0, (
+            "Q heads per KV group must be divisible by tp_size / num_kv_heads."
+        )
+        q_rows_per_rank = q_rows_per_group // replicas
+        assert q_rows_per_group % block == 0 and q_rows_per_rank % block == 0, (
+            "Q rows per group and per rank must be multiples of the block size."
+        )
+        g_idx = tp_rank // replicas
+        sub = tp_rank % replicas
+        row0 = g_idx * rows_per_group
+        s0 = g_idx * scale_rows_per_group
+        q_blocks_per_rank = q_rows_per_rank // block
+        kv_block_start = q_rows_per_group // block
+        # Q sub-shard: a block-aligned slice of this group's Q weight and scale.
+        q_w = w_full[row0 + sub * q_rows_per_rank : row0 + (sub + 1) * q_rows_per_rank]
+        q_s = s_full[s0 + sub * q_blocks_per_rank : s0 + (sub + 1) * q_blocks_per_rank]
+        # Replicated K and V: the stripe's tail, kept with their original blocks.
+        kv_w = w_full[row0 + q_rows_per_group : row0 + rows_per_group]
+        kv_s = s_full[s0 + kv_block_start : s0 + scale_rows_per_group]
+        return torch.cat([q_w, kv_w], dim=0), torch.cat([q_s, kv_s], dim=0)
 
     kv_heads_per_rank = num_kv_heads // tp_size
     if kv_heads_per_rank == 1:
@@ -505,11 +550,6 @@ def _shard_fp8_qkv_proj(
         s = s_full.chunk(tp_size, dim=0)[tp_rank]
         return w, s
 
-    q_rows_per_group = (num_heads // num_kv_heads) * head_dim
-    k_rows_per_group = head_dim
-    v_rows_per_group = v_head_dim
-    rows_per_group = q_rows_per_group + k_rows_per_group + v_rows_per_group
-    scale_rows_per_group = s_full.shape[0] // num_kv_heads
     qs, ks, vs = [], [], []
     for g_idx in range(tp_rank * kv_heads_per_rank, (tp_rank + 1) * kv_heads_per_rank):
         row_start = g_idx * rows_per_group

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -504,7 +504,10 @@ def _shard_fp8_qkv_proj(
     would not be possible anyway).
     """
     assert num_kv_heads % tp_size == 0 or tp_size % num_kv_heads == 0, (
-        "TP size and the number of KV heads must divide one another."
+        f"tp_size ({tp_size}) and num_kv_heads ({num_kv_heads}) must divide "
+        "one another: either tp_size divides num_kv_heads (TP evenly splits "
+        "the KV heads across ranks) or num_kv_heads divides tp_size (each KV "
+        "head is evenly replicated across TP ranks)."
     )
 
     q_rows_per_group = (num_heads // num_kv_heads) * head_dim

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -505,7 +505,10 @@ def _shard_fp8_qkv_proj(
     would not be possible anyway).
     """
     assert num_kv_heads % tp_size == 0 or tp_size % num_kv_heads == 0, (
-        "TP size and the number of KV heads must divide one another."
+        f"tp_size ({tp_size}) and num_kv_heads ({num_kv_heads}) must divide "
+        "one another: either tp_size divides num_kv_heads (TP evenly splits "
+        "the KV heads across ranks) or num_kv_heads divides tp_size (each KV "
+        "head is evenly replicated across TP ranks)."
     )
 
     q_rows_per_group = (num_heads // num_kv_heads) * head_dim

--- a/vllm/model_executor/models/mimo_v2_mtp.py
+++ b/vllm/model_executor/models/mimo_v2_mtp.py
@@ -45,7 +45,7 @@ from .interfaces import (
     SupportsMultiModal,
     _require_is_multimodal,
 )
-from .mimo_v2 import MiMoV2Attention, MiMoV2MLP
+from .mimo_v2 import MiMoV2Attention, MiMoV2MLP, _shard_fp8_qkv_proj
 from .utils import _merge_multimodal_embeddings, maybe_prefix
 
 # MiMo-V2 checkpoints contain multiple MTP layers, but vLLM currently supports
@@ -266,6 +266,8 @@ class MiMoV2MTP(nn.Module):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        # Buffers the fp8 fused qkv_proj weight/scale pair until both arrive.
+        pending_fp8_qkv_proj: dict[str, dict[str, torch.Tensor]] = {}
 
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
@@ -279,13 +281,49 @@ class MiMoV2MTP(nn.Module):
             ):
                 continue
 
-            # Support fused qkv_proj checkpoint (Pro format).
-            # The checkpoint is stored pre-sharded for TP=8 as
-            # [Q_rank0, K_rank0, V_rank0, Q_rank1, ...], so splitting along
-            # dim 0 with chunk(tp_size) gives each rank its Q+K+V slice for
-            # both the FP8 weight and the block weight_scale_inv. This matches
-            # how the main model loads the same layout.
+            # Support fused qkv_proj checkpoint (Pro format). The fused fp8
+            # weight and its block scale are stored as ``num_kv_heads`` stripes
+            # ``[Q | K | V]`` (one per KV head), so a plain ``chunk(tp_size)``
+            # only yields the right per-rank layout when tp_size == num_kv_heads.
+            # Reuse the main model's helper, which de-interleaves the stripes for
+            # any TP size (including tp_size > num_kv_heads, where K/V replicate).
             if "qkv_proj" in name:
+                is_weight = (
+                    name.endswith("qkv_proj.weight")
+                    and loaded_weight.dtype == torch.float8_e4m3fn
+                )
+                is_scale = name.endswith("qkv_proj.weight_scale_inv")
+                if is_weight or is_scale:
+                    prefix, qkv_kind = name.rsplit(".", 1)
+                    entry = pending_fp8_qkv_proj.setdefault(prefix, {})
+                    entry[qkv_kind] = loaded_weight
+                    if "weight" in entry and "weight_scale_inv" in entry:
+                        del pending_fp8_qkv_proj[prefix]
+                        attn = self.get_submodule(prefix.rsplit(".", 1)[0])
+                        w_rank, s_rank = _shard_fp8_qkv_proj(
+                            entry["weight"],
+                            entry["weight_scale_inv"],
+                            num_heads=attn.total_num_heads,
+                            num_kv_heads=attn.total_num_kv_heads,
+                            head_dim=attn.head_dim,
+                            v_head_dim=attn.v_head_dim,
+                            tp_rank=tp_rank,
+                            tp_size=tp_size,
+                        )
+                        for kind, tensor in (
+                            ("weight", w_rank),
+                            ("weight_scale_inv", s_rank),
+                        ):
+                            pname = f"{prefix}.{kind}"
+                            if pname not in params_dict:
+                                continue
+                            param = params_dict[pname]
+                            if tensor.shape[0] > param.shape[0]:
+                                tensor = tensor[: param.shape[0]]
+                            default_weight_loader(param, tensor)
+                            loaded_params.add(pname)
+                    continue
+                # Non-fp8 fused qkv: plain chunk (correct at tp == num_kv_heads).
                 if name in params_dict:
                     param = params_dict[name]
                     loaded_weight = loaded_weight.chunk(tp_size, dim=0)[tp_rank]


### PR DESCRIPTION
## Summary

The MiMo-V2 (Pro) loader cannot shard the fused FP8 `qkv_proj` when `tensor_parallel_size > num_kv_heads`:

- `mimo_v2.py::_shard_fp8_qkv_proj` asserts `tp_size <= num_kv_heads and num_kv_heads % tp_size == 0`.
- `mimo_v2_mtp.py` (the MTP draft) shards the fused weight with a plain `loaded_weight.chunk(tp_size, dim=0)[tp_rank]`, which only produces the correct per-rank layout when `tp_size == num_kv_heads`.

**MiMo-V2.5-Pro** has **128 Q heads / 8 KV heads** and ~1.02T params. On 80 GB H100s it cannot run at TP=8 (~120 GB/rank, OOM), so TP=16 is required — but TP=16 > 8 KV heads hits the assert above (and the MTP path shape-mismatches). **Net effect: the model is currently unservable on H100.** At TP16 the weight load fails with a shape error (`1696 vs 1856 rows`) because a fused stripe gets split mid-Q.

## Root cause

The checkpoint stores the fused QKV as `num_kv_heads` contiguous **stripes**, one per KV head, each ordered `[Q | K | V]`:

```
[Q_1 | K_1 | V_1 | Q_2 | K_2 | V_2 | ... | Q_n | K_n | V_n]   (n = num_kv_heads)
```

i.e. it is effectively pre-sharded for `TP = num_kv_heads`. The existing code handles `tp_size <= num_kv_heads` (one stripe per rank → plain chunk; multiple stripes per rank → dequantize, de-interleave, re-quantize, because the FP8 block scales straddle the K/V boundary). It has no path for `tp_size > num_kv_heads`, where each KV head must be **replicated** across `tp_size / num_kv_heads` ranks while its Q heads are split between them — i.e. standard GQA replication at large TP.

## Fix

- **`_shard_fp8_qkv_proj`**: relax the assert to require that `tp_size` and `num_kv_heads` divide one another, and add a `tp_size > num_kv_heads` branch. Each rank takes a `1/replicas` slice of its KV group's Q heads plus a replicated copy of that group's single K and V head (`[Q_sub | K | V]`). Because a group's Q rows are block-aligned, `Q_sub` lands on whole blocks and the K/V tail keeps its original blocks, so this is a **direct slice** of the stored FP8 weight and its block scale — no de-interleave or re-quantize. (Unlike the `g > 1` path, the per-rank row count here is not a multiple of the FP8 block size, so `scaled_quantize` could not produce it anyway.)
- **`mimo_v2_mtp.py`**: route the fused FP8 `qkv_proj` through the same `_shard_fp8_qkv_proj` helper (buffering the weight/scale pair) instead of the plain chunk, so the draft model shards correctly for any TP size. Non-FP8 fused QKV keeps the existing chunk fallback.

This is purely a weight-loading change; no runtime/forward behavior changes, and the `tp_size <= num_kv_heads` paths are unchanged.

## Test plan

- **New unit test** `tests/models/quantization/test_mimo_v2_qkv_shard.py`: builds a synthetic stripe-interleaved block-FP8 QKV checkpoint with a distinct, identifiable weight per head and asserts that every TP rank receives exactly the heads it should own, for `tp ∈ {2, 4, 8, 16}` (covering tp < / == / > num_kv_heads), plus an invariant that ranks sharing a KV head get identical (replicated) K/V and disjoint Q. Reconstruction error is a single FP8 round-trip (~0.03 rel-L2).
- **Real deployment**: MiMo-V2.5-Pro served on vLLM at **TP=16 across 16×H100** with this change — weights load (~61 GiB/rank), output is coherent, and throughput is ~1.8k tok/s with MTP spec-decode enabled.

> Note: the live run used this logic backported onto a `v0.21.0` build (its `_shard_fp8_qkv_proj` predates the dequant/requant refactor); this PR ports the same head-assignment onto main's current implementation. I have not run the full vLLM CI locally — please run CI.

## Relation to #42270

The `tp_size > num_kv_heads` support was first implemented by @amd-satre in #42270 (which also bundles SWA fixes and is stacked on the now-merged #41797). That PR has been stuck in `needs-rebase` since its base merged on 2026-06-11 and appears stalled. This PR is a **minimal, conflict-free re-implementation against current `main`** that fixes only the loader gap, so the FP8 model is servable again at large TP while #42270 is unblocked. Happy to close this in favor of a rebased #42270 if that lands first — full credit to @amd-satre for the original approach.
