### PR TITLE
[Bugfix][Realtime] Add idle watchdog for audio WebSocket sessions

### DIFF
--- a/tests/entrypoints/speech_to_text/realtime/test_realtime_connection.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_realtime_connection.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import json
+from typing import cast
+
+import numpy as np
+import pybase64 as base64
+import pytest
+
+from vllm import envs
+from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection
+
+
+class DummyWebSocket:
+    def __init__(self):
+        self.close_calls: list[tuple[int, str | None]] = []
+        self.sent: list[dict] = []
+
+    async def close(self, code: int = 1000, reason: str | None = None):
+        self.close_calls.append((code, reason))
+
+    async def send_text(self, data: str):
+        self.sent.append(json.loads(data))
+
+
+class DummyServing:
+    def _is_model_supported(self, model: str | None) -> bool:
+        return True
+
+
+def _connection(
+    monkeypatch: pytest.MonkeyPatch, idle_timeout_s: float = 0.05
+) -> RealtimeConnection:
+    monkeypatch.setattr(
+        envs, "VLLM_REALTIME_AUDIO_IDLE_TIMEOUT_S", idle_timeout_s, raising=False
+    )
+    conn = RealtimeConnection(DummyWebSocket(), DummyServing())  # type: ignore[arg-type]
+    conn._is_connected = True
+    conn._is_model_validated = True
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_idle_watchdog_forces_final_and_closes(monkeypatch):
+    conn = _connection(monkeypatch)
+
+    async def wait_for_final():
+        assert await conn.audio_queue.get() is None
+
+    conn.generation_task = asyncio.create_task(wait_for_final())
+    conn._reset_idle_watchdog()
+    assert conn.idle_watchdog_task is not None
+
+    await asyncio.wait_for(conn.idle_watchdog_task, timeout=1.0)
+
+    websocket = cast(DummyWebSocket, conn.websocket)
+    assert conn.generation_task.done()
+    assert websocket.close_calls == [(1000, "Realtime session idle timeout.")]
+    assert not conn._is_connected
+
+
+@pytest.mark.asyncio
+async def test_final_commit_cancels_idle_watchdog(monkeypatch):
+    conn = _connection(monkeypatch)
+    conn._reset_idle_watchdog()
+    watchdog_task = conn.idle_watchdog_task
+    assert watchdog_task is not None
+
+    await conn.handle_event({"type": "input_audio_buffer.commit", "final": True})
+    await asyncio.sleep(0)
+    await asyncio.sleep(0.1)
+
+    websocket = cast(DummyWebSocket, conn.websocket)
+    assert conn.idle_watchdog_task is None
+    assert watchdog_task.done()
+    assert not websocket.close_calls
+
+
+@pytest.mark.asyncio
+async def test_noop_commit_does_not_refresh_idle_watchdog(monkeypatch):
+    conn = _connection(monkeypatch, idle_timeout_s=1.0)
+    conn.generation_task = asyncio.create_task(asyncio.sleep(10.0))
+    conn._reset_idle_watchdog()
+    watchdog_task = conn.idle_watchdog_task
+    assert watchdog_task is not None
+
+    await conn.handle_event({"type": "input_audio_buffer.commit"})
+
+    assert conn.idle_watchdog_task is watchdog_task
+    await conn.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_append_refreshes_idle_watchdog(monkeypatch):
+    conn = _connection(monkeypatch, idle_timeout_s=1.0)
+    conn._reset_idle_watchdog()
+    watchdog_task = conn.idle_watchdog_task
+    assert watchdog_task is not None
+
+    audio = np.array([1], dtype=np.int16)
+    await conn.handle_event(
+        {
+            "type": "input_audio_buffer.append",
+            "audio": base64.b64encode(audio.tobytes()).decode("utf-8"),
+        }
+    )
+    await asyncio.sleep(0)
+
+    assert watchdog_task.done()
+    assert conn.idle_watchdog_task is not None
+    assert conn.idle_watchdog_task is not watchdog_task
+    await conn.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_idle_watchdog_can_be_disabled(monkeypatch):
+    conn = _connection(monkeypatch, idle_timeout_s=0.0)
+
+    conn._reset_idle_watchdog()
+
+    assert conn.idle_watchdog_task is None
+    await conn.cleanup()

