### PR TITLE
[Core] Add post-load weight processing registry

### DIFF
--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -9,8 +9,10 @@ import torch
 
 from vllm.config import ModelConfig
 from vllm.logger import init_logger
-from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
+from vllm.model_executor.model_loader.weight_processing import (
+    WeightProcessingFactory,
+)
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from .meta import (
@@ -185,7 +187,7 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         )
 
         # Do not online process attention layers, must wait until finalize
-        if isinstance(layer, (Attention, MLAAttention)):
+        if WeightProcessingFactory.is_registered_module(layer):
             return ret
 
         # Log warnings allocating excessive buffers on device
@@ -238,8 +240,8 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
             info.reset()
             continue
 
-        # Attention/MLA layers are processed after all other layers
-        if isinstance(layer, (Attention, MLAAttention)):
+        # Registered weight-processing layers are processed after all other layers
+        if WeightProcessingFactory.is_registered_module(layer):
             deferred_attn.append((layer, info))
             continue
 

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -15,11 +15,6 @@ from typing_extensions import assert_never
 import vllm.envs as envs
 from vllm.config import ModelConfig, VllmConfig, set_current_vllm_config
 from vllm.logger import init_logger
-from vllm.model_executor.layers.attention import (
-    Attention,
-    MLAAttention,
-    MMEncoderAttention,
-)
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
@@ -27,6 +22,9 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.model_loader.reload import (
     record_metadata_for_reloading,
     set_torchao_reload_attrs,
+)
+from vllm.model_executor.model_loader.weight_processing import (
+    WeightProcessingFactory,
 )
 from vllm.model_executor.models.interfaces import SupportsQuant
 from vllm.tracing import instrument
@@ -117,9 +115,9 @@ def process_weights_after_loading(
     # Initialize post-load attention weights for Attention, MLA, and MM encoder.
     # NOTE: Happens after other modules so we can easily decompress weights.
     for _, module in model.named_modules():
-        if isinstance(
-            module, (Attention, MLAAttention, MMEncoderAttention)
-        ) and hasattr(module, "process_weights_after_loading"):
+        if WeightProcessingFactory.is_registered_module(module) and hasattr(
+            module, "process_weights_after_loading"
+        ):
             # TODO(lucas): see if there is a way to unify the signatures
             # of process_weights_after_loading
             with device_loading_context(module, target_device):

--- a/vllm/model_executor/model_loader/weight_processing.py
+++ b/vllm/model_executor/model_loader/weight_processing.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Registry for post-load weight processing module types."""
+
+import importlib
+from collections.abc import Callable, Iterable
+
+from torch import nn
+
+
+class WeightProcessingFactory:
+    """Registry for modules that need deferred post-load weight processing."""
+
+    _registry: dict[str, Callable[[], type[nn.Module]]] = {}
+
+    @classmethod
+    def register_module(
+        cls,
+        name: str,
+        module_path: str,
+        class_name: str,
+    ) -> None:
+        """Register a module type with a lazy-loading module and class name."""
+        if name in cls._registry:
+            raise ValueError(f"Module type '{name}' is already registered.")
+
+        def loader() -> type[nn.Module]:
+            module = importlib.import_module(module_path)
+            module_type = getattr(module, class_name)
+            if not issubclass(module_type, nn.Module):
+                raise TypeError(
+                    "Registered module type must be a subclass of torch.nn.Module, "
+                    f"got {module_type!r}."
+                )
+            return module_type
+
+        cls._registry[name] = loader
+
+    @classmethod
+    def get_module_types(cls) -> tuple[type[nn.Module], ...]:
+        return tuple(loader() for loader in cls._registry.values())
+
+    @classmethod
+    def is_registered_module(cls, module: object) -> bool:
+        return isinstance(module, cls.get_module_types())
+
+    @classmethod
+    def iter_registered_module_types(cls) -> Iterable[type[nn.Module]]:
+        return tuple(loader() for loader in cls._registry.values())
+
+
+WeightProcessingFactory.register_module(
+    "Attention",
+    "vllm.model_executor.layers.attention.attention",
+    "Attention",
+)
+
+WeightProcessingFactory.register_module(
+    "MLAAttention",
+    "vllm.model_executor.layers.attention.mla_attention",
+    "MLAAttention",
+)
+
+WeightProcessingFactory.register_module(
+    "MMEncoderAttention",
+    "vllm.model_executor.layers.attention.mm_encoder_attention",
+    "MMEncoderAttention",
+)


### PR DESCRIPTION
﻿## Purpose

This PR adds a small post-load weight processing registry in `model_loader` so out-of-tree hardware plugins can register module types that need `process_weights_after_loading()` to be called by the standard model loading flow.

This is useful for hardware plugins such as NPU backends. When a plugin implements a custom attention module, it may still need the same post-load hook timing as built-in `Attention`, `MLAAttention`, or `MMEncoderAttention`. With the previous hard-coded type checks, plugins had to patch vLLM loader internals to include their custom module, which is more invasive and harder to maintain.

With this registry, plugins can register additional modules through a lazy `module_path` / `class_name` entry and keep the original loader and layerwise reload behavior. One concrete downstream use case is vLLM Ascend's DSA attention support in https://github.com/vllm-project/vllm-ascend/pull/10694.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

