### PR TITLE
[CI] Raise gsm8k startup timeout for Qwen3 NVFP4 trtllm configs

### DIFF
--- a/tests/evals/gsm8k/configs/Qwen3-30B-A3B-NVFP4.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3-30B-A3B-NVFP4.yaml
@@ -2,4 +2,5 @@ model_name: "nvidia/Qwen3-30B-A3B-FP4"
 accuracy_threshold: 0.89
 num_questions: 1319
 num_fewshot: 5
+startup_max_wait_seconds: 1200
 server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/Qwen3-Next-80B-A3B-NVFP4-EP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3-Next-80B-A3B-NVFP4-EP2.yaml
@@ -2,6 +2,7 @@ model_name: "nm-testing/Qwen3-Next-80B-A3B-Instruct-NVFP4"
 accuracy_threshold: 0.75
 num_questions: 1319
 num_fewshot: 5
+startup_max_wait_seconds: 1200
 server_args: >-
   --enforce-eager
   --max-model-len 4096


### PR DESCRIPTION
## Purpose

Two B200 gsm8k evals fail during **server startup**, not on accuracy, in builds such as [#74616](https://buildkite.com/vllm/ci/builds/74616):

- `LM Eval Small Models (B200)` → `test_gsm8k_correctness[Qwen3-30B-A3B-NVFP4]`
- `LM Eval Large Models (B200, EP)` → `test_gsm8k_correctness[Qwen3-Next-80B-A3B-NVFP4-EP2]`

Both die with `RuntimeError: Server failed to start in time.` The model loads fine in seconds, but FlashInfer FP4 kernel autotuning (`fp4_gemm`, then `flashinfer::trtllm_fp4_block_scale_moe`) runs past the default 600s startup budget, so `RemoteOpenAIServer` SIGKILLs the server before it's healthy and the eval never runs. From the build #74616 logs, both tests were killed ~624s in, still mid-autotune (only ~10% into the final MoE tuning pass) — i.e. they need only modestly more than the 600s default.

Other configs in the same job (FP8 variants, and even `Nemotron-3-Super-120B-A12B-NVFP4`) pass, so this is specific to the slow FP4 autotune warmup on these two Qwen3 NVFP4 configs, not a code or accuracy regression.

## Change

Add `startup_max_wait_seconds: 1200` to the two affected configs. This matches the existing convention already used by the heavier `DeepSeek-V3.2-*`, `DeepSeek-R1-*`, and `Nemotron-3-Super-120B-A12B-NVFP4` gsm8k configs, and the test already supports the field:

```python
max_wait_seconds=eval_config.get("startup_max_wait_seconds", 600)
```

1200s gives comfortable headroom over the observed ~624s-and-still-running startup.

## Test

No code change; this only relaxes a CI startup timeout for two eval configs. Validation is the affected B200 LM Eval jobs passing on re-run. Logs analyzed from build [#74616](https://buildkite.com/vllm/ci/builds/74616).

AI assistance (Claude Code) was used to triage the CI logs and prepare this change; the author has reviewed every changed line.