### PR TITLE
[Bugfix][KV Offload] Track allocated block IDs when num_external_tokens is 0

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -750,6 +750,11 @@ class OffloadingConnectorScheduler:
         self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         if num_external_tokens == 0:
+            for group_blocks in blocks.blocks:
+                self._current_batch_allocated_block_ids.update(
+                    block.block_id for block in group_blocks
+                    if block.block_id != 0
+                )
             return
 
         req_status = self._req_status[request.request_id]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -994,6 +994,11 @@ class OffloadingConnectorScheduler:
         self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         if num_external_tokens == 0:
+            for group_blocks in blocks.blocks:
+                self._current_batch_allocated_block_ids.update(
+                    block.block_id for block in group_blocks
+                    if block.block_id != 0
+                )
             return
 
         req_status = self._req_status[request.request_id]

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -40,8 +40,8 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "Decode Context Parallelism (DCP) requires attention "
                     "implementations to return the softmax LSE during decode, "
                     f"but {layer_impl.__class__.__name__} does not. "
-                    "Try a different backend by setting "
-                    "--attention-backend or disable DCP."
+                    "Try a different backend using --attention-backend, "
+                    "or set --decode-context-parallel-size 1 to disable DCP."
                 )
 
             if pcp_size > 1:


### PR DESCRIPTION
Fixes #46951.
 
  update_state_after_alloc() returns early when num_external_tokens == 0 without recording allocated block IDs in _current_batch_allocated_block_ids.
  Blocks allocated by other async connectors (via MultiConnector) are invisible to re-allocation detection — pending store jobs won't be flushed if those blocks are reused.

  Fix: record block IDs before the early return, matching the same pattern already used later in this function and in _update_req_states().