### PR TITLE
[Feature] implement return indexer topk of sparse attention

### DIFF
--- a/tests/entrypoints/openai/test_return_indexer_topk.py
+++ b/tests/entrypoints/openai/test_return_indexer_topk.py
@@ -18,16 +18,17 @@ The GPU memory fraction can be tuned via ``VLLM_TEST_GPU_MEMORY_UTILIZATION``
 (defaults to 0.5).
 """
 
-import base64
 import io
 import os
 
 import numpy as np
+import pybase64 as base64
 import pytest
 
-from ...utils import RemoteOpenAIServer
 from vllm.platforms import current_platform
 from vllm.utils.import_utils import has_deep_gemm
+
+from ...utils import RemoteOpenAIServer
 
 # DeepSeek-V3.2 carries a SparseAttnIndexer in every backbone layer when
 # ``index_topk`` is set. Shrink the model so it fits in CI:

--- a/tests/entrypoints/openai/test_return_indexer_topk.py
+++ b/tests/entrypoints/openai/test_return_indexer_topk.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end tests for ``--enable-return-indexer-topk``.
+
+Verifies that the OpenAI-compatible endpoints (``/v1/completions`` and
+``/v1/chat/completions``) return per-token sparse-attention indexer topk
+indices when the server is launched with ``--enable-return-indexer-topk``.
+
+The indices are base64-encoded ``.npy`` bytes; after decoding the ndarray
+has shape ``(num_tokens, num_indexer_layers, index_topk)`` and dtype
+``int32`` (see :class:`IndexerTopkManager`).
+
+Only models with :class:`SparseAttnIndexer` layers (DeepSeek-V32 / V4)
+emit indexer topk. To keep the test CI-friendly we launch
+``deepseek-ai/DeepSeek-V3.2`` with ``--load-format dummy`` (random weights)
+and shrink it via ``--hf-overrides`` to a tiny 2-layer / 128-hidden config.
+The GPU memory fraction can be tuned via ``VLLM_TEST_GPU_MEMORY_UTILIZATION``
+(defaults to 0.5).
+"""
+
+import base64
+import io
+import os
+
+import numpy as np
+import pytest
+
+from ...utils import RemoteOpenAIServer
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_deep_gemm
+
+# DeepSeek-V3.2 carries a SparseAttnIndexer in every backbone layer when
+# ``index_topk`` is set. Shrink the model so it fits in CI:
+#   - 2 hidden layers  -> 2 indexer layers (default freq=1, offset=2
+#     still produces an indexer in every layer because
+#     max(layer_id - offset + 1, 0) % freq == 0 for all layer ids).
+#   - index_topk=128 keeps the per-token payload small (smallest value
+#     that still exercises multi-slot selection).
+#   - hidden_size=128 / intermediate=256 / 2 experts keeps memory tiny.
+#   - num_experts_per_tok=2 must be <= n_routed_experts.
+SMALL_V32_OVERRIDES = {
+    "num_hidden_layers": 2,
+    "hidden_size": 128,
+    "intermediate_size": 256,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 1,
+    "n_routed_experts": 2,
+    "num_experts_per_tok": 2,
+    "index_topk": 128,
+}
+
+MODEL_NAME = "deepseek-ai/DeepSeek-V3.2"
+NUM_INDEXER_LAYERS = 2
+INDEX_TOPK = 128
+
+# Allow CI / developers to override the GPU memory fraction used by the
+# server. Default 0.5 is conservative enough for H100 80GB but small enough
+# to coexist with other GPU processes on smaller cards.
+DEFAULT_GPU_MEM_UTIL = float(os.environ.get("VLLM_TEST_GPU_MEMORY_UTILIZATION", "0.5"))
+
+# SparseAttnIndexer currently requires CUDA + DeepGEMM (Hopper+).
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda() or not has_deep_gemm(),
+    reason="indexer_topk e2e test requires CUDA with DeepGEMM (Hopper+).",
+)
+
+
+@pytest.fixture(scope="module")
+def server():
+    args = [
+        "--max-model-len",
+        "1024",
+        "--max-num-seqs",
+        "4",
+        "--enforce-eager",
+        "--load-format",
+        "dummy",
+        "--trust-remote-code",
+        "--enable-return-indexer-topk",
+        "--gpu-memory-utilization",
+        str(DEFAULT_GPU_MEM_UTIL),
+    ]
+    with RemoteOpenAIServer(
+        MODEL_NAME,
+        args,
+        override_hf_configs=SMALL_V32_OVERRIDES,
+    ) as remote_server:
+        yield remote_server
+
+
+def _decode_indexer_topk(b64: str) -> np.ndarray:
+    """Decode the base64 ``.npy`` payload returned by the server."""
+    return np.load(io.BytesIO(base64.b64decode(b64)))
+
+
+@pytest.mark.asyncio
+async def test_indexer_topk_completions(server):
+    """``/v1/completions`` returns base64 indexer_topk with valid shape."""
+    async with server.get_async_client() as client:
+        result = await client.completions.create(
+            model=MODEL_NAME,
+            prompt="Hello, world",
+            max_tokens=5,
+            temperature=0,
+            extra_body={
+                "return_token_ids": True,
+                # Request indexer topk for the full prompt + generated tokens.
+                "indexer_topk_prompt_start": 0,
+            },
+        )
+
+        choice = result.model_dump()["choices"][0]
+
+        # Field must exist and be populated when the flag is enabled.
+        assert choice["indexer_topk"] is not None, (
+            "indexer_topk is None; ensure --enable-return-indexer-topk is set "
+            "and the model has SparseAttnIndexer layers."
+        )
+        assert choice["token_ids"] is not None
+
+        indexer_topk = _decode_indexer_topk(choice["indexer_topk"])
+
+        # Shape contract: (num_tokens, num_indexer_layers, index_topk).
+        assert indexer_topk.ndim == 3
+        num_tokens, num_indexer_layers, index_topk = indexer_topk.shape
+        # prompt (>=1) + generated tokens (5)
+        assert num_tokens > 0
+        assert num_indexer_layers == NUM_INDEXER_LAYERS
+        assert index_topk == INDEX_TOPK
+
+        # dtype is int32 (KV slot indices can exceed 65535).
+        assert indexer_topk.dtype == np.int32
+
+        # KV-slot indices are non-negative; -1 is the documented "no valid
+        # slot" sentinel used by the top-k kernels (see
+        # ``sparse_attn_indexer.py`` and ``dcp_indexer_cutedsl.py``). When the
+        # sequence is shorter than ``index_topk``, unfilled positions remain
+        # -1, so we require at least one valid index rather than all.
+        assert (indexer_topk >= 0).any(), (
+            "Expected at least one valid (non-negative) indexer_topk entry, "
+            "but all values are -1 sentinels."
+        )
+
+
+@pytest.mark.asyncio
+async def test_indexer_topk_chat_completions(server):
+    """``/v1/chat/completions`` also surfaces indexer_topk."""
+    async with server.get_async_client() as client:
+        result = await client.chat.completions.create(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "What is 2+2?"}],
+            max_tokens=5,
+            temperature=0,
+            extra_body={
+                "return_token_ids": True,
+                "indexer_topk_prompt_start": 0,
+            },
+        )
+
+        choice = result.model_dump()["choices"][0]
+        assert choice["indexer_topk"] is not None
+
+        indexer_topk = _decode_indexer_topk(choice["indexer_topk"])
+        assert indexer_topk.ndim == 3
+        assert indexer_topk.shape[0] > 0
+        assert indexer_topk.shape[1] == NUM_INDEXER_LAYERS
+        assert indexer_topk.shape[2] == INDEX_TOPK
+        assert indexer_topk.dtype == np.int32
+        # -1 is the expected sentinel for unfilled top-k positions.
+        assert (indexer_topk >= 0).any(), (
+            "Expected at least one valid (non-negative) indexer_topk entry."
+        )
+
+
+@pytest.mark.asyncio
+async def test_indexer_topk_prompt_start_offset(server):
+    """``indexer_topk_prompt_start`` trims the leading prompt tokens."""
+    prompt = "The quick brown fox jumps over the lazy dog."
+    prompt_start = 4
+
+    async with server.get_async_client() as client:
+        full = await client.completions.create(
+            model=MODEL_NAME,
+            prompt=prompt,
+            max_tokens=3,
+            temperature=0,
+            extra_body={"indexer_topk_prompt_start": 0},
+        )
+        trimmed = await client.completions.create(
+            model=MODEL_NAME,
+            prompt=prompt,
+            max_tokens=3,
+            temperature=0,
+            extra_body={"indexer_topk_prompt_start": prompt_start},
+        )
+
+        full_topk = _decode_indexer_topk(
+            full.model_dump()["choices"][0]["indexer_topk"]
+        )
+        trimmed_topk = _decode_indexer_topk(
+            trimmed.model_dump()["choices"][0]["indexer_topk"]
+        )
+
+        # The trimmed output should drop exactly `prompt_start` tokens
+        # from the leading prompt (same number of generated tokens).
+        assert full_topk.shape[0] - trimmed_topk.shape[0] == prompt_start
+        # Layer / index_topk dimensions are unaffected.
+        assert full_topk.shape[1:] == trimmed_topk.shape[1:]

