### PR TITLE
[MRV2][Spec] Fuse AR speculator multi-step decodes back into one CUDA graph

### DIFF
--- a/docs/design/model_runner_v2.md
+++ b/docs/design/model_runner_v2.md
@@ -191,6 +191,14 @@ V1's CUDA graph handling is implicit and hard to reason about. MRV2 uses a `CUDA
 
 This makes graph lifecycle and execution mode decisions more understandable and easier to extend. Example: MRV2 can capture multiple draft-model forward passes into one CUDA graph.
 
+### Fused Multi-Step Draft Decoding
+
+Autoregressive speculative decoding executes several dependent draft steps per scheduler step. In the fused path, MRV2 captures all post-prefill draft steps in one full CUDA graph instead of replaying a separate graph for each draft token. Attention metadata is built once before the loop, while common step-dependent tensors keep stable addresses and are updated in place between draft steps.
+
+Some attention backends also materialize derived state, such as scheduler metadata or sparse indices. Before opting into the fused path, these backends must implement `AttentionMetadataBuilder.update_draft_decode_metadata()` to update or invalidate that state after the draft inputs advance. The hook runs during CUDA graph capture, so only the GPU operations it issues are recorded and executed during replay; its Python body is not run again. Implementations must therefore use capture-safe operations and keep all replayed tensor state in persistent storage.
+
+For draft models that advance positions, the fused path is enabled only when every draft attention group declares `supports_draft_decode_metadata_update`. Otherwise, MRV2 falls back to rebuilding attention metadata between draft steps. Draft models that keep positions fixed do not require this update. Before enabling a backend, developers must audit all derived metadata, including state inherited from parent builders or owned by auxiliary attention backends.
+
 ## Development Philosophy
 
 MRV2 changes should meet a higher code quality bar. As feature gaps with V1 are filled, features should be reconsidered from first principles in the MRV2 design context instead of quickly porting V1 behavior.

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -3,6 +3,7 @@
 
 from contextlib import nullcontext
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -16,6 +17,7 @@ from vllm.model_executor.models.mistral_eagle import EagleMistralForCausalLM
 from vllm.model_executor.models.mistral_large_3_eagle import (
     EagleMistralLarge3ForCausalLM,
 )
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.spec_decode import speculator as base_spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive import speculator as spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
@@ -278,3 +280,52 @@ def test_run_model_reuses_tensor_return_for_mtp(monkeypatch):
 
     assert actual_logits_hidden is hidden
     assert actual_feedback_hidden is hidden
+
+
+@pytest.mark.parametrize(
+    (
+        "cg_mode",
+        "use_fused_decode_graph",
+        "expected_eager_calls",
+        "expected_graph_replays",
+    ),
+    [
+        (CUDAGraphMode.NONE, True, 3, 0),
+        (CUDAGraphMode.FULL, True, 0, 1),
+        (CUDAGraphMode.FULL, False, 0, 3),
+    ],
+)
+def test_multi_step_decode_replays_captured_graph_as_expected(
+    cg_mode,
+    use_fused_decode_graph,
+    expected_eager_calls,
+    expected_graph_replays,
+):
+    speculator = object.__new__(_TestSpeculator)
+    speculator.num_speculative_steps = 4
+    speculator.current_draft_step = torch.tensor(0)
+    speculator.input_buffers = SimpleNamespace(
+        positions=torch.arange(2),
+        query_start_loc=torch.arange(3),
+    )
+    speculator.idx_mapping = torch.arange(2)
+    speculator.use_fused_decode_graph = use_fused_decode_graph
+    generate_draft = Mock()
+    speculator._generate_draft = generate_draft
+    run_fullgraph = Mock()
+    speculator.decode_cudagraph_manager = SimpleNamespace(run_fullgraph=run_fullgraph)
+    batch_desc = BatchExecutionDescriptor(
+        cg_mode=cg_mode,
+        num_tokens=2,
+        num_reqs=2,
+    )
+
+    speculator._multi_step_decode(
+        num_reqs=2,
+        skip_attn=True,
+        batch_desc=batch_desc,
+        num_tokens_across_dp=None,
+    )
+
+    assert generate_draft.call_count == expected_eager_calls
+    assert run_fullgraph.call_count == expected_graph_replays

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -17,6 +17,8 @@ from vllm.model_executor.models.mistral_eagle import EagleMistralForCausalLM
 from vllm.model_executor.models.mistral_large_3_eagle import (
     EagleMistralLarge3ForCausalLM,
 )
+from vllm.v1.attention.backends import flash_attn as flash_attn_module
+from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadata
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.spec_decode import speculator as base_spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive import speculator as spec_module
@@ -324,8 +326,124 @@ def test_multi_step_decode_replays_captured_graph_as_expected(
         num_reqs=2,
         skip_attn=True,
         batch_desc=batch_desc,
+        seq_lens_cpu_upper_bound=None,
         num_tokens_across_dp=None,
     )
 
     assert generate_draft.call_count == expected_eager_calls
     assert run_fullgraph.call_count == expected_graph_replays
