### PR TITLE
[CI] Add GSM8K accuracy configs for large NVFP4/INT4 MoEs (4xB200)

### DIFF
--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -89,6 +89,18 @@ steps:
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-blackwell-ep.txt
 
+- label: LM Eval Large Models (4xB200)
+  key: lm-eval-large-models-4xb200
+  timeout_in_minutes: 120
+  device: b200-k8s
+  optional: true
+  num_devices: 4
+  source_file_dependencies:
+  - csrc/
+  - vllm/model_executor/layers/quantization
+  commands:
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-blackwell-large.txt
+
 - label: LM Eval Qwen3.5 Models (2xB200)
   key: lm-eval-qwen3-5-models-2xb200
   timeout_in_minutes: 120

--- a/tests/evals/gsm8k/configs/DeepSeek-R1-0528-NVFP4.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-R1-0528-NVFP4.yaml
@@ -1,0 +1,10 @@
+model_name: "nvidia/DeepSeek-R1-0528-NVFP4-v2"
+accuracy_threshold: 0.95
+num_questions: 1319
+num_fewshot: 5
+startup_max_wait_seconds: 1200
+server_args: >-
+  --enforce-eager
+  --max-model-len 4096
+  --tensor-parallel-size 4
+  --enable-expert-parallel

--- a/tests/evals/gsm8k/configs/DeepSeek-V3.2-NVFP4.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-V3.2-NVFP4.yaml
@@ -1,0 +1,10 @@
+model_name: "nvidia/DeepSeek-V3.2-NVFP4"
+accuracy_threshold: 0.95
+num_questions: 1319
+num_fewshot: 5
+startup_max_wait_seconds: 1200
+server_args: >-
+  --enforce-eager
+  --max-model-len 4096
+  --tensor-parallel-size 4
+  --enable-expert-parallel

--- a/tests/evals/gsm8k/configs/Kimi-K2-Thinking-INT4.yaml
+++ b/tests/evals/gsm8k/configs/Kimi-K2-Thinking-INT4.yaml
@@ -1,0 +1,10 @@
+model_name: "moonshotai/Kimi-K2-Thinking"
+accuracy_threshold: 0.91
+num_questions: 1319
+num_fewshot: 5
+startup_max_wait_seconds: 1800
+server_args: >-
+  --enforce-eager
+  --max-model-len 4096
+  --tensor-parallel-size 4
+  --enable-expert-parallel

--- a/tests/evals/gsm8k/configs/Kimi-K2-Thinking-NVFP4.yaml
+++ b/tests/evals/gsm8k/configs/Kimi-K2-Thinking-NVFP4.yaml
@@ -1,0 +1,10 @@
+model_name: "nvidia/Kimi-K2-Thinking-NVFP4"
+accuracy_threshold: 0.92
+num_questions: 1319
+num_fewshot: 5
+startup_max_wait_seconds: 1800
+server_args: >-
+  --enforce-eager
+  --max-model-len 4096
+  --tensor-parallel-size 4
+  --enable-expert-parallel

--- a/tests/evals/gsm8k/configs/models-blackwell-large.txt
+++ b/tests/evals/gsm8k/configs/models-blackwell-large.txt
@@ -1,0 +1,4 @@
+DeepSeek-R1-0528-NVFP4.yaml
+DeepSeek-V3.2-NVFP4.yaml
+Kimi-K2-Thinking-NVFP4.yaml
+Kimi-K2-Thinking-INT4.yaml


### PR DESCRIPTION
## Purpose

Adds GSM8K accuracy coverage for four large NVFP4/INT4 MoEs that currently have
no upstream accuracy test, on a new **4x B200** LM Eval lane (Blackwell native
FP4). This is the large-model DeepSeek/Kimi accuracy coverage the new B200
cluster now makes possible:

- `nvidia/DeepSeek-R1-0528-NVFP4-v2`
- `nvidia/DeepSeek-V3.2-NVFP4`
- `nvidia/Kimi-K2-Thinking-NVFP4`
- `moonshotai/Kimi-K2-Thinking` (INT4)

The lane uses `device: b200-k8s`, `num_devices: 4` (the same convention as the
DeepSeek 4x B200 lanes in #41655). It is `optional` (nightly), so there is no
per-commit CI cost. Thresholds are set from measured runs.

Tracking issue: https://github.com/vllm-project/vllm/issues/36264

No existing/open PR adds gsm8k accuracy configs for these models (checked open
PRs and the tracking issue).

## Test Plan

```
pytest -s -v tests/evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-blackwell-large.txt
```

## Test Result

Verified on 4x B100 (SM100 Blackwell, native NVFP4 kernels, the same FP4 path
as B200), TP4, vLLM 0.22.1rc1.dev392, GSM8K 1319 questions / 5-shot:

| Model | accuracy | threshold |
|---|---|---|
| nvidia/DeepSeek-R1-0528-NVFP4-v2 | 0.956 | 0.95 |
| nvidia/DeepSeek-V3.2-NVFP4 | 0.954 | 0.95 |
| nvidia/Kimi-K2-Thinking-NVFP4 | 0.921 | 0.92 |
| moonshotai/Kimi-K2-Thinking (INT4) | 0.914 | 0.91 |

All passed, 0% invalid (kimi-NVFP4 0.08%).

## Note

AI assistance was used to author these configs. All changes were reviewed by
hand, and the tests above were run and verified on the listed hardware.
