### PR TITLE
[CI][Bugfix] Fix `Hybrid SSM NixlConnector PD prefix cache test (2 GPUs)`

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/run_mamba_prefix_cache_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_mamba_prefix_cache_test.sh
@@ -51,6 +51,7 @@ vllm serve $MODEL \
   --trust-remote-code \
   --enable-prefix-caching \
   --mamba-cache-mode all \
+  --attention-backend FLASHINFER \
   --kv-transfer-config "$KV_CONFIG" &
 
 # Start decode instance
@@ -68,6 +69,7 @@ vllm serve $MODEL \
   --trust-remote-code \
   --enable-prefix-caching \
   --mamba-cache-mode all \
+  --attention-backend FLASHINFER \
   --kv-transfer-config "$KV_CONFIG" &
 
 echo "Waiting for prefill instance on port $PREFILL_PORT..."


### PR DESCRIPTION
Fix flaky CI test https://buildkite.com/vllm/ci/builds/74969/list?sid=019f1009-547c-4b3c-9eae-3e500fda953a&tab=output, in which the output of two identical requests might be ~slightly different, causing the assertion to trigger.

I currently suspect this might be due to a recent change to FA https://github.com/vllm-project/vllm/pull/36701, which should still be the default on hopper
```
[2026-06-28T21:10:21Z] [0;36m(EngineCore pid=954)[0;0m [32mINFO[0m [90m06-28 21:10:21[0m [90m[cuda.py:483][0m Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
```
and that would also explain why I am not able to repro it on blackwell currently.

cc @ZhanqiuHu @zhewenl 
