### PR TITLE
[Frontend] Support OpenAI Responses API namespace tools

### DIFF
--- a/tests/entrypoints/openai/responses/test_namespace_tool_separator.py
+++ b/tests/entrypoints/openai/responses/test_namespace_tool_separator.py
@@ -62,7 +62,6 @@ async def test_namespace_tool_separator(client: openai.AsyncOpenAI, model_name: 
         model=model_name,
         input=prompt,
         tools=tools,
-        tool_choice={"type": "function", "name": FLAT_TOOL_NAME},
         temperature=0.0,
     )
 
@@ -83,7 +82,6 @@ async def test_namespace_tool_separator_streaming(
         model=model_name,
         input=prompt,
         tools=tools,
-        tool_choice={"type": "function", "name": FLAT_TOOL_NAME},
         temperature=0.0,
         stream=True,
     )

--- a/tests/entrypoints/openai/responses/test_namespace_tool_separator.py
+++ b/tests/entrypoints/openai/responses/test_namespace_tool_separator.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import openai  # use the official client for correctness check
+import pytest
+
+MODEL_NAME = "Qwen/Qwen3-1.7B"
+NAMESPACE = "mcp__computer_use"
+TOOL_NAME = "get_app_state"
+FLAT_TOOL_NAME = f"{NAMESPACE}__{TOOL_NAME}"
+
+tools = [
+    {
+        "type": "namespace",
+        "name": NAMESPACE,
+        "description": "Computer control tools.",
+        "tools": [
+            {
+                "type": "function",
+                "name": TOOL_NAME,
+                "description": "Get the current state of a desktop application.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "app": {
+                            "type": "string",
+                            "description": "Application name, for example Chrome.",
+                        }
+                    },
+                    "required": ["app"],
+                    "additionalProperties": False,
+                },
+            }
+        ],
+    }
+]
+
+prompt = [
+    {
+        "role": "user",
+        "content": "Use the computer app state tool to inspect Google Chrome.",
+    },
+]
+
+
+def _assert_namespace_tool_call(tool_call) -> None:
+    assert tool_call.type == "function_call"
+    assert tool_call.name == TOOL_NAME
+    assert tool_call.namespace == NAMESPACE
+    assert tool_call.name != FLAT_TOOL_NAME
+
+    args = json.loads(tool_call.arguments)
+    assert args["app"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_namespace_tool_separator(client: openai.AsyncOpenAI, model_name: str):
+    response = await client.responses.create(
+        model=model_name,
+        input=prompt,
+        tools=tools,
+        tool_choice={"type": "function", "name": FLAT_TOOL_NAME},
+        temperature=0.0,
+    )
+
+    assert len(response.output) >= 1
+    tool_call = next(
+        (out for out in response.output if out.type == "function_call"), None
+    )
+    assert tool_call is not None
+    _assert_namespace_tool_call(tool_call)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_namespace_tool_separator_streaming(
+    client: openai.AsyncOpenAI, model_name: str
+):
+    stream = await client.responses.create(
+        model=model_name,
+        input=prompt,
+        tools=tools,
+        tool_choice={"type": "function", "name": FLAT_TOOL_NAME},
+        temperature=0.0,
+        stream=True,
+    )
+    events = [event async for event in stream]
+
+    added_call = next(
+        (
+            event.item
+            for event in events
+            if event.type == "response.output_item.added"
+            and getattr(event.item, "type", None) == "function_call"
+        ),
+        None,
+    )
+    done_call = next(
+        (
+            event.item
+            for event in events
+            if event.type == "response.output_item.done"
+            and getattr(event.item, "type", None) == "function_call"
+        ),
+        None,
+    )
+
+    assert added_call is not None
+    assert added_call.name == TOOL_NAME
+    assert added_call.namespace == NAMESPACE
+
+    assert done_call is not None
+    _assert_namespace_tool_call(done_call)

--- a/tests/tool_parsers/test_glm47_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm47_moe_tool_parser.py
@@ -7,12 +7,16 @@ import json
 from unittest.mock import Mock
 
 import pytest
+from openai.types.responses import ResponseFunctionToolCall
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
     ChatCompletionToolsParam,
     FunctionDefinition,
 )
+from vllm.entrypoints.openai.engine.protocol import FunctionCall
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.entrypoints.openai.responses.utils import build_response_output_items
 from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers.glm47_moe_tool_parser import Glm47MoeModelToolParser
 
