### PR TITLE
Add Triton Backend for Unlimited-OCR R-SWA

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -75,7 +75,7 @@ class UnlimitedOCRForCausalLMConfig(VerifyAndUpdateConfig):
              → Triton unified attention with an R-SWA decode mask.
 
           4. ``--attention-config '{"backend": "auto"}'`` (or omitted)
-             → Auto-detect: FA4 if available (H20/H100 SM90), else FlexAttention.
+             → Auto-detect: FA4 if available (H20/H100 SM90), else TritonAttention.
 
         Regardless of backend, prefix caching is disabled for this model: R-SWA
         decode-phase KV is not a pure causal function of the prefix (so decode
@@ -99,7 +99,7 @@ class UnlimitedOCRForCausalLMConfig(VerifyAndUpdateConfig):
             attn_config.backend = (
                 AttentionBackendEnum.FLASH_ATTN
                 if fa4_available
-                else AttentionBackendEnum.FLEX_ATTENTION
+                else AttentionBackendEnum.TRITON_ATTN
             )
             logger.info(
                 "Unlimited-OCR: auto-selected attention backend=%s (fa4_available=%s).",
@@ -113,8 +113,8 @@ class UnlimitedOCRForCausalLMConfig(VerifyAndUpdateConfig):
                 raise RuntimeError(
                     "Unlimited-OCR: --attention-config backend=FLASH_ATTN "
                     "requires FA4 (rswa_mask_mod), but FA4 is not available on "
-                    "this device/installation.  Use backend=FLEX_ATTENTION or "
-                    "upgrade vllm-flash-attn."
+                    "this device/installation. Use backend=TRITON_ATTN or "
+                    "FLEX_ATTENTION, or upgrade vllm-flash-attn."
                 )
             # On SM90 (H20), the default FA version is FA3 regardless of FA4
             # availability (FA4 is only auto-upgraded when head_size > 256).
@@ -133,6 +133,11 @@ class UnlimitedOCRForCausalLMConfig(VerifyAndUpdateConfig):
                 attn_config.flash_attn_version,
             )
 
+        elif attn_config.backend == AttentionBackendEnum.TRITON_ATTN:
+            logger.info(
+                "Unlimited-OCR: TritonAttention — R-SWA via unified attention mask."
+            )
+
         elif attn_config.backend == AttentionBackendEnum.FLEX_ATTENTION:
             logger.info(
                 "Unlimited-OCR: FlexAttention — R-SWA via Triton block mask%s.",
@@ -143,16 +148,11 @@ class UnlimitedOCRForCausalLMConfig(VerifyAndUpdateConfig):
                 ),
             )
 
-        elif attn_config.backend == AttentionBackendEnum.TRITON_ATTN:
-            logger.info(
-                "Unlimited-OCR: TritonAttention — R-SWA via unified attention mask."
-            )
-
         else:
             raise ValueError(
                 f"Unlimited-OCR: unsupported attention backend "
                 f"{attn_config.backend!r} for R-SWA. "
-                "Use FLASH_ATTN (FA4), FLEX_ATTENTION, or TRITON_ATTN."
+                "Use FLASH_ATTN (FA4), TRITON_ATTN or FLEX_ATTENTION."
             )
 
         # R-SWA windows the *generated* tokens, so a decode-token's KV is not a

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -71,7 +71,10 @@ class UnlimitedOCRForCausalLMConfig(VerifyAndUpdateConfig):
           2. ``--attention-config '{"backend": "FLEX_ATTENTION"}'``
              → FlexAttention R-SWA via Triton block mask.
 
-          3. ``--attention-config '{"backend": "auto"}'`` (or omitted)
+          3. ``--attention-config '{"backend": "TRITON_ATTN"}'``
+             → Triton unified attention with an R-SWA decode mask.
+
+          4. ``--attention-config '{"backend": "auto"}'`` (or omitted)
              → Auto-detect: FA4 if available (H20/H100 SM90), else FlexAttention.
 
         Regardless of backend, prefix caching is disabled for this model: R-SWA
@@ -140,11 +143,16 @@ class UnlimitedOCRForCausalLMConfig(VerifyAndUpdateConfig):
                 ),
             )
 
+        elif attn_config.backend == AttentionBackendEnum.TRITON_ATTN:
+            logger.info(
+                "Unlimited-OCR: TritonAttention — R-SWA via unified attention mask."
+            )
+
         else:
             raise ValueError(
                 f"Unlimited-OCR: unsupported attention backend "
                 f"{attn_config.backend!r} for R-SWA. "
-                "Use FLASH_ATTN (FA4) or FLEX_ATTENTION."
+                "Use FLASH_ATTN (FA4), FLEX_ATTENTION, or TRITON_ATTN."
             )
 
         # R-SWA windows the *generated* tokens, so a decode-token's KV is not a

