### PR TITLE
[ROCM] Rocm/aiter rdna opt in

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -95,12 +95,9 @@ def is_aiter_found_and_supported() -> bool:
     Does NOT check environment variables - that's handled by rocm_aiter_ops.is_enabled().
 
     This function determines if aiter CAN be used, not if it SHOULD be used.
-
-    Default acceptance is MI3xx (CDNA, gfx942/gfx950), where AITER's full kernel
-    set (CK + ASM + Triton) is upstream-validated. Consumer RDNA (gfx10/11/12)
-    is gated behind VLLM_ROCM_USE_AITER_RDNA=1 because only AITER's Triton-backed
-    paths are RDNA-eligible; per-feature gates below then keep CK/MFMA-bound
-    capabilities CDNA-only.
+    Accepted by default on MI3xx (CDNA); consumer RDNA is gated behind
+    VLLM_ROCM_USE_AITER_RDNA, with per-feature checks below keeping CK / MFMA
+    paths CDNA-only.
 
     Separation of concerns:
     - This function: Can aiter work on this system? (platform + library availability)
@@ -1647,7 +1644,6 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_linear_enabled(cls) -> bool:
-        # AITER's default linear path uses ASM/CK kernels with MFMA; CDNA only.
         from vllm.platforms.rocm import on_mi3xx
 
         return cls._AITER_ENABLED and cls._LINEAR_ENABLED and on_mi3xx()
@@ -1660,8 +1656,6 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_fused_moe_enabled(cls) -> bool:
-        # ck_moe / asm_moe paths require MFMA; CDNA only. RDNA MoE goes through
-        # vLLM's stock Triton fused-MoE path.
         from vllm.platforms.rocm import on_mi3xx
 
         return cls._AITER_ENABLED and cls._FMOE_ENABLED and on_mi3xx()
@@ -1720,7 +1714,6 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_mla_enabled(cls) -> bool:
-        # AITER MLA prefill/decode rely on CK kernels with MFMA; CDNA only.
         from vllm.platforms.rocm import on_mi3xx
 
         return cls._AITER_ENABLED and cls._MLA_ENABLED and on_mi3xx()
@@ -1728,8 +1721,6 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_mha_enabled(cls) -> bool:
-        # AITER MHA (ROCM_AITER_FA backend) is built on CK Flash Attention;
-        # CDNA only. RDNA users get vLLM's Triton FA paths instead.
         from vllm.platforms.rocm import on_mi3xx
 
         return cls._AITER_ENABLED and cls._MHA_ENABLED and on_mi3xx()

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -91,10 +91,16 @@ class AiterCustomAllreduceProto(Protocol):
 def is_aiter_found_and_supported() -> bool:
     """Check if AITER library is available and platform supports it.
 
-    Checks: platform (ROCm), device arch (gfx9), and library existence.
+    Checks: platform (ROCm), device arch, and library existence.
     Does NOT check environment variables - that's handled by rocm_aiter_ops.is_enabled().
 
     This function determines if aiter CAN be used, not if it SHOULD be used.
+
+    Default acceptance is MI3xx (CDNA, gfx942/gfx950), where AITER's full kernel
+    set (CK + ASM + Triton) is upstream-validated. Consumer RDNA (gfx10/11/12)
+    is gated behind VLLM_ROCM_USE_AITER_RDNA=1 because only AITER's Triton-backed
+    paths are RDNA-eligible; per-feature gates below then keep CK/MFMA-bound
+    capabilities CDNA-only.
 
     Separation of concerns:
     - This function: Can aiter work on this system? (platform + library availability)
@@ -104,10 +110,14 @@ def is_aiter_found_and_supported() -> bool:
     This allows explicit backend selection via attention_config to work even when
     VLLM_ROCM_USE_AITER=0, while preventing unwanted JIT warnings for auto-discovery.
     """
-    if current_platform.is_rocm() and IS_AITER_FOUND:
-        from vllm.platforms.rocm import on_mi3xx
+    if not (current_platform.is_rocm() and IS_AITER_FOUND):
+        return False
+    from vllm.platforms.rocm import on_mi3xx, on_rdna
 
-        return on_mi3xx()
+    if on_mi3xx():
+        return True
+    if on_rdna() and envs.VLLM_ROCM_USE_AITER_RDNA:
+        return True
     return False
 
 
