### PR TITLE
Recover GLM-4.7 tool calls missing arg_key start

### DIFF
--- a/tests/tool_parsers/test_glm47_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm47_moe_tool_parser.py
@@ -85,6 +85,34 @@ class TestGlm47ExtractToolCalls:
         assert r.tools_called
         assert json.loads(r.tool_calls[0].function.arguments) == {"city": "Beijing"}
 
+    def test_missing_arg_key_start_same_line(self, glm47_tool_parser, mock_request):
+        out = "<tool_call>get_weathercity</arg_key><arg_value>Beijing</arg_value></tool_call>"
+        r = glm47_tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called
+        assert r.tool_calls[0].function.name == "get_weather"
+        assert json.loads(r.tool_calls[0].function.arguments) == {"city": "Beijing"}
+
+    def test_missing_arg_key_start_with_space(self, glm47_tool_parser, mock_request):
+        out = "<tool_call>get_weather city</arg_key><arg_value>Beijing</arg_value></tool_call>"
+        r = glm47_tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called
+        assert r.tool_calls[0].function.name == "get_weather"
+        assert json.loads(r.tool_calls[0].function.arguments) == {"city": "Beijing"}
+
+    def test_missing_arg_key_start_with_following_args(
+        self, glm47_tool_parser, mock_request
+    ):
+        out = (
+            "<tool_call>get_weathercity</arg_key><arg_value>Beijing</arg_value>"
+            "<arg_key>date</arg_key><arg_value>today</arg_value></tool_call>"
+        )
+        r = glm47_tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called
+        assert json.loads(r.tool_calls[0].function.arguments) == {
+            "city": "Beijing",
+            "date": "today",
+        }
+
     def test_args_with_newlines(self, glm47_tool_parser, mock_request):
         out = "<tool_call>get_weather\n<arg_key>city</arg_key>\n<arg_value>Beijing</arg_value>\n</tool_call>"
         r = glm47_tool_parser.extract_tool_calls(out, request=mock_request)
@@ -200,3 +228,47 @@ class TestGlm47Streaming:
         ]
         args = json.loads("".join(arguments))
         assert args["city"] == "Beijing"
+
+    def test_streaming_missing_arg_key_start(self, glm47_tool_parser, mock_request):
+        _reset(glm47_tool_parser)
+        chunks = [
+            "<tool_call>",
+            "get_weather",
+            "city</arg_key>",
+            "<arg_value>",
+            "Beijing",
+            "</arg_value>",
+            "</tool_call>",
+        ]
+        current_text = ""
+        deltas = []
+        for chunk in chunks:
+            current_text += chunk
+            delta = glm47_tool_parser.extract_tool_calls_streaming(
+                previous_text="",
+                current_text=current_text,
+                delta_text=chunk,
+                previous_token_ids=[],
+                current_token_ids=[],
+                delta_token_ids=[],
+                request=mock_request,
+            )
+            if delta:
+                deltas.append(delta)
+
+        tool_calls = [
+            tool_call for delta in deltas for tool_call in (delta.tool_calls or [])
+        ]
+        names = [
+            tool_call.function.name
+            for tool_call in tool_calls
+            if tool_call.function and tool_call.function.name
+        ]
+        arguments = [
+            tool_call.function.arguments
+            for tool_call in tool_calls
+            if tool_call.function and tool_call.function.arguments
+        ]
+        assert names == ["get_weather"]
+        assert all("</arg_key>" not in name for name in names)
+        assert json.loads("".join(arguments)) == {"city": "Beijing"}

--- a/vllm/parser/glm47_moe.py
+++ b/vllm/parser/glm47_moe.py
@@ -20,7 +20,7 @@ import regex as re
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
-from vllm.parser.engine.events import EventType
+from vllm.parser.engine.events import EventType, SemanticEvent
 from vllm.parser.engine.parser_engine import ParserEngine
 from vllm.parser.engine.parser_engine_config import (
     ParserEngineConfig,
@@ -51,6 +51,7 @@ _PARTIAL_ARG_RE = re.compile(
     r"<arg_value>(?P<value>.*)$",
     re.DOTALL,
 )
+_ARG_KEY_END_RE = re.compile(r"\s*([^\s<][^<]*?)</arg_key>", re.DOTALL)
 
 
 def _glm47_arg_converter(raw_args: str, partial: bool) -> str:
@@ -200,11 +201,61 @@ class Glm47MoeParser(ParserEngine):
             name = name.strip()
         super()._emit_name_delta(idx, deltas, name)
 
+    def _recover_missing_arg_key_start(self, idx: int) -> None:
+        slot = self._tool_slots[idx]
+        name = slot.name.strip()
+        if not name or self._is_valid_tool_name(name):
+            slot.name = name
+            return
+
+        text = name + slot.args
+        best_name = ""
+        best_end = -1
+        for end in range(len(text), 0, -1):
+            candidate = text[:end].strip()
+            if candidate and self._is_valid_tool_name(candidate):
+                best_name = candidate
+                best_end = end
+                break
+
+        if not best_name:
+            slot.name = name
+            return
+
+        tail = text[best_end:].lstrip(" \t\r\n(")
+        if not _ARG_KEY_END_RE.match(tail):
+            slot.name = name
+            return
+
+        slot.name = best_name
+        slot._args_parts = [ARG_KEY_START + tail]
+        slot._args_joined = None
+        slot.streamed_json = ""
+        slot.string_keys = None
+
     def _handle_tool_end(self, event, deltas) -> None:
         idx = event.tool_index
         if 0 <= idx < len(self._tool_slots):
-            self._tool_slots[idx].name = self._tool_slots[idx].name.strip()
+            self._recover_missing_arg_key_start(idx)
         super()._handle_tool_end(event, deltas)
+
+    def _handle_arg_chunk(self, event, deltas) -> None:
+        idx = event.tool_index
+        if idx < 0 or idx >= len(self._tool_slots):
+            super()._handle_arg_chunk(event, deltas)
+            return
+
+        slot = self._tool_slots[idx]
+        if slot.name_sent:
+            super()._handle_arg_chunk(event, deltas)
+            return
+
+        if event.value:
+            slot.append_args(event.value)
+        self._recover_missing_arg_key_start(idx)
+        super()._handle_arg_chunk(
+            SemanticEvent(type=event.type, value="", tool_index=idx), deltas
+        )
 
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
         if not self.thinking_enabled:


### PR DESCRIPTION
## Summary
- recover GLM-4.7 XML tool calls where the model emits `tool_namearg</arg_key>` instead of `tool_name<arg_key>arg</arg_key>`
- keep recovery limited to prefixes that match a requested tool name
- recover before streaming name emission, so malformed names are not sent as function names mid-stream
- add regression coverage for adjacent, spaced, multi-argument, and streaming malformed calls

## Context
This is separate from #47146. That PR enables required/named tool-choice when strict tool calling is disabled; it does not repair malformed structural tag output where the opening `<arg_key>` token is missing.

Observed malformed examples from a GLM-4.7-compatible serving setup include:
- `<tool_call>send_command_to_shellcommand</arg_key><arg_value>echo test</arg_value></tool_call>`
- `<tool_call>grep_toolpattern</arg_key><arg_value>...</arg_value></tool_call>`
- `<tool_call>browser_action task</arg_key><arg_value>...</arg_value></tool_call>`

## Verification
- `python3 -m py_compile vllm/parser/glm47_moe.py tests/tool_parsers/test_glm47_moe_tool_parser.py`

Could not run the targeted pytest suite locally because the repository uv environment does not resolve on this macOS environment due the pinned Torch split, and `pytest` is not installed in the no-sync environment.
