### PR TITLE
[Bugfix] Check CPU KV offload shared-memory capacity

### DIFF
--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -8,12 +8,14 @@ import os
 import threading
 import time
 import uuid
+from types import SimpleNamespace
 
 import pytest
 
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.kv_offload.cpu.shared_offload_region import (
     SharedOffloadRegion,
+    _ensure_backing_store_has_space,
     _wait_for_file_size,
 )
 
@@ -161,6 +163,64 @@ def _mp_race_construct_and_write(
 def iid():
     """Fresh instance ID for each test."""
     return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Constructor — backing store capacity checks
+# ---------------------------------------------------------------------------
+
+
+def test_backing_store_space_check_raises_clear_error(monkeypatch):
+    def fake_statvfs(path):
+        assert path == "/dev/shm"
+        return SimpleNamespace(f_bavail=1, f_frsize=PAGE_SIZE)
+
+    monkeypatch.setattr(os, "statvfs", fake_statvfs)
+    monkeypatch.setattr(
+        "vllm.v1.kv_offload.cpu.shared_offload_region.psutil.virtual_memory",
+        lambda: SimpleNamespace(available=10 * PAGE_SIZE),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Insufficient shared memory.*\\/dev\\/shm.*--kv-offloading-size",
+    ):
+        _ensure_backing_store_has_space(
+            "/dev/shm/vllm_offload_test.mmap",
+            required_bytes=2 * PAGE_SIZE,
+        )
+
+
+def test_creator_closes_and_unlinks_when_space_check_fails(monkeypatch, iid):
+    fake_fd = 123
+    closed_fds = []
+    unlinked_paths = []
+    expected_path = f"/dev/shm/vllm_offload_{iid}.mmap"
+
+    def fail_space_check(path, required_bytes):
+        assert path == expected_path
+        assert required_bytes == PAGE_SIZE
+        raise RuntimeError("no shm")
+
+    monkeypatch.setattr(
+        "vllm.v1.kv_offload.cpu.shared_offload_region._ensure_backing_store_has_space",
+        fail_space_check,
+    )
+    monkeypatch.setattr(os, "open", lambda *args: fake_fd)
+    monkeypatch.setattr(os, "close", lambda fd: closed_fds.append(fd))
+    monkeypatch.setattr(os, "unlink", lambda path: unlinked_paths.append(path))
+
+    with pytest.raises(RuntimeError, match="no shm"):
+        SharedOffloadRegion(
+            instance_id=iid,
+            num_blocks=1,
+            rank=0,
+            kv_bytes_per_block=PAGE_SIZE,
+            cpu_page_size=PAGE_SIZE,
+        )
+
+    assert closed_fds == [fake_fd]
+    assert unlinked_paths == [expected_path]
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -3,7 +3,9 @@
 import mmap
 import os
 import time
+from contextlib import suppress
 
+import psutil
 import torch
 
 from vllm.logger import init_logger
@@ -23,6 +25,29 @@ def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> N
                 f"Timed out waiting for mmap file to reach {expected_size} bytes"
             )
         time.sleep(0.005)
+
+
+def _ensure_backing_store_has_space(mmap_path: str, required_bytes: int) -> None:
+    backing_dir = os.path.dirname(mmap_path)
+    stats = os.statvfs(backing_dir)
+    shm_available_bytes = stats.f_bavail * stats.f_frsize
+    memory_available_bytes = psutil.virtual_memory().available
+    available_bytes = min(shm_available_bytes, memory_available_bytes)
+    if required_bytes > available_bytes:
+        bottleneck = (
+            backing_dir
+            if shm_available_bytes <= memory_available_bytes
+            else "system memory"
+        )
+        raise RuntimeError(
+            "Insufficient shared memory for CPU KV offloading: "
+            f"requested {required_bytes / 1e9:.2f} GB, but only "
+            f"{available_bytes / 1e9:.2f} GB is available "
+            f"(limited by {bottleneck}; {backing_dir} has "
+            f"{shm_available_bytes / 1e9:.2f} GB and system memory has "
+            f"{memory_available_bytes / 1e9:.2f} GB available). "
+            "Reduce --kv-offloading-size or increase the available /dev/shm space."
+        )
 
 
 class SharedOffloadRegion:
@@ -63,10 +88,17 @@ class SharedOffloadRegion:
             self._worker_area_end = (rank + 1) * cpu_page_size
         try:
             # Exclusive create — only one worker succeeds
-            self.fd: int | None = os.open(
-                self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
-            )
-            os.ftruncate(self.fd, self.total_size_bytes)
+            self.fd: int | None = None
+            fd = os.open(self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+            try:
+                _ensure_backing_store_has_space(self.mmap_path, self.total_size_bytes)
+                os.ftruncate(fd, self.total_size_bytes)
+            except Exception:
+                os.close(fd)
+                with suppress(FileNotFoundError):
+                    os.unlink(self.mmap_path)
+                raise
+            self.fd = fd
             self._creator = True
             logger.info(
                 "Created mmap file %s (%.2f GB)",


### PR DESCRIPTION
Fixes #46949.

Summary:
- add an explicit capacity check before creating the CPU KV offload shared mmap region
- report the limiting resource between `/dev/shm` and available system memory instead of surfacing an opaque `madvise` error
- close and unlink the just-created mmap file if the capacity check fails
- add regression coverage for the clear error and cleanup path

Tests:
- `ruff format vllm/v1/kv_offload/cpu/shared_offload_region.py tests/v1/kv_offload/cpu/test_shared_offload_region.py`
- `ruff check vllm/v1/kv_offload/cpu/shared_offload_region.py tests/v1/kv_offload/cpu/test_shared_offload_region.py`
- `/opt/homebrew/bin/python3.11 -m pytest --confcutdir=tests/v1/kv_offload/cpu tests/v1/kv_offload/cpu/test_shared_offload_region.py -k "backing_store_space_check or creator_closes" -q`
- `/opt/homebrew/bin/python3.11 -m py_compile vllm/v1/kv_offload/cpu/shared_offload_region.py tests/v1/kv_offload/cpu/test_shared_offload_region.py`