### PR TITLE
[CI][Bugfix] Rerun test_engine_log_metrics_ray on Ray GCS startup timeout

### DIFF
--- a/tests/v1/metrics/test_ray_metrics.py
+++ b/tests/v1/metrics/test_ray_metrics.py
@@ -7,6 +7,7 @@ import pytest
 import ray
 
 from vllm.config.model import ModelDType
+from vllm.platforms import current_platform
 from vllm.sampling_params import SamplingParams
 from vllm.v1.engine.async_llm import AsyncEngineArgs, AsyncLLM
 from vllm.v1.metrics.ray_wrappers import (
@@ -22,6 +23,18 @@ MODELS = [
 ]
 
 
+# The first .remote() call starts a local Ray cluster via ray.init(), whose
+# GCS server occasionally fails to start within Ray's fixed 30s bootstrap
+# window on ROCm CI (RuntimeError: "Timed out waiting for file
+# .../gcs_server_port_..."). That timeout is not configurable, so retry the
+# whole test: a fresh ray.init() gets a new GCS process. Scoped to that error
+# so real failures still fail immediately.
+@pytest.mark.flaky(
+    reruns=2,
+    reruns_delay=5,
+    only_rerun="Timed out waiting for file",
+    condition=current_platform.is_rocm(),
+)
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("dtype", ["half"])
 @pytest.mark.parametrize("max_tokens", [16])


### PR DESCRIPTION
## Purpose

`tests/v1/metrics/test_ray_metrics.py::test_engine_log_metrics_ray` intermittently fails on ROCm CI (e.g. buildkite build 75329, the "AMD: V1 Core + KV + Metrics" step) with:

```
RuntimeError: Timed out waiting for file .../gcs_server_port_...
```

The test starts a Ray cluster implicitly: the first `EngineTestActor.remote()` call triggers Ray's `auto_init_ray()` ~F~R bare `ray.init()`. On a contended CI host, Ray's GCS server subprocess occasionally fails to write its port file within Ray's fixed 30s bootstrap ww
indow, so `ray.init()` raises before the test body runs. This is a Ray cluster-bootstrap flake, not a defect in vLLM. Ray's 30s timeout is compiled into the binary and is not configurable (no env var or `ray.init()` kwarg reaches it), so the only resilient option is to retry the bootstrap ~@~T a fresh `ray.init()` gets a fresh GCS subprocess and a fresh 30s window.

This marks the test flaky with reruns scoped to that specific error via `only_rerun`, matching the existing `@pytest.mark.flaky` convention already used across the suite (`pytest-rerunfailures` is pinned in `requirements/test/{rocm,cuda,xpu}.txt`). Scoping to the message ensures only the GCS bootstrap timeout is retried; any genuine failure in the metrics-logging code fails immediately and is not masked.

AI assistance (Claude) was used to diagnose the failure and prepare this change. Not a duplicate: no open PR references `test_ray_metrics`, `test_engine_log_metrics_ray`, or the GCS-port flake.

## Test Plan

ROCm (gfx942), the CI command from `.buildkite/test-amd.yaml`:

```
pytest -v -s -m 'not cpu_test' v1/metrics
```

Plus targeted validation of the rerun behavior by injecting a real GCS-startup failure (redirecting Ray's `gcs_server` binary to a wrapper that hangs past the 30s timeout) and a non-matching failure, to confirm the `only_rerun` scoping.

## Test Result

- Transient GCS timeout (first attempt fails, then recovers): `RERUN` ~F~R `PASSED` (`1 passed, 1 rerun`), confirming the scoped marker retries the bootstrap and the rerun's fresh `ray.init()` succeeds.
- Persistent GCS timeout (every attempt fails): `RERUN` ~W 3 ~F~R `FAILED` (`1 failed, 3 rerun`) with the genuine `RuntimeError: Timed out waiting for file .../gcs_server_port_...` ~@~T a sustained problem is still surfaced, not hidden.
- Non-matching failure (unrelated `AssertionError`): `FAILED` immediately with no rerun (`1 failed`, no rerun delay), confirming `only_rerun` does not mask real regressions.
- Baseline with no fault: `PASSED` with no spurious reruns.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

