### PR TITLE
[ROCm][Bugfix] window-correct shuffled fp8 decode for SWA layers

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -1155,10 +1155,55 @@ class AiterFlashAttentionImpl(AttentionImpl):
                     or decode_max_query_len > 1
                     or self.sinks is not None
                 ):
-                    assert not rocm_aiter_ops.is_shuffle_kv_cache_enabled(), (
-                        "Shuffle KV cache layout is not supported with sliding "
-                        "window, sinks, or speculative decoding (multi-token decode)."
-                    )
+                    if rocm_aiter_ops.is_shuffle_kv_cache_enabled():
+                        # flash_attn_with_kvcache / unified_attention below read
+                        # the plain KV layout. The shuffled fp8 layout only has a
+                        # decode kernel for the sliding-window case; sinks and
+                        # multi-token (spec decode) over it are still unsupported.
+                        assert (
+                            self.sliding_window[0] != -1
+                            and decode_max_query_len == 1
+                            and self.sinks is None
+                        ), (
+                            "Shuffle KV cache layout is not supported with sinks "
+                            "or speculative decoding (multi-token decode)."
+                        )
+                        from aiter.ops.triton.attention.pa_decode_shuffle import (
+                            paged_attention_decode_shuffle_swa,
+                        )
+
+                        _, _, head_size = query.shape
+                        num_blocks, block_size, num_kv_heads, _ = key_cache.shape
+                        x = 16 // key_cache.element_size()
+                        new_key_cache = key_cache.reshape(
+                            num_blocks, num_kv_heads, head_size // x, block_size, x
+                        )
+                        new_value_cache = value_cache.reshape(
+                            num_blocks, num_kv_heads, block_size // x, head_size, x
+                        )
+                        k_qscale = (
+                            layer._k_scale
+                            if attn_metadata.k_scale is None
+                            else attn_metadata.k_scale
+                        )
+                        v_qscale = (
+                            layer._v_scale
+                            if attn_metadata.v_scale is None
+                            else attn_metadata.v_scale
+                        )
+                        paged_attention_decode_shuffle_swa(
+                            output[:num_decode_tokens],
+                            query[:num_decode_tokens],
+                            new_key_cache,
+                            new_value_cache,
+                            attn_metadata.block_table[:num_decodes],
+                            attn_metadata.seq_lens[:num_decodes],
+                            self.scale,
+                            k_qscale,
+                            v_qscale,
+                            self.sliding_window[0] + 1,
+                        )
+                        return
                     if not attn_metadata.causal:
                         from aiter.ops.triton.attention.mha_v3 import (
                             flash_attn_with_kvcache,


### PR DESCRIPTION
## Purpose

`AiterFlashAttentionImpl.forward` routes sliding-window (and sinks / multi-token
spec-decode) decode through a branch that calls `flash_attn_with_kvcache` or
`unified_attention`, both of which read the plain (non-shuffled) KV layout. That
branch opens with `assert not rocm_aiter_ops.is_shuffle_kv_cache_enabled()`, so a
sliding-window model with the shuffled fp8 cache enabled hard-fails at engine warmup:

```
AssertionError: Shuffle KV cache layout is not supported with sliding window,
sinks, or speculative decoding (multi-token decode).
```

So you currently cannot run a sliding-window model with the shuffled fp8 KV layout.
The non-windowed shuffled path (`paged_attention_common`) is fine; only the windowed
case is blocked, because there was no kernel that reads the shuffled layout and
applies a window.

This replaces that blanket assert: when the shuffled layout is enabled and the case
is sliding-window decode (one query token, no sinks), it reshapes the cache to the
shuffled view and calls `paged_attention_decode_shuffle_swa`, which reads the shuffled
fp8 layout and masks the window. Sinks and multi-token spec decode over the shuffled
layout are still unsupported, so the assert is kept for those.

## Test Plan

Built vLLM from source at current `main` on MI300X (gfx942), applied this patch and
the companion aiter kernel (`paged_attention_decode_shuffle_swa`). Mistral-family SWA
model (head 128, `sliding_window=4096`), `--kv-cache-dtype fp8`,
`VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1`, `--attention-backend ROCM_AITER_FA`,
`--max-model-len 8192` (above the window so SWA is actually active). Prompt longer than
the window so decode crosses it. Compared against the bf16 default SWA path; decode
dispatch confirmed with a per-call sentinel.

## Test Result

gfx942, torch 2.10 / ROCm 7.2.1, GPU clock-locked:

- Before this patch the build aborts at engine warmup with the assertion above. After:
  the SWA shuffled decode kernel fires on every decode step (at a 6722-token prompt the
  dispatch logged 2592 calls = 81 decode steps x 32 layers). A 7222-token-prompt run
  produces coherent, on-topic output.
- fp8 shuffled vs bf16 default, batch 32: fp8 gives 2x KV-cache capacity (2,413,877 vs
  1,206,938 tokens; max concurrency 294x vs 147x) at the same ~163.6 GiB reservation,
  with decode throughput at parity within run-to-run spread (bf16 1037-1293, fp8
  1166-1226 tok/s). The point of the PR is that the windowed shuffled path now works at
  all instead of asserting; the deterministic win is the 2x capacity.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
