### PR TITLE
[BugFix] Rebuild InputBatch when max_model_len is auto-reduced

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7108,6 +7108,7 @@ class GPUModelRunner(
             or kernel_block_sizes != self._init_kernel_block_sizes
             or max_num_blocks != self._init_max_num_blocks
             or slot_mapping_modes != self._init_slot_mapping_modes
+            or max_model_len != self.input_batch.max_model_len
         ):
             self._init_block_sizes = block_sizes
             self._init_kernel_block_sizes = kernel_block_sizes

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7366,6 +7366,7 @@ class GPUModelRunner(
             or slot_mapping_modes != self._init_slot_mapping_modes
             or self.cp_kv_cache_interleave_size
             != self.parallel_config.cp_kv_cache_interleave_size
+            or max_model_len != self.input_batch.max_model_len
         ):
             self._init_block_sizes = block_sizes
             self._init_kernel_block_sizes = kernel_block_sizes


### PR DESCRIPTION
When the engine auto-reduces max_model_len to fit GPU memory after
  InputBatch creation, the MLA indexer's expanded_block_table_buffer
  gets fewer columns than InputBatch.block_table, causing a shape
  mismatch during decode. 
  
  may_reinitialize_input_batch() only guarded against block_size
  changes, which never fire for FlashMLA (block_size always 64).
  Add a max_model_len comparison so the InputBatch is rebuilt.
  
  Fixes #46787