### PR TITLE
[Bugfix]fix(v1): clear stale async speculative placeholders

### DIFF
--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -136,6 +136,33 @@ def test_preempt():
         assert req.num_output_tokens == abort_order_copy.index(i)
 
 
+def test_async_spec_placeholders_cleared_for_unscheduled_reqs():
+    scheduler = create_scheduler(
+        async_scheduling=True,
+        num_speculative_tokens=2,
+    )
+    req0, req1 = create_requests(num_requests=2, max_tokens=4)
+    scheduler.add_request(req0)
+    scheduler.add_request(req1)
+
+    scheduler.schedule()
+    assert req0.spec_token_ids == [-1, -1]
+    assert req1.spec_token_ids == [-1, -1]
+
+    scheduler.max_num_scheduled_tokens = 1
+    sched_output = scheduler.schedule()
+
+    assert req0.request_id in sched_output.num_scheduled_tokens
+    assert req1.request_id not in sched_output.num_scheduled_tokens
+    assert req1.spec_token_ids == []
+
+    scheduler.running = [req1, req0]
+    sched_output = scheduler.schedule()
+
+    assert req1.request_id in sched_output.num_scheduled_tokens
+    assert req1.request_id not in sched_output.scheduled_spec_decode_tokens
+
+
 def test_prefix_caching_for_prefill_dedup():
     CHUNK_SIZE = 1000
     BLOCK_SIZE = 16

--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -19,11 +19,23 @@ class AsyncScheduler(Scheduler):
     def _update_after_schedule(self, scheduler_output: SchedulerOutput) -> None:
         super()._update_after_schedule(scheduler_output)
         spec_decode_tokens = scheduler_output.scheduled_spec_decode_tokens
+        scheduled_req_ids = scheduler_output.num_scheduled_tokens.keys()
+        scheduled_req_id_set = set(scheduled_req_ids)
+        # Speculative placeholders are only valid for the next scheduling
+        # window, where worker-side draft tokens can overwrite them.
+        for request in self.running:
+            if request.request_id in scheduled_req_id_set:
+                continue
+            if request.spec_token_ids and all(
+                token_id == -1 for token_id in request.spec_token_ids
+            ):
+                request.spec_token_ids = []
+
         # Use the latest num of scheduled draft tokens in next step as placeholder.
         self._spec_token_placeholders = [
             -1
         ] * scheduler_output.num_spec_tokens_to_schedule
-        for req_id in scheduler_output.num_scheduled_tokens:
+        for req_id in scheduled_req_ids:
             request = self.requests[req_id]
             if request.is_prefill_chunk:
                 continue


### PR DESCRIPTION

## Purpose

> note: This issue occurred in the production environment with a low occurrence rate. The bug was reproduced via a patch for this PR. After code fixes, the production environment has been stabilized and no longer crashes.

Fix an issue in vLLM V1 where `-1` speculative placeholders can outlive their intended async scheduling window when `async_scheduling` and speculative decoding are enabled together, and can later be incorrectly treated as valid draft tokens and passed into model inputs.

Issue mechanism:

1. `AsyncScheduler` reserves positions for the next round of speculative tokens after each scheduling step by temporarily setting `request.spec_token_ids` to `[-1, ...]`.
2. These `-1` placeholders are only expected to live within the next async scheduling window and should be overwritten by real draft tokens on the worker side.
3. If a request already holds placeholders but is not scheduled in the next round because of token budget limits or a scheduling gap, the old placeholders can remain in `request.spec_token_ids`. This is easier to trigger on multimodal paths because encoder / decoder scheduling windows and budget constraints introduce more scheduling gaps.
4. When the request is scheduled again later, the stale `-1` values can be added to `scheduler_output.scheduled_spec_decode_tokens`.
5. The worker uses the scheduler output to build the input token buffer. If the corresponding positions are not overwritten by real draft tokens, `-1` enters the model as an input id.
6. In the eager embedding path, a negative token id triggers an embedding lookup out-of-bounds error. In CUDA environments this usually appears as a `device-side assert`.

Fix direction:

