### PR TITLE
[Spec Decode] Add D-cut: Adaptive Verification Depth Pruning for Batched Speculative Decoding

### DIFF
--- a/tests/v1/spec_decode/test_dcut.py
+++ b/tests/v1/spec_decode/test_dcut.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for DFlash D-Cut dynamic draft pruning.
+
+These tests cover the policy-free, hardware-independent parts of D-Cut:
+the keep-count formula, the keep-ratio metrics, the scheduler-side
+truncation/accounting, and the config surface (validation, mode
+normalization, and the async-scheduling gate).
+
+The GPU tensor selection path in ``DFlashProposer._select_dcut_keep_lens``
+and the warmup cost-table profiling are exercised by end-to-end runs, not
+here; they require real device tensors and a loaded DFlash model.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from tests.v1.core.utils import create_scheduler
+from vllm.config import SpeculativeConfig
+from vllm.v1.spec_decode.dflash import DFlashProposer
+from vllm.v1.spec_decode.metrics import SpecDecodingLogging, SpecDecodingStats
+
+
+# ---------------------------------------------------------------------------
+# Keep-count formula
+# ---------------------------------------------------------------------------
+# D-Cut interprets the ratio as the fraction of target-forward query tokens
+# kept, including the one bonus token reserved per request. The draft-token
+# budget is therefore ceil(bs * (num_draft + 1) * ratio) - bs.
+def test_dcut_keep_count_full_ratio_keeps_all_drafts():
+    # ratio=1.0 keeps every draft token: bs*(K+1) - bs == bs*K.
+    assert DFlashProposer._get_dcut_keep_count(8, 3, 1.0) == 8 * 3
+
+
+def test_dcut_keep_count_reserves_bonus_token():
+    # 4 reqs, K=3 -> 16 forward slots; half of that is 8, minus 4 bonus = 4.
+    assert DFlashProposer._get_dcut_keep_count(4, 3, 0.5) == 4
+
+
+def test_dcut_keep_count_zero_ratio_keeps_nothing():
+    assert DFlashProposer._get_dcut_keep_count(8, 3, 0.0) == 0
+
+
+def test_dcut_keep_count_never_negative():
+    # A ratio small enough to not even cover the bonus tokens clamps to 0.
+    assert DFlashProposer._get_dcut_keep_count(8, 3, 0.1) == 0
+
+
+def test_dcut_keep_count_rounds_up():
+    # ceil(1 * (3 + 1) * 0.6) - 1 = ceil(2.4) - 1 = 3 - 1 = 2.
+    assert DFlashProposer._get_dcut_keep_count(1, 3, 0.6) == 2
+
+
+def test_dcut_keep_count_bonus_boundary():
+    # ceil(1 * 4 * 0.25) - 1 = 1 - 1 = 0: the only kept slot is the bonus.
+    assert DFlashProposer._get_dcut_keep_count(1, 3, 0.25) == 0
+    # Just above the bonus boundary keeps a single draft.
+    assert DFlashProposer._get_dcut_keep_count(1, 3, 0.26) == 1
+
+
+# ---------------------------------------------------------------------------
+# Config: dflash_dcut validation, mode normalization, async gate
+# ---------------------------------------------------------------------------
+def _dflash_dcut_mode(dcut: float | str) -> str:
+    # dflash_dcut_mode reads only dflash_dcut, so a method="dflash" config is
+    # not required to exercise normalization. Build a lightweight ngram config
+    # and set the field directly to avoid loading a real DFlash model.
+    cfg = SpeculativeConfig(model="ngram", num_speculative_tokens=3)
+    cfg.dflash_dcut = dcut
+    return cfg.dflash_dcut_mode
+
+
+def test_dflash_dcut_mode_off():
+    assert _dflash_dcut_mode(0.0) == "off"
+
+
+def test_dflash_dcut_mode_fixed_ratio():
+    assert _dflash_dcut_mode(0.5) == "fixed_ratio"
+
+
+def test_dflash_dcut_mode_selector():
+    assert _dflash_dcut_mode("auto") == "selector"
+
+
+@pytest.mark.parametrize("bad_value", [-0.1, 1.1, "AUTO"])
+def test_dflash_dcut_rejects_invalid_values(bad_value):
+    # Out-of-range floats and non-"auto" strings are rejected. (A numeric
+    # string like "0.5" is intentionally not tested: pydantic coerces it to
+    # the float 0.5, which is a valid ratio.)
+    with pytest.raises(ValidationError):
+        SpeculativeConfig(
+            model="ngram", num_speculative_tokens=3, dflash_dcut=bad_value
+        )
+
+
+def test_dflash_dcut_disabled_for_non_dflash_method():
+    # ngram is not dflash, so a non-zero dflash_dcut is reset to 0 with a warn.
+    cfg = SpeculativeConfig(model="ngram", num_speculative_tokens=3, dflash_dcut=0.5)
+    assert cfg.dflash_dcut == 0.0
+    assert cfg.dflash_dcut_mode == "off"
+
+
+def test_uses_dflash_dcut_false_for_non_dflash():
+    # ngram resets dflash_dcut to 0, so the D-Cut gate predicate is False.
+    cfg = SpeculativeConfig(model="ngram", num_speculative_tokens=3, dflash_dcut=0.5)
+    assert cfg.uses_dflash_dcut() is False
+
+
+def test_uses_dflash_dcut_tracks_mode():
+    # uses_dflash_dcut() requires both the dflash method and a non-off mode.
+    cfg = SpeculativeConfig(model="ngram", num_speculative_tokens=3)
+    # Not dflash: always disabled regardless of the field value.
+    cfg.dflash_dcut = 0.5
+    assert cfg.uses_dflash_dcut() is False
+    # Stub the method check to isolate the mode half of the predicate.
+    cfg.use_dflash = lambda: True  # type: ignore[method-assign]
+    assert cfg.uses_dflash_dcut() is True
+    cfg.dflash_dcut = 0.0
+    assert cfg.uses_dflash_dcut() is False
+    cfg.dflash_dcut = "auto"
+    assert cfg.uses_dflash_dcut() is True
+
+
+# The cudagraph-mode override (full / full_and_piecewise -> piecewise) and the
+# Model-Runner-V2 fallback for D-Cut are wired in VllmConfig the same way as
+# dynamic speculative decoding; like the async gate they need a full VllmConfig
+# (and thus a real model_config) to reach, so they are covered by end-to-end
+# runs rather than these pure-logic unit tests.
+
+
+# The async-scheduling gate in vllm.py (raise on explicit async_scheduling,
+# auto-disable otherwise when D-Cut is enabled) is exercised by end-to-end
+# runs: constructing a VllmConfig that reaches the gate needs a real
+# model_config, which is out of scope for these pure-logic unit tests.
+
+
+# ---------------------------------------------------------------------------
+# Metrics: keep-ratio accounting
+# ---------------------------------------------------------------------------
+def test_spec_decoding_stats_observe_dcut_accumulates():
+    stats = SpecDecodingStats.new(num_spec_tokens=3)
+    stats.observe_dcut(kept_draft_tokens=6, total_draft_tokens=10)
+    stats.observe_dcut(kept_draft_tokens=2, total_draft_tokens=6)
+    assert stats.dcut_kept_draft_tokens == 8
+    assert stats.dcut_total_draft_tokens == 16
+
+
+def _capture_log(logging: SpecDecodingLogging) -> str:
+    messages: list[str] = []
+    logging.log(log_fn=lambda *args: messages.append(args[0] % args[1:]))
+    return messages[0]
+
+
+def test_spec_decoding_logging_reports_keep_ratio():
+    logging = SpecDecodingLogging()
+    stats = SpecDecodingStats.new(num_spec_tokens=3)
+    stats.observe_draft(num_draft_tokens=3, num_accepted_tokens=2)
+    stats.observe_dcut(kept_draft_tokens=6, total_draft_tokens=12)
+    logging.observe(stats)
+    assert "D-Cut keep ratio: 0.500" in _capture_log(logging)
+
+
+def test_spec_decoding_logging_aggregates_keep_ratio_across_steps():
+    # Ratio is over summed counts, not an average of per-step ratios:
+    # (6 + 1) / (12 + 3) = 7 / 15 = 0.467.
+    logging = SpecDecodingLogging()
+    for kept, total in [(6, 12), (1, 3)]:
+        stats = SpecDecodingStats.new(num_spec_tokens=3)
+        stats.observe_draft(num_draft_tokens=3, num_accepted_tokens=1)
+        stats.observe_dcut(kept_draft_tokens=kept, total_draft_tokens=total)
+        logging.observe(stats)
+    assert "D-Cut keep ratio: 0.467" in _capture_log(logging)
+
+
+def test_spec_decoding_logging_keep_ratio_nan_without_dcut():
+    # No D-Cut observations -> ratio is nan, not a division-by-zero error.
+    logging = SpecDecodingLogging()
+    stats = SpecDecodingStats.new(num_spec_tokens=3)
+    stats.observe_draft(num_draft_tokens=3, num_accepted_tokens=1)
+    logging.observe(stats)
+    assert "D-Cut keep ratio: nan" in _capture_log(logging)
+
+
+# ---------------------------------------------------------------------------
+# Scheduler: truncation + pending accounting
+# ---------------------------------------------------------------------------
+def _make_scheduler():
+    return create_scheduler(
+        max_num_seqs=16,
+        max_num_batched_tokens=8192,
+        num_speculative_tokens=3,
+    )
+
+
+def test_dcut_truncate_keeps_prefix_and_counts_bonus():
+    scheduler = _make_scheduler()
+    kept = scheduler._dcut_truncate([10, 11, 12], keep_len=2)
+    assert kept == [10, 11]
+    # kept counts the bonus token: keep_len + 1; total: len + 1.
+    assert scheduler._pending_dcut_kept_draft_tokens == 3
+    assert scheduler._pending_dcut_total_draft_tokens == 4
+
+
+def test_dcut_truncate_keep_len_zero_keeps_only_bonus():
+    scheduler = _make_scheduler()
+    kept = scheduler._dcut_truncate([10, 11, 12], keep_len=0)
+    assert kept == []
+    assert scheduler._pending_dcut_kept_draft_tokens == 1
+    assert scheduler._pending_dcut_total_draft_tokens == 4
+
+
+def test_dcut_truncate_keep_len_at_or_above_len():
+    scheduler = _make_scheduler()
+    # keep_len == len keeps everything; slicing beyond len is a no-op.
+    assert scheduler._dcut_truncate([10, 11, 12], keep_len=3) == [10, 11, 12]
+    assert scheduler._dcut_truncate([20, 21], keep_len=5) == [20, 21]
+
+
+def test_dcut_truncate_clamps_accounting_to_available_tokens():
+    scheduler = _make_scheduler()
+    assert scheduler._dcut_truncate([10, 11], keep_len=5) == [10, 11]
+    assert scheduler._pending_dcut_kept_draft_tokens == 3
+    assert scheduler._pending_dcut_total_draft_tokens == 3
+
+
+def test_dcut_truncate_accumulates_across_requests():
+    scheduler = _make_scheduler()
+    scheduler._dcut_truncate([10, 11, 12], keep_len=1)
+    scheduler._dcut_truncate([20, 21, 22], keep_len=3)
+    assert scheduler._pending_dcut_kept_draft_tokens == (1 + 1) + (3 + 1)
+    assert scheduler._pending_dcut_total_draft_tokens == (3 + 1) + (3 + 1)
+
+
+def test_make_or_update_dcut_stats_feeds_and_resets():
+    scheduler = _make_scheduler()
+    scheduler._dcut_truncate([10, 11, 12], keep_len=2)
+
+    stats = SpecDecodingStats.new(num_spec_tokens=3)
+    out = scheduler._make_or_update_dcut_stats(stats)
+    assert out is stats
+    assert stats.dcut_kept_draft_tokens == 3
+    assert stats.dcut_total_draft_tokens == 4
+    # Pending counters are drained after being observed.
+    assert scheduler._pending_dcut_kept_draft_tokens == 0
+    assert scheduler._pending_dcut_total_draft_tokens == 0
+
+
+def test_make_or_update_dcut_stats_noop_without_pending():
+    scheduler = _make_scheduler()
+    stats = SpecDecodingStats.new(num_spec_tokens=3)
+    out = scheduler._make_or_update_dcut_stats(stats)
+    assert out is stats
+    assert stats.dcut_kept_draft_tokens == 0
+    assert stats.dcut_total_draft_tokens == 0
+
+
+def test_make_or_update_dcut_stats_preserves_pending_when_no_stats():
+    scheduler = _make_scheduler()
+    scheduler._dcut_truncate([10, 11, 12], keep_len=2)
+    # When no SpecDecodingStats exists this step, pending counters are left
+    # intact for a later step rather than being silently dropped.
+    assert scheduler._make_or_update_dcut_stats(None) is None
+    assert scheduler._pending_dcut_kept_draft_tokens == 3
+    assert scheduler._pending_dcut_total_draft_tokens == 4
+
+
+def test_make_or_update_dcut_stats_noop_when_log_stats_disabled():
+    scheduler = _make_scheduler()
+    scheduler.log_stats = False
+    scheduler._dcut_truncate([10, 11, 12], keep_len=2)
+    stats = SpecDecodingStats.new(num_spec_tokens=3)
+    # log_stats=False short-circuits; the provided stats are returned untouched
+    # and pending counters are not drained.
+    out = scheduler._make_or_update_dcut_stats(stats)
+    assert out is stats
+    assert stats.dcut_total_draft_tokens == 0

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -76,6 +76,7 @@ SpeculativeMethod = Literal[
 ]
 RejectionSampleMethod = Literal["standard", "synthetic", "block"]
 DraftSampleMethod = Literal["greedy", "probabilistic"]
