### PR TITLE
[Distributed] Default FlashInfer allreduce to mnnvl on single node

### DIFF
--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -92,25 +92,32 @@ def _create_workspace(
     return workspace
 
 
-def _resolve_fi_ar_backend() -> str:
+def _resolve_fi_ar_backend() -> tuple[str, bool]:
+    """Resolve the flashinfer allreduce backend for the current setup.
+
+    Returns:
+        A ``(backend, allow_trtllm_fallback)`` tuple. ``allow_trtllm_fallback``
+        is True only when ``auto`` selects mnnvl for a single node, so that
+        workspace creation can fall back to trtllm on single-node topologies
+        without NVSwitch multicast support (where mnnvl is unavailable).
+    """
     backend = envs.VLLM_FLASHINFER_ALLREDUCE_BACKEND
     if backend != "auto":
         logger.info_once(f"Using flashinfer allreduce backend: {backend}")
-        return backend
+        return backend, False
 
-    if get_node_count() > 1:  # noqa: SIM108
-        # Use mnnvl backend for multi-node setup since
-        # trtllm backend does not support multi-node allreduce
-        backend = "mnnvl"
-    else:
-        # Currently defaulting to trtllm backend for single-node
-        # setup since mnnvl has issues with cudagraph:
-        # https://github.com/vllm-project/vllm/issues/35772
-        # Should switch back to auto when the issue is resolved.
-        backend = "trtllm"
+    # Default to mnnvl for both single- and multi-node setups. The mnnvl
+    # cudagraph hang that previously forced single-node to trtllm
+    # (https://github.com/vllm-project/vllm/issues/35772) was fixed upstream in
+    # FlashInfer (>= 0.6.12, vLLM pins 0.6.13), so mnnvl is safe here. trtllm
+    # does not support multi-node allreduce, so mnnvl is required there anyway.
+    # mnnvl needs NVSwitch multicast; on single-node topologies without it,
+    # fall back to trtllm so fused allreduce stays enabled.
+    backend = "mnnvl"
+    allow_trtllm_fallback = get_node_count() == 1
 
     logger.info_once(f"Auto-selected flashinfer allreduce backend: {backend}")
-    return backend
+    return backend, allow_trtllm_fallback
 
 
 def get_fi_ar_workspace(
@@ -132,7 +139,7 @@ def get_fi_ar_workspace(
     if _fi_ar_workspace is not None:
         return _fi_ar_workspace
 
-    backend = _resolve_fi_ar_backend()
+    backend, allow_trtllm_fallback = _resolve_fi_ar_backend()
 
     if get_node_count() > 1 and backend == "trtllm":
         raise ValueError(
@@ -140,14 +147,23 @@ def get_fi_ar_workspace(
             "'trtllm' backend. Please use 'mnnvl' backend instead."
         )
 
-    # Reuse the quant workspace if it was already created with the same backend
-    if _fi_ar_quant_workspace is not None and _fi_ar_quant_workspace.backend == backend:
-        _fi_ar_workspace = _fi_ar_quant_workspace
-        return _fi_ar_workspace
+    def _get_or_create(be: str):
+        # Reuse the quant workspace if it was already created with the same backend
+        if _fi_ar_quant_workspace is not None and _fi_ar_quant_workspace.backend == be:
+            return _fi_ar_quant_workspace
+        return _create_workspace(
+            be, world_size, rank, max_token_num, hidden_dim, dtype, group
+        )
 
-    _fi_ar_workspace = _create_workspace(
-        backend, world_size, rank, max_token_num, hidden_dim, dtype, group
-    )
+    _fi_ar_workspace = _get_or_create(backend)
+    if _fi_ar_workspace is None and allow_trtllm_fallback and backend != "trtllm":
+        logger.warning_once(
+            "FlashInfer mnnvl allreduce workspace unavailable (likely no NVSwitch "
+            "multicast support); falling back to trtllm backend for single node."
+        )
+        backend = "trtllm"
+        _fi_ar_workspace = _get_or_create(backend)
+
     if _fi_ar_workspace is not None:
         logger.info_once(
             "Initialized FlashInfer Allreduce norm fusion workspace "


### PR DESCRIPTION
## Purpose

The single-node default for the FlashInfer fused allreduce backend was pinned
to `trtllm` to work around an `mnnvl` cudagraph capture/replay hang
(#35772). That hang was root-caused and fixed upstream in FlashInfer
([flashinfer-ai/flashinfer#3304](https://github.com/flashinfer-ai/flashinfer/pull/3304),
released in `>= 0.6.12`; vLLM currently pins `flashinfer-python==0.6.13`), so
the workaround is no longer needed.

This PR makes `VLLM_FLASHINFER_ALLREDUCE_BACKEND=auto` select `mnnvl` for both
single- and multi-node setups, giving a single uniform backend and resolving
the long-standing "switch back to auto when the issue is resolved" TODO in
`_resolve_fi_ar_backend`.

## Behavior

- `auto` + multi-node → `mnnvl` (unchanged; `trtllm` has no multi-node support).
- `auto` + single-node → `mnnvl` (**changed** from `trtllm`).
- Explicit `trtllm` / `mnnvl` → respected (unchanged).

### NVSwitch fallback

`mnnvl` requires NVSwitch multicast. On single-node topologies without it
(NVLink-bridge / PCIe), the mnnvl workspace cannot be created. Previously
`trtllm` (IPC P2P) was always used there. To avoid regressing those setups
from fused allreduce to plain NCCL, `auto` now falls back to `trtllm` when the
single-node `mnnvl` workspace fails to initialize, so fused allreduce stays
enabled. Multi-node and explicit selections keep their existing behavior.

## Test Plan / Results

Hardware: single node, 4× NVIDIA GB200 (SM100, NVSwitch fabric),
FlashInfer 0.6.12 (contains the fix).

Existing fused-allreduce pass test, which spawns TP=2 and exercises the
`mnnvl` cudagraph capture/replay path that previously hung:

```
.venv/bin/python -m pytest \
  tests/compile/passes/distributed/test_fusion_all_reduce.py -k "mnnvl" -q
```

Result: `10 passed, 14 deselected in 382.43s` — no hang.

Backend-resolution unit check (mocked node count):

| env | nodes | resolved |
|-----|-------|----------|
| auto | 1 | `('mnnvl', fallback=True)` |
| auto | 2 | `('mnnvl', fallback=False)` |
| trtllm | 1 | `('trtllm', fallback=False)` |
| mnnvl | 1 | `('mnnvl', fallback=False)` |

Lint: `pre-commit` (ruff, mypy, etc.) passes.

## Not a duplicate

Checked open PRs (`flashinfer allreduce backend mnnvl`, `35772 in:body`); no
open PR changes the single-node auto backend default. Existing related PRs
(#40970 benchmark fix, #39758 quant-fusion perf, #38136 multi-node selection)
do not touch this default.

## Known tradeoff

For quantized models on a single node, quant fusion (FP8/FP4) still requires
`trtllm` (`get_fi_ar_quant_workspace`). With non-quant patterns now on `mnnvl`,
such models may allocate both an `mnnvl` and a `trtllm` workspace rather than
sharing one. This is a deliberate tradeoff for the uniform/default `mnnvl`
path; reviewers who prefer to avoid it could instead keep `trtllm` when a quant
fusion pattern is present.

---

AI assistance (Claude) was used to investigate the upstream fix, implement the
change, and run the test above. A human maintainer has reviewed every changed
line.
