### PR TITLE
[Spec Decode] Avoid redundant hidden-states gather in draft prefill

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -360,7 +360,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             self.current_draft_step,
             self.draft_logits,
         )
-        self.hidden_states[:num_reqs] = hidden_states[last_token_indices]
+        if last_hidden_states is hidden_states:
+            self.hidden_states[:num_reqs] = sample_hidden_states
+        else:
+            self.hidden_states[:num_reqs] = hidden_states[last_token_indices]
         self.input_buffers.positions[:num_reqs] = positions
 
     def _multi_step_decode(


### PR DESCRIPTION
Some EAGLE and MTP draft models reuse the same hidden states for both sampling and the next-step input. In these cases, we do not need to gather the last hidden states twice.

This PR adds a small optimization to skip the redundant `torch.gather`, avoiding unnecessary overhead in the draft-model path.