### PR TITLE
[Bugfix][Frontend] Accept Anthropic server tools without input_schema

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -31,6 +31,7 @@ from vllm.entrypoints.anthropic.serving import (
     _build_anthropic_usage,
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
     ChatCompletionResponseStreamChoice,
@@ -1456,3 +1457,45 @@ class TestCacheSalt:
 
         assert response.status_code == HTTPStatus.BAD_REQUEST
         handler.create_messages.assert_not_awaited()
+
+
+# ======================================================================
+# _convert_tools — server tools without input_schema
+# ======================================================================
+
+
+class TestConvertServerTools:
+    def test_server_tool_accepted_without_input_schema(self):
+        # Anthropic server tools (web_search, computer use, ...) carry no
+        # input_schema; the request must still validate.
+        request = _make_request(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
+            ],
+        )
+        assert request.tools[0].input_schema is None
+
+    def test_convert_tools_skips_server_tool_keeps_function(self):
+        request = _make_request(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {"type": "web_search_20250305", "name": "web_search", "max_uses": 8},
+                {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            ],
+        )
+        req = ChatCompletionRequest(
+            model="test-model", messages=[{"role": "user", "content": "hi"}]
+        )
+        AnthropicServingMessages._convert_tools(request, req)
+
+        assert req.tools is not None
+        assert len(req.tools) == 1
+        assert req.tools[0].function.name == "get_weather"

--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -38,6 +38,7 @@ from vllm.entrypoints.generate.base.protocol import (
     DeltaToolCall,
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
     ChatCompletionResponseStreamChoice,
@@ -1701,3 +1702,45 @@ class TestClientErrorResponses:
 
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json()["error"]["type"] == "BadRequestError"
+
+
+# ======================================================================
+# _convert_tools — server tools without input_schema
+# ======================================================================
+
+
+class TestConvertServerTools:
+    def test_server_tool_accepted_without_input_schema(self):
+        # Anthropic server tools (web_search, computer use, ...) carry no
+        # input_schema; the request must still validate.
+        request = _make_request(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
+            ],
+        )
+        assert request.tools[0].input_schema is None
+
+    def test_convert_tools_skips_server_tool_keeps_function(self):
+        request = _make_request(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {"type": "web_search_20250305", "name": "web_search", "max_uses": 8},
+                {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            ],
+        )
+        req = ChatCompletionRequest(
+            model="test-model", messages=[{"role": "user", "content": "hi"}]
+        )
+        AnthropicServingMessages._convert_tools(request, req)
+
+        assert req.tools is not None
+        assert len(req.tools) == 1
+        assert req.tools[0].function.name == "get_weather"

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -74,13 +74,18 @@ class AnthropicTool(BaseModel):
 
     name: str
     description: str | None = None
-    input_schema: dict[str, Any]
+    # Optional: Anthropic server tools (web_search_20250305, computer_*, bash_*,
+    # text_editor_*, code_execution_*) are sent without an input_schema, so a
+    # required field rejects otherwise-valid requests (e.g. Claude Code).
+    input_schema: dict[str, Any] | None = None
     strict: bool | None = None
     defer_loading: bool | None = None
 
     @field_validator("input_schema")
     @classmethod
     def validate_input_schema(cls, v):
+        if v is None:
+            return v
         if not isinstance(v, dict):
             raise ValueError("input_schema must be a dictionary")
         if "type" not in v:

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -76,13 +76,18 @@ class AnthropicTool(BaseModel):
 
     name: str
     description: str | None = None
-    input_schema: dict[str, Any]
+    # Optional: Anthropic server tools (web_search_20250305, computer_*, bash_*,
+    # text_editor_*, code_execution_*) are sent without an input_schema, so a
+    # required field rejects otherwise-valid requests (e.g. Claude Code).
+    input_schema: dict[str, Any] | None = None
     strict: bool | None = None
     defer_loading: bool | None = None
 
     @field_validator("input_schema")
     @classmethod
     def validate_input_schema(cls, v):
+        if v is None:
+            return v
         if not isinstance(v, dict):
             raise ValueError("input_schema must be a dictionary")
         if "type" not in v:

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -566,6 +566,11 @@ class AnthropicServingMessages(OpenAIServingChat):
 
         tools = []
         for tool in anthropic_request.tools:
+            # Server tools (web_search, computer use, bash, ...) arrive without an
+            # input_schema; vLLM can't run them as function tools, so skip them
+            # rather than emit a malformed function declaration.
+            if tool.input_schema is None:
+                continue
             tools.append(
                 ChatCompletionToolsParam.model_validate(
                     {

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -569,6 +569,11 @@ class AnthropicServingMessages(OpenAIServingChat):
 
         tools = []
         for tool in anthropic_request.tools:
+            # Server tools (web_search, computer use, bash, ...) arrive without an
+            # input_schema; vLLM can't run them as function tools, so skip them
+            # rather than emit a malformed function declaration.
+            if tool.input_schema is None:
+                continue
             tools.append(
                 ChatCompletionToolsParam.model_validate(
                     {


### PR DESCRIPTION
Fixes #46790.

Anthropic server tools (`web_search_20250305`, computer use, bash, text_editor, code_execution) are sent without an `input_schema`. `AnthropicTool.input_schema` was required, so Claude Code's WebSearch tool 400'd at validation before anything ran.

Make `input_schema` optional and skip schema-less server tools in the OpenAI function conversion (vLLM can't run them as function tools). Normal function tools are unchanged; a non-dict schema is still rejected.

Scope: this fixes the validation crash only — actually executing server tools (real web search) is out of scope.

Verified locally (GPU stack unavailable here, so direct import):
```
PASS: web_search server tool validates; input_schema = None
PASS: normal tool unchanged, type defaulted to object
PASS: non-dict input_schema still rejected -> ValidationError
```
Conversion-skip covered by the added test in tests/entrypoints/anthropic/test_anthropic_messages_conversion.py (runs in CI).