### PR TITLE
[Misc] Report prefix cache hit rate in vllm bench serve

### DIFF
--- a/tests/benchmarks/test_serve_metrics.py
+++ b/tests/benchmarks/test_serve_metrics.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.benchmarks.serve import PrefixCacheMetrics, _parse_prefix_cache_metrics
+
+
+def test_parse_prefix_cache_metrics() -> None:
+    metrics = """
+# HELP vllm:prefix_cache_queries_total Prefix cache queries
+vllm:prefix_cache_queries_total{engine="0"} 100
+vllm:prefix_cache_queries_total{engine="1"} 50
+vllm:prefix_cache_hits_total{engine="0"} 40
+vllm:prefix_cache_hits_total{engine="1"} 20
+vllm:external_prefix_cache_hits_total{engine="0"} 1000
+"""
+
+    assert _parse_prefix_cache_metrics(metrics) == PrefixCacheMetrics(
+        queries=150, hits=60
+    )
+
+
+def test_parse_prefix_cache_metrics_unavailable() -> None:
+    assert _parse_prefix_cache_metrics("# no prefix cache metrics\n") is None

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -312,6 +312,55 @@ async def fetch_diffusion_metrics(
         return None
 
 
+@dataclass
+class PrefixCacheMetrics:
+    """Prefix cache (token-count) metrics from the server's Prometheus endpoint."""
+
+    queries: int
+    hits: int
+
+
+def _parse_prefix_cache_metrics(text: str) -> PrefixCacheMetrics | None:
+    queries = 0
+    hits = 0
+    found = False
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        parts = line.split(None, 1)
+        metric_name = parts[0].split("{")[0]
+        with contextlib.suppress(ValueError):
+            if metric_name == "vllm:prefix_cache_queries_total":
+                queries += int(float(parts[-1]))
+                found = True
+            elif metric_name == "vllm:prefix_cache_hits_total":
+                hits += int(float(parts[-1]))
+                found = True
+
+    if not found:
+        return None
+    return PrefixCacheMetrics(queries=queries, hits=hits)
+
+
+async def fetch_prefix_cache_metrics(
+    base_url: str, session: aiohttp.ClientSession
+) -> PrefixCacheMetrics | None:
+    """Fetch prefix cache metrics from the server's Prometheus endpoint.
+
+    Returns None if prefix caching is disabled or metrics are not available.
+    """
+    metrics_url = f"{base_url}/metrics"
+    try:
+        async with session.get(metrics_url) as response:
+            if response.status != 200:
+                return None
+            return _parse_prefix_cache_metrics(await response.text())
+    except (aiohttp.ClientError, asyncio.TimeoutError):
+        return None
+
+
 class TaskType(Enum):
     GENERATION = "generation"
     POOLING = "pooling"
@@ -956,6 +1005,7 @@ async def benchmark(
 
     spec_decode_metrics_before = await fetch_spec_decode_metrics(base_url, session)
     diffusion_metrics_before = await fetch_diffusion_metrics(base_url, session)
+    prefix_cache_metrics_before = await fetch_prefix_cache_metrics(base_url, session)
 
     pbar = None if disable_tqdm else tqdm(total=len(input_requests))
 
@@ -1117,6 +1167,25 @@ async def benchmark(
                 "committed_per_step": delta_committed / denoising_steps,
             }
 
+    prefix_cache_metrics_after = await fetch_prefix_cache_metrics(base_url, session)
+    prefix_cache_stats: dict[str, Any] | None = None
+    if (
+        prefix_cache_metrics_before is not None
+        and prefix_cache_metrics_after is not None
+    ):
+        delta_queries = (
+            prefix_cache_metrics_after.queries - prefix_cache_metrics_before.queries
+        )
+        delta_hits = prefix_cache_metrics_after.hits - prefix_cache_metrics_before.hits
+        # Counters are cumulative since server start, so use the per-run delta
+        # and skip runs that did not query the prefix cache.
+        if delta_queries > 0:
+            prefix_cache_stats = {
+                "queries": delta_queries,
+                "hits": delta_hits,
+                "hit_rate": delta_hits / delta_queries * 100,
+            }
+
     metrics: BenchmarkMetrics | EmbedBenchmarkMetrics
     actual_output_lens: list[int] | int
     if task_type == TaskType.GENERATION:
@@ -1188,6 +1257,12 @@ async def benchmark(
                 "Total token throughput (tok/s):", metrics.total_token_throughput
             )
         )
+    if prefix_cache_stats is not None:
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Prefix cache hit rate (%):", prefix_cache_stats["hit_rate"]
+            )
+        )
 
     result: dict[str, Any]
     if isinstance(metrics, BenchmarkMetrics):