--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -287,6 +287,8 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.vllm_config = Mock()
     scheduler.vllm_config.model_config.enable_return_routed_experts = False
     scheduler.enable_return_routed_experts = False
+    scheduler.vllm_config.model_config.enable_return_indexer_topk = False
+    scheduler.enable_return_indexer_topk = False
     scheduler.recompute_kv_load_failures = False
     scheduler.defer_block_free = False
     scheduler.make_stats = Mock(return_value=None)

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3181,6 +3181,8 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.vllm_config = Mock()
     scheduler.vllm_config.model_config.enable_return_routed_experts = False
     scheduler.enable_return_routed_experts = False
+    scheduler.vllm_config.model_config.enable_return_indexer_topk = False
+    scheduler.enable_return_indexer_topk = False
     scheduler.recompute_kv_load_failures = False
     scheduler.defer_block_free = False
     scheduler.make_stats = Mock(return_value=None)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -221,6 +221,10 @@ class ModelConfig:
     flexibility."""
     enable_return_routed_experts: bool = False
     """Whether to return routed experts."""
+    enable_return_indexer_topk: bool = False
+    """Whether to return indexer topk indices (sparse-attention selected KV
+    slots) with responses. Only applicable to models with sparse attention
+    indexers (e.g. DeepSeek-V32/V4)."""
     max_logprobs: int = Field(default=20, ge=-1)
     """Maximum number of log probabilities to return when `logprobs` is
     specified in `SamplingParams`. The default value comes the default for the

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -974,6 +974,24 @@ class VllmConfig:
                     "connectors (PD disaggregation, KV cache offload)."
                 )
 
+        if (
+            self.model_config is not None
+            and self.model_config.enable_return_indexer_topk
+        ):
+            if self.parallel_config.pipeline_parallel_size > 1:
+                raise ValueError(
+                    "--enable-return-indexer-topk is incompatible with "
+                    "pipeline parallelism (PP > 1)."
+                )
+            if (
+                self.kv_transfer_config is not None
+                and self.kv_transfer_config.is_kv_transfer_instance
+            ):
+                raise ValueError(
+                    "--enable-return-indexer-topk is incompatible with KV "
+                    "connectors (PD disaggregation, KV cache offload)."
+                )
+
         if self.lora_config is not None:
             self.lora_config.verify_with_model_config(self.model_config)
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -419,6 +419,7 @@ class EngineArgs:
 
     model: str = ModelConfig.model
     enable_return_routed_experts: bool = ModelConfig.enable_return_routed_experts
+    enable_return_indexer_topk: bool = ModelConfig.enable_return_indexer_topk
     model_weights: str = ModelConfig.model_weights
     served_model_name: str | list[str] | None = ModelConfig.served_model_name
     tokenizer: str | None = ModelConfig.tokenizer
@@ -837,6 +838,10 @@ class EngineArgs:
         model_group.add_argument(
             "--enable-return-routed-experts",
             **model_kwargs["enable_return_routed_experts"],
+        )
+        model_group.add_argument(
+            "--enable-return-indexer-topk",
+            **model_kwargs["enable_return_indexer_topk"],
         )
         model_group.add_argument("--max-logprobs", **model_kwargs["max_logprobs"])
         model_group.add_argument("--logprobs-mode", **model_kwargs["logprobs_mode"])
@@ -1652,6 +1657,7 @@ class EngineArgs:
             allow_deprecated_quantization=self.allow_deprecated_quantization,
             enforce_eager=self.enforce_eager,
             enable_return_routed_experts=self.enable_return_routed_experts,
+            enable_return_indexer_topk=self.enable_return_indexer_topk,
             max_logprobs=self.max_logprobs,
             logprobs_mode=self.logprobs_mode,
             use_fp64_gumbel=self.use_fp64_gumbel,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -140,6 +140,9 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             disable CUDA graph and always execute the model in eager mode.
             If False, we will use CUDA graph and eager execution in hybrid.
         enable_return_routed_experts: Whether to return routed experts.
+        enable_return_indexer_topk: Whether to return indexer topk indices
+            (sparse-attention selected KV slots) with responses. Only
+            applicable to models with sparse attention indexers.
         disable_custom_all_reduce: See
             [ParallelConfig][vllm.config.ParallelConfig].
         hf_token: The token to use as HTTP bearer authorization for remote files
@@ -200,6 +203,7 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
         offload_params: set[str] | None = None,
         enforce_eager: bool = False,
         enable_return_routed_experts: bool = False,
+        enable_return_indexer_topk: bool = False,
         disable_custom_all_reduce: bool = False,
         hf_token: bool | str | None = None,
         hf_overrides: HfOverrides | None = None,
@@ -316,6 +320,7 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             offload_params=offload_params or set(),
             enforce_eager=enforce_eager,
             enable_return_routed_experts=enable_return_routed_experts,
+            enable_return_indexer_topk=enable_return_indexer_topk,
             disable_custom_all_reduce=disable_custom_all_reduce,
             hf_token=hf_token,
             hf_overrides=hf_overrides,

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -111,6 +111,15 @@ class ChatCompletionResponseChoice(OpenAIBaseModel):
     # or (b) ``enable_return_routed_experts`` is off server-side.
     routed_experts: str | None = None
 
