### PR TITLE
[Bugfix] Fix MLA indexer block_table shape mismatch when max_model_len

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6998,6 +6998,7 @@ class GPUModelRunner(
         if (
             block_sizes != self._init_block_sizes
             or kernel_block_sizes != self._init_kernel_block_sizes
+            or max_model_len != self.input_batch.max_model_len
         ):
             self._init_block_sizes = block_sizes
             self._init_kernel_block_sizes = kernel_block_sizes


### PR DESCRIPTION
## Describe the bug

When running MLA models with MTP (Multi-Token Prediction) speculative decoding, and the engine auto-reduces `max_model_len` to fit available GPU memory, a `RuntimeError` occurs during the decode phase:

```
RuntimeError: The expanded size of the tensor (2464) must match the existing size (3168)
at non-singleton dimension 1. Target sizes: [51, 2464]. Tensor sizes: [51, 3168]
```

The MLA indexer's `expanded_block_table_buffer` is allocated with fewer columns than the `InputBatch.block_table` because `InputBatch` was created **before** `max_model_len` was reduced, and it is never rebuilt afterward.

## Root Cause Analysis

The initialization sequence in `GPUModelRunner` has a timing issue between `InputBatch` creation and `max_model_len` auto-reduction:

### Timeline

1. **`GPUModelRunner.__init__()`** creates `InputBatch` with the **original** `max_model_len` (e.g., 202,752):
   ```python
   # block_table columns = cdiv(202752, 64) = 3168
   self.input_batch = InputBatch(...)
   ```

2. **Engine detects insufficient GPU memory** and calls `update_max_model_len(157696)` to auto-reduce the value.

3. **`initialize_kv_cache()` → `initialize_metadata_builders()`** creates the MLA indexer with the **new** `max_model_len`:
   ```python
   # expanded_block_table_buffer columns = cdiv(157696, 64) = 2464
   ```

4. **`may_reinitialize_input_batch()`** is called but only checks:
   ```python
   if (
       block_sizes != self._init_block_sizes        # False (both [64])
       or kernel_block_sizes != self._init_kernel_block_sizes  # False
   ):
   ```
   It does **NOT** check whether `max_model_len` has changed.

5. Since the condition is not triggered, `InputBatch` is **NOT rebuilt**, retaining the stale `block_table` with **3168 columns**.

6. During decode, `torch.repeat_interleave` tries to expand `block_table[N, 3168]` into the indexer buffer `[max_num_batched_tokens, 2464]` → **RuntimeError**.

### Why the existing checks miss this case

`may_reinitialize_input_batch()` guards against changes in `block_size` or `kernel_block_size`, but when `max_model_len` is reduced without changing the block size (FlashMLA always uses block_size=64), neither check fires.

## Steps to Reproduce

**Trigger conditions** (all must be met simultaneously):

1. Use an MLA attention backend (FlashMLA with `block_size=64`)
2. Enable MTP speculative decoding (`num_speculative_tokens >= 1`)
3. Use a configuration that causes high memory pressure (e.g., DP + EP), forcing the engine to auto-reduce `max_model_len`
4. The auto-reduction must NOT change `block_size` (always the case for FlashMLA)
5. Send enough requests to enter the decode phase

**Example launch configuration**:

```bash
vllm serve GLM-5.1 --host 0.0.0.0 --port 8999  --max-model-len auto --trust-remote-code --speculative-config '{"method": "mtp", "num_speculative_tokens": 2}' --data-parallel-size 8 --enable-expert-parallel --all2all-backend deepep_low_latency --no-enable-prefix-caching
```

With insufficient GPU memory to support `max_model_len=202752`, the engine auto-reduces it (e.g., to 157696). The crash occurs on the first decode step.

