### PR TITLE
[XPU] exclude unsupported models for test_tensor_sechma.py

### DIFF
--- a/.buildkite/intel_jobs/models_multimodal_intel.yaml
+++ b/.buildkite/intel_jobs/models_multimodal_intel.yaml
@@ -125,7 +125,5 @@ steps:
       pip install open-clip-torch --no-deps &&
       cd tests &&
       pytest -v -s models/multimodal/processing/test_tensor_schema.py
-      --deselect "tests/models/multimodal/processing/test_tensor_schema.py::test_model_tensor_schema[mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4]"
-      --deselect "tests/models/multimodal/processing/test_tensor_schema.py::test_model_tensor_schema[Qwen/Qwen2.5-Omni-7B-AWQ]"
       --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB'
   parallelism: 4

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -85,7 +85,7 @@ MM_DATA_PATCHES = {
 }
 
 _XPU_EXCLUDED_MODEL_IDS = {
-    "baidu/UnlimitedOCR",
+    "baidu/Unlimited-OCR",
     "mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4",
     "Qwen/Qwen2.5-Omni-7B-AWQ",
 }

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -107,11 +107,9 @@ def _get_model_ids_to_test(model_arch_list: AbstractSet[str]):
     model_ids = list(_iter_model_ids_to_test(model_arch_list))
 
     if current_platform.is_xpu():
-        model_ids = [
-            model_id
-            for model_id in model_ids
-            if model_id not in _XPU_EXCLUDED_MODEL_IDS
-        ]
+        for excluded_model_id in _XPU_EXCLUDED_MODEL_IDS:
+            while excluded_model_id in model_ids:
+                model_ids.remove(excluded_model_id)
 
     return model_ids
 

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -20,6 +20,7 @@ from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.cache import MultiModalProcessorOnlyCache
 from vllm.multimodal.inputs import batched_tensors_equal
 from vllm.multimodal.processing import BaseMultiModalProcessor, InputProcessingContext
+from vllm.platforms import current_platform
 from vllm.tokenizers import TokenizerLike, cached_tokenizer_from_config
 from vllm.utils.mistral import is_mistral_tokenizer
 
@@ -83,6 +84,12 @@ MM_DATA_PATCHES = {
     "glmasr": glmasr_patch_mm_data,
 }
 
+_XPU_EXCLUDED_MODEL_IDS = {
+    "baidu/UnlimitedOCR",
+    "mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4",
+    "Qwen/Qwen2.5-Omni-7B-AWQ",
+}
+
 
 def _iter_model_ids_to_test(model_arch_list: AbstractSet[str]):
     for model_arch in model_arch_list:
@@ -97,7 +104,16 @@ def _iter_model_ids_to_test(model_arch_list: AbstractSet[str]):
 
 
 def _get_model_ids_to_test(model_arch_list: AbstractSet[str]):
-    return list(_iter_model_ids_to_test(model_arch_list))
+    model_ids = list(_iter_model_ids_to_test(model_arch_list))
+
+    if current_platform.is_xpu():
+        model_ids = [
+            model_id
+            for model_id in model_ids
+            if model_id not in _XPU_EXCLUDED_MODEL_IDS
+        ]
+
+    return model_ids
 
 
 def get_model_ids_to_test():


### PR DESCRIPTION



## Purpose
Some multi-modality `models(mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4`, `baidu/UnlimitedOCR`, etc) are not supported on XPU platform and should excluded in tests like `test_tensor_schema.py`.
## Test Plan
`pytest -s -v tests/models/multimodal/processing/test_tensor_schema.py`
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

