### PR TITLE
[Docs] Add Phi-4-mini-instruct to batch invariance tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -105,6 +105,7 @@ Batch invariance has been tested and verified on the following models:
 - **Qwen3 (MoE)**: `Qwen/Qwen3-30B-A3B`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, `Qwen/Qwen3-30B-A3B-Thinking-2507-FP8`
 - **Qwen2.5**: `Qwen/Qwen2.5-0.5B-Instruct`, `Qwen/Qwen2.5-1.5B-Instruct`, `Qwen/Qwen2.5-3B-Instruct`, `Qwen/Qwen2.5-7B-Instruct`, `Qwen/Qwen2.5-14B-Instruct`, `Qwen/Qwen2.5-32B-Instruct`
 - **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.2-3B-Instruct` for example
+- **Phi**: `microsoft/Phi-4-mini-instruct`
 - **GPT-OSS**: `openai/gpt-oss-20b`, `openai/gpt-oss-120b`
 - **Mistral**: `mistralai/Mistral-7B-v0.3`
 


### PR DESCRIPTION


## Purpose

Adds `microsoft/Phi-4-mini-instruct` to the list of models tested with batch
invariance.

This follows the model validation request in #27433.

## Test Plan

Ran the official batch invariance needle-in-batch test with
`microsoft/Phi-4-mini-instruct` on `FLASH_ATTN`.

```bash
VLLM_TEST_MODEL=microsoft/Phi-4-mini-instruct \
VLLM_BATCH_INVARIANT=1 \
VLLM_USE_FLASHINFER_SAMPLER=0 \
VLLM_NEEDLE_BATCH_SIZE=8 \
VLLM_NEEDLE_TRIALS=5 \
VLLM_GPU_MEMORY_UTILIZATION=0.85 \
VLLM_MAX_MODEL_LEN=4096 \
.venv/bin/python -m pytest \
  tests/v1/determinism/test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle \
  -k FLASH_ATTN -s -v --timeout=1000
```

## Test Result

Environment:

- Hardware: 1x NVIDIA RTX 4070
- Backend: `FLASH_ATTN`
- Model: `microsoft/Phi-4-mini-instruct`

Result:

```text
tests/v1/determinism/test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[FLASH_ATTN]
1 passed, 2 deselected, 17 warnings in 207.78s
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

