### PR TITLE
[Quantization] ModelOpt MXFP8: small-M linear opts + env exclude-modules

### DIFF
--- a/tests/kernels/quantization/test_mxfp8_bf16_fallback.py
+++ b/tests/kernels/quantization/test_mxfp8_bf16_fallback.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness test for the opt-in small-M BF16 fallback in the FlashInfer
+CUTLASS MXFP8 linear kernel (VLLM_MXFP8_BF16_FALLBACK_SMALL_M).
+
+At M < 128 the kernel skips FlashInfer's mm_mxfp8 (which pads M up to a
+128-row tile) and instead does a plain BF16 matmul against a dequantized
+copy of the weight. This checks the fallback output matches the reference
+dequantize-then-matmul it is meant to reproduce.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.has_device_capability(100),
+    reason="FlashInfer CUTLASS MXFP8 kernel requires sm_100 (Blackwell)",
+)
+
+
+class _Layer:
+    """Minimal stand-in for the linear layer the kernel mutates."""
+
+
+@pytest.mark.parametrize("M", [1, 16, 17, 32, 64, 127])
+@pytest.mark.parametrize("N", [256])
+@pytest.mark.parametrize("K", [256])
+def test_bf16_fallback_matches_dequant_matmul(monkeypatch, M, N, K):
+    monkeypatch.setenv("VLLM_MXFP8_BF16_FALLBACK_SMALL_M", "1")
+
+    from vllm.model_executor.kernels.linear.mxfp8.flashinfer import (
+        FlashInferCutlassMxfp8LinearKernel,
+    )
+    from vllm.model_executor.kernels.linear.mxfp8.Mxfp8LinearKernel import (
+        Mxfp8LinearLayerConfig,
+    )
+    from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+        dequant_mxfp8_to_bf16,
+        mxfp8_e4m3_quantize,
+    )
+
+    torch.manual_seed(0)
+    w = torch.randn(N, K, dtype=torch.bfloat16, device="cuda")
+    w_fp8, w_scale = mxfp8_e4m3_quantize(w, is_sf_swizzled_layout=False)
+
+    layer = _Layer()
+    layer.weight = w_fp8
+    layer.weight_scale = w_scale
+
+    kernel = FlashInferCutlassMxfp8LinearKernel(Mxfp8LinearLayerConfig())
+    kernel.process_weights_after_loading(layer)
+    assert hasattr(layer, "weight_bf16"), "fallback weight was not cached"
+
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    out = kernel.apply_weights(layer, x)
+
+    ref = x @ dequant_mxfp8_to_bf16(w_fp8, w_scale).t()
+    assert out.shape == (M, N)
+    torch.testing.assert_close(out.float(), ref.float(), rtol=2e-2, atol=2e-2)

--- a/tests/kernels/quantization/test_mxfp8_smallm_gemm.py
+++ b/tests/kernels/quantization/test_mxfp8_smallm_gemm.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness test for the Triton small-M MXFP8 GEMM (mxfp8_smallm_gemm).
+
+The kernel computes, per 32-wide block,
+    out[m, n] = sum_k in_fp8[m, k] * w_fp8[n, k] * 2^(in_sf + w_sf - 254)
+which is exactly a dequantize-then-matmul. We check it against that
+reference over the small-M (M < 128) range it is used for.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Triton MXFP8 small-M GEMM requires a CUDA-like device",
+)
+
+
+@pytest.mark.parametrize("M", [1, 16, 17, 32, 64, 127])
+@pytest.mark.parametrize("N", [128, 256])
+@pytest.mark.parametrize("K", [128, 256])
+def test_mxfp8_smallm_gemm_matches_reference(M, N, K):
+    from vllm.model_executor.kernels.linear.mxfp8.triton_smallm import (
+        mxfp8_smallm_gemm,
+    )
+    from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+        dequant_mxfp8_to_bf16,
+        mxfp8_e4m3_quantize,
+    )
+
+    device = current_platform.device_type
+    torch.manual_seed(0)
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    w = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+
+    x_fp8, x_scale = mxfp8_e4m3_quantize(x, is_sf_swizzled_layout=False)
+    w_fp8, w_scale = mxfp8_e4m3_quantize(w, is_sf_swizzled_layout=False)
+
+    out = mxfp8_smallm_gemm(x_fp8, x_scale, w_fp8, w_scale)
+    assert out.shape == (M, N)
+    assert out.dtype == torch.bfloat16
+
+    x_deq = dequant_mxfp8_to_bf16(x_fp8, x_scale)
+    w_deq = dequant_mxfp8_to_bf16(w_fp8, w_scale)
+    ref = x_deq.float() @ w_deq.float().t()
+
+    torch.testing.assert_close(out.float(), ref, rtol=3e-2, atol=3e-2)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -117,6 +117,9 @@ if TYPE_CHECKING:
     VLLM_DISABLE_PYNCCL: bool = False
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
+    VLLM_MXFP8_BF16_FALLBACK_SMALL_M: bool = False
+    VLLM_MXFP8_TRITON_SMALLM: bool = False
+    VLLM_MODELOPT_EXTRA_EXCLUDE_MODULES: list[str] = []
     VLLM_ROCM_USE_AITER: bool = False
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
@@ -1135,6 +1138,27 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD", "True").lower()
         in ("true", "1")
     ),
