### PR TITLE
[BugFix] Improve DCP error message with actionable remedy

### DIFF
--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -47,8 +47,8 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "Decode Context Parallelism (DCP) requires attention "
                     "implementations to return the softmax LSE during decode, "
                     f"but {layer_impl.__class__.__name__} does not. "
-                    "Try a different backend by setting "
-                    "--attention-backend or disable DCP."
+                    "Try a different backend using --attention-backend, "
+                    "or set --decode-context-parallel-size 1 to disable DCP."
                 )
 
 


### PR DESCRIPTION
 When an attention backend doesn't support DCP, the error message
  now tells the user how to fix it: try --attention-backend to switch
  backends, or --decode-context-parallel-size 1 to disable DCP.

  The original message only mentioned --attention-backend without
  any guidance on disabling DCP.