### PR TITLE
[XPU][Bugfix] Fix FP8 block-scaled GEMM for unaligned N

### DIFF
--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -98,7 +98,11 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
       'export VLLM_XPU_FUSED_MOE_USE_REF=1 &&
       cd tests &&
-      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[Eagle3MiniMaxM2ForCausalLM]'
+      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[Eagle3MiniMaxM2ForCausalLM] &&
+      pytest -v -s models/test_initialization.py::test_can_initialize_small_subset[DeepSeekMTPModel] && 
+      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[DeepseekV3ForCausalLM] && 
+      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[DeepseekV32ForCausalLM]'
+
 
 - label: XPU CPU Offload
   timeout_in_minutes: 60

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -256,6 +256,7 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
     "DeepseekV3ForCausalLM": _HfExamplesInfo(
         "deepseek-ai/DeepSeek-V3",
         trust_remote_code=True,
+        max_model_len=4096,
     ),
     "DeepseekV32ForCausalLM": _HfExamplesInfo("deepseek-ai/DeepSeek-V3.2-Exp"),
     "DeepseekV4ForCausalLM": _HfExamplesInfo(
@@ -1449,6 +1450,7 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
         "eagle618/deepseek-v3-random",
         speculative_model="eagle618/eagle-deepseek-v3-random",
         trust_remote_code=True,
+        max_model_len=4096,
     ),
     "EagleLlamaForCausalLM": _HfExamplesInfo(
         "meta-llama/Meta-Llama-3-8B-Instruct",
@@ -1564,6 +1566,7 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
         "luccafong/deepseek_mtp_main_random",
         speculative_model="luccafong/deepseek_mtp_draft_random",
         trust_remote_code=True,
+        max_model_len=4096,
     ),
     "DeepSeekV4MTPModel": _HfExamplesInfo(
         "deepseek-ai/DeepSeek-V4-Flash",

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -5,6 +5,9 @@ from collections.abc import Sequence
 
 import torch
 
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    process_fp8_weight_block_strategy,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8DynamicTensorSym,
     kFp8DynamicTokenSym,
@@ -196,6 +199,58 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         if not current_platform.is_xpu():
             return False, "XPUFp8BlockScaledMM only support on XPU"
         return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module):
+        params = self._get_layer_params(layer)
+        # Fp8LinearMethod registered weight scale
+        # buffer as weight_scale_inv unlike compressed tensors.
+        weight_scale = (
+            params.weight_scale
+            if params.weight_scale_inv is None
+            else params.weight_scale_inv
+        )
+        scale_attr_name = (
+            params.WEIGHT_SCALE
+            if params.weight_scale_inv is None
+            else params.WEIGHT_SCALE_INV
+        )
+        new_weight, new_weight_scale = process_fp8_weight_block_strategy(
+            params.weight,
+            weight_scale,
+        )
+
+        N, K = new_weight.shape
+        bs = K // new_weight_scale.shape[1] if new_weight_scale.shape[1] > 0 else 1
+        n_padded = ((N + bs - 1) // bs) * bs
+
+        if n_padded != N:
+            # Block FP8 format requires N % bs == 0.
+            # Some model layers (e.g., DeepSeek MTP kv_a_proj_with_mqa with N=576)
+            # do not satisfy this condition, so we pad weight and scale at load time.
+            layer._xpu_fp8_original_n = N
+
+            new_weight = torch.nn.functional.pad(new_weight, (0, 0, 0, n_padded - N))
+            n_scale_pad = n_padded // bs - new_weight_scale.shape[0]
+            if n_scale_pad > 0:
+                new_weight_scale = torch.nn.functional.pad(
+                    new_weight_scale, (0, 0, 0, n_scale_pad)
+                )
+
+        replace_parameter(layer, params.WEIGHT, new_weight.data)
+        replace_parameter(layer, scale_attr_name, new_weight_scale.data)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        output = super().apply_weights(layer, x, bias, **kwargs)
+        original_n = getattr(layer, "_xpu_fp8_original_n", None)
+        if original_n is not None:
+            output = output[..., :original_n]
+        return output
 
     def apply_block_scaled_mm(
         self,


### PR DESCRIPTION

## Summary

Fix `XPUFp8BlockScaledMMKernel.apply_block_scaled_mm` to correctly derive
`block_size` from the weight scale tensor, and pad weight N-dimension when
it is not aligned to `block_size`. This fixes DeepSeek MTP model
initialization on XPU.

## Root Cause

The block_size was derived as `K // Bs.shape[0]`, but `Bs` has shape `[ceil(N/bs), ceil(K/bs)]`, so `Bs.shape[0]` is the N-group count, not K-group count. For `kv_a_proj_with_mqa` (N=576, K=2560, block_size=128):

- **Before**: `bs = 2560 // 5 = 512` → pads N to 1024 → `group_n = 1024/5 = 204` → oneDNN rejects
- **After**: `bs = 2560 // 20 = 128` → pads N to 640 → `group_n = 640/5 = 128` → works

## Changes

- **`vllm/model_executor/kernels/linear/scaled_mm/xpu.py`**:  Add N-dimension padding and output slicing for unaligned weights.
- **`tests/models/registry.py`**: Add `max_model_len=4096` for `DeepseekV3ForCausalLM`, `EagleDeepSeekMTPModel`, and `DeepSeekMTPModel` to prevent OOM on 24 GiB XPU devices.
- **`.buildkite/intel_jobs/misc_intel.yaml`**: Enable additional model initialization tests in Intel CI.

## Test
```bash
VLLM_XPU_FUSED_MOE_USE_REF=1 pytest -v -s \
  models/test_initialization.py::test_can_initialize_small_subset[DeepSeekMTPModel]