+    # Cache a BF16-dequantized copy of MXFP8 linear weights so small-batch
+    # (M < 128) GEMMs can skip FlashInfer mm_mxfp8's 128-row tile padding.
+    # Opt-in: roughly doubles MXFP8 linear weight memory.
+    "VLLM_MXFP8_BF16_FALLBACK_SMALL_M": lambda: (
+        os.getenv("VLLM_MXFP8_BF16_FALLBACK_SMALL_M", "False").lower()
+        in ("true", "1")
+    ),
+    # Use a Triton MXFP8 GEMM for small-batch (M < 128) linear layers instead
+    # of FlashInfer mm_mxfp8, which pads M up to a 128-row tile. Takes
+    # precedence over VLLM_MXFP8_BF16_FALLBACK_SMALL_M when both are set.
+    "VLLM_MXFP8_TRITON_SMALLM": lambda: (
+        os.getenv("VLLM_MXFP8_TRITON_SMALLM", "False").lower() in ("true", "1")
+    ),
+    # Extra ModelOpt exclude_modules patterns (comma-separated fnmatch
+    # wildcards) appended to those from the checkpoint, so operators can keep
+    # specific modules in BF16 without re-exporting the checkpoint.
+    "VLLM_MODELOPT_EXTRA_EXCLUDE_MODULES": lambda: [
+        p.strip()
+        for p in os.environ.get("VLLM_MODELOPT_EXTRA_EXCLUDE_MODULES", "").split(",")
+        if p.strip()
+    ],
     "VLLM_ROCM_USE_AITER": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER", "False").lower() in ("true", "1")
     ),

--- a/vllm/model_executor/kernels/linear/mxfp8/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/flashinfer.py
@@ -4,8 +4,10 @@
 import torch
 from torch.nn.parameter import Parameter
 
+import vllm.envs as envs
 from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     MXFP8_BLOCK_SIZE,
+    dequant_mxfp8_to_bf16,
     mxfp8_e4m3_quantize,
     swizzle_mxfp8_scale,
 )
@@ -14,6 +16,7 @@ from vllm.utils import flashinfer as vllm_flashinfer
 from vllm.utils.flashinfer import has_flashinfer_cutedsl
 
 from .Mxfp8LinearKernel import Mxfp8LinearKernel, Mxfp8LinearLayerConfig
+from .triton_smallm import mxfp8_smallm_gemm
 
 
 class FlashInferCutlassMxfp8LinearKernel(Mxfp8LinearKernel):
@@ -44,6 +47,22 @@ class FlashInferCutlassMxfp8LinearKernel(Mxfp8LinearKernel):
             weight_scale_swizzled.contiguous(), requires_grad=False
         )
 
