### PR TITLE
[Bugfix] Include SM12x in _is_fa4_supported() compute capability check

### DIFF
--- a/vllm/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm/vllm_flash_attn/flash_attn_interface.py
@@ -78,10 +78,12 @@ def _is_fa4_supported() -> tuple[bool, str | None]:
         current_platform.is_device_capability_family(90)
         or current_platform.is_device_capability_family(100)
         or current_platform.is_device_capability_family(110)
+        or current_platform.is_device_capability_family(120)
     ):
         return (
             False,
-            "FA4 is only supported on devices with compute capability 9.x, 10.x, or 11.x",
+            "FA4 is only supported on devices with compute capability "
+            "9.x, 10.x, 11.x, or 12.x",
         )
     return True, None
 


### PR DESCRIPTION
## Problem

`_is_fa4_supported()` in `vllm/vllm_flash_attn/flash_attn_interface.py` checks `is_device_capability_family()` for 90/100/110 but omits 120, so FA4 is unconditionally reported unsupported on SM120/SM121 (RTX PRO 6000 Blackwell, GB10/DGX Spark) — even though the FA4 CuTe-DSL kernel itself dispatches correctly to a dedicated SM120 path.

`FlashAttentionForwardSm120` (`vllm-project/flash-attention`) subclasses `FlashAttentionForwardSm80` and is architecturally distinct from the SM100/SM110-only `FlashAttentionForwardSm100` class, which asserts `arch <= Arch.sm_110f`. The `arch // 10 == 12` branch in `flash_attn/cute/interface.py` already routes SM12x correctly to `FlashAttentionForwardSm120`, never to the SM100-only kernel — so adding `120` to this capability check doesn't risk a misroute into a kernel that doesn't support it.

## Fix

```diff
     if not (
         current_platform.is_device_capability_family(90)
         or current_platform.is_device_capability_family(100)
         or current_platform.is_device_capability_family(110)
+        or current_platform.is_device_capability_family(120)
     ):
```

## Verification

Verified on real GB10 (SM121) hardware. With this gate fix plus two additional fixes for pre-existing bugs in flash-attention's shared SM80/SM120 forward kernel (an unrelated `NameError` on `mDynamicCausal`, and a missing `self.is_split_kv` default — both still present on flash-attention's current `main` and reported separately in [vllm-project/flash-attention](https://github.com/vllm-project/flash-attention) — see companion PR), `flash_attn_varlen_func` (the function vLLM's attention backend calls in production) produces output matching a PyTorch SDPA reference:

- bf16, head_dim=128, varlen causal attention (two sequences, lengths 64/96)
- max abs diff vs `torch.nn.functional.scaled_dot_product_attention`: 0.0078
- mean abs diff: 0.00025 (normal bf16 rounding)

Models with `head_dim > 128` (other than `192`) still correctly fall back to FA2 via the existing TMEM-capacity check in `vllm/v1/attention/backends/fa_utils.py` — unrelated to this fix, and correct as-is; that limit applies to all Blackwell-family GPUs per [Dao-AILab/flash-attention#1959](https://github.com/Dao-AILab/flash-attention/issues/1959).

## Not a duplicate

#40110 (closed) added a new opt-in `FLASH_ATTN_4` backend with its own registry entry. This PR instead fixes the gate on the existing **default** FA4 dispatch path, used automatically by models like Gemma 4 when their head dims are compatible.

## AI assistance disclosure

This fix and its verification were developed with Claude Code (Anthropic) while building a custom vLLM v0.24.0 image for GB10. I reviewed and understand the change.