### PR TITLE
[Model Runner V2][Spec Decode] Handle tuple hidden states from MTP draft models

### DIFF
--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import torch
+
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.worker.gpu.spec_decode.autoregressive import speculator as spec_module
+from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
+    AutoRegressiveSpeculator,
+)
+
+
+class _TestSpeculator(AutoRegressiveSpeculator):
+    @property
+    def model_returns_tuple(self) -> bool:
+        return False
+
+    def load_draft_model(self, target_model, target_attn_layer_names):
+        raise NotImplementedError
+
+
+class _DraftModel(torch.nn.Module):
+    def __init__(self, output: torch.Tensor | tuple[torch.Tensor, torch.Tensor]):
+        super().__init__()
+        self.output = output
+
+    def forward(self, **kwargs):
+        return self.output
+
+
+def _make_speculator(
+    monkeypatch,
+    output: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+) -> _TestSpeculator:
+    monkeypatch.setattr(
+        spec_module,
+        "set_forward_context",
+        lambda *args, **kwargs: nullcontext(),
+    )
+
+    speculator = object.__new__(_TestSpeculator)
+    speculator.supports_mm_inputs = False
+    speculator.vllm_config = None
+    speculator.input_buffers = SimpleNamespace(
+        input_ids=torch.arange(4),
+        positions=torch.arange(4),
+    )
+    speculator.hidden_states = torch.zeros(4, 3)
+    speculator.model = _DraftModel(output)
+    return speculator
+
+
+def test_run_model_unpacks_tuple_return_for_mtp(monkeypatch):
+    logits_hidden = torch.full((4, 3), 1.0)
+    feedback_hidden = torch.full((4, 3), 2.0)
+    speculator = _make_speculator(monkeypatch, (logits_hidden, feedback_hidden))
+
+    actual_logits_hidden, actual_feedback_hidden = speculator._run_model(
+        4,
+        attn_metadata=None,
+        slot_mappings=None,
+        num_tokens_across_dp=None,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+
+    assert actual_logits_hidden is logits_hidden
+    assert actual_feedback_hidden is feedback_hidden
+
+
+def test_run_model_reuses_tensor_return_for_mtp(monkeypatch):
+    hidden = torch.full((4, 3), 1.0)
+    speculator = _make_speculator(monkeypatch, hidden)
+
+    actual_logits_hidden, actual_feedback_hidden = speculator._run_model(
+        4,
+        attn_metadata=None,
+        slot_mappings=None,
+        num_tokens_across_dp=None,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+
+    assert actual_logits_hidden is hidden
+    assert actual_feedback_hidden is hidden

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -14,10 +14,6 @@ from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
 
 
 class _TestSpeculator(AutoRegressiveSpeculator):
-    @property
-    def model_returns_tuple(self) -> bool:
-        return False
-
     def load_draft_model(self, target_model, target_attn_layer_names):
         raise NotImplementedError
 

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -60,16 +60,6 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         """
         return True
 
-    @property
-    def model_returns_tuple(self) -> bool:
-        """
-        Whether the draft model's forward() returns a tuple.
-
-        True: returns (last_hidden_states, hidden_states) — Eagle, Gemma4 MTP.
-        False: returns a single tensor used for both — standard MTP (DeepSeek).
-        """
-        return True
-
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         # Initialize cudagraph manager for draft prefill (draft position 0).
         self.prefill_cudagraph_manager = PrefillSpeculatorCudaGraphManager(

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -328,7 +328,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             else:
                 # Eager (NONE): call the raw model directly.
                 ret_hidden_states = self.model(**model_inputs)
-        if self.model_returns_tuple:
+        # Some MTP models declare a single-tensor contract but return
+        # (logits_hidden, feedback_hidden) for final-norm correctness.
+        if isinstance(ret_hidden_states, tuple):
             last_hidden_states, hidden_states = ret_hidden_states
         else:
             last_hidden_states = ret_hidden_states

--- a/vllm/v1/worker/gpu/spec_decode/gemma4/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/gemma4/speculator.py
@@ -30,13 +30,6 @@ class Gemma4Speculator(AutoRegressiveSpeculator):
         # No new KV slots are written, so positions and seq_lens stay fixed.
         return False
 
-    @property
-    def model_returns_tuple(self) -> bool:
-        # forward() returns (draft_hidden_states, backbone_hidden_states).
-        # The proposer uses draft_hidden_states for compute_logits and
-        # backbone_hidden_states for the hidden-state feedback buffer.
-        return True
-
     def load_draft_model(
         self,
         target_model: nn.Module,

--- a/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
@@ -10,10 +10,6 @@ from vllm.v1.worker.gpu.spec_decode.eagle.utils import load_eagle_model
 
 
 class MTPSpeculator(AutoRegressiveSpeculator):
-    @property
-    def model_returns_tuple(self) -> bool:
-        return False
-
     def load_draft_model(
         self,
         target_model: nn.Module,


### PR DESCRIPTION
Some MTP models declare a single-tensor contract but return (logits_hidden, feedback_hidden) for final-norm correctness.

## Purpose
Fix https://github.com/vllm-project/vllm/issues/46798
[Spec Decode] Handle tuple hidden states from MTP draft models

## Test Plan
```
VLLM_USE_V2_MODEL_RUNNER=1 VLLM_NIXL_SIDE_CHANNEL_HOST=172.16.1.247 VLLM_NIXL_SIDE_CHANNEL_PORT=5600 VLLM_ENGINE_READY_TIMEOUT_S=1800 vllm serve /mnt/data1/models/zai-org/GLM-5.2-FP8 \
            --served-model-name public/glm-52 \
            --trust-remote-code \
            --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both", "kv_connector_extra_config": {"enforce_handshake_compat": false}}' \
            --chat-template-content-format=string \
            --tensor-parallel-size 8 \
            --tool-call-parser glm47 \
            --enable-auto-tool-choice \
            --reasoning-parser glm45 \
            --gpu-memory-utilization 0.92 \
            --enable-prompt-tokens-details \
            --speculative-config='{"method":"mtp","num_speculative_tokens":1}' \
            --shutdown-timeout 300 \
            --fingerprint-mode=none --max-model-len 1000
...
....
Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/eplb_utils.py", line 37, in wrapper
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     result = fn(self, *args, **kwargs)
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     self.model_runner.profile_run()
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     result = fn(self, *args, **kwargs)
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000] Traceback (most recent call last):
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     result = fn(self, *args, **kwargs)
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]              ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/eplb_utils.py", line 37, in wrapper
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]              ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/executor/multiproc_executor.py", line 992, in worker_busy_loop
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]              ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/model_runner.py", line 607, in _dummy_run
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     result = fn(self, *args, **kwargs)
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/model_runner.py", line 607, in _dummy_run
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     output = func(*args, **kwargs)
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/model_runner.py", line 607, in _dummy_run
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     self.speculator.propose(
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]              ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     self.speculator.propose(
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]              ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     self.speculator.propose(
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/model_runner.py", line 654, in profile_run
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/model_runner.py", line 607, in _dummy_run
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     hidden_states, sample_hidden_states = self._dummy_run(
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     self.speculator.propose(
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]                                           ^^^^^^^^^^^^^^^^
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py", line 234, in propose
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py", line 234, in propose
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu_worker.py", line 438, in determine_available_memory
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py", line 234, in propose
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     self._prefill(
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     self._prefill(
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     self.model_runner.profile_run()
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     self._prefill(
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py", line 360, in _prefill
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py", line 234, in propose
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py", line 360, in _prefill
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py", line 360, in _prefill
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     sample_hidden_states = last_hidden_states[last_token_indices]
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/eplb_utils.py", line 37, in wrapper
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     self._prefill(
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     sample_hidden_states = last_hidden_states[last_token_indices]
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     sample_hidden_states = last_hidden_states[last_token_indices]
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]                            ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     result = fn(self, *args, **kwargs)
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py", line 360, in _prefill
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]                            ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]                            ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
(Worker_TP6 pid=3384772) ERROR 06-26 11:22:08 [multiproc_executor.py:1000] TypeError: only integer tensors of a single element can be converted to an index
(Worker_TP0 pid=3384741) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]              ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=3384743) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]     sample_hidden_states = last_hidden_states[last_token_indices]
(Worker_TP7 pid=3384775) ERROR 06-26 11:22:08 [multiproc_executor.py:1000] TypeError: only integer tensors of a single element can be converted to an index
(Worker_TP3 pid=3384746) ERROR 06-26 11:22:08 [multiproc_executor.py:1000]   File "/mnt/data4/jxy/vllm/vllm/v1/worker/gpu/model_runner.py", line 654, in profile_run
(Worker_TP5 pid=3384751) ERROR 06-26 11:22:08 [multiproc_executor.py:1000] TypeError: only integer tensors of a single element can be converted to an index
```

this pr:
```
rver pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/chat/completions/batch, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /generative_scoring, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/chat/completions/derender, Methods: POST
(APIServer pid=885189) INFO 06-26 11:19:45 [launcher.py:46] Route: /v1/completions/derender, Methods: POST
(APIServer pid=885189) INFO:     Started server process [885189]
(APIServer pid=885189) INFO:     Waiting for application startup.
(APIServer pid=885189) INFO:     Application startup complete.

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

