### PR TITLE
[Kernel][XPU] TD operand loads for Mamba2 _bmm_chunk_fwd

### DIFF
--- a/tests/kernels/mamba/test_mamba_ssm_ssd.py
+++ b/tests/kernels/mamba/test_mamba_ssm_ssd.py
@@ -577,3 +577,43 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
             rtol=rtol,
             msg=lambda x, i=i: f"seq{i} state " + x,
         )
+
+
+# TD operand-load path for _bmm_chunk_fwd (CB = C @ B.T), selected via the
+# use_td kwarg. Checks the TD path matches the plain load path.
+@pytest.mark.parametrize("ngroups", [1, 8])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("k", [64, 128])
+def test_bmm_chunk_td_matches_plain(ngroups, causal, k):
+    from vllm.model_executor.layers.mamba.ops.ssd_bmm import _bmm_chunk_fwd
+
+    set_random_seed(0)
+    chunk_size, nchunks = 256, 3
+    seqlen = chunk_size * nchunks
+    a = torch.randn(seqlen, ngroups, k, device=DEVICE, dtype=torch.bfloat16)
+    b = torch.randn(seqlen, ngroups, k, device=DEVICE, dtype=torch.bfloat16)
+    cu_chunk_seqlens = (
+        torch.arange(0, nchunks + 1, device=DEVICE, dtype=torch.int32) * chunk_size
+    )
+
+    def run(use_td):
+        return _bmm_chunk_fwd(
+            a,
+            b,
+            chunk_size,
+            cu_chunk_seqlens,
+            causal=causal,
+            output_dtype=torch.float32,
+            use_td=use_td,
+        )
+
+    out_plain = run(False)
+    out_td = run(True)
+    if causal:
+        # only out[i, j] with j <= i (lower triangle) is defined for causal
+        tri = torch.tril(
+            torch.ones(chunk_size, chunk_size, device=DEVICE, dtype=torch.bool)
+        )
+        out_plain = out_plain * tri
+        out_td = out_td * tri
+    torch.testing.assert_close(out_td, out_plain, atol=1e-3, rtol=1e-3)

--- a/vllm/model_executor/layers/mamba/ops/ssd_bmm.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_bmm.py
@@ -8,7 +8,12 @@
 
 import torch
 
+import vllm.envs as envs
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.triton_utils.allocation import set_triton_allocator
+
+_TD_ALLOCATOR_DEVICES: set[torch.device] = set()
 
 
 @triton.autotune(
@@ -88,6 +93,7 @@ def _bmm_chunk_fwd_kernel(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
+    USE_TD: tl.constexpr = False,
 ):
     pid_ch = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_ch // ngroups
@@ -112,22 +118,44 @@ def _bmm_chunk_fwd_kernel(
     b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_b_seqlen)
     chunk_size_limit = chunk_seqlen_end - chunk_seqlen_start
 
+    if USE_TD:
+        # a and b are both [chunk_rows, K] with K contiguous. Load a directly as
+        # [M, K]; load b as [N, K] and transpose for the a @ b.T dot
+        a_desc = tl.make_tensor_descriptor(
+            a_ptr,
+            shape=[chunk_size_limit, K],
+            strides=[stride_a_seqlen, 1],
+            block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
+        )
+        b_desc = tl.make_tensor_descriptor(
+            b_ptr,
+            shape=[chunk_size_limit, K],
+            strides=[stride_b_seqlen, 1],
+            block_shape=[BLOCK_SIZE_N, BLOCK_SIZE_K],
+        )
+
     acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
     # compute a * b.T
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        a = tl.load(
-            a_ptrs,
-            mask=(offs_m[:, None] < chunk_size_limit)
-            & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
-            other=0.0,
-        ).to(dot_dtype)
-        b = tl.load(
-            b_ptrs,
-            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K)
-            & (offs_n[None, :] < chunk_size_limit),
-            other=0.0,
-        ).to(dot_dtype)
+        if USE_TD:
+            a = a_desc.load([pid_m * BLOCK_SIZE_M, k * BLOCK_SIZE_K]).to(dot_dtype)
+            b = tl.trans(b_desc.load([pid_n * BLOCK_SIZE_N, k * BLOCK_SIZE_K])).to(
+                dot_dtype
+            )
+        else:
+            a = tl.load(
+                a_ptrs,
+                mask=(offs_m[:, None] < chunk_size_limit)
+                & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+                other=0.0,
+            ).to(dot_dtype)
+            b = tl.load(
+                b_ptrs,
+                mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K)
+                & (offs_n[None, :] < chunk_size_limit),
+                other=0.0,
+            ).to(dot_dtype)
         acc += tl.dot(a, b)
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk
@@ -145,7 +173,9 @@ def _bmm_chunk_fwd_kernel(
     )
 
 
