### PR TITLE
Add benchmark JSONL append helper

### DIFF
--- a/tests/benchmarks/test_result_jsonl.py
+++ b/tests/benchmarks/test_result_jsonl.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import math
+
+from vllm.benchmarks.lib.utils import append_jsonl_record
+
+
+def test_append_jsonl_record_writes_one_record_per_line(tmp_path):
+    output_file = tmp_path / "benchmarks.jsonl"
+
+    append_jsonl_record(output_file, {"backend": "vllm", "throughput": 1.0})
+    append_jsonl_record(output_file, {"backend": "openai", "throughput": 2.0})
+
+    lines = output_file.read_text(encoding="utf-8").splitlines()
+
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == {"backend": "vllm", "throughput": 1.0}
+    assert json.loads(lines[1]) == {"backend": "openai", "throughput": 2.0}
+
+
+def test_append_jsonl_record_handles_existing_file_without_trailing_newline(
+    tmp_path,
+):
+    output_file = tmp_path / "benchmarks.jsonl"
+    output_file.write_text('{"backend": "vllm"}', encoding="utf-8")
+
+    append_jsonl_record(output_file, {"backend": "openai"})
+
+    lines = output_file.read_text(encoding="utf-8").splitlines()
+
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == {"backend": "vllm"}
+    assert json.loads(lines[1]) == {"backend": "openai"}
+
+
+def test_append_jsonl_record_creates_parent_dirs(tmp_path):
+    output_file = tmp_path / "nested" / "results" / "benchmarks.jsonl"
+
+    append_jsonl_record(output_file, {"backend": "vllm"})
+
+    assert json.loads(output_file.read_text(encoding="utf-8")) == {"backend": "vllm"}
+
+
+def test_append_jsonl_record_encodes_infinity(tmp_path):
+    output_file = tmp_path / "benchmarks.jsonl"
+
+    append_jsonl_record(output_file, {"request_rate": math.inf})
+
+    assert json.loads(output_file.read_text(encoding="utf-8")) == {
+        "request_rate": "inf"
+    }

--- a/vllm/benchmarks/lib/utils.py
+++ b/vllm/benchmarks/lib/utils.py
@@ -6,6 +6,7 @@ import json
 import math
 import os
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
 
 
@@ -118,6 +119,30 @@ def write_to_json(filename: str, records: list) -> None:
             cls=InfEncoder,
             default=lambda o: f"<{type(o).__name__} is not JSON serializable>",
         )
+
+
+def append_jsonl_record(filename: str | Path, record: dict[str, Any]) -> None:
+    """Append one benchmark record to a JSONL file."""
+    path = Path(filename)
+    if path.parent != Path("."):
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    needs_leading_newline = False
+    if path.exists() and path.stat().st_size > 0:
+        with path.open("rb") as f:
+            f.seek(-1, os.SEEK_END)
+            needs_leading_newline = f.read(1) != b"\n"
+
+    with path.open("a", encoding="utf-8") as f:
+        if needs_leading_newline:
+            f.write("\n")
+        json.dump(
+            record,
+            f,
+            cls=InfEncoder,
+            default=lambda o: f"<{type(o).__name__} is not JSON serializable>",
+        )
+        f.write("\n")
 
 
 @contextmanager

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -50,7 +50,11 @@ from vllm.benchmarks.lib.endpoint_request_func import (
     RequestFuncOutput,
 )
 from vllm.benchmarks.lib.ready_checker import wait_for_endpoint
-from vllm.benchmarks.lib.utils import convert_to_pytorch_benchmark_format, write_to_json
+from vllm.benchmarks.lib.utils import (
+    append_jsonl_record,
+    convert_to_pytorch_benchmark_format,
+    write_to_json,
+)
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.gc_utils import freeze_gc_heap
@@ -2272,13 +2276,11 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         assert file_name is not None, (
             "file_name must be set when save_result or append_result is enabled"
         )
-        with open(
-            file_name, mode="a+" if args.append_result else "w", encoding="utf-8"
-        ) as outfile:
-            # Append a newline.
-            if args.append_result and outfile.tell() != 0:
-                outfile.write("\n")
-            json.dump(result_json, outfile)
+        if args.append_result:
+            append_jsonl_record(file_name, result_json)
+        else:
+            with open(file_name, mode="w", encoding="utf-8") as outfile:
+                json.dump(result_json, outfile)
         save_to_pytorch_benchmark_format(args, result_json, file_name)
 
     return result_json


### PR DESCRIPTION
## Purpose

Related to #35639

This PR adds a shared `append_jsonl_record` helper for benchmark result records and uses it in `vllm bench serve --append-result`.

Previously, the append-result JSONL behavior was implemented inline in `serve.py`. This change centralizes the newline and serialization behavior in a reusable benchmark utility, while preserving compatibility with existing append-result files that do not end with a newline.

This is intentionally narrower than #36172, which implements the larger `vllm bench eval` CLI. This PR only improves the existing benchmark result append path and does not duplicate that work.

This PR was prepared with OpenAI Codex assistance.

## Test Plan

- Compile the modified benchmark files.
- Run focused regression tests for the new JSONL append helper.
- Check for whitespace errors.

## Test Result

```text
python -m py_compile vllm/benchmarks/lib/utils.py vllm/benchmarks/serve.py tests/benchmarks/test_result_jsonl.py
passed

git diff --check
passed

python -m pytest tests/benchmarks/test_result_jsonl.py -q --confcutdir=tests/benchmarks
4 passed, 1 warning