### PR TITLE
Fix moriio completion notification

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_tp_ack.py
+++ b/tests/v1/kv_connector/unit/test_moriio_tp_ack.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -10,12 +11,17 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     MoRIIOTransferAck,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector import (
+    MoRIIOConnectorScheduler,
     MoRIIOConnectorWorker,
     get_moriio_expected_ack_count,
     get_moriio_remote_tp_rank,
     resolve_moriio_transfer_ack,
     validate_moriio_heterogeneous_tp_kv_heads,
 )
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.request import RequestStatus
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 
 def test_remote_tp_rank_same_tp_maps_to_self():
@@ -229,6 +235,126 @@ def test_ack_for_non_live_transfer_is_ignored():
     )
     assert notification_counts == {}
     assert completed_transfer_ids == set()
+
+
+def _bare_scheduler(is_producer: bool = True) -> MoRIIOConnectorScheduler:
+    scheduler = object.__new__(MoRIIOConnectorScheduler)
+    scheduler.is_producer = is_producer
+    scheduler.transfer_id_to_request_id = {}
+    scheduler.request_id_to_transfer_id = {}
+    scheduler._reqs_need_recv = {}
+    scheduler._reqs_need_send = {}
+    scheduler._deferred_send_deadlines = {}
+    scheduler._defer_timeout = 60.0
+    scheduler.engine_id = "127.0.0.1:6301"
+    scheduler.host_ip = "127.0.0.1"
+    scheduler.handshake_port = 6301
+    scheduler.side_notify_port = 61005
+    scheduler.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            data_parallel_size=1,
+            tensor_parallel_size=1,
+        )
+    )
+    return scheduler
+
+
+def test_transfer_id_remap_does_not_let_stale_unmap_delete_new_mapping():
+    scheduler = _bare_scheduler()
+
+    scheduler.map_request_id("old-req", "tx0")
+    scheduler.map_request_id("new-req", "tx0")
+    scheduler.unmap_request_id("old-req")
+
+    assert scheduler.transfer_id_to_request_id == {"tx0": "new-req"}
+    assert scheduler.request_id_to_transfer_id == {"new-req": "tx0"}
+
+
+def test_request_remap_removes_stale_transfer_mapping():
+    scheduler = _bare_scheduler()
+
+    scheduler.map_request_id("req0", "tx0")
+    scheduler.map_request_id("req0", "tx1")
+
+    assert scheduler.transfer_id_to_request_id == {"tx1": "req0"}
+    assert scheduler.request_id_to_transfer_id == {"req0": "tx1"}
+
+
+def test_producer_request_finished_unmaps_when_blocks_not_deferred():
+    scheduler = _bare_scheduler(is_producer=True)
+    scheduler.map_request_id("req0", "tx0")
+    request = SimpleNamespace(
+        request_id="req0",
+        kv_transfer_params={"transfer_id": "tx0", "do_remote_decode": False},
+        status=RequestStatus.FINISHED_STOPPED,
+    )
+
+    delay_free, new_params = scheduler.request_finished(request, block_ids=[])
+
+    assert delay_free is False
+    assert new_params is None
+    assert scheduler.transfer_id_to_request_id == {}
+    assert scheduler.request_id_to_transfer_id == {}
+
+
+def test_producer_request_finished_keeps_mapping_when_blocks_deferred():
+    scheduler = _bare_scheduler(is_producer=True)
+    scheduler.map_request_id("req0", "tx0")
+    request = SimpleNamespace(
+        request_id="req0",
+        kv_transfer_params={"transfer_id": "tx0", "do_remote_decode": True},
+        status=RequestStatus.FINISHED_LENGTH_CAPPED,
+    )
+
+    delay_free, new_params = scheduler.request_finished(request, block_ids=[1])
+
+    assert delay_free is True
+    assert new_params is not None
+    assert scheduler.transfer_id_to_request_id == {"tx0": "req0"}
+    assert scheduler.request_id_to_transfer_id == {"req0": "tx0"}
+    assert scheduler._reqs_need_send.keys() == {"req0"}
+    assert scheduler._deferred_send_deadlines.keys() == {"req0"}
+
+
+def test_deferred_send_timeout_marks_finished_and_clears_mapping():
+    scheduler = _bare_scheduler(is_producer=True)
+    scheduler.map_request_id("req0", "tx0")
+    scheduler._deferred_send_deadlines["req0"] = 0.0
+    connector_output = KVConnectorOutput()
+
+    scheduler.update_connector_output(connector_output)
+
+    assert connector_output.finished_sending == {"req0"}
+    assert scheduler._deferred_send_deadlines == {}
+    assert scheduler.transfer_id_to_request_id == {}
+    assert scheduler.request_id_to_transfer_id == {}
+
+
+def test_write_completion_before_transfer_mapping_is_retried():
+    class FakeWrapper:
+        def __init__(self):
+            self.batches = [{"tx-early"}, set()]
+
+        def pop_finished_write_req_ids(self):
+            return self.batches.pop(0)
+
+        def shutdown(self):
+            pass
+
+    worker = object.__new__(MoRIIOConnectorWorker)
+    worker.is_producer = False
+    worker.mode = MoRIIOMode.WRITE
+    worker.moriio_wrapper = FakeWrapper()
+    worker.transfer_id_to_request_id = {}
+    worker._unmatched_write_completions = set()
+
+    assert worker.get_finished() == (set(), set())
+    assert worker._unmatched_write_completions == {"tx-early"}
+
+    worker.transfer_id_to_request_id = {"tx-early": "req0"}
+
+    assert worker.get_finished() == (set(), {"req0"})
+    assert worker._unmatched_write_completions == set()
 
 
 def test_worker_get_finished_counts_structured_release_fan_in():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -407,6 +407,28 @@ class MoRIIOConnectorScheduler:
         self.request_id_to_transfer_id: dict[ReqId, TransferId] = {}
 
     def map_request_id(self, request_id: ReqId, transfer_id: TransferId):
