### PR TITLE
ds-v4-nvfp4 support v1

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -22,6 +22,10 @@ from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
     prepare_nvfp4_moe_layer_for_fi_or_cutlass,
     prepare_nvfp4_moe_layer_for_flashinfer_cutedsl,
 )
+from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+    FlashinferMoeBackend,
+    get_flashinfer_moe_backend,
+)
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
     prepare_nvfp4_moe_layer_for_marlin,
 )
@@ -53,6 +57,12 @@ FLASHINFER_NVFP4_MOE_BACKENDS = [
     NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED,
     NvFp4MoeBackend.FLASHINFER_B12X,
 ]
+
+fi_2_vllm_backend_map: dict[FlashinferMoeBackend, NvFp4MoeBackend] = {
+    FlashinferMoeBackend.CUTLASS: NvFp4MoeBackend.FLASHINFER_CUTLASS,
+    FlashinferMoeBackend.TENSORRT_LLM: NvFp4MoeBackend.FLASHINFER_TRTLLM,
+    FlashinferMoeBackend.CUTEDSL: NvFp4MoeBackend.FLASHINFER_CUTEDSL,
+}
 
 
 def is_global_sf_supported_for_nvfp4_backend(backend: NvFp4MoeBackend) -> bool:
@@ -174,8 +184,7 @@ def select_nvfp4_moe_backend(
 
     NVFP4_BACKENDS_WITH_CLAMP = {
         NvFp4MoeBackend.FLASHINFER_TRTLLM,
-        NvFp4MoeBackend.FLASHINFER_CUTLASS,
-        NvFp4MoeBackend.MARLIN,
+        NvFp4MoeBackend.EMULATION,
     }
 
     if config.swiglu_limit is not None:
@@ -249,6 +258,55 @@ def select_nvfp4_moe_backend(
         return _return_or_raise(
             requested_backend, config, weight_key, activation_key, activation_format
         )
+
+    if envs.is_set("VLLM_USE_FLASHINFER_MOE_FP4"):
+        if not envs.VLLM_USE_FLASHINFER_MOE_FP4:
+            # If the user rejects FlashInfer remove those backends.
+            for b in FLASHINFER_NVFP4_MOE_BACKENDS:
+                if b in AVAILABLE_BACKENDS:
+                    AVAILABLE_BACKENDS.remove(b)
+
+        elif envs.is_set("VLLM_FLASHINFER_MOE_BACKEND"):
+            # If user is explicit about backend, validate it.
+            backend = fi_2_vllm_backend_map[get_flashinfer_moe_backend()]
+            if (
+                config.swiglu_limit is not None
+                and backend not in NVFP4_BACKENDS_WITH_CLAMP
+            ):
+                raise ValueError(
+                    f"Model sets swiglu_limit={config.swiglu_limit}, but the "
+                    f"FlashInfer backend selected via VLLM_FLASHINFER_MOE_BACKEND "
+                    f"({backend.value}) does not apply the SwiGLU clamp."
+                )
+            return _return_or_raise(
+                backend, config, weight_key, activation_key, activation_format
+            )
+        else:
+            # If the user is not explicit about the backend, try each.
+            fi_backends = [
+                b
+                for b in FLASHINFER_NVFP4_MOE_BACKENDS
+                if config.swiglu_limit is None or b in NVFP4_BACKENDS_WITH_CLAMP
+            ]
+            for backend in fi_backends:
+                for k_cls in backend_to_kernel_cls(backend):
+                    supported, reason = k_cls.is_supported_config(
+                        k_cls,
+                        config,
+                        weight_key,
+                        activation_key,
+                        activation_format,
+                    )
+                    if supported:
+                        logger.info_once(_make_log_backend(backend))
+                        return backend, k_cls
+                    else:
+                        logger.debug_once(_make_log_unsupported(backend, reason))
+
+            raise NotImplementedError(
+                "Found VLLM_USE_FLASHINFER_MOE_FP4=1, but no "
+                "FlashInfer NVFP4 MoE backend supports the configuration."
+            )
 
     if envs.VLLM_TEST_FORCE_FP8_MARLIN:
         backend = NvFp4MoeBackend.MARLIN
@@ -425,7 +483,6 @@ def make_nvfp4_moe_quant_config(
             g2_alphas=w2_scale_2,
             w1_scale=w13_scale,
             w2_scale=w2_scale,
-            gemm1_clamp_limit=swiglu_limit,
         )
     elif backend == NvFp4MoeBackend.EMULATION:
         return nvfp4_moe_quant_config(

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import torch
+from torch.nn.parameter import UninitializedParameter
 
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.logger import init_logger
@@ -31,6 +32,10 @@ if TYPE_CHECKING:
 
 
 logger = init_logger(__name__)
+
+
+def _dsv4_is_current_stream_capturing() -> bool:
+    return torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
 
 
 class FusedMoeWeightScaleSupported(Enum):
@@ -72,8 +77,6 @@ class RoutedExperts(PluggableLayer):
         scoring_func: str = "softmax",
         routed_scaling_factor: float = 1.0,
         swiglu_limit: float | None = None,
-        swiglu_alpha: float | None = None,
-        swiglu_beta: float | None = None,
         e_score_correction_bias: torch.Tensor | None = None,
         apply_router_weight_on_input: bool = False,
     ):
@@ -105,8 +108,6 @@ class RoutedExperts(PluggableLayer):
         self.scoring_func = scoring_func
         self.routed_scaling_factor = routed_scaling_factor
         self.swiglu_limit = swiglu_limit
-        self.swiglu_alpha = swiglu_alpha
-        self.swiglu_beta = swiglu_beta
         self.e_score_correction_bias = e_score_correction_bias
         self.apply_router_weight_on_input = apply_router_weight_on_input
         # End random parameters
@@ -201,7 +202,6 @@ class RoutedExperts(PluggableLayer):
             "AutoGPTQMoEMethod",
             "CompressedTensorsWNA16MarlinMoEMethod",
             "CompressedTensorsWNA16MoEMethod",
-            "CompressedTensorsW4A16FlydslMoEMethod",
         )
 
     def _ensure_moe_quant_config_init(self):
@@ -237,6 +237,62 @@ class RoutedExperts(PluggableLayer):
             self.register_buffer("expert_global_to_physical", global_to_physical)
             self.register_buffer("expert_physical_to_global", physical_to_global)
             self.register_buffer("expert_local_to_global", local_global)
+
+        self._dsv4_debug_routing_maps("update_expert_map_info")
+
+    def _dsv4_debug_routing_map_tensor(
+        self,
+        label: str,
+        tensor: torch.Tensor | None,
+    ) -> str:
+        if tensor is None:
+            return f"{label}=None"
+        with torch.no_grad():
+            data = tensor.detach()
+            if data.numel() == 0:
+                return f"{label}=shape={tuple(data.shape)} dtype={data.dtype} EMPTY"
+            stat = data.to(torch.int64)
+            unique = torch.unique(stat)
+            sample = unique[:16].tolist()
+            return (
+                f"{label}=shape={tuple(data.shape)} dtype={data.dtype} "
+                f"min={int(stat.min().item())} max={int(stat.max().item())} "
+                f"neg={(stat < 0).sum().item()} nonzero={(stat != 0).sum().item()} "
+                f"unique_count={unique.numel()} unique_sample={sample}"
+            )
+
+    def _dsv4_debug_routing_maps(self, where: str) -> None:
+        if _dsv4_is_current_stream_capturing():
+            return
+        layer_name = getattr(self, "layer_name", getattr(self, "prefix", ""))
+        if "layers.60.ffn.experts" not in layer_name:
+            return
+        raw_expert_map = self._buffers.get("_expert_map")
+        expert_mask = self._buffers.get("expert_mask")
+        rocm_aiter_fmoe_enabled = getattr(self, "rocm_aiter_fmoe_enabled", None)
+        property_equivalent = (
+            expert_mask if rocm_aiter_fmoe_enabled else raw_expert_map
+        )
+        logger.warning_once(
+            "[DSV4_ROUTED_EXPERTS_MAP_DEBUG] where=%s layer=%s "
+            "rocm_aiter_fmoe_enabled=%s use_ep=%s global=%s local=%s "
+            "property_%s raw_%s mask_%s",
+            where,
+            layer_name,
+            rocm_aiter_fmoe_enabled,
+            self.use_ep,
+            self.global_num_experts,
+            self.local_num_experts,
+            self._dsv4_debug_routing_map_tensor(
+                "expert_map_equivalent", property_equivalent
+            ),
+            self._dsv4_debug_routing_map_tensor(
+                "_expert_map", raw_expert_map
+            ),
+            self._dsv4_debug_routing_map_tensor(
+                "expert_mask", expert_mask
+            ),
+        )
 
     def _expert_routing_tables(
         self,
@@ -275,12 +331,6 @@ class RoutedExperts(PluggableLayer):
     # Weight Loading Methods
     #
 
-    @staticmethod
-    def _to_scalar(loaded_weight: torch.Tensor) -> torch.Tensor:
-        # Per-tensor scales arrive 0-D or as shape-(1,) (llm-compressor NVFP4);
-        # reduce to a 0-D scalar. numel > 1 raises instead of broadcasting.
-        return loaded_weight.reshape(())
-
     def _load_per_tensor_weight_scale(
         self,
         shard_id: str,
@@ -294,10 +344,10 @@ class RoutedExperts(PluggableLayer):
             # We have to keep the weight scales of w1 and w3 because
             # we need to re-quantize w1/w3 weights after weight loading.
             idx = 0 if shard_id == "w1" else 1
-            param_data[expert_id][idx] = self._to_scalar(loaded_weight)
+            param_data[expert_id][idx] = loaded_weight
         # If we are in the row parallel case (down_proj)
         elif shard_id == "w2":
-            param_data[expert_id] = self._to_scalar(loaded_weight)
+            param_data[expert_id] = loaded_weight
 
     def _load_combined_w13_weight_scale(
         self,
@@ -530,9 +580,7 @@ class RoutedExperts(PluggableLayer):
     ):
         param_data = param.data
 
-        # Used for both scalar input_scale and the size-2 `weight_shape`
-        # param (compressed-tensors). Assign directly so both shapes load;
-        # _to_scalar's reshape(()) would reject the size-2 weight_shape.
+        # Input scales can be loaded directly and should be equal.
         param_data[expert_id] = loaded_weight
 
     def _load_g_idx(
@@ -623,7 +671,6 @@ class RoutedExperts(PluggableLayer):
             "CompressedTensorsWNA16MarlinMoEMethod",
             "CompressedTensorsWNA16MoEMethod",
             "CompressedTensorsWNA16RDNA3MoEMethod",
-            "CompressedTensorsW4A16FlydslMoEMethod",
         ):
             if is_transposed:
                 loaded_weight = loaded_weight.t().contiguous()
@@ -637,6 +684,13 @@ class RoutedExperts(PluggableLayer):
         # based on the shard id. This will be whatever
         # dimension intermediate_size_per_partition is used.
         SHARD_ID_TO_SHARDED_DIM = {"w1": 0, "w2": 1, "w3": 0}
+
+        is_gguf_weight = getattr(param, "is_gguf_weight", False)
+        is_gguf_weight_type = getattr(param, "is_gguf_weight_type", False)
+        if is_gguf_weight_type:
+            param.weight_type = loaded_weight.item()
+            param.data.copy_(loaded_weight)
+            return True if return_success else None
 
         # Case for BitsAndBytes
         use_bitsandbytes_4bit = getattr(param, "use_bitsandbytes_4bit", False)
@@ -683,6 +737,18 @@ class RoutedExperts(PluggableLayer):
         if full_load:
             shard_dim += 1
 
+        # Materialize GGUF UninitializedParameter accounting merged weights
+        if is_gguf_weight and isinstance(param, UninitializedParameter):
+            # To materialize a tensor, we must have full shape including
+            # number of experts, making this portion to require `full_load`.
+            assert full_load
+            final_shape = list(loaded_weight.shape)
+            # w1 and w3 are merged per expert.
+            if shard_id in {"w1", "w3"}:
+                final_shape[1] *= 2
+            final_shape[shard_dim] = final_shape[shard_dim] // self.moe_config.tp_size
+            param.materialize(final_shape, dtype=loaded_weight.dtype)
+
         expert_data = param.data if full_load else param.data[expert_id]
 
         # Case input scale: input_scale loading is only supported for fp8
@@ -700,9 +766,7 @@ class RoutedExperts(PluggableLayer):
             ):
                 scale_expert_id = global_expert_id if use_global_sf else expert_id
                 scale_shard_id = 0 if shard_id == "w1" else 1
-                param.data[scale_expert_id][scale_shard_id] = self._to_scalar(
-                    loaded_weight
-                )
+                param.data[scale_expert_id][scale_shard_id] = loaded_weight.reshape(())
                 return True if return_success else None
 
             if (
@@ -1086,6 +1150,35 @@ class RoutedExperts(PluggableLayer):
             Output tensor from routed experts
         """
         assert not self.quant_method.is_monolithic
+
+        layer_name = getattr(self, "layer_name", getattr(self, "prefix", ""))
+        if "layers.60.ffn.experts" in layer_name:
+            count = getattr(self, "_dsv4_forward_modular_debug_count", 0)
+            if count < 4 and not _dsv4_is_current_stream_capturing():
+                self._dsv4_forward_modular_debug_count = count + 1
+                with torch.no_grad():
+                    ids = topk_ids.detach().to(torch.int64)
+                    weights = topk_weights.detach().float()
+                    logger.warning(
+                        "[DSV4_ROUTED_EXPERTS_FORWARD_DEBUG] layer=%s count=%s "
+                        "topk_ids_shape=%s min=%s max=%s unique=%s "
+                        "topk_weights_shape=%s mean=%.6g std=%.6g min=%.6g "
+                        "max=%.6g",
+                        layer_name,
+                        count,
+                        tuple(topk_ids.shape),
+                        int(ids.min().item()) if ids.numel() else None,
+                        int(ids.max().item()) if ids.numel() else None,
+                        torch.unique(ids).numel() if ids.numel() else 0,
+                        tuple(topk_weights.shape),
+                        weights.mean().item() if weights.numel() else 0.0,
+                        weights.std(unbiased=False).item()
+                        if weights.numel()
+                        else 0.0,
+                        weights.min().item() if weights.numel() else 0.0,
+                        weights.max().item() if weights.numel() else 0.0,
+                    )
+                self._dsv4_debug_routing_maps("forward_modular")
 
         # Modular kernels use pre-computed routing
         return self.quant_method.apply(

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Callable, Iterable
 from contextlib import nullcontext
+import os
 from typing import TYPE_CHECKING
 
 import torch
@@ -55,6 +56,431 @@ from vllm.utils.torch_utils import (
 )
 
 logger = init_logger(__name__)
+
+_DSV4_ROUTER_FOCUS_DIMS = (3753, 2404, 5308, 1040, 532, 4265, 5414, 2949)
+
+
+def _dsv4_debug_runner_tensor(
+    counts: dict[str, int],
+    layer_name: str,
+    label: str,
+    tensor: torch.Tensor | None,
+    max_logs: int = 8,
+) -> None:
+    if "layers.60.ffn.experts" not in layer_name:
+        return
+    if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+        return
+    if tensor is None:
+        logger.warning("[DSV4_MOE_RUNNER_DEBUG] %s:%s None", layer_name, label)
+        return
+    key = f"{label}:{tuple(tensor.shape)}"
+    count = counts.get(key, 0)
+    if count >= max_logs:
+        return
+    counts[key] = count + 1
+    with torch.no_grad():
+        data = tensor.detach()
+        stat = data.float() if data.is_floating_point() else data.to(torch.float32)
+        finite = torch.isfinite(stat) if data.is_floating_point() else None
+        if finite is not None and not finite.all():
+            stat = stat[finite]
+        if stat.numel() == 0:
+            logger.warning(
+                "[DSV4_MOE_RUNNER_DEBUG] %s:%s count=%s shape=%s dtype=%s EMPTY",
+                layer_name,
+                label,
+                count,
+                tuple(data.shape),
+                data.dtype,
+            )
+            return
+        logger.warning(
+            "[DSV4_MOE_RUNNER_DEBUG] %s:%s count=%s shape=%s dtype=%s "
+            "finite=%s mean=%.6g std=%.6g max=%.6g min=%.6g nonzero=%.6g",
+            layer_name,
+            label,
+            count,
+            tuple(data.shape),
+            data.dtype,
+            bool(finite.all().item()) if finite is not None else True,
+            stat.mean().item(),
+            stat.std(unbiased=False).item(),
+            stat.abs().max().item(),
+            stat.min().item(),
+            (data != 0).float().mean().item(),
+        )
+
+
+def _dsv4_debug_router_selection(
+    counts: dict[str, int],
+    layer_name: str,
+    router: FusedMoERouter,
+    gate: torch.nn.Module | None,
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    input_ids: torch.Tensor | None,
+    max_logs: int = 4,
+) -> None:
+    if "layers.60.ffn.experts" not in layer_name:
+        return
+    if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+        return
+    key = f"router_selection:{tuple(router_logits.shape)}"
+    count = counts.get(key, 0)
+    if count >= max_logs:
+        return
+    counts[key] = count + 1
+    with torch.no_grad():
+        hidden = hidden_states.detach().float()
+        logits = router_logits.detach().float()
+        weights = topk_weights.detach().float()
+        ids = topk_ids.detach().to(torch.int64)
+        finite = torch.isfinite(logits)
+        finite_logits = logits[finite] if finite.numel() else logits
+        if finite_logits.numel() == 0:
+            finite_logits = logits.reshape(-1)[:0]
+
+        scoring_func = getattr(router, "scoring_func", None)
+        routed_scaling_factor = float(
+            getattr(router, "routed_scaling_factor", 1.0)
+        )
+        renormalize = bool(getattr(router, "renormalize", False))
+        e_score_bias = getattr(router, "e_score_correction_bias", None)
+        bias_124 = None
+        top_bias = None
+        if e_score_bias is not None and e_score_bias.numel() > 124:
+            bias = e_score_bias.detach().float()
+            bias_124 = float(bias[124].item())
+            top_bias_values, top_bias_ids = torch.topk(
+                bias, k=min(12, bias.numel()), dim=-1
+            )
+            top_bias = [
+                (int(expert_id.item()), float(value.item()))
+                for expert_id, value in zip(top_bias_ids, top_bias_values)
+            ]
+
+        unscaled_weights = (
+            weights / routed_scaling_factor
+            if routed_scaling_factor != 0.0
+            else weights
+        )
+        row_sums = weights.sum(dim=-1) if weights.ndim >= 2 else weights
+        unscaled_row_sums = (
+            unscaled_weights.sum(dim=-1)
+            if unscaled_weights.ndim >= 2
+            else unscaled_weights
+        )
+
+        mask_124 = ids == 124
+        if mask_124.any():
+            weights_124 = weights[mask_124]
+            unscaled_124 = unscaled_weights[mask_124]
+            token_has_124 = mask_124.any(dim=-1) if mask_124.ndim >= 2 else mask_124
+            first_pos = int(torch.nonzero(mask_124.reshape(-1), as_tuple=False)[0].item())
+        else:
+            weights_124 = weights.reshape(-1)[:0]
+            unscaled_124 = unscaled_weights.reshape(-1)[:0]
+            token_has_124 = mask_124.reshape(-1)[:0]
+            first_pos = -1
+
+        scores_124 = None
+        logits_124 = None
+        scores = None
+        if logits.ndim >= 2 and logits.shape[-1] > 124:
+            logits_124 = logits[:, 124]
+            if scoring_func == "sigmoid":
+                scores = logits.sigmoid()
+            elif scoring_func == "softmax":
+                scores = torch.softmax(logits, dim=-1)
+            elif scoring_func == "sqrtsoftplus":
+                scores = torch.sqrt(F.softplus(logits))
+            if scores is not None:
+                scores_124 = scores[:, 124]
+
+        top_logits_by_mean = None
+        top_scores_by_mean = None
+        if logits.ndim >= 2 and logits.shape[-1] > 0:
+            logits_mean_by_expert = logits.mean(dim=0)
+            top_logit_values, top_logit_ids = torch.topk(
+                logits_mean_by_expert,
+                k=min(12, logits_mean_by_expert.numel()),
+                dim=-1,
+            )
+            top_logits_by_mean = [
+                (int(expert_id.item()), float(value.item()))
+                for expert_id, value in zip(top_logit_ids, top_logit_values)
+            ]
+        if scores is not None and scores.ndim >= 2 and scores.shape[-1] > 0:
+            scores_mean_by_expert = scores.mean(dim=0)
+            top_score_values, top_score_ids = torch.topk(
+                scores_mean_by_expert,
+                k=min(12, scores_mean_by_expert.numel()),
+                dim=-1,
+            )
+            top_scores_by_mean = [
+                (int(expert_id.item()), float(value.item()))
+                for expert_id, value in zip(top_score_ids, top_score_values)
+            ]
+
+        gate124_stats = None
+        gate_top_norms = None
+        gate124_recomputed_stats = None
+        hidden_norm_stats = None
+        hidden_dim_top_signed_124 = None
+        hidden_dim_top_abs_124 = None
+        expert124_logit_sample = None
+        focus_counterfactual = None
+        gate_weight = getattr(gate, "weight", None) if gate is not None else None
+        if gate_weight is not None and gate_weight.ndim == 2:
+            gate_data = gate_weight.detach().float()
+            if gate_data.shape[0] > 124:
+                gate124 = gate_data[124]
+                gate124_stats = (
+                    tuple(gate124.shape),
+                    float(gate124.mean().item()),
+                    float(gate124.std(unbiased=False).item()),
+                    float(gate124.abs().max().item()),
+                    float(torch.linalg.vector_norm(gate124).item()),
+                )
+                if hidden.ndim == 2 and hidden.shape[-1] == gate124.shape[-1]:
+                    hidden_norm = torch.linalg.vector_norm(hidden, dim=-1)
+                    hidden_norm_stats = (
+                        float(hidden_norm.mean().item()),
+                        float(hidden_norm.std(unbiased=False).item()),
+                        float(hidden_norm.min().item()),
+                        float(hidden_norm.max().item()),
+                    )
+                    recomputed_124 = torch.matmul(hidden, gate124)
+                    gate_bias = getattr(gate, "bias", None)
+                    if gate_bias is not None and gate_bias.numel() > 124:
+                        recomputed_124 = recomputed_124 + gate_bias.detach().float()[124]
+                    if logits_124 is not None and logits_124.numel():
+                        diff = recomputed_124 - logits_124
+                        gate124_recomputed_stats = (
+                            float(recomputed_124.mean().item()),
+                            float(recomputed_124.std(unbiased=False).item()),
+                            float(recomputed_124.min().item()),
+                            float(recomputed_124.max().item()),
+                            float(diff.abs().max().item()),
+                            float(diff.abs().mean().item()),
+                        )
+                        expert124_logit_sample = [
+                            float(v.item()) for v in logits_124[:8]
+                        ]
+
+                    mean_hidden = hidden.mean(dim=0)
+                    mean_abs_hidden = hidden.abs().mean(dim=0)
+                    signed_contrib = mean_hidden * gate124
+                    abs_contrib = mean_abs_hidden * gate124.abs()
+                    top_signed_values, top_signed_ids = torch.topk(
+                        signed_contrib.abs(),
+                        k=min(16, signed_contrib.numel()),
+                        dim=-1,
+                    )
+                    hidden_dim_top_signed_124 = [
+                        (
+                            int(dim_id.item()),
+                            float(signed_contrib[dim_id].item()),
+                            float(mean_hidden[dim_id].item()),
+                            float(gate124[dim_id].item()),
+                        )
+                        for dim_id in top_signed_ids
+                    ]
+                    top_abs_values, top_abs_ids = torch.topk(
+                        abs_contrib,
+                        k=min(16, abs_contrib.numel()),
+                        dim=-1,
+                    )
+                    hidden_dim_top_abs_124 = [
+                        (
+                            int(dim_id.item()),
+                            float(top_value.item()),
+                            float(mean_abs_hidden[dim_id].item()),
+                            float(gate124[dim_id].item()),
+                        )
+                        for dim_id, top_value in zip(top_abs_ids, top_abs_values)
+                    ]
+                    focus_dims = [
+                        d for d in _DSV4_ROUTER_FOCUS_DIMS if d < hidden.shape[-1]
+                    ]
+                    if focus_dims and gate_data.shape[-1] == hidden.shape[-1]:
+                        focus = torch.tensor(
+                            focus_dims, device=hidden.device, dtype=torch.long
+                        )
+                        hidden_zero = hidden.clone()
+                        hidden_zero[:, focus] = 0
+                        logits_zero = torch.matmul(hidden_zero, gate_data.T)
+                        hidden_centered = hidden.clone()
+                        hidden_centered[:, focus] = (
+                            hidden_centered[:, focus]
+                            - hidden_centered[:, focus].mean(dim=0, keepdim=True)
+                        )
+                        logits_centered = torch.matmul(hidden_centered, gate_data.T)
+                        gate_bias_full = getattr(gate, "bias", None)
+                        if gate_bias_full is not None:
+                            logits_zero = logits_zero + gate_bias_full.detach().float()
+                            logits_centered = (
+                                logits_centered + gate_bias_full.detach().float()
+                            )
+                        zero_mean = logits_zero.mean(dim=0)
+                        centered_mean = logits_centered.mean(dim=0)
+                        zero_top_vals, zero_top_ids = torch.topk(
+                            zero_mean, k=min(8, zero_mean.numel())
+                        )
+                        centered_top_vals, centered_top_ids = torch.topk(
+                            centered_mean, k=min(8, centered_mean.numel())
+                        )
+                        focus_counterfactual = {
+                            "dims": focus_dims,
+                            "zero124_mean": float(zero_mean[124].item()),
+                            "zero124_rank": int(
+                                (zero_mean > zero_mean[124]).sum().item() + 1
+                            ),
+                            "zero_top": [
+                                (int(i.item()), float(v.item()))
+                                for i, v in zip(zero_top_ids, zero_top_vals)
+                            ],
+                            "centered124_mean": float(centered_mean[124].item()),
+                            "centered124_rank": int(
+                                (centered_mean > centered_mean[124]).sum().item() + 1
+                            ),
+                            "centered_top": [
+                                (int(i.item()), float(v.item()))
+                                for i, v in zip(centered_top_ids, centered_top_vals)
+                            ],
+                        }
+            norms = torch.linalg.vector_norm(gate_data, dim=1)
+            top_norm_values, top_norm_ids = torch.topk(
+                norms, k=min(12, norms.numel()), dim=-1
+            )
+            gate_top_norms = [
+                (int(expert_id.item()), float(value.item()))
+                for expert_id, value in zip(top_norm_ids, top_norm_values)
+            ]
+
+        logger.warning(
+            "[DSV4_ROUTER_SELECTION_DEBUG] layer=%s count=%s "
+            "router=%s scoring=%s renormalize=%s routed_scaling_factor=%.6g "
+            "bias124=%s input_shape=%s logits_shape=%s logits_dtype=%s "
+            "logits_finite=%s logits_mean=%.6g logits_std=%.6g "
+            "logits_min=%.6g logits_max=%.6g topk_ids_shape=%s "
+            "topk_min=%s topk_max=%s topk_unique=%s weights_shape=%s "
+            "weights_mean=%.6g weights_std=%.6g weights_min=%.6g "
+            "weights_max=%.6g row_sum_mean=%.6g row_sum_min=%.6g "
+            "row_sum_max=%.6g unscaled_row_sum_mean=%.6g "
+            "expert124_count=%s expert124_token_frac=%.6g "
+            "expert124_weight_mean=%.6g expert124_weight_max=%.6g "
+            "expert124_unscaled_mean=%.6g expert124_unscaled_max=%.6g "
+            "expert124_logit_mean=%s expert124_logit_max=%s "
+            "expert124_score_mean=%s expert124_score_max=%s first124_flat_pos=%s",
+            layer_name,
+            count,
+            type(router).__name__,
+            scoring_func,
+            renormalize,
+            routed_scaling_factor,
+            bias_124,
+            tuple(input_ids.shape) if input_ids is not None else None,
+            tuple(router_logits.shape),
+            router_logits.dtype,
+            bool(finite.all().item()) if finite.numel() else True,
+            finite_logits.mean().item() if finite_logits.numel() else 0.0,
+            finite_logits.std(unbiased=False).item()
+            if finite_logits.numel()
+            else 0.0,
+            finite_logits.min().item() if finite_logits.numel() else 0.0,
+            finite_logits.max().item() if finite_logits.numel() else 0.0,
+            tuple(topk_ids.shape),
+            int(ids.min().item()) if ids.numel() else None,
+            int(ids.max().item()) if ids.numel() else None,
+            int(torch.unique(ids).numel()) if ids.numel() else 0,
+            tuple(topk_weights.shape),
+            weights.mean().item() if weights.numel() else 0.0,
+            weights.std(unbiased=False).item() if weights.numel() else 0.0,
+            weights.min().item() if weights.numel() else 0.0,
+            weights.max().item() if weights.numel() else 0.0,
+            row_sums.mean().item() if row_sums.numel() else 0.0,
+            row_sums.min().item() if row_sums.numel() else 0.0,
+            row_sums.max().item() if row_sums.numel() else 0.0,
+            unscaled_row_sums.mean().item() if unscaled_row_sums.numel() else 0.0,
+            int(mask_124.sum().item()) if mask_124.numel() else 0,
+            token_has_124.float().mean().item() if token_has_124.numel() else 0.0,
+            weights_124.mean().item() if weights_124.numel() else 0.0,
+            weights_124.max().item() if weights_124.numel() else 0.0,
+            unscaled_124.mean().item() if unscaled_124.numel() else 0.0,
+            unscaled_124.max().item() if unscaled_124.numel() else 0.0,
+            logits_124.mean().item()
+            if logits_124 is not None and logits_124.numel()
+            else None,
+            logits_124.max().item()
+            if logits_124 is not None and logits_124.numel()
+            else None,
+            scores_124.mean().item()
+            if scores_124 is not None and scores_124.numel()
+            else None,
+            scores_124.max().item()
+            if scores_124 is not None and scores_124.numel()
+            else None,
+            first_pos,
+        )
+
+        if weights.numel() and ids.numel():
+            flat_ids = ids.reshape(-1)
+            flat_weights = weights.reshape(-1)
+            unique_ids = torch.unique(flat_ids, sorted=True)
+            summaries: list[tuple[int, int, float, float]] = []
+            for expert_id in unique_ids[:384]:
+                expert_mask = flat_ids == expert_id
+                expert_weights = flat_weights[expert_mask]
+                summaries.append(
+                    (
+                        int(expert_id.item()),
+                        int(expert_mask.sum().item()),
+                        float(expert_weights.mean().item()),
+                        float(expert_weights.max().item()),
+                    )
+                )
+            summaries.sort(key=lambda item: item[2], reverse=True)
+            logger.warning(
+                "[DSV4_ROUTER_SELECTION_DEBUG] layer=%s count=%s "
+                "top_experts_by_avg_weight=%s",
+                layer_name,
+                count,
+                summaries[:12],
+            )
+
+        logger.warning(
+            "[DSV4_ROUTER_GATE_DEBUG] layer=%s count=%s top_bias=%s "
+            "top_logits_by_mean=%s top_scores_by_mean=%s "
+            "gate124_stats=(shape,mean,std,absmax,l2)=%s "
+            "hidden_norm_stats=(mean,std,min,max)=%s "
+            "gate124_recomputed=(mean,std,min,max,diff_absmax,diff_absmean)=%s "
+            "expert124_logit_sample=%s gate_top_norms=%s",
+            layer_name,
+            count,
+            top_bias,
+            top_logits_by_mean,
+            top_scores_by_mean,
+            gate124_stats,
+            hidden_norm_stats,
+            gate124_recomputed_stats,
+            expert124_logit_sample,
+            gate_top_norms,
+        )
+        logger.warning(
+            "[DSV4_ROUTER_INPUT_CONTRIB_DEBUG] layer=%s count=%s "
+            "expert124_top_signed_dims=(dim,mean_hidden_x_weight,mean_hidden,weight)=%s "
+            "expert124_top_abs_dims=(dim,mean_abs_hidden_x_abs_weight,mean_abs_hidden,weight)=%s "
+            "focus_counterfactual=%s",
+            layer_name,
+            count,
+            hidden_dim_top_signed_124,
+            hidden_dim_top_abs_124,
+            focus_counterfactual,
+        )
 
 
 def register_layer_for_moe_forward_op(
@@ -286,6 +712,7 @@ class MoERunner(MoERunnerInterface):
 
         # Needed for string -> MoERunner layer lookup in custom ops.
         self.layer_name = layer_name
+        self._dsv4_debug_counts: dict[str, int] = {}
 
         self._forward_entry = self._select_forward()
 
@@ -423,7 +850,6 @@ class MoERunner(MoERunnerInterface):
         if (
             shared_output is not None
             and not self.moe_config.is_sequence_parallel
-            and not self.moe_config.skip_final_all_reduce
             and self._fused_output_is_reduced
         ):
             shared_output = tensor_model_parallel_all_reduce(shared_output)
@@ -446,7 +872,6 @@ class MoERunner(MoERunnerInterface):
         # - The MK already reduced the fused output itself.
         if (
             not self.moe_config.is_sequence_parallel
-            and not self.moe_config.skip_final_all_reduce
             and (self.moe_config.tp_size > 1 or self.moe_config.ep_size > 1)
             and not self._fused_output_is_reduced
         ):
@@ -501,13 +926,11 @@ class MoERunner(MoERunnerInterface):
         #   pre_xform:  applied to fused_output BEFORE routed_output_transform
         #   post_xform: applied to the final result AFTER all-reduce
         #
-        # MoE with routed output transform or shared experts:
-        #   - pre_xform applies if the transform needs unpadded routed output
-        #     or shared+routed add needs matching hidden dims. For Nemotron-3
-        #     Nano, TRTLLM NVFP4 pads routed MoE hidden dim 2688->2816, while
-        #     shared output stays 2688.
-        #   - post_xform uses shared_experts_hidden_dim when transform and shared
-        #     experts make the final output full hidden dim.
+        # Latent MoE with shared experts (NemotronH):
+        #   - pre_xform strips padding from the latent dim so
+        #     routed_output_transform receives the correct input size
+        #   - post_xform truncates to shared_experts_hidden_dim (full hidden)
+        #     after shared + routed outputs are combined and all-reduced
         #
         # Standard MoE / MoE without transforms (GPT-OSS, Mixtral):
         #   - pre_xform is None (no early truncation)
@@ -515,12 +938,12 @@ class MoERunner(MoERunnerInterface):
         if transformed_hidden_dim == hidden_states.shape[-1]:
             transformed_hidden_dim = None
 
-        pre_xform_trunc_size = None
-        if self.routed_output_transform is not None or shared_experts_hidden_dim > 0:
-            pre_xform_trunc_size = transformed_hidden_dim
-        post_xform_trunc_size = transformed_hidden_dim
         if self.routed_output_transform is not None and shared_experts_hidden_dim > 0:
+            pre_xform_trunc_size = transformed_hidden_dim
             post_xform_trunc_size = shared_experts_hidden_dim
+        else:
+            pre_xform_trunc_size = None
+            post_xform_trunc_size = transformed_hidden_dim
 
         return hidden_states, pre_xform_trunc_size, post_xform_trunc_size
 
@@ -564,6 +987,17 @@ class MoERunner(MoERunnerInterface):
                 router_logits=router_logits,
                 topk_indices_dtype=self._quant_method.topk_indices_dtype,
                 input_ids=input_ids,
+            )
+            _dsv4_debug_router_selection(
+                self._dsv4_debug_counts,
+                self.layer_name,
+                self.router,
+                self.gate,
+                hidden_states,
+                router_logits,
+                topk_weights,
+                topk_ids,
+                input_ids,
             )
 
             fused_out = self.routed_experts.forward_modular(
@@ -693,6 +1127,18 @@ class MoERunner(MoERunnerInterface):
 
         # Extract outputs from result
         shared_output, fused_output = _unpack(result)
+        _dsv4_debug_runner_tensor(
+            self._dsv4_debug_counts,
+            self.layer_name,
+            "shared_output_raw",
+            shared_output,
+        )
+        _dsv4_debug_runner_tensor(
+            self._dsv4_debug_counts,
+            self.layer_name,
+            "fused_output_raw",
+            fused_output,
+        )
 
         if og_hidden_dim_pre_xform is not None:
             fused_output = fused_output[..., :og_hidden_dim_pre_xform]
@@ -700,10 +1146,58 @@ class MoERunner(MoERunnerInterface):
         # If combine kernel already reduced fused, reduce shared to match.
         # See note above re: the two all-reduce points.
         shared_output = self._maybe_reduce_shared_expert_output(shared_output)
+        _dsv4_debug_runner_tensor(
+            self._dsv4_debug_counts,
+            self.layer_name,
+            "shared_output_after_maybe_reduce",
+            shared_output,
+        )
 
         shared_output, fused_output = self._maybe_apply_routed_scale_to_output(
             shared_output, fused_output
         )
+        _dsv4_debug_runner_tensor(
+            self._dsv4_debug_counts,
+            self.layer_name,
+            "shared_output_after_routed_scale",
+            shared_output,
+        )
+        _dsv4_debug_runner_tensor(
+            self._dsv4_debug_counts,
+            self.layer_name,
+            "fused_output_after_routed_scale",
+            fused_output,
+        )
+
+        if (
+            shared_output is not None
+            and "layers.60.ffn.experts" in self.layer_name
+        ):
+            shared_scale = os.environ.get("DSV4_DEBUG_LAYER60_SHARED_SCALE")
+            if shared_scale is not None:
+                try:
+                    shared_scale_value = float(shared_scale)
+                except ValueError:
+                    shared_scale_value = 1.0
+                    logger.warning(
+                        "[DSV4_MOE_RUNNER_DEBUG] %s invalid "
+                        "DSV4_DEBUG_LAYER60_SHARED_SCALE=%r; using 1.0",
+                        self.layer_name,
+                        shared_scale,
+                    )
+                logger.warning(
+                    "[DSV4_MOE_RUNNER_DEBUG] %s applying "
+                    "DSV4_DEBUG_LAYER60_SHARED_SCALE=%s",
+                    self.layer_name,
+                    shared_scale_value,
+                )
+                shared_output = shared_output * shared_scale_value
+                _dsv4_debug_runner_tensor(
+                    self._dsv4_debug_counts,
+                    self.layer_name,
+                    "shared_output_after_debug_scale",
+                    shared_output,
+                )
 
         # Apply output transform (e.g. latent -> full dim)
         fused_output = self.apply_routed_output_transform(fused_output)
@@ -712,8 +1206,20 @@ class MoERunner(MoERunnerInterface):
             result = shared_output + fused_output
         else:
             result = fused_output
+        _dsv4_debug_runner_tensor(
+            self._dsv4_debug_counts,
+            self.layer_name,
+            "result_before_final_reduce",
+            result,
+        )
 
         result = self._maybe_reduce_final_output(result, og_hidden_dim_post_xform)
+        _dsv4_debug_runner_tensor(
+            self._dsv4_debug_counts,
+            self.layer_name,
+            "result_after_final_reduce",
+            result,
+        )
 
         return self._maybe_add_zero_expert_output(result)
 

--- a/vllm/model_executor/layers/mhc.py
+++ b/vllm/model_executor/layers/mhc.py
@@ -1,30 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+
 import torch
 
 # this import will also register the custom ops
 # import vllm.model_executor.kernels.mhc  # noqa: F401
 import vllm.model_executor.kernels.mhc as mhc_kernels
 from vllm.model_executor.custom_op import CustomOp
-from vllm.platforms import current_platform
 from vllm.utils.import_utils import has_tilelang
 
-
-def _has_tilelang_mhc() -> bool:
-    if not has_tilelang():
-        return False
-    if current_platform.is_cuda():
-        return True
-    if current_platform.is_rocm():
-        from vllm.platforms.rocm import on_gfx942
-
-        # TileLang MHC currently produces incorrect results on gfx942. Keep
-        # gfx942 on the existing torch/triton fallbacks until that path is fixed.
-        return not on_gfx942()
-    return False
-
-
-HAS_TILELANG_MHC = _has_tilelang_mhc()
+HAS_TILELANG = has_tilelang()
 
 
 # --8<-- [start:mhc_pre]
@@ -105,7 +91,7 @@ class MHCPreOp(CustomOp):
         #         sinkhorn_repeat,
         #     )
         # else:
-        if HAS_TILELANG_MHC:
+        if HAS_TILELANG:
             return torch.ops.vllm.mhc_pre_tilelang(
                 residual,
                 fn,
@@ -240,7 +226,7 @@ class MHCPostOp(CustomOp):
         #         comb_res_mix,
         #     )
         # else:
-        if HAS_TILELANG_MHC:
+        if HAS_TILELANG:
             return torch.ops.vllm.mhc_post_tilelang(
                 x, residual, post_layer_mix, comb_res_mix
             )
@@ -326,7 +312,10 @@ class HCHeadOp(CustomOp):
         outer_shape = hidden_states.shape[:-2]
         hs_flat = hidden_states.view(-1, hc_mult, hidden_size)
 
-        if HAS_TILELANG_MHC:
+        if (
+            HAS_TILELANG
+            and os.environ.get("DSV4_DEBUG_FORCE_HC_HEAD_TRITON") != "1"
+        ):
             out = torch.ops.vllm.hc_head_fused_kernel_tilelang(
                 hs_flat,
                 hc_fn,
@@ -463,26 +452,7 @@ class MHCFusedPostPreOp(CustomOp):
         norm_weight: torch.Tensor | None = None,
         norm_eps: float = 0.0,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        if HAS_TILELANG_MHC:
-            return torch.ops.vllm.mhc_fused_post_pre_tilelang(
-                x,
-                residual,
-                post_layer_mix,
-                comb_res_mix,
-                fn,
-                hc_scale,
-                hc_base,
-                rms_eps,
-                hc_pre_eps,
-                hc_sinkhorn_eps,
-                hc_post_mult_value,
-                sinkhorn_repeat,
-                n_splits,
-                tile_n,
-                norm_weight,
-                norm_eps,
-            )
-        return self.forward_native(
+        return torch.ops.vllm.mhc_fused_post_pre_tilelang(
             x,
             residual,
             post_layer_mix,

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -30,6 +30,7 @@ from vllm.model_executor.layers.quantization.quark.schemes import (
     QuarkScheme,
     QuarkW4A8_MXFP4_FP8,
     QuarkW8A8Fp8,
+    QuarkW8A8Fp8Block,
     QuarkW8A8Int8,
 )
 from vllm.model_executor.layers.quantization.quark.utils import (
@@ -345,6 +346,30 @@ class QuarkConfig(QuantizationConfig):
         is_per_tensor_activation = input_quant.get("qscheme") == "per_tensor"
         return is_per_tensor_activation
 
+    def _is_fp8_block_w8a8(
+        self,
+        weight_quant: dict[str, Any] | None,
+        input_quant: dict[str, Any] | None,
+    ) -> bool:
+        if weight_quant is None or input_quant is None:
+            return False
+
+        is_weight_block_fp8 = (
+            weight_quant.get("dtype") == "fp8_e4m3"
+            and weight_quant.get("qscheme") == "per_block"
+            and weight_quant.get("block_size") == [128, 128]
+            and weight_quant.get("scale_type") == "float8_e8m0fnu"
+            and not weight_quant.get("is_dynamic")
+        )
+        is_input_dynamic_group_fp8 = (
+            input_quant.get("dtype") == "fp8_e4m3"
+            and input_quant.get("qscheme") == "per_group"
+            and input_quant.get("group_size") == 128
+            and input_quant.get("is_dynamic") is True
+        )
+
+        return is_weight_block_fp8 and is_input_dynamic_group_fp8
+
     def _is_static_tensor_w8a8(
         self,
         weight_quant: dict[str, Any] | None,
@@ -627,6 +652,8 @@ class QuarkConfig(QuantizationConfig):
 
         if self._is_nvfp4(weight_config, input_config):
             return QuarkNVFP4()
+        elif self._is_fp8_block_w8a8(weight_config, input_config):
+            return QuarkW8A8Fp8Block(weight_config, input_config)
         elif self._is_fp8_w8a8(weight_config, input_config):
             is_fp8_w8a8_supported = self._check_scheme_supported(
                 QuarkW8A8Fp8.get_min_capability(), error=False
@@ -679,17 +706,16 @@ class QuarkConfig(QuantizationConfig):
 
         return scheme
 
-    @staticmethod
-    def get_cache_scale_mapper() -> "WeightsMapper":
+    def get_cache_scale_mapper(self) -> "WeightsMapper":
         """Map Quark KV-cache scale names to vLLM names."""
-        orig_to_new_suffix = {
-            ".k_proj.output_scale": ".attn.k_scale",
-            ".v_proj.output_scale": ".attn.v_scale",
-            ".q_proj.output_scale": ".attn.q_scale",
-            ".self_attn.prob_output_scale": ".self_attn.attn.prob_scale",
-        }
-        cache_scale_mapper = WeightsMapper(orig_to_new_suffix=orig_to_new_suffix)
-        return cache_scale_mapper | QuantizationConfig.get_cache_scale_mapper()
+        return WeightsMapper(
+            orig_to_new_suffix={
+                ".k_proj.output_scale": ".attn.k_scale",
+                ".v_proj.output_scale": ".attn.v_scale",
+                ".q_proj.output_scale": ".attn.q_scale",
+                ".self_attn.prob_output_scale": ".self_attn.attn.prob_scale",
+            }
+        )
 
 
 class QuarkLinearMethod(LinearMethodBase):

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -7,6 +7,7 @@ import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm import _custom_ops as ops
+from vllm import envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
@@ -14,6 +15,7 @@ from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
     FusedMoEMethodBase,
     FusedMoeWeightScaleSupported,
+    MoEActivation,
     RoutedExperts,
     SharedExperts,
 )
@@ -26,13 +28,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     mxfp4_w4a16_moe_quant_config,
     ocp_mx_moe_quant_config,
 )
-from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
-    Fp8MoeBackend,
-    convert_to_fp8_moe_kernel_format,
-    make_fp8_moe_kernel,
-    make_fp8_moe_quant_config,
-    select_fp8_moe_backend,
-)
+from vllm.model_executor.layers.fused_moe.experts.marlin_moe import fused_marlin_moe
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
     TRITON_BACKENDS,
     Mxfp4MoeBackend,
@@ -44,10 +40,14 @@ from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
     select_mxfp4_moe_backend,
 )
 from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
     convert_to_nvfp4_moe_kernel_format,
     make_nvfp4_moe_kernel,
     make_nvfp4_moe_quant_config,
     select_nvfp4_moe_backend,
+)
+from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import (
+    prepare_fp8_moe_layer_for_marlin,
 )
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import (
     OCP_MX_BLOCK_SIZE,
@@ -55,9 +55,6 @@ from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
-    kFp8DynamicTensorSym,
-    kFp8DynamicTokenSym,
-    kFp8StaticChannelSym,
     kFp8StaticTensorSym,
     kMxfp4Dynamic,
     kNvfp4Dynamic,
@@ -70,8 +67,70 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 )
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 from vllm.platforms import current_platform
+from vllm.scalar_type import scalar_types
 
 logger = init_logger(__name__)
+
+
+def _dsv4_debug_nvfp4_moe_scales(layer: RoutedExperts) -> None:
+    if getattr(layer, "_dsv4_nvfp4_scale_debug_printed", False):
+        return
+    layer._dsv4_nvfp4_scale_debug_printed = True
+    with torch.no_grad():
+        w1 = layer.w13_weight_scale_2[:, 0].detach().float()
+        w3 = layer.w13_weight_scale_2[:, 1].detach().float()
+        w2 = layer.w2_weight_scale_2.detach().float()
+        fused = torch.maximum(w1, w3)
+        denom = torch.minimum(w1.abs(), w3.abs()).clamp_min(torch.finfo(torch.float32).tiny)
+        ratio = fused.abs() / denom
+        topk = min(8, ratio.numel())
+        top_vals, top_ids = torch.topk(ratio, k=topk)
+        layer_name = getattr(layer, "layer_name", None)
+        if layer_name is None:
+            layer_name = getattr(layer, "prefix", None)
+        if layer_name is None:
+            layer_name = layer.__class__.__name__
+        logger.warning(
+            "[DSV4_NVFP4_MOE_SCALE_RATIO] layer=%s local_experts=%s "
+            "w1_min=%.6g w1_max=%.6g w1_mean=%.6g "
+            "w3_min=%.6g w3_max=%.6g w3_mean=%.6g "
+            "w2_min=%.6g w2_max=%.6g w2_mean=%.6g "
+            "fused_min=%.6g fused_max=%.6g fused_mean=%.6g "
+            "ratio_min=%.6g ratio_max=%.6g ratio_mean=%.6g "
+            "ratio_top_ids=%s ratio_top_vals=%s",
+            layer_name,
+            ratio.numel(),
+            w1.min().item(),
+            w1.max().item(),
+            w1.mean().item(),
+            w3.min().item(),
+            w3.max().item(),
+            w3.mean().item(),
+            w2.min().item(),
+            w2.max().item(),
+            w2.mean().item(),
+            fused.min().item(),
+            fused.max().item(),
+            fused.mean().item(),
+            ratio.min().item(),
+            ratio.max().item(),
+            ratio.mean().item(),
+            top_ids.detach().cpu().tolist(),
+            [round(v, 6) for v in top_vals.detach().cpu().tolist()],
+        )
+        for expert_id in top_ids.detach().cpu().tolist():
+            logger.warning(
+                "[DSV4_NVFP4_MOE_SCALE_RATIO_EXPERT] layer=%s expert_id=%s "
+                "w1=%.6g w3=%.6g w2=%.6g fused=%.6g ratio=%.6g",
+                layer_name,
+                expert_id,
+                w1[expert_id].item(),
+                w3[expert_id].item(),
+                w2[expert_id].item(),
+                fused[expert_id].item(),
+                ratio[expert_id].item(),
+            )
+
 
 __all__ = [
     "QuarkMoEMethod",
@@ -123,6 +182,11 @@ class QuarkMoEMethod(FusedMoEMethodBase):
                 weight_config, input_config, module.moe_config
             )
         else:
+            logger.error(
+                "Unsupported Quark MoE config. Weight config: %s, Input config: %s",
+                weight_config,
+                input_config,
+            )
             raise RuntimeError("Unsupported FusedMoe scheme")
 
 
@@ -166,22 +230,17 @@ class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
                 "channelwise, dynamic per token quantization."
             )
 
-        # Determine quant keys for oracle backend selection
-        if per_channel:
-            weight_key = kFp8StaticChannelSym
-            activation_key = kFp8DynamicTokenSym
-        elif self.static_input_scales:
-            weight_key = kFp8StaticTensorSym
-            activation_key = kFp8StaticTensorSym
-        else:
-            weight_key = kFp8StaticTensorSym
-            activation_key = kFp8DynamicTensorSym
-
-        self.fp8_backend, self.experts_cls = select_fp8_moe_backend(
-            config=moe,
-            weight_key=weight_key,
-            activation_key=activation_key,
+        # For GPUs that lack FP8 hardware support, we can leverage the Marlin
+        # kernel for fast weight-only FP8 quantization
+        self.use_marlin = (
+            not current_platform.has_device_capability(89)
+            or envs.VLLM_TEST_FORCE_FP8_MARLIN
         )
+        # Disable marlin for rocm
+        if current_platform.is_rocm():
+            self.use_marlin = False
+
+        self.rocm_aiter_moe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
 
         self.model_type = getattr(
             get_current_vllm_config().model_config.hf_config, "model_type", None
@@ -415,51 +474,50 @@ class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
                 layer.w2_weight_scale = torch.nn.Parameter(
                     w2_weight_scale, requires_grad=False
                 )
-        self._setup_kernel(layer)
+        # Property to determine if AITER is used
+        if self.rocm_aiter_moe_enabled:
+            # reshaping weights is required for aiter moe kernel.
+            shuffled_w13, shuffled_w2 = rocm_aiter_ops.shuffle_weights(
+                layer.w13_weight.data, layer.w2_weight.data
+            )
 
-    def _setup_kernel(self, layer: RoutedExperts) -> None:
-        w13, w2, w13_scale, w2_scale = convert_to_fp8_moe_kernel_format(
-            fp8_backend=self.fp8_backend,
-            layer=layer,
-            w13=layer.w13_weight,
-            w2=layer.w2_weight,
-            w13_scale=layer.w13_weight_scale,
-            w2_scale=layer.w2_weight_scale,
-            w13_input_scale=layer.w13_input_scale,
-            w2_input_scale=layer.w2_input_scale,
-        )
-        replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w2_weight", w2)
-        replace_parameter(layer, "w13_weight_scale", w13_scale)
-        replace_parameter(layer, "w2_weight_scale", w2_scale)
+            layer.w13_weight = torch.nn.Parameter(shuffled_w13, requires_grad=False)
+            layer.w2_weight = torch.nn.Parameter(shuffled_w2, requires_grad=False)
 
-        if self.fp8_backend == Fp8MoeBackend.AITER:
-            layer.w13_weight.is_shuffled = True
-            layer.w2_weight.is_shuffled = True
+        elif self.use_marlin:
+            w13_weight, w2_weight, w13_weight_scale, w2_weight_scale = (
+                prepare_fp8_moe_layer_for_marlin(
+                    layer,
+                    layer.w13_weight,
+                    layer.w2_weight,
+                    layer.w13_weight_scale,
+                    layer.w2_weight_scale,
+                )
+            )
+            # TODO(rob): once we apply refactor to Quark, switch to using
+            # replace_parameter for compatibility with reloading in RL.
+            layer.w13_weight = torch.nn.Parameter(w13_weight, requires_grad=False)
+            layer.w2_weight = torch.nn.Parameter(w2_weight, requires_grad=False)
+            layer.w13_weight_scale = torch.nn.Parameter(
+                w13_weight_scale, requires_grad=False
+            )
+            layer.w2_weight_scale = torch.nn.Parameter(
+                w2_weight_scale, requires_grad=False
+            )
 
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        assert self.moe_quant_config is not None
-        assert self.experts_cls is not None
-        self.moe_kernel = make_fp8_moe_kernel(
-            moe_quant_config=self.moe_quant_config,
-            moe_config=self.moe,
-            fp8_backend=self.fp8_backend,
-            experts_cls=self.experts_cls,
-            routing_tables=layer._expert_routing_tables(),
-        )
-
-    def get_fused_moe_quant_config(self, layer: RoutedExperts) -> FusedMoEQuantConfig:
-        return make_fp8_moe_quant_config(
-            fp8_backend=self.fp8_backend,
+    def get_fused_moe_quant_config(
+        self, layer: RoutedExperts
+    ) -> FusedMoEQuantConfig | None:
+        return fp8_w8a8_moe_quant_config(
             w1_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
             a1_scale=layer.w13_input_scale,
             a2_scale=layer.w2_input_scale,
-            w1_bias=getattr(layer, "w13_bias", None),
-            w2_bias=getattr(layer, "w2_bias", None),
+            w1_bias=layer.w13_bias,
+            w2_bias=layer.w2_bias,
             per_act_token_quant=self.input_qscheme == "per_channel",
             per_out_ch_quant=self.weight_qscheme == "per_channel",
-            swiglu_limit=getattr(layer, "swiglu_limit", None),
+            gemm1_clamp_limit=getattr(layer, "swiglu_limit", None),
         )
 
     def apply(
@@ -471,20 +529,57 @@ class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
         shared_experts: SharedExperts | None,
         shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
-        assert self.moe_kernel is not None
-        return self.moe_kernel.apply(
-            hidden_states=x,
-            w1=layer.w13_weight,
-            w2=layer.w2_weight,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            activation=layer.activation,
-            global_num_experts=layer.global_num_experts,
-            apply_router_weight_on_input=layer.apply_router_weight_on_input,
-            expert_map=layer.expert_map,
-            shared_experts=shared_experts,
-            shared_experts_input=shared_experts_input,
-        )
+        if self.rocm_aiter_moe_enabled:
+            from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+                rocm_aiter_fused_experts,
+            )
+
+            return rocm_aiter_fused_experts(
+                hidden_states=x,
+                w1=layer.w13_weight,
+                w2=layer.w2_weight,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation=layer.activation,
+                apply_router_weight_on_input=layer.apply_router_weight_on_input,
+                quant_config=self.moe_quant_config,
+                moe_config=layer.moe_config,
+                expert_map=layer.expert_map,
+            )
+        elif self.use_marlin:
+            assert layer.activation == MoEActivation.SILU, (
+                f"{layer.activation} not supported for Marlin MoE."
+            )
+            return fused_marlin_moe(
+                x,
+                layer.w13_weight,
+                layer.w2_weight,
+                None,
+                None,
+                layer.w13_weight_scale,
+                layer.w2_weight_scale,
+                topk_weights,
+                topk_ids,
+                quant_type_id=scalar_types.float8_e4m3fn.id,
+                apply_router_weight_on_input=layer.apply_router_weight_on_input,
+                global_num_experts=layer.global_num_experts,
+                expert_map=layer.expert_map,
+            )
+        else:
+            from vllm.model_executor.layers.fused_moe import fused_experts
+
+            return fused_experts(
+                hidden_states=x,
+                w1=layer.w13_weight,
+                w2=layer.w2_weight,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation=layer.activation,
+                apply_router_weight_on_input=layer.apply_router_weight_on_input,
+                global_num_experts=layer.global_num_experts,
+                expert_map=layer.expert_map,
+                quant_config=self.moe_quant_config,
+            )
 
 
 class QuarkW8A8Int8MoEMethod(QuarkMoEMethod):
@@ -1211,8 +1306,6 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
                 w2_weight_scale=layer.w2_weight_scale,
                 w13_bias=w13_bias,
                 w2_bias=w2_bias,
-                w13_input_scale=layer.w13_input_scale,
-                w2_input_scale=layer.w2_input_scale,
             )
         )
 
@@ -1277,10 +1370,6 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
                 w2_bias=getattr(layer, "w2_bias", None),
                 a1_scale=getattr(layer, "w13_input_scale", None),
                 a2_scale=getattr(layer, "w2_input_scale", None),
-                gemm1_alpha=getattr(layer, "swiglu_alpha", None),
-                gemm1_beta=getattr(layer, "swiglu_beta", None),
-                swiglu_limit=getattr(layer, "swiglu_limit", None),
-                layer=layer,
             )
 
         # Emulation and other schemes
@@ -1317,9 +1406,6 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
                 a1_scale=None,
                 a2_scale=None,
                 block_shape=None,
-                gemm1_alpha=getattr(layer, "swiglu_alpha", None),
-                gemm1_beta=getattr(layer, "swiglu_beta", None),
-                gemm1_clamp_limit=getattr(layer, "swiglu_limit", None),
             )
 
     @property
@@ -1376,7 +1462,7 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
     def __init__(
         self,
         weight_config: dict[str, Any],
-        input_config: dict[str, Any],
+        input_config: dict[str, Any] | None,
         moe: FusedMoEConfig,
         quant_config: "QuarkConfig",  # type: ignore # noqa E501 # noqa F821
     ):
@@ -1507,12 +1593,26 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
         if not torch.allclose(
             layer.w13_weight_scale_2[:, 0], layer.w13_weight_scale_2[:, 1]
         ):
-            raise ValueError("Different global scales for w1 and w3 is not supported.")
+            logger.warning_once(
+                "In NVFP4 MoE, the global scales for w1 and w3 are different. "
+                "Using the maximum scale for the fused w13 tensor. This may "
+                "slightly reduce accuracy; prefer checkpoints with shared "
+                "w1/w3 global scales for fused experts."
+            )
 
-        # Use a single gscale for w13
-        w13_weight_scale_2 = torch.maximum(
-            layer.w13_weight_scale_2[:, 0], layer.w13_weight_scale_2[:, 1]
-        ).contiguous()
+        _dsv4_debug_nvfp4_moe_scales(layer)
+
+        if getattr(self.nvfp4_backend, "value", None) == "EMULATION":
+            logger.warning_once(
+                "[DSV4_NVFP4_MOE_SCALE_FIX] Using separate w1/w3 global "
+                "scales for the NVFP4 MoE emulation backend."
+            )
+            w13_weight_scale_2 = layer.w13_weight_scale_2.contiguous()
+        else:
+            # Use a single gscale for w13
+            w13_weight_scale_2 = torch.maximum(
+                layer.w13_weight_scale_2[:, 0], layer.w13_weight_scale_2[:, 1]
+            ).contiguous()
 
         w2_weight_scale_2 = layer.w2_weight_scale_2
 
@@ -1563,7 +1663,7 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
     ) -> FusedMoEQuantConfig | None:
-        return make_nvfp4_moe_quant_config(
+        quant_config = make_nvfp4_moe_quant_config(
             backend=self.nvfp4_backend,
             w13_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
@@ -1572,6 +1672,12 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
             a13_scale=layer.w13_input_scale_2,
             a2_scale=layer.w2_input_scale_2,
         )
+        setattr(
+            quant_config,
+            "_dsv4_layer_name",
+            getattr(layer, "layer_name", getattr(layer, "prefix", "unknown")),
+        )
+        return quant_config
 
     def apply(
         self,
@@ -1583,6 +1689,11 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
         shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
         assert self.moe_kernel is not None
+        expert_map = layer.expert_map
+        if self.nvfp4_backend == NvFp4MoeBackend.EMULATION:
+            # AITER exposes `layer.expert_map` as a 0/1 expert mask, but the
+            # Triton emulation backend expects a global-to-local expert map.
+            expert_map = getattr(layer, "_expert_map", expert_map)
         return self.moe_kernel.apply(
             x,
             layer.w13_weight,
@@ -1591,7 +1702,7 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
             topk_ids,
             activation=layer.activation,
             global_num_experts=layer.global_num_experts,
-            expert_map=layer.expert_map,
+            expert_map=expert_map,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             shared_experts=shared_experts,
             shared_experts_input=shared_experts_input,

--- a/vllm/model_executor/layers/quantization/quark/schemes/__init__.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/__init__.py
@@ -5,6 +5,7 @@ from .quark_nvfp4 import QuarkNVFP4
 from .quark_ocp_mx import QuarkOCP_MX
 from .quark_scheme import QuarkScheme
 from .quark_w4a8_mxfp4_fp8 import QuarkW4A8_MXFP4_FP8
+from .quark_w8a8_fp8_block import QuarkW8A8Fp8Block
 from .quark_w8a8_fp8 import QuarkW8A8Fp8
 from .quark_w8a8_int8 import QuarkW8A8Int8
 
@@ -15,4 +16,5 @@ __all__ = [
     "QuarkOCP_MX",
     "QuarkW4A8_MXFP4_FP8",
     "QuarkNVFP4",
+    "QuarkW8A8Fp8Block",
 ]

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_nvfp4.py
@@ -116,8 +116,8 @@ class QuarkNVFP4(QuarkScheme):
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         input_global_scale = layer.input_scale_2.max().to(torch.float32)
-        layer.input_global_scale = Parameter(input_global_scale, requires_grad=False)
         del layer.input_scale_2
+        layer.input_global_scale = Parameter(input_global_scale, requires_grad=False)
 
         weight_global_scale = layer.weight_scale_2.to(torch.float32)
 

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -169,10 +169,36 @@ class _ColumnvLLMParameter(BasevLLMParameter):
         param_data = self.data
 
         param_data = param_data.narrow(self.output_dim, shard_offset, shard_size)
-        loaded_weight = loaded_weight.narrow(
-            self.output_dim, self.tp_rank * shard_size, shard_size
-        )
-        assert param_data.shape == loaded_weight.shape
+        if loaded_weight.shape[self.output_dim] != shard_size:
+            loaded_dim_size = loaded_weight.shape[self.output_dim]
+            loaded_start = self.tp_rank * shard_size
+            if loaded_start + shard_size > loaded_dim_size:
+                raise AssertionError(
+                    "vLLM merged-column narrow out of range: "
+                    f"param_type={type(self).__name__}, "
+                    f"output_dim={self.output_dim}, "
+                    f"tp_rank={self.tp_rank}, tp_size={self.tp_size}, "
+                    f"shard_offset={shard_offset}, shard_size={shard_size}, "
+                    f"param_data_shape={tuple(param_data.shape)}, "
+                    f"loaded_shape={tuple(loaded_weight.shape)}, "
+                    f"loaded_dim_size={loaded_dim_size}, "
+                    f"loaded_start={loaded_start}, "
+                    f"loaded_dtype={loaded_weight.dtype}"
+                )
+            loaded_weight = loaded_weight.narrow(
+                self.output_dim, self.tp_rank * shard_size, shard_size
+            )
+        if param_data.shape != loaded_weight.shape:
+            raise AssertionError(
+                "vLLM merged-column shape mismatch: "
+                f"param_type={type(self).__name__}, "
+                f"output_dim={self.output_dim}, "
+                f"tp_rank={self.tp_rank}, tp_size={self.tp_size}, "
+                f"shard_offset={shard_offset}, shard_size={shard_size}, "
+                f"param_data_shape={tuple(param_data.shape)}, "
+                f"loaded_shape={tuple(loaded_weight.shape)}, "
+                f"loaded_dtype={loaded_weight.dtype}"
+            )
         param_data.copy_(loaded_weight)
 
     def load_qkv_weight(self, loaded_weight: torch.Tensor, **kwargs):

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -14,6 +14,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul, SiluAndMulWithClamp
 from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
@@ -27,7 +28,6 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.mhc import (
-    HAS_TILELANG_MHC,
     HCHeadOp,
     MHCFusedPostPreOp,
     MHCPostOp,
@@ -52,6 +52,214 @@ from vllm.model_executor.models.utils import (
 from vllm.models.deepseek_v4.amd.rocm import DeepseekV4ROCMAiterMLAAttention
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
+from vllm.utils.import_utils import has_tilelang
+
+logger = init_logger(__name__)
+
+_DSV4_AMD_FOCUS_DIMS = (3753, 2404, 5308, 1040, 532, 4265, 5414, 2949)
+
+
+def _dsv4_amd_debug_phase(
+    input_ids: torch.Tensor | None = None,
+    positions: torch.Tensor | None = None,
+    hidden_states: torch.Tensor | None = None,
+) -> str:
+    if positions is not None:
+        num_tokens = positions.shape[0]
+    elif input_ids is not None:
+        num_tokens = input_ids.shape[0]
+    elif hidden_states is not None:
+        num_tokens = hidden_states.shape[0]
+    else:
+        num_tokens = -1
+    if num_tokens == 1:
+        return "RUNTIME_DECODE_N1"
+    if num_tokens > 1:
+        return f"RUNTIME_PREFILL_N{num_tokens}"
+    return "RUNTIME_UNKNOWN"
+
+
+def _dsv4_amd_debug_tensor(
+    counts: dict[str, int],
+    label: str,
+    tensor: torch.Tensor | None,
+    prefix: str,
+    input_ids: torch.Tensor | None = None,
+    positions: torch.Tensor | None = None,
+    max_logs: int = 8,
+) -> None:
+    if tensor is None:
+        return
+    if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+        return
+    phase = _dsv4_amd_debug_phase(input_ids, positions, tensor)
+    label_with_phase = f"{label}_{phase}"
+    count = counts.get(label_with_phase, 0)
+    if count >= max_logs:
+        return
+    counts[label_with_phase] = count + 1
+    with torch.no_grad():
+        tf = tensor.detach().float()
+        if tf.numel() == 0:
+            logger.warning(
+                "[%s] count=%s prefix=%s shape=%s dtype=%s empty_tensor=True",
+                label_with_phase,
+                count,
+                prefix,
+                tuple(tensor.shape),
+                tensor.dtype,
+            )
+            return
+        pos_info = ""
+        if positions is not None and positions.numel() > 0:
+            pos = positions.detach()
+            pos_info = (
+                f" pos_first={pos.flatten()[0].item()}"
+                f" pos_last={pos.flatten()[-1].item()}"
+            )
+        input_info = ""
+        if input_ids is not None and input_ids.numel() > 0:
+            ids = input_ids.detach()
+            input_info = (
+                f" input_first={ids.flatten()[0].item()}"
+                f" input_last={ids.flatten()[-1].item()}"
+            )
+        logger.warning(
+            "[%s] count=%s prefix=%s shape=%s dtype=%s finite=%s "
+            "mean=%.6g std=%.6g max=%.6g nonzero=%.6g%s%s",
+            label_with_phase,
+            count,
+            prefix,
+            tuple(tensor.shape),
+            tensor.dtype,
+            torch.isfinite(tf).all().item(),
+            tf.mean().item(),
+            tf.std().item(),
+            tf.abs().max().item(),
+            (tf != 0).float().mean().item(),
+            pos_info,
+            input_info,
+        )
+
+
+def _dsv4_amd_debug_focus_dims(
+    counts: dict[str, int],
+    label: str,
+    tensor: torch.Tensor | None,
+    prefix: str,
+    input_ids: torch.Tensor | None = None,
+    positions: torch.Tensor | None = None,
+    max_logs: int = 8,
+) -> None:
+    if tensor is None or tensor.ndim < 2:
+        return
+    if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+        return
+    phase = _dsv4_amd_debug_phase(input_ids, positions, tensor)
+    label_with_phase = f"{label}_FOCUS_DIMS_{phase}"
+    count = counts.get(label_with_phase, 0)
+    if count >= max_logs:
+        return
+    counts[label_with_phase] = count + 1
+    with torch.no_grad():
+        tf = tensor.detach().float().reshape(-1, tensor.shape[-1])
+        dims = [d for d in _DSV4_AMD_FOCUS_DIMS if d < tf.shape[-1]]
+        if not dims:
+            return
+        vals = tf[:, dims]
+        mean = vals.mean(dim=0)
+        std = vals.std(dim=0, unbiased=False)
+        min_vals = vals.min(dim=0).values
+        max_vals = vals.max(dim=0).values
+        first = vals[0]
+        last = vals[-1]
+        all_dim_mean = tf.mean(dim=0)
+        top_mean_vals, top_mean_ids = torch.topk(
+            all_dim_mean.abs(), k=min(12, all_dim_mean.numel())
+        )
+        logger.warning(
+            "[%s] count=%s prefix=%s shape=%s dtype=%s dims=%s "
+            "mean=%s std=%s min=%s max=%s first=%s last=%s "
+            "top_abs_mean_dims=%s",
+            label_with_phase,
+            count,
+            prefix,
+            tuple(tensor.shape),
+            tensor.dtype,
+            dims,
+            [round(v, 6) for v in mean.detach().cpu().tolist()],
+            [round(v, 6) for v in std.detach().cpu().tolist()],
+            [round(v, 6) for v in min_vals.detach().cpu().tolist()],
+            [round(v, 6) for v in max_vals.detach().cpu().tolist()],
+            [round(v, 6) for v in first.detach().cpu().tolist()],
+            [round(v, 6) for v in last.detach().cpu().tolist()],
+            [
+                (int(dim.item()), round(float(val.item()), 6))
+                for dim, val in zip(top_mean_ids, top_mean_vals)
+            ],
+        )
+
+
+def _dsv4_amd_debug_logits_topk(
+    counts: dict[str, int],
+    label: str,
+    logits: torch.Tensor | None,
+    prefix: str,
+    k: int = 10,
+    max_logs: int = 16,
+) -> None:
+    if logits is None:
+        return
+    if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+        return
+    phase = _dsv4_amd_debug_phase(hidden_states=logits)
+    label_with_phase = f"{label}_{phase}"
+    count = counts.get(label_with_phase, 0)
+    if count >= max_logs:
+        return
+    counts[label_with_phase] = count + 1
+    with torch.no_grad():
+        lf = logits.detach().float()
+        if lf.numel() == 0 or lf.ndim == 0:
+            logger.warning(
+                "[%s] count=%s prefix=%s shape=%s dtype=%s empty_or_scalar=True",
+                label_with_phase,
+                count,
+                prefix,
+                tuple(logits.shape),
+                logits.dtype,
+            )
+            return
+        row = lf.reshape(-1, lf.shape[-1])[-1]
+        topk = min(k, row.numel())
+        vals, ids = torch.topk(row, k=topk)
+        logger.warning(
+            "[%s] count=%s prefix=%s shape=%s dtype=%s row=last "
+            "top_ids=%s top_vals=%s",
+            label_with_phase,
+            count,
+            prefix,
+            tuple(logits.shape),
+            logits.dtype,
+            ids.detach().cpu().tolist(),
+            [round(v, 6) for v in vals.detach().cpu().tolist()],
+        )
+
+
+def _dsv4_amd_local_vocab_id(module: nn.Module, local_idx: int) -> int:
+    shard_indices = getattr(module, "shard_indices", None)
+    if shard_indices is None:
+        return local_idx
+    num_org_padded = shard_indices.num_org_elements_padded
+    num_org = shard_indices.num_org_elements
+    if local_idx < num_org:
+        return shard_indices.org_vocab_start_index + local_idx
+    if local_idx < num_org_padded:
+        return -1
+    added_idx = local_idx - num_org_padded
+    if added_idx < shard_indices.num_added_elements:
+        return shard_indices.added_vocab_start_index + added_idx
+    return -1
 
 
 class DeepseekV4MLP(nn.Module):
@@ -117,6 +325,7 @@ class DeepseekV4MoE(nn.Module):
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         self.prefix = prefix
+        self._dsv4_amd_debug_counts: dict[str, int] = {}
 
         self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
         self.hidden_size = config.hidden_size
@@ -199,6 +408,40 @@ class DeepseekV4MoE(nn.Module):
             router_logits_dtype=torch.float32,
         )
 
+    def _debug_layer60_moe_tensor(
+        self,
+        label: str,
+        tensor: torch.Tensor | None,
+    ) -> None:
+        if not self.prefix.endswith("layers.60.ffn"):
+            return
+        _dsv4_amd_debug_tensor(
+            self._dsv4_amd_debug_counts,
+            f"DSV4_AMD_LAYER60_MOE_{label}",
+            tensor,
+            self.prefix,
+            max_logs=8,
+        )
+        _dsv4_amd_debug_focus_dims(
+            self._dsv4_amd_debug_counts,
+            f"DSV4_AMD_LAYER60_MOE_{label}",
+            tensor,
+            self.prefix,
+            max_logs=8,
+        )
+
+    def _debug_layer60_router_topk(self, router_logits: torch.Tensor | None) -> None:
+        if not self.prefix.endswith("layers.60.ffn"):
+            return
+        _dsv4_amd_debug_logits_topk(
+            self._dsv4_amd_debug_counts,
+            "DSV4_AMD_LAYER60_MOE_ROUTER_TOPK",
+            router_logits,
+            self.prefix,
+            k=self.n_activated_experts,
+            max_logs=8,
+        )
+
     def forward(
         self, hidden_states: torch.Tensor, input_ids: torch.Tensor | None = None
     ) -> torch.Tensor:
@@ -206,8 +449,10 @@ class DeepseekV4MoE(nn.Module):
             raise ValueError("DeepSeek V4 hash MoE routing requires input_ids.")
 
         org_shape = hidden_states.shape
+        self._debug_layer60_moe_tensor("INPUT", hidden_states)
         if self.experts.is_internal_router:
             # In this case, the gate/router runs inside the FusedMoE class
+            self._debug_layer60_moe_tensor("INTERNAL_ROUTER_INPUT", hidden_states)
             final_hidden_states = self.experts(
                 hidden_states=hidden_states,
                 router_logits=hidden_states,
@@ -215,11 +460,14 @@ class DeepseekV4MoE(nn.Module):
             )
         else:
             router_logits, _ = self.gate(hidden_states)
+            self._debug_layer60_moe_tensor("ROUTER_LOGITS", router_logits)
+            self._debug_layer60_router_topk(router_logits)
             final_hidden_states = self.experts(
                 hidden_states=hidden_states,
                 router_logits=router_logits,
                 input_ids=input_ids,
             )
+        self._debug_layer60_moe_tensor("OUTPUT_FLAT", final_hidden_states)
 
         return final_hidden_states.view(org_shape)
 
@@ -240,6 +488,15 @@ class DeepseekV4DecoderLayer(nn.Module):
 
         config = vllm_config.model_config.hf_config
         self.hidden_size = config.hidden_size
+        self.prefix = prefix
+        self.layer_idx = extract_layer_index(prefix)
+        self._dsv4_amd_debug_printed = False
+        self._dsv4_amd_debug_counts: dict[str, int] = {}
+        if prefix.endswith("layers.0"):
+            print(
+                f"[DSV4_AMD_LAYER_INIT] prefix={prefix} hidden_size={self.hidden_size}",
+                flush=True,
+            )
 
         self.rms_norm_eps = config.rms_norm_eps
         self.attn = DeepseekV4ROCMAiterMLAAttention(
@@ -303,7 +560,53 @@ class DeepseekV4DecoderLayer(nn.Module):
         self.mhc_pre = MHCPreOp()
         self.mhc_post = MHCPostOp()
         self.mhc_fused_post_pre = MHCFusedPostPreOp()
-        self.has_tilelang = HAS_TILELANG_MHC
+        self.has_tilelang = has_tilelang()
+
+    def _debug_layer0_tensor(
+        self,
+        label: str,
+        tensor: torch.Tensor | None,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+    ) -> None:
+        if not self.prefix.endswith("layers.0"):
+            return
+        _dsv4_amd_debug_tensor(
+            self._dsv4_amd_debug_counts,
+            label,
+            tensor,
+            self.prefix,
+            input_ids=input_ids,
+            positions=positions,
+        )
+
+    def _debug_selected_layer_tensor(
+        self,
+        label: str,
+        tensor: torch.Tensor | None,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+    ) -> None:
+        if self.layer_idx not in {0, 15, 30, 45, 60}:
+            return
+        _dsv4_amd_debug_tensor(
+            self._dsv4_amd_debug_counts,
+            f"DSV4_AMD_LAYER{self.layer_idx}_{label}",
+            tensor,
+            self.prefix,
+            input_ids=input_ids,
+            positions=positions,
+            max_logs=4,
+        )
+        _dsv4_amd_debug_focus_dims(
+            self._dsv4_amd_debug_counts,
+            f"DSV4_AMD_LAYER{self.layer_idx}_{label}",
+            tensor,
+            self.prefix,
+            input_ids=input_ids,
+            positions=positions,
+            max_logs=4,
+        )
 
     def hc_pre(
         self,
@@ -334,6 +637,22 @@ class DeepseekV4DecoderLayer(nn.Module):
     ):
         return self.mhc_post(x, residual, post, comb)
 
+    def _attention_input(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+    ) -> torch.Tensor:
+        x = self.attn_norm(x)
+        if self.prefix.endswith("layers.0") and not self._dsv4_amd_debug_printed:
+            self._dsv4_amd_debug_printed = True
+            print(
+                "[DSV4_AMD_ATTN_INPUT] "
+                f"prefix={self.prefix} x={tuple(x.shape)} "
+                f"residual={tuple(residual.shape)}",
+                flush=True,
+            )
+        return x
+
     def _forward_fused_post_pre(
         self,
         x: torch.Tensor,
@@ -348,6 +667,9 @@ class DeepseekV4DecoderLayer(nn.Module):
             residual = x
             x, post_mix, res_mix = self.hc_pre(
                 x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
+            )
+            self._debug_layer0_tensor(
+                "DSV4_AMD_LAYER0_HC_ATTN_PRE_OUT", x, input_ids, positions
             )
         else:
             residual, post_mix, res_mix, x = self.mhc_fused_post_pre(
@@ -364,9 +686,17 @@ class DeepseekV4DecoderLayer(nn.Module):
                 self.hc_post_alpha,
                 self.hc_sinkhorn_iters,
             )
+            self._debug_layer0_tensor(
+                "DSV4_AMD_LAYER0_ATTN_FUSED_POST_PRE_OUT", x, input_ids, positions
+            )
 
-        x = self.attn_norm(x)
+        x = self._attention_input(x, residual)
+        self._debug_layer0_tensor(
+            "DSV4_AMD_LAYER0_ATTN_NORM_OUT", x, input_ids, positions
+        )
         x = self.attn(positions, x, None)
+        self._debug_layer0_tensor("DSV4_AMD_LAYER0_ATTN_OUT", x, input_ids, positions)
+        self._debug_selected_layer_tensor("ATTN_OUT", x, input_ids, positions)
 
         residual, post_mix, res_mix, x = self.mhc_fused_post_pre(
             x,
@@ -382,8 +712,16 @@ class DeepseekV4DecoderLayer(nn.Module):
             self.hc_post_alpha,
             self.hc_sinkhorn_iters,
         )
+        self._debug_layer0_tensor(
+            "DSV4_AMD_LAYER0_FFN_FUSED_POST_PRE_OUT", x, input_ids, positions
+        )
         x = self.ffn_norm(x)
+        self._debug_layer0_tensor(
+            "DSV4_AMD_LAYER0_FFN_NORM_OUT", x, input_ids, positions
+        )
         x = self.ffn(x, input_ids)
+        self._debug_layer0_tensor("DSV4_AMD_LAYER0_FFN_OUT", x, input_ids, positions)
+        self._debug_selected_layer_tensor("FFN_OUT", x, input_ids, positions)
         return x, residual, post_mix, res_mix
 
     def _forward_unfused_post_pre(
@@ -401,17 +739,37 @@ class DeepseekV4DecoderLayer(nn.Module):
         x, post, comb = self.hc_pre(
             x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
         )
-        x = self.attn_norm(x)
+        x = self._attention_input(x, residual)
+        self._debug_layer0_tensor(
+            "DSV4_AMD_LAYER0_UNFUSED_ATTN_NORM_OUT", x, input_ids, positions
+        )
         x = self.attn(positions, x, None)
+        self._debug_layer0_tensor(
+            "DSV4_AMD_LAYER0_UNFUSED_ATTN_OUT", x, input_ids, positions
+        )
+        self._debug_selected_layer_tensor("UNFUSED_ATTN_OUT", x, input_ids, positions)
         x = self.hc_post(x, residual, post, comb)
+        self._debug_layer0_tensor(
+            "DSV4_AMD_LAYER0_UNFUSED_ATTN_HC_POST_OUT", x, input_ids, positions
+        )
 
         residual = x
         x, post, comb = self.hc_pre(
             x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base
         )
         x = self.ffn_norm(x)
+        self._debug_layer0_tensor(
+            "DSV4_AMD_LAYER0_UNFUSED_FFN_NORM_OUT", x, input_ids, positions
+        )
         x = self.ffn(x, input_ids)
+        self._debug_layer0_tensor(
+            "DSV4_AMD_LAYER0_UNFUSED_FFN_OUT", x, input_ids, positions
+        )
+        self._debug_selected_layer_tensor("UNFUSED_FFN_OUT", x, input_ids, positions)
         x = self.hc_post(x, residual, post, comb)
+        self._debug_layer0_tensor(
+            "DSV4_AMD_LAYER0_UNFUSED_FFN_HC_POST_OUT", x, input_ids, positions
+        )
         return x, None, None, None
 
     def forward(
@@ -446,6 +804,7 @@ class DeepseekV4Model(nn.Module):
         self.hc_mult = config.hc_mult
         self.hc_dim = self.hc_mult * config.hidden_size
         self.rms_norm_eps = config.rms_norm_eps
+        self._dsv4_amd_debug_counts: dict[str, int] = {}
 
         # Three aux streams: one per non-default input GEMM in
         # DeepseekV4Attention.attn_gemm_parallel_execute
@@ -513,7 +872,7 @@ class DeepseekV4Model(nn.Module):
             requires_grad=False,
         )
         self.hc_head_op = HCHeadOp()
-        self.has_tilelang = HAS_TILELANG_MHC
+        self.has_tilelang = has_tilelang()
         # Pre-hc_head residual stream buffer for the MTP draft. Stable
         # address (outside the cudagraph pool) so the copy_ in forward()
         # refreshes it correctly across captured shapes.
@@ -532,6 +891,50 @@ class DeepseekV4Model(nn.Module):
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
+
+    def _debug_model_tensor(
+        self,
+        label: str,
+        tensor: torch.Tensor | None,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+    ) -> None:
+        _dsv4_amd_debug_tensor(
+            self._dsv4_amd_debug_counts,
+            label,
+            tensor,
+            "model",
+            input_ids=input_ids,
+            positions=positions,
+        )
+
+    def _debug_hc_head_params(self) -> None:
+        label = "DSV4_AMD_MODEL_HC_HEAD_PARAMS"
+        if self._dsv4_amd_debug_counts.get(label, 0) > 0:
+            return
+        if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+            return
+        self._dsv4_amd_debug_counts[label] = 1
+        with torch.no_grad():
+            for name, param in (
+                ("fn", self.hc_head_fn),
+                ("base", self.hc_head_base),
+                ("scale", self.hc_head_scale),
+            ):
+                pf = param.detach().float()
+                logger.warning(
+                    "[%s] name=%s shape=%s dtype=%s finite=%s mean=%.6g "
+                    "std=%.6g max=%.6g nonzero=%.6g",
+                    label,
+                    name,
+                    tuple(param.shape),
+                    param.dtype,
+                    torch.isfinite(pf).all().item(),
+                    pf.mean().item(),
+                    pf.std().item() if pf.numel() > 1 else 0.0,
+                    pf.abs().max().item() if pf.numel() > 0 else 0.0,
+                    (pf != 0).float().mean().item() if pf.numel() > 0 else 0.0,
+                )
 
     def make_empty_intermediate_tensors(
         self,
@@ -566,9 +969,15 @@ class DeepseekV4Model(nn.Module):
             else:
                 hidden_states = self.embed_input_ids(input_ids)
             hidden_states = hidden_states.unsqueeze(-2).repeat(1, self.hc_mult, 1)
+            self._debug_model_tensor(
+                "DSV4_AMD_MODEL_EMBED_EXPANDED", hidden_states, input_ids, positions
+            )
         else:
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
+            self._debug_model_tensor(
+                "DSV4_AMD_MODEL_PP_INPUT", hidden_states, input_ids, positions
+            )
 
         residual, post_mix, res_mix = None, None, None
         for layer in islice(self.layers, self.start_layer, self.end_layer):
@@ -580,8 +989,17 @@ class DeepseekV4Model(nn.Module):
                 res_mix,
                 residual,
             )
+        self._debug_model_tensor(
+            "DSV4_AMD_MODEL_POST_LAYERS", hidden_states, input_ids, positions
+        )
         if layer is not None and self.has_tilelang:
             hidden_states = layer.hc_post(hidden_states, residual, post_mix, res_mix)
+            self._debug_model_tensor(
+                "DSV4_AMD_MODEL_FINAL_HC_POST_OUT",
+                hidden_states,
+                input_ids,
+                positions,
+            )
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({"hidden_states": hidden_states})
@@ -590,6 +1008,7 @@ class DeepseekV4Model(nn.Module):
         num_tokens = hidden_states.shape[0]
         self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
 
+        self._debug_hc_head_params()
         hidden_states = self.hc_head_op(
             hidden_states,
             self.hc_head_fn,
@@ -598,7 +1017,13 @@ class DeepseekV4Model(nn.Module):
             self.rms_norm_eps,
             self.hc_eps,
         )
+        self._debug_model_tensor(
+            "DSV4_AMD_MODEL_HC_HEAD_OUT", hidden_states, input_ids, positions
+        )
         hidden_states = self.norm(hidden_states)
+        self._debug_model_tensor(
+            "DSV4_AMD_MODEL_FINAL_NORM_OUT", hidden_states, input_ids, positions
+        )
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -613,6 +1038,19 @@ class DeepseekV4Model(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+
+        def resolve_input_scale_name(name: str) -> str:
+            if name in params_dict:
+                return name
+            if name.endswith(".input_scale"):
+                input_scale_2_name = name[: -len(".input_scale")] + ".input_scale_2"
+                if input_scale_2_name in params_dict:
+                    return input_scale_2_name
+            if name.endswith("_input_scale"):
+                input_scale_2_name = name + "_2"
+                if input_scale_2_name in params_dict:
+                    return input_scale_2_name
+            return name
 
         # TP for attention
         tp_size = get_tensor_model_parallel_world_size()
@@ -636,9 +1074,59 @@ class DeepseekV4Model(nn.Module):
 
                 if is_pp_missing_parameter(name, self):
                     break
+                name = resolve_input_scale_name(name)
+                if name not in params_dict and name.endswith(".weight_scale"):
+                    weight_scale_inv_name = (
+                        name[: -len(".weight_scale")] + ".weight_scale_inv"
+                    )
+                    if weight_scale_inv_name in params_dict:
+                        name = weight_scale_inv_name
+                if name not in params_dict and name.endswith(".weight_scale_inv"):
+                    if param_name == "attn.fused_wqa_wkv":
+                        # DeepSeek-V4 checkpoints store attn.wkv scales as
+                        # FP8 block scales, while the fused projection registers
+                        # NVFP4-style group scales under weight_scale. They are
+                        # not layout-compatible, so do not fall back and load
+                        # a (num_blocks_n, num_blocks_k) tensor into a
+                        # per-group scale matrix.
+                        break
+                    name = name[: -len(".weight_scale_inv")] + ".weight_scale"
                 param = params_dict[name]
                 weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
+                try:
+                    weight_loader(param, loaded_weight, shard_id)
+                except Exception as exc:
+                    print(
+                        "[DeepSeek-V4 weight load shape mismatch] "
+                        f"name={name} shard_id={shard_id} "
+                        f"param_type={type(param).__name__} "
+                        f"param_shape={tuple(param.shape)} "
+                        f"loaded_shape={tuple(loaded_weight.shape)} "
+                        f"loaded_dtype={loaded_weight.dtype} "
+                        f"inner_error={exc}",
+                        flush=True,
+                    )
+                    logger.error(
+                        "DeepSeek-V4 weight load shape mismatch: name=%s "
+                        "shard_id=%s param_type=%s param_shape=%s "
+                        "loaded_shape=%s loaded_dtype=%s inner_error=%s",
+                        name,
+                        shard_id,
+                        type(param).__name__,
+                        tuple(param.shape),
+                        tuple(loaded_weight.shape),
+                        loaded_weight.dtype,
+                        exc,
+                    )
+                    raise AssertionError(
+                        "DeepSeek-V4 weight load shape mismatch: "
+                        f"name={name}, shard_id={shard_id}, "
+                        f"param_type={type(param).__name__}, "
+                        f"param_shape={tuple(param.shape)}, "
+                        f"loaded_shape={tuple(loaded_weight.shape)}, "
+                        f"loaded_dtype={loaded_weight.dtype}; "
+                        f"inner_error={exc}"
+                    ) from exc
                 loaded_params.add(name)
                 break
             else:
@@ -659,6 +1147,7 @@ class DeepseekV4Model(nn.Module):
                         name_mapped = name.replace(weight_name, param_name)
                         if is_pp_missing_parameter(name_mapped, self):
                             continue
+                        name_mapped = resolve_input_scale_name(name_mapped)
                         param = params_dict[name_mapped]
                         # We should ask the weight loader to return success or not
                         # here since otherwise we may skip experts with other
@@ -690,6 +1179,13 @@ class DeepseekV4Model(nn.Module):
                 else:
                     if is_pp_missing_parameter(name, self):
                         continue
+                    name = resolve_input_scale_name(name)
+                    if name not in params_dict and name.endswith(".weight_scale"):
+                        weight_scale_inv_name = (
+                            name[: -len(".weight_scale")] + ".weight_scale_inv"
+                        )
+                        if weight_scale_inv_name in params_dict:
+                            name = weight_scale_inv_name
                     param = params_dict[name]
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
@@ -697,6 +1193,52 @@ class DeepseekV4Model(nn.Module):
                     weight_loader(param, loaded_weight)
                     loaded_params.add(name)
                     continue
+
+        debug_layers = {0, 59, 60}
+        for module_name, module in self.named_modules():
+            if not module_name.endswith("attn.fused_wqa_wkv"):
+                continue
+            match = re.search(r"layers\.(\d+)\.attn\.fused_wqa_wkv$", module_name)
+            if match is None or int(match.group(1)) not in debug_layers:
+                continue
+            weight = getattr(module, "weight", None)
+            if weight is not None:
+                wf = weight.detach().float()
+                print(
+                    "[DSV4_LOAD_FUSED_WQA_WKV_WEIGHT] "
+                    f"name={module_name} shape={tuple(weight.shape)} "
+                    f"dtype={weight.dtype} min={wf.min().item():.6g} "
+                    f"max={wf.max().item():.6g} mean={wf.mean().item():.6g} "
+                    f"nonzero={(wf != 0).float().mean().item():.6g}",
+                    flush=True,
+                )
+            scale_infos = []
+            for param_name, param in module.named_parameters(recurse=True):
+                if "scale" not in param_name:
+                    continue
+                pf = param.detach().float()
+                scale_infos.append(
+                    f"{param_name}:shape={tuple(param.shape)},dtype={param.dtype},"
+                    f"min={pf.min().item():.6g},max={pf.max().item():.6g},"
+                    f"mean={pf.mean().item():.6g},"
+                    f"nonzero={(pf != 0).float().mean().item():.6g}"
+                )
+            for buffer_name, buffer in module.named_buffers(recurse=True):
+                if "scale" not in buffer_name:
+                    continue
+                bf = buffer.detach().float()
+                scale_infos.append(
+                    f"buffer.{buffer_name}:shape={tuple(buffer.shape)},"
+                    f"dtype={buffer.dtype},min={bf.min().item():.6g},"
+                    f"max={bf.max().item():.6g},mean={bf.mean().item():.6g},"
+                    f"nonzero={(bf != 0).float().mean().item():.6g}"
+                )
+            print(
+                "[DSV4_LOAD_FUSED_WQA_WKV_SCALES] "
+                f"name={module_name} "
+                f"{' | '.join(scale_infos) if scale_infos else '<none>'}",
+                flush=True,
+            )
 
         return loaded_params
 
@@ -751,6 +1293,10 @@ def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
 
 class DeepseekV4ForCausalLM(nn.Module, SupportsPP):
     model_cls = DeepseekV4Model
+    packed_modules_mapping = {
+        "gate_up_proj": ["w1", "w3"],
+        "fused_wqa_wkv": ["wq_a", "wkv"],
+    }
 
     # Default mapper assumes the original FP4-expert checkpoint layout.
     # Overridden per-instance in __init__ when expert_dtype != "fp4".
@@ -761,6 +1307,7 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP):
 
         config = vllm_config.model_config.hf_config
         self.config = config
+        self._dsv4_amd_debug_counts: dict[str, int] = {}
         expert_dtype = getattr(config, "expert_dtype", "fp4")
         if expert_dtype != "fp4":
             self.hf_to_vllm_mapper = _make_deepseek_v4_weights_mapper(expert_dtype)
@@ -784,11 +1331,164 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    def _debug_lm_head_info(self) -> None:
+        label = "DSV4_AMD_LM_HEAD_INFO"
+        if self._dsv4_amd_debug_counts.get(label, 0) > 0:
+            return
+        if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+            return
+        self._dsv4_amd_debug_counts[label] = 1
+        weight = getattr(self.lm_head, "weight", None)
+        embed_weight = getattr(getattr(self.model, "embed_tokens", None), "weight", None)
+        shard_indices = getattr(self.lm_head, "shard_indices", None)
+        with torch.no_grad():
+            if weight is None:
+                logger.warning("[%s] rank=%s lm_head_weight=None", label, get_tensor_model_parallel_rank())
+                return
+            wf = weight.detach().float()
+            logger.warning(
+                "[%s] rank=%s config_vocab=%s lm_head_num_embeddings=%s "
+                "lm_head_org_vocab=%s lm_head_padded=%s per_partition=%s "
+                "weight_shape=%s weight_dtype=%s finite=%s mean=%.6g std=%.6g "
+                "max=%.6g nonzero=%.6g shard=%s",
+                label,
+                get_tensor_model_parallel_rank(),
+                self.config.vocab_size,
+                getattr(self.lm_head, "num_embeddings", None),
+                getattr(self.lm_head, "org_vocab_size", None),
+                getattr(self.lm_head, "num_embeddings_padded", None),
+                getattr(self.lm_head, "num_embeddings_per_partition", None),
+                tuple(weight.shape),
+                weight.dtype,
+                torch.isfinite(wf).all().item(),
+                wf.mean().item(),
+                wf.std().item(),
+                wf.abs().max().item(),
+                (wf != 0).float().mean().item(),
+                shard_indices,
+            )
+            if embed_weight is not None:
+                ewf = embed_weight.detach().float()
+                logger.warning(
+                    "[%s_EMBED] rank=%s embed_shape=%s embed_dtype=%s "
+                    "finite=%s mean=%.6g std=%.6g max=%.6g nonzero=%.6g",
+                    label,
+                    get_tensor_model_parallel_rank(),
+                    tuple(embed_weight.shape),
+                    embed_weight.dtype,
+                    torch.isfinite(ewf).all().item(),
+                    ewf.mean().item(),
+                    ewf.std().item(),
+                    ewf.abs().max().item(),
+                    (ewf != 0).float().mean().item(),
+                )
+            interesting_ids = [1, 14, 16, 19, 28, 67, 223, 271, 294, 305, 6328, 13318]
+            for token_id in interesting_ids:
+                local_idx = None
+                if shard_indices is None:
+                    if token_id < weight.shape[0]:
+                        local_idx = token_id
+                elif (
+                    shard_indices.org_vocab_start_index
+                    <= token_id
+                    < shard_indices.org_vocab_end_index
+                ):
+                    local_idx = token_id - shard_indices.org_vocab_start_index
+                elif (
+                    shard_indices.added_vocab_start_index
+                    <= token_id
+                    < shard_indices.added_vocab_end_index
+                ):
+                    local_idx = (
+                        shard_indices.num_org_elements_padded
+                        + token_id
+                        - shard_indices.added_vocab_start_index
+                    )
+                if local_idx is None or local_idx >= weight.shape[0]:
+                    continue
+                row = wf[local_idx]
+                row_msg = (
+                    "[%s_ROW] rank=%s token_id=%s local_idx=%s mean=%.6g "
+                    "std=%.6g max=%.6g norm=%.6g nonzero=%.6g"
+                )
+                row_args = [
+                    label,
+                    get_tensor_model_parallel_rank(),
+                    token_id,
+                    local_idx,
+                    row.mean().item(),
+                    row.std().item(),
+                    row.abs().max().item(),
+                    torch.linalg.vector_norm(row).item(),
+                    (row != 0).float().mean().item(),
+                ]
+                if embed_weight is not None and local_idx < embed_weight.shape[0]:
+                    embed_row = ewf[local_idx]
+                    diff = (row - embed_row).abs()
+                    row_msg += " embed_diff_max=%.6g embed_diff_mean=%.6g"
+                    row_args.extend([diff.max().item(), diff.mean().item()])
+                logger.warning(row_msg, *row_args)
+
+    def _debug_manual_lm_head_logits(self, hidden_states: torch.Tensor) -> None:
+        weight = getattr(self.lm_head, "weight", None)
+        if weight is None or hidden_states is None:
+            return
+        if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+            return
+        phase = _dsv4_amd_debug_phase(hidden_states=hidden_states)
+        label = f"DSV4_AMD_MANUAL_LM_HEAD_LOCAL_TOPK_{phase}"
+        count = self._dsv4_amd_debug_counts.get(label, 0)
+        if count >= 16:
+            return
+        self._dsv4_amd_debug_counts[label] = count + 1
+        with torch.no_grad():
+            h = hidden_states.detach().reshape(-1, hidden_states.shape[-1])[-1].float()
+            w = weight.detach().float()
+            local_logits = torch.matmul(w, h)
+            vals, local_ids = torch.topk(local_logits, k=min(10, local_logits.numel()))
+            global_ids = [
+                _dsv4_amd_local_vocab_id(self.lm_head, int(idx))
+                for idx in local_ids.detach().cpu().tolist()
+            ]
+            logger.warning(
+                "[%s] count=%s rank=%s hidden_shape=%s weight_shape=%s "
+                "local_ids=%s global_ids=%s vals=%s hidden_norm=%.6g",
+                label,
+                count,
+                get_tensor_model_parallel_rank(),
+                tuple(hidden_states.shape),
+                tuple(weight.shape),
+                local_ids.detach().cpu().tolist(),
+                global_ids,
+                [round(v, 6) for v in vals.detach().cpu().tolist()],
+                torch.linalg.vector_norm(h).item(),
+            )
+
     def compute_logits(
         self,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
+        self._debug_lm_head_info()
+        self._debug_manual_lm_head_logits(hidden_states)
+        _dsv4_amd_debug_tensor(
+            self._dsv4_amd_debug_counts,
+            "DSV4_AMD_CAUSAL_LM_LOGITS_INPUT",
+            hidden_states,
+            "causal_lm",
+        )
         logits = self.logits_processor(self.lm_head, hidden_states)
+        _dsv4_amd_debug_tensor(
+            self._dsv4_amd_debug_counts,
+            "DSV4_AMD_CAUSAL_LM_LOGITS_OUT",
+            logits,
+            "causal_lm",
+        )
+        _dsv4_amd_debug_logits_topk(
+            self._dsv4_amd_debug_counts,
+            "DSV4_AMD_CAUSAL_LM_LOGITS_TOPK",
+            logits,
+            "causal_lm",
+        )
         return logits
 
     def forward(
@@ -800,6 +1500,14 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP):
     ) -> torch.Tensor | IntermediateTensors:
         hidden_states = self.model(
             input_ids, positions, intermediate_tensors, inputs_embeds
+        )
+        _dsv4_amd_debug_tensor(
+            self._dsv4_amd_debug_counts,
+            "DSV4_AMD_CAUSAL_LM_FORWARD_OUT",
+            hidden_states if isinstance(hidden_states, torch.Tensor) else None,
+            "causal_lm",
+            input_ids=input_ids,
+            positions=positions,
         )
         return hidden_states
 

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -62,22 +62,23 @@ logger = init_logger(__name__)
 
 
 def _resolve_dsv4_kv_cache_dtype(
-    use_fp8_ds_mla_layout: bool,
+    use_flashmla_fp8_layout: bool,
     kv_cache_dtype: str,
     cache_config: CacheConfig | None,
 ) -> tuple[str, torch.dtype]:
     """Map ``(layout, --kv-cache-dtype)`` to ``(cache_dtype_str, torch_dtype)``.
 
     Both layouts are paged; they differ in the per-token block format. The
-    ``fp8_ds_mla`` format is UE8M0 block-scaled fp8 packed as ``uint8`` (the
-    canonical ``fp8_ds_mla`` string is written back onto ``cache_config`` so the
-    page-size specs pick the 576B per-token slot). Plain-row backends store each
-    token's KV row in its element dtype: bf16 or per-tensor FP8 E4M3.
+    FlashMLA fp8 layout (FlashMLA / ROCm Aiter) is the ``fp8_ds_mla`` format:
+    UE8M0 block-scaled fp8 packed as ``uint8`` (the canonical ``fp8_ds_mla``
+    string is written back onto ``cache_config`` so the page-size specs pick
+    the 576B per-token slot). Otherwise (FlashInfer) each token's KV row is
+    stored in its plain element dtype — bf16 or per-tensor FP8 E4M3.
     """
-    if use_fp8_ds_mla_layout:
+    if use_flashmla_fp8_layout:
         # fp8_ds_mla block format: UE8M0 block-scaled fp8 packed as uint8.
         assert kv_cache_dtype.startswith("fp8"), (
-            f"DeepseekV4 fp8_ds_mla layout only supports fp8 kv-cache, "
+            f"DeepseekV4 FlashMLA fp8 layout only supports fp8 kv-cache, "
             f"got {kv_cache_dtype}"
         )
         if kv_cache_dtype != "fp8_ds_mla":
@@ -99,20 +100,18 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
     The platform-specific sparse-MLA forward (``forward_mqa`` /
     ``get_padded_num_q_heads`` / ``_o_proj`` / ``backend_cls``) is provided by a
-    subclass — ``DeepseekV4FlashMLAAttention`` /
-    ``DeepseekV4FlashInferSM120Attention`` /
-    ``DeepseekV4FlashInferMLAAttention`` (CUDA) or
-    ``DeepseekV4ROCMAiterMLAAttention`` (ROCm) — selected by the platform-specific
-    deepseek_v4 model module. The base is never instantiated directly.
+    subclass — ``DeepseekV4FlashMLAAttention`` / ``DeepseekV4FlashInferMLAAttention``
+    (CUDA) or ``DeepseekV4ROCMAiterMLAAttention`` (ROCm) — selected by the
+    platform-specific deepseek_v4 model module. The base is never instantiated
+    directly.
     """
 
     # Provided by the platform subclass.
     backend_cls: ClassVar[type[AttentionBackend]]
     # KV-cache per-token block format (both layouts are paged). True (default)
-    # = fp8_ds_mla (UE8M0 block-scaled fp8 packed as uint8); False = plain
-    # bf16 / per-tensor fp8 KV row. Backends can override the instance hook when
-    # a single attention class dispatches across arch-specific layouts.
-    use_fp8_ds_mla_layout: ClassVar[bool] = True
+    # = FlashMLA / ROCm fp8_ds_mla (UE8M0 block-scaled fp8 packed as uint8);
+    # False = FlashInfer plain bf16 / per-tensor fp8 KV row.
+    use_flashmla_fp8_layout: ClassVar[bool] = True
     # Prefill is processed in fixed-size chunks; this bounds the bf16 kv-gather
     # workspace allocated in _forward_prefill and is also read by the dummy-run
     # path to pre-reserve that workspace.
@@ -146,10 +145,6 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         """Inverse-RoPE + wo_a + wo_b output projection (platform-specific)."""
         raise NotImplementedError
 
-    def _uses_fp8_ds_mla_layout(self) -> bool:
-        """Return whether this instance stores fp8 KV in fp8_ds_mla layout."""
-        return self.use_fp8_ds_mla_layout
-
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -163,9 +158,20 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         cache_config = vllm_config.cache_config
         tp_size = get_tensor_model_parallel_world_size()
         layer_id = extract_layer_index(prefix)
+        self.layer_id = layer_id
 
         self.prefix = prefix  # Alias for compatibility with compressor
         self.hidden_size = config.hidden_size
+        self.hc_input_size = self.hidden_size
+        self._dsv4_debug_printed = False
+        self._dsv4_debug_labels: set[str] = set()
+        if layer_id == 0:
+            logger.warning(
+                "[DSV4_INIT] prefix=%s layer_id=%s hc_input_size=%s",
+                prefix,
+                layer_id,
+                self.hc_input_size,
+            )
         self.n_heads = config.num_attention_heads
         assert self.n_heads % tp_size == 0
         self.n_local_heads = self.n_heads // tp_size
@@ -197,7 +203,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         )
 
         self.fused_wqa_wkv = MergedColumnParallelLinear(
-            self.hidden_size,
+            self.hc_input_size,
             [self.q_lora_rank, self.head_dim],
             bias=False,
             quant_config=quant_config,
@@ -281,10 +287,13 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         )
         self.max_model_len = vllm_config.model_config.max_model_len
 
-        # Resolve the kv-cache dtype from this backend's block format. The same
-        # resolution drives the SWA cache tensor dtype below.
+        # Resolve the kv-cache dtype from this backend's block format (a
+        # ClassVar set by the subclass): fp8_ds_mla (UE8M0 block-scaled fp8 as
+        # uint8) for FlashMLA / ROCm, vs a plain bf16 / per-tensor fp8 row for
+        # FlashInfer. The same resolution drives the SWA cache tensor dtype
+        # below.
         self.kv_cache_dtype, self.kv_cache_torch_dtype = _resolve_dsv4_kv_cache_dtype(
-            self._uses_fp8_ds_mla_layout(), cache_config.cache_dtype, cache_config
+            self.use_flashmla_fp8_layout, cache_config.cache_dtype, cache_config
         )
 
         self.swa_cache_layer = DeepseekV4SWACache(
@@ -335,8 +344,18 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         # Metadata-independent input GEMMs + RMSNorm stay in the captured
         # graph; the metadata-dependent rest (q up-proj + kv-insert, indexer,
         # compressor, MLA attention) runs in the eager break.
+        hidden_states_base = (
+            hidden_states[:, 0, :] if hidden_states.dim() == 3 else hidden_states
+        )
+        hidden_states_flat = hidden_states_base
         qr_kv, kv_score, indexer_kv_score, indexer_weights = (
-            self.attn_gemm_parallel_execute(hidden_states)
+            self.attn_gemm_parallel_execute(hidden_states_base, hidden_states_flat)
+        )
+        self._debug_layer0_attention_input(
+            hidden_states,
+            hidden_states_base,
+            hidden_states_flat,
+            qr_kv,
         )
         qr, kv = qr_kv.split([self.q_lora_rank, self.head_dim], dim=-1)
         qr, kv = fused_q_kv_rmsnorm(
@@ -346,12 +365,14 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             self.kv_norm.weight.data,
             self.eps,
         )
+        self._debug_layer0_tensor("DSV4_QR_NORM", qr)
+        self._debug_layer0_tensor("DSV4_KV_NORM", kv)
 
         # attention_impl is wrapped with @eager_break_during_capture: this is
         # where the breakable cudagraph capture breaks (the attention op runs
         # eagerly between captured graph segments).
         self.attention_impl(
-            hidden_states,
+            hidden_states_flat,
             qr,
             kv,
             kv_score,
@@ -361,11 +382,165 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             o_padded,
         )
         o = o_padded[:, : self.n_local_heads, :]
+        self._debug_layer0_tensor("DSV4_ATTN_O_PADDED", o_padded)
+        self._debug_layer0_tensor("DSV4_ATTN_O", o)
 
         # Inverse-RoPE + wo_a + wo_b output projection (platform-specific).
-        return self._o_proj(o, positions)
+        out = self._o_proj(o, positions)
+        self._debug_layer0_tensor("DSV4_OPROJ_OUT", out)
+        return out
 
-    def attn_gemm_parallel_execute(self, hidden_states) -> tuple[Any, ...]:
+    def _debug_layer0_tensor(self, label: str, tensor: torch.Tensor | None) -> None:
+        phase = self._debug_layer0_phase()
+        label_with_phase = f"{label}_{phase}"
+        if (
+            self.layer_id != 0
+            or tensor is None
+            or label_with_phase in self._dsv4_debug_labels
+        ):
+            return
+        if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+            return
+        self._dsv4_debug_labels.add(label_with_phase)
+        with torch.no_grad():
+            tf = tensor.detach().float()
+            if tf.numel() == 0:
+                logger.warning(
+                    "[%s] prefix=%s shape=%s dtype=%s empty_tensor=True",
+                    label_with_phase,
+                    self.prefix,
+                    tuple(tensor.shape),
+                    tensor.dtype,
+                )
+                return
+            logger.warning(
+                "[%s] prefix=%s shape=%s dtype=%s finite=%s mean=%.6g "
+                "std=%.6g max=%.6g nonzero=%.6g",
+                label_with_phase,
+                self.prefix,
+                tuple(tensor.shape),
+                tensor.dtype,
+                torch.isfinite(tf).all().item(),
+                tf.mean().item(),
+                tf.std().item(),
+                tf.abs().max().item(),
+                (tf != 0).float().mean().item(),
+            )
+
+    def _debug_layer0_phase(self) -> str:
+        try:
+            attn_metadata = get_forward_context().attn_metadata
+        except Exception:
+            return "NOCTX"
+        if not isinstance(attn_metadata, dict):
+            return "WARMUP"
+        swa_metadata = attn_metadata.get(self.swa_cache_layer.prefix)
+        if swa_metadata is None:
+            return "RUNTIME_NO_SWA"
+        num_prefills = getattr(swa_metadata, "num_prefills", 0)
+        num_decode_tokens = getattr(swa_metadata, "num_decode_tokens", 0)
+        if num_prefills > 0:
+            return "RUNTIME_PREFILL"
+        if num_decode_tokens > 16:
+            return f"RUNTIME_DUMMY_DECODE_N{num_decode_tokens}"
+        if num_decode_tokens > 0:
+            return f"RUNTIME_DECODE_N{num_decode_tokens}"
+        return "RUNTIME_EMPTY"
+
+    def _debug_layer0_attention_input(
+        self,
+        hidden_states: torch.Tensor,
+        hidden_states_base: torch.Tensor,
+        hidden_states_flat: torch.Tensor,
+        qr_kv: torch.Tensor,
+    ) -> None:
+        phase = self._debug_layer0_phase()
+        label = f"DSV4_ATTN_INPUT_{phase}"
+        if label in self._dsv4_debug_labels:
+            return
+        if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+            return
+        if self.layer_id != 0 and hidden_states_flat.shape[-1] != 2 * self.hidden_size:
+            return
+        self._dsv4_debug_labels.add(label)
+        with torch.no_grad():
+            qf = qr_kv.detach().float()
+            w = self.fused_wqa_wkv.weight.detach()
+            wf = w.float()
+            scale_infos = []
+            for n, p in self.fused_wqa_wkv.named_parameters(recurse=True):
+                if "scale" in n:
+                    pf = p.detach().float()
+                    scale_infos.append(
+                        f"{n}:shape={tuple(p.shape)},dtype={p.dtype},"
+                        f"min={pf.min().item():.6g},max={pf.max().item():.6g},"
+                        f"mean={pf.mean().item():.6g},"
+                        f"nonzero={(pf != 0).float().mean().item():.6g}"
+                    )
+            for n, b in self.fused_wqa_wkv.named_buffers(recurse=True):
+                if "scale" in n:
+                    bf = b.detach().float()
+                    scale_infos.append(
+                        f"buffer.{n}:shape={tuple(b.shape)},dtype={b.dtype},"
+                        f"min={bf.min().item():.6g},max={bf.max().item():.6g},"
+                        f"mean={bf.mean().item():.6g},"
+                        f"nonzero={(bf != 0).float().mean().item():.6g}"
+                    )
+            logger.warning(
+                "[%s] prefix=%s layer_id=%s hidden_states=%s "
+                "base=%s flat=%s fused_weight=%s",
+                label,
+                self.prefix,
+                self.layer_id,
+                tuple(hidden_states.shape),
+                tuple(hidden_states_base.shape),
+                tuple(hidden_states_flat.shape),
+                tuple(self.fused_wqa_wkv.weight.shape),
+            )
+            if hidden_states.dim() == 3 and hidden_states.shape[1] >= 2:
+                s0 = hidden_states[:, 0, :].detach().float()
+                s1 = hidden_states[:, 1, :].detach().float()
+                cos = F.cosine_similarity(s0, s1, dim=-1).mean()
+                logger.warning(
+                    "[DSV4_STREAM] s0_mean=%.6g s0_std=%.6g s0_max=%.6g "
+                    "s1_mean=%.6g s1_std=%.6g s1_max=%.6g cos=%.6g",
+                    s0.mean().item(),
+                    s0.std().item(),
+                    s0.abs().max().item(),
+                    s1.mean().item(),
+                    s1.std().item(),
+                    s1.abs().max().item(),
+                    cos.item(),
+                )
+            logger.warning(
+                "[DSV4_FUSED_WQA_WKV_WEIGHT_%s] shape=%s dtype=%s min=%.6g "
+                "max=%.6g mean=%.6g nonzero=%.6g",
+                phase,
+                tuple(w.shape),
+                w.dtype,
+                wf.min().item(),
+                wf.max().item(),
+                wf.mean().item(),
+                (wf != 0).float().mean().item(),
+            )
+            logger.warning(
+                "[DSV4_FUSED_WQA_WKV_SCALES_%s] %s",
+                phase,
+                " | ".join(scale_infos) if scale_infos else "<none>",
+            )
+            logger.warning(
+                "[DSV4_QRKV_%s] shape=%s finite=%s mean=%.6g std=%.6g max=%.6g",
+                phase,
+                tuple(qr_kv.shape),
+                torch.isfinite(qf).all().item(),
+                qf.mean().item(),
+                qf.std().item(),
+                qf.abs().max().item(),
+            )
+
+    def attn_gemm_parallel_execute(
+        self, hidden_states, hidden_states_flat
+    ) -> tuple[Any, ...]:
         aux_streams = self.aux_stream_list
         if aux_streams is not None:
             assert len(aux_streams) >= 3
@@ -410,7 +585,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
         def fused_wqa_wkv() -> torch.Tensor:
             # MergedColumnParallelLinear returns (output, bias); bias is None.
-            qr_kv, _ = self.fused_wqa_wkv(hidden_states)
+            qr_kv, _ = self.fused_wqa_wkv(hidden_states_flat)
             return qr_kv
 
         qr_kv, (kv_score, indexer_weights, indexer_kv_score) = execute_in_parallel(
@@ -453,7 +628,9 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
             def wq_b_kv_insert() -> torch.Tensor:
                 q = self.wq_b(qr).view(-1, self.n_local_heads, self.head_dim)
+                self._debug_layer0_tensor("DSV4_WQB_Q", q)
                 q = self._fused_qnorm_rope_kv_insert(q, kv, positions, attn_metadata)
+                self._debug_layer0_tensor("DSV4_Q_AFTER_KV_INSERT", q)
                 return q
 
             # 3-way overlap (matches TRT-LLM PR #14142 Level 1): default runs
@@ -487,7 +664,9 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
             def wq_b_kv_insert() -> torch.Tensor:
                 q = self.wq_b(qr).view(-1, self.n_local_heads, self.head_dim)
+                self._debug_layer0_tensor("DSV4_WQB_Q", q)
                 q = self._fused_qnorm_rope_kv_insert(q, kv, positions, attn_metadata)
+                self._debug_layer0_tensor("DSV4_Q_AFTER_KV_INSERT", q)
                 return q
 
             q, _ = maybe_execute_in_parallel(
@@ -500,11 +679,14 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         else:
             # SWA-only layer: no compressor, no overlap.
             q = self.wq_b(qr).view(-1, self.n_local_heads, self.head_dim)
+            self._debug_layer0_tensor("DSV4_WQB_Q", q)
             q = self._fused_qnorm_rope_kv_insert(q, kv, positions, attn_metadata)
+            self._debug_layer0_tensor("DSV4_Q_AFTER_KV_INSERT", q)
 
         # MLA attention writes into the pre-allocated `out` buffer
         # ([num_tokens, padded_heads, head_dim]).
         self.forward_mqa(q, kv, positions, out)
+        self._debug_layer0_tensor("DSV4_FORWARD_MQA_OUT", out)
 
     def _fused_qnorm_rope_kv_insert(
         self,
@@ -541,7 +723,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
         # kv is unchanged; attention reads kv solely via swa_kv_cache.
         if cache_dtype == torch.uint8:
-            # fp8_ds_mla UE8M0 paged path. Horizontally fused:
+            # Legacy FlashMLA UE8M0 paged path. Horizontally fused:
             #   Q side:  per-head RMSNorm (no weight) + GPT-J RoPE, zero-filling
             #            the padding head slots; the kernel allocates and returns
             #            the padded q tensor.
@@ -559,10 +741,10 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
                 swa_metadata.block_size,
             )
 
-        # Plain-row path: the [num_blocks, block_size, 512] cache stores the KV
-        # row in its element dtype (no Q padding). bf16 rewrites q in place;
-        # per-tensor fp8 writes a separately-allocated fp8 q and quantizes the
-        # KV row.
+        # FlashInfer full-cache path: the [num_blocks, block_size, 512] cache
+        # stores the KV row in its plain dtype (no Q padding). bf16 rewrites q
+        # in place; per-tensor fp8 writes a separately-allocated fp8 q and
+        # quantizes the KV row.
         block_size = swa_metadata.block_size
         swa_kv_cache_3d = swa_kv_cache.view(-1, block_size, self.head_dim)
         if cache_dtype == torch.bfloat16:
@@ -603,18 +785,18 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             self.compress_ratio <= 1
         ):  # SWA part. Allocated separately as DeepseekV4SWACache.
             return None
-        # fp8_ds_mla is a UE8M0 block-scaled uint8 layout and needs 576B
-        # alignment; plain bf16 / per-tensor fp8 rows use natural element-size
-        # pages.
-        uses_fp8_ds_mla_layout = self.kv_cache_dtype == "fp8_ds_mla"
+        # FlashMLA uses the fp8_ds_mla block format (UE8M0 block-scaled fp8 as
+        # uint8, 576B aligned); FlashInfer stores a plain bf16 / per-tensor fp8
+        # row with no extra alignment.
+        is_flashmla = self.kv_cache_dtype == "fp8_ds_mla"
         return MLAAttentionSpec(
             block_size=vllm_config.cache_config.block_size,
             num_kv_heads=1,
             head_size=self.head_dim,
-            dtype=torch.uint8 if uses_fp8_ds_mla_layout else self.kv_cache_torch_dtype,
+            dtype=torch.uint8 if is_flashmla else self.kv_cache_torch_dtype,
             compress_ratio=self.compress_ratio,
             cache_dtype_str=self.kv_cache_dtype,
-            alignment=576 if uses_fp8_ds_mla_layout else None,
+            alignment=576 if is_flashmla else None,  # FlashMLA needs 576B
             model_version="deepseek_v4",
         )
 


### PR DESCRIPTION



## Purpose

This PR adds ROCm support fixes for serving DeepSeek V4 Pro NVFP4 checkpoints in vLLM.

The main purpose is to make DeepSeek V4 Pro NVFP4 checkpoints load and run correctly on AMD ROCm with tensor parallelism, expert parallelism, FP8 KV cache, and the DeepSeek V4 AMD model path.

The change set covers:

- Add Quark full NVFP4 dense linear support.
- Add Quark NVFP4 MoE expert support.
- Add FP8 block-scaled W8A8 Quark linear support for selected DeepSeek V4 attention projections.
- Add DeepSeek V4 AMD loader compatibility for checkpoint scale names such as `.input_scale -> .input_scale_2`.
- Add ROCm-compatible NVFP4 MoE EMULATION backend support.
- Fix DeepSeek V4 attention input-shape handling for ROCm fused attention paths.
- Improve parameter loading robustness for already TP-sharded tensors.
- Avoid ROCm graph-capture failures from GPU-to-CPU debug synchronization in DeepSeek V4 MoE diagnostics.
- Document the NVIDIA ModelOpt NVFP4 runtime workaround for ROCm expert parallelism.

This PR intentionally removes the earlier experimental weight-only NVFP4 code path. The current DeepSeek V4 NVFP4 checkpoints are treated as full NVFP4 configurations with activation input scales.

## Test Plan

### 1. Static validation

Compile all files touched by this change set:

```bash
cd /root/vllm

python -m py_compile \
  vllm/model_executor/layers/quantization/quark/quark.py \
  vllm/model_executor/layers/quantization/quark/schemes/__init__.py \
  vllm/model_executor/layers/quantization/quark/schemes/quark_nvfp4.py \
  vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8_block.py \
  vllm/model_executor/layers/quantization/quark/quark_moe.py \
  vllm/model_executor/layers/fused_moe/routed_experts.py \
  vllm/models/deepseek_v4/amd/model.py \
  vllm/models/deepseek_v4/attention.py \
  vllm/model_executor/layers/fused_moe/oracle/nvfp4.py \
  vllm/model_executor/layers/fused_moe/runner/moe_runner.py \
  vllm/model_executor/parameter.py \
  vllm/model_executor/layers/mhc.py