### PR TITLE
Fix packed KV cache planning for FlashAttention

### DIFF
--- a/tests/v1/core/test_contiguous_kv_packing.py
+++ b/tests/v1/core/test_contiguous_kv_packing.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
+from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
 from vllm.v1.core.kv_cache_utils import (
     _get_kv_cache_config_packed,
     get_kv_cache_config_from_groups,
@@ -31,25 +32,28 @@ def _make_mla_spec(page_size: int, block_size: int = 256) -> MLAAttentionSpec:
         cache_dtype_str="fp8_ds_mla",
         model_version="deepseek_v4",
         alignment=576,
+        supports_packed_kv_cache=True,
     )
 
 
-def _make_full_spec() -> FullAttentionSpec:
+def _make_full_spec(supports_packed_kv_cache: bool = False) -> FullAttentionSpec:
     return FullAttentionSpec(
         block_size=16,
         num_kv_heads=2,
         head_size=64,
         dtype=torch.float16,
+        supports_packed_kv_cache=supports_packed_kv_cache,
     )
 
 
-def _make_sw_spec() -> SlidingWindowSpec:
+def _make_sw_spec(supports_packed_kv_cache: bool = False) -> SlidingWindowSpec:
     return SlidingWindowSpec(
         block_size=16,
         num_kv_heads=2,
         head_size=64,
         dtype=torch.float16,
         sliding_window=128,
+        supports_packed_kv_cache=supports_packed_kv_cache,
     )
 
 
@@ -110,6 +114,9 @@ def _page_sizes_by_layer(
 
 
 class TestInterleavedPacking:
+    def test_flash_attention_does_not_advertise_packed_kv_cache(self):
+        assert not FlashAttentionBackend.supports_packed_kv_cache()
+
     def test_all_tensors_have_block_stride(self):
         _, tensors = _run()
         for t in tensors:
@@ -181,8 +188,8 @@ class TestInterleavedPacking:
         ]
 
     def test_hma_attention_groups_use_packed_backing_with_enable_cross_layers(self):
-        full = _make_full_spec()
-        sw = _make_sw_spec()
+        full = _make_full_spec(supports_packed_kv_cache=True)
+        sw = _make_sw_spec(supports_packed_kv_cache=True)
         page_size = full.page_size_bytes
         groups = [
             KVCacheGroupSpec(["full.0", "full.1"], full),
@@ -211,6 +218,28 @@ class TestInterleavedPacking:
                 offset=page_size,
                 block_stride=page_size * 2,
             ),
+        ]
+
+    def test_enable_cross_layers_requires_packed_kv_cache_support(self):
+        full = _make_full_spec(supports_packed_kv_cache=False)
+        sw = _make_sw_spec(supports_packed_kv_cache=True)
+        page_size = full.page_size_bytes
+        groups = [
+            KVCacheGroupSpec(["full.0", "full.1"], full),
+            KVCacheGroupSpec(["sw.0", "sw.2"], sw),
+            KVCacheGroupSpec(["sw.1", "sw.3"], sw),
+        ]
+
+        config = get_kv_cache_config_from_groups(
+            _mock_vllm_config({"enable_cross_layers_blocks": "True"}),
+            groups,
+            available_memory=page_size * 2 * 32,
+        )
+
+        assert config.num_blocks == 32
+        assert config.kv_cache_tensors == [
+            KVCacheTensor(size=page_size * 32, shared_by=["full.0", "sw.0", "sw.1"]),
+            KVCacheTensor(size=page_size * 32, shared_by=["full.1", "sw.2", "sw.3"]),
         ]
 
     def test_single_group_attention_keeps_unpacked_layout(self):

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -234,6 +234,11 @@ class AttentionBackend(ABC):
         return layered_kv_cache_stride_order[0] != 0
 
     @classmethod
+    def supports_packed_kv_cache(cls) -> bool:
+        """Whether the backend supports a cross-layer packed KV cache pool."""
+        return cls.indexes_kv_by_block_stride()
+
+    @classmethod
     def is_mla(cls) -> bool:
         return False
 

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -111,6 +111,12 @@ class FlashAttentionBackend(AttentionBackend):
         fa_version = get_flash_attn_version()
         return fa_version is not None and fa_version >= 3
 
+    @classmethod
+    def supports_packed_kv_cache(cls) -> bool:
+        # FlashAttention block-table kernels require native per-layer page
+        # spacing, even when they support padded pages by block stride.
+        return False
+
     @staticmethod
     def get_impl_cls() -> type["FlashAttentionImpl"]:
         return FlashAttentionImpl

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1256,6 +1256,14 @@ def _use_packed_kv_cache_config(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
 ) -> bool:
+    def supports_packed_cache(spec: KVCacheSpec) -> bool:
+        if isinstance(spec, UniformTypeKVCacheSpecs):
+            return all(
+                supports_packed_cache(layer_spec)
+                for layer_spec in spec.kv_cache_specs.values()
+            )
+        return isinstance(spec, AttentionSpec) and spec.supports_packed_kv_cache
+
     is_dsv4 = all(
         isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
         for group in kv_cache_groups
@@ -1271,7 +1279,17 @@ def _use_packed_kv_cache_config(
     enable_cross_layers = (
         str(extra_config.get("enable_cross_layers_blocks", "False")).lower() == "true"
     )
-    return is_dsv4 or (enable_cross_layers and len(kv_cache_groups) > 1)
+    use_packed_cache = is_dsv4 or (enable_cross_layers and len(kv_cache_groups) > 1)
+    if not use_packed_cache:
+        return False
+    if all(supports_packed_cache(group.kv_cache_spec) for group in kv_cache_groups):
+        return True
+    if enable_cross_layers:
+        logger.warning(
+            "Ignoring enable_cross_layers_blocks because at least one attention "
+            "backend does not support packed KV cache layout."
+        )
+    return False
 
 
 def _get_kv_cache_config_packed(

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -168,6 +168,7 @@ class AttentionSpec(KVCacheSpec):
     kv_quant_mode: KVQuantMode = KVQuantMode.NONE
     page_size_padded: int | None = None
     indexes_kv_by_block_stride: bool = False
+    supports_packed_kv_cache: bool = False
 
     @property
     def page_size_bytes(self) -> int:
@@ -286,6 +287,7 @@ class FullAttentionSpec(AttentionSpec):
             kv_quant_mode=specs[0].kv_quant_mode,
             page_size_padded=specs[0].page_size_padded,
             indexes_kv_by_block_stride=specs[0].indexes_kv_by_block_stride,
+            supports_packed_kv_cache=specs[0].supports_packed_kv_cache,
             sliding_window=cls.merge_window_sizes(sliding_window),
             attention_chunk_size=cls.merge_window_sizes(attention_chunk_size),
             # If any layer in the group is non-causal, treat the group as
@@ -406,15 +408,17 @@ class MLAAttentionSpec(FullAttentionSpec):
         compress_ratio_set = set(spec.compress_ratio for spec in specs)
         model_version_set = set(spec.model_version for spec in specs)
         block_stride_set = set(spec.indexes_kv_by_block_stride for spec in specs)
+        packed_cache_set = set(spec.supports_packed_kv_cache for spec in specs)
         assert (
             len(cache_dtype_str_set) == 1
             and len(compress_ratio_set) == 1
             and len(model_version_set) == 1
             and len(block_stride_set) == 1
+            and len(packed_cache_set) == 1
         ), (
             "All attention layers in the same KV cache group must use the same "
-            "quantization method, compress ratio, model version, and KV block "
-            "stride indexing."
+            "quantization method, compress ratio, model version, KV block "
+            "stride indexing, and packed KV cache support."
         )
         return cls(
             block_size=specs[0].block_size,
@@ -424,6 +428,7 @@ class MLAAttentionSpec(FullAttentionSpec):
             kv_quant_mode=specs[0].kv_quant_mode,
             page_size_padded=specs[0].page_size_padded,
             indexes_kv_by_block_stride=block_stride_set.pop(),
+            supports_packed_kv_cache=packed_cache_set.pop(),
             cache_dtype_str=cache_dtype_str_set.pop(),
             compress_ratio=compress_ratio_set.pop(),
             model_version=model_version_set.pop(),
@@ -470,6 +475,7 @@ class RSWASpec(FullAttentionSpec):
             kv_quant_mode=base.kv_quant_mode,
             page_size_padded=base.page_size_padded,
             indexes_kv_by_block_stride=base.indexes_kv_by_block_stride,
+            supports_packed_kv_cache=base.supports_packed_kv_cache,
             sliding_window=base.sliding_window,
             attention_chunk_size=base.attention_chunk_size,
             non_causal=base.non_causal,
@@ -631,16 +637,18 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
         model_version_set = set(spec.model_version for spec in specs)
         sliding_window_set = set(spec.sliding_window for spec in specs)
         block_stride_set = set(spec.indexes_kv_by_block_stride for spec in specs)
+        packed_cache_set = set(spec.supports_packed_kv_cache for spec in specs)
         assert (
             len(cache_dtype_str_set) == 1
             and len(compress_ratio_set) == 1
             and len(model_version_set) == 1
             and len(sliding_window_set) == 1
             and len(block_stride_set) == 1
+            and len(packed_cache_set) == 1
         ), (
             "All attention layers in the same KV cache group must use the same "
             "quantization method, compress ratio, model version, sliding "
-            "window size, and KV block stride indexing."
+            "window size, KV block stride indexing, and packed KV cache support."
         )
         return cls(
             block_size=specs[0].block_size,
@@ -649,6 +657,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
             dtype=specs[0].dtype,
             page_size_padded=specs[0].page_size_padded,
             indexes_kv_by_block_stride=block_stride_set.pop(),
+            supports_packed_kv_cache=packed_cache_set.pop(),
             sliding_window=sliding_window_set.pop(),
             cache_dtype_str=cache_dtype_str_set.pop(),
             compress_ratio=compress_ratio_set.pop(),
@@ -761,6 +770,7 @@ class SinkFullAttentionSpec(FullAttentionSpec):
             kv_quant_mode=specs[0].kv_quant_mode,
             page_size_padded=specs[0].page_size_padded,
             indexes_kv_by_block_stride=specs[0].indexes_kv_by_block_stride,
+            supports_packed_kv_cache=specs[0].supports_packed_kv_cache,
             sliding_window=cls.merge_window_sizes(sliding_window),
             attention_chunk_size=cls.merge_window_sizes(attention_chunk_size),
             non_causal=any(spec.non_causal for spec in specs),

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -57,7 +57,12 @@ def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
                 # get_kv_cache_layout() needs the current vLLM config.
                 with set_current_vllm_config(vllm_config):
                     indexes = backend.indexes_kv_by_block_stride()
-                spec = replace(spec, indexes_kv_by_block_stride=indexes)
+                    supports_packed = backend.supports_packed_kv_cache()
+                spec = replace(
+                    spec,
+                    indexes_kv_by_block_stride=indexes,
+                    supports_packed_kv_cache=supports_packed,
+                )
             kv_cache_spec[layer_name] = spec
     return kv_cache_spec
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7513,7 +7513,12 @@ class GPUModelRunner(
                     # -> get_kv_cache_layout() needs the current vLLM config.
                     with set_current_vllm_config(self.vllm_config):
                         indexes = backend.indexes_kv_by_block_stride()
-                    spec = replace(spec, indexes_kv_by_block_stride=indexes)
+                        supports_packed = backend.supports_packed_kv_cache()
+                    spec = replace(
+                        spec,
+                        indexes_kv_by_block_stride=indexes,
+                        supports_packed_kv_cache=supports_packed,
+                    )
                 kv_cache_spec[layer_name] = spec
 
         return kv_cache_spec


### PR DESCRIPTION
Fixes #47054.

This separates backend support for padded-page block-stride indexing from support for the cross-layer packed KV cache pool. FlashAttention keeps its existing block-stride behavior but no longer advertises packed KV cache support, so `enable_cross_layers_blocks=True` falls back to the normal per-layer layout instead of planning a packed layout that FlashAttention block-table kernels cannot safely read.

Duplicate-work checks:
- `gh issue view 47054 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search "47054 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "CPUOffloading enable_cross_layers_blocks gpt-oss"`
- `gh pr list --repo vllm-project/vllm --state open --search "packed KV cache FlashAttention"`
- `gh pr list --repo vllm-project/vllm --state open --search "enable_cross_layers_blocks FlashAttention"`
- `gh pr list --repo vllm-project/vllm --state open --search "CPUOffloading packed KV cache"`
- `gh pr list --repo vllm-project/vllm --state open --search "gpt-oss-120b CPUOffloading"`

No open PR was found that addresses this issue.

Tests:
- `.venv/bin/python -m pytest tests/v1/core/test_contiguous_kv_packing.py tests/v1/worker/test_attn_utils.py -q`
- `.venv/bin/python -m pytest tests/v1/core/test_contiguous_kv_packing.py tests/v1/core/test_kv_cache_utils.py tests/v1/worker/test_attn_utils.py -q`
- `.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_connector.py::test_register_kv_caches -q`
- `pre-commit run ruff-check --files vllm/v1/attention/backend.py vllm/v1/attention/backends/flash_attn.py vllm/v1/kv_cache_interface.py vllm/v1/worker/gpu/attn_utils.py vllm/v1/worker/gpu_model_runner.py vllm/v1/core/kv_cache_utils.py tests/v1/core/test_contiguous_kv_packing.py`
- `pre-commit run ruff-format --files vllm/v1/attention/backend.py vllm/v1/attention/backends/flash_attn.py vllm/v1/kv_cache_interface.py vllm/v1/worker/gpu/attn_utils.py vllm/v1/worker/gpu_model_runner.py vllm/v1/core/kv_cache_utils.py tests/v1/core/test_contiguous_kv_packing.py`
- Full pre-commit hook stack ran during `git commit` and passed.

AI assistance was used to prepare this change.