### PR TITLE
[ROCm][MiniMax-M3] Defer FFN all-reduce into the next RMSNorm

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -123,9 +123,10 @@ steps:
   - tests/models/test_utils.py
   - tests/models/test_vision.py
   - tests/models/test_adapters.py
+  - tests/models/test_minimax_m3_amd_deferred_allreduce.py
   - tests/models/transformers/fusers/
   commands:
-  - pytest -v -s models/test_utils.py models/test_vision.py models/test_adapters.py models/transformers/fusers/
+  - pytest -v -s models/test_utils.py models/test_vision.py models/test_adapters.py models/test_minimax_m3_amd_deferred_allreduce.py models/transformers/fusers/
 
 - label: ":computer: (CPU) Multimodal Processor Shard %N" # TBD
   timeout_in_minutes: 90

--- a/tests/models/test_minimax_m3_amd_deferred_allreduce.py
+++ b/tests/models/test_minimax_m3_amd_deferred_allreduce.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+import vllm.models.minimax_m3.amd.model as minimax_m3
+import vllm.models.minimax_m3.amd.mtp as minimax_m3_mtp
+
+
+class _Attention(nn.Module):
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+
+    def forward(
+        self, positions: torch.Tensor, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        return hidden_states
+
+
+class _Norm(nn.Module):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            return hidden_states
+        residual = hidden_states + residual
+        return residual + 100, residual
+
+
+class _FFN(nn.Module):
+    def __init__(self, *, reduce_results: bool, **kwargs) -> None:
+        super().__init__()
+        self.down_proj = SimpleNamespace(reduce_results=reduce_results)
+        self.experts = SimpleNamespace(
+            moe_config=SimpleNamespace(skip_final_all_reduce=not reduce_results)
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states
+
+
+class _ReplicatedLinear(nn.Module):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+
+
+class _DeferredLayer(nn.Module):
+    def __init__(self, deferred: bool) -> None:
+        super().__init__()
+        self.fuse_input_allreduce = False
+        self.ffn_all_reduce_deferred = deferred
+
+
+class _FinalDeferredLayer(nn.Module):
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        capture_aux: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert not capture_aux
+        return torch.ones_like(hidden_states), torch.full_like(hidden_states, 10)
+
+
+@pytest.mark.parametrize("force_moe", [False, True], ids=["dense", "moe"])
+@pytest.mark.parametrize(
+    ("pipeline_parallel_size", "is_mtp_block", "expected_deferred"),
+    [
+        pytest.param(1, False, True, id="target-tp-only"),
+        pytest.param(2, False, False, id="pipeline-boundary"),
+        pytest.param(1, True, False, id="mtp-output"),
+    ],
+)
+def test_decoder_defers_only_when_the_next_layer_can_consume_it(
+    monkeypatch,
+    force_moe: bool,
+    pipeline_parallel_size: int,
+    is_mtp_block: bool,
+    expected_deferred: bool,
+) -> None:
+    monkeypatch.setattr(minimax_m3, "MiniMaxM3Attention", _Attention)
+    monkeypatch.setattr(minimax_m3, "MiniMaxM3SparseAttention", _Attention)
+    monkeypatch.setattr(minimax_m3, "MiniMaxM3MLP", _FFN)
+    monkeypatch.setattr(minimax_m3, "MiniMaxM3MoE", _FFN)
+    monkeypatch.setattr(minimax_m3, "MiniMAXGemmaRMSNorm", _Norm)
+    monkeypatch.setattr(minimax_m3, "_sparse_attention_layer_ids", lambda _: ())
+    monkeypatch.setattr(minimax_m3, "_is_moe_layer", lambda *_: False)
+    config = SimpleNamespace(
+        hidden_size=8,
+        dense_intermediate_size=16,
+        rms_norm_eps=1e-6,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_text_config=config),
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(hf_config=config)
+        ),
+        cache_config=None,
+        quant_config=None,
+        parallel_config=SimpleNamespace(pipeline_parallel_size=pipeline_parallel_size),
+    )
+    layer = minimax_m3.MiniMaxM3DecoderLayer(
+        vllm_config=vllm_config,
+        prefix="model.layers.0",
+        force_moe=force_moe,
+        is_mtp_block=is_mtp_block,
+    )
+
+    assert layer.ffn_all_reduce_deferred is expected_deferred
+
+
+def test_mtp_decoder_keeps_its_ffn_output_reduced(monkeypatch) -> None:
+    decoder_kwargs = {}
+
+    class _Decoder(nn.Module):
+        def __init__(self, **kwargs) -> None:
+            super().__init__()
+            decoder_kwargs.update(kwargs)
+
+    monkeypatch.setattr(minimax_m3_mtp, "MiniMaxM3DecoderLayer", _Decoder)
+    monkeypatch.setattr(minimax_m3_mtp, "MiniMAXGemmaRMSNorm", _Norm)
+    monkeypatch.setattr(minimax_m3_mtp, "ReplicatedLinear", _ReplicatedLinear)
+    config = SimpleNamespace(hidden_size=8, rms_norm_eps=1e-6)
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(hf_config=config)
+        ),
+        quant_config=None,
+    )
+
+    minimax_m3_mtp.MiniMaxM3MultiTokenPredictorLayer(vllm_config, "mtp.layers.0")
+
+    assert decoder_kwargs["vllm_config"] is vllm_config
+    assert decoder_kwargs["is_mtp_block"] is True
+
+
+@pytest.mark.parametrize(
+    ("deferred", "expected_input_fusion", "expected_final_fusion"),
+    [
+        pytest.param((True, True), (False, True), True, id="both-deferred"),
+        pytest.param((True, False), (False, True), False, id="first-deferred"),
+        pytest.param((False, True), (False, False), True, id="last-deferred"),
+        pytest.param((False, False), (False, False), False, id="none-deferred"),
+    ],
+)
+def test_model_fusion_schedule_follows_effective_ffn_reduction(
+    deferred: tuple[bool, bool],
+    expected_input_fusion: tuple[bool, bool],
+    expected_final_fusion: bool,
+) -> None:
+    layers = nn.ModuleList([_DeferredLayer(value) for value in deferred])
+    final_fusion = minimax_m3._configure_cross_layer_allreduce(layers, 0, len(layers))
+
+    assert tuple(layer.fuse_input_allreduce for layer in layers) == (
+        expected_input_fusion
+    )
+    assert final_fusion is expected_final_fusion
+
+
+def test_eagle_aux_capture_is_full_and_rank_invariant(monkeypatch) -> None:
+    layer = minimax_m3.MiniMaxM3DecoderLayer.__new__(minimax_m3.MiniMaxM3DecoderLayer)
+    nn.Module.__init__(layer)
+    layer.fuse_input_allreduce = True
+    layer.is_moe_layer = False
+    layer.input_layernorm = _Norm()
+    layer.post_attention_layernorm = _Norm()
+    layer.self_attn = _Attention()
+    layer.mlp = _FFN(reduce_results=False)
+
+    input_residuals: list[torch.Tensor] = []
+    all_rank_sum = torch.full((2, 3), 4.0)
+
+    def fused_allreduce(
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        norm: nn.Module,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        reduced = all_rank_sum if norm is layer.input_layernorm else hidden_states * 4
+        normed, combined = norm(reduced, residual)
+        if norm is layer.input_layernorm:
+            input_residuals.append(combined)
+        return normed, combined
+
+    monkeypatch.setattr(minimax_m3, "fused_allreduce_gemma_rms_norm", fused_allreduce)
+    residual = torch.full((2, 3), 10.0)
+    rank_partials = [torch.ones(2, 3), torch.full((2, 3), 3.0)]
+    aux_hidden_states = []
+    for partial in rank_partials:
+        _, _, aux_hidden_state = layer(
+            torch.arange(2), partial, residual, capture_aux=True
+        )
+        aux_hidden_states.append(aux_hidden_state)
+
+    expected = torch.full((2, 3), 14.0)
+    for aux_hidden_state, input_residual in zip(
+        aux_hidden_states, input_residuals, strict=True
+    ):
+        torch.testing.assert_close(aux_hidden_state, expected)
+        assert aux_hidden_state.data_ptr() != input_residual.data_ptr()
+    torch.testing.assert_close(aux_hidden_states[0], aux_hidden_states[1])
+
+
+def test_eagle_aux_capture_at_final_deferred_boundary(monkeypatch) -> None:
+    model = minimax_m3.MiniMaxM3Model.__new__(minimax_m3.MiniMaxM3Model)
+    nn.Module.__init__(model)
+    model.layers = nn.ModuleList([_FinalDeferredLayer()])
+    model.start_layer = 0
+    model.end_layer = 1
+    model.aux_hidden_state_layers = (1,)
+    model.fuse_final_norm_allreduce = True
+    model.norm = _Norm()
+
+    pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=True)
+    monkeypatch.setattr(minimax_m3, "get_pp_group", lambda: pp_group)
+    full_residuals: list[torch.Tensor] = []
+
+    def fused_allreduce(
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        norm: nn.Module,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        normed, full_residual = norm(hidden_states * 4, residual)
+        full_residuals.append(full_residual)
+        return normed, full_residual
+
+    monkeypatch.setattr(minimax_m3, "fused_allreduce_gemma_rms_norm", fused_allreduce)
+    inputs_embeds = torch.zeros(2, 3)
+    hidden_states, aux_hidden_states = model(
+        input_ids=None,
+        positions=torch.arange(2),
+        intermediate_tensors=None,
+        inputs_embeds=inputs_embeds,
+    )
+
+    expected_residual = torch.full((2, 3), 14.0)
+    torch.testing.assert_close(hidden_states, expected_residual + 100)
+    assert len(aux_hidden_states) == 1
+    torch.testing.assert_close(aux_hidden_states[0], expected_residual)
+    assert aux_hidden_states[0].data_ptr() != full_residuals[0].data_ptr()

--- a/vllm/models/minimax_m3/amd/model.py
+++ b/vllm/models/minimax_m3/amd/model.py
@@ -782,12 +782,17 @@ class MiniMaxM3DecoderLayer(nn.Module):
                 quant_config=quant_config,
                 prefix=f"{prefix}.block_sparse_moe",
             )
