### PR TITLE
[Misc] Fix incorrect layer type annotation in Fp8LinearMethod

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -320,7 +320,7 @@ class Fp8LinearMethod(LinearMethodBase):
 
     def create_weights(
         self,
-        layer: RoutedExperts,
+        layer: torch.nn.Module,
         input_size_per_partition: int,
         output_partition_sizes: list[int],
         input_size: int,
@@ -394,7 +394,7 @@ class Fp8LinearMethod(LinearMethodBase):
 
         self.use_marlin = isinstance(self.fp8_linear, MarlinFP8ScaledMMLinearKernel)
 
-    def process_weights_after_loading(self, layer: RoutedExperts) -> None:
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if self.use_marlin:
             if not self.block_quant:
                 # Canonicalize to (K, N) for the kernel.


### PR DESCRIPTION
## Purpose

`Fp8LinearMethod.create_weights` and `process_weights_after_loading` annotate
their `layer` parameter as `RoutedExperts`, but these methods only ever receive
a `LinearBase` module. `Fp8Config.get_quant_method` routes `LinearBase` layers
to `Fp8LinearMethod` and `RoutedExperts` layers to `Fp8MoEMethod`, so a
`RoutedExperts` instance never reaches `Fp8LinearMethod`.

The annotation is a copy-paste leftover from the MoE methods and is misleading:
the method bodies operate on linear-layer attributes (`logical_widths`, a single
`[out, in]` `weight`), not expert weights. It is also inconsistent within the
same class — `apply` already annotates `layer` as `torch.nn.Module`.

This PR changes both annotations to `torch.nn.Module`, matching the base
`LinearMethodBase.create_weights` signature and the sibling `apply` method.

## Changes

- `Fp8LinearMethod.create_weights`: `layer: RoutedExperts` → `torch.nn.Module`
- `Fp8LinearMethod.process_weights_after_loading`: `layer: RoutedExperts` → `torch.nn.Module`

The `RoutedExperts` annotations in `Fp8MoEMethod` / `Fp8OnlineMoEMethod` are
correct and left unchanged.

## Test Plan

Type-annotation-only change with **no runtime behavior change** (Python
annotations are not enforced at runtime, and both types are `nn.Module`
subclasses). `ruff check` and `ruff format --check` pass on the modified file.