### PR TITLE
[Bugfix][SM120][MLA] Validate sparse MLA top-k buffer

### DIFF
--- a/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
@@ -4,6 +4,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm.config import set_current_vllm_config
@@ -12,13 +13,23 @@ from vllm.utils import flashinfer as fi_utils
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     FlashInferMLASparseSM120Backend,
 )
+from vllm.v1.attention.backends.mla.flashinfer_mla_sparse_sm120 import (
+    FlashInferMLASparseSM120Impl,
+)
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 
-def _fake_vllm_config(model_type: str) -> SimpleNamespace:
+def _fake_vllm_config(
+    model_type: str,
+    *,
+    index_topk: int | None = 2048,
+) -> SimpleNamespace:
+    hf_text_config = SimpleNamespace(model_type=model_type)
+    if index_topk is not None:
+        hf_text_config.index_topk = index_topk
     return SimpleNamespace(
         model_config=SimpleNamespace(
-            hf_text_config=SimpleNamespace(model_type=model_type, index_topk=2048),
+            hf_text_config=hf_text_config,
         ),
     )
 
@@ -52,3 +63,79 @@ def test_v32_glm_sm120_backend_accepts_glm_block_size(
         )
 
     assert invalid_reasons == []
+
+
+def test_sm120_sparse_backend_rejects_model_without_index_topk(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(fi_utils, "has_flashinfer_sparse_mla_sm120", lambda: True)
+
+    with set_current_vllm_config(_fake_vllm_config("glm4_moe", index_topk=None)):
+        invalid_reasons = FlashInferMLASparseSM120Backend.validate_configuration(
+            head_size=576,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="fp8",
+            block_size=256,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+            use_mm_prefix=False,
+            use_per_head_quant_scales=False,
+            device_capability=DeviceCapability(12, 0),
+            attn_type="decoder",
+        )
+
+    assert invalid_reasons == [
+        "FLASHINFER_MLA_SPARSE_SM120 requires a model with index_topk config"
+    ]
+
+
+def test_sm120_sparse_impl_accepts_shared_topk_buffer_without_indexer(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(fi_utils, "has_flashinfer_sparse_mla_sm120", lambda: True)
+    topk_indices_buffer = torch.empty(4, 2048, dtype=torch.int32)
+
+    with set_current_vllm_config(_fake_vllm_config("glm4_moe")):
+        impl = FlashInferMLASparseSM120Impl(
+            num_heads=16,
+            head_size=576,
+            scale=1.0,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="fp8_ds_mla",
+            logits_soft_cap=None,
+            attn_type="decoder",
+            kv_sharing_target_layer_name=None,
+            indexer=None,
+            kv_lora_rank=512,
+            qk_nope_head_dim=512,
+            qk_rope_head_dim=64,
+            topk_indices_buffer=topk_indices_buffer,
+        )
+
+    assert impl.topk_indices_buffer is topk_indices_buffer
+
+
+def test_sm120_sparse_impl_rejects_missing_topk_indices() -> None:
+    with (
+        set_current_vllm_config(_fake_vllm_config("glm4_moe")),
+        pytest.raises(ValueError, match="requires sparse-MLA top-k indices"),
+    ):
+        FlashInferMLASparseSM120Impl(
+            num_heads=16,
+            head_size=576,
+            scale=1.0,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="fp8_ds_mla",
+            logits_soft_cap=None,
+            attn_type="decoder",
+            kv_sharing_target_layer_name=None,
+            indexer=None,
+            kv_lora_rank=512,
+            qk_nope_head_dim=512,
+            qk_rope_head_dim=64,
+        )

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -81,13 +81,17 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
             )
         self.kv_scale_format = _kv_scale_format_for_model(model_type)
 
-        # Skip-topk layers are built with indexer=None and get the shared
-        # buffer via mla_args instead (cf. FLASHMLA_SPARSE).
-        self.topk_indices_buffer: torch.Tensor | None = (
-            indexer.topk_indices_buffer
-            if indexer is not None
-            else mla_args.get("topk_indices_buffer")
-        )
+        if indexer is not None:
+            topk_indices_buffer = indexer.topk_indices_buffer
+        else:
+            topk_indices_buffer = mla_args.get("topk_indices_buffer")
+        if topk_indices_buffer is None:
+            raise ValueError(
+                "FLASHINFER_MLA_SPARSE_SM120 requires sparse-MLA top-k "
+                "indices from an indexer or shared topk_indices_buffer "
+                "(model with index_topk in its config)."
+            )
+        self.topk_indices_buffer: torch.Tensor | None = topk_indices_buffer
         from vllm.utils.flashinfer import has_flashinfer_sparse_mla_sm120
 
         if not has_flashinfer_sparse_mla_sm120():
@@ -95,8 +99,6 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
                 "FLASHINFER_MLA_SPARSE_SM120 requires FlashInfer's "
                 "sparse MLA decode API."
             )
