### PR TITLE
fix: [Bug]: ModelOpt Llama-4 Checkpoints Take 5+ minutes to load

### DIFF
--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -525,6 +525,14 @@ class Llama4Model(LlamaModel):
                 # TODO: add EP support for non fused weights
                 pass
 
+            # The transpose, chunk, and expert indexing above leave
+            # new_loaded_weight as a non-contiguous CPU tensor. Copying a
+            # non-contiguous CPU tensor to the GPU is very slow (seconds per
+            # weight), so make it contiguous on the CPU first, which is a cheap
+            # CPU-side operation, before handing it to the weight loader.
+            if not new_loaded_weight.is_contiguous():
+                new_loaded_weight = new_loaded_weight.contiguous()
+
             # Load the weight into the module parameter with corresponding
             # shard id and expert id.
             weight_loader(


### PR DESCRIPTION
## Summary

ModelOpt Llama-4 (Scout/Maverick FP8) checkpoints store the MoE expert weights in a single fused tensor. In `Llama4Model.load_moe_expert_weights` (`vllm/model_executor/models/llama4.py`), the fused path transforms this tensor with a chain of view-only operations before loading: 1.


## Root cause

ModelOpt Llama-4 (Scout/Maverick FP8) checkpoints store the MoE expert weights
in a single fused tensor. In `Llama4Model.load_moe_expert_weights`
(`vllm/model_executor/models/llama4.py`), the fused path transforms this tensor
with a chain of view-only operations before loading:

1. `loaded_weight.transpose(-1, -2)` to match the parameter layout.
2. `chunk(2, dim=-2)` to split the fused `gate_up_proj` into gate/up.
3. `new_loaded_weight[local_expert_indices]` for expert-parallel selection.

All of these return non-contiguous views of the original CPU tensor. The result
is then passed to the fused MoE `weight_loader`, which ends in
`expert_data.copy_(loaded_weight)` (`fused_moe/routed_experts.py`). When the
destination `expert_data` lives on the GPU, this is a host-to-device copy of a
non-contiguous CPU tensor, which PyTorch performs very slowly (about 3-4 seconds
per weight). Across all expert weights this adds up to the reported 5+ minute
load time.


## What changed

File: `vllm/model_executor/models/llama4.py`

Right before the `weight_loader(...)` call in `load_moe_expert_weights`, make
`new_loaded_weight` contiguous on the CPU when it is not already:

```python
if not new_loaded_weight.is_contiguous():
 new_loaded_weight = new_loaded_weight.contiguous()
```

Making the tensor contiguous on the CPU is a cheap CPU-side gather. The
subsequent `copy_` then transfers a contiguous CPU buffer to the GPU, which is
fast. This keeps the gather on the CPU (as opposed to the issue author's
temporary hack of moving the whole tensor to the GPU first) and does not change
any loaded values. The guard avoids an unnecessary copy when the tensor is
already contiguous (e.g. some non-fused paths).


## Issue

Fixes #31624

Issue: https://github.com/vllm-project/vllm/issues/31624


## Diffstat

```
vllm/model_executor/models/llama4.py | 8 ++++++++
 1 file changed, 8 insertions(+)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.


---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/vllm/pr/46766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785011564&installation_id=142609222&pr_number=46766&repository=vllm-project%2Fvllm&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Fvllm%2Fpull%2F46766&signature=a03ebcb4ea88984b17871920bb10325be2b10d5cc68975fc9f4804c531a9e672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/vllm/pr/46766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785011573&installation_id=142609222&pr_number=46766&repository=vllm-project%2Fvllm&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Fvllm%2Fpull%2F46766&signature=b05038520c73ba7cdf9a3ca4d37435848bcdbfd6defb7a469ac149b38b552e80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->