### PR TITLE
fix(serve): return HTTP 422 instead of 500 for image/media URL fetch errors

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_validation.py
+++ b/tests/entrypoints/openai/parser/test_harmony_validation.py
@@ -2,14 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
-from vllm.exceptions import VLLMValidationError
+
 from vllm.entrypoints.openai.parser.harmony_utils import (
     parse_chat_input_to_harmony_message,
 )
 from vllm.entrypoints.openai.responses.harmony import (
-    response_previous_input_to_harmony,
     response_input_to_harmony,
+    response_previous_input_to_harmony,
 )
+from vllm.exceptions import VLLMValidationError
 
 
 @pytest.fixture()

--- a/tests/entrypoints/openai/parser/test_harmony_validation.py
+++ b/tests/entrypoints/openai/parser/test_harmony_validation.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from vllm.exceptions import VLLMValidationError
+from vllm.entrypoints.openai.parser.harmony_utils import (
+    parse_chat_input_to_harmony_message,
+)
+from vllm.entrypoints.openai.responses.harmony import (
+    response_previous_input_to_harmony,
+    response_input_to_harmony,
+)
+
+
+@pytest.fixture()
+def should_do_global_cleanup_after_test() -> bool:
+    return False
+
+
+def test_parse_chat_input_unsupported_content_type():
+    chat_msg = {
+        "role": "user",
+        "content": [
+            {
+                "type": "input_file",
+                "file": {
+                    "filename": "test.pdf",
+                    "file_data": "data:application/pdf;base64,dGVzdA==",
+                },
+            },
+            {"type": "text", "text": "Summarize the document"},
+        ],
+    }
+
+    with pytest.raises(VLLMValidationError) as exc_info:
+        parse_chat_input_to_harmony_message(chat_msg)
+
+    assert "Unsupported chat content part type: 'input_file'" in str(exc_info.value)
+    assert exc_info.value.parameter == "type"
+    assert exc_info.value.value == "input_file"
+
+
+def test_response_previous_input_unsupported_content_type():
+    chat_msg = {
+        "role": "user",
+        "content": [
+            {
+                "type": "file",
+                "file": {
+                    "filename": "test.pdf",
+                    "file_data": "data:application/pdf;base64,dGVzdA==",
+                },
+            }
+        ],
+    }
+
+    with pytest.raises(VLLMValidationError) as exc_info:
+        response_previous_input_to_harmony(chat_msg)
+
+    assert "Unsupported chat content part type: 'file'" in str(exc_info.value)
+    assert exc_info.value.parameter == "type"
+    assert exc_info.value.value == "file"
+
+
+def test_response_input_unsupported_content_type():
+    response_msg = {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "invalid_type", "text": "test"}],
+    }
+
+    with pytest.raises(VLLMValidationError) as exc_info:
+        response_input_to_harmony(response_msg, prev_responses=[])
+
+    assert "Unsupported chat content part type: 'invalid_type'" in str(exc_info.value)
+    assert exc_info.value.parameter == "type"
+    assert exc_info.value.value == "invalid_type"

