### PR TITLE
[Bugfix] Fix online-quant MoE loading zero weights after #47058

### DIFF
--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -904,10 +904,13 @@ class RoutedExperts(PluggableLayer):
                     experts_shard = loaded_weight.unsqueeze(0)
                     start = expert_id
 
+                # Dispatch via the param's own loader; online quant wraps it
+                # to defer materialization, so self.weight_loader would bypass it.
+                weight_loader = getattr(param, "weight_loader", self.weight_loader)
                 # Unified loading logic for fused and non-fused experts
                 loaded_experts = experts_shard.unbind()
                 for expert_id, loaded_expert in enumerate(loaded_experts, start=start):
-                    success = self.weight_loader(
+                    success = weight_loader(
                         param=param,
                         loaded_weight=loaded_expert,
                         weight_name=weight_name,


### PR DESCRIPTION
After #47058, `RoutedExperts.load_weights` called `self.weight_loader` directly, bypassing the per-parameter loader that online quant (fp8/mxfp8) wraps to materialize and quantize the meta-device expert weights. As a result online-quantized MoE models loaded all-zero experts and produced garbage; this dispatches through the param's own loader instead.

Fixes the `Quantized Models Test` `[moe]` failures on main.

Tested: `pytest tests/models/quantization/test_fp8_per_channel.py` (dense + moe) passes on H100. AI-assisted.