### PR TITLE
[RoCm][Build/CI][The Rock] Fix test_gemma4router.py for The Rock due to unstable torch.topk 

### DIFF
--- a/tests/kernels/moe/test_gemma4router.py
+++ b/tests/kernels/moe/test_gemma4router.py
@@ -99,7 +99,7 @@ def test_gemma4_routing_kernel_triton(
         .values
     )
 
-    # Check that the top-k gating values returned for each token.
+    # Check that the top-k gating values returned for each token are a top-k.
     torch.testing.assert_close(topk_values, tri_gating_values, atol=1e-2, rtol=1e-2)
 
     # 2) Check for correct weight computation.

--- a/tests/kernels/moe/test_gemma4router.py
+++ b/tests/kernels/moe/test_gemma4router.py
@@ -31,22 +31,80 @@ def test_gemma4_routing_kernel_triton(
     gating = torch.randn(num_tokens, num_experts, dtype=dtype, device="cuda")
     scales = torch.rand(num_experts, dtype=torch.float32, device="cuda")
 
-    ref_w, ref_ids = gemma4_routing_function_torch(gating, topk, scales)
     tri_w, tri_ids = gemma4_fused_routing_kernel_triton(gating, topk, scales)
 
-    # Sort by expert id — to remove tie-breaking differences
+    # Used with gamma4_routing_function_torch, it doesn't use the
+    # first return value and the second value needs to be a LongTensor.
+    def topk_function(x, k, dim):
+        return None, tri_ids.long()
+
+    # The two properties needed will be checked separately, in this order:
+    # 1) Check that the tri_ids do constitute a valid top-k set.
+    #
+    # Use the top-k indices to check that the gating values were actually
+    # a valid top-k
+    #
+    # 2) Check that the Triton implementation computes weights correctly.
+    #
+    # To check that the weights returned have been computed correctly,
+    # take the returned ids, which were already checked and return them
+    # into the Torch implementation using the topk_function above.
+    #
+    # This process is used  because torch.topk is unstable and tl.sort
+    # uses Bitonic Mergesort, which is also unstable.
+    #
+    # Since scales are applied after the top-k computation, the
+    # scale * weight computation could be different for two unshared experts
+    # that tied for the same place since the scale could be different,
+    # but gating value the same.
+
+    ref_w, ref_ids = gemma4_routing_function_torch(
+        gating, topk, scales, topk_function=topk_function
+    )
+
+    assert ref_ids.shape == tri_ids.shape, (
+        f"Returned weights shape must match reference weights shape,"
+        f"ref_ids.shape={ref_ids.shape}, tri_ids.shape={tri_ids.shape}."
+    )
+    assert ref_ids.dtype == tri_ids.dtype, (
+        "Returned weights dtype must match reference dtype."
+    )
+
+    assert ref_w.shape == tri_w.shape, (
+        f"Returned weights shape must match reference weights shape,"
+        f"ref_w.shape={ref_w.shape}, tri_w.shape={tri_w.shape}."
+    )
+    assert ref_w.dtype == tri_w.dtype, (
+        "Returned weights dtype must match reference dtype."
+    )
+
+    # 1) Check for valid top-k.
+    #
+    # Get a stable sort of the gating values and take the top-k.
+    topk_values, topk_indices = torch.sort(gating, descending=True, stable=True, dim=-1)
+    topk_values = topk_values[:, :topk]
+    topk_indices = topk_indices[:, :topk]
+
+    # Gather all of the gating values corresponding to the selected top-k ids.
+    # Since softmax preserves the ordering of a monotonic sequence, this can
+    # be used do check that the ids returned from the Triton implementation
+    # form a valid top-k.
+    tri_gating_values = (
+        gating.gather(dim=-1, index=tri_ids)
+        .sort(descending=True, stable=True, dim=-1)
+        .values
+    )
+
+    # Check that the top-k gating values returned for each token.
+    torch.testing.assert_close(topk_values, tri_gating_values, atol=1e-2, rtol=1e-2)
+
+    # 2) Check for correct weight computation.
     ref_ws, ref_is = sort_by_id(ref_w, ref_ids)
     tri_ws, tri_is = sort_by_id(tri_w, tri_ids)
 
-    ids_match = (ref_is == tri_is).all().item()
     weights_match = torch.allclose(ref_ws, tri_ws, atol=1e-2, rtol=1e-2)
-    all_match = ids_match and weights_match
     max_err = (ref_ws - tri_ws).abs().max().item()
-    print(
-        f"T={num_tokens:5d} E={num_experts:4d} K={topk} "
-        f"{str(dtype).split('.')[-1]:7s} ids={ids_match} max_Δweight={max_err:.2e}"
-    )
-    if not all_match:
+    if not weights_match:
         bad = (ref_is != tri_is).any(dim=-1).nonzero(as_tuple=True)[0]
         if len(bad):
             r = bad[0].item()
@@ -54,4 +112,4 @@ def test_gemma4_routing_kernel_triton(
                 f"  first bad row {r}: ref_ids={ref_ids[r].tolist()} "
                 f"tri_ids={tri_ids[r].tolist()}"
             )
-        assert all_match
+        assert weights_match

--- a/tests/kernels/moe/test_gemma4router.py
+++ b/tests/kernels/moe/test_gemma4router.py
@@ -78,6 +78,10 @@ def test_gemma4_routing_kernel_triton(
         "Returned weights dtype must match reference dtype."
     )
 
+    assert (tri_ids >= 0).all().item() and (tri_ids < num_experts).all().item(), (
+        f"Returned indices must be within the range of 0 to {num_experts}"
+    )
+
     # 1) Check for valid top-k.
     #
     # Get a stable sort of the gating values and take the top-k.

--- a/tests/kernels/moe/test_gemma4router.py
+++ b/tests/kernels/moe/test_gemma4router.py
@@ -30,10 +30,12 @@ def test_gemma4_routing_kernel_triton(
 
     tri_w, tri_ids = gemma4_fused_routing_kernel_triton(gating, topk, scales)
 
-    # Used with gamma4_routing_function_torch, it doesn't use the
-    # first return value and the second value needs to be a LongTensor.
+    # Mock topk function to be used with the torch implementation.
+    # Return the corresponding gating weights for completeness.
+    topk_gating = torch.gather(gating, 1, tri_ids)
+
     def mock_topk(x, k, dim):
-        return None, tri_ids.long()
+        return topk_gating, tri_ids.long()
 
     # The two properties needed will be checked separately, in this order:
     # 1) Check that the tri_ids do constitute a valid top-k set.

--- a/tests/kernels/moe/test_gemma4router.py
+++ b/tests/kernels/moe/test_gemma4router.py
@@ -21,10 +21,7 @@ def sort_by_id(w, ids):
 @pytest.mark.parametrize("topk", [8])  # gemma4 topk
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.half, torch.float32])
 def test_gemma4_routing_kernel_triton(
-    num_tokens: int,
-    num_experts: int,
-    topk: int,
-    dtype: torch.dtype,
+    num_tokens: int, num_experts: int, topk: int, dtype: torch.dtype, monkeypatch
 ):
     torch.manual_seed(0)
 
