### PR TITLE
[Kernel][Bugfix] TRITON_MLA fix silent accuracy drop with dynamic num_kv_splits for SWA

### DIFF
--- a/tests/kernels/attention/test_triton_decode_sliding_window_bug.py
+++ b/tests/kernels/attention/test_triton_decode_sliding_window_bug.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kernel-only reproducer for the TRITON split-KV decode sliding-window bug.
+
+The split-KV decode kernels disagree on how the KV range is tiled when a
+sliding window is active:
+
+* stage 1 (``_fwd_kernel_stage1`` / ``_fwd_grouped_kernel_stage1``) tiles only
+  the *windowed* range ``[seq_len - W, seq_len)`` -- so trailing splits can be
+  empty and are left unwritten in ``attn_logits``.
+* stage 2 (``_fwd_kernel_stage2``) recomputes split boundaries from the *full*
+  ``seq_len`` (it is never told the window) and merges every split whose
+  full-seq range is non-empty -- including the ones stage 1 left unwritten.
+
+``attn_logits`` is allocated with ``torch.empty`` (uninitialized), so stage 2
+folds garbage LSE/values into the softmax merge. In production this is
+*intermittent* (depends on what is in memory) and only appears once the dynamic
+``num_kv_splits`` grows past the window (long context). Here we make it
+deterministic by poisoning ``attn_logits`` with a large finite value before the
+call, then assert the property the kernel must satisfy: **the result must not
+depend on num_kv_splits.**
+
+Run: pytest -q tests/kernels/attention/test_triton_decode_sliding_window_bug.py
+Fails on buggy code (the >window split count diverges), passes once stage 2 is
+made window-aware.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.attention.ops.triton_decode_attention import decode_attention_fwd
+
+DEVICE = current_platform.device_type
+
+# Small, model-independent MHA setup (kv_group_num == 1 -> normal kernel path).
+B, H, D = 1, 1, 16
+SEQ_LEN = 64
+WINDOW = 8
+POISON = 1.0e30
+
+
+def _run(num_kv_splits: int) -> torch.Tensor:
+    torch.manual_seed(0)
+    q = torch.randn(B, H, D, dtype=torch.bfloat16, device=DEVICE)
+    k = torch.randn(SEQ_LEN, H, D, dtype=torch.bfloat16, device=DEVICE)
+    v = torch.randn(SEQ_LEN, H, D, dtype=torch.bfloat16, device=DEVICE)
+    # Identity paged mapping, page_size = 1.
+    req_to_token = torch.arange(SEQ_LEN, device=DEVICE).view(1, SEQ_LEN)
+    b_seq_len = torch.full((B,), SEQ_LEN, device=DEVICE)
+
+    o = torch.zeros(B, H, D, dtype=torch.bfloat16, device=DEVICE)
+    lse = torch.zeros(B, H, dtype=torch.bfloat16, device=DEVICE)
+    # Poison the scratch buffer to model worst-case uninitialized memory.
+    attn_logits = torch.full(
+        (B, H, num_kv_splits, D + 1), POISON, dtype=torch.float32, device=DEVICE
+    )
+
+    decode_attention_fwd(
+        q,
+        k,
+        v,
+        o,
+        lse,
+        req_to_token,
+        b_seq_len,
+        attn_logits,
+        num_kv_splits,
+        1.0 / (D**0.5),
+        page_size=1,
+        sliding_window=WINDOW,
+    )
+    return o
+
+
+def _torch_windowed_ref() -> torch.Tensor:
+    torch.manual_seed(0)
+    q = torch.randn(B, H, D, dtype=torch.bfloat16, device=DEVICE).float()
+    k = torch.randn(SEQ_LEN, H, D, dtype=torch.bfloat16, device=DEVICE).float()
+    v = torch.randn(SEQ_LEN, H, D, dtype=torch.bfloat16, device=DEVICE).float()
+    sw_start = max(SEQ_LEN - WINDOW, 0)
+    kw = k[sw_start:SEQ_LEN, 0]  # [W, D]
+    vw = v[sw_start:SEQ_LEN, 0]
+    scores = (q[0, 0] @ kw.T) * (1.0 / (D**0.5))  # [W]
+    p = torch.softmax(scores, dim=-1)
+    return (p @ vw).view(B, H, D)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(), reason="Triton decode kernel needs GPU"
+)
+def test_sliding_window_decode_independent_of_num_kv_splits():
+    ref = _torch_windowed_ref()
+    out_1 = _run(num_kv_splits=1)  # 1 split: no empty split -> correct
+    out_4 = _run(num_kv_splits=4)  # 4 <= W, divides W: no empty split -> correct
+    out_16 = _run(num_kv_splits=16)  # 16 > W: trailing empty splits -> bug
+
+    # Baselines agree with the windowed reference.
+    torch.testing.assert_close(out_1.float(), ref, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(out_4.float(), ref, atol=2e-2, rtol=2e-2)
+    # The property under test: the result must not depend on the split count.
+    # On buggy code out_16 is dominated by the poisoned (unwritten) splits.
+    torch.testing.assert_close(out_16.float(), out_1.float(), atol=2e-2, rtol=2e-2)

--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -144,10 +144,9 @@ def _fwd_kernel_stage1(
             ).to(tl.int64)  # page_number * page stride overflows int32
             kv_in_page = offs_n % PAGE_SIZE
             offs_buf_k = (
-                (
-                    kv_page_number.to(tl.int64) * stride_buf_kpbs
-                    + kv_in_page * stride_buf_kbs
-                )[:, None]
+                (kv_page_number * stride_buf_kpbs + kv_in_page * stride_buf_kbs)[
+                    :, None
+                ]
                 + cur_kv_head * stride_buf_kh
                 + offs_d[None, :]
             )
@@ -167,10 +166,9 @@ def _fwd_kernel_stage1(
             qk = tl.where(offs_n < split_kv_end, qk, float("-inf"))
 
             offs_buf_v = (
-                (
-                    kv_page_number.to(tl.int64) * stride_buf_vpbs
-                    + kv_in_page * stride_buf_vbs
-                )[:, None]
+                (kv_page_number * stride_buf_vpbs + kv_in_page * stride_buf_vbs)[
+                    :, None
+                ]
                 + cur_kv_head * stride_buf_vh
                 + offs_dv[None, :]
             )
@@ -397,8 +395,7 @@ def _fwd_grouped_kernel_stage1(
                 cache_modifier=".ca",
             ).to(tl.int64)  # page_number * page stride overflows int32
             kv_off_k = (
-                kv_page_number.to(tl.int64) * stride_buf_kpbs
-                + (offs_n % PAGE_SIZE) * stride_buf_kbs
+                kv_page_number * stride_buf_kpbs + (offs_n % PAGE_SIZE) * stride_buf_kbs
             )
 
             # explicitly facilitate overlapping load/compute

--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -97,6 +97,7 @@ def _fwd_kernel_stage1(
     logit_cap: tl.constexpr,
     Lk: tl.constexpr,
     Lv: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr = 0,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -114,8 +115,15 @@ def _fwd_kernel_stage1(
     off_q = cur_batch * stride_qbs + cur_head * stride_qh + offs_d
     q = tl.load(Q + off_q, mask=mask_d, other=0.0)
 
-    kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
-    split_kv_start = kv_len_per_split * split_kv_id
+    if SLIDING_WINDOW > 0:
+        sw_start = tl.maximum(cur_batch_seq_len - SLIDING_WINDOW, 0)
+        effective_len = cur_batch_seq_len - sw_start
+    else:
+        sw_start = 0
+        effective_len = cur_batch_seq_len
+
+    kv_len_per_split = tl.cdiv(effective_len, NUM_KV_SPLITS)
+    split_kv_start = sw_start + kv_len_per_split * split_kv_id
     split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
 
     e_max = -float("inf")
@@ -136,9 +144,10 @@ def _fwd_kernel_stage1(
             ).to(tl.int64)  # page_number * page stride overflows int32
             kv_in_page = offs_n % PAGE_SIZE
             offs_buf_k = (
-                (kv_page_number * stride_buf_kpbs + kv_in_page * stride_buf_kbs)[
-                    :, None
-                ]
+                (
+                    kv_page_number.to(tl.int64) * stride_buf_kpbs
+                    + kv_in_page * stride_buf_kbs
+                )[:, None]
                 + cur_kv_head * stride_buf_kh
                 + offs_d[None, :]
             )
@@ -158,9 +167,10 @@ def _fwd_kernel_stage1(
             qk = tl.where(offs_n < split_kv_end, qk, float("-inf"))
 
             offs_buf_v = (
-                (kv_page_number * stride_buf_vpbs + kv_in_page * stride_buf_vbs)[
-                    :, None
-                ]
+                (
+                    kv_page_number.to(tl.int64) * stride_buf_vpbs
+                    + kv_in_page * stride_buf_vbs
+                )[:, None]
                 + cur_kv_head * stride_buf_vh
                 + offs_dv[None, :]
             )
@@ -220,6 +230,7 @@ def _decode_att_m_fwd(
     logit_cap,
     k_scale,
     v_scale,
+    sliding_window=0,
 ):
     BLOCK = 64 if not is_hip_ else 8
 
@@ -272,6 +283,7 @@ def _decode_att_m_fwd(
         num_stages=2,
         Lk=Lk,
         Lv=Lv,
+        SLIDING_WINDOW=sliding_window,
     )
 
 
@@ -311,6 +323,7 @@ def _fwd_grouped_kernel_stage1(
     Lk: tl.constexpr,
     Lv: tl.constexpr,
     IS_MLA: tl.constexpr = False,
+    SLIDING_WINDOW: tl.constexpr = 0,
 ):
     cur_batch = tl.program_id(0)
     cur_head_id = tl.program_id(1)
@@ -350,8 +363,15 @@ def _fwd_grouped_kernel_stage1(
             cache_modifier=".ca",
         )
 
-    kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
-    split_kv_start = kv_len_per_split * split_kv_id
+    if SLIDING_WINDOW > 0:
+        sw_start = tl.maximum(cur_batch_seq_len - SLIDING_WINDOW, 0)
+        effective_len = cur_batch_seq_len - sw_start
+    else:
+        sw_start = 0
+        effective_len = cur_batch_seq_len
+
+    kv_len_per_split = tl.cdiv(effective_len, NUM_KV_SPLITS)
+    split_kv_start = sw_start + kv_len_per_split * split_kv_id
     split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
 
     e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")
@@ -377,7 +397,8 @@ def _fwd_grouped_kernel_stage1(
                 cache_modifier=".ca",
             ).to(tl.int64)  # page_number * page stride overflows int32
             kv_off_k = (
-                kv_page_number * stride_buf_kpbs + (offs_n % PAGE_SIZE) * stride_buf_kbs
+                kv_page_number.to(tl.int64) * stride_buf_kpbs
+                + (offs_n % PAGE_SIZE) * stride_buf_kbs
             )
 
             # explicitly facilitate overlapping load/compute
@@ -481,6 +502,7 @@ def _decode_grouped_att_m_fwd(
     k_scale,
     v_scale,
     is_mla=False,
+    sliding_window=0,
 ):
     # with is_mla there is only a single c_kv in smem.
     # could increase BLOCK or num_stages.
@@ -568,6 +590,7 @@ def _decode_grouped_att_m_fwd(
         Lk=Lk,
         Lv=Lv,
         IS_MLA=is_mla,
+        SLIDING_WINDOW=sliding_window,
         **extra_kargs,
     )
 
@@ -588,6 +611,7 @@ def _fwd_kernel_stage2(
     BLOCK_DV: tl.constexpr,
     Lv: tl.constexpr,
     OUTPUT_FP16: tl.constexpr = 0,
+    SLIDING_WINDOW: tl.constexpr = 0,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -604,9 +628,20 @@ def _fwd_kernel_stage2(
     offs_v = cur_batch * stride_mid_ob + cur_head * stride_mid_oh + offs_d
     offs_logic = cur_batch * stride_mid_ob + cur_head * stride_mid_oh + Lv
 
+    # Must tile the KV range exactly as stage 1 did, otherwise the splits this
+    # kernel includes won't match the splits stage 1 actually wrote and we would
+    # merge uninitialized `Mid_O` entries. With a sliding window stage 1 only
+    # covers [seq_len - SLIDING_WINDOW, seq_len); default (0) covers the full seq.
+    if SLIDING_WINDOW > 0:
+        sw_start = tl.maximum(cur_batch_seq_len - SLIDING_WINDOW, 0)
+        effective_len = cur_batch_seq_len - sw_start
+    else:
+        sw_start = 0
+        effective_len = cur_batch_seq_len
+    kv_len_per_split = tl.cdiv(effective_len, NUM_KV_SPLITS)
+
     for split_kv_id in range(0, NUM_KV_SPLITS):
-        kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
-        split_kv_start = kv_len_per_split * split_kv_id
+        split_kv_start = sw_start + kv_len_per_split * split_kv_id
         split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
 
         if split_kv_end > split_kv_start:
@@ -647,6 +682,7 @@ def _decode_softmax_reducev_fwd(
     v_buffer,
     b_seq_len,
     num_kv_splits,
+    sliding_window=0,
 ):
     batch, head_num = q.shape[0], q.shape[1]
     Lv = v_buffer.shape[-1]
@@ -675,6 +711,7 @@ def _decode_softmax_reducev_fwd(
         NUM_KV_SPLITS=NUM_KV_SPLITS,
         BLOCK_DV=BLOCK_DV,
         Lv=Lv,
+        SLIDING_WINDOW=sliding_window,
         num_warps=4,
         num_stages=2,
         **extra_kargs,
@@ -696,6 +733,7 @@ def decode_attention_fwd_normal(
     logit_cap=0.0,
     k_scale=None,
     v_scale=None,
+    sliding_window=0,
 ):
     _decode_att_m_fwd(
         q,
@@ -710,9 +748,10 @@ def decode_attention_fwd_normal(
         logit_cap,
         k_scale,
         v_scale,
+        sliding_window=sliding_window,
     )
     _decode_softmax_reducev_fwd(
-        attn_logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits
+        attn_logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits, sliding_window
     )
 
 
@@ -732,6 +771,7 @@ def decode_attention_fwd_grouped(
     k_scale=None,
     v_scale=None,
     is_mla=False,
+    sliding_window=0,
 ):
     _decode_grouped_att_m_fwd(
         q,
@@ -747,9 +787,10 @@ def decode_attention_fwd_grouped(
         k_scale,
         v_scale,
         is_mla=is_mla,
+        sliding_window=sliding_window,
     )
     _decode_softmax_reducev_fwd(
-        attn_logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits
+        attn_logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits, sliding_window
     )
 
 
@@ -769,6 +810,7 @@ def decode_attention_fwd(
     k_scale=None,
     v_scale=None,
     is_mla=False,
+    sliding_window=0,
 ):
     assert num_kv_splits == attn_logits.shape[2]
 
@@ -796,6 +838,7 @@ def decode_attention_fwd(
             logit_cap,
             k_scale,
             v_scale,
+            sliding_window=sliding_window,
         )
     else:
         # GQA/MQA/MLA
@@ -815,4 +858,5 @@ def decode_attention_fwd(
             k_scale,
             v_scale,
             is_mla=is_mla,
+            sliding_window=sliding_window,
         )


### PR DESCRIPTION
Adds support for Triton backend to run SWA.
Also addresses a limitation with `num_kv_splits` that would cause silent accuracy drops when SW is enabled (described below).

The Triton split-KV decode merge (stage 2) did not account for the sliding window, while the per-split compute (stage 1) does.
The empty-split situation arises when the split count grows **large** relative to the sliding window - `kv_len_per_split = ceil(window / num_kv_splits)` rounds down to cover fewer tokens than the splits span, leaving trailing splits with nothing to do. eg at long context the count climbs past the window size and trailing splits go empty.
 
This could cause incorrect decode outputs for sliding-window layers — intermittently, depending on the chosen `num_kv_splits` and on uninitialized scratch memory. 

One workaround to the above was to set `VLLM_BATCH_INVARIANT` https://github.com/vllm-project/vllm/blob/245888ff77d4754a76bc899727fcf4290733dfd4/vllm/v1/attention/backends/mla/triton_mla.py#L211-L213
which traded-off perf for a consistent execution path.
With a small fixed num_kv_splits (e.g. 4), every split is large enough to cover real tokens, so none of them end up empty — and the bug only triggers when a split is empty in stage 1 but still merged in stage 2.

This PR makes the result consistent and independent of the split count.
Affects MLA sliding-window decode (e.g. via `TRITON_MLA`); the non-sliding path is unchanged.

### Repro 

One can repro the issue in isolation with the provided `tests/kernels/attention/test_triton_decode_sliding_window_bug.py`, which describes the bug in more details. The test fails on main while it passes on this PR.
```
# main
FAILED tests/kernels/attention/test_triton_decode_sliding_window_bug.py::test_sliding_window_decode_independent_of_num_kv_splits - AssertionError: Tensor-likes are not close!
---
# this pr
tests/kernels/attention/test_triton_decode_sliding_window_bug.py::test_sliding_window_decode_independent_of_num_kv_splits PASSED
```

### Test plan
  - Added `tests/kernels/attention/test_triton_decode_sliding_window_bug.py`
  - `pytest
  tests/kernels/attention/test_triton_decode_attention.py` — no
    regression on the non-sliding path.