### PR TITLE
[Bugfix] Handle list slot_mapping in remaining KV-cache consumers

### DIFF
--- a/tests/v1/spec_decode/test_extract_hidden_states.py
+++ b/tests/v1/spec_decode/test_extract_hidden_states.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+from types import SimpleNamespace
 from unittest import mock
 
 import numpy as np
@@ -24,6 +25,8 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.config.load import LoadConfig
+from vllm.forward_context import ForwardContext, override_forward_context
+from vllm.model_executor.models.extract_hidden_states import unified_kv_cache_update
 from vllm.platforms import current_platform
 from vllm.transformers_utils.config import get_hf_text_config
 from vllm.transformers_utils.configs.extract_hidden_states import (
@@ -331,6 +334,31 @@ def test_propose_different_layer_counts(num_hidden_layers):
 
     assert draft_tokens.shape == (batch_size, 1)
     assert torch.equal(draft_tokens, sampled_token_ids)
+
+
+def test_unified_kv_cache_update_slot_mapping_list():
+    # spec decode passes slot_mapping as list[dict]; [0] is the base model (#46830)
+    layer_name = "layer.0"
+    slots = torch.arange(4)
+
+    class _RecordingImpl:
+        def __init__(self):
+            self.captured = None
+
+        def do_kv_cache_update(self, layer, to_cache, kv_cache, slot_mapping):
+            self.captured = slot_mapping
+
+    impl = _RecordingImpl()
+    attn_layer = SimpleNamespace(kv_cache=torch.empty(0), impl=impl)
+    ctx = ForwardContext(
+        no_compile_layers={layer_name: attn_layer},
+        attn_metadata={layer_name: None},
+        slot_mapping=[{layer_name: slots}],
+    )
+    with override_forward_context(ctx):
+        unified_kv_cache_update(torch.empty(0), layer_name)
+
+    assert torch.equal(impl.captured, slots)
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -54,6 +54,8 @@ def unified_kv_cache_update(
     kv_cache = attn_layer.kv_cache
 
     slot_mapping = forward_context.slot_mapping
+    if isinstance(slot_mapping, list):
+        slot_mapping = slot_mapping[0]  # spec decode: [0] is the base model
     assert isinstance(slot_mapping, dict), (
         f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
     )

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -369,6 +369,8 @@ class DeepseekV32Attention(MLAAttention):
             attn_metadata = attn_metadata_raw
 
         slot_mapping = forward_context.slot_mapping
+        if isinstance(slot_mapping, list):
+            slot_mapping = slot_mapping[0]  # spec decode: [0] is the base model
         assert isinstance(slot_mapping, dict)
         mla_slot = slot_mapping.get(self.layer_name)
 


### PR DESCRIPTION
## Purpose

Follow-up to #46830. #46908 fixes `get_attention_context()` and the MLA base path, but two other `forward_context.slot_mapping` consumers still assert `dict` and crash on the `list[dict]` form from speculative decoding / MTP:

- `extract_hidden_states.py` (`unified_kv_cache_update`)
- `deepseek_v32/nvidia/attention.py` (already unwraps `attn_metadata` but not `slot_mapping`)

## Test

`pytest tests/v1/spec_decode/test_extract_hidden_states.py::test_unified_kv_cache_update_slot_mapping_list`