### PR TITLE
[Bugfix][Model] Harden DiffusionGemma self-conditioning matmul against torch.compile shape mismatch (#47129)

### DIFF
--- a/tests/model_executor/test_diffusion_gemma.py
+++ b/tests/model_executor/test_diffusion_gemma.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for DiffusionGemma sampler helpers."""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.model_executor.models.diffusion_gemma import (
+    DiffusionSampler,
+    _compiled_sample_step,
+)
+
+
+def test_compiled_sample_step_self_conditioning_matmul():
+    """``_compiled_sample_step`` should not crash on the self-conditioning
+    matmul that previously failed under ``torch.compile`` when
+    ``embed_weight`` and ``probs`` had mismatched vocab dimensions.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/47129.
+    """
+    num_decode = 2
+    num_reqs = 3
+    max_num_reqs = 4
+    CL = 8
+    vocab = 16
+    hidden = 8
+    ST = 2
+    device = "cpu"
+
+    logits = torch.randn(num_decode * CL, vocab, device=device)
+    decode_slots = torch.arange(num_decode, device=device, dtype=torch.int64)
+    decode_idx = torch.arange(num_decode, device=device, dtype=torch.int64)
+    all_slots = torch.arange(num_reqs, device=device, dtype=torch.int64)
+    valid_canvas_len = torch.full(
+        (num_decode,), CL, device=device, dtype=torch.int64
+    )
+    canvas = torch.zeros(max_num_reqs, CL, device=device, dtype=torch.int64)
+    argmax_canvas = torch.zeros(
+        max_num_reqs, CL, device=device, dtype=torch.int64
+    )
+    step_tensor = torch.zeros(max_num_reqs, device=device, dtype=torch.int32)
+    is_encoder_phase = torch.zeros(
+        max_num_reqs, device=device, dtype=torch.bool
+    )
+    confident_tensor = torch.zeros(
+        max_num_reqs, device=device, dtype=torch.bool
+    )
+    sc_embeds = torch.zeros(
+        max_num_reqs, CL, hidden, device=device, dtype=torch.float32
+    )
+    local_embed_weight = torch.randn(vocab, hidden, device=device)
+    normalizer = torch.tensor(1.0, device=device)
+    history = torch.zeros(
+        max_num_reqs, ST, CL, device=device, dtype=torch.int64
+    )
+    history_len_tensor = torch.zeros(
+        max_num_reqs, device=device, dtype=torch.int32
+    )
+    sampled = torch.zeros(num_reqs, CL, device=device, dtype=torch.int32)
+    num_sampled = torch.zeros(num_reqs, device=device, dtype=torch.int32)
+    draft_tokens = torch.zeros(
+        max_num_reqs, CL, device=device, dtype=torch.int64
+    )
+
+    scaled = _compiled_sample_step(
+        logits,
+        decode_slots,
+        decode_idx,
+        all_slots,
+        valid_canvas_len,
+        canvas,
+        argmax_canvas,
+        step_tensor,
+        is_encoder_phase,
+        confident_tensor,
+        sc_embeds,
+        local_embed_weight,
+        normalizer,
+        history,
+        history_len_tensor,
+        sampled,
+        num_sampled,
+        draft_tokens,
+        max_denoising_steps=16.0,
+        t_min=0.0,
+        t_max=1.0,
+        confidence_threshold=10.0,
+        vocab_size=vocab,
+        CL=CL,
+        ST=ST,
+        entropy_bound=0.1,
+        sc_vocab_start=0,
+        sc_vocab_end=vocab,
+        tp_size=1,
+        tp_group_name="",
+    )
+
+    assert scaled.shape == (num_decode, CL, vocab)
+    # Self-conditioning embeddings should have been written for the decode
+    # slots (all of them, because we left is_encoder_phase as False and the
+    # function treated every slot as a denoise step).
+    assert sc_embeds[decode_slots].abs().sum() > 0
+
+
+def test_diffusion_sampler_pre_slices_embed_weight():
+    """``DiffusionSampler`` should pre-slice ``embed_weight`` once at init
+    and reject an embedding that is smaller than the expected shard size.
+    """
+    mock_sampler = MagicMock()
+    mock_sampler.sampling_states = MagicMock()
+    mock_sampler.req_states = MagicMock()
+    mock_diffusion_states = MagicMock()
+    mock_diffusion_states.max_num_reqs = 4
+    mock_diffusion_states.device = torch.device("cpu")
+
+    vocab = 16
+    hidden = 8
+    embed_weight = torch.randn(vocab, hidden)
+
+    sampler = DiffusionSampler(
+        sampler=mock_sampler,
+        diffusion_config=None,
+        vocab_size=vocab,
+        diffusion_states=mock_diffusion_states,
+        confidence_threshold=10.0,
+        t_min=0.0,
+        t_max=1.0,
+        entropy_bound=0.1,
+        embed_weight=embed_weight,
+        normalizer=torch.tensor(1.0),
+        sc_vocab_start=0,
+        sc_vocab_end=vocab,
+        tp_size=1,
+        tp_group_name="",
+    )
+
+    assert sampler.local_embed_weight.shape == (vocab, hidden)
+    assert sampler.local_embed_weight.data_ptr() == embed_weight.data_ptr()
+
+    # A shard size larger than the weight should fail at init time rather
+    # than inside the compiled step.
+    with pytest.raises(ValueError, match="self-conditioning shard size"):
+        DiffusionSampler(
+            sampler=mock_sampler,
+            diffusion_config=None,
+            vocab_size=vocab,
+            diffusion_states=mock_diffusion_states,
+            confidence_threshold=10.0,
+            t_min=0.0,
+            t_max=1.0,
+            entropy_bound=0.1,
+            embed_weight=embed_weight,
+            normalizer=torch.tensor(1.0),
+            sc_vocab_start=0,
+            sc_vocab_end=vocab + 4,
+            tp_size=1,
+            tp_group_name="",
+        )

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -482,7 +482,7 @@ def _compiled_sample_step(
     is_encoder_phase: torch.Tensor,  # [max_num_reqs]
     confident_tensor: torch.Tensor,  # [max_num_reqs]
     sc_embeds: torch.Tensor,  # [max_num_reqs, CL, hidden]
-    embed_weight: torch.Tensor,  # [vocab, hidden]
+    local_embed_weight: torch.Tensor,  # [vocab_shard, hidden]
     normalizer: torch.Tensor,
     history: torch.Tensor,  # [max_num_reqs, ST, CL]
     history_len_tensor: torch.Tensor,  # [max_num_reqs]
@@ -501,8 +501,9 @@ def _compiled_sample_step(
     # Sampler config
     entropy_bound: float,
     # Tensor-parallel vocab sharding for the self-conditioning matmul.
-    # ``embed_weight`` is vocab-sharded ([vocab/tp, hidden]) while ``probs``
-    # spans the full vocab; [sc_vocab_start, sc_vocab_end) is this rank's slice.
+    # ``local_embed_weight`` is the pre-sliced vocab shard ([vocab/tp, hidden])
+    # while ``probs`` spans the full vocab; [sc_vocab_start, sc_vocab_end) is
+    # this rank's slice.
     sc_vocab_start: int,
     sc_vocab_end: int,
     tp_size: int,
@@ -641,10 +642,10 @@ def _compiled_sample_step(
     # parallelism the embedding is vocab-sharded ([vocab/tp, hidden]) while
     # probs spans the full vocab, so each rank multiplies its local vocab slice
     # [sc_vocab_start, sc_vocab_end) and the partials are summed across ranks.
-    local_probs = probs[..., sc_vocab_start:sc_vocab_end].to(embed_weight.dtype)
-    soft_embeds = torch.matmul(
-        local_probs, embed_weight[: sc_vocab_end - sc_vocab_start]
-    )
+    # The caller pre-slices ``local_embed_weight`` so the compiled region sees
+    # a single constant-shape tensor and never needs to slice a Parameter.
+    local_probs = probs[..., sc_vocab_start:sc_vocab_end].to(local_embed_weight.dtype)
+    soft_embeds = torch.matmul(local_probs, local_embed_weight)
     if tp_size > 1:
         soft_embeds = torch.ops.vllm.all_reduce(soft_embeds, group_name=tp_group_name)
     soft_embeds = soft_embeds * normalizer
@@ -1076,6 +1077,16 @@ class DiffusionSampler:
         self.sc_vocab_end = sc_vocab_end if sc_vocab_end is not None else vocab_size
         self.tp_size = tp_size
         self.tp_group_name = tp_group_name
+        # Pre-slice the embedding shard outside the compiled step. This keeps
+        # the slice (a view over a Parameter) out of the torch.compile region,
+        # avoiding any symbolic-shape confusion on the matmul reduction dim.
+        shard_size = self.sc_vocab_end - self.sc_vocab_start
+        if embed_weight.shape[0] < shard_size:
+            raise ValueError(
+                f"embed_weight has {embed_weight.shape[0]} rows but "
+                f"self-conditioning shard size is {shard_size}"
+            )
+        self.local_embed_weight = embed_weight[:shard_size]
         self.canvas_length = (
             diffusion_config.canvas_length if diffusion_config is not None else 32
         )
@@ -1297,7 +1308,7 @@ class DiffusionSampler:
             states.is_encoder_phase,
             states.confident,
             states.self_conditioning_embeds,
-            self.embed_weight,
+            self.local_embed_weight,
             self.normalizer,
             states.accepted_canvas_history,
             states.accepted_canvas_history_len,


### PR DESCRIPTION
### Problem

Issue #47129 reports that `DiffusionGemma` fails during warmup when `torch.compile` traces `_compiled_sample_step`. The failure is a matmul shape mismatch in the self-conditioning path:

```text
RuntimeError: a and b must have same reduction dim, but got
[s23*((s88//s23)), s3] X [131072, 2816].
```

The root cause is that the compiled region sliced `embed_weight` (a `Parameter`) with a dynamic-shape-dependent expression (`embed_weight[: sc_vocab_end - sc_vocab_start]`). Depending on how Dynamo materialises fake tensors for `probs` and `embed_weight`, the reduction dimensions can be seen as mismatched, especially under tensor parallelism where `probs` spans the full vocab but `embed_weight` is a vocab-sharded view.

### Fix

Move the embedding shard slicing **out of the compiled region**:

1. In `DiffusionSampler.__init__`, pre-compute `local_embed_weight = embed_weight[:shard_size]` once.
2. Add an init-time guard that raises a clear `ValueError` if the weight has fewer rows than the expected shard size.
3. Pass `local_embed_weight` (already the correct shape) into `_compiled_sample_step` and use it directly in `torch.matmul`, removing the slice from the compiled graph.

This keeps the slice (a view over a `Parameter`) out of the `torch.compile` region, so Dynamo sees a single constant-shape tensor for the matmul and cannot confuse the reduction dimension.

### Code changes

- `vllm/model_executor/models/diffusion_gemma.py`
  - `_compiled_sample_step`: rename `embed_weight` parameter to `local_embed_weight`, remove inline slice.
  - `DiffusionSampler.__init__`: pre-slice and validate `local_embed_weight`.
  - `DiffusionSampler.__call__`: pass `self.local_embed_weight` into the compiled step.
- `tests/model_executor/test_diffusion_gemma.py` (new)
  - Regression test that calls `_compiled_sample_step` on CPU and asserts the self-conditioning matmul runs and writes `sc_embeds`.
  - Unit test verifying `DiffusionSampler` pre-slices `embed_weight` and rejects weights smaller than the shard size.

### Test commands

```bash
# Unit tests for the sampler helpers
.venv/bin/python -m pytest tests/model_executor/test_diffusion_gemma.py -v
```

### Checklist

- [x] Made minimal, focused changes.
- [x] Added regression test for the reported shape mismatch.
- [x] Verified Python syntax with `py_compile`.
- [x] Full GPU/TP run of the reproduction command from the issue (requires `diffusiongemma-26B-A4B` weights and 2x GPU).

### Related issue

Closes #47129

---