@@ -1637,7 +1647,10 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_linear_enabled(cls) -> bool:
-        return cls._AITER_ENABLED and cls._LINEAR_ENABLED
+        # AITER's default linear path uses ASM/CK kernels with MFMA; CDNA only.
+        from vllm.platforms.rocm import on_mi3xx
+
+        return cls._AITER_ENABLED and cls._LINEAR_ENABLED and on_mi3xx()
 
     @classmethod
     @if_aiter_supported
@@ -1647,7 +1660,11 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_fused_moe_enabled(cls) -> bool:
-        return cls._AITER_ENABLED and cls._FMOE_ENABLED
+        # ck_moe / asm_moe paths require MFMA; CDNA only. RDNA MoE goes through
+        # vLLM's stock Triton fused-MoE path.
+        from vllm.platforms.rocm import on_mi3xx
+
+        return cls._AITER_ENABLED and cls._FMOE_ENABLED and on_mi3xx()
 
     @classmethod
     @if_aiter_supported
@@ -1703,12 +1720,19 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_mla_enabled(cls) -> bool:
-        return cls._AITER_ENABLED and cls._MLA_ENABLED
+        # AITER MLA prefill/decode rely on CK kernels with MFMA; CDNA only.
+        from vllm.platforms.rocm import on_mi3xx
+
+        return cls._AITER_ENABLED and cls._MLA_ENABLED and on_mi3xx()
 
     @classmethod
     @if_aiter_supported
     def is_mha_enabled(cls) -> bool:
-        return cls._AITER_ENABLED and cls._MHA_ENABLED
+        # AITER MHA (ROCM_AITER_FA backend) is built on CK Flash Attention;
+        # CDNA only. RDNA users get vLLM's Triton FA paths instead.
+        from vllm.platforms.rocm import on_mi3xx
+
+        return cls._AITER_ENABLED and cls._MHA_ENABLED and on_mi3xx()
 
     @classmethod
     @if_aiter_supported

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -117,6 +117,7 @@ if TYPE_CHECKING:
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
     VLLM_ROCM_USE_AITER: bool = False
+    VLLM_ROCM_USE_AITER_RDNA: bool = False
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
     VLLM_ROCM_USE_AITER_LINEAR_HIPBMM: bool = False
@@ -1129,6 +1130,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_ROCM_USE_AITER": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER", "False").lower() in ("true", "1")
+    ),
+    # Experimental opt-in to allow AITER on consumer RDNA GPUs (gfx10/11/12).
+    # AITER upstream only validates on CDNA (MI200/MI300); when this is set
+    # together with VLLM_ROCM_USE_AITER=1, vLLM unlocks the Triton-backed AITER
+    # paths (unified attention, rotary, Triton GEMM, RMSNorm fusions) on RDNA.
+    # CK / MFMA / HipBMM paths remain CDNA-only inside the per-feature gates.
+    "VLLM_ROCM_USE_AITER_RDNA": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_RDNA", "False").lower() in ("true", "1")
     ),
     # Whether to use aiter paged attention.
     # By default is disabled.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1131,11 +1131,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ROCM_USE_AITER": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER", "False").lower() in ("true", "1")
     ),
-    # Experimental opt-in to allow AITER on consumer RDNA GPUs (gfx10/11/12).
-    # AITER upstream only validates on CDNA (MI200/MI300); when this is set
-    # together with VLLM_ROCM_USE_AITER=1, vLLM unlocks the Triton-backed AITER
-    # paths (unified attention, rotary, Triton GEMM, RMSNorm fusions) on RDNA.
-    # CK / MFMA / HipBMM paths remain CDNA-only inside the per-feature gates.
+    # Experimental: also allow AITER on consumer RDNA GPUs (gfx10/11/12).
+    # Only the Triton-backed AITER paths are unlocked; CK / MFMA paths
+    # stay CDNA-only via per-feature gates in rocm_aiter_ops.
     "VLLM_ROCM_USE_AITER_RDNA": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_RDNA", "False").lower() in ("true", "1")
     ),

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -213,6 +213,10 @@ _ON_GFX11 = "gfx11" in _GCN_ARCH
 _ON_GFX1100 = "gfx1100" in _GCN_ARCH
 _ON_GFX1151 = "gfx1151" in _GCN_ARCH
 _ON_GFX12X = any(arch in _GCN_ARCH for arch in ["gfx12"])