+    # Per-token indexer topk indices (sparse-attention selected KV
+    # slots), base64-encoded ``.npy`` bytes. Shape after decode:
+    #   (num_tokens, num_indexer_layers, index_topk)  dtype int32
+    # Decode:
+    #   np.load(io.BytesIO(base64.b64decode(s)))
+    # ``None`` if (a) the request was aborted before any forward pass,
+    # or (b) ``enable_return_indexer_topk`` is off server-side.
+    indexer_topk: str | None = None
+
 
 class ChatCompletionResponse(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"chatcmpl-{random_uuid()}")

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -406,6 +406,22 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "need to map generated text back to input tokens."
         ),
     )
+    routed_experts_prompt_start: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When enable_return_routed_experts is active, skip the first "
+            "N prompt tokens from the returned routing data."
+        ),
+    )
+    indexer_topk_prompt_start: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When enable_return_indexer_topk is active, skip the first "
+            "N prompt tokens from the returned indexer topk indices."
+        ),
+    )
     return_token_offsets: bool | None = Field(
         default=False,
         description=(
@@ -707,6 +723,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone
             repetition_detection=self.repetition_detection,
+            routed_experts_prompt_start=self.routed_experts_prompt_start,
+            indexer_topk_prompt_start=self.indexer_topk_prompt_start,
         )
 
     @model_validator(mode="before")

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -988,6 +988,12 @@ class OpenAIServingChat(GenerateBaseServing):
                 np.save(buf, output.routed_experts)
                 routed_experts_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
 
+            indexer_topk_b64 = None
+            if output.indexer_topk is not None:
+                buf = io.BytesIO()
+                np.save(buf, output.indexer_topk)
+                indexer_topk_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+
             choice_data = ChatCompletionResponseChoice(
                 index=output.index,
                 message=message,
@@ -1004,6 +1010,7 @@ class OpenAIServingChat(GenerateBaseServing):
                     else None
                 ),
                 routed_experts=routed_experts_b64,
+                indexer_topk=indexer_topk_b64,
             )
             choice_data = maybe_filter_parallel_tool_calls(choice_data, request)
 

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -611,6 +611,15 @@ class CompletionResponseChoice(OpenAIBaseModel):
     # or (b) ``enable_return_routed_experts`` is off server-side.
     routed_experts: str | None = None
 
+    # Per-token indexer topk indices (sparse-attention selected KV
+    # slots), base64-encoded ``.npy`` bytes. Shape after decode:
+    #   (num_tokens, num_indexer_layers, index_topk)  dtype int32
+    # Decode:
+    #   np.load(io.BytesIO(base64.b64decode(s)))
+    # ``None`` if (a) the request was aborted before any forward pass,
+    # or (b) ``enable_return_indexer_topk`` is off server-side.
+    indexer_topk: str | None = None
+
 
 class CompletionResponse(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"cmpl-{random_uuid()}")

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -166,6 +166,22 @@ class CompletionRequest(OpenAIBaseModel):
             "need to map generated text back to input tokens."
         ),
     )
+    routed_experts_prompt_start: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When enable_return_routed_experts is active, skip the first "
+            "N prompt tokens from the returned routing data."
+        ),
+    )
+    indexer_topk_prompt_start: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When enable_return_indexer_topk is active, skip the first "
+            "N prompt tokens from the returned indexer topk indices."
+        ),
+    )
     return_token_offsets: bool | None = Field(
         default=False,
         description=(
@@ -373,6 +389,8 @@ class CompletionRequest(OpenAIBaseModel):
             skip_clone=True,  # Created fresh per request, safe to skip clone
             repetition_detection=self.repetition_detection,
             thinking_token_budget=self.thinking_token_budget,
+            routed_experts_prompt_start=self.routed_experts_prompt_start,
+            indexer_topk_prompt_start=self.indexer_topk_prompt_start,
         )
 
     @model_validator(mode="before")

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -579,6 +579,12 @@ class OpenAIServingCompletion(GenerateBaseServing):
                         "ascii"
                     )
 
+                indexer_topk_b64 = None
+                if output.indexer_topk is not None:
+                    buf = io.BytesIO()
+                    np.save(buf, output.indexer_topk)
+                    indexer_topk_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+
                 choice_data = CompletionResponseChoice(
                     index=len(choices),
                     text=output_text,
@@ -593,6 +599,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                         as_list(output.token_ids) if request.return_token_ids else None
                     ),
                     routed_experts=routed_experts_b64,
+                    indexer_topk=indexer_topk_b64,
                 )
                 choices.append(choice_data)
 

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Custom Sparse Attention Indexer layers."""
 
-from typing import Callable
+from collections.abc import Callable
 
 import torch
 
@@ -16,9 +16,7 @@ from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.attention.pcp import maybe_gather_indexer_k
-from vllm.model_executor.layers.quantization.utils.quant_utils import (
-    get_fp8_min_max,
-)
+from vllm.model_executor.layers.quantization.utils.quant_utils import get_fp8_min_max
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.deep_gemm import (
@@ -33,9 +31,7 @@ from vllm.utils.torch_utils import (
     _resolve_layer_name,
     direct_register_custom_op,
 )
-from vllm.v1.attention.backends.mla.indexer import (
-    DeepseekV32IndexerMetadata,
-)
+from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerMetadata
 from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
 from vllm.v1.worker.workspace import current_workspace_manager
 

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Custom Sparse Attention Indexer layers."""
 
+from typing import Callable
+
 import torch
 
 import vllm.envs as envs
@@ -739,6 +741,10 @@ class SparseAttnIndexer(CustomOp):
         self.topk_indices_buffer = topk_indices_buffer
         self.skip_k_cache_insert = skip_k_cache_insert
         self.use_fp4_cache = use_fp4_cache
+        # Optional capture callback set by GPUModelRunner when
+        # ``enable_return_indexer_topk`` is active. Called with the
+        # topk-indices slice after each forward.
+        self.capture_fn: Callable[[torch.Tensor], None] | None = None
         # DCP scalars are constant for the run; resolve them here (config is set
         # during model construction) and pass them into the custom op, rather
         # than threading them through per-step metadata.
@@ -783,7 +789,7 @@ class SparseAttnIndexer(CustomOp):
             q_values, q_scale = q_quant
         else:
             q_values, q_scale = q_quant, None
