### PR TITLE
[Bugfix] Track offloading allocations without load tokens

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -15,6 +15,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     OffloadingConnectorScheduler,
     RequestOffloadState,
 )
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
@@ -982,6 +984,28 @@ def test_fence_at_update_state_after_alloc(request_runner):
         expected_flushed=(0,),
     )
     assert runner.connector_scheduler._block_id_to_pending_jobs == {}
+
+
+def test_update_state_after_alloc_records_zero_token_allocations():
+    scheduler = object.__new__(OffloadingConnectorScheduler)
+    scheduler._current_batch_allocated_block_ids = set()
+    blocks = KVCacheBlocks(
+        (
+            (
+                KVCacheBlock(block_id=7),
+                KVCacheBlock(block_id=0),
+            ),
+            (KVCacheBlock(block_id=11),),
+        )
+    )
+
+    scheduler.update_state_after_alloc(
+        SimpleNamespace(request_id="req-0"),
+        blocks,
+        num_external_tokens=0,
+    )
+
+    assert scheduler._current_batch_allocated_block_ids == {7, 11}
 
 
 def test_fence_at_build_store_jobs(request_runner):

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -1997,6 +1997,28 @@ def test_fence_at_update_state_after_alloc(request_runner):
     assert runner.connector_scheduler._block_id_to_pending_jobs == {}
 
 
+def test_update_state_after_alloc_records_zero_token_allocations():
+    scheduler = object.__new__(OffloadingConnectorScheduler)
+    scheduler._current_batch_allocated_block_ids = set()
+    blocks = KVCacheBlocks(
+        (
+            (
+                KVCacheBlock(block_id=7),
+                KVCacheBlock(block_id=0),
+            ),
+            (KVCacheBlock(block_id=11),),
+        )
+    )
+
+    scheduler.update_state_after_alloc(
+        SimpleNamespace(request_id="req-0"),
+        blocks,
+        num_external_tokens=0,
+    )
+
+    assert scheduler._current_batch_allocated_block_ids == {7, 11}
+
+
 def test_fence_at_build_store_jobs(request_runner):
     """A new prefill (no load -> update_state_after_alloc returns early)
     reusing a finished request's pending-store block is flushed by

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -694,6 +694,7 @@ class OffloadingConnectorScheduler:
     def update_state_after_alloc(
         self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
+        self._record_allocated_blocks(blocks)
         if num_external_tokens == 0:
             return
 
@@ -712,10 +713,6 @@ class OffloadingConnectorScheduler:
             req_status.group_states,
             blocks.blocks,
         ):
-            self._current_batch_allocated_block_ids.update(
-                block.block_id for block in group_blocks if block.block_id != 0
-            )
-
             gpu_block_size = group_config.gpu_block_size
             offloaded_block_size = group_config.offloaded_block_size
             offload_keys = group_state.offload_keys
@@ -788,6 +785,14 @@ class OffloadingConnectorScheduler:
 
         if self._blocks_being_loaded is not None:
             self._blocks_being_loaded.update(keys_to_load)
+
+    def _record_allocated_blocks(self, blocks: KVCacheBlocks) -> None:
+        self._current_batch_allocated_block_ids.update(
+            block.block_id
+            for group_blocks in blocks.blocks
+            for block in group_blocks
+            if block.block_id != 0
+        )
 
     def _update_req_states(self, scheduler_output: SchedulerOutput) -> None:
         """

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1070,6 +1070,7 @@ class OffloadingConnectorScheduler:
     def update_state_after_alloc(
         self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
+        self._record_allocated_blocks(blocks)
         if num_external_tokens == 0:
             return
 
@@ -1091,10 +1092,6 @@ class OffloadingConnectorScheduler:
             req_status.group_states,
         ):
             group_blocks = blocks.blocks[group_config.group_idx]
-            self._current_batch_allocated_block_ids.update(
-                block.block_id for block in group_blocks if block.block_id != 0
-            )
-
             tokens_per_block = group_config.tokens_per_block
             tokens_per_chunk = group_config.tokens_per_chunk
             offload_keys = group_state.offload_keys
@@ -1179,6 +1176,14 @@ class OffloadingConnectorScheduler:
         if self._chunks_being_loaded is not None:
             self._chunks_being_loaded.update(keys_to_load)
         req_status.partial_tail_boundary = None
+
+    def _record_allocated_blocks(self, blocks: KVCacheBlocks) -> None:
+        self._current_batch_allocated_block_ids.update(
+            block.block_id
+            for group_blocks in blocks.blocks
+            for block in group_blocks
+            if block.block_id != 0
+        )
 
     def _update_req_states(self, scheduler_output: SchedulerOutput) -> None:
         """


### PR DESCRIPTION
Fixes #46951.

## Root cause

`OffloadingConnectorScheduler.update_state_after_alloc` returned early when
`num_external_tokens == 0` before recording newly allocated GPU block IDs.
With `MultiConnector`, blocks allocated through another asynchronous connector
could therefore be absent from the stale-transfer fence and reused while an
older store was still pending.

## Changes

- record every non-null allocated block before the zero-token early return;
- use the same helper for zero-token and normal load paths;
- add a focused regression covering multiple cache groups and null block ID 0.

## Duplicate status

#46960 and #47046 both address #46951, and only one implementation should
merge. #46960 was opened first and keeps a focused two-file diff: the scheduler
change plus a regression test covering multiple cache groups and null block ID
0. #47046 currently makes the corresponding production-code change but does
not add regression coverage for this bug. This comparison is documented so
maintainers can choose one implementation without treating the PRs as
independent fixes.

## Validation

Rebased onto `main` at `756794a9a7f08900c00fbfaa6d8332631503f528`.

- `VLLM_TARGET_DEVICE=empty .venv/bin/python -m pytest tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py -q` — 216 passed
- focused regression, existing fence test, and boundary-load test — 3 passed
- `.venv/bin/pre-commit run --files vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py` — all applicable hooks passed
- `.venv/bin/pre-commit run mypy-3.12 --files vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py --hook-stage manual` — passed
- negative control: suppressing the pre-return recording makes the regression assertion reject the old empty allocation set

The tests used the macOS empty-device environment; no GPU runtime validation is
claimed. Model evaluation is not applicable because this changes scheduler
bookkeeping and stale-transfer protection, not model output or accuracy.

## AI assistance

AI assistance was used for implementation review, rebase conflict resolution,
test execution, and validation. The PR remains draft until the submitting
human reviews every changed line as required by `AGENTS.md`.
