### PR TITLE
fix(flashinfer): guard trtllm MoE behind x86_64 check

### DIFF
--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -10,6 +10,7 @@ import functools
 import importlib
 import importlib.util
 import os
+import platform
 import shutil
 from collections.abc import Callable
 from typing import Any, NoReturn
@@ -243,6 +244,12 @@ def has_flashinfer_cutedsl() -> bool:
 @functools.cache
 def has_flashinfer_trtllm_fused_moe() -> bool:
     """Return `True` if FlashInfer TRTLLM fused MoE is available."""
+    if platform.machine() != "x86_64":
+        logger.debug_once(
+            "FlashInfer TRTLLM fused MoE unavailable on %s (x86_64 only)",
+            platform.machine(),
+        )
+        return False
     if not has_flashinfer_moe():
         return False
     required_functions = [


### PR DESCRIPTION
Fixes #46861

Add an early return to `has_flashinfer_trtllm_fused_moe()` when `platform.machine() != "x86_64"`.



## Purpose

On aarch64/Grace (B200/GB200), three checks in `_supports_current_device()` all pass:
- `is_cuda()` — True
- `is_device_capability_family(100)` — True, B200 is SM100
- `has_flashinfer_trtllm_fused_moe()` — True, Python symbols exist

So vLLM selects `FLASHINFER_TRTLLM`. During engine init, `kernel_warmup` fires `flashinfer_autotune()`, which runs CUDA graph capture against `trtllm_bf16_moe`. The trtllm MoE cubins are x86_64-only, so the kernel faults with:

```
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```

The fix lives in `has_flashinfer_trtllm_fused_moe()` because all five trtllm kernel classes (`trtllm_bf16_moe.py`, `trtllm_fp8_moe.py`, `trtllm_nvfp4_moe.py`, `trtllm_mxint4_moe.py`, `trtllm_mxfp4_moe.py`) call it. One guard covers all of them. On aarch64 the function returns False, vLLM falls through to Triton.

## Test Plan

- [ ] Tested manually on aarch64/Grace B200 with `--moe-backend flashinfer_trtllm` — engine should now boot and auto-select Triton (I don't have access to the hardware; the reporter **@leopck can verify**)
- [x] `pre-commit run ruff-format ruff-check` passes on changed file (verified locally)

## Test Result

- [x] ruff format and ruff check pass on `vllm/utils/flashinfer.py`
- [ ] aarch64/Grace boot test pending — @leopck to verify

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