-        return torch.ops.vllm.sparse_attn_indexer(
+        result = torch.ops.vllm.sparse_attn_indexer(
             hidden_states,
             _encode_layer_name(self.k_cache.prefix),
             self.k_cache.kv_cache,
@@ -805,6 +811,13 @@ class SparseAttnIndexer(CustomOp):
             self.dcp_world_size,
             self.cp_kv_cache_interleave_size,
         )
+        # Capture topk indices for return_indexer_topk if enabled.
+        # The op writes into ``topk_indices_buffer[:num_tokens, :topk_tokens]``;
+        # we slice to the actual token count and forward to the capturer.
+        if self.capture_fn is not None:
+            num_tokens = hidden_states.shape[0]
+            self.capture_fn(self.topk_indices_buffer[:num_tokens, : self.topk_tokens])
+        return result
 
     def forward_xpu(
         self,
@@ -827,7 +840,7 @@ class SparseAttnIndexer(CustomOp):
             "AMD sparse_attn_indexer expects a single FP8 q_quant tensor"
         )
         if rocm_aiter_ops.is_enabled():
-            return torch.ops.vllm.rocm_aiter_sparse_attn_indexer(
+            result = torch.ops.vllm.rocm_aiter_sparse_attn_indexer(
                 hidden_states,
                 _encode_layer_name(self.k_cache.prefix),
                 self.k_cache.kv_cache,
@@ -843,6 +856,12 @@ class SparseAttnIndexer(CustomOp):
                 self.topk_indices_buffer,
                 skip_k_cache_insert=self.skip_k_cache_insert,
             )
+            if self.capture_fn is not None:
+                num_tokens = hidden_states.shape[0]
+                self.capture_fn(
+                    self.topk_indices_buffer[:num_tokens, : self.topk_tokens]
+                )
+            return result
         raise RuntimeError(
             "Sparse attention indexer ROCm path is only supported on AITER. "
             "Please enable aiter with VLLM_ROCM_USE_AITER=1"

--- a/vllm/model_executor/layers/sparse_attn_indexer_capturer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer_capturer.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Worker-side capturer and scheduler-side manager for indexer topk indices.
+
+Mirrors the architecture of :mod:`routed_experts_capturer`: the worker
+captures per-layer sparse-attention topk indices into a device buffer
+during the forward pass, D2H-copies them into a pinned CPU buffer, and
+hands them to the scheduler via :class:`IndexerTopkLists`. The scheduler
+persists them into a slot-indexed CPU buffer keyed by the physical KV-cache
+block layout, and returns the per-request slice when the request finishes.
+
+Key differences from routed_experts:
+  - Capture source is :class:`SparseAttnIndexer` (not MoE router).
+  - Only indexer layers capture (compact layer dimension, not
+    ``num_hidden_layers``).
+  - ``topk_size`` is ``index_topk`` (typically 512+), much larger than
+    ``num_experts_per_tok`` (4-8).
+  - dtype is ``int32`` (KV slot indices can exceed 65535).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import torch
+
+from vllm.config import VllmConfig
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _get_index_topk(hf_config) -> int:
+    """Resolve ``index_topk`` from the HF config.
+
+    DeepSeek-V32 and V4 store the sparse-attention topk under
+    ``index_topk``. Returns 0 when the model has no indexer.
+    """
+    return getattr(hf_config, "index_topk", 0)
+
+
+def _get_num_indexer_layers(hf_config) -> int:
+    """Count the number of backbone layers that build an indexer.
+
+    Mirrors the skip logic in
+    :func:`vllm.model_executor.models.deepseek_v2.DeepseekV32Attention.__init__`:
+    when ``index_topk_pattern`` is ``None``, layer ``i`` builds an indexer
+    iff ``max(i - index_skip_topk_offset + 1, 0) % index_topk_freq == 0``;
+    otherwise the per-layer pattern string ``"S"`` means skip.
+    """
+    if not hasattr(hf_config, "index_topk"):
+        return 0
+    num_hidden_layers = hf_config.num_hidden_layers
+    freq = getattr(hf_config, "index_topk_freq", 1)
+    pattern = getattr(hf_config, "index_topk_pattern", None)
+    skip_offset = getattr(hf_config, "index_skip_topk_offset", 2)
+
+    if pattern is not None:
+        return sum(
+            1 for i in range(min(len(pattern), num_hidden_layers)) if pattern[i] != "S"
+        )
+    count = 0
+    for layer_id in range(num_hidden_layers):
+        if max(layer_id - skip_offset + 1, 0) % freq == 0:
+            count += 1
+    return count
+
+
+class IndexerTopkCapturer:
+    """Worker-side capturer for indexer topk indices, lives on GPU.
+
+    :class:`SparseAttnIndexer` calls :meth:`capture` from inside its
+    forward pass with the per-layer topk-indices tensor. The tensor is
+    written into a preallocated device buffer indexed by a compact
+    layer id. At the end of the step, :class:`GPUModelRunner` reads the
+    device buffer, issues a D2H copy into a pinned CPU buffer, and hands
+    the result to the scheduler via :class:`IndexerTopkLists`.
+
+    Invariants:
+        - One instance per worker; shape is fixed at init and covers the
+          worst-case step (``max_num_batched_tokens`` tokens).
+        - :meth:`clear_buffer` is called at the start of every step, so
+          unused slots stay zero.
+        - ``device_buffer.dtype`` is ``torch.int32``.
+    """
+
+    def __init__(
+        self,
+        max_num_batched_tokens: int,
+        num_indexer_layers: int,
+        index_topk: int,
+        device: str,
+    ) -> None:
+        self.num_indexer_layers = num_indexer_layers
+        self.index_topk = index_topk
+        self.device_buffer = torch.zeros(
+            (
+                max_num_batched_tokens,
+                num_indexer_layers,
+                index_topk,
+            ),
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def capture(self, compact_layer_id: int, topk_indices: torch.Tensor) -> None:
+        """Capture topk indices for a specific indexer layer.
+
+        Args:
+            compact_layer_id: The compact index (0..num_indexer_layers-1)
+                assigned at bind time, NOT the model layer_id.
+            topk_indices: Tensor of shape (batch_size, index_topk).
+        """
+        batch_size = topk_indices.shape[0]
+        if compact_layer_id >= self.device_buffer.shape[1]:
+            return
+        self.device_buffer[:batch_size, compact_layer_id, :] = topk_indices
+
+    def clear_buffer(self) -> None:
+        """Zero the device buffer. Called at the start of every step."""
+        self.device_buffer.zero_()
+
+    def get_device_buffer(self) -> torch.Tensor:
+        """Return the underlying device buffer for D2H copy."""
+        return self.device_buffer
+
+
+class IndexerTopkManager:
+    """Scheduler-side slot-indexed buffer for indexer topk indices.
+
+    Lives on CPU in the scheduler process. Each slot corresponds to
+    ``block_id * block_size + offset_in_block``, tying topk data to
+    physical KV-cache blocks (same layout as :class:`RoutedExpertsManager`).
+
+    Data flow per step:
+      1. Worker D2Hs its device capture buffer into
+         :class:`IndexerTopkLists` and returns it via
+         :class:`ModelRunnerOutput`.
+      2. Scheduler calls :meth:`store_batch` with that step's
+         ``(topk_data, slot_mapping)``.
+      3. On request completion, the scheduler calls :meth:`get` with the
+         request's block IDs to recover the full per-token topk.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+    ) -> None:
+        self.attn_gid = next(
+            gid
+            for gid, g in enumerate(kv_cache_config.kv_cache_groups)
+            if isinstance(g.kv_cache_spec, FullAttentionSpec)
+        )
+        attn_group = kv_cache_config.kv_cache_groups[self.attn_gid]
+        self.block_size = attn_group.kv_cache_spec.block_size
+
+        hf_config = vllm_config.model_config.hf_text_config
+        self.num_indexer_layers = _get_num_indexer_layers(hf_config)
+        self.index_topk = _get_index_topk(hf_config)
+        max_num_slots = kv_cache_config.num_blocks * self.block_size
+        self.indexer_topk_by_slot = np.zeros(
+            (
+                max_num_slots,
+                self.num_indexer_layers,
+                self.index_topk,
+            ),
+            dtype=np.int32,
+        )
+        logger.info(
+            "IndexerTopkManager CPU buffer: %.2f GB "
+            "(slots=%d, indexer_layers=%d, index_topk=%d)",
+            self.indexer_topk_by_slot.nbytes / 1e9,
+            max_num_slots,
+            self.num_indexer_layers,
+            self.index_topk,
+        )
+
+    def store_batch(self, data: np.ndarray, slot_mapping: np.ndarray) -> None:
+        """Persist one step's indexer topk into the slot buffer.
+
+        Equivalent to ``slot_buffer[slot_mapping] = data``.
+        """
+        self.indexer_topk_by_slot[slot_mapping] = data
+
+    def get(
+        self,
+        block_ids: list[int],
+        num_tokens: int,
+        token_start: int = 0,
+    ) -> np.ndarray:
+        """Read indexer topk for a completed / preempted request.
+
+        Args:
+            block_ids: Block IDs from the attention KV-cache group.
+            num_tokens: Number of tokens that have gone through a forward
+                pass (typically ``request.num_tokens - 1``).
+            token_start: Skip the first ``token_start`` tokens.
+
+        Returns:
+            Array of shape (num_tokens - token_start, num_indexer_layers,
+            index_topk).
+        """
+        bs = self.block_size
+        block_ids_array = np.array(block_ids, dtype=np.int32)
+        block_offsets = np.arange(bs)
+        slot_mapping = (
+            block_ids_array.reshape(-1, 1) * bs + block_offsets.reshape(1, -1)
+        ).flatten()[:num_tokens]
+        slot_mapping = slot_mapping[token_start:]
+        return self.indexer_topk_by_slot[slot_mapping]

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -43,6 +43,8 @@ class CompletionOutput:
     cumulative_logprob: float | None
     logprobs: SampleLogprobs | None
     routed_experts: np.ndarray | None = None  # [seq_len,layer_num,topk]
+    # [seq_len, num_indexer_layers, index_topk]
+    indexer_topk: np.ndarray | None = None
     finish_reason: str | None = None
     stop_reason: int | str | None = None
     lora_request: LoRARequest | None = None
@@ -56,6 +58,7 @@ class CompletionOutput:
             f"text={self.text!r}, "
             f"token_ids={self.token_ids}, "
             f"routed_experts={self.routed_experts}, "
+            f"indexer_topk={self.indexer_topk}, "
             f"cumulative_logprob={self.cumulative_logprob}, "
             f"logprobs={self.logprobs}, "
             f"finish_reason={self.finish_reason}, "

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -332,6 +332,10 @@ class SamplingParams(
     already-returned prefix to avoid duplicating routing for prompt tokens
     covered by earlier turns. Default 0 returns routing for all prompt
     tokens."""
+    indexer_topk_prompt_start: int = 0
+    """When enable_return_indexer_topk is active, skip the first
+    indexer_topk_prompt_start prompt tokens from the returned topk
+    indices. Same semantics as routed_experts_prompt_start."""
 
     # Fields used for bad words
     bad_words: list[str] | None = None

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -388,6 +388,8 @@ class SamplingParams(
         skip_clone: bool = False,
         repetition_detection: RepetitionDetectionParams | None = None,
         logprob_token_ids: list[int] | None = None,
+        routed_experts_prompt_start: int = 0,
+        indexer_topk_prompt_start: int = 0,
     ) -> "SamplingParams":
         if logit_bias is not None:
             # Fast path uses a dict comprehension; on failure we iterate once
@@ -449,6 +451,8 @@ class SamplingParams(
             extra_args=extra_args,
             skip_clone=skip_clone,
             repetition_detection=repetition_detection,
+            routed_experts_prompt_start=routed_experts_prompt_start,
+            indexer_topk_prompt_start=indexer_topk_prompt_start,
         )
 
     def __post_init__(self) -> None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -28,6 +28,9 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     RoutedExpertsManager,
 )
+from vllm.model_executor.layers.sparse_attn_indexer_capturer import (
+    IndexerTopkManager,
+)
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
 from vllm.multimodal.utils import get_mm_features_in_window
@@ -340,6 +343,17 @@ class Scheduler(SchedulerInterface):
             # so update_from_output can read slot data even if a later
             # schedule() frees the blocks (async scheduling race).
             self._re_block_ids: dict[str, list[int]] = {}
+
+        self.enable_return_indexer_topk = (
+            vllm_config.model_config.enable_return_indexer_topk
+        )
+
+        if self.enable_return_indexer_topk:
+            self.indexer_topk_mgr = IndexerTopkManager(
+                vllm_config=vllm_config,
+                kv_cache_config=kv_cache_config,
+            )
+            self._it_block_ids: dict[str, list[int]] = {}
 
         self._pause_state: PauseState = PauseState.UNPAUSED
 
@@ -1260,9 +1274,18 @@ class Scheduler(SchedulerInterface):
                 }
             )
 
-        # Clear the finished and preempted request IDs.
-        # NOTE: We shouldn't just clear() here because it will also affect
-        # the scheduler output.
+        if self.enable_return_indexer_topk:
+            gid = self.indexer_topk_mgr.attn_gid
+            self._it_block_ids.update(
+                {
+                    rid: self.kv_cache_manager.get_blocks(rid).get_block_ids()[gid]
+                    for rid in num_scheduled_tokens
+                }
+            )
+
+        # Clear the finished request IDs.
+        # NOTE: We shouldn't do self.finished_req_ids.clear() here because
+        # it will also affect the scheduler output.
         self.finished_req_ids = set()
         self.reset_preempted_req_ids = set()
 
@@ -1627,6 +1650,10 @@ class Scheduler(SchedulerInterface):
                 routing_offsets[rid] = offset
                 offset += num_scheduled_tokens[rid]
 
+        if model_runner_output.indexer_topk is not None:
+            it = model_runner_output.indexer_topk
+            self.indexer_topk_mgr.store_batch(it.topk_data, it.slot_mapping)
+
         # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,
         # the below loop can be a performance bottleneck. We should do our best
         # to avoid expensive operations inside the loop.
@@ -1788,6 +1815,28 @@ class Scheduler(SchedulerInterface):
                         self.kv_cache_manager.estimate_cached_tokens(request)
                     )
 
