### PR TITLE
Fix transient dependency issues caused by `requirements/common.txt`

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -194,6 +194,7 @@ FROM base AS vllm-test-deps
 WORKDIR /vllm-workspace
 
 # Copy test requirements
+COPY requirements/common.txt requirements/common.txt
 COPY requirements/test/cuda.in requirements/test/cpu.in
 
 RUN \

--- a/requirements/test/cuda.in
+++ b/requirements/test/cuda.in
@@ -1,3 +1,5 @@
+-r ../common.txt
+
 # testing
 pytest
 tensorizer==2.10.1
@@ -13,7 +15,6 @@ albumentations # required for Nemotron Parse in test_common.py
 av  # required for audio_in_video tests
 backoff # required for phi4mm test
 blobfile # required for kimi-vl test
-einops # required for MPT, qwen-vl
 httpx
 librosa # required for audio tests
 vector_quantize_pytorch # required for minicpmo_26 test
@@ -34,7 +35,6 @@ matplotlib # required for qwen-vl test
 mistral_common[image,audio] >= 1.11.5 # required for voxtral test
 num2words # required for smolvlm test
 open_clip_torch==2.32.0 # Required for nemotron_vl test, Nemotron Parse in test_common.py
-opencv-python-headless >= 4.13.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]>=0.4.12 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test
@@ -55,11 +55,9 @@ grpcio-reflection==1.78.0
 
 arctic-inference == 0.1.1; platform_machine == "x86_64" # Required for suffix decoding test
 numba == 0.65.0 # Required for N-gram speculative decoding
-numpy
 runai-model-streamer[s3,gcs,azure]==0.15.7
 fastsafetensors>=0.3.2
 instanttensor>=0.1.5; platform_machine == "x86_64"
-pydantic>=2.12 # 2.11 leads to error on python 3.13
 decord==0.6.0; platform_machine == "x86_64"
 # terratorch is temporarily disabled while PyPI has the `lightning` package
 # in `quarantined` status (every published terratorch version transitively

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -9,6 +9,7 @@ aiohappyeyeballs==2.6.1
 aiohttp==3.13.3
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   aiohttp-cors
     #   datasets
     #   fsspec
@@ -24,17 +25,34 @@ albumentations==1.4.6
 alembic==1.16.4
     # via optuna
 annotated-doc==0.0.4
-    # via fastapi
+    # via
+    #   fastapi
+    #   typer
 annotated-types==0.7.0
     # via pydantic
-anyio==4.6.2.post1
+anthropic==0.112.0
     # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+anyio==4.14.1
+    # via
+    #   anthropic
     #   httpx
+    #   mcp
+    #   openai
+    #   sse-starlette
     #   starlette
+    #   watchfiles
+apache-tvm-ffi==0.1.9
+    # via
+    #   -c requirements/cuda.txt
+    #   xgrammar
 arctic-inference==0.1.1
     # via -r requirements/test/cuda.in
 argcomplete==3.5.1
     # via datamodel-code-generator
+astor==0.8.1
+    # via depyf
 attrs==24.2.0
     # via
     #   aiohttp
@@ -59,6 +77,8 @@ bitsandbytes==0.49.2
     # via -r requirements/test/cuda.in
 black==24.10.0
     # via datamodel-code-generator
+blake3==1.0.9
+    # via -r requirements/test/../common.txt
 blobfile==3.0.0
     # via -r requirements/test/cuda.in
 bm25s==0.2.13
@@ -76,12 +96,17 @@ bounded-pool-executor==0.0.3
 buildkite-test-collector==0.1.9
     # via -r requirements/test/cuda.in
 cachetools==5.5.2
-    # via google-auth
+    # via
+    #   -r requirements/test/../common.txt
+    #   google-auth
+cbor2==6.1.2
+    # via -r requirements/test/../common.txt
 certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   requests
+    #   sentry-sdk
 cffi==2.0.0
     # via
     #   cryptography
@@ -98,9 +123,11 @@ click==8.1.7
     #   jiwer
     #   nltk
     #   ray
+    #   rich-toolkit
     #   schemathesis
-    #   typer
     #   uvicorn
+cloudpickle==3.1.2
+    # via -r requirements/test/../common.txt
 cohere-melody==0.9.0
     # via -r requirements/test/cuda.in
 colorama==0.4.6
@@ -111,6 +138,10 @@ colorful==0.5.6
     # via ray
 colorlog==6.10.1
     # via optuna
+compressed-tensors==0.17.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 contourpy==1.3.0
     # via matplotlib
 coverage==7.10.6
@@ -149,30 +180,49 @@ decorator==5.1.1
     # via librosa
 decord==0.6.0
     # via -r requirements/test/cuda.in
+depyf==0.20.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+detect-installer==0.1.0
+    # via fastapi-cloud-cli
 dill==0.3.8
     # via
     #   datasets
+    #   depyf
     #   evaluate
     #   lm-eval
     #   multiprocess
+diskcache==5.6.3
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 distlib==0.3.9
     # via virtualenv
+distro==1.9.0
+    # via
+    #   anthropic
+    #   openai
 dnspython==2.7.0
     # via email-validator
 docker==7.1.0
     # via gpt-oss
 docopt==0.6.2
     # via num2words
+docstring-parser==0.18.0
+    # via anthropic
 einops==0.8.1
     # via
-    #   -r requirements/test/cuda.in
+    #   -r requirements/test/../common.txt
     #   encodec
     #   vector-quantize-pytorch
     #   vocos
 einx==0.3.0
     # via vector-quantize-pytorch
 email-validator==2.2.0
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 encodec==0.1.1
     # via vocos
 et-xmlfile==2.0.0
@@ -182,7 +232,17 @@ evaluate==0.4.3
 fastapi==0.136.3
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   gpt-oss
+    #   model-hosting-container-standards
+fastapi-cli==0.0.27
+    # via fastapi
+fastapi-cloud-cli==0.21.0
+    # via fastapi-cli
+fastar==0.11.0
+    # via
+    #   fastapi
+    #   fastapi-cloud-cli
 fastparquet==2024.11.0
     # via genai-perf
 fastrlock==0.8.2
@@ -194,6 +254,7 @@ fastsafetensors==0.3.2
 filelock==3.16.1
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   blobfile
     #   datasets
     #   huggingface-hub
@@ -243,7 +304,10 @@ google-crc32c==1.7.1
 google-resumable-media==2.7.2
     # via google-cloud-storage
 googleapis-common-protos==1.70.0
-    # via google-api-core
+    # via
+    #   google-api-core
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 gpt-oss==0.0.8
     # via -r requirements/test/cuda.in
 graphql-core==3.2.6
@@ -254,6 +318,7 @@ grpcio==1.78.0
     # via
     #   -r requirements/test/cuda.in
     #   grpcio-reflection
+    #   opentelemetry-exporter-otlp-proto-grpc
     #   ray
 grpcio-reflection==1.78.0
     # via -r requirements/test/cuda.in
@@ -275,12 +340,22 @@ html2text==2025.4.15
     # via gpt-oss
 httpcore==1.0.6
     # via httpx
+httptools==0.8.0
+    # via uvicorn
 httpx==0.27.2
     # via
     #   -r requirements/test/cuda.in
+    #   anthropic
+    #   fastapi
+    #   fastapi-cloud-cli
     #   huggingface-hub
+    #   mcp
+    #   model-hosting-container-standards
+    #   openai
     #   perceptron
     #   schemathesis
+httpx-sse==0.4.3
+    # via mcp
 huggingface-hub==1.10.2
     # via
     #   accelerate
@@ -314,6 +389,8 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
+ijson==3.5.0
+    # via -r requirements/test/../common.txt
 imagehash==4.3.2
     # via -r requirements/test/cuda.in
 imageio==2.37.0
@@ -326,6 +403,8 @@ iniconfig==2.0.0
     # via pytest
 instanttensor==0.1.5
     # via -r requirements/test/cuda.in
+interegular==0.3.3
+    # via lm-format-enforcer
 isodate==0.7.2
     # via azure-storage-blob
 isort==5.13.2
@@ -333,15 +412,21 @@ isort==5.13.2
 jinja2==3.1.6
     # via
     #   datamodel-code-generator
+    #   fastapi
     #   genai-perf
     #   lm-eval
     #   torch
+jiter==0.15.0
+    # via
+    #   anthropic
+    #   openai
 jiwer==3.0.5
     # via -r requirements/test/cuda.in
 jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+    #   model-hosting-container-standards
 joblib==1.4.2
     # via
     #   librosa
@@ -350,7 +435,9 @@ joblib==1.4.2
 jsonschema==4.23.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   hypothesis-jsonschema
+    #   mcp
     #   mistral-common
     #   ray
 jsonschema-rs==0.46.5
@@ -365,6 +452,10 @@ kaleido==0.2.1
     # via genai-perf
 kiwisolver==1.4.7
     # via matplotlib
+lark==1.2.2
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 lazy-loader==0.4
     # via
     #   librosa
@@ -373,10 +464,20 @@ libnacl==2.1.0
     # via tensorizer
 librosa==0.10.2.post1
     # via -r requirements/test/cuda.in
+llguidance==1.7.6
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 llvmlite==0.47.0
     # via numba
 lm-eval==0.4.12
     # via -r requirements/test/cuda.in
+lm-format-enforcer==0.11.3
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+loguru==0.7.3
+    # via compressed-tensors
 lxml==5.3.0
     # via
     #   blobfile
@@ -398,12 +499,19 @@ mbstrdecoder==1.1.3
     #   dataproperty
     #   pytablewriter
     #   typepy
+mcp==1.28.1
+    # via -r requirements/test/../common.txt
 mdurl==0.1.2
     # via markdown-it-py
 mistral-common==1.11.5
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   -r requirements/test/cuda.in
+model-hosting-container-standards==0.1.16
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 more-itertools==10.5.0
     # via lm-eval
 mpmath==1.3.0
@@ -418,6 +526,8 @@ msgpack==1.1.0
     # via
     #   librosa
     #   ray
+msgspec==0.21.1
+    # via -r requirements/test/../common.txt
 mteb==2.8.3
     # via -r requirements/test/cuda.in
 multidict==6.1.0
@@ -434,6 +544,8 @@ networkx==3.2.1
     # via
     #   scikit-image
     #   torch
+ninja==1.13.0
+    # via -r requirements/test/../common.txt
 nltk==3.9.1
     # via rouge-score
 num2words==0.5.14
@@ -445,7 +557,7 @@ numba==0.65.0
     #   librosa
 numpy==2.2.6
     # via
-    #   -r requirements/test/cuda.in
+    #   -r requirements/test/../common.txt
     #   accelerate
     #   albumentations
     #   bitsandbytes
@@ -489,6 +601,7 @@ numpy==2.2.6
     #   transformers
     #   tritonclient
     #   vocos
+    #   xgrammar
 nvidia-cublas==13.1.0.3
     # via
     #   cuda-toolkit
@@ -530,9 +643,14 @@ nvidia-nvtx==13.0.85
     # via cuda-toolkit
 open-clip-torch==2.32.0
     # via -r requirements/test/cuda.in
+openai==2.44.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 openai-harmony==0.0.4
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   gpt-oss
 opencensus==0.11.4
     # via ray
@@ -541,7 +659,7 @@ opencensus-context==0.1.3
 opencv-python-headless==4.13.0.90
     # via
     #   -c requirements/common.txt
-    #   -r requirements/test/cuda.in
+    #   -r requirements/test/../common.txt
     #   albumentations
     #   mistral-common
 openpyxl==3.1.5
@@ -549,24 +667,54 @@ openpyxl==3.1.5
 opentelemetry-api==1.35.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-exporter-prometheus
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp==1.35.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+opentelemetry-exporter-otlp-proto-common==1.35.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.35.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.35.0
+    # via opentelemetry-exporter-otlp
 opentelemetry-exporter-prometheus==0.56b0
     # via ray
 opentelemetry-proto==1.35.0
-    # via ray
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   ray
 opentelemetry-sdk==1.35.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-exporter-prometheus
     #   ray
 opentelemetry-semantic-conventions==0.56b0
     # via opentelemetry-sdk
+opentelemetry-semantic-conventions-ai==0.4.13
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 optuna==3.6.1
     # via genai-perf
 orjson==3.11.5
     # via genai-perf
+outlines-core==0.2.14
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 packaging==24.2
     # via
     #   accelerate
@@ -578,6 +726,7 @@ packaging==24.2
     #   fastparquet
     #   huggingface-hub
     #   lazy-loader
+    #   lm-format-enforcer
     #   matplotlib
     #   optuna
     #   peft
@@ -597,6 +746,8 @@ pandas==2.2.3
     #   fastparquet
     #   genai-perf
     #   statsmodels
+partial-json-parser==0.2.1.1.post7
+    # via -r requirements/test/../common.txt
 pathspec==0.12.1
     # via black
 pathvalidate==3.2.1
@@ -611,6 +762,7 @@ perf-analyzer==0.1.0
     # via genai-perf
 pillow==10.4.0
     # via
+    #   -r requirements/test/../common.txt
     #   genai-perf
     #   imagehash
     #   imageio
@@ -644,8 +796,14 @@ pqdm==0.2.0
 prometheus-client==0.22.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   opentelemetry-exporter-prometheus
+    #   prometheus-fastapi-instrumentator
     #   ray
+prometheus-fastapi-instrumentator==8.0.2
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 propcache==0.2.0
     # via
     #   aiohttp
@@ -655,6 +813,7 @@ proto-plus==1.26.1
 protobuf==6.33.6
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   google-api-core
     #   googleapis-common-protos
     #   grpcio-reflection
@@ -664,11 +823,14 @@ protobuf==6.33.6
     #   tensorizer
 psutil==6.1.0
     # via
+    #   -r requirements/test/../common.txt
     #   accelerate
     #   peft
     #   tensorizer
 py==1.11.0
     # via pytest-forked
+py-cpuinfo==9.0.0
+    # via -r requirements/test/../common.txt
 py-spy==0.4.0
     # via ray
 pyarrow==23.0.0
@@ -681,6 +843,8 @@ pyasn1==0.6.1
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
+pybase64==1.4.3
+    # via -r requirements/test/../common.txt
 pycountry==24.6.1
     # via pydantic-extra-types
 pycparser==2.22