+            # Defer the FFN cross-rank all-reduce; it is fused into the next
+            # layer's input_layernorm (or the model's final norm) via
+            # fused_allreduce_gemma_rms_norm, matching the post-attention path.
+            self.block_sparse_moe.experts.moe_config.skip_final_all_reduce = True
         else:
             self.mlp = MiniMaxM3MLP(
                 config=config,
                 intermediate_size=config.dense_intermediate_size,
                 quant_config=quant_config,
                 prefix=f"{prefix}.mlp",
+                reduce_results=False,
             )
 
         # config.use_gemma_norm is True for M3 -> Gemma-style RMSNorm.
@@ -809,7 +814,11 @@ class MiniMaxM3DecoderLayer(nn.Module):
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
         else:
-            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+            # Fuse the previous layer's deferred FFN all-reduce into this
+            # input_layernorm (all-reduce + add residual + GemmaRMSNorm).
+            hidden_states, residual = fused_allreduce_gemma_rms_norm(
+                hidden_states, residual, self.input_layernorm
+            )
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
@@ -916,7 +925,10 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
                 {"hidden_states": hidden_states, "residual": residual}
             )
 
-        hidden_states, _ = self.norm(hidden_states, residual)
+        # The last layer's FFN all-reduce is deferred; fuse it into the final norm.
+        hidden_states, _ = fused_allreduce_gemma_rms_norm(
+            hidden_states, residual, self.norm
+        )
 
         if len(aux_hidden_states) > 0:
             return hidden_states, aux_hidden_states

