### PR TITLE
Enable FlashInfer + FP8 KV cache for text-only requests in Gemma 4 multimodal models

### DIFF
--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -316,18 +316,65 @@ class Attention(nn.Module, AttentionLayerBase):
         # weight and activation dtype.
         dtype = torch.get_default_dtype()
         if attn_backend is None:
-            self.attn_backend = get_attn_backend(
-                head_size,
-                dtype,
-                kv_cache_dtype,
-                use_mla=False,
-                has_sink=self.has_sink,
-                use_mm_prefix=self.use_mm_prefix,
-                use_per_head_quant_scales=use_per_head_quant_scales,
-                attn_type=attn_type,
-            )
+            # GEMMA4_FP8: Dual backend support for multimodal models
+            # Create both FlashInfer (text-only) and Triton (multimodal) backends
+            # to enable FP8 KV cache on both paths
+            if self.use_mm_prefix:
+                # Multimodal model: create dual backends for runtime selection
+                logger.info(
+                    "[GEMMA4_FP8] Creating dual backends for multimodal model: "
+                    "FlashInfer (text-only) + Triton (multimodal)"
+                )
+
+                # Backend for text-only requests (FlashInfer - faster on B200)
+                self.attn_backend_text = get_attn_backend(
+                    head_size,
+                    dtype,
+                    kv_cache_dtype,
+                    use_mla=False,
+                    has_sink=self.has_sink,
+                    use_mm_prefix=False,  # Disable mm_prefix for FlashInfer
+                    use_per_head_quant_scales=use_per_head_quant_scales,
+                    attn_type=attn_type,
+                )
+
+                # Backend for multimodal requests (Triton - supports mm_prefix)
+                self.attn_backend_multimodal = get_attn_backend(
+                    head_size,
+                    dtype,
+                    kv_cache_dtype,
+                    use_mla=False,
+                    has_sink=self.has_sink,
+                    use_mm_prefix=True,  # Enable mm_prefix for Triton
+                    use_per_head_quant_scales=use_per_head_quant_scales,
+                    attn_type=attn_type,
+                )
+
+                # Default to multimodal backend for compatibility
+                self.attn_backend = self.attn_backend_multimodal
+
+                logger.info(
+                    f"[GEMMA4_FP8] Text backend: {self.attn_backend_text.get_name()}, "
+                    f"Multimodal backend: {self.attn_backend_multimodal.get_name()}"
+                )
+            else:
+                # Standard model: single backend
+                self.attn_backend = get_attn_backend(
+                    head_size,
+                    dtype,
+                    kv_cache_dtype,
+                    use_mla=False,
+                    has_sink=self.has_sink,
+                    use_mm_prefix=self.use_mm_prefix,
+                    use_per_head_quant_scales=use_per_head_quant_scales,
+                    attn_type=attn_type,
+                )
+                self.attn_backend_text = None
+                self.attn_backend_multimodal = None
         else:
             self.attn_backend = attn_backend
+            self.attn_backend_text = None
+            self.attn_backend_multimodal = None
         backend_supports_alibi_sqrt = self.attn_backend.supports_alibi_sqrt()
         use_alibi_sqrt = use_alibi_sqrt if use_alibi_sqrt else False
         if use_alibi_sqrt and not backend_supports_alibi_sqrt:
@@ -384,20 +431,71 @@ class Attention(nn.Module, AttentionLayerBase):
             if block_n is not None:
                 extra_impl_args.setdefault("block_n", block_n)
 
