### PR TITLE
Fix Cutlass FP8 padded weight loader replacement

### DIFF
--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -15,6 +15,7 @@ from tests.quantization.utils import is_quant_method_supported
 from vllm import _custom_ops as ops
 from vllm.config.model import ModelConfig
 from vllm.model_executor.kernels.linear.scaled_mm import (
+    CutlassFP8ScaledMMLinearKernel,
     MarlinFP8ScaledMMLinearKernel,
 )
 from vllm.model_executor.layers.fused_moe import FusedMoE
@@ -41,6 +42,28 @@ MODELS = [
         marks=pytest.mark.skip(reason="Checkpoint removed from HF."),
     ),
 ]
+
+
+def test_cutlass_fp8_padding_updates_weight_loaders():
+    class Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(17, 17))
+            self.weight_scale = torch.nn.Parameter(torch.ones(17, 1))
+
+    layer = Layer()
+    layer.weight.weight_loader = default_weight_loader
+    layer.weight_scale.weight_loader = default_weight_loader
+
+    kernel = CutlassFP8ScaledMMLinearKernel.__new__(CutlassFP8ScaledMMLinearKernel)
+    kernel.layer_param_names = ("weight", "weight_scale", "input_scale", None)
+
+    kernel.process_weights_after_loading(layer)
+
+    assert layer.weight.shape == torch.Size([32, 32])
+    assert layer.weight_scale.shape == torch.Size([32, 1])
+    assert layer.weight.weight_loader == kernel.padded_weight_loader
+    assert layer.weight_scale.weight_loader == kernel.padded_weight_loader
 
 
 @pytest.mark.skipif(

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -15,6 +15,7 @@ from tests.quantization.utils import is_quant_method_supported
 from vllm import _custom_ops as ops
 from vllm.config.model import ModelConfig
 from vllm.model_executor.kernels.linear.scaled_mm import (
+    CutlassFP8ScaledMMLinearKernel,
     MarlinFP8ScaledMMLinearKernel,
 )
 from vllm.model_executor.layers.attention.attention import (
@@ -58,6 +59,28 @@ def test_static_fp8_moe_input_scales_remain_scalar() -> None:
     )
 
     assert a1_scale.ndim == a2_scale.ndim == 0
+
+
+def test_cutlass_fp8_padding_updates_weight_loaders():
+    class Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(17, 17))
+            self.weight_scale = torch.nn.Parameter(torch.ones(17, 1))
+
+    layer = Layer()
+    layer.weight.weight_loader = default_weight_loader
+    layer.weight_scale.weight_loader = default_weight_loader
+
+    kernel = CutlassFP8ScaledMMLinearKernel.__new__(CutlassFP8ScaledMMLinearKernel)
+    kernel.layer_param_names = ("weight", "weight_scale", "input_scale", None)
+
+    kernel.process_weights_after_loading(layer)
+
+    assert layer.weight.shape == torch.Size([32, 32])
+    assert layer.weight_scale.shape == torch.Size([32, 1])
+    assert layer.weight.weight_loader == kernel.padded_weight_loader
+    assert layer.weight_scale.weight_loader == kernel.padded_weight_loader
 
 
 @pytest.mark.skipif(

--- a/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
@@ -201,6 +201,11 @@ class CutlassFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         else:
             param.data.copy_(loaded_weight.view(param.shape))
 
+    def _set_padded_weight_loader(self, param: torch.Tensor) -> None:
+        if hasattr(param, "weight_loader"):
+            delattr(param, "weight_loader")
+        set_weight_attrs(param, {"weight_loader": self.padded_weight_loader})
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         weight_name, weight_scale_name, _, _ = self.layer_param_names
         weight = getattr(layer, weight_name)
@@ -219,12 +224,7 @@ class CutlassFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
             (0, pad_k, 0, pad_n),
         ).t()
         replace_parameter(layer, weight_name, padded_weight.data)
-        set_weight_attrs(
-            getattr(layer, weight_name),
-            {
-                "weight_loader": self.padded_weight_loader,
-            },
-        )
+        self._set_padded_weight_loader(getattr(layer, weight_name))
 
         weight_scale = getattr(layer, weight_scale_name, None)
         if weight_scale is not None and pad_n > 0 and weight_scale.numel() > 1:
@@ -233,12 +233,7 @@ class CutlassFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
                 flat_scale, dim=0, alignment=16, value=1.0
             ).view(-1, *weight_scale.shape[1:])
             replace_parameter(layer, weight_scale_name, padded_scale.data)
-            set_weight_attrs(
-                getattr(layer, weight_name),
-                {
-                    "weight_loader": self.padded_weight_loader,
-                },
-            )
+            self._set_padded_weight_loader(getattr(layer, weight_scale_name))
 
     def apply_scaled_mm(
         self,


### PR DESCRIPTION
# Fix Cutlass FP8 padded loader overwrite

Fixes #47005

## Summary

Fix the Cutlass FP8 post-load padding path so padded replacement parameters can install `padded_weight_loader` without tripping the existing `set_weight_attrs` overwrite assertion.

`replace_parameter` preserves an existing `weight_loader` on the replacement parameter. The Cutlass FP8 padding path then needs to replace that loader because future reloads must copy the original unpadded checkpoint tensor into the padded parameter. This change clears the copied loader only for padded weight and weight scale parameters before setting `padded_weight_loader`.

Also adds a focused regression test for padded weight and per-channel scale parameters that already have loaders.

## Duplicate-work checks

- `gh issue view 47005 --repo vllm-project/vllm --comments`: no comment output.
- `gh pr list --repo vllm-project/vllm --state open --search "47005 in:body"`: no open PR output before this PR.
- `gh pr list --repo vllm-project/vllm --state open --search "Cutlass FP8 weight_loader padding"`: no open PR output before this PR.
- `gh pr list --repo vllm-project/vllm --state open --search "Overwriting existing tensor attribute weight_loader fp8"`: no open PR output before this PR.

AI assistance was used to prepare this patch. The human submitter should review every changed line and be prepared to defend the change end-to-end.

## Test evidence

- `VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto`
- `.venv/bin/python -m pytest tests/quantization/test_fp8.py::test_cutlass_fp8_padding_updates_weight_loaders -q`
  - `1 passed, 16 warnings in 1.09s`
- `.venv/bin/python -m ruff check vllm/model_executor/kernels/linear/scaled_mm/cutlass.py tests/quantization/test_fp8.py`
  - `All checks passed!`

## Risks or notes for maintainers

- The regression test exercises the post-load padding logic directly on CPU tensors by bypassing kernel initialization; it does not require CUDA or the reporter's large FP8 model.
- The `set_weight_attrs` no-overwrite guard remains unchanged globally. The loader replacement is limited to parameters that were just padded by this Cutlass FP8 path.