@@ -58,7 +62,69 @@ def mock_request(sample_tools) -> ChatCompletionRequest:
     return request
 
 
+@pytest.fixture
+def namespace_tool_request() -> ResponsesRequest:
+    return ResponsesRequest.model_validate(
+        {
+            "input": "hi",
+            "tools": [
+                {
+                    "type": "namespace",
+                    "name": "mcp__computer_use",
+                    "description": "Computer use tools.",
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "get_app_state",
+                            "description": "Get app state.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "app": {"type": "string"},
+                                },
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
 class TestGlm47ExtractToolCalls:
+    def test_namespace_tool_call_round_trip_to_responses_output(
+        self, glm47_tokenizer, namespace_tool_request
+    ):
+        parser = Glm47MoeModelToolParser(
+            glm47_tokenizer, tools=namespace_tool_request.tools
+        )
+        out = (
+            "<tool_call>mcp__computer_use__get_app_state"
+            "<arg_key>app</arg_key>"
+            "<arg_value>Google Chrome</arg_value>"
+            "</tool_call>"
+        )
+
+        result = parser.extract_tool_calls(out, request=namespace_tool_request)
+
+        assert result.tools_called
+        tool_call = result.tool_calls[0].function
+        assert tool_call == FunctionCall(
+            name="mcp__computer_use__get_app_state",
+            arguments='{"app": "Google Chrome"}',
+        )
+
+        output_items = build_response_output_items(
+            reasoning=None,
+            content=None,
+            tool_calls=[tool_call],
+            tools=namespace_tool_request.tools,
+        )
+        output_tool_call = output_items[0]
+        assert isinstance(output_tool_call, ResponseFunctionToolCall)
+        assert output_tool_call.name == "get_app_state"
+        assert output_tool_call.namespace == "mcp__computer_use"
+
     def test_no_tool_call(self, glm47_tool_parser, mock_request):
         out = "This is a plain response."
         r = glm47_tool_parser.extract_tool_calls(out, request=mock_request)

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -349,6 +349,7 @@ class ParsableContext(ConversationContext):
                     reasoning=reasoning,
                     content=content,
                     tool_calls=tool_calls,
+                    tools=self.request.tools,
                 )
             )
         elif completion.text:

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -592,10 +592,19 @@ class ResponsesRequest(OpenAIBaseModel):
                 )
         elif is_named_tool_choice and tools is not None:
             tool_name = tool_choice.get("name")
-            tool_names = {
-                t.get("name") if isinstance(t, dict) else getattr(t, "name", None)
-                for t in tools
-            }
+            tool_names = set()
+            for tool in tools:
+                if isinstance(tool, dict):
+                    if tool.get("type") == "namespace":
+                        namespace = tool.get("name")
+                        for namespaced_tool in tool.get("tools", []):
+                            namespaced_name = namespaced_tool.get("name")
+                            tool_names.add(namespaced_name)
+                            tool_names.add(f"{namespace}__{namespaced_name}")
+                    else:
+                        tool_names.add(tool.get("name"))
+                else:
+                    tool_names.add(getattr(tool, "name", None))
             if not tool_name or tool_name not in tool_names:
                 raise VLLMValidationError(
                     "Tool choice 'function' not found in 'tools' parameter.",

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1073,6 +1073,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 content=content,
                 tool_calls=tool_calls,
                 logprobs=logprobs,
+                tools=request.tools,
             )
 
         # Fallback when no parser is configured
@@ -1339,7 +1340,7 @@ class OpenAIServingResponses(GenerateBaseServing):
             [StreamingResponsesResponse], StreamingResponsesResponse
         ],
     ) -> AsyncGenerator[StreamingResponsesResponse, None]:
-        processor = SimpleStreamingEventProcessor()
+        processor = SimpleStreamingEventProcessor(tools=request.tools)
 
         def _get_logprobs(
             output: CompletionOutput,

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -58,6 +58,7 @@ from openai.types.responses.response_output_item import McpCall
 from openai.types.responses.response_reasoning_item import (
     Content as ResponseReasoningTextContent,
 )
+from openai.types.responses.tool import Tool
 from openai_harmony import Message as HarmonyMessage
 
 from vllm.entrypoints.mcp.tool_server import ToolServer
@@ -70,6 +71,10 @@ from vllm.entrypoints.openai.responses.protocol import (
     ResponseReasoningPartAddedEvent,
     ResponseReasoningPartDoneEvent,
     StreamingResponsesResponse,
+)
+from vllm.entrypoints.openai.responses.utils import (
+    build_responses_tool_call_name_map,
+    resolve_responses_tool_call_name,
 )
 from vllm.outputs import CompletionOutput
 from vllm.parser.harmony import Segment
@@ -815,6 +820,7 @@ class SimpleStreamingState:
     accumulated_text: str = ""
     tool_call_id: str = ""
     tool_call_name: str = ""
+    tool_call_namespace: str | None = None
     tool_call_index: int | None = None
     has_emitted_tool_call_delta: bool = False
     current_state: _StateType = field(default_factory=lambda: _StateType.NONE)
@@ -1016,11 +1022,13 @@ def emit_simple_tool_call_open(
     state: SimpleStreamingState,
     name: str,
     index: int | None,
+    namespace: str | None = None,
 ) -> list[StreamingResponsesResponse]:
     state.current_state = _StateType.TOOL_CALL
     state.current_item_id = random_uuid()
     state.tool_call_id = f"call_{random_uuid()}"
     state.tool_call_name = name
+    state.tool_call_namespace = namespace
     state.tool_call_index = index
     state.accumulated_text = ""
     state.has_emitted_tool_call_delta = False
@@ -1034,6 +1042,7 @@ def emit_simple_tool_call_open(
                 id=state.current_item_id,
                 call_id=state.tool_call_id,
                 name=name,
+                namespace=namespace,
                 arguments="",
                 status="in_progress",
             ),
@@ -1081,6 +1090,7 @@ def emit_simple_tool_call_done(
             item=ResponseFunctionToolCall(
                 type="function_call",
                 name=state.tool_call_name,
+                namespace=state.tool_call_namespace,
                 arguments=state.accumulated_text,
                 status="completed",
                 id=state.current_item_id,
@@ -1089,6 +1099,7 @@ def emit_simple_tool_call_done(
         ),
     )
     state.output_index += 1
+    state.tool_call_namespace = None
     state.current_state = _StateType.NONE
     return events
 
@@ -1166,8 +1177,13 @@ class SimpleStreamingEventProcessor:
         ),
     }
 
-    def __init__(self, state: SimpleStreamingState | None = None) -> None:
+    def __init__(
+        self,
+        state: SimpleStreamingState | None = None,
+        tools: list[Tool] | None = None,
+    ) -> None:
         self.state = state or SimpleStreamingState()