- Limit the lifetime of speculative placeholders in `vllm/v1/core/sched/async_scheduler.py`.
- For running requests that are not scheduled in the current step, clear `spec_token_ids` if they contain placeholder-only `-1` values.
- Prevent stale placeholders from being emitted later through `scheduled_spec_decode_tokens`.

## Test Plan

### Temporarily modify source code to reproduce the issue

Note: the following change is for reproduction only and must not be committed. Restore `scheduler.py` after reproduction.

Add a debug branch in `vllm/v1/core/sched/scheduler.py` to simulate a scheduling gap where a request holds `-1` placeholders but is skipped in the next scheduling step:

```bash
cat <<'PATCH' | git apply
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -6,6 +6,7 @@ from collections import defaultdict, deque
 from collections.abc import Iterable
 from dataclasses import replace
 from typing import Any
+import os
 
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import VllmConfig
@@ -433,6 +434,21 @@ class Scheduler(SchedulerInterface):
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
+            if (
+                os.environ.get("VLLM_DEBUG_SKIP_STALE_SPEC_ONCE") == "1"
+                and len(self.running) > 1
+                and request.spec_token_ids
+                and all(token_id == -1 for token_id in request.spec_token_ids)
+            ):
+                os.environ["VLLM_DEBUG_SKIP_STALE_SPEC_ONCE"] = "0"
+                logger.warning(
+                    "Debug stale spec repro: skip request %s once with "
+                    "spec_token_ids=%s",
+                    request.request_id,
+                    request.spec_token_ids,
+                )
+                req_index += 1
+                continue
 
             if (
                 request.num_output_placeholders > 0
PATCH
```

This branch is controlled by `VLLM_DEBUG_SKIP_STALE_SPEC_ONCE=1` and triggers only once. After it triggers, the server log should contain:

```text
Debug stale spec repro: skip request <request_id> once with spec_token_ids=[-1, ...]
```

### Start the server

```bash
#!/bin/bash

TIMESTAMP=$(date +%Y%m%d_%H%M%S)

export VLLM_DEBUG_SKIP_STALE_SPEC_ONCE=1

MODEL=${MODEL:-Qwen/Qwen3.5-0.8B}

EXTRA_PARAMS=(
    --enable-log-requests
    --enforce-eager
    --tensor-parallel-size 1
    --gpu-memory-utilization 0.85
    --trust-remote-code
    --async-scheduling
    --allowed-local-media-path /
    --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}'
)

vllm serve "$MODEL" \
    --served-model-name "default-model" \
    --host 0.0.0.0 \
    --port 8080 \
    "${EXTRA_PARAMS[@]}" \
    2>&1 | tee "logs/server/$(basename "$MODEL")_${TIMESTAMP}.log"
```

### Run the concurrent benchmark

