### PR TITLE
[codex] Add task embedding serve alias

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -214,6 +214,21 @@ def test_jit_monitor_verbose_arg():
     assert EngineArgs(model="test", jit_monitor_verbose=True).jit_monitor_verbose
 
 
+@pytest.mark.parametrize("task", ["embed", "embedding"])
+def test_task_embedding_alias_sets_pooling_runner(task):
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(["--task", task])
+
+    assert args.runner == "pooling"
+
+
+def test_task_alias_rejects_unknown_task():
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--task", "generate"])
+
+
 @pytest.mark.parametrize("mode", ["warn", "error"])
 def test_jit_monitor_mode_arg(mode):
     parser = EngineArgs.add_cli_args(FlexibleArgumentParser())

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -134,6 +134,17 @@ else:
 
 logger = init_logger(__name__)
 
+
+def pooling_runner_alias(value: str) -> str:
+    if value in ("embed", "embedding"):
+        return "pooling"
+    msg = (
+        f"invalid task: {value!r} (choose from 'embed', 'embedding'; "
+        "use --runner for other runner types)"
+    )
+    raise argparse.ArgumentTypeError(msg)
+
+
 # object is used to allow for special typing forms
 T = TypeVar("T")
 TypeHint: TypeAlias = type[Any] | object
@@ -796,6 +807,15 @@ class EngineArgs:
         if not ("serve" in sys.argv[1:] and "--help" in sys.argv[1:]):
             model_group.add_argument("--model", **model_kwargs["model"])
         model_group.add_argument("--runner", **model_kwargs["runner"])
+        model_group.add_argument(
+            "--task",
+            dest="runner",
+            type=pooling_runner_alias,
+            default=argparse.SUPPRESS,
+            metavar="{embed,embedding}",
+            help="Deprecated compatibility alias for embedding servers. "
+            "Use --runner pooling instead.",
+        )
         model_group.add_argument("--convert", **model_kwargs["convert"])
         model_group.add_argument("--tokenizer", **model_kwargs["tokenizer"])
         model_group.add_argument("--tokenizer-mode", **model_kwargs["tokenizer_mode"])


### PR DESCRIPTION
## Summary

Adds a small compatibility alias for embedding servers so `vllm serve ... --task embedding` and `--task embed` select the existing pooling runner path, equivalent to `--runner pooling`.

This addresses #35603, where users following embedding-model terminology hit an argparse failure before the server can start or expose `/v1/embeddings`.

## Why

The OpenAI-compatible embeddings endpoint is served through vLLM's pooling runner. Current CLI parsing rejects `--task embedding` outright, which is a common spelling users try for embedding models. Mapping the alias at parse time keeps the existing `ModelConfig.runner` flow unchanged while providing a focused migration path to `--runner pooling`.

## Tests

- `python -m py_compile vllm/engine/arg_utils.py tests/engine/test_arg_utils.py`
- `git diff --check`
- Attempted: `python -m pytest tests/engine/test_arg_utils.py -k 'task_embedding_alias or task_alias_rejects_unknown_task'`
  - Blocked locally before test collection by a broken Anaconda PyTorch install: `libtorch_global_deps.dylib` is missing.