+
+
+def test_refresh_meta_for_draft_decodes_updates_fa3_scheduler_metadata(
+    monkeypatch,
+):
+    builder = object.__new__(flash_attn_module.FlashAttentionMetadataBuilder)
+    builder.aot_schedule = True
+    builder.use_full_cuda_graph = True
+    builder.scheduler_metadata = torch.zeros(8, dtype=torch.int32)
+    builder.cache_config = SimpleNamespace(cache_dtype="bfloat16")
+    builder.kv_cache_dtype = torch.bfloat16
+    builder.num_heads_q = 2
+    builder.num_heads_kv = 1
+    builder.headdim = 128
+    builder.block_size = 16
+    builder.dcp_world_size = 1
+    builder.dcp_rank = 0
+    builder.cp_kv_cache_interleave_size = 1
+    builder.aot_sliding_window = None
+
+    expected = torch.tensor([7, 8, 9], dtype=torch.int32)
+
+    def fake_get_scheduler_metadata(**kwargs):
+        return expected
+
+    monkeypatch.setattr(builder, "_get_scheduler_metadata", fake_get_scheduler_metadata)
+
+    metadata = FlashAttentionMetadata(
+        num_actual_tokens=3,
+        max_query_len=2,
+        query_start_loc=torch.tensor([0, 1, 3], dtype=torch.int32),
+        max_seq_len=8,
+        seq_lens=torch.tensor([5, 6], dtype=torch.int32),
+        block_table=torch.zeros((2, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros(3, dtype=torch.int32),
+        use_cascade=False,
+        common_prefix_len=0,
+        cu_prefix_query_lens=None,
+        prefix_kv_lens=None,
+        suffix_kv_lens=None,
+        max_dcp_context_kv_len=None,
+        dcp_context_kv_lens=None,
+        num_decode_reqs=2,
+        num_prefill_reqs=0,
+        num_decode_tokens=3,
+        num_prefill_tokens=0,
+        scheduler_metadata=torch.tensor([-1, -1, -1], dtype=torch.int32),
+        prefix_scheduler_metadata=None,
+        max_num_splits=4,
+        causal=True,
+        sliding_window=None,
+        mm_prefix_range_tensor=None,
+        rswa_prefix_lens=None,
+        rswa_window=None,
+        rswa_window_tensor=None,
+    )
+
+    builder.refresh_meta_for_draft_decodes(metadata)
+
+    assert torch.equal(metadata.scheduler_metadata, expected)
+    assert torch.equal(builder.scheduler_metadata[:3], expected)
+
+
+def test_refresh_meta_for_draft_decodes_skips_non_fa3_builders(monkeypatch):
+    builder = object.__new__(flash_attn_module.FlashAttentionMetadataBuilder)
+    builder.aot_schedule = False
+    builder.use_full_cuda_graph = True
+    builder.scheduler_metadata = torch.zeros(4, dtype=torch.int32)
+
+    called = False
+
+    def fake_get_scheduler_metadata(**kwargs):
+        nonlocal called
+        called = True
+        return torch.tensor([1], dtype=torch.int32)
+
+    monkeypatch.setattr(builder, "_get_scheduler_metadata", fake_get_scheduler_metadata)
+
+    metadata = FlashAttentionMetadata(
+        num_actual_tokens=1,
+        max_query_len=1,
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        max_seq_len=1,
+        seq_lens=torch.tensor([1], dtype=torch.int32),
+        block_table=torch.zeros((1, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros(1, dtype=torch.int32),
+        use_cascade=False,
+        common_prefix_len=0,
+        cu_prefix_query_lens=None,
+        prefix_kv_lens=None,
+        suffix_kv_lens=None,
+        max_dcp_context_kv_len=None,
+        dcp_context_kv_lens=None,
+        num_decode_reqs=1,
+        num_prefill_reqs=0,
+        num_decode_tokens=1,
+        num_prefill_tokens=0,
+        scheduler_metadata=torch.tensor([5], dtype=torch.int32),
+        prefix_scheduler_metadata=None,
+        max_num_splits=1,
+        causal=True,
+        sliding_window=None,
+        mm_prefix_range_tensor=None,
+        rswa_prefix_lens=None,
+        rswa_window=None,
+        rswa_window_tensor=None,
+    )
+
+    builder.refresh_meta_for_draft_decodes(metadata)
+
+    assert not called
+    assert torch.equal(
+        metadata.scheduler_metadata,
+        torch.tensor([5], dtype=torch.int32),
+    )

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -383,7 +383,7 @@ def test_update_draft_decode_metadata_updates_fa3_scheduler_metadata(
         max_num_splits=4,
         causal=True,
         sliding_window=None,
-        mm_prefix_range_tensor=None,
+        mm_prefix_query_range_tensor=None,
         rswa_prefix_lens=None,
         rswa_window=None,
         rswa_window_tensor=None,
@@ -395,9 +395,9 @@ def test_update_draft_decode_metadata_updates_fa3_scheduler_metadata(
     assert torch.equal(builder.scheduler_metadata[:3], expected)
 
 
-def test_update_draft_decode_metadata_skips_non_fa3_builders(monkeypatch):
+def test_update_draft_decode_metadata_skips_without_scheduler_metadata(monkeypatch):
     builder = object.__new__(flash_attn_module.FlashAttentionMetadataBuilder)
-    builder.aot_schedule = False
+    builder.aot_schedule = True
     builder.use_full_cuda_graph = True
     builder.scheduler_metadata = torch.zeros(4, dtype=torch.int32)
 
@@ -429,12 +429,12 @@ def test_update_draft_decode_metadata_skips_non_fa3_builders(monkeypatch):
         num_prefill_reqs=0,
         num_decode_tokens=1,
         num_prefill_tokens=0,
-        scheduler_metadata=torch.tensor([5], dtype=torch.int32),
+        scheduler_metadata=None,
         prefix_scheduler_metadata=None,
         max_num_splits=1,
         causal=True,
         sliding_window=None,
-        mm_prefix_range_tensor=None,
+        mm_prefix_query_range_tensor=None,
         rswa_prefix_lens=None,
         rswa_window=None,
         rswa_window_tensor=None,
@@ -443,7 +443,4 @@ def test_update_draft_decode_metadata_skips_non_fa3_builders(monkeypatch):
     builder.update_draft_decode_metadata(metadata)
 
     assert not called
-    assert torch.equal(
-        metadata.scheduler_metadata,
-        torch.tensor([5], dtype=torch.int32),
-    )
+    assert metadata.scheduler_metadata is None

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -334,7 +334,7 @@ def test_multi_step_decode_replays_captured_graph_as_expected(
     assert run_fullgraph.call_count == expected_graph_replays
 
 
-def test_refresh_meta_for_draft_decodes_updates_fa3_scheduler_metadata(
+def test_update_draft_decode_metadata_updates_fa3_scheduler_metadata(
     monkeypatch,
 ):
     builder = object.__new__(flash_attn_module.FlashAttentionMetadataBuilder)
@@ -389,13 +389,13 @@ def test_refresh_meta_for_draft_decodes_updates_fa3_scheduler_metadata(
         rswa_window_tensor=None,
     )
 
-    builder.refresh_meta_for_draft_decodes(metadata)
+    builder.update_draft_decode_metadata(metadata)
 
     assert torch.equal(metadata.scheduler_metadata, expected)
     assert torch.equal(builder.scheduler_metadata[:3], expected)
 
 
-def test_refresh_meta_for_draft_decodes_skips_non_fa3_builders(monkeypatch):
+def test_update_draft_decode_metadata_skips_non_fa3_builders(monkeypatch):
     builder = object.__new__(flash_attn_module.FlashAttentionMetadataBuilder)
     builder.aot_schedule = False
     builder.use_full_cuda_graph = True
@@ -440,7 +440,7 @@ def test_refresh_meta_for_draft_decodes_skips_non_fa3_builders(monkeypatch):
         rswa_window_tensor=None,
     )
 
-    builder.refresh_meta_for_draft_decodes(metadata)
+    builder.update_draft_decode_metadata(metadata)
 
     assert not called
     assert torch.equal(

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -286,20 +286,21 @@ def test_run_model_reuses_tensor_return_for_mtp(monkeypatch):
 
 @pytest.mark.parametrize(
     (
+        "method_name",
         "cg_mode",
-        "use_fused_decode_graph",
         "expected_eager_calls",
         "expected_graph_replays",
     ),
     [
-        (CUDAGraphMode.NONE, True, 3, 0),
-        (CUDAGraphMode.FULL, True, 0, 1),
-        (CUDAGraphMode.FULL, False, 0, 3),
+        ("_multi_step_decode", CUDAGraphMode.NONE, 3, 0),
+        ("_multi_step_decode", CUDAGraphMode.FULL, 0, 3),
+        ("_fused_multi_step_decode", CUDAGraphMode.NONE, 3, 0),
+        ("_fused_multi_step_decode", CUDAGraphMode.FULL, 0, 1),
     ],
 )
 def test_multi_step_decode_replays_captured_graph_as_expected(
+    method_name,
     cg_mode,
-    use_fused_decode_graph,
     expected_eager_calls,
     expected_graph_replays,
 ):
@@ -311,7 +312,6 @@ def test_multi_step_decode_replays_captured_graph_as_expected(
         query_start_loc=torch.arange(3),
     )
     speculator.idx_mapping = torch.arange(2)
-    speculator.use_fused_decode_graph = use_fused_decode_graph
     generate_draft = Mock()
     speculator._generate_draft = generate_draft
     run_fullgraph = Mock()
@@ -322,7 +322,7 @@ def test_multi_step_decode_replays_captured_graph_as_expected(
         num_reqs=2,
     )
 
-    speculator._multi_step_decode(
+    getattr(speculator, method_name)(
         num_reqs=2,
         skip_attn=True,
         batch_desc=batch_desc,

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -138,9 +138,6 @@ class SpeculativeConfig:
     will use the default version."""
 
     # Advanced control
-    enable_fused_decode_graph: bool = True
-    """Fuse autoregressive draft decode steps into one CUDA graph when the
-    attention backends support it. Unsupported backends use per-step graphs."""
     disable_padded_drafter_batch: bool = False
     """Disable input padding for speculative decoding. If set to True,
     speculative input batches can contain sequences of different lengths,
@@ -333,7 +330,6 @@ class SpeculativeConfig:
                 # Convert to tuple to make it hashable
                 factors.append(tuple(layer_ids))
 
-        factors.append(self.enable_fused_decode_graph)
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -138,6 +138,9 @@ class SpeculativeConfig:
     will use the default version."""
 
     # Advanced control
+    enable_fused_decode_graph: bool = True
+    """Fuse autoregressive draft decode steps into one CUDA graph when the
+    attention backends support it. Unsupported backends use per-step graphs."""
     disable_padded_drafter_batch: bool = False
     """Disable input padding for speculative decoding. If set to True,
     speculative input batches can contain sequences of different lengths,
@@ -330,6 +333,7 @@ class SpeculativeConfig:
                 # Convert to tuple to make it hashable
                 factors.append(tuple(layer_ids))
 
+        factors.append(self.enable_fused_decode_graph)
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 

--- a/vllm/models/deepseek_v4/amd/rocm.py
+++ b/vllm/models/deepseek_v4/amd/rocm.py
@@ -372,6 +372,10 @@ class DeepseekV4ROCMAiterMLASparseMetadataBuilder(DeepseekV4FlashMLAMetadataBuil
 
 
 class DeepseekV4ROCMAiterSparseSWAMetadataBuilder(DeepseekSparseSWAMetadataBuilder):
+    # Keep fused multi-step decode disabled until update_draft_decode_metadata()
+    # also refreshes the ROCm-specific ragged SWA indices and indptrs.
+    supports_draft_decode_metadata_update = False
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         max_tokens = self.vllm_config.scheduler_config.max_num_batched_tokens

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -761,6 +761,13 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
         )
 
     def update_draft_decode_metadata(self, metadata: M) -> None:
+        """Update step-dependent draft decode metadata in place.
+
+        The fused draft loop may call this method during full CUDA graph
+        capture. CUDA graph replay does not run this Python method, so
+        implementations must emit capture-safe operations and keep replayed
+        tensor state in persistent storage.
+        """
         raise NotImplementedError
 
     def use_cascade_attention(

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -633,10 +633,9 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
     supports_update_block_table: bool = False
     # Whether the builder constructor requires the block-table width.
     requires_block_table_width: ClassVar[bool] = False
-    # Does this backend support capture mutiple draft decode steps into one
-    # CUDA Graph (default: no), which requires no step-dependent metadata
-    # or can refresh metadata over steps.
-    supports_fused_decode_graph: bool = False
+    # Whether all step-dependent draft decode metadata can be updated in place,
+    # allowing one metadata build to be reused across autoregressive draft steps.
+    supports_draft_decode_metadata_update: bool = False
 
     @abstractmethod
     def __init__(
@@ -761,8 +760,8 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
             fast_build=True,
         )
 
-    def refresh_meta_for_draft_decodes(self, metadata: M) -> None:
-        pass
+    def update_draft_decode_metadata(self, metadata: M) -> None:
+        raise NotImplementedError
 
     def use_cascade_attention(
         self,

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -633,6 +633,10 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
     supports_update_block_table: bool = False
     # Whether the builder constructor requires the block-table width.
     requires_block_table_width: ClassVar[bool] = False
+    # Does this backend support capture mutiple draft decode steps into one
+    # CUDA Graph (default: no), which requires no step-dependent metadata
+    # or can refresh metadata over steps.
+    supports_fused_decode_graph: bool = False
 
     @abstractmethod
     def __init__(
@@ -756,6 +760,9 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
             common_attn_metadata=common_attn_metadata,
             fast_build=True,
         )
+
+    def refresh_meta_for_draft_decodes(self, metadata: M) -> None:
+        pass
 
     def use_cascade_attention(
         self,

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -803,7 +803,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         return new_metadata
 
     def update_draft_decode_metadata(self, metadata: FlashAttentionMetadata) -> None:
-        if not self.aot_schedule:
+        if metadata.scheduler_metadata is None:
             return
 
         num_reqs = metadata.num_decode_reqs or metadata.seq_lens.shape[0]

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -462,7 +462,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         # path (for example max_dcp_context_kv_len), and those Python-side
         # fields are not refreshed in-place between graph replays. Keep the
         # fused path disabled until DCP gets a full replay-safe refresh model.
-        self.supports_fused_decode_graph = self.dcp_world_size == 1
+        self.supports_draft_decode_metadata_update = self.dcp_world_size == 1
 
         self.cp_kv_cache_interleave_size = (
             self.parallel_config.cp_kv_cache_interleave_size
@@ -802,7 +802,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         new_metadata.slot_mapping = slot_mapping
         return new_metadata
 
-    def refresh_meta_for_draft_decodes(self, metadata: FlashAttentionMetadata) -> None:
+    def update_draft_decode_metadata(self, metadata: FlashAttentionMetadata) -> None:
         if not self.aot_schedule:
             return
 

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -370,6 +370,57 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
     ) -> AttentionCGSupport:
         return cls._cudagraph_support
 
+    def _get_scheduler_metadata(
+        self,
+        *,
+        aot_schedule: bool,
+        batch_size: int,
+        cu_query_lens: torch.Tensor,
+        max_query_len: int,
+        seqlens: torch.Tensor,
+        max_seq_len: int,
+        causal: bool | torch.Tensor,
+        max_num_splits: int,
+    ) -> torch.Tensor | None:
+        if not aot_schedule:
+            return None
+
+        cache_dtype = self.cache_config.cache_dtype
+        if is_quantized_kv_cache(cache_dtype):
+            qkv_dtype = current_platform.fp8_dtype()
+        else:
+            qkv_dtype = self.kv_cache_dtype
+        return get_scheduler_metadata(
+            batch_size=batch_size,
+            max_seqlen_q=max_query_len,
+            max_seqlen_k=max_seq_len,
+            num_heads_q=self.num_heads_q * self.dcp_world_size,
+            num_heads_kv=self.num_heads_kv,
+            headdim=self.headdim,
+            cache_seqlens=seqlens,
+            qkv_dtype=qkv_dtype,
+            cu_seqlens_q=cu_query_lens,
+            page_size=self.block_size,
+            causal=causal,
+            window_size=_maybe_symmetrize_window(self.aot_sliding_window, causal),
+            num_splits=max_num_splits,
+        )
+
+    def _store_scheduler_metadata(
+        self, scheduler_metadata: torch.Tensor | None
+    ) -> torch.Tensor | None:
+        if self.use_full_cuda_graph and scheduler_metadata is not None:
+            n = scheduler_metadata.shape[0]
+            assert self.scheduler_metadata is not None
+            self.scheduler_metadata[:n] = scheduler_metadata
+            # NOTE(woosuk): We should zero out the rest of the scheduler
+            # metadata to guarantee the correctness. Otherwise, some thread
+            # blocks may use the invalid scheduler metadata and overwrite the
+            # output buffer.
+            self.scheduler_metadata[n:] = 0
+            return self.scheduler_metadata[:n]
+        return scheduler_metadata
+
     def __init__(
         self,
         kv_cache_spec: AttentionSpec,
@@ -404,6 +455,14 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             # DCP might not be initialized in testing
             self.dcp_world_size = 1
             self.dcp_rank = 0
+
+        # Fused draft decode reuses the captured metadata object across draft
+        # steps. For DCP, build-time host-side decisions such as
+        # skip_dcp_context_attention() can change the metadata shape/control
+        # path (for example max_dcp_context_kv_len), and those Python-side
+        # fields are not refreshed in-place between graph replays. Keep the
+        # fused path disabled until DCP gets a full replay-safe refresh model.
+        self.supports_fused_decode_graph = self.dcp_world_size == 1
 
         self.cp_kv_cache_interleave_size = (
             self.parallel_config.cp_kv_cache_interleave_size
@@ -533,34 +592,6 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         if envs.VLLM_BATCH_INVARIANT:
             max_num_splits = 1
 
-        def schedule(
-            batch_size, cu_query_lens, max_query_len, seqlens, max_seq_len, causal
-        ):
-            cache_dtype = self.cache_config.cache_dtype
-            if is_quantized_kv_cache(cache_dtype):
-                qkv_dtype = current_platform.fp8_dtype()
-            else:
-                qkv_dtype = self.kv_cache_dtype
-            if aot_schedule:
-                return get_scheduler_metadata(
-                    batch_size=batch_size,
-                    max_seqlen_q=max_query_len,
-                    max_seqlen_k=max_seq_len,
-                    num_heads_q=self.num_heads_q * self.dcp_world_size,
-                    num_heads_kv=self.num_heads_kv,
-                    headdim=self.headdim,
-                    cache_seqlens=seqlens,
-                    qkv_dtype=qkv_dtype,
-                    cu_seqlens_q=cu_query_lens,
-                    page_size=self.block_size,
-                    causal=causal,
-                    window_size=_maybe_symmetrize_window(
-                        self.aot_sliding_window, causal
-                    ),
-                    num_splits=max_num_splits,
-                )
-            return None
-
         use_cascade = common_prefix_len > 0
         max_dcp_context_kv_len = 0
         dcp_context_kv_lens = None
@@ -627,13 +658,15 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
                     (max_seq_len + num_partitions - 1) // num_partitions
                 ) * self.cp_kv_cache_interleave_size
 
-                scheduler_metadata = schedule(
+                scheduler_metadata = self._get_scheduler_metadata(
+                    aot_schedule=aot_schedule,
                     batch_size=num_reqs,
                     cu_query_lens=query_start_loc,
                     max_query_len=max_query_len,
                     seqlens=dcp_context_kv_lens,
                     max_seq_len=max_dcp_context_kv_len,
                     causal=False,
+                    max_num_splits=max_num_splits,
                 )
         elif use_cascade:
             cu_prefix_query_lens = torch.tensor(
@@ -644,41 +677,38 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             )
             # Use GPU tensor directly - no CPU sync needed
             suffix_kv_lens = seq_lens[:num_reqs] - common_prefix_len
-            prefix_scheduler_metadata = schedule(
+            prefix_scheduler_metadata = self._get_scheduler_metadata(
+                aot_schedule=aot_schedule,
                 batch_size=1,
                 cu_query_lens=cu_prefix_query_lens,
                 max_query_len=num_actual_tokens,
                 seqlens=prefix_kv_lens,
                 max_seq_len=common_prefix_len,
                 causal=False,
+                max_num_splits=max_num_splits,
             )
-            scheduler_metadata = schedule(
+            scheduler_metadata = self._get_scheduler_metadata(
+                aot_schedule=aot_schedule,
                 batch_size=num_reqs,
                 cu_query_lens=query_start_loc,
                 max_query_len=max_query_len,
                 seqlens=suffix_kv_lens,
                 max_seq_len=max_seq_len - common_prefix_len,
                 causal=True,
+                max_num_splits=max_num_splits,
             )
         else:
-            scheduler_metadata = schedule(
+            scheduler_metadata = self._get_scheduler_metadata(
+                aot_schedule=aot_schedule,
                 batch_size=num_reqs,
                 cu_query_lens=query_start_loc,
                 max_query_len=max_query_len,
                 seqlens=seq_lens,
                 max_seq_len=max_seq_len,
                 causal=causal,
+                max_num_splits=max_num_splits,
             )
-        # For FA3 + full cudagraph
-        if self.use_full_cuda_graph and scheduler_metadata is not None:
-            n = scheduler_metadata.shape[0]
-            self.scheduler_metadata[:n] = scheduler_metadata
-            # NOTE(woosuk): We should zero out the rest of the scheduler
-            # metadata to guarantee the correctness. Otherwise, some thread
-            # blocks may use the invalid scheduler metadata and overwrite the
-            # output buffer.
-            self.scheduler_metadata[n:] = 0
-            scheduler_metadata = self.scheduler_metadata[:n]
+        scheduler_metadata = self._store_scheduler_metadata(scheduler_metadata)
 
         if isinstance(causal, torch.Tensor) and causal.dtype != torch.int32:
             causal = causal.to(torch.int32)
@@ -771,6 +801,51 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         new_metadata.block_table = blk_table
         new_metadata.slot_mapping = slot_mapping
         return new_metadata
+
+    def refresh_meta_for_draft_decodes(self, metadata: FlashAttentionMetadata) -> None:
+        if not self.aot_schedule:
+            return
+
+        num_reqs = metadata.num_decode_reqs or metadata.seq_lens.shape[0]
+
+        if metadata.use_cascade:
+            assert metadata.cu_prefix_query_lens is not None
+            assert metadata.prefix_kv_lens is not None
+            assert metadata.suffix_kv_lens is not None
+            prefix_scheduler_metadata = self._get_scheduler_metadata(
+                aot_schedule=True,
+                batch_size=1,
+                cu_query_lens=metadata.cu_prefix_query_lens,
+                max_query_len=metadata.num_actual_tokens,
+                seqlens=metadata.prefix_kv_lens,
+                max_seq_len=metadata.common_prefix_len,
+                causal=False,
+                max_num_splits=metadata.max_num_splits,
+            )
+            metadata.prefix_scheduler_metadata = prefix_scheduler_metadata
+            scheduler_metadata = self._get_scheduler_metadata(
+                aot_schedule=True,
+                batch_size=num_reqs,
+                cu_query_lens=metadata.query_start_loc,
+                max_query_len=metadata.max_query_len,
+                seqlens=metadata.suffix_kv_lens,
+                max_seq_len=metadata.max_seq_len - metadata.common_prefix_len,
+                causal=True,
+                max_num_splits=metadata.max_num_splits,
+            )
+        else:
+            scheduler_metadata = self._get_scheduler_metadata(
+                aot_schedule=True,
+                batch_size=num_reqs,
+                cu_query_lens=metadata.query_start_loc,
+                max_query_len=metadata.max_query_len,
+                seqlens=metadata.seq_lens,
+                max_seq_len=metadata.max_seq_len,
+                causal=metadata.causal,
+                max_num_splits=metadata.max_num_splits,
+            )
+
+        metadata.scheduler_metadata = self._store_scheduler_metadata(scheduler_metadata)
 
     def use_cascade_attention(self, *args, **kwargs) -> bool:
         return use_cascade_attention(*args, **kwargs)

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -808,42 +808,19 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
 
         num_reqs = metadata.num_decode_reqs or metadata.seq_lens.shape[0]
 
-        if metadata.use_cascade:
-            assert metadata.cu_prefix_query_lens is not None
-            assert metadata.prefix_kv_lens is not None
-            assert metadata.suffix_kv_lens is not None
-            prefix_scheduler_metadata = self._get_scheduler_metadata(
-                aot_schedule=True,
-                batch_size=1,
-                cu_query_lens=metadata.cu_prefix_query_lens,
-                max_query_len=metadata.num_actual_tokens,
-                seqlens=metadata.prefix_kv_lens,
-                max_seq_len=metadata.common_prefix_len,
-                causal=False,
-                max_num_splits=metadata.max_num_splits,
-            )
-            metadata.prefix_scheduler_metadata = prefix_scheduler_metadata
-            scheduler_metadata = self._get_scheduler_metadata(
-                aot_schedule=True,
-                batch_size=num_reqs,
-                cu_query_lens=metadata.query_start_loc,
-                max_query_len=metadata.max_query_len,
-                seqlens=metadata.suffix_kv_lens,
-                max_seq_len=metadata.max_seq_len - metadata.common_prefix_len,
-                causal=True,
-                max_num_splits=metadata.max_num_splits,
-            )
-        else:
-            scheduler_metadata = self._get_scheduler_metadata(
-                aot_schedule=True,
-                batch_size=num_reqs,
-                cu_query_lens=metadata.query_start_loc,
-                max_query_len=metadata.max_query_len,
-                seqlens=metadata.seq_lens,
-                max_seq_len=metadata.max_seq_len,
-                causal=metadata.causal,
-                max_num_splits=metadata.max_num_splits,
-            )
+        assert self.dcp_world_size == 1
+        assert not metadata.use_cascade
+
+        scheduler_metadata = self._get_scheduler_metadata(
+            aot_schedule=True,
+            batch_size=num_reqs,
+            cu_query_lens=metadata.query_start_loc,
+            max_query_len=metadata.max_query_len,
+            seqlens=metadata.seq_lens,
+            max_seq_len=metadata.max_seq_len,
+            causal=metadata.causal,
+            max_num_splits=metadata.max_num_splits,
+        )
 
         metadata.scheduler_metadata = self._store_scheduler_metadata(scheduler_metadata)
 

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -400,6 +400,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
 
     reorder_batch_threshold: int | None = None
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    supports_fused_decode_graph = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -648,6 +649,39 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             tile_sched_c128a=tile_sched[_LAYER_TYPE_C128A],
             **deepseek_v4_fields,  # type: ignore[arg-type]
         )
+
+    def refresh_meta_for_draft_decodes(
+        self,
+        metadata: DeepseekSparseSWAMetadata,
+    ) -> None:
+        if metadata.num_decode_tokens == 0:
+            return
+        assert metadata.query_start_loc is not None
+        assert metadata.seq_lens is not None
+        assert metadata.token_to_req_indices is not None
+        assert metadata.is_valid_token is not None
+        assert metadata.decode_swa_indices is not None
+        assert metadata.decode_swa_lens is not None
+
+        _compute_swa_indices_and_lens_kernel[(metadata.num_decode_tokens,)](
+            metadata.decode_swa_indices,
+            metadata.decode_swa_indices.stride(0),
+            metadata.decode_swa_lens,
+            metadata.decode_swa_indices.shape[-1],
+            metadata.query_start_loc,
+            metadata.seq_lens,
+            metadata.token_to_req_indices,
+            metadata.is_valid_token,
+            metadata.block_table,
+            metadata.block_table.stride(0),
+            self.block_size,
+            token_offset=0,
+            TRITON_BLOCK_SIZE=1024,
+        )
+        tile_sched = self.build_tile_scheduler(metadata.num_decode_tokens)
+        metadata.tile_sched_swaonly = tile_sched[_LAYER_TYPE_SWAONLY]
+        metadata.tile_sched_c4a = tile_sched[_LAYER_TYPE_C4A]
+        metadata.tile_sched_c128a = tile_sched[_LAYER_TYPE_C128A]
 
     def build_tile_scheduler(
         self, num_decode_tokens: int

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -400,7 +400,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
 
     reorder_batch_threshold: int | None = None
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
-    supports_fused_decode_graph = True
+    supports_draft_decode_metadata_update = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -650,7 +650,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             **deepseek_v4_fields,  # type: ignore[arg-type]
         )
 
-    def refresh_meta_for_draft_decodes(
+    def update_draft_decode_metadata(
         self,
         metadata: DeepseekSparseSWAMetadata,
     ) -> None:

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -682,6 +682,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         metadata.tile_sched_swaonly = tile_sched[_LAYER_TYPE_SWAONLY]
         metadata.tile_sched_c4a = tile_sched[_LAYER_TYPE_C4A]
         metadata.tile_sched_c128a = tile_sched[_LAYER_TYPE_C128A]
+        metadata.flashinfer_sparse_index_cache.clear()
 
     def build_tile_scheduler(
         self, num_decode_tokens: int

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -57,12 +57,17 @@ class TritonMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
 
     def __init__(self, kv_cache_spec, layer_names, vllm_config, device):
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        # DCP local sequence lengths are not advanced between draft steps.
+        self.supports_draft_decode_metadata_update = self.dcp_world_size == 1
         # Only the non-causal DSpark draft group serves multi-token blocks via
         # the decode path; raise its reorder threshold to the spec block length
         # so full-cudagraph capture admits it. Causal usage stays single-token.
         if getattr(self, "non_causal_multi_token_decode", False):
             self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
         self._reserve_attn_logits_workspace()
+
+    def update_draft_decode_metadata(self, _metadata: MLACommonMetadata) -> None:
+        pass
 
     def _reserve_attn_logits_workspace(self) -> None:
         """Pre-size the shared workspace for the decode split-KV attn logits.

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -100,6 +100,8 @@ class TritonAttentionMetadata:
 
 class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.ALWAYS
+    # Step-dependent fields reference persistent input buffers directly.
+    supports_draft_decode_metadata_update = True
 
     def __init__(
         self,
@@ -266,6 +268,9 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             attn_metadata.rswa_window = self.rswa_window
 
         return attn_metadata
+
+    def update_draft_decode_metadata(self, _metadata: TritonAttentionMetadata) -> None:
+        pass
 
 
 class TritonAttentionBackend(AttentionBackend):

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -45,7 +45,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         self.prefill_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.decode_cudagraph_manager: SpeculatorCudaGraphManager | None = None
-        self.use_fused_decode_graph = False
+        self.use_fused_multi_step_decode = False
 
     def load_model(self, target_model: nn.Module) -> None:
         super().load_model(target_model)
@@ -96,11 +96,15 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             target_input_buffers,
             target_attn_groups,
         )
-        self._configure_fused_decode_graph()
+        self._configure_fused_multi_step_decode()
 
-    def _configure_fused_decode_graph(self) -> None:
+    def _configure_fused_multi_step_decode(self) -> None:
         if self.num_speculative_steps == 1:
-            self.use_fused_decode_graph = False
+            self.use_fused_multi_step_decode = False
+            return
+
+        if not self.advance_draft_positions:
+            self.use_fused_multi_step_decode = True
             return
 
         unsupported_backends = sorted(
@@ -108,13 +112,13 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                 attn_group.backend.get_name()
                 for attn_groups in self.attn_groups
                 for attn_group in attn_groups
-                if not attn_group.supports_fused_decode_graph
+                if not attn_group.supports_draft_decode_metadata_update
             }
         )
-        self.use_fused_decode_graph = not unsupported_backends
+        self.use_fused_multi_step_decode = not unsupported_backends
         if unsupported_backends:
             logger.info_once(
-                "Fused draft decode graph is not supported by attention "
+                "Fused multi-step draft decode is not supported by attention "
                 "backend(s) %s; falling back to rebuilding attention metadata "
                 "between draft steps.",
                 ", ".join(unsupported_backends),
@@ -181,7 +185,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         assert self.decode_cudagraph_manager is not None
         decode_fn = (
             self._generate_fused_drafts
-            if self.use_fused_decode_graph
+            if self.use_fused_multi_step_decode
             else self._generate_draft
         )
         self.decode_cudagraph_manager.capture(
@@ -339,7 +343,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         # Generate the remaining num_speculative_steps - 1 draft tokens.
         decode_fn = (
             self._fused_multi_step_decode
-            if self.use_fused_decode_graph
+            if self.use_fused_multi_step_decode
             else self._multi_step_decode
         )
         decode_fn(
@@ -589,7 +593,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                     num_tokens_padded,
                 )
                 for attn_group in attn_groups:
-                    attn_group.refresh_meta_for_draft_decodes(attn_metadata)
+                    attn_group.update_draft_decode_metadata(attn_metadata)
 
     def _generate_draft(
         self,

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -152,6 +152,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         # Reset indices to zeros to prevent stale values from prior
         # dummy runs to cause out-of-bounds indexing during capture.
         self.last_token_indices.zero_()
+        self.idx_mapping.zero_()
 
         # Capture the prefill routine (model forward + compute_logits +
         # sample).

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -10,17 +10,21 @@ from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
+from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
+from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     get_uniform_token_count,
 )
 from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
     SpeculatorCudaGraphManager,
 )
 from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+from vllm.v1.worker.utils import AttentionGroup
 
 logger = init_logger(__name__)
 
@@ -41,6 +45,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         self.prefill_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.decode_cudagraph_manager: SpeculatorCudaGraphManager | None = None
+        self.use_fused_decode_graph = False
 
     def load_model(self, target_model: nn.Module) -> None:
         super().load_model(target_model)
@@ -75,6 +80,48 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         False for Gemma4 MTP (Q-only, shares target KV, constant positions).
         """
         return True
+
+    def set_attn(
+        self,
+        model_state: ModelState,
+        kv_cache_config: KVCacheConfig,
+        block_tables: BlockTables,
+        target_input_buffers: InputBuffers,
+        target_attn_groups: list[list[AttentionGroup]],
+    ) -> None:
+        super().set_attn(
+            model_state,
+            kv_cache_config,
+            block_tables,
+            target_input_buffers,
+            target_attn_groups,
+        )
+        self._configure_fused_decode_graph()
+
+    def _configure_fused_decode_graph(self) -> None:
+        if (
+            not self.speculative_config.enable_fused_decode_graph
+            or self.num_speculative_steps == 1
+        ):
+            self.use_fused_decode_graph = False
+            return
+
+        unsupported_backends = sorted(
+            {
+                attn_group.backend.get_name()
+                for attn_groups in self.attn_groups
+                for attn_group in attn_groups
+                if not attn_group.supports_fused_decode_graph
+            }
+        )
+        self.use_fused_decode_graph = not unsupported_backends
+        if unsupported_backends:
+            logger.info_once(
+                "Fused draft decode graph is not supported by attention "
+                "backend(s) %s; falling back to rebuilding attention metadata "
+                "between draft steps.",
+                ", ".join(unsupported_backends),
+            )
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         # Initialize cudagraph manager for draft prefill (draft position 0).
@@ -133,12 +180,15 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             return
 
         self.on_multi_step_decode_begin(self.max_num_reqs)
-        # Capture the decode draft generation routine (model forward +
-        # sample + update_draft_inputs) for a single
-        # step.
+        # Capture either the fused decode loop or one decode step per graph.
         assert self.decode_cudagraph_manager is not None
+        decode_fn = (
+            self._run_draft_decode_loop
+            if self.use_fused_decode_graph
+            else self._generate_draft
+        )
         self.decode_cudagraph_manager.capture(
-            self._generate_draft,
+            decode_fn,
             self.model_state,
             self.input_buffers,
             self.block_tables,
@@ -412,6 +462,27 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
         idx_mapping = self.idx_mapping[:num_reqs]
 
+        if batch_desc.cg_mode == CUDAGraphMode.FULL and self.use_fused_decode_graph:
+            if not skip_attn:
+                self.block_tables.compute_slot_mappings(
+                    idx_mapping,
+                    query_start_loc,
+                    positions,
+                    batch_desc.num_tokens,
+                )
+                # Continuous draft decode replays usually consume only device metadata,
+                # so the host-side vars should have no effect and therefore pinned.
+                self._build_draft_attn_metadata(
+                    num_reqs=num_reqs,
+                    num_reqs_padded=batch_desc.num_reqs or num_reqs,
+                    num_tokens_padded=batch_desc.num_tokens,
+                    seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
+                    step=1,
+                )
+            assert self.decode_cudagraph_manager is not None
+            self.decode_cudagraph_manager.run_fullgraph(batch_desc)
+            return
+
         attn_metadata = None
         slot_mappings_by_layer = None
         for step in range(1, self.num_speculative_steps):
@@ -435,10 +506,8 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                     step=step,
                 )
 
-            # Update the current draft step.
             self.current_draft_step.fill_(step)
 
-            # Generate draft tokens for the current step.
             if batch_desc.cg_mode == CUDAGraphMode.FULL:
                 assert self.decode_cudagraph_manager is not None
                 self.decode_cudagraph_manager.run_fullgraph(batch_desc)
@@ -451,6 +520,45 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                     num_tokens_across_dp=num_tokens_across_dp,
                     cudagraph_runtime_mode=batch_desc.cg_mode,
                 )
+
+    def _run_draft_decode_loop(
+        self,
+        num_reqs: int,
+        num_tokens_padded: int,
+        attn_metadata: dict[str, Any] | None,
+        slot_mappings: dict[str, torch.Tensor] | None,
+        num_tokens_across_dp: torch.Tensor | None,
+        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+    ) -> None:
+        idx_mapping = self.idx_mapping[:num_reqs]
+        positions = self.input_buffers.positions[:num_reqs]
+        query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
+        attn_groups = (
+            [group for groups in self.attn_groups for group in groups]
+            if attn_metadata is not None
+            else []
+        )
+
+        for step in range(1, self.num_speculative_steps):
+            self.current_draft_step.fill_(step)
+            self._generate_draft(
+                num_reqs,
+                num_tokens_padded,
+                attn_metadata,
+                slot_mappings,
+                num_tokens_across_dp,
+                cudagraph_runtime_mode,
+            )
+            if step < self.num_speculative_steps - 1 and attn_metadata is not None:
+                if self.advance_draft_positions:
+                    self.block_tables.compute_slot_mappings(
+                        idx_mapping,
+                        query_start_loc,
+                        positions,
+                        num_tokens_padded,
+                    )
+                for attn_group in attn_groups:
+                    attn_group.refresh_meta_for_draft_decodes(attn_metadata)
 
     def _generate_draft(
         self,

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -99,10 +99,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         self._configure_fused_decode_graph()
 
     def _configure_fused_decode_graph(self) -> None:
-        if (
-            not self.speculative_config.enable_fused_decode_graph
-            or self.num_speculative_steps == 1
-        ):
+        if self.num_speculative_steps == 1:
             self.use_fused_decode_graph = False
             return
 
@@ -183,7 +180,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         # Capture either the fused decode loop or one decode step per graph.
         assert self.decode_cudagraph_manager is not None
         decode_fn = (
-            self._run_draft_decode_loop
+            self._generate_fused_drafts
             if self.use_fused_decode_graph
             else self._generate_draft
         )
@@ -340,7 +337,12 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         self.on_multi_step_decode_begin(num_reqs)
         # Generate the remaining num_speculative_steps - 1 draft tokens.
-        self._multi_step_decode(
+        decode_fn = (
+            self._fused_multi_step_decode
+            if self.use_fused_decode_graph
+            else self._multi_step_decode
+        )
+        decode_fn(
             num_reqs,
             dummy_run and skip_attn_for_dummy_run,
             decode_batch_desc,
@@ -462,27 +464,6 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
         idx_mapping = self.idx_mapping[:num_reqs]
 
-        if batch_desc.cg_mode == CUDAGraphMode.FULL and self.use_fused_decode_graph:
-            if not skip_attn:
-                self.block_tables.compute_slot_mappings(
-                    idx_mapping,
-                    query_start_loc,
-                    positions,
-                    batch_desc.num_tokens,
-                )
-                # Continuous draft decode replays usually consume only device metadata,
-                # so the host-side vars should have no effect and therefore pinned.
-                self._build_draft_attn_metadata(
-                    num_reqs=num_reqs,
-                    num_reqs_padded=batch_desc.num_reqs or num_reqs,
-                    num_tokens_padded=batch_desc.num_tokens,
-                    seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
-                    step=1,
-                )
-            assert self.decode_cudagraph_manager is not None
-            self.decode_cudagraph_manager.run_fullgraph(batch_desc)
-            return
-
         attn_metadata = None
         slot_mappings_by_layer = None
         for step in range(1, self.num_speculative_steps):
@@ -521,7 +502,54 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                     cudagraph_runtime_mode=batch_desc.cg_mode,
                 )
 
-    def _run_draft_decode_loop(
+    def _fused_multi_step_decode(
+        self,
+        num_reqs: int,
+        skip_attn: bool,
+        batch_desc: BatchExecutionDescriptor,
+        num_tokens_across_dp: torch.Tensor | None,
+        seq_lens_cpu_upper_bound: torch.Tensor,
+    ) -> None:
+        positions = self.input_buffers.positions[:num_reqs]
+        query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
+        idx_mapping = self.idx_mapping[:num_reqs]
+
+        attn_metadata = None
+        slot_mappings_by_layer = None
+        if not skip_attn:
+            slot_mappings = self.block_tables.compute_slot_mappings(
+                idx_mapping,
+                query_start_loc,
+                positions,
+                batch_desc.num_tokens,
+            )
+            if batch_desc.cg_mode != CUDAGraphMode.FULL:
+                slot_mappings_by_layer = build_slot_mappings_by_layer(
+                    slot_mappings, self.kv_cache_config
+                )
+            attn_metadata = self._build_draft_attn_metadata(
+                num_reqs=num_reqs,
+                num_reqs_padded=batch_desc.num_reqs or num_reqs,
+                num_tokens_padded=batch_desc.num_tokens,
+                seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
+                step=1,
+            )
+
+        if batch_desc.cg_mode == CUDAGraphMode.FULL:
+            assert self.decode_cudagraph_manager is not None
+            self.decode_cudagraph_manager.run_fullgraph(batch_desc)
+            return
+
+        self._generate_fused_drafts(
+            num_reqs,
+            batch_desc.num_tokens,
+            attn_metadata,
+            slot_mappings_by_layer,
+            num_tokens_across_dp,
+            batch_desc.cg_mode,
+        )
+
+    def _generate_fused_drafts(
         self,
         num_reqs: int,
         num_tokens_padded: int,
@@ -549,14 +577,17 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                 num_tokens_across_dp,
                 cudagraph_runtime_mode,
             )
-            if step < self.num_speculative_steps - 1 and attn_metadata is not None:
-                if self.advance_draft_positions:
-                    self.block_tables.compute_slot_mappings(
-                        idx_mapping,
-                        query_start_loc,
-                        positions,
-                        num_tokens_padded,
-                    )
+            if (
+                step < self.num_speculative_steps - 1
+                and attn_metadata is not None
+                and self.advance_draft_positions
+            ):
+                self.block_tables.compute_slot_mappings(
+                    idx_mapping,
+                    query_start_loc,
+                    positions,
+                    num_tokens_padded,
+                )
                 for attn_group in attn_groups:
                     attn_group.refresh_meta_for_draft_decodes(attn_metadata)
 

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -299,6 +299,17 @@ class AttentionGroup:
         assert len(self.metadata_builders) > ubatch_id
         return self.metadata_builders[ubatch_id]
 
+    @property
+    def supports_fused_decode_graph(self) -> bool:
+        return self.get_metadata_builder().supports_fused_decode_graph
+
+    def refresh_meta_for_draft_decodes(
+        self,
+        attn_metadata: Mapping[str, Any],
+    ) -> None:
+        metadata = attn_metadata[self.layer_names[0]]
+        self.get_metadata_builder().refresh_meta_for_draft_decodes(metadata)
+
 
 def select_common_block_size(
     kv_manager_block_size: int,

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -300,15 +300,15 @@ class AttentionGroup:
         return self.metadata_builders[ubatch_id]
 
     @property
-    def supports_fused_decode_graph(self) -> bool:
-        return self.get_metadata_builder().supports_fused_decode_graph
+    def supports_draft_decode_metadata_update(self) -> bool:
+        return self.get_metadata_builder().supports_draft_decode_metadata_update
 
-    def refresh_meta_for_draft_decodes(
+    def update_draft_decode_metadata(
         self,
         attn_metadata: Mapping[str, Any],
     ) -> None:
         metadata = attn_metadata[self.layer_names[0]]
-        self.get_metadata_builder().refresh_meta_for_draft_decodes(metadata)
+        self.get_metadata_builder().update_draft_decode_metadata(metadata)
 
 
 def select_common_block_size(


### PR DESCRIPTION
## Purpose

This PR restores fused multi-step CUDA graph execution for autoregressive speculative decoding in Model Runner V2.

#41162 fixed stale attention metadata by rebuilding it and replaying a separate CUDA graph for every draft step. While correct, that design reintroduces per-step Python dispatch, metadata construction, and CUDA graph launch overhead.

This PR instead captures the post-prefill draft loop into one CUDA graph. Attention metadata is built once, and backend-owned step-dependent metadata is updated in place between draft steps.

### Additional Background
Our local tests suggest the historical illegal memory access is not fully explained by stale draft metadata:

1. A pre-#41162 version reproduces the illegal memory access, but adding this metadata refresh alone does not fix it.
2. Since v0.23.0, the illegal memory access does not reproduce even when this refresh is disabled.

## Design

Design of #41162:

```mermaid
sequenceDiagram
    participant Spec as AutoRegressiveSpeculator
    participant Inputs as Draft Input Buffers
    participant Builder as Attention Metadata Builder
    participant Graph as Draft CUDA graph

    loop draft_step = 0..N-1
        Spec->>Builder: _build_draft_attn_metadata()
        Builder-->>Spec: fresh attn_metadata
        Spec->>Graph: replay per-step draft graph
        Spec->>Inputs: update_draft_inputs()
    end
```

Design of this PR:

```mermaid
sequenceDiagram
    participant Spec as AutoRegressiveSpeculator
    participant Input as Draft input buffers
    participant Attn as Attention metadata builder
    participant Graph as Fused draft CUDA graph

    Spec->>Attn: Build metadata once
    Spec->>Graph: Replay fused multi-step graph
    loop Each captured draft step
        Graph->>Graph: Draft model forward and sampling
        Graph->>Input: Advance draft inputs and positions
        Graph->>Attn: `update_draft_decode_metadata()`
        Attn-->>Attn: Update backend-derived metadata
    end
```

Backends opt in through `supports_draft_decode_metadata_update`. The default is disabled, so unadapted backends retain the split-graph path and rebuild metadata between draft steps.

`update_draft_decode_metadata()` is executed while the fused graph is being captured. Implementations must emit CUDA graph capture-safe operations and keep replayed tensor state in persistent storage; Python code is not executed during replay.

Current backend handling:

| Backend | Fused path | Metadata handling |
|---|---|---|
| FlashAttention / FA3 without DCP | Enabled | FA3 scheduler metadata is regenerated into persistent storage; other FlashAttention paths are no-op |
| DeepSeek V4 sparse SWA | Enabled | Recomputes SWA lengths and indices, refreshes tile schedulers, and invalidates the FlashInfer sparse-index cache |
| Triton Attention | Enabled | Step-dependent fields already reference persistent input buffers |
| Triton MLA without DCP | Enabled | No additional materialized metadata requires updating |
| Position-static draft models | Enabled | Positions do not advance, so no metadata update is required |
| DeepSeek V4 ROCm sparse SWA | Disabled | ROCm-specific ragged SWA indices and indptrs still require adaptation |
| Other backends | Disabled by default | Fall back to per-step metadata rebuilding |

## Test Plan

Tested on:
- Device: H100 8 * 80G
- vLLM version: main branch (0406ba22c431e5fd2000165b594323f5afa312a2, fix pre-commit broken (#51341)) + this PR

### Online serving: device-bound workload

The online serving sweep used:

```sh
vllm-bench \
--backend openai-chat \
--base-url http://127.0.0.1:8000 \
--model <model> \
--dataset-name hf \
--dataset-path philschmid/mt-bench \
--ignore-eos \
--request-rate inf \
--temperature <0 or 1> \
--num-warmups 64 \
--hf-output-len 1024 \
--seed 0 \
--disable-shuffle \
--sweep-max-concurrency 1,16,64 \
--sweep-num-prompts-factor 10
```

```sh
VLLM_USE_FLASHINFER_MOE_FP8=0 \
FLASHINFER_DISABLE_VERSION_CHECK=1 \
VLLM_USE_V2_MODEL_RUNNER=1 \
vllm serve /path/to/DeepSeek-V4-Flash \
--tensor-parallel-size 8 \
--enable-expert-parallel \
--max-model-len 32768 \
--max-num-seqs 128 \
--block-size 256 \
--kv-cache-dtype fp8 \
--tokenizer-mode deepseek_v4 \
--tool-call-parser deepseek_v4 \
--reasoning-parser deepseek_v4 \
--no-enable-prefix-caching \
--kernel-config.enable_flashinfer_autotune=False \
--speculative-config '{"method":"mtp","num_speculative_tokens":3}'

# For Qwen3.5-9B, we increased `num_speculative_tokens` to 7 to amplify host-side overhead.
FLASHINFER_DISABLE_VERSION_CHECK=1 \
VLLM_USE_V2_MODEL_RUNNER=1 \
vllm serve /path/to/Qwen3_5-9B \
--tensor-parallel-size 2 \
--max-model-len 32768 \
--max-num-seqs 128 \
--language-model-only \
--enable-auto-tool-choice \
--tool-call-parser qwen3_coder \
--reasoning-parser qwen3 \
--no-enable-prefix-caching \
--speculative-config '{"method":"mtp","num_speculative_tokens":7}'
```

The baseline forces `use_fused_multi_step_decode=False`; the fused runs use normal backend capability selection. All 24 runs completed without failed requests.

For DeepSeek-V4-Flash:
| Temp | Concurrency | Median ITL baseline (ms) | Median ITL fused (ms) | ITL delta | Acceptance baseline | Acceptance fused | Acceptance delta | Acceptance-normalized ITL delta |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 | 1 | 10.75 | 10.70 | -0.4% | 46.50% | 48.85% | +2.36 pp | +2.5% |
| 0 | 16 | 34.44 | 34.91 | +1.4% | 53.47% | 53.57% | +0.10 pp | +1.5% |
| 0 | 64 | 85.44 | 78.09 | -8.6% | 54.31% | 54.20% | -0.12 pp | -8.7% |
| 1 | 1 | 10.88 | 10.99 | +1.0% | 38.53% | 36.75% | -1.78 pp | -1.5% |
| 1 | 16 | 35.28 | 34.90 | -1.1% | 43.33% | 42.78% | -0.55 pp | -1.8% |
| 1 | 64 | 79.16 | 81.52 | +3.0% | 43.42% | 43.25% | -0.17 pp | +2.7% |

For Qwen3.5-9B:
| Temp | Concurrency | Median ITL baseline (ms) | Median ITL fused (ms) | ITL delta | Acceptance baseline | Acceptance fused | Acceptance delta | Acceptance-normalized ITL delta |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 | 1 | 8.90 | 9.05 | +1.7% | 36.70% | 36.70% | +0.00 pp | +1.7% |
| 0 | 16 | 11.55 | 11.49 | -0.5% | 45.07% | 44.55% | -0.52 pp | -1.4% |
| 0 | 64 | 23.14 | 22.78 | -1.5% | 45.75% | 45.75% | +0.00 pp | -1.5% |
| 1 | 1 | 8.92 | 9.02 | +1.1% | 27.40% | 26.31% | -1.10 pp | -1.6% |
| 1 | 16 | 11.59 | 11.50 | -0.8% | 33.52% | 33.16% | -0.36 pp | -1.5% |
| 1 | 64 | 23.17 | 23.05 | -0.5% | 34.01% | 33.77% | -0.24 pp | -1.0% |

The acceptance-normalized ITL delta compares `median ITL * acceptance length`, which approximates the time per speculative scheduler step and removes the effect of small acceptance-rate differences between paired runs.

The normalized results fluctuate in both directions and show no systematic regression so we cannot conclude it has performance gain. My guess is that these workloads remain device-bound, so reducing host dispatch helps little.

### Host-bound profiling

To expose host dispatch overhead, Qwen3.5-9B was profiled with TP=2 and `torch_profiler_with_stack=True`.

```python
llm = LLM(
    model=MODEL,
    trust_remote_code=True,
    tensor_parallel_size=2,
    max_model_len=4096,
    max_num_seqs=4,
    enable_prefix_caching=False,
    speculative_config={
        "method": "mtp",
        "num_speculative_tokens": 3,
    },
    disable_log_stats=False,
    profiler_config={
        "profiler": "torch",
        "torch_profiler_dir": "vllm-profile/",
        "torch_profiler_with_stack": True,
        "torch_profiler_use_gzip": False,
        "wait_iterations": 4,
        "max_iterations": 4,
    }
)
```

The table below averages rank 0 `ProfilerStep#5` through `ProfilerStep#7`, excluding the first profiled iteration.

| Metric | Split graph | Fused graph | Change |
|---|---:|---:|---:|
| CUDA graph launches per scheduler step | 4 | 3 | -1 |
| Multi-step draft decode CPU span | 2.050 ms | 0.860 ms | -58.1% |
| Complete draft `propose` CPU span | 2.971 ms | 1.493 ms | -49.8% |
| Profiler step CPU span | 20.385 ms | 14.537 ms | -28.7% |

With three speculative tokens, the split path launches one target graph, one draft-prefill graph, and two draft-decode graphs per scheduler step. The fused path replaces the two draft-decode launches with one multi-step graph.

#### Trace screenshots

<img width="3839" height="2071" alt="image" src="https://github.com/user-attachments/assets/9e0f20a4-a2f2-4c01-bb13-edbbf37ebcfc" />
<img width="3839" height="2072" alt="image" src="https://github.com/user-attachments/assets/a598449c-fbcb-4cad-a970-dcd5898b4eab" />

**Split graph:** Each post-prefill draft step returns to Python, rebuilds attention metadata, and launches a separate draft graph. In the stable rank 0 iterations, `_multi_step_decode` takes 1.929–2.149 ms.

**Fused graph:** Both post-prefill draft steps execute inside one CUDA graph. Input advancement and backend metadata updates are captured as part of that graph. In the same rank 0 interval, `_fused_multi_step_decode` takes 0.848–0.883 ms.

Raw traces for both TP ranks and the profiler summary outputs are attached here:
[fused-graph.zip](https://github.com/user-attachments/files/30855857/fused-graph.zip)
[split-graph.zip](https://github.com/user-attachments/files/30855887/split-graph.zip)

### Per-step Metadata Check

The following values were captured with temporary debug instrumentation. The
final PR does not keep this logging path.

With refresh enabled, SWA metadata advances from draft step 1 to draft step 2:

```text
draft_step=1 num_decodes=4 scheduler=FlashMLASchedMeta:have_initialized=False,tile_scheduler_metadata_shape=None,num_splits_shape=None
field=is_valid_token sample=[True, False, False, False]
field=decode_swa_lens sample=[6, 0, 0, 0]
field=decode_swa_indices sample=[192, 193, 194, 195, 196, 197, -1, -1, -1, -1, -1, -1]

draft_step=2 num_decodes=4 scheduler=FlashMLASchedMeta:have_initialized=False,tile_scheduler_metadata_shape=None,num_splits_shape=None
field=is_valid_token sample=[True, False, False, False]
field=decode_swa_lens sample=[7, 0, 0, 0]
field=decode_swa_indices sample=[192, 193, 194, 195, 196, 197, 198, -1, -1, -1, -1, -1]
```

With refresh disabled, draft step 2 keeps step-1 SWA metadata:

```text
draft_step=1 num_decodes=4 scheduler=FlashMLASchedMeta:have_initialized=False,tile_scheduler_metadata_shape=None,num_splits_shape=None
field=is_valid_token sample=[True, False, False, False]
field=decode_swa_lens sample=[6, 0, 0, 0]
field=decode_swa_indices sample=[192, 193, 194, 195, 196, 197, -1, -1, -1, -1, -1, -1]

draft_step=2 num_decodes=4 scheduler=FlashMLASchedMeta:have_initialized=True,tile_scheduler_metadata_shape=(132, 8),num_splits_shape=(5,)
field=is_valid_token sample=[True, False, False, False]
field=decode_swa_lens sample=[6, 0, 0, 0]
field=decode_swa_indices sample=[192, 193, 194, 195, 196, 197, -1, -1, -1, -1, -1, -1]
```

So the refresh path updates the same SWA metadata that the split-graph path would rebuild. `is_valid_token` stays unchanged, as expected, because the padded request set is unchanged across draft steps.

## Other things
AI assistance was used for code review, performance-data aggregation. The human author made and reviewed the changes and ran the evaluations above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
