### PR TITLE
[CI/Test] Skip FlashAttnMLA + FP8 KV cache cell in test_mla_rope_kvcache_cat_fusion

### DIFF
--- a/tests/compile/passes/test_mla_rope_kvcache_cat_fusion.py
+++ b/tests/compile/passes/test_mla_rope_kvcache_cat_fusion.py
@@ -272,6 +272,14 @@ def test_mla_rope_kvcache_cat_fusion(
     kv_cache_dtype: str,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    # FlashAttnMLA V1 does not support an FP8 KV cache (it raises
+    # NotImplementedError at backend construction), so this cell of the
+    # parametrize matrix is not a valid configuration. Skip it, mirroring
+    # the is_quantized_kv_cache() gate in
+    # vllm/v1/attention/backends/mla/flashattn_mla.py.
+    if attn_backend == AttentionBackendEnum.FLASH_ATTN_MLA and kv_cache_dtype == "fp8":
+        pytest.skip("FlashAttnMLA V1 with FP8 KV cache not yet supported")
+
     torch.set_default_device("cuda")
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)


### PR DESCRIPTION
## Purpose

Fixes #46581.

`tests/compile/passes/test_mla_rope_kvcache_cat_fusion.py::test_mla_rope_kvcache_cat_fusion` parametrizes `kv_cache_dtype=["auto", "fp8"]` across `MLA_BACKENDS`, which includes `FLASH_ATTN_MLA` on Hopper (where `flash_attn_supports_mla()` is `True`). `FlashAttnMLA` V1 does not support an FP8 KV cache — it raises `NotImplementedError("FlashAttnMLA V1 with FP8 KV cache not yet supported")` at backend construction (the `is_quantized_kv_cache()` gate in `vllm/v1/attention/backends/mla/flashattn_mla.py`). So the `(FLASH_ATTN_MLA, fp8)` cell of the matrix is not a valid configuration and always fails there.

## Fix

Skip that cell at runtime, mirroring the backend's own capability gate (issue option 2). This is the minimal, lowest-risk fix:
- Option 1 (implement FP8 KV cache in `FlashAttnMLA`) is a feature, out of scope for a test bug.
- Option 3 (filter `MLA_BACKENDS`) is awkward because `attn_backend` and `kv_cache_dtype` are independent parametrize axes, so the backend list can't be filtered on the dtype at collection time.

The change is purely additive and test-only: it only skips a cell that currently errors; `auto` KV-cache dtype and the other backends (`TRITON_MLA`, `ROCM_AITER_MLA`) are unaffected.

## Test Plan / Verification

Note on local verification: the failing cells only appear where `flash_attn_supports_mla()` is `True` (Hopper); on non-Hopper hardware they aren't collected at all, so the regression reproduces on Hopper per the issue. The skip condition mirrors the exact gate in `flashattn_mla.py` (`is_quantized_kv_cache(kv_cache_dtype)` → the `"FlashAttnMLA V1 with FP8 KV cache not yet supported"` `NotImplementedError`).

- `ruff check` / `ruff format` pass.
- Change is verified by inspection against the backend gate; CI exercises it on Hopper runners.
- Behavior on the other (collected) cells is unchanged — the guard is the first statement and only triggers for `(FLASH_ATTN_MLA, fp8)`.

---

AI assistance was used; I have reviewed and can defend the change.
