### PR TITLE
[CI] Add GSM8K accuracy configs for Blackwell NVFP4/FP8 models

### DIFF
--- a/tests/evals/gsm8k/configs/Devstral-Small-2-24B-2512.yaml
+++ b/tests/evals/gsm8k/configs/Devstral-Small-2-24B-2512.yaml
@@ -1,0 +1,8 @@
+model_name: "mistralai/Devstral-Small-2-24B-Instruct-2512"
+accuracy_threshold: 0.83
+num_questions: 1319
+num_fewshot: 5
+server_args: >-
+  --enforce-eager
+  --max-model-len 4096
+  --limit-mm-per-prompt '{"image":0}'

--- a/tests/evals/gsm8k/configs/Gemma-4-31B-IT-NVFP4.yaml
+++ b/tests/evals/gsm8k/configs/Gemma-4-31B-IT-NVFP4.yaml
@@ -1,0 +1,5 @@
+model_name: "nvidia/Gemma-4-31B-IT-NVFP4"
+accuracy_threshold: 0.70
+num_questions: 1319
+num_fewshot: 5
+server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/Llama-3.3-70B-Instruct-NVFP4.yaml
+++ b/tests/evals/gsm8k/configs/Llama-3.3-70B-Instruct-NVFP4.yaml
@@ -1,0 +1,5 @@
+model_name: "nvidia/Llama-3.3-70B-Instruct-NVFP4"
+accuracy_threshold: 0.91
+num_questions: 1319
+num_fewshot: 5
+server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/Mistral-Small-4-119B-NVFP4.yaml
+++ b/tests/evals/gsm8k/configs/Mistral-Small-4-119B-NVFP4.yaml
@@ -1,0 +1,9 @@
+model_name: "mistralai/Mistral-Small-4-119B-2603-NVFP4"
+accuracy_threshold: 0.90
+num_questions: 1319
+num_fewshot: 5
+startup_max_wait_seconds: 1200
+server_args: >-
+  --enforce-eager
+  --max-model-len 4096
+  --limit-mm-per-prompt '{"image":0}'

--- a/tests/evals/gsm8k/configs/models-blackwell.txt
+++ b/tests/evals/gsm8k/configs/models-blackwell.txt
@@ -3,3 +3,7 @@ Qwen2.5-VL-3B-Instruct-FP8-dynamic.yaml
 Qwen1.5-MoE-W4A16-CT.yaml
 DeepSeek-V2-Lite-Instruct-FP8.yaml
 Qwen3-30B-A3B-NVFP4.yaml
+Gemma-4-31B-IT-NVFP4.yaml
+Llama-3.3-70B-Instruct-NVFP4.yaml
+Devstral-Small-2-24B-2512.yaml
+Mistral-Small-4-119B-NVFP4.yaml


### PR DESCRIPTION
## Purpose

Adds GSM8K accuracy coverage for four Blackwell models that currently have no
upstream correctness test, reusing the existing `tests/evals/gsm8k` harness on
the 1x-B200 LM Eval lane:

- `nvidia/Gemma-4-31B-IT-NVFP4`
- `nvidia/Llama-3.3-70B-Instruct-NVFP4`
- `mistralai/Devstral-Small-2-24B-Instruct-2512` (FP8)
- `mistralai/Mistral-Small-4-119B-2603-NVFP4`

Thresholds are set from measured runs. The two Mistral checkpoints are
multimodal, so image inputs are disabled (this is a text-only eval), which also
avoids a current `MistralCommonImageProcessor` profiling crash on these models.

Tracking issue: https://github.com/vllm-project/vllm/issues/36264

No existing/open PR adds gsm8k configs for these models (checked open PRs and
the tracking issue).

## Test Plan

```
pytest -s -v tests/evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-blackwell.txt
```

## Test Result

B100 (SM100), vLLM 0.22.1rc1.dev392, GSM8K 1319 questions / 5-shot:

| Model | accuracy | threshold |
|---|---|---|
| nvidia/Gemma-4-31B-IT-NVFP4 | 0.702 | 0.70 |
| nvidia/Llama-3.3-70B-Instruct-NVFP4 | 0.911 | 0.91 |
| mistralai/Devstral-Small-2-24B-Instruct-2512 (FP8) | 0.834 | 0.83 |
| mistralai/Mistral-Small-4-119B-2603-NVFP4 | 0.905 | 0.90 |

All passed (0% invalid except Gemma at 1.5%).

## Note

AI assistance was used to author these configs. All changes were reviewed by
hand, and the tests above were run and verified on the listed hardware.
