### PR TITLE
[BugFix][Spec Decode] Compact shared topk indices buffer after first MTP draft step

### DIFF
--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -169,6 +169,21 @@ class DeepSeekMultiTokenPredictor(nn.Module):
                     if mla_attn is not None and hasattr(mla_attn, "skip_topk"):
                         mla_attn.skip_topk = skip
 
+    def compact_topk_indices(self, slot_ids: torch.Tensor):
+        """Gather the top-k index rows at ``slot_ids`` to the front of the buffer."""
+        num_slots = slot_ids.numel()
+        for layer in self.layers.values():
+            mtp_block = getattr(layer, "mtp_block", None)
+            if mtp_block is not None:
+                self_attn = getattr(mtp_block, "self_attn", None)
+                if self_attn is not None:
+                    mla_attn = getattr(self_attn, "mla_attn", None)
+                    if mla_attn is not None and hasattr(
+                        mla_attn, "topk_indices_buffer"
+                    ):
+                        topk_indices_buffer = mla_attn.topk_indices_buffer
+                        topk_indices_buffer[:num_slots] = topk_indices_buffer[slot_ids]
+
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -130,6 +130,15 @@ class DeepseekV32MultiTokenPredictor(nn.Module):
             if self_attn is not None and hasattr(self_attn, "skip_topk"):
                 self_attn.skip_topk = skip
 
+    def compact_topk_indices(self, slot_ids: torch.Tensor):
+        """Gather the top-k index rows at ``slot_ids`` to the front of the buffer."""
+        num_slots = slot_ids.numel()
+        for layer in self.layers.values():
+            self_attn = getattr(layer.mtp_block, "self_attn", None)
+            if self_attn is not None and hasattr(self_attn, "topk_indices_buffer"):
+                topk_indices_buffer = self_attn.topk_indices_buffer
+                topk_indices_buffer[:num_slots] = topk_indices_buffer[slot_ids]
+
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -560,6 +560,9 @@ class SpecDecodeBaseProposer:
         # and read the indices that step 0 just wrote into the shared buffer.
         if self._share_mtp_indices and hasattr(self.model.model, "set_skip_topk"):
             self.model.model.set_skip_topk(True)
+            # The topk indices were written for each query token in the multi-token
+            # batch. Compact the topk indices for each request's last token.
+            self.model.model.compact_topk_indices(token_indices_to_sample)
 
         sample_hidden_states = last_hidden_states[token_indices_to_sample]
 


### PR DESCRIPTION
# Context
Deepseek-style topk index selection for MTP has a bug during proposal stage when the topk indices are shared among all MTP draft step forward passes. After the first draft step, `set_skip_topk` is called on the MTP model to force the remaining draft steps to reuse the same topk indices values (held within `topk_indices_buffer` of the attention module). The issue is that the first draft forward pass will fill the `topk_indices_buffer` tensor with the per-request, multi-token, bonus + accepted tokens. So they are laid out like:
```
a0, a1, a2, a3, b0, b1, b2, b3, c0, c1, c2, c3, ...
```
with a total of `num_tokens = num_reqs * (1 + num_spec_tokens))` rows.

But the remaining `num_spec_tokens - 1` draft steps are expecting a layout of:
```
a3, b3, c3, ...
``` 
with a total of `num_tokens = num_reqs`. Consequently, they use the wrong topk indices, potentially from other requests. The draft tokens becomes lower quality, and acceptance rates drop.

# This PR
Fixes the above issue by compacting the topk indices for the last query token of each request, so that they are contiguous at the front of the buffer.

# Validation
**Server**
```
vllm serve nvidia/DeepSeek-V3.2-NVFP4 \
  -tp 4 \
  -O3 \
  --no-enable-prefix-caching \
  --max-num-seqs 64 \
  --kernel-config.enable_flashinfer_autotune=False \
  --speculative_config '{"method":"mtp","num_speculative_tokens":3}' \
  --compilation-config '{"cudagraph_mode": "full_decode_only", "mode": 0}'
```

**Bench**
```
vllm-bench \
    --model $MODEL \
    --backend openai-chat \
    --dataset-name speed-bench \
    --speed-bench-config throughput_16k \
    --speed-bench-max-input-len 10240 \
    --speed-bench-category low_entropy \
    --request-rate inf \
    --max-concurrency 32 \
    --num-prompts 256 \
    --output-len 2048 \
    --ignore-eos \
    --temperature 1.0 \
    --percentile-metrics "ttft,tpot,itl,e2el" \
    --result-dir ~/dev \
    --save-result
```

**Results**
Metric | index sharing = True, main | index sharing = True, #47238
-- | -- | --
Request throughput (req/s) | 0.74 | 0.79
Output token throughput (tok/s) | 1517.50 | 1625.59
Total token throughput (tok/s) | 9105.00 | 9753.52
Median TTFT (ms) | 676.75 | 605.60
P90 TTFT (ms) | 4772.12 | 4512.80
Median TPOT (ms) | 19.61 | 18.46
P90 TPOT (ms) | 22.95 | 21.72
Acceptance rate (%) | 57.73 | 61.48
Acceptance length | 2.73 | 2.84
Drafts | 191,923 | 184,332
Draft tokens | 575,769 | 552,996
Accepted tokens | 332,388 | 339,992
Pos 0 (%) | 88.18 | 87.27
Pos 1 (%) | 56.03 | 60.86
Pos 2 (%) | 28.97 | 36.31

The position > 0 acceptance rates are fixed.

