### PR TITLE
[Bugfix] Use larger workspace size for Flashinfer MLA LSE

### DIFF
--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -28,6 +28,22 @@ from vllm.v1.attention.backends.utils import KVCacheLayoutType
 logger = init_logger(__name__)
 
 FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE = 128 * 1024 * 1024
+FLASHINFER_MLA_LSE_WORKSPACE_BUFFER_SIZE = 256 * 1024 * 1024
+
+_fi_workspace: torch.Tensor | None = None
+
+
+def _get_workspace_buffer(return_lse: bool) -> torch.Tensor:
+    global _fi_workspace
+
+    buffer_size = (
+        FLASHINFER_MLA_LSE_WORKSPACE_BUFFER_SIZE
+        if return_lse
+        else FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE
+    )
+    if _fi_workspace is None or _fi_workspace.numel() < buffer_size:
+        _fi_workspace = torch.zeros(buffer_size, dtype=torch.uint8, device="cuda")
+    return _fi_workspace
 
 
 class FlashInferMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
@@ -105,13 +121,6 @@ class FlashInferMLABackend(MLACommonBackend):
         return "HND"
 
 
-g_fi_workspace = torch.zeros(
-    FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE,
-    dtype=torch.uint8,
-    device="cuda",
-)
-
-
 class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
     can_return_lse_for_decode: bool = True
 
@@ -159,7 +168,6 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
                 "FlashInferMLAImpl"
             )
 
-        self._workspace_buffer = g_fi_workspace
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
 
@@ -199,10 +207,11 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
                 self.bmm2_scale *= layer._k_scale_float
 
         return_lse = self.need_to_return_lse_for_decode
+        workspace_buffer = _get_workspace_buffer(return_lse)
         kernel_out = trtllm_batch_decode_with_kv_cache_mla(
             query=q,
             kv_cache=kv_c_and_k_pe_cache.unsqueeze(1),
-            workspace_buffer=self._workspace_buffer,
+            workspace_buffer=workspace_buffer,
             qk_nope_head_dim=self.qk_nope_head_dim,
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,


### PR DESCRIPTION
## Purpose
When using Flashinfer MLA LSE with Kimi K2.6, the following error is thrown due to insufficient workspace size:
```
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]   File "/vllm/vllm/v1/attention/backends/mla/flashinfer_mla.py", line 202, in forward_mqa
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]     kernel_out = trtllm_batch_decode_with_kv_cache_mla(
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]   File "/vllm/.venv/lib/python3.12/site-packages/flashinfer/api_logging.py", line 2333, in _auto_dump_wrapper
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]     return _inner(*args, **kwargs)
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]   File "/vllm/.venv/lib/python3.12/site-packages/flashinfer/mla/_core.py", line 1996, in trtllm_batch_decode_with_kv_cache_mla
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]     runner(inputs=inputs, tactic=tactic)
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]   File "/vllm/.venv/lib/python3.12/site-packages/flashinfer/autotuner.py", line 419, in __call__
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]     return self.forward(inputs, **kwargs)
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]   File "/vllm/.venv/lib/python3.12/site-packages/flashinfer/mla/_core.py", line 1446, in forward
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]     self._run(
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000]   File "python/tvm_ffi/cython/function.pxi", line 929, in tvm_ffi.core.Function.__call__
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000] RuntimeError: Error in function 'aligned_alloc' at /workspace/include/flashinfer/allocator.h:49: Buffer overflow when allocating memory for trtllm_gen_softmax_workspace with size 135266304 and alignment 16, but only 125829120 bytes available in AlignedAllocator. Increase the workspace buffer size.
 ERROR 06-29 13:11:30 [multiproc_executor.py:1000] 
```
This PR fixes it by using 256 MB workspace size when LSE is used.

## Test Plan
```
vllm serve nvidia/Kimi-K2.6-NVFP4 \
  --kv-cache-dtype fp8 \
  --trust-remote-code \
  --block-size 64 \
  --language-model-only \
  --attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}' \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
  --max-cudagraph-capture-size 2048 \
  --max-num-batched-tokens 16384 \
  --stream-interval 10 \
  --enable-prefix-caching \
  --tensor-parallel-size 4 \
  --decode-context-parallel-size 4 \
  --port 8000
```

## Test Result
```
lm_eval --model local-completions --model_args "base_url=http://0.0.0.0:8000/v1/completions,max_length=8192,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32" --tasks gsm8k --num_fewshot 5

local-completions ({'base_url': 'http://0.0.0.0:8000/v1/completions', 'max_length': 8192, 'tokenized_requests': False, 'tokenizer_backend':None, 'num_concurrent': 32}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9287|±  |0.0071|
|     |       |strict-match    |     5|exact_match|↑  |0.9287|±  |0.0071|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

