### PR TITLE
Fix Responses API null field serialization

### DIFF
--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -1,10 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseReasoningItem,
+)
+from openai.types.responses.response_reasoning_item import (
+    Content as ResponseReasoningTextContent,
+)
 from openai_harmony import (
     Message,
 )
 
 from vllm.entrypoints.openai.responses.protocol import (
+    ResponseRawMessageAndToken,
+    ResponsesRequest,
+    ResponsesResponse,
+    _omit_openai_response_non_nullable_nulls,
     serialize_message,
     serialize_messages,
 )
@@ -37,3 +48,229 @@ def test_serialize_messages() -> None:
     }
     msg = Message.from_dict(msg_value)
     assert serialize_messages([msg, dict_value]) == [msg_value, dict_value]
+
+
+def test_responses_response_omits_non_nullable_null_fields() -> None:
+    request = ResponsesRequest(
+        model="test-model",
+        input="What is the horoscope? She is an Aquarius.",
+        tools=[
+            {
+                "type": "function",
+                "name": "get_horoscope",
+                "description": "Get today's horoscope for an astrological sign.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "sign": {
+                            "type": "string",
+                            "description": (
+                                "An astrological sign like Taurus or Aquarius"
+                            ),
+                        }
+                    },
+                    "required": ["sign"],
+                },
+            }
+        ],
+    )
+    sampling_params = request.to_sampling_params(default_max_tokens=64)
+    response = ResponsesResponse.from_request(
+        request=request,
+        sampling_params=sampling_params,
+        model_name="test-model",
+        created_time=0,
+        output=[
+            ResponseReasoningItem(
+                id="rs_test",
+                type="reasoning",
+                summary=[],
+                content=[
+                    ResponseReasoningTextContent(
+                        text="Use get_horoscope for Aquarius.",
+                        type="reasoning_text",
+                    )
+                ],
+                encrypted_content=None,
+                status=None,
+            ),
+            ResponseFunctionToolCall(
+                id="fc_test",
+                call_id="call_test",
+                name="get_horoscope",
+                type="function_call",
+                arguments='{"sign":"Aquarius"}',
+                namespace=None,
+                status=None,
+            ),
+        ],
+        status="completed",
+        usage=None,
+    )
+
+    data = response.model_dump(mode="json", by_alias=True)
+
+    # These fields are nullable in OpenAI's OpenAPI schema and should remain.
+    assert data["error"] is None
+    assert data["incomplete_details"] is None
+    assert data["instructions"] is None
+    assert data["metadata"] is None
+    assert data["max_tool_calls"] is None
+    assert data["previous_response_id"] is None
+    assert data["prompt"] is None
+    assert data["reasoning"] is None
+    assert data["top_logprobs"] is None
+
+    # These fields are optional but not nullable, so they should be omitted
+    # instead of serialized as null.
+    assert "text" not in data
+    assert "user" not in data
+    assert "kv_transfer_params" not in data
+    assert "input_messages" not in data
+    assert "output_messages" not in data
+    assert "status" not in data["output"][0]
+    assert "namespace" not in data["output"][1]
+    assert "status" not in data["output"][1]
+    assert "defer_loading" not in data["tools"][0]
+
+    # strict is explicitly nullable in the OpenAPI function tool schema.
+    assert data["tools"][0]["strict"] is None
+
+
+def test_response_null_omission_is_position_aware() -> None:
+    data = _omit_openai_response_non_nullable_nulls(
+        {
+            "id": "resp_test",
+            "object": "response",
+            "status": None,
+            "text": None,
+            "metadata": {
+                "status": None,
+                "namespace": None,
+                "defer_loading": None,
+                "text": None,
+                "user": None,
+            },
+            "output": [
+                {
+                    "type": "function_call",
+                    "status": None,
+                    "namespace": None,
+                    "arguments": "{}",
+                    "extra": {"status": None},
+                }
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "defer_loading": None,
+                    "parameters": {
+                        "type": "object",
+                        "status": None,
+                    },
+                }
+            ],
+        }
+    )
+
+    assert data["status"] is None
+    assert "text" not in data
+    assert data["metadata"] == {
+        "status": None,
+        "namespace": None,
+        "defer_loading": None,
+        "text": None,
+        "user": None,
+    }
+    assert "status" not in data["output"][0]
+    assert "namespace" not in data["output"][0]
+    assert data["output"][0]["extra"]["status"] is None
+    assert "defer_loading" not in data["tools"][0]
+    assert data["tools"][0]["parameters"]["status"] is None
+
+
+def test_response_null_omission_handles_streaming_response_events() -> None:
+    data = _omit_openai_response_non_nullable_nulls(
+        {
+            "type": "response.completed",
+            "sequence_number": 1,
+            "response": {
+                "id": "resp_test",
+                "object": "response",
+                "text": None,
+                "output": [{"type": "reasoning", "status": None}],
+                "tools": [{"type": "function", "defer_loading": None}],
+            },
+        }
+    )
+
+    assert data["type"] == "response.completed"
+    assert data["sequence_number"] == 1
+    assert "text" not in data["response"]
+    assert "status" not in data["response"]["output"][0]
+    assert "defer_loading" not in data["response"]["tools"][0]
+
+
+def test_response_null_omission_handles_streaming_item_events() -> None:
+    data = _omit_openai_response_non_nullable_nulls(
+        {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "type": "function_call",
+                "status": None,
+                "namespace": None,
+                "extra": {"status": None},
+            },
+        }
+    )
+
+    assert data["type"] == "response.output_item.done"
+    assert "status" not in data["item"]
+    assert "namespace" not in data["item"]
+    assert data["item"]["extra"]["status"] is None
+
+
+def test_response_null_omission_leaves_unrelated_events_unchanged() -> None:
+    event = {
+        "type": "response.output_text.done",
+        "text": None,
+        "user": None,
+        "status": None,
+        "payload": {"defer_loading": None},
+    }
+
+    assert _omit_openai_response_non_nullable_nulls(event) == event
+
+
+def test_responses_response_keeps_populated_vllm_extension_fields() -> None:
+    request = ResponsesRequest(model="test-model", input="hello")
+    sampling_params = request.to_sampling_params(default_max_tokens=64)
+    response = ResponsesResponse.from_request(
+        request=request,
+        sampling_params=sampling_params,
+        model_name="test-model",
+        created_time=0,
+        output=[],
+        status="completed",
+        usage=None,
+        input_messages=[
+            ResponseRawMessageAndToken(
+                message="rendered prompt",
+                tokens=[1, 2, 3],
+            )
+        ],
+        output_messages=[
+            ResponseRawMessageAndToken(
+                message="rendered output",
+                tokens=[4, 5],
+            )
+        ],
+        kv_transfer_params={"transfer_id": "kv-test"},
+    )
+
+    data = response.model_dump(mode="json", by_alias=True)
+
+    assert data["input_messages"][0]["message"] == "rendered prompt"
+    assert data["output_messages"][0]["message"] == "rendered output"
+    assert data["kv_transfer_params"] == {"transfer_id": "kv-test"}

