### PR TITLE
Update DeepGEMM tag to point to latest nv-dev branch for sm120 support

### DIFF
--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -29,7 +29,8 @@ if(DEEPGEMM_SRC_DIR)
 else()
   # Keep in sync with tools/install_deepgemm.sh
   set(_DEEPGEMM_UPSTREAM_REPO "https://github.com/deepseek-ai/DeepGEMM.git")
-  set(_DEEPGEMM_UPSTREAM_TAG "891d57b4db1071624b5c8fa0d1e51cb317fa709f")
+  # NOTE: This is currently targeting nv-dev branch due to sm120 support
+  set(_DEEPGEMM_UPSTREAM_TAG "a6b593d2826719dcf4892609af7b84ee23aaf32a")
 
   set(_deepgemm_fc_root "${FETCHCONTENT_BASE_DIR}")
   if(NOT _deepgemm_fc_root)

--- a/tools/install_deepgemm.sh
+++ b/tools/install_deepgemm.sh
@@ -7,7 +7,8 @@ set -e
 # Default values
 # Keep DEEPGEMM_GIT_REF in sync with cmake/external_projects/deepgemm.cmake
 DEEPGEMM_GIT_REPO="https://github.com/deepseek-ai/DeepGEMM.git"
-DEEPGEMM_GIT_REF="891d57b4db1071624b5c8fa0d1e51cb317fa709f"
+# NOTE: This is currently targeting nv-dev branch due to sm120 support
+DEEPGEMM_GIT_REF="a6b593d2826719dcf4892609af7b84ee23aaf32a"
 WHEEL_DIR=""
 
 # Parse command line arguments


### PR DESCRIPTION



## Purpose

This PR https://github.com/vllm-project/vllm/pull/43477 landed in vLLM without bumping up our commit tag for DeepGEMM for the SM120 support, which resulted in many failures for models that trigger DeepGEMM kernels i.e. https://github.com/vllm-project/vllm/issues/47169, https://github.com/vllm-project/vllm/issues/47266

For now we should bump the DeepGEMM commit for nv-dev (which includes https://github.com/deepseek-ai/DeepGEMM/pull/324), but this will likely be an ongoing issue if this gets out of sync with upstream main

## Test Plan

## Test Result

Tested locally on DGX Spark Qwen3-0.6B-FP8. Before it crashes during startup and now it works fine.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

