### PR TITLE
[CI] Fix segfault in tracing test

### DIFF
--- a/tests/v1/tracing/test_tracing.py
+++ b/tests/v1/tracing/test_tracing.py
@@ -25,11 +25,10 @@ def test_traces(
 ):
     with monkeypatch.context() as m:
         m.setenv(OTEL_EXPORTER_OTLP_TRACES_INSECURE, "true")
-        if current_platform.is_rocm():
-            # The fake OTLP server starts gRPC worker threads before the engine
-            # core is launched. On ROCm CI, forking while those threads are
-            # active can segfault in gRPC during engine startup or teardown.
-            m.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+        # The fake OTLP server starts gRPC worker threads before the engine
+        # core is launched. gRPC's C-core is not fork-safe and can segfault
+        # if forked.
+        m.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 
         sampling_params = SamplingParams(
             temperature=0.01,


### PR DESCRIPTION
This was actually already fixed for rocm case but it is not rocm-specific and the regular metrics test fails intermittently due to this.

E.g. https://buildkite.com/vllm/ci/builds/75740/list?jid=019f1d4f-1e55-4e15-b6db-fd8f495f8bef&tab=output