--- a/tests/entrypoints/speech_to_text/realtime/test_realtime_validation.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_realtime_validation.py
@@ -20,6 +20,7 @@ from vllm.multimodal.media.audio import load_audio
 REALTIME_ENV_OVERRIDES = {
     **ROCM_ENV_OVERRIDES,
     "VLLM_ENGINE_ITERATION_TIMEOUT_S": "600",
+    "VLLM_REALTIME_AUDIO_IDLE_TIMEOUT_S": "600",
 }
 
 MISTRAL_FORMAT_ARGS = [

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import contextlib
 import json
 from collections.abc import AsyncGenerator
 from http import HTTPStatus
@@ -42,17 +43,86 @@ class RealtimeConnection:
     - Error handling and cleanup
     """
 
+    _IDLE_CLOSE_REASON = "Realtime session idle timeout."
+    _IDLE_STOP_GRACE_S = 5.0
+
     def __init__(self, websocket: WebSocket, serving: OpenAIServingRealtime):
         self.websocket = websocket
         self.connection_id = f"ws-{uuid4()}"
         self.serving = serving
         self.audio_queue: asyncio.Queue[np.ndarray | None] = asyncio.Queue()
         self.generation_task: asyncio.Task | None = None
+        self.idle_watchdog_task: asyncio.Task | None = None
 
         self._is_connected = False
         self._is_model_validated = False
+        self._audio_input_finished = False
 
         self._max_audio_filesize_mb = envs.VLLM_MAX_AUDIO_CLIP_FILESIZE_MB
+        self._idle_timeout_s = envs.VLLM_REALTIME_AUDIO_IDLE_TIMEOUT_S
+
+    def _is_idle_watchdog_enabled(self) -> bool:
+        return self._idle_timeout_s > 0
+
+    def _cancel_idle_watchdog(self) -> None:
+        task = self.idle_watchdog_task
+        self.idle_watchdog_task = None
+        if task is not None and not task.done() and task is not asyncio.current_task():
+            task.cancel()
+
+    def _reset_idle_watchdog(self) -> None:
+        if not self._is_idle_watchdog_enabled() or self._audio_input_finished:
+            return
+
+        self._cancel_idle_watchdog()
+        self.idle_watchdog_task = asyncio.create_task(self._run_idle_watchdog())
+
+    async def _run_idle_watchdog(self) -> None:
+        try:
+            await asyncio.sleep(self._idle_timeout_s)
+            logger.warning(
+                "Realtime session %s idle for %.1f seconds. Closing session.",
+                self.connection_id,
+                self._idle_timeout_s,
+            )
+            await self.force_stop_generation()
+        except asyncio.CancelledError:
+            pass
+        finally:
+            if self.idle_watchdog_task is asyncio.current_task():
+                self.idle_watchdog_task = None
+
+    def _finish_audio_input(self) -> None:
+        if self._audio_input_finished:
+            return
+        self._audio_input_finished = True
+        self._cancel_idle_watchdog()
+        self.audio_queue.put_nowait(None)
+
+    async def force_stop_generation(self) -> None:
+        """Stop an idle realtime session and release its engine request."""
+        self._finish_audio_input()
+
+        if self.generation_task is not None and not self.generation_task.done():
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(self.generation_task),
+                    timeout=self._IDLE_STOP_GRACE_S,
+                )
+            except TimeoutError:
+                self.generation_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self.generation_task
+
+        await self.close(self._IDLE_CLOSE_REASON)
+
+    async def close(self, reason: str | None = None) -> None:
+        if not self._is_connected:
+            return
+
+        self._is_connected = False
+        with contextlib.suppress(RuntimeError):
+            await self.websocket.close(code=1000, reason=reason)
 
     async def handle_connection(self):
         """Main connection loop."""
@@ -134,6 +204,7 @@ class RealtimeConnection:
 
                 # Put audio chunk in queue
                 self.audio_queue.put_nowait(audio_array)
+                self._reset_idle_watchdog()
 
             except Exception as e:
                 logger.error("Failed to decode audio: %s", e)
@@ -154,9 +225,11 @@ class RealtimeConnection:
             commit_event = InputAudioBufferCommit(**event)
             # final signals that the audio is finished
             if commit_event.final:
-                self.audio_queue.put_nowait(None)
+                self._finish_audio_input()
             else:
-                await self.start_generation()
+                started = await self.start_generation()
+                if started:
+                    self._reset_idle_watchdog()
         else:
             await self.send_error(f"Unknown event type: {event_type}", "unknown_event")
 
@@ -168,11 +241,12 @@ class RealtimeConnection:
                 break
             yield audio_chunk
 
-    async def start_generation(self):
+    async def start_generation(self) -> bool:
         """Start the transcription generation task."""
         if self.generation_task is not None and not self.generation_task.done():
             logger.warning("Generation already in progress, ignoring commit")
-            return
+            return False
+        self._audio_input_finished = False
 
         # Create audio stream generator
         audio_stream = self.audio_stream_generator()
@@ -187,6 +261,7 @@ class RealtimeConnection:
         self.generation_task = asyncio.create_task(
             self._run_generation(streaming_input_gen, input_stream)
         )
+        return True
 
     async def _run_generation(
         self,
@@ -264,6 +339,8 @@ class RealtimeConnection:
         except Exception as e:
             logger.exception("Error in generation: %s", e)
             await self.send_error(sanitize_message(str(e)), "processing_error")
+        finally:
+            self._cancel_idle_watchdog()
 
     async def send(
         self, event: SessionCreated | TranscriptionDelta | TranscriptionDone
@@ -280,10 +357,14 @@ class RealtimeConnection:
     async def cleanup(self):
         """Cleanup resources."""
         # Signal audio stream to stop
-        self.audio_queue.put_nowait(None)
+        self._finish_audio_input()
 
         # Cancel generation task if running
-        if self.generation_task and not self.generation_task.done():
+        if self.generation_task is not None and not self.generation_task.done():
             self.generation_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.generation_task
+
+        self._cancel_idle_watchdog()
 
         logger.debug("Connection cleanup complete: %s", self.connection_id)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
     VLLM_MAX_AUDIO_CLIP_FILESIZE_MB: int = 25
     VLLM_MAX_AUDIO_DECODE_DURATION_S: int = 600
     VLLM_MAX_AUDIO_PREPROCESS_WORKERS: int = max(1, min(os.cpu_count() or 1, 2))
+    VLLM_REALTIME_AUDIO_IDLE_TIMEOUT_S: float = 30.0
     VLLM_VIDEO_LOADER_BACKEND: str = "opencv"
     VLLM_MEDIA_CONNECTOR: str = "http"
     VLLM_MM_HASHER_ALGORITHM: str = "blake3"
@@ -945,6 +946,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
             "VLLM_MAX_AUDIO_PREPROCESS_WORKERS",
             str(max(1, min(os.cpu_count() or 1, 2))),
         )
+    ),
+    # Realtime audio WebSocket sessions are closed after this many seconds
+    # without valid audio input. Set to 0 or a negative value to disable.
+    "VLLM_REALTIME_AUDIO_IDLE_TIMEOUT_S": lambda: float(
+        os.getenv("VLLM_REALTIME_AUDIO_IDLE_TIMEOUT_S", "30")
     ),
     # Backend for Video IO — selects the frame-sampling algorithm.
     # - "opencv": uniform sampling.


### PR DESCRIPTION
## Summary

Add an application-layer idle watchdog for `/v1/realtime` audio WebSocket sessions.

Today, a realtime client can keep a WebSocket connection open without sending `final=True` or disconnecting. In that state, the underlying resumable streaming request can keep holding and extending KV cache as new chunks are committed, and the server has no session-level idle policy to force cleanup. This PR adds a configurable idle timeout so stale realtime audio sessions are finalized and closed automatically.

## Changes

- Add `VLLM_REALTIME_AUDIO_IDLE_TIMEOUT_S`, defaulting to `30` seconds.
  - Set to `0` or a negative value to disable the watchdog.
- Add an asyncio idle watchdog to `RealtimeConnection`.
  - Valid `input_audio_buffer.append` refreshes the watchdog.
  - A non-final `input_audio_buffer.commit` refreshes it only when it actually starts generation.
  - Repeated no-op commits while generation is already running do not keep the session alive.
- On idle timeout, gracefully finish the audio stream first by enqueueing the final sentinel.
  - This lets the streaming request unwind and release engine-side KV cache.
  - If generation does not finish within a short grace period, the task is cancelled and the WebSocket is closed.
- Cancel the watchdog on explicit `final=True`, cleanup, or generation completion.
- Document the new environment variable.
- Add unit coverage for watchdog timeout, final cancellation, append refresh, no-op commit behavior, and disabling the watchdog.
- Increase the realtime integration-test idle timeout to avoid false failures during slow ROCm/JIT startup.


## Test Plan

Ran:

```bash
uvx --from ruff ruff check \
  vllm/entrypoints/speech_to_text/realtime/connection.py \
  vllm/envs.py \
  tests/entrypoints/speech_to_text/realtime/test_realtime_connection.py \
  tests/entrypoints/speech_to_text/realtime/test_realtime_validation.py

uvx --from ruff ruff format --check \
  vllm/entrypoints/speech_to_text/realtime/connection.py \
  vllm/envs.py \
  tests/entrypoints/speech_to_text/realtime/test_realtime_connection.py \
  tests/entrypoints/speech_to_text/realtime/test_realtime_validation.py

git diff --check