-        assert self.topk_indices_buffer is not None
-
         self.supports_quant_query_input = False
         self._workspace_buffer: torch.Tensor | None = None
 

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -81,17 +81,19 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
             )
         self.kv_scale_format = _kv_scale_format_for_model(model_type)
 
-        if indexer is not None:
-            topk_indices_buffer = indexer.topk_indices_buffer
-        else:
-            topk_indices_buffer = mla_args.get("topk_indices_buffer")
-        if topk_indices_buffer is None:
+        # Skip-topk layers are built with indexer=None and get the shared
+        # buffer via mla_args instead (cf. FLASHMLA_SPARSE).
+        self.topk_indices_buffer: torch.Tensor | None = (
+            indexer.topk_indices_buffer
+            if indexer is not None
+            else mla_args.get("topk_indices_buffer")
+        )
+        if self.topk_indices_buffer is None:
             raise ValueError(
                 "FLASHINFER_MLA_SPARSE_SM120 requires sparse-MLA top-k "
                 "indices from an indexer or shared topk_indices_buffer "
                 "(model with index_topk in its config)."
             )
-        self.topk_indices_buffer: torch.Tensor | None = topk_indices_buffer
         from vllm.utils.flashinfer import has_flashinfer_sparse_mla_sm120
 
         if not has_flashinfer_sparse_mla_sm120():


### PR DESCRIPTION
## Purpose

Addresses #46726.

This PR improves SM120 FlashInfer sparse MLA construction error handling and adds regression coverage for skip-topk layers that rely on a shared `topk_indices_buffer`.

The current implementation already supports the valid skip-topk path where `indexer is None` and the implementation falls back to the shared `topk_indices_buffer` passed by the upper MLA path. This PR keeps that behavior, and adds targeted tests to make sure it remains covered.

This PR also replaces the internal assertion for the missing top-k buffer case with an explicit `ValueError`. This makes the failure mode clearer when neither an `indexer` nor a shared `topk_indices_buffer` is available.

I checked for duplicate work before opening this PR:

```bash
gh issue view 46726 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "46726 in:body"
gh pr list --repo vllm-project/vllm --state open --search "SM120 sparse MLA topk_indices_buffer"
gh pr list --repo vllm-project/vllm --state open --search "FlashInfer sparse MLA indexer"
```

Results:

* No open PR directly references #46726.
* I did not find an existing open PR that adds this specific SM120 FlashInfer sparse MLA API coverage or replaces the missing top-k buffer assertion with an explicit `ValueError`.

AI assistance was used while investigating the issue, reasoning about the sparse MLA construction path, and drafting parts of the PR description. I personally reviewed the changed code, verified that the implementation matches the intended behavior, and ran the tests listed below before submitting.

## Test Plan

Run the relevant SM120 FlashInfer sparse MLA API tests:

```bash
.venv/bin/python -m pytest -s -v tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
```

Run the sparse MLA backend tests:

```bash
.venv/bin/python -m pytest -s -v tests/v1/attention/test_sparse_mla_backends.py
```

Run pre-commit on the modified files:

```bash
pre-commit run --files \
  tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py \
  vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
```

The targeted tests cover:

* Models without `index_topk` are rejected by the SM120 sparse backend.
* Skip-topk layers with `indexer=None` can be constructed when a shared `topk_indices_buffer` is provided.
* A clear `ValueError` is raised when both `indexer` and the shared top-k buffer are missing.

## Test Result

Passed:

```text
tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py: all relevant tests passed
tests/v1/attention/test_sparse_mla_backends.py: all relevant tests passed
pre-commit run --files tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py: passed
```

Not fully validated locally:

I do not have access to the original SM120 setup from the issue report, so validation from the issue reporter or maintainers on the original failing environment would be appreciated.