### PR TITLE
Revert "[Distributed] Default FlashInfer allreduce to mnnvl on single node" (#47219)

### DIFF
--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -92,32 +92,25 @@ def _create_workspace(
     return workspace
 
 
-def _resolve_fi_ar_backend() -> tuple[str, bool]:
-    """Resolve the flashinfer allreduce backend for the current setup.
-
-    Returns:
-        A ``(backend, allow_trtllm_fallback)`` tuple. ``allow_trtllm_fallback``
-        is True only when ``auto`` selects mnnvl for a single node, so that
-        workspace creation can fall back to trtllm on single-node topologies
-        without NVSwitch multicast support (where mnnvl is unavailable).
-    """
+def _resolve_fi_ar_backend() -> str:
     backend = envs.VLLM_FLASHINFER_ALLREDUCE_BACKEND
     if backend != "auto":
         logger.info_once(f"Using flashinfer allreduce backend: {backend}")
-        return backend, False
+        return backend
 
-    # Default to mnnvl for both single- and multi-node setups. The mnnvl
-    # cudagraph hang that previously forced single-node to trtllm
-    # (https://github.com/vllm-project/vllm/issues/35772) was fixed upstream in
-    # FlashInfer (>= 0.6.12, vLLM pins 0.6.13), so mnnvl is safe here. trtllm
-    # does not support multi-node allreduce, so mnnvl is required there anyway.
-    # mnnvl needs NVSwitch multicast; on single-node topologies without it,
-    # fall back to trtllm so fused allreduce stays enabled.
-    backend = "mnnvl"
-    allow_trtllm_fallback = get_node_count() == 1
+    if get_node_count() > 1:  # noqa: SIM108
+        # Use mnnvl backend for multi-node setup since
+        # trtllm backend does not support multi-node allreduce
+        backend = "mnnvl"
+    else:
+        # Currently defaulting to trtllm backend for single-node
+        # setup since mnnvl has issues with cudagraph:
+        # https://github.com/vllm-project/vllm/issues/35772
+        # Should switch back to auto when the issue is resolved.
+        backend = "trtllm"
 
     logger.info_once(f"Auto-selected flashinfer allreduce backend: {backend}")
-    return backend, allow_trtllm_fallback
+    return backend
 
 
 def get_fi_ar_workspace(
@@ -139,7 +132,7 @@ def get_fi_ar_workspace(
     if _fi_ar_workspace is not None:
         return _fi_ar_workspace
 
-    backend, allow_trtllm_fallback = _resolve_fi_ar_backend()
+    backend = _resolve_fi_ar_backend()
 
     if get_node_count() > 1 and backend == "trtllm":
         raise ValueError(
@@ -147,23 +140,14 @@ def get_fi_ar_workspace(
             "'trtllm' backend. Please use 'mnnvl' backend instead."
         )
 
-    def _get_or_create(be: str):
-        # Reuse the quant workspace if it was already created with the same backend
-        if _fi_ar_quant_workspace is not None and _fi_ar_quant_workspace.backend == be:
-            return _fi_ar_quant_workspace
-        return _create_workspace(
-            be, world_size, rank, max_token_num, hidden_dim, dtype, group
-        )
+    # Reuse the quant workspace if it was already created with the same backend
+    if _fi_ar_quant_workspace is not None and _fi_ar_quant_workspace.backend == backend:
+        _fi_ar_workspace = _fi_ar_quant_workspace
+        return _fi_ar_workspace
 
-    _fi_ar_workspace = _get_or_create(backend)
-    if _fi_ar_workspace is None and allow_trtllm_fallback and backend != "trtllm":
-        logger.warning_once(
-            "FlashInfer mnnvl allreduce workspace unavailable (likely no NVSwitch "
-            "multicast support); falling back to trtllm backend for single node."
-        )
-        backend = "trtllm"
-        _fi_ar_workspace = _get_or_create(backend)
-
+    _fi_ar_workspace = _create_workspace(
+        backend, world_size, rank, max_token_num, hidden_dim, dtype, group
+    )
     if _fi_ar_workspace is not None:
         logger.info_once(
             "Initialized FlashInfer Allreduce norm fusion workspace "


### PR DESCRIPTION
## Revert of https://github.com/vllm-project/vllm/pull/47219

This reverts commit a264e419751a9248865aefb1547e0109e246934a (merge commit of PR #47219).

### Reason

PR #47219 changed `flashinfer_all_reduce.py` to default the FlashInfer allreduce backend to `mnnvl` on single-node setups. This caused a crash in `flashinfer_trtllm_fused_allreduce_norm` during CUDA graph capture when running with TP=4 on H100 GPUs.

**Failing tests (1):**
- `LM Eval Large Models (4xH100)` — Both Qwen3-235B-A22B and NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 models fail with `RuntimeError: Engine core initialization failed` during cudagraph warmup

**Build:** https://buildkite.com/vllm/ci/builds/75663

---
*Auto-generated by CI failure analyzer.*