### PR TITLE
[Bugfix][Frontend] Include usage in non-streaming GenerateResponse

### DIFF
--- a/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
@@ -223,6 +223,8 @@ class GenerateResponse(BaseModel):
     )
     choices: list[GenerateResponseChoice]
 
+    usage: UsageInfo | None = Field(default=None)
+
     prompt_logprobs: list[dict[int, Logprob] | None] | None = None
 
     kv_transfer_params: dict[str, Any] | None = Field(

--- a/vllm/entrypoints/scale_out/token_in_token_out/serving.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/serving.py
@@ -4,7 +4,6 @@
 
 import asyncio
 import io
-import time
 from collections.abc import AsyncGenerator
 from collections.abc import Sequence as GenericSequence
 
@@ -246,7 +245,6 @@ class ServingTokens(OpenAIServing):
         model_name: str,
         request_metadata: RequestResponseMetadata,
     ) -> ErrorResponse | GenerateResponse:
-        created_time = int(time.time())
         final_res: RequestOutput | None = None
         sampling_params: SamplingParams = request.sampling_params
 
@@ -320,9 +318,7 @@ class ServingTokens(OpenAIServing):
         request_metadata.final_usage_info = usage
 
         response = GenerateResponse(
-            id=request_id,
-            created=created_time,
-            model=model_name,
+            request_id=request_id,
             choices=choices,
             usage=usage,
             prompt_logprobs=clamp_prompt_logprobs(final_res.prompt_logprobs),


### PR DESCRIPTION
The token-in-token-out `/inference/v1/generate` non-streaming handler builds a `usage` block (including `prompt_tokens_details.cached_tokens` when `--enable-prompt-tokens-details` is set) and passes it to `GenerateResponse(..., usage=usage, ...)`. But `GenerateResponse` never declared a `usage` field and has no `extra="allow"`, so pydantic silently drops it — non-streaming clients never receive token usage or prefix-cache stats. `GenerateStreamResponse` already declares `usage`; this mirrors it on the non-streaming response.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