@@ -1247,6 +1322,11 @@ async def benchmark(
         result["diffusion_committed_tokens"] = int(diffusion_stats["committed_tokens"])
         result["diffusion_denoising_steps"] = int(diffusion_stats["denoising_steps"])
         result["diffusion_canvas_positions"] = int(diffusion_stats["canvas_positions"])
+
+    if prefix_cache_stats is not None:
+        result["prefix_cache_hit_rate"] = prefix_cache_stats["hit_rate"]
+        result["prefix_cache_queries"] = int(prefix_cache_stats["queries"])
+        result["prefix_cache_hits"] = int(prefix_cache_stats["hits"])
 
     def process_one_metric(
         # E.g., "ttft"


### PR DESCRIPTION
## Purpose

`vllm bench serve` reports latency and throughput, but not the prefix cache
hit rate — so benchmarking prefix caching means manually scraping `/metrics`
and computing the rate by hand. That is error-prone: the Prometheus counters
are cumulative since server start, and the server's logged hit rate uses a
rolling 1000-request window — neither corresponds to "this run".

This mirrors the existing spec-decode / diffusion metric handling: snapshot the
`vllm:prefix_cache_queries_total` / `vllm:prefix_cache_hits_total` counters
before and after the main run and report the per-run hit rate (plus raw queries
and hits) in the console summary and the saved JSON. The rate uses vLLM's own
definition (`hits / queries` in tokens, see `CachingMetrics.hit_rate`). When
prefix caching is disabled or the backend is not vLLM, the fields are omitted.

## Test Plan

vLLM server with prefix caching (on by default), benchmarked with a shared
512-token prefix so the cache is exercised:

```bash
vllm serve Qwen/Qwen2.5-7B-Instruct --port 8000
vllm bench serve --model Qwen/Qwen2.5-7B-Instruct \
  --dataset-name random --num-prompts 200 \
  --random-input-len 512 --random-output-len 64 --random-prefix-len 512 \
  --max-concurrency 16 --save-result --result-filename pc_on.json

Test Result
============ Serving Benchmark Result ============
Successful requests:                     200       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  31.64     
Total input tokens:                      204800    
Total generated tokens:                  12800     
Request throughput (req/s):              6.32      
Output token throughput (tok/s):         404.52    
Peak output token throughput (tok/s):    880.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          6876.78   
Prefix cache hit rate (%):               49.75     
---------------Time to First Token----------------
Mean TTFT (ms):                          975.77    
Median TTFT (ms):                        459.05    
P99 TTFT (ms):                           7643.05   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          23.84     
Median TPOT (ms):                        23.43     
P99 TPOT (ms):                           29.06     
---------------Inter-token Latency----------------
Mean ITL (ms):                           23.84     
Median ITL (ms):                         17.36     
P99 ITL (ms):                            208.05    
==================================================

New line in the summary and new JSON fields:

Prefix cache hit rate (%):               49.75
{"prefix_cache_hit_rate": 49.75, "prefix_cache_queries": 204800, "prefix_cache_hits": 101888}

The value is consistent (101888 / 204800 = 49.75%) and matches the workload:
each 1024-token prompt shares a 512-token prefix, so ~half the queried tokens
hit the cache.

Note: AI assistance was used for this change.
