### PR TITLE
[Model] Enable LoRA support for Fuyu

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -555,7 +555,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `Eagle2_5_VLForConditionalGeneration` | Eagle2.5-VL | T + I<sup>E+</sup> | `nvidia/Eagle2.5-8B`, etc. | ✅︎ | ✅︎ |
 | `Ernie4_5_VLMoeForConditionalGeneration` | Ernie4.5-VL | T + I<sup>+</sup>/ V<sup>+</sup> | `baidu/ERNIE-4.5-VL-28B-A3B-PT`, `baidu/ERNIE-4.5-VL-424B-A47B-PT` | | ✅︎ |
 | `Exaone4_5_ForConditionalGeneration` | EXAONE-4.5 | T + I<sup>E+</sup> | `LGAI-EXAONE/EXAONE-4.5-33B`, etc. | ✅︎ | ✅︎ |
-| `FuyuForCausalLM` | Fuyu | T + I | `adept/fuyu-8b`, etc. | | ✅︎ |
+| `FuyuForCausalLM` | Fuyu | T + I | `adept/fuyu-8b`, etc. | ✅︎ | ✅︎ |
 | `Gemma3ForConditionalGeneration` | Gemma 3 | T + I<sup>E+</sup> | `google/gemma-3-4b-it`, `google/gemma-3-27b-it`, etc. | ✅︎ | ✅︎ |
 | `Gemma3nForConditionalGeneration` | Gemma 3n | T + I + A | `google/gemma-3n-E2B-it`, `google/gemma-3n-E4B-it`, etc. | | |
 | `Gemma4ForConditionalGeneration` | Gemma 4 | T + I<sup>+</sup> + V + A<sup>*</sup> | `google/gemma-4-E2B-it`, etc. | | ✅︎ |

--- a/vllm/model_executor/models/fuyu.py
+++ b/vllm/model_executor/models/fuyu.py
@@ -48,7 +48,13 @@ from vllm.multimodal.processing import (
 from vllm.sequence import IntermediateTensors
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
-from .interfaces import MultiModalEmbeddings, SupportsMultiModal, SupportsPP
+from .interfaces import (
+    MultiModalEmbeddings,
+    SupportsLoRA,
+    SupportsMultiModal,
+    SupportsPP,
+)
+from .module_mapping import MultiModelKeys
 from .utils import AutoWeightsLoader, WeightsMapper, flatten_bn, maybe_prefix
 
 # Cannot find the following 2 numbers from hf config.
@@ -259,7 +265,15 @@ class FuyuMultiModalProcessor(BaseMultiModalProcessor[FuyuProcessingInfo]):
     info=FuyuProcessingInfo,
     dummy_inputs=FuyuDummyInputsBuilder,
 )
-class FuyuForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
+class FuyuForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA):
+    # Persimmon fuses attention into a single ``query_key_value`` projection
+    # (QKVParallelLinear). LoRA can only wrap a fused QKV when it is declared
+    # packed, so map it to itself (same pattern as Falcon / GPT-BigCode);
+    # without this the language-model attention LoRA is silently dropped.
+    packed_modules_mapping = {
+        "query_key_value": ["query_key_value"],
+    }
+
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
             "model.vision_embed_tokens.": "vision_embed_tokens.",
@@ -366,3 +380,15 @@ class FuyuForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)
+
+    def get_mm_mapping(self) -> MultiModelKeys:
+        # Fuyu has no vision transformer; ``vision_embed_tokens`` is the entire
+        # vision tower (a single linear projecting image patches into the LM).
+        return MultiModelKeys.from_string_field(
+            language_model="language_model",
+            tower_model="vision_embed_tokens",
+        )
+
+    def get_num_mm_encoder_tokens(self, num_image_tokens: int) -> int:
+        # The projection is 1 patch -> 1 embedding, so the count is unchanged.
+        return num_image_tokens


### PR DESCRIPTION
## Enable LoRA support for Fuyu

Adds LoRA support for `FuyuForCausalLM`, following the multimodal tower-LoRA
interface from #31479 and mirroring the merged PaliGemma enablement (#31656).

### What changed
- `FuyuForCausalLM` now declares `SupportsLoRA`.
- `packed_modules_mapping = {"query_key_value": ["query_key_value"]}` — Persimmon
  fuses attention into one `query_key_value` (`QKVParallelLinear`); LoRA only
  wraps a fused QKV when it is declared packed (same self-mapping pattern as
  Falcon / GPT-BigCode).
- `get_mm_mapping()` returns `language_model="language_model"` and
  `tower_model="vision_embed_tokens"`.
- `get_num_mm_encoder_tokens()` is the identity.
- `docs/models/supported_models.md`: Fuyu marked LoRA-capable.

### Why `vision_embed_tokens` is the tower (and the hook is the identity)
Fuyu has no vision transformer. `vision_embed_tokens` is a single
`ColumnParallelLinear` that projects flattened image patches directly into the
LM hidden space, and it is already wrapped in `_mark_tower_model(..., "image")`.
It is therefore the model's entire (degenerate) vision tower — there is no
separate connector, so only the encoder-token hook is implemented.

`PlaceholderRange.get_num_embeds()` for an image equals the number of
`_IMAGE_TOKEN_ID` placeholders, which equals `ncols * nrows`, which equals the
number of patches fed to `vision_embed_tokens`. The projection maps one patch to
one embedding, so `get_num_mm_encoder_tokens` returns its argument unchanged
(no off-by-k) and the tower punica buffer is sized exactly.

### Not a duplicate
Checked open PRs (`gh pr list --repo vllm-project/vllm --state open --search
"fuyu lora"` / `"Fuyu"`) — no existing PR enables LoRA for Fuyu. This follows the
same pattern as the merged #31656 (PaliGemma) and #31479.

### Tests
Validated on an A100 (single GPU). A randomly-initialized LoRA adapter targeting
both `vision_embed_tokens` (tower) and `query_key_value` (LM attention) was
loaded with `enable_lora=True, enable_tower_connector_lora=True`, and
`adept/fuyu-8b` ran inference on an image prompt:

- Generation completes without any shape/buffer error — i.e. the tower punica
  buffer sized by `get_num_mm_encoder_tokens` matches the patch count that
  `vision_embed_tokens` actually receives.
- With `packed_modules_mapping` in place, the language-model `query_key_value`
  LoRA layers wrap correctly (no "could not be wrapped … will be ignored"
  warnings). Without that mapping all 36 attention layers were silently dropped —
  which is why it is included here.

Structurally this mirrors #31656 (model file + docs matrix; no new e2e test, as
that PR did). Local static checks: `ast.parse` clean and all changed lines are
within the 88-char limit; full `pre-commit`/CI lint runs on the PR.

### Note
AI assistance (Claude Code) was used to author this change. Every changed line
was reviewed by hand and the A100 validation above was run before submitting.