@@ -690,26 +854,43 @@ pycryptodomex==3.22.0
 pydantic==2.12.0
     # via
     #   -c requirements/common.txt
-    #   -r requirements/test/cuda.in
+    #   -r requirements/test/../common.txt
     #   albumentations
+    #   anthropic
+    #   compressed-tensors
     #   datamodel-code-generator
     #   fastapi
+    #   fastapi-cloud-cli
     #   gpt-oss
+    #   lm-format-enforcer
+    #   mcp
     #   mistral-common
+    #   model-hosting-container-standards
     #   mteb
+    #   openai
     #   openai-harmony
     #   pydantic-extra-types
+    #   pydantic-settings
     #   ray
+    #   xgrammar
 pydantic-core==2.41.1
     # via pydantic
 pydantic-extra-types==2.10.5
-    # via mistral-common
+    # via
+    #   fastapi
+    #   mistral-common
+pydantic-settings==2.14.2
+    # via
+    #   fastapi
+    #   mcp
 pygments==2.18.0
     # via
     #   pytest
     #   rich
 pyjwt==2.11.0
-    # via msal
+    # via
+    #   mcp
+    #   msal
 pyparsing==3.2.0
     # via matplotlib
 pyrate-limiter==4.4.0
@@ -751,6 +932,16 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   pandas
     #   typepy
+python-dotenv==1.2.2
+    # via
+    #   pydantic-settings
+    #   uvicorn
+python-json-logger==4.1.0
+    # via -r requirements/test/../common.txt
+python-multipart==0.0.32
+    # via
+    #   fastapi
+    #   mcp
 python-rapidjson==1.20
     # via tritonclient
 pytrec-eval-terrier==0.5.7
@@ -763,12 +954,14 @@ pywavelets==1.9.0
     # via imagehash
 pyyaml==6.0.2
     # via
+    #   -r requirements/test/../common.txt
     #   accelerate
     #   albumentations
     #   datamodel-code-generator
     #   datasets
     #   genai-perf
     #   huggingface-hub
+    #   lm-format-enforcer
     #   optuna
     #   peft
     #   ray
@@ -776,7 +969,12 @@ pyyaml==6.0.2
     #   schemathesis
     #   timm
     #   transformers
+    #   uvicorn
     #   vocos
+pyzmq==27.1.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 rapidfuzz==3.12.1
     # via jiwer
 ray==2.48.0
@@ -789,6 +987,7 @@ referencing==0.35.1
     #   jsonschema-specifications
 regex==2026.2.28
     # via
+    #   -r requirements/test/../common.txt
     #   nltk
     #   open-clip-torch
     #   sacrebleu
@@ -797,6 +996,7 @@ regex==2026.2.28
 requests==2.32.3
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   azure-core
     #   buildkite-test-collector
     #   datasets
@@ -809,6 +1009,7 @@ requests==2.32.3
     #   mistral-common
     #   msal
     #   mteb
+    #   opentelemetry-exporter-otlp-proto-http
     #   pooch
     #   ray
     #   responses
@@ -822,8 +1023,15 @@ rich==13.9.4
     #   genai-perf
     #   mteb
     #   perceptron
+    #   rich-toolkit
     #   schemathesis
     #   typer
+rich-toolkit==0.20.1
+    # via
+    #   fastapi-cli
+    #   fastapi-cloud-cli
+rignore==0.7.6
+    # via fastapi-cloud-cli
 rouge-score==0.1.2
     # via lm-eval
 rpds-py==0.20.1
@@ -847,6 +1055,7 @@ sacrebleu==2.4.3
 safetensors==0.7.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   accelerate
     #   open-clip-torch
     #   peft
@@ -882,9 +1091,17 @@ sentence-transformers==5.2.0
     # via
     #   -r requirements/test/cuda.in
     #   mteb
+sentencepiece==0.2.1
+    # via -r requirements/test/../common.txt
+sentry-sdk==2.63.0
+    # via fastapi-cloud-cli
+setproctitle==1.3.7
+    # via -r requirements/test/../common.txt
 setuptools==77.0.3
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+    #   model-hosting-container-standards
     #   pytablewriter
     #   torch
 shellingham==1.5.4
@@ -894,6 +1111,7 @@ shellingham==1.5.4
 six==1.16.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   junit-xml
     #   opencensus
     #   python-dateutil
@@ -902,8 +1120,9 @@ smart-open==7.1.0
     # via ray
 sniffio==1.3.1
     # via
-    #   anyio
+    #   anthropic
     #   httpx
+    #   openai
 sortedcontainers==2.4.0
     # via hypothesis
 soundfile==0.12.1
@@ -922,10 +1141,17 @@ sqlalchemy==2.0.41
     #   optuna
 sqlitedict==2.1.0
     # via lm-eval
+sse-starlette==3.4.5
+    # via mcp
 starlette==1.3.1
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   fastapi
+    #   mcp
+    #   model-hosting-container-standards
+    #   prometheus-fastapi-instrumentator
+    #   sse-starlette
     #   starlette-testclient
 starlette-testclient==0.4.1
     # via schemathesis
@@ -933,6 +1159,8 @@ statsmodels==0.14.4
     # via genai-perf
 structlog==25.4.0
     # via gpt-oss
+supervisor==4.3.0
+    # via model-hosting-container-standards
 sympy==1.13.3
     # via
     #   einx
@@ -962,6 +1190,7 @@ tifffile==2025.3.30
 tiktoken==0.12.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   gpt-oss
     #   lm-eval
     #   mistral-common
@@ -973,6 +1202,7 @@ timm==1.0.17
 tokenizers==0.22.2
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   -r requirements/test/cuda.in
     #   transformers
 torch==2.11.0+cu130
@@ -981,6 +1211,7 @@ torch==2.11.0+cu130
     #   -r requirements/test/cuda.in
     #   accelerate
     #   bitsandbytes
+    #   compressed-tensors
     #   encodec
     #   instanttensor
     #   mteb
@@ -994,6 +1225,7 @@ torch==2.11.0+cu130
     #   torchvision
     #   vector-quantize-pytorch
     #   vocos
+    #   xgrammar
 torchaudio==2.11.0+cu130
     # via
     #   -c requirements/cuda.txt
@@ -1009,6 +1241,7 @@ torchvision==0.26.0+cu130
     #   timm
 tqdm==4.67.3
     # via
+    #   -r requirements/test/../common.txt
     #   datasets
     #   evaluate
     #   huggingface-hub
@@ -1016,6 +1249,7 @@ tqdm==4.67.3
     #   mteb
     #   nltk
     #   open-clip-torch
+    #   openai
     #   optuna
     #   peft
     #   pqdm
@@ -1025,15 +1259,20 @@ tqdm==4.67.3
 transformers==5.5.3
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   -r requirements/test/cuda.in
+    #   compressed-tensors
     #   genai-perf
     #   peft
     #   sentence-transformers
     #   transformers-stream-generator
+    #   xgrammar
 transformers-stream-generator==0.0.5
     # via -r requirements/test/cuda.in
 triton==3.6.0
-    # via torch
+    # via
+    #   torch
+    #   xgrammar
 tritonclient==2.64.0
     # via -r requirements/test/cuda.in
 typepy==1.3.2
@@ -1041,8 +1280,10 @@ typepy==1.3.2
     #   dataproperty
     #   pytablewriter
     #   tabledata
-typer==0.15.2
+typer==0.26.8
     # via
+    #   fastapi-cli
+    #   fastapi-cloud-cli
     #   fastsafetensors
     #   huggingface-hub
     #   perceptron
@@ -1050,9 +1291,13 @@ typer==0.15.2
 typing-extensions==4.15.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   aiosignal
     #   albumentations
     #   alembic
+    #   anthropic
+    #   anyio
+    #   apache-tvm-ffi
     #   azure-core
     #   azure-identity
     #   azure-storage-blob
@@ -1062,9 +1307,13 @@ typing-extensions==4.15.0
     #   huggingface-hub
     #   librosa
     #   lm-eval
+    #   mcp
     #   mistral-common
     #   mteb
+    #   openai
     #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pqdm
@@ -1072,17 +1321,20 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   pydantic-extra-types
     #   pytest-asyncio
+    #   rich-toolkit
     #   schemathesis
     #   sentence-transformers
     #   sqlalchemy
     #   starlette
     #   torch
-    #   typer
     #   typing-inspection
+    #   xgrammar
 typing-inspection==0.4.2
     # via
     #   fastapi
+    #   mcp
     #   pydantic
+    #   pydantic-settings
 tzdata==2024.2
     # via pandas
 urllib3==2.2.3
@@ -1092,23 +1344,41 @@ urllib3==2.2.3
     #   docker
     #   requests
     #   responses
+    #   sentry-sdk
     #   tritonclient
 uvicorn==0.35.0
-    # via gpt-oss
+    # via
+    #   fastapi
+    #   fastapi-cli
+    #   fastapi-cloud-cli
+    #   gpt-oss
+    #   mcp
+uvloop==0.22.1
+    # via uvicorn
 vector-quantize-pytorch==1.21.2
     # via -r requirements/test/cuda.in
 virtualenv==20.31.2
     # via ray
 vocos==0.1.0
     # via -r requirements/test/cuda.in
+watchfiles==1.2.0
+    # via
+    #   -r requirements/test/../common.txt
+    #   uvicorn
 wcwidth==0.2.13
     # via ftfy
+websockets==16.0
+    # via uvicorn
 werkzeug==3.1.3
     # via schemathesis
 word2number==1.1
     # via lm-eval
 wrapt==1.17.2
     # via smart-open
+xgrammar==0.2.3
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 xxhash==3.5.0
     # via
     #   datasets

--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -15,7 +15,6 @@ albumentations # required for Nemotron Parse in test_common.py
 av # required for audio_in_video tests
 backoff # required for phi4mm test
 blobfile # required for kimi-vl test
-einops # required for MPT, qwen-vl
 httpx
 librosa # required for audio tests
 vector_quantize_pytorch # required for minicpmo_26 test
@@ -33,7 +32,6 @@ matplotlib # required for qwen-vl test
 mistral_common[image,audio]>=1.11.5 # required for voxtral test
 num2words # required for smolvlm test
 open_clip_torch==2.32.0 # Required for nemotron_vl test, Nemotron Parse in test_common.py
-opencv-python-headless>=4.13.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]>=0.4.12 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test
@@ -54,11 +52,9 @@ grpcio-reflection==1.78.0
 
 arctic-inference==0.1.1 # Required for suffix decoding test
 numba==0.65.0 # Required for N-gram speculative decoding
-numpy
 runai-model-streamer[s3,gcs,azure]==0.15.7
 fastsafetensors>=0.3.2
 instanttensor>=0.1.5
-pydantic>=2.12 # 2.11 leads to error on python 3.13
 decord==0.6.0
 
 # Prithvi tests

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -2,11 +2,11 @@
 #    uv pip compile requirements/test/rocm.in -c requirements/rocm.txt -o requirements/test/rocm.txt --index-strategy unsafe-best-match --python-platform x86_64-manylinux_2_28 --python-version 3.12 --no-emit-package torch --no-emit-package torchvision --no-emit-package torchaudio --no-emit-package triton --no-emit-package cuda-bindings --no-emit-package cuda-pathfinder --no-emit-package cuda-toolkit --no-emit-package cupy-cuda12x --no-emit-package nvidia-cublas --no-emit-package nvidia-cuda-cupti --no-emit-package nvidia-cuda-nvrtc --no-emit-package nvidia-cuda-runtime --no-emit-package nvidia-cudnn --no-emit-package nvidia-cufft --no-emit-package nvidia-cufile --no-emit-package nvidia-curand --no-emit-package nvidia-cusolver --no-emit-package nvidia-cusparse --no-emit-package nvidia-cusparselt --no-emit-package nvidia-nccl --no-emit-package nvidia-nvjitlink --no-emit-package nvidia-nvshmem --no-emit-package nvidia-nvtx --no-emit-package nvidia-cublas-cu12 --no-emit-package nvidia-cuda-cupti-cu12 --no-emit-package nvidia-cuda-nvrtc-cu12 --no-emit-package nvidia-cuda-runtime-cu12 --no-emit-package nvidia-cudnn-cu12 --no-emit-package nvidia-cufft-cu12 --no-emit-package nvidia-cufile-cu12 --no-emit-package nvidia-curand-cu12 --no-emit-package nvidia-cusolver-cu12 --no-emit-package nvidia-cusparse-cu12 --no-emit-package nvidia-cusparselt-cu12 --no-emit-package nvidia-nccl-cu12 --no-emit-package nvidia-nvjitlink-cu12 --no-emit-package nvidia-nvshmem-cu12 --no-emit-package nvidia-nvtx-cu12 --no-emit-package nvidia-cublas-cu13 --no-emit-package nvidia-cuda-cupti-cu13 --no-emit-package nvidia-cuda-nvrtc-cu13 --no-emit-package nvidia-cuda-runtime-cu13 --no-emit-package nvidia-cudnn-cu13 --no-emit-package nvidia-cufft-cu13 --no-emit-package nvidia-cufile-cu13 --no-emit-package nvidia-curand-cu13 --no-emit-package nvidia-cusolver-cu13 --no-emit-package nvidia-cusparse-cu13 --no-emit-package nvidia-cusparselt-cu13 --no-emit-package nvidia-nccl-cu13 --no-emit-package nvidia-nvjitlink-cu13 --no-emit-package nvidia-nvshmem-cu13 --no-emit-package nvidia-nvtx-cu13
 absl-py==2.4.0
     # via rouge-score
-accelerate==1.13.0
+accelerate==1.14.0
     # via peft
-aiohappyeyeballs==2.6.1
+aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.1
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -19,9 +19,11 @@ aiohttp-cors==0.8.1
     # via ray
 aiosignal==1.4.0
     # via aiohttp
-albumentations==1.4.6
+albucore==0.0.24
+    # via albumentations
+albumentations==2.0.8
     # via -r requirements/test/rocm.in
-alembic==1.18.4
+alembic==1.18.5
     # via optuna
 annotated-doc==0.0.4
     # via
