### PR TITLE
[Attention] Fix cascade NameError + D2H sync in triton/rocm backends

### DIFF
--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -818,3 +818,46 @@ def test_non_causal_backend_correctness(
             causal=False,
             block_size=128,
         )
+
+
+@pytest.mark.parametrize(
+    "backend_enum",
+    [
+        AttentionBackendEnum.TRITON_ATTN,
+        AttentionBackendEnum.ROCm_ATTN,
+    ],
+)
+def test_cascade_metadata_build_no_unbound_local(
+    backend_enum: AttentionBackendEnum,
+):
+    """Regression: build() with cascade must not raise UnboundLocalError.
+
+    prefix_scheduler_metadata was previously only initialized in the
+    else (no-cascade) branch of build() in triton_attn.py and
+    rocm_attn.py, causing UnboundLocalError when use_cascade=True.
+    This test also verifies suffix_kv_lens stays on the input device
+    (no .cpu() round-trip) and has correct values.
+    """
+    builder_cls, _ = try_get_attention_backend(backend_enum)
+
+    batch_spec = BatchSpec(seq_lens=[64, 128], query_lens=[1, 1])
+    vllm_config = create_vllm_config()
+    kv_cache_spec = create_standard_kv_cache_spec(vllm_config)
+    device = torch.device(current_platform.device_type)
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec, block_size=16, device=device
+    )
+
+    common_prefix_len = 16
+
+    builder = builder_cls(kv_cache_spec, ["layer_0"], vllm_config, device)
+    attn_metadata = builder.build(
+        common_prefix_len=common_prefix_len,
+        common_attn_metadata=common_attn_metadata,
+    )
+
+    assert attn_metadata.use_cascade is True
+    assert attn_metadata.suffix_kv_lens is not None
+    assert attn_metadata.suffix_kv_lens.device == device
+    expected = common_attn_metadata.seq_lens[:2] - common_prefix_len
+    torch.testing.assert_close(attn_metadata.suffix_kv_lens, expected)

