### PR TITLE
[WIP][Perf] AsyncTP fusion for dynamic per-group FP8 scaled_mm + comms

### DIFF
--- a/tests/compile/passes/distributed/test_async_tp_pergroup_fp8.py
+++ b/tests/compile/passes/distributed/test_async_tp_pergroup_fp8.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""AsyncTP fusion: dynamic per-group (block-wise) FP8 scaled_mm + comms.
+
+WIP. Tracks the `scaled_mm+comms` row, dynamic per-group FP8 variant in the
+central fusion tracker (#36066), currently marked not supported across
+sm100/sm90/ROCm.
+
+Existing AsyncTP FP8 coverage:
+- per-tensor (scalar) FP8 via the FlashInfer bmm_fp8 path (#39505)
+- per-token / row-wise FP8 via ScaledMMReduceScatterPattern /
+  AllGatherScaledMMPattern (scale_a=[M,1], scale_b=[1,N])
+
+Gap targeted here: block-wise scales (scale_a=[M, K/group_size],
+scale_b=[N/group_size, K/group_size], e.g. group_size=128). The fused
+collective path is scalar-only today: the symm-mem adapter asserts
+A_scale.numel()==1 and B_scale.numel()==1, and no registered pattern matches
+block-wise scale shapes.
+
+This module will hold the correctness check (fused block-wise scaled_mm +
+reduce_scatter / all_gather vs the unfused quant -> block scaled_mm ->
+reduce_scatter reference) once the pattern + fused path land.
+"""
+
+import pytest
+
+pytest.skip(
+    "WIP: per-group FP8 scaled_mm+comms AsyncTP fusion not implemented yet "
+    "(see #36066).",
+    allow_module_level=True,
+)


### PR DESCRIPTION
## WIP: AsyncTP fusion for dynamic per-group (block-wise) FP8 scaled_mm + comms

Draft / work in progress. Opening early to signal this is being worked on.

Targets the `scaled_mm+comms` row, dynamic per-group FP8 variant in the central fusion tracker #36066, currently marked not supported (kernel wanted) across sm100/sm90/ROCm. A tracked sub-issue will be filed and linked shortly; this PR is the implementation branch.

### Context

`AsyncTPPass` (`vllm/compilation/passes/fusion/collective_fusion.py`) already fuses FP8 GEMM with reduce-scatter / all-gather for:
- per-tensor (scalar) FP8, via the FlashInfer `bmm_fp8` path (#39505)
- per-token / row-wise FP8 (`scale_a=[M,1]`, `scale_b=[1,N]`), via `ScaledMMReduceScatterPattern` / `AllGatherScaledMMPattern` and the `cutlass_scaled_mm` variants

Dynamic per-group (block-wise) FP8 (`scale_a=[M, K/group_size]`, `scale_b=[N/group_size, K/group_size]`, e.g. `group_size=128`) is not handled. The fused collective path is scalar-only today: the symm-mem adapter asserts `A_scale.numel()==1 and B_scale.numel()==1`, and no registered pattern matches block-wise scale shapes. Block-wise models fall back to an unfused `quant -> scaled_mm -> reduce_scatter` and lose the collective/matmul overlap.

In-tree block-wise FP8 GEMM already exists (`vllm/model_executor/layers/quantization/utils/fp8_utils.py`, `cutlass_block_fp8_supported`, `w8a8_block_fp8_linear`), so the local compute half is solved. Missing piece: a block-scale-aware fused GEMM + reduce-scatter / all-gather, plus the pattern-match registration.

### Plan

1. Pattern match for block-wise scale shapes (reduce-scatter + all-gather).
2. Block-scale-aware fused scaled-matmul + collective (the torch symm-mem path is scalar-only, so this needs either a symm-mem extension or a vLLM-side fused op on the in-tree block-wise GEMM).
3. Gate behind a working block-wise FP8 GEMM backend; leave row-wise / per-tensor paths unchanged.
4. Correctness test vs the unfused reference + an overlap/throughput benchmark at TP.

### Status

Skipped test scaffold only at this point. Implementation to follow. Feedback on the preferred route for carrying per-group scales through the fused collective (extend PyTorch symm-mem vs vLLM-side fused op) is welcome.

Related: #36066, #39505.