@@ -29,11 +31,11 @@ annotated-doc==0.0.4
     #   typer
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.93.0
+anthropic==0.112.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-anyio==4.13.0
+anyio==4.14.1
     # via
     #   anthropic
     #   httpx
@@ -58,35 +60,35 @@ attrs==26.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
-audioread==3.0.1
+audioread==3.1.0
     # via librosa
-av==16.1.0
+av==17.1.0
     # via -r requirements/test/rocm.in
-azure-core==1.39.0
+azure-core==1.41.0
     # via
     #   azure-identity
     #   azure-storage-blob
 azure-identity==1.25.3
     # via runai-model-streamer-azure
-azure-storage-blob==12.28.0
+azure-storage-blob==12.30.0
     # via runai-model-streamer-azure
 backoff==2.2.1
     # via -r requirements/test/rocm.in
 bitsandbytes==0.49.2
     # via -r requirements/test/rocm.in
-black==26.3.1
+black==26.5.1
     # via datamodel-code-generator
-blake3==1.0.8
+blake3==1.0.9
     # via -r requirements/test/../common.txt
-blobfile==3.0.0
+blobfile==3.2.0
     # via -r requirements/test/rocm.in
-bm25s==0.2.13
+bm25s==0.3.9
     # via mteb
-boto3==1.42.74
+boto3==1.43.36
     # via
     #   runai-model-streamer-s3
     #   tensorizer
-botocore==1.42.74
+botocore==1.43.36
     # via
     #   boto3
     #   s3transfer
@@ -94,31 +96,32 @@ bounded-pool-executor==0.0.3
     # via pqdm
 buildkite-test-collector==0.1.9
     # via -r requirements/test/rocm.in
-cachetools==7.0.5
+cachetools==7.1.4
     # via -r requirements/test/../common.txt
-cbor2==5.9.0
+cbor2==6.1.2
     # via -r requirements/test/../common.txt
-certifi==2026.2.25
+certifi==2026.6.17
     # via
     #   httpcore
     #   httpx
     #   requests
     #   sentry-sdk
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   cryptography
     #   soundfile
-chardet==5.2.0
+chardet==6.0.0.post1
     # via mbstrdecoder
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-choreographer==1.2.1
+choreographer==1.3.0
     # via kaleido
 chz==0.4.0
     # via gpt-oss
-click==8.3.1
+click==8.4.2
     # via
     #   black
+    #   huggingface-hub
     #   jiwer
     #   nltk
     #   ray
@@ -144,11 +147,11 @@ compressed-tensors==0.17.0
     #   -r requirements/test/../common.txt
 contourpy==1.3.3
     # via matplotlib
-coverage==7.13.5
+coverage==7.14.3
     # via pytest-cov
 cramjam==2.11.0
     # via fastparquet
-cryptography==46.0.0
+cryptography==49.0.0
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -157,9 +160,9 @@ cryptography==46.0.0
     #   pyjwt
 cycler==0.12.1
     # via matplotlib
-datamodel-code-generator==0.55.0
+datamodel-code-generator==0.66.0
     # via -r requirements/test/rocm.in
-dataproperty==1.1.0
+dataproperty==1.1.1
     # via
     #   pytablewriter
     #   tabledata
@@ -169,7 +172,7 @@ datasets==3.6.0
     #   evaluate
     #   lm-eval
     #   mteb
-decorator==5.2.1
+decorator==5.3.1
     # via librosa
 decord==0.6.0
     # via -r requirements/test/rocm.in
@@ -177,6 +180,8 @@ depyf==0.20.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
+detect-installer==0.1.0
+    # via fastapi-cloud-cli
 dill==0.3.8
     # via
     #   datasets
@@ -188,7 +193,7 @@ diskcache==5.6.3
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-distlib==0.4.0
+distlib==0.4.3
     # via virtualenv
 distro==1.9.0
     # via
@@ -200,16 +205,15 @@ docker==7.1.0
     # via gpt-oss
 docopt==0.6.2
     # via num2words
-docstring-parser==0.17.0
+docstring-parser==0.18.0
     # via anthropic
 einops==0.8.2
     # via
     #   -r requirements/test/../common.txt
-    #   -r requirements/test/rocm.in
     #   encodec
     #   vector-quantize-pytorch
     #   vocos
-einx==0.4.2
+einx==0.4.3
     # via vector-quantize-pytorch
 email-validator==2.3.0
     # via
@@ -221,25 +225,27 @@ et-xmlfile==2.0.0
     # via openpyxl
 evaluate==0.4.6
     # via lm-eval
-fastapi==0.135.2
+fastapi==0.136.3
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
     #   gpt-oss
     #   model-hosting-container-standards
-fastapi-cli==0.0.24
+fastapi-cli==0.0.27
     # via fastapi
-fastapi-cloud-cli==0.16.1
+fastapi-cloud-cli==0.21.0
     # via fastapi-cli
-fastar==0.10.0
-    # via fastapi-cloud-cli
-fastparquet==2026.3.0
+fastar==0.11.0
+    # via
+    #   fastapi
+    #   fastapi-cloud-cli
+fastparquet==2026.5.0
     # via genai-perf
 fastsafetensors==0.3.2
     # via
     #   -c requirements/rocm.txt
     #   -r requirements/test/rocm.in
-filelock==3.25.2
+filelock==3.29.4
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -250,7 +256,7 @@ filelock==3.25.2
     #   ray
     #   torch
     #   virtualenv
-fonttools==4.62.1
+fonttools==4.63.0
     # via matplotlib
 frozendict==2.4.7
     # via einx
@@ -271,37 +277,37 @@ genai-perf==0.0.16
     # via -r requirements/test/rocm.in
 genson==1.3.0
     # via datamodel-code-generator
-google-api-core==2.30.0
+google-api-core==2.31.0
     # via
     #   google-cloud-core
     #   google-cloud-storage
     #   opencensus
-google-auth==2.49.1
+google-auth==2.55.1
     # via
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
     #   runai-model-streamer-gcs
-google-cloud-core==2.5.0
+google-cloud-core==2.6.0
     # via google-cloud-storage
-google-cloud-storage==3.10.1
+google-cloud-storage==3.12.0
     # via runai-model-streamer-gcs
 google-crc32c==1.8.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.8.0
+google-resumable-media==2.10.0
     # via google-cloud-storage
-googleapis-common-protos==1.73.0
+googleapis-common-protos==1.75.0
     # via
     #   google-api-core
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-gpt-oss==0.0.8
+gpt-oss==0.0.9
     # via -r requirements/test/rocm.in
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via hypothesis-graphql
-greenlet==3.3.2
+greenlet==3.5.3
     # via sqlalchemy
 grpcio==1.78.0
     # via
@@ -322,19 +328,19 @@ h2==4.3.0
     # via httpx
 harfile==0.5.0
     # via schemathesis
-hf-xet==1.4.3
+hf-xet==1.5.1
     # via huggingface-hub
-hiredis==3.3.1
+hiredis==3.4.0
     # via tensorizer
-hpack==4.1.0
+hpack==4.2.0
     # via h2
 html2text==2025.4.15
     # via gpt-oss
 httpcore==1.0.9
     # via httpx
-httptools==0.7.1
+httptools==0.8.0
     # via uvicorn
-httpx==0.27.2
+httpx==0.28.1
     # via
     #   -r requirements/test/rocm.in
     #   anthropic
@@ -348,7 +354,7 @@ httpx==0.27.2
     #   schemathesis
 httpx-sse==0.4.3
     # via mcp
-huggingface-hub==1.10.2
+huggingface-hub==1.21.0
     # via
     #   accelerate
     #   datasets
@@ -365,7 +371,7 @@ humanize==4.15.0
     # via runai-model-streamer
 hyperframe==6.1.0
     # via h2
-hypothesis==6.151.9
+hypothesis==6.155.7
     # via
     #   hypothesis-graphql
     #   hypothesis-jsonschema
@@ -374,7 +380,7 @@ hypothesis-graphql==0.13.0
     # via schemathesis
 hypothesis-jsonschema==0.23.1
     # via schemathesis
-idna==3.11
+idna==3.18
     # via
     #   anyio
     #   email-validator
@@ -385,15 +391,11 @@ ijson==3.5.0
     # via -r requirements/test/../common.txt
 imagehash==4.3.2
     # via -r requirements/test/rocm.in
-imageio==2.37.3
-    # via scikit-image
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 inflect==7.5.0
     # via datamodel-code-generator
 iniconfig==2.3.0
     # via pytest
-instanttensor==0.1.6
+instanttensor==0.1.9
     # via -r requirements/test/rocm.in
 interegular==0.3.3
     # via lm-format-enforcer
@@ -408,7 +410,7 @@ jinja2==3.1.6
     #   genai-perf
     #   lm-eval
     #   torch
-jiter==0.14.0
+jiter==0.15.0
     # via
     #   anthropic
     #   openai
@@ -432,15 +434,19 @@ jsonschema==4.26.0
     #   mcp
     #   mistral-common
     #   ray
-jsonschema-rs==0.46.5
+jsonschema-rs==0.46.6
     # via schemathesis
 jsonschema-specifications==2025.9.1
     # via jsonschema
 junit-xml==1.9
     # via schemathesis
+jupyter-client==8.9.1
+    # via gpt-oss
+jupyter-core==5.9.1
+    # via jupyter-client
 kaldi-native-fbank==1.22.3
     # via -r requirements/test/rocm.in
-kaleido==1.0.0
+kaleido==1.3.0
     # via genai-perf
 kiwisolver==1.5.0
     # via matplotlib
@@ -448,15 +454,13 @@ lark==1.2.2
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-lazy-loader==0.4
-    # via
-    #   librosa
-    #   scikit-image
+lazy-loader==0.5
+    # via librosa
 libnacl==2.1.0
     # via tensorizer
-librosa==0.10.2.post1
+librosa==0.11.0
     # via -r requirements/test/rocm.in
-llguidance==1.7.5
+llguidance==1.7.6
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -474,28 +478,28 @@ logistro==2.0.1
     #   kaleido
 loguru==0.7.3
     # via compressed-tensors
-lxml==6.0.2
+lxml==6.1.1
     # via
     #   blobfile
     #   gpt-oss
     #   sacrebleu
-mako==1.3.10
+mako==1.3.12
     # via alembic
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.10.8
+matplotlib==3.11.0
     # via -r requirements/test/rocm.in
-mbstrdecoder==1.1.4
+mbstrdecoder==1.1.5
     # via
     #   dataproperty
     #   pytablewriter
     #   typepy
-mcp==1.27.0
+mcp==1.28.1
     # via -r requirements/test/../common.txt
 mdurl==0.1.2
     # via markdown-it-py
@@ -505,30 +509,32 @@ mistral-common==1.11.5
     #   -r requirements/test/../common.txt
     #   -r requirements/test/rocm.in
 ml-dtypes==0.5.4
-    # via tilelang
-model-hosting-container-standards==0.1.14
+    # via
+    #   tilelang
+    #   tritonclient
+model-hosting-container-standards==0.1.16
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   inflect
     #   lm-eval
 mpmath==1.3.0
     # via sympy
-msal==1.35.1
+msal==1.37.0
     # via
     #   azure-identity
     #   msal-extensions
 msal-extensions==1.3.1
     # via azure-identity
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   librosa
     #   ray
-msgspec==0.21.0
+msgspec==0.21.1
     # via -r requirements/test/../common.txt
-mteb==2.11.5
+mteb==2.16.1
     # via -r requirements/test/rocm.in
 multidict==6.7.1
     # via
@@ -541,15 +547,15 @@ multiprocess==0.70.16
     #   evaluate
 mypy-extensions==1.1.0
     # via black
-narwhals==2.18.0
-    # via plotly
-networkx==3.6.1
+narwhals==2.22.1
     # via
-    #   scikit-image
-    #   torch
+    #   plotly
+    #   scikit-learn
+networkx==3.6.1
+    # via torch
 ninja==1.13.0
     # via -r requirements/test/../common.txt
-nltk==3.9.3
+nltk==3.9.4
     # via rouge-score
 num2words==0.5.14
     # via -r requirements/test/rocm.in
@@ -558,11 +564,11 @@ numba==0.65.0
     #   -c requirements/rocm.txt
     #   -r requirements/test/rocm.in
     #   librosa
-numpy==2.2.6
+numpy==2.3.5
     # via
     #   -r requirements/test/../common.txt
-    #   -r requirements/test/rocm.in
     #   accelerate
+    #   albucore
     #   albumentations
     #   bitsandbytes
     #   bm25s
@@ -576,7 +582,6 @@ numpy==2.2.6
     #   fastparquet
     #   genai-perf
     #   imagehash
-    #   imageio
     #   librosa
     #   lm-eval
     #   matplotlib
@@ -595,7 +600,6 @@ numpy==2.2.6
     #   rouge-score
     #   runai-model-streamer
     #   sacrebleu
-    #   scikit-image
     #   scikit-learn
     #   scipy
     #   segmentation-models-pytorch
@@ -604,7 +608,6 @@ numpy==2.2.6
     #   soxr
     #   statsmodels
     #   tensorizer
-    #   tifffile
     #   tilelang
     #   torchvision
     #   transformers
@@ -613,7 +616,7 @@ numpy==2.2.6
     #   xgrammar
 open-clip-torch==2.32.0
     # via -r requirements/test/rocm.in
-openai==2.31.0
+openai==2.44.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -630,12 +633,12 @@ opencv-python-headless==4.13.0.92
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-    #   -r requirements/test/rocm.in
+    #   albucore
     #   albumentations
     #   mistral-common
 openpyxl==3.1.5
     # via -r requirements/test/rocm.in
-opentelemetry-api==1.40.0
+opentelemetry-api==1.43.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -644,27 +647,27 @@ opentelemetry-api==1.40.0
     #   opentelemetry-exporter-prometheus
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.43.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.43.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.43.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.43.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-prometheus==0.61b0
+opentelemetry-exporter-prometheus==0.64b0
     # via ray
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.43.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   ray
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.43.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -673,7 +676,7 @@ opentelemetry-sdk==1.40.0
     #   opentelemetry-exporter-prometheus
     #   opentelemetry-semantic-conventions-ai
     #   ray
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.64b0
     # via
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions-ai
@@ -683,7 +686,7 @@ opentelemetry-semantic-conventions-ai==0.5.1
     #   -r requirements/test/../common.txt
 optuna==3.6.1
     # via genai-perf
