### PR TITLE
[XPU] fix collecting oneccl version info

### DIFF
--- a/vllm/collect_env.py
+++ b/vllm/collect_env.py
@@ -303,8 +303,8 @@ def get_xpu_runtime_version():
 def get_pkg_version(run_lambda, pkg):
     assert get_platform() == "linux"
 
-    if pkg == "vllm_xpu_kernels":
-        rc, out, _ = run_lambda("pip show vllm-xpu-kernels")
+    if pkg in ["vllm_xpu_kernels", "oneccl"]:
+        rc, out, _ = run_lambda(f"pip show {pkg}")
         if rc == 0:
             match = re.search(r"Version: (.*)", out)
             return match.group(1).strip() if match else None
@@ -314,7 +314,6 @@ def get_pkg_version(run_lambda, pkg):
         "igc": ["intel-igc-core", "libigc2", "libigc1"],
         "level_zero_loader": ["level-zero", "libze1"],
         "level_zero_driver": ["libze-intel-gpu1", "intel-level-zero-gpu"],
-        "oneccl": ["intel-oneapi-ccl", "oneccl"],
         "libigdgmm": ["libigdgmm12", "libigdgmm"],
     }
 


### PR DESCRIPTION



## Purpose
`oneccl` version info on XPU platform should not be collected from apt lib. Here we refer the `mpirun --version` as it reflects the correct oneCCL system really uses.

## Test Plan
`python vllm/collect_env.py`

