### PR TITLE
[ROCm][CI] Fix rlhf_nccl.py on ROCm

### DIFF
--- a/examples/rl/rlhf_nccl.py
+++ b/examples/rl/rlhf_nccl.py
@@ -29,6 +29,7 @@ causes unexpected behavior.
 import os
 
 import ray
+import torch
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from transformers import AutoModelForCausalLM
@@ -39,10 +40,23 @@ from vllm.distributed.weight_transfer.nccl_engine import (
     NCCLTrainerSendWeightsArgs,
     NCCLWeightTransferEngine,
 )
+from vllm.platforms import current_platform
 from vllm.utils.network_utils import get_ip, get_open_port
 
 MODEL_NAME = "facebook/opt-125m"
 # MODEL_NAME = "inference-optimization/Qwen3-0.6B-W4A16-G128"
+
+
+def get_assigned_gpu():
+    """This is a temporary workaround for a runtime bug in RCCL on ROCm."""
+    if not current_platform.is_rocm():
+        return 0
+    assigned_gpu = int(ray.get_gpu_ids()[0])
+    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+    os.environ.pop("HIP_VISIBLE_DEVICES", None)
+    torch.accelerator.set_device(assigned_gpu)
+    print(f"Training model on GPU {assigned_gpu}")
+    return assigned_gpu
 
 
 class MyLLM(LLM):
@@ -58,9 +72,11 @@ class TrainModel:
     """Ray actor that wraps the training model on a dedicated GPU."""
 
     def __init__(self, model_name: str):
+        assigned_gpu = get_assigned_gpu()
+
         self.model = AutoModelForCausalLM.from_pretrained(
             model_name,
-        ).to("cuda:0")
+        ).to(f"cuda:{assigned_gpu}")
 
         self.port = get_open_port()
         self.master_address = get_ip()
@@ -124,11 +140,12 @@ scheduling_inference = PlacementGroupSchedulingStrategy(
 # start-up latency.
 # Note: Weight transfer APIs (init_weight_transfer_engine, update_weights)
 # are now native to vLLM workers.
-llm = ray.remote(
+llm_handle = ray.remote(
     num_cpus=0,
     num_gpus=0,
     scheduling_strategy=scheduling_inference,
-)(MyLLM).remote(
+)(MyLLM)
+llm = llm_handle.remote(
     model=MODEL_NAME,
     enforce_eager=True,
     tensor_parallel_size=2,

--- a/examples/rl/rlhf_nccl.py
+++ b/examples/rl/rlhf_nccl.py
@@ -54,8 +54,7 @@ def get_assigned_gpu():
     assigned_gpu = int(ray.get_gpu_ids()[0])
     os.environ.pop("CUDA_VISIBLE_DEVICES", None)
     os.environ.pop("HIP_VISIBLE_DEVICES", None)
-    torch.accelerator.set_device(assigned_gpu)
-    print(f"Training model on GPU {assigned_gpu}")
+    torch.accelerator.set_device_idx(assigned_gpu)
     return assigned_gpu
 
 

--- a/examples/rl/rlhf_nccl.py
+++ b/examples/rl/rlhf_nccl.py
@@ -139,12 +139,11 @@ scheduling_inference = PlacementGroupSchedulingStrategy(
 # start-up latency.
 # Note: Weight transfer APIs (init_weight_transfer_engine, update_weights)
 # are now native to vLLM workers.
-llm_handle = ray.remote(
+llm = ray.remote(
     num_cpus=0,
     num_gpus=0,
     scheduling_strategy=scheduling_inference,
-)(MyLLM)
-llm = llm_handle.remote(
+)(MyLLM).remote(
     model=MODEL_NAME,
     enforce_eager=True,
     tensor_parallel_size=2,


### PR DESCRIPTION
There is a runtime bug in RCCL handling the envs `HIP_VISIBLE_DEVICES` and `CUDA_VISIBLE_DEVICES` causing crash of rlhf_nccl.py.

This PR tries to post a temporary workaround for this.