### PR TITLE
[Bugfix] Avoid leaking Pydantic repr in tool_choice error message

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2124,6 +2124,13 @@ async def test_tool_choice_validation_without_parser():
     assert isinstance(response_named, ErrorResponse)
     assert "tool_choice" in response_named.error.message
     assert "--tool-call-parser" in response_named.error.message
+    # The function name should appear in a clean, readable form -
+    # guards against leaking Pydantic's internal repr of the
+    # ChatCompletionNamedToolChoiceParam/ChatCompletionNamedFunction
+    # objects directly into the client-facing error message.
+    assert "get_weather" in response_named.error.message
+    assert "ChatCompletionNamedFunction" not in response_named.error.message
+    assert "ChatCompletionNamedToolChoiceParam" not in response_named.error.message
 
 
 @pytest.mark.asyncio

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -12,6 +12,7 @@ from vllm.entrypoints.chat_utils import (
     ConversationMessage,
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.completion.protocol import (
@@ -134,8 +135,12 @@ class OnlineRenderer:
                 )
             elif request.tool_choice != "auto":
                 # "required" or named tool requires tool parser
+                if isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam):
+                    tool_choice_desc = f'function "{request.tool_choice.function.name}"'
+                else:
+                    tool_choice_desc = f'"{request.tool_choice}"'
                 return self.create_error_response(
-                    f'tool_choice="{request.tool_choice}" requires '
+                    f"tool_choice={tool_choice_desc} requires "
                     "--tool-call-parser to be set"
                 )
 


### PR DESCRIPTION
## Purpose

Part of #31683 (Error Logging Redesign).

When a named or forced `tool_choice` is sent to a vLLM server that has no `--tool-call-parser` configured, the client-facing error message leaks Pydantic's default `__str__` repr of the internal `ChatCompletionNamedToolChoiceParam` / `ChatCompletionNamedFunction` objects.

This affects both `/v1/messages` and `/v1/chat/completions`, since both route through the same logic in `vllm/renderers/online_renderer.py`.

### Before

`POST /v1/messages` with `"tool_choice": {"type": "tool", "name": "ghost_tool"}`:

```json
{"type":"error","error":{"type":"BadRequestError","message":"tool_choice=\"function=ChatCompletionNamedFunction(name='ghost_tool') type='function'\" requires --tool-call-parser to be set"}}
```

`POST /v1/chat/completions` with `"tool_choice": {"type": "function", "function": {"name": "real_tool"}}`:

```json
{"error":{"message":"tool_choice=\"function=ChatCompletionNamedFunction(name='real_tool') type='function'\" requires --tool-call-parser to be set", ...}}
```

### After

`POST /v1/messages`, named tool:

```json
{"type":"error","error":{"type":"BadRequestError","message":"tool_choice=function \"ghost_tool\" requires --tool-call-parser to be set"}}
```

`POST /v1/chat/completions`, named function:

```json
{"error":{"message":"tool_choice=function \"real_tool\" requires --tool-call-parser to be set","type":"BadRequestError","param":null,"code":400}}
```

`POST /v1/chat/completions`, `"tool_choice": "required"` (non-named, else branch — confirms no regression):

```json
{"error":{"message":"tool_choice=\"required\" requires --tool-call-parser to be set","type":"BadRequestError","param":null,"code":400}}
```

## Test Plan

- New regression assertions appended to `test_tool_choice_validation_without_parser` in `tests/entrypoints/openai/chat_completion/test_serving_chat.py`, guarding against `ChatCompletionNamedFunction` / `ChatCompletionNamedToolChoiceParam` ever reappearing in the client-facing message and confirming the readable function name (`get_weather`) is present.
- Verified the test fails on unpatched code and passes with the fix (stash/pop cycle).
- Live-verified all three branches (named on `/v1/messages`, named on `/v1/chat/completions`, `"required"` on `/v1/chat/completions`) against a running vLLM server with `Qwen/Qwen2.5-Coder-1.5B-Instruct` — curl payloads and responses captured above.

## Test Result

- `test_tool_choice_validation_without_parser`: **PASSED**.
- Full `tests/entrypoints/openai/chat_completion/test_serving_chat.py`: 29 passed, 0 failed. (10 unrelated `TestGPTOSS*` cases error out with `RuntimeError: Failed to infer device type` due to no GPU in the test environment; confirmed via stash/pop they fail identically without this patch — pre-existing environment gap, not introduced here.)
- `ruff check` + `ruff format --check`: pass.
- All three live curls return clean messages with no Pydantic internal type names anywhere in the response.

## Related

- Builds on the same error-message-quality theme as merged PRs #46038 and #46457, and the in-review PR #46415.
- Observed during testing: the `/v1/chat/completions` error envelope still echoes the full request body and an internal traceback for a *different* validation path (the upfront `tool_choice` name-vs-tools mismatch check). That leak is covered by #46415 (generic FastAPI validation handler), so not in scope here.

---
