### PR TITLE
[Model Runner V2][Spec Decode] Use fp32 uniform threshold for acceptance

### DIFF
--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -74,6 +74,14 @@ def tl_rand64(seed, offset, includes_zero: tl.constexpr):
 
 
 @triton.jit
+def tl_rand32(seed, offset, includes_zero: tl.constexpr):
+    u = tl.rand(seed, offset)
+    if not includes_zero:
+        u = tl.maximum(u, _TL_RAND_MIN)
+    return u
+
+
+@triton.jit
 def gumbel_block_argmax(
     logits,
     block,
@@ -131,8 +139,7 @@ def gumbel_block_argmax(
             u = tl_rand64(gumbel_seed, block, includes_zero=False)
             gumbel_noise = -tl.log(-tl.log(u))
         else:
-            u = tl.rand(gumbel_seed, block)
-            u = tl.maximum(u, _TL_RAND_MIN)
+            u = tl_rand32(gumbel_seed, block, includes_zero=False)
             # Draw the large-noise tail (which decides the argmax winner) from u -> 0,
             # where fp32 has fine resolution, instead of u -> 1, where fp32 spacing is
             # ~2**-24. The naive `-log(-log(u))` puts the winning tail at u -> 1,

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
@@ -3,7 +3,7 @@
 import torch
 
 from vllm.triton_utils import tl, tldevice, triton
-from vllm.v1.worker.gpu.sample.gumbel import gumbel_block_argmax, tl_rand64
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_block_argmax, tl_rand32
 
 
 @triton.jit
@@ -243,7 +243,7 @@ def _rejection_kernel(
 
                 if SYNTHETIC_MODE:
                     pos = tl.load(pos_ptr + logit_idx)
-                    u = tl_rand64(seed, pos, includes_zero=False)
+                    u = tl_rand32(seed, pos, includes_zero=False)
                     rate = tl.load(synthetic_conditional_rates_ptr + i)
                     # -1 is used for padded draft token ids that should be rejected.
                     accepted &= (u < rate) & (draft_sampled >= 0)
@@ -272,7 +272,7 @@ def _rejection_kernel(
                 )
                 target_log_prob = target_logit - target_lse
                 pos = tl.load(pos_ptr + logit_idx)
-                u = tl_rand64(seed, pos, includes_zero=False)
+                u = tl_rand32(seed, pos, includes_zero=False)
                 if HAS_DRAFT_LOGITS:
                     draft_logit = tl.load(
                         draft_logits_ptr


### PR DESCRIPTION
# Context
Currently in MRV2 we do an FP64 uniform random draw in the rejection sample kernel. This precision level is higher than necessary.

# This PR
Switch to FP32 uniform random draw, similar to what is done in gumbel sampling.

# Benchmarks
```
      vllm-bench \
      --backend openai-chat \
      --base-url http://127.0.0.1:8000 \
      --model {model} \
      --dataset-name hf \
      --dataset-path philschmid/mt-bench \
      --ignore-eos \
      --request-rate inf \
      --temperature 1.0 \
      --num-warmups 50 \
      --output-len 2048 \
      --sweep-max-concurrency 1,2,4,8,16,32,64 \
      --sweep-num-prompts-factor 20 \
      --save-result \
      --result-dir /home/${USER}/dev/bench \
```

## Llama3 8B + Eagle + 4 spec tokens
Metric | main | #46878 | Δ
-- | -- | -- | --
Acceptance rate (%) | 24.83 | 25.03 | +0.20
Acceptance length | 1.99 | 2.00 | +0.01
Drafts | 82,077 | 81,723 | −354
Draft tokens | 328,308 | 326,892 | −1,416
Accepted tokens | 81,515 | 81,831 | +316
Per-position acceptance — Pos 0 (%) | 53.92 | 54.01 | +0.09
Per-position acceptance — Pos 1 (%) | 26.51 | 26.93 | +0.42
Per-position acceptance — Pos 2 (%) | 12.77 | 12.91 | +0.14
Per-position acceptance — Pos 3 (%) | 6.12 | 6.28 | +0.16

## Qwen3 8B + Eagle3 + 4 spec tokens
Metric | main | #46878 | Δ
-- | -- | -- | --
Acceptance rate (%) | 34.21 | 34.31 | +0.10
Acceptance length | 2.37 | 2.37 | 0.00
Drafts | 69,168 | 69,071 | −97
Draft tokens | 276,672 | 276,284 | −388
Accepted tokens | 94,641 | 94,789 | +148
Per-position acceptance — Pos 0 (%) | 65.16 | 65.20 | +0.04
Per-position acceptance — Pos 1 (%) | 39.79 | 40.13 | +0.34
Per-position acceptance — Pos 2 (%) | 20.76 | 20.90 | +0.14
Per-position acceptance — Pos 3 (%) | 11.12 | 11.00 | −0.12

## MiMo 2.5 Pro FP4 + DFlash + 8 spec tokens
```
Metric | main | #46878 | Δ
-- | -- | -- | --
Acceptance rate (%) | 28.11 | 27.78 | −0.33
Acceptance length | 3.25 | 3.22 | −0.03
Drafts | 12,679 | 12,807 | +128
Draft tokens | 101,432 | 102,456 | +1,024
Accepted tokens | 28,511 | 28,464 | −47
Per-position acceptance — Pos 0 (%) | 71.35 | 71.14 | −0.21
Per-position acceptance — Pos 1 (%) | 48.37 | 48.53 | +0.16
Per-position acceptance — Pos 2 (%) | 33.50 | 33.07 | −0.43
Per-position acceptance — Pos 3 (%) | 24.37 | 24.03 | −0.34
Per-position acceptance — Pos 4 (%) | 17.72 | 17.44 | −0.28
Per-position acceptance — Pos 5 (%) | 13.15 | 12.56 | −0.59
Per-position acceptance — Pos 6 (%) | 9.85 | 9.24 | −0.61
Per-position acceptance — Pos 7 (%) | 6.55 | 6.25 | −0.30
```

Any differences seem to be within noise