### PR TITLE
Resolve local refs for tool argument coercion

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -571,12 +571,19 @@ class TestPostToolContentDeferral:
 # ── TestFixArgTypes ──────────────────────────────────────────────────
 
 
-def _make_tool(name: str, properties: dict) -> ChatCompletionToolsParam:
+def _make_tool(
+    name: str,
+    properties: dict,
+    extra_parameters: dict | None = None,
+) -> ChatCompletionToolsParam:
+    parameters = {"type": "object", "properties": properties}
+    if extra_parameters is not None:
+        parameters.update(extra_parameters)
     return ChatCompletionToolsParam(
         type="function",
         function=FunctionDefinition(
             name=name,
-            parameters={"type": "object", "properties": properties},
+            parameters=parameters,
         ),
     )
 
@@ -697,6 +704,62 @@ class TestFixArgTypes:
         result = engine._fix_arg_types('{"inner": {"count": "42"}}', "f")
         parsed = json.loads(result)
         assert parsed["inner"]["count"] == 42
+
+    def test_nested_ref_object_coercion(self):
+        tool = _make_tool(
+            "f",
+            {
+                "period": {
+                    "$ref": "#/$defs/PeriodSpec",
+                    "description": "Business period.",
+                },
+                "scope": {"$ref": "#/$defs/ScopeSpec"},
+            },
+            {
+                "$defs": {
+                    "PeriodSpec": {
+                        "type": "object",
+                        "properties": {
+                            "kind": {"type": "string"},
+                            "days": {
+                                "anyOf": [
+                                    {"type": "integer"},
+                                    {"type": "null"},
+                                ]
+                            },
+                        },
+                    },
+                    "ScopeSpec": {
+                        "type": "object",
+                        "properties": {
+                            "shops": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "terminals": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        engine = _make_engine(tools=[tool])
+
+        result = engine._fix_arg_types(
+            json.dumps(
+                {
+                    "period": '{"kind": "week", "days": "7"}',
+                    "scope": '{"shops": [], "terminals": []}',
+                }
+            ),
+            "f",
+        )
+
+        parsed = json.loads(result)
+        assert parsed["period"] == {"kind": "week", "days": 7}
+        assert parsed["scope"] == {"shops": [], "terminals": []}
 
     def test_array_item_coercion(self):
         tool = _make_tool(

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -227,6 +227,8 @@ class ParserEngine(Parser):
             types = extract_types_from_schema(schema)
             coerced = coerce_to_schema_type(value, types)
             if coerced is not value:
+                if isinstance(coerced, (dict, list)):
+                    coerced, _ = ParserEngine._coerce_value(coerced, schema)
                 return coerced, True
             return value, False
 

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import ast
+import copy
 import json
 import math
 import warnings
@@ -181,6 +182,44 @@ def _extract_tool_info(
         raise TypeError(f"Unsupported tool type: {type(tool)}")
 
 
+def _resolve_local_json_ref(
+    schema: Any,
+    root_schema: dict[str, Any],
+    seen_refs: frozenset[str] = frozenset(),
+) -> Any:
+    if isinstance(schema, list):
+        return [
+            _resolve_local_json_ref(item, root_schema, seen_refs) for item in schema
+        ]
+    if not isinstance(schema, dict):
+        return schema
+
+    ref = schema.get("$ref")
+    if not isinstance(ref, str) or not ref.startswith("#/$defs/") or ref in seen_refs:
+        return {
+            key: _resolve_local_json_ref(value, root_schema, seen_refs)
+            for key, value in schema.items()
+        }
+
+    def_name = ref.removeprefix("#/$defs/")
+    defs = root_schema.get("$defs", {})
+    if not isinstance(defs, dict) or def_name not in defs:
+        return {
+            key: _resolve_local_json_ref(value, root_schema, seen_refs)
+            for key, value in schema.items()
+        }
+
+    resolved = _resolve_local_json_ref(
+        copy.deepcopy(defs[def_name]),
+        root_schema,
+        seen_refs | frozenset({ref}),
+    )
+    for key, value in schema.items():
+        if key != "$ref":
+            resolved[key] = _resolve_local_json_ref(value, root_schema, seen_refs)
+    return resolved
+
+
 def find_tool_properties(
     tools: list[Tool] | None,
     tool_name: str,
@@ -193,7 +232,16 @@ def find_tool_properties(
             continue
         name, params = _extract_tool_info(tool)
         if name == tool_name:
-            return (params or {}).get("properties", {})
+            params = params or {}
+            properties = params.get("properties", {})
+            if not isinstance(properties, dict):
+                return {}
+            if "$defs" not in params:
+                return properties
+            return {
+                prop_name: _resolve_local_json_ref(prop_schema, params)
+                for prop_name, prop_schema in properties.items()
+            }
     return {}
 
 


### PR DESCRIPTION
## Summary

Fixes schema-aware tool argument coercion when function parameters use Pydantic v2-style `$defs` / local `$ref` schemas. The parser now resolves local refs before extracting parameter types, so JSON object/array arguments are not preserved as double-encoded strings.

Also recurses into object/array values that were parsed from strings, preserving nested coercion such as integer fields inside referenced object schemas.

Fixes #46924.

## Duplicate-work check

I searched for open PRs covering #46924, `qwen3_coder`, `find_tool_properties`, and `extract_types_from_schema`, and did not find an existing open PR addressing this parser/coercion path.

## Tests

- `/tmp/vllm-pr-venv/bin/python -m pytest --confcutdir=tests/parser/engine tests/parser/engine/test_parser_engine.py::TestFixArgTypes -q`
- `/tmp/vllm-pr-venv/bin/python -m pytest --confcutdir=tests/tool_parsers tests/tool_parsers/test_utils.py -q`

## Disclosure

AI assistance was used to prepare this PR. I reviewed the changed lines and ran the tests listed above.
