### PR TITLE
Fix symmetric Triton W4A16 qzeros handling

### DIFF
--- a/tests/kernels/quantization/test_triton_w4a16.py
+++ b/tests/kernels/quantization/test_triton_w4a16.py
@@ -302,3 +302,53 @@ def test_triton_w4a16_process_weights_after_loading_repacks_layout():
     torch.testing.assert_close(layer.weight_packed, expected_w_kn8)
     torch.testing.assert_close(layer.weight_scale, expected_scales_gn)
     torch.testing.assert_close(layer.weight_zero_point, expected_zeros_gn8)
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")
+def test_triton_w4a16_symmetric_apply_ignores_qzeros(monkeypatch):
+    from vllm.model_executor.kernels.linear.mixed_precision.MPLinearKernel import (
+        MPLinearLayerConfig,
+    )
+    from vllm.scalar_type import scalar_types
+
+    K, N, G = 256, 256, 32
+    config = MPLinearLayerConfig(
+        full_weight_shape=(K, N),
+        partition_weight_shape=(K, N),
+        weight_type=scalar_types.uint4b8,
+        act_type=torch.float16,
+        group_size=G,
+        zero_points=False,
+        has_g_idx=False,
+    )
+    kernel = TritonW4A16LinearKernel(
+        config,
+        w_q_param_name="qweight",
+        w_s_param_name="scales",
+        w_zp_param_name="qzeros",
+        w_gidx_param_name=None,
+    )
+
+    class DummyLayer(torch.nn.Module):
+        pass
+
+    layer = DummyLayer()
+    layer.qweight = torch.empty((K, N // 8), device=device, dtype=torch.int32)
+    layer.scales = torch.empty((K // G, N), device=device, dtype=torch.float16)
+    layer.qzeros = torch.empty((1, 1), device=device, dtype=torch.int32)
+
+    captured = {}
+
+    def fake_gemm(*, a, b_q, scales, qzeros, group_size, zp_bias):
+        captured["qzeros"] = qzeros
+        captured["zp_bias"] = zp_bias
+        return torch.empty((a.shape[0], N), device=a.device, dtype=a.dtype)
+
+    monkeypatch.setattr(triton_w4a16_module, "triton_w4a16_gemm", fake_gemm)
+
+    x = torch.empty((2, K), device=device, dtype=torch.float16)
+    output = kernel.apply_weights(layer, x)
+
+    assert output.shape == (2, N)
+    assert captured["qzeros"] is None
+    assert captured["zp_bias"] == scalar_types.uint4b8.bias

--- a/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
@@ -420,14 +420,17 @@ class TritonW4A16LinearKernel(MPLinearKernel):
         K = c.partition_weight_shape[0]
         group_size = c.group_size if c.group_size != -1 else K
 
-        # For symmetric types (uint4b8), use the scalar bias; no zeros tensor
+        # For symmetric types (uint4b8), use the scalar bias; no zeros tensor.
+        # Some checkpoint loaders still register qzeros parameters for GPTQ
+        # layers, but they are not part of the symmetric kernel contract.
         zp_bias = c.weight_type.bias if c.weight_type.has_bias() else 0
+        qzeros = None if c.weight_type.has_bias() else w_zp
 
         output = triton_w4a16_gemm(
             a=x_2d,
             b_q=w_q,
             scales=w_s,
-            qzeros=w_zp,
+            qzeros=qzeros,
             group_size=group_size,
             zp_bias=zp_bias,
         )


### PR DESCRIPTION
Fixes #47159

## What

- Ignore registered `qzeros` tensors when the Triton W4A16 kernel is using a symmetric biased weight type such as `uint4b8`.
- Add a regression test that verifies `TritonW4A16LinearKernel.apply_weights` passes `qzeros=None` and uses the scalar zero-point bias for the symmetric path.

## Why

`triton_w4a16_gemm` already supports symmetric quantization via `qzeros=None` plus `zp_bias`. However, some GPTQ loading paths still register a `qzeros` parameter on the layer. Passing that tensor into the symmetric path can trip the kernel-side qzeros shape assertion even though explicit zero points are not part of the symmetric kernel contract.

This PR keeps asymmetric behavior unchanged while ensuring symmetric `uint4b8` uses the intended no-qzeros path.

This is not duplicating an existing PR: I checked open PRs mentioning #47159 and did not find one.

## Testing

- `python -m py_compile vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py tests/kernels/quantization/test_triton_w4a16.py`
- `git diff --check`
- `python -m pytest tests/kernels/quantization/test_triton_w4a16.py -q --confcutdir=tests/kernels/quantization`

The pytest command is ROCm-only and was skipped on my local Windows/CPU environment (`1 skipped`).

## AI assistance

AI assistance from OpenAI Codex was used to help prepare this patch. I reviewed the changed lines and ran the checks above.