### PR TITLE
[Metrics] Skip unknown metric types in `get_metrics_snapshot()`

### DIFF
--- a/tests/v1/metrics/test_metrics_reader.py
+++ b/tests/v1/metrics/test_metrics_reader.py
@@ -125,3 +125,30 @@ def test_vector_metric(test_registry, num_engines):
         assert m.labels["model"] == "llama"
         assert m.labels["engine_index"] in engine_labels
         engine_labels.remove(m.labels["engine_index"])
+
+
+def test_unknown_metric_type_skipped(test_registry, caplog):
+    """Unknown metric types must be skipped, not raise.
+
+    get_metrics_snapshot() is consumed by both the offline LLM.get_metrics()
+    library API and the ORCA endpoint-load-metrics HTTP response header path.
+    Raising on a future vllm:-prefixed metric of a type the reader doesn't
+    handle (e.g. Summary) would crash these live consumers; graceful skip
+    with a debug log keeps them available. See the parallel pattern in
+    vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py.
+    """
+    prometheus_client.Summary(
+        "vllm:test_summary",
+        "Summary metric the reader does not model",
+        labelnames=["model", "engine_index"],
+        registry=test_registry,
+    )
+
+    with caplog.at_level("DEBUG", logger="vllm.v1.metrics.reader"):
+        metrics = get_metrics_snapshot()
+
+    assert metrics == []
+    assert any(
+        "Skipping unknown metric type summary" in record.getMessage()
+        for record in caplog.records
+    )

--- a/vllm/v1/metrics/reader.py
+++ b/vllm/v1/metrics/reader.py
@@ -7,6 +7,10 @@ from prometheus_client import REGISTRY
 from prometheus_client import Metric as PromMetric
 from prometheus_client.samples import Sample
 
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
 
 @dataclass
 class Metric:
@@ -138,7 +142,12 @@ def get_metrics_snapshot() -> list[Metric]:
                     )
                 )
         else:
-            raise AssertionError(f"Unknown metric type {metric.type}")
+            logger.debug(
+                "Skipping unknown metric type %s for metric %s",
+                metric.type,
+                metric.name,
+            )
+            continue
 
     return collected
 


### PR DESCRIPTION
## Purpose

Fixes #46919. See the issue for the full root-cause analysis and a
statement of why this is not a duplicate of #35649.

`vllm/v1/metrics/reader.py::get_metrics_snapshot()` dispatched over
`metric.type` for every `vllm:`-prefixed entry in
`prometheus_client.REGISTRY` and the trailing `else` branch raised
`AssertionError(\"Unknown metric type ...\")`. The two live consumers
of this reader (`LLM.get_metrics()` and the ORCA
`endpoint-load-metrics` header on `/v1/chat/completions`) would crash
the day any `vllm:`-prefixed metric was added with a prometheus_client
type outside `{gauge, counter, histogram}` (e.g. `Summary`,
`Info`, `untyped`).

Replace the `raise` with a graceful skip + `logger.debug(...)`, matching
the existing unknown-type handling pattern already used in
`vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py:189`,
`:216`, `:451`.

### Relationship to existing work

PR #35649 touches the same line and proposes `raise ValueError(...)`.
That keeps the production hazard (the reader still crashes both live
consumers; it just does so with a different exception class). The
behaviour proposed here (skip, not raise) is materially different: it
prioritises availability for library/header consumers that were never
in a position to read a metric type they have no dataclass for anyway.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/metrics/test_metrics_reader.py -v
```

Adds one regression test `test_unknown_metric_type_skipped` that
registers a `prometheus_client.Summary` (type `\"summary\"`) to the
test registry and asserts that:
- `get_metrics_snapshot()` returns `[]` (no entry surfaced), and
- the reader emits a `DEBUG` log line containing
  `\"Skipping unknown metric type summary\"`.

The first four existing tests are unchanged and continue to pin
behaviour for `Gauge`, `Counter`, `Histogram`, and the
`vllm:spec_decode_num_accepted_tokens_per_pos` `Vector` special case.

## Test Result

```
tests/v1/metrics/test_metrics_reader.py::test_gauge_metric[1] PASSED
tests/v1/metrics/test_metrics_reader.py::test_gauge_metric[4] PASSED
tests/v1/metrics/test_metrics_reader.py::test_counter_metric[1] PASSED
tests/v1/metrics/test_metrics_reader.py::test_counter_metric[4] PASSED
tests/v1/metrics/test_metrics_reader.py::test_histogram_metric[1] PASSED
tests/v1/metrics/test_metrics_reader.py::test_histogram_metric[4] PASSED
tests/v1/metrics/test_metrics_reader.py::test_vector_metric[1] PASSED
tests/v1/metrics/test_metrics_reader.py::test_vector_metric[4] PASSED
tests/v1/metrics/test_metrics_reader.py::test_unknown_metric_type_skipped PASSED
```

Run locally on macOS 14 (arm64) against `main` commit
`867fd5e8ed6b0bfcf84b24f82658c9fb698a6d35`. CI on Linux x86_64 is the
ground truth; behaviours asserted by the existing tests are unchanged
on this platform as well.

`pre-commit run --files vllm/v1/metrics/reader.py tests/v1/metrics/test_metrics_reader.py`
passes (ruff, ruff-format, mypy-3.10, typos, SPDX, forbidden-imports,
no-torch.cuda, validate-config-defaults, attention-backend-docs,
bool-in-with, signoff).

## Why this is not duplicating an existing PR

- This PR is not #35649. #35649 raises a different exception type;
  this PR changes the behaviour to skip-and-log so the live consumers
  (LLM.get_metrics(), ORCA header) no longer crash on an unknown type.
  Issue #46919 captures the additional analysis and the producer-side
  reasoning.

## AI Assistance

This change was investigated and prepared with AI assistance (Claude).
The underlying source locations, dispatch logic, and consumer paths were
reviowed end-to-end by me before submission.

## Out of scope (deferred)

The `vllm:spec_decode_num_accepted_tokens_per_pos` \\\"Ugly ... special
case\\\" inline at `vllm/v1/metrics/reader.py:98` (hard-coupling the
generic reader to a specific metric name by string equality) is left
untouched. It's structure debt worth generalising in a follow-up; it
would inflate this PR's scope without changing the crash behaviour this
PR fixes.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as \"Fix some issue (link existing issues this PR will resolve)\".
- [x] The test plan, such as providing the test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>