### PR TITLE
[Model Runner V2][Perf] Warm up GLM-5.2 DSA indexer prefill metadata kernel

### DIFF
--- a/vllm/model_executor/warmup/sparse_mla_triton_warmup.py
+++ b/vllm/model_executor/warmup/sparse_mla_triton_warmup.py
@@ -29,6 +29,7 @@ _GENERIC_SPARSE_MLA_BACKENDS = frozenset(
         "FLASHINFER_MLA_SPARSE_SM120",
     }
 )
+_INDEXER_PREFILL_CHUNK_METADATA_BACKENDS = frozenset({"DEEPSEEK_V32_INDEXER"})
 
 _SPARSE_PREFILL_METADATA_NUM_PREFILLS = (1, 2, 4, 8)
 _SPARSE_PREFILL_METADATA_NUM_DECODES = (0, 1, 2)
@@ -325,6 +326,12 @@ def sparse_mla_triton_warmup_if_needed(worker: "Worker") -> None:
                 runner,
                 num_tokens,
                 compress_ratios=(1,),
+            )
+        elif _has_attention_backend(runner, _INDEXER_PREFILL_CHUNK_METADATA_BACKENDS):
+            _warm_prefill_chunk_metadata_kernel(
+                getattr(runner, "device", torch.device("cuda")),
+                compress_ratio=1,
+                query_len=num_tokens,
             )
     except Exception:
         logger.warning("Skipping sparse MLA Triton warmup.", exc_info=True)


### PR DESCRIPTION



## Purpose

[Perf] Warm up GLM-5.2 DSA indexer prefill metadata kernel

## Test Plan
```
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve /mnt/data1/models/zai-org/GLM-5.2-FP8 -tp 8 --tool-call-parser glm47 --reasoning-parser glm45  --enable-auto-tool-choice  --chat-template-content-format=string --served-model-name zai-org/GLM-5.2-FP8 --max-model-len 272640 --port 8001 --jit-monitor-verbose
```
## Test Result
before
```
(APIServer pid=3465377) INFO:     127.0.0.1:55664 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(Worker_TP2 pid=3477064) WARNING 07-01 18:02:58 [jit_monitor.py:125] Triton kernel JIT compilation during inference: _build_prefill_chunk_metadata_kernel (constexprs={BLOCK_SIZE=1024, COMPRESS_RATIO=1, DCP_INTERLEAVE=1, DCP_WORLD=1}; signature={BLOCK_SIZE='constexpr', COMPRESS_RATIO='constexpr', DCP_INTERLEAVE='constexpr', DCP_RANK='i32', DCP_WORLD='constexpr', cu_compressed_seq_len_ke_ptr='*i32', cu_compressed_seq_len_ks_ptr='*i32', cu_compressed_seq_lens_ptr='*i32', query_slice_start='i32', query_slice_stop='i32', query_start_loc_ptr='*i32', row_start_cu_compressed_seq_lens_ptr='*i32', token_to_seq_ptr='*i32', uncompressed_seq_lens_ptr='*i32'}; extra_compile_info={configs=[{(0,): [['tt.divisibility', 16]], (1,): [['tt.divisibility', 16]], (2,): [['tt.divisibility', 16]], (3,): [['tt.divi..., device=2, enable_fp_fusion=True, extern_libs=(('libdevice', '/mnt/data4/jxy/venv/lib/python3.12/site-packages/triton/backends/nvidia/lib/libdevice.10.bc'),), is_warmup=False, launch_cooperative_grid=False, num_ctas=1, num_stages=3, num_warps=4, specialization_data='{"name": "vllm.v1.attention.backends.mla.indexer._build_prefill_chunk_metadata_kernel", "signature": {"query_start_l...}; key="[('*i32', 'D'), ('*i32', 'D'), ('*i32', 'D'), ('*i32', 'D'), ('*i32', 'D'), ('*i32', 'D'), ('*i32', 'D'), ('i32', 'D...). This causes a latency spike; consider extending warmup to cover this shape/config.

```
after
```
(APIServer pid=3834534) INFO:     127.0.0.1:34634 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=3834534) INFO:     127.0.0.1:34634 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

