### PR TITLE
[ROCm][CI] Enable LoRA TP Distributed Test Group In AMD CI

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1374,8 +1374,6 @@ steps:
   - tests/lora
   - vllm/platforms/rocm.py
   commands:
-  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  - export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
   - pytest -v -s -x lora/test_chatglm3_tp.py
   - pytest -v -s -x lora/test_llama_tp.py
   - pytest -v -s -x lora/test_qwen3_with_multi_loras.py

--- a/tests/lora/test_gptoss_tp.py
+++ b/tests/lora/test_gptoss_tp.py
@@ -1,13 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import importlib.metadata
+from importlib.util import find_spec
+
 import pytest
+import torch
+from packaging import version
 
 import vllm
 from vllm.lora.request import LoRARequest
 from vllm.platforms import current_platform
 
 from ..utils import multi_gpu_test
+
+# Require amd-quark >= 0.12 on torch >= 2.11.
+# Earlier torch releases work with older quark versions. See
+# https://github.com/amd/Quark/issues/34
+# TODO: Remove once amd-quark>=0.12.0
+QUARK_TORCH_COMPATIBLE = find_spec("quark") is not None and (
+    version.parse(importlib.metadata.version("amd-quark")) >= version.parse("0.12.0")
+    if version.parse(torch.__version__.split("+")[0]) >= version.parse("2.11")
+    else True
+)
+
+if current_platform.is_rocm() and not QUARK_TORCH_COMPATIBLE:
+    pytest.skip(
+        "This test requires amd-quark >= 0.12 on torch >= 2.11.",
+        allow_module_level=True,
+    )
 
 MODEL_PATH = "openai/gpt-oss-20b"
 


### PR DESCRIPTION

There were a couple of issues in this test group. First, `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` was copied over from the upstream CI definition which was included as a workaround for a bug which only impacts CUDA CI, not ROCm. It was causing an issue with custom all reduce in `pytest -v -s tests/lora/test_chatglm3_tp.py::test_chatglm3_lora_tp4_fully_sharded_loras` (example log here https://buildkite.com/vllm/amd-ci/builds/10250/list?sid=019f17c1-f274-4a4e-b71e-1dc156e1f823&tab=output). We've removed the unneeded env vars on AMD CI.

The second issue is a known limitation with Quark and Torch 2.11, which will be fixed in the upcoming Quark 0.12 release. Until then, we will have to skip the affected test `lora/test_gptoss_tp.py`.