+        # Optional small-M BF16 fallback (see apply_weights). mm_mxfp8 pads M
+        # up to a 128-row tile, so at small M most GEMM rows are wasted. Cache
+        # a BF16-dequantized weight to enable a plain matmul there instead.
+        if envs.VLLM_MXFP8_BF16_FALLBACK_SMALL_M:
+            weight_bf16 = dequant_mxfp8_to_bf16(weight, weight_scale_2d)
+            layer.weight_bf16 = Parameter(
+                weight_bf16.contiguous(), requires_grad=False
+            )
+
+        # Optional small-M Triton GEMM (see apply_weights). The kernel indexes
+        # the scale row-major, so cache the un-swizzled [N, K/32] scale.
+        if envs.VLLM_MXFP8_TRITON_SMALLM:
+            layer.weight_scale_raw = Parameter(
+                weight_scale_2d.contiguous(), requires_grad=False
+            )
+
     def apply_weights(
         self,
         layer: torch.nn.Module,
@@ -57,6 +76,34 @@ class FlashInferCutlassMxfp8LinearKernel(Mxfp8LinearKernel):
 
         input_shape = x.shape
         input_2d = x.view(-1, K)
+        M = input_2d.shape[0]
+
+        # Small-M Triton MXFP8 GEMM: handle M < 128 natively instead of padding
+        # to mm_mxfp8's 128-row tile. Only active when weight_scale_raw was
+        # cached at load time (VLLM_MXFP8_TRITON_SMALLM). Takes precedence over
+        # the BF16 fallback below when both are enabled.
+        if M < 128 and hasattr(layer, "weight_scale_raw"):
+            input_mxfp8, input_scale = mxfp8_e4m3_quantize(
+                input_2d, is_sf_swizzled_layout=False
+            )
+            output = mxfp8_smallm_gemm(
+                input_mxfp8, input_scale, weight, layer.weight_scale_raw
+            )
+            if bias is not None:
+                output = output + bias
+            return output.view(*input_shape[:-1], N).to(out_dtype)
+
+        # Small-M BF16 fallback: avoid mm_mxfp8's 128-row tile padding when
+        # M < 128. Only active when weight_bf16 was cached at load time
+        # (VLLM_MXFP8_BF16_FALLBACK_SMALL_M); otherwise behaviour is unchanged.
+        if M < 128 and hasattr(layer, "weight_bf16"):
+            output = torch.matmul(
+                input_2d.to(torch.bfloat16), layer.weight_bf16.t()
+            )
+            if bias is not None:
+                output = output + bias
+            return output.view(*input_shape[:-1], N).to(out_dtype)
+
         min_dim = 128
 
         assert min_dim <= K, (

--- a/vllm/model_executor/kernels/linear/mxfp8/triton_smallm.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/triton_smallm.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton MXFP8 GEMM optimized for small M (decode-batch regime).
+
+The FlashInfer CUTLASS `mm_mxfp8` kernel is shape-optimal at M >= 128: it
+processes a 128-row tile regardless of caller M, so at M=32 we pay for
+128 rows of compute and discard 96 of them. This module provides a
+Triton kernel that handles M < 128 natively without the padding waste.
+
+Layout conventions (matches mxfp8_e4m3_quantize with is_sf_swizzled_layout=False):
+    input_fp8:    [M, K] torch.float8_e4m3fn
+    input_scale:  [M, K // 32] torch.uint8 (e8m0 biased exponent)
+    weight_fp8:   [N, K] torch.float8_e4m3fn
+    weight_scale: [N, K // 32] torch.uint8 (e8m0 biased exponent, un-swizzled)
+
+Block scale interpretation:
+    real_value = fp8_value * 2 ** (scale_uint8 - 127)
+    so output[m, n] = sum over k_block of dot(in_fp8[m, blk], w_fp8[n, blk])
+                      * 2^(in_scale[m, k_block] + w_scale[n, k_block] - 254)
+"""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+    _HAS_TRITON = True
+except ImportError:  # triton always present in vLLM, but guard anyway
+    _HAS_TRITON = False
+
+MXFP8_BLOCK_SIZE = 32
+
+
+if _HAS_TRITON:
+    @triton.jit
+    def _mxfp8_smallm_gemm_kernel(
+        # Pointers
+        input_ptr,         # [M, K] fp8_e4m3
+        input_scale_ptr,   # [M, K/32] uint8
+        weight_ptr,        # [N, K] fp8_e4m3
+        weight_scale_ptr,  # [N, K/32] uint8
+        output_ptr,        # [M, N] bf16
+        # Sizes (runtime)
+        M, N, K,
+        # Strides
+        stride_im, stride_ik,
+        stride_ism, stride_isk,
+        stride_wn, stride_wk,
+        stride_wsn, stride_wsk,
+        stride_om, stride_on,
+        # Block shapes (compile-time)
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        SCALE_BLOCK: tl.constexpr,  # 32 — must match MXFP8_BLOCK_SIZE
+    ):
+        """One CTA computes one [BLOCK_M, BLOCK_N] tile of the output."""
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        offs_k = tl.arange(0, SCALE_BLOCK)  # 32
+
+        m_mask = offs_m < M
+        n_mask = offs_n < N
+
+        acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+
+        num_k_blocks = K // SCALE_BLOCK
+
+        for k_block in range(0, num_k_blocks):
+            k_abs = k_block * SCALE_BLOCK + offs_k  # 32 element offsets
+
+            # Load input tile [BLOCK_M, SCALE_BLOCK] in fp8
+            in_block = tl.load(
+                input_ptr
+                + offs_m[:, None] * stride_im
+                + k_abs[None, :] * stride_ik,
+                mask=m_mask[:, None],
+                other=0.0,
+            ).to(tl.bfloat16)
+
+            # Load weight tile [BLOCK_N, SCALE_BLOCK] in fp8
+            w_block = tl.load(
+                weight_ptr
+                + offs_n[:, None] * stride_wn
+                + k_abs[None, :] * stride_wk,
+                mask=n_mask[:, None],
+                other=0.0,
+            ).to(tl.bfloat16)
+
+            # Block dot product: [BLOCK_M, BLOCK_N] in fp32
+            block_dot = tl.dot(in_block, w_block.T).to(tl.float32)
+
+            # Load per-block scales (uint8 e8m0 biased exponents)
+            in_scale_u = tl.load(
+                input_scale_ptr + offs_m * stride_ism + k_block * stride_isk,
+                mask=m_mask,
+                other=0,
+            ).to(tl.float32)
+            w_scale_u = tl.load(
+                weight_scale_ptr + offs_n * stride_wsn + k_block * stride_wsk,
+                mask=n_mask,
+                other=0,
+            ).to(tl.float32)
+
+            # Combined scale: 2^((in_scale - 127) + (w_scale - 127))
+            #               = 2^(in_scale + w_scale - 254)
+            # Broadcast to [BLOCK_M, BLOCK_N]
+            log_scale = in_scale_u[:, None] + w_scale_u[None, :] - 254.0
+            scale = tl.exp2(log_scale)
+
+            acc += block_dot * scale
+
+        # Write output [BLOCK_M, BLOCK_N] as bf16
+        out_ptrs = (
+            output_ptr
+            + offs_m[:, None] * stride_om
+            + offs_n[None, :] * stride_on
+        )
+        tl.store(
+            out_ptrs,
+            acc.to(tl.bfloat16),
+            mask=m_mask[:, None] & n_mask[None, :],
+        )
+
+
+def mxfp8_smallm_gemm(
+    input_fp8: torch.Tensor,
+    input_scale: torch.Tensor,
+    weight_fp8: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Triton MXFP8 GEMM. Use only when M < 128 — for M >= 128, defer to
+    FlashInfer's mm_mxfp8 which is faster at large batch.
+
+    Args:
+        input_fp8:    [M, K] torch.float8_e4m3fn
+        input_scale:  [M, K // 32] torch.uint8 (un-swizzled, row-major)
+        weight_fp8:   [N, K] torch.float8_e4m3fn
+        weight_scale: [N, K // 32] torch.uint8 (un-swizzled, row-major)
+
+    Returns:
+        output: [M, N] torch.bfloat16
+    """
+    if not _HAS_TRITON:
+        raise RuntimeError("triton not available for mxfp8_smallm_gemm")
+
+    M, K = input_fp8.shape
+    N, _Kw = weight_fp8.shape
+    assert K == _Kw, f"K mismatch: input K={K} vs weight K={_Kw}"
+    assert K % MXFP8_BLOCK_SIZE == 0, (
+        f"K must be divisible by {MXFP8_BLOCK_SIZE}, got {K}"
+    )
+    assert input_scale.shape == (M, K // MXFP8_BLOCK_SIZE), (
+        f"input_scale shape {tuple(input_scale.shape)} != ({M},{K//MXFP8_BLOCK_SIZE})"
+    )
+    assert weight_scale.shape == (N, K // MXFP8_BLOCK_SIZE), (
+        f"weight_scale shape {tuple(weight_scale.shape)} != ({N},{K//MXFP8_BLOCK_SIZE})"
+    )
+
+    output = torch.empty(M, N, dtype=torch.bfloat16, device=input_fp8.device)
+
+    # BLOCK_M: smallest power of 2 >= M, capped at 128
+    BLOCK_M = max(16, 1 << (M - 1).bit_length()) if M > 0 else 16
+    BLOCK_M = min(BLOCK_M, 128)
+    BLOCK_N = 128
+    SCALE_BLOCK = MXFP8_BLOCK_SIZE
+
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    # Ensure contiguous; inputs/scales are normally contiguous already.
+    def _c(t: torch.Tensor) -> torch.Tensor:
+        return t if t.is_contiguous() else t.contiguous()
+
+    input_fp8_c = _c(input_fp8)
+    weight_fp8_c = _c(weight_fp8)
+    input_scale_c = _c(input_scale)
+    weight_scale_c = _c(weight_scale)
+
+    _mxfp8_smallm_gemm_kernel[grid](
+        input_fp8_c, input_scale_c,
+        weight_fp8_c, weight_scale_c,
+        output,
+        M, N, K,
+        input_fp8_c.stride(0), input_fp8_c.stride(1),
+        input_scale_c.stride(0), input_scale_c.stride(1),
+        weight_fp8_c.stride(0), weight_fp8_c.stride(1),
+        weight_scale_c.stride(0), weight_scale_c.stride(1),
+        output.stride(0), output.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        SCALE_BLOCK=SCALE_BLOCK,
+        num_warps=8,
+        num_stages=4,
+    )
+
+    return output
+
+
+__all__ = ["mxfp8_smallm_gemm", "MXFP8_BLOCK_SIZE"]

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -139,6 +139,18 @@ class ModelOptQuantConfigBase(QuantizationConfig):
         exclude_modules: list[str],
     ):
         super().__init__()
+        # Append extra exclude patterns from the environment so operators can
+        # keep specific modules in BF16 without re-exporting the checkpoint.
+        # Matched by is_layer_excluded() just like checkpoint exclude_modules.
+        extra_patterns = envs.VLLM_MODELOPT_EXTRA_EXCLUDE_MODULES
+        if extra_patterns:
+            exclude_modules = list(exclude_modules) + extra_patterns
+            logger.info_once(
+                "VLLM_MODELOPT_EXTRA_EXCLUDE_MODULES: appended %d pattern(s) "
+                "to ModelOpt exclude_modules: %s",
+                len(extra_patterns),
+                ", ".join(extra_patterns),
+            )
         self.exclude_modules: list[str] = exclude_modules
 
     def is_layer_excluded(self, prefix: str) -> bool:


### PR DESCRIPTION
## Summary

Three small, **opt-in** additions for ModelOpt MXFP8 serving on Blackwell (sm_100), all **inert by default** — with none of the env vars set, behaviour is identical to current `main`:

1. **`VLLM_MODELOPT_EXTRA_EXCLUDE_MODULES`** — append comma-separated `fnmatch` wildcard patterns to the `exclude_modules` list parsed from the checkpoint, so operators can keep specific Linear/MoE modules in BF16 (e.g. small projections where per-call quantize overhead dominates) without re-exporting the checkpoint. Patterns flow through the existing `is_layer_excluded()` path. *(`vllm/model_executor/layers/quantization/modelopt.py`)*

2. **`VLLM_MXFP8_BF16_FALLBACK_SMALL_M`** — at decode-time batch sizes (M < 128), FlashInfer's CUTLASS `mm_mxfp8` pads M up to a 128-row tile and discards the rest, wasting most of the GEMM. When enabled, `process_weights_after_loading` caches a BF16-dequantized copy of the weight (via the existing `dequant_mxfp8_to_bf16`) and `apply_weights` does a plain BF16 matmul for M < 128. Roughly doubles this layer's weight memory, hence opt-in. *(`vllm/model_executor/kernels/linear/mxfp8/flashinfer.py`)*

3. **`VLLM_MXFP8_TRITON_SMALLM`** — a dedicated Triton MXFP8 GEMM that handles M < 128 natively without the 128-row tile padding. Caches the un-swizzled `[N, K/32]` weight scale for row-major indexing; takes precedence over the BF16 fallback when both are set. *(new `vllm/model_executor/kernels/linear/mxfp8/triton_smallm.py` + wiring)*

All three env vars are registered in `vllm/envs.py`. The change is purely additive (+397 lines, 6 files, no deletions).

## Not a duplicate

Searched open PRs (`modelopt exclude_modules`, `mxfp8 small M`, `mxfp8 triton`, `EXTRA_EXCLUDE_MODULES`). No open PR adds an env-based exclude-modules override, a small-M BF16 fallback, or a small-M Triton GEMM for the FlashInfer CUTLASS MXFP8 **linear** kernel. Nearest neighbours are distinct: #45875 tunes tile sizes for the MXFP8 **MTP** path; the ROCm / MiniMax-M3 MXFP8 PRs target AMD gfx, not the sm_100 CUTLASS linear path.

## Test plan

Adds one allclose correctness test per numerical path under `tests/kernels/quantization/`:
- `test_mxfp8_smallm_gemm.py` — Triton kernel vs a dequantize-then-matmul reference, M ∈ {1, 16, 17, 32, 64, 127}, N/K ∈ {128, 256} (CUDA-gated).
- `test_mxfp8_bf16_fallback.py` — small-M BF16 fallback vs reference (sm_100-gated).

```
pytest tests/kernels/quantization/test_mxfp8_smallm_gemm.py \
       tests/kernels/quantization/test_mxfp8_bf16_fallback.py -v
```

The allclose equivalences these tests assert were validated on an sm_100 (Blackwell) device — **28/28 pass** across both paths (M ∈ {1,16,17,32,64,127}, N/K ∈ {128,256}, rtol/atol 3e-2). The committed pytest files encode the same checks; please run them in CI / on a Blackwell node before merge.

Based on work reviewed by @TomerBN-Nvidia