--- a/vllm/models/minimax_m3/amd/model.py
+++ b/vllm/models/minimax_m3/amd/model.py
@@ -327,6 +327,7 @@ class MiniMaxM3MoE(nn.Module):
         config: PretrainedConfig,
         layer_id: int,
         quant_config: QuantizationConfig | None = None,
+        reduce_results: bool = True,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -448,6 +449,7 @@ class MiniMaxM3MoE(nn.Module):
             ),
             fuse_shared_experts=self.is_fused_shared_expert_enabled,
             quant_config=quant_config,
+            reduce_results=reduce_results,
             prefix=f"{prefix}.experts",
         )
 
@@ -1029,20 +1031,29 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
 class MiniMaxM3DecoderLayer(nn.Module):
     def __init__(
         self,
-        config: PretrainedConfig,
+        *,
+        vllm_config: VllmConfig,
         prefix: str,
-        cache_config: CacheConfig | None = None,
-        quant_config: QuantizationConfig | None = None,
         force_sparse_attn: bool = False,
         force_moe: bool = False,
+        is_mtp_block: bool = False,
         topk_indices_buffer: torch.Tensor | None = None,
     ) -> None:
         super().__init__()
+        if is_mtp_block:
+            assert vllm_config.speculative_config is not None
+            config = vllm_config.speculative_config.draft_model_config.hf_config
+        else:
+            config = vllm_config.model_config.hf_text_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
         self.hidden_size = config.hidden_size
         # DecoderLayers are created with `make_layers` which passes the prefix
         # with the layer's index.
         layer_id = int(prefix.split(sep=".")[-1])
         self.layer_id = layer_id