--- a/vllm/model_executor/models/unlimited_ocr.py
+++ b/vllm/model_executor/models/unlimited_ocr.py
@@ -21,15 +21,11 @@ backbone architecture, FlexAttention for R-SWA, vision encoder backend, and
 Attention backend: the reference applies Reference Sliding Window Attention
 (R-SWA) -- the prompt/image tokens form a globally-visible prefix while the
 *generated* tokens additionally attend only a fixed sliding window (128) of
-recent tokens. We reproduce this (Level 1: full KV cache + custom mask) by
-forcing the language model onto the FlexAttention backend and installing an
-R-SWA ``mask_mod``. FlexAttention is the only backend able to express the
-"global prefix + sliding window" mask; FlashAttention-3 / Triton only support a
-uniform window (and additionally crash or compute incorrectly on this decoder's
-10-head,
-head_dim-128 shape), and FlashInfer's paged decode exposes no custom mask. The
-window size is published via ``model_config.rswa_window``, which the model
-runner reads to plumb per-request prefix lengths into the FlexAttention mask.
+recent tokens. We reproduce this with backend-specific custom masks: FA4 uses a
+``mask_mod``, FlexAttention uses a Triton block mask, and TritonAttention uses a
+unified-attention decode mask. FlashInfer's paged decode exposes no custom mask.
+The window size is published via ``model_config.rswa_window``, which the model
+runner reads to plumb per-request prefix lengths into the attention metadata.
 
 The *vision encoder* (DeepEncoder's CLIP stage, head_dim 64) is unaffected and
 does not use R-SWA: it runs a single full-attention prefill pass. FlashAttention,

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -93,6 +93,8 @@ class TritonAttentionMetadata:
     prefix_scheduler_metadata: torch.Tensor | None = None
     mm_prefix_range: dict[int, list[tuple[int, int]]] | None = None
     mm_prefix_range_tensor: torch.Tensor | None = None
+    rswa_prefix_lens: torch.Tensor | None = None
+    rswa_window: int | None = None
 
 
 class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMetadata]):
@@ -169,6 +171,14 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             dtype=torch.float32,
             device=device,
         )
+        self.rswa_window = model_config.rswa_window
+        self.persistent_rswa_prefix_lens: torch.Tensor | None = None
+        if self.rswa_window is not None:
+            self.persistent_rswa_prefix_lens = torch.empty(
+                vllm_config.scheduler_config.max_num_seqs,
+                dtype=torch.int32,
+                device=device,
+            )
 
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata
@@ -241,6 +251,17 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             attn_metadata.mm_prefix_range_tensor = compute_mm_prefix_range_tensor(
                 mm_ranges, num_reqs, seq_lens.device
             )
+
+        rswa_prefix_lens = common_attn_metadata.rswa_prefix_lens
+        if self.rswa_window is not None and rswa_prefix_lens is not None:
+            assert self.persistent_rswa_prefix_lens is not None
+            rswa_prefix_lens = rswa_prefix_lens.to(
+                device=self.device, dtype=torch.int32, non_blocking=True
+            )
+            persistent_prefix_lens = self.persistent_rswa_prefix_lens[:num_reqs]
+            persistent_prefix_lens.copy_(rswa_prefix_lens[:num_reqs])
+            attn_metadata.rswa_prefix_lens = persistent_prefix_lens
+            attn_metadata.rswa_window = self.rswa_window
 
         return attn_metadata
 
@@ -669,6 +690,8 @@ class TritonAttentionImpl(AttentionImpl):
             sinks=self.sinks,
             output_scale=output_scale,
             mm_prefix_range=mm_prefix_range_tensor,
+            rswa_prefix_lens=attn_metadata.rswa_prefix_lens,
+            rswa_window=attn_metadata.rswa_window,
             kv_quant_mode=self._kv_quant_mode,
             k_scale_cache=k_scale_cache,
             v_scale_cache=v_scale_cache,

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -279,6 +279,9 @@ def compute_kv_seq_mask(
     USE_CAUSAL: tl.constexpr = True,
     USE_PER_SEQ_CAUSAL: tl.constexpr = False,
     per_seq_causal_ptr=None,
+    rswa_prefix_lens_ptr=None,
+    R_SWA_WINDOW: tl.constexpr = 0,
+    USE_R_SWA: tl.constexpr = False,
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
 ):
