### PR TITLE
[Bugfix][Spec Decode] Clamp negative placeholder token ids before multimodal text embedding

### DIFF
--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -358,6 +358,14 @@ class SupportsMultiModal(Protocol):
         *,
         is_multimodal: Tensor | None,
     ) -> Tensor:
+        # Speculative decoding fills padding/placeholder slots with a negative
+        # sentinel token id (PADDING_SLOT_ID = -1). These positions are discarded
+        # downstream, but a negative id is not a valid embedding index and triggers
+        # a CUDA "vectorized gather kernel index out of bounds" assertion. Clamp
+        # negatives into range before the embedding gather; their (unused) output
+        # is harmless. This is only reached for multimodal models whose image
+        # placeholder token is in-vocab (_has_oov_mm_tokens is False), so the
+        # masked_fill branch below does not run.
         if is_multimodal is not None and self._has_oov_mm_tokens:
             # Force all input IDs to be in vocab; we do this instead of squeezing
             # to ensure that any external configuration requiring offset tracking,
@@ -366,9 +374,9 @@ class SupportsMultiModal(Protocol):
             in_vocab_ids = input_ids.masked_fill(
                 is_multimodal.to(device=input_ids.device, non_blocking=True), 0
             )
-            return embed_input_ids(in_vocab_ids)
+            return embed_input_ids(in_vocab_ids.clamp_min_(0))
 
-        return embed_input_ids(input_ids)
+        return embed_input_ids(input_ids.clamp_min(0))
 
     def embed_input_ids(
         self,


### PR DESCRIPTION
# [Bugfix][Spec Decode] Clamp negative placeholder token ids before multimodal text embedding

## Summary

VLM + MTP/EAGLE speculative decoding crashes under concurrent multi-image load with:

```
/pytorch/aten/src/ATen/native/cuda/IndexKernelUtils.cu:16: vectorized_gather_kernel:
  Assertion `ind >= 0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds"` failed.
```

The crash is asynchronous and surfaces at misleading sync points (the logits GEMM,
`triton_reshape_and_cache_flash`, or `synchronize_input_prep`), which is why it has been
hard to localize.

## Root cause

Speculative decoding fills padding / placeholder draft-token slots with the sentinel
`PADDING_SLOT_ID = -1` (`vllm/v1/spec_decode/utils.py`). For a mixed decode + new-image-prefill
batch these `-1` ids end up in the `input_ids` that the **target** model embeds in
`GPUModelRunner._preprocess`.

`SupportsMultiModal._embed_text_input_ids` only sanitizes ids when
`is_multimodal is not None and self._has_oov_mm_tokens`. For models whose image placeholder
token is **in-vocab** (e.g. Gemma 4, where `_has_oov_mm_tokens` is `False`) that branch is
skipped, so the raw `input_ids` — including `-1` — are passed straight to
`VocabParallelEmbedding` → `F.embedding(-1, weight)` → out-of-bounds gather.

This only manifests with speculative decoding (the `-1` placeholders come from the drafter),
only for multimodal models (text-only spec-decode paths sanitize the ids), and only under
concurrency high enough to schedule a mixed decode+prefill batch — matching all field reports.

Confirmed via on-cluster instrumentation; the offending embedding input was captured as:

```
OOB embedding: range[-1, 236770] weight_rows=262144 ntok=640 badcount=16 bad_ids=[-1, -1, ...]
scheduled_spec_decode_tokens={<every req>: [-1, -1, -1, -1]}
```

## Fix

Clamp negative ids to 0 before the embedding gather in `_embed_text_input_ids`. The clamped
positions are padding/placeholder slots whose embeddings are discarded downstream, so the
output is unaffected. This mirrors the existing `token_ids != -1` guard the spec-decode code
already applies elsewhere (`utils.py`) and the in-vocab masking Gemma already does for
per-layer embeddings (`get_per_layer_inputs`).

```python
# in SupportsMultiModal._embed_text_input_ids
return embed_input_ids(in_vocab_ids.clamp_min_(0))   # oov branch (in-place; already a copy)
...
return embed_input_ids(input_ids.clamp_min(0))       # default branch
```

Fixing it in this shared helper covers all multimodal models (also the same assertion seen
with Qwen3-VL, e.g. #28785), not just Gemma 4.

## Testing

Reproduced and verified on `vllm/vllm-openai:v0.23.0` serving
`RedHatAI/gemma-4-31B-it-FP8-block` with `--speculative_config '{"...gemma-4-31B-it-assistant","num_speculative_tokens":4}'`,
`--limit-mm-per-prompt '{"image":4}'`, `gpu_memory_utilization=0.95`, default
`cudagraph_mode=FULL_AND_PIECEWISE`, driven by sustained ~128-way concurrent 4-image requests.

- **Before:** thousands of `vectorized_gather_kernel` assertions → `EngineDeadError` (reproduced
  with `FULL_AND_PIECEWISE`, with `enforce_eager`, and across `max_model_len`/image-size variants).
- **After (this patch):** **0** gather assertions under the identical recipe; sustained mixed
  load (540 requests) completes cleanly with `FULL_AND_PIECEWISE` retained. The only failure left
  at extreme burst is an unrelated capacity `torch.OutOfMemoryError` (also present on
  `cudagraph_mode=FULL`).

Validated by overlaying the patched `interfaces.py` into the running engine via a ConfigMap mount.

Recommended unit coverage to add: a spec-decode + multimodal test that feeds `input_ids`
containing `PADDING_SLOT_ID` (-1) through a `SupportsMultiModal` model's `embed_input_ids`
and asserts no OOB.

## Not a duplicate

Searched open issues/PRs (`vectorized_gather_kernel`, `_embed_text_input_ids`,
`PADDING_SLOT_ID`, spec-decode + multimodal). Related but distinct: #28785 (Qwen3-VL, same
assertion, no general fix landed), #42005 (docs — draft-model path already guarded with
`NotImplementedError`, but MTP is not). No open PR clamps placeholder ids in the shared
multimodal embed helper.

## AI assistance

This change was prepared with AI assistance (Claude). The submitting human has reviewed every
changed line and is accountable for it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
