### PR TITLE
Fix Qwen3-VL video prompt wrapper replacement

### DIFF
--- a/tests/models/multimodal/processing/test_qwen3_vl.py
+++ b/tests/models/multimodal/processing/test_qwen3_vl.py
@@ -95,6 +95,33 @@ def test_processor_num_frames_timestamp(
 
 
 @pytest.mark.parametrize("model_id", [MODEL_ID])
+def test_processor_video_preserves_outer_vision_wrapper(model_id: str) -> None:
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"image": 0, "video": 1},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+
+    num_frames = 8
+    prompt = "<|vision_start|><|video_pad|><|vision_end|>"
+    mm_data = _build_video_mm_data(num_frames=num_frames)
+
+    processed = processor(
+        prompt,
+        mm_items=processor.info.parse_mm_data(mm_data),
+        hf_processor_mm_kwargs={"num_frames": num_frames},
+    )
+
+    token_ids = processed["prompt_token_ids"]
+    hf_config = processor.info.get_hf_config()
+
+    assert token_ids[0] == hf_config.vision_start_token_id
+    assert token_ids[-1] == hf_config.vision_end_token_id
+    assert token_ids.count(hf_config.vision_start_token_id) == num_frames + 1
+    assert token_ids.count(hf_config.vision_end_token_id) == num_frames + 1
+
+
+@pytest.mark.parametrize("model_id", [MODEL_ID])
 @pytest.mark.parametrize("num_videos", [2, 4])
 def test_processor_multi_video(
     model_id: str,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1490,7 +1490,7 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
             # token ids takes more time.
             PromptReplacement(
                 modality="video",
-                target="<|vision_start|><|video_pad|><|vision_end|>",
+                target=hf_processor.video_token,
                 replacement=get_video_replacement_qwen3vl,
             ),
         ]


### PR DESCRIPTION
## Summary

Fix Qwen3-VL video prompt replacement to preserve the outer vision wrapper emitted by the HuggingFace chat template.

Qwen3-VL's chat template renders video as:

```text
<|vision_start|><|video_pad|><|vision_end|>
```

The HF processor replaces only the inner `<|video_pad|>`, so the final prompt keeps an outer `<|vision_start|>` / `<|vision_end|>` around the per-frame expansion. vLLM was replacing the whole wrapper string, dropping the outer pair and shifting/reordering the video prompt tokens.

This changes Qwen3-VL video prompt replacement to target `hf_processor.video_token`, matching image handling and the Qwen2/Qwen2.5-VL processors.

## Notes

`get_video_repl` still emits the per-frame `timestamp + vision_start + video tokens + vision_end` sequence. This patch does not add extra frame-level wrappers or change pruning behavior; it only preserves the outer wrapper that was already present in the prompt text.

## Tests

- `PYTHONDONTWRITEBYTECODE=1 /opt/homebrew/bin/python3.11 -m py_compile vllm/model_executor/models/qwen3_vl.py tests/models/multimodal/processing/test_qwen3_vl.py`
- `ruff check vllm/model_executor/models/qwen3_vl.py tests/models/multimodal/processing/test_qwen3_vl.py`
- `git diff --check`

Not run locally: targeted pytest, because this local environment is missing vLLM test/runtime dependencies (`tblib`, `regex`, `transformers`). CI should run the added Qwen3-VL processor regression.

Fixes #46817.