-orjson==3.11.7
+orjson==3.11.9
     # via
     #   genai-perf
     #   kaleido
@@ -691,7 +694,7 @@ outlines-core==0.2.14
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-packaging==26.0
+packaging==26.2
     # via
     #   -c requirements/rocm.txt
     #   accelerate
@@ -712,11 +715,10 @@ packaging==26.0
     #   pytest
     #   pytest-rerunfailures
     #   ray
-    #   scikit-image
     #   statsmodels
     #   transformers
     #   typepy
-pandas==3.0.1
+pandas==3.0.4
     # via
     #   datasets
     #   evaluate
@@ -725,37 +727,37 @@ pandas==3.0.1
     #   statsmodels
 partial-json-parser==0.2.1.1.post7
     # via -r requirements/test/../common.txt
-pathspec==1.0.4
+pathspec==1.1.1
     # via black
 pathvalidate==3.3.1
     # via pytablewriter
 patsy==1.0.2
     # via statsmodels
-peft==0.18.1
+peft==0.19.1
     # via -r requirements/test/rocm.in
-perceptron==0.1.4
+perceptron==0.3.5
     # via -r requirements/test/rocm.in
 perf-analyzer==0.1.0
     # via genai-perf
-pillow==12.1.1
+pillow==11.3.0
     # via
     #   -r requirements/test/../common.txt
     #   genai-perf
     #   imagehash
-    #   imageio
     #   matplotlib
     #   mistral-common
     #   perceptron
-    #   scikit-image
     #   segmentation-models-pytorch
     #   torchvision
-platformdirs==4.3.6
+platformdirs==4.10.0
     # via
     #   black
+    #   choreographer
+    #   jupyter-core
     #   pooch
     #   python-discovery
     #   virtualenv
-plotly==6.6.0
+plotly==6.8.0
     # via
     #   -r requirements/test/rocm.in
     #   genai-perf
@@ -763,32 +765,32 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.39.3
+polars==1.42.0
     # via mteb
-polars-runtime-32==1.39.3
+polars-runtime-32==1.42.0
     # via polars
-pooch==1.8.2
+pooch==1.9.0
     # via librosa
 portalocker==3.2.0
     # via sacrebleu
 pqdm==0.2.0
     # via -r requirements/test/rocm.in
-prometheus-client==0.24.1
+prometheus-client==0.25.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
     #   opentelemetry-exporter-prometheus
     #   prometheus-fastapi-instrumentator
     #   ray
-prometheus-fastapi-instrumentator==8.0.0
+prometheus-fastapi-instrumentator==8.0.2
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-propcache==0.4.1
+propcache==0.5.2
     # via
     #   aiohttp
     #   yarl
-proto-plus==1.27.1
+proto-plus==1.28.0
     # via google-api-core
 protobuf==6.33.6
     # via
@@ -812,9 +814,9 @@ py==1.11.0
     # via pytest-forked
 py-cpuinfo==9.0.0
     # via -r requirements/test/../common.txt
-py-spy==0.4.1
+py-spy==0.4.2
     # via ray
-pyarrow==23.0.1
+pyarrow==24.0.0
     # via
     #   datasets
     #   genai-perf
@@ -830,11 +832,10 @@ pycparser==3.0
     # via cffi
 pycryptodomex==3.23.0
     # via blobfile
-pydantic==2.12.5
+pydantic==2.13.4
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-    #   -r requirements/test/rocm.in
     #   albumentations
     #   anthropic
     #   compressed-tensors
@@ -849,25 +850,26 @@ pydantic==2.12.5
     #   mteb
     #   openai
     #   openai-harmony
+    #   perceptron
     #   pydantic-extra-types
     #   pydantic-settings
     #   ray
     #   xgrammar
-pydantic-core==2.41.5
+pydantic-core==2.46.4
     # via pydantic
 pydantic-extra-types==2.11.1
     # via
     #   fastapi
     #   mistral-common
-pydantic-settings==2.13.1
+pydantic-settings==2.14.2
     # via
     #   fastapi
     #   mcp
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   pytest
     #   rich
-pyjwt==2.12.1
+pyjwt==2.13.0
     # via
     #   mcp
     #   msal
@@ -875,11 +877,11 @@ pyparsing==3.3.2
     # via matplotlib
 pyrate-limiter==4.4.0
     # via schemathesis
-pystemmer==3.0.0
+pystemmer==3.1.0
     # via mteb
 pytablewriter==1.2.1
     # via lm-eval
-pytest==9.1.0
+pytest==9.1.1
     # via
     #   -r requirements/test/rocm.in
     #   buildkite-test-collector
@@ -894,25 +896,26 @@ pytest==9.1.0
     #   schemathesis
 pytest-asyncio==1.4.0
     # via -r requirements/test/rocm.in
-pytest-cov==6.3.0
+pytest-cov==7.1.0
     # via -r requirements/test/rocm.in
 pytest-forked==1.6.0
     # via -r requirements/test/rocm.in
 pytest-mock==3.15.1
     # via genai-perf
-pytest-rerunfailures==14.0
+pytest-rerunfailures==16.3
     # via -r requirements/test/rocm.in
 pytest-shard==0.1.2
     # via -r requirements/test/rocm.in
-pytest-timeout==2.3.1
+pytest-timeout==2.4.0
     # via -r requirements/test/rocm.in
 python-dateutil==2.9.0.post0
     # via
     #   botocore
+    #   jupyter-client
     #   matplotlib
     #   pandas
     #   typepy
-python-discovery==1.2.0
+python-discovery==1.4.2
     # via virtualenv
 python-dotenv==1.2.2
     # via
@@ -920,7 +923,7 @@ python-dotenv==1.2.2
     #   uvicorn
 python-json-logger==4.1.0
     # via -r requirements/test/../common.txt
-python-multipart==0.0.26
+python-multipart==0.0.32
     # via
     #   fastapi
     #   mcp
@@ -930,7 +933,7 @@ pytokens==0.4.1
     # via black
 pytrec-eval-terrier==0.5.10
     # via mteb
-pytz==2026.1.post1
+pytz==2026.2
     # via typepy
 pywavelets==1.9.0
     # via imagehash
@@ -957,19 +960,20 @@ pyzmq==27.1.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-rapidfuzz==3.12.1
+    #   jupyter-client
+rapidfuzz==3.14.5
     # via
     #   -r requirements/test/rocm.in
     #   jiwer
-ray==2.54.0
+ray==2.55.1
     # via -r requirements/test/rocm.in
-redis==7.3.0
+redis==8.0.1
     # via tensorizer
 referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2026.2.28
+regex==2026.6.28
     # via
     #   -r requirements/test/../common.txt
     #   nltk
@@ -977,7 +981,7 @@ regex==2026.2.28
     #   sacrebleu
     #   tiktoken
     #   transformers
-requests==2.32.5
+requests==2.34.2
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -1000,9 +1004,9 @@ requests==2.32.5
     #   schemathesis
     #   starlette-testclient
     #   tiktoken
-responses==0.26.0
+responses==0.26.1
     # via genai-perf
-rich==14.3.3
+rich==15.0.0
     # via
     #   genai-perf
     #   mteb
@@ -1010,7 +1014,7 @@ rich==14.3.3
     #   rich-toolkit
     #   schemathesis
     #   typer
-rich-toolkit==0.19.7
+rich-toolkit==0.20.1
     # via
     #   fastapi-cli
     #   fastapi-cloud-cli
@@ -1018,7 +1022,7 @@ rignore==0.7.6
     # via fastapi-cloud-cli
 rouge-score==0.1.2
     # via lm-eval
-rpds-py==0.30.0
+rpds-py==2026.5.1
     # via
     #   jsonschema
     #   referencing
@@ -1032,11 +1036,11 @@ runai-model-streamer-gcs==0.15.7
     # via runai-model-streamer
 runai-model-streamer-s3==0.15.7
     # via runai-model-streamer
-s3transfer==0.16.0
+s3transfer==0.19.0
     # via boto3
 sacrebleu==2.6.0
     # via lm-eval
-safetensors==0.7.0
+safetensors==0.8.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -1046,39 +1050,34 @@ safetensors==0.7.0
     #   segmentation-models-pytorch
     #   timm
     #   transformers
-schemathesis==4.21.6
+schemathesis==4.21.10
     # via -r requirements/test/rocm.in
-scikit-image==0.26.0
-    # via albumentations
-scikit-learn==1.8.0
+scikit-learn==1.9.0
     # via
-    #   albumentations
     #   librosa
     #   lm-eval
     #   mteb
     #   sentence-transformers
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   albumentations
-    #   bm25s
     #   imagehash
     #   librosa
     #   mteb
     #   pytrec-eval-terrier
-    #   scikit-image
     #   scikit-learn
     #   sentence-transformers
     #   statsmodels
     #   vocos
 segmentation-models-pytorch==0.5.0
     # via -r requirements/test/rocm.in
-sentence-transformers==5.3.0
+sentence-transformers==5.6.0
     # via
     #   -r requirements/test/rocm.in
     #   mteb
 sentencepiece==0.2.1
     # via -r requirements/test/../common.txt
-sentry-sdk==2.55.0
+sentry-sdk==2.63.0
     # via fastapi-cloud-cli
 setproctitle==1.3.7
     # via -r requirements/test/../common.txt
@@ -1094,8 +1093,10 @@ shellingham==1.5.4
     # via
     #   perceptron
     #   typer
-simplejson==3.20.2
+simplejson==4.1.1
     # via choreographer
+simsimd==6.5.16
+    # via albucore
 six==1.17.0
     # via
     #   -c requirements/common.txt
@@ -1104,32 +1105,31 @@ six==1.17.0
     #   opencensus
     #   python-dateutil
     #   rouge-score
-smart-open==7.5.1
+smart-open==8.0.0
     # via ray
 sniffio==1.3.1
     # via
     #   anthropic
-    #   httpx
     #   openai
 sortedcontainers==2.4.0
     # via hypothesis
-soundfile==0.13.1
+soundfile==0.14.0
     # via
     #   -r requirements/test/rocm.in
     #   genai-perf
     #   librosa
     #   mistral-common
-soxr==0.5.0.post1
+soxr==1.1.0
     # via
     #   librosa
     #   mistral-common
-sqlalchemy==2.0.48
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   optuna
 sqlitedict==2.1.0
     # via lm-eval
-sse-starlette==3.3.4
+sse-starlette==3.4.5
     # via mcp
 starlette==1.3.1
     # via
@@ -1145,7 +1145,9 @@ starlette-testclient==0.4.1
     # via schemathesis
 statsmodels==0.14.6
     # via genai-perf
-structlog==25.5.0
+stringzilla==4.6.2
+    # via albucore
+structlog==26.1.0
     # via gpt-oss
 supervisor==4.3.0
     # via model-hosting-container-standards
@@ -1153,11 +1155,11 @@ sympy==1.14.0
     # via
     #   einx
     #   torch
-tabledata==1.3.4
+tabledata==1.3.5
     # via pytablewriter
 tabulate==0.10.0
     # via sacrebleu
-tblib==3.1.0
+tblib==3.2.2
     # via -r requirements/test/rocm.in
 tcolorpy==0.1.7
     # via pytablewriter
@@ -1174,9 +1176,7 @@ termcolor==3.3.0
     # via gpt-oss
 threadpoolctl==3.6.0
     # via scikit-learn
-tifffile==2026.3.3
-    # via scikit-image
-tiktoken==0.12.0
+tiktoken==0.13.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -1187,7 +1187,7 @@ tilelang==0.1.10
     # via
     #   -c requirements/rocm.txt
     #   -r requirements/test/rocm.in
-timm==1.0.17
+timm==1.0.27
     # via
     #   -c requirements/rocm.txt
     #   -r requirements/test/rocm.in
@@ -1201,7 +1201,9 @@ tokenizers==0.22.2
     #   transformers
 torch-c-dlpack-ext==0.1.5
     # via tilelang
-tqdm==4.67.3
+tornado==6.5.7
+    # via jupyter-client
+tqdm==4.68.3
     # via
     #   -r requirements/test/../common.txt
     #   datasets
@@ -1219,6 +1221,10 @@ tqdm==4.67.3
     #   sentence-transformers
     #   tilelang
     #   transformers
+traitlets==5.15.1
+    # via
+    #   jupyter-client
+    #   jupyter-core
 transformers==5.5.3
     # via
     #   -c requirements/common.txt
@@ -1226,22 +1232,23 @@ transformers==5.5.3
     #   -r requirements/test/rocm.in
     #   compressed-tensors
     #   genai-perf
+    #   mteb
     #   peft
     #   sentence-transformers
     #   transformers-stream-generator
     #   xgrammar
 transformers-stream-generator==0.0.5
     # via -r requirements/test/rocm.in
-tritonclient==2.66.0
+tritonclient==2.70.0
     # via -r requirements/test/rocm.in
-typeguard==4.5.1
+typeguard==4.5.2
     # via inflect
-typepy==1.3.4
+typepy==1.3.5
     # via
     #   dataproperty
     #   pytablewriter
     #   tabledata
-typer==0.24.1
+typer==0.25.1
     # via
     #   fastapi-cli
     #   fastapi-cloud-cli
@@ -1253,8 +1260,8 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
+    #   aiohttp
     #   aiosignal
-    #   albumentations
     #   alembic
     #   anthropic
     #   anyio
@@ -1266,6 +1273,7 @@ typing-extensions==4.15.0
     #   fastapi
     #   grpcio
     #   huggingface-hub
+    #   jupyter-client
     #   librosa
     #   lm-eval
     #   mcp
@@ -1286,6 +1294,7 @@ typing-extensions==4.15.0
     #   rich-toolkit
     #   schemathesis
     #   sentence-transformers
+    #   soundfile
     #   sqlalchemy
     #   starlette
     #   tilelang
@@ -1299,7 +1308,7 @@ typing-inspection==0.4.2
     #   mcp
     #   pydantic
     #   pydantic-settings
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   blobfile
     #   botocore
