### PR TITLE
[Bugfix][Test] Skip test_mla_rope_kvcache_cat_fusion for FlashAttnMLA + fp8 KV cache

### DIFF
--- a/tests/compile/passes/test_mla_rope_kvcache_cat_fusion.py
+++ b/tests/compile/passes/test_mla_rope_kvcache_cat_fusion.py
@@ -272,6 +272,12 @@ def test_mla_rope_kvcache_cat_fusion(
     kv_cache_dtype: str,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    if (
+        attn_backend == AttentionBackendEnum.FLASH_ATTN_MLA
+        and kv_cache_dtype == "fp8"
+    ):
+        pytest.skip("FlashAttnMLA V1 does not support FP8 KV cache yet.")
+
     torch.set_default_device("cuda")
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)


### PR DESCRIPTION
## Purpose

`test_mla_rope_kvcache_cat_fusion` fails on Hopper (sm90) for the `(FLASH_ATTN_MLA, fp8)` parametrization. Closes #46581.

## Root cause

The test parametrizes `kv_cache_dtype` over `["auto", "fp8"]` across all MLA backends in `MLA_BACKENDS`, but `FlashAttnMLA` V1 explicitly raises at backend init:

```
NotImplementedError: FlashAttnMLA V1 with FP8 KV cache not yet supported
```
(`vllm/v1/attention/backends/mla/flashattn_mla.py`)

There's no guard for the `(FLASH_ATTN_MLA, fp8)` combination, so those two cells fail instead of being skipped.

## Fix

Skip that unsupported combination at runtime, mirroring the backend's own capability gate. TRITON_MLA / ROCM_AITER_MLA and the `auto` dtype are unaffected.

## Test

Verified on 1×H20 (sm90): `pytest -k "FLASH_ATTN_MLA"` goes from **2 failed** (the fp8 cells) to **2 passed, 2 skipped** — the `auto` cells still run and pass, the `fp8` cells skip cleanly.
