### PR TITLE
[Structured Output] Drop ngram padding (-1) in guidance validate_tokens (fixes #47025)

### DIFF
--- a/tests/v1/structured_output/test_backend_guidance.py
+++ b/tests/v1/structured_output/test_backend_guidance.py
@@ -75,6 +75,33 @@ def test_backend_guidance_rollback_terminated():
     assert grammar.is_terminated()
 
 
+def test_backend_guidance_validate_tokens_ignores_ngram_padding():
+    # ngram_gpu pads unfilled speculative slots with -1. Those negative ids must
+    # not reach the Rust matcher (which raises OverflowError converting them to
+    # unsigned); validate_tokens should truncate at the first -1 and behave like
+    # the unpadded prefix. See https://github.com/vllm-project/vllm/issues/47025.
+    structured_outputs_config = StructuredOutputsConfig(backend="guidance")
+    vllm_config = VllmConfig(structured_outputs_config=structured_outputs_config)
+    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER)
+    backend = GuidanceBackend(vllm_config, tokenizer=tokenizer, vocab_size=50257)
+    grammar = backend.compile_grammar(
+        StructuredOutputOptions.JSON, '{"type": "object"}'
+    )
+
+    valid = tokenizer.encode('{"a"')
+    assert len(valid) >= 1
+
+    # validate_tokens does not advance the parser, so the padded draft must
+    # match validating the unpadded prefix — and crucially must not raise.
+    expected = grammar.validate_tokens(valid)
+    padded = grammar.validate_tokens([*valid, -1, -1])
+    assert padded == expected
+    assert all(t >= 0 for t in padded)
+
+    # A draft that begins with padding yields nothing.
+    assert grammar.validate_tokens([-1, -1]) == []
+
+
 def test_grammar_bitmask_with_specdec():
     tokenizer = AutoTokenizer.from_pretrained(TOKENIZER)
     prompt = tokenizer.encode('{"a": "b"}')

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -189,6 +189,19 @@ class GuidanceGrammar(StructuredOutputGrammar):
         if self.ll_matcher.is_stopped():
             return []
 
+        # Speculative proposers (e.g. ngram_gpu) pad unfilled draft slots with
+        # -1. A negative id is never a valid token, and the underlying Rust
+        # matcher raises OverflowError converting it to an unsigned int, so
+        # validate only the leading run of real tokens (everything from the
+        # first -1 on is padding and cannot be an accepted prefix anyway).
+        # See https://github.com/vllm-project/vllm/issues/47025.
+        for i, token in enumerate(tokens):
+            if token < 0:
+                tokens = tokens[:i]
+                break
+        if len(tokens) == 0:
+            return []
+
         num_tokens = self.ll_matcher.validate_tokens(tokens)
 
         self.check_error()


### PR DESCRIPTION
## Summary

Fixes #47025.

Structured output + `ngram_gpu` speculative decoding crashes the engine:

```
File ".../v1/structured_output/backend_guidance.py", line 192, in validate_tokens
    num_tokens = self.ll_matcher.validate_tokens(tokens)
OverflowError: out of range integral type conversion attempted
```
→ `EngineDeadError`.

The ngram proposer pads unfilled draft slots with `-1`
(`draft_tokens = torch.where(mask, results, -1)`; only the *leading contiguous*
run is valid). Those `spec_token_ids` flow through
`scheduler.update_draft_token_ids_in_output` into the guidance backend, where the
Rust `ll_matcher.validate_tokens` raises `OverflowError` converting `-1` to an
unsigned int. Removing either structured output or speculative decoding avoids it.
Thanks @GaurangTandon for the root cause.

## Fix

Truncate the candidate list at the first negative id in
`GuidanceGrammar.validate_tokens` before handing it to the matcher.
`validate_tokens` returns the **accepted prefix**, and `-1` can never be an
accepted token, so this is the correct prefix semantics — and it matches
`ngram_proposer_gpu`'s own "leading contiguous valid tokens" definition. Token id
`0` is preserved (only negatives are dropped); an all-padding draft returns `[]`.

The fix sits at the guidance/matcher boundary where the crash happens; both
scheduler `validate_tokens` call sites already rely on the backend returning an
accepted prefix, so this avoids duplicating the normalization across them.

## Tests

`test_backend_guidance_validate_tokens_ignores_ngram_padding`: a draft with
trailing `-1` padding validates to the same prefix as the unpadded tokens (no
`OverflowError`), and an all-`-1` draft returns `[]`.

## Note

E2E reproduction needs structured output + `ngram_gpu` spec decoding together
(GPU). I validated the truncation logic + the prefix semantics; a maintainer run
against the original repro would be welcome.