### PR TITLE
[CI][Bugfix] Add cohere_melody to ROCm test requirements

### DIFF
--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -74,6 +74,7 @@ gpt-oss>=0.0.7; python_version > '3.11'
 
 perceptron # required for isaac test
 kaldi-native-fbank>=1.18.7 # required for fireredasr2 test
+cohere_melody>=0.9.0 # required for cohere command reasoning parser test
 
 # Newer versions of datasets require torchcoded, that makes the tests fail in CI because of a missing library.
 # Older versions are in conflict with terratorch requirements.

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -130,6 +130,8 @@ cloudpickle==3.1.2
     # via
     #   -r requirements/test/../common.txt
     #   tilelang
+cohere-melody==0.9.0
+    # via -r requirements/test/rocm.in
 colorama==0.4.6
     # via
     #   perceptron


### PR DESCRIPTION



## Purpose

ROCm CI runs `pytest -v -s reasoning` (`.buildkite/test-amd.yaml`). `tests/reasoning/test_cohere_command_reasoning_parser.py` hard-imports the `cohere_melody` package, which was declared only in `requirements/test/cuda.in` ~@~T so the ROCm image never installs it and the file errors at collection with `ModuleNotFoundError: No module named 'cohere_melody'`.

Fix: add `cohere_melody` to `requirements/test/rocm.in` and regenerate `rocm.txt`. It's a CPU-only wheel with no CUDA/ROCm linkage or transitive deps, so it works identically on ROCm; the lockfile gains only `cohere-melody==0.9.0`.

AI assistance (Claude) was used; reviewed and tested by the submitter. Not a duplicate ~@~T no open PR addresses the missing ROCm test dependency.

## Test Plan

```bash
pytest -v -s reasoning/test_cohere_command_reasoning_parser.py
```

Run on ROCm gfx90a (MI250), Python 3.12.

## Test Result

Before (matches ROCm CI): `1 error during collection` ~@~T `ModuleNotFoundError: No module named 'cohere_melody'`.

After: `40 passed, 16 warnings in 7.40s`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

