### PR TITLE
[Bugfix][Spec Decode] Clamp negative placeholder token ids before multimodal text embedding

### DIFF
--- a/tests/multimodal/test_text_embed_clamp_unit.py
+++ b/tests/multimodal/test_text_embed_clamp_unit.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for placeholder-id clamping in multimodal text embedding.
+
+Speculative decoding fills padding/placeholder draft-token slots with the
+sentinel ``PADDING_SLOT_ID = -1``. These ids can reach a multimodal model's
+text embedding via ``SupportsMultiModal._embed_text_input_ids``; a negative id
+is not a valid embedding index and triggers a CUDA
+"vectorized gather kernel index out of bounds" assertion.
+
+These tests verify the ids handed to the embedding lookup are always in range.
+
+Run with: pytest tests/multimodal/test_text_embed_clamp_unit.py -v
+"""
+
+import torch
+
+from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
+
+
+class _Stub:
+    """Minimal stand-in carrying only the attribute the method reads."""
+
+    def __init__(self, has_oov_mm_tokens: bool):
+        self._has_oov_mm_tokens = has_oov_mm_tokens
+
+
+def _capture_embed():
+    """Return (embed_fn, seen) where seen[-1] is the last ids tensor passed."""
+    seen: list[torch.Tensor] = []
+
+    def embed_fn(ids: torch.Tensor) -> torch.Tensor:
+        seen.append(ids.clone())
+        # Mimic an embedding table lookup that would assert on a bad index.
+        assert int(ids.min()) >= 0, "negative id reached the embedding lookup"
+        return ids.float().unsqueeze(-1)
+
+    return embed_fn, seen
+
+
+def test_default_branch_clamps_negative_placeholder_ids():
+    # Gemma4-style: image token is in-vocab so _has_oov_mm_tokens is False,
+    # meaning is_multimodal-based masking does not run.
+    input_ids = torch.tensor([5, PADDING_SLOT_ID, 7, PADDING_SLOT_ID])
+    embed_fn, seen = _capture_embed()
+
+    SupportsMultiModal._embed_text_input_ids(
+        _Stub(has_oov_mm_tokens=False),
+        input_ids,
+        embed_fn,
+        is_multimodal=None,
+    )
+
+    passed = seen[-1]
+    assert int(passed.min()) >= 0
+    # Placeholder slots are clamped to 0; real ids are untouched.
+    assert passed.tolist() == [5, 0, 7, 0]
+    # The caller's tensor must not be mutated.
+    assert input_ids.tolist() == [5, PADDING_SLOT_ID, 7, PADDING_SLOT_ID]
+
+
+def test_oov_branch_clamps_after_masking():
+    # _has_oov_mm_tokens=True: multimodal positions are masked to 0, and any
+    # remaining negative placeholder ids must still be clamped.
+    input_ids = torch.tensor([5, 999, PADDING_SLOT_ID, 7])
+    is_multimodal = torch.tensor([False, True, False, False])
+    embed_fn, seen = _capture_embed()
+
+    SupportsMultiModal._embed_text_input_ids(
+        _Stub(has_oov_mm_tokens=True),
+        input_ids,
+        embed_fn,
+        is_multimodal=is_multimodal,
+    )
+
+    passed = seen[-1]
+    assert int(passed.min()) >= 0
+    # idx1 masked by is_multimodal, idx2 clamped from the -1 placeholder.
+    assert passed.tolist() == [5, 0, 0, 7]
+
+
+def test_all_in_vocab_ids_unchanged():
+    input_ids = torch.tensor([0, 1, 2, 3])
+    embed_fn, seen = _capture_embed()
+
+    SupportsMultiModal._embed_text_input_ids(
+        _Stub(has_oov_mm_tokens=False),
+        input_ids,
+        embed_fn,
+        is_multimodal=None,
+    )
+
+    assert seen[-1].tolist() == [0, 1, 2, 3]

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -358,6 +358,14 @@ class SupportsMultiModal(Protocol):
         *,
         is_multimodal: Tensor | None,
     ) -> Tensor:
+        # Speculative decoding fills padding/placeholder slots with a negative
+        # sentinel token id (PADDING_SLOT_ID = -1). These positions are discarded
+        # downstream, but a negative id is not a valid embedding index and triggers
+        # a CUDA "vectorized gather kernel index out of bounds" assertion. Clamp
+        # negatives into range before the embedding gather; their (unused) output
+        # is harmless. This is only reached for multimodal models whose image
+        # placeholder token is in-vocab (_has_oov_mm_tokens is False), so the
+        # masked_fill branch below does not run.
         if is_multimodal is not None and self._has_oov_mm_tokens:
             # Force all input IDs to be in vocab; we do this instead of squeezing
             # to ensure that any external configuration requiring offset tracking,
@@ -366,9 +374,9 @@ class SupportsMultiModal(Protocol):
             in_vocab_ids = input_ids.masked_fill(
                 is_multimodal.to(device=input_ids.device, non_blocking=True), 0
             )
-            return embed_input_ids(in_vocab_ids)
+            return embed_input_ids(in_vocab_ids.clamp_min_(0))
 
-        return embed_input_ids(input_ids)
+        return embed_input_ids(input_ids.clamp_min(0))
 
     def embed_input_ids(
         self,


### PR DESCRIPTION
# [Bugfix][Spec Decode] Clamp negative placeholder token ids before multimodal text embedding

## Summary

VLM + MTP/EAGLE speculative decoding crashes under concurrent multi-image load with:

```
/pytorch/aten/src/ATen/native/cuda/IndexKernelUtils.cu:16: vectorized_gather_kernel:
  Assertion `ind >= 0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds"` failed.
```

The crash is asynchronous and surfaces at misleading sync points (the logits GEMM,
`triton_reshape_and_cache_flash`, or `synchronize_input_prep`), which is why it has been
hard to localize.

## Root cause

Speculative decoding fills padding / placeholder draft-token slots with the sentinel
`PADDING_SLOT_ID = -1` (`vllm/v1/spec_decode/utils.py`). For a mixed decode + new-image-prefill
batch these `-1` ids end up in the `input_ids` that the **target** model embeds in
`GPUModelRunner._preprocess`.

`SupportsMultiModal._embed_text_input_ids` only sanitizes ids when
`is_multimodal is not None and self._has_oov_mm_tokens`. For models whose image placeholder
token is **in-vocab** (e.g. Gemma 4, where `_has_oov_mm_tokens` is `False`) that branch is
skipped, so the raw `input_ids` — including `-1` — are passed straight to
`VocabParallelEmbedding` → `F.embedding(-1, weight)` → out-of-bounds gather.

This only manifests with speculative decoding (the `-1` placeholders come from the drafter),
only for multimodal models (text-only spec-decode paths sanitize the ids), and only under
concurrency high enough to schedule a mixed decode+prefill batch — matching all field reports.

Confirmed via on-cluster instrumentation; the offending embedding input was captured as:

```
OOB embedding: range[-1, 236770] weight_rows=262144 ntok=640 badcount=16 bad_ids=[-1, -1, ...]
scheduled_spec_decode_tokens={<every req>: [-1, -1, -1, -1]}
```

## Fix

Clamp negative ids to 0 before the embedding gather in `_embed_text_input_ids`. The clamped
positions are padding/placeholder slots whose embeddings are discarded downstream, so the
output is unaffected. This mirrors the existing `token_ids != -1` guard the spec-decode code
already applies elsewhere (`utils.py`) and the in-vocab masking Gemma already does for
per-layer embeddings (`get_per_layer_inputs`).

```python
# in SupportsMultiModal._embed_text_input_ids
return embed_input_ids(in_vocab_ids.clamp_min_(0))   # oov branch (in-place; already a copy)
...
return embed_input_ids(input_ids.clamp_min(0))       # default branch
```

Fixing it in this shared helper covers all multimodal models (also the same assertion seen
with Qwen3-VL, e.g. #28785), not just Gemma 4.

## Testing

Reproduced and verified on `vllm/vllm-openai:v0.23.0` serving
`RedHatAI/gemma-4-31B-it-FP8-block` with `--speculative_config '{"...gemma-4-31B-it-assistant","num_speculative_tokens":4}'`,
`--limit-mm-per-prompt '{"image":4}'`, `gpu_memory_utilization=0.95`, default
`cudagraph_mode=FULL_AND_PIECEWISE`, driven by sustained ~128-way concurrent 4-image requests.

- **Before:** thousands of `vectorized_gather_kernel` assertions → `EngineDeadError` (reproduced
  with `FULL_AND_PIECEWISE`, with `enforce_eager`, and across `max_model_len`/image-size variants).
- **After (this patch):** **0** gather assertions under the identical recipe; sustained mixed
  load (540 requests) completes cleanly with `FULL_AND_PIECEWISE` retained. The only failure left
  at extreme burst is an unrelated capacity `torch.OutOfMemoryError` (also present on
  `cudagraph_mode=FULL`).

Validated by overlaying the patched `interfaces.py` into the running engine via a ConfigMap mount.

Recommended unit coverage to add: a spec-decode + multimodal test that feeds `input_ids`
containing `PADDING_SLOT_ID` (-1) through a `SupportsMultiModal` model's `embed_input_ids`
and asserts no OOB.

## Not a duplicate

Searched open issues/PRs (`vectorized_gather_kernel`, `_embed_text_input_ids`,
`PADDING_SLOT_ID`, spec-decode + multimodal). Related but distinct: #28785 (Qwen3-VL, same
assertion, no general fix landed), #42005 (docs — draft-model path already guarded with
`NotImplementedError`, but MTP is not). No open PR clamps placeholder ids in the shared
multimodal embed helper.

## AI assistance

This change was prepared with AI assistance; the submitting author has reviewed every
changed line and is accountable for it.