+DFlashDcutMode = Literal["off", "fixed_ratio", "selector"]
 
 
 @config
@@ -167,6 +168,28 @@ class SpeculativeConfig:
     in parallel rather than sequentially. This can improve performance but
     requires the speculative model be trained to support parallel drafting.
     Only compatible with EAGLE and draft model methods."""
+    dflash_dcut: float | Literal["auto"] = 0.0
+    """Dynamic draft pruning (D-Cut) policy. Currently DFlash-only.
+
+    Accepted values:
+
+    - ``0`` (default): disabled.
+    - a float in ``(0, 1]``: ``fixed_ratio`` policy. Interpreted as the
+      fraction of target-forward query tokens to keep across the batch,
+      counting the one bonus token reserved per request. The draft-token
+      budget is ``ceil(value * batch_size * (num_draft + 1)) - batch_size``,
+      and the highest-scoring drafts are kept via a batch-level (global)
+      top-K rather than a per-request truncation.
+    - ``"auto"``: ``selector`` policy; choose how many drafts to keep at
+      runtime from a warmup full-cost table.
+
+    D-Cut prunes the verification width based on draft confidence. The
+    transport (keep lengths on ``DraftTokenIds``), the scheduler-side
+    truncation, and the keep-ratio metrics are all method-agnostic; only
+    the selection policy and warmup profiling currently live in the DFlash
+    proposer, so the option is gated to ``method='dflash'`` for now. It can
+    be extended to other parallel-drafting methods (e.g. parallel-drafting
+    EAGLE) by adding their own keep-length selection."""
 
     # required configuration params passed from engine
     target_model_config: SkipValidation[ModelConfig] = None  # type: ignore
@@ -323,6 +346,7 @@ class SpeculativeConfig:
             if layer_ids is not None:
                 # Convert to tuple to make it hashable
                 factors.append(tuple(layer_ids))
+        factors.append(self.dflash_dcut)
 
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
@@ -1234,6 +1258,24 @@ class SpeculativeConfig:
                 f"than zero ({self.num_speculative_tokens})."
             )
 
+        dflash_dcut_is_valid = (
+            self.dflash_dcut == "auto"
+            if isinstance(self.dflash_dcut, str)
+            else 0 <= self.dflash_dcut <= 1
+        )
+        if not dflash_dcut_is_valid:
+            raise ValueError(
+                'dflash_dcut must be a float in [0, 1] or "auto", '
+                f"got {self.dflash_dcut!r}."
+            )
+        if self.dflash_dcut != 0 and self.method != "dflash":
+            logger.warning(
+                "DFlash D-Cut is only supported with method='dflash'; "
+                "disabling dflash_dcut for method='%s'.",
+                self.method,
+            )
+            self.dflash_dcut = 0.0
+
         if self.rejection_sample_method == "synthetic":
             # Consolidate to per-position rates
             self.synthetic_acceptance_rates = self._resolve_synthetic_acceptance_rates(
@@ -1332,6 +1374,19 @@ class SpeculativeConfig:
 
     def use_dspark(self) -> bool:
         return self.method == "dspark"
+
+    @property
+    def dflash_dcut_mode(self) -> DFlashDcutMode:
+        """Normalized D-Cut policy derived from ``dflash_dcut``."""
+        if self.dflash_dcut == "auto":
+            return "selector"
+        if self.dflash_dcut == 0:
+            return "off"
+        return "fixed_ratio"
+
+    def uses_dflash_dcut(self) -> bool:
+        """Whether DFlash D-Cut draft pruning is enabled."""
+        return self.use_dflash() and self.dflash_dcut_mode != "off"
 
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -820,7 +820,10 @@ class VllmConfig:
         speculative_config = self.speculative_config
         if (
             speculative_config is None
-            or not speculative_config.uses_dynamic_speculative_decoding()
+            or not (
+                speculative_config.uses_dynamic_speculative_decoding()
+                or speculative_config.uses_dflash_dcut()
+            )
             or not self.compilation_config.cudagraph_mode.has_full_cudagraphs()
             or self.use_v2_model_runner
         ):
@@ -1024,6 +1027,10 @@ class VllmConfig:
             and self.parallel_config.enable_dbo
             and self.parallel_config.all2all_backend == "deepep_high_throughput"
         )
+        dflash_dcut_enabled = (
+            self.speculative_config is not None
+            and self.speculative_config.uses_dflash_dcut()
+        )
 
         if self.scheduler_config.async_scheduling:
             # Async scheduling explicitly enabled, hard fail any incompatibilities.
@@ -1034,6 +1041,10 @@ class VllmConfig:
                     "Async scheduling is not compatible with ROCm DeepEP "
                     "high-throughput DBO. Please use --no-async-scheduling or "
                     "select a different all2all backend."
+                )
+            if dflash_dcut_enabled:
+                raise ValueError(
+                    "Async scheduling is currently not supported with DFlash D-Cut."
                 )
             if self.speculative_config is not None:
                 if (
@@ -1066,6 +1077,12 @@ class VllmConfig:
                 # impacts performance of pooling models, so we disable by default.
                 logger.debug(
                     "Disabling asynchronous scheduling by default for pooling model."
+                )
+                self.scheduler_config.async_scheduling = False
+            elif dflash_dcut_enabled:
+                logger.warning_once(
+                    "Async scheduling is currently not supported with DFlash "
+                    "D-Cut and will be disabled."
                 )
                 self.scheduler_config.async_scheduling = False
             elif (
@@ -2163,6 +2180,9 @@ class VllmConfig:
                 "dspark",
             ):
                 unsupported.append(f"speculative method '{speculative_config.method}'")
+
+            if speculative_config.uses_dflash_dcut():
+                unsupported.append("DFlash D-Cut draft pruning")
 
             # V2 EagleSpeculator does not support parallel_drafting (for P-Eagle).
             # DFlash and DSpark use parallel drafting natively in V2 via their

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -260,6 +260,8 @@ class Scheduler(SchedulerInterface):
                 # anchor itself is the first prediction position (no separate bonus
                 # query), so it needs exactly num_spec_tokens lookahead slots.
                 self.num_lookahead_tokens = self.num_spec_tokens
+        self._pending_dcut_kept_draft_tokens = 0
+        self._pending_dcut_total_draft_tokens = 0
 
         # Create the KV cache manager.
         if hash_block_size is None:
@@ -1929,6 +1931,7 @@ class Scheduler(SchedulerInterface):
                     )
             finished_req_ids.clear()
 
+        spec_decoding_stats = self._make_or_update_dcut_stats(spec_decoding_stats)
         if (
             stats := self.make_stats(
                 spec_decoding_stats,
@@ -2042,9 +2045,12 @@ class Scheduler(SchedulerInterface):
                 self.encoder_cache_manager.free_encoder_input(request, input_id)
 
     def update_draft_token_ids(self, draft_token_ids: DraftTokenIds) -> None:
-        for req_id, spec_token_ids in zip(
-            draft_token_ids.req_ids,
-            draft_token_ids.draft_token_ids,
+        dcut_keep_lens = draft_token_ids.dcut_keep_lens
+        for i, (req_id, spec_token_ids) in enumerate(
+            zip(
+                draft_token_ids.req_ids,
+                draft_token_ids.draft_token_ids,
+            )
         ):
             request = self.requests.get(req_id)
             if request is None or request.is_finished():
@@ -2061,6 +2067,8 @@ class Scheduler(SchedulerInterface):
             if self.structured_output_manager.should_advance(request):
                 metadata = request.structured_output_request
                 spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)  # type: ignore[union-attr]
+            if dcut_keep_lens is not None:
+                spec_token_ids = self._dcut_truncate(spec_token_ids, dcut_keep_lens[i])
             request.spec_token_ids = spec_token_ids
 
     def update_draft_token_ids_in_output(
@@ -2446,6 +2454,29 @@ class Scheduler(SchedulerInterface):
             num_draft_tokens=num_draft_tokens, num_accepted_tokens=num_accepted_tokens
         )
         return spec_decoding_stats
+
+    def _make_or_update_dcut_stats(
+        self, spec_decoding_stats: SpecDecodingStats | None
+    ) -> SpecDecodingStats | None:
+        if (
+            not self.log_stats
+            or not self._pending_dcut_total_draft_tokens
+            or spec_decoding_stats is None
+        ):
+            return spec_decoding_stats
+        spec_decoding_stats.observe_dcut(
+            kept_draft_tokens=self._pending_dcut_kept_draft_tokens,
+            total_draft_tokens=self._pending_dcut_total_draft_tokens,
+        )
+        self._pending_dcut_kept_draft_tokens = 0
+        self._pending_dcut_total_draft_tokens = 0
+        return spec_decoding_stats
+
+    def _dcut_truncate(self, spec_token_ids: list[int], keep_len: int) -> list[int]:
+        actual_keep_len = min(keep_len, len(spec_token_ids))
+        self._pending_dcut_kept_draft_tokens += actual_keep_len + 1
+        self._pending_dcut_total_draft_tokens += len(spec_token_ids) + 1
+        return spec_token_ids[:actual_keep_len]
 
     def shutdown(self) -> None:
         logger.debug_once("[shutdown] Scheduler: start")

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -340,6 +340,8 @@ class DraftTokenIds:
     req_ids: list[str]
     # num_reqs x num_draft_tokens
     draft_token_ids: list[list[int]]
+    # Optional per-request number of draft tokens to keep for D-Cut.
+    dcut_keep_lens: list[int] | None = None
 
 
 def make_empty_encoder_model_runner_output(

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 from dataclasses import replace
 from typing import Any
 
@@ -11,6 +12,7 @@ from vllm.config import VllmConfig
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
 from vllm.v1.spec_decode.utils import (
     copy_and_expand_dflash_inputs_kernel,
@@ -18,6 +20,12 @@ from vllm.v1.spec_decode.utils import (
 )
 
 logger = init_logger(__name__)
+
+_DCUT_FALLBACK_RATIO = 3 / 4
+_DCUT_RATIO_NUMS = (1, 2, 3, 4)
+_DCUT_PROFILE_SEQ_LEN = 2048
+_DCUT_PROFILE_WARMUPS = 3
+_DCUT_PROFILE_STEPS = 5
 
 
 class DFlashProposer(SpecDecodeBaseProposer):
@@ -35,6 +43,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
             pass_hidden_states_to_model=True,
             runner=runner,
         )
+        self._runner = runner
 
         # Only next_token_ids and mask tokens are query tokens, all other context is K/V
         self.max_query_tokens = self.max_batch_size * (1 + self.num_speculative_tokens)
@@ -75,6 +84,8 @@ class DFlashProposer(SpecDecodeBaseProposer):
         self.dflash_causal = not dflash_has_any_non_causal(
             self.draft_model_config.hf_config
         )
+        self._dcut_keep_lens_cache: torch.Tensor | None = None
+        self._dcut_costs_by_bs: dict[int, torch.Tensor] = {}
 
     @override
     def _create_draft_vllm_config(self) -> VllmConfig:
@@ -96,6 +107,153 @@ class DFlashProposer(SpecDecodeBaseProposer):
     def _warn_if_multimodal(self):
         # Override to allow multimodal inputs since DFlash supports Qwen3.5 models
         pass
+
+    @override
+    def _sample_draft_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        self._dcut_keep_lens_cache = None
+        if self.speculative_config.dflash_dcut_mode == "off":
+            return super()._sample_draft_tokens(hidden_states, sampling_metadata)
+
+        logits = self.model.compute_logits(hidden_states)
+        draft_token_ids, draft_probs = self._sample_from_logits(
+            logits, sampling_metadata
+        )
+        token_logprobs = (
+            logits.gather(1, draft_token_ids.unsqueeze(1)).squeeze(1).float()
+            - torch.logsumexp(logits, dim=-1).float()
+            if draft_probs is None
+            else torch.log(
+                draft_probs.gather(1, draft_token_ids.unsqueeze(1)).squeeze(1)
+            )
+        )
+
+        self._dcut_keep_lens_cache = self._select_dcut_keep_lens(
+            token_logprobs.view(-1, self.num_speculative_tokens)
+        )
+        return draft_token_ids, draft_probs
+
+    def _select_dcut_keep_lens(self, logprobs: torch.Tensor) -> torch.Tensor:
+        bs, num_draft_tokens = logprobs.shape
+        cumlogprobs = logprobs.cumsum(dim=1).flatten()
+        profile_bs = min((x for x in self._dcut_costs_by_bs if x >= bs), default=None)
+        if profile_bs is None:
+            dcut = self.speculative_config.dflash_dcut
+            if dcut == "auto":
+                logger.warning_once(
+                    "DFlash D-Cut selector has no profiled cost for bs=%d; "
+                    "fallback ratio %.2f.",
+                    bs,
+                    _DCUT_FALLBACK_RATIO,
+                )
+                dcut = _DCUT_FALLBACK_RATIO
+            num_keep_draft_tokens = self._get_dcut_keep_count(
+                bs, num_draft_tokens, float(dcut)
+            )
+            _, top_indices = torch.topk(cumlogprobs, k=num_keep_draft_tokens)
+            updates = torch.ones_like(top_indices, dtype=torch.int32)
+        else:
+            keep_counts = self._dcut_keep_counts[bs]
+            costs = self._dcut_costs_by_bs[profile_bs]
+            sorted_logprobs, top_indices = torch.sort(cumlogprobs, descending=True)
+            prefix_scores = torch.cumsum(torch.exp(sorted_logprobs), dim=0)
+            candidate_scores = torch.zeros_like(costs)
+            valid = keep_counts > 0
+            candidate_scores[valid] = prefix_scores[keep_counts[valid] - 1]
+            num_keep_draft_tokens = keep_counts[torch.argmax(candidate_scores / costs)]
+            updates = (
+                torch.arange(bs * num_draft_tokens, device=self.device)
+                < num_keep_draft_tokens
+            ).to(torch.int32)
+        keep_lens = torch.zeros((bs,), dtype=torch.int32, device=self.device)
+        keep_lens.scatter_add_(0, top_indices // num_draft_tokens, updates)
+        return keep_lens
+
+    @staticmethod
+    def _get_dcut_keep_count(bs: int, num_draft_tokens: int, ratio: float) -> int:
+        return max(0, math.ceil(bs * (num_draft_tokens + 1) * ratio) - bs)
+
+    def take_dcut_keep_lens(self) -> torch.Tensor | None:
+        return self._dcut_keep_lens_cache
+
+    def profile_dcut_cost_table(self) -> None:
+        costs_by_bs: dict[int, list[tuple[int, float]]] = {}
+        max_bs = min(self.max_batch_size, self._runner.max_num_reqs)
+        bs_range = torch.arange(max_bs + 1, device=self.device, dtype=torch.long)[
+            :, None
+        ]
+        ratio_nums = torch.tensor(
+            _DCUT_RATIO_NUMS, device=self.device, dtype=torch.long
+        )
+        keep_counts = torch.div(
+            bs_range * (self.num_speculative_tokens + 1) * ratio_nums + 3,
+            4,
+            rounding_mode="floor",
+        )
+        self._dcut_keep_counts = torch.clamp(keep_counts - bs_range, min=0)
+        for bs in self._get_dcut_profile_batch_sizes():
+            entries: list[tuple[int, float]] = []
+            full_draft_tokens = bs * (1 + self.num_speculative_tokens)
+            self._dcut_costs_by_bs[bs] = torch.ones(
+                len(_DCUT_RATIO_NUMS), dtype=torch.float32, device=self.device
+            )
+            for keep_count in self._dcut_keep_counts[bs].tolist():
+                target_tokens = bs + keep_count
+                cost = self._profile_dcut_full_cost_ms(
+                    bs=bs,
+                    target_tokens=target_tokens,
+                    draft_tokens=full_draft_tokens,
+                )
+                entries.append((keep_count, cost))
+            costs_by_bs[bs] = entries
+            self._dcut_costs_by_bs[bs] = torch.tensor(
+                [x[1] for x in entries], dtype=torch.float32, device=self.device
+            )
+        if costs_by_bs:
+            logger.info("DFlash D-Cut warmup full-cost table: %s", costs_by_bs)
+
+    def _get_dcut_profile_batch_sizes(self) -> tuple[int, ...]:
+        full_tokens_per_req = 1 + self.num_speculative_tokens
+        max_bs = min(self.max_batch_size, self._runner.max_num_reqs)
+        capture_sizes = self.compilation_config.cudagraph_capture_sizes or []
+        sizes = [
+            capture_size // full_tokens_per_req
+            for capture_size in capture_sizes
+            if capture_size % full_tokens_per_req == 0
+            and 0 < capture_size // full_tokens_per_req <= max_bs
+        ]
+        sizes.append(max_bs)
+        return tuple(sorted(set(sizes)))
+
+    def _profile_dcut_full_cost_ms(
+        self, *, bs: int, target_tokens: int, draft_tokens: int
+    ) -> float:
+        profile_seq_lens = min(
+            _DCUT_PROFILE_SEQ_LEN,
+            self._runner.max_model_len,
+        )
+        dummy_run_kwargs = dict(
+            force_attention=True,
+            allow_microbatching=False,
+            skip_eplb=True,
+            is_profile=False,
+            dcut_profile_num_reqs=bs,
+            drafter_dummy_num_tokens=draft_tokens,
+            profile_seq_lens=profile_seq_lens,
+        )
+        for _ in range(_DCUT_PROFILE_WARMUPS):
+            self._runner._dummy_run(target_tokens, **dummy_run_kwargs)
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(_DCUT_PROFILE_STEPS):
+            self._runner._dummy_run(target_tokens, **dummy_run_kwargs)
+        end.record()
+        torch.cuda.synchronize()
+        return start.elapsed_time(end) / _DCUT_PROFILE_STEPS
 
     @override
     def set_inputs_first_pass(
@@ -210,6 +368,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
         use_cudagraphs: bool = True,
         is_graph_capturing: bool = False,
         slot_mappings: dict[str, torch.Tensor] | None = None,
+        num_query_tokens: int | None = None,
     ) -> None:
         """
         Key differences to default dummy_run:
@@ -219,7 +378,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
         - max_query_tokens is quite small, DFlash only sees spec tokens as queries
         - Multimodal inputs are not currently supported
         """
-        num_query_tokens = min(num_tokens, self.max_query_tokens)
+        num_query_tokens = min(num_query_tokens or num_tokens, self.max_query_tokens)
         cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
             self._determine_batch_execution_and_padding(
                 num_query_tokens, use_cudagraphs=use_cudagraphs

--- a/vllm/v1/spec_decode/metrics.py
+++ b/vllm/v1/spec_decode/metrics.py
@@ -29,6 +29,8 @@ class SpecDecodingStats:
     num_accepted_tokens: int = 0
     num_accepted_tokens_per_pos: list[int] = field(default_factory=list)
     num_draft_tokens_per_pos: list[int] = field(default_factory=list)
+    dcut_kept_draft_tokens: int = 0
+    dcut_total_draft_tokens: int = 0
 
     @classmethod
     def new(cls, num_spec_tokens: int) -> "SpecDecodingStats":
@@ -47,6 +49,10 @@ class SpecDecodingStats:
             self.num_accepted_tokens_per_pos[i] += 1
         for i in range(num_draft_tokens):
             self.num_draft_tokens_per_pos[i] += 1
+
+    def observe_dcut(self, kept_draft_tokens: int, total_draft_tokens: int):
+        self.dcut_kept_draft_tokens += kept_draft_tokens
+        self.dcut_total_draft_tokens += total_draft_tokens
 
 
 class SpecDecodingLogging:
@@ -68,6 +74,8 @@ class SpecDecodingLogging:
         self.num_drafts: list[int] = []
         self.num_draft_tokens: list[int] = []
         self.num_accepted_tokens: list[int] = []
+        self.dcut_kept_draft_tokens: list[int] = []
+        self.dcut_total_draft_tokens: list[int] = []
         self.accepted_tokens_per_pos_lists: list[list[int]] = []
         self.last_log_time = time.monotonic()
 
@@ -75,6 +83,8 @@ class SpecDecodingLogging:
         self.num_drafts.append(spec_decoding_stats.num_drafts)
         self.num_draft_tokens.append(spec_decoding_stats.num_draft_tokens)
         self.num_accepted_tokens.append(spec_decoding_stats.num_accepted_tokens)
+        self.dcut_kept_draft_tokens.append(spec_decoding_stats.dcut_kept_draft_tokens)
+        self.dcut_total_draft_tokens.append(spec_decoding_stats.dcut_total_draft_tokens)
         self.accepted_tokens_per_pos_lists.append(
             spec_decoding_stats.num_accepted_tokens_per_pos
         )
@@ -109,6 +119,13 @@ class SpecDecodingLogging:
             if num_draft_tokens > 0
             else float("nan")
         )
+        dcut_kept_draft_tokens = np.sum(self.dcut_kept_draft_tokens)
+        dcut_total_draft_tokens = np.sum(self.dcut_total_draft_tokens)
+        dcut_keep_ratio = (
+            dcut_kept_draft_tokens / dcut_total_draft_tokens
+            if dcut_total_draft_tokens > 0
+            else float("nan")
+        )
 
         # Conventionally, mean acceptance length includes the bonus token
         mean_acceptance_length = 1 + (num_accepted_tokens / num_drafts)
@@ -125,7 +142,8 @@ class SpecDecodingLogging:
             "Accepted: %d tokens, "
             "Drafted: %d tokens, "
             "Per-position acceptance rate: %s, "
-            "Avg Draft acceptance rate: %.1f%%",
+            "Avg Draft acceptance rate: %.1f%%, "
+            "D-Cut keep ratio: %.3f",
             mean_acceptance_length,
             accepted_throughput,
             draft_throughput,
@@ -133,6 +151,7 @@ class SpecDecodingLogging:
             num_draft_tokens,
             rates_str,
             draft_acceptance_rate,
+            dcut_keep_ratio,
         )
         self.reset()
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -877,6 +877,7 @@ class GPUModelRunner(
         self._draft_token_ids: list[list[int]] | torch.Tensor | None = None
         self._draft_probs: torch.Tensor | None = None
         self._draft_prob_req_ids: list[str] | None = None
+        self._dcut_keep_lens: torch.Tensor | None = None
         # N-gram GPU path: async D2H buffer/event for per-request valid draft counts.
         self._num_valid_draft_tokens: torch.Tensor | None = None
         self._num_valid_draft_tokens_cpu: torch.Tensor | None = None
@@ -911,6 +912,7 @@ class GPUModelRunner(
         self.draft_token_ids_copy_stream: torch.cuda.Stream | None = None
         self.valid_sampled_token_count_cpu: torch.Tensor | None = None
         self.draft_token_ids_cpu: torch.Tensor | None = None
+        self.dcut_keep_lens_cpu: torch.Tensor | None = None
         self.num_accepted_tokens_event: torch.Event | None = None
         if self.num_spec_tokens:
             self.draft_token_ids_event = torch.Event()
@@ -919,6 +921,12 @@ class GPUModelRunner(
             self.draft_token_ids_cpu = torch.empty(
                 (self.max_num_reqs, self.num_spec_tokens),
                 dtype=torch.int64,
+                device="cpu",
+                pin_memory=PIN_MEMORY,
+            )
+            self.dcut_keep_lens_cpu = torch.empty(
+                self.max_num_reqs,
+                dtype=torch.int32,
                 device="cpu",
                 pin_memory=PIN_MEMORY,
             )
@@ -4546,6 +4554,7 @@ class GPUModelRunner(
         self._draft_token_ids = None
         self._draft_probs = None
         self._draft_prob_req_ids = None
+        self._dcut_keep_lens = None
         self._draft_token_req_ids = None
         self.valid_sampled_token_count_gpu = None
         self.input_batch.prev_sampled_token_ids = None
@@ -4832,6 +4841,12 @@ class GPUModelRunner(
         if not self.num_spec_tokens or not self._draft_token_req_ids:
             return None
         draft_token_ids, req_ids = self._get_draft_token_ids_cpu()
+        if self._dcut_keep_lens is not None and self.dcut_keep_lens_cpu is not None:
+            return DraftTokenIds(
+                req_ids,
+                draft_token_ids,
+                self.dcut_keep_lens_cpu[: len(req_ids)].tolist(),
+            )
         return DraftTokenIds(req_ids, draft_token_ids)
 
     def _copy_draft_token_ids_to_cpu(
@@ -4842,9 +4857,13 @@ class GPUModelRunner(
             self.prev_num_spec_tokens = self._draft_token_ids.shape[1]
         # Check if we need to copy draft tokens to CPU. In async scheduling,
         # we only copy when needed for structured output, penalties or bad_words.
-        if self.use_async_scheduling and not (
-            scheduler_output.has_structured_output_requests
-            or self.input_batch.sampling_metadata.output_token_ids
+        if (
+            self.use_async_scheduling
+            and not (
+                scheduler_output.has_structured_output_requests
+                or self.input_batch.sampling_metadata.output_token_ids
+            )
+            and self._dcut_keep_lens is None
         ):
             return
         # We must also set the corresponding request ids.
@@ -4869,6 +4888,10 @@ class GPUModelRunner(
             else:
                 # No copy needed, just zero-out cpu tensor.
                 self.draft_token_ids_cpu[:num_reqs, :num_spec_tokens] = 0
+            if self._dcut_keep_lens is not None and self.dcut_keep_lens_cpu is not None:
+                self.dcut_keep_lens_cpu[:num_reqs].copy_(
+                    self._dcut_keep_lens[:num_reqs], non_blocking=True
+                )
             self.draft_token_ids_event.record()
 
     def _get_draft_token_ids_cpu(self) -> tuple[list[list[int]], list[str]]:
@@ -5225,6 +5248,8 @@ class GPUModelRunner(
                 if draft_probs is not None:
                     self._draft_probs = draft_probs
                     self._draft_prob_req_ids = self.input_batch.req_ids.copy()
+            if hasattr(self.drafter, "take_dcut_keep_lens"):
+                self._dcut_keep_lens = self.drafter.take_dcut_keep_lens()
 
         return draft_token_ids
 
@@ -5689,7 +5714,10 @@ class GPUModelRunner(
 
     @contextmanager
     def maybe_randomize_inputs(
-        self, input_ids: torch.Tensor | None, inputs_embeds: torch.Tensor | None
+        self,
+        input_ids: torch.Tensor | None,
+        inputs_embeds: torch.Tensor | None,
+        force_randomize: bool = False,
     ):
         """
         Randomize input_ids if VLLM_RANDOMIZE_DP_DUMMY_INPUTS is set.
