### PR TITLE
[ROCm][CI] Apply xgrammar bitmasks in vLLM on ROCm

### DIFF
--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -2,10 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+import torch
 
 from vllm.v1.structured_output.backend_xgrammar import (
     has_xgrammar_unsupported_json_features,
 )
+from vllm.v1.structured_output.utils import _apply_grammar_bitmask_torch
 
 pytestmark = pytest.mark.cpu_test
 
@@ -104,3 +106,59 @@ def test_supported_json_features(supported_schema):
     assert not has_xgrammar_unsupported_json_features(supported_schema), (
         "Schema should be supported"
     )
+
+
+def _pack_allowed_tokens(token_ids: list[int]) -> int:
+    value = 0
+    for token_id in token_ids:
+        value |= 1 << token_id
+    return value
+
+
+def test_apply_grammar_bitmask_torch_with_sparse_indices():
+    logits = torch.arange(30, dtype=torch.float32).reshape(3, 10)
+    original = logits.clone()
+    grammar_bitmask = torch.tensor(
+        [
+            [-1],
+            [_pack_allowed_tokens([2, 5, 9])],
+            [_pack_allowed_tokens([0])],
+        ],
+        dtype=torch.int32,
+    )
+
+    _apply_grammar_bitmask_torch(
+        logits,
+        grammar_bitmask,
+        out_indices=[1],
+        skip_out_indices=False,
+    )
+
+    assert torch.equal(logits[0], original[0])
+    assert torch.equal(logits[2], original[2])
+    assert torch.equal(logits[1, [2, 5, 9]], original[1, [2, 5, 9]])
+    disallowed = [0, 1, 3, 4, 6, 7, 8]
+    assert torch.isneginf(logits[1, disallowed]).all()
+
+
+def test_apply_grammar_bitmask_torch_aligned_batch():
+    logits = torch.arange(20, dtype=torch.float32).reshape(2, 10)
+    grammar_bitmask = torch.tensor(
+        [
+            [_pack_allowed_tokens([0, 1])],
+            [_pack_allowed_tokens([8, 9])],
+        ],
+        dtype=torch.int32,
+    )
+
+    _apply_grammar_bitmask_torch(
+        logits,
+        grammar_bitmask,
+        out_indices=[0, 1],
+        skip_out_indices=True,
+    )
+
+    assert torch.isfinite(logits[0, [0, 1]]).all()
+    assert torch.isneginf(logits[0, 2:]).all()
+    assert torch.isneginf(logits[1, :8]).all()
+    assert torch.isfinite(logits[1, [8, 9]]).all()

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -16,6 +16,8 @@ from cachetools import LRUCache
 
 import vllm.envs as envs
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON, tl, triton
 from vllm.utils.import_utils import LazyLoader
 from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
@@ -42,6 +44,111 @@ logger = init_logger(__name__)
 _T = TypeVar("_T")
 
 CACHE = None
