### PR TITLE
[Bug] Fix sparse attention issue for GLM5.2 non-torch compile path

### DIFF
--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -467,10 +467,6 @@ class DeepseekV32Attention(MLAAttention):
             index_rope_interleave=self._index_rope_interleave,
         )
 
-        if attn_metadata is None:
-            output.zero_()
-            return
-
         if self.indexer is not None:
             sparse_attn_indexer(
                 q_c,
@@ -491,6 +487,10 @@ class DeepseekV32Attention(MLAAttention):
                 False,  # use_fp4_cache
                 True,  # skip_topk_buffer_clear (fused_norm_rope already did it)
             )
+
+        if attn_metadata is None:
+            output.zero_()
+            return
 
         num_actual = attn_metadata.num_actual_tokens  # type: ignore[attr-defined]
         kv_cache = self.kv_cache


### PR DESCRIPTION
## Purpose

`sparse_attn_indexer` will allocate a lot of memory during dummy run, we should return after it.

CC @WoosukKwon 

## Test

` vllm serve zai-org/GLM-5.2-FP8   --kv-cache-dtype fp8_e4m3   --enable-expert-parallel   --tensor-parallel-size 4   --tool-call-parser glm47   --enable-auto-tool-choice   --reasoning-parser glm45 --port 9256`

```bash
lm_eval --model local-completions --model_args "base_url=http://127.0.0.1:9256/v1/completions,model=$MODEL,num_concurrent=1024" --tasks gsm8k
```

Originally

```bash
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]   File "/home/yewentao256/vllm-source/vllm/models/deepseek_v32/nvidia/attention.py", line 475, in _fused_attention
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]     sparse_attn_indexer(
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]   File "/home/yewentao256/vllm-source/vllm/compilation/breakable_cudagraph.py", line 97, in wrapper
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]     return fn(*args, **kwargs)
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/sparse_attn_indexer.py", line 326, in sparse_attn_indexer
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]     k_quant_full, k_scale_full = workspace_manager.get_simultaneous(
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]   File "/home/yewentao256/vllm-source/vllm/v1/worker/workspace.py", line 110, in get_simultaneous
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]     current_workspace = self._ensure_workspace_size(total_bytes)
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]   File "/home/yewentao256/vllm-source/vllm/v1/worker/workspace.py", line 157, in _ensure_workspace_size
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000]     raise AssertionError(
(Worker_TP3_EP3 pid=1112885) ERROR 06-29 22:11:15 [multiproc_executor.py:1000] AssertionError: Workspace is locked but allocation from 'sparse_attn_indexer.py:326:sparse_attn_indexer' requires 5280.00 MB, current size is 1.00 MB. Workspace growth is not allowed after locking.
```

Now

```bash
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9409|±  |0.0065|
|     |       |strict-match    |     5|exact_match|↑  |0.9424|±  |0.0064|
```

