### PR TITLE
[Docs][Core] Document Mamba/hybrid prefix caching and surface how to enable it

### DIFF
--- a/docs/usage/v1_guide.md
+++ b/docs/usage/v1_guide.md
@@ -130,7 +130,18 @@ Hybrid models that combine Mamba-2 and Mamba-1 layers with standard attention la
 
 Hybrid models with mechanisms different to Mamba are also supported (e.g, `Lfm2ForCausalLM`).
 
-Please note that prefix caching is not yet supported for any of the above models.
+Prefix caching for the recurrent (Mamba/SSM/GDN) layers of these models is supported, but is
+**experimental and disabled by default**. Enable it with `--enable-prefix-caching`; the Mamba cache
+mode is then selected automatically (`all` for models that support it, otherwise `align`), or you
+can set it explicitly with `--mamba-cache-mode`. The `align` mode requires chunked prefill, which is
+enabled by default for generative models. For example, to serve Qwen3-Next with prefix caching:
+
+```bash
+vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct \
+    --enable-prefix-caching \
+    --mamba-cache-mode align \
+    --enable-chunked-prefill
+```
 
 #### Encoder-Decoder Models
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -459,6 +459,14 @@ class MambaModelConfig(VerifyAndUpdateConfig):
                 )
             if cache_config.mamba_block_size is None:
                 cache_config.mamba_block_size = model_config.max_model_len
+            logger.info_once(
+                "Prefix caching is disabled for this Mamba/hybrid model. It is "
+                "supported (experimental) for the recurrent layers and can be "
+                "enabled with --enable-prefix-caching, which uses Mamba cache "
+                "'%s' mode and requires chunked prefill (on by default for "
+                "generative models).",
+                "all" if model_config.supports_mamba_prefix_caching else "align",
+            )
 
 
 class NemotronHForCausalLMConfig(VerifyAndUpdateConfig):


### PR DESCRIPTION
## Purpose

Prefix caching for the recurrent (Mamba/SSM/GDN) layers of hybrid models such as
Qwen3-Next is already supported via `--enable-prefix-caching` (which selects
`mamba_cache_mode=align` for models that don't support `all` mode), but it is
effectively undiscoverable:

- `docs/usage/v1_guide.md` states *"prefix caching is not yet supported for any of
  the above models"* — no longer accurate, and it directly contradicts the working
  feature.
- When a Mamba/hybrid model starts with prefix caching disabled, nothing hints that
  it can be enabled.

This is the core ask in #25874 (10+ user requests, several reporting the model is
"unusable" without prefix caching). This PR closes the documentation/discoverability
gap **without changing any defaults**:

1. Rewrites the stale note in `docs/usage/v1_guide.md` to explain that prefix caching
   is supported (experimental, opt-in) for Mamba/hybrid models, how `mamba_cache_mode`
   is selected (`all` for models that support it, otherwise `align`), that `align`
   requires chunked prefill, and adds a copy-pasteable Qwen3-Next example.
2. Adds a single one-time `logger.info_once` in
   `MambaModelConfig.verify_and_update_config` (the shared config path every
   Mamba/hybrid model passes through) that, when prefix caching is disabled, tells the
   user it can be enabled and names the mode that would be selected.

Prefix caching remains **opt-in** for hybrid models; no default behavior changes.

This intentionally does **not** implement `all`-mode prefix caching for Qwen3-Next
(a larger GDN-kernel feature) — see *Relationship to other PRs* below.

## Test Plan

- Run the project's pre-commit hooks on the changed files.
- A config-level check that the new hint fires **only** when prefix caching is disabled
  and names the correct mode (`align` for Qwen3-Next, `all` for models exposing
  `supports_mamba_prefix_caching`).
- Runtime correctness of align-mode APC for Qwen3-Next is already covered by the
  existing e2e test `tests/v1/e2e/general/test_mamba_prefix_cache.py`
  (`Qwen/Qwen3-Next-80B-A3B-Instruct-FP8`), which this PR does not modify.

## Test Result

- `pre-commit run --files vllm/model_executor/models/config.py docs/usage/v1_guide.md`
  → all hooks pass: ruff check, ruff format, typos, markdownlint-cli2, mypy, SPDX
  headers, config validation.
- Config-level check (no GPU/weights needed): calling
  `MambaModelConfig.verify_and_update_config` with prefix caching off emits the hint
  and names `align` for Qwen3-Next / `all` for models that support it; with prefix
  caching on, the hint is silent. ✅
- I do not have GPU hardware to run the e2e suite locally and am relying on project CI
  for `tests/v1/e2e/general/test_mamba_prefix_cache.py`.

## Relationship to other PRs (no duplication)

- **#46048** *(`[Model][GDN] Add prefix caching support for 'all' mode in Qwen3.5`)* —
  targets Qwen3.5 and implements `all`-mode GDN state. Different model, different
  feature; this PR is docs + align-mode discoverability.
- **#26807** *(`[V1][Hybrid] GatedDeltaNet Automatic Prefix Caching ('all'-mode)`)* —
  general GDN `all`-mode work.
- No open PR references #25874 or addresses the docs/discoverability gap.

## AI assistance

This change was prepared with AI assistance (Claude Code). The submitter is accountable
for it per the repository's contribution policy and has reviewed the diff and the local
test results above.

Addresses #25874.
