### PR TITLE
[Doc] Fix broken disaggregated example link in kv_transfer README

### DIFF
--- a/vllm/distributed/kv_transfer/README.md
+++ b/vllm/distributed/kv_transfer/README.md
@@ -22,7 +22,7 @@ NOTE: If you want to not only transfer KV caches, but adjust the model execution
 
 ## Disaggregated prefilling
 
-The example usage is in [this file](../../../examples/disaggregated/disaggregated_prefill.sh).
+The example usage is in [these examples](../../../examples/disaggregated).
 
 Here is the diagram of how we run disaggregated prefilling.
 


### PR DESCRIPTION
## Purpose

The "Disaggregated prefilling" section of `vllm/distributed/kv_transfer/README.md` links to `examples/disaggregated/disaggregated_prefill.sh`. That script was removed in #44854 (Remove `P2pNcclConnector`) — it was the demo for that connector — but this README link was never updated, so it now points at a missing file. The disaggregated examples now live as a collection of subdirectories under `examples/disaggregated/`, so this points the link there.

## Test Plan

Resolve the link relative to the README's location (`vllm/distributed/kv_transfer/`) and check it against the current tree.

## Test Result

- Old target `../../../examples/disaggregated/disaggregated_prefill.sh` → no longer exists anywhere in the repo.
- New target `../../../examples/disaggregated` → exists and holds the current disaggregated examples (`disaggregated_serving`, `lmcache`, `example_connector`, ...).

Docs-only change; no other references to the removed script remain.
