### PR TITLE
[Feature] DP supervisor using rust frontend

### DIFF
--- a/tests/entrypoints/openai/test_dp_supervisor.py
+++ b/tests/entrypoints/openai/test_dp_supervisor.py
@@ -176,6 +176,49 @@ def test_build_multi_port_external_lb_child_args_sets_external_rank_server():
     assert child_args.api_server_count == 1
 
 
+def test_run_vllm_dp_server_uses_python_server_by_default(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setattr(dp_sup.os, "setpgrp", lambda: None)
+    monkeypatch.setattr(dp_sup, "set_process_title", lambda *_args: None)
+    monkeypatch.setattr(dp_sup, "decorate_logs", lambda *_args: None)
+    monkeypatch.setattr(dp_sup.envs, "VLLM_RUST_FRONTEND_PATH", None, raising=False)
+    monkeypatch.setattr(
+        dp_sup, "_run_python_vllm_dp_server", lambda _args: calls.append("python")
+    )
+    monkeypatch.setattr(
+        dp_sup, "_run_rust_vllm_dp_server", lambda _args: calls.append("rust")
+    )
+
+    dp_sup._run_vllm_dp_server(_make_unit_args(data_parallel_rank=4))
+
+    assert calls == ["python"]
+
+
+def test_run_vllm_dp_server_uses_rust_frontend_when_enabled(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setattr(dp_sup.os, "setpgrp", lambda: None)
+    monkeypatch.setattr(dp_sup, "set_process_title", lambda *_args: None)
+    monkeypatch.setattr(dp_sup, "decorate_logs", lambda *_args: None)
+    monkeypatch.setattr(
+        dp_sup.envs,
+        "VLLM_RUST_FRONTEND_PATH",
+        "/tmp/vllm-rs",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        dp_sup, "_run_python_vllm_dp_server", lambda _args: calls.append("python")
+    )
+    monkeypatch.setattr(
+        dp_sup, "_run_rust_vllm_dp_server", lambda _args: calls.append("rust")
+    )
+
+    dp_sup._run_vllm_dp_server(_make_unit_args(data_parallel_rank=4))
+
+    assert calls == ["rust"]
+
+
 def test_validate_multi_port_external_lb_args_allows_ssl():
     args = _make_unit_args(
         ssl_keyfile="/tmp/server.key",

--- a/vllm/entrypoints/openai/dp_supervisor.py
+++ b/vllm/entrypoints/openai/dp_supervisor.py
@@ -22,6 +22,7 @@ import uvicorn
 import uvloop
 from fastapi import FastAPI, Response
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.utils.system_utils import (
     decorate_logs,
@@ -233,12 +234,22 @@ def _build_dp_supervisor_app(supervisor: DPSupervisor) -> FastAPI:
     return app
 
 
+def _run_python_vllm_dp_server(child_args: argparse.Namespace) -> None:
+    from vllm.entrypoints.openai.api_server import run_server
+
+    uvloop.run(run_server(child_args))
+
+
+def _run_rust_vllm_dp_server(child_args: argparse.Namespace) -> None:
+    from vllm.entrypoints.cli.serve import run_multi_api_server
+
+    run_multi_api_server(child_args)
+
+
 def _run_vllm_dp_server(child_args: argparse.Namespace) -> None:
     """
     Entrypoint function for the vLLM DP Server.
     """
-    from vllm.entrypoints.openai.api_server import run_server
-
     # Create a fresh process group for the vLLM DP Server,
     # so that CTRL-C is propagated cleanly.
     os.setpgrp()
@@ -246,7 +257,10 @@ def _run_vllm_dp_server(child_args: argparse.Namespace) -> None:
     name = f"APIServer_DP{child_args.data_parallel_rank}"
     set_process_title(name)
     decorate_logs(name)
-    uvloop.run(run_server(child_args))
+    if envs.VLLM_RUST_FRONTEND_PATH:
+        _run_rust_vllm_dp_server(child_args)
+    else:
+        _run_python_vllm_dp_server(child_args)
 
 
 class DPSupervisor:


### PR DESCRIPTION
## Purpose

A better way for https://github.com/vllm-project/vllm/pull/44915

The DP supervisor is quite thin, we can still use Python, but get the performance using Rust for DP sub ranks.

## Test

```bash
vllm serve deepseek-ai/DeepSeek-V2-lite   --data-parallel-size 2   --data-parallel-size-local 2   --data-parallel-multi-port-external-lb   --data-parallel-address 127.0.0.1   --data-parallel-rpc-port 29500   --port 8000   --data-parallel-supervisor-port 9256   --dp-supervisor-probe-interval-s 1  --dp-supervisor-probe-timeout-s 1

(EngineCore_DP0 pid=1025987) INFO 06-29 20:56:28 [kernel.py:278] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(APIServer_DP0 pid=1024276) INFO 06-29 20:56:28 [utils.py:534] Waiting for API servers to complete ...

(RustFrontend pid=1025988) INFO 06-29 20:56:28 [server/src/lib.rs:170] starting OpenAI server bind_address=0.0.0.0:8000 model=deepseek-ai/DeepSeek-V2-lite
```

```bash
kill -TERM 1024276
```

Then we exit elegantly.

```bash
(RustFrontend pid=1025988) WARNING 06-29 20:58:44 [server/src/lib.rs:224] HTTP graceful shutdown deadline elapsed; aborting server
(RustFrontend pid=1025988) WARNING 06-29 20:58:44 [state.rs:239] shutdown deadline elapsed before app state became idle; skipping engine-client shutdown ref_count=54
(APIServer_DP0 pid=1024276) WARNING 06-29 20:58:44 [utils.py:624] [shutdown] Process manager: force killing remaining processes count=1
(EngineCore_DP0 pid=1025987) INFO 06-29 20:58:44 [core.py:1214] [shutdown] EngineCore: trigger received signal=SIGTERM
(EngineCore_DP0 pid=1025987) INFO 06-29 20:58:44 [core.py:1333] [shutdown] EngineCore: start mode=abort timeout=0s
(EngineCore_DP0 pid=1025987) INFO 06-29 20:58:44 [core.py:1364] [shutdown] EngineCore: request processing complete; starting resource teardown
(EngineCore_DP0 pid=1025987) INFO 06-29 20:58:44 [core.py:1227] [shutdown] EngineCore: exiting busy loop
(Worker_DP0 pid=1026356) INFO 06-29 20:58:44 [multiproc_executor.py:790] Parent process exited, terminating worker queues
(EngineCore_DP0 pid=1025987) INFO 06-29 20:58:44 [multiproc_executor.py:426] [shutdown] Executor: waiting for worker exit count=1
(APIServer_DP0 pid=1024276) WARNING 06-29 20:58:44 [utils.py:624] [shutdown] Process manager: force killing remaining processes count=1
(RustFrontend pid=1025409) INFO 06-29 20:58:45  Peer PeerIdentity(b"\x95Z\x8d\x84\xed\xceH\xf6\xbe\xa5x\xedy\x89\xd3\xab") disconnected from tcp://127.0.0.1:33627, starting reconnection
(RustFrontend pid=1025409) WARNING 06-29 20:58:45  Reconnection attempt 1 to tcp://127.0.0.1:33627 failed: Network(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })
(RustFrontend pid=1025409) WARNING 06-29 20:58:45  Reconnection attempt 2 to tcp://127.0.0.1:33627 failed: Network(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })
[rank1]:[W629 20:58:45.233428272 TCPStore.cpp:125] [c10d] recvValue failed on SocketImpl(fd=108, addr=[localhost]:49368, remote=[localhost]:40589): Failed to recv, got 0 bytes. Connection was likely closed. Did the remote server shutdown or crash?
Exception raised from recvBytes at /pytorch/torch/csrc/distributed/c10d/Utils.hpp:682 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x9d (0x7f04dd37305d in /home/yewentao256/.venv/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0x6a914bd (0x7f040d8914bd in /home/yewentao256/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so)
frame #2: c10d::TCPStore::check(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) + 0x273 (0x7f040d88f413 in /home/yewentao256/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so)
frame #3: c10d::ProcessGroupNCCL::HeartbeatMonitor::runLoop() + 0x4a5 (0x7f03efeff8c5 in /home/yewentao256/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xee0e4 (0x7f049c6ee0e4 in /lib64/libstdc++.so.6)
frame #5: <unknown function> + 0x95128 (0x7f04de111128 in /lib64/libc.so.6)
frame #6: <unknown function> + 0x105afc (0x7f04de181afc in /lib64/libc.so.6)

[rank1]:[W629 20:58:45.235622909 ProcessGroupNCCL.cpp:1826] [PG ID 0 PG GUID 0 Rank 1] Failed to check the "should dump" flag on TCPStore, (maybe TCPStore server has shut down too early), with error: Failed to recv, got 0 bytes. Connection was likely closed. Did the remote server shutdown or crash?
(RustFrontend pid=1025409) WARNING 06-29 20:58:45  Reconnection attempt 3 to tcp://127.0.0.1:33627 failed: Network(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })
[rank1]:[W629 20:58:46.235744930 TCPStore.cpp:106] [c10d] sendBytes failed on SocketImpl(fd=108, addr=[localhost]:49368, remote=[localhost]:40589): Broken pipe
Exception raised from sendBytes at /pytorch/torch/csrc/distributed/c10d/Utils.hpp:653 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x9d (0x7f04dd37305d in /home/yewentao256/.venv/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0x6a90931 (0x7f040d890931 in /home/yewentao256/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so)
frame #2: c10d::TCPStore::check(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) + 0x24d (0x7f040d88f3ed in /home/yewentao256/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so)
frame #3: c10d::ProcessGroupNCCL::HeartbeatMonitor::runLoop() + 0x4a5 (0x7f03efeff8c5 in /home/yewentao256/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xee0e4 (0x7f049c6ee0e4 in /lib64/libstdc++.so.6)
frame #5: <unknown function> + 0x95128 (0x7f04de111128 in /lib64/libc.so.6)
frame #6: <unknown function> + 0x105afc (0x7f04de181afc in /lib64/libc.so.6)

[rank1]:[W629 20:58:46.237775496 ProcessGroupNCCL.cpp:1826] [PG ID 0 PG GUID 0 Rank 1] Failed to check the "should dump" flag on TCPStore, (maybe TCPStore server has shut down too early), with error: Broken pipe
(DPSupervisor pid=1023961) INFO 06-29 20:58:47 [dp_supervisor.py:451] DPSupervisor found 1 exited DP Servers.
(DPSupervisor pid=1023961) INFO 06-29 20:58:47 [dp_supervisor.py:484] DPSupervisor forwarding SIGTERM to DP Servers.
(APIServer_DP1 pid=1024277) INFO 06-29 20:58:47 [serve.py:383] Waiting up to 0 seconds for processes to exit
(RustFrontend pid=1025409) INFO 06-29 20:58:47 [cmd/src/main.rs:72] received shutdown signal (SIGTERM), shutting down...
(RustFrontend pid=1025409) WARNING 06-29 20:58:47 [server/src/lib.rs:224] HTTP graceful shutdown deadline elapsed; aborting server
(RustFrontend pid=1025409) INFO 06-29 20:58:47 [client.rs:754] shutting down engine-core client
(RustFrontend pid=1025409) INFO 06-29 20:58:47 [client.rs:769] engine-core client shut down
(APIServer_DP1 pid=1024277) WARNING 06-29 20:58:47 [utils.py:624] [shutdown] Process manager: force killing remaining processes count=1
(EngineCore_DP1 pid=1025408) INFO 06-29 20:58:47 [core.py:1214] [shutdown] EngineCore: trigger received signal=SIGTERM
(EngineCore_DP1 pid=1025408) INFO 06-29 20:58:47 [core.py:1333] [shutdown] EngineCore: start mode=abort timeout=0s
(EngineCore_DP1 pid=1025408) INFO 06-29 20:58:47 [core.py:1364] [shutdown] EngineCore: request processing complete; starting resource teardown
(EngineCore_DP1 pid=1025408) INFO 06-29 20:58:47 [core.py:1227] [shutdown] EngineCore: exiting busy loop
(Worker_DP1 pid=1026357) INFO 06-29 20:58:47 [multiproc_executor.py:790] Parent process exited, terminating worker queues
(EngineCore_DP1 pid=1025408) INFO 06-29 20:58:47 [multiproc_executor.py:426] [shutdown] Executor: waiting for worker exit count=1
(DPSupervisor pid=1023961) INFO:     Shutting down
(DPSupervisor pid=1023961) INFO:     Waiting for application shutdown.
(DPSupervisor pid=1023961) INFO:     Application shutdown complete.
(DPSupervisor pid=1023961) INFO:     Finished server process [1023961]
```