```python
"""Simple steady-concurrency benchmark for an OpenAI-compatible server."""

import os
import random
import statistics
import time
from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
from functools import cache

from openai import OpenAI
from transformers import AutoTokenizer

BASE_URL = os.environ.get("BASE_URL", "http://127.0.0.1:8080/v1")
CONCURRENCY = int(os.environ.get("CONCURRENCY", "16"))
INPUT_TOKENS = int(os.environ.get("INPUT_TOKENS", "512"))
OUTPUT_TOKENS = int(os.environ.get("OUTPUT_TOKENS", "128"))
TOTAL_REQUESTS = 100


@cache
def token_ids():
    model_info = client.models.list().data[0]
    tokenizer_path = getattr(model_info, "root", None) or MODEL
    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
    special_token_ids = set(tokenizer.all_special_ids)
    return [i for i in range(len(tokenizer)) if i not in special_token_ids]


def random_prompt():
    return random.choices(token_ids(), k=INPUT_TOKENS)


def run_one(index):
    start = time.perf_counter()
    try:
        response = client.completions.create(
            model=MODEL,
            prompt=random_prompt(),
            max_tokens=OUTPUT_TOKENS,
            temperature=0.7,
            extra_body={
                "add_special_tokens": False,
                "ignore_eos": True,
                "min_tokens": OUTPUT_TOKENS,
            },
        )
        elapsed = time.perf_counter() - start
        usage = response.usage
        prompt_tokens = usage.prompt_tokens if usage else 0
        output_tokens = usage.completion_tokens if usage else 0
        tokens = usage.total_tokens if usage else 0
        ok = prompt_tokens == INPUT_TOKENS and output_tokens == OUTPUT_TOKENS
        error = "" if ok else f"token mismatch: input={prompt_tokens}, output={output_tokens}"
        return {
            "index": index,
            "ok": ok,
            "seconds": elapsed,
            "input_tokens": prompt_tokens,
            "output_tokens": output_tokens,
            "tokens": tokens,
            "error": error,
        }
    except Exception as e:
        elapsed = time.perf_counter() - start
        return {
            "index": index,
            "ok": False,
            "seconds": elapsed,
            "input_tokens": 0,
            "output_tokens": 0,
            "tokens": 0,
            "error": str(e),
        }


def percentile(values, p):
    if not values:
        return 0.0
    values = sorted(values)
    idx = min(int(len(values) * p), len(values) - 1)
    return values[idx]


def main():
    total = max(TOTAL_REQUESTS, CONCURRENCY)
    inflight = set()
    next_index = 0
    results = []
    start = time.perf_counter()

    print_start(total)

    with ThreadPoolExecutor(max_workers=CONCURRENCY) as pool:
        while next_index < min(CONCURRENCY, total):
            inflight.add(pool.submit(run_one, next_index))
            next_index += 1

        while inflight:
            done, inflight = wait(inflight, return_when=FIRST_COMPLETED)
            for future in done:
                result = future.result()
                results.append(result)

                if next_index < total:
                    inflight.add(pool.submit(run_one, next_index))
                    next_index += 1

                print_progress(result, len(results), total, len(inflight), time.perf_counter() - start)

    print_summary(results, time.perf_counter() - start)


client = OpenAI(base_url=BASE_URL, api_key="empty")
MODEL = client.models.list().data[0].id


def print_start(total):
    print("-" * 80)
    print("start")
    print(f"base_url={BASE_URL}")
    print(f"model={MODEL}")
    print(f"concurrency={CONCURRENCY}")
    print(f"input_tokens={INPUT_TOKENS}")
    print(f"output_tokens={OUTPUT_TOKENS}")
    print(f"total_requests={total}")
    print("-" * 80)


def print_progress(result, done, total, inflight, elapsed):
    status = "ok" if result["ok"] else "err"
    print(
        f"#{result['index']:04d} {status} "
        f"done={done}/{total} inflight={inflight} "
        f"latency={result['seconds']:.3f}s rps={done / elapsed:.2f} "
        f"in={result['input_tokens']} out={result['output_tokens']} total={result['tokens']}"
    )
    if result["error"]:
        print(f"  error={result['error']}")


def print_summary(results, elapsed):
    ok = [r for r in results if r["ok"]]
    seconds = [r["seconds"] for r in ok]
    total_tokens = sum(r["tokens"] for r in ok)

    print("-" * 80)
    print("summary")
    print(f"requests={len(results)} ok={len(ok)} errors={len(results) - len(ok)}")
    print(f"elapsed={elapsed:.3f}s rps={len(results) / elapsed:.2f}")
    print(f"tokens={total_tokens} tokens/s={total_tokens / elapsed:.2f}")
    print(f"latency_avg={statistics.mean(seconds) if seconds else 0.0:.3f}s")
    print(f"latency_p50={percentile(seconds, 0.50):.3f}s")
    print(f"latency_p95={percentile(seconds, 0.95):.3f}s")
    print(f"latency_max={max(seconds) if seconds else 0.0:.3f}s")
    print("-" * 80)


if __name__ == "__main__":
    main()
```

## Test Result

Current code state:

- `vllm/v1/core/sched/async_scheduler.py`: contains the real fix.
- `tests/v1/core/test_async_scheduler.py`: adds the regression test `test_async_spec_placeholders_cleared_for_unscheduled_reqs`.

After the fix, vLLM service crashes no longer occur.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

