### PR TITLE
[MoE] [MoE Refactor] Migrate int8 w4a8int8 oracle 37753

### DIFF
--- a/tests/kernels/moe/test_moe_kernel_oracle.py
+++ b/tests/kernels/moe/test_moe_kernel_oracle.py
@@ -2,50 +2,248 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for the MoEKernelOracle ABC introduced in PR series for #37753.
 
-This file contains a single canonical demonstration that
-`UnquantizedMoEKernelOracle` methods delegate one-to-one to the
-existing module-level functions in `oracle/unquantized.py`. Each method
-on `UnquantizedMoEKernelOracle` follows the same `return module_fn(args)`
-pattern, so verifying delegation for one method (`make_kernel`) gives
-high confidence in the rest.
+This file exercises two layers:
+
+1. The base class's generic `select_backend` logic — the priority
+   loop, `is_supported_config` iteration, and user-explicit backend
+   override behave correctly. Driven by an in-test stub oracle so the
+   tests don't depend on any concrete oracle's data or platform
+   conditions.
+
+2. Each concrete oracle — `backend_enum_cls`,
+   `get_priority_backends`, `backend_to_kernel_cls`, `map_backend`,
+   and with its specific guards.
 """
 
-from unittest.mock import patch
+from enum import Enum
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
-from vllm.model_executor.layers.fused_moe.oracle import UnquantizedMoEKernelOracle
-from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
-    UnquantizedMoeBackend,
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
+from vllm.model_executor.layers.fused_moe.oracle.int8 import (
+    Int8MoeBackend,
+    Int8MoEKernelOracle,
+)
+from vllm.model_executor.layers.fused_moe.oracle.w4a8_int8 import (
+    W4A8Int8MoeBackend,
+    W4A8Int8MoEKernelOracle,
 )
 
+# ---------------------------------------------------------------------------
+# Stubs for exercising the base class's generic select_backend logic.
+# ---------------------------------------------------------------------------
 
-class TestUnquantizedDelegation:
-    """UnquantizedMoEKernelOracle methods must delegate to the existing
-    module-level functions; behaviour is bit-identical."""
 
-    def test_make_kernel_delegates(self) -> None:
-        quant_config = object()
-        moe_config = object()
-        experts_cls = TritonExperts
-        sentinel_kernel = object()
+class _StubBackend(Enum):
+    A = "A"
+    B = "B"
 
-        with patch(
-            "vllm.model_executor.layers.fused_moe.oracle.unquantized."
-            "make_unquantized_moe_kernel",
-            return_value=sentinel_kernel,
-        ) as mocked:
-            out = UnquantizedMoEKernelOracle().make_kernel(
-                quant_config,
-                moe_config,
-                UnquantizedMoeBackend.TRITON,
-                experts_cls,
-            )
 
-        mocked.assert_called_once_with(
-            quant_config,
-            moe_config,
-            UnquantizedMoeBackend.TRITON,
-            experts_cls,
-            None,  # routing_tables default
+class _StubSupportedExperts:
+    """Stub experts class whose `is_supported_config` always returns True."""
+
+    @staticmethod
+    def is_supported_config(cls, config, weight_key, activation_key, fmt):
+        return True, None
+
+
+class _StubUnsupportedExperts:
+    @staticmethod
+    def is_supported_config(cls, config, weight_key, activation_key, fmt):
+        return False, "stub: not supported"
+
+
+class _StubOracle(MoEKernelOracle[_StubBackend]):
+    """In-test stub oracle for exercising base class behaviour."""
+
+    def __init__(self, priority, kernel_map, mapping=None):
+        self._priority = priority
+        self._kernel_map = kernel_map
+        self._mapping = mapping or {}
+
+    def backend_enum_cls(self):
+        return _StubBackend
+
+    def get_priority_backends(self, moe_config):
+        return self._priority
+
+    def backend_to_kernel_cls(self, backend):
+        return self._kernel_map[backend]
+
+    def map_backend(self, runner_backend):
+        if runner_backend not in self._mapping:
+            raise ValueError(f"unknown: {runner_backend}")
+        return self._mapping[runner_backend]
+
+
+def _stub_moe_config(moe_backend="auto", use_batched=False):
+    config = MagicMock()
+    config.moe_backend = moe_backend
+    config.moe_parallel_config.use_batched_activation_format = use_batched
+    return config
+
+
+class TestGenericSelectBackend:
+    """The base class's generic `select_backend` should
+    - iterate `get_priority_backends` in order
+    - for each backend, iterate `backend_to_kernel_cls` candidates,
+      asking each one's `is_supported_config` until one accepts
+    - return the first supported (backend, kernel_class) tuple
+    - raise NotImplementedError when none of the candidates supports
+      the configuration
+    - honour a user-explicit `moe_backend` override (raise on unsupported)
+    """
+
+    def test_first_supported_backend_wins(self) -> None:
+        oracle = _StubOracle(
+            priority=[_StubBackend.A, _StubBackend.B],
+            kernel_map={
+                _StubBackend.A: [_StubSupportedExperts],
+                _StubBackend.B: [_StubSupportedExperts],
+            },
         )
-        assert out is sentinel_kernel
+        backend, k_cls = oracle.select_backend(_stub_moe_config())
+        assert backend == _StubBackend.A
+        assert k_cls is _StubSupportedExperts
+
+    def test_skips_unsupported_backend(self) -> None:
+        oracle = _StubOracle(
+            priority=[_StubBackend.A, _StubBackend.B],
+            kernel_map={
+                _StubBackend.A: [_StubUnsupportedExperts],
+                _StubBackend.B: [_StubSupportedExperts],
+            },
+        )
+        backend, k_cls = oracle.select_backend(_stub_moe_config())
+        assert backend == _StubBackend.B
+        assert k_cls is _StubSupportedExperts
+
+    def test_skips_unsupported_class_within_backend(self) -> None:
+        oracle = _StubOracle(
+            priority=[_StubBackend.A],
+            kernel_map={
+                _StubBackend.A: [_StubUnsupportedExperts, _StubSupportedExperts],
+            },
+        )
+        backend, k_cls = oracle.select_backend(_stub_moe_config())
+        assert backend == _StubBackend.A
+        assert k_cls is _StubSupportedExperts
+
+    def test_all_unsupported_raises(self) -> None:
+        oracle = _StubOracle(
+            priority=[_StubBackend.A, _StubBackend.B],
+            kernel_map={
+                _StubBackend.A: [_StubUnsupportedExperts],
+                _StubBackend.B: [_StubUnsupportedExperts],
+            },
+        )
+        with pytest.raises(NotImplementedError, match="No _StubOracle backend"):
+            oracle.select_backend(_stub_moe_config())
+
+    def test_user_explicit_override_picks_requested(self) -> None:
+        oracle = _StubOracle(
+            priority=[_StubBackend.A],
+            kernel_map={
+                _StubBackend.A: [_StubSupportedExperts],
+                _StubBackend.B: [_StubSupportedExperts],
+            },
+            mapping={"b": _StubBackend.B},
+        )
+        backend, _ = oracle.select_backend(_stub_moe_config(moe_backend="b"))
+        assert backend == _StubBackend.B
+
+    def test_user_explicit_unsupported_raises(self) -> None:
+        oracle = _StubOracle(
+            priority=[_StubBackend.A],
+            kernel_map={
+                _StubBackend.A: [_StubUnsupportedExperts],
+            },
+            mapping={"a": _StubBackend.A},
+        )
+        with pytest.raises(ValueError, match="does not support"):
+            oracle.select_backend(_stub_moe_config(moe_backend="a"))
+
+
+class TestInt8OracleDataDeclarations:
+    """Int8MoEKernelOracle declares TRITON + HUMMING + CPU backends, maps
+    `triton` from the user-facing override, and prioritises CPU on CPU
+    platforms."""
+
+    def test_backend_enum_cls(self) -> None:
+        assert Int8MoEKernelOracle().backend_enum_cls() is Int8MoeBackend
+
+    def test_get_priority_backends_non_cpu(self) -> None:
+        with patch(
+            "vllm.model_executor.layers.fused_moe.oracle.int8.current_platform.is_cpu",
+            return_value=False,
+        ):
+            assert Int8MoEKernelOracle().get_priority_backends(_stub_moe_config()) == [
+                Int8MoeBackend.TRITON,
+                Int8MoeBackend.HUMMING,
+                Int8MoeBackend.CPU,
+            ]
+
+    def test_get_priority_backends_cpu_moves_cpu_front(self) -> None:
+        with patch(
+            "vllm.model_executor.layers.fused_moe.oracle.int8.current_platform.is_cpu",
+            return_value=True,
+        ):
+            assert Int8MoEKernelOracle().get_priority_backends(_stub_moe_config()) == [
+                Int8MoeBackend.CPU,
+                Int8MoeBackend.TRITON,
+                Int8MoeBackend.HUMMING,
+            ]
+
+    def test_backend_to_kernel_cls_triton(self) -> None:
+        out = Int8MoEKernelOracle().backend_to_kernel_cls(Int8MoeBackend.TRITON)
+        assert out == [TritonExperts]
+
+    def test_map_backend_triton(self) -> None:
+        assert Int8MoEKernelOracle().map_backend("triton") is Int8MoeBackend.TRITON
+
+    def test_map_backend_unknown_raises(self) -> None:
+        with pytest.raises(ValueError, match="not supported"):
+            Int8MoEKernelOracle().map_backend("flashinfer")
+
+
+class TestW4A8Int8OracleDataDeclarations:
+    """W4A8Int8MoEKernelOracle is a CPU-only oracle with a single
+    backend (CPU_INT4) that requires monolithic experts."""
+
+    def test_backend_enum_cls(self) -> None:
+        assert W4A8Int8MoEKernelOracle().backend_enum_cls() is W4A8Int8MoeBackend
+
+    def test_map_backend_cpu(self) -> None:
+        assert (
+            W4A8Int8MoEKernelOracle().map_backend("cpu") is W4A8Int8MoeBackend.CPU_INT4
+        )
+
+    def test_map_backend_unknown_raises(self) -> None:
+        with pytest.raises(ValueError, match="not supported"):
+            W4A8Int8MoEKernelOracle().map_backend("triton")
+
+    def test_select_backend_raises_on_non_cpu(self) -> None:
+        with (
+            patch(
+                "vllm.model_executor.layers.fused_moe.oracle.w4a8_int8."
+                "current_platform.is_cpu",
+                return_value=False,
+            ),
+            pytest.raises(NotImplementedError, match="CPU platforms"),
+        ):
+            W4A8Int8MoEKernelOracle().select_backend(_stub_moe_config())
+
+    def test_make_kernel_requires_monolithic_experts(self) -> None:
+        # Pass a non-monolithic stub class to trigger the guard.
+        class _NonMonolithicExperts:
+            pass
+
+        with pytest.raises(ValueError, match="monolithic"):
+            W4A8Int8MoEKernelOracle().make_kernel(
+                MagicMock(),
+                _stub_moe_config(),
+                _NonMonolithicExperts,
+                W4A8Int8MoeBackend.CPU_INT4,
+            )

--- a/vllm/model_executor/layers/fused_moe/oracle/base.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/base.py
@@ -12,12 +12,8 @@ that follow an informal convention.
 This module declares the abstract contract; concrete oracles inherit from
 `MoEKernelOracle` and provide the platform-specific behaviour.
 
-This is the first PR in the series suggested by @robertgshaw2-redhat in
-PR #37776 (see issue #37753). It intentionally only introduces the ABC;
-follow-up PRs migrate each oracle to inherit from it. The single concrete
-subclass shipped here (`UnquantizedMoEKernelOracle`) delegates to the
-existing module-level functions to keep behaviour bit-identical with
-pre-class code.
+Part of the series of issue #37753.
+Follow-up PRs are planned.
 """
 
 from abc import ABC, abstractmethod
