### PR TITLE
[Kernel][Test] Enable HND layout testing for Triton reshape_and_cache…

### DIFF
--- a/benchmarks/kernels/benchmark_reshape_and_cache_flash.py
+++ b/benchmarks/kernels/benchmark_reshape_and_cache_flash.py
@@ -46,8 +46,6 @@ def run_benchmark(
             f"Unsupported implementation: {implementation}. "
             "Only 'cuda' and 'triton' are supported."
         )
-    if implementation == "triton" and kv_cache_layout == "HND":
-        return float("nan")  # Triton does not support HND layout yet.
 
     set_random_seed(42)
     torch.set_default_device(device)

--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -196,8 +196,6 @@ def test_reshape_and_cache_flash(
     torch.set_default_device(device)
     torch.accelerator.set_device_index(device)
     assert implementation in ["cuda", "triton"]
-    if implementation == "triton" and kv_cache_layout == "HND":
-        pytest.skip("Triton implementation only supports NHD layout.")
 
     if kv_scale_type == "attn_head" and implementation != "cuda":
         pytest.skip("Only CUDA implementation supports attn_head scaling.")


### PR DESCRIPTION
# [Kernel][Test] Enable HND layout testing for Triton `reshape_and_cache_flash`

## Purpose

The Triton implementation of `reshape_and_cache_flash` already supports the
**HND** (head-major) KV-cache layout correctly, but two stale guards skip that
combination as if it were unsupported:

- `tests/kernels/attention/test_cache.py` — `pytest.skip("Triton implementation only supports NHD layout.")`
- `benchmarks/kernels/benchmark_reshape_and_cache_flash.py` — `return float("nan")  # Triton does not support HND layout yet.`

These guards date back to the kernel's introduction (#24503) and are no longer
accurate. The kernel computes its destination index purely from the cache
tensor's **strides**:

```python
tgt_idx_k = (block_idx * block_stride
             + block_offset * page_stride
             + cur_head * head_stride
             + cur_dim)
```

`block_stride`, `page_stride`, and `head_stride` are read directly from
`key_cache.stride()`, so the 4-D code path handles NHD and HND identically —
HND is simply a 4-D tensor with head-major strides (e.g. shape
`(num_blocks, block_size, num_heads, head_size)`, stride
`(.., 128, 2048, 1)`). The `ndim == 5` head-major branch is a separate legacy
layout and is unaffected.

This matters because **HND is the default KV-cache layout for several
production paths** (FlashInfer, KV-cache offloading, and NIXL/hetero-TP KV
transfer), so the Triton backend on HND is a real, exercised code path that was
not being validated.

## Modifications

Remove the two stale `triton + HND` guards. No kernel code is changed — the
kernel already supports HND. Removing the test skip lets the existing
parametrized matrix validate Triton + HND; removing the benchmark guard makes
the benchmark report real numbers instead of `NaN`.

The legitimate CUDA-only skips (`nvfp4`, `attn_head` per-head scaling) are
**left intact** — they have their own separate guards and are not affected.

## Test Plan

```
pytest tests/kernels/attention/test_cache.py \
  -k "reshape_and_cache_flash and triton and HND" -v
```

Also verified the Triton output is bitwise-identical to the CUDA reference
(`ops.reshape_and_cache_flash`) for HND across
`num_heads ∈ {4,8,16}`, `head_size ∈ {64,128,256}`, `block_size ∈ {16,32}`.

## Test Result

On 1× NVIDIA H100 80GB (locked clocks):

```
== 148 passed, 288 skipped, 2010 deselected, 17 warnings in 158.53s ==
```

Triton + HND cases that were previously **skipped** now run and **pass**
(e.g. `test_reshape_and_cache_flash_unaligned_rows[triton-HND-auto-dtype0] PASSED`).
The remaining skips are the unrelated `nvfp4` / `attn_head` CUDA-only
parametrizations. `pre-commit run --files <both files>` passes (ruff, ruff
format, mypy, typos, SPDX).

Bitwise check vs CUDA reference: `max|Δkey| = max|Δvalue| = 0.0` for every
tested HND config.

Suggested reviewer: @bringlein (author of the Triton `reshape_and_cache_flash`
kernel in #24503), who can confirm the HND guard was conservative rather than
intentional.

---
*This change was developed with AI assistance (profiling, verification, and
drafting); all code and results were reviewed and validated on real H100
hardware by the author.*