### PR TITLE
[BugFix] Report correct cached_tokens for disaggregated prefill

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -612,6 +612,38 @@ class Scheduler(SchedulerInterface):
                             num_local_cached_tokens=num_new_local_computed_tokens,
                             num_external_cached_tokens=num_external_computed_tokens,
                         )
+                        # [PD disagg cached_tokens fix] In disaggregated
+                        # prefill, the decode node cannot tell prefix-cache
+                        # hits from freshly computed tokens among the KV it
+                        # received from the prefill node, so cached_tokens is
+                        # wrong. Propagate the prefill node's real prefix-cache
+                        # hit count through kv_transfer_params and use it on the
+                        # decode node.
+                        params = request.kv_transfer_params
+                        if params and params.get("do_remote_decode"):
+                            # Prefill (P) node: record real prefix-cache hits so
+                            # they can be forwarded to the decode node. Include
+                            # both local prefix-cache hits and external (e.g.
+                            # memcache / KV pool) hits. The two are disjoint:
+                            # num_external_computed_tokens is the number of NEW
+                            # tokens matched beyond num_new_local_computed_tokens
+                            # (see KVConnectorBase_V1.get_num_new_matched_tokens),
+                            # so summing them does not double-count.
+                            params["remote_num_cached_tokens"] = (
+                                num_new_local_computed_tokens
+                                + num_external_computed_tokens
+                            )
+                        elif params and params.get("do_remote_prefill") and (
+                            "remote_num_cached_tokens" in params
+                        ):
+                            # Decode (D) node: override cached_tokens with the
+                            # prefill node's real hit count. Do NOT add D's local
+                            # hit (num_local) -- it is the same prefix and would
+                            # double-count.
+                            request.prefill_stats.num_cached_tokens = (
+                                params["remote_num_cached_tokens"]
+                            )
+
                 else:
                     # KVTransfer: WAITING reqs have num_computed_tokens > 0
                     # after async KV recvs are completed.


### PR DESCRIPTION
In disaggregated prefill, the decode node treats all KV blocks received from the prefill node as cache hits, so cached_tokens always equals prompt_tokens regardless of actual prefix-cache hits.

Override num_cached_tokens with the prefill node's real hit count forwarded via kv_transfer_params (remote_num_cached_tokens). Applies to the native Scheduler path (when recompute_scheduler_enable=false).

Companion to vllm-project/vllm-ascend#<fill>




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