+            indexer_topk = None
+            if (
+                self.enable_return_indexer_topk
+                and model_runner_output.indexer_topk is not None
+                and new_token_ids
+            ):
+                block_ids = self._it_block_ids.pop(req_id, [])
+                if num_output_tokens_before == 0:
+                    # Prefill completed: read full prompt topk from slot
+                    # buffer using the block-ID snapshot taken at
+                    # schedule time (immune to async preemption).
+                    if request.sampling_params is not None:
+                        prompt_start = request.sampling_params.indexer_topk_prompt_start
+                        assert prompt_start < request.num_prompt_tokens
+                    else:
+                        prompt_start = 0
+                    indexer_topk = self.indexer_topk_mgr.get(
+                        block_ids,
+                        request.num_prompt_tokens,
+                        token_start=prompt_start,
+                    )
+
             finish_reason = None
             if stopped:
                 # Capture finish_reason BEFORE _handle_stopped_request, which may
@@ -1832,6 +1881,7 @@ class Scheduler(SchedulerInterface):
                         ec_transfer_params=ec_transfer_params,
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
+                        indexer_topk=indexer_topk,
                         num_nans_in_logits=request.num_nans_in_logits,
                     )
                 )

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -197,6 +197,9 @@ class EngineCoreOutput(
     prefill_stats: PrefillStats | None = None
 
     routed_experts: np.ndarray | None = None
+    # Per-token indexer topk indices (sparse-attention selected KV slots).
+    # Shape: (num_tokens, num_indexer_layers, index_topk), dtype int32.
+    indexer_topk: np.ndarray | None = None
     # The number of NaNs in logits.
     # A value greater than 0 indicates that the output is corrupted.
     num_nans_in_logits: int = 0

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -178,6 +178,7 @@ class RequestState:
 
         # Routed experts accumulation (prompt + sample chunks)
         self.routed_experts_chunks: list[np.ndarray] = []
+        self.indexer_topk_chunks: list[np.ndarray] = []
 
         # Stream Interval
         self.stream_interval = stream_interval
@@ -408,11 +409,17 @@ class RequestState:
         if finished and self.routed_experts_chunks:
             routed_experts = np.concatenate(self.routed_experts_chunks, axis=0)
 
+        # Concatenate indexer topk on finish
+        indexer_topk = None
+        if finished and self.indexer_topk_chunks:
+            indexer_topk = np.concatenate(self.indexer_topk_chunks, axis=0)
+
         return CompletionOutput(
             index=self.request_index,
             text=text,
             token_ids=token_ids,
             routed_experts=routed_experts,
+            indexer_topk=indexer_topk,
             logprobs=logprobs,
             cumulative_logprob=self.logprobs_processor.cumulative_logprob,
             finish_reason=str(finish_reason) if finished else None,
@@ -635,6 +642,9 @@ class OutputProcessor:
                 req_state.routed_experts_chunks.append(
                     engine_core_output.routed_experts
                 )
+
+            if engine_core_output.indexer_topk is not None:
+                req_state.indexer_topk_chunks.append(engine_core_output.indexer_topk)
 
             if req_state.is_prefilling:
                 if engine_core_output.prefill_stats is not None:

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -177,6 +177,44 @@ class RoutedExpertsLists(NamedTuple):
     slot_mapping: np.ndarray
 
 
+class IndexerTopkTensors(NamedTuple):
+    """Device-side snapshot of indexer topk indices, pending async D2H.
+
+    Mirrors :class:`RoutedExpertsTensors` but for sparse-attention topk
+    indices. Shape:
+      - ``topk_data``: (num_scheduled_tokens, num_indexer_layers, index_topk)
+      - ``slot_mapping``: (num_scheduled_tokens,)
+    """
+
+    topk_data: torch.Tensor
+    slot_mapping: torch.Tensor
+
+    def to_cpu_nonblocking(self) -> "IndexerTopkTensors":
+        if self.topk_data.device.type == "cpu":
+            return self
+        return IndexerTopkTensors(
+            self.topk_data.to("cpu", non_blocking=True),
+            self.slot_mapping.to("cpu", non_blocking=True),
+        )
+
+    def tolists(self) -> "IndexerTopkLists":
+        return IndexerTopkLists(
+            self.topk_data.cpu().numpy(),
+            self.slot_mapping.cpu().numpy(),
+        )
+
+
+class IndexerTopkLists(NamedTuple):
+    """CPU-side indexer topk, the form :meth:`IndexerTopkManager.store_batch`
+    consumes.
+    """
+
+    # (num_scheduled_tokens, num_indexer_layers, index_topk)
+    topk_data: np.ndarray
+    # (num_scheduled_tokens,)
+    slot_mapping: np.ndarray
+
+
 # [num_reqs, <dynamic>]
 # The shape of each element depends on the pooler used
 PoolerOutput: TypeAlias = torch.Tensor | list[torch.Tensor] | list[torch.Tensor | None]
@@ -279,6 +317,10 @@ class ModelRunnerOutput:
     # its slot buffer via ``slot_buffer[slot_mapping] = routing_data``.
     # ``None`` when ``enable_return_routed_experts`` is off.
     routed_experts: RoutedExpertsLists | None = None
+
+    # Per-token indexer topk indices (sparse-attention selected KV slots).
+    # ``None`` when ``enable_return_indexer_topk`` is off.
+    indexer_topk: IndexerTopkLists | None = None
 
     @staticmethod
     def with_kv_conn_output_only(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -50,10 +50,7 @@ from vllm.distributed.parallel_state import (
     is_global_first_rank,
     prepare_communication_buffer_for_model,
 )
-from vllm.forward_context import (
-    BatchDescriptor,
-    set_forward_context,
-)
+from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
 from vllm.lora.layers import LoRAMapping, LoRAMappingType
 from vllm.model_executor.layers.attention import Attention, MLAAttention
@@ -62,10 +59,6 @@ from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_ma
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     RoutedExpertsCapturer,
 )
-from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
-from vllm.model_executor.layers.sparse_attn_indexer_capturer import (
-    IndexerTopkCapturer,
-)
 from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
@@ -73,6 +66,8 @@ from vllm.model_executor.layers.rotary_embedding import (
     MRotaryEmbedding,
     XDRotaryEmbedding,
 )
+from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
+from vllm.model_executor.layers.sparse_attn_indexer_capturer import IndexerTopkCapturer
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.model_executor.model_loader.reload import (
     finalize_layerwise_reload,
@@ -97,11 +92,7 @@ from vllm.model_executor.models.interfaces_base import (
     is_pooling_model,
     is_text_generation_model,
 )
-from vllm.model_executor.offloader import (
-    create_offloader,
-    get_offloader,
-    set_offloader,
-)
+from vllm.model_executor.offloader import create_offloader, get_offloader, set_offloader
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.encoder_budget import MultiModalBudget
 from vllm.multimodal.inputs import (
@@ -142,9 +133,7 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
 )
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
-from vllm.v1.attention.backends.linear_attn import (
-    BailingLinearAttentionMetadataBuilder,
-)
+from vllm.v1.attention.backends.linear_attn import BailingLinearAttentionMetadataBuilder
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
@@ -176,6 +165,8 @@ from vllm.v1.outputs import (
     AsyncModelRunnerOutput,
     DraftTokenIds,
     ECConnectorOutput,
+    IndexerTopkLists,
+    IndexerTopkTensors,
     KVConnectorOutput,
     LogprobsLists,
     LogprobsTensors,
@@ -183,8 +174,6 @@ from vllm.v1.outputs import (
     PoolerOutput,
     RoutedExpertsLists,
     RoutedExpertsTensors,
-    IndexerTopkLists,
-    IndexerTopkTensors,
     SamplerOutput,
     make_empty_encoder_model_runner_output,
 )
@@ -6603,9 +6592,7 @@ class GPUModelRunner(
             SupportsEncoderCudaGraph,
             supports_encoder_cudagraph,
         )
-        from vllm.v1.worker.encoder_cudagraph import (
-            EncoderCudaGraphManager,
-        )
+        from vllm.v1.worker.encoder_cudagraph import EncoderCudaGraphManager
 
         raw_model = self.get_model()
         if not supports_encoder_cudagraph(raw_model):
@@ -7720,9 +7707,7 @@ class GPUModelRunner(
         from vllm.model_executor.layers.fused_moe.modular_kernel import (
             FusedMoEExpertsMonolithic,
         )
-        from vllm.model_executor.layers.fused_moe.router.base_router import (
-            BaseRouter,
-        )
+        from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
 
         for module in self.model.modules():
             if not isinstance(module, MoERunner):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -62,6 +62,10 @@ from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_ma
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     RoutedExpertsCapturer,
 )
+from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
+from vllm.model_executor.layers.sparse_attn_indexer_capturer import (
+    IndexerTopkCapturer,
+)
 from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
@@ -179,6 +183,8 @@ from vllm.v1.outputs import (
     PoolerOutput,
     RoutedExpertsLists,
     RoutedExpertsTensors,
+    IndexerTopkLists,
+    IndexerTopkTensors,
     SamplerOutput,
     make_empty_encoder_model_runner_output,
 )
@@ -264,6 +270,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         async_output_copy_stream: torch.cuda.Stream,
         vocab_size: int,
         routed_experts: RoutedExpertsTensors | None = None,
+        indexer_topk: IndexerTopkTensors | None = None,
         check_ep_fault: bool = False,
     ):
         self._model_runner_output = model_runner_output
@@ -279,6 +286,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         self.vocab_size = vocab_size
         self._logprobs_tensors = logprobs_tensors
         self._routed_experts = routed_experts
+        self._indexer_topk = indexer_topk
         self._has_fault: torch.Tensor | None = None
 
         # Initiate the copy on a separate stream, but do not synchronize it.
@@ -296,6 +304,11 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
             self._routed_experts_cpu = (
                 self._routed_experts.to_cpu_nonblocking()
                 if self._routed_experts is not None
+                else None
+            )
+            self._indexer_topk_cpu = (
+                self._indexer_topk.to_cpu_nonblocking()
+                if self._indexer_topk is not None
                 else None
             )
             if check_ep_fault:
@@ -336,6 +349,10 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         if self._routed_experts_cpu is not None:
             output.routed_experts = self._routed_experts_cpu.tolists()
         del self._routed_experts
+
+        if self._indexer_topk_cpu is not None:
+            output.indexer_topk = self._indexer_topk_cpu.tolists()
+        del self._indexer_topk
 
         if self._has_fault is not None and self._has_fault.item():
             mask = get_ep_all2all_manager().query_active_mask()
@@ -494,6 +511,8 @@ class GPUModelRunner(
         # Set to True after init_routed_experts_capturer() completes.
         # Prevents routed experts code from running during profiling/dummy run.
         self.routed_experts_initialized = False
+        # Set to True after init_indexer_topk_capturer() completes.
+        self.indexer_topk_initialized = False
         self.max_model_len = model_config.max_model_len
 
         # Always set to false after the first forward pass
@@ -2333,6 +2352,13 @@ class GPUModelRunner(
                 slot_mapping_attn[:num_tokens]
             )
 
+        if self.indexer_topk_initialized:
+            attn_gid = self.routed_experts_attn_gid
+            slot_mapping_attn = slot_mappings[attn_gid]
+            self.indexer_topk_slot_mapping_device[:num_tokens].copy_(
+                slot_mapping_attn[:num_tokens]
+            )
+
         num_computed_tokens_cpu = self.input_batch.num_computed_tokens_cpu_tensor[
             :num_reqs_padded
         ]
@@ -3719,6 +3745,15 @@ class GPUModelRunner(
                     non_blocking=True,
                 )
 
+            if self.indexer_topk_initialized:
+                buf = self.indexer_topk_capturer.get_device_buffer()
+                total = scheduler_output.total_num_scheduled_tokens
+                self.indexer_topk_cpu[:total].copy_(buf[:total], non_blocking=True)
+                self.indexer_topk_slot_mapping_cpu[:total].copy_(
+                    self.indexer_topk_slot_mapping_device[:total],
+                    non_blocking=True,
+                )
+
             # Get the valid generated tokens.
             max_gen_len = sampled_token_ids.shape[-1]
             if max_gen_len == 1:
@@ -4120,6 +4155,9 @@ class GPUModelRunner(
 
         if self.routed_experts_initialized:
             self.routed_experts_capturer.clear_buffer()
+
+        if self.indexer_topk_initialized:
+            self.indexer_topk_capturer.clear_buffer()
 
         # If ngram_gpu is used, we need to copy the scheduler_output to avoid
         # the modification has influence on the scheduler_output in engine core process.
@@ -4732,6 +4770,12 @@ class GPUModelRunner(
                     routing_data=self.routed_experts_cpu[:total].numpy(),
                     slot_mapping=self.routed_experts_slot_mapping_cpu[:total].numpy(),
                 )
+            if self.indexer_topk_initialized:
+                total = scheduler_output.total_num_scheduled_tokens
+                output.indexer_topk = IndexerTopkLists(
+                    topk_data=self.indexer_topk_cpu[:total].numpy(),
+                    slot_mapping=self.indexer_topk_slot_mapping_cpu[:total].numpy(),
+                )
             return output
 
         with record_function_or_nullcontext(
@@ -4760,6 +4804,15 @@ class GPUModelRunner(
                     ].clone(),
                 )
 
+            indexer_topk_snapshot = None
+            if self.indexer_topk_initialized:
+                buf = self.indexer_topk_capturer.get_device_buffer()
+                total = scheduler_output.total_num_scheduled_tokens
+                indexer_topk_snapshot = IndexerTopkTensors(
+                    topk_data=buf[:total].clone(),
+                    slot_mapping=self.indexer_topk_slot_mapping_device[:total].clone(),
+                )
+
             async_output = AsyncGPUModelRunnerOutput(
                 model_runner_output=output,
                 sampled_token_ids=sampler_output.sampled_token_ids,
@@ -4768,6 +4821,7 @@ class GPUModelRunner(
                 async_output_copy_stream=self._get_or_create_async_output_copy_stream(),
                 vocab_size=self.input_batch.vocab_size,
                 routed_experts=routed_experts_snapshot,
+                indexer_topk=indexer_topk_snapshot,
                 check_ep_fault=self.check_ep_fault,
             )
         with record_function_or_nullcontext(
@@ -7695,6 +7749,75 @@ class GPUModelRunner(
                 fused_experts.set_capture_fn(_capture_fn)
             elif isinstance(module.router, BaseRouter):
                 module.router.set_capture_fn(_capture_fn)
+
+    def init_indexer_topk_capturer(self):
+        """Initialize the indexer topk capturer and bind it to all
+        :class:`SparseAttnIndexer` modules in the model.
+
+        Mirrors :meth:`init_routed_experts_capturer` but for sparse-
+        attention topk indices. The device buffer uses a *compact* layer
+        dimension (only indexer layers, not all ``num_hidden_layers``),
+        so we assign sequential indices during binding.
+        """
+        logger.info(
+            "Initializing indexer topk capturer, enable_return_indexer_topk: %s",
+            self.model_config.enable_return_indexer_topk,
+        )
+        # Discover all SparseAttnIndexer instances and build compact mapping.
+        indexer_modules: list[SparseAttnIndexer] = []
+        for module in self.model.modules():
+            if isinstance(module, SparseAttnIndexer):
+                indexer_modules.append(module)
+        num_indexer_layers = len(indexer_modules)
+        if num_indexer_layers == 0:
+            logger.warning(
+                "No SparseAttnIndexer layers found, IndexerTopkCapturer disabled"
+            )
+            return
+        index_topk = indexer_modules[0].topk_tokens
+
+        self.indexer_topk_capturer = IndexerTopkCapturer(
+            max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
+            num_indexer_layers=num_indexer_layers,
+            index_topk=index_topk,
+            device=self.device,
+        )
+        # Bind capture functions with compact layer indices.
+        for compact_idx, module in enumerate(indexer_modules):
+
+            def _capture_fn(
+                topk_indices,
+                _idx=compact_idx,
+                _capturer=self.indexer_topk_capturer,
+            ):
+                _capturer.capture(_idx, topk_indices)
+
+            module.capture_fn = _capture_fn
+
+        # Reuse the same attention gid for slot mapping as routed_experts.
+        if not hasattr(self, "routed_experts_attn_gid"):
+            self.routed_experts_attn_gid = self._get_attention_kv_cache_gid()
+
+        # Pinned CPU buffer for non-blocking D2H.
+        self.indexer_topk_cpu = torch.empty(
+            self.indexer_topk_capturer.device_buffer.shape,
+            dtype=self.indexer_topk_capturer.device_buffer.dtype,
+            device="cpu",
+            pin_memory=PIN_MEMORY,
+        )
+        max_tokens = self.scheduler_config.max_num_batched_tokens
+        self.indexer_topk_slot_mapping_cpu = torch.empty(
+            (max_tokens,),
+            dtype=torch.int64,
+            device="cpu",
+            pin_memory=PIN_MEMORY,
+        )
+        self.indexer_topk_slot_mapping_device = torch.empty(
+            (max_tokens,),
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self.indexer_topk_initialized = True
 
     def may_add_encoder_only_layers_to_kv_cache_config(self) -> None:
         """

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -651,6 +651,9 @@ class Worker(WorkerBase):
         if self.model_config.enable_return_routed_experts:
             self.model_runner.init_routed_experts_capturer()
 
+        if self.model_config.enable_return_indexer_topk:
+            self.model_runner.init_indexer_topk_capturer()
+
         # Build KV-zero metadata outside the CuMem pool so the bookkeeping
         # GPU tensors (seg_addrs, block-id buffers) use the standard PyTorch
         # allocator and are not discarded during sleep/wake cycles.


### PR DESCRIPTION



## Purpose
Add an `--enable-return-indexer-topk` flag to vLLM that surfaces per-token
sparse-attention top-k indices (the KV slots selected by the indexer layer)
back to the client alongside generated tokens. This mirrors the existing
`--enable-return-routed-experts` flag and follows the same capture →
D2H → slot-indexed-persist → API-encode pipeline.

please see https://github.com/vllm-project/vllm/issues/47280， new PR https://github.com/vllm-project/vllm/pull/49555
## Test Plan

**Server flag:**
```bash
vllm serve deepseek-ai/DeepSeek-V3.2 \
    --enable-return-indexer-topk ...
```

**SamplingParams (per-request):**
```python
class SamplingParams:
    indexer_topk_prompt_start: int = 0
    # Skip the first N prompt tokens from the returned topk. In multi-turn
    # agent scenarios, set to the length of the already-returned prefix to
    # avoid duplicating topk for prompt tokens covered by earlier turns.
```

**OpenAI Chat/Completion response:**
```json
{
  "choices": [{
    "index": 0,
    "message": { "role": "assistant", "content": "..." },
    "finish_reason": "stop",
    "indexer_topk": "<base64-encoded .npy bytes>"
  }]
}
```

Decode:
```python
import base64, io, numpy as np
arr = np.load(io.BytesIO(base64.b64decode(choice["indexer_topk"])))
# arr.shape == (num_tokens, num_indexer_layers, index_topk), dtype=int32
```


## Test Result

pytest -sv tests/entrypoints/openai/test_return_indexer_topk.py

(EngineCore pid=1449893) WARNING 07-22 18:30:04 [jit_monitor.py:135] Triton kernel JIT compilation during inference: _compute_slot_mapping_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
(EngineCore pid=1449893) WARNING 07-22 18:30:04 [jit_monitor.py:135] Triton kernel JIT compilation during inference: _convert_req_index_to_global_index_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
(APIServer pid=1449657) INFO:     127.0.0.1:34808 - "POST /v1/completions HTTP/1.1" 200 OK
PASSED
tests/entrypoints/openai/test_return_indexer_topk.py::test_indexer_topk_chat_completions (APIServer pid=1449657) INFO:     127.0.0.1:34810 - "POST /v1/chat/completions HTTP/1.1" 200 OK
PASSED
tests/entrypoints/openai/test_return_indexer_topk.py::test_indexer_topk_prompt_start_offset (APIServer pid=1449657) INFO:     127.0.0.1:34812 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=1449657) INFO:     127.0.0.1:34812 - "POST /v1/completions HTTP/1.1" 200 OK
PASSED[RemoteOpenAIServer] Sent SIGTERM to process 1449657
(APIServer pid=1449657) INFO 07-22 18:30:06 [launcher.py:100] [shutdown] API server: shutdown triggered
(APIServer pid=1449657) INFO 07-22 18:30:06 [launcher.py:116] [shutdown] API server: stopping engine client mode=abort timeout=0s
(APIServer pid=1449657) INFO 07-22 18:30:06 [core_client.py:655] [shutdown] MPClient: start timeout=0s
(APIServer pid=1449657) INFO 07-22 18:30:06 [core_client.py:657] [shutdown] MPClient: stopping engine manager
(APIServer pid=1449657) WARNING 07-22 18:30:06 [utils.py:626] [shutdown] Process manager: force killing remaining processes count=1
(EngineCore pid=1449893) INFO 07-22 18:30:06 [core.py:1313] [shutdown] EngineCore: trigger received signal=SIGTERM
(EngineCore pid=1449893) INFO 07-22 18:30:06 [core.py:1432] [shutdown] EngineCore: start mode=abort timeout=0s
(EngineCore pid=1449893) INFO 07-22 18:30:06 [core.py:1463] [shutdown] EngineCore: request processing complete; starting resource teardown
(EngineCore pid=1449893) INFO 07-22 18:30:06 [core.py:1326] [shutdown] EngineCore: exiting busy loop
(APIServer pid=1449657) INFO 07-22 18:30:06 [core_client.py:659] [shutdown] MPClient: engine manager stopped
(APIServer pid=1449657) INFO 07-22 18:30:06 [core_client.py:660] [shutdown] MPClient: cleaning up background resources
(APIServer pid=1449657) INFO 07-22 18:30:06 [core_client.py:662] [shutdown] MPClient: complete
(APIServer pid=1449657) INFO:     Shutting down
(APIServer pid=1449657) INFO 07-22 18:30:06 [launcher.py:125] [shutdown] API server: engine client stopped
(APIServer pid=1449657) INFO 07-22 18:30:06 [launcher.py:128] [shutdown] API server: signalling HTTP server shutdown
(APIServer pid=1449657) INFO 07-22 18:30:06 [launcher.py:149] [shutdown] API server: shutting down FastAPI HTTP server
(APIServer pid=1449657) INFO:     Shutting down
(APIServer pid=1449657) INFO:     Waiting for application shutdown.
(APIServer pid=1449657) INFO:     Application shutdown complete.
[RemoteOpenAIServer] Server 1449657 terminated gracefully
[RemoteOpenAIServer] GPU memory released to 0.51 GB (target: 2.65 GB) in 0.0s


=============================================================================================== warnings summary ================================================================================================
<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../../data/miniconda3/envs/liurong_vllm/lib/python3.11/site-packages/torch/jit/_script.py:365: 14 warnings
  /data/miniconda3/envs/liurong_vllm/lib/python3.11/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================== 3 passed, 16 warnings in 58.73s ========================================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
---


<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

