### PR TITLE
[Bugfix][KVOffload] Restore evicted CPU blocks and fix cursor advancement

### DIFF
--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -1839,3 +1839,424 @@ def test_cp_lazy_target_blocks_scaling(cp_world_size: int) -> None:
             f"cp_world_size={cp_world_size}: target_cp={target_cp} should be "
             f"less than target_base={target_base}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Test 18: Active request GPU blocks are protected by ref_cnt
+# ---------------------------------------------------------------------------
+def test_active_request_blocks_not_evicted() -> None:
+    """Verify that GPU blocks belonging to active requests (ref_cnt > 0) are
+    never freed. This proves the LRU safety property: CPU LRU can only evict
+    cache entries for blocks with ref_cnt == 0.
+
+    Note: Phase 1a handles the case where CPU blocks freed after store
+    completion are re-allocated, removing their cache entries. The GPU block
+    may still be active — CPU and GPU ref_cnts are independent. This test
+    verifies the GPU-side protection that prevents active blocks from being
+    freed prematurely.
+    """
+    fix = make_scheduler(num_cpu_blocks=5, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+
+    req_a = make_request(num_blocks=2)
+    req_b = make_request(num_blocks=2)
+    kv_a = _alloc_and_register(fix, req_a, 2)
+    kv_b = _alloc_and_register(fix, req_b, 2)
+    sched.update_state_after_alloc(req_a, kv_a, num_external_tokens=0)
+    sched.update_state_after_alloc(req_b, kv_b, num_external_tokens=0)
+
+    ids_a = kv_a.get_block_ids()
+    ids_b = kv_b.get_block_ids()
+    sched_out1 = make_scheduler_output(
+        {req_a.request_id: 2 * BLOCK_SIZE, req_b.request_id: 2 * BLOCK_SIZE},
+        new_reqs={req_a.request_id: ids_a, req_b.request_id: ids_b},
+    )
+    meta1 = sched.build_connector_meta(sched_out1)
+    simulate_store_completion(sched, meta1.store_event)
+
+    all_ids_a = [bid for group in ids_a for bid in group]
+    sched.request_finished(req_a, all_ids_a)
+
+    req_c = make_request(num_blocks=2)
+    kv_c = _alloc_and_register(fix, req_c, 2)
+    sched.update_state_after_alloc(req_c, kv_c, num_external_tokens=0)
+    ids_c = kv_c.get_block_ids()
+    sched_out2 = make_scheduler_output(
+        {req_c.request_id: 2 * BLOCK_SIZE},
+        new_reqs={req_c.request_id: ids_c},
+    )
+    meta2 = sched.build_connector_meta(sched_out2)
+    simulate_store_completion(sched, meta2.store_event)
+
+    for bhash in req_a.block_hashes[:2]:
+        bhash_wg = make_block_hash_with_group_id(bhash, 0)
+        assert (
+            sched.cpu_block_pool.cached_block_hash_to_block.get_one_block(bhash_wg)
+            is None
+        )
+
+    for bhash in req_b.block_hashes[:2]:
+        bhash_wg = make_block_hash_with_group_id(bhash, 0)
+        assert (
+            sched.cpu_block_pool.cached_block_hash_to_block.get_one_block(bhash_wg)
+            is not None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 19: In-flight store blocks are not evicted by concurrent stores
+# ---------------------------------------------------------------------------
+def test_in_flight_store_protected() -> None:
+    """Prove that an in-flight store's CPU blocks are not evicted by
+    a concurrent store attempt.
+
+    When get_new_blocks() allocates CPU blocks for a store, the blocks
+    leave the free queue (ref_cnt becomes 1). During the async DMA window,
+    those blocks are invisible to the allocator.
+
+    Setup:
+    - CPU: 5 total = 4 usable (null_block takes 1).
+    - Store req_a (2 blocks) + req_b (2 blocks) → fills CPU, complete store.
+      All 4 blocks are cached with ref_cnt = 0 in the free queue.
+    - Start req_c's store for 4 blocks → get_new_blocks(4) empties free queue.
+      req_c's blocks are in-flight (ref_cnt = 1, not in free queue,
+      not yet in cached_block_hash_to_block).
+      Note: get_new_blocks evicts the old cached entries (req_a, req_b) via
+      _maybe_evict_cached_block — this is expected LRU behavior.
+    - Attempt to store req_d (2 blocks) while req_c is in-flight.
+
+    Expected:
+    - num_free = 0 → out_of_space = True → no blocks allocated for req_d.
+    - No store event is created for req_d.
+    - req_c's in-flight blocks retain ref_cnt = 1.
+    - After req_c completes, its blocks are properly cached.
+
+    This proves that the allocator does not evict in-flight blocks — when
+    num_free=0, it defers (out_of_space) rather than touching blocks with
+    ref_cnt > 0.
+    """
+    fix = make_scheduler(num_cpu_blocks=5, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+
+    # Store req_a (2 blocks) + req_b (2 blocks) → fills CPU (4 usable).
+    req_a = make_request(num_blocks=2)
+    req_b = make_request(num_blocks=2)
+    kv_a = _alloc_and_register(fix, req_a, 2)
+    kv_b = _alloc_and_register(fix, req_b, 2)
+    sched.update_state_after_alloc(req_a, kv_a, num_external_tokens=0)
+    sched.update_state_after_alloc(req_b, kv_b, num_external_tokens=0)
+
+    ids_a = kv_a.get_block_ids()
+    ids_b = kv_b.get_block_ids()
+    sched_out1 = make_scheduler_output(
+        {req_a.request_id: 2 * BLOCK_SIZE, req_b.request_id: 2 * BLOCK_SIZE},
+        new_reqs={req_a.request_id: ids_a, req_b.request_id: ids_b},
+    )
+    meta1 = sched.build_connector_meta(sched_out1)
+    assert meta1.store_event >= 0
+    simulate_store_completion(sched, meta1.store_event)
+
+    # Start req_c's store for 4 blocks → takes all 4 from free queue.
+    # get_new_blocks evicts old cached entries; free queue becomes empty.
+    req_c = make_request(num_blocks=4)
+    kv_c = _alloc_and_register(fix, req_c, 4)
+    sched.update_state_after_alloc(req_c, kv_c, num_external_tokens=0)
+    ids_c = kv_c.get_block_ids()
+    sched_out2 = make_scheduler_output(
+        {req_c.request_id: 4 * BLOCK_SIZE},
+        new_reqs={req_c.request_id: ids_c},
+    )
+    meta2 = sched.build_connector_meta(sched_out2)
+    assert meta2.store_event >= 0
+
+    # Verify: free queue is empty (req_c's blocks are in-flight, ref_cnt=1).
+    cpu_pool = sched.cpu_block_pool
+    assert cpu_pool.get_num_free_blocks() == 0, (
+        "free queue should be empty while req_c is in-flight"
+    )
+
+    # Verify: old cached entries (req_a, req_b) were evicted by get_new_blocks.
+    for bhash in req_a.block_hashes[:2]:
+        bhash_with_group = make_block_hash_with_group_id(bhash, 0)
+        assert (
+            cpu_pool.cached_block_hash_to_block.get_one_block(bhash_with_group) is None
+        ), "req_a block should be evicted by req_c's get_new_blocks"
+
+    # Attempt to store req_d (2 blocks) while req_c is in-flight.
+    req_d = make_request(num_blocks=2)
+    kv_d = _alloc_and_register(fix, req_d, 2)
+    sched.update_state_after_alloc(req_d, kv_d, num_external_tokens=0)
+    ids_d = kv_d.get_block_ids()
+    sched_out3 = make_scheduler_output(
+        {req_d.request_id: 2 * BLOCK_SIZE},
+        new_reqs={req_d.request_id: ids_d},
+    )
+    meta3 = sched.build_connector_meta(sched_out3)
+
+    # Verify: no store event for req_d (out_of_space).
+    assert meta3.store_event < 0, (
+        "req_d should NOT have a store event (out_of_space while req_c in-flight)"
+    )
+
+    # Verify: req_c's in-flight blocks still have ref_cnt = 1.
+    # The 4 usable CPU blocks are block_ids 1-4 (block 0 is null_block).
+    for blk_id in range(1, 5):
+        blk = cpu_pool.blocks[blk_id]
+        assert blk.ref_cnt == 1, f"CPU block {blk_id} should have ref_cnt=1 (in-flight)"
+
+    # Now complete req_c's store.
+    simulate_store_completion(sched, meta2.store_event)
+
+    # Verify: after completion, blocks are freed (ref_cnt=0) and cached.
+    assert cpu_pool.get_num_free_blocks() == 4, (
+        "free queue should have 4 blocks after req_c store completes"
+    )
+    # req_c's blocks are now in the cache map (with req_c's hashes).
+    for bhash in req_c.block_hashes[:4]:
+        bhash_with_group = make_block_hash_with_group_id(bhash, 0)
+        assert (
+            cpu_pool.cached_block_hash_to_block.get_one_block(bhash_with_group)
+            is not None
+        ), "req_c block should be cached after store completion"
+
+
+# ---------------------------------------------------------------------------
+# Test 20: Active request blocks CAN be evicted after store completion
+# ---------------------------------------------------------------------------
+def test_active_request_blocks_can_be_evicted() -> None:
+    """Prove that blocks belonging to an active (not finished) request CAN be
+    evicted after their store completes.
+
+    After _process_store_completion() frees blocks (ref_cnt→0), they join the
+    free queue tail (MRU). A subsequent store that needs CPU blocks will take
+    from the free queue head (LRU), evicting the oldest cached entries.
+
+    This is the scenario the original FIXME worried about: evicted blocks below
+    the cursor are never re-stored. The NOTE explains why this is safe: the
+    load path recomputes missing tokens from GPU — no data loss.
+
+    Setup:
+    - CPU: 5 total = 4 usable (null_block takes 1).
+    - Store req_a (2 blocks) + req_b (2 blocks) → fills CPU, complete.
+      req_a's blocks are at LRU head (freed first), req_b's at MRU tail.
+    - Store req_c (2 blocks) → takes 2 from free queue → evicts req_a's blocks.
+
+    Expected:
+    - req_a's blocks are evicted from cache (req_a is still active!).
+    - req_b's blocks survive (at MRU tail, evicted last).
+    """
+    fix = make_scheduler(num_cpu_blocks=5, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+
+    # Store req_a (2 blocks) + req_b (2 blocks) → fills CPU (4 usable).
+    req_a = make_request(num_blocks=2)
+    req_b = make_request(num_blocks=2)
+    kv_a = _alloc_and_register(fix, req_a, 2)
+    kv_b = _alloc_and_register(fix, req_b, 2)
+    sched.update_state_after_alloc(req_a, kv_a, num_external_tokens=0)
+    sched.update_state_after_alloc(req_b, kv_b, num_external_tokens=0)
+
+    ids_a = kv_a.get_block_ids()
+    ids_b = kv_b.get_block_ids()
+    sched_out1 = make_scheduler_output(
+        {req_a.request_id: 2 * BLOCK_SIZE, req_b.request_id: 2 * BLOCK_SIZE},
+        new_reqs={req_a.request_id: ids_a, req_b.request_id: ids_b},
+    )
+    meta1 = sched.build_connector_meta(sched_out1)
+    assert meta1.store_event >= 0
+    simulate_store_completion(sched, meta1.store_event)
+
+    # Verify: all blocks cached after store completion.
+    cpu_pool = sched.cpu_block_pool
+    for bhash in req_a.block_hashes[:2]:
+        bhash_with_group = make_block_hash_with_group_id(bhash, 0)
+        assert (
+            cpu_pool.cached_block_hash_to_block.get_one_block(bhash_with_group)
+            is not None
+        ), "req_a block should be cached after store"
+    for bhash in req_b.block_hashes[:2]:
+        bhash_with_group = make_block_hash_with_group_id(bhash, 0)
+        assert (
+            cpu_pool.cached_block_hash_to_block.get_one_block(bhash_with_group)
+            is not None
+        ), "req_b block should be cached after store"
+
+    # Store req_c (2 blocks) → needs 2 CPU blocks → takes from LRU head.
+    # req_a's blocks are at LRU head (freed first), so they get evicted.
+    req_c = make_request(num_blocks=2)
+    kv_c = _alloc_and_register(fix, req_c, 2)
+    sched.update_state_after_alloc(req_c, kv_c, num_external_tokens=0)
+    ids_c = kv_c.get_block_ids()
+    sched_out2 = make_scheduler_output(
+        {req_c.request_id: 2 * BLOCK_SIZE},
+        new_reqs={req_c.request_id: ids_c},
+    )
+    meta2 = sched.build_connector_meta(sched_out2)
+    assert meta2.store_event >= 0
+    simulate_store_completion(sched, meta2.store_event)
+
+    # Verify: req_a's blocks were evicted (req_a is still active!).
+    for bhash in req_a.block_hashes[:2]:
+        bhash_with_group = make_block_hash_with_group_id(bhash, 0)
+        assert (
+            cpu_pool.cached_block_hash_to_block.get_one_block(bhash_with_group) is None
+        ), "req_a block (active, not finished) should be evicted by req_c's store"
+
+    # Verify: req_b's blocks survive (at MRU tail).
+    for bhash in req_b.block_hashes[:2]:
+        bhash_with_group = make_block_hash_with_group_id(bhash, 0)
+        assert (
+            cpu_pool.cached_block_hash_to_block.get_one_block(bhash_with_group)
+            is not None
+        ), "req_b block (at MRU tail) should survive"
+
+    # Verify: req_c's blocks are cached.
+    for bhash in req_c.block_hashes[:2]:
+        bhash_with_group = make_block_hash_with_group_id(bhash, 0)
+        assert (
+            cpu_pool.cached_block_hash_to_block.get_one_block(bhash_with_group)
+            is not None
+        ), "req_c block should be cached after store"
+
+
+# ---------------------------------------------------------------------------
+# Test 21: Eviction signal is correctly set and consumed
+# ---------------------------------------------------------------------------
+def test_eviction_signal_set_and_consumed() -> None:
+    """Prove that consume_eviction_signal() correctly detects eviction.
+
+    After store completion, CPU blocks are freed (ref_cnt=0) but still have
+    their hash entries in the cache map. When get_new_blocks() re-allocates
+    these blocks, _maybe_evict_cached_block() removes the cache entries and
+    sets _had_recent_eviction = True.
+
+    This proves the flag lifecycle fix: the flag is NOT reset at the end
+    of get_new_blocks(), so the manager can consume it in the next step.
+    """
+    fix = make_scheduler(num_cpu_blocks=5, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+    cpu_pool = sched.cpu_block_pool
+
+    # Initial state: no eviction
+    assert cpu_pool.consume_eviction_signal() is False
+
+    # Manually set up a block with a hash entry in the cache map
+    # (simulating what happens after store completion)
+    block = cpu_pool.blocks[1]
+    test_hash = make_block_hash_with_group_id(b"\x01" * 32, 0)
+    block._block_hash = test_hash
+    cpu_pool.cached_block_hash_to_block.insert(test_hash, block)
+    # Put block in free queue (ref_cnt=0, like after store completion)
+    assert block.ref_cnt == 0
+
+    # Allocate the block → should trigger eviction of the cache entry
+    blocks = cpu_pool.get_new_blocks(1)
+    assert len(blocks) == 1
+    assert blocks[0].block_id == 1
+
+    # Verify: eviction signal was set
+    assert cpu_pool.consume_eviction_signal() is True, (
+        "eviction signal should be True after get_new_blocks evicts cached entry"
+    )
+
+    # Verify: flag is reset after consume
+    assert cpu_pool.consume_eviction_signal() is False, (
+        "eviction signal should be False after being consumed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 22: Phase 1a re-store enables cache hit after eviction
+# ---------------------------------------------------------------------------
+def test_phase1a_restore_enables_cache_hit() -> None:
+    """End-to-end: after eviction + Phase 1a re-store, a new request with
+    the same prefix gets a CPU cache hit (no re-prefill needed).
+
+    Scenario:
+    - req_a stores 2 blocks → complete → cached
+    - req_c allocates CPU blocks → evicts req_a's cache entries
+    - req_a continues → Phase 1a re-scans and re-stores evicted blocks
+    - req_d (same prefix as req_a) → should get CPU cache hit
+
+    Without Phase 1a re-store, req_d would get 0 cache hit tokens and need
+    to re-prefill/recompute. After re-store, req_d hits all blocks.
+    """
+    fix = make_scheduler(num_cpu_blocks=5, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+    cpu_pool = sched.cpu_block_pool
+
+    # Step 1: req_a stores 2 blocks
+    req_a = make_request(num_blocks=2)
+    kv_a = _alloc_and_register(fix, req_a, 2)
+    sched.update_state_after_alloc(req_a, kv_a, num_external_tokens=0)
+    ids_a = kv_a.get_block_ids()
+    sched_out1 = make_scheduler_output(
+        {req_a.request_id: 2 * BLOCK_SIZE},
+        new_reqs={req_a.request_id: ids_a},
+    )
+    meta1 = sched.build_connector_meta(sched_out1)
+    assert meta1.store_event >= 0
+    simulate_store_completion(sched, meta1.store_event)
+
+    # Verify: req_a's blocks are cached
+    for bhash in req_a.block_hashes[:2]:
+        bhash_wg = make_block_hash_with_group_id(bhash, 0)
+        assert cpu_pool.cached_block_hash_to_block.get_one_block(bhash_wg) is not None
+
+    # Step 2: req_c allocates CPU blocks → evicts req_a's cache entries
+    req_c = make_request(num_blocks=4)
+    kv_c = _alloc_and_register(fix, req_c, 4)
+    sched.update_state_after_alloc(req_c, kv_c, num_external_tokens=0)
+    ids_c = kv_c.get_block_ids()
+    sched_out2 = make_scheduler_output(
+        {req_c.request_id: 4 * BLOCK_SIZE},
+        new_reqs={req_c.request_id: ids_c},
+    )
+    meta2 = sched.build_connector_meta(sched_out2)
+    assert meta2.store_event >= 0
+    simulate_store_completion(sched, meta2.store_event)
+
+    # Verify: req_a's blocks were evicted
+    for bhash in req_a.block_hashes[:2]:
+        bhash_wg = make_block_hash_with_group_id(bhash, 0)
+        assert cpu_pool.cached_block_hash_to_block.get_one_block(bhash_wg) is None, (
+            "req_a blocks should be evicted after req_c allocation"
+        )
+
+    # Step 3: req_a continues → Phase 1a re-scans and re-stores
+    kv_a2 = _alloc_and_register(fix, req_a, 2, confirmed=False)
+    req_a.num_computed_tokens = 4 * BLOCK_SIZE
+    sched.update_state_after_alloc(req_a, kv_a2, num_external_tokens=0)
+    ids_a2 = kv_a2.get_block_ids()
+    sched_out3 = make_scheduler_output(
+        {req_a.request_id: 4 * BLOCK_SIZE},
+        cached_req_new_blocks={req_a.request_id: ids_a2},
+    )
+    meta3 = sched.build_connector_meta(sched_out3)
+    assert meta3.store_event >= 0, "Phase 1a should trigger re-store of evicted blocks"
+    simulate_store_completion(sched, meta3.store_event)
+
+    # Verify: req_a's blocks are back in cache after re-store
+    for bhash in req_a.block_hashes[:2]:
+        bhash_wg = make_block_hash_with_group_id(bhash, 0)
+        assert (
+            cpu_pool.cached_block_hash_to_block.get_one_block(bhash_wg) is not None
+        ), "req_a blocks should be re-cached after Phase 1a re-store"
+
+    # Step 4: req_d (same prefix) → should get full CPU cache hit
+    req_d = Request(
+        request_id="req-d-same-prefix",
+        prompt_token_ids=req_a.prompt_token_ids[: 2 * BLOCK_SIZE + 1],
+        sampling_params=req_a.sampling_params,
+        pooling_params=None,
+        mm_features=None,
+        block_hasher=req_a._block_hasher,
+    )
+    hit_tokens, is_async = sched.get_num_new_matched_tokens(
+        req_d, num_computed_tokens=0
+    )
+    assert hit_tokens == 2 * BLOCK_SIZE, (
+        f"req_d should hit all {2 * BLOCK_SIZE} tokens from CPU cache, "
+        f"got {hit_tokens}. Phase 1a re-store did not restore cache entries."
+    )
+    assert is_async is True, "Cache hit should trigger async load"

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -184,6 +184,7 @@ class BlockPool:
         # Cache for block lookup
         self.cached_block_hash_to_block: BlockHashToBlockMap = BlockHashToBlockMap()
         self.cached_block_hashes_by_block: dict[int, set[BlockHashWithGroupId]] = {}
+        self._had_recent_eviction = False
 
         # To represent a placeholder block with block_id=0.
         # The ref_cnt of null_block is not maintained, needs special care to
@@ -548,7 +549,7 @@ class BlockPool:
             num_blocks: The number of blocks to allocate.
 
         Returns:
-            A list of new block.
+            List of newly allocated blocks.
         """
         if num_blocks > self.get_num_free_blocks():
             raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
@@ -569,6 +570,7 @@ class BlockPool:
                 block.ref_cnt += 1
                 if self.metrics_collector:
                     self.metrics_collector.on_block_allocated(block)
+
         return ret
 
     def _maybe_evict_cached_block(self, block: KVCacheBlock) -> bool:
@@ -591,8 +593,23 @@ class BlockPool:
             # The block doesn't have hash, eviction is not needed
             return False
 
+        self._had_recent_eviction = True
         self._emit_block_removed_events(evicted_hashes)
         return True
+
+    def consume_eviction_signal(self) -> bool:
+        """Read and reset the eviction flag atomically.
+
+        Used by SimpleCPUOffloadScheduler to detect whether LRU eviction
+        freed any cached blocks since the last call, triggering a re-scan
+        of previously stored blocks.
+
+        Returns:
+            True if a cached block was evicted since the last call.
+        """
+        val = self._had_recent_eviction
+        self._had_recent_eviction = False
+        return val
 
     def touch(self, blocks: Sequence[KVCacheBlock]) -> None:
         """Touch a block increases its reference count by 1, and may remove

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -536,6 +536,26 @@ class SimpleCPUOffloadScheduler:
 
         return gpu_ids, cpu_ids, []
 
+    @staticmethod
+    def _should_skip_block(
+        gpu_block: "KVCacheBlock",
+        in_flight: set[int],
+        cpu_block_pool: "BlockPool",
+    ) -> bool:
+        """Return True if block should be skipped (no store needed)."""
+        if gpu_block.is_null:
+            return True
+        if gpu_block.block_hash is None:
+            return True
+        if gpu_block.block_id in in_flight:
+            return True
+        return (
+            cpu_block_pool.cached_block_hash_to_block.get_one_block(
+                gpu_block.block_hash
+            )
+            is not None
+        )
+
     def _prepare_eager_store_specs(
         self, scheduler_output: SchedulerOutput
     ) -> tuple[list[int], list[int], list[str]]:
@@ -564,6 +584,10 @@ class SimpleCPUOffloadScheduler:
         # Dedup against blocks already scheduled.
         in_flight = self._in_flight_store_gpu_blocks
 
+        # Consume the eviction signal once — snapshot applies to all requests
+        # in this step. Phase 1a re-scans only if eviction actually happened.
+        had_recent_eviction = cpu_block_pool.consume_eviction_signal()
+
         for req_id, new_block_id_groups, preempted in yield_req_data(scheduler_output):
             state = self._reqs_to_store.get(req_id)
             if state is None or state.finished:
@@ -579,8 +603,6 @@ class SimpleCPUOffloadScheduler:
                         state.block_ids[g].extend(new_block_id_groups[g])
 
             num_new_tokens = scheduler_output.num_scheduled_tokens.get(req_id, 0)
-            if num_new_tokens == 0:
-                continue
 
             block_ids_by_group = state.block_ids
             if not block_ids_by_group:
@@ -589,6 +611,8 @@ class SimpleCPUOffloadScheduler:
             # --- Phase 1: Scan blocks, classify as cached vs to-store ---
             gpu_block_ids: list[int] = []
             block_hashes_to_store: list[bytes] = []
+            # advanced_per_group tracks absolute cursor position:
+            # init = already_stored_g, Phase 1a doesn't modify, Phase 1b adds delta.
             advanced_per_group: list[int] = [0] * num_groups
             out_of_space = False
             # Confirmed tokens: KV data written and visible to all streams.
@@ -598,9 +622,10 @@ class SimpleCPUOffloadScheduler:
             aligned_tokens = confirmed_tokens // self.block_size * self.block_size
 
             for g in range(num_groups):
-                # FIXME (yifan): handle CPU cache eviction, where
-                # num_stored_blocks can be stale and omit evicted blocks in
-                # the middle of the request.
+                # NOTE: Phase 1a re-scans previously stored blocks whose CPU
+                # cache entries may have been removed when get_new_blocks()
+                # re-allocated the CPU blocks. CPU and GPU ref_cnts are
+                # independent — see test_active_request_blocks_can_be_evicted.
                 already_stored_g = state.num_stored_blocks[g]
                 group_gpu_ids = block_ids_by_group[g]
 
@@ -608,43 +633,56 @@ class SimpleCPUOffloadScheduler:
                     kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
                 )
                 ready_blocks_g = aligned_tokens // g_block_size
-                scannable = group_gpu_ids[already_stored_g:ready_blocks_g]
 
-                for gpu_block_id in scannable:
-                    gpu_block = gpu_block_pool.blocks[gpu_block_id]
-                    if gpu_block.is_null:
-                        advanced_per_group[g] += 1
-                        continue
+                # Phase 1a: Re-scan stored blocks (0..already_stored_g) if
+                # eviction was detected, re-storing any that lost their cache
+                # entries. Runs regardless of num_new_tokens.
+                if already_stored_g > 0 and had_recent_eviction:
+                    for i in range(min(already_stored_g, len(group_gpu_ids))):
+                        gpu_block_id = group_gpu_ids[i]
+                        gpu_block = gpu_block_pool.blocks[gpu_block_id]
+                        if self._should_skip_block(
+                            gpu_block, in_flight, cpu_block_pool
+                        ):
+                            continue
 
-                    bhash_with_group = gpu_block.block_hash
-                    if bhash_with_group is None:
-                        # Masked-out SWA position the coordinator chose not to
-                        # hash; it can never serve a prefix-cache hit, so skip.
-                        advanced_per_group[g] += 1
-                        continue
+                        if num_free <= 0:
+                            out_of_space = True
+                            break
+                        num_free -= 1
 
-                    # Skip if already scheduled for store or already cached in CPU.
-                    if (
-                        gpu_block_id in in_flight
-                        or cpu_block_pool.cached_block_hash_to_block.get_one_block(
-                            bhash_with_group
-                        )
-                        is not None
-                    ):
-                        advanced_per_group[g] += 1
-                        continue
+                        assert gpu_block.block_hash is not None
+                        gpu_block_ids.append(gpu_block_id)
+                        block_hashes_to_store.append(gpu_block.block_hash)
 
-                    if num_free <= 0:
-                        out_of_space = True
+                    if out_of_space:
                         break
-                    num_free -= 1
 
-                    gpu_block_ids.append(gpu_block_id)
-                    block_hashes_to_store.append(bhash_with_group)
-                    advanced_per_group[g] += 1
+                # Phase 1b: Scan newly ready blocks (already_stored_g..ready_blocks_g).
+                # Only execute when there are new tokens to store.
+                if num_new_tokens > 0:
+                    scannable = group_gpu_ids[already_stored_g:ready_blocks_g]
 
-                if out_of_space:
-                    break
+                    for gpu_block_id in scannable:
+                        gpu_block = gpu_block_pool.blocks[gpu_block_id]
+                        if self._should_skip_block(
+                            gpu_block, in_flight, cpu_block_pool
+                        ):
+                            advanced_per_group[g] += 1
+                            continue
+
+                        if num_free <= 0:
+                            out_of_space = True
+                            break
+                        num_free -= 1
+
+                        assert gpu_block.block_hash is not None
+                        gpu_block_ids.append(gpu_block_id)
+                        block_hashes_to_store.append(gpu_block.block_hash)
+                        advanced_per_group[g] += 1
+
+                    if out_of_space:
+                        break
 
             # --- Phase 2: Batch allocate CPU blocks and stamp hashes ---
             n_to_alloc = len(gpu_block_ids)
@@ -674,9 +712,9 @@ class SimpleCPUOffloadScheduler:
                     num_groups,
                 )
 
-            # Advance per-group cursors (includes cached hits + newly stored)
+            # Advance per-group cursors (absolute position).
             for g in range(num_groups):
-                state.num_stored_blocks[g] += advanced_per_group[g]
+                state.num_stored_blocks[g] = advanced_per_group[g]
 
         return merged_gpu_block_ids, merged_cpu_block_ids, req_ids
 


### PR DESCRIPTION
## Purpose

Add CPU eviction tracking to `SimpleCPUOffloadScheduler` to re-store blocks whose
cache entries were lost when CPU blocks are re-allocated, avoiding unnecessary
re-prefill for requests with matching prefixes.

Resolves the FIXME: `num_stored_blocks can be stale and omit evicted blocks in the middle of the request`

### Problem

When CPU blocks are freed after store completion (`ref_cnt → 0`) and later
re-allocated by `get_new_blocks()`, their cache entries are removed by
`_maybe_evict_cached_block()`. This can happen while the original request is
still active — CPU and GPU `ref_cnt`s are independent. Without re-store,
subsequent requests with matching prefixes miss the CPU cache and need to
re-prefill.

### Solution

- **Eviction signal**: Add `consume_eviction_signal()` to `BlockPool` — atomically
  reads and resets an eviction flag set by `_maybe_evict_cached_block()`. The
  manager consumes this signal once per step before the request loop.

- **Phase 1a re-scan**: When eviction is detected, re-scan previously stored
  blocks (0..already_stored_g) and re-store any that lost their cache entries.
  Phase 1b continues to scan newly ready blocks (already_stored_g..ready_blocks_g).

- **Cursor advancement**: Use absolute position semantics — initialize
  `advanced_per_group[g]` to `already_stored_g`, Phase 1a does not modify it,
  Phase 1b adds delta. Final assignment: `state.num_stored_blocks[g] = advanced_per_group[g]`.

- **Helper extraction**: Extract `_should_skip_block()` for reuse between phases.

### Changes

| File | Changes |
|------|---------|
| `vllm/v1/core/block_pool.py` | Add `_had_recent_eviction` flag and `consume_eviction_signal()` method |
| `vllm/v1/simple_kv_offload/manager.py` | Consume signal per step; Phase 1a (re-scan evicted) + Phase 1b (scan new); absolute position cursor; extract `_should_skip_block()`; update NOTE |
| `tests/v1/simple_kv_offload/test_scheduler.py` | Add 4 tests (see below) |

### Impact

| Aspect | Before | After |
|--------|--------|-------|
| Evicted block re-store | Blocks never re-stored (FIXME) | Re-stored on next step |
| Cursor complexity | O(n) per step | O(n) per step |
| Phase 1a overhead | N/A | Zero when no eviction |

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/simple_kv_offload/test_scheduler.py::test_eviction_signal_set_and_consumed tests/v1/simple_kv_offload/test_scheduler.py::test_phase1a_restore_enables_cache_hit tests/v1/simple_kv_offload/test_scheduler.py::test_in_flight_store_protected tests/v1/simple_kv_offload/test_scheduler.py::test_active_request_blocks_can_be_evicted -v
```

| Test | What it verifies |
|------|-----------------|
| `test_eviction_signal_set_and_consumed` | Flag is set on eviction and reset on consume |
| `test_phase1a_restore_enables_cache_hit` | End-to-end: after eviction + re-store, new request with same prefix gets full CPU cache hit (no re-prefill) |
| `test_in_flight_store_protected` | In-flight blocks are not evicted by concurrent stores |
| `test_active_request_blocks_can_be_evicted` | Active request blocks CAN be evicted after store completion (CPU ref_cnt is independent of GPU ref_cnt) |

## Test Result

```
tests/v1/simple_kv_offload/test_scheduler.py::test_eviction_signal_set_and_consumed PASSED
tests/v1/simple_kv_offload/test_scheduler.py::test_phase1a_restore_enables_cache_hit PASSED
tests/v1/simple_kv_offload/test_scheduler.py::test_in_flight_store_protected PASSED
tests/v1/simple_kv_offload/test_scheduler.py::test_active_request_blocks_can_be_evicted PASSED

4 passed, 16 warnings in 7.27s
```

ruff: All checks passed.

## Limitations

- **Trigger scenarios are relatively rare**: eviction only occurs when CPU blocks
  from a previous store are re-allocated by `get_new_blocks()`, which requires
  high CPU memory pressure or many concurrent stores. When it does occur, Phase 1a
  ensures re-store happens.
- **Cross-file changes**: touches both `block_pool.py` (signal API) and
  `manager.py` (Phase 1a/1b logic) — the split is intentional as a producer-consumer
  contract between the two modules.

### Alternative approach

If reviewers consider the above limitations too significant for the rare trigger
scenario, an alternative is to document the current eviction behavior as a known
property rather than adding re-store logic:
**[#47234](https://github.com/vllm-project/vllm/pull/47234)** — documents CPU
eviction behavior as reference (control branch).
