### PR TITLE
[Rust Frontend] Coerce completion `max_tokens: null` to default

### DIFF
--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -199,6 +199,7 @@ mod tests {
     use super::prepare_completion_request;
     use crate::lora::LoraModelResolution;
     use crate::routes::openai::completions::types::CompletionRequest;
+    use crate::routes::openai::utils::types::Normalizable;
     use crate::utils::{ResolvedRequestContext, resolve_request_context};
 
     fn request_context(headers: &HeaderMap, request_id: Option<&str>) -> ResolvedRequestContext {
@@ -271,6 +272,28 @@ mod tests {
         assert_eq!(request.prompt, Prompt::TokenIds(vec![11, 22, 33]));
         assert_eq!(request.max_tokens, Some(7));
         assert!(request.ignore_eos);
+    }
+
+    #[test]
+    fn normalize_coerces_null_max_tokens_to_default() {
+        // An absent `max_tokens` already gets the serde default.
+        let absent: CompletionRequest =
+            serde_json::from_value(base_request_json()).expect("parse request");
+        assert_eq!(absent.max_tokens, Some(16));
+
+        // An explicit `null` deserializes to `None`, bypassing the default;
+        // `normalize` must coerce it back to match Python vLLM.
+        let mut request: CompletionRequest = serde_json::from_value(json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "prompt": "hello",
+            "stream": true,
+            "max_tokens": null
+        }))
+        .expect("parse request");
+        assert_eq!(request.max_tokens, None);
+
+        request.normalize();
+        assert_eq!(request.max_tokens, Some(16));
     }
 
     #[test]

--- a/rust/src/server/src/routes/openai/completions/types.rs
+++ b/rust/src/server/src/routes/openai/completions/types.rs
@@ -179,7 +179,17 @@ pub struct CompletionRequest {
     pub other: Map<String, Value>,
 }
 
-impl Normalizable for CompletionRequest {}
+impl Normalizable for CompletionRequest {
+    /// Normalize the request by applying defaults.
+    fn normalize(&mut self) {
+        // An explicit `"max_tokens": null` deserializes to `None`, bypassing the
+        // serde field default. Coerce it back to the default so it behaves like
+        // an absent field, matching Python vLLM's `normalize_null_max_tokens`.
+        if self.max_tokens.is_none() {
+            self.max_tokens = default_completion_max_tokens();
+        }
+    }
+}
 
 /// Mirrors the Python vLLM `CompletionResponse` class.
 #[serde_with::skip_serializing_none]


### PR DESCRIPTION
## Summary

An explicit `"max_tokens": null` in a `/v1/completions` request is silently treated as "no limit" instead of the default of 16, causing runaway generation.

`CompletionRequest::max_tokens` uses `#[serde(default = "default_completion_max_tokens")]` (→ `Some(16)`). Serde's field default only applies when the JSON key is **absent** — an explicit `{"max_tokens": null}` deserializes `Option<u32>` to `None`. That `None` flows through `prepare_completion_request` into `resolve_max_tokens` (`rust/src/text/src/lower.rs`), which defaults `None` to the full remaining context window (`max_model_len - prompt_len`) rather than 16.

This matters in practice because the official OpenAI Python SDK serializes an unset `max_tokens` as explicit JSON `null`, so a client that doesn't set `max_tokens` gets full-context generation (latency/cost) instead of the documented short default.

## Fix

Implement `normalize()` for `CompletionRequest` to coerce a `None` `max_tokens` back to the default. `normalize()` is already invoked post-deserialization by the `ValidatedJson` extractor, so no wiring is needed.

This mirrors Python vLLM's `CompletionRequest.normalize_null_max_tokens` validator, added in #45491 ("Treat null completion max_tokens like the default"). Chat completions are unaffected: they use `max_completion_tokens`, whose Python default is `None`, not 16.

## Not a duplicate

No open PR addresses `max_tokens: null` handling in the Rust frontend (checked open PRs touching completions / `max_tokens`). This is the Rust-side counterpart of the already-merged Python fix #45491.

## Testing

Added a regression test `normalize_coerces_null_max_tokens_to_default` asserting that an explicit `max_tokens: null` deserializes to `None` and normalizes to `Some(16)`, while an absent field already gets the default. Verified the test fails without the fix (non-vacuous).

```
cargo test -p vllm-server --lib completions::
# 85 passed, 215 filtered out

cargo clippy -p vllm-server --lib -- -D warnings
# No issues found

cargo fmt -p vllm-server -- --check
# clean
```

## AI assistance

AI assistance (Claude) was used to help identify and implement this change. I have reviewed every changed line and run the tests above.
