### PR TITLE
[Bugfix][Kernel] Re-bias exponent in BF16 NVFP4 Marlin scale dequant

### DIFF
--- a/csrc/libtorch_stable/quantization/marlin/dequant.h
+++ b/csrc/libtorch_stable/quantization/marlin/dequant.h
@@ -536,11 +536,19 @@ __device__ inline void dequant_fp8_scales<nv_bfloat162, vllm::kFE4M3fn.id()>(
   constexpr int FP8_EXPONENT = 4, BF16_EXPONENT = 8;
   constexpr int RIGHT_SHIFT = BF16_EXPONENT - FP8_EXPONENT;
   constexpr int MASK = 0x7F007F00;
+  // Re-bias the exponent when widening FP8 E4M3 (bias 7) to BF16 (bias 127).
+  // Shifting alone (as in the half2 path, whose 5-bit FP16 exponent lines up
+  // with FP8's after the shift) leaves the BF16 exponent un-biased, collapsing
+  // every scale to ~2^-120 and zeroing the dequantized weights (issue #34694).
+  // The half2 path emits scale * 2^-8 (compensated downstream), so match that
+  // convention here: add (127 - 7 - 8) = 112 to each BF16 exponent field.
+  // (FP8 denormal scales are assumed not to occur, as in the kFE8M0fnu path.)
+  constexpr int BF16_BIAS = 0x38003800;  // (112 << 7) replicated per bf16 lane
 
-  // Extract and shift FP8 values to BF16 format
-  int Out1 = ((q & 0x80008000) >> 1) | ((q & MASK) >> RIGHT_SHIFT);
+  // Sign-extend and shift FP8 values to BF16 format, re-biasing the exponent
+  int Out1 = (q & 0x80008000) | (((q & MASK) >> RIGHT_SHIFT) + BF16_BIAS);
   q <<= 8;
-  int Out2 = ((q & 0x80008000) >> 1) | ((q & MASK) >> RIGHT_SHIFT);
+  int Out2 = (q & 0x80008000) | (((q & MASK) >> RIGHT_SHIFT) + BF16_BIAS);
 
   // Note: reverse indexing is intentional because weights are permuted
   frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);


### PR DESCRIPTION
## Purpose

Fixes #34694.

BF16 NVFP4 models produce garbled output on GPUs **without native FP4** (Ada SM89, Volta SM70, etc.), which fall back to the Marlin kernel for FP4 weight dequant. Reported independently by two users on the issue; the earlier #34577 rescaled *weight* scales but did not touch this path.

## Root cause

`dequant_fp8_scales<nv_bfloat162, vllm::kFE4M3fn.id()>` (in `csrc/libtorch_stable/quantization/marlin/dequant.h`) widens the FP8 E4M3 scale exponent into BF16 by **shifting only** — it never re-biases the exponent from FP8's bias 7 to BF16's bias 127:

```cpp
// before: exponent left un-biased
int Out1 = ((q & 0x80008000) >> 1) | ((q & MASK) >> RIGHT_SHIFT);
```

So the BF16 exponent field ends up holding the raw FP8 exponent (0–15) instead of `fp8_exp + bias`. Every scale collapses to ~2⁻¹¹², the dequantized weights underflow to zero, and generation is garbage. The **half2 (FP16) path is unaffected** because FP16's 5-bit exponent lines up with FP8's after the shift.

## Fix

Add the exponent bias in the BF16 exponent field: **`+112 = (127 − 7 − 8)`**. The `−8` matches the half2 path's convention of emitting `scale × 2⁻⁸` (compensated downstream) — so this keeps the two dtype paths consistent. Also place the sign at bit 15 (it was shifted to bit 14).

```cpp
constexpr int BF16_BIAS = 0x38003800;  // (112 << 7) per bf16 lane
int Out1 = (q & 0x80008000) | (((q & MASK) >> RIGHT_SHIFT) + BF16_BIAS);
```

Important subtlety: a naive "convert to the *true* value" fix would be **256× too large** — the kernel intentionally works in the `× 2⁻⁸` domain (per the half2 path), so the fix must too.

## Correctness

Verified against `torch`'s reference FP8 E4M3 → BF16 conversion (in the `value × 2⁻⁸` domain the kernel uses):

- **Bit-exact for all 238 normal FP8 E4M3 scale values** — the range real quantization scales occupy.
- The fixed BF16 path now produces the same real value as the known-good half2 (FP16) path for every byte.
- The 16 FP8-**denormal** edge bytes (`|scale| < 2⁻⁶`) are not represented bit-exactly — consistent with the documented assumption in the adjacent `kFE8M0fnu` path ("such extreme scales don't occur in real models"), and still far closer than the old code (wrong for all 254 values).

## Test Plan / Verification status

The changed function is a `__device__ inline` consumed inside the Marlin gemm. `tests/kernels/quantization/test_marlin_gemm.py` exercises the NVFP4 gemm in bfloat16 (which routes through this dequant) and compares against a float reference (`max_diff < 0.04`) — it will exercise this fix on CI's FP4-capable hardware. Note the bf16 cells are `skip`ped on `capability major < 9`, which is why this never failed on Ada CI.

Transparency: I was unable to complete a local from-source rebuild to run the marlin gemm end-to-end on my SM89 GPU (the from-source build repeatedly got torn down in my environment). The fix is established by the bit-exact static proof above and consistency with the working FP16 path; I'm relying on CI to validate the runtime path on real FP4 hardware. Happy to iterate if CI surfaces anything.

- `clang-format` passes.

---

AI assistance was used; I have reviewed the reasoning and the numeric derivation, and stand behind the change.
