### PR TITLE
[ROCm][CI] Move LM Eval Large Models (8 GPUs) to mi300 pool

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1198,6 +1198,27 @@ steps:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx.txt
 
+- label: ROCm LM Eval Large Models (8 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
+  agent_pool: mi300_8
+  optional: true
+  num_gpus: 8
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  source_file_dependencies:
+  - vllm/model_executor/models/
+  - vllm/model_executor/model_loader/
+  - vllm/model_executor/layers/quantization/
+  - vllm/v1/attention/backends/
+  - vllm/v1/attention/selector.py
+  - vllm/model_executor/layers/layernorm.py
+  - csrc/
+  - vllm/_aiter_ops.py
+  - vllm/platforms/rocm.py
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm.txt --tp-size=8
+
 #---------------------------------------------------------  mi300 · examples  ----------------------------------------------------------#
 
 - label: Examples # TBD
@@ -2391,27 +2412,6 @@ steps:
   commands:
   - export VLLM_USE_DEEP_GEMM=0
   - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm-fp8.txt --tp-size=4
-
-- label: ROCm LM Eval Large Models (8 GPUs) # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi325]
-  agent_pool: mi325_8
-  optional: true
-  num_gpus: 8
-  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/model_executor/layers/quantization/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/model_executor/layers/layernorm.py
-  - csrc/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  commands:
-  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm.txt --tp-size=8
 
 #-----------------------------------------------------  mi325 · models / language  -----------------------------------------------------#
 


### PR DESCRIPTION
## Purpose

This moves the "ROCm LM Eval Large Models (8 GPUs)" Buildkite step from the mi325 pool (`amdmi325` / `mi325_8`) to the mi300 pool (`amdmi300` / `mi300_8`), grouping it with the other mi300 LM-eval steps. The test command, source-file dependencies, timeout, and `num_gpus` are unchanged — only the hardware target moves. This routes the 8-GPU LM-eval job to mi300 8-GPU capacity.

AI assistance (Claude) was used to prepare this change. This is not a duplicate: a search of open PRs against `vllm-project/vllm` found no existing PR relocating this step between the mi325 and mi300 pools.

## Test Plan

This is a Buildkite pipeline configuration change (`.buildkite/test-amd.yaml`); there is no unit test. Validation is that the YAML remains well-formed and the step now schedules on the mi300 8-GPU pool. The underlying step command is unchanged:

```
export VLLM_WORKER_MULTIPROC_METHOD=spawn
pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm.txt --tp-size=8
```

## Test Result

The diff only changes `mirror_hardwares` (`amdmi325` → `amdmi300`) and `agent_pool` (`mi325_8` → `mi300_8`) and relocates the step block into the mi300 section. No behavioral change to the test itself. The job will run on the mi300 8-GPU agent pool once merged.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

