### PR TITLE
fix(deepseek_v4): resolve auto kv-cache-dtype to fp8_ds_mla on SM120

### DIFF
--- a/tests/models/test_deepseek_v4_kv_cache_dtype.py
+++ b/tests/models/test_deepseek_v4_kv_cache_dtype.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Resolution of ``--kv-cache-dtype`` for the DeepSeek V4 fp8_ds_mla layout.
+
+Regression for the SM120 crash where the default ``auto`` was asserted instead
+of resolving to ``fp8_ds_mla`` (the layout has no non-fp8 variant), so
+``vllm serve <dsv4-model>`` with no flag failed on Blackwell.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.attention import _resolve_dsv4_kv_cache_dtype
+
+
+@pytest.mark.parametrize("kv_cache_dtype", ["auto", None, "fp8", "fp8_e4m3"])
+def test_fp8_ds_mla_layout_resolves_to_ds_mla(kv_cache_dtype):
+    cache_config = SimpleNamespace(cache_dtype=kv_cache_dtype)
+    resolved, torch_dtype = _resolve_dsv4_kv_cache_dtype(
+        True, kv_cache_dtype, cache_config
+    )
+    assert resolved == "fp8_ds_mla"
+    assert torch_dtype is torch.uint8
+    # canonical string is written back so the page-size spec picks the 576B slot
+    assert cache_config.cache_dtype == "fp8_ds_mla"
+
+
+def test_fp8_ds_mla_layout_rejects_non_fp8():
+    with pytest.raises(AssertionError):
+        _resolve_dsv4_kv_cache_dtype(True, "bfloat16", SimpleNamespace(cache_dtype=""))
+
+
+@pytest.mark.parametrize(
+    "kv_cache_dtype, expected_dtype",
+    [
+        ("auto", torch.bfloat16),
+        ("bfloat16", torch.bfloat16),
+        ("fp8", torch.float8_e4m3fn),
+    ],
+)
+def test_plain_row_layout_unchanged(kv_cache_dtype, expected_dtype):
+    resolved, torch_dtype = _resolve_dsv4_kv_cache_dtype(False, kv_cache_dtype, None)
+    assert resolved == kv_cache_dtype
+    assert torch_dtype is expected_dtype

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -76,6 +76,13 @@ def _resolve_dsv4_kv_cache_dtype(
     """
     if use_fp8_ds_mla_layout:
         # fp8_ds_mla block format: UE8M0 block-scaled fp8 packed as uint8.
+        # This layout has no non-fp8 variant, so the default "auto" resolves to
+        # fp8 here rather than asserting -- otherwise SM120 crashes on the HF
+        # model card's `vllm serve <model>` (no --kv-cache-dtype flag). It then
+        # flows through the fp8 -> fp8_ds_mla upgrade below (which also writes the
+        # canonical string back onto cache_config for the page-size spec).
+        if kv_cache_dtype in ("auto", None):
+            kv_cache_dtype = "fp8"
         assert kv_cache_dtype.startswith("fp8"), (
             f"DeepseekV4 fp8_ds_mla layout only supports fp8 kv-cache, "
             f"got {kv_cache_dtype}"

--- a/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
+++ b/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
@@ -108,7 +108,10 @@ class DeepseekV4FlashInferMLASparseBackend(DeepseekV4FlashMLABackend):
                 return "kv_cache_dtype not supported"
             return None
         if device_capability.major == 12:
-            if kv_cache_dtype not in ("fp8", "fp8_e4m3", "fp8_ds_mla"):
+            # "auto"/None resolve to fp8_ds_mla for this layout (see
+            # _resolve_dsv4_kv_cache_dtype); accept them so the backend isn't
+            # rejected before resolution.
+            if kv_cache_dtype not in (None, "auto", "fp8", "fp8_e4m3", "fp8_ds_mla"):
                 return "kv_cache_dtype not supported"
             from vllm.utils.flashinfer import has_flashinfer_sparse_mla_sm120
 


### PR DESCRIPTION
Fixes #47174

On SM120 the fp8_ds_mla layout has no non-fp8 variant, but the default `auto` hit an assert in `_resolve_dsv4_kv_cache_dtype` instead of resolving. So `vllm serve <dsv4-model>` with no flag (as on the HF model card) crashed on Blackwell:

```
AssertionError: DeepseekV4 fp8_ds_mla layout only supports fp8 kv-cache, got auto
```

Map `auto`/`None` to `fp8` so it flows through the existing `fp8 -> fp8_ds_mla` upgrade (which also writes the canonical string back onto cache_config), and accept them in the SM120 backend validator so selection isn't rejected first. Explicit `bfloat16` on this layout still errors; the plain-row (SM10x) path is untouched.

Added a CPU unit test covering both layouts. Ran ruff clean; can't run the full test locally (no GPU box for the full vllm import) so leaving the suite to CI.