### PR TITLE
[CPU][Spec Decode] Fix Dynamic Speculative Decoding on CPU backend

### DIFF
--- a/vllm/v1/worker/cpu_model_runner.py
+++ b/vllm/v1/worker/cpu_model_runner.py
@@ -198,6 +198,9 @@ class CPUModelRunner(GPUModelRunner):
         self, scheduler_output: "SchedulerOutput", zeros_only: bool = False
     ) -> None:
         """CPU-safe version: no async copy needed, tensors already on CPU."""
+        draft_ids = self._draft_token_ids
+        if isinstance(draft_ids, torch.Tensor):
+            self.prev_num_spec_tokens = draft_ids.shape[1]
         if self.use_async_scheduling and not (
             scheduler_output.has_structured_output_requests
             or self.input_batch.sampling_metadata.output_token_ids
@@ -210,9 +213,12 @@ class CPUModelRunner(GPUModelRunner):
             return
 
         num_reqs = draft_token_ids.shape[0]
+        num_spec_tokens = draft_token_ids.shape[1]
         if self.draft_token_ids_cpu is not None:
             if not zeros_only:
-                self.draft_token_ids_cpu[:num_reqs].copy_(draft_token_ids)
+                self.draft_token_ids_cpu[:num_reqs, :num_spec_tokens].copy_(
+                    draft_token_ids
+                )
             else:
                 self.draft_token_ids_cpu[:num_reqs] = 0
 
@@ -224,7 +230,10 @@ class CPUModelRunner(GPUModelRunner):
         if req_ids is None:
             return [], []
         if self.draft_token_ids_cpu is not None:
-            return self.draft_token_ids_cpu[: len(req_ids)].tolist(), req_ids
+            num_spec_tokens = self.prev_num_spec_tokens
+            return self.draft_token_ids_cpu[
+                : len(req_ids), :num_spec_tokens
+            ].tolist(), req_ids
         return [], []
 
     def _copy_valid_sampled_token_count(


### PR DESCRIPTION
## Purpose

Fix #47014 — Dynamic Speculative Decoding (DSD, from #32374) crashes on the CPU backend when `num_speculative_tokens_per_batch_size` is configured and K varies at runtime.

**Root cause:** The CPU model runner overrides (`_copy_draft_token_ids_to_cpu` and `_get_draft_token_ids_cpu`) assumed a static number of speculative tokens. When DSD adjusts K based on batch size:

1. `_copy_draft_token_ids_to_cpu` copied the full buffer width (`[:num_reqs]`) instead of slicing to the current K (`[:num_reqs, :num_spec_tokens]`), causing a tensor size mismatch when K shrinks.

2. `_get_draft_token_ids_cpu` returned the full buffer width, exposing stale data from a previous (larger) K, leading to int32 overflow errors.

**Fix:** Track `prev_num_spec_tokens` and slice both methods to the actual K in each step.

## Test Plan

```bash
python -m vllm.entrypoints.openai.api_server \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --dtype bfloat16 --max-model-len 4096 --port 8100 \
    --speculative-config '{"method":"draft_model","model":"meta-llama/Llama-3.2-1B-Instruct","num_speculative_tokens":7,"num_speculative_tokens_per_batch_size":[[1,4,7],[5,16,5],[17,64,3]]}'
```

Then send concurrent requests at BS=1,4,8,16 that cross schedule boundaries.

## Test Result

**Before (crash when K changes from 7 to 5 at BS=8):**
```
RuntimeError: The size of tensor a (5) must match the size of tensor b (7) at non-singleton dimension 1
```
and
```
OverflowError: Python int too large to convert to C long
```

**After (all batch sizes pass):**
```
=== DSD BS=1 ===
  BS=1: TPOT=109.4ms, throughput=9.1 tok/s (1/1 ok)
=== DSD BS=4 ===
  BS=4: TPOT=272.9ms, throughput=14.7 tok/s (4/4 ok)
=== DSD BS=8 ===
  BS=8: TPOT=410.7ms, throughput=19.5 tok/s (8/8 ok)
=== DSD BS=16 ===
  BS=16: TPOT=834.8ms, throughput=19.2 tok/s (16/16 ok)
```

Tested on Intel Xeon 8580 (120 cores) with Llama-3.1-8B + Llama-3.2-1B draft model.

@ekagra-ranjan