### PR TITLE
Fuse grouped_topk routing for bias-free softmax models (Mistral Large 3)

### DIFF
--- a/csrc/libtorch_stable/moe/grouped_topk_kernels.cu
+++ b/csrc/libtorch_stable/moe/grouped_topk_kernels.cu
@@ -25,6 +25,7 @@
 #include "libtorch_stable/torch_utils.h"
 
 #include <cmath>
+#include <optional>
 #include <tuple>
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
@@ -472,19 +473,22 @@ __device__ inline T apply_scoring(T val) {
   }
 }
 
-template <typename T, typename BiasT, ScoringFunc SF>
-__device__ void topk_with_k2(T* output, T const* input, BiasT const* bias,
-                             cg::thread_block_tile<32> const& tile,
-                             int32_t const lane_id,
-                             int const num_experts_per_group) {
+template <typename T, typename BiasT, ScoringFunc SF, bool UseMaxGroupScore>
+__device__ void compute_group_score(float* output, T const* input,
+                                    BiasT const* bias,
+                                    cg::thread_block_tile<32> const& tile,
+                                    int32_t const lane_id,
+                                    int const num_experts_per_group) {
   // Get the top2 per thread
-  T largest = neg_inf<T>();
-  T second_largest = neg_inf<T>();
+  float largest = neg_inf<float>();
+  float second_largest = neg_inf<float>();
 
   if (num_experts_per_group > WARP_SIZE) {
     for (int i = lane_id; i < num_experts_per_group; i += WARP_SIZE) {
-      T value = apply_scoring<SF>(input[i]);
-      value = value + static_cast<T>(bias[i]);
+      float value = static_cast<float>(apply_scoring<SF>(input[i]));
+      if (bias != nullptr) {
+        value += static_cast<float>(bias[i]);
+      }
 
       if (value > largest) {
         second_largest = largest;
@@ -495,30 +499,43 @@ __device__ void topk_with_k2(T* output, T const* input, BiasT const* bias,
     }
   } else {
     for (int i = lane_id; i < num_experts_per_group; i += WARP_SIZE) {
-      T value = apply_scoring<SF>(input[i]);
-      value = value + static_cast<T>(bias[i]);
+      float value = static_cast<float>(apply_scoring<SF>(input[i]));
+      if (bias != nullptr) {
+        value += static_cast<float>(bias[i]);
+      }
       largest = value;
     }
   }
-  // Get the top2 warpwise
-  T max1 = cg::reduce(tile, largest, cg::greater<T>());
+  float max1 = cg::reduce(tile, largest, cg::greater<float>());
 
-  T max2 = max1;
+  if constexpr (UseMaxGroupScore) {
+    if (lane_id == 0) {
+      *output = max1;
+    }
+    return;
+  }
+
+  float max2 = max1;
   bool equal_to_max1 = (max1 == largest);
 
   int count_max1 = __popc(__ballot_sync(FULL_WARP_MASK, equal_to_max1));
 
   if (count_max1 == 1) {
     largest = (largest == max1) ? second_largest : largest;
-    max2 = cg::reduce(tile, largest, cg::greater<T>());
+    max2 = cg::reduce(tile, largest, cg::greater<float>());
   }
 
   if (lane_id == 0) {
-    *output = max1 + max2;
+    float group_score = max1 + max2;
+    if (bias == nullptr) {
+      group_score = static_cast<float>(static_cast<T>(group_score));
+    }
+    *output = group_score;
   }
 }
 
-template <typename T, typename BiasT, typename IdxT, ScoringFunc SF>
+template <typename T, typename BiasT, typename IdxT, ScoringFunc SF,
+          bool UseMaxGroupScore = false>
 __global__ void grouped_topk_fused_kernel(
     T* scores, float* topk_values, IdxT* topk_indices, BiasT const* bias,
     int64_t const num_tokens, int64_t const num_experts, int64_t const n_group,
@@ -552,7 +569,7 @@ __global__ void grouped_topk_fused_kernel(
   extern __shared__ char smem_buf[];
   // warpSelect internal staging buffer layout
   size_t const val_bytes =
-      static_cast<size_t>(num_warps) * WARP_SIZE * sizeof(T);
+      static_cast<size_t>(num_warps) * WARP_SIZE * sizeof(float);
   size_t const val_bytes_aligned =
       warp_topk::round_up_to_multiple_of<256>(val_bytes);
   size_t const idx_bytes =
@@ -562,7 +579,7 @@ __global__ void grouped_topk_fused_kernel(
   // user-managed shared memory starts after warpSelect internal staging.
   uintptr_t ptr_u = reinterpret_cast<uintptr_t>(smem_buf + internal_bytes);
   ptr_u = (ptr_u + 15) & ~static_cast<uintptr_t>(15);  // align to 16B
-  T* s_group_scores = reinterpret_cast<T*>(ptr_u);
+  float* s_group_scores = reinterpret_cast<float*>(ptr_u);
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();  // I think all prolog can be put before
@@ -571,9 +588,10 @@ __global__ void grouped_topk_fused_kernel(
 
   // phase 1: per-group scan
   int32_t const group_offset = warp_id * num_experts_per_group;
-  topk_with_k2<T, BiasT, SF>(s_group_scores + warp_id,
-                             scores_token + group_offset, bias + group_offset,
-                             tile, lane_id, num_experts_per_group);
+  compute_group_score<T, BiasT, SF, UseMaxGroupScore>(
+      s_group_scores + warp_id, scores_token + group_offset,
+      bias == nullptr ? nullptr : bias + group_offset, tile, lane_id,
+      num_experts_per_group);
 
   __syncthreads();
 
@@ -586,12 +604,13 @@ __global__ void grouped_topk_fused_kernel(
   topk_indices += static_cast<int64_t>(token_id) * topk;
 
   // select topk_group groups by group score
-  warp_topk::WarpSelect</*capability*/ WARP_SIZE, /*greater*/ true, T, int32_t,
-                        /* is_stable */ true>
-      group_sel(static_cast<int32_t>(topk_group_i32), neg_inf<T>());
+  warp_topk::WarpSelect</*capability*/ WARP_SIZE, /*greater*/ true, float,
+                        int32_t, /* is_stable */ true>
+      group_sel(static_cast<int32_t>(topk_group_i32), neg_inf<float>());
 
   // all lanes must participate in WarpSelect::add().
-  T gscore = (lane_id < n_group_i32) ? s_group_scores[lane_id] : neg_inf<T>();
+  float gscore =
+      (lane_id < n_group_i32) ? s_group_scores[lane_id] : neg_inf<float>();
   group_sel.add(gscore, lane_id);
   group_sel.done();
 
@@ -600,8 +619,8 @@ __global__ void grouped_topk_fused_kernel(
   if (topk_group_i32 > 0) {
     int const kth_lane = topk_group_i32 - 1;
     // broadcast the k-th selected group score to all lanes
-    T kth_val = __shfl_sync(FULL_WARP_MASK, group_sel.get_val(0), kth_lane);
-    proceed = (kth_val != neg_inf<T>());
+    float kth_val = __shfl_sync(FULL_WARP_MASK, group_sel.get_val(0), kth_lane);
+    proceed = (kth_val != neg_inf<float>());
   }
 
   if (!proceed) {
@@ -616,9 +635,9 @@ __global__ void grouped_topk_fused_kernel(
   }
 
   // merge per-group topk candidates for selected groups, then select topk
-  warp_topk::WarpSelect</*capability*/ WARP_SIZE, /*greater*/ true, T, int32_t,
-                        /* is_stable */ true>
-      expert_sel(static_cast<int32_t>(topk_i32), neg_inf<T>());
+  warp_topk::WarpSelect</*capability*/ WARP_SIZE, /*greater*/ true, float,
+                        int32_t, /* is_stable */ true>
+      expert_sel(static_cast<int32_t>(topk_i32), neg_inf<float>());
 
   // selected group ids reside in lanes [0, topk_group)
   int32_t sel_gid_lane = (lane_id < topk_group_i32) ? group_sel.get_idx(0) : 0;
@@ -631,14 +650,16 @@ __global__ void grouped_topk_fused_kernel(
         warp_topk::round_up_to_multiple_of<WARP_SIZE>(num_experts_per_group);
     for (int32_t i = lane_id; i < align_num_experts_per_group; i += WARP_SIZE) {
       // all lanes must call `add()` the same number of times.
-      T cand = neg_inf<T>();
+      float cand = neg_inf<float>();
       int32_t idx = 0;
       if (i < num_experts_per_group) {
         idx = offset + i;
         T input = scores_token[idx];
         if (is_finite(input)) {
-          T score = apply_scoring<SF>(input);
-          cand = score + static_cast<T>(bias[idx]);
+          cand = static_cast<float>(apply_scoring<SF>(input));
+          if (bias != nullptr) {
+            cand += static_cast<float>(bias[idx]);
+          }
         }
       }
       expert_sel.add(cand, idx);
@@ -677,7 +698,8 @@ __global__ void grouped_topk_fused_kernel(
 
 template <typename T, typename BiasT, typename IdxT, ScoringFunc SF,
           int MaxNumExperts, bool UseGroups,
-          int MaxNumTopExperts = DefaultMaxNumTopExperts>
+          int MaxNumTopExperts = DefaultMaxNumTopExperts,
+          bool UseMaxGroupScore = false>
 __global__ void grouped_topk_fused_small_expert_count_kernel(
     T* scores, float* topkValues, IdxT* topkIndices, BiasT const* routingBias,
     int64_t const numTokens, int64_t const numGroup, int64_t const topkGroup,
@@ -722,8 +744,10 @@ __global__ void grouped_topk_fused_small_expert_count_kernel(
   }
 
   auto scoreIdx = int64_t{blockIdx.x} * int64_t{numExperts} + threadExpert;
-  auto biasVal = expertSelected ? static_cast<float>(routingBias[threadExpert])
-                                : invalidScoreFloat;
+  auto biasVal = !expertSelected ? invalidScoreFloat
+                 : routingBias == nullptr
+                     ? 0.0F
+                     : static_cast<float>(routingBias[threadExpert]);
   topkValues += blockIdx.x * topk;
   topkIndices += blockIdx.x * topk;
 
@@ -762,7 +786,11 @@ __global__ void grouped_topk_fused_small_expert_count_kernel(
 
     // get the final group score and write it to shared
     if (warp.thread_rank() == 0) {
-      auto groupScore = topExpGroupScores[0] + topExpGroupScores[1];
+      // UseMaxGroupScore=true: max per group.
+      // UseMaxGroupScore=false: sum of top two per group.
+      auto groupScore = UseMaxGroupScore
+                            ? topExpGroupScores[0]
+                            : topExpGroupScores[0] + topExpGroupScores[1];
       smemGroupScores[warpIdx] = groupScore;
     }
   }
@@ -896,8 +924,8 @@ void invokeNoAuxTc(T* scores, float* topk_values, IdxT* topk_indices,
                    int64_t const num_experts, int64_t const n_group,
                    int64_t const topk_group, int64_t const topk,
                    bool const renormalize, double const routed_scaling_factor,
-                   const bool enable_pdl = false,
-                   cudaStream_t const stream = 0) {
+                   const bool enable_pdl = false, cudaStream_t const stream = 0,
+                   bool use_max_group_score = false) {
   cudaLaunchConfig_t config;
   config.stream = stream;
   cudaLaunchAttribute attrs[1];
@@ -916,9 +944,25 @@ void invokeNoAuxTc(T* scores, float* topk_values, IdxT* topk_indices,
   int64_t const experts_per_group = num_experts / n_group;
   bool const is_multi_group =
       (n_group > 1) && (num_experts <= NumDeepseekExperts) &&
+      (n_group <= NumDeepseekExperts / WARP_SIZE) &&
       (experts_per_group <= WARP_SIZE) &&
       (experts_per_group * topk_group <= MaxNumExpertsUnit) &&
       (topk <= DefaultMaxNumTopExperts) && (topk_group <= MaxNumTopGroups);
+
+  if (use_max_group_score && is_multi_group) {
+    // Single-group routing does not depend on the group score.
+    auto* kern = &grouped_topk_fused_small_expert_count_kernel<
+        T, BiasT, IdxT, SF, NumDeepseekExperts, true, DefaultMaxNumTopExperts,
+        true>;
+    config.gridDim = num_tokens;
+    config.blockDim = NumDeepseekExperts;
+    config.dynamicSmemBytes = 0;
+    cudaLaunchKernelEx(&config, kern, scores, topk_values, topk_indices, bias,
+                       num_tokens, n_group, topk_group, topk, num_experts,
+                       num_experts / n_group, renormalize,
+                       routed_scaling_factor);
+    return;
+  }
 
   if (is_single_group || is_multi_group) {
     auto* kernel_instance =
@@ -958,20 +1002,24 @@ void invokeNoAuxTc(T* scores, float* topk_values, IdxT* topk_indices,
                        topk, num_experts, num_experts / n_group, renormalize,
                        routed_scaling_factor);
   } else {
-    auto* kernel_instance = &grouped_topk_fused_kernel<T, BiasT, IdxT, SF>;
+    auto* kernel_instance =
+        use_max_group_score
+            ? &grouped_topk_fused_kernel<T, BiasT, IdxT, SF, true>
+            : &grouped_topk_fused_kernel<T, BiasT, IdxT, SF, false>;
     // One block per token; one warp per group.
     config.gridDim = static_cast<uint32_t>(num_tokens);
     config.blockDim = static_cast<uint32_t>(n_group) * WARP_SIZE;
     // Dynamic shared memory: WarpSelect staging + per-group topk buffers.
     int32_t const num_warps = static_cast<int32_t>(n_group);
     size_t const val_bytes =
-        static_cast<size_t>(num_warps) * WARP_SIZE * sizeof(T);
+        static_cast<size_t>(num_warps) * WARP_SIZE * sizeof(float);
     size_t const val_bytes_aligned =
         warp_topk::round_up_to_multiple_of<256>(val_bytes);
     size_t const idx_bytes =
         static_cast<size_t>(num_warps) * WARP_SIZE * sizeof(int32_t);
     size_t const internal_bytes = val_bytes_aligned + idx_bytes;
-    size_t const extra_bytes = 16 + static_cast<size_t>(n_group) * sizeof(T);
+    size_t const extra_bytes =
+        16 + static_cast<size_t>(n_group) * sizeof(float);
     config.dynamicSmemBytes = internal_bytes + extra_bytes;
     cudaLaunchKernelEx(&config, kernel_instance, scores, topk_values,
                        topk_indices, bias, num_tokens, num_experts, n_group,
@@ -985,7 +1033,8 @@ void invokeNoAuxTc(T* scores, float* topk_values, IdxT* topk_indices,
       int64_t const num_tokens, int64_t const num_experts,                   \
       int64_t const n_group, int64_t const topk_group, int64_t const topk,   \
       bool const renormalize, double const routed_scaling_factor,            \
-      const bool enable_pdl, cudaStream_t const stream);
+      const bool enable_pdl, cudaStream_t const stream,                      \
+      bool use_max_group_score);
 
 INSTANTIATE_NOAUX_TC(float, float, int32_t, SCORING_SIGMOID);
 INSTANTIATE_NOAUX_TC(float, half, int32_t, SCORING_SIGMOID);
@@ -1011,9 +1060,10 @@ INSTANTIATE_NOAUX_TC(__nv_bfloat16, __nv_bfloat16, int32_t, SCORING_NONE);
 std::tuple<torch::stable::Tensor, torch::stable::Tensor> grouped_topk(
     torch::stable::Tensor const& scores, int64_t n_group, int64_t topk_group,
     int64_t topk, bool renormalize, double routed_scaling_factor,
-    torch::stable::Tensor const& bias, int64_t scoring_func = 0) {
+    std::optional<torch::stable::Tensor> const& bias, int64_t scoring_func = 0,
+    int64_t group_scoring_func = 0) {
   const auto data_type = scores.scalar_type();
-  const auto bias_type = bias.scalar_type();
+  const auto bias_type = bias.has_value() ? bias->scalar_type() : data_type;
   STD_TORCH_CHECK(scores.dim() == 2, "scores must be a 2D Tensor");
   const int64_t num_tokens = scores.size(0);
   const int64_t num_experts = scores.size(1);
@@ -1033,7 +1083,17 @@ std::tuple<torch::stable::Tensor, torch::stable::Tensor> grouped_topk(
       scoring_func == vllm::moe::SCORING_NONE ||
           scoring_func == vllm::moe::SCORING_SIGMOID,
       "scoring_func must be SCORING_NONE (0) or SCORING_SIGMOID (1)");
+  STD_TORCH_CHECK(group_scoring_func == 0 || group_scoring_func == 1,
+                  "group_scoring_func must be 0 (top2) or 1 (max)");
+  bool const use_max_group_score = (group_scoring_func == 1);
+  STD_TORCH_CHECK(use_max_group_score || num_experts / n_group >= 2,
+                  "top2 group scoring requires at least two experts per group");
 
+  if (bias.has_value()) {
+    STD_TORCH_CHECK(bias->dim() == 1, "bias must be a 1D Tensor");
+    STD_TORCH_CHECK(bias->size(0) == num_experts,
+                    "bias length must equal number of experts");
+  }
   // Always output float32 for topk_values (eliminates Python-side conversion)
   auto topk_values = torch::stable::new_empty(
       scores, {num_tokens, topk}, torch::headeronly::ScalarType::Float);
@@ -1055,18 +1115,22 @@ std::tuple<torch::stable::Tensor, torch::stable::Tensor> grouped_topk(
             reinterpret_cast<T*>(scores.mutable_data_ptr()),                  \
             reinterpret_cast<float*>(topk_values.mutable_data_ptr()),         \
             reinterpret_cast<IdxT*>(topk_indices.mutable_data_ptr()),         \
-            reinterpret_cast<BiasT const*>(bias.data_ptr()), num_tokens,      \
-            num_experts, n_group, topk_group, topk, renormalize,              \
-            routed_scaling_factor, pdl_flag, stream);                         \
+            bias.has_value()                                                  \
+                ? reinterpret_cast<BiasT const*>(bias->data_ptr())            \
+                : nullptr,                                                    \
+            num_tokens, num_experts, n_group, topk_group, topk, renormalize,  \
+            routed_scaling_factor, pdl_flag, stream, use_max_group_score);    \
         break;                                                                \
       case vllm::moe::SCORING_SIGMOID:                                        \
         vllm::moe::invokeNoAuxTc<T, BiasT, IdxT, vllm::moe::SCORING_SIGMOID>( \
             reinterpret_cast<T*>(scores.mutable_data_ptr()),                  \
             reinterpret_cast<float*>(topk_values.mutable_data_ptr()),         \
             reinterpret_cast<IdxT*>(topk_indices.mutable_data_ptr()),         \
-            reinterpret_cast<BiasT const*>(bias.data_ptr()), num_tokens,      \
-            num_experts, n_group, topk_group, topk, renormalize,              \
-            routed_scaling_factor, pdl_flag, stream);                         \
+            bias.has_value()                                                  \
+                ? reinterpret_cast<BiasT const*>(bias->data_ptr())            \
+                : nullptr,                                                    \
+            num_tokens, num_experts, n_group, topk_group, topk, renormalize,  \
+            routed_scaling_factor, pdl_flag, stream, use_max_group_score);    \
         break;                                                                \
       default:                                                                \
         STD_TORCH_CHECK(false, "Unsupported scoring_func");                   \

--- a/csrc/libtorch_stable/moe/moe_ops.h
+++ b/csrc/libtorch_stable/moe/moe_ops.h
@@ -68,7 +68,8 @@ torch::stable::Tensor moe_wna16_gemm(
 std::tuple<torch::stable::Tensor, torch::stable::Tensor> grouped_topk(
     const torch::stable::Tensor& scores, int64_t n_group, int64_t topk_group,
     int64_t topk, bool renormalize, double routed_scaling_factor,
-    const torch::stable::Tensor& bias, int64_t scoring_func);
+    const std::optional<torch::stable::Tensor>& bias, int64_t scoring_func,
+    int64_t group_scoring_func);
 #endif
 
 bool moe_permute_unpermute_supported();

--- a/csrc/libtorch_stable/moe/torch_bindings.cpp
+++ b/csrc/libtorch_stable/moe/torch_bindings.cpp
@@ -124,8 +124,8 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_moe_C, m) {
   m.def(
       "grouped_topk(Tensor scores, int n_group, int "
       "topk_group, int topk, bool renormalize, float "
-      "routed_scaling_factor, Tensor bias, int scoring_func) -> (Tensor, "
-      "Tensor)");
+      "routed_scaling_factor, Tensor? bias, int scoring_func, int "
+      "group_scoring_func) -> (Tensor, Tensor)");
 
   // DeepSeek V3 optimized router GEMM for SM90+
   m.def("dsv3_router_gemm(Tensor! output, Tensor mat_a, Tensor mat_b) -> ()");

--- a/tests/kernels/moe/test_grouped_topk.py
+++ b/tests/kernels/moe/test_grouped_topk.py
@@ -15,6 +15,7 @@ from vllm.config import (
     get_cached_compilation_config,
     set_current_vllm_config,
 )
+from vllm.model_executor.layers.fused_moe.config import GroupScoringFunc
 from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
     GroupedTopk,
     fused_grouped_topk,
@@ -77,6 +78,7 @@ def test_grouped_topk(
             topk_group=topk_group,
             scoring_func=scoring_func,
             routed_scaling_factor=routed_scaling_factor,
+            group_scoring_func="top2",
         )
         assert grouped_topk._forward_method.__name__ == "forward_cuda"
         baseline_topk_weights, baseline_topk_ids = grouped_topk(
@@ -95,9 +97,107 @@ def test_grouped_topk(
             scoring_func=scoring_func,
             routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
+            group_scoring_func="top2",
         )
 
         torch.testing.assert_close(
             baseline_topk_weights, test_topk_weights, atol=2e-2, rtol=0
         )
         torch.testing.assert_close(baseline_topk_ids, test_topk_ids, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
+)
+@pytest.mark.parametrize("n_token", [1, 25])
+@pytest.mark.parametrize("n_hidden", [128])
+@pytest.mark.parametrize(
+    "n_expert,topk,num_expert_group,topk_group,scoring_func,bias_dtype",
+    [
+        (64, 8, 8, 4, "softmax", None),
+        (64, 8, 8, 4, "softmax", torch.float16),
+        (64, 8, 8, 4, "softmax", torch.bfloat16),
+        (64, 8, 8, 4, "softmax", torch.float32),
+        (256, 8, 16, 4, "softmax", None),
+        (256, 8, 16, 4, "softmax", torch.float16),
+        (256, 8, 16, 4, "softmax", torch.bfloat16),
+        (256, 8, 16, 4, "softmax", torch.float32),
+        (64, 8, 8, 4, "sigmoid", torch.float16),
+        (64, 8, 8, 4, "sigmoid", torch.bfloat16),
+        (64, 8, 8, 4, "sigmoid", torch.float32),
+        (384, 8, 8, 4, "softmax", torch.float16),
+        (384, 8, 8, 4, "softmax", torch.bfloat16),
+        (384, 8, 8, 4, "softmax", torch.float32),
+    ],
+)
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("group_scoring_func", ["max", "top2"])
+def test_grouped_topk_bias_and_group_scoring_are_independent(
+    monkeypatch: pytest.MonkeyPatch,
+    n_token: int,
+    n_hidden: int,
+    n_expert: int,
+    topk: int,
+    num_expert_group: int,
+    topk_group: int,
+    bias_dtype: torch.dtype | None,
+    group_scoring_func: GroupScoringFunc,
+    scoring_func: str,
+    input_dtype: torch.dtype,
+):
+    """Supported bias dtypes and group reductions match native."""
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(custom_ops=["all", "+grouped_topk"])
+    )
+    get_cached_compilation_config.cache_clear()
+
+    set_random_seed(0)
+    e_score_correction_bias = (
+        torch.randn((n_expert,), dtype=bias_dtype, device="cuda")
+        if bias_dtype is not None
+        else None
+    )
+    hidden_states = torch.randn((n_token, n_hidden), dtype=input_dtype, device="cuda")
+    gating_output = torch.randn((n_token, n_expert), dtype=input_dtype, device="cuda")
+
+    with set_current_vllm_config(vllm_config), monkeypatch.context() as m:
+        m.setenv("VLLM_USE_FUSED_MOE_GROUPED_TOPK", "0")
+        m.setattr(envs, "VLLM_BATCH_INVARIANT", True)
+        grouped_topk_op = GroupedTopk(
+            topk=topk,
+            renormalize=True,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
+            scoring_func=scoring_func,
+            routed_scaling_factor=1.0,
+            group_scoring_func=group_scoring_func,
+        )
+        ref_weights, ref_ids = grouped_topk_op(
+            hidden_states=hidden_states,
+            gating_output=gating_output,
+            e_score_correction_bias=e_score_correction_bias,
+        )
+
+    fused_weights, fused_ids = fused_grouped_topk(
+        hidden_states=hidden_states,
+        gating_output=gating_output,
+        topk=topk,
+        renormalize=True,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        scoring_func=scoring_func,
+        routed_scaling_factor=1.0,
+        e_score_correction_bias=e_score_correction_bias,
+        group_scoring_func=group_scoring_func,
+    )
+
+    ref_order = ref_ids.argsort(dim=-1)
+    fused_order = fused_ids.argsort(dim=-1)
+    ref_ids = ref_ids.gather(1, ref_order)
+    fused_ids = fused_ids.gather(1, fused_order)
+    ref_weights = ref_weights.gather(1, ref_order)
+    fused_weights = fused_weights.gather(1, fused_order)
+
+    torch.testing.assert_close(ref_ids, fused_ids, atol=0, rtol=0)
+    atol = 2e-2 if input_dtype == torch.bfloat16 or scoring_func == "sigmoid" else 1e-5
+    torch.testing.assert_close(ref_weights, fused_weights, atol=atol, rtol=0)

--- a/tests/kernels/moe/test_routing.py
+++ b/tests/kernels/moe/test_routing.py
@@ -8,6 +8,10 @@ import torch
 
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.model_executor.layers.fused_moe.config import (
+    GroupScoringFunc,
+    RoutingMethodType,
+)
 from vllm.model_executor.layers.fused_moe.router.base_router import (
     eplb_map_to_physical_and_record,
 )
@@ -34,6 +38,36 @@ def _is_aiter_capable() -> bool:
 MK_S = [(32, 256), (64, 512)]
 TOP_KS = [2, 4, 6]
 NUM_EXPERTS = [8, 16, 64]
+
+
+@pytest.mark.parametrize(
+    "has_bias,group_scoring_func,scoring_func,expected_routing_method",
+    [
+        (True, "top2", "sigmoid", RoutingMethodType.DeepSeekV3),
+        (True, "max", "sigmoid", RoutingMethodType.Unspecified),
+        (False, "max", "softmax", RoutingMethodType.RenormalizeNaive),
+        (False, "top2", "softmax", RoutingMethodType.Unspecified),
+    ],
+)
+def test_grouped_topk_routing_method_respects_group_scoring_func(
+    has_bias: bool,
+    group_scoring_func: GroupScoringFunc,
+    scoring_func: str,
+    expected_routing_method: RoutingMethodType,
+) -> None:
+    bias = torch.empty(64) if has_bias else None
+    router = create_fused_moe_router(
+        top_k=8,
+        global_num_experts=64,
+        use_grouped_topk=True,
+        num_expert_group=8,
+        topk_group=4,
+        scoring_func=scoring_func,
+        e_score_correction_bias=bias,
+        group_scoring_func=group_scoring_func,
+    )
+
+    assert router.routing_method_type == expected_routing_method
 
 
 def setup_eplb_state(

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2483,8 +2483,9 @@ def grouped_topk(
     topk: int,
     renormalize: bool,
     routed_scaling_factor: float,
-    bias: torch.Tensor,
+    bias: torch.Tensor | None,
     scoring_func: int = 0,
+    group_scoring_func: int = 0,
 ):
     """
     Perform grouped top-k routing for mixture of experts.
@@ -2496,8 +2497,10 @@ def grouped_topk(
         topk: Number of experts to select per token
         renormalize: Whether to renormalize the output weights
         routed_scaling_factor: Scaling factor for routing weights
-        bias: Bias tensor (e_score_correction_bias). Always fused in kernel.
+        bias: Optional correction bias for expert selection
         scoring_func: 0=none (no activation), 1=sigmoid
+        group_scoring_func: Group reduction: 0=sum of top two scores, 1=max
+            score
     """
     if not current_platform.is_cuda():
         raise NotImplementedError(
@@ -2512,7 +2515,28 @@ def grouped_topk(
         routed_scaling_factor,
         bias,
         scoring_func,
+        group_scoring_func,
     )
+
+
+if hasattr(torch.ops, "_moe_C") and hasattr(torch.ops._moe_C, "grouped_topk"):
+
+    @register_fake("_moe_C::grouped_topk")
+    def grouped_topk_fake(
+        scores: torch.Tensor,
+        n_group: int,
+        topk_group: int,
+        topk: int,
+        renormalize: bool,
+        routed_scaling_factor: float,
+        bias: torch.Tensor | None,
+        scoring_func: int,
+        group_scoring_func: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        num_tokens = scores.shape[0]
+        topk_values = scores.new_empty((num_tokens, topk), dtype=torch.float32)
+        topk_indices = scores.new_empty((num_tokens, topk), dtype=torch.int32)
+        return topk_values, topk_indices
 
 
 def moe_wna16_marlin_gemm(

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Union
+from typing import Literal, Union
 
 import torch
 
@@ -21,6 +21,8 @@ from vllm.utils.import_utils import has_triton_kernels
 from vllm.utils.math_utils import cdiv
 
 logger = init_logger(__name__)
+
+GroupScoringFunc = Literal["max", "top2"]
 
 if has_triton_kernels():
     try:

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
     FusedMoEParallelConfig,
+    GroupScoringFunc,
 )
 from vllm.model_executor.layers.fused_moe.expert_map_manager import (
     ExpertMapManager,
@@ -143,6 +144,7 @@ def FusedMoE(
     runner_args: dict[str, Any] | None = None,
     routed_experts_cls: type[RoutedExperts] | None = None,
     routed_experts_args: dict[str, Any] | None = None,
+    group_scoring_func: GroupScoringFunc | None = None,
 ) -> MoERunner:
     """Factory function for creating MoE execution pipeline.
 
@@ -206,6 +208,7 @@ def FusedMoE(
         runner_args: Additional arguments for runner constructor
         routed_experts_cls: Custom RoutedExperts class (None = use default)
         routed_experts_args: Additional arguments for routed_experts constructor
+        group_scoring_func: Group-score reduction ("max" or "top2")
 
     Returns:
         MoERunner: Configured MoE execution pipeline ready for forward passes
@@ -288,6 +291,7 @@ def FusedMoE(
             use_grouped_topk=use_grouped_topk,
             num_expert_group=num_expert_group,
             topk_group=topk_group,
+            group_scoring_func=group_scoring_func,
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
             # When apply_routed_scale_to_output is True, we set the scaling factor

--- a/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -10,6 +10,7 @@ from vllm._aiter_ops import rocm_aiter_ops
 from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.fused_moe.config import (
+    GroupScoringFunc,
     RoutingMethodType,
     get_routing_method_type,
 )
@@ -25,50 +26,66 @@ from vllm.model_executor.utils import maybe_disable_graph_partition
 from vllm.platforms import current_platform
 
 
+def _resolve_group_scoring_func(
+    group_scoring_func: GroupScoringFunc | None,
+    e_score_correction_bias: torch.Tensor | None,
+) -> GroupScoringFunc:
+    if group_scoring_func is None:
+        return "top2" if e_score_correction_bias is not None else "max"
+    if group_scoring_func not in ("max", "top2"):
+        raise ValueError(f"Unsupported group scoring function: {group_scoring_func}")
+    return group_scoring_func
+
+
+def _uses_default_group_scoring_func(
+    group_scoring_func: GroupScoringFunc | None,
+    e_score_correction_bias: torch.Tensor | None,
+) -> bool:
+    return _resolve_group_scoring_func(
+        group_scoring_func, e_score_correction_bias
+    ) == _resolve_group_scoring_func(None, e_score_correction_bias)
+
+
 def fused_grouped_topk(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
     topk: int,
     renormalize: bool,
-    e_score_correction_bias: torch.Tensor,
+    e_score_correction_bias: torch.Tensor | None,
     num_expert_group: int = 0,
     topk_group: int = 0,
     scoring_func: str = "softmax",
     routed_scaling_factor: float = 1.0,
+    group_scoring_func: GroupScoringFunc | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     assert hidden_states.size(0) == gating_output.size(0), "Number of tokens mismatch"
 
+    group_scoring_func = _resolve_group_scoring_func(
+        group_scoring_func, e_score_correction_bias
+    )
     if scoring_func == "sigmoid":
-        # Fully fused kernel path for sigmoid
-        topk_values, topk_indices = ops.grouped_topk(
-            gating_output,  # raw logits
-            num_expert_group,
-            topk_group,
-            topk,
-            renormalize,
-            routed_scaling_factor,
-            e_score_correction_bias,
-            1,  # scoring_func=1 for sigmoid
+        assert e_score_correction_bias is not None, (
+            "sigmoid scoring requires e_score_correction_bias"
         )
+        scores = gating_output
+        scoring_func_id = 1
     elif scoring_func == "softmax":
-        # Apply softmax in Python, then use fused kernel
-        # TODO: Add support for softmax in kernel
         scores = torch.softmax(gating_output, dim=-1)
-        topk_values, topk_indices = ops.grouped_topk(
-            scores,  # pre-computed scores
-            num_expert_group,
-            topk_group,
-            topk,
-            renormalize,
-            routed_scaling_factor,
-            e_score_correction_bias,
-            0,  # scoring_func=0 (no activation, scores already computed)
-        )
+        scoring_func_id = 0
     else:
         raise ValueError(f"Unsupported scoring function: {scoring_func}")
 
-    # Fused kernel outputs float32 values and int32 indices directly
-    return topk_values, topk_indices
+    return ops.grouped_topk(
+        scores,
+        num_expert_group,
+        topk_group,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        e_score_correction_bias,
+        scoring_func_id,
+        1 if group_scoring_func == "max" else 0,
+    )
 
 
 # This is used by the Deepseek-V2 and Deepseek-V3 model
@@ -87,13 +104,17 @@ def grouped_topk(
     scoring_func: str = "softmax",
     routed_scaling_factor: float = 1.0,
     e_score_correction_bias: torch.Tensor | None = None,
+    group_scoring_func: GroupScoringFunc | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    group_scoring_func = _resolve_group_scoring_func(
+        group_scoring_func, e_score_correction_bias
+    )
     if (
         envs.VLLM_USE_FUSED_MOE_GROUPED_TOPK
         and current_platform.is_cuda()
         and num_expert_group <= 32
         and topk <= 32
-        and e_score_correction_bias is not None
+        and (e_score_correction_bias is not None or scoring_func == "softmax")
     ):
         return fused_grouped_topk(
             hidden_states=hidden_states,
@@ -105,6 +126,7 @@ def grouped_topk(
             topk_group=topk_group,
             scoring_func=scoring_func,
             routed_scaling_factor=routed_scaling_factor,
+            group_scoring_func=group_scoring_func,
         )
 
     assert hidden_states.size(0) == gating_output.size(0), "Number of tokens mismatch"
@@ -118,18 +140,14 @@ def grouped_topk(
 
     num_token = scores.size(0)
     if e_score_correction_bias is not None:
-        # Store original scores before applying correction bias. We use biased
-        # scores for expert selection but original scores for routing weights
         original_scores = scores
-        scores = scores + e_score_correction_bias.unsqueeze(0)
+        scores = scores + e_score_correction_bias.float().unsqueeze(0)
+    if group_scoring_func == "top2":
         group_scores = (
             scores.view(num_token, num_expert_group, -1).topk(2, dim=-1)[0].sum(dim=-1)
         )
     else:
-        group_scores = (
-            scores.view(num_token, num_expert_group, -1).max(dim=-1).values
-        )  # [n, n_group]
-
+        group_scores = scores.view(num_token, num_expert_group, -1).max(dim=-1).values
     # For batch invariance, use sorted=True to ensure deterministic expert selection
     use_sorted = envs.VLLM_BATCH_INVARIANT
     group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=use_sorted)[
@@ -177,6 +195,7 @@ class GroupedTopk(CustomOp):
         scoring_func: str = "softmax",
         routed_scaling_factor: float = 1.0,
         num_fused_shared_experts: int = 0,
+        group_scoring_func: GroupScoringFunc | None = None,
     ) -> None:
         super().__init__()
         self.native_impl = grouped_topk
@@ -186,6 +205,7 @@ class GroupedTopk(CustomOp):
         self.topk_group = topk_group
         self.scoring_func = scoring_func
         self.routed_scaling_factor = routed_scaling_factor
+        self.group_scoring_func = group_scoring_func
         self.num_fused_shared_experts = num_fused_shared_experts
 
     def forward_native(
@@ -204,6 +224,7 @@ class GroupedTopk(CustomOp):
             self.scoring_func,
             self.routed_scaling_factor,
             e_score_correction_bias,
+            self.group_scoring_func,
         )
 
     def forward_cuda(
@@ -222,7 +243,9 @@ class GroupedTopk(CustomOp):
         gating_output: torch.Tensor,
         e_score_correction_bias: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if rocm_aiter_ops.is_fused_moe_enabled():
+        if rocm_aiter_ops.is_fused_moe_enabled() and _uses_default_group_scoring_func(
+            self.group_scoring_func, e_score_correction_bias
+        ):
             if not rocm_aiter_ops.is_fusion_moe_shared_experts_enabled():
                 assert self.num_fused_shared_experts == 0
             return rocm_aiter_grouped_topk(
@@ -258,6 +281,7 @@ class GroupedTopKRouter(BaseRouter):
         e_score_correction_bias: torch.Tensor | None = None,
         num_fused_shared_experts: int = 0,
         eplb_state: EplbLayerState | None = None,
+        group_scoring_func: GroupScoringFunc | None = None,
     ):
         super().__init__(
             top_k=top_k,
@@ -270,10 +294,15 @@ class GroupedTopKRouter(BaseRouter):
         self.scoring_func = scoring_func
         self.routed_scaling_factor = routed_scaling_factor
         self.e_score_correction_bias = e_score_correction_bias
+        self.group_scoring_func = group_scoring_func
         self.num_fused_shared_experts = num_fused_shared_experts
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
+        if not _uses_default_group_scoring_func(
+            self.group_scoring_func, self.e_score_correction_bias
+        ):
+            return RoutingMethodType.Unspecified
         return get_routing_method_type(
             scoring_func=self.scoring_func,
             top_k=self.top_k,
@@ -324,7 +353,9 @@ class GroupedTopKRouter(BaseRouter):
             return topk_weights, topk_ids
 
         # Select grouped_topk implementation
-        if rocm_aiter_ops.is_fused_moe_enabled():
+        if rocm_aiter_ops.is_fused_moe_enabled() and _uses_default_group_scoring_func(
+            self.group_scoring_func, self.e_score_correction_bias
+        ):
             if not rocm_aiter_ops.is_fusion_moe_shared_experts_enabled():
                 assert self.num_fused_shared_experts == 0
             grouped_topk_impl = partial(
@@ -332,7 +363,10 @@ class GroupedTopKRouter(BaseRouter):
                 num_fused_shared_experts=self.num_fused_shared_experts,
             )
         else:
-            grouped_topk_impl = grouped_topk
+            grouped_topk_impl = partial(
+                grouped_topk,
+                group_scoring_func=self.group_scoring_func,
+            )
 
         topk_weights, topk_ids = grouped_topk_impl(
             hidden_states=hidden_states,

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -8,6 +8,7 @@ import vllm.envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.model_executor.layers.fused_moe.config import (
+    GroupScoringFunc,
     RoutingMethodType,
 )
 from vllm.model_executor.layers.fused_moe.router.aiter_shared_routed_fused_moe_router import (  # noqa: E501
@@ -59,6 +60,7 @@ def create_fused_moe_router(
     zero_expert_type: str | None = None,
     num_logical_experts: int | None = None,
     hash_indices_table: torch.Tensor | None = None,
+    group_scoring_func: GroupScoringFunc | None = None,
 ) -> FusedMoERouter:
     """
     Factory function to create the appropriate FusedMoERouter subclass based on
@@ -84,6 +86,8 @@ def create_fused_moe_router(
         num_expert_group: Number of expert groups (for grouped routing)
         topk_group: Top-k within each group (for grouped routing)
         scoring_func: Scoring function to use ("softmax" or "sigmoid")
+        group_scoring_func: Group-score reduction ("max" or "top2"). The
+            default preserves existing behavior based on correction bias.
         num_fused_shared_experts: Number of fused shared experts (for ROCm AITER)
 
     Grouped topk and fused topk bias arguments:
@@ -153,6 +157,7 @@ def create_fused_moe_router(
             scoring_func=scoring_func,
             routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
+            group_scoring_func=group_scoring_func,
             num_fused_shared_experts=num_fused_shared_experts,
         )
         if (

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -375,6 +375,9 @@ class DeepseekV2MoE(nn.Module):
             topk_group=getattr(config, "topk_group", 1),
             prefix=f"{prefix}.experts",
             scoring_func=getattr(config, "scoring_func", "softmax"),
+            group_scoring_func=(
+                "top2" if getattr(config, "topk_method", None) == "noaux_tc" else "max"
+            ),
             routed_scaling_factor=self.routed_scaling_factor,
             apply_routed_scale_to_output=apply_routed_scale_to_output,
             e_score_correction_bias=self.gate.e_score_correction_bias,


### PR DESCRIPTION
## Purpose

Extends support of `grouped_topk` fused routing kernel to routing methods with:
- No bias
- Group selection based on max instead of sum of top 2

These two choices are now independent, so the fused kernel supports both group-scoring methods with or without a correction bias.

The implementation goes like this:
- Add a `GroupScoringFunc` to the configuration abstractions which can be either `max` or `top2`
- Add it as an argument to the `FusedMoE` layer
- Propagate it through the router factory and `GroupedTopKRouter` down to the fused CUDA op
- Keep the previous implicit behavior as the default: `top2` when a correction bias is present and `max` otherwise
- Set the value explicitly for DeepSeek models based on `topk_method`
- Make the correction bias optional in the C++ op schema and CUDA implementation
- Generalize the CUDA kernels to conditionally apply the bias and compute either the max or the sum of the top 2 scores for each group
- Enable the fused path for bias-free softmax routing when the existing kernel shape constraints are satisfied
- Avoid selecting specialized routing implementations which assume the old scoring semantics when a non-default combination is requested

Tests cover:


Incidentally we also:
- Fixed a pre-existing compile-support gap by registering the fake `grouped_topk_fake`


## Test Plan

- Biased and bias-free routing
- `max` and `top2` group scoring
- Softmax and sigmoid scoring
- `bfloat16` and `float32` inputs
- Multiple token and expert counts
- Router method selection for default and non-default combinations

## Test Result

All tests added and/or modified pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
