### PR TITLE
[Perf] Build prompt mask with presence-only scatter in apply_penalties

### DIFF
--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -48,6 +48,19 @@ def get_token_bin_counts_and_mask(
     return bin_counts, mask
 
 
+def get_token_presence_mask(
+    tokens: torch.Tensor,
+    vocab_size: int,
+    num_seqs: int,
+) -> torch.Tensor:
+    # vocab_size + 1 for padding.
+    mask = torch.zeros(
+        (num_seqs, vocab_size + 1), dtype=torch.bool, device=tokens.device
+    )
+    mask.scatter_(1, tokens, True)
+    return mask[:, :vocab_size].contiguous()
+
+
 def apply_penalties(
     logits: torch.Tensor,
     prompt_tokens_tensor: torch.Tensor,
@@ -70,9 +83,7 @@ def apply_penalties(
     repetition_penalties: The repetition penalties of shape (num_seqs, )
     """
     num_seqs, vocab_size = logits.shape
-    _, prompt_mask = get_token_bin_counts_and_mask(
-        prompt_tokens_tensor, vocab_size, num_seqs
-    )
+    prompt_mask = get_token_presence_mask(prompt_tokens_tensor, vocab_size, num_seqs)
     output_bin_counts, output_mask = get_token_bin_counts_and_mask(
         output_tokens_tensor, vocab_size, num_seqs
     )


### PR DESCRIPTION
## Purpose

`apply_penalties` builds the mask for prompt tokens with `get_token_bin_counts_and_mask`, which runs an int64 `scatter_add` over the vocab to count tokens, then discards the counts and keeps only the mask. New `get_token_presence_mask` builds just the mask with a single bool `scatter_`.

## Test Plan
- Correctness: compare `get_token_presence_mask` against `get_token_bin_counts_and_mask`
- Existing penalty tests: `pytest tests/v1/sample/test_sampler.py tests/kernels/test_apply_repetition_penalties.py`.
- E2E throughput.

## Test Result
Masks are identical. Existing penalty tests pass.

### E2E throughput - RTX 4090, Qwen2.5-1.5B
Qwen default sampling (repetition_penalty=1.1), 128-token prompts, 256 output tokens.

| Batch | Before (tok/s) | After (tok/s) |    Δ |
|------:|---------------:|--------------:|-----:|
|    64 |         10,087 |        10,278 | +1.9% |
|   128 |         14,471 |        15,004 | +3.7% |
|   256 |         17,161 |        17,886 | +4.2% |

Developed with AI assistance (Claude). Every changed line was reviewed by the submitter, who understands and can defend the change end-to-end.