### PR TITLE
Remove boilerplate missed by #46820

### DIFF
--- a/vllm/model_executor/models/gemma4_unified.py
+++ b/vllm/model_executor/models/gemma4_unified.py
@@ -335,7 +335,6 @@ class Gemma4UnifiedForConditionalGeneration(Gemma4ForConditionalGeneration):
                 )
 
         # --- MixtureOfExperts delegation to language_model ---
-        self.expert_weights = self.language_model.expert_weights
         self.moe_layers = self.language_model.moe_layers
         self.num_moe_layers = self.language_model.num_moe_layers
         self.num_logical_experts = self.language_model.num_logical_experts
@@ -345,6 +344,7 @@ class Gemma4UnifiedForConditionalGeneration(Gemma4ForConditionalGeneration):
         self.num_expert_groups = self.language_model.num_expert_groups
         self.num_shared_experts = self.language_model.num_shared_experts
         self.num_redundant_experts = self.language_model.num_redundant_experts
+        self.set_eplb_state = self.language_model.set_eplb_state
 
         gen_cfg = vllm_config.model_config.try_get_generation_config()
         self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -812,17 +812,6 @@ class Llama4ForConditionalGeneration(
         )
         return self.language_model.get_eagle3_default_aux_hidden_state_layers()
 
-    def set_eplb_state(
-        self,
-        expert_load_view: torch.Tensor,
-        logical_to_physical_map: torch.Tensor,
-        logical_replica_count: torch.Tensor,
-    ):
-        self.language_model.set_eplb_state(
-            expert_load_view, logical_to_physical_map, logical_replica_count
-        )
-        self.expert_weights = self.language_model.expert_weights
-
     def update_physical_experts_metadata(
         self, num_physical_experts: int, num_local_physical_experts: int
     ):

--- a/vllm/model_executor/models/param2moe.py
+++ b/vllm/model_executor/models/param2moe.py
@@ -705,8 +705,6 @@ class Param2MoEModel(nn.Module):
 class Param2MoEMixtureOfExperts(MixtureOfExperts):
     """Implements the vLLM MixtureOfExperts protocol for Param2MoE."""
 
-    expert_weights: list[torch.Tensor]
-
     def extract_moe_parameters(self, example_moe: Param2MoEMoEBlock | None) -> None:
         if example_moe is None:
             raise RuntimeError(
@@ -744,24 +742,6 @@ class Param2MoEMixtureOfExperts(MixtureOfExperts):
                 fused.n_redundant_experts = self.num_redundant_experts
             if hasattr(fused, "update_expert_map"):
                 fused.update_expert_map()
-
-    def set_eplb_state(
-        self,
-        expert_load_view: torch.Tensor,
-        logical_to_physical_map: torch.Tensor,
-        logical_replica_count: torch.Tensor,
-    ) -> None:
-        self.expert_weights = []
-        for layer_idx, layer in enumerate(self.moe_layers):
-            if hasattr(layer, "get_expert_weights"):
-                self.expert_weights.append(layer.get_expert_weights())
-            if hasattr(layer, "set_eplb_state"):
-                layer.set_eplb_state(
-                    moe_layer_idx=layer_idx,
-                    expert_load_view=expert_load_view,
-                    logical_to_physical_map=logical_to_physical_map,
-                    logical_replica_count=logical_replica_count,
-                )
 
 
 class Param2MoEForCausalLM(

--- a/vllm/model_executor/models/sarvam.py
+++ b/vllm/model_executor/models/sarvam.py
@@ -711,7 +711,6 @@ class SarvamMLAForCausalLM(nn.Module, SupportsPP, SupportsLoRA, SarvamMixtureOfE
             self.model.make_empty_intermediate_tensors
         )
 
-        self.expert_weights = []
         self.num_moe_layers = 0
 
         self.moe_layers = []

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -318,7 +318,6 @@ class DeepseekV32ForCausalLM(DeepseekV2ForCausalLM):
     def set_moe_parameters(self):
         # Same as the base, but keyed on the MoE block type rather than the
         # decoder-layer type (DeepseekV32DecoderLayer is a plain nn.Module).
-        self.expert_weights = []
         self.num_expert_groups = getattr(self.config, "n_group", 1)
         self.moe_layers = []
         self.moe_mlp_layers = []

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -166,7 +166,6 @@ class DeepseekV32MTP(nn.Module, DeepseekV2MixtureOfExperts):
         self.set_moe_parameters()
 
     def set_moe_parameters(self):
-        self.expert_weights = []
         self.num_moe_layers = self.config.num_nextn_predict_layers
         self.num_expert_groups = self.config.n_group
         self.moe_layers = []


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/46820 missed a couple of references to `self.expert_weights` and this caused models like Gemma4 Unified to atempt to read a non-existent attribute from the language model.

This PR removes the remaining references to `self.expert_weights` in all modelling code.

Fixes https://github.com/vllm-project/vllm/issues/46948