### PR TITLE
[Perf][MoE] Write FlashInfer combine into final output

### DIFF
--- a/tests/distributed/test_mnnvl_alltoall.py
+++ b/tests/distributed/test_mnnvl_alltoall.py
@@ -206,6 +206,36 @@ requires_deep_ep_v2 = pytest.mark.skipif(
 # should run even when FlashInfer NVLink backends are not installed.
 
 
+@pytest.mark.parametrize("supports_output", [False, True])
+def test_one_sided_combine_into_compatibility(supports_output):
+    from vllm.distributed.device_communicators.all2all import (
+        FlashInferNVLinkOneSidedManager,
+    )
+
+    class FakeMoeAlltoAll:
+        def combine(
+            self,
+            payload,
+            runtime_max_tokens_per_rank,
+            output=None,
+        ):
+            result = payload + runtime_max_tokens_per_rank
+            if output is None:
+                return result
+            output.copy_(result)
+            return output
+
+    manager = FlashInferNVLinkOneSidedManager.__new__(FlashInferNVLinkOneSidedManager)
+    manager.moe_alltoall = FakeMoeAlltoAll()
+    manager._combine_supports_output = supports_output
+    payload = torch.arange(4, dtype=torch.float32)
+    output = torch.empty_like(payload)
+
+    manager.combine_into(payload, runtime_max_tokens_per_rank=2, output=output)
+
+    torch.testing.assert_close(output, payload + 2)
+
+
 # ---------------------------------------------------------------------------
 # Test 1: Two-sided manager lifecycle (init, cleanup, reinit, ensure_init)
 # ---------------------------------------------------------------------------

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -16,6 +16,7 @@ from vllm.utils.flashinfer import (
     has_flashinfer_nvlink_one_sided,
     has_flashinfer_nvlink_two_sided,
 )
+from vllm.utils.func_utils import supports_kw
 from vllm.utils.import_utils import has_deep_ep, has_deep_ep_v2, has_mori
 
 from .base_device_communicator import All2AllManagerBase, Cache
@@ -690,6 +691,7 @@ class FlashInferNVLinkOneSidedManager(All2AllManagerBase):
         self.max_num_tokens = 0
         self.top_k = 0
         self.num_experts = 0
+        self._combine_supports_output = False
 
     def initialize(
         self,
@@ -790,6 +792,12 @@ class FlashInferNVLinkOneSidedManager(All2AllManagerBase):
             workspace_size_per_rank=self.workspace_size,
             mnnvl_config=ep_config,
         )
+        try:
+            self._combine_supports_output = supports_kw(
+                self.moe_alltoall.combine, "output", allow_var_kwargs=False
+            )
+        except (TypeError, ValueError):
+            self._combine_supports_output = False
 
         self.gpus_per_node = gpus_per_node
         self.initialized = True
@@ -803,6 +811,27 @@ class FlashInferNVLinkOneSidedManager(All2AllManagerBase):
         # rebuild a different number of times if their MoE layers have
         # different shape sequences, so a world-level barrier would deadlock.
         dist.barrier(group=self.cpu_group)
+
+    def combine_into(
+        self,
+        payload: torch.Tensor,
+        runtime_max_tokens_per_rank: int,
+        output: torch.Tensor,
+    ) -> None:
+        """Combine into ``output``, with a fallback for older FlashInfer."""
+        assert self.moe_alltoall is not None
+        if self._combine_supports_output:
+            self.moe_alltoall.combine(
+                payload=payload,
+                runtime_max_tokens_per_rank=runtime_max_tokens_per_rank,
+                output=output,
+            )
+        else:
+            combined_output = self.moe_alltoall.combine(
+                payload=payload,
+                runtime_max_tokens_per_rank=runtime_max_tokens_per_rank,
+            )
+            output.copy_(combined_output)
 
     def get_handle(self, kwargs):
         return self

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
@@ -161,8 +161,8 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
             ep_size, self.runtime_max_tokens_per_rank, hidden_size
         )
 
