### PR TITLE
fix(security): validate g_idx bounds in CPU WNA16 GPTQ desc_act kernel

### DIFF
--- a/csrc/cpu/cpu_wna16.cpp
+++ b/csrc/cpu/cpu_wna16.cpp
@@ -317,6 +317,14 @@ void cpu_gemm_wna16(
   bool use_desc_act = g_idx.has_value();
   TORCH_CHECK(!(has_zp && use_desc_act));
 
+  if (use_desc_act && g_idx->numel() > 0) {
+    const auto g_min = g_idx->min().item<int64_t>();
+    const auto g_max = g_idx->max().item<int64_t>();
+    TORCH_CHECK(g_min >= 0 && g_max < group_num,
+                "cpu_gemm_wna16: g_idx values must be in [0, ", group_num,
+                "), got [", g_min, ", ", g_max, "]");
+  }
+
   ISA isa = [&]() {
     if (isa_hint == "amx") {
       return ISA::AMX;

--- a/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
@@ -86,6 +86,19 @@ class CPUWNA16LinearKernel(MPLinearKernel):
         )
         getattr(layer, self.w_q_name).data = weight
 
+        if self.config.has_g_idx and self.w_gidx_name is not None:
+            g_idx_tensor = getattr(layer, self.w_gidx_name)
+            if g_idx_tensor is not None:
+                group_num = getattr(layer, self.w_s_name).size(0)
+                g_min = g_idx_tensor.min().item()
+                g_max = g_idx_tensor.max().item()
+                if g_min < 0 or g_max >= group_num:
+                    raise ValueError(
+                        f"g_idx values must be in [0, {group_num}), "
+                        f"got [{g_min}, {g_max}]. The model checkpoint "
+                        "may be corrupted or malicious."
+                    )
+
     # note assumes that
     #  `weight_packed` is: {input_dim = 0, output_dim = 1, packed_dim = 0}
     #  `weight_scale`  is: {input_dim = 0, output_dim = 1}


### PR DESCRIPTION
Add bounds checking for the g_idx tensor on the CPU WNA16 GPTQ act-order (desc_act) dequantization path to prevent out-of-bounds reads from malicious quantized model checkpoints.
Defense in depth:
- C++ kernel: TORCH_CHECK rejects g_idx values outside [0, group_num) at runtime, converting a potential SIGSEGV into a clean RuntimeError.
- Python loader: validates g_idx range at weight load time in _process_gptq_weights_w4a16(), catching corrupt models early with zero per-forward cost. This mirrors the validation already performed by GPU backends (marlin, exllama, rdna3_w4a16) which sort/validate g_idx during weight loading.