### PR TITLE
[MoE] Allow is_act_and_mul=False (non-gated MoE) on TPU

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1339,10 +1339,13 @@ class FusedMoEConfig:
             )
 
         if not self.is_act_and_mul and not (
-            current_platform.is_cuda_alike() or current_platform.is_xpu()
+            current_platform.is_cuda_alike()
+            or current_platform.is_xpu()
+            or current_platform.is_tpu()
         ):
             raise NotImplementedError(
-                "is_act_and_mul=False is supported only for CUDA, XPU and ROCm for now"
+                "is_act_and_mul=False is supported only for "
+                "CUDA, XPU, ROCm and TPU for now"
             )
 
     @property


### PR DESCRIPTION
## Summary

vLLM currently rejects `FusedMoEConfig(is_act_and_mul=False)` on TPU during config validation, even when the TPU backend can handle the non-gated MoE path.

This PR adds TPU to the existing allow-list for `is_act_and_mul=False`. The change only affects TPU (CUDA, XPU, and ROCm behavior is unchanged), and unsupported platforms remain blocked.

The corresponding TPU implementation and end-to-end Nemotron-H validation are in the companion PR:
https://github.com/vllm-project/tpu-inference/pull/3012

## Change

* Add `current_platform.is_tpu()` to the `is_act_and_mul=False` platform guard.
* Update the error message to include TPU.

## Testing

With vllm-project/tpu-inference#3012 installed, `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` runs end-to-end on TPU v6e-4 and produces expected outputs for basic prompts.

Without this change, model construction fails during config validation:

```text
NotImplementedError: is_act_and_mul=False is supported only for CUDA, XPU and ROCm for now
```

## AI assistance

Developed with AI assistance. Every changed line has been reviewed by the submitter.


## Acknowledgements

This work is part of the effort from the [medusa-compute](https://github.com/medusa-compute) team.

Special thanks to @Raphael-Hao for his substantial help and guidance throughout this work.