### PR TITLE
[XPU] relpace torch.xpu.mem_get_info

### DIFF
--- a/vllm/v1/worker/xpu_model_runner.py
+++ b/vllm/v1/worker/xpu_model_runner.py
@@ -45,7 +45,7 @@ def _torch_cuda_wrapper():
     torch.cuda.default_stream = torch.xpu.current_stream
     torch.cuda.current_stream = torch.xpu.current_stream
     torch.cuda.stream = torch.xpu.stream
-    torch.cuda.mem_get_info = torch.xpu.mem_get_info
+    torch.cuda.mem_get_info = torch.ops._C_cache_ops.getMemoryInfo
     torch.cuda.Event = torch.Event
     torch.cuda.set_stream = torch.xpu.set_stream
     if supports_xpu_graph():


### PR DESCRIPTION
Torch.xpu.mem_get_info returns wrong memory info with latest UMD.
More details please refer to https://github.com/vllm-project/vllm-xpu-kernels/blob/70387bfdcc15f85628ed31b8faf62af537096435/tests/test_get_memory_info.py#L16
Use API of kernels to replace it.