+        prev_req = self.transfer_id_to_request_id.get(transfer_id)
+        if prev_req is not None and prev_req != request_id:
+            logger.warning(
+                "Duplicate transfer_id %s remapped from request %s to %s; "
+                "the previous mapping is overwritten (possible id collision).",
+                transfer_id,
+                prev_req,
+                request_id,
+            )
+            if self.request_id_to_transfer_id.get(prev_req) == transfer_id:
+                del self.request_id_to_transfer_id[prev_req]
+        prev_transfer = self.request_id_to_transfer_id.get(request_id)
+        if prev_transfer is not None and prev_transfer != transfer_id:
+            logger.warning(
+                "Request %s remapped from transfer_id %s to %s; "
+                "the previous mapping is overwritten.",
+                request_id,
+                prev_transfer,
+                transfer_id,
+            )
+            if self.transfer_id_to_request_id.get(prev_transfer) == request_id:
+                del self.transfer_id_to_request_id[prev_transfer]
         self.transfer_id_to_request_id[transfer_id] = request_id
         self.request_id_to_transfer_id[request_id] = transfer_id
 
@@ -414,12 +436,21 @@ class MoRIIOConnectorScheduler:
         if request_id in self.request_id_to_transfer_id:
             transfer_id = self.request_id_to_transfer_id[request_id]
             del self.request_id_to_transfer_id[request_id]
-            if transfer_id in self.transfer_id_to_request_id:
+            mapped_req_id = self.transfer_id_to_request_id.get(transfer_id)
+            if mapped_req_id == request_id:
                 del self.transfer_id_to_request_id[transfer_id]
-            else:
+            elif mapped_req_id is None:
                 logger.warning(
                     "transfer id not in transfer_id_to_request_id lookup"
                     "table. there is likely a bug!"
+                )
+            else:
+                logger.warning(
+                    "Not removing transfer_id %s while unmapping request %s: "
+                    "it now maps to request %s.",
+                    transfer_id,
+                    request_id,
+                    mapped_req_id,
                 )
         else:
             logger.warning(
@@ -696,12 +727,18 @@ class MoRIIOConnectorScheduler:
         """
 
         request_id = request.request_id
-        # Consumer: can unmap transfer_id<->request_id immediately since done_recving
-        #   has fired at this point (i.e. KV has been transferred)
-        # Producer: must keep the mapping until we get notification that blocks can
-        #   be freed, which may be several scheduler steps later.
+
+        def clear_mapping_if_done(delay_free_blocks: bool = False) -> None:
+            # Consumer: done_recving has fired at this point, so the mapping is
+            # no longer needed. Producer only keeps the mapping while block
+            # freeing is deferred until a later finished_sending signal.
+            if self.is_producer and delay_free_blocks:
+                return
+            if request_id in self.request_id_to_transfer_id:
+                self.unmap_request_id(request_id)
+
         if not self.is_producer:
-            self.unmap_request_id(request_id)
+            clear_mapping_if_done()
 
         params = request.kv_transfer_params
         logger.debug(
@@ -711,6 +748,7 @@ class MoRIIOConnectorScheduler:
             params,
         )
         if not params:
+            clear_mapping_if_done()
             return False, None
 
         if params.get("do_remote_prefill"):
@@ -728,12 +766,14 @@ class MoRIIOConnectorScheduler:
             else:
                 self._reqs_need_recv[request.request_id] = (request, [])
             params["do_remote_prefill"] = False
+            clear_mapping_if_done()
             return False, None
 
         if (
             not params.get("do_remote_decode")
             or request.status != RequestStatus.FINISHED_LENGTH_CAPPED
         ):
+            clear_mapping_if_done()
             return False, None
 
         # computed_block_ids = block_ids if all_full else block_ids[:-1]
@@ -750,6 +790,8 @@ class MoRIIOConnectorScheduler:
             self._deferred_send_deadlines[request.request_id] = (
                 time.monotonic() + self._defer_timeout
             )
+        else:
+            clear_mapping_if_done(delay_free_blocks=False)
 
         # Return KV transfer params forwarded verbatim to the decode instance by
         # the router.


### PR DESCRIPTION
## Summary

MoriIO uses a separate completion signal after the data transfer. If that signal is lost, delayed, or fails, vLLM must not leave KV blocks or requests stuck forever.

This PR hardens the vLLM MoriIO integration so request and transfer bookkeeping stays consistent when completion notifications arrive late, are dropped, or are superseded by newer mappings.

## Changes

- Keep `transfer_id` to `request_id` mappings consistent when requests are remapped or cleaned up.
- Prevent stale request mappings from deleting newer transfer mappings.
- Keep producer-side mappings only while they are needed for deferred KV block freeing.
- Preserve early write-completion notifications that arrive before the scheduler has installed the transfer mapping, then resolve them once the mapping exists.
- Add focused CPU-only unit tests for remapping, deferred cleanup, and early completion handling.

## Test Plan

```bash
python3 -m pytest tests/v1/kv_connector/unit/test_moriio_tp_ack.py -q