@@ -35,7 +32,7 @@ def test_gemma4_routing_kernel_triton(
 
     # Used with gamma4_routing_function_torch, it doesn't use the
     # first return value and the second value needs to be a LongTensor.
-    def topk_function(x, k, dim):
+    def mock_topk(x, k, dim):
         return None, tri_ids.long()
 
     # The two properties needed will be checked separately, in this order:
@@ -48,7 +45,7 @@ def test_gemma4_routing_kernel_triton(
     #
     # To check that the weights returned have been computed correctly,
     # take the returned ids, which were already checked and return them
-    # into the Torch implementation using the topk_function above.
+    # into the Torch implementation using the mock_topk above.
     #
     # This process is used  because torch.topk is unstable and tl.sort
     # uses Bitonic Mergesort, which is also unstable.
@@ -58,9 +55,9 @@ def test_gemma4_routing_kernel_triton(
     # that tied for the same place since the scale could be different,
     # but gating value the same.
 
-    ref_w, ref_ids = gemma4_routing_function_torch(
-        gating, topk, scales, topk_function=topk_function
-    )
+    monkeypatch.setattr(torch, "topk", mock_topk)
+
+    ref_w, ref_ids = gemma4_routing_function_torch(gating, topk, scales)
 
     assert ref_ids.shape == tri_ids.shape, (
         f"Returned weights shape must match reference weights shape,"

--- a/tests/kernels/moe/test_gemma4router.py
+++ b/tests/kernels/moe/test_gemma4router.py
@@ -111,7 +111,7 @@ def test_gemma4_routing_kernel_triton(
 
     print(
         f"T={num_tokens:5d} E={num_experts:4d} K={topk} "
-        f"{str(dtype).split('.')[-1]:7s} ids={ids_match} max_Δweight={max_err:.2e}"
+        f"{str(dtype).split('.')[-1]:7s} max_Δweight={max_err:.2e}"
     )
     if not weights_match:
         bad = (ref_is != tri_is).any(dim=-1).nonzero(as_tuple=True)[0]

--- a/tests/kernels/moe/test_gemma4router.py
+++ b/tests/kernels/moe/test_gemma4router.py
@@ -108,6 +108,11 @@ def test_gemma4_routing_kernel_triton(
 
     weights_match = torch.allclose(ref_ws, tri_ws, atol=1e-2, rtol=1e-2)
     max_err = (ref_ws - tri_ws).abs().max().item()
+
+    print(
+        f"T={num_tokens:5d} E={num_experts:4d} K={topk} "
+        f"{str(dtype).split('.')[-1]:7s} ids={ids_match} max_Δweight={max_err:.2e}"
+    )
     if not weights_match:
         bad = (ref_is != tri_is).any(dim=-1).nonzero(as_tuple=True)[0]
         if len(bad):

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -18,7 +18,7 @@
 # limitations under the License.
 """Gemma 4 model implementation for vLLM."""
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import replace
 from itertools import islice
 
@@ -184,8 +184,9 @@ def gemma4_routing_function_torch(
     gating_output: torch.Tensor,
     topk: int,
     per_expert_scale: torch.Tensor,
+    topk_function: Callable = torch.topk,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    _, topk_ids = torch.topk(gating_output, k=topk, dim=-1)
+    _, topk_ids = topk_function(gating_output, k=topk, dim=-1)
     router_probabilities = torch.nn.functional.softmax(gating_output, dim=-1)
     indicator = torch.nn.functional.one_hot(
         topk_ids, num_classes=gating_output.size(-1)

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -18,7 +18,7 @@
 # limitations under the License.
 """Gemma 4 model implementation for vLLM."""
 
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from dataclasses import replace
 from itertools import islice
 
@@ -184,9 +184,8 @@ def gemma4_routing_function_torch(
     gating_output: torch.Tensor,
     topk: int,
     per_expert_scale: torch.Tensor,
-    topk_function: Callable = torch.topk,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    _, topk_ids = topk_function(gating_output, k=topk, dim=-1)
+    _, topk_ids = torch.topk(gating_output, k=topk, dim=-1)
     router_probabilities = torch.nn.functional.softmax(gating_output, dim=-1)
     indicator = torch.nn.functional.one_hot(
         topk_ids, num_classes=gating_output.size(-1)


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
The `test_gemma4router.py` fails when testing against `The Rock` ([https://github.com/rocm/therock](https://github.com/rocm/therock)) due to the fact that `torch.topk` is unstable.  In the current ROCm environment, this behavior isn't exhibited very much, but in `The Rock` is occurs more frequently.

Furthermore, `tl.sort`, the sorting algorithm using tin the `gemma4_routing_function_triton` uses Bitonic Mergesort which is also unstable.

This PR updates the test to account for unstable sorting / top-k algorithms exhibiting unstable behavior more frequently.

* The testing is done in two steps:
    1. Check that the ids returned for each token are a valid set of top-k selections by sorting the gating values using a stable sort and comparing the corresponding weights for the returned ids directly.
    2. Check that the weight computation was done correctly by using the returned ids from the Triton implementation and using a mock top-k function to ensure that the Torch implementation computes its weights using the same scales that the Triton implementation used.
     
## Test Plan
 `pytest -sv kernels/moe/test_gemma4router.py`

## Test Result
`Current ROCm: == 12 passed, 16 warnings in 8.93s ==`
`The Rock: == 12 passed, 16 warnings in 9.90s ==`


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X ] The test plan, such as providing test command.
- [X ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