@@ -28,6 +24,10 @@ import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.config.kernel import MoEBackend
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.all2all_utils import (
+    maybe_make_prepare_finalize,
+)
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
     FusedMoEQuantConfig,
@@ -36,20 +36,25 @@ from vllm.model_executor.layers.fused_moe.config import (
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 
+logger = init_logger(__name__)
+
 BackendT = TypeVar("BackendT", bound=Enum)
 
 
 class MoEKernelOracle(ABC, Generic[BackendT]):
     """Abstract base for MoE kernel-selection oracles.
 
-    Concrete oracles MUST implement: `backend_enum_cls`,
-    `get_priority_backends`, `backend_to_kernel_cls`, `map_backend`,
-    `select_backend`, `make_kernel`.
+    Concrete oracles MUST implement methods:
+    `backend_enum_cls`, `get_priority_backends`,
+    `backend_to_kernel_cls`, `map_backend`.
 
-    Concrete oracles MAY override: `convert_to_kernel_format`,
-    `make_quant_config`. The base class provides default implementations
-    that are appropriate for oracles which do not need them
-    (e.g. `make_quant_config` raises on the unquantized oracle).
+    The base class provides generic implementations of `select_backend`
+    and `make_kernel` that use the above methods to pick a backend and
+    construct the kernel. Oracles with quirks
+    (env-var gates, platform-specific reordering, LoRA forced routing,
+    monolithic-only constraints, etc.) override these.
+
+    MAY override `convert_to_kernel_format` and `make_quant_config`
     """
 
     @abstractmethod
@@ -66,45 +71,149 @@ class MoEKernelOracle(ABC, Generic[BackendT]):
     def backend_to_kernel_cls(
         self, backend: BackendT
     ) -> list[type[mk.FusedMoEExperts]]:
-        """Map a backend enum value to its concrete `FusedMoEExperts`
-        subclasses, in selection priority order."""
+        """Map a backend enum value to its candidate `FusedMoEExperts`
+        subclasses, ordered by preference. Returning a list of
+        multiple experts variants (e.g. Fp8 TrtLlm has both monolithic
+        and modular flavours); callers iterate until one's
+        `is_supported_config` returns True. Backends with only a
+        single variant return a 1-element list.
+        """
 
     @abstractmethod
     def map_backend(self, runner_backend: MoEBackend) -> BackendT:
         """Map a user-facing `MoEBackend` (from the runner config) to
         this oracle's enum."""
 
-    @abstractmethod
     def select_backend(
         self,
         moe_config: FusedMoEConfig,
         weight_key: "QuantKey | None" = None,
         activation_key: "QuantKey | None" = None,
     ) -> tuple[BackendT, type[mk.FusedMoEExperts] | None]:
-        """Primary entry point: choose the best supported backend for
-        the given `moe_config`.
-
-        `weight_key` / `activation_key` carry the quantization scheme of
-        the weights and activations and are consumed by quantized oracles
-        (fp8, nvfp4, int8, ...) to disambiguate backends. The unquantized
-        oracle ignores them. Subclasses with additional selection inputs
-        (e.g. int_wna16 needs `weight_bits`, fp8 needs
-        `allow_vllm_cutlass`) widen the signature in their override; a
-        per-oracle config object is the longer-term target tracked in
-        the #37753 follow-up PRs.
+        """Generic backend selection — try user-explicit override first,
+        then iterate the subclass-provided priority list and ask each
+        candidate kernel class via ``is_supported_config`` until one
+        accepts. Oracles with quirks (env-var gates, platform-specific
+        reordering, LoRA forced routing, etc.) override this entirely.
         """
+        available = self.get_priority_backends(moe_config)
 
-    @abstractmethod
+        activation_format = (
+            mk.FusedMoEActivationFormat.BatchedExperts
+            if moe_config.moe_parallel_config.use_batched_activation_format
+            else mk.FusedMoEActivationFormat.Standard
+        )
+
+        oracle_name = type(self).__name__
+
+        def _make_log_backend(backend: BackendT) -> str:
+            available_strs = [b.value for b in available]
+            return (
+                f"Using {backend.value} {oracle_name} backend out "
+                f"of potential backends: {available_strs}."
+            )
+
+        def _make_log_unsupported(backend: BackendT, reason: str | None) -> str:
+            if reason:
+                return (
+                    f"{oracle_name} backend {backend.value!r} does not support "
+                    f"the deployment configuration since {reason}."
+                )
+            return (
+                f"{oracle_name} backend {backend.value!r} does not support "
+                "the deployment configuration."
+            )
+
+        def _return_or_raise(
+            backend: BackendT,
+        ) -> tuple[BackendT, type[mk.FusedMoEExperts]]:
+            reason: str | None = None
+            for k_cls in self.backend_to_kernel_cls(backend):
+                supported, reason = k_cls.is_supported_config(
+                    k_cls,
+                    moe_config,
+                    weight_key,
+                    activation_key,
+                    activation_format,
+                )
+                if supported:
+                    logger.info_once(_make_log_backend(backend))
+                    return backend, k_cls
+            raise ValueError(_make_log_unsupported(backend, reason))
+
+        # Handle explicit moe_backend from user.
+        runner_backend = moe_config.moe_backend
+        if runner_backend != "auto":
+            requested_backend = self.map_backend(runner_backend)
+            return _return_or_raise(requested_backend)
+
+        # Iterate priorities, return first supported.
+        last_reason: str | None = None
+        for backend in available:
+            for k_cls in self.backend_to_kernel_cls(backend):
+                supported, reason = k_cls.is_supported_config(
+                    k_cls,
+                    moe_config,
+                    weight_key,
+                    activation_key,
+                    activation_format,
+                )
+                last_reason = reason
+                if supported:
+                    logger.info_once(_make_log_backend(backend))
+                    return backend, k_cls
+                logger.debug_once(_make_log_unsupported(backend, reason))
+
+        raise NotImplementedError(
+            f"No {oracle_name} backend supports the deployment configuration"
+            + (f": {last_reason}." if last_reason else ".")
+        )
+
     def make_kernel(
         self,
         quant_config: FusedMoEQuantConfig,
         moe_config: FusedMoEConfig,
-        backend: BackendT,
         experts_cls: type[mk.FusedMoEExperts],
+        backend: BackendT,
         routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
     ) -> mk.FusedMoEKernel:
-        """Construct the `FusedMoEKernel` (Prepare/Finalize + Experts
-        combinator) for the chosen backend."""
+        """Generic kernel construction — build the Prepare/Finalize
+        stage, instantiate ``experts_cls``, and combine them into a
+        ``FusedMoEKernel``. Subclasses with extra construction
+        arguments (e.g. ``w4a8`` needs ``b_strides``) or extra
+        constraints (e.g. monolithic experts support-only) override this.
+        """
+        is_monolithic = issubclass(experts_cls, mk.FusedMoEExpertsMonolithic)
+        prepare_finalize = maybe_make_prepare_finalize(
+            moe=moe_config,
+            quant_config=quant_config,
+            routing_tables=routing_tables,
+            allow_new_interface=True,
+            use_monolithic=is_monolithic,
+        )
+        assert prepare_finalize is not None
+
+        logger.info_once("Using %s", prepare_finalize.__class__.__name__)
+
+        if (
+            prepare_finalize.activation_format
+            == mk.FusedMoEActivationFormat.BatchedExperts
+        ):
+            max_num_tokens = prepare_finalize.max_num_tokens_per_rank()
+            assert max_num_tokens is not None
+            experts = experts_cls(
+                moe_config=moe_config,
+                quant_config=quant_config,
+                max_num_tokens=max_num_tokens,
+                num_dispatchers=prepare_finalize.num_dispatchers(),
+            )
+        else:
+            experts = experts_cls(
+                moe_config=moe_config,
+                quant_config=quant_config,
+            )
+
+        return mk.FusedMoEKernel(prepare_finalize, experts)
 
     def convert_to_kernel_format(
         self,

--- a/vllm/model_executor/layers/fused_moe/oracle/int8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int8.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     int8_w8a8_moe_quant_config,
     int8_w8a16_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kInt8DynamicTokenSym,
@@ -35,149 +36,178 @@ class Int8MoeBackend(Enum):
     CPU = "CPU"
 
 
-def _get_priority_backends(
-    moe_config: FusedMoEConfig,
-) -> list[Int8MoeBackend]:
+class Int8MoEKernelOracle(MoEKernelOracle[Int8MoeBackend]):
+    """Int8 MoE kernel oracle.
+
+    Int8 MoE has three backends (Triton, Humming, CPU); the CPU backend is
+    moved to the front of the priority list on CPU platforms. ``select_backend``
+    is inherited from ``MoEKernelOracle`` — the generic priority loop handles
+    all three. The Humming backend threads ``layer`` through weight conversion,
+    quant-config construction, and kernel construction, so ``make_quant_config``,
+    ``convert_to_kernel_format`` and ``make_kernel`` are overridden with the
+    Int8-specific signatures (delegating to the module-level helpers, which
+    keep the backend-branching bodies).
     """
-    Get available backends in priority order based on platform and config.
-    """
-    _AVAILABLE_BACKENDS = [
-        Int8MoeBackend.TRITON,
-        Int8MoeBackend.HUMMING,
-        Int8MoeBackend.CPU,
-    ]
 
-    def _move_to_front(backends: list[Int8MoeBackend], backend: Int8MoeBackend) -> None:
-        backends.insert(0, backends.pop(backends.index(backend)))
+    def backend_enum_cls(self) -> type[Int8MoeBackend]:
+        return Int8MoeBackend
 
-    if current_platform.is_cpu():
-        _move_to_front(_AVAILABLE_BACKENDS, Int8MoeBackend.CPU)
+    def get_priority_backends(self, moe_config: FusedMoEConfig) -> list[Int8MoeBackend]:
+        backends = [
+            Int8MoeBackend.TRITON,
+            Int8MoeBackend.HUMMING,
+            Int8MoeBackend.CPU,
+        ]
+        if current_platform.is_cpu():
+            backends.insert(0, backends.pop(backends.index(Int8MoeBackend.CPU)))
+        return backends
 
-    return _AVAILABLE_BACKENDS
+    def backend_to_kernel_cls(
+        self, backend: Int8MoeBackend
+    ) -> list[type[mk.FusedMoEExperts]]:
+        if backend == Int8MoeBackend.TRITON:
+            from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+                TritonExperts,
+            )
+
+            return [TritonExperts]
+        if backend == Int8MoeBackend.HUMMING:
+            from vllm.model_executor.layers.fused_moe.experts.fused_humming_moe import (
+                BatchedHummingGroupedExperts,
+                HummingGroupedExperts,
+                HummingIndexedExperts,
+            )
+
+            return [
+                BatchedHummingGroupedExperts,
+                HummingGroupedExperts,
+                HummingIndexedExperts,
+            ]
+        if backend == Int8MoeBackend.CPU:
+            from vllm.model_executor.layers.fused_moe.experts.cpu_moe import (
+                CPUExpertsInt8,
+            )
+
+            return [CPUExpertsInt8]
+        raise ValueError(f"Unknown Int8 MoE backend: {backend.value}")
+
+    def map_backend(self, runner_backend: MoEBackend) -> Int8MoeBackend:
+        mapping = {
+            "triton": Int8MoeBackend.TRITON,
+            "humming": Int8MoeBackend.HUMMING,
+        }
+        if backend := mapping.get(runner_backend):
+            return backend
+        raise ValueError(
+            f"moe_backend={runner_backend!r} is not supported for Int8 MoE. "
+            f"Expected one of {list(mapping.keys())}."
+        )
+
+    def select_backend(
+        self,
+        moe_config: FusedMoEConfig,
+        weight_key: QuantKey | None = kInt8StaticChannelSym,
+        activation_key: QuantKey | None = kInt8DynamicTokenSym,
+    ) -> tuple[Int8MoeBackend, type[mk.FusedMoEExperts] | None]:
+        return super().select_backend(moe_config, weight_key, activation_key)
+
+    def make_quant_config(  # type: ignore[override]
+        self,
+        int8_backend: Int8MoeBackend,
+        w1_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+        a1_scale: torch.Tensor | None = None,
+        a2_scale: torch.Tensor | None = None,
+        w1_bias: torch.Tensor | None = None,
+        w2_bias: torch.Tensor | None = None,
+        per_act_token_quant: bool = False,
+        layer: torch.nn.Module | None = None,
+    ) -> FusedMoEQuantConfig:
+        return make_int8_moe_quant_config(
+            int8_backend,
+            w1_scale,
+            w2_scale,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+            per_act_token_quant=per_act_token_quant,
+            layer=layer,
+        )
+
+    def convert_to_kernel_format(  # type: ignore[override]
+        self,
+        int8_backend: Int8MoeBackend,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+        layer: torch.nn.Module | None = None,
+        w13_scale: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return convert_to_int8_moe_kernel_format(
+            int8_backend, w13, w2, layer=layer, w13_scale=w13_scale
+        )
+
+    def make_kernel(  # type: ignore[override]
+        self,
+        int8_backend: Int8MoeBackend,
+        moe_quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        experts_cls: type[mk.FusedMoEExperts],
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+        layer: torch.nn.Module | None = None,
+    ) -> mk.FusedMoEKernel:
+        return make_int8_moe_kernel(
+            int8_backend,
+            moe_quant_config,
+            moe_config,
+            experts_cls,
+            routing_tables=routing_tables,
+            layer=layer,
+        )
+
+
+_ORACLE = Int8MoEKernelOracle()
+
+
+# ---------------------------------------------------------------------------
+# Module-level function wrappers / helpers
+#
+# The data-declaration functions below delegate to the oracle singleton so the
+# public API stays bit-identical while the logic lives on the class. The
+# backend-branching helpers (make_quant_config / convert / make_kernel and the
+# humming schema) keep their bodies here — the Humming backend threads a
+# ``layer`` through them, which does not fit the generic ABC signatures — and
+# the oracle methods above delegate to them.
+# ---------------------------------------------------------------------------
+
+
+def _get_priority_backends(moe_config: FusedMoEConfig) -> list[Int8MoeBackend]:
+    """Wrapper preserved for backward compat."""
+    return _ORACLE.get_priority_backends(moe_config)
 
 
 def backend_to_kernel_cls(
     backend: Int8MoeBackend,
 ) -> list[type[mk.FusedMoEExperts]]:
-    if backend == Int8MoeBackend.TRITON:
-        from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
-            TritonExperts,
-        )
-
-        return [TritonExperts]
-
-    elif backend == Int8MoeBackend.HUMMING:
-        from vllm.model_executor.layers.fused_moe.experts.fused_humming_moe import (
-            BatchedHummingGroupedExperts,
-            HummingGroupedExperts,
-            HummingIndexedExperts,
-        )
-
-        return [
-            BatchedHummingGroupedExperts,
-            HummingGroupedExperts,
-            HummingIndexedExperts,
-        ]
-
-    elif backend == Int8MoeBackend.CPU:
-        from vllm.model_executor.layers.fused_moe.experts.cpu_moe import (
-            CPUExpertsInt8,
-        )
-
-        return [CPUExpertsInt8]
-
-    else:
-        raise ValueError(f"Unknown Int8 MoE backend: {backend.value}")
+    """Wrapper preserved for backward compat."""
+    return _ORACLE.backend_to_kernel_cls(backend)
 
 
 def map_int8_backend(runner_backend: MoEBackend) -> Int8MoeBackend:
-    """Map user's MoEBackend to Int8MoeBackend."""
-    mapping = {
-        "triton": Int8MoeBackend.TRITON,
-        "humming": Int8MoeBackend.HUMMING,
-    }
-    if backend := mapping.get(runner_backend):
-        return backend
-    raise ValueError(
-        f"moe_backend='{runner_backend}' is not supported for Int8 MoE. "
-        f"Expected one of {list(mapping.keys())}."
-    )
+    """Wrapper preserved for backward compat."""
+    return _ORACLE.map_backend(runner_backend)
 
 
 def select_int8_moe_backend(
     config: FusedMoEConfig,
     weight_key: QuantKey | None = kInt8StaticChannelSym,
     activation_key: QuantKey | None = kInt8DynamicTokenSym,
-) -> tuple[Int8MoeBackend, type[mk.FusedMoEExperts]]:
-    """
-    Select the primary Int8 MoE backend.
+) -> tuple[Int8MoeBackend, type[mk.FusedMoEExperts] | None]:
+    """Wrapper preserved for backward compat.
+
     Note: Shape-specific fallbacks may still occur at runtime.
     """
-
-    AVAILABLE_BACKENDS = _get_priority_backends(config)
-
-    activation_format = (
-        mk.FusedMoEActivationFormat.BatchedExperts
-        if config.moe_parallel_config.use_batched_activation_format
-        else mk.FusedMoEActivationFormat.Standard
-    )
-
-    def _make_log_backend(backend: Int8MoeBackend) -> str:
-        available_backend_strs = [b.value for b in AVAILABLE_BACKENDS]
-        return (
-            f"Using {backend.value} Int8 MoE backend out "
-            f"of potential backends: {available_backend_strs}."
-        )
-
-    def _make_log_unsupported(backend: Int8MoeBackend, reason: str | None) -> str:
-        if reason:
-            return (
-                f"Int8 MoE backend {backend.value} does not support the "
-                f"deployment configuration since {reason}."
-            )
-        else:
-            return (
-                f"Int8 MoE backend '{backend.value}' does not support the "
-                "deployment configuration."
-            )
-
-    def _return_or_raise(
-        backend: Int8MoeBackend,
-    ) -> tuple[Int8MoeBackend, type[mk.FusedMoEExperts]]:
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls, config, weight_key, activation_key, activation_format
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend))
-                return backend, k_cls
-        raise ValueError(_make_log_unsupported(backend, reason))
-
-    # Handle explicit moe_backend from user.
-    runner_backend = config.moe_backend
-    if runner_backend != "auto":
-        requested_backend = map_int8_backend(runner_backend)
-        return _return_or_raise(requested_backend)
-
-    # Select kernels in order of backend.
-    for backend in AVAILABLE_BACKENDS:
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls,
-                config,
-                weight_key,
-                activation_key,
-                activation_format,
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend))
-                return backend, k_cls
-            else:
-                logger.debug_once(_make_log_unsupported(backend, reason))
-
-    raise NotImplementedError(
-        "No Int8 MoE backend supports the deployment configuration."
-    )
+    return _ORACLE.select_backend(config, weight_key, activation_key)
 
 
 def make_int8_moe_quant_config(

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -419,8 +419,8 @@ class UnquantizedMoEKernelOracle(MoEKernelOracle[UnquantizedMoeBackend]):
         self,
         quant_config: FusedMoEQuantConfig,
         moe_config: FusedMoEConfig,
-        backend: UnquantizedMoeBackend,
         experts_cls: type[mk.FusedMoEExperts],
+        backend: UnquantizedMoeBackend,
         routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
     ) -> mk.FusedMoEKernel:
         return make_unquantized_moe_kernel(

--- a/vllm/model_executor/layers/fused_moe/oracle/w4a8_int8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/w4a8_int8.py
@@ -7,154 +7,157 @@ import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.config.kernel import MoEBackend
-from vllm.logger import init_logger
-from vllm.model_executor.layers.fused_moe.all2all_utils import (
-    maybe_make_prepare_finalize,
-)
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
     FusedMoEQuantConfig,
     FusedMoEQuantDesc,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     QuantKey,
 )
 from vllm.platforms import current_platform
 
-logger = init_logger(__name__)
-
 
 class W4A8Int8MoeBackend(Enum):
     CPU_INT4 = "CPU_INT4"
 
 
+class W4A8Int8MoEKernelOracle(MoEKernelOracle[W4A8Int8MoeBackend]):
+    """W4A8 Int8 MoE kernel oracle.
+
+    W4A8 Int8 MoE has a single backend (CPU_INT4) and is CPU-only.
+    The subclass declares the backend data
+    ``select_backend`` is inherited from ``MoEKernelOracle`` but wrapped to raise
+    a CPU-only message early on non-CPU platforms.
+    ``make_kernel`` is overridden to enforce monolithic-only experts.
+    ``make_quant_config`` and ``convert_to_kernel_format`` are overridden
+    with their full W4A8-specific signatures.
+    """
+
+    def backend_enum_cls(self) -> type[W4A8Int8MoeBackend]:
+        return W4A8Int8MoeBackend
+
+    def get_priority_backends(
+        self, moe_config: FusedMoEConfig
+    ) -> list[W4A8Int8MoeBackend]:
+        if current_platform.is_cpu():
+            return [W4A8Int8MoeBackend.CPU_INT4]
+        return []
+
+    def backend_to_kernel_cls(
+        self, backend: W4A8Int8MoeBackend
+    ) -> list[type[mk.FusedMoEExperts]]:
+        if backend == W4A8Int8MoeBackend.CPU_INT4:
+            from vllm.model_executor.layers.fused_moe.experts.cpu_int4_moe import (
+                CPUExpertsInt4,
+            )
+
+            return [CPUExpertsInt4]
+        raise ValueError(f"Unknown W4A8 Int8 MoE backend: {backend.value}")
+
+    def map_backend(self, runner_backend: MoEBackend) -> W4A8Int8MoeBackend:
+        mapping = {"cpu": W4A8Int8MoeBackend.CPU_INT4}
+        if backend := mapping.get(runner_backend):
+            return backend
+        raise ValueError(
+            f"moe_backend={runner_backend!r} is not supported for W4A8 Int8 "
+            f"MoE. Expected one of {list(mapping.keys())}."
+        )
+
+    def select_backend(
+        self,
+        moe_config: FusedMoEConfig,
+        weight_key: QuantKey | None = None,
+        activation_key: QuantKey | None = None,
+    ) -> tuple[W4A8Int8MoeBackend, type[mk.FusedMoEExperts] | None]:
+        if not current_platform.is_cpu():
+            raise NotImplementedError(
+                "W4A8 Int8 MoE is only supported on CPU platforms"
+            )
+        return super().select_backend(moe_config, weight_key, activation_key)
+
+    def make_kernel(
+        self,
+        quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        experts_cls: type[mk.FusedMoEExperts],
+        backend: W4A8Int8MoeBackend,
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    ) -> mk.FusedMoEKernel:
+        if not issubclass(experts_cls, mk.FusedMoEExpertsMonolithic):
+            raise ValueError(
+                f"W4A8 Int8 MoE only supports monolithic experts, "
+                f"but got {experts_cls.__name__}"
+            )
+        return super().make_kernel(
+            quant_config, moe_config, experts_cls, backend, routing_tables
+        )
+
+    def convert_to_kernel_format(  # type: ignore[override]
+        self,
+        w13_weight: torch.Tensor,
+        w2_weight: torch.Tensor,
+        w13_weight_scale: torch.Tensor,
+        w2_weight_scale: torch.Tensor,
+        group_size: int,
+        w13_bias: torch.Tensor | None = None,
+        w2_bias: torch.Tensor | None = None,
+    ):
+        return convert_to_w4a8_int8_moe_format(
+            w13_weight,
+            w2_weight,
+            w13_weight_scale,
+            w2_weight_scale,
+            group_size,
+            w13_bias=w13_bias,
+            w2_bias=w2_bias,
+        )
+
+    def make_quant_config(
+        self,
+        block_shape: tuple[int, int] | None = None,
+    ) -> FusedMoEQuantConfig:
+        return make_w4a8_int8_moe_quant_config(block_shape=block_shape)
+
+
+_ORACLE = W4A8Int8MoEKernelOracle()
+
+
+# ---------------------------------------------------------------------------
+# Module-level function wrappers preserved for backward compat.
+# These delegate to the oracle singleton above so the behaviour is
+# bit-identical with the pre-refactor code path.
+# ---------------------------------------------------------------------------
+
+
 def _get_priority_backends(
     moe_config: FusedMoEConfig,
 ) -> list[W4A8Int8MoeBackend]:
-    """
-    Get available backends in priority order based on platform and config.
-
-    Currently only CPU INT4 backend is available for W4A8 INT8 MoE.
-    """
-    if current_platform.is_cpu():
-        return [W4A8Int8MoeBackend.CPU_INT4]
-    return []
+    """Wrapper preserved for backward compat."""
+    return _ORACLE.get_priority_backends(moe_config)
 
 
 def backend_to_kernel_cls(
     backend: W4A8Int8MoeBackend,
 ) -> list[type[mk.FusedMoEExperts]]:
-    """Map W4A8Int8MoeBackend to kernel class."""
-    if backend == W4A8Int8MoeBackend.CPU_INT4:
-        from vllm.model_executor.layers.fused_moe.experts.cpu_int4_moe import (
-            CPUExpertsInt4,
-        )
-
-        return [CPUExpertsInt4]
-
-    else:
-        raise ValueError(f"Unknown W4A8 Int8 MoE backend: {backend.value}")
+    """Wrapper preserved for backward compat."""
+    return _ORACLE.backend_to_kernel_cls(backend)
 
 
 def map_w4a8_int8_backend(runner_backend: MoEBackend) -> W4A8Int8MoeBackend:
-    """Map user's MoEBackend to W4A8Int8MoeBackend."""
-    mapping = {
-        "cpu": W4A8Int8MoeBackend.CPU_INT4,
-    }
-    if backend := mapping.get(runner_backend):
-        return backend
-    raise ValueError(
-        f"moe_backend='{runner_backend}' is not supported for W4A8 Int8 MoE. "
-        f"Expected one of {list(mapping.keys())}."
-    )
+    """Wrapper preserved for backward compat."""
+    return _ORACLE.map_backend(runner_backend)
 
 
 def select_w4a8_int8_moe_backend(
     config: FusedMoEConfig,
     weight_key: QuantKey | None,
     activation_key: QuantKey | None,
-) -> tuple[W4A8Int8MoeBackend, type[mk.FusedMoEExperts]]:
-    """
-    Select the primary W4A8 Int8 MoE backend.
-
-    Args:
-        config: MoE configuration
-        weight_key: Weight quantization key (should be one of kInt4W4A8Static*)
-        activation_key: Activation quantization key (currently unused for W4A8)
-
-    Returns:
-        Tuple of (backend, kernel_class)
-    """
-
-    AVAILABLE_BACKENDS = _get_priority_backends(config)
-
-    if not AVAILABLE_BACKENDS:
-        raise NotImplementedError("W4A8 Int8 MoE is only supported on CPU platforms")
-
-    activation_format = (
-        mk.FusedMoEActivationFormat.BatchedExperts
-        if config.moe_parallel_config.use_batched_activation_format
-        else mk.FusedMoEActivationFormat.Standard
-    )
-
-    def _make_log_backend(backend: W4A8Int8MoeBackend) -> str:
-        available_backend_strs = [b.value for b in AVAILABLE_BACKENDS]
-        return (
-            f"Using {backend.value} W4A8 Int8 MoE backend out "
-            f"of potential backends: {available_backend_strs}."
-        )
-
-    def _make_log_unsupported(backend: W4A8Int8MoeBackend, reason: str | None) -> str:
-        if reason:
-            return (
-                f"W4A8 Int8 MoE backend {backend.value} does not support the "
-                f"deployment configuration since {reason}."
-            )
-        else:
-            return (
-                f"W4A8 Int8 MoE backend '{backend.value}' does not support the "
-                "deployment configuration."
-            )
-
-    def _return_or_raise(
-        backend: W4A8Int8MoeBackend,
-    ) -> tuple[W4A8Int8MoeBackend, type[mk.FusedMoEExperts]]:
-        reason = None
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls, config, weight_key, activation_key, activation_format
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend))
-                return backend, k_cls
-        raise ValueError(_make_log_unsupported(backend, reason))
-
-    # Handle explicit moe_backend from user.
-    runner_backend = config.moe_backend
-    if runner_backend != "auto":
-        requested_backend = map_w4a8_int8_backend(runner_backend)
-        return _return_or_raise(requested_backend)
-
-    # Select kernels in order of backend.
-    for backend in AVAILABLE_BACKENDS:
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls,
-                config,
-                weight_key,
-                activation_key,
-                activation_format,
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend))
-                return backend, k_cls
-            else:
-                logger.debug_once(_make_log_unsupported(backend, reason))
-
-    raise NotImplementedError(
-        "No W4A8 Int8 MoE backend supports the deployment configuration."
-    )
+) -> tuple[W4A8Int8MoeBackend, type[mk.FusedMoEExperts] | None]:
+    """Wrapper preserved for backward compat."""
+    return _ORACLE.select_backend(config, weight_key, activation_key)
 
 
 def make_w4a8_int8_moe_quant_config(
@@ -315,46 +318,11 @@ def make_w4a8_int8_moe_kernel(
     experts_cls: type[mk.FusedMoEExperts],
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
 ) -> mk.FusedMoEKernel:
-    """
-    Create FusedMoEKernel for W4A8 Int8 MoE.
-
-    Args:
-        moe_quant_config: Quantization configuration
-        moe_config: MoE configuration
-        experts_cls: Expert kernel class (should be CPUExpertsInt4)
-        routing_tables: Optional routing tables for expert parallelism
-
-    Returns:
-        Configured FusedMoEKernel instance
-    """
-    # Create Prepare/Finalize.
-    prepare_finalize = maybe_make_prepare_finalize(
-        moe=moe_config,
-        quant_config=moe_quant_config,
-        routing_tables=routing_tables,
-        allow_new_interface=True,
-        use_monolithic=issubclass(experts_cls, mk.FusedMoEExpertsMonolithic),
+    """Wrapper preserved for backward compat."""
+    return _ORACLE.make_kernel(
+        moe_quant_config,
+        moe_config,
+        experts_cls,
+        W4A8Int8MoeBackend.CPU_INT4,
+        routing_tables,
     )
-    assert prepare_finalize is not None
-
-    logger.info_once("Using %s", prepare_finalize.__class__.__name__)
-
-    # Create Experts.
-    # W4A8 Int8 currently only supports monolithic interface
-    if not issubclass(experts_cls, mk.FusedMoEExpertsMonolithic):
-        raise ValueError(
-            f"W4A8 Int8 MoE only supports monolithic experts, "
-            f"but got {experts_cls.__name__}"
-        )
-
-    experts = experts_cls(
-        moe_config=moe_config,
-        quant_config=moe_quant_config,
-    )
-
-    kernel = mk.FusedMoEKernel(
-        prepare_finalize,
-        experts,
-    )
-
-    return kernel


### PR DESCRIPTION



## Purpose

Part of the MoE kernel oracle refactor series tracked in #37753 (follow-up to the ABC introduced in #43461).

#43461 added the `MoEKernelOracle` ABC and migrated the unquantized oracle as a delegate. This PR does the first real refactor, which lifts the backend selection and kernel construction logic duplicated across the per-oracle module-level functions up into the base class, and converts the int8** and w4a8_int8 oracles into proper subclasses.

These two demonstrate the value of a generic base without platform or env-var quirks, so migrate them first. This PR preserves the selection logic. The runtime kernel paths are unchanged. Caller migration off the wrappers with forward run validation is the next follow-up PR.

## Changes

`base.py`
- `MoEKernelOracle` now provides a generic `select_backend` and a `make_kernel`. Both move from `@abstractmethod` to concrete defaults; oracles with quirks override them.
- `backend_to_kernel_cls` now returns `list[type[FusedMoEExperts]]` (candidate kernels in preference order; callers iterate until one is supported), matching how multi-variant backends already behaved.

`int8.py` — `Int8MoEKernelOracle` is now a pure data declaration (`backend_enum_cls` / `get_priority_backends` / `backend_to_kernel_cls` / `map_backend` + `make_quant_config`), which inherits the generic `select_backend` / `make_kernel`. It only overrides `select_backend` to set the int8 default quant keys.

`w4a8_int8.py` — `W4A8Int8MoEKernelOracle` declares its data and adds two guards before deferring to `super()`, because W4A8 Int8 MoE is only supported on CPU platforms (`select_backend`) and only supports monolithic experts(`make_kernel`). Keeps its `make_quant_config` / `convert_to_kernel_format` overrides.

The existing module-level functions (`select_int8_moe_backend`, `make_int8_moe_kernel`, `select_w4a8_int8_moe_backend`, etc.) are kept as wrappers delegating to a module singleton, so the public API used by callers (`compressed_tensors_moe_*`, `online/int8`) is preserved. Migrating callers off these wrappers, removing them  and validate with real model runs is the immediate follow-up PR.

## Test Plan

```bash
pytest tests/kernels/moe/test_moe_kernel_oracle.py -q
```

`tests/kernels/moe/test_moe_kernel_oracle.py` covers:
- generic `select_backend` behavior via a minimal stub oracle
- int8 oracle data declarations,
- w4a8_int8 oracle data declarations including the CPU-only and monolithic-only guards.

## Test Result

```
============================================================ test session starts ============================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /workspace/vllm
configfile: pyproject.toml
plugins: anyio-4.13.0, timeout-2.4.0, asyncio-1.4.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 16 items                                                                                                                          

tests/kernels/moe/test_moe_kernel_oracle.py ................                                                                          [100%]

====================================================== 16 passed, 16 warnings in 2.19s ======================================================
```