-        combined_output = self.all2all_manager.moe_alltoall.combine(  # type: ignore[attr-defined]
+        self.all2all_manager.moe_alltoall.combine(  # type: ignore[attr-defined]
             payload=fused_expert_output,
             runtime_max_tokens_per_rank=self.runtime_max_tokens_per_rank,
+            output=output,
         )
-        output.copy_(combined_output)

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import inspect
+
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
@@ -54,6 +56,11 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
             hidden_size=self.hidden_size,
             dispatch_dtype_bytes_per_elem=dispatch_dtype_bytes_per_elem,
             dispatch_scale_bytes_per_token=dispatch_scale_bytes_per_token,
+        )
+        moe_alltoall = self.all2all_manager.moe_alltoall  # type: ignore[attr-defined]
+        assert moe_alltoall is not None
+        self._combine_supports_output = (
+            "output" in inspect.signature(moe_alltoall.combine).parameters
         )
 
     @property
@@ -161,8 +168,15 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
             ep_size, self.runtime_max_tokens_per_rank, hidden_size
         )
 
-        self.all2all_manager.moe_alltoall.combine(  # type: ignore[attr-defined]
-            payload=fused_expert_output,
-            runtime_max_tokens_per_rank=self.runtime_max_tokens_per_rank,
-            output=output,
-        )
+        if self._combine_supports_output:
+            self.all2all_manager.moe_alltoall.combine(  # type: ignore[attr-defined]
+                payload=fused_expert_output,
+                runtime_max_tokens_per_rank=self.runtime_max_tokens_per_rank,
+                output=output,
+            )
+        else:
+            combined_output = self.all2all_manager.moe_alltoall.combine(  # type: ignore[attr-defined]
+                payload=fused_expert_output,
+                runtime_max_tokens_per_rank=self.runtime_max_tokens_per_rank,
+            )
+            output.copy_(combined_output)

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import inspect
-
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
@@ -56,11 +54,6 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
             hidden_size=self.hidden_size,
             dispatch_dtype_bytes_per_elem=dispatch_dtype_bytes_per_elem,
             dispatch_scale_bytes_per_token=dispatch_scale_bytes_per_token,
-        )
-        moe_alltoall = self.all2all_manager.moe_alltoall  # type: ignore[attr-defined]
-        assert moe_alltoall is not None
-        self._combine_supports_output = (
-            "output" in inspect.signature(moe_alltoall.combine).parameters
         )
 
     @property
@@ -168,15 +161,8 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
             ep_size, self.runtime_max_tokens_per_rank, hidden_size
         )
 
-        if self._combine_supports_output:
-            self.all2all_manager.moe_alltoall.combine(  # type: ignore[attr-defined]
-                payload=fused_expert_output,
-                runtime_max_tokens_per_rank=self.runtime_max_tokens_per_rank,
-                output=output,
-            )
-        else:
-            combined_output = self.all2all_manager.moe_alltoall.combine(  # type: ignore[attr-defined]
-                payload=fused_expert_output,
-                runtime_max_tokens_per_rank=self.runtime_max_tokens_per_rank,
-            )
-            output.copy_(combined_output)
+        self.all2all_manager.combine_into(  # type: ignore[attr-defined]
+            payload=fused_expert_output,
+            runtime_max_tokens_per_rank=self.runtime_max_tokens_per_rank,
+            output=output,
+        )


### PR DESCRIPTION
## Summary

Pass vLLM's preallocated MoE output tensor to FlashInfer one-sided combine,
removing the temporary combine output and subsequent `output.copy_()`.

Requires FlashInfer PR: https://github.com/flashinfer-ai/flashinfer/pull/3776

## Performance

Nemotron Ultra 550B A55B NVFP4, one GB200 node (4 gpus), TP1/DP4/EP4, FlashInfer
one-sided, ISL/OSL 50000/2048, concurrency 16:

| | Baseline | Direct output | Delta |
| --- | ---: | ---: | ---: |
| Output throughput | 470.26 tok/s | 481.14 tok/s | **+2.31%** |
| Mean TPOT | 27.418 ms | 26.567 ms | **-3.10%** |

TTFT showed no statistically resolved change: 13.45 → 13.62 s nominally (+1.27%), while the four paired wave deltas ranged from -21.3% to +32.2%. Pending more perf data.


### Relation to #44452
This is a narrower alternative, not the same implementation. #44452 changes
the output-ownership contract across all modular MoE backends. This PR keeps
the existing contract and changes only FlashInfer one-sided by letting its
combine kernel write into the already-owned vLLM output buffer.

## Validation

- Nemotron Ultra NVFP4 end-to-end A/B reported above.
- `ruff check vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py`
- `ruff format --check vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py`
- `git diff --check upstream/main...HEAD`

AI assistance was used to develop and benchmark this change.