### PR TITLE
[Bugfix][Spec Decode][V1] Guard stale async spec prev rows

### DIFF
--- a/tests/v1/spec_decode/test_async_batch_change.py
+++ b/tests/v1/spec_decode/test_async_batch_change.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.v1.spec_decode.utils import (
+    update_num_computed_tokens_for_batch_change,
+)
+
+
+def test_update_num_computed_tokens_skips_stale_positive_prev_position():
+    num_computed_tokens = torch.tensor([10, 20, 30, 40, 50, 60], dtype=torch.int32)
+    num_accepted_tokens = torch.tensor([9, 8, 7], dtype=torch.int32)
+    prev_positions = torch.tensor([0, 2, -1], dtype=torch.int64)
+    valid_sampled_token_count = torch.tensor([3, 4], dtype=torch.int32)
+    prev_num_draft_tokens = torch.tensor([2, 0, 5, 0, 0, 0], dtype=torch.int32)
+    cpu_num_computed_tokens = torch.tensor([100, 200, 300], dtype=torch.int32)
+
+    update_num_computed_tokens_for_batch_change(
+        num_computed_tokens,
+        num_accepted_tokens,
+        prev_positions,
+        valid_sampled_token_count,
+        prev_num_draft_tokens,
+        cpu_num_computed_tokens,
+    )
+
+    assert num_computed_tokens.tolist() == [13, 200, 300, 40, 50, 60]
+    assert num_accepted_tokens.tolist() == [3, 8, 7]
+
+
+def test_update_num_computed_tokens_handles_empty_valid_counts():
+    num_computed_tokens = torch.tensor([10, 20, 30], dtype=torch.int32)
+    num_accepted_tokens = torch.tensor([9, 8], dtype=torch.int32)
+    prev_positions = torch.tensor([-1, 2], dtype=torch.int64)
+    valid_sampled_token_count = torch.empty((0,), dtype=torch.int32)
+    prev_num_draft_tokens = torch.tensor([2, 5, 7], dtype=torch.int32)
+    cpu_num_computed_tokens = torch.tensor([100, 200], dtype=torch.int32)
+
+    update_num_computed_tokens_for_batch_change(
+        num_computed_tokens,
+        num_accepted_tokens,
+        prev_positions,
+        valid_sampled_token_count,
+        prev_num_draft_tokens,
+        cpu_num_computed_tokens,
+    )
+
+    assert num_computed_tokens.tolist() == [100, 200, 30]
+    assert num_accepted_tokens.tolist() == [9, 8]

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -51,7 +51,10 @@ from vllm.v1.worker.gpu.lora_utils import LoraState
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.mm.lora import set_active_mm_loras
 from vllm.v1.worker.gpu_input_batch import InputBatch
-from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+from vllm.v1.worker.gpu_model_runner import (
+    GPUModelRunner,
+    _valid_sampled_count_for_prev_index,
+)
 from vllm.v1.worker.utils import select_common_block_size
 
 BLOCK_SIZE = 16
@@ -137,6 +140,22 @@ def model_runner():
 
 
 model_runner_2 = model_runner
+
+
+class _FakeInputIdsBuffer:
+    def __init__(self, cpu_values: list[int], device: torch.device) -> None:
+        self.cpu = torch.tensor(cpu_values, dtype=torch.int32)
+        self.gpu = torch.full(
+            (len(cpu_values),), -999, dtype=torch.int32, device=device
+        )
+
+    def copy_to_gpu(self, n: int) -> None:
+        self.gpu[:n].copy_(self.cpu[:n].to(self.gpu.device))
+
+
+class _FakePrevPositions:
+    def __init__(self, values: list[int]) -> None:
+        self.np = np.array(values, dtype=np.int64)
 
 
 def _schedule_new_request(*req_ids: str) -> SchedulerOutput:
