### PR TITLE
Fix truncated Qwen3 tool call opener handling

### DIFF
--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -70,6 +70,31 @@ class TestNonStreaming:
         args = json.loads(result.tool_calls[0].function.arguments)
         assert args == {"city": "Tokyo"}
 
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "<tool",
+            "<tool_call",
+        ],
+    )
+    def test_truncated_tool_call_opener_not_emitted(
+        self,
+        parser,
+        mock_request,
+        text,
+    ):
+        """Incomplete tool-call openers should be treated like streamed holdback.
+
+        When generation stops before a full ``<tool_call>`` terminal is emitted,
+        the parser should not leak the partial markup as content or promote it
+        into a tool call.
+        """
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is False
+        assert result.tool_calls == []
+        assert result.content is None
+
     def test_parallel_tool_calls(self, parser, mock_request):
         text = (
             "<tool_call>\n"
@@ -541,6 +566,63 @@ class TestStreaming:
         assert args_text
         parsed = json.loads(args_text)
         assert parsed["x"] == "1"
+
+    @pytest.mark.parametrize(
+        "chunks",
+        [
+            ["<tool"],
+            ["<tool", "_call"],
+        ],
+    )
+    def test_truncated_tool_call_opener_matches_non_streaming(
+        self,
+        parser,
+        mock_tokenizer,
+        mock_request,
+        chunks,
+    ):
+        """Streaming and non-streaming should both drop truncated openers."""
+        current_text = ""
+        deltas = []
+
+        for i, chunk in enumerate(chunks):
+            current_text += chunk
+            is_last = i == len(chunks) - 1
+
+            delta = parser.parse_delta(
+                chunk,
+                [],
+                mock_request,
+                prompt_token_ids=[] if i == 0 else None,
+                finished=is_last,
+            )
+            deltas.append(delta)
+
+        streaming_content = "".join(
+            delta.content for delta in deltas if delta and delta.content
+        )
+        streaming_tool_calls = [
+            tool_call
+            for delta in deltas
+            if delta and delta.tool_calls
+            for tool_call in delta.tool_calls
+        ]
+
+        non_streaming_parser = ParserEngine(
+            mock_tokenizer,
+            parser_engine_config=qwen3_config(thinking=False),
+        )
+        _, non_streaming_content, non_streaming_tool_calls = (
+            non_streaming_parser.parse(
+                current_text,
+                mock_request,
+                enable_auto_tools=True,
+            )
+        )
+
+        assert streaming_content == (non_streaming_content or "")
+        assert streaming_tool_calls == []
+        assert non_streaming_tool_calls is None
 
     def test_char_by_char_streaming(self, mock_request):
         """Feed text character-by-character to test lexer robustness.

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -130,6 +130,9 @@ class ParserEngine(Parser):
         self._strip_content_ws_with_tools = (
             parser_engine_config.strip_content_whitespace_with_tools
         )
+        self._tool_start_prefixes = self._compute_tool_start_prefixes(
+            parser_engine_config
+        )
 
         vocab = self.vocab
         self._reasoning_start_token_id: int | None = None
@@ -194,6 +197,42 @@ class ParserEngine(Parser):
         self._deferred_reasoning = ""
         self._content_has_nonws = False
         self._prompt_streaming_prepared = False
+
+    @staticmethod
+    def _compute_tool_start_prefixes(config: ParserEngineConfig) -> tuple[str, ...]:
+        tool_start_terminals: set[str] = set()
+        for (state, terminal), transition in config.transitions.items():
+            if (
+                state in (ParserState.CONTENT, ParserState.REASONING)
+                and transition.next_state
+                in (
+                    ParserState.TOOL_PREAMBLE,
+                    ParserState.TOOL_NAME,
+                    ParserState.TOOL_ARGS,
+                    ParserState.TOOL_BETWEEN,
+                )
+            ):
+                tool_start_terminals.add(terminal)
+
+        prefixes: set[str] = set()
+        for terminal in tool_start_terminals:
+            terminal_text = config.terminals.get(terminal)
+            if terminal_text is None:
+                continue
+            for prefix_len in range(1, len(terminal_text)):
+                prefixes.add(terminal_text[:prefix_len])
+
+        return tuple(sorted(prefixes, key=len, reverse=True))
+
+    def _strip_truncated_tool_start(self, content: str, finished: bool) -> str:
+        if not finished:
+            return content
+        if self._tool_slots or self._content_has_nonws:
+            return content
+        for prefix in self._tool_start_prefixes:
+            if content == prefix:
+                return ""
+        return content
 
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest
@@ -741,6 +780,7 @@ class ParserEngine(Parser):
             self._deferred_content = ""
 
         content_str = "".join(content_parts)
+        content_str = self._strip_truncated_tool_start(content_str, finished)
 
         if self._content_has_nonws:
             pass


### PR DESCRIPTION
Fixes #47137

## What

- Fix handling of truncated Qwen3 tool-call opener prefixes (e.g. `<tool` and `<tool_call`) when generation ends before the complete opener is emitted.
- Add regression tests covering both streaming and non-streaming parser paths.

## Why

While adding regression tests for #47137, I found that the current implementation still leaks truncated tool opener prefixes as normal content in this scenario. This PR includes a minimal parser fix together with regression coverage.

This is not duplicating #42213: that PR handles streaming stop/terminal flushing for buffered parser content, while this PR specifically fixes Qwen3 truncated tool-call opener prefix handling in `ParserEngine`.

## Testing

Previously run locally:

- `pytest tests/parser/engine/test_qwen3.py -q --confcutdir=tests/parser/engine`
- `pytest tests/parser/engine/test_parser_engine.py -q --confcutdir=tests/parser/engine`
- `pytest tests/parser/engine -q --confcutdir=tests/parser/engine`

After rebasing onto latest `upstream/main`:

- `git diff --check`
- `python -m py_compile vllm/parser/engine/parser_engine.py tests/parser/engine/test_qwen3.py`

Note: Re-running pytest after rebase was blocked by the current Windows environment dependency state (`openai.types.chat.chat_completion_audio` missing in the available conda env).

## AI assistance

AI assistance from OpenAI Codex was used to help prepare this patch. I reviewed the changed lines and ran the tests/checks above.