### PR TITLE
[Bug] Avoid Triton 3.8 nvidia cuInit poisoning forked CUDA init

### DIFF
--- a/tests/test_triton_utils.py
+++ b/tests/test_triton_utils.py
@@ -3,7 +3,10 @@
 
 import sys
 import types
+from importlib.util import find_spec
 from unittest import mock
+
+import pytest
 
 from vllm.triton_utils.importing import TritonLanguagePlaceholder, TritonPlaceholder
 
@@ -75,6 +78,36 @@ def test_triton_placeholder_language_from_parent():
     triton = TritonPlaceholder()
     lang = triton.language
     assert isinstance(lang, TritonLanguagePlaceholder)
+
+
+def test_known_backends_skip_driver_is_active():
+    if find_spec("triton") is None:
+        pytest.skip("triton not installed")
+
+    def _poison():
+        drv = mock.MagicMock()
+        drv.is_active.side_effect = AssertionError(
+            "driver.is_active() must not be called for known backends"
+        )
+        b = mock.MagicMock()
+        b.driver = drv
+        return b
+
+    fake_backends = {"nvidia": _poison(), "amd": _poison(), "cpu": _poison()}
+
+    sys.modules.pop("vllm.triton_utils", None)
+    sys.modules.pop("vllm.triton_utils.importing", None)
+
+    with (
+        mock.patch("triton.backends.backends", fake_backends),
+        mock.patch("vllm.platforms.current_platform.is_cuda", return_value=True),
+        mock.patch("vllm.platforms.current_platform.is_rocm", return_value=False),
+        mock.patch("vllm.platforms.current_platform.is_cpu", return_value=False),
+    ):
+        import vllm.triton_utils.importing  # noqa: F401
+
+    for b in fake_backends.values():
+        b.driver.is_active.assert_not_called()
 
 
 def test_no_triton_fallback():

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -20,12 +20,23 @@ if HAS_TRITON:
     try:
         from triton.backends import backends
 
-        # It's generally expected that x.driver exists and has
-        # an is_active method.
-        # The `x.driver and` check adds a small layer of safety.
-        active_drivers = [
-            x.driver for x in backends.values() if x.driver and x.driver.is_active()
-        ]
+        # Avoid driver.is_active() for known backends: triton 3.8's nvidia
+        # probe calls cuInit(0), poisoning forked-child CUDA init (#46996).
+        _platform_active = {
+            "nvidia": current_platform.is_cuda,
+            "amd": current_platform.is_rocm,
+            "cpu": current_platform.is_cpu,
+        }
+        active_drivers = []
+        for name, backend in backends.items():
+            if not backend.driver:
+                continue
+            check = _platform_active.get(name)
+            if check is None:
+                if backend.driver.is_active():
+                    active_drivers.append(backend.driver)
+            elif check():
+                active_drivers.append(backend.driver)
 
         # Check if we're in a distributed environment where CUDA_VISIBLE_DEVICES
         # or HIP_VISIBLE_DEVICES might be temporarily empty (e.g., Ray sets it to ""


### PR DESCRIPTION
Triton 3.8 reroutes the nvidia backend `driver.is_active()` probe through `libcuda.cuInit(0)` (triton-lang/triton#9578). `vllm/triton_utils/importing.py` calls that probe at import time, leaving CUDA driver state initialized in the parent process in a way that breaks any subsequently forked CUDA worker with:

```
RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
```

This affects the default `fork`-based EngineCore/worker path on NVIDIA whenever the driver-pinned Triton lands at 3.8.

Fixes #46996

## Fix

For known triton backends (`nvidia`, `amd`, `cpu`), consult `vllm.platforms.current_platform` instead of `driver.is_active()`. CUDA detection in `current_platform` goes through NVML (`nvmlInit` + `nvmlDeviceGetCount`), not libcuda, so no `cuInit` runs before fork. Unknown backends still fall back to `driver.is_active()` to preserve forward compatibility.

This matches the approach the reporter suggested and validated in the issue body.

## Why this is not a duplicate

Checked open and closed PRs for issue #46996 and \"triton cuInit\" / \"triton_utils import\" — no in-flight or merged PR addresses this. The issue is unassigned.

```
gh pr list --repo vllm-project/vllm --state open --search \"46996 in:body\"
gh pr list --repo vllm-project/vllm --state open --search \"triton cuInit\"
gh pr list --repo vllm-project/vllm --state closed --search \"46996 in:body\"
```

## Tests run

Validated on a Lambda H100 PCIe, Python 3.12, PyTorch 2.11.0+cu130, with **real Triton 3.8.0 built from source** (triton-lang/triton main @ \`285de7a1\`, which contains PR #9578).

**Reproducer from the issue** (\`repro.py\`):

| Scenario | Result |
|---|---|
| Unpatched \`importing.py\` + Triton 3.8 | \`RuntimeError: CUDA driver initialization failed\` / exitcode 1 (bug reproduced exactly as reporter) |
| Patched \`importing.py\` + Triton 3.8 | \`child OK\` / exitcode 0 / \`HAS_TRITON True\` |

Unit tests:

\`\`\`
.venv/bin/python -m pytest tests/test_triton_utils.py -v
8 passed (includes new test_known_backends_skip_driver_is_active regression test)
\`\`\`

The new test injects fake nvidia/amd/cpu backends whose \`is_active()\` raises \`AssertionError\` and verifies the patched detection path never invokes them.