-        impl_cls = self.attn_backend.get_impl_cls()
-        self.impl = impl_cls(  # type: ignore[assignment]  # impl_cls always returns an AttentionImpl subclass
-            num_heads,
-            head_size,
-            scale,
-            num_kv_heads,
-            alibi_slopes,
-            sliding_window,
-            kv_cache_dtype,
-            logits_soft_cap,
-            attn_type,
-            kv_sharing_target_layer_name,
-            **extra_impl_args,
-        )
+        # GEMMA4_FP8: Create dual impl instances for dual backend models
+        if self.use_mm_prefix and self.attn_backend_text is not None:
+            # Filter extra_impl_args for FlashInfer (doesn't accept some params)
+            # FlashInfer only accepts: sinks (no use_alibi_sqrt, chunk_lookback, block_m, block_n)
+            flashinfer_extra_args = {
+                k: v for k, v in extra_impl_args.items()
+                if k == 'sinks'
+            }
+
+            # Triton accepts all extra_impl_args
+            triton_extra_args = extra_impl_args
+
+            # Create impl for text backend (FlashInfer)
+            impl_cls_text = self.attn_backend_text.get_impl_cls()
+            self.impl_text = impl_cls_text(
+                num_heads,
+                head_size,
+                scale,
+                num_kv_heads,
+                alibi_slopes,
+                sliding_window,
+                kv_cache_dtype,
+                logits_soft_cap,
+                attn_type,
+                kv_sharing_target_layer_name,
+                **flashinfer_extra_args,
+            )
+
+            # Create impl for multimodal backend (Triton)
+            impl_cls_multimodal = self.attn_backend_multimodal.get_impl_cls()
+            self.impl_multimodal = impl_cls_multimodal(
+                num_heads,
+                head_size,
+                scale,
+                num_kv_heads,
+                alibi_slopes,
+                sliding_window,
+                kv_cache_dtype,
+                logits_soft_cap,
+                attn_type,
+                kv_sharing_target_layer_name,
+                **triton_extra_args,
+            )
+
+            # Default to multimodal impl
+            self.impl = self.impl_multimodal
+        else:
+            # Single backend mode
+            impl_cls = self.attn_backend.get_impl_cls()
+            self.impl = impl_cls(  # type: ignore[assignment]  # impl_cls always returns an AttentionImpl subclass
+                num_heads,
+                head_size,
+                scale,
+                num_kv_heads,
+                alibi_slopes,
+                sliding_window,
+                kv_cache_dtype,
+                logits_soft_cap,
+                attn_type,
+                kv_sharing_target_layer_name,
+                **extra_impl_args,
+            )
+            self.impl_text = None
+            self.impl_multimodal = None
+
         self.backend = AttentionBackendEnum[self.attn_backend.get_name()]
         self.dtype = dtype
 
@@ -449,6 +547,44 @@ class Attention(nn.Module, AttentionLayerBase):
                 else GroupShape.PER_TENSOR,
             )
 
