### PR TITLE
Fix Qwen3.5 text causal LM hybrid support

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1303,6 +1303,14 @@ _MULTIMODAL_EXAMPLE_MODELS = {
         max_model_len=4096,
         min_transformers_version="4.57",
     ),
+    "Qwen3_5ForCausalLM": _HfExamplesInfo(
+        "Qwen/Qwen3.5-0.8B",
+        max_model_len=4096,
+    ),
+    "Qwen3_5MoeForCausalLM": _HfExamplesInfo(
+        "Qwen/Qwen3.5-35B-A3B",
+        max_model_len=4096,
+    ),
     "Qwen3_5ForConditionalGeneration": _HfExamplesInfo(
         "Qwen/Qwen3.5-0.8B",
         max_model_len=4096,

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -66,6 +66,7 @@ from .interfaces import (
     MultiModalEmbeddings,
     SupportsEagle3,
     SupportsLoRA,
+    SupportsMRoPE,
     SupportsPP,
     _require_is_multimodal,
 )
@@ -271,6 +272,8 @@ class Qwen3_5Model(Qwen3NextModel):
 class Qwen3_5ForCausalLMBase(
     nn.Module,
     HasInnerState,
+    IsHybrid,
+    SupportsMRoPE,
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
@@ -362,6 +365,18 @@ class Qwen3_5ForCausalLMBase(
             skip_prefixes=["mtp."],
         )
         return loader.load_weights(weights)
+
+    def get_mrope_input_positions(
+        self,
+        input_tokens: list[int],
+        mm_features: list,
+    ) -> tuple[torch.Tensor, int]:
+        # Text-only Qwen3.5 uses the same token position for all M-RoPE axes.
+        seq_len = len(input_tokens)
+        positions = torch.arange(seq_len, dtype=torch.long).unsqueeze(0).expand(
+            3, seq_len
+        )
+        return positions, 1
 
 
 class Qwen3_5ForCausalLM(Qwen3_5ForCausalLMBase):

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -191,6 +191,8 @@ _TEXT_GENERATION_MODELS = {
     "Qwen2MoeForCausalLM": ("qwen2_moe", "Qwen2MoeForCausalLM"),
     "Qwen3ForCausalLM": ("qwen3", "Qwen3ForCausalLM"),
     "Qwen3MoeForCausalLM": ("qwen3_moe", "Qwen3MoeForCausalLM"),
+    "Qwen3_5ForCausalLM": ("qwen3_5", "Qwen3_5ForCausalLM"),
+    "Qwen3_5MoeForCausalLM": ("qwen3_5", "Qwen3_5MoeForCausalLM"),
     "RWForCausalLM": ("falcon", "FalconForCausalLM"),
     "SarvamMoEForCausalLM": ("sarvam", "SarvamMoEForCausalLM"),
     "SarvamMLAForCausalLM": ("sarvam", "SarvamMLAForCausalLM"),


### PR DESCRIPTION
Register Qwen3.5 text causal LM architectures and make the text causal LM base advertise the hybrid and M-RoPE interfaces it needs to use the existing hybrid cache alignment path.

## Purpose

Fixes #41153.

Qwen3.5 text causal LM models share the hybrid full-attention/GDN layout with the existing Qwen3.5 conditional generation implementation, but `Qwen3_5ForCausalLMBase` did not advertise the hybrid and M-RoPE interfaces.

This PR:

- registers `Qwen3_5ForCausalLM` and `Qwen3_5MoeForCausalLM` as text generation architectures
- makes `Qwen3_5ForCausalLMBase` implement `IsHybrid`
- makes `Qwen3_5ForCausalLMBase` implement `SupportsMRoPE`
- adds text-only M-RoPE position generation for pure text Qwen3.5 inputs
- adds registry examples for the text causal LM architectures

This is intentionally narrower than the TurboQuant page-size work in #39931 / #41123. It wires the Qwen3.5 text causal LM classes into the existing hybrid cache alignment and M-RoPE machinery instead of changing the cache planner.

## Test Plan

- Run Python syntax checks on the modified files.
- Validate the same change in a local vLLM environment by loading a Qwen3.5 text causal LM checkpoint with:
  - `mamba_cache_mode="align"`
  - `enable_prefix_caching=True`
  - `mamba_block_size=16`
- Confirm that vLLM resolves the model as `Qwen3_5ForCausalLM`, initializes KV cache, applies hybrid page-size alignment, and generates tokens.

## Test Result

Local syntax check passed:

```bash
python -m py_compile qwen3_5.py registry.py tests_models_registry.py
```

Local end-to-end validation passed in a vLLM 0.23 environment. The model initialized and generated successfully. Relevant logs:

```text
Resolved architecture: Qwen3_5ForCausalLM
Setting attention block size to 272 tokens to ensure that attention page size is >= mamba page size.
Padding mamba page size by 1.49% to ensure that mamba page size and attention page size are exactly equal.
GPU KV cache size: 716,986 tokens
```

A single prompt generation completed successfully after KV cache initialization.