### PR TITLE
[Hybird][PrefixCache] Pre-copy-free align prefix cache

### DIFF
--- a/tests/kernels/mamba/test_gdn_align_copy_vs_resolve.py
+++ b/tests/kernels/mamba/test_gdn_align_copy_vs_resolve.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Micro-benchmark: mamba "align" pre-copy cost vs the copy-free per-step extra.
+
+For the Qwen3.5-35B-A3B GDN config (TP1 state sizes) it compares, per decode
+step, the two approaches the copy-free change trades between:
+
+* OLD pre-copy (``batch_memcpy``): migrates a request's full mamba state (conv +
+  ssm of every GDN layer) from the previous block to the new running block. This
+  fires ONCE per block-boundary crossing, i.e. roughly every
+  ``block_size / accept_len`` steps. ``block_size`` is the prefix-cache value
+  from the serve log line "Setting attention block size to N tokens".
+* NEW copy-free extra (``_gather_resolve_align_src_kernel`` + the per-step H2D
+  copy of the src columns done in ``preprocess_mamba``): resolves the src block
+  ids in ``gdn_attn.build``. This fires EVERY step.
+
+So the fair comparison is amortized-old (``copy / steps_per_copy``) vs new
+(every step). Run with ``pytest -s`` or ``python <thisfile>``; it only prints a
+table (no hard perf assert -- the numbers are the point).
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import triton
+from vllm.v1.attention.backends.gdn_attn import _gather_resolve_align_src_kernel
+from vllm.v1.worker.mamba_utils import batch_memcpy
+
+try:
+    import pytest
+
+    pytestmark = pytest.mark.skipif(
+        not current_platform.is_cuda(),
+        reason="GDN align micro-bench needs CUDA/Triton",
+    )
+except ModuleNotFoundError:  # allow running directly as `python <thisfile>`
+    pytest = None
+
+# --- Qwen3.5-35B-A3B-FP8 GDN config (from the model config.json) ------------
+# TP shards the value/conv heads, so per-rank state (and thus the pre-copy
+# bytes) shrink by TP while the resolve kernel is per-request and TP-invariant.
+# Default TP2 matches the deployment config; set BENCH_TP=1 for single-GPU.
+TP = int(os.environ.get("BENCH_TP", "2"))
+NUM_K_HEADS = 16
+NUM_V_HEADS = 32
+HEAD_K_DIM = 128
+HEAD_V_DIM = 128
+CONV_KERNEL = 4  # linear_conv_kernel_dim
+NUM_SPEC = 2  # num_speculative_tokens (MTP) -> widens the conv state
+NUM_GDN_LAYERS = 30  # 30 linear_attention layers (+10 full_attention)
+SSM_DTYPE = torch.float32  # mamba_ssm_dtype
+CONV_DTYPE = torch.bfloat16
+
+# Prefix-cache serve log: "Setting attention block size to N tokens".
+BLOCK_SIZE_TOKENS = int(os.environ.get("BENCH_BLOCK_SIZE", "1088"))
+ACCEPT_LEN = 2.05  # measured acceptance length (num_spec=2)
+
+CONV_DIM = HEAD_K_DIM * NUM_K_HEADS * 2 + HEAD_V_DIM * NUM_V_HEADS  # 8192
+SSM_SHAPE = (NUM_V_HEADS // TP, HEAD_V_DIM, HEAD_K_DIM)
+CONV_SHAPE = (CONV_DIM // TP, CONV_KERNEL - 1 + NUM_SPEC)
+
+NUM_BLOCKS = 2048  # state-pool blocks (pool >> L2, so copies miss cache)
+BLOCK = 256  # resolve-kernel tile
+BATCHES = [1, 2, 4, 8, 16, 32, 64, 128, 256]
+
+
+def _bench(fn, iters, warmup=20):
+    for _ in range(warmup):
+        fn()
+    torch.accelerator.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.accelerator.synchronize()
+    return start.elapsed_time(end) / iters * 1e3  # microseconds / call
+
+
+def _make_copy_inputs(B, device):
+    """batch_memcpy ptr/size arrays for B reqs each migrating conv+ssm of every
+    GDN layer (2 * NUM_GDN_LAYERS * B entries) through shared conv/ssm pools."""
+    ssm_pool = torch.empty((NUM_BLOCKS, *SSM_SHAPE), dtype=SSM_DTYPE, device=device)
+    conv_pool = torch.empty((NUM_BLOCKS, *CONV_SHAPE), dtype=CONV_DTYPE, device=device)
+    ssm_bytes = ssm_pool[0].numel() * ssm_pool.element_size()
+    conv_bytes = conv_pool[0].numel() * conv_pool.element_size()
+
+    src_ptrs, dst_ptrs, sizes = [], [], []
+    n = 0
+    for _layer in range(NUM_GDN_LAYERS):
+        for _r in range(B):
+            s = n % NUM_BLOCKS
+            d = (n + NUM_BLOCKS // 2) % NUM_BLOCKS  # distinct src/dst block
+            n += 1
+            src_ptrs += [ssm_pool[s].data_ptr(), conv_pool[s].data_ptr()]
+            dst_ptrs += [ssm_pool[d].data_ptr(), conv_pool[d].data_ptr()]
+            sizes += [ssm_bytes, conv_bytes]
+
+    src = torch.tensor(src_ptrs, dtype=torch.int64, device=device)
+    dst = torch.tensor(dst_ptrs, dtype=torch.int64, device=device)
+    sz = torch.tensor(sizes, dtype=torch.int64, device=device)
+    total_mib = sum(sizes) / 2**20
+    return (ssm_pool, conv_pool), (src, dst, sz), total_mib
+
+
+def _make_resolve_inputs(B, device):
+    g = torch.Generator().manual_seed(0)
+    idx = torch.arange(B, dtype=torch.int32, device=device)  # identity (V1)
+    ssm_col = torch.randint(0, 64, (B,), dtype=torch.int32, generator=g).to(device)
+    conv_col = torch.randint(0, 64, (B,), dtype=torch.int32, generator=g).to(device)
+    conv_off = torch.randint(0, 4, (B,), dtype=torch.int32, generator=g).to(device)
+    bt = torch.randint(1, 100000, (B, 128), dtype=torch.int32, generator=g).to(device)
+    out = tuple(torch.empty(B, dtype=torch.int32, device=device) for _ in range(3))
+    # host columns for the per-step H2D copy that preprocess_mamba does
+    host = tuple(torch.empty(B, dtype=torch.int32, pin_memory=True) for _ in range(3))
+    dev = tuple(torch.empty(B, dtype=torch.int32, device=device) for _ in range(3))
+    return idx, ssm_col, conv_col, conv_off, bt, out, host, dev
+
+
+def _resolve_call(inp):
+    idx, ssm_col, conv_col, conv_off, bt, out, _host, _dev = inp
+    B = idx.shape[0]
+    _gather_resolve_align_src_kernel[(triton.cdiv(B, BLOCK),)](
+        idx,
+        ssm_col,
+        conv_col,
+        conv_off,
+        bt,
+        bt.stride(0),
+        bt.stride(1),
+        bt.size(1) - 1,
+        out[0],
+        out[1],
+        out[2],
+        B,
+        B,
+        BLOCK=BLOCK,
+    )
+
+
+def _h2d_call(inp):
+    *_, host, dev = inp
+    for h, d in zip(host, dev):
+        d.copy_(h, non_blocking=True)
+
+
+def _run_bench():
+    device = torch.device("cuda")
+    steps_per_copy = BLOCK_SIZE_TOKENS / ACCEPT_LEN
+    print(
+        f"\nQwen3.5-35B GDN TP{TP}: ssm/block={SSM_SHAPE} {SSM_DTYPE}, "
+        f"conv/block={CONV_SHAPE} {CONV_DTYPE}, {NUM_GDN_LAYERS} GDN layers"
+    )
+    print(
+        f"block_size={BLOCK_SIZE_TOKENS} tok, accept_len={ACCEPT_LEN} "
+        f"-> ~{steps_per_copy:.0f} steps/copy\n"
+    )
+    print(
+        f"{'B':>4} {'MiB/copy':>9} {'copy_full':>10} {'copy/step':>10} "
+        f"{'resolve':>8} {'h2d':>7} {'extra/step':>11} {'copyfree Δ/step':>16}"
+    )
+    print(
+        f"{'':>4} {'':>9} {'(us)':>10} {'(us,amort)':>10} {'(us)':>8} "
+        f"{'(us)':>7} {'(us)':>11} {'(us)':>16}"
+    )
+    for B in BATCHES:
+        pools, (src, dst, sz), mib = _make_copy_inputs(B, device)
+        copy_us = _bench(lambda s=src, d=dst, z=sz: batch_memcpy(s, d, z), iters=50)
+        r_inputs = _make_resolve_inputs(B, device)
+        resolve_us = _bench(lambda r=r_inputs: _resolve_call(r), iters=300)
+        h2d_us = _bench(lambda r=r_inputs: _h2d_call(r), iters=300)
+        del pools, src, dst, sz, r_inputs
+        torch.accelerator.empty_cache()
+
+        amort = copy_us / steps_per_copy
+        extra = resolve_us + h2d_us
+        delta = extra - amort  # >0: copy-free costs more per step; <0: it saves
+        print(
+            f"{B:>4} {mib:>9.0f} {copy_us:>10.1f} {amort:>10.2f} "
+            f"{resolve_us:>8.2f} {h2d_us:>7.2f} {extra:>11.2f} {delta:>+16.2f}"
+        )
+
+
+def test_align_copy_vs_resolve_bench(capsys):
+    with capsys.disabled():
+        _run_bench()
+
+
+if __name__ == "__main__":
+    _run_bench()

--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -741,7 +741,7 @@ def fill_following_kv_cache_block_ids(test_config: TestConfig) -> None:
 
 
 @create_new_process_for_each_test()
-def test_mamba_prefix_cache_mrv1(monkeypatch: pytest.MonkeyPatch):
+def test_mamba_prefix_cache(monkeypatch: pytest.MonkeyPatch):
     run_ref_mamba_state_in_subprocess()
     apply_patch(monkeypatch)
     prompt_dataset = datasets.load_dataset("heheda/a_long_article")
@@ -841,32 +841,23 @@ def test_mamba_prefix_cache_mrv2(monkeypatch: pytest.MonkeyPatch):
     ) -> None:
         captured["block_tables"] = block_tables
         captured["kv_cache_config"] = kv_cache_config
-        expected = (
-            None if cur_step_action is None else cur_step_action.preprocess_copy_idx
-        )
-        snapshots = []
-        if expected is not None and expected != (-1, -1):
-            for temporal, bt in temporal_states(self, block_tables, kv_cache_config):
-                snapshots.append(
-                    (temporal, bt, temporal_block(temporal, bt, expected[0]).clone())
-                )
         ret = original_preprocess_state(
             self, input_batch, block_tables, kv_cache_config, num_computed_tokens
         )
-        if cur_step_action is not None:
+        # Copy-free does not migrate state here; it stages the src columns the
+        # forward reads from. Validate those against the step action.
+        action = cur_step_action
+        if action is not None:
+            info = self.mamba_cache_align_info
             req_idx = int(input_batch.idx_mapping[0].item())
-            src_col = int(self._mamba_src_col_gpu[req_idx].item())
-            off = int(self._mamba_src_off_gpu[req_idx].item())
-            dst = int(self._mamba_state_idx_gpu[req_idx].item())
+            src_col = int(info.conv_src_col_gpu[req_idx].item())
+            off = int(info.conv_src_off_gpu[req_idx].item())
+            dst = int(info.state_idx_gpu[req_idx].item())
             actual = (-1, -1) if src_col < 0 or src_col == dst else (src_col + off, dst)
-            assert actual == expected, (
-                f"V2 align preprocess copy: expected={expected}, "
-                f"actual={actual}, {cur_step_action=}"
+            assert actual == action.preprocess_copy_idx, (
+                f"copy-free align preprocess src: "
+                f"expected={action.preprocess_copy_idx}, actual={actual}, {action=}"
             )
-            for temporal, bt, src_state in snapshots:
-                torch.testing.assert_close(
-                    temporal_block(temporal, bt, expected[1]), src_state
-                )
         return ret
 
     def wrapped_postprocess_state(
@@ -874,12 +865,15 @@ def test_mamba_prefix_cache_mrv2(monkeypatch: pytest.MonkeyPatch):
         idx_mapping: torch.Tensor,
         num_sampled: torch.Tensor | int,
         num_computed_tokens: torch.Tensor | None = None,
+        num_reqs: int | None = None,
+        query_start_loc: torch.Tensor | None = None,
     ) -> None:
         action = cur_step_action
         block_tables = captured.get("block_tables")
         kv_cache_config = captured.get("kv_cache_config")
-        # The postprocess kernel does not expose its indices, so only the copy
-        # case is checked, by effect: snapshot the src block, expect dst == src.
+        # The postprocess save kernel does not expose its indices, so only the
+        # copy case is checked, by effect: snapshot the src block, expect
+        # dst == src.
         if (
             action is None
             or num_computed_tokens is None
@@ -887,7 +881,12 @@ def test_mamba_prefix_cache_mrv2(monkeypatch: pytest.MonkeyPatch):
             or action.postprocess_copy_idx == (-1, -1)
         ):
             return original_postprocess_state(
-                self, idx_mapping, num_sampled, num_computed_tokens
+                self,
+                idx_mapping,
+                num_sampled,
+                num_computed_tokens,
+                num_reqs,
+                query_start_loc,
             )
         expected = action.postprocess_copy_idx
         snapshots = [
@@ -895,7 +894,12 @@ def test_mamba_prefix_cache_mrv2(monkeypatch: pytest.MonkeyPatch):
             for temporal, bt in temporal_states(self, block_tables, kv_cache_config)
         ]
         ret = original_postprocess_state(
-            self, idx_mapping, num_sampled, num_computed_tokens
+            self,
+            idx_mapping,
+            num_sampled,
+            num_computed_tokens,
+            num_reqs,
+            query_start_loc,
         )
         for temporal, bt, src_state in snapshots:
             torch.testing.assert_close(

--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -13,14 +13,18 @@ import torch
 from vllm.triton_utils import tl, triton
 
 from .op import exp
+from .utils import select_ssm_src_indices
 
 
 @triton.heuristics(
     {
         "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
-        "IS_CONTINUOUS_BATCHING": lambda args: args["ssm_state_indices"] is not None,
+        "IS_CONTINUOUS_BATCHING": lambda args: args["dst_ssm_state_indices"]
+        is not None,
         "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
+        # SRC_PRERESOLVED is passed explicitly (src and dst can both be 1D, so a
+        # None-check heuristic cannot tell them apart -- identity is used).
     }
 )
 @triton.jit(do_not_specialize=["N", "T"])
@@ -34,7 +38,8 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     h0,
     ht,
     cu_seqlens,
-    ssm_state_indices,
+    src_ssm_state_indices,
+    dst_ssm_state_indices,
     num_accepted_tokens,
     scale,
     N: tl.int64,  # num of sequences
@@ -58,6 +63,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     IS_CONTINUOUS_BATCHING: tl.constexpr,
     IS_SPEC_DECODING: tl.constexpr,
     IS_KDA: tl.constexpr,
+    SRC_PRERESOLVED: tl.constexpr,
 ):
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_n, i_hv = i_nh // HV, i_nh % HV
@@ -102,14 +108,18 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     b_h = tl.zeros([BV, BK], dtype=tl.float32)
     if USE_INITIAL_STATE:
         if IS_CONTINUOUS_BATCHING:
-            if IS_SPEC_DECODING:
-                i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+            if SRC_PRERESOLVED:
+                # copy-free align: read from the pre-resolved 1D physical src.
+                state_idx = tl.load(src_ssm_state_indices + i_n).to(tl.int64)
             else:
-                i_t = 0
-            # Load state index and check for invalid entries
-            state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
-                tl.int64
-            )
+                # no redirect: src aliases the 2D dst window; resolve column.
+                if IS_SPEC_DECODING:
+                    i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+                else:
+                    i_t = 0
+                state_idx = tl.load(
+                    src_ssm_state_indices + i_n * stride_indices_seq + i_t
+                ).to(tl.int64)
             # Skip if state index is invalid (NULL_BLOCK_ID=0)
             if state_idx <= 0:
                 return
@@ -150,9 +160,10 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
 
         # keep the states for multi-query tokens
         if INPLACE_FINAL_STATE:
-            # Load state index and check for invalid entries
+            # Write to the dst window at the per-token loop column i_t (distinct
+            # from the SRC_PRERESOLVED read offset num_accepted-1).
             final_state_idx = tl.load(
-                ssm_state_indices + i_n * stride_indices_seq + i_t
+                dst_ssm_state_indices + i_n * stride_indices_seq + i_t
             ).to(tl.int64)
             # Only store if state index is valid (not NULL_BLOCK_ID=0)
             if final_state_idx > 0:
@@ -186,6 +197,7 @@ def fused_recurrent_gated_delta_rule_fwd(
     inplace_final_state: bool = True,
     cu_seqlens: torch.Tensor | None = None,
     ssm_state_indices: torch.Tensor | None = None,
+    src_ssm_state_indices: torch.Tensor | None = None,
     num_accepted_tokens: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -214,6 +226,13 @@ def fused_recurrent_gated_delta_rule_fwd(
     else:
         stride_indices_seq, stride_indices_tok = ssm_state_indices.stride()
 
+    src_ssm_state_indices, src_preresolved = select_ssm_src_indices(
+        src_ssm_state_indices, ssm_state_indices, N
+    )
+    if num_accepted_tokens is not None and ssm_state_indices is not None:
+        # the multi-token write loop indexes dst at column i_t -> needs a 2D dst
+        assert ssm_state_indices.ndim == 2
+
     grid = (NK, NV, N * HV)
     fused_recurrent_gated_delta_rule_fwd_kernel[grid](
         q=q,
@@ -225,7 +244,8 @@ def fused_recurrent_gated_delta_rule_fwd(
         h0=initial_state,
         ht=final_state,
         cu_seqlens=cu_seqlens,
-        ssm_state_indices=ssm_state_indices,
+        src_ssm_state_indices=src_ssm_state_indices,
+        dst_ssm_state_indices=ssm_state_indices,
         num_accepted_tokens=num_accepted_tokens,
         scale=scale,
         N=N,
@@ -245,6 +265,7 @@ def fused_recurrent_gated_delta_rule_fwd(
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         INPLACE_FINAL_STATE=inplace_final_state,
         IS_KDA=False,
+        SRC_PRERESOLVED=src_preresolved,
         num_warps=num_warps,
         num_stages=num_stages,
     )
@@ -262,7 +283,8 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     o,
     h0,
     ht,
-    ssm_state_indices,
+    src_ssm_state_indices,
+    dst_ssm_state_indices,
     scale,
     stride_mixed_qkv_tok: tl.constexpr,
     stride_a_tok: tl.constexpr,
@@ -278,6 +300,7 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     BV: tl.constexpr,
     SOFTPLUS_THRESHOLD: tl.constexpr,
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    SRC_PRERESOLVED: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_hv = i_nh // HV, i_nh % HV
@@ -289,16 +312,24 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     mask_v = o_v < V
     mask_h = mask_v[:, None] & mask_k[None, :]
 
-    state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq).to(tl.int64)
+    dst_idx = tl.load(dst_ssm_state_indices + i_n * stride_indices_seq).to(tl.int64)
     p_o = o + (i_n * HV + i_hv) * V + o_v
 
-    # Skip if state index is invalid (NULL_BLOCK_ID=0)
-    if state_idx <= 0:
+    # Skip if the write (window) index is invalid (NULL_BLOCK_ID=0 -> padding)
+    if dst_idx <= 0:
         zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
         tl.store(p_o, zero, mask=mask_v)
         return
 
-    p_h0 = h0 + state_idx * stride_init_state_token
+    # copy-free align reads from the pre-resolved 1D src; otherwise reuse the
+    # already-loaded dst window index (no redirect).
+    src_idx = (
+        tl.load(src_ssm_state_indices + i_n).to(tl.int64)
+        if SRC_PRERESOLVED
+        else dst_idx
+    )
+
+    p_h0 = h0 + src_idx * stride_init_state_token
     p_h0 = p_h0 + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
     b_h = tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
 
@@ -331,7 +362,7 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     b_o = tl.sum(b_h * b_q[None, :], 1)
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
 
-    p_ht = ht + state_idx * stride_final_state_token
+    p_ht = ht + dst_idx * stride_final_state_token
     p_ht = p_ht + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
     tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
 
@@ -346,6 +377,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
     initial_state: torch.Tensor,
     out: torch.Tensor,
     ssm_state_indices: torch.Tensor,
+    src_ssm_state_indices: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if mixed_qkv.ndim != 2:
@@ -445,6 +477,10 @@ def fused_recurrent_gated_delta_rule_packed_decode(
     stride_final_state_token = initial_state.stride(0)
     stride_indices_seq = ssm_state_indices.stride(0)
 
+    src_ssm_state_indices, src_preresolved = select_ssm_src_indices(
+        src_ssm_state_indices, ssm_state_indices, B
+    )
+
     NV = triton.cdiv(V, BV)
     grid = (NV, B * HV)
     fused_recurrent_gated_delta_rule_packed_decode_kernel[grid](
@@ -456,7 +492,8 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         o=out,
         h0=initial_state,
         ht=initial_state,
-        ssm_state_indices=ssm_state_indices,
+        src_ssm_state_indices=src_ssm_state_indices,
+        dst_ssm_state_indices=ssm_state_indices,
         scale=scale,
         stride_mixed_qkv_tok=stride_mixed_qkv_tok,
         stride_a_tok=stride_a_tok,
@@ -472,6 +509,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         BV=BV,
         SOFTPLUS_THRESHOLD=20.0,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        SRC_PRERESOLVED=src_preresolved,
         num_warps=num_warps,
         num_stages=num_stages,
     )
@@ -492,6 +530,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
         inplace_final_state: bool = True,
         cu_seqlens: torch.Tensor | None = None,
         ssm_state_indices: torch.Tensor | None = None,
+        src_ssm_state_indices: torch.Tensor | None = None,
         num_accepted_tokens: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = False,
     ):
@@ -506,6 +545,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
             inplace_final_state=inplace_final_state,
             cu_seqlens=cu_seqlens,
             ssm_state_indices=ssm_state_indices,
+            src_ssm_state_indices=src_ssm_state_indices,
             num_accepted_tokens=num_accepted_tokens,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
         )
@@ -524,6 +564,7 @@ def fused_recurrent_gated_delta_rule(
     inplace_final_state: bool = True,
     cu_seqlens: torch.Tensor | None = None,
     ssm_state_indices: torch.Tensor | None = None,
+    src_ssm_state_indices: torch.Tensor | None = None,
     num_accepted_tokens: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -554,7 +595,14 @@ def fused_recurrent_gated_delta_rule(
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
         ssm_state_indices (Optional[torch.Tensor]):
-            Indices to map the input sequences to the initial/final states.
+            Write (dst) indices mapping the input sequences to the final states.
+        src_ssm_state_indices (Optional[torch.Tensor]):
+            Optional read (src) indices for the initial state (mamba "align"
+            copy-free preprocess). When a distinct 1D ``[N]`` tensor of
+            pre-resolved physical indices is passed, the kernel reads the initial
+            state from it directly (``SRC_PRERESOLVED=True``). When omitted, the
+            read self-aliases to ``ssm_state_indices`` and the column is resolved
+            in-kernel from ``num_accepted_tokens`` (no prefix cache).
         num_accepted_tokens (Optional[torch.Tensor]):
             Number of accepted tokens for each sequence during decoding.
 
@@ -613,6 +661,7 @@ def fused_recurrent_gated_delta_rule(
         inplace_final_state,
         cu_seqlens,
         ssm_state_indices,
+        src_ssm_state_indices,
         num_accepted_tokens,
         use_qk_l2norm_in_kernel,
     )

--- a/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
+++ b/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
@@ -11,13 +11,17 @@ import torch
 
 from vllm.triton_utils import tl, triton
 
+from .utils import select_ssm_src_indices
+
 
 @triton.heuristics(
     {
         "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
-        "IS_CONTINUOUS_BATCHING": lambda args: args["ssm_state_indices"] is not None,
+        "IS_CONTINUOUS_BATCHING": lambda args: args["dst_ssm_state_indices"]
+        is not None,
         "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
+        # SRC_PRERESOLVED is passed explicitly from the wrapper (src_preresolved).
     }
 )
 @triton.jit(do_not_specialize=["N", "T"])
@@ -35,7 +39,8 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     h0,
     ht,
     cu_seqlens,
-    ssm_state_indices,
+    src_ssm_state_indices,
+    dst_ssm_state_indices,
     num_accepted_tokens,
     scale,
     N: tl.int64,  # num of sequences
@@ -57,6 +62,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     IS_VARLEN: tl.constexpr,
     IS_CONTINUOUS_BATCHING: tl.constexpr,
     IS_SPEC_DECODING: tl.constexpr,
+    SRC_PRERESOLVED: tl.constexpr,
     IS_KDA: tl.constexpr,
 ):
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -102,14 +108,19 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     b_h = tl.zeros([BV, BK], dtype=tl.float32)
     if USE_INITIAL_STATE:
         if IS_CONTINUOUS_BATCHING:
-            if IS_SPEC_DECODING:
-                i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+            if SRC_PRERESOLVED:
+                # copy-free align: read from the pre-resolved 1D physical src
+                # (NULL_BLOCK_ID=0 == fresh / start from zero state).
+                state_idx = tl.load(src_ssm_state_indices + i_n).to(tl.int64)
             else:
-                i_t = 0
-            # Load state index and check for invalid entries
-            state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
-                tl.int64
-            )
+                # no redirect: src aliases the 2D dst window; resolve column.
+                if IS_SPEC_DECODING:
+                    i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+                else:
+                    i_t = 0
+                state_idx = tl.load(
+                    src_ssm_state_indices + i_n * stride_indices_seq + i_t
+                ).to(tl.int64)
             # Skip if state index is invalid (NULL_BLOCK_ID=0)
             if state_idx <= 0:
                 return
@@ -155,9 +166,9 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
 
         # keep the states for multi-query tokens
         if INPLACE_FINAL_STATE:
-            # Load state index and check for invalid entries
+            # Write to the dst window at the per-token loop column i_t.
             final_state_idx = tl.load(
-                ssm_state_indices + i_n * stride_indices_seq + i_t
+                dst_ssm_state_indices + i_n * stride_indices_seq + i_t
             ).to(tl.int64)
             # Only store if state index is valid (not NULL_BLOCK_ID=0)
             if final_state_idx > 0:
@@ -194,6 +205,7 @@ def fused_sigmoid_gating_delta_rule_update(
     cu_seqlens: torch.Tensor | None = None,
     ssm_state_indices: torch.Tensor | None = None,
     num_accepted_tokens: torch.Tensor | None = None,
+    src_ssm_state_indices: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     is_kda: bool = False,
 ):
@@ -238,6 +250,13 @@ def fused_sigmoid_gating_delta_rule_update(
     else:
         stride_indices_seq, stride_indices_tok = ssm_state_indices.stride()
 
+    src_ssm_state_indices, src_preresolved = select_ssm_src_indices(
+        src_ssm_state_indices, ssm_state_indices, N
+    )
+    if num_accepted_tokens is not None and ssm_state_indices is not None:
+        # the multi-token write loop indexes dst at column i_t -> needs a 2D dst
+        assert ssm_state_indices.ndim == 2
+
     grid = (NK, NV, N * HV)
     fused_sigmoid_gating_delta_rule_update_kernel[grid](
         A_log=A_log,
@@ -253,7 +272,8 @@ def fused_sigmoid_gating_delta_rule_update(
         h0=initial_state,
         ht=final_state,
         cu_seqlens=cu_seqlens,
-        ssm_state_indices=ssm_state_indices,
+        src_ssm_state_indices=src_ssm_state_indices,
+        dst_ssm_state_indices=ssm_state_indices,
         num_accepted_tokens=num_accepted_tokens,
         scale=scale,
         N=N,
@@ -272,6 +292,7 @@ def fused_sigmoid_gating_delta_rule_update(
         INPLACE_FINAL_STATE=inplace_final_state,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_KDA=is_kda,
+        SRC_PRERESOLVED=src_preresolved,
         num_warps=num_warps,
         num_stages=num_stages,
     )

--- a/vllm/model_executor/layers/fla/ops/kda.py
+++ b/vllm/model_executor/layers/fla/ops/kda.py
@@ -23,7 +23,7 @@ from .index import prepare_chunk_indices
 from .l2norm import l2norm_fwd
 from .op import exp2, log
 from .solve_tril import solve_tril
-from .utils import FLA_CHUNK_SIZE, is_amd
+from .utils import FLA_CHUNK_SIZE, is_amd, select_ssm_src_indices
 
 BT_LIST_AUTOTUNE = [32, 64, 128]
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [4, 8, 16, 32]
@@ -40,6 +40,7 @@ def fused_recurrent_kda_fwd(
     inplace_final_state: bool = True,
     cu_seqlens: torch.Tensor | None = None,
     ssm_state_indices: torch.Tensor | None = None,
+    src_ssm_state_indices: torch.Tensor | None = None,
     num_accepted_tokens: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -68,6 +69,14 @@ def fused_recurrent_kda_fwd(
     else:
         stride_indices_seq, stride_indices_tok = ssm_state_indices.stride()
 
+    # Launches fused_recurrent_gated_delta_rule_fwd_kernel directly (not its
+    # wrapper), so the src/dst selection is replicated here.
+    src_ssm_state_indices, src_preresolved = select_ssm_src_indices(
+        src_ssm_state_indices, ssm_state_indices, N
+    )
+    if num_accepted_tokens is not None and ssm_state_indices is not None:
+        assert ssm_state_indices.ndim == 2
+
     grid = (NK, NV, N * HV)
     fused_recurrent_gated_delta_rule_fwd_kernel[grid](
         q=q,
@@ -79,7 +88,8 @@ def fused_recurrent_kda_fwd(
         h0=initial_state,
         ht=final_state,
         cu_seqlens=cu_seqlens,
-        ssm_state_indices=ssm_state_indices,
+        src_ssm_state_indices=src_ssm_state_indices,
+        dst_ssm_state_indices=ssm_state_indices,
         num_accepted_tokens=num_accepted_tokens,
         scale=scale,
         N=N,
@@ -99,6 +109,7 @@ def fused_recurrent_kda_fwd(
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         INPLACE_FINAL_STATE=inplace_final_state,
         IS_KDA=True,
+        SRC_PRERESOLVED=src_preresolved,
         num_warps=num_warps,
         num_stages=num_stages,
     )
@@ -118,6 +129,7 @@ def fused_recurrent_kda(
     use_qk_l2norm_in_kernel: bool = True,
     cu_seqlens: torch.Tensor | None = None,
     ssm_state_indices: torch.LongTensor | None = None,
+    src_ssm_state_indices: torch.Tensor | None = None,
     **kwargs,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if cu_seqlens is not None and q.shape[0] != 1:
@@ -139,6 +151,7 @@ def fused_recurrent_kda(
         inplace_final_state=inplace_final_state,
         cu_seqlens=cu_seqlens,
         ssm_state_indices=ssm_state_indices,
+        src_ssm_state_indices=src_ssm_state_indices,
         num_accepted_tokens=None,
         use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
     )

--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -31,6 +31,29 @@ SUPPRESS_LEVEL = int(os.getenv("GDN_RECOMPUTE_SUPPRESS_LEVEL", "0"))
 FLA_CHUNK_SIZE = 64
 
 
+def select_ssm_src_indices(
+    src_indices: torch.Tensor | None,
+    dst_indices: torch.Tensor | None,
+    num_seqs: int,
+) -> tuple[torch.Tensor | None, bool]:
+    """Pick the read (src) state-index tensor for the copy-free "align" path.
+
+    The forward always writes to ``dst_indices`` (the window). When a distinct
+    ``src_indices`` tensor is passed it holds pre-resolved 1D physical block ids
+    that the kernel reads the initial state from directly (returns
+    ``src_preresolved=True``). When ``src_indices`` is None the read self-aliases
+    to ``dst_indices`` (no redirect). src and dst can both be 1D, so identity --
+    not a None check -- is the only safe selector; capture it before aliasing.
+    Both tensors are read-only, so the self-alias is safe.
+    """
+    src_preresolved = src_indices is not None and src_indices is not dst_indices
+    if src_indices is None:
+        src_indices = dst_indices
+    if src_preresolved:
+        assert src_indices.ndim == 1 and src_indices.shape[0] == num_seqs
+    return src_indices, src_preresolved
+
+
 def tensor_cache(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
     """
     A decorator that caches the most recent results of a function with tensor inputs.

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -291,6 +291,13 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         non_spec_state_indices_tensor = (
             attn_metadata_narrowed.non_spec_state_indices_tensor
         )  # noqa: E501
+        non_spec_ssm_src_state_indices = (
+            attn_metadata_narrowed.non_spec_ssm_src_state_indices
+        )
+        non_spec_conv_src_state_indices = (
+            attn_metadata_narrowed.non_spec_conv_src_state_indices
+        )
+        non_spec_conv_src_offset = attn_metadata_narrowed.non_spec_conv_src_offset
         num_actual_tokens = attn_metadata_narrowed.num_actual_tokens
         constant_caches = self.kv_cache
 
@@ -329,6 +336,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 conv_states=conv_state_q,
                 has_initial_state=has_initial_state,
                 cache_indices=non_spec_state_indices_tensor,
+                src_conv_state_indices=non_spec_conv_src_state_indices,
                 query_start_loc=non_spec_query_start_loc,
                 metadata=attn_metadata_narrowed,
             ).transpose(0, 1)
@@ -340,6 +348,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 conv_states=conv_state_k,
                 has_initial_state=has_initial_state,
                 cache_indices=non_spec_state_indices_tensor,
+                src_conv_state_indices=non_spec_conv_src_state_indices,
                 query_start_loc=non_spec_query_start_loc,
                 metadata=attn_metadata_narrowed,
             ).transpose(0, 1)
@@ -351,6 +360,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 conv_states=conv_state_v,
                 has_initial_state=has_initial_state,
                 cache_indices=non_spec_state_indices_tensor,
+                src_conv_state_indices=non_spec_conv_src_state_indices,
                 query_start_loc=non_spec_query_start_loc,
                 metadata=attn_metadata_narrowed,
             ).transpose(0, 1)
@@ -359,6 +369,16 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             decode_conv_indices = non_spec_state_indices_tensor[
                 : attn_metadata_narrowed.num_actual_tokens
             ]
+            src_conv = (
+                non_spec_conv_src_state_indices[:num_actual_tokens]
+                if non_spec_conv_src_state_indices is not None
+                else None
+            )
+            src_conv_off = (
+                non_spec_conv_src_offset[:num_actual_tokens]
+                if non_spec_conv_src_offset is not None
+                else None
+            )
             q = causal_conv1d_update(
                 q_proj_states,
                 conv_state_q,
@@ -366,6 +386,8 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 self.q_conv1d.bias,
                 activation="silu",
                 conv_state_indices=decode_conv_indices,
+                src_conv_state_indices=src_conv,
+                src_conv_token_offset=src_conv_off,
                 validate_data=True,
             )
             k = causal_conv1d_update(
@@ -375,6 +397,8 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 self.k_conv1d.bias,
                 activation="silu",
                 conv_state_indices=decode_conv_indices,
+                src_conv_state_indices=src_conv,
+                src_conv_token_offset=src_conv_off,
                 validate_data=True,
             )
             v = causal_conv1d_update(
@@ -384,6 +408,8 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 self.v_conv1d.bias,
                 activation="silu",
                 conv_state_indices=decode_conv_indices,
+                src_conv_state_indices=src_conv,
+                src_conv_token_offset=src_conv_off,
                 validate_data=True,
             )
 
@@ -394,9 +420,13 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         if attn_metadata_narrowed.num_prefills > 0:
             assert non_spec_state_indices_tensor is not None
             assert has_initial_state is not None
-            zero_idx = non_spec_state_indices_tensor[~has_initial_state]
-            recurrent_state[zero_idx] = 0
-            initial_state = recurrent_state[non_spec_state_indices_tensor].contiguous()
+            prefill_src_indices = (
+                non_spec_ssm_src_state_indices
+                if non_spec_ssm_src_state_indices is not None
+                else non_spec_state_indices_tensor
+            )
+            initial_state = recurrent_state[prefill_src_indices].contiguous()
+            initial_state[~has_initial_state, ...] = 0
             (
                 core_attn_out_non_spec,
                 last_recurrent_state,
@@ -438,6 +468,11 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                     : attn_metadata_narrowed.num_decodes + 1
                 ],
                 ssm_state_indices=non_spec_state_indices_tensor,
+                src_ssm_state_indices=(
+                    non_spec_ssm_src_state_indices[:num_actual_tokens]
+                    if non_spec_ssm_src_state_indices is not None
+                    else None
+                ),
             )
         core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[
             0, :num_actual_tokens

--- a/vllm/model_executor/layers/mamba/gdn/olmo_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/olmo_gdn_linear_attn.py
@@ -315,6 +315,12 @@ class OlmoHybridGatedDeltaNetAttention(GatedDeltaNetAttention):
         non_spec_token_indx = attn_metadata.non_spec_token_indx
         spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor
         non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor
+        spec_ssm_src_state_indices = attn_metadata.spec_ssm_src_state_indices
+        non_spec_ssm_src_state_indices = attn_metadata.non_spec_ssm_src_state_indices
+        spec_conv_src_state_indices = attn_metadata.spec_conv_src_state_indices
+        non_spec_conv_src_state_indices = attn_metadata.non_spec_conv_src_state_indices
+        spec_conv_src_offset = attn_metadata.spec_conv_src_offset
+        non_spec_conv_src_offset = attn_metadata.non_spec_conv_src_offset
         self_kv_cache = self.kv_cache
         # conv_state must be (..., dim, width-1) for the conv kernels.
         # DS layout stores it that way directly; SD layout needs a transpose.
@@ -359,6 +365,16 @@ class OlmoHybridGatedDeltaNetAttention(GatedDeltaNetAttention):
                 conv_state_indices=spec_state_indices_tensor[:, 0][
                     : attn_metadata.num_spec_decodes
                 ],
+                src_conv_state_indices=(
+                    spec_conv_src_state_indices[: attn_metadata.num_spec_decodes]
+                    if spec_conv_src_state_indices is not None
+                    else None
+                ),
+                src_conv_token_offset=(
+                    spec_conv_src_offset[: attn_metadata.num_spec_decodes]
+                    if spec_conv_src_offset is not None
+                    else None
+                ),
                 num_accepted_tokens=num_accepted_tokens,
                 query_start_loc=spec_query_start_loc,
                 max_query_len=spec_state_indices_tensor.size(-1),
@@ -378,6 +394,7 @@ class OlmoHybridGatedDeltaNetAttention(GatedDeltaNetAttention):
                 cache_indices=non_spec_state_indices_tensor,
                 query_start_loc=non_spec_query_start_loc,
                 metadata=attn_metadata,
+                src_conv_state_indices=non_spec_conv_src_state_indices,
             ).transpose(0, 1)
         elif attn_metadata.num_decodes > 0:
             assert non_spec_state_indices_tensor is not None
@@ -390,6 +407,16 @@ class OlmoHybridGatedDeltaNetAttention(GatedDeltaNetAttention):
                 conv_state_indices=non_spec_state_indices_tensor[
                     : attn_metadata.num_decodes
                 ],
+                src_conv_state_indices=(
+                    non_spec_conv_src_state_indices[: attn_metadata.num_decodes]
+                    if non_spec_conv_src_state_indices is not None
+                    else None
+                ),
+                src_conv_token_offset=(
+                    non_spec_conv_src_offset[: attn_metadata.num_decodes]
+                    if non_spec_conv_src_offset is not None
+                    else None
+                ),
                 validate_data=True,
             )
         else:
@@ -437,6 +464,11 @@ class OlmoHybridGatedDeltaNetAttention(GatedDeltaNetAttention):
                 inplace_final_state=True,
                 cu_seqlens=spec_query_start_loc[: attn_metadata.num_spec_decodes + 1],
                 ssm_state_indices=spec_state_indices_tensor,
+                src_ssm_state_indices=(
+                    spec_ssm_src_state_indices[: attn_metadata.num_spec_decodes]
+                    if spec_ssm_src_state_indices is not None
+                    else None
+                ),
                 num_accepted_tokens=num_accepted_tokens,
                 use_qk_l2norm_in_kernel=True,
             )
@@ -447,7 +479,12 @@ class OlmoHybridGatedDeltaNetAttention(GatedDeltaNetAttention):
             assert non_spec_state_indices_tensor is not None
             assert has_initial_state is not None
             assert non_spec_query_start_loc is not None
-            initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()
+            prefill_src_indices = (
+                non_spec_ssm_src_state_indices
+                if non_spec_ssm_src_state_indices is not None
+                else non_spec_state_indices_tensor
+            )
+            initial_state = ssm_state[prefill_src_indices].contiguous()
             initial_state[~has_initial_state, ...] = 0
             (
                 core_attn_out_non_spec,
@@ -482,6 +519,11 @@ class OlmoHybridGatedDeltaNetAttention(GatedDeltaNetAttention):
                         : attn_metadata.num_decodes + 1
                     ],
                     ssm_state_indices=non_spec_state_indices_tensor,
+                    src_ssm_state_indices=(
+                        non_spec_ssm_src_state_indices[: attn_metadata.num_decodes]
+                        if non_spec_ssm_src_state_indices is not None
+                        else None
+                    ),
                     use_qk_l2norm_in_kernel=True,
                 )
             )

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -1305,6 +1305,17 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         non_spec_token_indx = attn_metadata.non_spec_token_indx
         spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor  # noqa: E501
         non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
+        # Read-side SSM block ids for mamba "align" cache mode (None otherwise).
+        # When set, the SSM recurrent kernels read their initial state from these
+        # blocks (the previous running block) instead of the write-side window,
+        # replacing the SSM temporal pre-copy.
+        spec_ssm_src_state_indices = attn_metadata.spec_ssm_src_state_indices
+        non_spec_ssm_src_state_indices = attn_metadata.non_spec_ssm_src_state_indices
+        # Read-side CONV src (prev running block) + pre-reset intra-block offset.
+        spec_conv_src_state_indices = attn_metadata.spec_conv_src_state_indices
+        non_spec_conv_src_state_indices = attn_metadata.non_spec_conv_src_state_indices
+        spec_conv_src_offset = attn_metadata.spec_conv_src_offset
+        non_spec_conv_src_offset = attn_metadata.non_spec_conv_src_offset
         self_kv_cache = self.kv_cache
         # conv_state must be (..., dim, width-1) for the conv kernels.
         # DS layout stores it that way directly; SD layout needs a transpose.
@@ -1351,6 +1362,16 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     : attn_metadata.num_spec_decodes  # type: ignore[attr-defined]
                 ],
                 num_accepted_tokens=num_accepted_tokens,
+                src_conv_state_indices=(
+                    spec_conv_src_state_indices[: attn_metadata.num_spec_decodes]
+                    if spec_conv_src_state_indices is not None
+                    else None
+                ),
+                src_conv_token_offset=(
+                    spec_conv_src_offset[: attn_metadata.num_spec_decodes]
+                    if spec_conv_src_offset is not None
+                    else None
+                ),
                 query_start_loc=spec_query_start_loc,
                 max_query_len=spec_state_indices_tensor.size(-1),
                 validate_data=False,
@@ -1370,6 +1391,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 conv_states=conv_state,
                 has_initial_state=has_initial_state,
                 cache_indices=non_spec_state_indices_tensor,
+                src_conv_state_indices=non_spec_conv_src_state_indices,
                 query_start_loc=non_spec_query_start_loc,
                 metadata=attn_metadata,
             ).transpose(0, 1)
@@ -1384,6 +1406,16 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 conv_state_indices=non_spec_state_indices_tensor[  # type: ignore[index]
                     : attn_metadata.num_actual_tokens  # type: ignore[attr-defined]
                 ],
+                src_conv_state_indices=(
+                    non_spec_conv_src_state_indices[: attn_metadata.num_actual_tokens]
+                    if non_spec_conv_src_state_indices is not None
+                    else None
+                ),
+                src_conv_token_offset=(
+                    non_spec_conv_src_offset[: attn_metadata.num_actual_tokens]
+                    if non_spec_conv_src_offset is not None
+                    else None
+                ),
                 validate_data=True,
             )
         else:
@@ -1470,6 +1502,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     ],
                     ssm_state_indices=spec_state_indices_tensor,
                     num_accepted_tokens=num_accepted_tokens,
+                    src_ssm_state_indices=(
+                        spec_ssm_src_state_indices[: attn_metadata.num_spec_decodes]
+                        if spec_ssm_src_state_indices is not None
+                        else None
+                    ),
                     use_qk_l2norm_in_kernel=True,
                 )
             )
@@ -1495,6 +1532,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     : attn_metadata.num_decodes + 1
                 ],
                 ssm_state_indices=non_spec_state_indices_tensor,
+                src_ssm_state_indices=(
+                    non_spec_ssm_src_state_indices[: attn_metadata.num_decodes]
+                    if non_spec_ssm_src_state_indices is not None
+                    else None
+                ),
                 use_qk_l2norm_in_kernel=True,
             )
         else:
@@ -1502,15 +1544,16 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # 2.3: Process the remaining part (prefill chunk, or non-spec decode-only)
         if attn_metadata.num_prefills > 0:
-            # State indices, initial-state mask and cu_seqlens for the chunk
-            # kernel are precomputed by the metadata builder (the prefill tail
-            # when decodes are peeled off, else the full non-spec batch), so they
-            # don't need to be re-derived per layer.
             prefill_state_indices = attn_metadata.prefill_state_indices
             prefill_has_initial_state = attn_metadata.prefill_has_initial_state
             assert prefill_state_indices is not None
             assert prefill_has_initial_state is not None
-            initial_state = ssm_state[prefill_state_indices]
+            prefill_init_indices = (
+                non_spec_ssm_src_state_indices[attn_metadata.num_decodes :]
+                if non_spec_ssm_src_state_indices is not None
+                else prefill_state_indices
+            )
+            initial_state = ssm_state[prefill_init_indices]
             initial_state[~prefill_has_initial_state, ...] = 0
             (
                 core_attn_out_non_spec,
@@ -1554,6 +1597,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                         + 1  # type: ignore[attr-defined]
                     ],
                     ssm_state_indices=non_spec_state_indices_tensor,
+                    src_ssm_state_indices=(
+                        non_spec_ssm_src_state_indices[: attn_metadata.num_decodes]
+                        if non_spec_ssm_src_state_indices is not None
+                        else None
+                    ),
                     use_qk_l2norm_in_kernel=True,
                 )
             )
@@ -1653,6 +1701,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         Core attention computation with a packed non-spec decode fast path.
         """
         non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
+        # mamba "align" copy-free src (None otherwise): read init conv/SSM from
+        # the prev running block while writing the window block.
+        non_spec_conv_src_state_indices = attn_metadata.non_spec_conv_src_state_indices
+        non_spec_conv_src_offset = attn_metadata.non_spec_conv_src_offset
+        non_spec_ssm_src_state_indices = attn_metadata.non_spec_ssm_src_state_indices
         self_kv_cache = self.kv_cache
         # conv_state must be (..., dim, width-1) for the conv kernels.
         # DS layout stores it that way directly; SD layout needs a transpose.
@@ -1678,6 +1731,16 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             self.conv1d.bias,
             self.activation,
             conv_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],  # type: ignore[index]
+            src_conv_state_indices=(
+                non_spec_conv_src_state_indices[:num_actual_tokens]
+                if non_spec_conv_src_state_indices is not None
+                else None
+            ),
+            src_conv_token_offset=(
+                non_spec_conv_src_offset[:num_actual_tokens]
+                if non_spec_conv_src_offset is not None
+                else None
+            ),
             validate_data=False,
         )
         out_buf = core_attn_out[:num_actual_tokens].unsqueeze(1)
@@ -1691,6 +1754,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             initial_state=ssm_state,
             out=out_buf,
             ssm_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],  # type: ignore[index]
+            src_ssm_state_indices=(
+                non_spec_ssm_src_state_indices[:num_actual_tokens]
+                if non_spec_ssm_src_state_indices is not None
+                else None
+            ),
             use_qk_l2norm_in_kernel=True,
         )
         return

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -29,6 +29,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     block_idx_first_scheduled_token,  # (batch,)
     block_idx_last_scheduled_token,  # (batch,)
     initial_state_idx,  # (batch,)
+    src_conv_state_indices_ptr,  # (batch,) phys block to READ init conv from
     num_computed_tokens,  # (batch,)
     o_ptr,  # (dim, seqlen) - actually pointing to x_ptr
     # Matrix dimensions
@@ -54,6 +55,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     KERNEL_WIDTH: tl.constexpr,
     SILU_ACTIVATION: tl.constexpr,
     IS_APC_ENABLED: tl.constexpr,
+    SRC_PRERESOLVED: tl.constexpr,
     HAS_NULL_BLOCK: tl.constexpr,
     NP2_STATELEN: tl.constexpr,
     BLOCK_M: tl.constexpr,
@@ -141,7 +143,23 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
         conv_states_ptr
         + (conv_states_input_coord * stride_conv_state_seq)
         + (idx_feats * stride_conv_state_dim)
-    )  # [BLOCK_N,]
+    )  # [BLOCK_N,]  WRITE base = window block (col0); also the null/padding check.
+
+    # copy-free align: READ the init conv state from the per-seq src block (the
+    # previous running block) while WRITES stay on the window block. On a
+    # block-boundary migration this reads the prev block directly, removing the
+    # conv pre-copy; otherwise src == window block, so it is a no-op.
+    if SRC_PRERESOLVED:
+        conv_states_read_coord = tl.load(src_conv_state_indices_ptr + idx_seq).to(
+            tl.int64
+        )
+    else:
+        conv_states_read_coord = conv_states_input_coord
+    conv_states_read_base = (
+        conv_states_ptr
+        + (conv_states_read_coord * stride_conv_state_seq)
+        + (idx_feats * stride_conv_state_dim)
+    )  # [BLOCK_N,]  READ base = src block.
 
     w_base = w_ptr + (idx_feats * stride_w_dim)  # [BLOCK_N,]
 
@@ -152,8 +170,10 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
         # read from conv_states
         load_init_state = tl.load(has_initial_states_ptr + idx_seq).to(tl.int1)
         if load_init_state:
-            # load from conv_states
-            prior_tokens = conv_states_base + (state_len - 1) * stride_conv_state_tok
+            # load from conv_states (READ from the src block, not the window)
+            prior_tokens = (
+                conv_states_read_base + (state_len - 1) * stride_conv_state_tok
+            )
             mask_w = idx_feats < dim
             if KERNEL_WIDTH == 2:
                 conv_states_ptrs = prior_tokens  # [BLOCK_N]
@@ -241,12 +261,12 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
 
                 conv_states_ptrs_source = (
                     conv_states_ptr
-                    + (conv_states_input_coord * stride_conv_state_seq)
+                    + (conv_states_read_coord * stride_conv_state_seq)
                     + (idx_feats * stride_conv_state_dim)[None, :]
                     + ((idx_tokens_conv + seqlen) * stride_conv_state_tok)[:, None]
                 )  # [BLOCK_M, BLOCK_N]
                 mask = (
-                    (conv_states_input_coord < num_cache_lines)
+                    (conv_states_read_coord < num_cache_lines)
                     & ((idx_tokens_conv + seqlen) < state_len)[:, None]
                     & (idx_feats < dim)[None, :]
                 )
@@ -479,6 +499,7 @@ def causal_conv1d_fn(
     block_idx_first_scheduled_token: torch.Tensor | None = None,
     block_idx_last_scheduled_token: torch.Tensor | None = None,
     initial_state_idx: torch.Tensor | None = None,
+    src_conv_state_indices: torch.Tensor | None = None,
     num_computed_tokens: torch.Tensor | None = None,
     block_size_to_align=0,
     metadata=None,
@@ -710,6 +731,7 @@ def causal_conv1d_fn(
         block_idx_first_scheduled_token,
         block_idx_last_scheduled_token,
         initial_state_idx,
+        src_conv_state_indices,
         num_computed_tokens,
         out,
         # Matrix dimensions
@@ -735,6 +757,7 @@ def causal_conv1d_fn(
         KERNEL_WIDTH=width,
         SILU_ACTIVATION=activation in ["silu", "swish"],
         IS_APC_ENABLED=block_idx_last_scheduled_token is not None,
+        SRC_PRERESOLVED=src_conv_state_indices is not None,
         HAS_NULL_BLOCK=null_block_id is not None,
         NP2_STATELEN=np2_statelen,
         # launch_cooperative_grid=True
@@ -752,11 +775,13 @@ def _causal_conv1d_update_kernel(
     w_ptr,  # (dim, width)
     bias_ptr,
     conv_state_ptr,
-    conv_state_indices_ptr,
     num_accepted_tokens_ptr,
     query_start_loc_ptr,  # (batch + 1)
     block_idx_last_scheduled_token,  # (batch,)
     initial_state_idx,  # (batch,)
+    src_conv_state_indices_ptr,  # (batch,) phys block id to READ init conv from
+    src_conv_token_offset_ptr,  # (batch,) intra-block token offset for the read
+    dst_conv_state_indices_ptr,  # (batch, n_blocks + padding) WRITE/cache index
     o_ptr,  # (batch, dim, seqlen)
     # Matrix dimensions
     batch: int,
@@ -786,6 +811,7 @@ def _causal_conv1d_update_kernel(
     IS_VARLEN: tl.constexpr,
     IS_APC_ENABLED: tl.constexpr,
     IS_SPEC_DECODING: tl.constexpr,
+    SRC_PRERESOLVED: tl.constexpr,
     NP2_STATELEN: tl.constexpr,
     HAS_NULL_BLOCK: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -807,9 +833,18 @@ def _causal_conv1d_update_kernel(
         current_last_index = 0
 
     # cache_idx
-    conv_states_input_coord = tl.load(
-        conv_state_indices_ptr + idx_seq * stride_state_indices + conv_state_init
-    ).to(tl.int64)
+    if SRC_PRERESOLVED:
+        # copy-free align: read the init conv state from the per-seq src block
+        # (the previous running block); the write side is unchanged.
+        conv_states_input_coord = tl.load(src_conv_state_indices_ptr + idx_seq).to(
+            tl.int64
+        )
+    else:
+        conv_states_input_coord = tl.load(
+            dst_conv_state_indices_ptr
+            + idx_seq * stride_state_indices
+            + conv_state_init
+        ).to(tl.int64)
 
     if HAS_NULL_BLOCK:  # noqa
         if conv_states_input_coord == null_block_id:
@@ -847,11 +882,24 @@ def _causal_conv1d_update_kernel(
         # - accept 1 tokens: [history2, ..., historyM, draft1]
         # - accept 2 tokens: [history3, ..., historyM, draft1, draft2]
         # - and so on.
-        conv_state_token_offset = (
-            tl.load(num_accepted_tokens_ptr + idx_seq).to(tl.int64) - 1
-        )
+        if SRC_PRERESOLVED:
+            # Pre-reset offset (captured before the per-step num_accepted reset)
+            # so the src read starts at the correct sliding-window position even
+            # on a block-boundary migration (where num_accepted was reset to 1).
+            conv_state_token_offset = tl.load(src_conv_token_offset_ptr + idx_seq).to(
+                tl.int64
+            )
+        else:
+            conv_state_token_offset = (
+                tl.load(num_accepted_tokens_ptr + idx_seq).to(tl.int64) - 1
+            )
     else:
-        conv_state_token_offset = 0
+        if SRC_PRERESOLVED:
+            conv_state_token_offset = tl.load(src_conv_token_offset_ptr + idx_seq).to(
+                tl.int64
+            )
+        else:
+            conv_state_token_offset = 0
 
     # STEP 1: READ init_state data
     conv_states_base = (
@@ -920,7 +968,7 @@ def _causal_conv1d_update_kernel(
     # Get the state from the initial_state_idx
     # cache_idx
     conv_states_offset = tl.load(
-        conv_state_indices_ptr + idx_seq * stride_state_indices + current_last_index
+        dst_conv_state_indices_ptr + idx_seq * stride_state_indices + current_last_index
     ).to(tl.int64)
     conv_state_ptrs_target = (
         conv_state_ptr
@@ -1079,6 +1127,8 @@ def causal_conv1d_update(
     null_block_id: int = NULL_BLOCK_ID,
     block_idx_last_scheduled_token: torch.Tensor | None = None,
     initial_state_idx: torch.Tensor | None = None,
+    src_conv_state_indices: torch.Tensor | None = None,
+    src_conv_token_offset: torch.Tensor | None = None,
     validate_data=False,
 ):
     """
@@ -1196,11 +1246,13 @@ def causal_conv1d_update(
         weight,
         bias,
         conv_state,
-        conv_state_indices,
         num_accepted_tokens,
         query_start_loc,
         block_idx_last_scheduled_token,
         initial_state_idx,
+        src_conv_state_indices,
+        src_conv_token_offset,
+        conv_state_indices,
         out,
         # Matrix dimensions
         batch,
@@ -1230,6 +1282,7 @@ def causal_conv1d_update(
         IS_VARLEN=query_start_loc is not None,
         IS_APC_ENABLED=block_idx_last_scheduled_token is not None,
         IS_SPEC_DECODING=num_accepted_tokens is not None,
+        SRC_PRERESOLVED=src_conv_state_indices is not None,
         NP2_STATELEN=np2_statelen,
         HAS_NULL_BLOCK=null_block_id is not None,
         BLOCK_N=256,

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -974,7 +974,12 @@ class DiffusionGemmaModelState(ModelState):
         return {"inputs_embeds": self._inputs_embeds_buf[:num_tokens]}
 
     def postprocess_state(
-        self, idx_mapping, num_sampled, num_computed_tokens=None
+        self,
+        idx_mapping,
+        num_sampled,
+        num_computed_tokens=None,
+        num_reqs=None,
+        query_start_loc=None,
     ) -> None:
         return None
 

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -8,6 +8,7 @@ from typing import Literal
 import torch
 
 from vllm.config import VllmConfig
+from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -22,6 +23,57 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
+
+
+@triton.jit
+def _gather_resolve_align_src_kernel(
+    idx_mapping_ptr,  # [>=n] batch position -> req state slot (-1 = filtered/PP)
+    src_ssm_col_ptr,  # [max_reqs] req-order SSM src column (-1 = fresh)
+    conv_src_col_ptr,  # [max_reqs] req-order conv src column (-1 = fresh)
+    conv_src_off_ptr,  # [max_reqs] req-order conv token offset
+    block_table_ptr,  # [num_reqs, max_blocks] int32 (FULL, non-windowed)
+    bt_stride0,
+    bt_stride1,
+    max_col,
+    ssm_phys_ptr,  # [num_reqs] int32 out (NULL_BLOCK_ID=0 for fresh)
+    conv_phys_ptr,  # [num_reqs] int32 out
+    conv_off_ptr,  # [num_reqs] int32 out (batch order)
+    n,
+    num_reqs,
+    BLOCK: tl.constexpr,
+):
+    """Gather the per-req align src COLUMNS into batch order (via idx_mapping)
+    and resolve them to physical block ids in one launch (SSM + conv together).
+    Rows in [n, num_reqs) are padding and rows whose req < 0 are filtered (PP);
+    both resolve to fresh (NULL_BLOCK_ID=0, offset 0).
+    """
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < num_reqs
+    valid = offs < n
+    req = tl.load(idx_mapping_ptr + offs, mask=valid, other=-1)
+    rmask = valid & (req >= 0)
+    req_safe = tl.maximum(req, 0)
+    # Gather: padding/filtered rows become fresh (-1 col, 0 off).
+    ssm_col = tl.where(
+        rmask, tl.load(src_ssm_col_ptr + req_safe, mask=rmask, other=-1), -1
+    )
+    conv_col = tl.where(
+        rmask, tl.load(conv_src_col_ptr + req_safe, mask=rmask, other=-1), -1
+    )
+    off = tl.where(rmask, tl.load(conv_src_off_ptr + req_safe, mask=rmask, other=0), 0)
+    # Resolve: col < 0 -> NULL(0); else block_table[row, clamp(col)]. Block-table
+    # loads use rmask (real cols, offs < n) not mask (offs < num_reqs): padded
+    # phys is discarded anyway, and this lets num_reqs exceed the block-table row
+    # count (resolving into a per-token CUDAGraph buffer) without an OOB read.
+    base = block_table_ptr + offs.to(tl.int64) * bt_stride0
+    ssm_c = tl.minimum(tl.maximum(ssm_col, 0), max_col).to(tl.int64)
+    conv_c = tl.minimum(tl.maximum(conv_col, 0), max_col).to(tl.int64)
+    ssm_phys = tl.load(base + ssm_c * bt_stride1, mask=rmask, other=0)
+    conv_phys = tl.load(base + conv_c * bt_stride1, mask=rmask, other=0)
+    tl.store(ssm_phys_ptr + offs, tl.where(ssm_col >= 0, ssm_phys, 0), mask=mask)
+    tl.store(conv_phys_ptr + offs, tl.where(conv_col >= 0, conv_phys, 0), mask=mask)
+    tl.store(conv_off_ptr + offs, off, mask=mask)
 
 
 class GDNAttentionBackend(AttentionBackend):
@@ -65,6 +117,20 @@ class GDNAttentionMetadata:
 
     num_accepted_tokens: torch.Tensor | None = None  # shape: [batch,]
 
+    # Read-side physical block ids for the mamba "align" SSM src redirect. When
+    # set, the SSM kernels source their initial state from these blocks instead
+    # of [non_]spec_state_indices_tensor, eliminating the SSM temporal pre-copy.
+    spec_ssm_src_state_indices: torch.Tensor | None = None  # shape: [num_spec_decodes,]
+    non_spec_ssm_src_state_indices: torch.Tensor | None = None  # shape: [num_decodes,]
+
+    # Read-side CONV src: physical block id (prev running block) + pre-reset
+    # intra-block token offset, so the conv kernel reads its init conv window
+    # from the prev block at that offset (copy-free conv pre).
+    spec_conv_src_state_indices: torch.Tensor | None = None
+    non_spec_conv_src_state_indices: torch.Tensor | None = None
+    spec_conv_src_offset: torch.Tensor | None = None
+    non_spec_conv_src_offset: torch.Tensor | None = None
+
     # Pre-computed FLA chunk metadata (avoids GPU->CPU sync in prepare_chunk_indices)
     chunk_indices: torch.Tensor | None = None
     chunk_offsets: torch.Tensor | None = None
@@ -102,6 +168,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
 
         self.gdn_prefill_backend: Literal["triton", "flashinfer", "cutedsl"]
         _, self.gdn_prefill_backend = _resolve_gdn_prefill_backend(vllm_config)
+
+        # Copy-free align (V1 and V2): the forward kernel reads the previous
+        # running state directly from its source block instead of pre-copying it.
+        # ``build`` resolves the src columns to physical block ids per step.
+        self.use_align_mode: bool = vllm_config.cache_config.mamba_cache_mode == "align"
 
         if self.speculative_config:
             assert self.speculative_config.num_speculative_tokens is not None
@@ -164,6 +235,93 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             dtype=torch.int32,
             device=device,
         )
+        # Persistent src buffers for full CUDAGraph (align only): SRC_PRERESOLVED
+        # is a constexpr baked at capture, so the src must flow through these
+        # fixed-address buffers -- a distinct object from the dst tensor, so the
+        # `src is not dst` selector bakes SRC_PRERESOLVED=True (NULL-filled at
+        # capture; each replay copies the real src into the same buffer).
+        self.spec_ssm_src_state_indices_buf: torch.Tensor | None = None
+        self.non_spec_ssm_src_state_indices_buf: torch.Tensor | None = None
+        self.spec_conv_src_state_indices_buf: torch.Tensor | None = None
+        self.non_spec_conv_src_state_indices_buf: torch.Tensor | None = None
+        self.spec_conv_src_offset_buf: torch.Tensor | None = None
+        self.non_spec_conv_src_offset_buf: torch.Tensor | None = None
+        if self.use_align_mode:
+            self.spec_ssm_src_state_indices_buf = torch.empty(
+                (self.decode_cudagraph_max_bs,),
+                dtype=torch.int32,
+                device=device,
+            )
+            self.non_spec_ssm_src_state_indices_buf = torch.empty(
+                (self.decode_cudagraph_max_bs,),
+                dtype=torch.int32,
+                device=device,
+            )
+            # CONV src physical-block + offset persistent buffers (same purpose).
+            self.spec_conv_src_state_indices_buf = torch.empty(
+                (self.decode_cudagraph_max_bs,), dtype=torch.int32, device=device
+            )
+            self.non_spec_conv_src_state_indices_buf = torch.empty(
+                (self.decode_cudagraph_max_bs,), dtype=torch.int32, device=device
+            )
+            self.spec_conv_src_offset_buf = torch.empty(
+                (self.decode_cudagraph_max_bs,), dtype=torch.int32, device=device
+            )
+            self.non_spec_conv_src_offset_buf = torch.empty(
+                (self.decode_cudagraph_max_bs,), dtype=torch.int32, device=device
+            )
+
+    @staticmethod
+    def _split_align_cache_src_info(
+        src_full: torch.Tensor | None,
+        spec_mask: torch.Tensor,
+        include_non_spec: bool = True,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """Split full-batch mamba align-cache src indices into spec and
+        non-spec portions. When include_non_spec=False (pure spec-only
+        batch), skip the non-spec computation and return None for it."""
+        if src_full is None:
+            return None, None
+        spec = src_full[spec_mask].contiguous()
+        non_spec = src_full[~spec_mask].contiguous() if include_non_spec else None
+        return spec, non_spec
+
+    def _resolve_align_src_into(
+        self,
+        idx_mapping: torch.Tensor,
+        src_ssm_col: torch.Tensor,
+        conv_src_col: torch.Tensor,
+        conv_src_off: torch.Tensor,
+        block_table: torch.Tensor,
+        out_ssm: torch.Tensor,
+        out_conv: torch.Tensor,
+        out_off: torch.Tensor,
+        n: int,
+        out_len: int,
+    ) -> None:
+        """Resolve the per-req src columns into ``out_*[:out_len]``: ``[:n]`` are
+        the resolved real reqs and ``[n:out_len]`` are NULL-filled by the kernel,
+        so one launch both resolves and stages. ``out_*`` are the persistent
+        CUDAGraph buffers on the decode path, or a fresh full-batch tensor on the
+        eager path. The columns resolve against the FULL (non-windowed) block
+        table, since the previous running block can lie outside the window on a
+        block-boundary crossing."""
+        _gather_resolve_align_src_kernel[(triton.cdiv(out_len, 256),)](
+            idx_mapping,
+            src_ssm_col,
+            conv_src_col,
+            conv_src_off,
+            block_table,
+            block_table.stride(0),
+            block_table.stride(1),
+            block_table.size(1) - 1,
+            out_ssm,
+            out_conv,
+            out_off,
+            n,
+            out_len,
+            BLOCK=256,
+        )
 
     def build(  # type: ignore[override]
         self,
@@ -171,6 +329,12 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         common_attn_metadata: CommonAttentionMetadata,
         num_accepted_tokens: torch.Tensor | None = None,
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
+        align_src_ssm_col: torch.Tensor | None = None,
+        align_conv_src_col: torch.Tensor | None = None,
+        align_conv_src_off: torch.Tensor | None = None,
+        align_idx_mapping: torch.Tensor | None = None,
+        align_num_reqs: int = 0,
+        for_capture: bool = False,
         fast_build: bool = False,
     ) -> GDNAttentionMetadata:
         m = common_attn_metadata
@@ -482,6 +646,185 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
             non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
 
+        # --- Mamba "align" copy-free src resolution --------------------------
+        # Resolve the per-req src columns to physical block ids in spec/non-spec
+        # order. The cg_spec / cg_nonspec conditions mirror the state-index
+        # CUDAGraph staging above, so the src lands in the same buffer the SSM /
+        # conv kernels read at replay; the eager / mixed path resolves into a
+        # fresh full-batch tensor and splits it.
+        spec_ssm_src_state_indices: torch.Tensor | None = None
+        non_spec_ssm_src_state_indices: torch.Tensor | None = None
+        spec_conv_src_state_indices: torch.Tensor | None = None
+        non_spec_conv_src_state_indices: torch.Tensor | None = None
+        spec_conv_src_offset: torch.Tensor | None = None
+        non_spec_conv_src_offset: torch.Tensor | None = None
+        if self.use_align_mode:
+            # No cached state -> all-fresh NULL src. True at CUDAGraph capture and
+            # on the profiling / warmup dummy runs (which never run
+            # preprocess_mamba, so the runner has no columns to feed); a real
+            # forward always carries the columns. Mirrors V2's for_capture path.
+            no_src_state = for_capture or align_src_ssm_col is None
+            cg_spec = (
+                self.use_full_cuda_graph
+                and num_prefills == 0
+                and num_decodes == 0
+                and num_spec_decodes <= self.decode_cudagraph_max_bs
+                and num_spec_decode_tokens <= self.decode_cudagraph_max_bs
+            )
+            cg_nonspec = (
+                self.use_full_cuda_graph
+                and num_prefills == 0
+                and num_spec_decodes == 0
+                and num_decodes <= self.decode_cudagraph_max_bs
+            )
+            if cg_spec:
+                assert self.spec_ssm_src_state_indices_buf is not None
+                assert self.spec_conv_src_state_indices_buf is not None
+                assert self.spec_conv_src_offset_buf is not None
+                if no_src_state:
+                    # No cached state (capture / profiling): NULL-fill buffers.
+                    self.spec_ssm_src_state_indices_buf[:batch_size].fill_(
+                        NULL_BLOCK_ID
+                    )
+                    self.spec_conv_src_state_indices_buf[:batch_size].fill_(
+                        NULL_BLOCK_ID
+                    )
+                    self.spec_conv_src_offset_buf[:batch_size].fill_(0)
+                else:
+                    assert (
+                        align_idx_mapping is not None
+                        and align_src_ssm_col is not None
+                        and align_conv_src_col is not None
+                        and align_conv_src_off is not None
+                    )
+                    self._resolve_align_src_into(
+                        align_idx_mapping,
+                        align_src_ssm_col,
+                        align_conv_src_col,
+                        align_conv_src_off,
+                        m.block_table_tensor,
+                        self.spec_ssm_src_state_indices_buf,
+                        self.spec_conv_src_state_indices_buf,
+                        self.spec_conv_src_offset_buf,
+                        num_spec_decodes,
+                        batch_size,
+                    )
+                spec_ssm_src_state_indices = self.spec_ssm_src_state_indices_buf[
+                    :batch_size
+                ]
+                spec_conv_src_state_indices = self.spec_conv_src_state_indices_buf[
+                    :batch_size
+                ]
+                spec_conv_src_offset = self.spec_conv_src_offset_buf[:batch_size]
+            elif cg_nonspec:
+                assert self.non_spec_ssm_src_state_indices_buf is not None
+                assert self.non_spec_conv_src_state_indices_buf is not None
+                assert self.non_spec_conv_src_offset_buf is not None
+                if no_src_state:
+                    # No cached state (capture / profiling): NULL-fill buffers.
+                    self.non_spec_ssm_src_state_indices_buf[:batch_size].fill_(
+                        NULL_BLOCK_ID
+                    )
+                    self.non_spec_conv_src_state_indices_buf[:batch_size].fill_(
+                        NULL_BLOCK_ID
+                    )
+                    self.non_spec_conv_src_offset_buf[:batch_size].fill_(0)
+                else:
+                    assert (
+                        align_idx_mapping is not None
+                        and align_src_ssm_col is not None
+                        and align_conv_src_col is not None
+                        and align_conv_src_off is not None
+                    )
+                    self._resolve_align_src_into(
+                        align_idx_mapping,
+                        align_src_ssm_col,
+                        align_conv_src_col,
+                        align_conv_src_off,
+                        m.block_table_tensor,
+                        self.non_spec_ssm_src_state_indices_buf,
+                        self.non_spec_conv_src_state_indices_buf,
+                        self.non_spec_conv_src_offset_buf,
+                        num_decodes,
+                        batch_size,
+                    )
+                non_spec_ssm_src_state_indices = (
+                    self.non_spec_ssm_src_state_indices_buf[:batch_size]
+                )
+                non_spec_conv_src_state_indices = (
+                    self.non_spec_conv_src_state_indices_buf[:batch_size]
+                )
+                non_spec_conv_src_offset = self.non_spec_conv_src_offset_buf[
+                    :batch_size
+                ]
+            elif not for_capture:
+                # Eager / mixed path: no CUDAGraph decode buffer applies (prefill
+                # / mixed / over capture size / non-cudagraph run). Resolve into a
+                # fresh full-batch tensor and split it. The elif chain makes this
+                # mutually exclusive with the cg_* branches above.
+                block_table = m.block_table_tensor
+                num_reqs_full = block_table.size(0)
+                align_ssm_src_full = torch.empty(
+                    num_reqs_full, dtype=torch.int32, device=block_table.device
+                )
+                align_conv_src_full = torch.empty(
+                    num_reqs_full, dtype=torch.int32, device=block_table.device
+                )
+                align_conv_off_full = torch.empty(
+                    num_reqs_full, dtype=torch.int32, device=block_table.device
+                )
+                if align_src_ssm_col is None:
+                    # No cached state (profiling / warmup): all-fresh NULL src.
+                    align_ssm_src_full.fill_(NULL_BLOCK_ID)
+                    align_conv_src_full.fill_(NULL_BLOCK_ID)
+                    align_conv_off_full.fill_(0)
+                else:
+                    assert align_conv_src_col is not None
+                    assert align_conv_src_off is not None
+                    assert align_idx_mapping is not None
+                    self._resolve_align_src_into(
+                        align_idx_mapping,
+                        align_src_ssm_col,
+                        align_conv_src_col,
+                        align_conv_src_off,
+                        block_table,
+                        align_ssm_src_full,
+                        align_conv_src_full,
+                        align_conv_off_full,
+                        align_num_reqs,
+                        num_reqs_full,
+                    )
+                if spec_sequence_masks is None:
+                    # Pure non-spec batch: rows are already in non-spec order.
+                    non_spec_ssm_src_state_indices = align_ssm_src_full
+                    non_spec_conv_src_state_indices = align_conv_src_full
+                    non_spec_conv_src_offset = align_conv_off_full
+                elif num_prefills == 0 and num_decodes == 0:
+                    # Pure spec batch: the spec rows are the contiguous front
+                    # prefix (padded rows are always at the back), so a view
+                    # suffices instead of a boolean-mask gather.
+                    spec_ssm_src_state_indices = align_ssm_src_full[:num_spec_decodes]
+                    spec_conv_src_state_indices = align_conv_src_full[:num_spec_decodes]
+                    spec_conv_src_offset = align_conv_off_full[:num_spec_decodes]
+                else:
+                    # Mixed batch: split by the spec mask.
+                    assert spec_sequence_masks_cpu is not None
+                    spec_ssm_src_state_indices, non_spec_ssm_src_state_indices = (
+                        self._split_align_cache_src_info(
+                            align_ssm_src_full, spec_sequence_masks_cpu
+                        )
+                    )
+                    spec_conv_src_state_indices, non_spec_conv_src_state_indices = (
+                        self._split_align_cache_src_info(
+                            align_conv_src_full, spec_sequence_masks_cpu
+                        )
+                    )
+                    spec_conv_src_offset, non_spec_conv_src_offset = (
+                        self._split_align_cache_src_info(
+                            align_conv_off_full, spec_sequence_masks_cpu
+                        )
+                    )
+
         attn_metadata = GDNAttentionMetadata(
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
@@ -504,6 +847,12 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_token_indx=spec_token_indx,
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
+            spec_ssm_src_state_indices=spec_ssm_src_state_indices,
+            non_spec_ssm_src_state_indices=non_spec_ssm_src_state_indices,
+            spec_conv_src_state_indices=spec_conv_src_state_indices,
+            non_spec_conv_src_state_indices=non_spec_conv_src_state_indices,
+            spec_conv_src_offset=spec_conv_src_offset,
+            non_spec_conv_src_offset=non_spec_conv_src_offset,
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
@@ -533,4 +882,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         num_accepted_tokens = torch.diff(m.query_start_loc)
         num_decode_draft_tokens_cpu = (num_accepted_tokens - 1).cpu()
 
-        return self.build(0, m, num_accepted_tokens, num_decode_draft_tokens_cpu)
+        return self.build(
+            0,
+            m,
+            num_accepted_tokens,
+            num_decode_draft_tokens_cpu,
+            for_capture=True,
+        )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1090,6 +1090,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         sampled_tokens: torch.Tensor,
         num_sampled: torch.Tensor,
         num_rejected: torch.Tensor,
+        num_reqs: int | None = None,
         query_start_loc: torch.Tensor | None = None,
     ) -> None:
         # Update the number of computed tokens.
@@ -1112,7 +1113,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
 
         self.model_state.postprocess_state(
-            idx_mapping, num_sampled, self.req_states.num_computed_tokens.gpu
+            idx_mapping,
+            num_sampled,
+            self.req_states.num_computed_tokens.gpu,
+            num_reqs if num_reqs is not None else idx_mapping.shape[0],
+            query_start_loc,
         )
 
     @torch.inference_mode()
@@ -1178,10 +1183,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # Prepare all the inputs and copy to the input buffers.
             input_batch = self.prepare_inputs(scheduler_output, batch_desc)
             block_tables, slot_mappings = self.prepare_attn(input_batch)
-            # Mamba "align" pre-copy: migrate recurrent state across block
-            # boundaries before the forward. Runs only on real batches, and
-            # before model_state.prepare_attn gathers num_accepted_tokens so the
-            # boundary reset is visible to the attention metadata.
+            # Mamba "align" prefix caching hook: emit per-request src columns
+            # before the forward (real batches only).
             self.model_state.preprocess_state(
                 input_batch,
                 block_tables,
@@ -1455,6 +1458,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             sampler_output.sampled_token_ids,
             num_sampled,
             num_rejected,
+            input_batch.num_reqs,
             input_batch.query_start_loc,
         )
 

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -103,15 +103,16 @@ class ModelState(ABC):
         num_computed_tokens: torch.Tensor,
     ) -> None:
         """Hook run on real batches before the forward pass (after block tables
-        are gathered). Used by mamba "align" prefix caching to pre-copy state
-        across block boundaries. No-op by default."""
+        are gathered). Used by mamba "align" prefix caching. No-op by default."""
         return None
 
     def postprocess_state(
         self,
         idx_mapping: torch.Tensor,
-        num_sampled: torch.Tensor,
+        num_sampled: torch.Tensor | int,
         num_computed_tokens: torch.Tensor | None = None,
+        num_reqs: int | None = None,
+        query_start_loc: torch.Tensor | None = None,
     ) -> None:
         return None
 

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -18,17 +18,62 @@ from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
-from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.gpu.attn_utils import build_attn_metadata
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.model_states.default import DefaultModelState
 from vllm.v1.worker.gpu.model_states.interface import ModelSpecificAttnMetadata
-from vllm.v1.worker.mamba_utils import (
-    MambaSpecDecodeGPUContext,
-    preprocess_mamba_align_fused_kernel,
-)
+from vllm.v1.worker.mamba_utils import postprocess_mamba_fused_kernel
 from vllm.v1.worker.utils import AttentionGroup
+
+
+@triton.jit
+def _preprocess_mamba_fused_kernel(
+    idx_mapping_ptr,
+    state_idx_ptr,
+    num_computed_tokens_ptr,
+    query_start_loc_ptr,
+    num_accepted_tokens_ptr,
+    src_ssm_col_ptr,
+    conv_src_col_ptr,
+    conv_src_off_ptr,
+    num_reqs: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    MAMBA_BLOCK_SIZE: tl.constexpr,
+):
+    """Fused preprocess: compute src columns for SSM/conv AND advance
+    state_idx with accepted-token reset, in a single kernel launch.
+
+    Per batch_idx (0..num_reqs-1):
+      1. Read pre-advance state_idx and num_accepted (last step's values).
+      2. Compute and store src columns for the forward pass:
+         - src_ssm_col = state_idx + num_accepted - 1  (or -1 if fresh)
+         - conv_src_col = state_idx
+         - conv_src_off = max(num_accepted - 1, 0)
+      3. Advance state_idx to the new block and reset num_accepted=1
+         when a block boundary is crossed.
+    """
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_reqs
+    req_indices = tl.load(idx_mapping_ptr + offsets, mask=mask, other=0)
+
+    state_idx = tl.load(state_idx_ptr + req_indices, mask=mask, other=-1)
+    num_accepted = tl.load(num_accepted_tokens_ptr + req_indices, mask=mask, other=1)
+
+    ssm_col = tl.where(state_idx >= 0, state_idx + num_accepted - 1, -1)
+    conv_off = tl.maximum(num_accepted - 1, 0)
+    tl.store(src_ssm_col_ptr + req_indices, ssm_col, mask=mask)
+    tl.store(conv_src_col_ptr + req_indices, state_idx, mask=mask)
+    tl.store(conv_src_off_ptr + req_indices, conv_off, mask=mask)
+
+    num_computed = tl.load(num_computed_tokens_ptr + req_indices, mask=mask, other=0)
+    query_start = tl.load(query_start_loc_ptr + offsets, mask=mask, other=0)
+    query_end = tl.load(query_start_loc_ptr + offsets + 1, mask=mask, other=0)
+    computed_after = num_computed + query_end - query_start
+    new_state_idx = (computed_after + MAMBA_BLOCK_SIZE - 1) // MAMBA_BLOCK_SIZE - 1
+    tl.store(state_idx_ptr + req_indices, new_state_idx, mask=mask)
+    should_reset = (state_idx >= 0) & (state_idx != new_state_idx)
+    tl.store(num_accepted_tokens_ptr + req_indices, 1, mask=mask & should_reset)
 
 
 @dataclass
@@ -36,6 +81,14 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
     is_prefilling: torch.Tensor
     num_accepted_tokens: torch.Tensor | None = None
     num_decode_draft_tokens_cpu: torch.Tensor | None = None
+    # SSM/conv src columns in request-state-slot order (-1 = fresh). gdn_attn
+    # gathers them into batch order via align_idx_mapping and resolves them to
+    # physical block ids, so kernels read init state from the src block directly.
+    align_src_ssm_col: torch.Tensor | None = None
+    align_conv_src_col: torch.Tensor | None = None
+    align_conv_src_off: torch.Tensor | None = None
+    align_idx_mapping: torch.Tensor | None = None
+    align_num_reqs: int = 0
 
     def get_extra_common_attn_kwargs(
         self,
@@ -61,7 +114,51 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
             "num_decode_draft_tokens_cpu": None
             if self.num_decode_draft_tokens_cpu is None
             else self.num_decode_draft_tokens_cpu[:num_reqs],
+            # Src columns are passed unsliced: they are indexed by req-state slot
+            # (which can be >= num_reqs); align_idx_mapping + align_num_reqs drive
+            # the batch-order gather + resolve.
+            "align_src_ssm_col": self.align_src_ssm_col,
+            "align_conv_src_col": self.align_conv_src_col,
+            "align_conv_src_off": self.align_conv_src_off,
+            "align_idx_mapping": self.align_idx_mapping,
+            "align_num_reqs": self.align_num_reqs,
         }
+
+
+class MambaCacheAlignInfo:
+    def __init__(self, max_num_reqs: int, device: torch.device) -> None:
+        self.state_idx_gpu = torch.empty(max_num_reqs, dtype=torch.int32, device=device)
+        # Src columns for SSM and conv (per request slot, -1 = fresh).
+        # SSM: state_idx + (num_accepted - 1); conv: state_idx, offset separately.
+        self.src_ssm_col_gpu = torch.full(
+            (max_num_reqs,), -1, dtype=torch.int32, device=device
+        )
+        self.conv_src_col_gpu = torch.full(
+            (max_num_reqs,), -1, dtype=torch.int32, device=device
+        )
+        self.conv_src_off_gpu = torch.zeros(
+            max_num_reqs, dtype=torch.int32, device=device
+        )
+        self.current_step_block_tables: tuple[torch.Tensor, ...] | None = None
+        self.current_step_kv_cache_config: KVCacheConfig | None = None
+        self.group_kv_cache_config: KVCacheConfig | None = None
+        self.group_ids: list[int] = []
+        self.spec: MambaSpec | None = None
+
+        # Fused postprocess metadata (initialized lazily on first call)
+        self.fused_initialized = False
+        self.fused_state_base_addrs: torch.Tensor | None = None
+        self.fused_state_block_strides: torch.Tensor | None = None
+        self.fused_state_elem_sizes: torch.Tensor | None = None
+        self.fused_state_inner_sizes: torch.Tensor | None = None
+        self.fused_state_conv_widths: torch.Tensor | None = None
+        self.fused_state_group_indices: torch.Tensor | None = None
+        self.fused_state_dim_row_count: torch.Tensor | None = None
+        self.fused_state_dim_row_stride: torch.Tensor | None = None
+        self.fused_block_table_ptrs: torch.Tensor | None = None
+        self.fused_block_table_stride_req: int = 0
+        self.fused_num_layers: int = 0
+        self.fused_num_state_types: int = 0
 
 
 class MambaHybridModelState(DefaultModelState):
@@ -79,89 +176,79 @@ class MambaHybridModelState(DefaultModelState):
         self.num_accepted_tokens_gpu = torch.ones(
             self.max_num_reqs, dtype=torch.int32, device=self.device
         )
-        # Pre-copy "align" prefix-cache state (V2). The migration of each
-        # request's mamba state across block boundaries runs as a fused GPU
-        # kernel reusing the postprocess copy machinery, so the per-step src
-        # columns and the running state_idx are kept GPU-resident.
-        self._align_mode = self.cache_config.mamba_cache_mode == "align"
-        if self._align_mode:
-            self._mamba_state_idx_gpu = torch.zeros(
-                self.max_num_reqs, dtype=torch.int32, device=self.device
+        if self.cache_config.mamba_cache_mode == "align":
+            self.mamba_cache_align_info = MambaCacheAlignInfo(
+                self.max_num_reqs, self.device
             )
-            self._mamba_src_col_gpu = torch.full(
-                (self.max_num_reqs,), -1, dtype=torch.int32, device=self.device
-            )
-            self._mamba_src_off_gpu = torch.zeros(
-                self.max_num_reqs, dtype=torch.int32, device=self.device
-            )
-            self._mamba_ctx: MambaSpecDecodeGPUContext | None = None
-            self._mamba_group_ids: list[int] = []
-            self._mamba_spec: MambaSpec | None = None
 
     def add_request(self, req_index: int, new_req_data: NewRequestData) -> None:
         super().add_request(req_index, new_req_data)
-        if self._align_mode:
-            # Seed the running state block from the resumed/prefilled position.
-            self._mamba_state_idx_gpu[req_index] = (
-                new_req_data.num_computed_tokens - 1
-            ) // self.cache_config.block_size
-            self.num_accepted_tokens_gpu[req_index] = 1
+        if self.cache_config.mamba_cache_mode == "align":
+            state_idx = (new_req_data.num_computed_tokens - 1) // (
+                self.cache_config.block_size
+            )
+            self.mamba_cache_align_info.state_idx_gpu[req_index] = state_idx
+        self.num_accepted_tokens_gpu[req_index] = 1
+
+    @staticmethod
+    def _get_mamba_group_ids(
+        kv_cache_config: KVCacheConfig,
+    ) -> tuple[list[int], MambaSpec]:
+        mamba_group_ids: list[int] = []
+        mamba_specs: list[MambaSpec] = []
+        for i, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
+            spec = kv_cache_group.kv_cache_spec
+            if isinstance(spec, MambaSpec):
+                mamba_group_ids.append(i)
+                mamba_specs.append(spec)
+        assert mamba_specs, "no mamba layers in the model"
+        assert all(mamba_specs[0] == spec for spec in mamba_specs)
+        return mamba_group_ids, mamba_specs[0]
 
     def _get_mamba_group_info(
-        self, kv_cache_config: KVCacheConfig
-    ) -> tuple[list[int], MambaSpec]:
-        if self._mamba_spec is None:
-            group_ids: list[int] = []
-            specs: list[MambaSpec] = []
-            for i, group in enumerate(kv_cache_config.kv_cache_groups):
-                spec = group.kv_cache_spec
-                if isinstance(spec, MambaSpec):
-                    group_ids.append(i)
-                    specs.append(spec)
-            assert specs, "no mamba layers in the model"
-            assert all(specs[0] == s for s in specs)
-            self._mamba_group_ids = group_ids
-            self._mamba_spec = specs[0]
-        return self._mamba_group_ids, self._mamba_spec
-
-    def _ensure_align_ctx(
         self,
         kv_cache_config: KVCacheConfig,
-        mamba_group_ids: list[int],
+    ) -> tuple[list[int], MambaSpec]:
+        info = self.mamba_cache_align_info
+        if info.group_kv_cache_config is not kv_cache_config:
+            mamba_group_ids, mamba_spec = self._get_mamba_group_ids(kv_cache_config)
+            info.group_kv_cache_config = kv_cache_config
+            info.group_ids = mamba_group_ids
+            info.spec = mamba_spec
+        assert info.spec is not None
+        return info.group_ids, info.spec
+
+    def _preprocess_mamba_cache_align(
+        self,
+        input_batch: InputBatch,
         block_tables: tuple[torch.Tensor, ...],
-    ) -> MambaSpecDecodeGPUContext:
-        if self._mamba_ctx is None:
-            copy_funcs = self.model.get_mamba_state_copy_func()
-            # The fused copy kernels shift conv windows assuming the SD layout;
-            # the DS layout cannot express a >0 spec-decode shift as a single
-            # contiguous copy (mirrors get_conv_copy_spec's NotImplementedError).
-            if get_conv_copy_spec in copy_funcs and is_conv_state_dim_first():
-                assert self.vllm_config.speculative_config is None, (
-                    "DS conv state layout does not support mamba align state "
-                    "copies with speculative decoding"
-                )
-            self._mamba_ctx = MambaSpecDecodeGPUContext.create(
-                max_num_reqs=self.max_num_reqs,
-                kv_cache_config=kv_cache_config,
-                num_state_types=len(copy_funcs),
-                device=self.device,
-                make_buffer=lambda n, dtype: CpuGpuBuffer(
-                    n, dtype=dtype, device=self.device
-                ),
-            )
-        ctx = self._mamba_ctx
-        if not ctx.is_initialized:
-            forward_context = self.vllm_config.compilation_config.static_forward_context
-            # block_tables are batch-order slices of the persistent
-            # input_block_tables (stable data_ptr), so the metadata is captured
-            # once here and reused across steps.
-            ctx.initialize_from_forward_context(
-                kv_cache_config,
-                forward_context,
-                self.model.get_mamba_state_copy_func(),
-                [block_tables[gid] for gid in mamba_group_ids],
-            )
-        return ctx
+        kv_cache_config: KVCacheConfig,
+        num_computed_tokens: torch.Tensor,
+    ) -> None:
+        mamba_group_ids, mamba_spec = self._get_mamba_group_info(kv_cache_config)
+        info = self.mamba_cache_align_info
+
+        info.current_step_block_tables = block_tables
+        info.current_step_kv_cache_config = kv_cache_config
+
+        num_reqs = input_batch.num_reqs
+        if num_reqs == 0:
+            return
+        block_size = 256
+        grid = (triton.cdiv(num_reqs, block_size),)
+        _preprocess_mamba_fused_kernel[grid](
+            input_batch.idx_mapping,
+            info.state_idx_gpu,
+            num_computed_tokens,
+            input_batch.query_start_loc,
+            self.num_accepted_tokens_gpu,
+            info.src_ssm_col_gpu,
+            info.conv_src_col_gpu,
+            info.conv_src_off_gpu,
+            num_reqs,
+            BLOCK_SIZE=block_size,
+            MAMBA_BLOCK_SIZE=mamba_spec.block_size,
+        )
 
     def preprocess_state(
         self,
@@ -170,46 +257,133 @@ class MambaHybridModelState(DefaultModelState):
         kv_cache_config: KVCacheConfig,
         num_computed_tokens: torch.Tensor,
     ) -> None:
-        """Migrate each request's mamba state across block boundaries before the
-        forward (V1 align semantics, done on GPU). Runs on real batches only
-        (dummy DP/profiling runs skip preprocess_state), and before
-        ``prepare_attn`` gathers ``num_accepted_tokens``, so the boundary reset
-        is visible to the forward kernels.
-        """
-        if not self._align_mode:
-            return
-        num_reqs = input_batch.num_reqs
-        if num_reqs == 0:
-            return
-        mamba_group_ids, mamba_spec = self._get_mamba_group_info(kv_cache_config)
-        ctx = self._ensure_align_ctx(kv_cache_config, mamba_group_ids, block_tables)
+        if self.cache_config.mamba_cache_mode == "align":
+            self._preprocess_mamba_cache_align(
+                input_batch,
+                block_tables,
+                kv_cache_config,
+                num_computed_tokens,
+            )
 
-        # The state-advance + pre-copy kernels run every step; they fast-exit per
-        # request when src_col < 0 or src_col == dst_col, so no copy happens on
-        # steps that don't cross a block boundary. (Skipping the launch entirely
-        # would need a V1-style async-D2H of the actual num_computed, since
-        # num_computed_tokens_np is an optimistic mirror under async scheduling;
-        # the launch cost is ~0.3% of TPOT, so the GPU fast-exit suffices.)
-        block = 256
-        grid = (triton.cdiv(num_reqs, block),)
-        preprocess_mamba_align_fused_kernel[grid](
-            input_batch.idx_mapping,
-            self._mamba_state_idx_gpu,
-            num_computed_tokens,
-            input_batch.query_start_loc,
-            self.num_accepted_tokens_gpu,
-            self._mamba_src_col_gpu,
-            self._mamba_src_off_gpu,
-            num_reqs,
-            BLOCK_SIZE=block,
-            MAMBA_BLOCK_SIZE=mamba_spec.block_size,
+    def _initialize_fused_postprocess(
+        self,
+        kv_cache_config: KVCacheConfig,
+        mamba_group_ids: list[int],
+        block_tables: tuple[torch.Tensor, ...],
+    ) -> None:
+        info = self.mamba_cache_align_info
+        if info.fused_initialized:
+            return
+
+        forward_context = self.vllm_config.compilation_config.static_forward_context
+        state_copy_funcs = self.model.get_mamba_state_copy_func()
+        num_state_types = len(state_copy_funcs)
+        num_layers = sum(
+            len(kv_cache_config.kv_cache_groups[gid].layer_names)
+            for gid in mamba_group_ids
         )
-        ctx.run_fused_precopy(
+        total_states = num_layers * num_state_types
+
+        base_addrs = torch.zeros(total_states, dtype=torch.int64, device=self.device)
+        block_strides = torch.zeros(total_states, dtype=torch.int64, device=self.device)
+        elem_sizes = torch.zeros(total_states, dtype=torch.int32, device=self.device)
+        inner_sizes = torch.zeros(total_states, dtype=torch.int64, device=self.device)
+        conv_widths = torch.zeros(total_states, dtype=torch.int32, device=self.device)
+        group_indices = torch.zeros(total_states, dtype=torch.int32, device=self.device)
+        # DS conv row metadata (zero keeps the single-region copy path for SD).
+        dim_row_count = torch.zeros(total_states, dtype=torch.int32, device=self.device)
+        dim_row_stride = torch.zeros(
+            total_states, dtype=torch.int64, device=self.device
+        )
+
+        idx = 0
+        for group_local_idx, gid in enumerate(mamba_group_ids):
+            layer_names = kv_cache_config.kv_cache_groups[gid].layer_names
+            for layer_name in layer_names:
+                kv_caches = forward_context[layer_name].kv_cache
+                for st_idx, state in enumerate(kv_caches):
+                    base_addrs[idx] = state.data_ptr()
+                    blk_stride = state.stride(0) if state.dim() > 1 else state.numel()
+                    block_strides[idx] = blk_stride * state.element_size()
+                    elem_sizes[idx] = state.element_size()
+
+                    copy_func = state_copy_funcs[st_idx]
+                    if copy_func is get_conv_copy_spec:
+                        conv_w = state.size(1) if state.dim() > 1 else 0
+                        conv_widths[idx] = conv_w
+                        inner_sizes[idx] = state.stride(1) if state.dim() > 2 else 1
+                    else:
+                        conv_widths[idx] = 0
+                        inner_sizes[idx] = state[0].numel() if state.dim() > 1 else 1
+                    group_indices[idx] = group_local_idx
+                    idx += 1
+
+        num_groups = len(mamba_group_ids)
+        bt_ptrs = torch.zeros(num_groups, dtype=torch.int64, device=self.device)
+        strides = {block_tables[gid].stride(0) for gid in mamba_group_ids}
+        assert len(strides) == 1
+        for i, gid in enumerate(mamba_group_ids):
+            bt_ptrs[i] = block_tables[gid].data_ptr()
+
+        info.fused_state_base_addrs = base_addrs
+        info.fused_state_block_strides = block_strides
+        info.fused_state_elem_sizes = elem_sizes
+        info.fused_state_inner_sizes = inner_sizes
+        info.fused_state_conv_widths = conv_widths
+        info.fused_state_group_indices = group_indices
+        info.fused_state_dim_row_count = dim_row_count
+        info.fused_state_dim_row_stride = dim_row_stride
+        info.fused_block_table_ptrs = bt_ptrs
+        info.fused_block_table_stride_req = int(next(iter(strides)))
+        info.fused_num_layers = num_layers
+        info.fused_num_state_types = num_state_types
+        info.fused_initialized = True
+
+    def _postprocess_mamba_cache_align(
+        self,
+        idx_mapping: torch.Tensor,
+        num_computed_tokens: torch.Tensor,
+        num_reqs: int,
+        query_start_loc: torch.Tensor | None,
+    ) -> None:
+        info = self.mamba_cache_align_info
+        block_tables = info.current_step_block_tables
+        kv_cache_config = info.current_step_kv_cache_config
+        assert block_tables is not None
+        assert kv_cache_config is not None
+        mamba_group_ids, mamba_spec = self._get_mamba_group_info(kv_cache_config)
+
+        self._initialize_fused_postprocess(
+            kv_cache_config, mamba_group_ids, block_tables
+        )
+
+        total_states = info.fused_num_layers * info.fused_num_state_types
+        grid = (num_reqs, total_states)
+
+        postprocess_mamba_fused_kernel[grid](
+            self.num_accepted_tokens_gpu,
+            info.state_idx_gpu,
+            None,
+            num_computed_tokens,
+            None,
+            info.fused_block_table_ptrs,
+            info.fused_block_table_stride_req,
+            info.fused_state_base_addrs,
+            info.fused_state_block_strides,
+            info.fused_state_elem_sizes,
+            info.fused_state_inner_sizes,
+            info.fused_state_conv_widths,
+            info.fused_state_group_indices,
+            info.fused_state_dim_row_count,
+            info.fused_state_dim_row_stride,
+            None,
+            idx_mapping,
             num_reqs,
-            self._mamba_state_idx_gpu,
-            self._mamba_src_col_gpu,
-            self._mamba_src_off_gpu,
-            input_batch.idx_mapping,
+            block_size=mamba_spec.block_size,
+            COPY_BLOCK_SIZE=1024,
+            CONV_STATE_DIM_FIRST=is_conv_state_dim_first(),
+            HAS_IDX_MAPPING=True,
+            PRECOMPUTED_NEW_COMPUTED=True,
         )
 
     def prepare_attn(
@@ -263,10 +437,31 @@ class MambaHybridModelState(DefaultModelState):
                 )
             num_decode_draft_tokens_cpu = torch.from_numpy(num_decode_draft_tokens_np)
 
+        # Copy-free src redirect: pass the req-order src columns + idx_mapping
+        # straight through; gdn_attn does the batch-order gather and resolve (no
+        # advanced-index gathers / padded allocations here).
+        align_src_ssm_col = None
+        align_conv_src_col = None
+        align_conv_src_off = None
+        align_idx_mapping = None
+        align_num_reqs_out = 0
+        if not for_capture and self.cache_config.mamba_cache_mode == "align":
+            info = self.mamba_cache_align_info
+            align_src_ssm_col = info.src_ssm_col_gpu
+            align_conv_src_col = info.conv_src_col_gpu
+            align_conv_src_off = info.conv_src_off_gpu
+            align_idx_mapping = input_batch.idx_mapping
+            align_num_reqs_out = input_batch.num_reqs
+
         mamba_attn_metadata = MambaHybridAttnMetadata(
             is_prefilling=is_prefilling,
             num_accepted_tokens=num_accepted_tokens,
             num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+            align_src_ssm_col=align_src_ssm_col,
+            align_conv_src_col=align_conv_src_col,
+            align_conv_src_off=align_conv_src_off,
+            align_idx_mapping=align_idx_mapping,
+            align_num_reqs=align_num_reqs_out,
         )
         return build_attn_metadata(
             attn_groups=attn_groups,
@@ -292,6 +487,8 @@ class MambaHybridModelState(DefaultModelState):
         idx_mapping: torch.Tensor,
         num_sampled: torch.Tensor | int,
         num_computed_tokens: torch.Tensor | None = None,
+        num_reqs: int | None = None,
+        query_start_loc: torch.Tensor | None = None,
     ) -> None:
         # Chunked prefill does not sample a token, so num_sampled can be 0.
         # Mamba treats num_accepted_tokens=1 as the neutral non-spec value.
@@ -304,29 +501,21 @@ class MambaHybridModelState(DefaultModelState):
                     idx_mapping, num_sampled, self.num_accepted_tokens_gpu
                 )
         else:
-            # Fill with single value.
             self.num_accepted_tokens_gpu.index_fill_(
                 0, idx_mapping, max(num_sampled, 1)
             )
 
-        # Align: save the running state to the block-aligned position when
-        # spec-decode acceptance leaves the sequence non-block-aligned (mirrors
-        # the V1 align postprocess). num_computed_tokens already holds the
-        # post-step advanced count.
         if (
-            self._align_mode
+            self.cache_config.mamba_cache_mode == "align"
             and num_computed_tokens is not None
-            and self._mamba_ctx is not None
+            and num_reqs is not None
         ):
-            num_reqs = idx_mapping.shape[0]
-            if num_reqs:
-                self._mamba_ctx.run_fused_postprocess_align(
-                    num_reqs,
-                    self.num_accepted_tokens_gpu,
-                    self._mamba_state_idx_gpu,
-                    num_computed_tokens,
-                    idx_mapping,
-                )
+            self._postprocess_mamba_cache_align(
+                idx_mapping,
+                num_computed_tokens,
+                num_reqs,
+                query_start_loc,
+            )
 
 
 @triton.jit

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -900,6 +900,12 @@ class GPUModelRunner(
         self.kv_connector_output: KVConnectorOutput | None = None
         self.mamba_state_idx: dict[str, int] = {}
         self._mamba_bufs: mamba_utils.MambaBuffers | None = None
+        # Identity idx_mapping for copy-free align: V1's preprocess_mamba already
+        # stages the src columns in batch order, so an identity arange makes the
+        # fused gather in gdn_attn.build a no-op (resolve-only). Sliced per step.
+        self._mamba_align_identity_idx = torch.arange(
+            self.max_num_reqs, dtype=torch.int32, device=self.device
+        )
         self.mamba_prev_last_scheduled_idx: CpuGpuBuffer | None = None
         if self.cache_config.mamba_cache_mode == "all" and self.num_spec_tokens > 0:
             self.mamba_prev_last_scheduled_idx = self._make_buffer(
@@ -2429,6 +2435,32 @@ class GPUModelRunner(
                     extra_attn_metadata_args["prev_last_scheduled_idx"] = (
                         self.mamba_prev_last_scheduled_idx.gpu[:num_reqs_padded]
                     )
+
+            # Copy-free align (GDN): feed the src columns staged by
+            # preprocess_mamba so build gathers + resolves them to physical
+            # blocks. Applies to non-spec decode too, so it sits outside the
+            # spec-decode guard above. Columns are passed unsliced (padded slots
+            # are -1 = fresh); build reads only align_num_reqs of them and uses
+            # the identity idx_mapping since the columns are already batch-order.
+            if (
+                self.cache_config.mamba_cache_mode == "align"
+                and isinstance(builder, GDNAttentionMetadataBuilder)
+                and self._mamba_bufs is not None
+            ):
+                copy_bufs = self._mamba_bufs.preprocess
+                extra_attn_metadata_args["align_src_ssm_col"] = (
+                    copy_bufs.src_ssm_col_buf.gpu
+                )
+                extra_attn_metadata_args["align_conv_src_col"] = (
+                    copy_bufs.conv_src_col_buf.gpu
+                )
+                extra_attn_metadata_args["align_conv_src_off"] = (
+                    copy_bufs.conv_src_off_buf.gpu
+                )
+                extra_attn_metadata_args["align_idx_mapping"] = (
+                    self._mamba_align_identity_idx[:num_reqs]
+                )
+                extra_attn_metadata_args["align_num_reqs"] = num_reqs
 
             if for_cudagraph_capture:
                 attn_metadata_i = builder.build_for_cudagraph_capture(

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -428,6 +428,12 @@ class MambaCopyBuffers:
     sizes: CpuGpuBuffer
     mamba_group_ids: list[int]
     mamba_spec: MambaSpec
+    # Per-request src columns for the copy-free align path (GDN only), staged by
+    # preprocess_mamba and resolved in GDNAttentionMetadataBuilder.build. Batch
+    # order; -1 == fresh. Unused (but harmless) on the Mamba2 pre-copy path.
+    src_ssm_col_buf: CpuGpuBuffer
+    conv_src_col_buf: CpuGpuBuffer
+    conv_src_off_buf: CpuGpuBuffer
     offset: int = 0
 
     @classmethod
@@ -451,6 +457,9 @@ class MambaCopyBuffers:
             sizes=make_buffer(n, dtype=torch.int32),
             mamba_group_ids=mamba_group_ids,
             mamba_spec=mamba_spec,
+            src_ssm_col_buf=make_buffer(max_num_reqs, dtype=torch.int32),
+            conv_src_col_buf=make_buffer(max_num_reqs, dtype=torch.int32),
+            conv_src_off_buf=make_buffer(max_num_reqs, dtype=torch.int32),
         )
 
 
@@ -751,6 +760,8 @@ class MambaSpecDecodeGPUContext:
             block_size=self.block_size,
             COPY_BLOCK_SIZE=1024,
             CONV_STATE_DIM_FIRST=is_conv_state_dim_first(),
+            HAS_IDX_MAPPING=False,
+            PRECOMPUTED_NEW_COMPUTED=False,
         )
 
     def run_fused_precopy(
@@ -962,17 +973,25 @@ def preprocess_mamba(
     mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
     copy_bufs: MambaCopyBuffers,
 ):
+    """Advance the per-request mamba ``state_idx`` for the current step.
+
+    Copy-free align: no state is copied. Instead we stage the per-request src
+    columns so the forward kernel reads the previous running state directly
+    from its source block (mirrors the V2 fused preprocess).
+    ``src_ssm_col = prev_state_idx + (num_accepted - 1)``,
+    ``conv_src_col = prev_state_idx``, ``conv_src_off = max(num_accepted-1, 0)``.
     """
-    Copy the mamba state of previous step to the last
-    (1 + num_speculative_blocks) block.
-    """
-    mamba_group_ids = copy_bufs.mamba_group_ids
     mamba_spec = copy_bufs.mamba_spec
     num_speculative_blocks = mamba_spec.num_speculative_blocks
     # TODO(Chen): we need to optimize this function a lot
     assert cache_config.enable_prefix_caching
     block_size = mamba_spec.block_size
     cleanup_mamba_state_idx(scheduler_output, mamba_state_idx)
+
+    num_reqs = len(input_batch.req_ids)
+    src_ssm_np = copy_bufs.src_ssm_col_buf.np
+    conv_col_np = copy_bufs.conv_src_col_buf.np
+    conv_off_np = copy_bufs.conv_src_off_buf.np
 
     copy_bufs.offset = 0
     for i, req_id in enumerate(input_batch.req_ids):
@@ -1000,21 +1019,30 @@ def preprocess_mamba(
         # Block 3: speculative block
         # And use block 1 to save the running state.
         curr_state_idx = num_blocks - 1 - num_speculative_blocks
+
+        # Copy-free: record the src columns the forward kernel reads from.
+        # ``num_accepted`` must be read BEFORE the reset below, matching the
+        # V2 fused-preprocess ordering (ssm_col uses last step's value).
+        num_accepted = int(input_batch.num_accepted_tokens_cpu[i])
+        src_ssm_np[i] = prev_state_idx + num_accepted - 1 if prev_state_idx >= 0 else -1
+        conv_col_np[i] = prev_state_idx
+        conv_off_np[i] = max(num_accepted - 1, 0)
+
         mamba_state_idx[req_id] = curr_state_idx
         if prev_state_idx != -1 and prev_state_idx != curr_state_idx:
-            collect_mamba_copy_meta(
-                copy_bufs,
-                kv_cache_config,
-                mamba_state_copy_funcs,
-                mamba_group_ids,
-                prev_state_idx,
-                curr_state_idx,
-                input_batch.num_accepted_tokens_cpu[i] - 1,
-                req_state,
-                forward_context,
-            )
+            # Reset on a block-boundary crossing so the forward kernel writes
+            # the new running state at init slot 0 of the new block (the GPU
+            # mirror is re-synced by the caller).
             input_batch.num_accepted_tokens_cpu[i] = 1
-    do_mamba_copy_block(copy_bufs)
+
+    # Tail-fill padded request slots so the build resolve treats them as
+    # fresh (-1 -> physical NULL block; kernel starts from zero state).
+    src_ssm_np[num_reqs:] = -1
+    conv_col_np[num_reqs:] = -1
+    conv_off_np[num_reqs:] = 0
+    copy_bufs.src_ssm_col_buf.copy_to_gpu()
+    copy_bufs.conv_src_col_buf.copy_to_gpu()
+    copy_bufs.conv_src_off_buf.copy_to_gpu()
 
 
 def postprocess_mamba_all(


### PR DESCRIPTION
Follow-up to the pre-copy align PR https://github.com/vllm-project/vllm/pull/42406 : instead of migrating the mamba/GDN recurrent state across block boundaries with a copy, the forward kernels read the initial state directly from the source block (resolved per request), so no per-boundary state copy is ever issued.

- gdn_attn: `_gather_resolve_align_src_kernel` resolves per-request src columns to physical block ids and feeds them to the GDN forward.
- fla/ops/{fused_recurrent,fused_sigmoid_gating,kda} + causal_conv1d + gdn layers: `SRC_PRERESOLVED` reads init state from the src block (decoupled read/write indices).
- mamba_hybrid / mamba_utils: the preprocess stages the src columns (no copy); the fused postprocess still saves running state across block boundaries.
- V1 (gpu_model_runner) and V2 (model_states) both wired for copy-free.
