### PR TITLE
[Core] Make sleep-mode backend capability flags communicator-agnostic

### DIFF
--- a/tests/v1/worker/test_sleep_mode_backend.py
+++ b/tests/v1/worker/test_sleep_mode_backend.py
@@ -23,13 +23,13 @@ def test_cumem_is_the_default_registered_backend():
 
 
 def test_cumem_capability_flags():
-    # cumem leaves NCCL untouched but does not preserve compiled artifacts,
-    # graphs, or durable state - these flags are what the executor and /health
-    # introspect to decide reinit / persistence behavior.
+    # cumem leaves communicators untouched but does not preserve compiled
+    # artifacts, graphs, or durable state - these flags are what the executor and
+    # /health introspect to decide reinit / persistence behavior.
     assert CuMemBackend.is_supported() is True
-    assert CuMemBackend.preserves_nccl() is True
+    assert CuMemBackend.preserves_communicators() is True
     assert CuMemBackend.preserves_compiled_artifacts() is False
-    assert CuMemBackend.preserves_graphs_with_nccl() is False
+    assert CuMemBackend.preserves_graphs_with_communicators() is False
     assert CuMemBackend.supports_durable_storage() is False
 
 

--- a/vllm/device_allocator/sleep_mode_backend.py
+++ b/vllm/device_allocator/sleep_mode_backend.py
@@ -81,9 +81,9 @@ class SleepModeBackend(ABC):
         return True
 
     @classmethod
-    def preserves_nccl(cls) -> bool:
-        """If False, NCCL communicators are destroyed by ``suspend`` and the
-        executor must re-initialize them on ``resume``."""
+    def preserves_communicators(cls) -> bool:
+        """If False, collective communicators (e.g. NCCL) are destroyed by
+        ``suspend`` and the executor must re-initialize them on ``resume``."""
         return False
 
     @classmethod
@@ -93,9 +93,10 @@ class SleepModeBackend(ABC):
         return False
 
     @classmethod
-    def preserves_graphs_with_nccl(cls) -> bool:
-        """If True, CUDA graphs containing NCCL collectives stay valid after
-        resume. False when NCCL is rebuilt (embedded comm handles go stale)."""
+    def preserves_graphs_with_communicators(cls) -> bool:
+        """If True, CUDA graphs containing collective communicators (e.g. NCCL)
+        stay valid after resume. False when communicators are rebuilt (embedded
+        comm handles go stale)."""
         return False
 
     @classmethod
@@ -132,9 +133,9 @@ class CuMemBackend(SleepModeBackend):
         self._state = "RUNNING"
 
     @classmethod
-    def preserves_nccl(cls) -> bool:
-        # NCCL buffers live outside CuMemAllocator's pool, so an allocator-level
-        # sleep leaves the communicators intact (no reinit needed on resume).
+    def preserves_communicators(cls) -> bool:
+        # Communicator buffers (e.g. NCCL) live outside CuMemAllocator's pool, so
+        # an allocator-level sleep leaves them intact (no reinit needed on resume).
         return True
 
 


### PR DESCRIPTION
Follow-up to #44074. Renames the two `SleepModeBackend` capability flags that named NCCL specifically, so the interface stays generic across communicator backends:

- `preserves_nccl` → `preserves_communicators`
- `preserves_graphs_with_nccl` → `preserves_graphs_with_communicators`

This addresses @galletas1712's review feedback on #44074 (NVIDIA Dynamo team): NCCL is not the only comms backend in vLLM, so a generic sleep-mode interface shouldn't bake it into the flag names. NCCL is kept as the concrete example in the docstrings.

Behavior is unchanged (the flags are pure classmethods) and they have no callers outside the backend and its unit test yet, so this is a clean rename.