### PR TITLE
[Model] Gemma-4 MoE: implement get_expert_mapping for LoRA

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1373,16 +1373,9 @@ class Gemma4Model(nn.Module, EagleModelMixin):
         #   moe.experts.{id}.gate_proj → FusedMoE w1 (shard of w13)
         #   moe.experts.{id}.up_proj   → FusedMoE w3 (shard of w13)
         #   moe.experts.{id}.down_proj → FusedMoE w2
-        num_experts = getattr(self.config, "num_experts", None) or 0
         # Strategy A: dot-separated suffix
         # (standard AWQ/GPTQ e.g. .qweight, .scales, .weight)
-        dot_suffix_expert_params_mapping = fused_moe_make_expert_params_mapping(
-            self,
-            ckpt_gate_proj_name="gate_proj",
-            ckpt_down_proj_name="down_proj",
-            ckpt_up_proj_name="up_proj",
-            num_experts=num_experts,
-        )
+        dot_suffix_expert_params_mapping = self.get_expert_mapping()
         # Strategy B: underscore-separated suffix
         # (CompressedTensors-format AWQ/W4A16 _packed, _scale)
         underscore_suffix_expert_params_mapping = [

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1497,6 +1497,17 @@ class Gemma4Model(nn.Module, EagleModelMixin):
 
         return loaded_params
 
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        num_experts = getattr(self.config, "num_experts", None) or 0
+        return fused_moe_make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=num_experts,
+            num_redundant_experts=getattr(self, "num_redundant_experts", 0),
+        )
+
 
 class Gemma4ForCausalLM(
     nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts, SupportsEagle3
@@ -1714,3 +1725,6 @@ class Gemma4ForCausalLM(
 
         loader = AutoWeightsLoader(self, skip_substrs=skip)
         return loader.load_weights(_weight_iterator())
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return self.model.get_expert_mapping()

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1708,3 +1708,6 @@ class Gemma4ForConditionalGeneration(
         if modality == "video":
             return "<|video|>"
         raise ValueError(f"Unsupported modality: {modality}")
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return self.language_model.get_expert_mapping()


### PR DESCRIPTION
## Purpose
Serving `gemma-4-26B-A4B` MoE (non-diffusion) with `--enable-lora` crashes at engine init:
`To support LoRA for MoE model, 'get_expert_mapping' must be implemented`.
Issue #39246 added LoRA for the dense Gemma-4 (`Gemma4ForCausalLM`), but the MoE
expert-mapping hook was never wired, so LoRA is unusable on the A4B MoE.

This mirrors `qwen3_moe.py`: implement `get_expert_mapping` on `Gemma4Model` via
`fused_moe_make_expert_params_mapping`, delegated from `Gemma4ForCausalLM` and
`Gemma4ForConditionalGeneration`. Dense variants are unaffected (`num_experts → 0
→ empty mapping`).

## Test Plan
Served `gemma-4-26B-A4B` (W4A16) with `--enable-lora --max-loras 2 --max-lora-rank 16`,
loaded two fine-tuned expert-layer LoRA adapters via `/v1/load_lora_adapter`, and ran
inference routed per request (`model=<adapter>`).
Base: [cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit](https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit).

## Test Result
Both adapters load and per-request routing applies the correct adapter.

No get_expert_mapping unit tests existed for other models so I left it out.


---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/vllm/pr/46772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785016104&installation_id=142609222&pr_number=46772&repository=vllm-project%2Fvllm&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Fvllm%2Fpull%2F46772&signature=7c710a7d197820ca668c5c56eb6709b5012db65a58407cc7dfcf9f580783cfff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/vllm/pr/46772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785016116&installation_id=142609222&pr_number=46772&repository=vllm-project%2Fvllm&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Fvllm%2Fpull%2F46772&signature=1095b5c4d20ddde73a3c31e8a64abfb0667241489970713193034bb3b39519d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->