### PR TITLE
[Bugfix][Kernel] Correct FlashInfer CUTLASS MoE tuning token bound

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -94,6 +94,7 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         # - skip input activation quantization (kernel applies scaling)
         self.use_deepseek_fp8_block_scale = quant_config.is_block_quantized
         self.max_capture_size = moe_config.max_capture_size
+        self.max_num_tokens = moe_config.max_num_tokens
         self.gemm1_clamp_limit: torch.Tensor | None = None
         if quant_config.gemm1_clamp_limit is not None:
             self.gemm1_clamp_limit = torch.tensor(
@@ -398,7 +399,7 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             use_deepseek_fp8_block_scale=self.use_deepseek_fp8_block_scale,
             use_mxfp8_act_scaling=use_mxfp8_act_scaling,
             use_w4_group_scaling=use_w4_group_scaling,
-            tune_max_num_tokens=max(self.max_capture_size, 1),
+            tune_max_num_tokens=self.max_num_tokens,
         )
 
     def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -93,8 +93,6 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         # - pass per-block weight scales to the kernel
         # - skip input activation quantization (kernel applies scaling)
         self.use_deepseek_fp8_block_scale = quant_config.is_block_quantized
-        self.max_capture_size = moe_config.max_capture_size
-        self.max_num_tokens = moe_config.max_num_tokens
         self.gemm1_clamp_limit: torch.Tensor | None = None
         if quant_config.gemm1_clamp_limit is not None:
             self.gemm1_clamp_limit = torch.tensor(
@@ -399,7 +397,6 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             use_deepseek_fp8_block_scale=self.use_deepseek_fp8_block_scale,
             use_mxfp8_act_scaling=use_mxfp8_act_scaling,
             use_w4_group_scaling=use_w4_group_scaling,
-            tune_max_num_tokens=self.max_num_tokens,
         )
 
     def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:


### PR DESCRIPTION
## Purpose

Previously, #34542 refactored the FlashInfer CUTLASS fused MoE backend and passed the CUDA graph max capture size (typically 512) as `tune_max_num_tokens` for flashinfer_cutlass_fused_moe. However, `max_capture_size` describes graph capture capacity and can be unrelated to the scheduler/MoE max batched token limit, so using it can select a tuning configuration for the wrong token range and thus cause suboptimal perf unexpectedly.

This PR partially reverts #34542 and leaves `tune_max_num_tokens` as the default value (8192 defined in FlashInfer). Conceptually, the best value for `tune_max_num_tokens` is `FusedMoEConfig.max_num_tokens * parallel_factor`, but the parallel factor can vary across different parallel configurations and erroneous to determine (as pointed out in [this comment](https://github.com/vllm-project/vllm/pull/46838#issuecomment-4834365663)), so we currently leave it as default, which is the behavior before #34542.

### Related Issue

This is part of the effort for #41306 to fix FlashInfer Cutlass fused MoE perf regression. There are also ongoing FlashInfer side fixes and optimizations to improve the MoE perf.

## Test Plan

#### Functional

```
python -m pytest tests/kernels/moe/test_flashinfer_moe.py
```

#### Performance

**Qwen/Qwen3-30B-A3B**

```
vllm bench throughput \
    --model Qwen/Qwen3-30B-A3B \
    --dataset-name random \
    --num-prompts 300 \
    --tensor-parallel-size 8 \
    --max-model-len 16384 \
    --max-num-seqs 16 \
    --dtype bfloat16 \
    --compilation-config '{"compile_sizes":[1,2,4,8],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
```

**mistralai/Mixtral-8x7B-Instruct-v0.1**

```
vllm bench throughput \
    --backend vllm \
    --model mistralai/Mixtral-8x7B-Instruct-v0.1 \
    --dataset-name sonnet \
    --dataset-path sonnet.txt \
    --input-len 4096 \
    --output-len 512 \
    --num-prompts 300 \
    --tensor-parallel-size 8 \
    --max-model-len 16384 \
    --max-num-seqs 16 \
    --dtype bfloat16 \
    --compilation-config '{"compile_sizes":[1,2,4,8],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
```

**deepseek-ai/DeepSeek-V2-Chat**

```
vllm bench throughput \
    --backend vllm \
    --model deepseek-ai/DeepSeek-V2-Chat \
    --dataset-name sonnet \
    --dataset-path sonnet.txt \
    --input-len 4096 \
    --output-len 512 \
    --num-prompts 300 \
    --tensor-parallel-size 8 \
    --max-model-len 16384 \
    --max-num-seqs 16 \
    --dtype bfloat16 \
    --gpu-memory-utilization 0.85 \
    --compilation-config '{"compile_sizes":[1,2,4,8],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
```

## Test Result

#### Functional

Test result on B100x4:
```
144 passed, 20 warnings in 976.54s
```

#### Performance

Benchmark result on H200x8:

| Model | Throughput - Triton | Throughput - Before | Throughput - After |
|--------|--------|--------|--------|
| Qwen/Qwen3-30B-A3B | **20.42 req/s** | 18.23 req/s | 18.50 req/s |
| mistralai/Mixtral-8x7B-Instruct-v0.1 | 4.58 req/s | 4.09 req/s | **4.60 req/s** |
| deepseek-ai/DeepSeek-V2-Chat | 1.51 req/s | 1.48 req/s | **1.54 req/s** | 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

