### PR TITLE
[Bugfix] Fail fast with a clear error when CPU offload region exceeds available space

### DIFF
--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -385,6 +385,33 @@ def test_creator_flag_set_on_first_open(iid):
         assert r._creator is True
 
 
+def test_insufficient_space_raises_clear_error(iid, monkeypatch):
+    """An oversized region must fail fast with an explanatory error.
+
+    Without an up-front capacity check the shortfall only surfaces later as an
+    opaque ``OSError: [Errno 14] Bad address`` from madvise(MADV_POPULATE_WRITE).
+    """
+    import os as _os
+
+    real_fstatvfs = _os.fstatvfs
+
+    class _TinyStat:
+        # Report only one free page so any real region exceeds it.
+        f_bavail = 1
+        f_frsize = PAGE_SIZE
+
+    monkeypatch.setattr(_os, "fstatvfs", lambda fd: _TinyStat())
+
+    with pytest.raises(RuntimeError, match="Not enough space"):
+        _make_region(iid, num_blocks=4)
+
+    # Restore before checking the filesystem so cleanup assertions are accurate.
+    monkeypatch.setattr(_os, "fstatvfs", real_fstatvfs)
+    # The partially created file must be removed so other workers do not block.
+    expected_path = f"/dev/shm/vllm_offload_{iid}.mmap"
+    assert not os.path.exists(expected_path)
+
+
 def test_joiner_flag_not_set(iid):
     """A second worker opening the same file must have _creator == False."""
     with _multi_region(iid, num_workers=2) as (r0, r1):

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
 import mmap
 import os
 import time
@@ -10,6 +11,34 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
+
+
+def _check_available_space(path: str, required_bytes: int, fd: int) -> None:
+    """Raise a clear error if the filesystem backing *path* cannot hold the region.
+
+    The offload region is created on a tmpfs (``/dev/shm``) whose capacity is
+    bounded by available RAM. ``ftruncate`` only reserves the size sparsely, so
+    an oversized request is not rejected here; it instead surfaces much later as
+    an opaque ``OSError: [Errno 14] Bad address`` when
+    ``madvise(MADV_POPULATE_WRITE)`` tries to fault in pages. Checking up front
+    lets us tell the user exactly what went wrong and how to fix it.
+    """
+    try:
+        stat = os.fstatvfs(fd)
+    except (OSError, AttributeError):
+        # statvfs may be unavailable (e.g. on some platforms); skip the check
+        # rather than block a configuration that might otherwise work.
+        return
+    available_bytes = stat.f_bavail * stat.f_frsize
+    if required_bytes > available_bytes:
+        raise RuntimeError(
+            f"Not enough space to create the CPU offload region at {path}: "
+            f"need {required_bytes / 1e9:.2f} GB but only "
+            f"{available_bytes / 1e9:.2f} GB is available on the backing "
+            f"filesystem (typically the /dev/shm tmpfs). Reduce the CPU "
+            f"offloading size (for example via the kv_offloading_size / "
+            f"cpu_bytes_to_use setting) or increase the size of /dev/shm."
+        )
 
 
 def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> None:
@@ -66,6 +95,20 @@ class SharedOffloadRegion:
             self.fd: int | None = os.open(
                 self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
             )
+            # Fail early with a clear message if the backing filesystem
+            # (typically the /dev/shm tmpfs) cannot hold the region. Without
+            # this check the shortfall only surfaces later as an opaque
+            # "OSError: [Errno 14] Bad address" from madvise(MADV_POPULATE_WRITE).
+            try:
+                _check_available_space(self.mmap_path, self.total_size_bytes, self.fd)
+            except RuntimeError:
+                # Remove the just-created empty file so other workers do not
+                # block waiting for it to reach the expected size.
+                os.close(self.fd)
+                self.fd = None
+                with contextlib.suppress(OSError):
+                    os.unlink(self.mmap_path)
+                raise
             os.ftruncate(self.fd, self.total_size_bytes)
             self._creator = True
             logger.info(


### PR DESCRIPTION
## Summary

Fixes #46949.

When CPU KV offloading is configured with a region larger than the backing tmpfs (`/dev/shm`) can hold, the failure currently surfaces deep in initialization as an opaque error:

```
File ".../vllm/v1/kv_offload/cpu/shared_offload_region.py", line 100, in __init__
    self.mmap_obj.madvise(...)
OSError: [Errno 14] Bad address
```

This happens because `ftruncate` only reserves the size sparsely (it succeeds even when the space is not really available), so the shortfall is only hit later when `madvise(MADV_POPULATE_WRITE)` faults the pages in. The resulting `Bad address` gives the user no indication that the real problem is an oversized offload size.

## Change

Add an explicit capacity check on the creator worker before `ftruncate`:

* `_check_available_space()` compares the requested region size against the free space reported by `os.fstatvfs` on the open fd (so it measures the file's own filesystem). If the region does not fit, it raises a `RuntimeError` naming the requested size, the available size, the path, and how to resolve it (reduce the CPU offloading size, or increase the size of `/dev/shm`).
* On that failure the creator removes the just-created empty file, so other workers do not block in `_wait_for_file_size` waiting for a file that will never reach the expected size.
* The check degrades gracefully (skips) if `statvfs` is unavailable, so it cannot block an otherwise-valid configuration.

Before:

```
OSError: [Errno 14] Bad address
```

After:

```
RuntimeError: Not enough space to create the CPU offload region at
/dev/shm/vllm_offload_<id>.mmap: need 40.00 GB but only 16.00 GB is available
on the backing filesystem (typically the /dev/shm tmpfs). Reduce the CPU
offloading size (for example via the kv_offloading_size / cpu_bytes_to_use
setting) or increase the size of /dev/shm.
```

## Why this PR is intentionally small

The fix is deliberately minimal and contained:

* It only adds a pre-flight check on the existing creation path; it does not change the allocation strategy, the mmap layout, the per-worker population loop, or any successful-path behaviour.
* The check is a pure read (`fstatvfs`) plus a comparison. On the happy path it is a no-op aside from one stat call, so there is no measurable overhead and no change to steady-state behaviour.
* It is local to `SharedOffloadRegion.__init__` and the new helper; no public APIs or call sites change.
* It fails closed only when the region provably cannot fit, and fails open (skips) where `statvfs` is unavailable, so it cannot regress a configuration that works today.

Keeping it scoped this way makes it easy to review and low risk to merge, while turning a confusing `Bad address` into an actionable message.

## Testing

Added `test_insufficient_space_raises_clear_error` in `tests/v1/kv_offload/cpu/test_shared_offload_region.py`, which monkeypatches `fstatvfs` to report insufficient free space, asserts the clear `RuntimeError` is raised, and verifies the partially created file is cleaned up.

`ruff check` and `ruff format --check` pass on both changed files.
