### PR TITLE
[Bugfix][Tool Parser] Fix granite4 streaming dropping content after a single-delta tool call

### DIFF
--- a/tests/tool_parsers/test_granite4_tool_parser.py
+++ b/tests/tool_parsers/test_granite4_tool_parser.py
@@ -145,3 +145,46 @@ def test_tool_call_parser_complex(min_chunk: int, max_chunk: int, tokenizer):
 
     assert content == "".join(text_messages)
     assert tool_calls == create_complex_input(False)
+
+
+def test_streaming_preserves_content_between_complete_tool_calls(tokenizer):
+    """Content in a delta that follows a tool call completed in a single delta
+    must not be dropped.
+
+    Regression: when both the start and end tool-call tokens arrived in the same
+    delta, the "entering a tool call" branch reset a misspelled attribute
+    (``start_in_tc``) instead of ``in_tc``, leaving the parser stuck
+    ``in_tc=True``. The next delta's leading assistant content then fell through
+    to the end-token branch and was silently discarded.
+    """
+    any_chat_request = ChatCompletionRequest(seed=42, model=MODEL, messages=[])
+    parser = Granite4ToolParser(tokenizer=tokenizer)
+
+    # Delta 1: a complete tool call. Delta 2: content, then another tool call.
+    deltas = [
+        '<tool_call> {"name": "find_bbox", "arguments": {}} </tool_call>',
+        "some explanation "
+        '<tool_call> {"name": "get_stock_price", "arguments": {}} </tool_call>',
+    ]
+
+    content = ""
+    tool_names = list[str]()
+    for text in deltas:
+        delta = parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text="",
+            delta_text=text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=any_chat_request,
+        )
+        if delta is not None:
+            if delta.content:
+                content += delta.content
+            for tool_call in delta.tool_calls:
+                if tool_call.function and tool_call.function.name:
+                    tool_names.append(tool_call.function.name)
+
+    assert "some explanation" in content
+    assert tool_names == ["find_bbox", "get_stock_price"]

--- a/vllm/tool_parsers/granite4_tool_parser.py
+++ b/vllm/tool_parsers/granite4_tool_parser.py
@@ -182,7 +182,7 @@ class Granite4ToolParser(ToolParser):
 
             content = delta_text[:start_token_pos]
             if end_token_pos > 0:
-                self.start_in_tc = False
+                self.in_tc = False
                 tc_text = delta_text[start_token_end:end_token_pos]
                 self.look_ahead = delta_text[end_token_end:]
                 done = False  # There could be more content already buffered


### PR DESCRIPTION
## Purpose

The granite4 tool parser silently **drops assistant content that appears between tool calls** when streaming, if a tool call completes within a single delta.

**Root cause:** in `Granite4ToolParser._tool_extraction_step`, the "entering a new tool call" branch sets `self.in_tc = True`, then — when the `</tool_call>` end token is present in the *same* delta — resets `self.start_in_tc` instead of `self.in_tc`. `start_in_tc` is defined nowhere and read nowhere in the codebase (`grep` finds exactly one occurrence: this assignment), so it is a no-op typo. The parser is left stuck `in_tc=True`; the next delta's leading content then falls into the end-token branch and is discarded. The sibling end-of-tool-call branch a few lines below correctly sets `self.in_tc = False`.

```diff
             if end_token_pos > 0:
-                self.start_in_tc = False
+                self.in_tc = False
```

## Test Plan

Added `test_streaming_preserves_content_between_complete_tool_calls` to `tests/tool_parsers/test_granite4_tool_parser.py`. It streams two deltas — a complete tool call, then assistant content followed by another tool call — and asserts the intervening content is preserved and both tool calls are emitted.

The existing `test_tool_call_parser_complex` only feeds 1–20 char random chunks, so a complete `<tool_call>...</tool_call>` never lands in a single delta and the affected branch was never covered.

```
pytest tests/tool_parsers/test_granite4_tool_parser.py
```

## Test Result

**Before the fix** (new test fails — content is dropped):
```
>       assert "some explanation" in content
E       AssertionError: assert 'some explanation' in ''
```

**After the fix** (new test passes; existing `test_tool_call_parser_complex` still passes):
```
tests/tool_parsers/test_granite4_tool_parser.py::test_streaming_preserves_content_between_complete_tool_calls PASSED
```
