### PR TITLE
[CI Failure] Add transformers version check for openai/privacy-filter

### DIFF
--- a/tests/models/language/pooling/test_token_classification.py
+++ b/tests/models/language/pooling/test_token_classification.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 from transformers import AutoModelForTokenClassification
 
+from tests.models.registry import HF_EXAMPLE_MODELS
 from tests.models.utils import softmax
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
@@ -136,6 +137,9 @@ def test_openai_privacy_filter(
     model: str,
     dtype: str,
 ) -> None:
+    model_info = HF_EXAMPLE_MODELS.find_hf_info(model)
+    model_info.check_transformers_version(on_fail="skip")
+
     with vllm_runner(model, max_model_len=None, dtype=dtype) as vllm_model:
         vllm_outputs = vllm_model.token_classify(PRIVACY_FILTER_PROMPTS)
 


### PR DESCRIPTION



## Purpose

Ci is currently using transformers==5.5.3, but openai/privacy-filter requires 5.6.0.

https://buildkite.com/vllm/ci/builds/75033/list?sid=019f11f7-e2cf-4055-82e0-33ed2a80a189&tab=output

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

