### PR TITLE
feat: expose stop reason in token generate responses

### DIFF
--- a/tests/entrypoints/scale_out/token_in_token_out/test_stop_reason.py
+++ b/tests/entrypoints/scale_out/token_in_token_out/test_stop_reason.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from vllm.entrypoints.openai.engine.protocol import RequestResponseMetadata
+from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateRequest
+from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
+from vllm.outputs import CompletionOutput, RequestOutput
+from vllm.sampling_params import SamplingParams
+
+
+async def _single_result(
+    output: RequestOutput,
+) -> AsyncGenerator[RequestOutput, None]:
+    yield output
+
+
+def _serving_tokens() -> ServingTokens:
+    serving = object.__new__(ServingTokens)
+    serving.enable_prompt_tokens_details = False
+    serving.enable_log_outputs = False
+    serving.request_logger = None
+    return serving
+
+
+def _request_output(stop_reason: int | str) -> RequestOutput:
+    return RequestOutput(
+        request_id="rid",
+        prompt=None,
+        prompt_token_ids=[1, 2],
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=0,
+                text="",
+                token_ids=[42],
+                cumulative_logprob=None,
+                logprobs=None,
+                finish_reason="stop",
+                stop_reason=stop_reason,
+            )
+        ],
+        finished=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_full_response_includes_stop_reason_from_engine():
+    request = GenerateRequest(token_ids=[1, 2], sampling_params=SamplingParams())
+
+    response = await _serving_tokens().serve_tokens_full_generator(
+        request,
+        _single_result(_request_output(42)),
+        "rid",
+        "test-model",
+        RequestResponseMetadata(request_id="rid"),
+    )
+
+    choice = response.model_dump()["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert choice["stop_reason"] == 42
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_response_includes_stop_reason_from_engine():
+    request = GenerateRequest(
+        token_ids=[1, 2],
+        sampling_params=SamplingParams(),
+        stream=True,
+    )
+
+    chunks = []
+    async for line in _serving_tokens().serve_tokens_stream_generator(
+        request,
+        _single_result(_request_output("done")),
+        "rid",
+        "test-model",
+        RequestResponseMetadata(request_id="rid"),
+    ):
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: ") :].strip()
+        if payload == "[DONE]":
+            break
+        chunks.append(json.loads(payload))
+
+    assert chunks
+    choice = chunks[0]["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert choice["stop_reason"] == "done"

--- a/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
@@ -178,6 +178,13 @@ class GenerateResponseChoice(BaseModel):
     logprobs: ChatCompletionLogProbs | None = None
     # per OpenAI spec this is the default
     finish_reason: str | None = "stop"
+    stop_reason: int | str | None = Field(
+        default=None,
+        description=(
+            "The stop string or token id that caused generation to stop; "
+            "None when generation ended for another reason, including EOS."
+        ),
+    )
     token_ids: list[int] | None = None
     # Per-token expert routing decisions, base64-encoded ``.npy`` bytes
     # (numpy serialization). Shape after decode:
@@ -195,6 +202,13 @@ class GenerateResponseStreamChoice(BaseModel):
     index: int
     logprobs: ChatCompletionLogProbs | None = None
     finish_reason: str | None = None
+    stop_reason: int | str | None = Field(
+        default=None,
+        description=(
+            "The stop string or token id that caused generation to stop; "
+            "None when generation ended for another reason, including EOS."
+        ),
+    )
     token_ids: list[int] | None = None
     routed_experts: str | None = None
 

--- a/vllm/entrypoints/scale_out/token_in_token_out/serving.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/serving.py
@@ -291,6 +291,7 @@ class ServingTokens(OpenAIServing):
                 index=output.index,
                 logprobs=logprobs,
                 finish_reason=output.finish_reason if output.finish_reason else "stop",
+                stop_reason=output.stop_reason,
                 token_ids=as_list(output.token_ids),
                 routed_experts=routed_experts_b64,
             )
@@ -416,6 +417,7 @@ class ServingTokens(OpenAIServing):
                                 index=i,
                                 logprobs=logprobs,
                                 finish_reason=finish_reason,
+                                stop_reason=output.stop_reason,
                                 token_ids=as_list(delta_token_ids),
                                 routed_experts=routed_experts_b64,
                             )


### PR DESCRIPTION
## Summary
- Adds `stop_reason` to `/inference/v1/generate` response choices.
- Propagates the engine-provided stop string or token id for both streaming and non-streaming token-in/token-out responses.
- Adds unit coverage for streaming and non-streaming response serialization.

## Duplicate-work check
- Searched open PRs for `stop_reason generate`, `"inference/v1/generate" stop_reason`, and `token_in_token_out stop_reason`.
- No open PR was found that implements this response field for `/inference/v1/generate`.

## Test Plan
- [x] `python -m pytest tests/entrypoints/scale_out/token_in_token_out/test_stop_reason.py -q` — 2 passed
- [x] `uvx ruff check tests/entrypoints/scale_out/token_in_token_out/test_stop_reason.py vllm/entrypoints/scale_out/token_in_token_out/protocol.py vllm/entrypoints/scale_out/token_in_token_out/serving.py` — passed
- [x] `uvx pre-commit run --files tests/entrypoints/scale_out/token_in_token_out/test_stop_reason.py vllm/entrypoints/scale_out/token_in_token_out/protocol.py vllm/entrypoints/scale_out/token_in_token_out/serving.py` — passed

AI assistance was used to prepare this change; the submitter should review and defend every changed line.