+
+        self.fuse_input_allreduce = False
 
         is_sparse_attention_layer = (
             force_sparse_attn or layer_id in _sparse_attention_layer_ids(config)
@@ -1068,12 +1079,18 @@ class MiniMaxM3DecoderLayer(nn.Module):
 
         # Dense layers store the FFN under `mlp`; MoE layers under
         # `block_sparse_moe` -- matching the checkpoint's naming.
+        # MTP consumes the output directly and pipeline stages cannot defer a
+        # collective across their boundary, so those paths keep the reduction.
+        reduce_results = (
+            is_mtp_block or vllm_config.parallel_config.pipeline_parallel_size > 1
+        )
         self.is_moe_layer = force_moe or _is_moe_layer(config, layer_id)
         if self.is_moe_layer:
             self.block_sparse_moe = MiniMaxM3MoE(
                 config=config,
                 layer_id=layer_id,
                 quant_config=quant_config,
+                reduce_results=reduce_results,
                 prefix=f"{prefix}.block_sparse_moe",
             )
         else:
@@ -1081,6 +1098,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
                 config=config,
                 intermediate_size=config.dense_intermediate_size,
                 quant_config=quant_config,
+                reduce_results=reduce_results,
                 prefix=f"{prefix}.mlp",
             )
 
@@ -1097,13 +1115,24 @@ class MiniMaxM3DecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+        capture_aux: bool = False,
+    ) -> (
+        tuple[torch.Tensor, torch.Tensor]
+        | tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ):
         # Self Attention
-        if residual is None:
-            residual = hidden_states
-            hidden_states = self.input_layernorm(hidden_states)
+        if self.fuse_input_allreduce and residual is not None:
+            hidden_states, residual = fused_allreduce_gemma_rms_norm(
+                hidden_states, residual, self.input_layernorm
+            )
         else:
-            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+            if residual is None:
+                residual = hidden_states
+                hidden_states = self.input_layernorm(hidden_states)
+            else:
+                hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        aux_hidden_state = residual.clone() if capture_aux else None
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
@@ -1114,7 +1143,26 @@ class MiniMaxM3DecoderLayer(nn.Module):
         )
         ffn = self.block_sparse_moe if self.is_moe_layer else self.mlp
         hidden_states = ffn(hidden_states)
+        if aux_hidden_state is not None:
+            return hidden_states, residual, aux_hidden_state
         return hidden_states, residual
