### PR TITLE
[Bugfix][MRV2] Forward seq_lens_cpu_upper_bound for mamba hybrid models

### DIFF
--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -137,6 +137,7 @@ class MambaHybridModelState(DefaultModelState):
             block_tables=block_tables,
             slot_mappings=slot_mappings,
             kv_cache_config=kv_cache_config,
+            seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             model_specific_attn_metadata=mamba_attn_metadata,
             for_cudagraph_capture=for_capture,


### PR DESCRIPTION
`MambaHybridModelState.prepare_attn` computes `seq_lens_cpu_upper_bound` but never forwards it to `build_attn_metadata`, so the mamba metadata builder receives `None` and fails `assert seq_lens_cpu is not None` during warmup. This blocks the V2 model runner (`VLLM_USE_V2_MODEL_RUNNER=1`) from starting for any mamba/conv-hybrid model. 

This one-line fix passes the already-computed tensor through, enabling MRV2 for these models (e.g. LFM2).

**Testing:** `VLLM_USE_V2_MODEL_RUNNER=1 vllm serve LiquidAI/LFM2.5-230M` now starts and serves (previously crashed at warmup). GSM8K 5-shot accuracy validated at `0.257`

AI assistance (Claude) was used for this change.


---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/vllm/pr/46759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785007812&installation_id=142609222&pr_number=46759&repository=vllm-project%2Fvllm&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Fvllm%2Fpull%2F46759&signature=4d260ab3bc0b484500e25bd9e2aeafbae0264c4353e6ef36ddb3a491836a2dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/vllm/pr/46759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785007822&installation_id=142609222&pr_number=46759&repository=vllm-project%2Fvllm&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Fvllm%2Fpull%2F46759&signature=a482529f5f02e283d9825b816b0ae5faa409cfb6e02d4bcccb553e67e7db8c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->