### PR TITLE
[CI] Raise gsm8k startup timeout for MoE Refactor Qwen3 NVFP4 configs

### DIFF
--- a/tests/evals/gsm8k/configs/moe-refactor-dp-ep/Qwen3-30B-A3B-NvFp4-CT-fi-cutlass.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor-dp-ep/Qwen3-30B-A3B-NvFp4-CT-fi-cutlass.yaml
@@ -2,4 +2,5 @@ model_name: "RedHatAI/Qwen3-30B-A3B-NVFP4"
 accuracy_threshold: 0.88
 num_questions: 1319
 num_fewshot: 5
+startup_max_wait_seconds: 1200
 server_args: "--enforce-eager --max-model-len 8192 --data-parallel-size 2 --enable-expert-parallel --moe-backend=flashinfer_cutlass"

--- a/tests/evals/gsm8k/configs/moe-refactor-dp-ep/Qwen3-30B-A3B-NvFp4-ModelOpt-fi-trtllm.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor-dp-ep/Qwen3-30B-A3B-NvFp4-ModelOpt-fi-trtllm.yaml
@@ -2,4 +2,5 @@ model_name: "nvidia/Qwen3-30B-A3B-NVFP4"
 accuracy_threshold: 0.88
 num_questions: 1319
 num_fewshot: 5
+startup_max_wait_seconds: 1200
 server_args: "--enforce-eager --max-model-len 8192 --data-parallel-size 2 --enable-expert-parallel --moe-backend=flashinfer_trtllm"

--- a/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-NvFp4-CT-fi-trtllm.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-NvFp4-CT-fi-trtllm.yaml
@@ -2,4 +2,5 @@ model_name: "RedHatAI/Qwen3-30B-A3B-NVFP4"
 accuracy_threshold: 0.88
 num_questions: 1319
 num_fewshot: 5
+startup_max_wait_seconds: 1200
 server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2 --moe-backend=flashinfer_trtllm"

--- a/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-NvFp4-ModelOpt-fi-trtllm.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-NvFp4-ModelOpt-fi-trtllm.yaml
@@ -2,4 +2,5 @@ model_name: "nvidia/Qwen3-30B-A3B-NVFP4"
 accuracy_threshold: 0.88
 num_questions: 1319
 num_fewshot: 5
+startup_max_wait_seconds: 1200
 server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2 --moe-backend=flashinfer_trtllm"


### PR DESCRIPTION
## Purpose

Follow-up to #46881. The **MoE Refactor Integration** B200 jobs hit the same FlashInfer NVFP4 startup-timeout as the LM Eval jobs fixed in #46881. In builds such as [#74616](https://buildkite.com/vllm/ci/builds/74616), these configs fail with `RuntimeError: Server failed to start in time.` — the model loads fine, but FlashInfer FP4 kernel autotuning (`fp4_gemm`, `flashinfer::trtllm_fp4_block_scale_moe`) runs past the default 600s startup budget, so `RemoteOpenAIServer` SIGKILLs the server before it's healthy and the eval never runs.

This affects four NVFP4 FlashInfer configs:

**MoE Refactor Integration Test (B200):**
- `moe-refactor/Qwen3-30B-A3B-NvFp4-CT-fi-trtllm`
- `moe-refactor/Qwen3-30B-A3B-NvFp4-ModelOpt-fi-trtllm`

**MoE Refactor Integration Test (B200 DP):**
- `moe-refactor-dp-ep/Qwen3-30B-A3B-NvFp4-CT-fi-cutlass`
- `moe-refactor-dp-ep/Qwen3-30B-A3B-NvFp4-ModelOpt-fi-trtllm`

## Change

Add `startup_max_wait_seconds: 1200` to those four configs, matching the value used for the lm-eval NVFP4 configs in #46881 and the existing convention in the DeepSeek/Nemotron gsm8k configs. The test already honors the field:

```python
max_wait_seconds=eval_config.get("startup_max_wait_seconds", 600)
```

## Out of scope

The `*-deepep-ll` (DeepEP low-latency) configs in the B200 DP job fail for a **different** reason — NVSHMEM/InfiniBand transport errors during all2all init (`ibv_modify_qp failed`, `nvshmem setup connections failed`), a node RDMA/IBGDA environment issue, not a startup-speed issue. A higher timeout would not help them, so they are intentionally left unchanged and need separate infra investigation.

Sibling NVFP4 FlashInfer configs that currently pass (e.g. the `*-fi-cutlass` ModelOpt variants) are left as-is; they can be bumped later if they start flaking near the 600s boundary.

## Test

No code change; this only relaxes a CI startup timeout for four eval configs. Validation is the affected MoE Refactor B200 jobs passing on re-run. Logs analyzed from build [#74616](https://buildkite.com/vllm/ci/builds/74616).

AI assistance (Claude Code) was used to triage the CI logs and prepare this change; the author has reviewed every changed line.