### PR TITLE
[Bugfix][NVFP4 MoE] Pad gated intermediate to 64 for FlashInfer TRT-LLM shuffle (M%128)

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -337,7 +337,13 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
         layer.moe_config.hidden_dim = padded_hidden
 
         # Align weights for FI NVFP4 MoE kernels.
-        min_alignment = 16 if is_gated else 128
+        # FlashInfer's TRT-LLM block-scale shuffle asserts the gate/up row dim
+        # (= up_mult * padded_intermediate, up_mult=2 when gated) is a multiple of
+        # 128. So gated needs padded_intermediate % 64 (2*64=128); the old value 16
+        # left 2*intermediate a multiple of only 32, so an NVFP4 MoE whose rank-local
+        # intermediate is not 128-aligned at TP>1 (e.g. Gemma-4-26B-A4B at tp4) hit
+        # `assert M % 128 == 0`. Padded rows are zero -> outputs unchanged.
+        min_alignment = 64 if is_gated else 128
         w13, w13_scale, w2, w2_scale, padded_intermediate = (
             align_fp4_moe_weights_for_fi(
                 w13, w13_scale, w2, w2_scale, is_act_and_mul, min_alignment


### PR DESCRIPTION
Closes #46879.

## Summary

FlashInfer's TRT-LLM NVFP4 MoE weight prep shuffles block-scale rows via
get_shuffle_matrix_sf_a_row_indices, which asserts the gate/up row dim is a
multiple of 128 (epilogue_tile_m). align_fp4_moe_weights_for_fi pads the
intermediate to min_alignment, and the gate/up dim is
up_mult*padded_intermediate (up_mult=2 when gated). The caller passes
min_alignment = 16 if is_gated else 128; 16 is the NVFP4 scale-block size
(num_elts_per_sf=16), which aligns the quant scale blocks but is weaker than
the shuffle's 128-row tile. For gated, 2 * round_up(intermediate, 16) is only
guaranteed a multiple of 32, so a gated NVFP4 MoE whose rank-local
intermediate isn't 64-aligned at TP>1 (e.g. nvidia/Gemma-4-26B-A4B-NVFP4 at
-tp 4: 2*(704/4)=352, 352%128=96) fails engine init with assert M % 128 == 0.

## Why Padding to M=64 (and not the tile size requirement of M%128)

64 is not itself a shuffle tile. Gated activations compute SwiGLU(x) =
SiLU(x·W_gate) ⊗ (x·W_up), and vLLM fuses the two projections into a single
W13 = [W_gate | W_up] — one GEMM whose row dim is up_mult*padded_intermediate
with up_mult=2. The shuffle's 128-row epilogue_tile_m applies to that fused
dim, so the per-shard padded_intermediate only needs to be a multiple of 128
// up_mult = 64 for 2 * padded_intermediate to land on the tile — i.e.
min_alignment = max(16, 128 // up_mult), keeping the NVFP4 scale block (16) as
the floor. The non-gated path (up_mult=1) keeps the full 128.

## Fix

min_alignment = 64 for gated, so 2 * padded_intermediate is a multiple of 128.
Padded rows are zero in both weights and scales, so outputs are unchanged.
Non-gated path (min_alignment=128) unchanged; Marlin path (#45295) unaffected.

## Validation

- Failure (verified): vllm serve nvidia/Gemma-4-26B-A4B-NVFP4 -tp 4
--quantization modelopt --trust-remote-code on B200 fails at
process_weights_after_loading with assert M % 128 == 0 (FLASHINFER_TRTLLM
backend confirmed selected in the log).
- Fix correctness (by construction): with min_alignment=64,
padded_intermediate = round_up(176,64) = 192, so the gate/up row dim 2*192 =
384 = 3*128 satisfies the assert.

