### PR TITLE
[Model] Restore DeepSeek V2 hidden_size for EPLB

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1338,6 +1338,7 @@ class DeepseekV2Model(nn.Module):
         self.device = current_platform.device_type
 
         self.vocab_size = config.vocab_size
+        self.hidden_size = config.hidden_size
         self.is_v32 = hasattr(config, "index_topk")
         if self.is_v32:
             topk_tokens = config.index_topk


### PR DESCRIPTION
Restores `DeepseekV2Model.hidden_size` from the model config. The DeepSeek V2 EPLB path reads `self.model.hidden_size` while building per-layer expert load statistics. `DeepseekV2Model` still has `config.hidden_size`, but the model object stopped exposing `hidden_size`, so the scheduled DeepSeek V2-Lite Sync EPLB accuracy job fails during generation with:

```text
AttributeError: 'DeepseekV2Model' object has no attribute 'hidden_size'
```