### PR TITLE
[ROCm][CI][Multimodal] Use ROCm-aware FA availability check for Unlimited-OCR

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -84,8 +84,8 @@ class UnlimitedOCRForCausalLMConfig(VerifyAndUpdateConfig):
             vllm serve baidu/Unlimited-OCR \\
                 --attention-config '{"backend": "FLEX_ATTENTION"}'
         """
+        from vllm.v1.attention.backends.fa_utils import is_fa_version_supported
         from vllm.v1.attention.backends.registry import AttentionBackendEnum
-        from vllm.vllm_flash_attn import is_fa_version_supported
 
         attn_config = vllm_config.attention_config
         fa4_available = is_fa_version_supported(4)


### PR DESCRIPTION
Use the attention backend helper for the Unlimited-OCR FlashAttention 4 availability check. Unlimited-OCR defaults to FlashAttention 4 when it is available, otherwise it falls back to FlexAttention. The config check imported `is_fa_version_supported` directly from `vllm.vllm_flash_attn`, which is CUDA-only in this ROCm environment. On ROCm that import can fail before the fallback decision is reached, so `test_model_tensor_schema[baidu/Unlimited-OCR]` fails during model config validation.