+
+    @property
+    def ffn_all_reduce_deferred(self) -> bool:
+        """Whether this layer leaves its FFN output TP-partial."""
+        if self.is_moe_layer:
+            return self.block_sparse_moe.experts.moe_config.skip_final_all_reduce
+        return not self.mlp.down_proj.reduce_results
+
+
+def _configure_cross_layer_allreduce(
+    layers: nn.ModuleList, start_layer: int, end_layer: int
+) -> bool:
+    prev_defers = False
+    for idx, layer in enumerate(layers[start_layer:end_layer]):
+        layer.fuse_input_allreduce = idx > 0 and prev_defers
+        prev_defers = layer.ffn_all_reduce_deferred
+    return prev_defers
 
 
 class MiniMaxM3Model(nn.Module, EagleModelMixin):
@@ -1124,7 +1172,6 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         super().__init__()
 
         config = vllm_config.model_config.hf_text_config
-        cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
         self.config = config
 
@@ -1159,10 +1206,8 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,
             lambda prefix: MiniMaxM3DecoderLayer(
-                config,
-                prefix,
-                cache_config=cache_config,
-                quant_config=quant_config,
+                vllm_config=vllm_config,
+                prefix=prefix,
                 topk_indices_buffer=self.topk_indices_buffer,
             ),
             prefix=f"{prefix}.layers",
