### PR TITLE
Flush Harmony parser at EOS for Responses API

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -33,7 +33,11 @@ from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
     RequestResponseMetadata,
 )
-from vllm.entrypoints.openai.responses.context import ConversationContext, SimpleContext
+from vllm.entrypoints.openai.responses.context import (
+    ConversationContext,
+    HarmonyContext,
+    SimpleContext,
+)
 from vllm.entrypoints.openai.responses.protocol import (
     ResponseCreatedEvent,
     ResponseRawMessageAndToken,
@@ -678,6 +682,61 @@ class TestHarmonyPreambleStreaming:
             type_names = [e.type for e in events]
             assert "response.output_item.added" in type_names
             assert "response.output_item.done" in type_names
+
+    @pytest.mark.asyncio
+    async def test_finished_partial_message_flushes_after_final_delta(self):
+        """Streaming Harmony flush must happen after the last text delta."""
+        serving = _make_serving_instance_with_reasoning()
+        serving.tool_server = None
+
+        content_part = MagicMock()
+        content_part.text = "hello"
+        previous_item = MagicMock()
+        previous_item.channel = "final"
+        previous_item.recipient = None
+        previous_item.content = [content_part]
+
+        ctx = MagicMock(spec=HarmonyContext)
+        ctx.finish_reason = None
+        ctx.function_tool_names = None
+        ctx.last_append_segments = [
+            Segment(channel="final", recipient=None, delta="hello"),
+            Segment(
+                channel="final",
+                recipient=None,
+                delta="",
+                completed_message=previous_item,
+            ),
+        ]
+
+        async def result_generator():
+            yield ctx
+
+        request = ResponsesRequest(input="hi", tools=[], stream=True)
+        sampling_params = SamplingParams(max_tokens=64)
+        metadata = RequestResponseMetadata(request_id="req")
+        _identity_increment._counter = 0  # type: ignore
+
+        events = []
+        async for event in serving._process_harmony_streaming_events(
+            request=request,
+            sampling_params=sampling_params,
+            result_generator=result_generator(),
+            context=ctx,
+            model_name="test-model",
+            tokenizer=MagicMock(),
+            request_metadata=metadata,
+            created_time=0,
+            _increment_sequence_number_and_return=_identity_increment,
+        ):
+            events.append(event)
+
+        type_names = [e.type for e in events]
+        assert "response.output_text.delta" in type_names
+        assert "response.output_text.done" in type_names
+        assert type_names.index("response.output_text.delta") < type_names.index(
+            "response.output_text.done"
+        )
 
 
 def _make_simple_context_with_output(text, token_ids, response_parser=None):

--- a/tests/entrypoints/unit_tests/test_context.py
+++ b/tests/entrypoints/unit_tests/test_context.py
@@ -4,7 +4,7 @@
 from unittest.mock import patch
 
 import pytest
-from openai_harmony import Author, Message, Role, TextContent
+from openai_harmony import Author, HarmonyError, Message, Role, TextContent
 
 from vllm.entrypoints.openai.responses.context import (
     HarmonyContext,
@@ -20,6 +20,8 @@ def create_mock_request_output(
     output_token_ids=None,
     num_cached_tokens=0,
     finished=True,
+    finish_reason=None,
+    text="Test output",
 ):
     """Helper function to create a mock RequestOutput object for testing."""
     outputs = []
@@ -27,11 +29,11 @@ def create_mock_request_output(
     outputs = [
         CompletionOutput(
             index=0,
-            text="Test output",
+            text=text,
             token_ids=token_ids,
             cumulative_logprob=0.0,
             logprobs=None,
-            finish_reason=None,
+            finish_reason=finish_reason,
             stop_reason=None,
         )
     ]
@@ -74,7 +76,8 @@ class FakeHarmonyParser(HarmonyParser):
         self.reasoning_parser = None
         self.tool_parser = None
         self._chunk_results: list[ChunkResult] = []
-        self._flush_results: list[Segment | None] = []
+        self._flush_results: list[Segment | HarmonyError | None] = []
+        self.flush_count = 0
         self.processed_chunks: list[list[int]] = []
 
     def enqueue_chunk_result(
@@ -92,6 +95,9 @@ class FakeHarmonyParser(HarmonyParser):
     def enqueue_flush_result(self, segment: Segment | None) -> None:
         self._flush_results.append(segment)
 
+    def enqueue_flush_error(self) -> None:
+        self._flush_results.append(HarmonyError("unexpected EOS"))
+
     def process_chunk(self, token_ids) -> ChunkResult:
         self.processed_chunks.append(list(token_ids))
         if self._chunk_results:
@@ -99,8 +105,12 @@ class FakeHarmonyParser(HarmonyParser):
         return ChunkResult(segments=[], reasoning_token_count=0)
 
     def flush(self) -> Segment | None:
+        self.flush_count += 1
         if self._flush_results:
-            return self._flush_results.pop(0)
+            result = self._flush_results.pop(0)
+            if isinstance(result, HarmonyError):
+                raise result
+            return result
         return None
 
 
@@ -300,6 +310,120 @@ def test_commentary_with_recipient_counted_as_reasoning():
 
     assert context.num_reasoning_tokens == 3
     assert context.num_output_tokens == 3
+
+
+def test_harmony_context_flushes_finished_parser_state():
+    """EOS should let Harmony commit a final message before output conversion."""
+    committed_message = Message.from_role_and_content(Role.ASSISTANT, "Answer")
+    committed_message = committed_message.with_channel("final")
+    flush_segment = Segment(
+        channel="final",
+        recipient=None,
+        delta="",
+        completed_message=committed_message,
+    )
+
+    context, parser = make_harmony_context()
+    parser.enqueue_flush_result(flush_segment)
+
+    context.append_output(
+        create_mock_request_output(
+            prompt_token_ids=[1, 2],
+            output_token_ids=[10, 11],
+            finished=True,
+            finish_reason="stop",
+        )
+    )
+
+    assert parser.flush_count == 1
+    assert context.messages == [committed_message]
+    assert context.last_append_segments == [flush_segment]
+
+
+def test_harmony_context_flushes_length_outputs_as_incomplete():
+    """Max-token truncation should preserve partial output as incomplete."""
+    committed_message = Message.from_role_and_content(Role.ASSISTANT, "Answer")
+    committed_message = committed_message.with_channel("final")
+    flush_segment = Segment(
+        channel="final",
+        recipient=None,
+        delta="",
+        completed_message=committed_message,
+    )
+
+    context, parser = make_harmony_context()
+    parser.enqueue_flush_result(flush_segment)
+
+    context.append_output(
+        create_mock_request_output(
+            prompt_token_ids=[1, 2],
+            output_token_ids=[10, 11],
+            finished=True,
+            finish_reason="length",
+        )
+    )
+
+    assert parser.flush_count == 1
+    assert context.messages == [committed_message]
+    assert context.last_append_flush_status is True
+    assert context.last_append_segments == [flush_segment]
+
+
+def test_harmony_context_recovers_raw_output_on_flush_error():
+    """Malformed Harmony output should surface raw text instead of raising."""
+    context, parser = make_harmony_context()
+    raw_prefix = "<|channel|>final "
+    raw_delta = '{"answer": "hi"}<|return|>'
+    raw_output = raw_prefix + raw_delta
+
+    context.append_output(
+        create_mock_request_output(
+            prompt_token_ids=[1, 2],
+            output_token_ids=[10],
+            finished=False,
+            text=raw_prefix,
+        )
+    )
+    parser.enqueue_flush_error()
+
+    context.append_output(
+        create_mock_request_output(
+            output_token_ids=[11],
+            finished=True,
+            finish_reason="stop",
+            text=raw_delta,
+        )
+    )
+
+    assert parser.flush_count == 1
+    assert context.last_append_flush_status is False
+    assert len(context.messages) == 1
+    assert context.messages[0].channel == "final"
+    assert context.messages[0].content[0].text == raw_output
+    assert context.last_append_segments[0].delta == raw_delta
+    assert context.last_append_segments[1].completed_message is context.messages[0]
+
+
+def test_harmony_context_recovers_raw_length_output_as_incomplete():
+    """Raw fallback on max-token truncation should stay incomplete."""
+    context, parser = make_harmony_context()
+    parser.enqueue_flush_error()
+    raw_output = '<|channel|>final {"answer": "hi"}'
+
+    context.append_output(
+        create_mock_request_output(
+            prompt_token_ids=[1, 2],
+            output_token_ids=[10, 11],
+            finished=True,
+            finish_reason="length",
+            text=raw_output,
+        )
+    )
+
+    assert parser.flush_count == 1
+    assert context.last_append_flush_status is True
+    assert len(context.messages) == 1
+    assert context.messages[0].content[0].text == raw_output
 
 
 def test_zero_tokens_edge_case():

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -624,14 +624,18 @@ class HarmonyContext(ConversationContext):
         self.all_turn_metrics: list[TurnMetrics] = []
         self.is_first_turn = True
         self.first_tok_of_message = True
+        self._raw_output_text = ""
         self.kv_transfer_params: dict[str, Any] | None = None
 
     def append_output(self, output: RequestOutput) -> None:
         if self.first_tok_of_message:
             self.finish_reason = None
+            self._raw_output_text = ""
             self._update_prefill_token_usage(output)
 
-        output_token_ids = output.outputs[0].token_ids
+        completion_output = output.outputs[0]
+        output_token_ids = completion_output.token_ids
+        self._raw_output_text += completion_output.text
         result = self.response_parser.process_chunk(output_token_ids)
         segments = result.segments
         self.num_reasoning_tokens += result.reasoning_token_count
@@ -642,11 +646,37 @@ class HarmonyContext(ConversationContext):
             self.kv_transfer_params = output.kv_transfer_params
 
         if output.finished:
-            self.finish_reason = output.outputs[0].finish_reason
-            flushed = self.response_parser.flush()
+            self.finish_reason = completion_output.finish_reason
+            flushed = None
+            recovered_from_harmony_error = False
+            try:
+                flushed = self.response_parser.flush()
+            except HarmonyError:
+                from vllm.parser.harmony import Segment
+
+                raw_message = Message.from_role_and_content(
+                    Role.ASSISTANT, self._raw_output_text
+                ).with_channel("final")
+                segments = [
+                    Segment(
+                        channel="final",
+                        recipient=None,
+                        delta=completion_output.text,
+                    ),
+                    Segment(
+                        channel="final",
+                        recipient=None,
+                        delta="",
+                        completed_message=raw_message,
+                    ),
+                ]
+                recovered_from_harmony_error = True
             if flushed is not None:
                 segments.append(flushed)
-            self.last_append_flush_status = flushed is not None
+            self.last_append_flush_status = flushed is not None or (
+                recovered_from_harmony_error
+                and completion_output.finish_reason == "length"
+            )
             self.all_turn_metrics.append(self.current_turn_metrics.copy())
             self.current_turn_metrics.reset()
 


### PR DESCRIPTION
## Summary
- Fix the Responses API equivalent of vllm-project/vllm#45736.
- Mirror the merged Chat Completions fix stack after vllm-project/vllm#47185 moved Responses onto `HarmonyParser`.
- For finished Responses generations, call `HarmonyParser.flush()` so valid partial Harmony messages are committed before output conversion.
- If `flush()` raises `HarmonyError`, surface the raw unparsed model output as a final Responses message instead of returning no output or propagating a parser failure.
- Preserve `finish_reason="length"` behavior by marking max-token truncation incomplete after flushing any recoverable partial content.

## Background
The original issue, vllm-project/vllm#45736, reports that GPT-OSS Harmony output can finish with `finish_reason="stop"` while the parser is still in a non-terminal state. In that case vLLM can return `content: null` and drop generated final-answer tokens.

Chat Completions was first addressed in vllm-project/vllm#46437 by adding a `HarmonyParser.flush()` path that calls `process_eos()`. vllm-project/vllm#47062 then changed that parser path to re-raise `HarmonyError` and recover by returning raw unparsed output from `parse()` / `parse_delta()`.

Responses API now uses the shared `HarmonyParser` after vllm-project/vllm#47185, but `HarmonyContext.append_output()` still calls `process_chunk()` and `flush()` directly. That bypasses the `parse()` / `parse_delta()` fallback added for Chat Completions, so this PR adds the corresponding Responses-side handling in `append_output()`.

## Before / After
Before:
- Finished Responses generations called `flush()` without handling `HarmonyError`.
- A valid but incomplete final header could be committed only if `flush()` succeeded.
- An invalid Harmony header such as `<|channel|>final ...` could raise out of `append_output()` instead of surfacing raw model output.

After:
- Valid partial final messages like `<|channel|>final<|message|>some content...` are flushed and marked incomplete.
- Invalid final headers like `<|channel|>final some content...` recover as a raw final output message.
- Max-token truncation still returns `status="incomplete"` while preserving recoverable partial output.
- Streaming emits the raw unparsed delta followed by done events for the recovered output item.

## Duplicate Check
- vllm-project/vllm#46437 and vllm-project/vllm#47062 fix the shared Chat Completions `HarmonyParser.parse()` / `parse_delta()` paths.
- This PR is not a duplicate because Responses `HarmonyContext.append_output()` uses `process_chunk()` / `flush()` directly and needs its own `HarmonyError` fallback.
- vllm-project/vllm#47185 is the refactor that made this mirror smaller; it does not add the Responses fallback.

## Validation
- Earlier H100 validation on this PR branch before the latest rebase:
  - `MAX_JOBS=32 NVCC_THREADS=1 python -m pip install -e . --no-build-isolation` succeeded.
  - `python -m pytest tests/entrypoints/unit_tests/test_context.py -q`: `24 passed, 16 warnings`.
  - `python -m pytest tests/entrypoints/openai/responses/test_serving_responses.py -q`: `22 passed, 16 warnings`.
- Latest rebase/update validation:
  - `git diff --check FETCH_HEAD...HEAD`: passed.
  - Conflict-marker scan on touched files: no markers found.
- Not rerun after the latest rebase: targeted pytest/build, because local `.venv/bin/python` and `uv` are unavailable in this workspace, and `ssh ubuntu@138.1.4.235` currently fails with `connect to host 138.1.4.235 port 22: Connection refused`.

## AI Assistance
AI assistance was used to prepare this PR. The submitting human should review every changed line and confirm the validation before upstream merge.
