### PR TITLE
[GLM4V] Avoid GLM4V processor init during startup metadata reads

### DIFF
--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -997,14 +997,42 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
     def get_video_processor(self, **kwargs: object) -> Glm4vVideoProcessor:
         return self.get_hf_processor(**kwargs).video_processor
 
+    def _get_processor_class_name(self) -> str | None:
+        from vllm.transformers_utils.processor import (
+            get_processor_cls_name_from_config,
+        )
+        from vllm.transformers_utils.utils import convert_model_repo_to_path
+
+        return get_processor_cls_name_from_config(
+            convert_model_repo_to_path(self.ctx.model_config.model),
+            revision=self.ctx.model_config.revision,
+        )
+
+    @staticmethod
+    def _get_longest_edge(size: Any, config_name: str) -> int:
+        if isinstance(size, dict):
+            longest_edge = size.get("longest_edge")
+        else:
+            longest_edge = getattr(size, "longest_edge", None)
+
+        if longest_edge is None:
+            raise ValueError(f"{config_name} must define longest_edge")
+
+        return int(longest_edge)
+
     def get_mm_max_tokens_per_item(
         self,
         seq_len: int,
         mm_counts: Mapping[str, int],
     ) -> Mapping[str, int] | None:
-        processor = self.get_hf_processor()
-        if isinstance(processor, Glm4vProcessor):
+        processor_class_name = self._get_processor_class_name()
+        if processor_class_name == "Glm4vProcessor":
             return None
+
+        if processor_class_name is None:
+            processor = self.get_hf_processor()
+            if isinstance(processor, Glm4vProcessor):
+                return None
 
         result: dict[str, int] = {}
 
@@ -1012,8 +1040,7 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
             result["image"] = self.get_max_image_tokens()
 
         if mm_counts.get("video", 0) > 0:
-            video_processor = self.get_video_processor()
-            max_pixels = video_processor.size["longest_edge"]
+            max_pixels = self._get_video_max_pixels()
 
             vision_config = self.get_hf_config().vision_config
             temporal_patch_size = vision_config.temporal_patch_size