@@ -1179,6 +1224,11 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
             self.norm = PPMissingLayer()
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
+        )
+
+        # Pair each deferred FFN reduction with the next local RMSNorm.
+        self.fuse_final_norm_allreduce = _configure_cross_layer_allreduce(
+            self.layers, self.start_layer, self.end_layer
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
@@ -1202,20 +1252,31 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
-        # EAGLE3 is not yet compatible with pipeline parallel
-        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
-        for idx, layer in enumerate(self.layers[self.start_layer : self.end_layer]):
-            hidden_states, residual = layer(positions, hidden_states, residual)
-            self._maybe_add_hidden_state(
-                aux_hidden_states, idx + 1, hidden_states, residual
-            )
+        aux_hidden_states: list[torch.Tensor] = []
+        for idx in range(self.start_layer, self.end_layer):
+            layer = self.layers[idx]
+            if idx in self.aux_hidden_state_layers:
+                hidden_states, residual, aux_hidden_state = layer(
+                    positions, hidden_states, residual, capture_aux=True
+                )
+                aux_hidden_states.append(aux_hidden_state)
+            else:
+                hidden_states, residual = layer(positions, hidden_states, residual)
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
 
-        hidden_states, _ = self.norm(hidden_states, residual)
+        if self.fuse_final_norm_allreduce:
+            hidden_states, residual = fused_allreduce_gemma_rms_norm(
+                hidden_states, residual, self.norm
+            )
+        else:
+            hidden_states, residual = self.norm(hidden_states, residual)
+
+        if self.end_layer in self.aux_hidden_state_layers:
+            aux_hidden_states.append(residual.clone())
 
         if len(aux_hidden_states) > 0:
             return hidden_states, aux_hidden_states

--- a/vllm/models/minimax_m3/amd/mtp.py
+++ b/vllm/models/minimax_m3/amd/mtp.py
@@ -59,7 +59,6 @@ class MiniMaxM3MultiTokenPredictorLayer(nn.Module):
 
         assert vllm_config.speculative_config is not None
         config = vllm_config.speculative_config.draft_model_config.hf_config
-        cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
 
         self.enorm = MiniMAXGemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -72,12 +71,11 @@ class MiniMaxM3MultiTokenPredictorLayer(nn.Module):
             prefix=f"{prefix}.eh_proj",
         )
         self.transformer_layer = MiniMaxM3DecoderLayer(
-            config=config,
+            vllm_config=vllm_config,
             prefix=prefix,
-            cache_config=cache_config,
-            quant_config=quant_config,
             force_sparse_attn=True,
             force_moe=True,
+            is_mtp_block=True,
         )
         self.final_layernorm = MiniMAXGemmaRMSNorm(
             config.hidden_size, eps=config.rms_norm_eps


### PR DESCRIPTION
## Summary

The AMD MiniMax-M3 target decoder currently reduces every dense/MoE FFN
output inside its producer layer, then launches the next layer's input
GemmaRMSNorm separately.

For tensor-parallel execution without pipeline parallelism, this PR leaves the
FFN output TP-partial and consumes its pending reduction at the next local
input norm through `fused_allreduce_gemma_rms_norm`. The final layer's pending
reduction is consumed by the model's final norm. The schedule follows each
producer's effective reduction setting, so an MoE backend that cannot defer its
reduction is not incorrectly treated as partial.

Runtime changes are limited to the AMD MiniMax-M3 model schedule. The PR also
adds focused tests and AMD CI wiring, but does not add or modify an AITER
kernel.

## Correctness boundaries

- Pipeline-parallel execution keeps FFN reductions enabled; a collective is
  never deferred across a pipeline boundary.
- MTP draft blocks keep their FFN outputs reduced because the draft block
  consumes that output directly.
- Dense and MoE FFNs use the same producer/consumer scheduling rule.
- EAGLE3 auxiliary states are captured only after the pending reduction and
  residual add. This includes the final model boundary, where the final norm
  consumes the last deferred reduction.
- The existing helper fallback remains numerically equivalent to explicit
  `all_reduce` followed by GemmaRMSNorm when no fused backend is available.

## Relationship to existing work

This is not a duplicate of the nearby all-reduce/RMSNorm changes:

- #47631 added the corresponding model-side schedule to the NVIDIA
  MiniMax-M3 implementation and added generic MoE plumbing, but did not modify
  AMD MiniMax-M3.
- #54787 adds ROCm/AITER backend selection inside the generic
  `fused_allreduce_gemma_rms_norm` helper. This PR does not modify that helper
  or AITER; it adds the missing AMD MiniMax-M3 FFN-to-input-norm and
  FFN-to-final-norm call sites. The PRs have no overlapping files.
- #43953 targets compiler-pattern fusion for GemmaRMSNorm graphs, rather than
  MiniMax-M3's explicit cross-layer residual schedule.

Without #54787, this PR remains correct through the helper's explicit
all-reduce fallback, but it does not reduce the ROCm kernel count. The
performance experiments below therefore include #54787 in both baseline and
candidate; only this PR varies between the two arms.

Duplicate-work checks run:

```bash
gh issue view 47270 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open \
  --search "47270 in:body"
gh pr list --repo vllm-project/vllm --state open \
  --search "MiniMax M3 allreduce RMSNorm AMD"
gh pr list --repo vllm-project/vllm --state open \
  --search '"skip_final_all_reduce" "minimax_m3/amd"'
```

No open PR implements this AMD model-side schedule.

## Validation

### Static and focused tests

Validated at PR HEAD `8e4fa7aa6ec0f17174e7551ebf0ceff634179079`:

```bash
cd /home/amd/vllm-pr47270-review

git diff --check upstream/main...HEAD
# PASS

/home/amd/vllm/.venv/bin/pre-commit run \
  --from-ref upstream/main --to-ref HEAD
# PASS

HIP_VISIBLE_DEVICES='' ROCR_VISIBLE_DEVICES='' CUDA_VISIBLE_DEVICES='' \
  VLLM_SOURCE_ROOT=/home/amd/vllm-pr47270-review \
  PYTHONPATH=/home/amd/vllm-pr47270-review \
  /home/amd/vllm/.venv/bin/python -m pytest -p no:cacheprovider -q \
  tests/models/test_minimax_m3_amd_deferred_allreduce.py
# 13 passed, 14 warnings
```

The focused tests cover dense and MoE scheduling, TP-only and
pipeline-parallel boundaries, MTP output ownership, scheduling from the
producer's effective reduction state, final-norm scheduling, rank-invariant
EAGLE3 capture at an intermediate deferred boundary, and EAGLE3 capture after
the final deferred reduction. The test file is included in AMD CI.

### TP4 helper microbenchmark

This isolates the operation that #47270 adds at 60 FFN boundaries when stacked
with #54787. It compares the production-dispatched explicit all-reduce plus
MiniMax-M3 GemmaRMSNorm against the fused helper at BF16 hidden size 7168.

```bash
/home/amd/vllm/mm3_rocm_bench/pr47270_helper_microbench/run.sh
```

Each shape used 200 warmup replays and 500 measured samples, eight rotating
pointer-distinct HIP graphs, alternating candidate order, and the median of
the per-sample maximum across all four TP ranks. Allocation, JIT compilation,
and graph capture were excluded.

| tokens | payload/rank (KiB) | explicit backend | AITER mode | explicit (us) | fused (us) | fused latency delta |
|---:|---:|:---|:---:|---:|---:|---:|
| 1 | 14 | AITER custom AR | one-stage | 22.640 | 19.320 | -14.66% |
| 8 | 112 | AITER custom AR | one-stage | 23.680 | 20.040 | -15.37% |
| 16 | 224 | AITER custom AR | one-stage | 22.561 | 21.920 | -2.84% |
| 32 | 448 | AITER custom AR | two-stage | 24.281 | 25.400 | +4.61% |
| 64 | 896 | AITER custom AR | two-stage | 28.440 | 30.120 | +5.91% |
| 128 | 1,792 | AITER custom AR | two-stage | 36.520 | 39.400 | +7.89% |
| 256 | 3,584 | AITER custom AR | two-stage | 53.521 | 57.881 | +8.15% |

Residual output was bit-exact at every shape; the maximum BF16 normalized
output difference from the explicit path was `0.0078125`.

This is an important limitation, not a claimed win across all batch sizes:
the fused helper is faster in the measured one-stage region, but slower after
AITER changes to its two-stage kernel. Backend selection is owned by #54787,
not by this model-scheduling PR. I reported the crossover and proposed a
vLLM-only one-stage eligibility fallback in
[#54787's discussion](https://github.com/vllm-project/vllm/pull/54787#issuecomment-5519902876).
Keeping that policy in the generic helper fixes both its existing attention
call sites and the FFN call sites added here without duplicating a TP/token
gate in MiniMax-M3.

### Fully warmed TP4 EAGLE3 8k/1k A/B

```bash
cd /home/amd/vllm/mm3_rocm_bench/pr47270_tp4_mtp_8k1k_ab
./run_ab.sh
```

- Baseline `c9cc71a0da0878c5a1d7148e08d16acb9a5b5936`: upstream plus
  #54682, #54845, and #54787.
- Candidate `9c63e7b2c68cac096ae7c6fc79a07ed9ecde4b6c`: the same stack plus
  #47270.
- Single-node TP4 on physical GPUs 0-3; EAGLE3 with three speculative tokens;
  FP8 KV cache; KV offload disabled; 8192 input and 1024 output tokens with
  random-range ratio 0.8.
- Each fresh server completed a discarded c1/c8/c64 conditioning grid,
  followed by a 30-second settle. Each arm then ran three measured repetitions
  per concurrency with a fixed request seed. Each repetition used `10 * c`
  measured prompts and `2 * c` internal warmup prompts.

| concurrency | output tok/s/GPU, baseline | candidate | delta | mean TPOT (ms), baseline -> candidate | delta | mean ITL (ms), baseline -> candidate | delta |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 78.04 | 78.00 | -0.04% | 2.950 -> 2.959 | +0.28% | 8.222 -> 8.016 | -2.51% |
| 8 | 283.75 | 282.14 | -0.57% | 6.540 -> 6.529 | -0.17% | 16.308 -> 16.480 | +1.06% |
| 64 | 688.86 | 681.41 | -1.08% | 21.670 -> 21.872 | +0.93% | 58.539 -> 58.269 | -0.46% |

These repeated serving results are mixed and do **not** establish a robust
end-to-end throughput improvement. Output throughput moved slightly down in
all three arm medians, while TPOT and ITL moved in different directions. The
speculative acceptance medians also differed by `-1.934`, `+1.420`, and
`-0.643` percentage points at c1, c8, and c64 respectively, making output
throughput particularly sensitive to the sampled request behavior. Those
acceptance counters include each measured segment's configured warmup
requests. The paired kernel trace and helper microbenchmark are the stronger
evidence for the specific operation and schedule; they should not be
extrapolated into a serving-throughput claim.

The benchmark stack was captured before the final test-only amendment to this
PR. That amendment adds the final-boundary EAGLE unit test and does not change
the measured runtime source.

### Paired Torch/Kineto GPU trace

```bash
/home/amd/vllm/mm3_rocm_bench/pr47270_tp4_mtp_c1_trace_ab/run_pair.sh
```

Both arms used the same stack and TP4 EAGLE3 c1 configuration as above. Each
fresh server completed two discarded warmup requests, ten complete 8k/1k c1
conditioning requests, and a 30-second settle before one pure-decode target
step was captured. Both uncompressed Chrome JSON traces import directly in
Perfetto and passed the integrity and compactness checks.

| target-forward kernel class | baseline | candidate | delta |
|---|---:|---:|---:|
| explicit cross-device reduction | 61 | 1 | -60 |
| fused all-reduce + GemmaRMSNorm | 60 | 120 | +60 |
| standalone Gemma add + RMSNorm | 60 | 0 | -60 |
| plain initial GemmaRMSNorm | 1 | 1 | 0 |

This is exact structural evidence for the intended transformation: 59
FFN-to-next-layer boundaries and the final FFN-to-model-norm boundary each
change from two launches to one fused launch. Total GPU kernel count was 1,155
for the baseline and 1,097 for the candidate. The total delta is -58 rather
than -60 because the two live requests reached slightly different sequence
lengths and launched different scheduler/cache housekeeping kernels; the four
model-boundary counts above are exact.

The traces are compact:

| trace check | baseline | candidate |
|---|---:|---:|
| minimum decode-window GPU busy fraction | 91.26% | 91.38% |
| p99 inter-kernel gap | 30.818 us | 36.521 us |
| maximum inter-kernel gap | 139.402 us | 110.762 us |
| longest true reduction | 11.399 us | 11.320 us |

The candidate's target-forward annotation/core in the captured step was
375.489 us (4.73%) shorter (7,938.158 us to 7,562.669 us). The full decode
window span was 380.411 us (4.02%) shorter (9,462.932 us to 9,082.521 us).
These are diagnostic one-step trace observations, not throughput results; the
repeated unprofiled A/B above remains authoritative for end-to-end behavior.

The baseline's initial capture-time status was a false failure because the
analyzer did not classify vLLM's local `_rocm_fp32_router_gemm_kernel` symbol
as the MoE-router sentinel. The trace was not modified or recaptured. After
correcting only that analysis classification, both immutable traces passed
Perfetto import, integrity, layer-count, and compactness validation.

### Model evaluation: GSM8K

```bash
/home/amd/vllm/mm3_rocm_bench/pr47270_tp4_gsm8k_eval/run.sh
```

The same TP4 EAGLE3 candidate stack completed the full public GSM8K test split
at concurrency 64: 1,319 examples, 5-shot, greedy (`temperature=0`,
`top_p=1`), and `max_tokens=2048`.

| filter | correct | accuracy |
|---|---:|---:|
| strict match | 1,246 / 1,319 | **0.944655** |
| flexible extract | 1,245 / 1,319 | **0.943897** |

The strict audit found all 1,319 unique document IDs, no unrecoverable
malformed records, no API errors, and no retries; it repaired two records split
by literal newlines. Both reported scores exactly matched independent
recomputation from the sample log. No inference-time JIT compilation was
reported in the full-evaluation server window. The server stopped and released
all GPU memory on physical GPUs 0-3.

The evaluation stack contains #47270 as commit
`8f042bccd5f11416353825252f3e2dee396176b7`. Its runtime patch for
`model.py` and `mtp.py` is byte-for-byte identical to current PR HEAD
`8e4fa7aa6ec0f17174e7551ebf0ceff634179079` (identical patch-stream SHA-256
`d276aef0b039e625d6045dc115d9ba9f3fbf7f6ce477382adcc2dd4461610d5b`).
The current PR HEAD additionally contains the final-boundary EAGLE3 unit test.

## AI assistance and submitter accountability

AI assistance from OpenAI Codex and Claude was used for code analysis,
implementation, test development, benchmarking, trace analysis, and drafting
this description.

Before marking this PR ready, the human submitter must review every changed
line, verify the commands and results above, and be able to explain and defend
the change end to end.
