### PR TITLE
[BugFix] Fix decode-phase blocks not stored in CPU KV cache offloading

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1000,6 +1000,16 @@ class OffloadingConnectorScheduler:
                     group_config, group_state, num_offloadable_tokens
                 )
 
+                # Clamp to the number of offload keys we actually have.
+                # num_offloadable_tokens is a forward-looking estimate
+                # (num_computed_tokens + num_scheduled_tokens), but
+                # offload_keys are only generated for tokens whose block
+                # hashes already exist. During decode, a chunk that
+                # completes in the *current* step won't have its hash
+                # yet — so num_chunks can overshoot. Clamping prevents
+                # silently skipping those chunks.
+                num_chunks = min(num_chunks, len(group_state.offload_keys))
+
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 if num_chunks <= start_chunk_idx:
                     continue

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1358,6 +1358,15 @@ class OffloadingConnectorScheduler:
 
                 if group_config.requires_cow_source:
                     continue
+                # Clamp to the number of offload keys we actually have.
+                # num_offloadable_tokens is a forward-looking estimate
+                # (num_computed_tokens + num_scheduled_tokens), but
+                # offload_keys are only generated for tokens whose block
+                # hashes already exist. During decode, a chunk that
+                # completes in the *current* step won't have its hash
+                # yet — so num_chunks can overshoot. Clamping prevents
+                # silently skipping those chunks.
+                num_chunks = min(num_chunks, len(group_state.offload_keys))
 
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 if num_chunks <= start_chunk_idx:


### PR DESCRIPTION
Body:
  OffloadingConnectorScheduler._build_store_jobs() calculates num_blocks
  from num_offloadable_tokens = num_computed_tokens + num_scheduled_tokens,
  which is a forward-looking estimate. During decode, a block that
  completes in the *current* step won't have its block hash generated
  yet, so num_blocks can overshoot the actual number of available
  offload_keys. This caused decode-formed blocks to be silently skipped.
  
  Fix: clamp num_blocks to len(offload_keys) so we only store blocks
  whose hashes actually exist.
  
  Fixes #33864
