### PR TITLE
[Kernel][XPU] Tensor-descriptor operand loads for W8A8 block-INT8 matmul

### DIFF
--- a/tests/kernels/quantization/test_block_int8.py
+++ b/tests/kernels/quantization/test_block_int8.py
@@ -14,7 +14,8 @@ from vllm.model_executor.layers.quantization.utils.int8_utils import (
 )
 from vllm.platforms import current_platform
 
-if current_platform.get_device_capability() < (7, 0):
+_cap = current_platform.get_device_capability()
+if _cap is not None and _cap < (7, 0):
     pytest.skip("INT8 Triton requires CUDA 7.0 or higher", allow_module_level=True)
 
 vllm_config = VllmConfig()
@@ -65,3 +66,28 @@ def test_w8a8_block_int8_matmul(M, N, K, block_size, out_dtype, seed):
         torch.abs(out.to(torch.float32) - ref_out.to(torch.float32))
     ) / torch.mean(torch.abs(ref_out.to(torch.float32)))
     assert rel_diff < 0.001
+
+@pytest.mark.skipif(
+    not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
+    reason="No GPU device available",
+)
+@pytest.mark.parametrize(
+    "M,N,K", [(1, 4096, 4096), (64, 4096, 4096), (256, 2048, 4096)]
+)
+@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.half])
+@torch.inference_mode()
+def test_w8a8_block_int8_matmul_td_matches_plain(M, N, K, out_dtype):
+    dev = current_platform.device_type
+    torch.manual_seed(0)
+    block_size = [128, 128]
+    bn, bk = block_size
+    A = torch.randint(-8, 8, (M, K), device=dev, dtype=torch.int8)
+    B = torch.randint(-8, 8, (N, K), device=dev, dtype=torch.int8)
+    As = torch.rand(M, K // bk, device=dev, dtype=torch.float32) * 1e-2
+    Bs = torch.rand(N // bn, K // bk, device=dev, dtype=torch.float32) * 1e-2
+
+    out_plain = w8a8_block_int8_matmul(
+        A, B, As, Bs, block_size, out_dtype, use_td=False
+    )
+    out_td = w8a8_block_int8_matmul(A, B, As, Bs, block_size, out_dtype, use_td=True)
+    torch.testing.assert_close(out_td, out_plain, rtol=0, atol=0)

--- a/tests/kernels/quantization/test_block_int8.py
+++ b/tests/kernels/quantization/test_block_int8.py
@@ -67,6 +67,7 @@ def test_w8a8_block_int8_matmul(M, N, K, block_size, out_dtype, seed):
     ) / torch.mean(torch.abs(ref_out.to(torch.float32)))
     assert rel_diff < 0.001
 
+
 @pytest.mark.skipif(
     not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
     reason="No GPU device available",

--- a/vllm/model_executor/layers/quantization/utils/int8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/int8_utils.py
@@ -10,15 +10,12 @@ from typing import Any
 
 import torch
 
-import vllm.envs as envs
 from vllm.platforms import current_platform
-from vllm.triton_utils import tl, triton
+from vllm.triton_utils import tl, triton, use_tensor_descriptor
 from vllm.triton_utils.allocation import set_triton_allocator
 from vllm.utils.platform_utils import get_device_name_as_file_name
 
 logger = logging.getLogger(__name__)
-
-_TD_ALLOCATOR_DEVICES: set[torch.device] = set()
 
 
 def block_dequant(
@@ -445,12 +442,9 @@ def w8a8_block_int8_matmul(
             triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
         )
 
-
     bm, bn, bk = config["BLOCK_SIZE_M"], config["BLOCK_SIZE_N"], config["BLOCK_SIZE_K"]
-    td_override = use_td if use_td is not None else envs.VLLM_TRITON_USE_TD
-    use_td = current_platform.is_xpu() if td_override is None else td_override
     use_td = (
-        use_td
+        use_tensor_descriptor(use_td)
         and A.stride(-1) == 1
         and B.stride(1) == 1
         and (K * A.element_size()) % 16 == 0
@@ -458,9 +452,8 @@ def w8a8_block_int8_matmul(
         and (bn & (bn - 1)) == 0
         and (bk & (bk - 1)) == 0
     )
-    if use_td and A.device not in _TD_ALLOCATOR_DEVICES:
+    if use_td:
         set_triton_allocator(A.device)
-        _TD_ALLOCATOR_DEVICES.add(A.device)
 
     _w8a8_block_int8_matmul[grid](
         A,

--- a/vllm/model_executor/layers/quantization/utils/int8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/int8_utils.py
@@ -10,11 +10,15 @@ from typing import Any
 
 import torch
 
+import vllm.envs as envs
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.triton_utils.allocation import set_triton_allocator
 from vllm.utils.platform_utils import get_device_name_as_file_name
 
 logger = logging.getLogger(__name__)
+
+_TD_ALLOCATOR_DEVICES: set[torch.device] = set()
 
 
 def block_dequant(
@@ -261,6 +265,7 @@ def _w8a8_block_int8_matmul(
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
+    USE_TD: tl.constexpr = False,
 ):
     """Triton-accelerated function used to perform linear operations (dot
     product) on input tensors `A` and `B` with block-wise quantization, and
@@ -287,10 +292,28 @@ def _w8a8_block_int8_matmul(
     offs_bsn = offs_bn // group_n
     Bs_ptrs = Bs + offs_bsn * stride_Bs_n
 
+    if USE_TD:
+        a_desc = tl.make_tensor_descriptor(
+            A,
+            shape=[M, K],
+            strides=[stride_am, 1],
+            block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
+        )
+        b_desc = tl.make_tensor_descriptor(
+            B,
+            shape=[N, K],
+            strides=[stride_bn, 1],
+            block_shape=[BLOCK_SIZE_N, BLOCK_SIZE_K],
+        )
+
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
-        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        if USE_TD:
+            a = a_desc.load([pid_m * BLOCK_SIZE_M, k * BLOCK_SIZE_K])
+            b = tl.trans(b_desc.load([pid_n * BLOCK_SIZE_N, k * BLOCK_SIZE_K]))
+        else:
+            a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
 
         k_start = k * BLOCK_SIZE_K
         offs_ks = k_start // group_k
@@ -364,6 +387,7 @@ def w8a8_block_int8_matmul(
     Bs: torch.Tensor,
     block_size: list[int],
     output_dtype: torch.dtype = torch.float16,
+    use_td: bool | None = None,
 ) -> torch.Tensor:
     """This function performs matrix multiplication with block-wise
     quantization.
@@ -421,6 +445,23 @@ def w8a8_block_int8_matmul(
             triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
         )
 
+
+    bm, bn, bk = config["BLOCK_SIZE_M"], config["BLOCK_SIZE_N"], config["BLOCK_SIZE_K"]
+    td_override = use_td if use_td is not None else envs.VLLM_TRITON_USE_TD
+    use_td = current_platform.is_xpu() if td_override is None else td_override
+    use_td = (
+        use_td
+        and A.stride(-1) == 1
+        and B.stride(1) == 1
+        and (K * A.element_size()) % 16 == 0
+        and (bm & (bm - 1)) == 0
+        and (bn & (bn - 1)) == 0
+        and (bk & (bk - 1)) == 0
+    )
+    if use_td and A.device not in _TD_ALLOCATOR_DEVICES:
+        set_triton_allocator(A.device)
+        _TD_ALLOCATOR_DEVICES.add(A.device)
+
     _w8a8_block_int8_matmul[grid](
         A,
         B,
@@ -442,6 +483,7 @@ def w8a8_block_int8_matmul(
         As.stride(-1),
         Bs.stride(1),
         Bs.stride(0),
+        USE_TD=use_td,
         **config,
     )
 


### PR DESCRIPTION
Adds a Tensor-Descriptor (TD) operand-load path to `_w8a8_block_int8_matmul` (compressed-tensors / SGLang-style W8A8 block-wise INT8 GEMM).

On XPU, masked `tl.load` feeding `tl.dot` bypasses the Xe XMX 2D-block-read path, and the per-element address arithmetic dominates the int8 operand loads. Loading both operands via `tl.make_tensor_descriptor` restores the 2D-block path. The block-scale multiply is applied to the `[M, N]` accumulator (not to the operands), so the int8 tiles load straight through descriptors. `A` is `[M, K]` (loaded directly); `B` is `[N, K]` (K-contiguous), so its `[N, K]` tile is `tl.trans`'d for the dot.

**XPU results** (Intel BX70, block `[128,128]`, int8, bf16 out), device self-time via `torch.profiler` steady-state:

| M | K=N | plain | TD | Δ |
|---|---|---|---|---|
| 1   | 4096 | 211.8 µs  | 161.8 µs | −23.6% |
| 64  | 4096 | 624.3 µs  | 178.1 µs | −71.5% |
| 256 | 4096 | 1175.9 µs | 639.3 µs | −45.6% |
| 64  | 8192 | 1732.0 µs | 635.5 µs | −63.3% |

Output is bit-exact vs the plain path.

Performance on H200 (sm_90), triton 3.6.0, torch 2.11/cu130. Block `[128,128]`, int8, bf16 out.
| M   | N    | K    | plain    | TD       | Δ       |
| --- | ---- | ---- | -------- | -------- | ------- | 
| 1   | 4096 | 4096 | 25.4 µs  | 17.6 µs  | −30.7%  |
| 64  | 4096 | 4096 | 18.7 µs  | 18.2 µs  | −2.7%   |
| 256 | 4096 | 4096 | 19.3 µs  | 18.9 µs  | −1.8%   |
| 64  | 8192 | 8192 | 44.7 µs  | 43.0 µs  | −3.7%   |