### PR TITLE
[Bugfix] Handle list slot mappings in attention context

### DIFF
--- a/tests/model_executor/layers/test_attention_context.py
+++ b/tests/model_executor/layers/test_attention_context.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.forward_context import set_forward_context
+from vllm.model_executor.layers.attention.attention import get_attention_context
+
+
+def test_get_attention_context_uses_base_slot_mapping_from_list():
+    layer_name = "model.layers.0.self_attn.attn"
+    kv_cache = torch.empty(0)
+    attn_layer = SimpleNamespace(kv_cache=kv_cache)
+    base_attn_metadata = object()
+    draft_attn_metadata = object()
+    base_slot_mapping = torch.tensor([0, 1])
+    draft_slot_mapping = torch.tensor([2, 3])
+
+    vllm_config = VllmConfig()
+    vllm_config.compilation_config.static_forward_context = {
+        layer_name: attn_layer,
+    }
+
+    with set_forward_context(
+        attn_metadata=[
+            {layer_name: base_attn_metadata},
+            {layer_name: draft_attn_metadata},
+        ],
+        vllm_config=vllm_config,
+        slot_mapping=[
+            {layer_name: base_slot_mapping},
+            {layer_name: draft_slot_mapping},
+        ],
+    ):
+        attn_metadata, returned_attn_layer, returned_kv_cache, layer_slot_mapping = (
+            get_attention_context(layer_name)
+        )
+
+    assert attn_metadata is base_attn_metadata
+    assert returned_attn_layer is attn_layer
+    assert returned_kv_cache is kv_cache
+    assert layer_slot_mapping is base_slot_mapping

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -728,6 +728,22 @@ direct_register_custom_op(
 )
 
 
+def _get_layer_slot_mapping(
+    forward_context: ForwardContext,
+    layer_name: str,
+) -> torch.Tensor | None:
+    slot_mapping = forward_context.slot_mapping
+    if isinstance(slot_mapping, list):
+        # list[dict[str, Tensor]]: used in speculative decoding where [0] is
+        # the base-model (non-speculative) slot mapping dict.
+        slot_mapping = slot_mapping[0]
+
+    assert isinstance(slot_mapping, dict), (
+        f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
+    )
+    return slot_mapping.get(layer_name)
+
+
 def get_attention_context(
     layer_name: str,
 ) -> tuple[Any, "Attention | MLAAttention", torch.Tensor, torch.Tensor]:
@@ -763,11 +779,7 @@ def get_attention_context(
         attn_metadata = attn_metadata_raw
     attn_layer: Attention | MLAAttention = forward_context.no_compile_layers[layer_name]
     kv_cache = attn_layer.kv_cache
-    slot_mapping = forward_context.slot_mapping
-    assert isinstance(slot_mapping, dict), (
-        f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
-    )
-    layer_slot_mapping = slot_mapping.get(layer_name)
+    layer_slot_mapping = _get_layer_slot_mapping(forward_context, layer_name)
     return attn_metadata, attn_layer, kv_cache, layer_slot_mapping
 
 

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -670,6 +670,22 @@ class Attention(nn.Module, AttentionLayerBase):
             )
 
 
+def _get_layer_slot_mapping(
+    forward_context: ForwardContext,
+    layer_name: str,
+) -> torch.Tensor | None:
+    slot_mapping = forward_context.slot_mapping
+    if isinstance(slot_mapping, list):
+        # list[dict[str, Tensor]]: used in speculative decoding where [0] is
+        # the base-model (non-speculative) slot mapping dict.
+        slot_mapping = slot_mapping[0]
+
+    assert isinstance(slot_mapping, dict), (
+        f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
+    )
+    return slot_mapping.get(layer_name)
+
+
 def get_attention_context(
     layer_name: str,
 ) -> tuple[Any, "Attention | MLAAttention", torch.Tensor, torch.Tensor]:
@@ -705,11 +721,7 @@ def get_attention_context(
         attn_metadata = attn_metadata_raw
     attn_layer: Attention | MLAAttention = forward_context.no_compile_layers[layer_name]
     kv_cache = attn_layer.kv_cache
-    slot_mapping = forward_context.slot_mapping
-    assert isinstance(slot_mapping, dict), (
-        f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
-    )
-    layer_slot_mapping = slot_mapping.get(layer_name)
+    layer_slot_mapping = _get_layer_slot_mapping(forward_context, layer_name)
     return attn_metadata, attn_layer, kv_cache, layer_slot_mapping
 
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -218,6 +218,7 @@ from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.attention.attention import (
+    _get_layer_slot_mapping,
     _init_kv_cache_quant,
     get_attention_context,
     set_default_quant_scales,
@@ -613,12 +614,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             else:
                 attn_metadata = attn_metadata_raw
             self_kv_cache = self.kv_cache
-            slot_mapping = forward_context.slot_mapping
-
-            assert isinstance(slot_mapping, dict), (
-                f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
+            layer_slot_mapping = _get_layer_slot_mapping(
+                forward_context, self.layer_name
             )
-            layer_slot_mapping = slot_mapping.get(self.layer_name)
             kv_for_cache, kpe_for_cache, layer_slot_mapping = (
                 maybe_gather_mla_latent_cache_inputs(
                     kv_c_normed,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -234,6 +234,7 @@ from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.attention.attention import (
+    _get_layer_slot_mapping,
     _init_kv_cache_quant,
     get_attention_context,
     set_default_quant_scales,
@@ -654,12 +655,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             else:
                 attn_metadata = attn_metadata_raw
             self_kv_cache = self.kv_cache
-            slot_mapping = forward_context.slot_mapping
-
-            assert isinstance(slot_mapping, dict), (
-                f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
+            layer_slot_mapping = _get_layer_slot_mapping(
+                forward_context, self.layer_name
             )
-            layer_slot_mapping = slot_mapping.get(self.layer_name)
             kv_for_cache, kpe_for_cache, layer_slot_mapping = (
                 maybe_gather_mla_latent_cache_inputs(
                     kv_c_normed,


### PR DESCRIPTION
Fixes #46830.

When speculative decoding / DBO provides per-microbatch forward context, `attn_metadata` can be a `list[dict]` and the attention path already unwraps the base-model entry at index 0. `slot_mapping` has the same shape in that case, but `get_attention_context()` and the MLA direct-call path still asserted that it must be a plain `dict`, causing startup to fail before the KV-cache update.

This PR adds a small shared helper for layer slot mapping lookup that mirrors the existing `attn_metadata` handling and uses it from both regular attention and MLA direct-call KV-cache updates.

Rebase note:
- Rebased onto current `main` at `d462dee37da2e1a744c6694cb65a1c735600f262`.
- Resolved the conflict in `vllm/model_executor/layers/attention/attention.py` by preserving current `main` behavior and not restoring the removed `maybe_calc_kv_scales` code path.

Duplicate check:
- Open PR #47013 is related but covers remaining slot-mapping consumers in `extract_hidden_states.py` and `deepseek_v32/attention.py`; it does not replace this PR's `get_attention_context()` / MLA direct-call fix.

Tests run on the remote RTX 3090 environment with `CUDA_VISIBLE_DEVICES=0,1`:
- `/ch_data/wzp/codex-work/vllm/.venv/bin/python -m pytest tests/model_executor/layers/test_attention_context.py -q` — 1 passed
- `/ch_data/wzp/codex-work/vllm/.venv/bin/python -m pytest tests/model_executor/layers/test_mla_short_prefill_indexer.py -q` — 6 passed
- `.venv/bin/pre-commit run --files tests/model_executor/layers/test_attention_context.py vllm/model_executor/layers/attention/attention.py vllm/model_executor/layers/attention/mla_attention.py` — passed
- `git diff --cached --check` — passed before commit

AI assistance was used to prepare the rebase/conflict resolution and validation commands. I reviewed the changed lines before updating the PR.
