### PR TITLE
[Bugfix][GB10] Fix negative CUDA graph memory estimate on unified-memory GPUs (#44740)

### DIFF
--- a/.buildkite/hardware_tests/dgx_spark.yaml
+++ b/.buildkite/hardware_tests/dgx_spark.yaml
@@ -1,0 +1,23 @@
+group: Hardware
+steps:
+  - label: "DGX Spark UMA Memory Invariant"
+    key: dgx-spark-uma-mem
+    timeout_in_minutes: 20
+    device: dgx-spark
+    optional: true
+    soft_fail: true
+    num_devices: 1
+    depends_on:
+      - arm64-image-build
+    # Trigger only on the code this invariant actually guards: UMA detection
+    # (platform resolution + is_integrated_gpu) and the free-memory correction,
+    # plus the test itself. Build-wide changes still reach it via run_all.
+    source_file_dependencies:
+      - vllm/platforms/__init__.py
+      - vllm/platforms/cuda.py
+      - vllm/platforms/interface.py
+      - vllm/utils/mem_utils.py
+      - tests/utils_/test_mem_utils_hardware.py
+    commands:
+      - nvidia-smi
+      - pytest -s -v utils_/test_mem_utils_hardware.py

--- a/tests/utils_/test_mem_utils.py
+++ b/tests/utils_/test_mem_utils.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 import torch
 from vllm_test_utils.monitor import monitor
 
-from vllm.utils.mem_utils import MemorySnapshot, memory_profiling
+from vllm.utils.mem_utils import (
+    MemorySnapshot,
+    get_device_memory_info,
+    memory_profiling,
+)
 
 from ..utils import create_new_process_for_each_test
 
@@ -103,6 +107,51 @@ def test_memory_snapshot_uses_psutil_on_integrated_gpu():
         assert snapshot.free_memory == mock_psutil_available
         assert snapshot.total_memory == mock_cuda_total
         mock_psutil.virtual_memory.assert_called_once()
+
+
+def test_get_device_memory_info_integrated_uses_psutil():
+    """On integrated (UMA) GPUs the free reading must come from psutil, not the
+    underreporting cudaMemGetInfo value."""
+    mock_cuda_free = 40 * 1024**3
+    mock_cuda_total = 120 * 1024**3
+    mock_psutil_available = 100 * 1024**3
+
+    with (
+        patch("vllm.utils.mem_utils.current_platform") as mock_platform,
+        patch("vllm.utils.mem_utils.psutil") as mock_psutil,
+        patch("torch.accelerator") as mock_accelerator,
+    ):
+        mock_accelerator.get_memory_info.return_value = (
+            mock_cuda_free,
+            mock_cuda_total,
+        )
+        mock_platform.is_integrated_gpu.return_value = True
+        mock_vmem = MagicMock()
+        mock_vmem.available = mock_psutil_available
+        mock_psutil.virtual_memory.return_value = mock_vmem
+
+        assert get_device_memory_info("cuda:0")[0] == mock_psutil_available
+        mock_psutil.virtual_memory.assert_called_once()
+
+
+def test_get_device_memory_info_discrete_is_noop():
+    """On discrete GPUs the helper is an exact no-op: raw get_memory_info, no psutil."""
+    mock_cuda_free = 70 * 1024**3
+    mock_cuda_total = 80 * 1024**3
+
+    with (
+        patch("vllm.utils.mem_utils.current_platform") as mock_platform,
+        patch("vllm.utils.mem_utils.psutil") as mock_psutil,
+        patch("torch.accelerator") as mock_accelerator,
+    ):
+        mock_accelerator.get_memory_info.return_value = (
+            mock_cuda_free,
+            mock_cuda_total,
+        )
+        mock_platform.is_integrated_gpu.return_value = False
+
+        assert get_device_memory_info("cuda:0")[0] == mock_cuda_free
+        mock_psutil.virtual_memory.assert_not_called()
 
 
 def test_memory_snapshot_uses_cuda_on_discrete_gpu():

--- a/tests/utils_/test_mem_utils_hardware.py
+++ b/tests/utils_/test_mem_utils_hardware.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Hardware-gated UMA (integrated-GPU) memory invariants.
+
+Runs only on a real integrated GPU (e.g. the DGX Spark / GB10 CI lane) and is
+skipped everywhere else. Guards the premise behind the UMA free-memory
+correction used by ``get_device_memory_info`` and
+``release_device_memory_under_pressure`` in ``vllm/utils/mem_utils.py``.
+"""
+
+import psutil
+import pytest
+import torch
+
+
+def _on_integrated_gpu() -> bool:
+    # Gate on the raw device property rather than vLLM's wrapper, so a regression
+    # in ``current_platform.is_integrated_gpu`` makes the test FAIL below instead
+    # of silently skipping.
+    try:
+        return (
+            torch.cuda.is_available()
+            and torch.cuda.get_device_properties(0).is_integrated
+        )
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _on_integrated_gpu(), reason="integrated (UMA) GPU hardware only"
+)
+def test_integrated_gpu_free_memory_underreport():
+    from vllm.platforms import current_platform
+
+    # vLLM must classify this UMA device as integrated; otherwise the free-memory
+    # correction silently no-ops and KV/cudagraph sizing can OOM (see #44740).
+    assert current_platform.is_integrated_gpu(0) is True
+
+    cuda_free = torch.accelerator.get_memory_info(0)[0]
+    psutil_available = psutil.virtual_memory().available
+
+    # On UMA, get_memory_info() reports only physically-free memory (== MemFree)
+    # and excludes reclaimable OS memory, while psutil.available (== MemAvailable)
+    # counts it. MemAvailable >= MemFree is a kernel invariant, so psutil is the
+    # truer, never-smaller allocatable figure -- which is why the correction
+    # exists. Assert the direction (deterministic); log the magnitude (varies).
+    gap_gib = (psutil_available - cuda_free) / 1024**3
+    print(
+        f"UMA free-memory underreport: get_memory_info="
+        f"{cuda_free / 1024**3:.1f} GiB vs psutil="
+        f"{psutil_available / 1024**3:.1f} GiB (gap {gap_gib:.1f} GiB)"
+    )
+    assert psutil_available >= cuda_free, (cuda_free, psutil_available)

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -48,6 +48,21 @@ def get_cpu_memory() -> int:
     return psutil.virtual_memory().total
 
 
+def get_device_memory_info(device: torch.types.Device) -> tuple[int, int]:
+    """Returns (free, total) device memory in bytes, with the UMA correction.
+
+    Like ``torch.accelerator.get_memory_info`` but, on integrated (UMA) GPUs
+    where cudaMemGetInfo underreports free memory, the free value comes from
+    ``psutil.virtual_memory().available`` instead (no-op on discrete/non-cuda).
+    https://docs.nvidia.com/cuda/cuda-for-tegra-appnote/#estimating-total-allocatable-device-memory-on-an-integrated-gpu-device
+    """
+    device = torch.device(device)
+    free_memory, total_memory = torch.accelerator.get_memory_info(device)
+    if current_platform.is_integrated_gpu(device.index):
+        free_memory = psutil.virtual_memory().available
+    return free_memory, total_memory
+
+
 _UMA_PRESSURE_THRESHOLD = 0.8
 _UMA_MIN_RELEASE_BYTES = 512 * MiB_bytes
 
@@ -143,15 +158,8 @@ class MemorySnapshot:
             "allocated_bytes.all.peak", 0
         )
 
-        self.free_memory, self.total_memory = torch.accelerator.get_memory_info(device)
-        if current_platform.is_integrated_gpu(device.index):
-            # On UMA (Unified Memory Architecture) platforms where CPU and
-            # GPU share physical memory (e.g. GH200, DGX Spark, Jetson Orin),
-            # cudaMemGetInfo underreports free memory because it does not
-            # account for reclaimable OS memory (page cache, buffers).
-            # Use psutil to get the true available memory.
-            # https://docs.nvidia.com/cuda/cuda-for-tegra-appnote/#estimating-total-allocatable-device-memory-on-an-integrated-gpu-device
-            self.free_memory = psutil.virtual_memory().available
+        # Free/total device memory, with the UMA free-memory correction.
+        self.free_memory, self.total_memory = get_device_memory_info(device)
 
         self.cuda_memory = self.total_memory - self.free_memory
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -46,7 +46,11 @@ from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
 from vllm.utils.math_utils import cdiv
-from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
+from vllm.utils.mem_utils import (
+    DeviceMemoryProfiler,
+    format_gib,
+    get_device_memory_info,
+)
 from vllm.utils.torch_utils import PIN_MEMORY, STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
@@ -701,7 +705,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         start_time = time.perf_counter()
         gc.collect()
         torch.accelerator.empty_cache()
-        start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+        start_free_gpu_memory = get_device_memory_info(self.device)[0]
 
         with self.maybe_setup_dummy_loras(self.lora_config):
             attn_states = self.cudagraph_manager.capture(
@@ -720,9 +724,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.speculator.capture(attn_states)
 
         end_time = time.perf_counter()
-        end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+        end_free_gpu_memory = get_device_memory_info(self.device)[0]
         elapsed_time = end_time - start_time
-        cuda_graph_size = start_free_gpu_memory - end_free_gpu_memory
+        # Clamp to >= 0: UMA free memory can rise across a capture (see
+        # get_device_memory_info); a negative size would log a wrong value.
+        cuda_graph_size = max(start_free_gpu_memory - end_free_gpu_memory, 0)
         # This usually takes 5~20 seconds.
         logger.info(
             "Graph capturing finished in %.0f secs, took %.2f GiB",

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6639,7 +6639,7 @@ class GPUModelRunner(
         with self._freeze_gc(), graph_capture(device=self.device):
             torch.accelerator.synchronize()
             torch.accelerator.empty_cache()
-            start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+            start_free_gpu_memory = get_device_memory_info(self.device)[0]
 
             for (
                 runtime_mode,
@@ -6657,7 +6657,7 @@ class GPUModelRunner(
                 self.encoder_cudagraph_manager.capture(graph_pool=encoder_graph_pool)
 
             torch.accelerator.synchronize()
-            end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+            end_free_gpu_memory = get_device_memory_info(self.device)[0]
 
         # Disable cudagraph capturing globally, so any unexpected cudagraph
         # capturing will be detected and raise an error after here.
@@ -6675,7 +6675,10 @@ class GPUModelRunner(
 
         end_time = time.perf_counter()
         elapsed_time = end_time - start_time
-        cuda_graph_size = start_free_gpu_memory - end_free_gpu_memory
+        # Clamp to >= 0: on UMA free memory can rise across a capture, so a
+        # negative size would understate non-KV memory in the logged
+        # --kv-cache-memory suggestion (mirrors profile_cudagraph_memory).
+        cuda_graph_size = max(start_free_gpu_memory - end_free_gpu_memory, 0)
         # This usually takes 5~20 seconds.
         logger.info_once(
             "Graph capturing finished in %.0f secs, took %.2f GiB",

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -113,7 +113,11 @@ from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
 from vllm.tracing import instrument
 from vllm.utils import length_from_prompt_token_ids_or_embeds
 from vllm.utils.math_utils import cdiv, round_up
-from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
+from vllm.utils.mem_utils import (
+    DeviceMemoryProfiler,
+    format_gib,
+    get_device_memory_info,
+)
 from vllm.utils.nvtx_pytorch_hooks import PytHooks
 from vllm.utils.platform_utils import num_compute_units
 from vllm.utils.torch_utils import (
@@ -6527,7 +6531,7 @@ class GPUModelRunner(
                     mem_samples: list[int] = []
 
                     for i, desc in enumerate(profile_descs):
-                        mem_before = torch.accelerator.get_memory_info()[0]
+                        mem_before, _ = get_device_memory_info(self.device)
                         self._warmup_and_capture(
                             desc,
                             cudagraph_runtime_mode=mode,
@@ -6541,8 +6545,11 @@ class GPUModelRunner(
                             ),
                         )
                         torch.accelerator.synchronize()
-                        free_after = torch.accelerator.get_memory_info()[0]
-                        mem_samples.append(mem_before - free_after)
+                        free_after, _ = get_device_memory_info(self.device)
+                        # Clamp to >= 0 (mirrors the encoder path below): on UMA
+                        # free memory can rise across a capture, and a negative
+                        # delta would inflate KV cache downstream and risk OOM.
+                        mem_samples.append(max(mem_before - free_after, 0))
 
                     first_capture = mem_samples[0]
                     # Use at least 1 MiB per graph for driver overhead
@@ -6563,10 +6570,10 @@ class GPUModelRunner(
                     )
 
                 if encoder_cudagraph_manager is not None:
-                    mem_before = torch.accelerator.get_memory_info()[0]
+                    mem_before, _ = get_device_memory_info(self.device)
                     encoder_cudagraph_manager.capture(graph_pool=encoder_profiling_pool)
                     torch.accelerator.synchronize()
-                    free_after = torch.accelerator.get_memory_info()[0]
+                    free_after, _ = get_device_memory_info(self.device)
                     encoder_memory_estimate = max(mem_before - free_after, 0)
 
                     logger.debug(


### PR DESCRIPTION

## Purpose

On UMA GPUs (GB10 / DGX Spark), MTP spec-decode logs a **negative** CUDA-graph memory estimate (e.g. `-35.69 GiB`). It is then *subtracted* in `determine_available_memory`, so a negative **inflates** the KV budget → OOM (silently, since the warning is gated on `estimate > 0`). Issue #44740. 

If the reviewer agrees & merges this PR, we can close #44745 #44740

## Background (skip this if you are familiar with vllm memory budget)

At startup vLLM decides how much memory to give the KV cache. Part of that is reserving room for CUDA graphs (captured replayable kernel sequences). GPUModelRunner.profile_cudagraph_memory() measures this by reading free GPU memory before and after a capture and taking the difference:
```
estimate ≈ free_before − free_after        # how much the capture consumed
```
The worker then sizes the KV cache as:
```
available_kv = requested − non_kv_memory − cudagraph_estimate
```
**Unified memory (UMA)**: on integrated GPUs (NVIDIA GB10 / DGX Spark, GH200, Jetson) the CPU and GPU share one physical pool. There, cudaMemGetInfo underreports free memory (it ignores reclaimable OS memory) and is non-monotonic — successive reads can go up as well as down. vLLM already knows this: `MemorySnapshot.measure()` in `vllm/utils/mem_utils.py` swaps in `psutil.virtual_memory()`.available when `current_platform.is_integrated_gpu()`

## Root cause
`profile_cudagraph_memory` reads free memory with raw `torch.cuda.mem_get_info()`, bypassing the UMA correction vLLM already uses everywhere else (`MemorySnapshot.measure` substitutes `psutil.virtual_memory().available` when `is_integrated_gpu()`). On UMA `cudaMemGetInfo` underreports and is non-monotonic, and the decoder per-sample delta was appended unclamped (the encoder path already clamped).

Fix:

- Add `get_device_memory_info(device) -> (free, total)` in `mem_utils.py` applying the existing UMA/psutil correction in one place (no-op on discrete GPUs); `MemorySnapshot.measure` now uses it.
- Route the cudagraph profiler's reads through it (estimate is now *correct* on UMA, not just non-negative) and clamp the decoder delta to match the encoder.

Not a duplicate: #44745/#45076 only clamp (estimate collapses to ≈0 on UMA — still wrong); #36720/#39977 skip the feature on ROCm/XPU. This corrects the reading.

## Test Plan / Result


**Root cause is observable on UMA hardware** — `cudaMemGetInfo` underreports free memory vs. reality (the baseline the profiler subtracts against). On a GB10:

```python
import psutil, torch
free, _ = torch.cuda.mem_get_info() # same with torch.accelerator.get_memory_info()
print(free >> 30, "GiB  vs psutil", psutil.virtual_memory().available >> 30, "GiB")
# -> 78 GiB  vs psutil 115 GiB   (cudaMemGetInfo underreports ~36 GiB)
```

**The negative estimate is not stably reproducible**, because it's a before/after *diff*. A steady ~36 GiB underreport cancels in the subtraction; the estimate only flips negative when the gap *shifts during a capture* (page migration / a large mid-capture free), which is intermittent and version-dependent (note ~36 GiB ≈ the reporter's `-35.69 GiB`). Our unforced runs all came out positive (+0.3 GiB). So the end-to-end check below uses a deterministic injection of that mid-capture shift (patching `mem_get_info` to report rising free), which only affects the unpatched profiler path.

## ModelRunner V2

V2's `profile_cudagraph_memory` is currently a stub 
https://github.com/vllm-project/vllm/blob/11a12305c0522c5c1ed273d7d3dc2304ac0cd495/vllm/v1/worker/gpu/model_runner.py#L686-L688
, so it computes no estimate and #44740 cannot occur there — no change needed. The fix lives in the shared `mem_utils` helper, so when V2 implements the estimate it can route through `get_device_memory_info` to stay UMA-correct.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

