### PR TITLE
[Model Runner V2][DFlash] Enable dflash attention backend selection

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
@@ -26,7 +26,9 @@ def load_dflash_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     draft_vllm_config = replace(
         vllm_config,
         attention_config=replace(
-            vllm_config.attention_config, use_non_causal=not causal
+            vllm_config.attention_config,
+            use_non_causal=not causal,
+            backend=speculative_config.attention_backend,
         ),
     )
     with set_model_tag("dflash_head"):


### PR DESCRIPTION
# Context
Currently, the speculative config's attention backend is not applied to the DFlash drfat model in Model Runner V2. The consequence is that if the attention backend defaults to FlashInfer, I get the error:
```
EngineCore pid=1280660)   File "/home/gdelfin/vllm/vllm/v1/executor/multiproc_executor.py", line 402, in collective_rpc
(EngineCore pid=1280660)     return future if non_block else future.result()
(EngineCore pid=1280660)                                     ^^^^^^^^^^^^^^^
(EngineCore pid=1280660)   File "/home/gdelfin/vllm/vllm/v1/executor/multiproc_executor.py", line 91, in result
(EngineCore pid=1280660)     return super().result()
(EngineCore pid=1280660)            ^^^^^^^^^^^^^^^^
(EngineCore pid=1280660)   File "/home/gdelfin/.local/share/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/concurrent/futures/_base.py", line 449, in result
(EngineCore pid=1280660)     return self.__get_result()
(EngineCore pid=1280660)            ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1280660)   File "/home/gdelfin/.local/share/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(EngineCore pid=1280660)     raise self._exception
(EngineCore pid=1280660)   File "/home/gdelfin/vllm/vllm/v1/executor/multiproc_executor.py", line 95, in _wait_for_response
(EngineCore pid=1280660)     response = self.aggregate(self.get_response())
(EngineCore pid=1280660)                               ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1280660)   File "/home/gdelfin/vllm/vllm/v1/executor/multiproc_executor.py", line 391, in get_response
(EngineCore pid=1280660)     raise RuntimeError(
(EngineCore pid=1280660) RuntimeError: Worker failed with error 'FlashInfer backend currently does not support attention sinks, please use trtllm on blackwell or flash attention on earlier GPUs.', please check the stack trace above for the root cause
```

Currently, DFlash only supports flash attention, so we need a way to override it via the speculative config.

# This PR
Simply passes the speculative config attention backend to the DFlash draft model attention config.

Verified that I can serve MiMo + DFlash in Model Runner V2 using this command:
```
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash \
  --tensor-parallel-size 4 \
  --trust-remote-code \
  --gpu-memory-utilization 0.95 \
  --max-num-seqs 64 \
  --max-model-len auto \
  --reasoning-parser mimo \
  --tool-call-parser mimo \
  --enable-auto-tool-choice \
  --generation-config vllm \
  --no-enable-prefix-caching \
  --speculative_config '{"method":"dflash","model":"<path_to_dflash>","num_speculative_tokens":8,"attention_backend":"FLASH_ATTN"}'
```


---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/vllm/pr/46770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785014267&installation_id=142609222&pr_number=46770&repository=vllm-project%2Fvllm&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Fvllm%2Fpull%2F46770&signature=ab8d81f8f24bfb6f2b988ac2aba764f2e6b76eb4b5cfbb5608f225955bc12c35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/vllm/pr/46770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785014276&installation_id=142609222&pr_number=46770&repository=vllm-project%2Fvllm&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Fvllm%2Fpull%2F46770&signature=38326def0a0e149a97c1ebfdad83da1d3fb88b3dff0ec113b65a4f619f17edb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->