@@ -1308,7 +1317,7 @@ urllib3==2.6.3
     #   responses
     #   sentry-sdk
     #   tritonclient
-uvicorn==0.42.0
+uvicorn==0.49.0
     # via
     #   fastapi
     #   fastapi-cli
@@ -1317,40 +1326,38 @@ uvicorn==0.42.0
     #   mcp
 uvloop==0.22.1
     # via uvicorn
-vector-quantize-pytorch==1.28.0
+vector-quantize-pytorch==1.29.1
     # via -r requirements/test/rocm.in
-virtualenv==21.2.0
+virtualenv==21.5.1
     # via ray
 vocos==0.1.0
     # via -r requirements/test/rocm.in
-watchfiles==1.1.1
+watchfiles==1.2.0
     # via
     #   -r requirements/test/../common.txt
     #   uvicorn
-wcwidth==0.6.0
+wcwidth==0.8.1
     # via ftfy
 websockets==16.0
     # via uvicorn
-werkzeug==3.1.6
+werkzeug==3.1.8
     # via schemathesis
 word2number==1.1
     # via lm-eval
-wrapt==2.1.2
+wrapt==2.2.2
     # via smart-open
-xgrammar==0.2.1
+xgrammar==0.2.3
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-xxhash==3.6.0
+xxhash==3.8.0
     # via
     #   datasets
     #   evaluate
-yarl==1.23.0
+yarl==1.24.2
     # via aiohttp
 z3-solver==4.15.4.0
     # via tilelang
-zipp==3.23.0
-    # via importlib-metadata
 
 # The following packages were excluded from the output:
 # torch

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -2,11 +2,11 @@
 #    uv pip compile requirements/test/rocm.in -c requirements/rocm.txt -o requirements/test/rocm.txt --index-strategy unsafe-best-match --python-platform x86_64-manylinux_2_28 --python-version 3.12 --no-emit-package torch --no-emit-package torchvision --no-emit-package torchaudio --no-emit-package triton --no-emit-package cuda-bindings --no-emit-package cuda-pathfinder --no-emit-package cuda-toolkit --no-emit-package cupy-cuda12x --no-emit-package nvidia-cublas --no-emit-package nvidia-cuda-cupti --no-emit-package nvidia-cuda-nvrtc --no-emit-package nvidia-cuda-runtime --no-emit-package nvidia-cudnn --no-emit-package nvidia-cufft --no-emit-package nvidia-cufile --no-emit-package nvidia-curand --no-emit-package nvidia-cusolver --no-emit-package nvidia-cusparse --no-emit-package nvidia-cusparselt --no-emit-package nvidia-nccl --no-emit-package nvidia-nvjitlink --no-emit-package nvidia-nvshmem --no-emit-package nvidia-nvtx --no-emit-package nvidia-cublas-cu12 --no-emit-package nvidia-cuda-cupti-cu12 --no-emit-package nvidia-cuda-nvrtc-cu12 --no-emit-package nvidia-cuda-runtime-cu12 --no-emit-package nvidia-cudnn-cu12 --no-emit-package nvidia-cufft-cu12 --no-emit-package nvidia-cufile-cu12 --no-emit-package nvidia-curand-cu12 --no-emit-package nvidia-cusolver-cu12 --no-emit-package nvidia-cusparse-cu12 --no-emit-package nvidia-cusparselt-cu12 --no-emit-package nvidia-nccl-cu12 --no-emit-package nvidia-nvjitlink-cu12 --no-emit-package nvidia-nvshmem-cu12 --no-emit-package nvidia-nvtx-cu12 --no-emit-package nvidia-cublas-cu13 --no-emit-package nvidia-cuda-cupti-cu13 --no-emit-package nvidia-cuda-nvrtc-cu13 --no-emit-package nvidia-cuda-runtime-cu13 --no-emit-package nvidia-cudnn-cu13 --no-emit-package nvidia-cufft-cu13 --no-emit-package nvidia-cufile-cu13 --no-emit-package nvidia-curand-cu13 --no-emit-package nvidia-cusolver-cu13 --no-emit-package nvidia-cusparse-cu13 --no-emit-package nvidia-cusparselt-cu13 --no-emit-package nvidia-nccl-cu13 --no-emit-package nvidia-nvjitlink-cu13 --no-emit-package nvidia-nvshmem-cu13 --no-emit-package nvidia-nvtx-cu13
 absl-py==2.4.0
     # via rouge-score
-accelerate==1.14.0
+accelerate==1.13.0
     # via peft
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.13.3
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -19,11 +19,9 @@ aiohttp-cors==0.8.1
     # via ray
 aiosignal==1.4.0
     # via aiohttp
-albucore==0.0.24
-    # via albumentations
-albumentations==2.0.8
+albumentations==1.4.6
     # via -r requirements/test/rocm.in
-alembic==1.18.5
+alembic==1.18.4
     # via optuna
 annotated-doc==0.0.4
     # via
@@ -31,11 +29,11 @@ annotated-doc==0.0.4
     #   typer
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.112.0
+anthropic==0.93.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-anyio==4.14.1
+anyio==4.13.0
     # via
     #   anthropic
     #   httpx
@@ -60,35 +58,35 @@ attrs==26.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
-audioread==3.1.0
+audioread==3.0.1
     # via librosa
-av==17.1.0
+av==16.1.0
     # via -r requirements/test/rocm.in
-azure-core==1.41.0
+azure-core==1.39.0
     # via
     #   azure-identity
     #   azure-storage-blob
 azure-identity==1.25.3
     # via runai-model-streamer-azure
-azure-storage-blob==12.30.0
+azure-storage-blob==12.28.0
     # via runai-model-streamer-azure
 backoff==2.2.1
     # via -r requirements/test/rocm.in
 bitsandbytes==0.49.2
     # via -r requirements/test/rocm.in
-black==26.5.1
+black==26.3.1
     # via datamodel-code-generator
-blake3==1.0.9
+blake3==1.0.8
     # via -r requirements/test/../common.txt
-blobfile==3.2.0
+blobfile==3.0.0
     # via -r requirements/test/rocm.in
-bm25s==0.3.9
+bm25s==0.2.13
     # via mteb
-boto3==1.43.36
+boto3==1.42.74
     # via
     #   runai-model-streamer-s3
     #   tensorizer
-botocore==1.43.36
+botocore==1.42.74
     # via
     #   boto3
     #   s3transfer
@@ -96,32 +94,31 @@ bounded-pool-executor==0.0.3
     # via pqdm
 buildkite-test-collector==0.1.9
     # via -r requirements/test/rocm.in
-cachetools==7.1.4
+cachetools==7.0.5
     # via -r requirements/test/../common.txt
-cbor2==6.1.2
+cbor2==5.9.0
     # via -r requirements/test/../common.txt
-certifi==2026.6.17
+certifi==2026.2.25
     # via
     #   httpcore
     #   httpx
     #   requests
     #   sentry-sdk
-cffi==2.0.0
+cffi==1.17.1
     # via
     #   cryptography
     #   soundfile
-chardet==6.0.0.post1
+chardet==5.2.0
     # via mbstrdecoder
-charset-normalizer==3.4.7
+charset-normalizer==3.4.6
     # via requests
-choreographer==1.3.0
+choreographer==1.2.1
     # via kaleido
 chz==0.4.0
     # via gpt-oss
-click==8.4.2
+click==8.3.1
     # via
     #   black
-    #   huggingface-hub
     #   jiwer
     #   nltk
     #   ray
@@ -147,11 +144,11 @@ compressed-tensors==0.17.0
     #   -r requirements/test/../common.txt
 contourpy==1.3.3
     # via matplotlib
-coverage==7.14.3
+coverage==7.13.5
     # via pytest-cov
 cramjam==2.11.0
     # via fastparquet
-cryptography==49.0.0
+cryptography==46.0.0
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -160,9 +157,9 @@ cryptography==49.0.0
     #   pyjwt
 cycler==0.12.1
     # via matplotlib
-datamodel-code-generator==0.66.0
+datamodel-code-generator==0.55.0
     # via -r requirements/test/rocm.in
-dataproperty==1.1.1
+dataproperty==1.1.0
     # via
     #   pytablewriter
     #   tabledata
@@ -172,7 +169,7 @@ datasets==3.6.0
     #   evaluate
     #   lm-eval
     #   mteb
-decorator==5.3.1
+decorator==5.2.1
     # via librosa
 decord==0.6.0
     # via -r requirements/test/rocm.in
@@ -180,8 +177,6 @@ depyf==0.20.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-detect-installer==0.1.0
-    # via fastapi-cloud-cli
 dill==0.3.8
     # via
     #   datasets
@@ -193,7 +188,7 @@ diskcache==5.6.3
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-distlib==0.4.3
+distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via
@@ -205,7 +200,7 @@ docker==7.1.0
     # via gpt-oss
 docopt==0.6.2
     # via num2words
-docstring-parser==0.18.0
+docstring-parser==0.17.0
     # via anthropic
 einops==0.8.2
     # via
@@ -213,7 +208,7 @@ einops==0.8.2
     #   encodec
     #   vector-quantize-pytorch
     #   vocos
-einx==0.4.3
+einx==0.4.2
     # via vector-quantize-pytorch
 email-validator==2.3.0
     # via
@@ -225,27 +220,25 @@ et-xmlfile==2.0.0
     # via openpyxl
 evaluate==0.4.6
     # via lm-eval
-fastapi==0.136.3
+fastapi==0.135.2
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
     #   gpt-oss
     #   model-hosting-container-standards
-fastapi-cli==0.0.27
+fastapi-cli==0.0.24
     # via fastapi
-fastapi-cloud-cli==0.21.0
+fastapi-cloud-cli==0.16.1
     # via fastapi-cli
-fastar==0.11.0
-    # via
-    #   fastapi
-    #   fastapi-cloud-cli
-fastparquet==2026.5.0
+fastar==0.10.0
+    # via fastapi-cloud-cli
+fastparquet==2026.3.0
     # via genai-perf
 fastsafetensors==0.3.2
     # via
     #   -c requirements/rocm.txt
     #   -r requirements/test/rocm.in
-filelock==3.29.4
+filelock==3.25.2
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -256,7 +249,7 @@ filelock==3.29.4
     #   ray
     #   torch
     #   virtualenv
-fonttools==4.63.0
+fonttools==4.62.1
     # via matplotlib
 frozendict==2.4.7
     # via einx
@@ -277,37 +270,37 @@ genai-perf==0.0.16
     # via -r requirements/test/rocm.in
 genson==1.3.0
     # via datamodel-code-generator
-google-api-core==2.31.0
+google-api-core==2.30.0
     # via
     #   google-cloud-core
     #   google-cloud-storage
     #   opencensus
-google-auth==2.55.1
+google-auth==2.49.1
     # via
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
     #   runai-model-streamer-gcs
-google-cloud-core==2.6.0
+google-cloud-core==2.5.0
     # via google-cloud-storage
-google-cloud-storage==3.12.0
+google-cloud-storage==3.10.1
     # via runai-model-streamer-gcs
 google-crc32c==1.8.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.10.0
+google-resumable-media==2.8.0
     # via google-cloud-storage
-googleapis-common-protos==1.75.0
+googleapis-common-protos==1.73.0
     # via
     #   google-api-core
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-gpt-oss==0.0.9
+gpt-oss==0.0.8
     # via -r requirements/test/rocm.in
-graphql-core==3.2.11
+graphql-core==3.2.8
     # via hypothesis-graphql
-greenlet==3.5.3
+greenlet==3.3.2
     # via sqlalchemy
 grpcio==1.78.0
     # via
@@ -328,19 +321,19 @@ h2==4.3.0
     # via httpx
 harfile==0.5.0
     # via schemathesis
-hf-xet==1.5.1
+hf-xet==1.4.3
     # via huggingface-hub
-hiredis==3.4.0
+hiredis==3.3.1
     # via tensorizer
-hpack==4.2.0
+hpack==4.1.0
     # via h2
 html2text==2025.4.15
     # via gpt-oss
 httpcore==1.0.9
     # via httpx
-httptools==0.8.0
+httptools==0.7.1
     # via uvicorn
-httpx==0.28.1
+httpx==0.27.2
     # via
     #   -r requirements/test/rocm.in
     #   anthropic
@@ -354,7 +347,7 @@ httpx==0.28.1
     #   schemathesis
 httpx-sse==0.4.3
     # via mcp
-huggingface-hub==1.21.0
+huggingface-hub==1.10.2
     # via
     #   accelerate
     #   datasets
@@ -371,7 +364,7 @@ humanize==4.15.0
     # via runai-model-streamer
 hyperframe==6.1.0
     # via h2
-hypothesis==6.155.7
+hypothesis==6.151.9
     # via
     #   hypothesis-graphql
     #   hypothesis-jsonschema
@@ -380,7 +373,7 @@ hypothesis-graphql==0.13.0
     # via schemathesis
 hypothesis-jsonschema==0.23.1
     # via schemathesis
-idna==3.18
+idna==3.11
     # via
     #   anyio
     #   email-validator
@@ -391,11 +384,15 @@ ijson==3.5.0
     # via -r requirements/test/../common.txt
 imagehash==4.3.2
     # via -r requirements/test/rocm.in
+imageio==2.37.3
+    # via scikit-image
+importlib-metadata==8.7.1
+    # via opentelemetry-api
 inflect==7.5.0
     # via datamodel-code-generator
 iniconfig==2.3.0
     # via pytest
-instanttensor==0.1.9
+instanttensor==0.1.6
     # via -r requirements/test/rocm.in
 interegular==0.3.3
     # via lm-format-enforcer
@@ -410,7 +407,7 @@ jinja2==3.1.6
     #   genai-perf
     #   lm-eval
     #   torch
-jiter==0.15.0
+jiter==0.14.0
     # via
     #   anthropic
     #   openai
@@ -434,19 +431,15 @@ jsonschema==4.26.0
     #   mcp
     #   mistral-common
     #   ray
-jsonschema-rs==0.46.6
+jsonschema-rs==0.46.5
     # via schemathesis
 jsonschema-specifications==2025.9.1
     # via jsonschema
 junit-xml==1.9
     # via schemathesis
