### PR TITLE
[Bugfix] Fix misclassification of prefill as uniform decode for hybrid models

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1595,6 +1595,106 @@ def test_is_uniform_decode() -> None:
     )
 
 
+def test_compute_force_uniform_decode() -> None:
+    # Non-hybrid models
+    assert (
+        GPUModelRunner._compute_force_uniform_decode(
+            _schedule_new_request("req_0"), is_hybrid=False
+        )
+        is None
+    )
+    assert (
+        GPUModelRunner._compute_force_uniform_decode(
+            _schedule_cached_requests(
+                ["req_0"],
+                num_scheduled_tokens={"req_0": 1},
+                new_token_ids=[[1]],
+                num_computed_tokens=[5],
+                num_output_tokens=[5],
+            ),
+            is_hybrid=False,
+        )
+        is None
+    )
+
+    # Hybrid model: a brand-new (prefill) request is a context request.
+    assert (
+        GPUModelRunner._compute_force_uniform_decode(
+            _schedule_new_request("req_0"), is_hybrid=True
+        )
+        is False
+    )
+
+    # Hybrid model: a chunked-prefill cached request (num_output_tokens == 0)
+    # is still a context request.
+    assert (
+        GPUModelRunner._compute_force_uniform_decode(
+            _schedule_cached_requests(
+                ["req_0"],
+                num_scheduled_tokens={"req_0": 3},
+                new_token_ids=[[1]],
+                num_computed_tokens=[3],
+                num_output_tokens=[0],
+            ),
+            is_hybrid=True,
+        )
+        is False
+    )
+
+    # Hybrid model: a decode-only cached request (num_output_tokens > 0) has no
+    # context request, so the heuristic decides (None).
+    assert (
+        GPUModelRunner._compute_force_uniform_decode(
+            _schedule_cached_requests(
+                ["req_0"],
+                num_scheduled_tokens={"req_0": 1},
+                new_token_ids=[[1]],
+                num_computed_tokens=[5],
+                num_output_tokens=[5],
+            ),
+            is_hybrid=True,
+        )
+        is None
+    )
+
+    # Hybrid model: a mixed batch (one prefill + one decode) still contains a
+    # context request and must not be treated as uniform decode.
+    mixed = SchedulerOutput(
+        scheduled_new_reqs=[
+            NewRequestData(
+                req_id="prefill_req",
+                prompt_token_ids=[1, 2, 3],
+                mm_features=[],
+                sampling_params=SamplingParams(),
+                pooling_params=None,
+                block_ids=([0],),
+                num_computed_tokens=0,
+                lora_request=None,
+            )
+        ],
+        scheduled_cached_reqs=CachedRequestData(
+            req_ids=["decode_req"],
+            resumed_req_ids=set(),
+            new_token_ids=[[1]],
+            all_token_ids={},
+            new_block_ids=[None],
+            num_computed_tokens=[5],
+            num_output_tokens=[5],
+        ),
+        num_scheduled_tokens={"prefill_req": 3, "decode_req": 1},
+        total_num_scheduled_tokens=4,
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    assert (
+        GPUModelRunner._compute_force_uniform_decode(mixed, is_hybrid=True)
+        is False
+    )
+
+
 @pytest.mark.skipif(
     not current_platform.is_cuda(),
     reason="Attention backend FLASHINFER is only supported on CUDA.",

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -209,7 +209,11 @@ from vllm.v1.spec_decode.step3p5 import Step3p5MTPProposer
 from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
 from vllm.v1.spec_decode.utils import update_num_computed_tokens_for_batch_change
 from vllm.v1.structured_output.utils import apply_grammar_bitmask
-from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
+from vllm.v1.utils import (
+    CpuGpuBuffer,
+    compute_iteration_details,
+    record_function_or_nullcontext,
+)
 from vllm.v1.worker import mamba_utils
 from vllm.v1.worker.block_table import SlotMappingMode
 from vllm.v1.worker.cp_utils import (
@@ -3977,6 +3981,26 @@ class GPUModelRunner(
             else force_uniform_decode
         )
 
+    @staticmethod
+    def _compute_force_uniform_decode(
+        scheduler_output: "SchedulerOutput",
+        is_hybrid: bool,
+    ) -> bool | None:
+        """
+        Compute `force_uniform_decode` for the current iteration.
+
+        For hybrid models, a batch that still contains any context (prefill)
+        request must not be classified as a uniform decode batch, otherwise the
+        prefill tokens would be misclassified as decode tokens. Non-hybrid models
+        defer to the default heuristic.
+        """
+        if not is_hybrid:
+            return None
+        iteration_details = compute_iteration_details(scheduler_output)
+        if iteration_details.num_ctx_requests > 0:
+            return False
+        return None
+
     def _allow_microbatching(
         self, num_reqs: int, num_scheduled_tokens_np: np.ndarray
     ) -> bool:
@@ -4352,6 +4376,10 @@ class GPUModelRunner(
                     scheduler_output.num_common_prefix_blocks,
                 )
 
+            force_uniform_decode = self._compute_force_uniform_decode(
+                scheduler_output, self.model_config.is_hybrid
+            )
+
             (
                 cudagraph_mode,
                 batch_desc,
@@ -4368,6 +4396,7 @@ class GPUModelRunner(
                 allow_microbatching=self._allow_microbatching(
                     num_reqs, num_scheduled_tokens_np
                 ),
+                force_uniform_decode=force_uniform_decode,
             )
 
             logger.debug(


### PR DESCRIPTION


## Purpose
Fix misclassification of prefill as uniform decode for hybrid models

In Hybrid models, prefill and decode/spec_decode are handled with different logic. If a prefill is misidentified as spec_decode, the model will produce garbage output. When handling prefill, the state must be zeroed out (or not) based on has_initial_state; if this step is skipped, a random (uninitialized) state will be used in the computation.

https://github.com/vllm-project/vllm/blob/42365140980d2f56149822136e89d8365dfc80ca/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py#L1503-L1514

https://github.com/vllm-project/vllm/blob/42365140980d2f56149822136e89d8365dfc80ca/vllm/model_executor/layers/mamba/mamba_mixer2.py#L832-L844

If the number of tokens in a request's prompt happens to equal exactly 1 + num_spec_tokens, that request's prefill computation will be mistakenly treated as spec_decode, thereby using an uninitialized state and producing garbage output.

https://github.com/vllm-project/vllm/blob/97b5ce5c3931173b3efebca58e597b8e58730cd3/vllm/v1/worker/gpu_model_runner.py#L3810-L3828

## Test Plan

```python
import vllm
from vllm import LLM, SamplingParams

# Number of tokens is 4, equal to (1 + num_speculative_tokens)
prompts = ["The capital of France"]                                                                                                                                                                                                    

sampling_params = SamplingParams(temperature=0, top_p=1, max_tokens=12)

if __name__ == '__main__':
    llm = LLM(model="Qwen/Qwen3.5-35B-A3B-GPTQ-Int4",
        max_model_len=1024,
        speculative_config = {"method":"qwen3_5_mtp","num_speculative_tokens":3},
    )

    for i in range(4):
        outputs = llm.generate(prompts, sampling_params)
        print(f"Input: {outputs[0].prompt!r}\nOutput: {outputs[0].outputs[0].text!r}\n")
```


## Test Result
Old Result
```
Rendering prompts: 100%
Processed prompts: 100%
Input: 'The capital of France'
Output: 'калибровочный\n=  =\n\n=== Мор'

Rendering prompts: 100%
Processed prompts: 100%
Input: 'The capital of France'
Output: ' is a 2019 American animated science fiction comedy'

Rendering prompts: 100%
Processed prompts: 100%
Input: 'The capital of France'
Output: ' is a comprehensive guide to the history of the English language,'

Rendering prompts: 100%
Processed prompts: 100%
Input: 'The capital of France'
Output: ', the only viable path is to acknowledge the impossibility of'
```

New Result
```
Rendering prompts: 100%
Processed prompts: 100%
Input: 'The capital of France'
Output: ' is Paris.\nThe capital of France is Paris.\n'

Rendering prompts: 100%
Processed prompts: 100%
Input: 'The capital of France'
Output: ' is Paris.\nThe capital of France is Paris.\n'

Rendering prompts: 100%
Processed prompts: 100%
Input: 'The capital of France'
Output: ' is Paris.\nThe capital of France is Paris.\n'

Rendering prompts: 100%
Processed prompts: 100%
Input: 'The capital of France'
Output: ' is Paris.\nThe capital of France is Paris.\n'
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