@@ -309,6 +328,43 @@ def test_sample_tokens_skips_pp_group_lookup_without_async_scheduling(
 
     output = GPUModelRunner.sample_tokens(runner, None)
     assert output in (EMPTY_MODEL_RUNNER_OUTPUT, None)
+
+
+def test_valid_sampled_count_for_prev_index_checks_bounds():
+    assert _valid_sampled_count_for_prev_index([3, 4], 0) == 3
+    assert _valid_sampled_count_for_prev_index([3, 4], None) is None
+    assert _valid_sampled_count_for_prev_index([3, 4], -1) is None
+    assert _valid_sampled_count_for_prev_index([3, 4], 2) is None
+
+
+def test_prepare_input_ids_skips_stale_positive_prev_position():
+    device = torch.device("cpu")
+    runner = SimpleNamespace()
+    runner.input_batch = SimpleNamespace(
+        prev_sampled_token_ids=torch.tensor(
+            [[111], [222]], dtype=torch.int32, device=device
+        ),
+        req_ids=["a", "b", "c"],
+    )
+    runner.input_ids = _FakeInputIdsBuffer([10, 20, 30], device)
+    runner.enable_prompt_embeds = False
+    runner.prev_positions = _FakePrevPositions([0, 2, -1])
+    runner.prev_num_spec_tokens = 5
+    runner._draft_token_ids = None
+    runner.device = device
+
+    scheduler_output = SimpleNamespace(scheduled_spec_decode_tokens={})
+    cu_num_tokens = np.array([1, 2, 3], dtype=np.int32)
+
+    GPUModelRunner._prepare_input_ids(
+        runner,
+        scheduler_output,
+        num_reqs=3,
+        total_num_scheduled_tokens=3,
+        cu_num_tokens=cu_num_tokens,
+    )
+
+    assert runner.input_ids.gpu.cpu().tolist() == [111, 20, 30]
 
 
 def test_select_common_block_size_no_valid_option():

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -576,22 +576,39 @@ def update_num_computed_tokens_for_batch_change(
     Requests that had drafts: corrected = prev_gpu + valid_count.
     New requests or non-draft (e.g. prefills): use CPU value directly.
     """
-    # Clamp because prev_positions can be -1 for new requests
-    gather_indices = prev_positions.clamp(min=0)
+    if valid_sampled_token_count.shape[0] == 0:
+        n = prev_positions.shape[0]
+        num_computed_tokens[:n].copy_(cpu_num_computed_tokens)
+        return
+
+    # prev_positions maps current request rows to the previous batch. In async
+    # scheduling, stale rows can be absent from the previous sampled-count
+    # tensor. Do not clamp those rows onto another request.
+    prev_count = valid_sampled_token_count.shape[0]
+    in_range = (prev_positions >= 0) & (prev_positions < prev_count)
+    gather_indices = torch.where(
+        in_range,
+        prev_positions,
+        torch.zeros_like(prev_positions),
+    )
 
     valid_counts = valid_sampled_token_count[gather_indices]
     prev_computed = num_computed_tokens[gather_indices]
     prev_drafts = prev_num_draft_tokens[gather_indices]
 
-    participating = (prev_positions >= 0) & (prev_drafts > 0)
-    corrected = prev_computed + valid_counts.int()
+    participating = in_range & (prev_drafts > 0)
+    corrected = prev_computed + valid_counts.to(prev_computed.dtype)
 
     n = prev_positions.shape[0]
     num_computed_tokens[:n].copy_(
         torch.where(participating, corrected, cpu_num_computed_tokens)
     )
     num_accepted_tokens.copy_(
-        torch.where(participating, valid_counts, num_accepted_tokens)
+        torch.where(
+            participating,
+            valid_counts.to(num_accepted_tokens.dtype),
+            num_accepted_tokens,
+        )
     )
 
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -239,6 +239,19 @@ AttnMetadataDict: TypeAlias = dict[str, AttentionMetadata]
 PerLayerAttnMetadata: TypeAlias = list[AttnMetadataDict] | AttnMetadataDict
 
 
+def _valid_sampled_count_for_prev_index(
+    valid_sampled_token_count: Sequence[int],
+    prev_req_index: int | None,
+) -> int | None:
+    if (
+        prev_req_index is None
+        or prev_req_index < 0
+        or prev_req_index >= len(valid_sampled_token_count)
+    ):
+        return None
+    return valid_sampled_token_count[prev_req_index]
+
+
 # Wrapper for ModelRunnerOutput to support overlapped execution.
 class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
     def __init__(
@@ -1493,9 +1506,12 @@ class GPUModelRunner(
                     req_state,
                 ) in deferred_spec_decode_corrections:
                     prev_req_index = prev_req_id_to_index.get(req_id)
-                    if prev_req_index is None:
+                    valid_count = _valid_sampled_count_for_prev_index(
+                        valid_sampled_token_count, prev_req_index
+                    )
+                    if valid_count is None:
                         continue
-                    num_accepted = valid_sampled_token_count[prev_req_index] - 1
+                    num_accepted = valid_count - 1
                     correction = optimistic_num_accepted - num_accepted
                     req_state.num_computed_tokens -= correction
                     cur_req_index = self.input_batch.req_id_to_index.get(req_id)
@@ -1756,6 +1772,8 @@ class GPUModelRunner(
         # Async scheduling case, where some decode requests from the previous
         # iteration won't have entries in input_ids_cpu and need to be copied
         # on the GPU from prev_sampled_token_ids.
+        prev_sampled_token_ids = self.input_batch.prev_sampled_token_ids
+        prev_sampled_count = prev_sampled_token_ids.shape[0]
         prev_positions = self.prev_positions.np[:num_reqs]
         scheduled_spec_tokens = scheduler_output.scheduled_spec_decode_tokens
         sample_flattened_indices: list[int] = []
@@ -1768,7 +1786,7 @@ class GPUModelRunner(
 
         for cur_index in range(num_reqs):
             prev_index = prev_positions[cur_index]
-            if prev_index < 0:
+            if prev_index < 0 or prev_index >= prev_sampled_count:
                 continue
             prev_indices.append(prev_index)
             req_id = self.input_batch.req_ids[cur_index]
@@ -1818,7 +1836,7 @@ class GPUModelRunner(
             # The indices are both the same permutation of 0..N-1 so
             # we can copy directly using a single slice.
             self.input_ids.gpu[:num_common_tokens].copy_(
-                self.input_batch.prev_sampled_token_ids[:num_common_tokens, 0],
+                prev_sampled_token_ids[:num_common_tokens, 0],
                 non_blocking=True,
             )
             return
@@ -1832,9 +1850,7 @@ class GPUModelRunner(
         self.input_ids.gpu.scatter_(
             dim=0,
             index=sampled_tokens_index_tensor,
-            src=self.input_batch.prev_sampled_token_ids[
-                prev_common_req_indices_tensor, 0
-            ],
+            src=prev_sampled_token_ids[prev_common_req_indices_tensor, 0],
         )
 
         # Scatter the draft tokens after the sampled tokens are scattered.


### PR DESCRIPTION
## Purpose

Fix an async speculative decoding batch-change failure mode where stale previous-batch row indices can outlive the tensors they index.

In async scheduling, `prev_positions` maps current request rows to rows from the previous worker batch. The existing code handled `-1` for new requests, but it did not guard positive stale indices when the previous sampled-token/count tensors are shorter than the old batch mapping. That can misattribute sampled counts or index out of bounds during input staging / token-count correction.

This PR makes those paths treat out-of-range previous rows the same way as new or non-participating rows.

## Summary

- Bounds-check `prev_positions` against `valid_sampled_token_count` before gathering accepted-token counts in `update_num_computed_tokens_for_batch_change`.
- Handle the empty valid-count tensor case explicitly.
- Bounds-check `prev_positions` against `prev_sampled_token_ids` in `GPUModelRunner._prepare_input_ids`.
- Add focused regression tests for stale positive previous positions and the empty valid-count edge case.

## Why this is a draft

The original failure was observed in a DGX Spark deployment running DeepSeek V4 Flash DSpark, while this PR currently contributes focused CPU-runnable regression tests for the worker/spec-decode bookkeeping paths. I am opening this as a draft to get early maintainer feedback on whether this should remain a separate worker-side guard or be folded into adjacent async-spec scheduling work before marking it ready for review.

## Scope and non-duplicate framing

This is narrower than #40768. That PR addresses `-1` placeholder materialization at the scheduler boundary. This PR addresses stale positive previous-row indices inside V1 worker/spec-decode bookkeeping after async batch changes.

This is also distinct from #41481, which warms spec-decode helper kernels and touches `update_num_computed_tokens_for_batch_change` for startup latency, not for stale-row correctness.

An adversarial placement review considered moving the guard into `_compute_prev_positions`, but the consumers have different validity bounds: input staging is bounded by `prev_sampled_token_ids`, while token-count correction is bounded by `valid_sampled_token_count`. Guarding at each consumer keeps the invariant local to the tensor being indexed.

## Files changed

- `vllm/v1/spec_decode/utils.py`
  - Guard previous-row gathers with `0 <= prev_position < valid_count_len`.
  - Avoid indexing empty `valid_sampled_token_count`.

- `vllm/v1/worker/gpu_model_runner.py`
  - Guard deferred correction lookup by sampled-count length.
  - Guard async input staging lookup by `prev_sampled_token_ids` length.

- `tests/v1/spec_decode/test_async_batch_change.py`
  - Regression tests for stale positive `prev_positions` and empty valid counts.

- `tests/v1/worker/test_gpu_model_runner.py`
  - Regression tests for bounded sampled-count lookup and async input staging.

## Test Plan

```bash
PYTHONPATH=. VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/v1/spec_decode/test_async_batch_change.py \
  tests/v1/worker/test_gpu_model_runner.py \
  -k 'async_batch_change or valid_sampled_count_for_prev_index or prepare_input_ids_skips_stale_positive_prev_position' -q

uvx ruff format --check \
  vllm/v1/spec_decode/utils.py \
  vllm/v1/worker/gpu_model_runner.py \
  tests/v1/spec_decode/test_async_batch_change.py \
  tests/v1/worker/test_gpu_model_runner.py
```

## Test Result

```text
4 passed, 35 deselected, 16 warnings in 10.42s
4 files already formatted
```

DGX Spark smoke against the deployment that motivated this patch:

- `spark-01:8888/v1/models` reports served model `deepseek-v4-flash-dspark`.
- `max_model_len`: `1048576`.
- Short chat completion finished normally.
- 4-way concurrent burst completed without transport failure.
- Recent service logs showed no engine death, CUDA assert, illegal memory access, or out-of-bounds errors after the smoke.

## AI assistance disclosure

This change was developed with AI assistance. The submitting author reviewed the changed lines, ran the test commands above, and kept this PR in draft for maintainer feedback before requesting review.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. Not applicable.
</details>