@@ -5699,7 +5727,9 @@ class GPUModelRunner(
         """
 
         dp_size = self.vllm_config.parallel_config.data_parallel_size
-        randomize_inputs = envs.VLLM_RANDOMIZE_DP_DUMMY_INPUTS and dp_size > 1
+        randomize_inputs = (
+            force_randomize or envs.VLLM_RANDOMIZE_DP_DUMMY_INPUTS and dp_size > 1
+        )
         if not randomize_inputs:
             yield
         elif input_ids is not None:
@@ -5776,6 +5806,8 @@ class GPUModelRunner(
         is_graph_capturing: bool = False,
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
+        dcut_profile_num_reqs: int | None = None,
+        drafter_dummy_num_tokens: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Run a dummy forward pass to warm up/profile run or capture the
@@ -5835,7 +5867,17 @@ class GPUModelRunner(
         # has num_tokens in total.
         assert num_tokens <= self.max_num_tokens
         max_num_reqs = self.scheduler_config.max_num_seqs
-        if create_mixed_batch:
+        if dcut_profile_num_reqs is not None:
+            assert not uniform_decode and not create_mixed_batch
+            assert 0 < dcut_profile_num_reqs <= num_tokens
+            num_reqs = dcut_profile_num_reqs
+            tokens_per_req, extra_tokens = divmod(num_tokens, num_reqs)
+            assert tokens_per_req > 0
+            num_scheduled_tokens_list = [
+                tokens_per_req + (1 if i < extra_tokens else 0) for i in range(num_reqs)
+            ]
+            max_query_len = max(num_scheduled_tokens_list)
+        elif create_mixed_batch:
             assert not uniform_decode
             # Create mixed batch:
             # first half decode tokens, second half one prefill
@@ -5991,6 +6033,13 @@ class GPUModelRunner(
                     num_tokens_unpadded=num_tokens_unpadded,
                     dcp_dummy_context_len=dcp_dummy_context_len,
                 )
+                if dcut_profile_num_reqs is not None:
+                    draft_lens = num_scheduled_tokens - 1
+                    self.num_decode_draft_tokens.np[:num_reqs] = draft_lens
+                    self.num_decode_draft_tokens.np[num_reqs:].fill(-1)
+                    self.num_decode_draft_tokens.copy_to_gpu()
+                    self.num_accepted_tokens.np[:num_reqs_padded].fill(1)
+                    self.num_accepted_tokens.copy_to_gpu(num_reqs_padded)
 
                 # Sync block table CPU->GPU so cleared rows from
                 # remove_request() are visible to the attention metadata
@@ -6067,7 +6116,11 @@ class GPUModelRunner(
                     num_tokens_across_dp[:] = num_tokens_padded
 
             with (
-                self.maybe_randomize_inputs(input_ids, inputs_embeds),
+                self.maybe_randomize_inputs(
+                    input_ids,
+                    inputs_embeds,
+                    force_randomize=dcut_profile_num_reqs is not None,
+                ),
                 set_forward_context(
                     attn_metadata,
                     self.vllm_config,
@@ -6130,11 +6183,17 @@ class GPUModelRunner(
                 ):
                     use_cudagraphs = False
 
+                drafter_extra: dict[str, Any] = {}
+                if drafter_dummy_num_tokens is not None and isinstance(
+                    self.drafter, DFlashProposer
+                ):
+                    drafter_extra["num_query_tokens"] = drafter_dummy_num_tokens
                 self.drafter.dummy_run(
                     num_tokens,
                     use_cudagraphs=use_cudagraphs,
                     is_graph_capturing=is_graph_capturing,
                     slot_mappings=slot_mappings,
+                    **drafter_extra,
                 )
 
         # We register layerwise NVTX hooks here after the first dynamo tracing is
@@ -6743,6 +6802,7 @@ class GPUModelRunner(
                 "Skipping CUDA graph capture. To turn on CUDA graph capture, "
                 "ensure `cudagraph_mode` was not manually set to `NONE`"
             )
+            self._profile_dflash_dcut_cost_table()
             return 0
 
         # Initialize encoder CUDA graph manager if enabled.
@@ -6830,6 +6890,7 @@ class GPUModelRunner(
 
         # Lock workspace to prevent resizing during execution.
         # Max workspace sizes should have been captured during warmup/profiling.
+        self._profile_dflash_dcut_cost_table()
         lock_workspace()
 
         end_time = time.perf_counter()
@@ -6842,6 +6903,18 @@ class GPUModelRunner(
             cuda_graph_size / (1 << 30),
         )
         return cuda_graph_size
+
+    def _profile_dflash_dcut_cost_table(self) -> None:
+        if self.speculative_config is None:
+            return
+        drafter = getattr(self, "drafter", None)
+        if (
+            not isinstance(drafter, DFlashProposer)
+            or self.speculative_config.dflash_dcut != "auto"
+            or not get_pp_group().is_last_rank
+        ):
+            return
+        drafter.profile_dcut_cost_table()
 
     def _warmup_and_capture(
         self,


### PR DESCRIPTION
## Purpose

This PR adds **D-Cut**, a confidence-based draft-pruning policy for the DFlash parallel drafter, that trims the per-step draft width *after* drafting and *before* target verification. By dropping low-confidence draft tokens, it cuts the number of tokens the target model must verify per step while keeping acceptance length almost unchanged — improving TPOT and end-to-end throughput, especially at higher batch sizes and on harder prompts where the draft is less likely to be accepted.

D-Cut is disabled by default (`dflash_dcut=0`); existing DFlash behavior is unchanged unless the option is set. The implementation is small and contained — **+367/-12 across 7 files** (only 12 lines of existing code touched), plus a ~270-line test file.

The technique is  documented by the AngelSlim team: <https://angelslim.readthedocs.io/zh-cn/latest/dcut.html>. 

### Why this is not a duplicate of existing dynamic-SD work

Dynamic speculative-decoding work in flight operates on **autoregressive** drafters and decides *before/during* drafting:

- **DSL (#35301)** early-exits the draft loop at a confidence threshold — requires a step-by-step drafter to "stop early".
- **DSD (#32374 family, e.g. #45953, #45963, #46399)** picks the runtime draft length `k` from batch size *before* drafting.

DFlash is a **parallel** drafter: it emits all `num_speculative_tokens` in one shot, so there is no draft loop to exit early and no per-step `k` to lower. D-Cut targets exactly that gap — it prunes the already-produced draft based on per-token confidence, reducing **target-side verification** cost rather than draft-side compute. The `auto` policy selects how many drafts to keep per batch size from a warmup-profiled cost table, which none of the above provide.

This PR **reuses** the DSD compatibility scaffolding (the `_maybe_override_dynamic_sd_cudagraph_mode` full→piecewise fallback and the v2-unsupported-features list) rather than conflicting with it.

## Design

Three policies, selected by a single `dflash_dcut` field on `SpeculativeConfig`:

| `dflash_dcut` | Policy | Behavior |
|---|---|---|
| `0` (default) | `off` | No pruning; standard DFlash. |
| float in `(0, 1]` | `fixed_ratio` | Keep a fixed fraction of target-forward query tokens (global top-K by draft score). **Hardware-independent.** |
| `"auto"` | `selector` | Keep length chosen at runtime from a warmup full-cost table. **Hardware-dependent.** |

The pipeline is intentionally split into a **method-agnostic** transport/apply path and a **DFlash-specific** selection path, so the option can later be extended to other parallel-drafting methods:

1. **Select** (DFlash proposer): from the draft logprobs, compute per-request keep lengths. For `fixed_ratio` the budget is `ceil(value * batch_size * (num_draft + 1)) - batch_size`; `auto` looks the batch size up in a cost table profiled during warmup.
2. **Transport**: keep lengths ride on `DraftTokenIds.dcut_keep_lens`.
3. **Apply** (scheduler): truncate each request's spec tokens to its keep length (the reserved bonus token is always retained), and record kept vs. total draft tokens.
4. **Observe**: `SpecDecodingStats`/`SpecDecodingLogging` report a D-Cut keep ratio alongside the existing acceptance metrics.

### Compatibility

D-Cut runs on the V1 model runner with piecewise CUDA graphs. To avoid silent misconfiguration it is gated the same way dynamic SD is:

- **Async scheduling**: hard-errors if explicitly enabled, otherwise disabled with a warning (async SD currently assumes a fixed draft width).
- **CUDA graphs**: full-graph mode falls back to piecewise (reusing the existing dynamic-SD override).
- **Model Runner V2**: listed as an unsupported feature so config resolution falls back to V1.

### Usage

```bash
# auto policy (recommended): keep length chosen from a profiled cost table
vllm serve Qwen/Qwen3-8B \
  --speculative-config '{"method":"dflash",
                         "model":"<dflash-draft-model>",
                         "num_speculative_tokens":7,
                         "dflash_dcut":"auto"}'

# fixed-ratio policy: keep ~50% of the draft width
vllm serve Qwen/Qwen3-8B \
  --speculative-config '{"method":"dflash", "model":"<dflash-draft-model>",
                         "num_speculative_tokens":7, "dflash_dcut":0.5}'
```

Setting `dflash_dcut=0` (default) restores standard DFlash.

## Benchmark

**Setup.** 5 target models (dense + MoE), 5 datasets, greedy decoding, 8×H20, serving concurrency swept {4,8,16,32,64}, results reported at **concurrency 32**. The primary metric is **output-token throughput speedup over autoregressive (AR) decoding** — under batched serving a longer draft raises mean accepted tokens (τ) but also enlarges the verification batch, so a higher τ does not necessarily mean higher throughput. `D-Cut (16)` is the `auto` policy on a block-16 drafter; `DFlash (16)` is the same drafter with no pruning. D-Cut keeps **92% of DFlash's τ on average** (85–97%) — it trims the low-confidence tail, not the useful prefix — so the throughput gains below come almost free of accepted-length loss.

Speedup vs. AR (AR = 1.00× reference; higher is better; **bold** = best per row). Averaged over the 5 datasets:

| Model | EAGLE-3 / MTP † | DFlash (16) | D-Cut (16) |
|---|---|---|---|
| Llama-3.1-8B | 1.03× | 0.67× | **1.12×** |
| Qwen3-4B | 1.29× | 0.98× | **1.35×** |
| Qwen3-8B | 1.11× | 0.80× | **1.21×** |
| Qwen3.5-27B | **1.31×** | 0.94× | 1.25× |
| Qwen3.5-35B-A3B (MoE) | 1.75× | 2.36× | **2.50×** |

<sub>† EAGLE-3 for Llama-3.1-8B / Qwen3-4B / Qwen3-8B; MTP for the Qwen3.5 models. `D-Cut (16)` is the `auto` policy on a block-16 drafter; `DFlash (16)` is the same drafter unpruned.</sub>

D-Cut beats unpruned DFlash on average throughput for **every** model, and beats the EAGLE-3/MTP baseline on 4 of 5. 

### Scaling with concurrency

The figure below shows absolute output-token throughput as concurrency grows 4→64 (rows = datasets, columns = models; green = D-Cut, blue = DFlash; solid = block-16, dashed = block-8). Throughput rises with concurrency for both, but they diverge at the high end: on dense targets DFlash (16) gains the least from batching (verifying long drafts cancels the accepted-token benefit), while D-Cut sustains the highest throughput, with the gap widening as load grows. 


<img width="2117" height="1719" alt="image" src="https://github.com/user-attachments/assets/57378f09-f151-4f27-8b44-7a2f7ffb97f3" />


Under **temperature-1 sampling** (Qwen3-8B, H20), stochastic decoding shortens accepted drafts and penalizes long fixed-depth proposals: DFlash falls below AR at high concurrency, while D-Cut (auto) sustains a 1.15× speedup over AR (1.68× relative to DFlash — a *larger* relative gain than under greedy decoding, since harsher sampling leaves more low-utility suffix to prune).

<img width="1782" height="470" alt="image" src="https://github.com/user-attachments/assets/9f255ca0-e442-4f45-94f7-cd760a10c59a" />


## Test Plan

```bash
pytest tests/v1/spec_decode/test_dcut.py -v
```

26 unit tests covering: keep-count arithmetic and bonus-token accounting, `dflash_dcut_mode` derivation and config validation (including the non-`dflash` method gate), keep-ratio stats accumulation/logging, and the scheduler-side truncation. All pure-logic (no GPU).

## Test Result

- `tests/v1/spec_decode/test_dcut.py`: **26 passed**.
- End-to-end on H20 (Qwen3-4B + DFlash-B16, `num_speculative_tokens=7`, `dflash_dcut=auto`, piecewise CUDA graph, prefix-cache and async scheduling disabled): server boots, warmup cost table builds, inference correct, and the D-Cut keep-ratio metric is reported in the SpecDecoding logs. The three compatibility gates (async, cudagraph, MRv2) trigger as designed.
- Benchmark numbers above collected on H20.

---

*AI assistance was used in preparing this change (code migration, test authoring, and this description). All changes have been reviewed line-by-line and validated end-to-end on GPU by the submitter.*