### PR TITLE
[Test] Disable P-side prefix caching in Mamba PD prefix cache test

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/run_mamba_prefix_cache_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_mamba_prefix_cache_test.sh
@@ -49,7 +49,7 @@ vllm serve $MODEL \
   --max-model-len 16384 \
   --block-size 128 \
   --trust-remote-code \
-  --enable-prefix-caching \
+  --no-enable-prefix-caching \
   --mamba-cache-mode all \
   --kv-transfer-config "$KV_CONFIG" &
 


### PR DESCRIPTION
## Summary
- Force-disable prefix caching on the prefill instance in the Mamba PD prefix cache test.
- The test validates D-side prefix cache hits. P-side prefix caching causes different chunk boundaries between cold and warm runs, leading to numerically different KV on FA v2 (L4), producing flaky output divergence.

## Test plan
- Trigger `Hybrid SSM NixlConnector PD prefix cache test (2 GPUs)` on L4 CI to confirm the fix.
