### PR TITLE
[Bugfix][MLA] Fix LSE log-base mismatch in DCP + FlashInfer MLA decode

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -818,14 +818,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                         attn_out,
                         lse,
                         get_dcp_group(),
-                        is_lse_base_on_e=True,
+                        is_lse_base_on_e=self.impl.lse_base_on_e,
                     )
                 else:
                     attn_out = cp_lse_ag_out_rs(
                         attn_out,
                         lse,
                         get_dcp_group(),
-                        is_lse_base_on_e=True,
+                        is_lse_base_on_e=self.impl.lse_base_on_e,
                     )
 
             # v_up projection

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -756,6 +756,17 @@ class AttentionImplBase(ABC, Generic[T]):
     # Some features like decode context parallelism require the softmax lse.
     can_return_lse_for_decode: bool = False
 
+    # Base of the logarithm used by this backend when returning softmax lse.
+    # True  => natural log (lse = ln(sum(exp(qk))))
+    #          -- e.g. Triton MLA, FlashAttention, FlashMLA, Cutlass MLA
+    # False => base 2      (lse = log2(sum(exp(qk))))
+    #          -- e.g. FlashInfer trtllm-gen MLA
+    # The DCP combine kernel (cp_lse_ag_out_rs / dcp_a2a_lse_reduce in
+    # vllm/v1/attention/ops/common.py) branches on this via its IS_BASE_E
+    # constexpr; getting it wrong silently corrupts the cross-shard
+    # softmax denominator.
+    lse_base_on_e: bool = True
+
     # Whether the attention impl supports Prefill Context Parallelism.
     supports_pcp: bool = False
     # Whether the attention impl(or ops) supports MTP

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -114,6 +114,13 @@ g_fi_workspace = torch.zeros(
 
 class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
     can_return_lse_for_decode: bool = True
+    # trtllm-gen MLA decode emits LSE in log2 (per flashinfer's own
+    # reference at flashinfer/trace/templates/attention.py:81:
+    # `logsumexp / log(2.0)`). Override the AttentionImplBase default
+    # so MLAAttention's DCP combine branches on the correct base
+    # (IS_BASE_E=False uses tl.exp2/tl.log2 natively, avoiding an FP
+    # multiply per decode step).
+    lse_base_on_e: bool = False
 
     def __init__(
         self,


### PR DESCRIPTION
## Purpose

FlashInfer's trtllm-gen MLA decode kernel returns LSE in **log2** (per flashinfer's own reference at `flashinfer/trace/templates/attention.py:81`: `logsumexp / log(2.0)`), but `MLAAttention`'s DCP combine in `vllm/model_executor/layers/attention/mla_attention.py` hard-codes `is_lse_base_on_e=True` when calling `cp_lse_ag_out_rs` / `dcp_a2a_lse_reduce`, asserting natural log. The mismatch makes the per-shard re-weighting use the wrong base when combining DCP partial attention outputs, producing incorrect softmax denominators and corrupted attention values.

This is the residual bug after #43729 ("Support DCP with FlashInfer MLA") merged: that PR wired LSE *return* through `FlashInferMLAImpl` (so DCP combine now runs), but left the combine assuming natural-log LSE.

**Symptom** on Kimi-K2.5-NVFP4 + FP8 KV + DCP=4 + `FLASHINFER_MLA`:
- Same prompt sent twice within one run produces different argmax tokens at 24/32 positions (vs ~4/32 noise floor on the no-DCP baseline with the same backend).
- Argmax tokens diverge from the no-DCP baseline on every test prompt.
- `TRITON_MLA`, FlashAttention MLA, FlashMLA, and Cutlass MLA are unaffected — their kernels emit LSE in natural log, matching the old hard-coded assumption.

**Fix:** declare each backend's LSE base as a capability flag (`lse_base_on_e`) on `AttentionImplBase` (default `True` / natural log), override it to `False` on `FlashInferMLAImpl`, and thread it through the DCP combine. The kernels already support both bases natively via their `IS_BASE_E` constexpr (`tl.exp/tl.log` vs `tl.exp2/tl.log2`), so there is no FP multiply or rounding loss — and adding another log2-emitting backend later is a one-line `ClassVar` instead of a call-site edit.

## Not a duplicate

- **#43729** (merged) added FlashInfer MLA + DCP support and the LSE-return plumbing, but not this log-base reconciliation.
- **#47074** ("Use larger workspace size for Flashinfer MLA LSE") touches the same file but fixes an orthogonal issue — a `trtllm_gen_softmax_workspace` allocation overflow — not the LSE base. The two are complementary.

## Test Plan & Results

Verified end-to-end on Kimi-K2.5-NVFP4 + DCP=4 + FP8 KV (Blackwell GB200) against a TEP4 (no DCP, same FlashInfer backend) baseline:

- **5-prompt greedy-decode refcomp** (max_tokens=32, top_p=1): **0 token mismatches** after fix vs `28+24+24+4+0` before; within-run stability `24/32 → 5/32` (matches baseline `4/32`).
- **5-shot GSM8K** (full 1319-problem set): baseline `0.9356 / 0.9363` vs DCP4-FI `0.9363 / 0.9371` (flexible / strict) — delta `+0.07% / +0.08%`, well under run-to-run variance.

Kernel-level equivalence test added (`tests/kernels/attention/test_flashinfer_mla_decode.py` was part of the original branch; this PR contains the core fix — happy to fold the test/CI-trigger commits back in if reviewers prefer).

## AI assistance

AI assistance (Claude) was used to diagnose and patch this issue end-to-end. The submitting author has reviewed every changed line.