-jupyter-client==8.9.1
-    # via gpt-oss
-jupyter-core==5.9.1
-    # via jupyter-client
 kaldi-native-fbank==1.22.3
     # via -r requirements/test/rocm.in
-kaleido==1.3.0
+kaleido==1.0.0
     # via genai-perf
 kiwisolver==1.5.0
     # via matplotlib
@@ -454,13 +447,15 @@ lark==1.2.2
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-lazy-loader==0.5
-    # via librosa
+lazy-loader==0.4
+    # via
+    #   librosa
+    #   scikit-image
 libnacl==2.1.0
     # via tensorizer
-librosa==0.11.0
+librosa==0.10.2.post1
     # via -r requirements/test/rocm.in
-llguidance==1.7.6
+llguidance==1.7.5
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -478,28 +473,28 @@ logistro==2.0.1
     #   kaleido
 loguru==0.7.3
     # via compressed-tensors
-lxml==6.1.1
+lxml==6.0.2
     # via
     #   blobfile
     #   gpt-oss
     #   sacrebleu
-mako==1.3.12
+mako==1.3.10
     # via alembic
-markdown-it-py==4.2.0
+markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.3
     # via
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.10.8
     # via -r requirements/test/rocm.in
-mbstrdecoder==1.1.5
+mbstrdecoder==1.1.4
     # via
     #   dataproperty
     #   pytablewriter
     #   typepy
-mcp==1.28.1
+mcp==1.27.0
     # via -r requirements/test/../common.txt
 mdurl==0.1.2
     # via markdown-it-py
@@ -509,32 +504,30 @@ mistral-common==1.11.5
     #   -r requirements/test/../common.txt
     #   -r requirements/test/rocm.in
 ml-dtypes==0.5.4
-    # via
-    #   tilelang
-    #   tritonclient
-model-hosting-container-standards==0.1.16
+    # via tilelang
+model-hosting-container-standards==0.1.14
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-more-itertools==11.1.0
+more-itertools==10.8.0
     # via
     #   inflect
     #   lm-eval
 mpmath==1.3.0
     # via sympy
-msal==1.37.0
+msal==1.35.1
     # via
     #   azure-identity
     #   msal-extensions
 msal-extensions==1.3.1
     # via azure-identity
-msgpack==1.2.1
+msgpack==1.1.2
     # via
     #   librosa
     #   ray
-msgspec==0.21.1
+msgspec==0.21.0
     # via -r requirements/test/../common.txt
-mteb==2.16.1
+mteb==2.11.5
     # via -r requirements/test/rocm.in
 multidict==6.7.1
     # via
@@ -547,15 +540,15 @@ multiprocess==0.70.16
     #   evaluate
 mypy-extensions==1.1.0
     # via black
-narwhals==2.22.1
-    # via
-    #   plotly
-    #   scikit-learn
+narwhals==2.18.0
+    # via plotly
 networkx==3.6.1
-    # via torch
+    # via
+    #   scikit-image
+    #   torch
 ninja==1.13.0
     # via -r requirements/test/../common.txt
-nltk==3.9.4
+nltk==3.9.3
     # via rouge-score
 num2words==0.5.14
     # via -r requirements/test/rocm.in
@@ -564,11 +557,10 @@ numba==0.65.0
     #   -c requirements/rocm.txt
     #   -r requirements/test/rocm.in
     #   librosa
-numpy==2.3.5
+numpy==2.2.6
     # via
     #   -r requirements/test/../common.txt
     #   accelerate
-    #   albucore
     #   albumentations
     #   bitsandbytes
     #   bm25s
@@ -582,6 +574,7 @@ numpy==2.3.5
     #   fastparquet
     #   genai-perf
     #   imagehash
+    #   imageio
     #   librosa
     #   lm-eval
     #   matplotlib
@@ -600,6 +593,7 @@ numpy==2.3.5
     #   rouge-score
     #   runai-model-streamer
     #   sacrebleu
+    #   scikit-image
     #   scikit-learn
     #   scipy
     #   segmentation-models-pytorch
@@ -608,6 +602,7 @@ numpy==2.3.5
     #   soxr
     #   statsmodels
     #   tensorizer
+    #   tifffile
     #   tilelang
     #   torchvision
     #   transformers
@@ -616,7 +611,7 @@ numpy==2.3.5
     #   xgrammar
 open-clip-torch==2.32.0
     # via -r requirements/test/rocm.in
-openai==2.44.0
+openai==2.31.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -633,12 +628,11 @@ opencv-python-headless==4.13.0.92
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-    #   albucore
     #   albumentations
     #   mistral-common
 openpyxl==3.1.5
     # via -r requirements/test/rocm.in
-opentelemetry-api==1.43.0
+opentelemetry-api==1.40.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -647,27 +641,27 @@ opentelemetry-api==1.43.0
     #   opentelemetry-exporter-prometheus
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.43.0
+opentelemetry-exporter-otlp==1.40.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-opentelemetry-exporter-otlp-proto-common==1.43.0
+opentelemetry-exporter-otlp-proto-common==1.40.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.43.0
+opentelemetry-exporter-otlp-proto-grpc==1.40.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.43.0
+opentelemetry-exporter-otlp-proto-http==1.40.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-prometheus==0.64b0
+opentelemetry-exporter-prometheus==0.61b0
     # via ray
-opentelemetry-proto==1.43.0
+opentelemetry-proto==1.40.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   ray
-opentelemetry-sdk==1.43.0
+opentelemetry-sdk==1.40.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -676,7 +670,7 @@ opentelemetry-sdk==1.43.0
     #   opentelemetry-exporter-prometheus
     #   opentelemetry-semantic-conventions-ai
     #   ray
-opentelemetry-semantic-conventions==0.64b0
+opentelemetry-semantic-conventions==0.61b0
     # via
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions-ai
@@ -686,7 +680,7 @@ opentelemetry-semantic-conventions-ai==0.5.1
     #   -r requirements/test/../common.txt
 optuna==3.6.1
     # via genai-perf
-orjson==3.11.9
+orjson==3.11.7
     # via
     #   genai-perf
     #   kaleido
@@ -694,7 +688,7 @@ outlines-core==0.2.14
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-packaging==26.2
+packaging==26.0
     # via
     #   -c requirements/rocm.txt
     #   accelerate
@@ -715,10 +709,11 @@ packaging==26.2
     #   pytest
     #   pytest-rerunfailures
     #   ray
+    #   scikit-image
     #   statsmodels
     #   transformers
     #   typepy
-pandas==3.0.4
+pandas==3.0.1
     # via
     #   datasets
     #   evaluate
@@ -727,37 +722,37 @@ pandas==3.0.4
     #   statsmodels
 partial-json-parser==0.2.1.1.post7
     # via -r requirements/test/../common.txt
-pathspec==1.1.1
+pathspec==1.0.4
     # via black
 pathvalidate==3.3.1
     # via pytablewriter
 patsy==1.0.2
     # via statsmodels
-peft==0.19.1
+peft==0.18.1
     # via -r requirements/test/rocm.in
-perceptron==0.3.5
+perceptron==0.1.4
     # via -r requirements/test/rocm.in
 perf-analyzer==0.1.0
     # via genai-perf
-pillow==11.3.0
+pillow==12.1.1
     # via
     #   -r requirements/test/../common.txt
     #   genai-perf
     #   imagehash
+    #   imageio
     #   matplotlib
     #   mistral-common
     #   perceptron
+    #   scikit-image
     #   segmentation-models-pytorch
     #   torchvision
-platformdirs==4.10.0
+platformdirs==4.3.6
     # via
     #   black
-    #   choreographer
-    #   jupyter-core
     #   pooch
     #   python-discovery
     #   virtualenv
-plotly==6.8.0
+plotly==6.6.0
     # via
     #   -r requirements/test/rocm.in
     #   genai-perf
@@ -765,32 +760,32 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.42.0
+polars==1.39.3
     # via mteb
-polars-runtime-32==1.42.0
+polars-runtime-32==1.39.3
     # via polars
-pooch==1.9.0
+pooch==1.8.2
     # via librosa
 portalocker==3.2.0
     # via sacrebleu
 pqdm==0.2.0
     # via -r requirements/test/rocm.in
-prometheus-client==0.25.0
+prometheus-client==0.24.1
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
     #   opentelemetry-exporter-prometheus
     #   prometheus-fastapi-instrumentator
     #   ray
-prometheus-fastapi-instrumentator==8.0.2
+prometheus-fastapi-instrumentator==8.0.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-propcache==0.5.2
+propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
-proto-plus==1.28.0
+proto-plus==1.27.1
     # via google-api-core
 protobuf==6.33.6
     # via
@@ -814,9 +809,9 @@ py==1.11.0
     # via pytest-forked
 py-cpuinfo==9.0.0
     # via -r requirements/test/../common.txt
-py-spy==0.4.2
+py-spy==0.4.1
     # via ray
-pyarrow==24.0.0
+pyarrow==23.0.1
     # via
     #   datasets
     #   genai-perf
@@ -832,7 +827,7 @@ pycparser==3.0
     # via cffi
 pycryptodomex==3.23.0
     # via blobfile
-pydantic==2.13.4
+pydantic==2.12.5
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -850,26 +845,25 @@ pydantic==2.13.4
     #   mteb
     #   openai
     #   openai-harmony
-    #   perceptron
     #   pydantic-extra-types
     #   pydantic-settings
     #   ray
     #   xgrammar
-pydantic-core==2.46.4
+pydantic-core==2.41.5
     # via pydantic
 pydantic-extra-types==2.11.1
     # via
     #   fastapi
     #   mistral-common
-pydantic-settings==2.14.2
+pydantic-settings==2.13.1
     # via
     #   fastapi
     #   mcp
-pygments==2.20.0
+pygments==2.19.2
     # via
     #   pytest
     #   rich
-pyjwt==2.13.0
+pyjwt==2.12.1
     # via
     #   mcp
     #   msal
@@ -877,11 +871,11 @@ pyparsing==3.3.2
     # via matplotlib
 pyrate-limiter==4.4.0
     # via schemathesis
-pystemmer==3.1.0
+pystemmer==3.0.0
     # via mteb
 pytablewriter==1.2.1
     # via lm-eval
-pytest==9.1.1
+pytest==9.1.0
     # via
     #   -r requirements/test/rocm.in
     #   buildkite-test-collector
@@ -896,26 +890,25 @@ pytest==9.1.1
     #   schemathesis
 pytest-asyncio==1.4.0
     # via -r requirements/test/rocm.in
-pytest-cov==7.1.0
+pytest-cov==6.3.0
     # via -r requirements/test/rocm.in
 pytest-forked==1.6.0
     # via -r requirements/test/rocm.in
 pytest-mock==3.15.1
     # via genai-perf
-pytest-rerunfailures==16.3
+pytest-rerunfailures==14.0
     # via -r requirements/test/rocm.in
 pytest-shard==0.1.2
     # via -r requirements/test/rocm.in
-pytest-timeout==2.4.0
+pytest-timeout==2.3.1
     # via -r requirements/test/rocm.in
 python-dateutil==2.9.0.post0
     # via
     #   botocore
-    #   jupyter-client
     #   matplotlib
     #   pandas
     #   typepy
-python-discovery==1.4.2
+python-discovery==1.2.0
     # via virtualenv
 python-dotenv==1.2.2
     # via
@@ -923,7 +916,7 @@ python-dotenv==1.2.2
     #   uvicorn
 python-json-logger==4.1.0
     # via -r requirements/test/../common.txt
-python-multipart==0.0.32
+python-multipart==0.0.26
     # via
     #   fastapi
     #   mcp
@@ -933,7 +926,7 @@ pytokens==0.4.1
     # via black
 pytrec-eval-terrier==0.5.10
     # via mteb
-pytz==2026.2
+pytz==2026.1.post1
     # via typepy
 pywavelets==1.9.0
     # via imagehash
@@ -960,20 +953,19 @@ pyzmq==27.1.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-    #   jupyter-client
-rapidfuzz==3.14.5
+rapidfuzz==3.12.1
     # via
     #   -r requirements/test/rocm.in
     #   jiwer
-ray==2.55.1
+ray==2.54.0
     # via -r requirements/test/rocm.in
-redis==8.0.1
+redis==7.3.0
     # via tensorizer
 referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2026.6.28
+regex==2026.2.28
     # via
     #   -r requirements/test/../common.txt
     #   nltk
@@ -981,7 +973,7 @@ regex==2026.6.28
     #   sacrebleu
     #   tiktoken
     #   transformers
-requests==2.34.2
+requests==2.32.5
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -1004,9 +996,9 @@ requests==2.34.2
     #   schemathesis
     #   starlette-testclient
     #   tiktoken
-responses==0.26.1
+responses==0.26.0
     # via genai-perf
-rich==15.0.0
+rich==14.3.3
     # via
     #   genai-perf
     #   mteb
@@ -1014,7 +1006,7 @@ rich==15.0.0
     #   rich-toolkit
     #   schemathesis
     #   typer
-rich-toolkit==0.20.1
+rich-toolkit==0.19.7
     # via
     #   fastapi-cli
     #   fastapi-cloud-cli
@@ -1022,7 +1014,7 @@ rignore==0.7.6
     # via fastapi-cloud-cli
 rouge-score==0.1.2
     # via lm-eval
-rpds-py==2026.5.1
+rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
@@ -1036,11 +1028,11 @@ runai-model-streamer-gcs==0.15.7
     # via runai-model-streamer
 runai-model-streamer-s3==0.15.7
     # via runai-model-streamer
-s3transfer==0.19.0
+s3transfer==0.16.0
     # via boto3
 sacrebleu==2.6.0
     # via lm-eval
-safetensors==0.8.0
+safetensors==0.7.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -1050,34 +1042,39 @@ safetensors==0.8.0
     #   segmentation-models-pytorch
     #   timm
     #   transformers
-schemathesis==4.21.10
+schemathesis==4.21.6
     # via -r requirements/test/rocm.in
-scikit-learn==1.9.0
+scikit-image==0.26.0
+    # via albumentations
+scikit-learn==1.8.0
     # via
+    #   albumentations
     #   librosa
     #   lm-eval
     #   mteb
     #   sentence-transformers
