### PR TITLE
[Hardware][AMD][CI] Toggle test coredumps on ROCm debug agent

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -534,8 +534,13 @@ else
   echo "--- Single-node job"
   echo "Render devices: $BUILDKITE_AGENT_META_DATA_RENDER_DEVICES"
 
-  # Disable core dumps in the ROCm test container unless the ROCm debug agent is enabled
-  coredump_flags="--ulimit core=0:$(ulimit -H -c)"
+  ulimit_core_hard=$(ulimit -H -c)
+  if [[ "$ulimit_core_hard" == "unlimited" ]]; then
+    # docker run can't pass "unlimited" to --ulimit
+    ulimit_core_hard="-1"
+  fi
+   # Disable core dumps in the ROCm test container unless the ROCm debug agent is enabled
+  coredump_flags="--ulimit core=0:$ulimit_core_hard"
   if [[ "$commands" == *"ROCm debug agent enabled"* ]]; then
     # Works around https://github.com/rocm/rocm-systems/issues/6206
     coredump_flags='-e HSA_COREDUMP_PATTERN="/tmp/gpucore.%p"'

--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -534,6 +534,15 @@ else
   echo "--- Single-node job"
   echo "Render devices: $BUILDKITE_AGENT_META_DATA_RENDER_DEVICES"
 
+  # Disable core dumps in the ROCm test container unless the ROCm debug agent is enabled
+  coredump_flags="--ulimit core=0:$(ulimit -H -c)"
+  if [[ "$commands" == *"ROCm debug agent enabled"* ]]; then
+    # Works around https://github.com/rocm/rocm-systems/issues/6206
+    coredump_flags='-e HSA_COREDUMP_PATTERN="/tmp/gpucore.%p"'
+  else
+    echo "ROCm debug agent not enabled, coredumps are disabled in the test container."
+  fi
+
   docker run \
     --device /dev/kfd $BUILDKITE_AGENT_META_DATA_RENDER_DEVICES \
     $RDMA_FLAGS \
@@ -541,6 +550,7 @@ else
     --shm-size=16gb \
     --group-add "$render_gid" \
     --rm \
+    $coredump_flags \
     -e HF_TOKEN \
     -e "HF_HUB_DOWNLOAD_TIMEOUT=${HF_HUB_DOWNLOAD_TIMEOUT}" \
     -e "HF_HUB_ETAG_TIMEOUT=${HF_HUB_ETAG_TIMEOUT}" \

--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -62,7 +62,7 @@ def _get_ray_assigned_device() -> torch.device:
 
 def _set_ray_assigned_device() -> torch.device:
     device = _get_ray_assigned_device()
-    torch.accelerator.set_device(device)
+    torch.accelerator.set_device_index(device)
     return device
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
We are observing some [cases](https://buildkite.com/vllm/ci/builds/75361/list?jid=019f1776-36c0-4fa9-a86e-dce516220735&tab=output#L1976) where AMD CI tests hang after memory access faults. The cause appears to be linked to the GPU coredump handler failing to attach/exit cleanly in some cases. In particular, the coredump handler currently always fails inside the ROCm test container with `GPU coredump: execvp failed: No such file or directory` due to https://github.com/rocm/rocm-systems/issues/6206.

As such, this PR disables core dumps in AMD CI test containers unless, for debugging purposes, the ROCm debug agent is enabled during BuildKite pipeline generation time with `VLLM_CI_ENABLE_ROCM_DEBUG_AGENT=1` (see https://github.com/vllm-project/ci-infra/pull/383). Conversely, when the ROCm debug agent agent and GPU coredumps are enabled, this PR sets `HSA_COREDUMP_PATTERN="/tmp/gpucore.%p"` in the test container to bypass the aforementioned issue in https://github.com/rocm/rocm-systems/issues/6206.

## Test Plan
Full AMD CI will run on this PR.

## Test Result
There are no test regressions, and tests eliciting memory access faults no longer attempt to generate core dumps.

cc @AndreasKaratzas 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
