### PR TITLE
Fix silent ignore of unsupported content part types in Harmony path

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_validation.py
+++ b/tests/entrypoints/openai/parser/test_harmony_validation.py
@@ -2,14 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
-from vllm.exceptions import VLLMValidationError
+
 from vllm.entrypoints.openai.parser.harmony_utils import (
     parse_chat_input_to_harmony_message,
 )
 from vllm.entrypoints.openai.responses.harmony import (
-    response_previous_input_to_harmony,
     response_input_to_harmony,
+    response_previous_input_to_harmony,
 )
+from vllm.exceptions import VLLMValidationError
 
 
 @pytest.fixture()

--- a/tests/entrypoints/openai/parser/test_harmony_validation.py
+++ b/tests/entrypoints/openai/parser/test_harmony_validation.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from vllm.exceptions import VLLMValidationError
+from vllm.entrypoints.openai.parser.harmony_utils import (
+    parse_chat_input_to_harmony_message,
+)
+from vllm.entrypoints.openai.responses.harmony import (
+    response_previous_input_to_harmony,
+    response_input_to_harmony,
+)
+
+
+@pytest.fixture()
+def should_do_global_cleanup_after_test() -> bool:
+    return False
+
+
+def test_parse_chat_input_unsupported_content_type():
+    chat_msg = {
+        "role": "user",
+        "content": [
+            {
+                "type": "input_file",
+                "file": {
+                    "filename": "test.pdf",
+                    "file_data": "data:application/pdf;base64,dGVzdA==",
+                },
+            },
+            {"type": "text", "text": "Summarize the document"},
+        ],
+    }
+
+    with pytest.raises(VLLMValidationError) as exc_info:
+        parse_chat_input_to_harmony_message(chat_msg)
+
+    assert "Unsupported chat content part type: 'input_file'" in str(exc_info.value)
+    assert exc_info.value.parameter == "type"
+    assert exc_info.value.value == "input_file"
+
+
+def test_response_previous_input_unsupported_content_type():
+    chat_msg = {
+        "role": "user",
+        "content": [
+            {
+                "type": "file",
+                "file": {
+                    "filename": "test.pdf",
+                    "file_data": "data:application/pdf;base64,dGVzdA==",
+                },
+            }
+        ],
+    }
+
+    with pytest.raises(VLLMValidationError) as exc_info:
+        response_previous_input_to_harmony(chat_msg)
+
+    assert "Unsupported chat content part type: 'file'" in str(exc_info.value)
+    assert exc_info.value.parameter == "type"
+    assert exc_info.value.value == "file"
+
+
+def test_response_input_unsupported_content_type():
+    response_msg = {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "invalid_type", "text": "test"}],
+    }
+
+    with pytest.raises(VLLMValidationError) as exc_info:
+        response_input_to_harmony(response_msg, prev_responses=[])
+
+    assert "Unsupported chat content part type: 'invalid_type'" in str(exc_info.value)
+    assert exc_info.value.parameter == "type"
+    assert exc_info.value.value == "invalid_type"

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -348,6 +348,65 @@ def build_harmony_preamble(
     return messages
 
 
+def _validate_content_parts(content: Any, role: str | None = None) -> None:
+    if role == "tool":
+        return
+    if isinstance(content, list):
+        for c in content:
+            if isinstance(c, dict):
+                part_type = c.get("type")
+                if part_type is None:
+                    if "image_url" in c:
+                        part_type = "image_url"
+                    elif "image_pil" in c:
+                        part_type = "image_pil"
+                    elif "image_embeds" in c:
+                        part_type = "image_embeds"
+                    elif "audio_embeds" in c:
+                        part_type = "audio_embeds"
+                    elif "prompt_embeds" in c:
+                        part_type = "prompt_embeds"
+                    elif "audio_url" in c:
+                        part_type = "audio_url"
+                    elif "input_audio" in c:
+                        part_type = "input_audio"
+                    elif "video_url" in c:
+                        part_type = "video_url"
+                    elif "tool_reference" in c:
+                        part_type = "tool_reference"
+                    else:
+                        part_type = "text"
+
+                # Check if it is valid/supported
+                from vllm.exceptions import VLLMValidationError
+
+                supported = {
+                    "text",
+                    "thinking",
+                    "input_text",
+                    "output_text",
+                    "input_image",
+                    "image_url",
+                    "image_embeds",
+                    "audio_embeds",
+                    "prompt_embeds",
+                    "image_pil",
+                    "audio_url",
+                    "input_audio",
+                    "refusal",
+                    "video_url",
+                    "tool_reference",
+                }
+                if part_type not in supported:
+                    supported_str = ", ".join(sorted(supported))
+                    raise VLLMValidationError(
+                        f"Unsupported chat content part type: {part_type!r}. "
+                        f"Supported types: {supported_str}.",
+                        parameter="type",
+                        value=part_type,
+                    )
+
+
 def parse_chat_input_to_harmony_message(
     chat_msg, tool_id_names: dict[str, str] | None = None
 ) -> list[Message]:
@@ -362,6 +421,7 @@ def parse_chat_input_to_harmony_message(
         chat_msg = chat_msg.model_dump(exclude_none=True)
 
     role = chat_msg.get("role")
+    _validate_content_parts(chat_msg.get("content"), role)
     msgs: list[Message] = []
 
     # Assistant message with tool calls

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -9,6 +9,7 @@ Handles two directions:
 """
 
 import json
+from typing import Any
 
 from openai.types.responses import (
     ResponseFunctionToolCall,
@@ -45,9 +46,64 @@ from vllm.utils import random_uuid
 
 logger = init_logger(__name__)
 
-# ---------------------------------------------------------------------------
-# 1. Private helpers for input parsing
-# ---------------------------------------------------------------------------
+
+def _validate_content_parts(content: Any, role: str | None = None) -> None:
+    if role == "tool":
+        return
+    if isinstance(content, list):
+        for c in content:
+            if isinstance(c, dict):
+                part_type = c.get("type")
+                if part_type is None:
+                    if "image_url" in c:
+                        part_type = "image_url"
+                    elif "image_pil" in c:
+                        part_type = "image_pil"
+                    elif "image_embeds" in c:
+                        part_type = "image_embeds"
+                    elif "audio_embeds" in c:
+                        part_type = "audio_embeds"
+                    elif "prompt_embeds" in c:
+                        part_type = "prompt_embeds"
+                    elif "audio_url" in c:
+                        part_type = "audio_url"
+                    elif "input_audio" in c:
+                        part_type = "input_audio"
+                    elif "video_url" in c:
+                        part_type = "video_url"
+                    elif "tool_reference" in c:
+                        part_type = "tool_reference"
+                    else:
+                        part_type = "text"
+
+                # Check if it is valid/supported
+                from vllm.exceptions import VLLMValidationError
+
+                supported = {
+                    "text",
+                    "thinking",
+                    "input_text",
+                    "output_text",
+                    "input_image",
+                    "image_url",
+                    "image_embeds",
+                    "audio_embeds",
+                    "prompt_embeds",
+                    "image_pil",
+                    "audio_url",
+                    "input_audio",
+                    "refusal",
+                    "video_url",
+                    "tool_reference",
+                }
+                if part_type not in supported:
+                    supported_str = ", ".join(sorted(supported))
+                    raise VLLMValidationError(
+                        f"Unsupported chat content part type: {part_type!r}. "
+                        f"Supported types: {supported_str}.",
+                        parameter="type",
+                        value=part_type,
+                    )
 
 
 def _parse_harmony_format_message(chat_msg: dict) -> Message:
@@ -58,6 +114,7 @@ def _parse_harmony_format_message(chat_msg: dict) -> Message:
     name = author_dict.get("name")
 
     raw_content = chat_msg.get("content", "")
+    _validate_content_parts(raw_content, role)
     if isinstance(raw_content, list):
         # TODO: Support refusal and non-text content types.
         contents = [TextContent(text=c.get("text", "")) for c in raw_content]
@@ -89,6 +146,8 @@ def _parse_chat_format_message(chat_msg: dict) -> list[Message]:
     role = chat_msg.get("role")
     if role is None:
         raise ValueError(f"Message has no 'role' key: {chat_msg}")
+
+    _validate_content_parts(chat_msg.get("content"), role)
 
     # Assistant message with tool calls
     tool_calls = chat_msg.get("tool_calls")
@@ -159,6 +218,7 @@ def response_input_to_harmony(
     if "type" not in response_msg or response_msg["type"] == "message":
         role = response_msg["role"]
         content = response_msg["content"]
+        _validate_content_parts(content, role)
         if role in ("system", "developer"):
             text = flatten_input_text_content(content)
             if text:


### PR DESCRIPTION
For models using the Harmony parsing/rendering path, if a user sends a request with an unsupported content type in the messages (such as `input_file` or `file`), the parser/renderer silently ignored them instead of raising an HTTP 400 Bad Request error. This PR adds validation to reject unsupported types.