-scipy==1.18.0
+scipy==1.17.1
     # via
     #   albumentations
+    #   bm25s
     #   imagehash
     #   librosa
     #   mteb
     #   pytrec-eval-terrier
+    #   scikit-image
     #   scikit-learn
     #   sentence-transformers
     #   statsmodels
     #   vocos
 segmentation-models-pytorch==0.5.0
     # via -r requirements/test/rocm.in
-sentence-transformers==5.6.0
+sentence-transformers==5.3.0
     # via
     #   -r requirements/test/rocm.in
     #   mteb
 sentencepiece==0.2.1
     # via -r requirements/test/../common.txt
-sentry-sdk==2.63.0
+sentry-sdk==2.55.0
     # via fastapi-cloud-cli
 setproctitle==1.3.7
     # via -r requirements/test/../common.txt
@@ -1093,10 +1090,8 @@ shellingham==1.5.4
     # via
     #   perceptron
     #   typer
-simplejson==4.1.1
+simplejson==3.20.2
     # via choreographer
-simsimd==6.5.16
-    # via albucore
 six==1.17.0
     # via
     #   -c requirements/common.txt
@@ -1105,31 +1100,32 @@ six==1.17.0
     #   opencensus
     #   python-dateutil
     #   rouge-score
-smart-open==8.0.0
+smart-open==7.5.1
     # via ray
 sniffio==1.3.1
     # via
     #   anthropic
+    #   httpx
     #   openai
 sortedcontainers==2.4.0
     # via hypothesis
-soundfile==0.14.0
+soundfile==0.13.1
     # via
     #   -r requirements/test/rocm.in
     #   genai-perf
     #   librosa
     #   mistral-common
-soxr==1.1.0
+soxr==0.5.0.post1
     # via
     #   librosa
     #   mistral-common
-sqlalchemy==2.0.51
+sqlalchemy==2.0.48
     # via
     #   alembic
     #   optuna
 sqlitedict==2.1.0
     # via lm-eval
-sse-starlette==3.4.5
+sse-starlette==3.3.4
     # via mcp
 starlette==1.3.1
     # via
@@ -1145,9 +1141,7 @@ starlette-testclient==0.4.1
     # via schemathesis
 statsmodels==0.14.6
     # via genai-perf
-stringzilla==4.6.2
-    # via albucore
-structlog==26.1.0
+structlog==25.5.0
     # via gpt-oss
 supervisor==4.3.0
     # via model-hosting-container-standards
@@ -1155,11 +1149,11 @@ sympy==1.14.0
     # via
     #   einx
     #   torch
-tabledata==1.3.5
+tabledata==1.3.4
     # via pytablewriter
 tabulate==0.10.0
     # via sacrebleu
-tblib==3.2.2
+tblib==3.1.0
     # via -r requirements/test/rocm.in
 tcolorpy==0.1.7
     # via pytablewriter
@@ -1176,7 +1170,9 @@ termcolor==3.3.0
     # via gpt-oss
 threadpoolctl==3.6.0
     # via scikit-learn
-tiktoken==0.13.0
+tifffile==2026.3.3
+    # via scikit-image
+tiktoken==0.12.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -1187,7 +1183,7 @@ tilelang==0.1.10
     # via
     #   -c requirements/rocm.txt
     #   -r requirements/test/rocm.in
-timm==1.0.27
+timm==1.0.17
     # via
     #   -c requirements/rocm.txt
     #   -r requirements/test/rocm.in
@@ -1201,9 +1197,7 @@ tokenizers==0.22.2
     #   transformers
 torch-c-dlpack-ext==0.1.5
     # via tilelang
-tornado==6.5.7
-    # via jupyter-client
-tqdm==4.68.3
+tqdm==4.67.3
     # via
     #   -r requirements/test/../common.txt
     #   datasets
@@ -1221,10 +1215,6 @@ tqdm==4.68.3
     #   sentence-transformers
     #   tilelang
     #   transformers
-traitlets==5.15.1
-    # via
-    #   jupyter-client
-    #   jupyter-core
 transformers==5.5.3
     # via
     #   -c requirements/common.txt
@@ -1232,23 +1222,22 @@ transformers==5.5.3
     #   -r requirements/test/rocm.in
     #   compressed-tensors
     #   genai-perf
-    #   mteb
     #   peft
     #   sentence-transformers
     #   transformers-stream-generator
     #   xgrammar
 transformers-stream-generator==0.0.5
     # via -r requirements/test/rocm.in
-tritonclient==2.70.0
+tritonclient==2.66.0
     # via -r requirements/test/rocm.in
-typeguard==4.5.2
+typeguard==4.5.1
     # via inflect
-typepy==1.3.5
+typepy==1.3.4
     # via
     #   dataproperty
     #   pytablewriter
     #   tabledata
-typer==0.25.1
+typer==0.24.1
     # via
     #   fastapi-cli
     #   fastapi-cloud-cli
@@ -1260,8 +1249,8 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-    #   aiohttp
     #   aiosignal
+    #   albumentations
     #   alembic
     #   anthropic
     #   anyio
@@ -1273,7 +1262,6 @@ typing-extensions==4.15.0
     #   fastapi
     #   grpcio
     #   huggingface-hub
-    #   jupyter-client
     #   librosa
     #   lm-eval
     #   mcp
@@ -1294,7 +1282,6 @@ typing-extensions==4.15.0
     #   rich-toolkit
     #   schemathesis
     #   sentence-transformers
-    #   soundfile
     #   sqlalchemy
     #   starlette
     #   tilelang
@@ -1308,7 +1295,7 @@ typing-inspection==0.4.2
     #   mcp
     #   pydantic
     #   pydantic-settings
-urllib3==2.7.0
+urllib3==2.6.3
     # via
     #   blobfile
     #   botocore
@@ -1317,7 +1304,7 @@ urllib3==2.7.0
     #   responses
     #   sentry-sdk
     #   tritonclient
-uvicorn==0.49.0
+uvicorn==0.42.0
     # via
     #   fastapi
     #   fastapi-cli
@@ -1326,38 +1313,40 @@ uvicorn==0.49.0
     #   mcp
 uvloop==0.22.1
     # via uvicorn
-vector-quantize-pytorch==1.29.1
+vector-quantize-pytorch==1.28.0
     # via -r requirements/test/rocm.in
-virtualenv==21.5.1
+virtualenv==21.2.0
     # via ray
 vocos==0.1.0
     # via -r requirements/test/rocm.in
-watchfiles==1.2.0
+watchfiles==1.1.1
     # via
     #   -r requirements/test/../common.txt
     #   uvicorn
-wcwidth==0.8.1
+wcwidth==0.6.0
     # via ftfy
 websockets==16.0
     # via uvicorn
-werkzeug==3.1.8
+werkzeug==3.1.6
     # via schemathesis
 word2number==1.1
     # via lm-eval
-wrapt==2.2.2
+wrapt==2.1.2
     # via smart-open
-xgrammar==0.2.3
+xgrammar==0.2.1
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-xxhash==3.8.0
+xxhash==3.6.0
     # via
     #   datasets
     #   evaluate
-yarl==1.24.2
+yarl==1.23.0
     # via aiohttp
 z3-solver==4.15.4.0
     # via tilelang
+zipp==3.23.0
+    # via importlib-metadata
 
 # The following packages were excluded from the output:
 # torch

--- a/requirements/test/xpu.in
+++ b/requirements/test/xpu.in
@@ -1,3 +1,5 @@
+-r ../common.txt
+
 # --- Test Infrastructure ---
 tblib
 pytest

--- a/requirements/test/xpu.txt
+++ b/requirements/test/xpu.txt
@@ -11,6 +11,7 @@ aiohappyeyeballs==2.6.1
 aiohttp==3.13.4
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   fsspec
     #   gpt-oss
     #   lm-eval
@@ -24,12 +25,25 @@ annotated-doc==0.0.4
     #   typer
 annotated-types==0.7.0
     # via pydantic
+anthropic==0.112.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 anyio==4.13.0
     # via
+    #   anthropic
     #   httpx
+    #   mcp
+    #   openai
+    #   sse-starlette
     #   starlette
+    #   watchfiles
+apache-tvm-ffi==0.1.12
+    # via xgrammar
 arctic-inference==0.1.1
     # via -r requirements/test/xpu.in
+astor==0.8.1
+    # via depyf
 attrs==26.1.0
     # via
     #   aiohttp
@@ -39,6 +53,8 @@ audioread==3.0.1
     # via
     #   -r requirements/test/xpu.in
     #   librosa
+blake3==1.0.9
+    # via -r requirements/test/../common.txt
 blobfile==3.0.0
     # via -r requirements/test/xpu.in
 bm25s==0.2.13
@@ -47,13 +63,20 @@ bm25s==0.2.13
     #   mteb
 bounded-pool-executor==0.0.3
     # via pqdm
+cachetools==7.1.4
+    # via -r requirements/test/../common.txt
+cbor2==6.1.2
+    # via -r requirements/test/../common.txt
 certifi==2026.2.25
     # via
     #   httpcore
     #   httpx
     #   requests
+    #   sentry-sdk
 cffi==2.0.0
-    # via soundfile
+    # via
+    #   cryptography
+    #   soundfile
 chardet==5.2.0
     # via mbstrdecoder
 charset-normalizer==3.4.6
@@ -64,13 +87,22 @@ click==8.3.1
     # via
     #   jiwer
     #   nltk
+    #   rich-toolkit
     #   schemathesis
     #   typer
     #   uvicorn
+cloudpickle==3.1.2
+    # via -r requirements/test/../common.txt
 colorama==0.4.6
     # via sacrebleu
+compressed-tensors==0.17.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 coverage==7.13.5
     # via pytest-cov
+cryptography==49.0.0
+    # via pyjwt
 dataproperty==1.1.0
     # via
     #   pytablewriter
@@ -82,16 +114,35 @@ datasets==4.8.4
     #   mteb
 decorator==5.2.1
     # via librosa
+depyf==0.20.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+detect-installer==0.1.0
+    # via fastapi-cloud-cli
 dill==0.4.1
     # via
     #   datasets
+    #   depyf
     #   evaluate
     #   lm-eval
     #   multiprocess
+diskcache==5.6.3
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+distro==1.9.0
+    # via
+    #   anthropic
+    #   openai
+dnspython==2.8.0
+    # via email-validator
 docker==7.1.0
     # via gpt-oss
 docopt==0.6.2
     # via num2words
+docstring-parser==0.18.0
+    # via anthropic
 dpcpp-cpp-rt==2025.3.2
     # via
     #   onemkl-sycl-blas
@@ -100,15 +151,30 @@ dpcpp-cpp-rt==2025.3.2
     #   onemkl-sycl-rng
     #   onemkl-sycl-sparse
     #   torch
+einops==0.8.2
+    # via -r requirements/test/../common.txt
+email-validator==2.3.0
+    # via
+    #   fastapi
+    #   pydantic
 evaluate==0.4.6
     # via lm-eval
 fastapi==0.135.2
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   gpt-oss
+    #   model-hosting-container-standards
+fastapi-cli==0.0.27
+    # via fastapi
+fastapi-cloud-cli==0.21.0
+    # via fastapi-cli
+fastar==0.11.0
+    # via fastapi-cloud-cli
 filelock==3.25.2
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   blobfile
     #   datasets
     #   huggingface-hub
@@ -124,10 +190,16 @@ fsspec==2026.2.0
     #   evaluate
     #   huggingface-hub
     #   torch
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 gpt-oss==0.0.8
     # via -r requirements/test/xpu.in
 graphql-core==3.2.8
     # via hypothesis-graphql
+grpcio==1.81.1
+    # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0
     # via
     #   httpcore
@@ -140,11 +212,21 @@ html2text==2025.4.15
     # via gpt-oss
 httpcore==1.0.9
     # via httpx
+httptools==0.8.0
+    # via uvicorn
 httpx==0.28.1
     # via
+    #   anthropic
     #   datasets
+    #   fastapi
+    #   fastapi-cloud-cli
     #   huggingface-hub
+    #   mcp
+    #   model-hosting-container-standards
+    #   openai
     #   schemathesis
+httpx-sse==0.4.3
+    # via mcp
 huggingface-hub==1.10.2
     # via
     #   accelerate
@@ -166,9 +248,12 @@ hypothesis-jsonschema==0.23.1
 idna==3.11
     # via
     #   anyio
+    #   email-validator
     #   httpx
     #   requests
     #   yarl
+ijson==3.5.0
+    # via -r requirements/test/../common.txt
 imageio==2.37.3
     # via scikit-image
 impi-rt==2021.17.2
@@ -212,13 +297,22 @@ intel-sycl-rt==2025.3.2
     #   dpcpp-cpp-rt
     #   oneccl
     #   torch
+interegular==0.3.3
+    # via lm-format-enforcer
 jinja2==3.1.6
     # via
     #   -c requirements/xpu.txt
+    #   fastapi
     #   lm-eval
     #   torch
+jiter==0.15.0
+    # via
+    #   anthropic
+    #   openai
 jiwer==4.0.0
     # via -r requirements/test/xpu.in
+jmespath==1.1.0
+    # via model-hosting-container-standards
 joblib==1.5.3
     # via
     #   librosa
@@ -227,7 +321,9 @@ joblib==1.5.3
 jsonschema==4.26.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   hypothesis-jsonschema
+    #   mcp
     #   mistral-common
     #   schemathesis
 jsonschema-rs==0.45.0
@@ -236,16 +332,30 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 junit-xml==1.9
     # via schemathesis
+lark==1.2.2
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 lazy-loader==0.5
     # via
     #   librosa
     #   scikit-image
 librosa==0.10.2.post1
     # via -r requirements/test/xpu.in
+llguidance==1.7.6
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 llvmlite==0.47.0
     # via numba
 lm-eval==0.4.12
     # via -r requirements/test/xpu.in
+lm-format-enforcer==0.11.3
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+loguru==0.7.3
+    # via compressed-tensors
 lxml==6.0.2
     # via
     #   blobfile
@@ -262,11 +372,14 @@ mbstrdecoder==1.1.4
     #   dataproperty
     #   pytablewriter
     #   typepy