## Test Result
```
Collecting environment information...
==============================
        System Info
==============================
OS                           : Ubuntu 24.04.4 LTS (x86_64)
GCC version                  : (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
Clang version                : Could not collect
CMake version                : version 4.4.0
Libc version                 : glibc-2.39

==============================
       PyTorch Info
==============================
PyTorch version              : 2.13.0+xpu
Is debug build               : False
CUDA used to build PyTorch   : None
ROCM used to build PyTorch   : N/A
XPU used to build PyTorch    : 20260000

==============================
      Python Environment
==============================
Python version               : 3.12.3 (main, Mar 23 2026, 19:04:32) [GCC 13.3.0] (64-bit runtime)
Python platform              : Linux-6.14.0-1009-intel-x86_64-with-glibc2.39

==============================
      Intel XPU / GPU Info
==============================
Is XPU available             : True
XPU runtime version          : 20260000
Intel GPU models             :
GPU 0: Intel(R) Arc(TM) Pro B60 Graphics
GPU 1: Intel(R) Arc(TM) Pro B60 Graphics
GPU 2: Intel(R) Arc(TM) Pro B60 Graphics
GPU 3: Intel(R) Arc(TM) Pro B60 Graphics
GPU 4: Intel(R) Arc(TM) Pro B60 Graphics
GPU 5: Intel(R) Arc(TM) Pro B60 Graphics
GPU 6: Intel(R) Arc(TM) Pro B60 Graphics
GPU 7: Intel(R) Arc(TM) Pro B60 Graphics


--Compile time--
oneAPI compiler version      : Could not collect
SYCL compiler build          : Could not collect
oneCCL version               : 2022.0.0

--Runtime--
Intel Graphics Compiler (IGC): 2.34.4
Intel GMM (libigdgmm)        : 22.10.0
Level Zero loader version    : 1.28.2
Level Zero driver version    : 26.18.38308.1-0
vLLM XPU kernels version     : 0.1.12.dev10+g6b00783

==============================
          CPU Info
==============================
Architecture:                            x86_64
CPU op-mode(s):                          32-bit, 64-bit
Address sizes:                           46 bits physical, 57 bits virtual
Byte Order:                              Little Endian
CPU(s):                                  192
On-line CPU(s) list:                     0-191
Vendor ID:                               GenuineIntel
BIOS Vendor ID:                          Intel(R) Corporation
Model name:                              Intel(R) Xeon(R) Platinum 8468
BIOS Model name:                         Intel(R) Xeon(R) Platinum 8468  CPU @ 2.1GHz
BIOS CPU family:                         179
CPU family:                              6
Model:                                   143
Thread(s) per core:                      2
Core(s) per socket:                      48
Socket(s):                               2
Stepping:                                8
CPU(s) scaling MHz:                      22%
CPU max MHz:                             3800.0000
CPU min MHz:                             800.0000
BogoMIPS:                                4200.00
Flags:                                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cat_l2 cdp_l3 intel_ppin cdp_l2 ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb intel_pt avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local split_lock_detect user_shstk avx_vnni avx512_bf16 wbnoinvd dtherm ida arat pln pts vnmi avx512vbmi umip pku ospke waitpkg avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq la57 rdpid bus_lock_detect cldemote movdiri movdir64b enqcmd fsrm md_clear serialize tsxldtrk pconfig arch_lbr ibt amx_bf16 avx512_fp16 amx_tile amx_int8 flush_l1d arch_capabilities
Virtualization:                          VT-x
L1d cache:                               4.5 MiB (96 instances)
L1i cache:                               3 MiB (96 instances)
L2 cache:                                192 MiB (96 instances)
L3 cache:                                210 MiB (2 instances)
NUMA node(s):                            8
NUMA node0 CPU(s):                       0-11,96-107
NUMA node1 CPU(s):                       12-23,108-119
NUMA node2 CPU(s):                       24-35,120-131
NUMA node3 CPU(s):                       36-47,132-143
NUMA node4 CPU(s):                       48-59,144-155
NUMA node5 CPU(s):                       60-71,156-167
NUMA node6 CPU(s):                       72-83,168-179
NUMA node7 CPU(s):                       84-95,180-191
Vulnerability Gather data sampling:      Not affected
Vulnerability Ghostwrite:                Not affected
Vulnerability Indirect target selection: Not affected
Vulnerability Itlb multihit:             Not affected
Vulnerability L1tf:                      Not affected
Vulnerability Mds:                       Not affected
Vulnerability Meltdown:                  Not affected
Vulnerability Mmio stale data:           Not affected
Vulnerability Reg file data sampling:    Not affected
Vulnerability Retbleed:                  Not affected
Vulnerability Spec rstack overflow:      Not affected
Vulnerability Spec store bypass:         Mitigation; Speculative Store Bypass disabled via prctl
Vulnerability Spectre v1:                Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:                Mitigation; Enhanced / Automatic IBRS; IBPB conditional; PBRSB-eIBRS SW sequence; BHI BHI_DIS_S
Vulnerability Srbds:                     Not affected
Vulnerability Tsx async abort:           Not affected

==============================
Versions of relevant libraries
==============================
[pip3] numpy==2.2.6
[pip3] pyzmq==27.1.0
[pip3] sentence-transformers==5.3.0
[pip3] torch==2.13.0+xpu
[pip3] torchaudio==2.11.0+xpu
[pip3] torchcodec==0.15.0+cpu
[pip3] torchvision==0.28.0+xpu
[pip3] transformers==5.13.1
[pip3] triton-xpu==3.7.2
[conda] Could not collect

==============================
         vLLM Info
==============================
ROCM Version                 : Could not collect
vLLM Version                 : 0.1.dev18804+g3e147c6c8.d20260720 (git sha: 3e147c6c8, date: 20260720)
vLLM Build Flags:
  CUDA Archs: Not Set; ROCm: Disabled; XPU: Enabled
GPU Topology:
  Could not collect

==============================
     Environment Variables
==============================
VLLM_WORKER_MULTIPROC_METHOD=spawn
VLLM_TARGET_DEVICE=xpu
LD_LIBRARY_PATH=/tmp/ucx_install/lib:/opt/venv/lib:/usr/local/lib
PYTORCH_NVML_BASED_CUDA_CHECK=1
TORCHINDUCTOR_COMPILE_THREADS=1
TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_root

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

