### PR TITLE
fix(responses): unflatten namespace tool names before returning function calls

### DIFF
--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -40,6 +40,11 @@ from vllm.entrypoints.openai.responses.protocol import (
     ResponseInputOutputItem,
     ResponsesRequest,
 )
+from vllm.entrypoints.openai.responses.utils import (
+    extract_instructions_from_messages,
+    has_custom_tools,
+    unflatten_tool_name,
+)
 from vllm.logger import init_logger
 from vllm.utils import random_uuid
 
@@ -312,11 +317,13 @@ def _parse_function_call(message: Message, recipient: str) -> list[ResponseOutpu
     output_items = []
     for content in message.content:
         random_id = random_uuid()
+        unflattened_name, namespace = unflatten_tool_name(function_name)
         response_item = ResponseFunctionToolCall(
             arguments=content.text,
             call_id=f"call_{random_id}",
             type="function_call",
-            name=function_name,
+            name=unflattened_name,
+            namespace=namespace,
             id=f"fc_{random_id}",
         )
         output_items.append(response_item)
@@ -485,12 +492,14 @@ def parser_state_to_response_output(
     if current_recipient:
         if is_function_recipient(current_recipient, function_tool_names):
             rid = random_uuid()
+            unflattened_name, namespace = unflatten_tool_name(extract_function_from_recipient(current_recipient))
             return [
                 ResponseFunctionToolCall(
                     arguments=parser.current_content,
                     call_id=f"call_{rid}",
                     type="function_call",
-                    name=extract_function_from_recipient(current_recipient),
+                    name=unflattened_name,
+                    namespace=namespace,
                     id=f"fc_{rid}",
                     status="in_progress",
                 )

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -311,13 +311,13 @@ def _parse_browser_tool_call(message: Message, recipient: str) -> ResponseOutput
     )
 
 
-def _parse_function_call(message: Message, recipient: str) -> list[ResponseOutputItem]:
+def _parse_function_call(message: Message, recipient: str, tools: list[Any] | None = None) -> list[ResponseOutputItem]:
     """Parse function calls into function tool call items."""
     function_name = extract_function_from_recipient(recipient)
     output_items = []
     for content in message.content:
         random_id = random_uuid()
-        unflattened_name, namespace = unflatten_tool_name(function_name)
+        unflattened_name, namespace = unflatten_tool_name(function_name, tools)
         response_item = ResponseFunctionToolCall(
             arguments=content.text,
             call_id=f"call_{random_id}",
@@ -434,6 +434,7 @@ def _parse_message_no_recipient(
 def harmony_to_response_output(
     message: Message,
     function_tool_names: frozenset[str] | None = None,
+    tools: list[Any] | None = None,
 ) -> list[ResponseOutputItem]:
     """Parse a Harmony message into a list of output response items.
 
@@ -455,7 +456,7 @@ def harmony_to_response_output(
 
         # Function calls (with or without "functions." prefix)
         elif is_function_recipient(recipient, function_tool_names):
-            output_items.extend(_parse_function_call(message, recipient))
+            output_items.extend(_parse_function_call(message, recipient, tools))
 
         # Built-in MCP tools (python, browser, container)
         elif recipient in BUILTIN_TOOL_TO_MCP_SERVER_LABEL:
@@ -475,6 +476,7 @@ def harmony_to_response_output(
 def parser_state_to_response_output(
     parser: StreamableParser,
     function_tool_names: frozenset[str] | None = None,
+    tools: list[Any] | None = None,
 ) -> list[ResponseOutputItem]:
     """Extract in-progress response items from incomplete parser state.
 
@@ -492,7 +494,7 @@ def parser_state_to_response_output(
     if current_recipient:
         if is_function_recipient(current_recipient, function_tool_names):
             rid = random_uuid()
-            unflattened_name, namespace = unflatten_tool_name(extract_function_from_recipient(current_recipient))
+            unflattened_name, namespace = unflatten_tool_name(extract_function_from_recipient(current_recipient), tools)
             return [
                 ResponseFunctionToolCall(
                     arguments=parser.current_content,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1069,6 +1069,7 @@ class OpenAIServingResponses(OpenAIServing):
                 content=content,
                 tool_calls=tool_calls,
                 logprobs=logprobs,
+                tools=request.tools,
             )
 
         # Fallback when no parser is configured
@@ -1099,9 +1100,9 @@ class OpenAIServingResponses(OpenAIServing):
         num_init_messages = context.num_init_messages
         fn_names = context.function_tool_names
         for msg in context.messages[num_init_messages:]:
-            output_items.extend(harmony_to_response_output(msg, fn_names))
+            output_items.extend(harmony_to_response_output(msg, fn_names, tools=context.request.tools))
         # Handle the generation stopped in the middle (if any).
-        last_items = parser_state_to_response_output(context.parser, fn_names)
+        last_items = parser_state_to_response_output(context.parser, fn_names, tools=context.request.tools)
         if last_items:
             output_items.extend(last_items)
         return output_items
@@ -1350,7 +1351,7 @@ class OpenAIServingResponses(OpenAIServing):
             [StreamingResponsesResponse], StreamingResponsesResponse
         ],
     ) -> AsyncGenerator[StreamingResponsesResponse, None]:
-        processor = SimpleStreamingEventProcessor()
+        processor = SimpleStreamingEventProcessor(tools=request.tools)
 
         def _get_logprobs(
             output: CompletionOutput,
@@ -1431,7 +1432,7 @@ class OpenAIServingResponses(OpenAIServing):
                 if len(ctx.parser.messages) > 0:
                     previous_item = ctx.parser.messages[-1]
                     for event in emit_previous_item_done_events(
-                        previous_item, state, ctx.function_tool_names
+                        previous_item, state, ctx.function_tool_names, tools=ctx.request.tools
                     ):
                         yield _increment_sequence_number_and_return(event)
                 state.reset_for_new_item()

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -72,6 +72,7 @@ from vllm.entrypoints.openai.responses.protocol import (
     ResponseReasoningPartDoneEvent,
     StreamingResponsesResponse,
 )
+from vllm.entrypoints.openai.responses.utils import unflatten_tool_name
 from vllm.outputs import CompletionOutput
 from vllm.utils import random_uuid
 
@@ -249,8 +250,10 @@ def emit_function_call_delta_events(
         state.is_first_function_call_delta = True
         state.current_item_id = f"fc_{random_uuid()}"
         state.current_call_id = f"call_{random_uuid()}"
+        unflattened_name, namespace = unflatten_tool_name(function_name)
         tool_call_item = ResponseFunctionToolCall(
-            name=function_name,
+            name=unflattened_name,
+            namespace=namespace,
             type="function_call",
             id=state.current_item_id,
             call_id=state.current_call_id,
@@ -476,12 +479,13 @@ def emit_function_call_done_events(
     state: StreamingState,
 ) -> list[StreamingResponsesResponse]:
     """Emit events when a function call completes."""
+    unflattened_name, namespace = unflatten_tool_name(function_name)
     events: list[StreamingResponsesResponse] = []
     events.append(
         ResponseFunctionCallArgumentsDoneEvent(
             type="response.function_call_arguments.done",
             arguments=arguments,
-            name=function_name,
+            name=unflattened_name,
             item_id=state.current_item_id,
             output_index=state.current_output_index,
             sequence_number=-1,
@@ -490,7 +494,8 @@ def emit_function_call_done_events(
     function_call_item = ResponseFunctionToolCall(
         type="function_call",
         arguments=arguments,
-        name=function_name,
+        name=unflattened_name,
+        namespace=namespace,
         id=state.current_item_id,
         output_index=state.current_output_index,
         sequence_number=-1,
@@ -832,6 +837,7 @@ class SimpleStreamingState:
     accumulated_text: str = ""
     tool_call_id: str = ""
     tool_call_name: str = ""
+    tool_call_namespace: str | None = None
     tool_call_index: int | None = None
     has_emitted_tool_call_delta: bool = False
     current_state: _StateType = field(default_factory=lambda: _StateType.NONE)
@@ -1037,7 +1043,9 @@ def emit_simple_tool_call_open(
     state.current_state = _StateType.TOOL_CALL
     state.current_item_id = random_uuid()
     state.tool_call_id = f"call_{random_uuid()}"
-    state.tool_call_name = name
+    unflattened_name, namespace = unflatten_tool_name(name)
+    state.tool_call_name = unflattened_name
+    state.tool_call_namespace = namespace
     state.tool_call_index = index
     state.accumulated_text = ""
     state.has_emitted_tool_call_delta = False
@@ -1050,7 +1058,8 @@ def emit_simple_tool_call_open(
                 type="function_call",
                 id=state.current_item_id,
                 call_id=state.tool_call_id,
-                name=name,
+                name=state.tool_call_name,
+                namespace=state.tool_call_namespace,
                 arguments="",
                 status="in_progress",
             ),
@@ -1098,6 +1107,7 @@ def emit_simple_tool_call_done(
             item=ResponseFunctionToolCall(
                 type="function_call",
                 name=state.tool_call_name,
+                namespace=state.tool_call_namespace,
                 arguments=state.accumulated_text,
                 status="completed",
                 id=state.current_item_id,

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -243,6 +243,7 @@ def emit_function_call_delta_events(
     delta: str,
     function_name: str,
     state: StreamingState,
+    tools: list[Any] | None = None,
 ) -> list[StreamingResponsesResponse]:
     """Emit events for function call argument deltas."""
     events: list[StreamingResponsesResponse] = []
@@ -250,7 +251,7 @@ def emit_function_call_delta_events(
         state.is_first_function_call_delta = True
         state.current_item_id = f"fc_{random_uuid()}"
         state.current_call_id = f"call_{random_uuid()}"
-        unflattened_name, namespace = unflatten_tool_name(function_name)
+        unflattened_name, namespace = unflatten_tool_name(function_name, tools)
         tool_call_item = ResponseFunctionToolCall(
             name=unflattened_name,
             namespace=namespace,
@@ -477,9 +478,10 @@ def emit_function_call_done_events(
     function_name: str,
     arguments: str,
     state: StreamingState,
+    tools: list[Any] | None = None,
 ) -> list[StreamingResponsesResponse]:
     """Emit events when a function call completes."""
-    unflattened_name, namespace = unflatten_tool_name(function_name)
+    unflattened_name, namespace = unflatten_tool_name(function_name, tools)
     events: list[StreamingResponsesResponse] = []
     events.append(
         ResponseFunctionCallArgumentsDoneEvent(
@@ -588,7 +590,7 @@ def emit_content_delta_events(
         fn_names = ctx.function_tool_names
         if is_function_recipient(recipient, fn_names):
             function_name = extract_function_from_recipient(recipient)
-            return emit_function_call_delta_events(delta, function_name, state)
+            return emit_function_call_delta_events(delta, function_name, state, ctx.request.tools)
         elif recipient == "python":
             return emit_code_interpreter_delta_events(delta, state)
         elif recipient.startswith("mcp.") or is_mcp_tool_by_namespace(
@@ -603,6 +605,7 @@ def emit_previous_item_done_events(
     previous_item: HarmonyMessage,
     state: StreamingState,
     function_tool_names: frozenset[str] | None = None,
+    tools: list[Any] | None = None,
 ) -> list[StreamingResponsesResponse]:
     """Emit done events for the previous item when expecting a new start.
 
@@ -614,7 +617,7 @@ def emit_previous_item_done_events(
         # Deal with tool call
         if is_function_recipient(previous_item.recipient, function_tool_names):
             function_name = extract_function_from_recipient(previous_item.recipient)
-            return emit_function_call_done_events(function_name, text, state)
+            return emit_function_call_done_events(function_name, text, state, tools)
         elif previous_item.recipient == "python":
             return emit_code_interpreter_completion_events(previous_item, state)
         elif (
@@ -1039,11 +1042,12 @@ def emit_simple_tool_call_open(
     state: SimpleStreamingState,
     name: str,
     index: int | None,
+    tools: list[Any] | None = None,
 ) -> list[StreamingResponsesResponse]:
     state.current_state = _StateType.TOOL_CALL
     state.current_item_id = random_uuid()
     state.tool_call_id = f"call_{random_uuid()}"
-    unflattened_name, namespace = unflatten_tool_name(name)
+    unflattened_name, namespace = unflatten_tool_name(name, tools)
     state.tool_call_name = unflattened_name
     state.tool_call_namespace = namespace
     state.tool_call_index = index
@@ -1193,8 +1197,9 @@ class SimpleStreamingEventProcessor:
         ),
     }
 
-    def __init__(self, state: SimpleStreamingState | None = None) -> None:
+    def __init__(self, state: SimpleStreamingState | None = None, tools: list[Any] | None = None) -> None:
         self.state = state or SimpleStreamingState()
+        self.tools = tools
 
     def resolve_target_state(
         self, delta_message: DeltaMessage
@@ -1252,7 +1257,7 @@ class SimpleStreamingEventProcessor:
         if target_state == _StateType.TOOL_CALL:
             assert tool_call is not None
             return handlers.open_fn(
-                self.state, tool_call.function.name, tool_call.index
+                self.state, tool_call.function.name, tool_call.index, self.tools
             )
         return handlers.open_fn(self.state)
 

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -40,6 +40,13 @@ from vllm.utils import random_uuid
 logger = init_logger(__name__)
 
 
+def unflatten_tool_name(function_name: str) -> tuple[str, str | None]:
+    if "__" in function_name:
+        parts = function_name.rsplit("__", 1)
+        if len(parts) == 2:
+            return parts[1], parts[0]
+    return function_name, None
+
 def build_response_output_items(
     reasoning: str | None,
     content: str | None,
@@ -88,7 +95,8 @@ def build_response_output_items(
                     or make_tool_call_id(func_name=tool_call.name, idx=idx),
                     type="function_call",
                     status="completed",
-                    name=tool_call.name,
+                    name=unflatten_tool_name(tool_call.name)[0],
+                    namespace=unflatten_tool_name(tool_call.name)[1],
                     arguments=tool_call.arguments,
                 )
             )

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -40,11 +40,20 @@ from vllm.utils import random_uuid
 logger = init_logger(__name__)
 
 
-def unflatten_tool_name(function_name: str) -> tuple[str, str | None]:
-    if "__" in function_name:
-        parts = function_name.rsplit("__", 1)
-        if len(parts) == 2:
-            return parts[1], parts[0]
+def unflatten_tool_name(
+    function_name: str,
+    tools: list[Any] | None = None,
+) -> tuple[str, str | None]:
+    if tools is not None:
+        for tool in tools:
+            tool_type = tool.get("type") if isinstance(tool, dict) else getattr(tool, "type", None)
+            if tool_type == "namespace":
+                namespace_name = tool.get("name") if isinstance(tool, dict) else getattr(tool, "name", "")
+                namespace_tools = tool.get("tools") if isinstance(tool, dict) else getattr(tool, "tools", [])
+                for subtool in namespace_tools:
+                    sub_name = subtool.get("name") if isinstance(subtool, dict) else getattr(subtool, "name", "")
+                    if function_name == f"{namespace_name}__{sub_name}":
+                        return sub_name, namespace_name
     return function_name, None
 
 def build_response_output_items(
@@ -52,6 +61,7 @@ def build_response_output_items(
     content: str | None,
     tool_calls: list[FunctionCall] | None,
     logprobs: list[Logprob] | None = None,
+    tools: list[Any] | None = None,
 ) -> list[ResponseOutputItem]:
     outputs: list[ResponseOutputItem] = []
 
@@ -95,8 +105,8 @@ def build_response_output_items(
                     or make_tool_call_id(func_name=tool_call.name, idx=idx),
                     type="function_call",
                     status="completed",
-                    name=unflatten_tool_name(tool_call.name)[0],
-                    namespace=unflatten_tool_name(tool_call.name)[1],
+                    name=unflatten_tool_name(tool_call.name, tools)[0],
+                    namespace=unflatten_tool_name(tool_call.name, tools)[1],
                     arguments=tool_call.arguments,
                 )
             )


### PR DESCRIPTION
Fixes #46737

### Description
This PR fixes the tool name flattening issue in the Responses API path. It introduces a `unflatten_tool_name` utility in `vllm/entrypoints/openai/responses/utils.py` to map flattened namespace tool names (e.g. `mcp__computer_use__get_app_state`) back to namespace-local tool names (`get_app_state`) and the corresponding namespace (`mcp__computer_use`). This is integrated in both the streaming and harmony paths to ensure the Codex client receives the correct format.