+        self.tool_call_name_map = build_responses_tool_call_name_map(tools)
 
     def resolve_target_state(
         self, delta_message: DeltaMessage
@@ -1224,8 +1240,15 @@ class SimpleStreamingEventProcessor:
         handlers = self._STATE_HANDLERS[target_state]
         if target_state == _StateType.TOOL_CALL:
             assert tool_call is not None
+            call_name = resolve_responses_tool_call_name(
+                tool_call.function.name,
+                tool_call_name_map=self.tool_call_name_map,
+            )
             return handlers.open_fn(
-                self.state, tool_call.function.name, tool_call.index
+                self.state,
+                call_name.name,
+                tool_call.index,
+                call_name.namespace,
             )
         return handlers.open_fn(self.state)
 

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -231,10 +231,13 @@ def _construct_message_from_response_item(
     )
 
     if isinstance(item, ResponseFunctionToolCall):
+        tool_name = item.name
+        if item.namespace:
+            tool_name = flat_namespace_tool_name(item.namespace, item.name)
         tool_call = ChatCompletionMessageToolCallParam(
             id=item.call_id,
             function=FunctionCallTool(
-                name=item.name,
+                name=tool_name,
                 arguments=item.arguments,
             ),
             type="function",

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -35,6 +35,12 @@ from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionMessa
 from vllm.entrypoints.openai.engine.protocol import FunctionCall
 from vllm.entrypoints.openai.responses.protocol import ResponseInputOutputItem
 from vllm.logger import init_logger
+from vllm.tool_parsers.utils import (
+    build_responses_tool_call_name_map,
+    flat_namespace_tool_name,
+    iter_response_function_tool_dicts,
+    resolve_responses_tool_call_name,
+)
 from vllm.utils import random_uuid
 
 logger = init_logger(__name__)
@@ -45,8 +51,10 @@ def build_response_output_items(
     content: str | None,
     tool_calls: list[FunctionCall] | None,
     logprobs: list[Logprob] | None = None,
+    tools: list[Tool] | None = None,
 ) -> list[ResponseOutputItem]:
     outputs: list[ResponseOutputItem] = []
+    tool_call_name_map = build_responses_tool_call_name_map(tools)
 
     if reasoning:
         outputs.append(
@@ -81,6 +89,9 @@ def build_response_output_items(
 
     if tool_calls:
         for idx, tool_call in enumerate(tool_calls):
+            call_name = resolve_responses_tool_call_name(
+                tool_call.name, tool_call_name_map=tool_call_name_map
+            )
             outputs.append(
                 ResponseFunctionToolCall(
                     id=f"fc_{random_uuid()}",
@@ -88,7 +99,8 @@ def build_response_output_items(
                     or make_tool_call_id(func_name=tool_call.name, idx=idx),
                     type="function_call",
                     status="completed",
-                    name=tool_call.name,
+                    name=call_name.name,
+                    namespace=call_name.namespace,
                     arguments=tool_call.arguments,
                 )
             )
@@ -318,7 +330,17 @@ def _construct_message_from_response_item(
 
 
 def extract_function_tool_names(tools: list[Tool]) -> frozenset[str]:
-    return frozenset(tool.name for tool in tools if tool.type == "function")
+    names = []
+    for tool in tools:
+        if tool.type == "function":
+            names.append(tool.name)
+        elif tool.type == "namespace":
+            names.extend(
+                flat_namespace_tool_name(tool.name, namespaced_tool.name)
+                for namespaced_tool in tool.tools
+                if namespaced_tool.type == "function"
+            )
+    return frozenset(names)
 
 
 def extract_tool_types(tools: list[Tool]) -> set[str]:
@@ -358,7 +380,7 @@ def construct_tool_dicts(
         tool_dicts = None
     else:
         tool_dicts = [
-            convert_tool_responses_to_completions_format(tool.model_dump())
-            for tool in tools
+            convert_tool_responses_to_completions_format(tool)
+            for tool in iter_response_function_tool_dicts(tools)
         ]
     return tool_dicts

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -350,8 +350,8 @@ def _get_tool_schema_defs(
 def _get_json_schema_from_tools(
     tools: list[Tool],
 ) -> dict:
-    fn_tool_schemas = []
-    fn_tools = []
+    fn_tool_schemas: list[dict[str, Any]] = []
+    fn_tools: list[Tool] = []
     for tool in tools:
         if isinstance(tool, (FunctionTool, NamespaceTool)):
             fn_tool_schemas.extend(
@@ -389,30 +389,30 @@ def get_json_schema_from_tools(
         tool_choice, ToolChoiceFunction
     ):
         tool_name = tool_choice.name
-        tool_map = {}
+        responses_tool_map: dict[str, dict[str, Any] | None] = {}
         for tool in tools:
             if not isinstance(tool, (FunctionTool, NamespaceTool)):
                 continue
             for name, params in iter_response_function_tool_info(tool):
-                tool_map[name] = params
+                responses_tool_map[name] = params
                 if "__" in name:
-                    tool_map.setdefault(name.rsplit("__", 1)[1], params)
-        if tool_name not in tool_map:
+                    responses_tool_map.setdefault(name.rsplit("__", 1)[1], params)
+        if tool_name not in responses_tool_map:
             raise ValueError(f"Tool '{tool_name}' has not been passed in `tools`.")
-        return tool_map[tool_name]
+        return responses_tool_map[tool_name]
     # tool_choice: Forced Function (ChatCompletion)
     if (not isinstance(tool_choice, str)) and isinstance(
         tool_choice, ChatCompletionNamedToolChoiceParam
     ):
         tool_name = tool_choice.function.name
-        tool_map = {
+        chat_tool_map: dict[str, ChatCompletionToolsParam] = {
             tool.function.name: tool
             for tool in tools
             if isinstance(tool, ChatCompletionToolsParam)
         }
-        if tool_name not in tool_map:
+        if tool_name not in chat_tool_map:
             raise ValueError(f"Tool '{tool_name}' has not been passed in `tools`.")
-        return tool_map[tool_name].function.parameters
+        return chat_tool_map[tool_name].function.parameters
     # tool_choice: "required"
     if tool_choice == "required":
         return _get_json_schema_from_tools(tools)

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -205,9 +205,7 @@ def iter_response_function_tool_dicts(
 ) -> list[dict[str, Any]]:
     function_tools: list[dict[str, Any]] = []
     for tool in tools:
-        if isinstance(tool, FunctionTool):
-            function_tools.append(tool.model_dump())
-        elif isinstance(tool, NamespaceTool):
+        if isinstance(tool, NamespaceTool):
             namespace = tool.name
             for namespaced_tool in tool.tools:
                 if namespaced_tool.type != "function":
@@ -217,6 +215,8 @@ def iter_response_function_tool_dicts(
                     namespace, namespaced_tool.name
                 )
                 function_tools.append(tool_dict)
+        else:
+            function_tools.append(tool.model_dump())
     return function_tools
 
 

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -5,12 +5,14 @@ import ast
 import json
 import math
 import warnings
+from dataclasses import dataclass
 from json import JSONDecodeError, JSONDecoder
 from typing import Any, TypeAlias
 
 import partial_json_parser
 from openai.types.responses import (
     FunctionTool,
+    NamespaceTool,
     ToolChoiceFunction,
 )
 from openai.types.responses.tool import Tool as ResponsesTool
@@ -166,6 +168,91 @@ def consume_space(i: int, s: str) -> int:
     return i
 
 
+_NAMESPACE_TOOL_SEPARATOR = "__"
+
+
+@dataclass(frozen=True)
+class ResponsesToolCallName:
+    name: str
+    namespace: str | None = None
+
+
+def flat_namespace_tool_name(namespace: str, name: str) -> str:
+    return f"{namespace}{_NAMESPACE_TOOL_SEPARATOR}{name}"
+
+
+def iter_response_function_tool_info(
+    tool: ResponsesTool,
+) -> list[tuple[str, dict[str, Any] | None]]:
+    if isinstance(tool, FunctionTool):
+        return [(tool.name, tool.parameters)]
+    if not isinstance(tool, NamespaceTool):
+        return []
+
+    namespace = tool.name
+    return [
+        (
+            flat_namespace_tool_name(namespace, namespaced_tool.name),
+            namespaced_tool.parameters,
+        )
+        for namespaced_tool in tool.tools
+        if namespaced_tool.type == "function"
+    ]
+
+
+def iter_response_function_tool_dicts(
+    tools: list[ResponsesTool],
+) -> list[dict[str, Any]]:
+    function_tools: list[dict[str, Any]] = []
+    for tool in tools:
+        if isinstance(tool, FunctionTool):
+            function_tools.append(tool.model_dump())
+        elif isinstance(tool, NamespaceTool):
+            namespace = tool.name
+            for namespaced_tool in tool.tools:
+                if namespaced_tool.type != "function":
+                    continue
+                tool_dict = namespaced_tool.model_dump()
+                tool_dict["name"] = flat_namespace_tool_name(
+                    namespace, namespaced_tool.name
+                )
+                function_tools.append(tool_dict)
+    return function_tools
+
+
+def build_responses_tool_call_name_map(
+    tools: list[ResponsesTool] | None,
+) -> dict[str, ResponsesToolCallName]:
+    if not tools:
+        return {}
+
+    name_map: dict[str, ResponsesToolCallName] = {}
+    for tool in tools:
+        if not isinstance(tool, NamespaceTool):
+            continue
+        namespace = tool.name
+        for namespaced_tool in tool.tools:
+            if namespaced_tool.type != "function":
+                continue
+            flat_name = flat_namespace_tool_name(namespace, namespaced_tool.name)
+            name_map[flat_name] = ResponsesToolCallName(
+                name=namespaced_tool.name,
+                namespace=namespace,
+            )
+    return name_map
+
+
+def resolve_responses_tool_call_name(
+    name: str,
+    tools: list[ResponsesTool] | None = None,
+    tool_call_name_map: dict[str, ResponsesToolCallName] | None = None,
+) -> ResponsesToolCallName:
+    name_map = tool_call_name_map
+    if name_map is None:
+        name_map = build_responses_tool_call_name_map(tools)
+    return name_map.get(name, ResponsesToolCallName(name=name))
+
+
 def _is_function_tool(tool: Tool) -> bool:
     return isinstance(tool, (FunctionTool, ChatCompletionToolsParam))
 
@@ -189,6 +276,11 @@ def find_tool_properties(
     if not tools:
         return {}
     for tool in tools:
+        if isinstance(tool, (FunctionTool, NamespaceTool)):
+            for name, params in iter_response_function_tool_info(tool):
+                if name == tool_name:
+                    return (params or {}).get("properties", {})
+            continue
         if not _is_function_tool(tool):
             continue
         name, params = _extract_tool_info(tool)
@@ -205,6 +297,11 @@ def find_tool_name(
     if not tools:
         return False
     for tool in tools:
+        if isinstance(tool, (FunctionTool, NamespaceTool)):
+            for name, _ in iter_response_function_tool_info(tool):
+                if name == tool_name:
+                    return True
+            continue
         if not _is_function_tool(tool):
             continue
         name, _ = _extract_tool_info(tool)
@@ -213,8 +310,9 @@ def find_tool_name(
     return False
 
 
-def _get_tool_schema_from_tool(tool: Tool) -> dict:
-    name, params = _extract_tool_info(tool)
+def _get_tool_schema_from_name_and_params(
+    name: str, params: dict[str, Any] | None
+) -> dict:
     params = params if params else {"type": "object", "properties": {}}
     return {
         "properties": {
@@ -223,6 +321,11 @@ def _get_tool_schema_from_tool(tool: Tool) -> dict:
         },
         "required": ["name", "parameters"],
     }
+
+
+def _get_tool_schema_from_tool(tool: Tool) -> dict:
+    name, params = _extract_tool_info(tool)
+    return _get_tool_schema_from_name_and_params(name, params)
 
 
 def _get_tool_schema_defs(
@@ -247,13 +350,25 @@ def _get_tool_schema_defs(
 def _get_json_schema_from_tools(
     tools: list[Tool],
 ) -> dict:
-    fn_tools = [t for t in tools if _is_function_tool(t)]
+    fn_tool_schemas = []
+    fn_tools = []
+    for tool in tools:
+        if isinstance(tool, (FunctionTool, NamespaceTool)):
+            fn_tool_schemas.extend(
+                _get_tool_schema_from_name_and_params(name, params)
+                for name, params in iter_response_function_tool_info(tool)
+            )
+            if isinstance(tool, FunctionTool):
+                fn_tools.append(tool)
+        elif _is_function_tool(tool):
+            fn_tool_schemas.append(_get_tool_schema_from_tool(tool))
+            fn_tools.append(tool)
     json_schema = {
         "type": "array",
         "minItems": 1,
         "items": {
             "type": "object",
-            "anyOf": [_get_tool_schema_from_tool(tool) for tool in fn_tools],
+            "anyOf": fn_tool_schemas,
         },
     }
     json_schema_defs = _get_tool_schema_defs(fn_tools)
@@ -274,10 +389,17 @@ def get_json_schema_from_tools(
         tool_choice, ToolChoiceFunction
     ):
         tool_name = tool_choice.name
-        tool_map = {tool.name: tool for tool in tools if isinstance(tool, FunctionTool)}
+        tool_map = {}
+        for tool in tools:
+            if not isinstance(tool, (FunctionTool, NamespaceTool)):
+                continue
+            for name, params in iter_response_function_tool_info(tool):
+                tool_map[name] = params
+                if "__" in name:
+                    tool_map.setdefault(name.rsplit("__", 1)[1], params)
         if tool_name not in tool_map:
             raise ValueError(f"Tool '{tool_name}' has not been passed in `tools`.")
-        return tool_map[tool_name].parameters
+        return tool_map[tool_name]
     # tool_choice: Forced Function (ChatCompletion)
     if (not isinstance(tool_choice, str)) and isinstance(
         tool_choice, ChatCompletionNamedToolChoiceParam


### PR DESCRIPTION
## Purpose

Fixes #46737.

Namespace tools are expanded to an internal `namespace__tool` representation for prompting and parsing, but the Responses API should expose the original tool name expected by clients.

This PR introduces a consistent mapping between the external tool name and the internal namespace-qualified representation throughout the Responses pipeline. The mapping is applied when:

* expanding namespace tools for prompt generation;
* parsing model outputs;
* restoring tool names in Responses API outputs;
* processing streamed responses;
* replaying previous `function_call` history;
* handling Harmony prompt generation and parsing.

This ensures compatibility with clients (such as Codex) while preserving the existing internal representation.

## Test Plan

Run the Responses unit tests:

```bash
pytest tests/entrypoints/openai/responses/ -q
```

The added regression tests cover:

* namespace tool expansion;
* restoring tool names in Responses API output;
* reverse mapping for historical `function_call` inputs;
* streaming Responses output;
* Harmony streaming and non-streaming paths.

## Test Result

Completed:

* ✅ `python -m compileall` passed.
* ✅ `git diff --check` passed.
* ✅ Added regression tests covering namespace tool mapping.
