### PR TITLE
[CI Bug] Fix h100 `AssertionError: Cold-start child failed`

### DIFF
--- a/tests/compile/h100/test_startup.py
+++ b/tests/compile/h100/test_startup.py
@@ -138,10 +138,10 @@ MODEL_SPECS = [
         ModelStartupSpec(
             model="deepseek-ai/DeepSeek-V3.2",
             hf_overrides=_SMALL_MOE_OVERRIDES,
-            cold_artifacts_saved=4,
+            cold_artifacts_saved=9,
             # https://github.com/vllm-project/vllm/issues/38051
-            warm_artifacts_saved=0 if is_torch_equal_or_newer("2.12.0") else 4,
-            warm_artifacts_loaded=4 if is_torch_equal_or_newer("2.12.0") else 0,
+            warm_artifacts_saved=0 if is_torch_equal_or_newer("2.12.0") else 9,
+            warm_artifacts_loaded=9 if is_torch_equal_or_newer("2.12.0") else 0,
         ),
         id="deepseek_v3.2",
     ),


### PR DESCRIPTION
## Purpose

Introduced by https://github.com/vllm-project/vllm/pull/46862

Now 9 is the correct number

`pytest tests/compile/h100/test_startup.py::test_model_startup[deepseek_v3.2]`

```bash
Process ForkProcess-1:
Traceback (most recent call last):
  File "/home/yewentao256/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/home/yewentao256/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/yewentao256/vllm-source/tests/compile/h100/test_startup.py", line 235, in _cold_start_model
    _check_model_run(vllm_runner, spec, is_cold_start=True)
  File "/home/yewentao256/vllm-source/tests/compile/h100/test_startup.py", line 228, in _check_model_run
    assert saved == expected_saved, f"{start_type.lower()}_artifacts_saved: got {saved}"
AssertionError: cold_artifacts_saved: got 9
assert 9 == 4
```

Now

```bash
======================= 1 passed, 17 warnings in 83.31s (0:01:23) =======================
```
