### PR TITLE
[GDN] Improve UX when FlashInfer JIT compilation is happening

### DIFF
--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -51,6 +51,14 @@ def _create_workspace(
     """Create a flashinfer allreduce workspace, returning None on failure."""
     comm_backend = TorchDistBackend(group=group)
     rng_state = random.getstate()
+    from flashinfer.jit import env as fi_jit_env
+
+    logger.info_once(
+        "Creating FlashInfer allreduce workspace (backend=%s); cold "
+        "cache JIT-compile may take several minutes (cached under %s).",
+        backend,
+        fi_jit_env.FLASHINFER_JIT_DIR,
+    )
     try:
         random.seed(int.from_bytes(os.urandom(16), byteorder="big"))
         workspace = flashinfer_comm.create_allreduce_fusion_workspace(

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -231,11 +231,6 @@ def _log_gdn_backend_decision(
         requested_backend,
         head_k_dim,
     )
-    if active_backend == "flashinfer" and current_platform.is_device_capability(90):
-        logger.warning_once(
-            "FlashInfer GDN prefill is JIT-compiled; first run may take a "
-            "while. Set --gdn-prefill-backend triton to skip JIT.",
-        )
 
 
 def fi_chunk_gated_delta_rule(
@@ -1093,6 +1088,18 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if self._prefill_kernels_warmed_up:
             return
         self._prefill_kernels_warmed_up = True
+
+        if self.gdn_prefill_backend == "flashinfer":
+            from flashinfer.jit import env as fi_jit_env
+
+            logger.info_once(
+                "Warming up FlashInfer GDN prefill kernel (cold cache "
+                "JIT-compile may take several minutes; cached under %s). "
+                "Pass --additional-config "
+                "'{\"gdn_prefill_backend\":\"triton\"}' for faster cold "
+                "startup, potentially slower steady-state.",
+                fi_jit_env.FLASHINFER_JIT_DIR,
+            )
 
         device = qkv_or_qkvz.device
         dtype = qkv_or_qkvz.dtype


### PR DESCRIPTION
## Purpose

When deploying Qwen3.5 on a fresh H100 pod, I'm seeing the startup stalling after torch compile step has completed. It is caused by FlashInfer JIT-compilation of GDN kernels. Similar issue exists for allreduce. 

While we do have some message about FI GDN taking a while at first run, it appears much earlier in the logs from where the JIT compile is actually happening. I don't think this is a great UX and can lead people to think that vLLM has hung, since there is no message about what it is doing during these minutes. 

## Test Plan

```
vllm serve Qwen/Qwen3.5-35B-A3B        --tensor-parallel-size 4        --language-model-only        --max-model-len 131072        --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}'        --enable-prefix-caching
```

## Test Result

```
(Worker_TP0 pid=243689) INFO 06-25 20:11:01 [flashinfer_all_reduce.py:56] Creating FlashInfer allreduce workspace (backend=trtllm); cold cache JIT-compile may take several minutes (cached under /home/develop/.cache/flashinfer/0.6.12/90a/cached_ops).
...
(Worker_TP0 pid=243689) INFO 06-25 20:11:05 [qwen_gdn_linear_attn.py:1095] Warming up FlashInfer GDN prefill kernel (cold cache JIT-compile may take several minutes; cached under /home/develop/.cache/flashinfer/0.6.12/90a/cached_ops). Pass --additional-config '{"gdn_prefill_backend":"triton"}' for faster cold startup, potentially slower steady-state.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/vllm/pr/46764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785010559&installation_id=142609222&pr_number=46764&repository=vllm-project%2Fvllm&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Fvllm%2Fpull%2F46764&signature=15a655bafeb626a043d1c3cb6d00c090b265bf6860e5e148dc4d4a8ffef8ca32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->