-def _bmm_chunk_fwd(a, b, chunk_size, cu_chunk_seqlens, causal=False, output_dtype=None):
+def _bmm_chunk_fwd(
+    a, b, chunk_size, cu_chunk_seqlens, causal=False, output_dtype=None, use_td=None
+):
     """
     Argument:
         a: (seqlen, ngroups, k)
@@ -179,6 +209,21 @@ def _bmm_chunk_fwd(a, b, chunk_size, cu_chunk_seqlens, causal=False, output_dtyp
             else tl.float32
         )
     )
+    # Tensor-descriptor operand loads. Gate on K-contiguity
+    # (descriptors require a unit innermost stride) and 16-byte tile alignment.
+    td_override = use_td if use_td is not None else envs.VLLM_TRITON_USE_TD
+    use_td = current_platform.is_xpu() if td_override is None else td_override
+    use_td = (
+        use_td
+        and a.stride(2) == 1
+        and b.stride(2) == 1
+        and k % 8 == 0
+        and chunk_size % 8 == 0
+    )
+    if use_td and a.device not in _TD_ALLOCATOR_DEVICES:
+        set_triton_allocator(a.device)
+        _TD_ALLOCATOR_DEVICES.add(a.device)
+
     grid = lambda META: (
         triton.cdiv(chunk_size, META["BLOCK_SIZE_M"])
         * triton.cdiv(chunk_size, META["BLOCK_SIZE_N"]),
@@ -205,5 +250,6 @@ def _bmm_chunk_fwd(a, b, chunk_size, cu_chunk_seqlens, causal=False, output_dtyp
             stride_outn=out.stride(-1),
             IS_CAUSAL=causal,
             dot_dtype=dot_dtype,
+            USE_TD=use_td,
         )
     return out


### PR DESCRIPTION
### [Kernel][XPU] Use Triton tensor descriptors for `_bmm_chunk_fwd` operand loads

Adds a Tensor-Descriptor (TD) operand-load path to the Mamba2/SSD batched matmul kernel `_bmm_chunk_fwd` (`CB = C @ Bᵀ`).

On XPU, masked `tl.load` feeding `tl.dot` bypasses the Xe XMX matrix-engine (2D-block read) path. Both operands are `K`-contiguous (`[seqlen, ngroups, K]`), so we load `a` directly as `[M, K]` and load `b` as `[N, K]` via `tl.make_tensor_descriptor`, transposing it for the dot. 

### Performance

Device: Intel Arc BX70, torch `2.12.0+xpu`. dtype `bfloat16`, `K=128`, `chunk_size=256`.

| seqlen | ngroups | causal | plain | TD | Δ |
|---|---|---|---|---|---|
| 4096 | 1 | no  | 258 µs | 98 µs  | **−62%** |
| 8192 | 1 | no  | 200 µs | 98 µs  | **−51%** |
| 4096 | 8 | no  | 597 µs | 122 µs | **−80%** |
| 4096 | 1 | yes | 296 µs | 100 µs | **−66%** |
| 4096 | 8 | yes | 520 µs | 318 µs | **−39%** |

### Correctness
- Added `test_bmm_chunk_td_matches_plain` (8 cases: `ngroups ∈ {1, 8}`, `causal ∈ {False, True}`, `K ∈ {64, 128}`) — TD vs plain via an explicit `use_td` argument 
- The combined-scan reference test `test_mamba_chunk_scan_single_example` (d_head=128, bf16) passes with the TD path auto-enabled.

### Test plan
- [x] `pytest tests/kernels/mamba/test_mamba_ssm_ssd.py -k bmm_chunk_td` (XPU)
- [x] `pytest "…::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-128-4-itype1]"` (XPU, TD auto-on)
