### PR TITLE
[KV-Offloading] Fix tensors_per_block stride

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
@@ -41,6 +41,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCacheTensor,
 )
 from vllm.v1.kv_offload.base import (
     CanonicalKVCaches,
@@ -241,9 +242,18 @@ class RequestRunner:
                 )
             ]
 
+        kv_cache_tensors = [
+            KVCacheTensor(
+                size=group.kv_cache_spec.page_size_bytes * num_gpu_blocks,
+                shared_by=[layer_name],
+            )
+            for group in kv_cache_groups
+            for layer_name in group.layer_names
+        ]
+
         kv_cache_config = KVCacheConfig(
             num_blocks=num_gpu_blocks,
-            kv_cache_tensors=[],
+            kv_cache_tensors=kv_cache_tensors,
             kv_cache_groups=kv_cache_groups,
         )
         vllm_config.cache_config.num_gpu_blocks = num_gpu_blocks

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -53,6 +53,16 @@ class OffloadingConnectorWorker:
         kv_cache_config = self.spec.kv_cache_config
         num_blocks = kv_cache_config.num_blocks
 
+        # Packed layouts (e.g. DSv4) set block_stride > 0; their tensors use
+        # stride(0) as the manager-block stride (equals total_num_bytes_per_block).
+        # General (non-packed) layouts size the tensor at page_size_bytes per
+        # manager block, so page_size_bytes is the correct offloading stride.
+        layer_is_packed: dict[str, bool] = {
+            ln: bool(kv_tensor.block_stride)
+            for kv_tensor in kv_cache_config.kv_cache_tensors
+            for ln in kv_tensor.shared_by
+        }
+
         # layer_name -> (num_blocks, page_size_bytes) tensor
         tensors_per_block: dict[str, tuple[torch.Tensor, ...]] = {}
         # layer_name -> size of (un-padded) page in bytes
@@ -77,7 +87,11 @@ class OffloadingConnectorWorker:
                     page = layer_kv_cache_spec.page_size_bytes
                     elem_size = layer_kv_cache.element_size()
                     byte_offset = layer_kv_cache.storage_offset() * elem_size
-                    block_stride_bytes = layer_kv_cache.stride(0) * elem_size
+                    block_stride_bytes = (
+                        layer_kv_cache.stride(0) * elem_size
+                        if layer_is_packed[layer_name]
+                        else page
+                    )
                     tensors_per_block[layer_name] = (
                         torch.tensor(
                             [],


### PR DESCRIPTION
## Purpose
On `main` Offloading connector fails for `Qwen/Qwen3.6-35B-A3B` & `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8` with the assert 
```
(Worker_TP3 pid=3812595) ERROR 06-26 23:01:48 [multiproc_executor.py:1000]   File "/home/varun-sundar-rabindranath/code/vllm/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py", line 174, in register_kv_caches
(Worker_TP3 pid=3812595) ERROR 06-26 23:01:48 [multiproc_executor.py:1000]     len({tensors_per_block[n][0].stride() for n in tensor_layer_names}) == 1
```

Why:
 PR https://github.com/vllm-project/vllm/pull/44577 introduced cross-layer layouts for DSV4. The PR introduced a change in the offloading/worker.py::register_kv_caches to set the 2D` tensors_per_block` stride directly from the layer_kv_cache.  This is incorrect when the KV cache tensor is not layer packed. 
 
Fix:
Special case based on if the kv cache tensor is packed. 

## Test Plan
vllm-serve command:
```
KV_TRANSFER_CONFIG=$(cat <<EOF
{
  "kv_connector": "OffloadingConnector",
  "kv_role": "kv_both",
  "kv_connector_extra_config": {
    "spec_name": "CPUOffloadingSpec",
    "cpu_bytes_to_use": 26843545600,
    "eviction_policy": "lru"
  }
}
EOF
)

vllm serve "${MODEL}" \
      --tensor-parallel-size=4 \
      --kv-transfer-config "${KV_TRANSFER_CONFIG}" \
      --enable-prefix-caching \
      --no-disable-hybrid-kv-cache-manager
```

lm_eval command:
```
lm_eval \
  --model local-completions \
  --model_args "base_url=http://127.0.0.1:${VLLM_PORT}/v1/completions,model=${MODEL},tokenized_requests=False,num_concurrent=1000,trust_remote_code=True" \
  --tasks gsm8k \
  --seed 42 \
  --num_fewshot 50 \
  --gen_kwargs temperature=0.0
```

## Test Result
PR 
`nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8`
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    50|exact_match|↑  |0.9181|±  |0.0076|
|     |       |strict-match    |    50|exact_match|↑  |0.9158|±  |0.0076|
```
`nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8 - without offloading`
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    50|exact_match|↑  |0.9121|±  |0.0078|
|     |       |strict-match    |    50|exact_match|↑  |0.9113|±  |0.0078|
```
`Qwen/Qwen3.6-35B-A3B`
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    50|exact_match|↑  |0.8886|±  |0.0087|
|     |       |strict-match    |    50|exact_match|↑  |0.8870|±  |0.0087|
```
`Qwen/Qwen3.6-35B-A3B - without offloading`
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    50|exact_match|↑  |0.8923|±  |0.0085|
|     |       |strict-match    |    50|exact_match|↑  |0.8916|±  |0.0086|
```