+# RDNA family covers consumer GPUs: gfx10 (RDNA2), gfx11 (RDNA3/3.5), gfx12 (RDNA4).
+# Used to gate AITER's Triton-backed kernel paths, which AITER itself bucketizes
+# as RDNA-eligible (see aiter/ops/triton/_triton_kernels/.../utils.py:RDNA_ARCHS).
+_ON_RDNA = _ON_GFX1X or "gfx10" in _GCN_ARCH
 _ON_MI3XX = any(arch in _GCN_ARCH for arch in ["gfx942", "gfx950"])
 _ON_GFX9 = any(arch in _GCN_ARCH for arch in ["gfx90a", "gfx942", "gfx950"])
 _ON_GFX90A = "gfx90a" in _GCN_ARCH
@@ -313,6 +317,10 @@ def on_gfx12x() -> bool:
 
 def on_mi3xx() -> bool:
     return _ON_MI3XX
+
+
+def on_rdna() -> bool:
+    return _ON_RDNA
 
 
 def on_gfx9() -> bool:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -213,9 +213,6 @@ _ON_GFX11 = "gfx11" in _GCN_ARCH
 _ON_GFX1100 = "gfx1100" in _GCN_ARCH
 _ON_GFX1151 = "gfx1151" in _GCN_ARCH
 _ON_GFX12X = any(arch in _GCN_ARCH for arch in ["gfx12"])
-# RDNA family covers consumer GPUs: gfx10 (RDNA2), gfx11 (RDNA3/3.5), gfx12 (RDNA4).
-# Used to gate AITER's Triton-backed kernel paths, which AITER itself bucketizes
-# as RDNA-eligible (see aiter/ops/triton/_triton_kernels/.../utils.py:RDNA_ARCHS).
 _ON_RDNA = _ON_GFX1X or "gfx10" in _GCN_ARCH
 _ON_MI3XX = any(arch in _GCN_ARCH for arch in ["gfx942", "gfx950"])
 _ON_GFX9 = any(arch in _GCN_ARCH for arch in ["gfx90a", "gfx942", "gfx950"])


### PR DESCRIPTION
## Purpose

vLLM gates AITER as a whole to MI3xx (CDNA), but AITER's Triton kernels (under `aiter/ops/triton/`) actually support consumer RDNA (gfx10/11/12) and AITER itself classifies these architectures as RDNA-eligible. Today, setting `VLLM_ROCM_USE_AITER=1` on an RDNA box is silently a no-op because `is_aiter_found_and_supported()` returns False, so every `is_*_enabled` method short-circuits via `@if_aiter_supported`.

This adds an opt-in:

- New env var `VLLM_ROCM_USE_AITER_RDNA` (default `False`). When set together with `VLLM_ROCM_USE_AITER=1` on RDNA, `is_aiter_found_and_supported()` returns True and the Triton-backed AITER paths become reachable.
- Per-feature gates added for the CK/MFMA-bound paths so RDNA opt-in does not accidentally route into them: `is_linear_enabled`, `is_fused_moe_enabled`,
`is_mla_enabled`, `is_mha_enabled` now also require `on_mi3xx()`. This mirrors the pattern already used by `is_linear_hipbmm_enabled`, `is_fp4bmm_enabled`,
`is_tgemm_enabled`, and matches `AiterFlashAttentionBackend.supports_compute_capability` which already returns `on_mi3xx()`.
- New `on_rdna()` helper covering gfx10/11/12.

What this unlocks on RDNA (only when both env vars are set):
- `is_triton_unified_attn_enabled` (`VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION`)
- `is_triton_rotary_embed_enabled` (`VLLM_ROCM_USE_AITER_TRITON_ROPE`)
- `is_triton_gemm_enabled` (`VLLM_ROCM_USE_AITER_TRITON_GEMM`)

CDNA behavior is unchanged: `on_mi3xx()` short-circuits the master gate before the RDNA arm is consulted, and the per-feature gates only added `on_mi3xx()` (no relaxation).


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