+_BITMASK_BIT_OFFSETS: dict[tuple[str, int | None], torch.Tensor] = {}
+
+
+def _get_bitmask_bit_offsets(device: torch.device) -> torch.Tensor:
+    device = torch.device(device)
+    key = (device.type, device.index)
+    bit_offsets = _BITMASK_BIT_OFFSETS.get(key)
+    if bit_offsets is None:
+        bit_offsets = torch.arange(32, dtype=torch.int32, device=device)
+        _BITMASK_BIT_OFFSETS[key] = bit_offsets
+    return bit_offsets
+
+
+def _apply_grammar_bitmask_torch(
+    logits: torch.Tensor,
+    grammar_bitmask: torch.Tensor,
+    out_indices: list[int],
+    skip_out_indices: bool,
+) -> None:
+    """Apply packed xgrammar bitmasks with PyTorch tensor ops."""
+    if skip_out_indices:
+        selected_logits = logits
+        selected_bitmask = grammar_bitmask
+        index_tensor = None
+    else:
+        if not out_indices:
+            return
+        index_tensor = torch.tensor(out_indices, dtype=torch.long, device=logits.device)
+        selected_logits = logits.index_select(0, index_tensor)
+        selected_bitmask = grammar_bitmask.index_select(0, index_tensor)
+
+    bit_offsets = _get_bitmask_bit_offsets(logits.device)
+    disallowed = (((selected_bitmask[..., None] >> bit_offsets) & 1) == 0).reshape(
+        selected_bitmask.shape[0], -1
+    )
+    selected_logits.masked_fill_(disallowed[:, : logits.shape[-1]], -float("inf"))
+
+    if index_tensor is not None:
+        logits.index_copy_(0, index_tensor, selected_logits)
+
+
+@triton.jit
+def _apply_grammar_bitmask_kernel(
+    logits_ptr,
+    bitmask_ptr,
+    indices_ptr,
+    vocab_size,
+    logits_stride,
+    bitmask_stride,
+    HAS_INDICES: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    block_id = tl.program_id(0)
+    row_id = tl.program_id(1)
+    logits_row = row_id
+    if HAS_INDICES:
+        logits_row = tl.load(indices_ptr + row_id)
+
+    offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    bitmask_offsets = block_id * (BLOCK_SIZE // 32) + tl.arange(0, BLOCK_SIZE // 32)
+    packed_bitmask = tl.load(
+        bitmask_ptr + row_id * bitmask_stride + bitmask_offsets,
+        mask=bitmask_offsets < bitmask_stride,
+        other=0,
+    )
+    disallowed = ((packed_bitmask[:, None] >> (tl.arange(0, 32)[None, :])) & 1) == 0
+    disallowed = disallowed.reshape(BLOCK_SIZE)
+
+    tl.store(
+        logits_ptr + logits_row * logits_stride + offsets,
+        -float("inf"),
+        mask=(offsets < vocab_size) & disallowed,
+    )
+
+
+def _apply_grammar_bitmask_triton(
+    logits: torch.Tensor,
+    grammar_bitmask: torch.Tensor,
+    logits_indices: torch.Tensor | None = None,
+) -> None:
+    vocab_size = min(logits.shape[-1], grammar_bitmask.shape[-1] * 32)
+    num_rows = grammar_bitmask.shape[0]
+    if num_rows == 0:
+        return
+
+    block_size = 4096
+    props = torch.cuda.get_device_properties(logits.device)
+    arch = getattr(props, "gcnArchName", "")
+    # AMD CDNA wavefronts use 64 lanes. Keep this in sync with xgrammar's
+    # Triton bitmask kernel configuration.
+    warp_size = 64 if torch.version.hip is not None and "gfx1" not in arch else 32
+
+    grid = (triton.cdiv(vocab_size, block_size), num_rows)
+    _apply_grammar_bitmask_kernel[grid](
+        logits,
+        grammar_bitmask,
+        logits_indices,
+        vocab_size,
+        logits.stride(0),
+        grammar_bitmask.stride(0),
+        logits_indices is not None,
+        block_size,
+        num_warps=block_size // warp_size // (16 // logits.element_size()),
+        num_stages=3,
+    )
 
 
 def compile_regex_with_timeout(fn: Callable[[str], _T], pattern: str) -> _T:
@@ -119,7 +226,52 @@ def apply_grammar_bitmask(
         if req_id in struct_out_req_ids:
             struct_out_req_batch_indices[req_id] = logit_index
 
-    out_indices = []
+    out_indices: list[int] = []
+    bitmask_indices: list[int] = []
+
+    cumulative_index = 0
+    for req_id in grammar_output.structured_output_request_ids:
+        num_spec_tokens = len(spec_tokens.get(req_id, ()))
+        if (logit_idx := struct_out_req_batch_indices.get(req_id)) is not None:
+            for i in range(1 + num_spec_tokens):
+                bitmask_index = logit_idx + i
+                out_indices.append(bitmask_index)
+                bitmask_indices.append(cumulative_index + i)
+        cumulative_index += 1 + num_spec_tokens
+
+    if not out_indices:
+        return
+
+    if not logits.is_cpu and current_platform.is_rocm() and HAS_TRITON:
+        # Keep the ROCm path compact: one bitmask row per row that will be
+        # masked, plus an optional logits-row mapping for sparse batches.
+        paired_indices = sorted(zip(out_indices, bitmask_indices))
+        out_indices = [logit_idx for logit_idx, _ in paired_indices]
+        bitmask_indices = [bitmask_idx for _, bitmask_idx in paired_indices]
+
+        compact_bitmask_tensor = torch.empty(
+            (len(bitmask_indices), grammar_bitmask.shape[1]),
+            dtype=torch.from_numpy(grammar_bitmask[:0]).dtype,
+            pin_memory=PIN_MEMORY,
+        )
+        compact_bitmask = compact_bitmask_tensor.numpy()
+        for row, bitmask_idx in enumerate(bitmask_indices):
+            compact_bitmask[row] = grammar_bitmask[bitmask_idx]
+
+        grammar_bitmask_tensor = compact_bitmask_tensor.to(
+            logits.device, non_blocking=True
+        )
+        logits_indices = None
+        if out_indices != list(range(logits.shape[0])):
+            logits_indices = async_tensor_h2d(
+                out_indices, dtype=torch.int32, device=logits.device
+            )
+        _apply_grammar_bitmask_triton(
+            logits,
+            grammar_bitmask_tensor,
+            logits_indices,
+        )
+        return
 
     # Reorder the bitmask to match the order of the requests in the batch.
     sorted_bitmask_tensor = torch.full(
@@ -129,15 +281,8 @@ def apply_grammar_bitmask(
         pin_memory=PIN_MEMORY,
     )
     sorted_bitmask = sorted_bitmask_tensor.numpy()
-    cumulative_index = 0
-    for req_id in grammar_output.structured_output_request_ids:
-        num_spec_tokens = len(spec_tokens.get(req_id, ()))
-        if (logit_idx := struct_out_req_batch_indices.get(req_id)) is not None:
-            for i in range(1 + num_spec_tokens):
-                bitmask_index = logit_idx + i
-                sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
-                out_indices.append(bitmask_index)
-        cumulative_index += 1 + num_spec_tokens
+    for logit_idx, bitmask_idx in zip(out_indices, bitmask_indices):
+        sorted_bitmask[logit_idx] = grammar_bitmask[bitmask_idx]
 
     # Copy async to device.
     grammar_bitmask = sorted_bitmask_tensor.to(logits.device, non_blocking=True)
@@ -148,6 +293,18 @@ def apply_grammar_bitmask(
     skip_out_indices = len(out_indices) == logits.shape[0]
 
     if not logits.is_cpu:
+        if current_platform.is_rocm():
+            # xgrammar auto-dispatches HIP tensors to its Triton bitmask
+            # kernel because PyTorch reports them as cuda tensors. Recent
+            # ROCm CI failures in structured-output generation point at that
+            # kernel being JITed during inference, so keep xgrammar for
+            # grammar compilation/matching. If Triton is unavailable, fall
+            # back to PyTorch with the full reordered bitmask.
+            _apply_grammar_bitmask_torch(
+                logits, grammar_bitmask, out_indices, skip_out_indices
+            )
+            return
+
         index_tensor = None
         if not skip_out_indices:
             # xgrammar expects a python list of indices but it will actually work with


### PR DESCRIPTION
Motivation (`AMD: Entrypoints Integration (LLM) (mi325_1)`, `test_structured_output[Qwen/Qwen2.5-1.5B-Instruct-xgrammar-auto-speculative_config8]`):
- https://buildkite.com/vllm/ci/builds/74414/list?jid=019f0077-3a5e-4916-a4b3-7762deac9498&tab=output#L2002
- https://buildkite.com/vllm/ci/builds/74356/list?jid=019eff9d-5391-408f-b53c-a4ca9707186e&tab=output#L1978
- https://buildkite.com/vllm/ci/builds/74407/list?jid=019f0066-4960-45e4-9cb0-e6e4981883d1&tab=output

Recent ROCm CI core dumps clustered around structured-output generation with xgrammar plus ngram speculative decoding. The repeated failing path JITed xgrammar's `apply_token_bitmask_inplace_kernel` shortly before the HSA hardware exception. We do not need to replace xgrammar grammar compilation or matching; the narrow local mitigation is to keep xgrammar's packed bitmask format and only own the final logits masking step on ROCm.

Proposed changed:
- Build compact bitmask rows only for logits rows that need masking.
- Pass an optional logits-row index tensor for sparse batches.
- Add a ROCm Triton kernel that applies the packed bitmask directly to logits.
- Add a PyTorch fallback for ROCm when Triton is unavailable.
- Add CPU coverage for sparse row mapping and aligned full-batch masking semantics.

CPU and non-ROCm GPU paths continue to use xgrammar's existing implementation. The new path is ROCm-only and preserves the same bit semantics: `1` means allowed, `0` means mask to `-inf`. The standalone bitmask benchmark compared xgrammar's Triton apply path against the vLLM Triton path on the local ROCm host with Qwen vocab size 151936, batch sizes 1..48, aligned and sparse row selection, `float16` and `bfloat16`, and allow densities from `1%` to `100%`. Across 70 paired cases, the vLLM Triton path was faster by a median `2.51 us`; no steady-state regression was measured.