### PR TITLE
Fix: handle non-str chat template in HF renderer

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1284,6 +1284,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
         "Qwen/Qwen2-Audio-7B-Instruct"
     ),
     "Qwen2VLForConditionalGeneration": _HfExamplesInfo("Qwen/Qwen2-VL-2B-Instruct"),
+    "Qwen3VLReranker": _HfExamplesInfo("Qwen/Qwen3-VL-Reranker-8B"),
     "Qwen2_5_VLForConditionalGeneration": _HfExamplesInfo(
         "Qwen/Qwen2.5-VL-3B-Instruct",
         max_model_len=4096,

--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -115,6 +115,7 @@ def test_no_load_chat_template_literallike():
     [
         "Qwen/Qwen2-VL-2B-Instruct",  # chat_template is of type str
         "NousResearch/Hermes-3-Llama-3.1-8B",  # chat_template is of type dict
+        "Qwen/Qwen3-VL-Reranker-8B",  # chat_templates are in additional_chat_templates
     ],
 )
 @pytest.mark.parametrize("use_tools", [True, False])

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -249,6 +249,8 @@ def _try_get_processor_chat_template(
             and hasattr(processor, "chat_template")
             and (chat_template := processor.chat_template) is not None
         ):
+            if isinstance(chat_template, dict):
+                chat_template = chat_template.get("default")
             _PROCESSOR_CHAT_TEMPLATES[cache_key] = chat_template
             return chat_template
     except Exception:


### PR DESCRIPTION
## Purpose

When resolving the `AutoProcessor` chat template in `resolve_chat_template`, processors that expose multiple named templates (e.g. a dict like `{"default": ..., "tool_use": ...}`) caused a crash: the `dict` was passed unchanged into the downstream `_cached_resolve_chat_template_kwargs` (`lru_cache`), raising `TypeError: unhashable type: 'dict'`.

This occurs when the model contains multiple chat templates under `additional_chat_templates` directory. `Qwen/Qwen3-VL-Reranker-8B` is a good example of such model.

See: https://huggingface.co/Qwen/Qwen3-VL-Reranker-8B/tree/main

This PR updates `_try_get_processor_chat_template` in `vllm/renderers/hf.py` so that when `chat_template` is a dict, it selects the `"default"` entry and resolves it to a `str` before caching and returning.

## Test Plan

```bash
uv run pytest tests/renderers/test_hf.py::test_resolve_chat_template -v
```

## Test Result

Before: models with a dict-typed `chat_template` failed with `TypeError: unhashable type: 'dict'`.
After: `test_resolve_chat_template[...]` passes and `chat_template` is correctly resolved to a `str` (the `"default"` entry).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>