+mcp==1.28.1
+    # via -r requirements/test/../common.txt
 mdurl==0.1.2
     # via markdown-it-py
 mistral-common==1.11.5
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   -r requirements/test/xpu.in
 mkl==2025.3.1
     # via
@@ -276,6 +389,10 @@ mkl==2025.3.1
     #   onemkl-sycl-rng
     #   onemkl-sycl-sparse
     #   torch
+model-hosting-container-standards==0.1.16
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 modelscope==1.35.3
     # via -r requirements/test/xpu.in
 more-itertools==10.8.0
@@ -284,6 +401,8 @@ mpmath==1.3.0
     # via sympy
 msgpack==1.1.2
     # via librosa
+msgspec==0.21.1
+    # via -r requirements/test/../common.txt
 mteb==2.12.7
     # via -r requirements/test/xpu.in
 multidict==6.7.1
@@ -298,6 +417,8 @@ networkx==3.6.1
     # via
     #   scikit-image
     #   torch
+ninja==1.13.0
+    # via -r requirements/test/../common.txt
 nltk==3.9.4
     # via rouge-score
 num2words==0.5.14
@@ -308,6 +429,7 @@ numba==0.65.0
     #   librosa
 numpy==2.2.6
     # via
+    #   -r requirements/test/../common.txt
     #   accelerate
     #   albumentations
     #   bm25s
@@ -333,6 +455,7 @@ numpy==2.2.6
     #   tifffile
     #   torchvision
     #   transformers
+    #   xgrammar
 oneccl==2021.17.2
     # via
     #   oneccl-devel
@@ -356,15 +479,65 @@ onemkl-sycl-rng==2025.3.1
     # via torch
 onemkl-sycl-sparse==2025.3.1
     # via torch
+openai==2.44.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 openai-harmony==0.0.8
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   gpt-oss
 opencv-python-headless==4.13.0.92
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   albumentations
     #   mistral-common
+opentelemetry-api==1.43.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp==1.43.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+opentelemetry-exporter-otlp-proto-common==1.43.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.43.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.43.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-proto==1.43.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.43.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-semantic-conventions-ai
+opentelemetry-semantic-conventions==0.64b0
+    # via
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions-ai
+opentelemetry-semantic-conventions-ai==0.5.1
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+outlines-core==0.2.14
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 packaging==26.0
     # via
     #   -c requirements/xpu.txt
@@ -373,6 +546,7 @@ packaging==26.0
     #   evaluate
     #   huggingface-hub
     #   lazy-loader
+    #   lm-format-enforcer
     #   modelscope
     #   pooch
     #   pytest
@@ -384,10 +558,13 @@ pandas==3.0.1
     # via
     #   datasets
     #   evaluate
+partial-json-parser==0.2.1.1.post7
+    # via -r requirements/test/../common.txt
 pathvalidate==3.3.1
     # via pytablewriter
 pillow==12.1.1
     # via
+    #   -r requirements/test/../common.txt
     #   imageio
     #   mistral-common
     #   scikit-image
@@ -410,16 +587,37 @@ portalocker==3.2.0
     # via sacrebleu
 pqdm==0.2.0
     # via -r requirements/test/xpu.in
+prometheus-client==0.25.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+    #   prometheus-fastapi-instrumentator
+prometheus-fastapi-instrumentator==8.0.2
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==7.35.1
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
-    # via accelerate
+    # via
+    #   -r requirements/test/../common.txt
+    #   accelerate
 py==1.11.0
     # via pytest-forked
+py-cpuinfo==9.0.0
+    # via -r requirements/test/../common.txt
 pyarrow==23.0.1
     # via datasets
+pybase64==1.4.3
+    # via -r requirements/test/../common.txt
 pycountry==26.2.16
     # via pydantic-extra-types
 pycparser==3.0
@@ -429,23 +627,41 @@ pycryptodomex==3.23.0
 pydantic==2.12.5
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   albumentations
+    #   anthropic
+    #   compressed-tensors
     #   fastapi
+    #   fastapi-cloud-cli
     #   gpt-oss
+    #   lm-format-enforcer
+    #   mcp
     #   mistral-common
+    #   model-hosting-container-standards
     #   mteb
+    #   openai
     #   openai-harmony
     #   pydantic-extra-types
+    #   pydantic-settings
+    #   xgrammar
 pydantic-core==2.41.5
     # via pydantic
 pydantic-extra-types==2.11.1
-    # via mistral-common
+    # via
+    #   fastapi
+    #   mistral-common
+pydantic-settings==2.14.2
+    # via
+    #   fastapi
+    #   mcp
 pyelftools==0.32
     # via triton-xpu
 pygments==2.20.0
     # via
     #   pytest
     #   rich
+pyjwt==2.13.0
+    # via mcp
 pyrate-limiter==4.1.0
     # via schemathesis
 pystemmer==3.0.0
@@ -480,19 +696,36 @@ python-dateutil==2.9.0.post0
     # via
     #   pandas
     #   typepy
+python-dotenv==1.2.2
+    # via
+    #   pydantic-settings
+    #   uvicorn
+python-json-logger==4.1.0
+    # via -r requirements/test/../common.txt
+python-multipart==0.0.32
+    # via
+    #   fastapi
+    #   mcp
 pytrec-eval-terrier==0.5.10
     # via mteb
 pytz==2026.1.post1
     # via typepy
 pyyaml==6.0.3
     # via
+    #   -r requirements/test/../common.txt
     #   accelerate
     #   albumentations
     #   datasets
     #   huggingface-hub
+    #   lm-format-enforcer
     #   schemathesis
     #   timm
     #   transformers
+    #   uvicorn
+pyzmq==27.1.0
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 rapidfuzz==3.12.1
     # via
     #   -r requirements/test/xpu.in
@@ -503,6 +736,7 @@ referencing==0.37.0
     #   jsonschema-specifications
 regex==2026.3.32
     # via
+    #   -r requirements/test/../common.txt
     #   nltk
     #   sacrebleu
     #   tiktoken
@@ -510,6 +744,7 @@ regex==2026.3.32
 requests==2.33.1
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   datasets
     #   docker
     #   evaluate
@@ -518,6 +753,7 @@ requests==2.33.1
     #   mistral-common
     #   modelscope
     #   mteb
+    #   opentelemetry-exporter-otlp-proto-http
     #   pooch
     #   schemathesis
     #   starlette-testclient
@@ -525,8 +761,15 @@ requests==2.33.1
 rich==14.3.3
     # via
     #   mteb
+    #   rich-toolkit
     #   schemathesis
     #   typer
+rich-toolkit==0.20.1
+    # via
+    #   fastapi-cli
+    #   fastapi-cloud-cli
+rignore==0.7.6
+    # via fastapi-cloud-cli
 rouge-score==0.1.2
     # via lm-eval
 rpds-py==0.30.0
@@ -538,6 +781,7 @@ sacrebleu==2.6.0
 safetensors==0.7.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   accelerate
     #   timm
     #   transformers
@@ -564,10 +808,18 @@ scipy==1.17.1
     #   sentence-transformers
 sentence-transformers==5.3.0
     # via mteb
+sentencepiece==0.2.1
+    # via -r requirements/test/../common.txt
+sentry-sdk==2.63.0
+    # via fastapi-cloud-cli
+setproctitle==1.3.7
+    # via -r requirements/test/../common.txt
 setuptools==80.10.2
     # via
     #   -c requirements/common.txt
     #   -c requirements/xpu.txt
+    #   -r requirements/test/../common.txt
+    #   model-hosting-container-standards
     #   modelscope
     #   pytablewriter
     #   torch
@@ -576,9 +828,14 @@ shellingham==1.5.4
 six==1.17.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   junit-xml
     #   python-dateutil
     #   rouge-score
+sniffio==1.3.1
+    # via
+    #   anthropic
+    #   openai
 sortedcontainers==2.4.0
     # via hypothesis
 soundfile==0.13.1
@@ -593,15 +850,24 @@ soxr==0.5.0.post1
     #   mistral-common
 sqlitedict==2.1.0
     # via lm-eval
+sse-starlette==3.4.5
+    # via mcp
 starlette==1.3.1
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   fastapi
+    #   mcp
+    #   model-hosting-container-standards
+    #   prometheus-fastapi-instrumentator
+    #   sse-starlette
     #   starlette-testclient
 starlette-testclient==0.4.1
     # via schemathesis
 structlog==25.5.0
     # via gpt-oss
+supervisor==4.3.0
+    # via model-hosting-container-standards
 sympy==1.14.0
     # via torch
 tabledata==1.3.4
@@ -636,6 +902,7 @@ tifffile==2026.3.3
 tiktoken==0.12.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   gpt-oss
     #   lm-eval
     #   mistral-common
@@ -644,19 +911,23 @@ timm==1.0.17
 tokenizers==0.22.2
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   transformers
 torch==2.12.0+xpu
     # via
     #   -c requirements/xpu.txt
     #   accelerate
+    #   compressed-tensors
     #   mteb
     #   sentence-transformers
     #   timm
     #   torchvision
+    #   xgrammar
 torchvision==0.27.0+xpu
     # via timm
 tqdm==4.67.3
     # via
+    #   -r requirements/test/../common.txt
     #   datasets
     #   evaluate
     #   huggingface-hub
@@ -664,13 +935,19 @@ tqdm==4.67.3
     #   modelscope
     #   mteb
     #   nltk
+    #   openai
     #   pqdm
     #   sentence-transformers
     #   transformers
 transformers==5.5.3
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
+    #   compressed-tensors
     #   sentence-transformers
+    #   xgrammar
+triton==3.7.1
+    # via xgrammar
 triton-xpu==3.7.1
     # via torch
 typepy==1.3.4
@@ -680,36 +957,53 @@ typepy==1.3.4
     #   tabledata
 typer==0.24.1
     # via
+    #   fastapi-cli
+    #   fastapi-cloud-cli
     #   huggingface-hub
     #   transformers
 typing-extensions==4.15.0
     # via
     #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
     #   aiosignal
     #   albumentations
+    #   anthropic
     #   anyio
+    #   apache-tvm-ffi
     #   chz
     #   fastapi
+    #   grpcio
     #   huggingface-hub
     #   librosa
     #   lm-eval
+    #   mcp
     #   mistral-common
     #   mteb
+    #   openai
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pqdm
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
     #   pytest-asyncio
     #   referencing
+    #   rich-toolkit
     #   schemathesis
     #   sentence-transformers
     #   starlette
     #   torch
     #   typing-inspection
+    #   xgrammar
 typing-inspection==0.4.2
     # via
     #   fastapi
+    #   mcp
     #   pydantic
+    #   pydantic-settings
 umf==1.0.3
     # via
     #   intel-cmplr-lib-ur
@@ -720,12 +1014,30 @@ urllib3==2.6.3
     #   docker
     #   modelscope
     #   requests
+    #   sentry-sdk
 uvicorn==0.42.0
-    # via gpt-oss
+    # via
+    #   fastapi
+    #   fastapi-cli
+    #   fastapi-cloud-cli
+    #   gpt-oss
+    #   mcp
+uvloop==0.22.1
+    # via uvicorn
+watchfiles==1.2.0
+    # via
+    #   -r requirements/test/../common.txt
+    #   uvicorn
+websockets==16.0
+    # via uvicorn
 werkzeug==3.1.7
     # via schemathesis
 word2number==1.1
     # via lm-eval
+xgrammar==0.2.3
+    # via
+    #   -c requirements/common.txt
+    #   -r requirements/test/../common.txt
 xxhash==3.6.0
     # via
     #   datasets

--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -102,45 +102,36 @@ def test_get_model_structural_tag_supports_vllm_hermes(
     )
 
     assert isinstance(tag, StructuralTag)
-    assert tag.model_dump() == {
-        "type": "structural_tag",
-        "format": {
-            "type": "tags_with_separator",
-            "tags": [
-                {
-                    "type": "tag",
-                    "begin": '<tool_call>\n{"name": "get_weather", "arguments": ',
-                    "content": {
-                        "type": "json_schema",
-                        "json_schema": {
-                            "type": "object",
-                            "properties": {"city": {"type": "string"}},
-                            "required": ["city"],
-                        },
-                        "style": "json",
-                    },
-                    "end": "}\n</tool_call>",
-                },
-                {
-                    "type": "tag",
-                    "begin": '<tool_call>{"name": "get_weather", "arguments": ',
-                    "content": {
-                        "type": "json_schema",
-                        "json_schema": {
-                            "type": "object",
-                            "properties": {"city": {"type": "string"}},
-                            "required": ["city"],
-                        },
-                        "style": "json",
-                    },
-                    "end": "}</tool_call>",
-                },
-            ],
-            "separator": "",
-            "at_least_one": True,
-            "stop_after_first": False,
-        },
+
+    # Assert the semantically meaningful structure rather than the full
+    # model_dump(), which gains version-specific keys across xgrammar releases
+    # (e.g. "any_order" was added to json_schema content in 0.2.3).
+    dump = tag.model_dump()
+    assert dump["type"] == "structural_tag"
+
+    fmt = dump["format"]
+    assert fmt["type"] == "tags_with_separator"
+    assert fmt["separator"] == ""
+    assert fmt["at_least_one"] is True
+    assert fmt["stop_after_first"] is False
+
+    expected_schema = {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
     }
+    expected_tags = [
+        ('<tool_call>\n{"name": "get_weather", "arguments": ', "}\n</tool_call>"),
+        ('<tool_call>{"name": "get_weather", "arguments": ', "}</tool_call>"),
+    ]
+    assert len(fmt["tags"]) == len(expected_tags)
+    for tag_dump, (begin, end) in zip(fmt["tags"], expected_tags):
+        assert tag_dump["type"] == "tag"
+        assert tag_dump["begin"] == begin
+        assert tag_dump["end"] == end
+        content = tag_dump["content"]
+        assert content["type"] == "json_schema"
+        assert content["json_schema"] == expected_schema
 
 
 def test_hermes_required_tool_calls_use_empty_separator():


### PR DESCRIPTION
- Fixes the test so that it passes before and after `0.2.3`
- Fixes the `requirements/test/*.in` files so that everything installed during testing is pinned, no more possibility for transient dependency issues