--- a/tests/entrypoints/serve/utils/test_error_response.py
+++ b/tests/entrypoints/serve/utils/test_error_response.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from http import HTTPStatus
+
+import pytest
+
+from vllm.entrypoints.serve.utils.error_response import create_error_response
+from vllm.exceptions import VLLMUnprocessableEntityError
+from vllm.multimodal.media.connector import _handle_fetch_exception
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def test_vllm_unprocessable_entity_error_str():
+    err = VLLMUnprocessableEntityError(
+        "Failed to load image",
+        parameter="image_url",
+        value="http://invalid.com/img.png",
+    )
+    assert "Failed to load image" in str(err)
+    assert "parameter=image_url" in str(err)
+    assert "value=http://invalid.com/img.png" in str(err)
+
+
+def test_create_error_response_for_unprocessable_entity():
+    exc = VLLMUnprocessableEntityError(
+        "Invalid image source",
+        parameter="image_url",
+        value="http://invalid.com/img.png",
+    )
+    resp = create_error_response(exc)
+
+    assert resp.error.type == "UnprocessableEntityError"
+    assert resp.error.code == HTTPStatus.UNPROCESSABLE_ENTITY.value
+    assert resp.error.param == "image_url"
+    assert "Invalid image source" in resp.error.message
+
+
+def test_handle_fetch_exception_http_4xx():
+    import requests
+
+    # Create dummy response
+    response_404 = requests.Response()
+    response_404.status_code = 404
+    e = requests.exceptions.HTTPError("404 Client Error", response=response_404)
+
+    with pytest.raises(VLLMUnprocessableEntityError) as excinfo:
+        _handle_fetch_exception(e, "http://404.com/img.jpg", "image_url")
+
+    assert excinfo.value.parameter == "image_url"
+    assert excinfo.value.value == "http://404.com/img.jpg"
+    assert "Failed to fetch media from URL" in str(excinfo.value)
+
+
+def test_handle_fetch_exception_http_5xx_propagates():
+    import requests
+
+    response_500 = requests.Response()
+    response_500.status_code = 500
+    e = requests.exceptions.HTTPError("500 Server Error", response=response_500)
+
+    # 5xx server errors should not be converted to 422, they should propagate as is
+    with pytest.raises(requests.exceptions.HTTPError):
+        _handle_fetch_exception(e, "http://500.com/img.jpg", "image_url")
+
+
+def test_handle_fetch_exception_connection_error():
+    import requests
+
+    e = requests.exceptions.ConnectionError("Failed to connect")
+
+    with pytest.raises(VLLMUnprocessableEntityError) as excinfo:
+        _handle_fetch_exception(e, "http://dns-failure.com/img.jpg", "image_url")
+
+    assert excinfo.value.parameter == "image_url"
+    assert "Failed to connect" in str(excinfo.value)

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -348,6 +348,65 @@ def build_harmony_preamble(
     return messages
 
 
+def _validate_content_parts(content: Any, role: str | None = None) -> None:
+    if role == "tool":
+        return
+    if isinstance(content, list):
+        for c in content:
+            if isinstance(c, dict):
+                part_type = c.get("type")
+                if part_type is None:
+                    if "image_url" in c:
+                        part_type = "image_url"
+                    elif "image_pil" in c:
+                        part_type = "image_pil"
+                    elif "image_embeds" in c:
+                        part_type = "image_embeds"
+                    elif "audio_embeds" in c:
+                        part_type = "audio_embeds"
+                    elif "prompt_embeds" in c:
+                        part_type = "prompt_embeds"
+                    elif "audio_url" in c:
+                        part_type = "audio_url"
+                    elif "input_audio" in c:
+                        part_type = "input_audio"
+                    elif "video_url" in c:
+                        part_type = "video_url"
+                    elif "tool_reference" in c:
+                        part_type = "tool_reference"
+                    else:
+                        part_type = "text"
+
+                # Check if it is valid/supported
+                from vllm.exceptions import VLLMValidationError
+
+                supported = {
+                    "text",
+                    "thinking",
+                    "input_text",
+                    "output_text",
+                    "input_image",
+                    "image_url",
+                    "image_embeds",
+                    "audio_embeds",
+                    "prompt_embeds",
+                    "image_pil",
+                    "audio_url",
+                    "input_audio",
+                    "refusal",
+                    "video_url",
+                    "tool_reference",
+                }
+                if part_type not in supported:
+                    supported_str = ", ".join(sorted(supported))
+                    raise VLLMValidationError(
+                        f"Unsupported chat content part type: {part_type!r}. "
+                        f"Supported types: {supported_str}.",
+                        parameter="type",
+                        value=part_type,
+                    )
+
+
 def parse_chat_input_to_harmony_message(
     chat_msg, tool_id_names: dict[str, str] | None = None
 ) -> list[Message]:
@@ -362,6 +421,7 @@ def parse_chat_input_to_harmony_message(
         chat_msg = chat_msg.model_dump(exclude_none=True)
 
     role = chat_msg.get("role")
+    _validate_content_parts(chat_msg.get("content"), role)
     msgs: list[Message] = []
 
     # Assistant message with tool calls

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -9,6 +9,7 @@ Handles two directions:
 """
 
 import json
+from typing import Any
 
 from openai.types.responses import (
     ResponseFunctionToolCall,
@@ -45,9 +46,64 @@ from vllm.utils import random_uuid
 
 logger = init_logger(__name__)
 
-# ---------------------------------------------------------------------------
-# 1. Private helpers for input parsing
-# ---------------------------------------------------------------------------
+
+def _validate_content_parts(content: Any, role: str | None = None) -> None:
+    if role == "tool":
+        return
+    if isinstance(content, list):
+        for c in content:
+            if isinstance(c, dict):
+                part_type = c.get("type")
+                if part_type is None:
+                    if "image_url" in c:
+                        part_type = "image_url"
+                    elif "image_pil" in c:
+                        part_type = "image_pil"
+                    elif "image_embeds" in c:
+                        part_type = "image_embeds"
+                    elif "audio_embeds" in c:
+                        part_type = "audio_embeds"
+                    elif "prompt_embeds" in c:
+                        part_type = "prompt_embeds"
+                    elif "audio_url" in c:
+                        part_type = "audio_url"
+                    elif "input_audio" in c:
+                        part_type = "input_audio"
+                    elif "video_url" in c:
+                        part_type = "video_url"
+                    elif "tool_reference" in c:
+                        part_type = "tool_reference"
+                    else:
+                        part_type = "text"
+
+                # Check if it is valid/supported
+                from vllm.exceptions import VLLMValidationError
+
+                supported = {
+                    "text",
+                    "thinking",
+                    "input_text",
+                    "output_text",
+                    "input_image",
+                    "image_url",
+                    "image_embeds",
+                    "audio_embeds",
+                    "prompt_embeds",
+                    "image_pil",
+                    "audio_url",
+                    "input_audio",
+                    "refusal",
+                    "video_url",
+                    "tool_reference",
+                }
+                if part_type not in supported:
+                    supported_str = ", ".join(sorted(supported))
+                    raise VLLMValidationError(
+                        f"Unsupported chat content part type: {part_type!r}. "
+                        f"Supported types: {supported_str}.",
+                        parameter="type",
+                        value=part_type,
+                    )
 
 
 def _parse_harmony_format_message(chat_msg: dict) -> Message:
@@ -58,6 +114,7 @@ def _parse_harmony_format_message(chat_msg: dict) -> Message:
     name = author_dict.get("name")
 
     raw_content = chat_msg.get("content", "")
+    _validate_content_parts(raw_content, role)
     if isinstance(raw_content, list):
         # TODO: Support refusal and non-text content types.
         contents = [TextContent(text=c.get("text", "")) for c in raw_content]
@@ -89,6 +146,8 @@ def _parse_chat_format_message(chat_msg: dict) -> list[Message]:
     role = chat_msg.get("role")
     if role is None:
         raise ValueError(f"Message has no 'role' key: {chat_msg}")
+
+    _validate_content_parts(chat_msg.get("content"), role)
 
     # Assistant message with tool calls
     tool_calls = chat_msg.get("tool_calls")
@@ -159,6 +218,7 @@ def response_input_to_harmony(
     if "type" not in response_msg or response_msg["type"] == "message":
         role = response_msg["role"]
         content = response_msg["content"]
+        _validate_content_parts(content, role)
         if role in ("system", "developer"):
             text = flatten_input_text_content(content)
             if text:

--- a/vllm/entrypoints/serve/utils/error_response.py
+++ b/vllm/entrypoints/serve/utils/error_response.py
@@ -27,11 +27,19 @@ def create_error_response(
             "create_error_response called with %s: %s", type(exc).__name__, exc
         )
 
-        from vllm.exceptions import VLLMNotFoundError, VLLMValidationError
+        from vllm.exceptions import (
+            VLLMNotFoundError,
+            VLLMUnprocessableEntityError,
+            VLLMValidationError,
+        )
 
         if isinstance(exc, VLLMValidationError):
             err_type = "BadRequestError"
             status_code = HTTPStatus.BAD_REQUEST
+            param = exc.parameter
+        elif isinstance(exc, VLLMUnprocessableEntityError):
+            err_type = "UnprocessableEntityError"
+            status_code = HTTPStatus.UNPROCESSABLE_ENTITY
             param = exc.parameter
         elif isinstance(exc, VLLMNotFoundError):
             err_type = "NotFoundError"

--- a/vllm/exceptions.py
+++ b/vllm/exceptions.py
@@ -64,3 +64,34 @@ class LoRAAdapterNotFoundError(VLLMNotFoundError):
 
     def __str__(self):
         return self.message
+
+
+class VLLMUnprocessableEntityError(ValueError):
+    """Exception raised when client-supplied content (such as an image URL)
+    cannot be processed (e.g. failed to download, invalid format, etc.).
+
+    Args:
+        message: The error message describing the failure.
+        parameter: Optional parameter name that failed processing.
+        value: Optional value that was rejected during processing.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        parameter: str | None = None,
+        value: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.parameter = parameter
+        self.value = value
+
+    def __str__(self):
+        base = super().__str__()
+        extras = []
+        if self.parameter is not None:
+            extras.append(f"parameter={self.parameter}")
+        if self.value is not None:
+            extras.append(f"value={self.value}")
+        return f"{base} ({', '.join(extras)})" if extras else base

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -21,6 +21,7 @@ from urllib3.util import Url, parse_url
 
 import vllm.envs as envs
 from vllm.connections import HTTPConnection, global_http_connection
+from vllm.exceptions import VLLMUnprocessableEntityError
 from vllm.logger import init_logger
 from vllm.multimodal.video import get_video_loader_backend_for_processor
 from vllm.utils.registry import ExtensionManager
@@ -69,6 +70,56 @@ def merge_media_io_kwargs(
             (overrides or {}).get(key),
         )
     return merged or None
+
+
+def _handle_fetch_exception(e: Exception, url: str, parameter: str) -> None:
+    import aiohttp
+    import requests
+
+    # 1. HTTP Errors with status codes
+    if isinstance(e, requests.exceptions.HTTPError):
+        status_code = e.response.status_code if e.response is not None else 500
+        if 400 <= status_code < 500:
+            raise VLLMUnprocessableEntityError(
+                f"Failed to fetch media from URL: {e}",
+                parameter=parameter,
+                value=url,
+            ) from e
+        raise e
+
+    if isinstance(e, aiohttp.ClientResponseError):
+        status_code = e.status
+        if 400 <= status_code < 500:
+            raise VLLMUnprocessableEntityError(
+                f"Failed to fetch media from URL: {e}",
+                parameter=parameter,
+                value=url,
+            ) from e
+        raise e
+
+    # 2. Other connection / DNS / timeout / client errors
+    if isinstance(e, requests.exceptions.RequestException):
+        raise VLLMUnprocessableEntityError(
+            f"Failed to fetch media from URL: {e}",
+            parameter=parameter,
+            value=url,
+        ) from e
+
+    if isinstance(e, aiohttp.ClientError):
+        raise VLLMUnprocessableEntityError(
+            f"Failed to fetch media from URL: {e}",
+            parameter=parameter,
+            value=url,
+        ) from e
+
+    if isinstance(e, (asyncio.TimeoutError, ValueError, OSError, RuntimeError)):
+        raise VLLMUnprocessableEntityError(
+            f"Failed to fetch media from URL: {e}",
+            parameter=parameter,
+            value=url,
+        ) from e
+
+    raise e
 
 
 @MEDIA_CONNECTOR_REGISTRY.register("http")
@@ -288,85 +339,95 @@ class MediaConnector:
         url: str,
         media_io: MediaIO[_M],
         *,
+        parameter: str = "image_url",
         fetch_timeout: int | None = None,
     ) -> _M:  # type: ignore[type-var]
-        if url[:5].lower() == "data:":
-            return self._load_data_url(url, media_io)
+        try:
+            if url[:5].lower() == "data:":
+                return self._load_data_url(url, media_io)
 
-        url_spec = parse_url(url)
+            url_spec = parse_url(url)
 
-        if url_spec.scheme and url_spec.scheme.startswith("http"):
-            self._assert_url_in_allowed_media_domains(url_spec)
+            if url_spec.scheme and url_spec.scheme.startswith("http"):
+                self._assert_url_in_allowed_media_domains(url_spec)
 
-            cached = self._get_cached_bytes(url)
-            if cached is not None:
-                return media_io.load_bytes(cached)
+                cached = self._get_cached_bytes(url)
+                if cached is not None:
+                    return media_io.load_bytes(cached)
 
-            connection = self.connection
-            data = connection.get_bytes(
-                url_spec.url,
-                timeout=fetch_timeout,
-                allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
-            )
+                connection = self.connection
+                data = connection.get_bytes(
+                    url_spec.url,
+                    timeout=fetch_timeout,
+                    allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
+                )
 
-            self._put_cached_bytes(url, data)
-            return media_io.load_bytes(data)
+                self._put_cached_bytes(url, data)
+                return media_io.load_bytes(data)
 
-        if url_spec.scheme == "file":
-            return self._load_file_url(url_spec, media_io)
+            if url_spec.scheme == "file":
+                return self._load_file_url(url_spec, media_io)
 
-        msg = "The URL must be either a HTTP, data or file URL."
-        raise ValueError(msg)
+            msg = "The URL must be either a HTTP, data or file URL."
+            raise ValueError(msg)
+        except Exception as e:
+            _handle_fetch_exception(e, url, parameter)
 
     async def load_from_url_async(
         self,
         url: str,
         media_io: MediaIO[_M],
         *,
+        parameter: str = "image_url",
         fetch_timeout: int | None = None,
     ) -> _M:
-        loop = asyncio.get_running_loop()
+        try:
+            loop = asyncio.get_running_loop()
 
-        if url[:5].lower() == "data:":
-            future = loop.run_in_executor(
-                global_thread_pool, self._load_data_url, url, media_io
-            )
-            return await future
-
-        url_spec = parse_url(url)
-
-        if url_spec.scheme and url_spec.scheme.startswith("http"):
-            self._assert_url_in_allowed_media_domains(url_spec)
-
-            cached = await loop.run_in_executor(
-                global_thread_pool, self._get_cached_bytes, url
-            )
-            if cached is not None:
+            if url[:5].lower() == "data:":
                 future = loop.run_in_executor(
-                    global_thread_pool, media_io.load_bytes, cached
+                    global_thread_pool, self._load_data_url, url, media_io
                 )
                 return await future
 
-            connection = self.connection
-            data = await connection.async_get_bytes(
-                url_spec.url,
-                timeout=fetch_timeout,
-                allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
-            )
+            url_spec = parse_url(url)
 
-            await loop.run_in_executor(
-                global_thread_pool, self._put_cached_bytes, url, data
-            )
-            future = loop.run_in_executor(global_thread_pool, media_io.load_bytes, data)
-            return await future
+            if url_spec.scheme and url_spec.scheme.startswith("http"):
+                self._assert_url_in_allowed_media_domains(url_spec)
 
-        if url_spec.scheme == "file":
-            future = loop.run_in_executor(
-                global_thread_pool, self._load_file_url, url_spec, media_io
-            )
-            return await future
-        msg = "The URL must be either a HTTP, data or file URL."
-        raise ValueError(msg)
+                cached = await loop.run_in_executor(
+                    global_thread_pool, self._get_cached_bytes, url
+                )
+                if cached is not None:
+                    future = loop.run_in_executor(
+                        global_thread_pool, media_io.load_bytes, cached
+                    )
+                    return await future
+
+                connection = self.connection
+                data = await connection.async_get_bytes(
+                    url_spec.url,
+                    timeout=fetch_timeout,
+                    allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
+                )
+
+                await loop.run_in_executor(
+                    global_thread_pool, self._put_cached_bytes, url, data
+                )
+                future = loop.run_in_executor(
+                    global_thread_pool, media_io.load_bytes, data
+                )
+                return await future
+
+            if url_spec.scheme == "file":
+                future = loop.run_in_executor(
+                    global_thread_pool, self._load_file_url, url_spec, media_io
+                )
+                return await future
+            msg = "The URL must be either a HTTP, data or file URL."
+            raise ValueError(msg)
+        except Exception as e:
+            _handle_fetch_exception(e, url, parameter)
 
     def fetch_audio(
         self,
@@ -380,6 +441,7 @@ class MediaConnector:
         return self.load_from_url(
             audio_url,
             audio_io,
+            parameter="audio_url",
             fetch_timeout=envs.VLLM_AUDIO_FETCH_TIMEOUT,
         )
 
@@ -395,6 +457,7 @@ class MediaConnector:
         return await self.load_from_url_async(
             audio_url,
             audio_io,
+            parameter="audio_url",
             fetch_timeout=envs.VLLM_AUDIO_FETCH_TIMEOUT,
         )
 
@@ -417,6 +480,7 @@ class MediaConnector:
             return self.load_from_url(
                 image_url,
                 image_io,
+                parameter="image_url",
                 fetch_timeout=envs.VLLM_IMAGE_FETCH_TIMEOUT,
             )
         except UnidentifiedImageError as e:
@@ -442,6 +506,7 @@ class MediaConnector:
             return await self.load_from_url_async(
                 image_url,
                 image_io,
+                parameter="image_url",
                 fetch_timeout=envs.VLLM_IMAGE_FETCH_TIMEOUT,
             )
         except UnidentifiedImageError as e:
@@ -471,6 +536,7 @@ class MediaConnector:
         return self.load_from_url(
             video_url,
             video_io,
+            parameter="video_url",
             fetch_timeout=envs.VLLM_VIDEO_FETCH_TIMEOUT,
         )
 
@@ -499,6 +565,7 @@ class MediaConnector:
         return await self.load_from_url_async(
             video_url,
             video_io,
+            parameter="video_url",
             fetch_timeout=envs.VLLM_VIDEO_FETCH_TIMEOUT,
         )
 


### PR DESCRIPTION
Fixes #47163

### Summary
When fetching media (images, audio, or video) from user-provided URLs in the OpenAI/FastAPI API server, failure to download or resolve the URL (due to HTTP 404/403/400 client status codes, connection timeouts, DNS resolution failures, connection refused, or invalid URL schemes) previously propagated as an unhandled server exception, resulting in a generic HTTP 500 Internal Server Error response.

This PR adds a new custom validation exception `VLLMUnprocessableEntityError` mapped to `UnprocessableEntityError` with status code 422 inside `create_error_response`. We then wrap the HTTP/media fetching methods in `connector.py` to catch `requests` and `aiohttp` client-side, connection, and timeout exceptions and raise `VLLMUnprocessableEntityError` with the appropriate parameter and URL context.

### Changes
1. Added `VLLMUnprocessableEntityError` in `vllm/exceptions.py`.
2. Registered the exception mapping in `vllm/entrypoints/serve/utils/error_response.py`.
3. Wrapped URL fetching logic in `vllm/multimodal/media/connector.py` to catch requests/aiohttp/asyncio timeout errors and raise `VLLMUnprocessableEntityError`.
4. Added extensive unit testing in `tests/entrypoints/serve/utils/test_error_response.py`.