--- a/vllm/entrypoints/openai/responses/api_router.py
+++ b/vllm/entrypoints/openai/responses/api_router.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import json
 from collections.abc import AsyncGenerator
 from http import HTTPStatus
 
@@ -13,6 +14,7 @@ from vllm.entrypoints.openai.responses.protocol import (
     ResponsesRequest,
     ResponsesResponse,
     StreamingResponsesResponse,
+    _omit_openai_response_non_nullable_nulls,
 )
 from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
 from vllm.entrypoints.serve.utils.api_utils import (
@@ -37,10 +39,14 @@ async def _convert_stream_to_sse_events(
     """Convert the generator to a stream of events in SSE format"""
     async for event in generator:
         event_type = getattr(event, "type", "unknown")
-        # https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format
+        event_payload = _omit_openai_response_non_nullable_nulls(
+            event.model_dump(mode="json", by_alias=True)
+        )
+        # https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/
+        # Using_server-sent_events#event_stream_format
         event_data = (
             f"event: {event_type}\ndata: "
-            f"{event.model_dump_json(indent=None, by_alias=True)}\n\n"
+            f"{json.dumps(event_payload, separators=(',', ':'))}\n\n"
         )
         yield event_data
 

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -52,6 +52,7 @@ from pydantic import (
     Field,
     ValidationError,
     field_serializer,
+    model_serializer,
     model_validator,
 )
 
@@ -116,6 +117,95 @@ def serialize_messages(msgs):
     Serializes multiple messages
     """
     return [serialize_message(msg) for msg in msgs] if msgs else None
+
+
+_OPENAI_RESPONSE_TOP_LEVEL_OMIT_IF_NONE_KEYS = frozenset(
+    {
+        # Optional but non-nullable in the OpenAI OpenAPI schema. If vLLM has
+        # no value for these fields, omit them rather than serializing null.
+        "text",
+        "user",
+        # vLLM extensions. Keep them when populated, but do not expose nulls
+        # on the OpenAI-compatible response surface.
+        "kv_transfer_params",
+        "input_messages",
+        "output_messages",
+    }
+)
+_OPENAI_RESPONSE_OUTPUT_ITEM_OMIT_IF_NONE_KEYS = frozenset(
+    {
+        "status",
+        "namespace",
+    }
+)
+_OPENAI_RESPONSE_TOOL_OMIT_IF_NONE_KEYS = frozenset({"defer_loading"})
+
+
+def _omit_none_keys(data: dict[str, Any], keys: frozenset[str]) -> dict[str, Any]:
+    for key in keys:
+        if data.get(key) is None:
+            data.pop(key, None)
+    return data
+
+
+def _sanitize_response_output_item(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    return _omit_none_keys(
+        dict(value), _OPENAI_RESPONSE_OUTPUT_ITEM_OMIT_IF_NONE_KEYS
+    )
+
+
+def _sanitize_response_tool(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    return _omit_none_keys(dict(value), _OPENAI_RESPONSE_TOOL_OMIT_IF_NONE_KEYS)
+
+
+def _sanitize_response_dict(value: dict[str, Any]) -> dict[str, Any]:
+    data = dict(value)
+
+    output = data.get("output")
+    if isinstance(output, list):
+        data["output"] = [_sanitize_response_output_item(item) for item in output]
+
+    tools = data.get("tools")
+    if isinstance(tools, list):
+        data["tools"] = [_sanitize_response_tool(tool) for tool in tools]
+
+    return _omit_none_keys(data, _OPENAI_RESPONSE_TOP_LEVEL_OMIT_IF_NONE_KEYS)
+
+
+def _omit_openai_response_non_nullable_nulls(value: Any) -> Any:
+    """Drop nulls at exact OpenAI response positions that are not nullable.
+
+    This is intentionally narrower than ``exclude_none=True`` because many
+    Responses API fields are explicitly nullable and should remain present as
+    null in OpenAI-compatible responses. It is also position-aware so arbitrary
+    nested payloads such as tool JSON schemas are preserved verbatim.
+    """
+    if not isinstance(value, dict):
+        return value
+
+    data = dict(value)
+
+    # Streaming lifecycle events wrap a full response object under "response".
+    response = data.get("response")
+    if isinstance(response, dict):
+        data["response"] = _sanitize_response_dict(response)
+        return data
+
+    # Output item events wrap a single output item under "item".
+    item = data.get("item")
+    if isinstance(item, dict):
+        data["item"] = _sanitize_response_output_item(item)
+        return data
+
+    # Non-streaming responses are serialized directly as response objects.
+    if data.get("object") == "response":
+        return _sanitize_response_dict(data)
+
+    return data
 
 
 class ResponseRawMessageAndToken(OpenAIBaseModel):
@@ -614,6 +704,7 @@ class ResponsesResponse(OpenAIBaseModel):
     metadata: Metadata | None = None
     model: str
     object: Literal["response"] = "response"
+    error: Any | None = None
     output: list[ResponseOutputItem]
     parallel_tool_calls: bool
     temperature: float
@@ -688,6 +779,10 @@ class ResponsesResponse(OpenAIBaseModel):
     @field_serializer("input_messages", when_used="json")
     def serialize_input_messages(self, msgs, _info):
         return serialize_messages(msgs)
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        return _omit_openai_response_non_nullable_nulls(handler(self))
 
     @classmethod
     def from_request(


### PR DESCRIPTION
## Summary

Fixes #47200.

Align the Responses API JSON serialization with OpenAI OpenAPI nullable semantics.

This fixes cases where vLLM serialized `null` for fields that are optional but not nullable in the OpenAI schema, while preserving fields that are explicitly nullable.

This is breaking SMG compatibility for the Responses API because SMG strictly deserializes the response schema and fails with:

```text
Failed to deserialize as ResponsesResponse at output[1]: invalid type: null, expected a string
```

## Changes

- Add `error: null` to successful `ResponsesResponse` objects, matching the OpenAI Response schema.
- Omit non-nullable `None` fields only at their exact response positions:
  - top-level response: `text`, `user`, `kv_transfer_params`, `input_messages`, `output_messages`
  - output items: `output[*].status`, `output[*].namespace`
  - tools: `tools[*].defer_loading`
- Keep spec-nullable fields as `null`, including `incomplete_details`, `instructions`, `metadata`, `max_tool_calls`, `previous_response_id`, `prompt`, `reasoning`, `top_logprobs`, `encrypted_content`, and function tool `strict`.
- Apply the same position-aware cleanup to streaming SSE payloads.
- Add regression coverage to ensure nested payloads/tool schemas with keys like `status: null` are preserved.

## Testing

- `python -m py_compile vllm/entrypoints/openai/responses/protocol.py vllm/entrypoints/openai/responses/api_router.py tests/entrypoints/openai/responses/test_protocol.py`
- `git diff --check`
- Live H100 validation with `gpt-oss-120b`:
### before patch reproduced invalid `null` fields
  ```
  {
    "id": "resp_8a560fdbb5350e2a",
    "created_at": 1782764749,
    "incomplete_details": null,
    "instructions": null,
    "metadata": null,
    "model": "vllm-model",
    "object": "response",
    "output": [
        {
            "id": "rs_89b849e20d9888a1",
            "summary": [],
            "type": "reasoning",
            "content": [
                {
                    "text": "The user wants horoscope for the person in the file. There's a file? Not provided. Possibly they referenced a file but not given. Maybe we need to ask for clarification or assume they want generic Aquarius horoscope. The user says \"What is the horoscope of the person in the file? She is an Aquarius.\" Since we don't have the file content, we can just provide generic Aquarius horoscope. Could also ask for more details. Likely respond with horoscope for Aquarius using the function get_horoscope. Use function: get_horoscope with sign \"Aquarius\".",
                    "type": "reasoning_text"
                }
            ],
            "encrypted_content": null,
            "status": null
        },
        {
            "arguments": "{\n  \"sign\": \"Aquarius\"\n}",
            "call_id": "call_a9ffe49ff074b8f0",
            "name": "get_horoscope",
            "type": "function_call",
            "id": "fc_a9ffe49ff074b8f0",
            "namespace": null,
            "status": null
        }
    ],
    "parallel_tool_calls": true,
    "temperature": 1.0,
    "tool_choice": "auto",
    "tools": [
        {
            "name": "get_horoscope",
            "parameters": {
                "type": "object",
                "properties": {
                    "sign": {
                        "type": "string",
                        "description": "An astrological sign like Taurus or Aquarius"
                    }
                },
                "required": [
                    "sign"
                ]
            },
            "strict": null,
            "type": "function",
            "defer_loading": null,
            "description": "Get todays horoscope for an astrological sign."
        }
    ],
    "top_p": 1.0,
    "background": false,
    "max_output_tokens": 130923,
    "max_tool_calls": null,
    "previous_response_id": null,
    "prompt": null,
    "reasoning": null,
    "service_tier": "auto",
    "status": "completed",
    "text": null,
    "top_logprobs": null,
    "truncation": "disabled",
    "usage": {
        "input_tokens": 149,
        "input_tokens_details": {
            "cached_tokens": 32,
            "input_tokens_per_turn": [
                149
            ],
            "cached_tokens_per_turn": [
                32
            ]
        },
        "output_tokens": 144,
        "output_tokens_details": {
            "reasoning_tokens": 125,
            "tool_output_tokens": 0,
            "output_tokens_per_turn": [
                144
            ],
            "tool_output_tokens_per_turn": [
                0
            ]
        },
        "total_tokens": 293
    },
    "user": null,
    "presence_penalty": 0.0,
    "frequency_penalty": 0.0,
    "kv_transfer_params": null,
    "input_messages": null,
    "output_messages": null
}
  
  ```
  
  ### After no null fields
  
  ```
  {
    "id": "resp_8b59f7dd2f6d3c92",
    "created_at": 1782765082,
    "incomplete_details": null,
    "instructions": null,
    "metadata": null,
    "model": "vllm-model",
    "object": "response",
    "error": null,
    "output": [
        {
            "id": "rs_8ae3781b7a60755d",
            "summary": [],
            "type": "reasoning",
            "content": [
                {
                    "text": "We need to get horoscope for Aquarius. Use function get_horoscope.",
                    "type": "reasoning_text"
                }
            ],
            "encrypted_content": null
        },
        {
            "arguments": "{\n  \"sign\": \"Aquarius\"\n}",
            "call_id": "call_91379d66d5eea525",
            "name": "get_horoscope",
            "type": "function_call",
            "id": "fc_91379d66d5eea525"
        }
    ],
    "parallel_tool_calls": true,
    "temperature": 1.0,
    "tool_choice": "auto",
    "tools": [
        {
            "name": "get_horoscope",
            "parameters": {
                "type": "object",
                "properties": {
                    "sign": {
                        "type": "string",
                        "description": "An astrological sign like Taurus or Aquarius"
                    }
                },
                "required": [
                    "sign"
                ]
            },
            "strict": null,
            "type": "function",
            "description": "Get todays horoscope for an astrological sign."
        }
    ],
    "top_p": 1.0,
    "background": false,
    "max_output_tokens": 130923,
    "max_tool_calls": null,
    "previous_response_id": null,
    "prompt": null,
    "reasoning": null,
    "service_tier": "auto",
    "status": "completed",
    "top_logprobs": null,
    "truncation": "disabled",
    "usage": {
        "input_tokens": 149,
        "input_tokens_details": {
            "cached_tokens": 0,
            "input_tokens_per_turn": [
                149
            ],
            "cached_tokens_per_turn": [
                0
            ]
        },
        "output_tokens": 46,
        "output_tokens_details": {
            "reasoning_tokens": 27,
            "tool_output_tokens": 0,
            "output_tokens_per_turn": [
                46
            ],
            "tool_output_tokens_per_turn": [
                0
            ]
        },
        "total_tokens": 195
    },
    "presence_penalty": 0.0,
    "frequency_penalty": 0.0
}
  
  ```