@@ -1092,7 +1119,40 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
         ``smart_resize`` as the ``max_pixels`` argument, which constrains
         ``t_bar * h_bar * w_bar <= max_pixels``.
         """
-        return self.get_image_processor().size["longest_edge"]
+        mm_kwargs = self.ctx.get_merged_mm_kwargs({})
+        if (override_max_pixels := mm_kwargs.get("max_pixels")) is not None:
+            return int(override_max_pixels)
+
+        image_processor_config = self.ctx.get_hf_image_processor_config()
+        if not image_processor_config.get("size"):
+            from transformers.image_processing_base import ImageProcessingMixin
+
+            image_processor_config, _ = ImageProcessingMixin.get_image_processor_dict(
+                self.ctx.model_config.model,
+                revision=self.ctx.model_config.revision,
+            )
+        size = image_processor_config["size"]
+        if override_size := mm_kwargs.get("size"):
+            size = size | override_size
+
+        return self._get_longest_edge(size, "GLM4V image processor size")
+
+    def _get_video_max_pixels(self) -> int:
+        from transformers.video_processing_utils import BaseVideoProcessor
+
+        mm_kwargs = self.ctx.get_merged_mm_kwargs({})
+        if (override_max_pixels := mm_kwargs.get("max_pixels")) is not None:
+            return int(override_max_pixels)
+
+        video_processor_config, _ = BaseVideoProcessor.get_video_processor_dict(
+            self.ctx.model_config.model,
+            revision=self.ctx.model_config.revision,
+        )
+        size = video_processor_config["size"]
+        if override_size := mm_kwargs.get("size"):
+            size = size | override_size
+
+        return self._get_longest_edge(size, "GLM4V video processor size")
 
     def get_image_size_with_most_features(self) -> ImageSize:
         # Use num_frames=1 for single-image budget estimation.
@@ -1440,13 +1500,12 @@ class Glm4vDummyInputsBuilder(BaseDummyInputsBuilder[Glm4vProcessingInfo]):
         num_videos = mm_counts.get("video", 0)
 
         hf_config = self.info.get_hf_config()
-        hf_processor = self.info.get_hf_processor()
         tokenizer = self.info.get_tokenizer()
 
-        image_token: str = hf_processor.image_token
+        image_token = tokenizer.decode([hf_config.image_token_id])
         video_token_ids = [
             hf_config.video_start_token_id,
-            hf_processor.video_token_id,
+            hf_config.video_token_id,
             hf_config.video_end_token_id,
         ]
         video_token = tokenizer.decode(video_token_ids)


### PR DESCRIPTION
GLM4V startup budget paths only need processor metadata such as
`processor_class` and `size.longest_edge`, but they were initializing the full
HF processor via `get_hf_processor()`. This happens independently in
`APIServer`, `EngineCore`, and `worker` processes, adding startup latency and host
memory usage.

Read `processor_class` and image/video size from config files instead, and
build dummy placeholder text from `hf_config` token ids. Keep the normal
`get_hf_processor()` path for real multimodal request preprocessing.



## Purpose

Reduce GLM4V startup latency and host memory usage by avoiding full HF processor
initialization in startup-only metadata paths.

The old startup budget path initialized a full processor just to decide whether
GLM-4.1V should skip multimodal budget estimation:

```python
processor = self.get_hf_processor()
if isinstance(processor, Glm4vProcessor):
    return None
```

This reaches:

```text
get_mm_max_tokens_per_item()
-> get_hf_processor()
-> cached_processor_from_config(...)
-> <processor class>.from_pretrained(...)
```

Startup reaches this independently in multiple processes: `APIServer`,
`EngineCore_DP0`, and each worker process. The first `get_hf_processor()` call in
each process costs about 2-3 seconds and allocates host memory.

This PR changes startup-only paths to:

- read `processor_class` from config instead of creating a processor for
  `isinstance(processor, Glm4vProcessor)`;
- read image/video `size["longest_edge"]` from processor config files instead of
  `get_image_processor()` / `get_video_processor()`;
- build dummy placeholder text from token ids in `hf_config`.

Real multimodal request preprocessing in the APIServer path still uses the
normal `get_hf_processor()` path.

AI assistance was used to draft and refine this change.

## Test Plan


### trace pss/rss

- It may vary across machines and environments.

``` python

``` python

#!/usr/bin/env python3
import time, psutil
from datetime import datetime

ROLES = (("VLLM::EngineCore", "vllm::enginecor", "enginecore"), ("worker", "vllm::worker", "worker_tp", "worker_dp"), ("server", "apiserver", "api_server", "vllm serve"))

while True:
    rows = []
    for p in psutil.process_iter(["pid", "name", "cmdline"]):
        try:
            text = f"{p.info['name']} {' '.join(p.info['cmdline'] or [])}".lower()
            role = next((x[0] for x in ROLES if any(k in text for k in x[1:])), None)
            if role:
                mem = p.memory_full_info()
                rows.append((role, p.info["pid"], mem.rss / 1024**3, mem.pss / 1024**3))
        except (psutil.NoSuchProcess, psutil.AccessDenied):
            pass
    print(f"\n{datetime.now():%H:%M:%S}")
    for r, pid, rss, pss in sorted(rows):
        print(f"{r:16s} pid={pid:<8d} rss={rss:.3f} GiB pss={pss:.3f} GiB")
    time.sleep(1)

```

Run GLM-OCR startup benchmark:

```bash
MODEL_PATH=${MODEL_PATH:-<glm-ocr-model-path>}
vllm serve "${MODEL_PATH}" --tensor-parallel-size 1 --port 20002
```

Run GLM-4.6V / GLM-4.1V style startup benchmark:

```bash
MODEL_PATH=${MODEL_PATH:-<glm-4.6v-model-path>}
vllm serve "${MODEL_PATH}" --tensor-parallel-size 2 --port 20002
```

Measure startup time from process launch until the server-ready log appears.

## Test Result

### GLM-OCR

| Version | Runs | Average |
|---|---:|---:|
| Old | `41.429s`, `41.833s`, `40.967s` | `41.410s` |
| New | `34.184s`, `33.200s`, `34.186s` | `33.857s` |

Delta: `-7.553s` (`-18.24%`).

### GLM-4.6V / GLM-4.1V style server

| Version | Runs | Average |
|---|---:|---:|
| Old | `76.439s`, `67.416s`, `66.368s` | `70.074s` |
| New | `57.320s`, `47.247s`, `47.270s` | `50.612s` |

Delta: `-19.462s` (`-27.77%`).

Using only the more stable run2/run3 average:

- old: `66.892s`
- new: `47.258s`
- delta: `-19.634s` (`-29.35%`)

### Host memory

Temporary instrumentation around the old processor-loading path showed that
startup loaded the processor in four processes:

| Process | Delta PSS |
|---|---:|
| `APIServer` | `+0.094 GiB` (`~96 MiB`) |
| `EngineCore_DP0` | `+0.085 GiB` (`~87 MiB`) |
| `Worker_TP0` | `+0.097 GiB` (`~99 MiB`) |
| `Worker_TP1` | `+0.088 GiB` (`~90 MiB`) |

Aggregate: `+0.364 GiB` PSS, about `~373 MiB`.

Representative RSS / PSS deltas:

| Process | RSS | PSS |
|---|---:|---:|
| `APIServer` | `0.900 -> 1.001 GiB` | `0.742 -> 0.831 GiB` |
| `EngineCore_DP0` | `0.955 -> 1.061 GiB` | `0.798 -> 0.891 GiB` |
| `Worker_TP0` | `0.958 -> 1.070 GiB` | `0.706 -> 0.800 GiB` |
| `Worker_TP1` | `0.957 -> 1.066 GiB` | `0.707 -> 0.799 GiB` |

Aggregate representative deltas:

- RSS: `+0.428 GiB`, about `~438 MiB`
- PSS: `+0.368 GiB`, about `~377 MiB`


### Other Test
Tested image/video inputs for the models; results were fine. The test also shows that both time and PSS memory consumption are lower.

- `ZhipuAI/GLM-OCR`
- `ZhipuAI/GLM-4.6V-Flash`
- `ZhipuAI/GLM-4.1V-9B-Thinking`
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

