### PR TITLE
[Bugfix][LoRA] Set is_3d_moe_weight=True on NemotronHForCausalLM so MoE LoRA adapters load

### DIFF
--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -788,6 +788,11 @@ class NemotronHForCausalLM(
     # Relevant only if self.has_moe is True
     is_non_gated_moe: bool = True
 
+    # For MoE LoRA weight loading: routed-expert LoRA is saved/served in the 3D
+    # stacked layout handled by FusedMoE3DWithLoRA (mirrors qwen3_5 / gpt_oss /
+    # qwen3_vl_moe). Without this, expert LoRA routes to the 2D wrapper and fails.
+    is_3d_moe_weight: bool = True
+
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={"backbone": "model"},
         orig_to_new_substr={"A_log": "A", "embeddings": "embed_tokens"},


### PR DESCRIPTION
## Summary
LoRA adapters trained on the routed experts of `nemotron_h` MoE models (e.g.
`nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B`) fail to load: `POST /v1/load_lora_adapter`
returns **HTTP 500** with `AssertionError` at
`vllm/lora/layers/fused_moe.py:316` (`assert isinstance(lora_a, list)`).

## Root cause
`NemotronHForCausalLM` does not set the `is_3d_moe_weight` class attribute, so it
inherits the default `False`. In `LoRAModelManager.__init__`:

```python
self._is_3d_moe_model = (
    self._is_moe and self.model.is_3d_moe_weight
    and not self._enable_mixed_moe_lora_format
)
```

With the flag `False`, the routed-expert LoRA is wrapped by the 2D
`FusedMoEWithLoRA` instead of `FusedMoE3DWithLoRA`. Only the 3D wrapper's loader
(`_stack_moe_lora_weights`) reshapes the standard PEFT-stacked expert LoRA
(`...experts.base_layer.lora_{A,B}` = gate_up/up_proj, `...experts.lora_{A,B}` =
down_proj) into the per-expert list that `set_lora` requires; the 2D path passes a
single tensor and trips the assertion.

The other fused-MoE LoRA models all set this flag — `qwen3_5` (`is_3d_moe_weight:
bool = True`), `gpt_oss`, `qwen3_vl_moe` — and serve the identical adapter layout
correctly. `nemotron_h` was simply missed.

## Fix
One line: set `is_3d_moe_weight = True` on `NemotronHForCausalLM` (the non-gated
expert path, `_w13_slices = 1`, is already handled by `FusedMoE3DWithLoRA`).

## Test plan
- Train a LoRA adapter targeting the routed experts of a `nemotron_h` MoE model
  (PEFT `target_parameters=[up_proj, down_proj]`).
- Serve with `--enable-lora`, then `POST /v1/load_lora_adapter` → previously 500,
  now loads via `FusedMoE3DWithLoRA` and generates.
- Pre-fix, the adapter loads only via the workaround
  `--enable-mixed-moe-lora-format` + `is_3d_lora_weight=true` on the load request,
  confirming the on-disk layout is already the standard 3D format and only the
  model-class flag was missing.