### PR TITLE
[Model] DeepSeek: migrate EAGLE3 aux capture to EagleModelMixin (enable final-layer extraction)

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -97,6 +97,7 @@ from vllm.v1.attention.backends.mla.indexer import (
 from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
 from .interfaces import (
+    EagleModelMixin,
     MixtureOfExperts,
     SupportsEagle,
     SupportsEagle3,
@@ -1228,7 +1229,7 @@ class DeepseekV2DecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class DeepseekV2Model(nn.Module):
+class DeepseekV2Model(nn.Module, EagleModelMixin):
     fall_back_to_pt_during_load = False
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -1278,8 +1279,6 @@ class DeepseekV2Model(nn.Module):
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
         )
-
-        self.aux_hidden_state_layers = tuple[int, ...]()
 
         # Needed by load_weights
         qk_nope_head_dim = getattr(config, "qk_nope_head_dim", 0)
@@ -1331,15 +1330,15 @@ class DeepseekV2Model(nn.Module):
         else:
             llama_4_scaling = None
 
-        aux_hidden_states = []
+        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer),
-            start=self.start_layer,
+            islice(self.layers, self.start_layer, self.end_layer)
         ):
-            if idx in self.aux_hidden_state_layers:
-                aux_hidden_states.append(hidden_states + residual)
             hidden_states, residual = layer(
                 positions, hidden_states, residual, llama_4_scaling
+            )
+            self._maybe_add_hidden_state(
+                aux_hidden_states, idx + 1, hidden_states, residual
             )
 
         if not get_pp_group().is_last_rank:


### PR DESCRIPTION
## Purpose

`extract_hidden_states` / EAGLE3 on DeepSeek-architecture models (incl. Kimi
K2.x, which wraps `DeepseekV2ForCausalLM`) cannot capture the **final decoder
layer's output** today, and setting `eagle_aux_hidden_state_layer_ids` to
`num_layers` (e.g. `61` for Kimi K2, `L`-th layer) silently captures nothing /
produces a hidden-state count mismatch downstream.

Root cause: `DeepseekV2Model.forward` still uses the pre-#36063 capture
style — it appends the residual stream **before** each decoder layer keyed by
the raw (global) layer index:

```python
for idx, layer in enumerate(islice(self.layers, start, end), start=self.start_layer):
    if idx in self.aux_hidden_state_layers:
        aux_hidden_states.append(hidden_states + residual)   # input to layer idx
    hidden_states, residual = layer(...)
```

So the largest reachable id is `num_layers - 1` (the input to the last layer =
output of the second-to-last layer); the last layer's **output** is never
reachable, and an id of `num_layers` matches no iteration.

This PR migrates `DeepseekV2Model` to the consolidated
`EagleModelMixin._maybe_add_hidden_state` pattern introduced in #36063 (the
same one already used by `qwen2`, `llama`, `gpt_oss`, etc.):

```python
aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
for idx, layer in enumerate(islice(self.layers, start, end)):
    hidden_states, residual = layer(...)
    self._maybe_add_hidden_state(aux_hidden_states, idx + 1, hidden_states, residual)
```

Now id `0` = embedding output and id `idx + 1` = output **after** layer `idx`,
so `eagle_aux_hidden_state_layer_ids` may reference the final layer
(`id == num_layers`) to extract its output.

### Behavior / compatibility

- **Non-pipeline-parallel runs: the captured states for every previously valid
  id are unchanged** (old `id=k` = input to layer `k` = output of layer `k-1`
  == new `id=k` = output after layer `k-1`); the change only *adds* the
  previously-unreachable `id == num_layers`.
- This also aligns DeepSeek's aux-layer indexing with the other models migrated
  in #36063 — DeepSeek was one of the stragglers still using the global-index /
  capture-before-layer convention (see #36151).
- `DeepseekV2ForCausalLM.set_aux_hidden_state_layers` /
  `get_eagle3_aux_hidden_state_layers` are intentionally **kept**, because
  wrapper models that were not migrated in #36063 (`kimi_k25.py`,
  `pixtral.py`) delegate to them via `self.language_model`.

## Not a duplicate

- #45985 (Eagle3 + Pipeline Parallelism) — adds PP support via new
  `eagle3_pp_utils.py` / `gpu_model_runner.py`; it does **not** migrate
  `deepseek_v2.py`'s capture loop.
- #42413 (Supports eagle3 for dsv4, draft) — touches `deepseek_v4/...`,
  `extract_hidden_states.py`, `kv_cache_utils.py`; different files, no overlap
  with `deepseek_v2.py`.
- #36151 is the open umbrella issue documenting exactly this indexing
  inconsistency; this PR is a step toward it for DeepSeek.

## Test plan / results

Verified in this (CPU-only) environment:
- `ruff check vllm/model_executor/models/deepseek_v2.py` → All checks passed
- `ruff format --check ...` → already formatted
- `python -m py_compile ...` → OK
- Caller audit: confirmed `kimi_k25.py` and `pixtral.py` still resolve
  `set_aux_hidden_state_layers` / `get_eagle3_aux_hidden_state_layers` after the
  change (kept on `DeepseekV2ForCausalLM`), and that no caller references the
  removed `self.aux_hidden_state_layers` init (now provided by `EagleModelMixin`).

**Not yet run (requires GPU — to be completed by the human submitter before
marking ready):**
- `tests/v1/spec_decode/` EAGLE3 / `extract_hidden_states` integration tests
- An end-to-end DeepSeek/Kimi EAGLE3 run confirming `id == num_layers` yields
  the final-layer hidden state and acceptance is unchanged for existing ids.

## Note

AI assistance (Claude) was used to draft this change. The human submitter is
reviewing every changed line and will run the GPU tests above before taking
this out of draft.
