### PR TITLE
[Frontend] Enforce max_tool_calls for Responses built-in tools

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -86,6 +86,48 @@ class MockConversationContext(ConversationContext):
         pass
 
 
+class ToolCallingConversationContext(MockConversationContext):
+    """Context that asks for multiple builtin tool calls."""
+
+    def __init__(self, requested_tool_calls: int):
+        super().__init__()
+        self.requested_tool_calls = requested_tool_calls
+        self.tool_call_count = 0
+
+    def need_builtin_tool_call(self) -> bool:
+        return self.tool_call_count < self.requested_tool_calls
+
+    async def call_tool(self):
+        self.tool_call_count += 1
+        return []
+
+
+class FakeServingForToolCalls:
+    def __init__(self):
+        self.model_config = MagicMock()
+        self.model_config.max_model_len = 100
+        self.engine_client = MagicMock()
+        self.engine_client.generate.side_effect = self._generate
+        self.default_sampling_params = None
+        self.override_max_tokens = None
+
+    def _log_inputs(self, *args, **kwargs):
+        pass
+
+    def _extract_prompt_len(self, engine_input):
+        return len(engine_input["prompt_token_ids"])
+
+    async def _generate(self, *args, **kwargs):
+        yield RequestOutput(
+            request_id="req",
+            prompt=None,
+            prompt_token_ids=[1],
+            prompt_logprobs=None,
+            outputs=[],
+            finished=True,
+        )
+
+
 def test_serialize_message_pydantic_model_returns_dict() -> None:
     msg = ResponseRawMessageAndToken(message="hello", tokens=[1, 2, 3])
 
@@ -203,6 +245,26 @@ def test_response_created_event_uses_public_json_schema_alias() -> None:
     assert event.response.text is not None
     assert event.response.text.format is not None
     assert event.response.text.format.model_dump(by_alias=True)["schema"] == schema
+
+
+@pytest.mark.asyncio
+async def test_generate_with_builtin_tools_honors_max_tool_calls() -> None:
+    serving = FakeServingForToolCalls()
+    context = ToolCallingConversationContext(requested_tool_calls=2)
+
+    generator = OpenAIServingResponses._generate_with_builtin_tools(
+        serving,
+        request_id="req",
+        engine_input=tokens_input([1]),
+        sampling_params=SamplingParams(max_tokens=16),
+        context=context,
+        max_tool_calls=1,
+    )
+    async for _ in generator:
+        pass
+
+    assert context.tool_call_count == 1
+    assert serving.engine_client.generate.call_count == 2
 
 
 class TestInitializeToolSessions:

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -519,6 +519,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 reasoning_parser_kwargs=reasoning_parser_kwargs
                 if self.parser and self.parser.reasoning_parser_cls is not None
                 else None,
+                max_tool_calls=request.max_tool_calls,
             )
             generators.append(generator)
 
@@ -664,11 +665,13 @@ class OpenAIServingResponses(GenerateBaseServing):
         priority: int = 0,
         trace_headers: Mapping[str, str] | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
+        max_tool_calls: int | None = None,
     ):
         max_model_len = self.model_config.max_model_len
 
         orig_priority = priority
         sub_request = 0
+        tool_call_count = 0
         while True:
             # Ensure that each sub-request has a unique request id.
             sub_request_id = f"{request_id}_{sub_request}"
@@ -698,9 +701,12 @@ class OpenAIServingResponses(GenerateBaseServing):
             if not context.need_builtin_tool_call():
                 # The model did not ask for a tool call, so we're done.
                 break
+            if max_tool_calls is not None and tool_call_count >= max_tool_calls:
+                break
 
             # Call the tool and update the context with the result.
             tool_output = await context.call_tool()
+            tool_call_count += 1
             context.append_tool_output(tool_output)
 
             # TODO: uncomment this and enable tool output streaming


### PR DESCRIPTION
## Purpose

This PR makes `ResponsesRequest.max_tool_calls` effective for Responses built-in tool execution.

The Responses API already accepts and returns `max_tool_calls`, but the built-in tool generation loop did not enforce it before calling tools. This change threads the request value into the loop and stops executing further built-in tool calls once the configured limit is reached.

I checked existing open PRs/issues for `max_tool_calls responses` and did not find an overlapping change. This PR was developed with AI assistance.

## Test Plan

Run the targeted regression test, the related Responses serving test file, and formatting/lint checks for the changed files.

## Test Result

```bash
.venv/bin/python -m pytest tests/entrypoints/openai/responses/test_serving_responses.py::test_generate_with_builtin_tools_honors_max_tool_calls -q
```

```text
1 passed
```

```bash
.venv/bin/python -m pytest tests/entrypoints/openai/responses/test_serving_responses.py -q
```

```text
22 passed
```

```bash
pre-commit run ruff-check --files vllm/entrypoints/openai/responses/serving.py tests/entrypoints/openai/responses/test_serving_responses.py
```

```text
ruff check...............................................................Passed
```

```bash
pre-commit run ruff-format --files vllm/entrypoints/openai/responses/serving.py tests/entrypoints/openai/responses/test_serving_responses.py
```

```text
ruff format..............................................................Passed
```

```bash
git diff --check
```

```text
Passed
```
