### PR TITLE
[ROCm][CI] Soft Fail `Spec Decode Ngram + Suffix` and `Entrypoints Integration (LLM)` AMD Mirrors

### DIFF
--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -29,6 +29,7 @@ steps:
   mirror:
     amd:
       device: mi325_1
+      # TODO(akaratza): Test after Torch >= 2.12 bump
       soft_fail: true
       depends_on:
       - image-build-amd

--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -29,6 +29,7 @@ steps:
   mirror:
     amd:
       device: mi325_1
+      soft_fail: true
       depends_on:
       - image-build-amd
 

--- a/.buildkite/test_areas/spec_decode.yaml
+++ b/.buildkite/test_areas/spec_decode.yaml
@@ -94,6 +94,7 @@ steps:
     amd:
       device: mi325_1
       timeout_in_minutes: 65
+      soft_fail: true
       depends_on:
       - image-build-amd
       source_file_dependencies:

--- a/.buildkite/test_areas/spec_decode.yaml
+++ b/.buildkite/test_areas/spec_decode.yaml
@@ -94,6 +94,7 @@ steps:
     amd:
       device: mi325_1
       timeout_in_minutes: 65
+      # TODO(akaratza): Test after Torch >= 2.12 bump
       soft_fail: true
       depends_on:
       - image-build-amd


### PR DESCRIPTION

`Entrypoints Integration (LLM)` failing: https://buildkite.com/vllm/ci/builds/75108/canvas?jid=019f1368-87e7-4e0f-997b-0783ac50ef9a&tab=output

`Spec Decode Ngram + Suffix` failing: https://buildkite.com/vllm/ci/builds/75164/summary?jid=019f143c-ef4c-4afd-bb36-52077e618271&tab=output#L605