### PR TITLE
[ROCm][Bugfix] Fix Triton "out of resource: shared memory" Error In One-Shot LoRA MoE

### DIFF
--- a/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
+++ b/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
@@ -10,6 +10,7 @@ from vllm.distributed import (
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.triton_utils.allocation import set_triton_allocator
+from vllm.utils.mem_utils import get_max_shared_memory_bytes
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from .utils import supports_pdl, supports_tma
@@ -428,10 +429,15 @@ def _run_fused_moe_lora_one_shot(
     # Tried BLOCK_N=64 for w13 (N=192) to avoid the half-wasted second
     # tile: regressed 11-29% because the "waste" was just masked stores
     # (cheap) and the extra iteration added load + index overhead.
+
+    # Devices with max shmem size less than 68KB can't support 3-stage
+    # pipeline. Fall back to a 2-stage on such devices
+    max_smem = get_max_shared_memory_bytes(device.index)
+    ns = 3 if max_smem >= 68 * 1024 else 2
     if npid > 1:
-        block_n, nw, ns = 128, 8, 3
+        block_n, nw = 128, 8
     else:
-        block_n, nw, ns = 128, 4, 3
+        block_n, nw = 128, 4
     # BLOCK_K choice: for hidden-sized K (≥256, i.e. the K=hidden_size
     # shrink input on w13) force BLOCK_K=128 -- the wider tile halves the
     # K-loop trip count and removes the scoreboard stalls that dominated

--- a/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
+++ b/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
@@ -429,15 +429,18 @@ def _run_fused_moe_lora_one_shot(
     # Tried BLOCK_N=64 for w13 (N=192) to avoid the half-wasted second
     # tile: regressed 11-29% because the "waste" was just masked stores
     # (cheap) and the extra iteration added load + index overhead.
+    if npid > 1:
+        block_n, nw, ns = 128, 8, 3
+    else:
+        block_n, nw, ns = 128, 4, 3
 
     # Devices with max shmem size less than 68KB can't support 3-stage
     # pipeline. Fall back to a 2-stage on such devices
-    max_smem = get_max_shared_memory_bytes(device.index)
-    ns = 3 if max_smem >= 68 * 1024 else 2
-    if npid > 1:
-        block_n, nw = 128, 8
-    else:
-        block_n, nw = 128, 4
+    if current_platform.is_cuda_alike():
+        max_shmem_bytes = 68 * 1024
+        if get_max_shared_memory_bytes(device.index) < max_shmem_bytes:
+            ns = min(ns, 2)
+
     # BLOCK_K choice: for hidden-sized K (≥256, i.e. the K=hidden_size
     # shrink input on w13) force BLOCK_K=128 -- the wider tile halves the
     # K-loop trip count and removes the scoreboard stalls that dominated


### PR DESCRIPTION

We're seeing the following error on MI300 and MI325:

```
pytest -v -s tests/lora/test_gptoss_tp.py::test_gpt_oss_lora
...
(EngineCore pid=434697)   File "/projects/vllm/vllm/lora/ops/triton_ops/fused_moe_lora_op.py", line 452, in _run_fused_moe_lora_one_shot
(EngineCore pid=434697)     _fused_moe_lora_one_shot_kernel[grid](
(EngineCore pid=434697)   File "/usr/local/lib/python3.12/dist-packages/triton/runtime/jit.py", line 370, in <lambda>
(EngineCore pid=434697)     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
(EngineCore pid=434697)                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=434697)   File "/usr/local/lib/python3.12/dist-packages/triton/runtime/autotuner.py", line 459, in run
(EngineCore pid=434697)     return self.fn.run(*args, **kwargs)
(EngineCore pid=434697)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=434697)   File "/usr/local/lib/python3.12/dist-packages/triton/runtime/jit.py", line 743, in run
(EngineCore pid=434697)     launch_metadata = kernel.launch_metadata(grid, stream, *bound_args.values())
(EngineCore pid=434697)                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=434697)   File "/usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py", line 491, in launch_metadata
(EngineCore pid=434697)     self._init_handles()
(EngineCore pid=434697)   File "/usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py", line 465, in _init_handles
(EngineCore pid=434697)     raise_(OutOfResources(self.metadata.shared, max_shared, "shared memory"))
(EngineCore pid=434697)   File "/usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py", line 457, in raise_
(EngineCore pid=434697)     raise err
(EngineCore pid=434697) triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 69632, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
```

As the error suggests, we need to take the platform's max shared mem into account when launching the LoRA one-shot MoE kernel `_fused_moe_lora_one_shot_kernel`. To handle this, I propose limiting `num_stages` to 2 if the platform doesn't support the listed shared memory requirement `69632` (68KB). This shouldn't impact the behavior of platforms that didn't observe this error (i.e. other platforms should still use `num_stages=3` if supported). I believe `get_max_shared_memory_bytes` is no good on non-CUDA-alike platforms (e.g. XPU), so I've guarded the changes under `current_platform.is_cuda_alike()`

With this change, I am seeing the tests passing:
```
pytest -v -s tests/lora/test_gptoss_tp.py::test_gpt_oss_lora
======= 2 passed, 2 skipped, 16 warnings in 105.96s (0:01:45) =========
```
