### PR TITLE
[Hardware][AMD][CI] Fix AMD CI image build

### DIFF
--- a/csrc/libtorch_stable/layernorm_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_kernels.cu
@@ -29,7 +29,6 @@ __global__ void rms_norm_kernel(
   float variance = 0.0f;
   const scalar_t* input_row;
   const scalar_t* weight_row;
-  int64_t weight_row_off = 0;
   if constexpr (NUM_DIMS == 2) {
     // 2D for layernorm normal case [batch_size, hidden]
     input_row = input + blockIdx.x * input_stride_d2;


### PR DESCRIPTION


## Purpose
This PR fixes the AMD CI image build, which was broken after https://github.com/vllm-project/vllm/pull/46761 because it left an unused variable in the layernorm kernels. On AMD CI, the vLLM wheel is compiled with `-Werror` and `-Wunused-variable`, so this led to a `csrc` compilation failure.

## Test Plan
AMD CI will build a CI testing image.

## Test Result
The CI testing image is successfully built.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

