### PR TITLE
Allow GLM-4.7 required tool parsing when strict mode is disabled

### DIFF
--- a/tests/tool_parsers/test_glm47_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm47_moe_tool_parser.py
@@ -4,6 +4,9 @@
 """Tests for the GLM-4.7 tool call parser."""
 
 import json
+import os
+import subprocess
+import sys
 from unittest.mock import Mock
 
 import pytest
@@ -17,6 +20,26 @@ from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers.glm47_moe_tool_parser import Glm47MoeModelToolParser
 
 MODEL = "zai-org/GLM-4.7"
+
+
+def test_supports_required_and_named_when_strict_tool_calling_disabled():
+    env = os.environ.copy()
+    env["VLLM_ENFORCE_STRICT_TOOL_CALLING"] = "0"
+    out = subprocess.check_output(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from vllm.tool_parsers.glm47_moe_tool_parser "
+                "import Glm47MoeModelToolParser; "
+                "print(Glm47MoeModelToolParser.supports_required_and_named)"
+            ),
+        ],
+        env=env,
+        text=True,
+    )
+
+    assert out.strip() == "True"
 
 
 @pytest.fixture(scope="module")

--- a/vllm/tool_parsers/glm47_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm47_moe_tool_parser.py
@@ -7,5 +7,4 @@ from vllm.parser.engine.registered_adapters import Glm47MoeParserToolAdapter
 
 
 class Glm47MoeModelToolParser(Glm47MoeParserToolAdapter):  # type: ignore[valid-type, misc]
-    supports_required_and_named = False
     structural_tag_model = "glm_4_7"


### PR DESCRIPTION
This is a draft for discussion based on observed GLM-4.7 behavior with `VLLM_ENFORCE_STRICT_TOOL_CALLING=0`.

## Summary
- Let `Glm47MoeModelToolParser` inherit the default `supports_required_and_named=True` when strict structural-tag enforcement is disabled.
- Keep the existing strict-mode behavior: `ToolParser.__init_subclass__` still forces structural-tag parsers to `supports_required_and_named=False` when `VLLM_ENFORCE_STRICT_TOOL_CALLING` is enabled.
- Add a subprocess regression test for importing GLM-4.7 with `VLLM_ENFORCE_STRICT_TOOL_CALLING=0`.

## Context
In local GLM-4.7 deployments using `--enable-auto-tool-choice --tool-call-parser glm47` with `VLLM_ENFORCE_STRICT_TOOL_CALLING=0`, forcing the parser to always set `supports_required_and_named=False` sends required/named tool-choice paths through the XML auto-parser fallback even when strict structural-tag enforcement is intentionally disabled. This increases exposure to malformed XML tool-call generations such as concatenating the tool name and first argument name.

## Testing
- `git diff --check`
- Attempted: `uv run --with pytest python -m pytest tests/tool_parsers/test_glm47_moe_tool_parser.py::test_supports_required_and_named_when_strict_tool_calling_disabled -q`
  - Could not run locally on macOS because the checkout resolves unsatisfiable project torch constraints (`torch==2.11.0+cpu`) for this platform.