### PR TITLE
[Doc] add AI Runway to integrations

### DIFF
--- a/docs/deployment/integrations/airunway.md
+++ b/docs/deployment/integrations/airunway.md
@@ -1,0 +1,5 @@
+# AI Runway
+
+[AI Runway](https://github.com/kaito-project/airunway) is a Kubernetes-native platform for deploying and managing LLM inference across multiple providers behind a single `ModelDeployment` API. It can serve models with vLLM directly — running the OpenAI-compatible `vllm serve` server as native Kubernetes `Deployment` and `Service` resources — or through vLLM-backed providers such as NVIDIA Dynamo, llm-d, KAITO, and KubeRay, all selected automatically from provider capabilities.
+
+For deploying vLLM directly, see the [Direct vLLM provider guide](https://kaito-project.github.io/airunway/providers/vllm). For an overview and installation, see the [AI Runway documentation](https://kaito-project.github.io/airunway/).

--- a/docs/deployment/k8s.md
+++ b/docs/deployment/k8s.md
@@ -19,6 +19,7 @@ Alternatively, you can deploy vLLM to Kubernetes using any of the following:
 - [KServe](integrations/kserve.md)
 - [Kthena](integrations/kthena.md)
 - [KubeRay](integrations/kuberay.md)
+- [kaito-project/airunway](integrations/airunway.md)
 - [kubernetes-sigs/lws](frameworks/lws.md)
 - [meta-llama/llama-stack](integrations/llamastack.md)
 - [substratusai/kubeai](integrations/kubeai.md)


### PR DESCRIPTION


## Purpose

Adding [AI Runway](https://github.com/kaito-project/airunway) as an integration. AI Runway is a Kubernetes-native platform for deploying and managing LLM inference across multiple providers behind a single `ModelDeployment` API. It can serve models with vLLM directly (running `vllm serve` as native Kubernetes `Deployment`/`Service` resources) as well as through vLLM-backed providers already listed here (Dynamo, llm-d, KAITO, KubeRay).

This adds a new `docs/deployment/integrations/airunway.md` page and links it from the Kubernetes deployment guide (`docs/deployment/k8s.md`), matching the existing integration entries.

## Test Plan

Docs-only change. Ran `markdownlint` on the changed files and verified the new page renders and the relative link from `deployment/k8s.md` resolves.

## Test Result

`markdownlint` passes on both changed files; the new AI Runway page appears in the "Alternatively, you can deploy vLLM to Kubernetes" list in the Kubernetes deployment guide.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
