### PR TITLE
[Bugfix][Frontend] GLM-4.7: guided-decode forced tool calls when strict tool-calling is disabled

### DIFF
--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -200,6 +200,79 @@ def test_tool_parsers_declare_matching_xgrammar_builtin_model(parser_cls, model)
     assert not parser_cls.supports_required_and_named
 
 
+def test_glm47_does_not_pin_supports_required_and_named():
+    # GLM must honor VLLM_ENFORCE_STRICT_TOOL_CALLING via __init_subclass__ like
+    # every other structural-tag parser, not hardcode the flag (which would keep
+    # forced tool calls off the full-schema guided-decode path even at strict=0).
+    assert "supports_required_and_named" not in Glm47MoeModelToolParser.__dict__
+
+
+def test_structural_tag_parser_honors_strict_env_toggle(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_ENFORCE_STRICT_TOOL_CALLING", "0")
+
+    class LooseStructuralTagParser(ToolParser):
+        structural_tag_model = "glm_4_7"
+
+    assert LooseStructuralTagParser.supports_required_and_named
+
+    monkeypatch.setenv("VLLM_ENFORCE_STRICT_TOOL_CALLING", "1")
+
+    class StrictStructuralTagParser(ToolParser):
+        structural_tag_model = "glm_4_7"
+
+    assert not StrictStructuralTagParser.supports_required_and_named
+
+
+def test_build_tool_choice_json_schema_named_returns_function_params():
+    params = {"type": "object", "properties": {"x": {"type": "string"}}}
+    func = SimpleNamespace(name="record_issue", parameters=params)
+    request = SimpleNamespace(
+        tools=[SimpleNamespace(type="function", function=func)],
+        tool_choice=None,
+    )
+    parser = MagicMock()
+    parser._get_function_name.return_value = "record_issue"
+    schema = DelegatingParser._build_tool_choice_json_schema(
+        parser, request, is_named=True
+    )
+    assert schema == params
+
+
+def test_build_tool_choice_json_schema_required_hoists_defs():
+    # A forced "required" call must validate as list[FunctionDefinition], i.e.
+    # an array of {name, parameters}. Nesting parameters moves "#/$defs/..."
+    # refs off the document root, so $defs has to be hoisted to the top level.
+    func = SimpleNamespace(
+        name="record_issue",
+        parameters={
+            "type": "object",
+            "properties": {"loc": {"$ref": "#/$defs/Loc"}},
+            "$defs": {
+                "Loc": {"type": "object", "properties": {"line": {"type": "integer"}}}
+            },
+        },
+    )
+    request = SimpleNamespace(
+        tools=[SimpleNamespace(type="function", function=func)],
+        tool_choice="required",
+    )
+    schema = DelegatingParser._build_tool_choice_json_schema(
+        MagicMock(), request, is_named=False
+    )
+    assert schema["type"] == "array"
+    assert schema["minItems"] == 1
+    assert schema["$defs"]["Loc"]["properties"]["line"]["type"] == "integer"
+    item = schema["items"]
+    assert item["properties"]["name"]["const"] == "record_issue"
+    # The nested ref is preserved and $defs no longer lives under parameters.
+    assert "$defs" not in item["properties"]["parameters"]
+    assert item["properties"]["parameters"]["properties"]["loc"]["$ref"] == (
+        "#/$defs/Loc"
+    )
+
+
 def test_tool_parsers_without_structural_tag_support_required_and_named():
     class NonStructuralTagToolParser(ToolParser):
         pass

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -502,6 +502,8 @@ class DelegatingParser(Parser):
         if self._tool_parser is not None:
             request = self._apply_structural_tag(request)
         if self._tool_parser is not None:
+            request = self._apply_tool_json_grammar(request)
+        if self._tool_parser is not None:
             request = self._tool_parser.adjust_request(request)
         return request
 
@@ -542,6 +544,88 @@ class DelegatingParser(Parser):
         else:
             request.response_format = None
         return request
+
+    def _apply_tool_json_grammar(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        # Encode-side guided decoding for forced (required/named) tool choice
+        # when the native structural-tag path is NOT used (strict=0). Mirrors
+        # the response_format json path, sourced from the request's own tool
+        # schema, so the forced call is constrained to schema-valid JSON and
+        # the JSON-based parse path (supports_required_and_named) sees output
+        # that conforms instead of unconstrained native syntax.
+        tool_parser = self._tool_parser
+        if tool_parser is None or not tool_parser.supports_required_and_named:
+            return request
+        if not request.tools:
+            return request
+        if request.structured_outputs is not None:
+            return request
+        is_named = isinstance(
+            request.tool_choice,
+            (ToolChoiceFunction, ChatCompletionNamedToolChoiceParam),
+        )
+        is_required = request.tool_choice == "required"
+        if not is_named and not is_required:
+            return request
+        schema = self._build_tool_choice_json_schema(request, is_named)
+        if schema is None:
+            return request
+        request.structured_outputs = StructuredOutputsParams(json=schema)
+        if isinstance(request, ResponsesRequest):
+            request.text = None
+        else:
+            request.response_format = None
+        return request
+
+    def _build_tool_choice_json_schema(
+        self, request: ChatCompletionRequest | ResponsesRequest, is_named: bool
+    ) -> dict | None:
+        functions = [
+            tool.function
+            for tool in request.tools
+            if getattr(tool, "type", "function") == "function"
+            and getattr(tool, "function", None) is not None
+        ]
+        if not functions:
+            return None
+        if is_named:
+            name = self._get_function_name(request)
+            for function in functions:
+                if function.name == name:
+                    return function.parameters or {
+                        "type": "object",
+                        "properties": {},
+                    }
+            return None
+        # "required": match the list[FunctionDefinition] shape the parse path
+        # validates, i.e. an array of {name, parameters} objects. Nesting each
+        # tool's parameters relocates it away from the document root, so hoist
+        # any "$defs" up to the top level to keep "#/$defs/..." refs resolvable.
+        top_defs: dict = {}
+        call_schemas = []
+        for function in functions:
+            params = dict(function.parameters or {"type": "object", "properties": {}})
+            defs = params.pop("$defs", None)
+            if defs:
+                top_defs.update(defs)
+            call_schemas.append(
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {"const": function.name},
+                        "parameters": params,
+                    },
+                    "required": ["name", "parameters"],
+                }
+            )
+        items_schema = (
+            {"anyOf": call_schemas} if len(call_schemas) > 1 else call_schemas[0]
+        )
+        schema: dict = {"type": "array", "items": items_schema, "minItems": 1}
+        if top_defs:
+            schema["$defs"] = top_defs
+        return schema
 
     def extract_reasoning_streaming(
         self,

--- a/vllm/tool_parsers/glm47_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm47_moe_tool_parser.py
@@ -7,5 +7,5 @@ from vllm.parser.engine.registered_adapters import Glm47MoeParserToolAdapter
 
 
 class Glm47MoeModelToolParser(Glm47MoeParserToolAdapter):  # type: ignore[valid-type, misc]
-    supports_required_and_named = False
+    # Honor VLLM_ENFORCE_STRICT_TOOL_CALLING via __init_subclass__ (strict=0 -> True).
     structural_tag_model = "glm_4_7"


### PR DESCRIPTION
## Purpose

On GLM-4.7 / GLM-5.2, forced tool calls (`tool_choice="required"` or a named function) return unconstrained native tool syntax (or an empty `tool_calls` list) when `VLLM_ENFORCE_STRICT_TOOL_CALLING=0`, which then fails downstream argument-schema validation — most visibly for tool schemas that use nested `$defs`/`$ref`.

There are two halves to the bug, and fixing only one is not enough:

1. **Parse side.** `Glm47MoeModelToolParser` hardcodes `supports_required_and_named = False`, overriding `ToolParser.__init_subclass__`. So even at `strict=0`, GLM never takes the JSON-based parse path for forced calls (every other structural-tag parser flips this to `True` at `strict=0`). This is the change in #47146.
2. **Encode side.** At `strict=0` the structural-tag path is skipped (`get_structural_tag(...) is None`) and nothing else installs a grammar for forced tool calls. The request therefore goes to the engine with **no** structured-outputs grammar, the model free-generates native tool syntax, and the now-JSON-based parse path cannot validate it. Flipping the flag alone (#47146 on its own) helps flat schemas but still leaves nested-schema forced calls unconstrained.

This PR fixes both:

- `glm47_moe_tool_parser`: drop the hardcoded flag and let `__init_subclass__` govern it via `VLLM_ENFORCE_STRICT_TOOL_CALLING`, like every other structural-tag parser.
- `DelegatingParser`: when no structural tag applies (`strict=0`) but `tool_choice` is `required`/named, build `StructuredOutputsParams(json=...)` from the request's **own tool schema** (mirroring the `response_format` json path). For `required`, the parameters are nested under `{name, parameters}` to match the `list[FunctionDefinition]` shape the parse path validates, and any `$defs` are hoisted to the top level so `#/$defs/...` refs stay resolvable after nesting.

The grammar is built entirely from the caller's existing tool definitions (no transpilation/heuristics), so a forced call is constrained to exactly the schema the caller already declared. The change only takes effect when `supports_required_and_named` is `True` (i.e. `strict=0`) and `structured_outputs` is not already set, so the structural-tag (`strict=1`) and `response_format` paths are untouched.

Builds on #47146 (parse-side flag) by adding the missing encode-side grammar.

## Test Plan

Unit tests (`tests/tool_parsers/test_structural_tag_registry.py`):

```
pytest tests/tool_parsers/test_structural_tag_registry.py -k "build_tool_choice or glm47_does_not_pin or honors_strict_env_toggle"
```

End-to-end on a GLM-4.7-family model served with `--enable-auto-tool-choice --tool-call-parser glm47` and `VLLM_ENFORCE_STRICT_TOOL_CALLING=0`, sending a tool whose parameters contain a nested object referenced via `$defs`/`$ref`, with `tool_choice="required"`, a named `tool_choice`, and a `response_format` json_schema control.

## Test Result

Unit tests: 4 passed (flag toggle is honored; GLM-4.7 no longer pins the flag; `_build_tool_choice_json_schema` returns the function params for a named choice and an array-of-`{name, parameters}` with hoisted `$defs` for `required`).

E2E (GLM-5.2, `strict=0`):

- Before: `tool_choice="required"` → empty `tool_calls`; named `tool_choice` → arguments contained raw native tool syntax; both failed schema validation on nested fields.
- After: both `required` and named return schema-valid JSON with the nested object populated (e.g. `{"location": {"file": "app.py", "line": 14}, ...}`). `response_format` json output is unchanged.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [x] (Optional) Documentation update — n/a (behavior fix, no new surface).
</details>