+    def select_backend(self, attn_metadata):
+        """Select appropriate attention backend based on batch composition.
+
+        For multimodal models with dual backends:
+        - Use FlashInfer for text-only batches (faster on B200 + FP8)
+        - Use Triton for multimodal batches (supports mm_prefix + FP8)
+
+        Args:
+            attn_metadata: Attention metadata containing batch information
+
+        Returns:
+            Selected attention backend instance
+        """
+        # Single backend mode (standard models)
+        if self.attn_backend_text is None:
+            return self.attn_backend
+
+        # Dual backend mode (multimodal models)
+        # Check if batch contains multimodal inputs via mm_prefix_range_tensor
+        has_multimodal = (
+            hasattr(attn_metadata, 'mm_prefix_range_tensor')
+            and attn_metadata.mm_prefix_range_tensor is not None
+        )
+
+        # DIAGNOSTIC LOGGING
+        logger.info(
+            f"[GEMMA4_FP8] Backend selection: has_multimodal={has_multimodal}, "
+            f"selected={'Triton' if has_multimodal else 'FlashInfer'}"
+        )
+
+        # Select backend based on batch composition
+        if has_multimodal:
+            # Batch contains images/audio/video - use Triton
+            return self.attn_backend_multimodal
+        else:
+            # Text-only batch - use FlashInfer (faster)
+            return self.attn_backend_text
+
     def forward(
         self,
         query: torch.Tensor,
@@ -468,6 +604,35 @@ class Attention(nn.Module, AttentionLayerBase):
         context using
         `vllm.forward_context.get_forward_context().attn_metadata`.
         """
+        # GEMMA4_FP8: Dynamic backend selection for dual backend models
+        if self.impl_text is not None and self.impl_multimodal is not None:
+            # Get attention metadata from forward context
+            try:
+                from vllm.forward_context import get_forward_context
+                forward_ctx = get_forward_context()
+                if forward_ctx and hasattr(forward_ctx, 'attn_metadata'):
+                    attn_metadata = forward_ctx.attn_metadata
+
+                    # Check if batch contains multimodal inputs
+                    has_multimodal = (
+                        hasattr(attn_metadata, 'mm_prefix_range_tensor')
+                        and attn_metadata.mm_prefix_range_tensor is not None
+                    )
+
+                    # Switch impl based on batch composition
+                    # NOTE: No logging here - torch.compile doesn't support it
+                    if has_multimodal:
+                        # Use Triton for multimodal (supports mm_prefix)
+                        self.impl = self.impl_multimodal
+                        self.attn_backend = self.attn_backend_multimodal
+                    else:
+                        # Use FlashInfer for text-only (faster on B200)
+                        self.impl = self.impl_text
+                        self.attn_backend = self.attn_backend_text
+            except Exception:
+                # If we can't get forward context, default to multimodal backend
+                pass
+
         if self.calculate_kv_scales:
             torch.ops.vllm.maybe_calc_kv_scales(
                 query, key, value, _encode_layer_name(self.layer_name)
@@ -576,6 +741,27 @@ class Attention(nn.Module, AttentionLayerBase):
             set_default_quant_scales(self, register_buffer=False)
 
     def get_attn_backend(self) -> type[AttentionBackend]:
+        """Get the active attention backend.
+
+        For dual-backend models, this returns the currently selected backend
+        based on the forward context's attention metadata.
+        """
+        # Single backend mode
+        if self.attn_backend_text is None:
+            return self.attn_backend
+
+        # Dual backend mode - select based on current batch
+        try:
+            from vllm.forward_context import get_forward_context
+            forward_ctx = get_forward_context()
+            if forward_ctx and hasattr(forward_ctx, 'attn_metadata'):
+                attn_metadata = forward_ctx.attn_metadata
+                return self.select_backend(attn_metadata)
+        except Exception:
+            # Fallback to default if context not available
+            pass
+
+        # Default to multimodal backend (safer)
         return self.attn_backend
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -480,6 +480,15 @@ class CudaPlatformBase(Platform):
                     selected_backend.name,
                 )
 
+        # DIAGNOSTIC LOGGING: Track backend selection for Gemma4 FP8 debugging
+        logger.info(
+            f"[GEMMA4_FP8_DEBUG] Backend selection: "
+            f"selected={selected_backend.name}, "
+            f"kv_cache_dtype={attn_selector_config.kv_cache_dtype}, "
+            f"use_mm_prefix={attn_selector_config.use_mm_prefix}, "
+            f"valid_backends={[c.backend.name for c in valid_backends_priorities]}"
+        )
+
         logger.info_once(
             "Using %s attention backend out of potential backends: %s.",
             selected_backend.name,

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -519,6 +519,14 @@ class TritonAttentionImpl(AttentionImpl):
         self._kv_quant_mode = get_kv_quant_mode(kv_cache_dtype)
         self._is_per_token_head_quant = self._kv_quant_mode.is_per_token_head
 
+        # DIAGNOSTIC LOGGING: Track FP8 configuration
+        logger.info(
+            f"[GEMMA4_FP8_DEBUG] TritonAttentionImpl.__init__: "
+            f"kv_cache_dtype={kv_cache_dtype}, "
+            f"_kv_quant_mode={self._kv_quant_mode.name}({self._kv_quant_mode.value}), "
+            f"is_per_token_head={self._is_per_token_head_quant}"
+        )
+
         # Enable tensor descriptors for Q/K/V load/store on platforms that
         # benefit from HW 2D block reads (Intel Xe2/Xe3).  The dead branch
         # is eliminated at Triton compile time, so other platforms see
@@ -602,6 +610,11 @@ class TritonAttentionImpl(AttentionImpl):
             k_scale_cache = self._k_scale_cache
             v_scale_cache = self._v_scale_cache
             q_descale = k_descale = v_descale = None
+            # DIAGNOSTIC LOGGING
+            logger.info(
+                f"[GEMMA4_FP8_DEBUG] forward: Using per-token-head quant path, "
+                f"mode={self._kv_quant_mode.name}"
+            )
         # FP8 per-tensor / auto path (original flow).
         else:
             key_cache, value_cache = kv_cache.unbind(1)
@@ -611,6 +624,22 @@ class TritonAttentionImpl(AttentionImpl):
             ):
                 key_cache = key_cache.view(self.fp8_dtype)
                 value_cache = value_cache.view(self.fp8_dtype)
+                # DIAGNOSTIC LOGGING
+                logger.info(
+                    f"[GEMMA4_FP8_DEBUG] forward: FP8 quantized KV cache detected, "
+                    f"kv_cache_dtype={self.kv_cache_dtype}, "
+                    f"key_cache.dtype={key_cache.dtype}, "
+                    f"value_cache.dtype={value_cache.dtype}"
+                )
+            else:
+                # DIAGNOSTIC LOGGING
+                logger.info(
+                    f"[GEMMA4_FP8_DEBUG] forward: Non-quantized or already correct dtype, "
+                    f"kv_cache_dtype={self.kv_cache_dtype}, "
+                    f"is_quantized={is_quantized_kv_cache(self.kv_cache_dtype)}, "
+                    f"key_cache.dtype={key_cache.dtype}, "
+                    f"fp8_dtype={self.fp8_dtype}"
+                )
             descale_shape = (
                 attn_metadata.query_start_loc.shape[0] - 1,
                 key_cache.shape[2],
@@ -641,6 +670,20 @@ class TritonAttentionImpl(AttentionImpl):
         softmax_segm_expsum = attn_metadata.softmax_segm_expsum
 
         mm_prefix_range_tensor = attn_metadata.mm_prefix_range_tensor
+
+        # DIAGNOSTIC LOGGING: Log kernel call parameters
+        logger.info(
+            f"[GEMMA4_FP8_DEBUG] Calling unified_attention: "
+            f"kv_quant_mode={self._kv_quant_mode.name}({self._kv_quant_mode.value}), "
+            f"has_mm_prefix_range={mm_prefix_range_tensor is not None}, "
+            f"k_descale={k_descale is not None}, "
+            f"v_descale={v_descale is not None}, "
+            f"k_scale_cache={k_scale_cache is not None}, "
+            f"v_scale_cache={v_scale_cache is not None}, "
+            f"query.dtype={query.dtype}, "
+            f"key_cache.dtype={key_cache.dtype}, "
+            f"value_cache.dtype={value_cache.dtype}"
+        )
 
         unified_attention(
             q=query[:num_actual_tokens],


### PR DESCRIPTION
# Problem

FlashInfer is the preferred attention backend for B200 GPUs and supports FP8 KV cache. However, Gemma 4 multimodal models set `use_mm_prefix=True` globally, which:

  - **Disables FlashInfer** (doesn't support `mm_prefix`)
  - **Forces Triton backend** with bfloat16 KV cache
  - **Affects ALL requests**, even text-only (which don't need `mm_prefix`)

  Result: Text-only workloads suffers performance significantly by not using FlashInfer + FP8.

  ## Solution

  Dual backend support with runtime switching:

  - **Text-only batches** → FlashInfer backend (`use_mm_prefix=False`) + FP8 KV cache
  - **Multimodal batches** → Triton backend (`use_mm_prefix=True`) + bfloat16
  - **Detection**: Check `mm_prefix_range_tensor` presence at runtime

### Performance Benchmark Results

**Configuration**: Gemma-4-31B-it, B200 GPUs (4x TP), 1024 tokens I/O

| Conc | Total (tok/s) | Output (tok/s) | TTFT (ms) | TPOT (ms) | E2EL (ms) |
|------|---------------|----------------|-----------|-----------|-----------|
|      | Main / **FP8** | Main / **FP8** | Main / **FP8** | Main / **FP8** | Main / **FP8** |
|------|---------------|----------------|-----------|-----------|-----------|
| 32 | 7055 / **8765** | 3527 / **4382** | 237 / **269** | 8.8 / **7.0** | 9286 / **7475** |
| 64 | 9170 / **14360** | 4585 / **7180** | 357 / **370** | 13.6 / **8.6** | 14290 / **9124** |
| 96 | 10099 / **17991** | 5049 / **8995** | 438 / **426** | 18.2 / **10.0** | 19047 / **10662** |
| 128 | 12752 / **21363** | 6376 / **10681** | 522 / **514** | 19.6 / **11.5** | 20541 / **12261** |
| 192 | 12752 / **21367** | 6376 / **10684** | 9493 / **5772** | 19.7 / **11.7** | 29622 / **17696** |
| 256 | 12746 / **21357** | 6373 / **10678** | 18513 / **11164** | 19.7 / **11.7** | 38647 / **23089** |
| 384 | 12741 / **21346** | 6370 / **10673** | 34064 / **20475** | 19.7 / **11.7** | 54198 / **32400** |
| 512 | 12736 / **21316** | 6368 / **10658** | 47066 / **28302** | 19.7 / **11.7** | 67199 / **40232** |
| 640 | 12722 / **21301** | 6361 / **10650** | 57569 / **34583** | 19.7 / **11.7** | 77713 / **46517** | 

 ## How to Reproduce
  
  ### Server Command (FP8)
  
  ```bash
  vllm serve google/gemma-4-31B-it \
      --port 8000 \
      --tensor-parallel-size 4 \
      --max-num-seqs 128 \
      --max-model-len 8192 \
      --kv-cache-dtype fp8_e4m3 \
      --quantization fp8

  Benchmark Command
  
  vllm bench serve \
      --port 8000 \
      --model google/gemma-4-31B-it \
      --dataset-name random \
      --max-concurrency 128 \
      --random-input-len 1024 \
      --random-output-len 1024 \
      --num-prompts 1024 \
      --ignore-eos \
      --trust-remote-code
```

##gsm8k
'''bash
python -m lm_eval --model vllm \
    --model_args "pretrained=google/gemma-4-31B-it,tensor_parallel_size=4,dtype=bfloat16,kv_cache_dtype=fp8_e4m3,gpu_memory_utilization=0.5,trust_remote_code=true,max_model_len=4096" \
    --tasks gsm8k \
    --num_fewshot 5 \
    --limit 1000 \
    --batch_size 8 \
    --output_path "/tmp/lm_eval_gsm_fp8_e4m3_<timestamp>.json"
```
vllm ({'pretrained': 'google/gemma-4-31B-it', 'tensor_parallel_size': 4, 'dtype': 'bfloat16', 'kv_cache_dtype': 'fp8_e4m3', 'gpu_memory_utilization': 0.5, 'max_model_len': 4096}), gen_kwargs: ({}), limit: 1000.0, num_fewshot: 5, batch_size: 8
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.722|±  |0.0142|
|     |       |strict-match    |     5|exact_match|↑  |0.717|±  |0.0143|


Here is the gsm8k result for main branch for gemma4 model:
vllm ({'pretrained': 'google/gemma-4-31B-it', 'tensor_parallel_size': 4, 'dtype': 'bfloat16', 'kv_cache_dtype': 'fp8_e4m3', 'gpu_memory_utilization': 0.5, 'max_model_len': 4096}), gen_kwargs: ({}), limit: 1000.0, num_fewshot: 5, batch_size: 8
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.728|±  |0.0141|
|     |       |strict-match    |     5|exact_match|↑  |0.717|±  |0.0143|