--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -125,8 +125,14 @@ class RocmAttentionMetadataBuilder(AttentionMetadataBuilder[RocmAttentionMetadat
         seq_lens = common_attn_metadata.seq_lens
         block_table_tensor = common_attn_metadata.block_table_tensor
         slot_mapping = common_attn_metadata.slot_mapping
+        num_reqs = common_attn_metadata.num_reqs
 
         use_cascade = common_prefix_len > 0
+
+        cu_prefix_query_lens = None
+        prefix_kv_lens = None
+        suffix_kv_lens = None
+        prefix_scheduler_metadata = None
 
         if use_cascade:
             cu_prefix_query_lens = torch.tensor(
@@ -135,13 +141,7 @@ class RocmAttentionMetadataBuilder(AttentionMetadataBuilder[RocmAttentionMetadat
             prefix_kv_lens = torch.tensor(
                 [common_prefix_len], dtype=torch.int32, device=self.device
             )
-            suffix_kv_lens = common_attn_metadata.seq_lens.cpu() - common_prefix_len
-            suffix_kv_lens = suffix_kv_lens.to(self.device)
-        else:
-            cu_prefix_query_lens = None
-            prefix_kv_lens = None
-            suffix_kv_lens = None
-            prefix_scheduler_metadata = None
+            suffix_kv_lens = seq_lens[:num_reqs] - common_prefix_len
 
         attn_metadata = RocmAttentionMetadata(
             num_actual_tokens=num_actual_tokens,

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -198,6 +198,11 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
 
         use_cascade = common_prefix_len > 0
 
+        cu_prefix_query_lens = None
+        prefix_kv_lens = None
+        suffix_kv_lens = None
+        prefix_scheduler_metadata = None
+
         if use_cascade:
             cu_prefix_query_lens = torch.tensor(
                 [0, num_actual_tokens], dtype=torch.int32, device=self.device
@@ -205,13 +210,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             prefix_kv_lens = torch.tensor(
                 [common_prefix_len], dtype=torch.int32, device=self.device
             )
-            suffix_kv_lens = common_attn_metadata.seq_lens.cpu() - common_prefix_len
-            suffix_kv_lens = suffix_kv_lens.to(self.device)
-        else:
-            cu_prefix_query_lens = None
-            prefix_kv_lens = None
-            suffix_kv_lens = None
-            prefix_scheduler_metadata = None
+            suffix_kv_lens = seq_lens[:num_reqs] - common_prefix_len
 
         attn_metadata = TritonAttentionMetadata(
             num_actual_tokens=num_actual_tokens,


### PR DESCRIPTION
## Purpose

Fixes two defects in the cascade attention metadata build path of both `TritonAttentionMetadataBuilder.build()` and `RocmAttentionMetadataBuilder.build()`:

### 1. NameError (correctness, crash)

`prefix_scheduler_metadata` was only initialized in the `else` (no-cascade) branch. When `use_cascade=True` (common prefix found via prefix caching), the variable was never defined but was passed unconditionally to the `TritonAttentionMetadata` / `RocmAttentionMetadata` constructor, causing `UnboundLocalError`.

Currently masked because the V2 model runner always passes `common_prefix_len=0` (`vllm/v1/worker/gpu/attn_utils.py:523`), but the V1 model runner passes real cascade lengths from `kv_cache_manager.get_num_common_prefix_blocks()` (`vllm/v1/worker/gpu_model_runner.py:2439`).

### 2. D2H sync (performance)

`suffix_kv_lens = common_attn_metadata.seq_lens.cpu() - common_prefix_len` followed by `.to(self.device)` triggers a synchronous GPU-to-CPU copy on every cascade step. The `seq_lens_cpu` property is `@deprecated` in `vllm/v1/attention/backend.py:474-485` precisely because it "breaks full async scheduling."

**Fix**: Match the established `flash_attn.py` pattern (lines 475-519):
- Initialize all cascade-related variables to `None` **before** the conditional branch (prevents `UnboundLocalError`).
- Compute `suffix_kv_lens = seq_lens[:num_reqs] - common_prefix_len` on GPU (eliminates `.cpu()` + `.to(device)` round-trip).

## Relationship to existing PRs

- [#39118](https://github.com/vllm-project/vllm/pull/39118) — Fixes the NameError in `rocm_attn.py` only. Does **not** address the D2H sync.
- [#39208](https://github.com/vllm-project/vllm/pull/39208) — Fixes the NameError in `triton_attn.py` only. Does **not** address the D2H sync.

This PR is a **superset**: it fixes the NameError in **both** backends **and** eliminates the D2H sync, matching the established `flash_attn.py` pattern. If maintainers prefer, the existing PRs can be closed in favor of this combined fix.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/attention/test_attention_backends.py::test_cascade_metadata_build_no_unbound_local -v
```

Added `test_cascade_metadata_build_no_unbound_local` to `tests/v1/attention/test_attention_backends.py`. It calls `builder.build(common_prefix_len=16, ...)` (cascade=True) for both `TRITON_ATTN` and `ROCm_ATTN` and asserts:
- No `UnboundLocalError` (the NameError bug).
- `suffix_kv_lens` is on the input device (not CPU — the sync fix).
- `suffix_kv_lens` values equal `seq_lens[:num_reqs] - common_prefix_len`.

## Test Result

Tested locally on macOS arm64 (CPU). The triton and rocm backends require GPU, so the test will be exercised by CI on Linux with CUDA/ROCm. Pre-commit passes (ruff, ruff-format, mypy-3.10, typos, forbidden-imports, no-torch.cuda, attention-backend-docs).

## AI Assistance

This change was investigated and prepared with AI assistance (Claude). The underlying source locations, control-flow analysis, and the `flash_attn.py` precedent were reviewed end-to-end by me before submission.

## Why this is not duplicating existing PRs

See "Relationship to existing PRs" above. This PR extends #39118/#39208 by also eliminating the D2H sync and combining both backends in one change.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing the test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>