### PR TITLE
[Docs] `kv_sharing_fast_prefill` correction

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -160,6 +160,7 @@ class CacheConfig:
     some layers can skip tokens corresponding to prefill. This flag enables
     attention metadata for eligible layers to be overridden with metadata
     necessary for implementing this optimization in some models (e.g. Gemma3n)
+    NOTE: KV cache sharing is not supported for MRv2 (v2 model runner).
     """
 
     kv_cache_memory_bytes: int | None = None

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -156,10 +156,7 @@ class CacheConfig:
     """Per-DP-engine maximum concurrency at max_model_len tokens."""
 
     kv_sharing_fast_prefill: bool = False
-    """This feature is work in progress and no prefill optimization takes place
-    with this flag enabled currently.
-
-    In some KV sharing setups, e.g. YOCO (https://arxiv.org/abs/2405.05254),
+    """In some KV sharing setups, e.g. YOCO (https://arxiv.org/abs/2405.05254),
     some layers can skip tokens corresponding to prefill. This flag enables
     attention metadata for eligible layers to be overridden with metadata
     necessary for implementing this optimization in some models (e.g. Gemma3n)

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -15,6 +15,8 @@ Even for shared features (for example, different parallelism modes), keep the
 complexity out of this path. The less common the feature, the more it should be
 hidden. Prefer utility functions defined elsewhere and call them from here,
 instead of embedding feature-specific logic directly.
+
+NOTE: KV cache sharing is not supported for MRv2 (v2 model runner).
 """
 
 import functools

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -15,8 +15,6 @@ Even for shared features (for example, different parallelism modes), keep the
 complexity out of this path. The less common the feature, the more it should be
 hidden. Prefer utility functions defined elsewhere and call them from here,
 instead of embedding feature-specific logic directly.
-
-NOTE: KV cache sharing is not supported for MRv2 (v2 model runner).
 """
 
 import functools


### PR DESCRIPTION
Current docstrings seem to imply that this flag is not doing anything, while in fact this is used in gemma3n/4 to enable YOCO style prefill. 
This is a leftover from some initial version of the feature.

@hmellor 