### PR TITLE
[Hardware][AMD][CI] Patch Whisper multi LoRA test to use TRITON_ATTN for now

### DIFF
--- a/tests/lora/test_whisper.py
+++ b/tests/lora/test_whisper.py
@@ -12,6 +12,7 @@ import pytest
 import vllm
 from vllm.assets.audio import AudioAsset
 from vllm.lora.request import LoRARequest
+from vllm.platforms import current_platform
 
 from ..utils import create_new_process_for_each_test
 
@@ -30,7 +31,9 @@ def use_spawn_for_whisper(monkeypatch):
     monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 
 
-def create_whisper_llm(enable_lora: bool = True, max_loras: int = 2):
+def create_whisper_llm(
+    enable_lora: bool = True, max_loras: int = 2, attn_backend: str | None = None
+):
     """Create a Whisper LLM instance with optional LoRA support."""
     return vllm.LLM(
         model=WHISPER_MODEL,
@@ -40,6 +43,7 @@ def create_whisper_llm(enable_lora: bool = True, max_loras: int = 2):
         max_model_len=448,
         dtype="half",
         enforce_eager=True,  # For stability in tests
+        attention_config={"backend": attn_backend},
     )
 
 
@@ -109,7 +113,11 @@ def test_whisper_multi_lora(whisper_lora_files):
     This test verifies that the same LoRA adapter can be loaded with
     different IDs and produce consistent results.
     """
-    llm = create_whisper_llm(enable_lora=True, max_loras=4)
+    llm = create_whisper_llm(
+        enable_lora=True,
+        max_loras=4,
+        attn_backend="TRITON_ATTN" if current_platform.is_rocm() else None,
+    )
 
     # Test with different LoRA IDs using the same adapter
     outputs_lora1 = run_whisper_inference(llm, lora_path=whisper_lora_files, lora_id=1)


### PR DESCRIPTION


## Purpose
This PR temporarily patches `tests/lora/test_whisper.py::test_whisper_multi_lora` to use `TRITON_ATTN`, as this test is currently failing on `main` and blocking CI. This test started failing after https://github.com/vllm-project/vllm/pull/46780, which had the effect of switching the test from using `ROCM_AITER_UNIFIED_ATTN` to `ROCM_ATTN` (because the former currently does not support FP16 dtypes after the AITER bump).

It remains under investigation why `ROCM_ATTN` leads to output divergence compared to the other attention backends in this test.

## Test Plan
`pytest -sv tests/lora/test_whisper.py::test_whisper_multi_lora`
This is run as part of `AMD: LoRA Tests 4` in CI.

## Test Result
The above test passes.

cc @AndreasKaratzas 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

