### PR TITLE
[Bugfix] Capture final-layer aux hidden state in deepseek_v2 backbone

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1470,6 +1470,9 @@ class DeepseekV2Model(nn.Module):
                 [self.hidden_size, self.hidden_size], dim=-1
             )
 
+        if self.end_layer in self.aux_hidden_state_layers:
+            aux_hidden_states.append(hidden_states + residual)
+
         hidden_states, _ = self.norm(hidden_states, residual)
         if len(aux_hidden_states) > 0:
             return hidden_states, aux_hidden_states


### PR DESCRIPTION
## Purpose
The `deepseek_v2` backbone captures EAGLE3 / `extract_hidden_states` aux hidden states only at decoder-layer *inputs* (ids `0..num_hidden_layers-1`), so an aux id equal to `num_hidden_layers` — the final layer's output — is silently dropped, returning one fewer hidden state than configured. This makes deepseek_v2-family models (DeepSeek V2/V3, GLM-MoE, Kimi, …) unusable as aux-hidden-state targets whenever the final-layer state is requested.

This captures the final layer's output as well, mirroring the `llama` backbone. It is a no-op when no aux hidden-state layers are set, so normal inference is unaffected.

## Test
With a deepseek_v2-family target (GLM-MoE) and `eagle_aux_hidden_state_layer_ids` that include the final layer, the model previously returned N-1 hidden states (RuntimeError on the consumer's fixed-size buffer). With this change it returns all N requested aux hidden states.