@@ -319,7 +322,7 @@ def compute_kv_seq_mask(
             (query_abs_pos // CHUNK_SIZE - seq_offset[None, :] // CHUNK_SIZE)
             <= CHUNK_LOOKBACK
         )
-    elif SLIDING_WINDOW > 0:
+    elif SLIDING_WINDOW > 0 and not USE_R_SWA:
         sw_left = (query_abs_pos - seq_offset) < SLIDING_WINDOW
         if USE_PER_SEQ_CAUSAL:
             sw_right = (seq_offset[None, :] - query_abs_pos) < SLIDING_WINDOW
@@ -329,6 +332,12 @@ def compute_kv_seq_mask(
             seq_mask = seq_mask & sw_left & sw_right
         else:
             seq_mask = seq_mask & sw_left
+
+    if USE_R_SWA:
+        prefix_len = tl.load(rswa_prefix_lens_ptr + seq_idx)
+        in_prefix = seq_offset[None, :] < prefix_len
+        in_window = (query_abs_pos - seq_offset) < R_SWA_WINDOW
+        seq_mask = seq_mask & (in_prefix | in_window)
 
     # PrefixLM: extend mask with bidirectional ranges for multimodal tokens.
     # Applied AFTER sliding window so mm_prefix ranges override SW restriction.

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -221,6 +221,9 @@ def kernel_unified_attention(
     USE_MM_PREFIX: tl.constexpr,  # bool
     MAX_MM_RANGES: tl.constexpr,  # int
     mm_prefix_range_ptr,
+    rswa_prefix_lens_ptr,
+    R_SWA_WINDOW: tl.constexpr,  # int
+    USE_R_SWA: tl.constexpr,  # bool
     stride_k_cache_0: tl.int64,  # int
     stride_k_cache_1: tl.int64,  # int
     stride_k_cache_2: tl.int64,  # int
@@ -391,7 +394,7 @@ def kernel_unified_attention(
         BLOCK_Q,
         num_queries_per_kv,
         SLIDING_WINDOW,
-        USE_MM_PREFIX,
+        USE_MM_PREFIX or USE_R_SWA,
         IS_3D,
         USE_CAUSAL,
         USE_PER_SEQ_CAUSAL,
@@ -507,6 +510,9 @@ def kernel_unified_attention(
             USE_CAUSAL,
             USE_PER_SEQ_CAUSAL,
             per_seq_causal_ptr,
+            rswa_prefix_lens_ptr,
+            R_SWA_WINDOW,
+            USE_R_SWA,
             CHUNK_LOOKBACK,
             CHUNK_SIZE,
         )
@@ -807,6 +813,10 @@ def unified_attention(
     sinks=None,
     # Optional tensor for prefix lengths (PrefixLM support)
     mm_prefix_range=None,
+    # R-SWA support: prefix tokens stay globally visible, generated tokens use
+    # a fixed sliding window.
+    rswa_prefix_lens=None,
+    rswa_window: int | None = None,
     use_alibi_sqrt=False,
     # KV cache quantization mode and per-token-head scale caches.
     kv_quant_mode: KVQuantMode = KVQuantMode.NONE,
@@ -888,6 +898,8 @@ def unified_attention(
             raise ValueError(
                 f"Unsupported mm_prefix_range shape: {mm_prefix_range.shape}"
             )
+
+    use_rswa = rswa_window is not None and rswa_prefix_lens is not None
 
     use_alibi_slopes = alibi_slopes is not None
     use_qq_bias = qq_bias is not None
@@ -1103,6 +1115,9 @@ def unified_attention(
         USE_MM_PREFIX=use_mm_prefix,
         MAX_MM_RANGES=max_mm_ranges,
         mm_prefix_range_ptr=mm_prefix_range,
+        rswa_prefix_lens_ptr=rswa_prefix_lens if use_rswa else seqused_k,
+        R_SWA_WINDOW=rswa_window or 0,
+        USE_R_SWA=use_rswa,
         stride_k_cache_0=k.stride(0),
         stride_k_cache_1=k.stride(1),
         stride_k_cache_2=k.stride(2),


### PR DESCRIPTION
## Summary

This PR adds explicit TritonAttention support for Unlimited-OCR's R-SWA decode
mask. The Triton path implements the mask with:

```python
if USE_R_SWA:
    prefix_len = tl.load(rswa_prefix_lens_ptr + seq_idx)
    in_prefix = seq_offset[None, :] < prefix_len
    in_window = (query_abs_pos - seq_offset) < R_SWA_WINDOW
    seq_mask = seq_mask & (in_prefix | in_window)
```

This keeps prompt/image prefix tokens globally visible, while generated tokens
use a causal sliding window. The implementation reuses existing
`rswa_prefix_lens` metadata and applies the mask inside Triton unified
attention. It also allows the R-SWA path to use TritonAttention's 3D segmented
softmax decode path when applicable.

## Test Environment

```text
GPU: 8 x NVIDIA H20-3e
GPU architecture: Hopper SM90, compute capability 9.0
Driver: 580.105.08
CUDA runtime reported by nvidia-smi: 13.0
Model: baidu/Unlimited-OCR
Dataset: OmniDocBench v1.6
```

## Performance

20-sample OmniDocBench v1.6 run:

| Backend | Elapsed | Completion tok/s | Speedup vs Flex |
|---|---:|---:|---:|
| FlexAttention | 97.38s | 248.74 | 1.00x |
| Triton R-SWA 2D | 49.78s | 485.83 | 1.96x |
| Triton R-SWA 3D | 35.28s | 692.12 | 2.76x |

Full OmniDocBench v1.6 8GPU run:

| Backend | e2e time | Pages/hour | Completion tok/s |
|---|---:|---:|---:|
| FlexAttention | 1565.34s | 3679.72 | 1341.50 |
| Triton R-SWA 3D | 463.67s | 12818.57 | 4980.91 |

Full-run speedup:

```text
3.38x faster e2e time
3.48x higher pages/hour
3.71x higher completion tok/s
```

## Accuracy

20-sample OmniDocBench v1.6 no-CDM metrics:

| Metric | FlexAttention | Triton R-SWA 3D |
|---|---:|---:|
| Text Edit ↓ | 0.123511843 | 0.121357226 |
| Formula Edit ↓ | 0.201904011 | 0.200388178 |
| Table TEDS ↑ | 87.768167687 | 87.768167687 |
| Table TEDS-S ↑ | 100.000000000 | 100.000000000 |
| Read-order Edit ↓ | 0.103801314 | 0.103801314 |

Full OmniDocBench v1.6 no-CDM metrics:

| Metric | FlexAttention | Triton R-SWA 3D |
|---|---:|---:|
| Text Edit ↓ | 0.09199 | 0.09016 |
| Formula Edit ↓ | 0.10277 | 0.10061 |
| Table TEDS ↑ | 89.73 | 90.06 |
| Table TEDS-S ↑ | 92.98 | 93.37 |
| Read-order Edit ↓ | 0.14807 | 0.14684 |

The Triton backend is slightly better than the Flex baseline on all metrics in this run.

## Test Commands

### 20-Sample Test

Start a Triton server:

```bash
VLLM_REPO=<path-to-vllm-unlimited-ocr-repo>
VLLM_PYTHON=<path-to-vllm-python>
MODEL_PATH=<path-to-baidu-Unlimited-OCR>
OMNIDOCBENCH_IMAGES=<path-to-OmniDocBench-images>

PYTHONPATH=${VLLM_REPO} \
HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
${VLLM_PYTHON} -m vllm.entrypoints.cli.main serve \
  ${MODEL_PATH} \
  --served-model-name baidu/Unlimited-OCR \
  --host 127.0.0.1 \
  --port 18121 \
  --max-model-len 32768 \
  --limit-mm-per-prompt '{"image":1}' \
  --allowed-local-media-path ${OMNIDOCBENCH_IMAGES} \
  --logits-processors vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor \
  --attention-config '{"backend": "TRITON_ATTN"}'
```

Run the first 20 OmniDocBench samples:

```bash
VLLM_PYTHON=<path-to-vllm-python>
OMNIDOCBENCH_JSON=<path-to-OmniDocBench.json>
OMNIDOCBENCH_IMAGES=<path-to-OmniDocBench-images>
RUN_OMNIDOCBENCH_SCRIPT=<path-to-run_vllm_omnidocbench.py>
OUTPUT_DIR=<path-to-20-sample-output-dir>

${VLLM_PYTHON} \
  ${RUN_OMNIDOCBENCH_SCRIPT} \
  --dataset ${OMNIDOCBENCH_JSON} \
  --images-dir ${OMNIDOCBENCH_IMAGES} \
  --out-dir ${OUTPUT_DIR} \
  --server http://127.0.0.1:18121 \
  --model baidu/Unlimited-OCR \
  --prompt 'document parsing.' \
  --image-mode gundam \
  --max-tokens 8192 \
  --ngram-size 35 \
  --ngram-window 128 \
  --limit 20
```