### PR TITLE
fix: clear shared_experts output when forward fails

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -164,11 +164,16 @@ class SharedExperts(torch.nn.Module):
 
         assert self._output[self._output_idx] is None
 
-        if order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
-            self._output[self._output_idx] = self._run_in_aux_stream(
-                shared_experts_input
-            )
-        else:
-            self._output[self._output_idx] = self._layer(shared_experts_input)
+        try:
+            if order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
+                self._output[self._output_idx] = self._run_in_aux_stream(
+                    shared_experts_input
+                )
+            else:
+                self._output[self._output_idx] = self._layer(shared_experts_input)
+        except Exception:
+            # Aborted forwards (e.g. failed AOT compile) must not leave stale output.
+            self._output[self._output_idx] = None
+            raise
 
         assert self._output[self._output_idx] is not None


### PR DESCRIPTION
Fixes #46857

When AOT compile aborts mid-forward (seen on TPU FP8 MoE + prefix caching), `_output` stayed set. The next warmup pass then hit `assert self._output[idx] is None` and died.

Clear `_output` in the except path so a failed forward doesn't poison the next one.

Not duplicating any open PR — checked #46857 has no existing fix PR.


Made with [Cursor](https://cursor.com)