### PR TITLE
[Kernel][XPU] Tensor-descriptor activation load for AWQ Triton GEMM

### DIFF
--- a/tests/kernels/quantization/test_awq_triton.py
+++ b/tests/kernels/quantization/test_awq_triton.py
@@ -175,3 +175,25 @@ def test_gemm(N, K, M, splitK, group_size):
     torch.testing.assert_close(
         output_triton.cpu(), output_torch.cpu(), atol=1e-1, rtol=1e-1
     )
+
+
+# TD activation load must be bit-exact vs the plain masked-load path.
+@pytest.mark.parametrize("M_out", [16, 32])
+@pytest.mark.parametrize("K", [256, 4096])
+@pytest.mark.parametrize("N_tok", [1, 64])
+@pytest.mark.parametrize("splitK", [1, 4])
+@pytest.mark.parametrize("group_size", [128])
+def test_gemm_td_matches_plain(M_out, K, N_tok, splitK, group_size):
+    set_random_seed(0)
+    qweight = torch.randint(
+        0, torch.iinfo(torch.int32).max, (K, M_out // 8), device=device
+    )
+    qzeros = torch.randint(
+        0, torch.iinfo(torch.int32).max, (K // group_size, M_out // 8), device=device
+    )
+    scales = torch.rand((K // group_size, M_out), dtype=torch.float16, device=device)
+    inp = (torch.rand((N_tok, K), dtype=torch.float16, device=device) - 0.5) * 0.1
+
+    out_plain = awq_gemm_triton(inp, qweight, scales, qzeros, splitK, use_td=False)
+    out_td = awq_gemm_triton(inp, qweight, scales, qzeros, splitK, use_td=True)
+    torch.testing.assert_close(out_td, out_plain, rtol=0, atol=0)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -88,6 +88,7 @@ if TYPE_CHECKING:
     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
     VLLM_BATCH_INVARIANT: bool = False
     VLLM_TRITON_ATTN_USE_TD: bool | None = None
+    VLLM_TRITON_AWQ_USE_TD: bool | None = None
     VLLM_GPU_SYNC_CHECK: Literal["warn", "error"] | None = None
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
@@ -585,6 +586,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # ``0`` forces TD off.  Useful for A/B benchmarking the TD path.
     "VLLM_TRITON_ATTN_USE_TD": lambda: {"1": True, "0": False}.get(
         os.getenv("VLLM_TRITON_ATTN_USE_TD", "").strip()
+    ),
+    # TD toggle for the AWQ Triton GEMM: unset -> auto (on for XPU); `1` on; `0` off.
+    "VLLM_TRITON_AWQ_USE_TD": lambda: {"1": True, "0": False}.get(
+        os.getenv("VLLM_TRITON_AWQ_USE_TD", "").strip()
     ),
     # If set, enable PyTorch's GPU<->CPU synchronization debug mode around
     # the worker's `execute_model` and `sample_tokens` calls. Valid values

--- a/vllm/model_executor/layers/quantization/awq_triton.py
+++ b/vllm/model_executor/layers/quantization/awq_triton.py
@@ -3,9 +3,14 @@
 
 import torch
 
+import vllm.envs as envs
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.triton_utils.allocation import set_triton_allocator
 
 AWQ_TRITON_SUPPORTED_GROUP_SIZES = [-1, 32, 64, 128]
+
+_TD_ALLOCATOR_DEVICES: set[torch.device] = set()
 
 
 @triton.jit
@@ -120,6 +125,7 @@ def awq_gemm_kernel(
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
     SPLIT_K: tl.constexpr,
+    USE_TD: tl.constexpr = False,
 ):
     pid = tl.program_id(axis=0)
     pid_z = tl.program_id(1)
@@ -172,13 +178,26 @@ def awq_gemm_kernel(
     a_ptrs = a_ptr + offsets_a
     b_ptrs = b_ptr + offsets_b
 
+    if USE_TD:
+        # Only the activation a is descriptor-loadable; b is packed 4-bit and
+        # dequantized in-loop.
+        a_desc = tl.make_tensor_descriptor(
+            a_ptr, shape=[M, K], strides=[K, 1],
+            block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
+        )
+
     # NOTE: Use this in TRITON_INTERPRET=1 mode instead of tl.cdiv
     # block_offset = BLOCK_SIZE_K * SPLIT_K
     # for k in range(0, (K + block_offset - 1) // (block_offset)):
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K * SPLIT_K)):
         masks_k = offsets_k < K
-        masks_a = masks_am[:, None] & masks_k[None, :]
-        a = tl.load(a_ptrs, mask=masks_a, other=0.0)
+        if USE_TD:
+            a = a_desc.load(
+                [pid_m * BLOCK_SIZE_M, pid_z * BLOCK_SIZE_K + k * BLOCK_SIZE_K * SPLIT_K]
+            )
+        else:
+            masks_a = masks_am[:, None] & masks_k[None, :]
+            a = tl.load(a_ptrs, mask=masks_a, other=0.0)
 
         masks_b = masks_k[:, None] & masks_bn[None, :]
         b = tl.load(b_ptrs, mask=masks_b, other=0.0)
@@ -293,6 +312,7 @@ def awq_gemm_triton(
     block_size_m: int = 32,
     block_size_n: int = 32,
     block_size_k: int = 32,
+    use_td: bool | None = None,
 ) -> torch.Tensor:
     M, K = input.shape
     N = qweight.shape[1] * 8
@@ -314,6 +334,21 @@ def awq_gemm_triton(
 
     result = torch.zeros((split_k_iters, M, N), dtype=scales.dtype, device=input.device)
 
+    # TD activation load; gated on contiguity, alignment and an unmasked K range.
+    td_override = use_td if use_td is not None else envs.VLLM_TRITON_AWQ_USE_TD
+    use_td = current_platform.is_xpu() if td_override is None else td_override
+    use_td = (
+        use_td
+        and input.stride(1) == 1
+        and (K * input.element_size()) % 16 == 0
+        and K % (block_size_k * split_k_iters) == 0
+        and (block_size_m & (block_size_m - 1)) == 0
+        and (block_size_k & (block_size_k - 1)) == 0
+    )
+    if use_td and input.device not in _TD_ALLOCATOR_DEVICES:
+        set_triton_allocator(input.device)
+        _TD_ALLOCATOR_DEVICES.add(input.device)
+
     # A = input, B = qweight, C = result
     # A = M x K, B = K x N, C = M x N
     awq_gemm_kernel[grid](
@@ -330,6 +365,7 @@ def awq_gemm_triton(
         BLOCK_SIZE_N=block_size_n,
         BLOCK_SIZE_K=block_size_k,
         SPLIT_K=split_k_iters,
+        USE_TD=use_td,
     )
 
     result = result.sum(0)


### PR DESCRIPTION
Adds a Tensor-Descriptor (TD) load path for the activation operand of
`awq_gemm_kernel` (AWQ 4-bit Triton GEMM).

On XPU, the masked `tl.load` of the fp16/bf16 activation `a` feeding `tl.dot` bypasses the Xe XMX 2D-block-read path. Loading `a` via `tl.make_tensor_descriptor` restores it. The weight operand `b` is packed 4-bit and dequantized inside the K-loop (`tl.interleave`/shift/`(b-zeros)*scales`), so it cannot be descriptor-loaded and is left unchanged — only the activation uses a descriptor.

**XPU results** (Intel B70, fp16 activation, group_size 128), device self-time via `torch.profiler` steady-state:

| M (tokens) | K | N | split_k | plain | a-TD | Δ |
|---|---|---|---|---|---|---|
| 1   | 4096 | 4096 | 1 | 526.5 µs | 355.9 µs | −32.4% |
| 1   | 7168 | 4096 | 1 | 894.7 µs | 612.6 µs | −31.5% |
| 64  | 4096 | 4096 | 1 | 600.7 µs | 329.3 µs | −45.2% |
| 64  | 4096 | 4096 | 4 | 190.2 µs | 110.2 µs | −42.1% |
| 64  | 8192 | 8192 | 1 | 1331.1 µs | 708.5 µs | −46.8% |
| 128 | 4096 | 14336 | 1 | 1295.0 µs | 697.6 µs | −46.1% |

Output is bit-exact vs the plain path (`max|plain−TD| = 0.0`) across split_k=1 and split_k=4. 
New parity test `test_gemm_td_matches_plain` covers tokens 1/64, K 256/4096, output 16/32, split_k 1/4.

Gated (XPU auto-on; K-contiguous activation, 16-byte tile alignment, power-of-two tiles, `K % (block_k*split_k) == 0` so  the descriptor load is unmasked along K) with clear fallback. 
