### PR TITLE
[compile][draft] Decouple stock torch.compile cudagraphs via StockCUDAGraphWrapper

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -174,6 +174,39 @@ def test_stock_torch_compile(vllm_runner, monkeypatch):
 
 # forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
 @pytest.mark.forked
+def test_stock_torch_compile_piecewise_graph_partition(vllm_runner, monkeypatch):
+    # Stock + use_inductor_graph_partition recovers piecewise cudagraphs (step 2 of
+    # the VllmBackend migration): Inductor partitions at the attention ops and the
+    # external wrapper captures each partition (FULL_AND_PIECEWISE). opt-125m at one
+    # capture size -> 13 piecewise + 1 full decode = 14 captured graphs (the same
+    # count as the VllmBackend FaP path), proving the stock piecewise path actually
+    # captures rather than running attention inside the cudagraph.
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    with (
+        compilation_counter.expect(
+            stock_torch_compile_count=1,
+            num_gpu_runner_capture_triggers=1,
+            num_cudagraph_captured=14,
+        ),
+        vllm_runner(
+            "facebook/opt-125m",
+            compilation_config={
+                "mode": CompilationMode.STOCK_TORCH_COMPILE,
+                "use_inductor_graph_partition": True,
+                "cudagraph_capture_sizes": [100],
+            },
+            gpu_memory_utilization=0.4,
+        ) as _,
+    ):
+        pass
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
 def test_no_compilation(vllm_runner, monkeypatch):
     # Disable multiprocessing so that the counter is in the same process
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
@@ -788,3 +821,567 @@ def test_inductor_asserts_user_override(monkeypatch):
     assert config.inductor_compile_config.get("size_asserts") is True
     if not _is_torch_equal_or_newer(torch.__version__, "2.12.0.dev"):
         assert config.inductor_compile_config.get("alignment_asserts") is False
+
+
+# --- STOCK_TORCH_COMPILE migration (SupportsStockCompile) config resolution ---
+# These build VllmConfig directly (no model load / GPU memory) and assert the
+# resolved compile mode / cudagraph mode. The cudagraph-mode assertions need a
+# platform that supports static graph mode (FDO is otherwise forced to NONE).
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+@pytest.mark.parametrize(
+    "user_cudagraph_mode,expected",
+    [
+        # Unset, partition explicitly off -> FULL_DECODE_ONLY (whole-graph stock,
+        # decode-only external cudagraph). The partition-on default is covered by
+        # test_stock_defaults_to_graph_partition_piecewise.
+        (None, CUDAGraphMode.FULL_DECODE_ONLY),
+        # Explicit NONE is the user's deliberate choice and must be preserved.
+        (CUDAGraphMode.NONE, CUDAGraphMode.NONE),
+        # Piecewise needs graph partition (off here); the stock path downgrades it to
+        # NONE (not silently re-promoted to FULL_DECODE_ONLY).
+        (CUDAGraphMode.PIECEWISE, CUDAGraphMode.NONE),
+        (CUDAGraphMode.FULL_AND_PIECEWISE, CUDAGraphMode.NONE),
+        # Explicit full modes are honored as-is.
+        (CUDAGraphMode.FULL, CUDAGraphMode.FULL),
+        (CUDAGraphMode.FULL_DECODE_ONLY, CUDAGraphMode.FULL_DECODE_ONLY),
+    ],
+)
+def test_stock_cudagraph_mode_resolution(user_cudagraph_mode, expected):
+    # Pin partition off so this isolates the no-partition resolution regardless of
+    # the torch version (the default auto-enables partition on torch>=2.9).
+    cc_kwargs = {
+        "mode": CompilationMode.STOCK_TORCH_COMPILE,
+        "use_inductor_graph_partition": False,
+    }
+    if user_cudagraph_mode is not None:
+        cc_kwargs["cudagraph_mode"] = user_cudagraph_mode
+    config = VllmConfig(compilation_config=CompilationConfig(**cc_kwargs))
+    assert config.compilation_config.cudagraph_mode == expected
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_defaults_to_graph_partition_piecewise():
+    # A stock-compile model with nothing set defaults to graph-partition piecewise
+    # (FULL_AND_PIECEWISE) on torch>=2.9, auto-enabling use_inductor_graph_partition;
+    # on older torch it falls back to FULL_DECODE_ONLY. The flag is folded into the
+    # SupportsStockCompile default rather than being opt-in.
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    cc = config.compilation_config
+    if is_torch_equal_or_newer("2.9.0.dev"):
+        assert cc.use_inductor_graph_partition is True
+        assert cc.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
+    else:
+        assert cc.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+@pytest.mark.parametrize(
+    "supported,user_mode,expected_mode,expected_cudagraph",
+    [
+        (
+            True,
+            None,
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        (
+            False,
+            None,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        # An explicit mode always wins over the allowlist auto-selection.
+        (
+            True,
+            CompilationMode.VLLM_COMPILE,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+    ],
+)
+def test_stock_mode_auto_selection(
+    supported, user_mode, expected_mode, expected_cudagraph
+):
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    cc_kwargs = {} if user_mode is None else {"mode": user_mode}
+    with patch.object(VllmConfig, "_stock_compile_supported", lambda self: supported):
+        config = VllmConfig(compilation_config=CompilationConfig(**cc_kwargs))
+    assert config.compilation_config.mode == expected_mode
+    # The stock default is graph-partition piecewise only on torch>=2.9; otherwise
+    # it falls back to the decode-only external cudagraph.
+    if (
+        expected_mode == CompilationMode.STOCK_TORCH_COMPILE
+        and not is_torch_equal_or_newer("2.9.0.dev")
+    ):
+        expected_cudagraph = CUDAGraphMode.FULL_DECODE_ONLY
+    assert config.compilation_config.cudagraph_mode == expected_cudagraph
+
+
+@pytest.mark.parametrize(
+    "mode,cudagraph_mode,expected",
+    [
+        (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+            CUDAGraphMode.NONE,
+        ),
+        (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            CUDAGraphMode.NONE,
+        ),
+        (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        ),
+        # VLLM_COMPILE keeps piecewise (it has the FX splitting to honor it).
+        (
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+            CUDAGraphMode.PIECEWISE,
+        ),
+    ],
+)
+def test_downgrade_piecewise_cudagraph_helper(mode, cudagraph_mode, expected):
+    # Pin partition off so the STOCK rows test the clamp (the default auto-enables
+    # partition on torch>=2.9, which is the exempt-from-clamp path).
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=mode, use_inductor_graph_partition=False
+        )
+    )
+    config.compilation_config.cudagraph_mode = cudagraph_mode
+    config._downgrade_piecewise_cudagraph_for_non_vllm_compile()
+    assert config.compilation_config.cudagraph_mode == expected
+
+
+# --- step 2: piecewise cudagraphs on the stock path via Inductor graph partition ---
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+@pytest.mark.parametrize(
+    "user_cudagraph_mode,expected",
+    [
+        # Unset + graph partition -> prefill can be piecewise-captured, so default to
+        # FULL_AND_PIECEWISE rather than FULL_DECODE_ONLY.
+        (None, CUDAGraphMode.FULL_AND_PIECEWISE),
+        # Explicit piecewise modes are now honored on the stock path (Inductor graph
+        # partition provides them) instead of being clamped to NONE.
+        (CUDAGraphMode.PIECEWISE, CUDAGraphMode.PIECEWISE),
+        (CUDAGraphMode.FULL_AND_PIECEWISE, CUDAGraphMode.FULL_AND_PIECEWISE),
+        # Explicit NONE is still the user's deliberate choice.
+        (CUDAGraphMode.NONE, CUDAGraphMode.NONE),
+    ],
+)
+def test_stock_graph_partition_cudagraph_mode(user_cudagraph_mode, expected):
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    cc_kwargs = {
+        "mode": CompilationMode.STOCK_TORCH_COMPILE,
+        "use_inductor_graph_partition": True,
+    }
+    if user_cudagraph_mode is not None:
+        cc_kwargs["cudagraph_mode"] = user_cudagraph_mode
+    config = VllmConfig(compilation_config=CompilationConfig(**cc_kwargs))
+    assert config.compilation_config.cudagraph_mode == expected
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_graph_partition_populates_splitting_ops():
+    # With graph partition, splitting_ops must name the attention ops so Inductor
+    # partitions there; without it the stock path is whole-graph (empty splitting_ops).
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+
+    partition = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=True,
+        )
+    )
+    assert partition.compilation_config.splitting_ops == list(
+        CompilationConfig._attention_ops
+    )
+
+    # An explicit empty list with partition on must still be populated (else
+    # FULL_AND_PIECEWISE would have zero piecewise partitions, silently capturing
+    # attention inside the cudagraph).
+    explicit_empty = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=True,
+            splitting_ops=[],
+        )
+    )
+    assert explicit_empty.compilation_config.splitting_ops == list(
+        CompilationConfig._attention_ops
+    )
+
+    # Partition explicitly off -> whole-graph stock, no splitting ops (the default
+    # now auto-enables partition, so this must pin it off to test the FDO path).
+    no_partition = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=False,
+        )
+    )
+    assert no_partition.compilation_config.splitting_ops == []
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="enable_qk_norm_rope_fusion is forced off on non-CUDA platforms",
+)
+def test_stock_inductor_options_fusion_gate():
+    # The fusion gate is derived from the configured PostGradPassManager rather
+    # than a hand-maintained flag list, so it cannot drift: dense bf16 (only the
+    # always-on noop pass) registers nothing, while a fusion the old list omitted
+    # (enable_qk_norm_rope_fusion) still registers the pass manager.
+    from types import SimpleNamespace
+
+    import vllm.compilation.passes.inductor_pass as inductor_pass_mod
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    def options_for(**pass_flags):
+        vc = VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.STOCK_TORCH_COMPILE,
+                pass_config=PassConfig(**pass_flags),
+            )
+        )
+        vc.model_config = MagicMock(dtype=torch.bfloat16)
+        stub = SimpleNamespace(compilation_config=vc.compilation_config, vllm_config=vc)
+        return GPUModelRunner._stock_inductor_options(stub)
+
+    assert options_for(eliminate_noops=True) is None
+
+    # The fusion-positive dict must actually wire the pre/post-grad passes through
+    # Inductor's custom-pass hooks, not merely be non-None.
+    from vllm.compilation.passes.ir.inplace_functionalization import (
+        VllmIRInplaceFunctionalizationPass,
+    )
+
+    # The fusion path installs a process-global pass context (set_pass_context has
+    # no teardown by design); restore it so this unit test leaves no global state.
+    prev_pass_context = inductor_pass_mod._pass_context
+    try:
+        opts = options_for(eliminate_noops=True, enable_qk_norm_rope_fusion=True)
+        assert opts is not None
+        assert isinstance(
+            opts["pre_grad_custom_pass"], VllmIRInplaceFunctionalizationPass
+        )
+        assert current_platform.pass_key in opts
+        assert "pre_grad_custom_pass" in opts["_cache_config_ignore_prefix"]
+    finally:
+        inductor_pass_mod._pass_context = prev_pass_context
+
+
+def test_stock_inert_flag_warning():
+    # VllmBackend-only flags on a stock model emit one warning that names the
+    # working escape hatch and never the broken -O.mode=3 form.
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE, compile_sizes=[1, 2]
+        )
+    )
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 1
+    fmt, *fmt_args = mock_warn.call_args.args
+    assert "--compilation-config" in fmt
+    assert "-O.mode=3" not in fmt
+    assert "compile_sizes" in " ".join(str(a) for a in fmt_args)
+
+    # cudagraph_copy_inputs and splitting_ops (without graph partition) are also
+    # VllmBackend-only on the stock path and must each surface in the warning args.
+    copy_cfg = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE, cudagraph_copy_inputs=True
+        )
+    )
+    copy_cfg.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        copy_cfg._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 1
+    assert "cudagraph_copy_inputs" in " ".join(
+        str(a) for a in mock_warn.call_args.args
+    )
+
+    split_cfg = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            splitting_ops=["vllm::unified_attention"],
+            use_inductor_graph_partition=False,
+        )
+    )
+    split_cfg.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        split_cfg._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 1
+    assert "splitting_ops" in " ".join(str(a) for a in mock_warn.call_args.args)
+
+    # VLLM_COMPILE honors these flags, so no warning.
+    other = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE, compile_sizes=[1, 2]
+        )
+    )
+    other.model_config = MagicMock(architectures=["LlamaForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        other._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 0
+
+
+def test_stock_graph_partition_no_piecewise_override_warning():
+    # With use_inductor_graph_partition the stock path provides piecewise cudagraphs,
+    # so resolving to FULL_AND_PIECEWISE must NOT warn about an unsupported/overridden
+    # cudagraph_mode (regression: the inert-flag warning used to fire here).
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=True,
+        )
+    )
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 0
+
+
+def test_stock_compile_cache_flags_warn(monkeypatch):
+    # vLLM's own compile cache is inert on the stock path (torch.compile uses its
+    # own cache); setting any of its knobs must warn, not be silently ignored.
+    monkeypatch.setenv("VLLM_COMPILE_CACHE_SAVE_FORMAT", "binary")
+
+    def warn_parts(**cc):
+        config = VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.STOCK_TORCH_COMPILE, **cc
+            )
+        )
+        config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+        with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+            config._warn_ignored_vllm_backend_only_flags()
+        assert mock_warn.call_count == 1
+        return " ".join(str(a) for a in mock_warn.call_args.args)
+
+    assert "cache_dir" in warn_parts(cache_dir="/tmp/vllm-cache")
+    assert "compile_cache_save_format" in warn_parts(
+        compile_cache_save_format="unpacked"
+    )
+
+    # VLLM_DISABLE_COMPILE_CACHE is an env var, not a field.
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 1
+    assert "VLLM_DISABLE_COMPILE_CACHE" in " ".join(
+        str(a) for a in mock_warn.call_args.args
+    )
+
+
+def test_stock_warn_no_false_positive_on_autopopulated_fields():
+    # compile_ranges_endpoints is auto-populated later in __post_init__ (and
+    # __post_init__ may re-run on a reused compilation_config), so a resolved
+    # non-empty value must NOT trigger a warning when the user set no inert flags.
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    # simulate the resolved/auto-populated state seen on a real run / re-run
+    config.compilation_config.compile_ranges_endpoints = [16384]
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 0
+
+
+def test_stock_warning_handles_missing_model_config():
+    # mode==STOCK with no model_config must not raise (the warn helper dereferences
+    # model_config.architectures only after a None guard).
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE, compile_sizes=[1, 2]
+        )
+    )
+    config.model_config = None
+    config._warn_ignored_vllm_backend_only_flags()
+
+
+def test_stock_compile_supported_safe_defaults():
+    # The real _stock_compile_supported (not patched out) must return False for
+    # both the no-model case and any registry resolution error, so a broken/unknown
+    # model never gets auto-selected onto the stock path.
+    no_model = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    no_model.model_config = None
+    assert no_model._stock_compile_supported() is False
+
+    raising = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    registry = MagicMock()
+    registry.is_stock_compile_supported_model.side_effect = RuntimeError("boom")
+    raising.model_config = MagicMock(
+        architectures=["GptOssForCausalLM"], registry=registry
+    )
+    assert raising._stock_compile_supported() is False
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_dynamic_sd_keeps_cudagraph_none():
+    # The auto-promotion from NONE to FULL_DECODE_ONLY is guarded by uses_dynamic_sd:
+    # dynamic spec decode varies the verification length, so external full-decode
+    # capture must NOT kick in. An algorithmic (ngram_gpu) drafter keeps the stock
+    # path, so this isolates the dynamic-SD guard on STOCK.
+    from types import SimpleNamespace
+
+    spec = SimpleNamespace(
+        method="ngram_gpu",
+        disable_padded_drafter_batch=False,
+        num_speculative_tokens=3,
+        max_num_new_slots_for_drafting=3,
+        parallel_drafting=False,
+        uses_dynamic_speculative_decoding=lambda: True,
+        use_eagle=lambda: False,
+        compute_hash=lambda: "spec",
+    )
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    # Assign the stub after construction (pydantic's dataclass validator rejects a
+    # SimpleNamespace at construction time) and re-run resolution to exercise the
+    # dynamic-SD guard in __post_init__.
+    config.speculative_config = spec
+    config.compilation_config.cudagraph_mode = None
+    # Reset the auto-resolved partition flag too: the spec-less first construction
+    # auto-enabled it, and a fresh resolution (the real single-construction path with
+    # a dynamic drafter) would not, since the dynamic-SD guard skips that block.
+    config.compilation_config.use_inductor_graph_partition = None
+    config.__post_init__()
+    assert config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["eagle", "eagle3", "mtp", "dflash", "draft_model", "medusa"],
+)
+def test_stock_falls_back_to_vllm_compile_for_model_backed_drafter(method):
+    # A model-backed spec-decode drafter is compiled by its own decorator under
+    # VLLM_COMPILE but never on the stock path, so a stock target with such a
+    # drafter must fall back to VLLM_COMPILE (overriding even an explicit STOCK).
+    from types import SimpleNamespace
+
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    config.speculative_config = SimpleNamespace(method=method)
+    config._maybe_fallback_stock_to_vllm_compile_for_drafter()
+    assert config.compilation_config.mode == CompilationMode.VLLM_COMPILE
+
+
+@pytest.mark.parametrize("method", ["ngram", "ngram_gpu", "suffix"])
+def test_stock_preserved_for_algorithmic_drafter(method):
+    # Algorithmic drafters have no model to compile, so the stock path is kept.
+    from types import SimpleNamespace
+
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    config.speculative_config = SimpleNamespace(method=method)
+    config._maybe_fallback_stock_to_vllm_compile_for_drafter()
+    assert config.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE
+
+
+def test_stock_drafter_fallback_noop_cases():
+    from types import SimpleNamespace
+
+    # No speculative config -> stock preserved (the validated no-spec sweep).
+    cfg = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    cfg.speculative_config = None
+    cfg._maybe_fallback_stock_to_vllm_compile_for_drafter()
+    assert cfg.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE
+
+    # Non-stock mode is left untouched even with a model-backed drafter.
+    cfg = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.VLLM_COMPILE)
+    )
+    cfg.speculative_config = SimpleNamespace(method="eagle")
+    cfg._maybe_fallback_stock_to_vllm_compile_for_drafter()
+    assert cfg.compilation_config.mode == CompilationMode.VLLM_COMPILE
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_torch_compile_captures_full_cudagraph(vllm_runner, monkeypatch):
+    # The headline parity path: a stock-compiled model must still attach vLLM's
+    # external FULL cudagraph wrapper and actually capture a FULL_DECODE_ONLY graph.
+    # opt-125m is not SupportsStockCompile, so mode=STOCK is forced explicitly here;
+    # the auto-FDO promotion is allowlist-independent, so this isolates the cudagraph
+    # fall-through (not the SupportsStockCompile selection).
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    with (
+        compilation_counter.expect(
+            stock_torch_compile_count=1,
+            num_gpu_runner_capture_triggers=1,
+            num_cudagraph_captured=1,
+        ),
+        vllm_runner(
+            "facebook/opt-125m",
+            compilation_config={
+                "mode": CompilationMode.STOCK_TORCH_COMPILE,
+                # Pin partition off: this test isolates the FULL_DECODE_ONLY fall-
+                # through, while the default now auto-enables graph-partition
+                # piecewise (covered by test_stock_torch_compile_piecewise_*).
+                "use_inductor_graph_partition": False,
+                "cudagraph_capture_sizes": [100],
+            },
+            gpu_memory_utilization=0.4,
+        ) as _,
+    ):
+        pass

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -207,6 +207,32 @@ def test_stock_torch_compile_piecewise_graph_partition(vllm_runner, monkeypatch)
 
 # forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
 @pytest.mark.forked
+def test_stock_uses_decoupled_cudagraph_wrapper(vllm_runner, monkeypatch):
+    # The stock path must capture via its own StockCUDAGraphWrapper, never the shared
+    # CUDAGraphWrapper (which is coupled to vLLM's non-torch.compile full-cudagraph
+    # path). Forked so the wrapper-class instance registries start empty.
+    from vllm.compilation.cuda_graph import CUDAGraphWrapper
+    from vllm.compilation.stock_cudagraph import StockCUDAGraphWrapper
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    with vllm_runner(
+        "facebook/opt-125m",
+        compilation_config={
+            "mode": CompilationMode.STOCK_TORCH_COMPILE,
+            "use_inductor_graph_partition": True,
+            "cudagraph_capture_sizes": [100],
+        },
+        gpu_memory_utilization=0.4,
+    ) as _:
+        assert len(StockCUDAGraphWrapper._all_instances) > 0
+        assert len(CUDAGraphWrapper._all_instances) == 0
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
 def test_no_compilation(vllm_runner, monkeypatch):
     # Disable multiprocessing so that the counter is in the same process
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -136,3 +136,27 @@ def test_hf_registry_coverage():
         "Please add the following architectures to "
         f"`tests/models/registry.py`: {untested_archs}"
     )
+
+
+def test_supports_stock_compile_marker():
+    # The SupportsStockCompile marker is the single bit that opts an architecture
+    # into the stock torch.compile path; guard it so the GPT-OSS opt-in cannot be
+    # dropped and no other architecture is migrated by accident.
+    from vllm.model_executor.models.interfaces import supports_stock_compile
+
+    gptoss = ModelRegistry._try_load_model_cls("GptOssForCausalLM")
+    llama = ModelRegistry._try_load_model_cls("LlamaForCausalLM")
+    assert supports_stock_compile(gptoss)
+    assert not supports_stock_compile(llama)
+
+    # Also exercise the production resolution path (the _ModelInfo field hop that
+    # config resolution actually consults), not just the marker free function.
+    from unittest.mock import MagicMock
+
+    model_config = MagicMock(model_impl="vllm")
+    assert ModelRegistry.is_stock_compile_supported_model(
+        "GptOssForCausalLM", model_config
+    )
+    assert not ModelRegistry.is_stock_compile_supported_model(
+        "LlamaForCausalLM", model_config
+    )

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -721,6 +721,58 @@ def _support_torch_compile(
     return cls
 
 
+def _make_cudagraph_partition_wrapper(vllm_config: VllmConfig) -> Callable[..., Any]:
+    """Build the customized Inductor graph-partition wrapper that wraps each
+    partition with vLLM's PIECEWISE static cudagraph wrapper. Shared by the
+    VLLM_COMPILE decorator path and the STOCK_TORCH_COMPILE graph-partition path so
+    the two cannot diverge on the per-partition cudagraph options.
+    """
+    from torch._inductor.utils import CUDAGraphWrapperMetadata
+
+    from vllm.compilation.cuda_graph import CUDAGraphOptions
+    from vllm.config import CUDAGraphMode
+    from vllm.platforms import current_platform
+
+    static_graph_wrapper_class = resolve_obj_by_qualname(
+        current_platform.get_static_graph_wrapper_cls()
+    )
+
+    def customized_cudagraph_wrapper(
+        f: Callable[..., Any], metadata: CUDAGraphWrapperMetadata
+    ) -> Any:
+        partition_id = metadata.partition_index
+        num_partitions = metadata.num_partitions
+        return static_graph_wrapper_class(
+            runnable=f,
+            vllm_config=vllm_config,
+            runtime_mode=CUDAGraphMode.PIECEWISE,
+            cudagraph_options=CUDAGraphOptions(
+                debug_log_enable=partition_id == 0,
+                gc_disable=partition_id != 0,
+                weak_ref_output=partition_id == num_partitions - 1,
+            ),
+        )
+
+    return customized_cudagraph_wrapper
+
+
+def install_cudagraph_partition_wrapper(vllm_config: VllmConfig) -> None:
+    """Persistently install the graph-partition cudagraph wrapper for the
+    engine-global STOCK_TORCH_COMPILE path. Stock torch.compile is lazy (the real
+    Inductor compile + post_compile partition wrapping run on the first forward),
+    so a scoped context manager cannot bracket it the way VLLM_COMPILE does -- the
+    install must outlive this call. Stock mode is engine-global and compiles the
+    target once. It is never unset: any later graph_partition compile would also be
+    wrapped, but the wrapper is a no-op pass-through unless a PIECEWISE forward
+    context dispatches to it (see CUDAGraphWrapper.__call__), so a stray compile is
+    not wrongly captured. A scoped unset (around the capture phase) is a possible
+    future hardening once a clean hook exists.
+    """
+    torch._inductor.utils.set_customized_partition_wrappers(
+        _make_cudagraph_partition_wrapper(vllm_config)
+    )
+
+
 @contextlib.contextmanager
 def maybe_use_cudagraph_partition_wrapper(
     vllm_config: VllmConfig,
@@ -735,40 +787,13 @@ def maybe_use_cudagraph_partition_wrapper(
     graph wrapper class to maintain more control over static graph
     capture and replay.
     """
-    from vllm.config import CUDAGraphMode
-
     compilation_config = vllm_config.compilation_config
     if (
         compilation_config.cudagraph_mode.has_piecewise_cudagraphs()
         and compilation_config.use_inductor_graph_partition
     ):
-        from torch._inductor.utils import CUDAGraphWrapperMetadata
-
-        from vllm.compilation.cuda_graph import CUDAGraphOptions
-        from vllm.platforms import current_platform
-
-        static_graph_wrapper_class = resolve_obj_by_qualname(
-            current_platform.get_static_graph_wrapper_cls()
-        )
-
-        def customized_cudagraph_wrapper(
-            f: Callable[..., Any], metadata: CUDAGraphWrapperMetadata
-        ) -> Any:
-            partition_id = metadata.partition_index
-            num_partitions = metadata.num_partitions
-            return static_graph_wrapper_class(
-                runnable=f,
-                vllm_config=vllm_config,
-                runtime_mode=CUDAGraphMode.PIECEWISE,
-                cudagraph_options=CUDAGraphOptions(
-                    debug_log_enable=partition_id == 0,
-                    gc_disable=partition_id != 0,
-                    weak_ref_output=partition_id == num_partitions - 1,
-                ),
-            )
-
         torch._inductor.utils.set_customized_partition_wrappers(
-            customized_cudagraph_wrapper
+            _make_cudagraph_partition_wrapper(vllm_config)
         )
 
     yield

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -723,9 +723,9 @@ def _support_torch_compile(
 
 def _make_cudagraph_partition_wrapper(vllm_config: VllmConfig) -> Callable[..., Any]:
     """Build the customized Inductor graph-partition wrapper that wraps each
-    partition with vLLM's PIECEWISE static cudagraph wrapper. Shared by the
-    VLLM_COMPILE decorator path and the STOCK_TORCH_COMPILE graph-partition path so
-    the two cannot diverge on the per-partition cudagraph options.
+    partition with vLLM's PIECEWISE static cudagraph wrapper. Used by the
+    VLLM_COMPILE decorator path (the STOCK_TORCH_COMPILE path uses its own
+    StockCUDAGraphWrapper via _make_stock_cudagraph_partition_wrapper).
     """
     from torch._inductor.utils import CUDAGraphWrapperMetadata
 
@@ -756,20 +756,55 @@ def _make_cudagraph_partition_wrapper(vllm_config: VllmConfig) -> Callable[..., 
     return customized_cudagraph_wrapper
 
 
+def _make_stock_cudagraph_partition_wrapper(
+    vllm_config: VllmConfig,
+) -> Callable[..., Any]:
+    """Like _make_cudagraph_partition_wrapper but wraps each Inductor partition with
+    the STOCK-only StockCUDAGraphWrapper (vllm/compilation/stock_cudagraph.py). The
+    stock torch.compile path deliberately does not reuse the shared CUDAGraphWrapper,
+    which is coupled to vLLM's non-torch.compile full-cudagraph path.
+    """
+    from torch._inductor.utils import CUDAGraphWrapperMetadata
+
+    from vllm.compilation.stock_cudagraph import (
+        StockCUDAGraphOptions,
+        StockCUDAGraphWrapper,
+    )
+    from vllm.config import CUDAGraphMode
+
+    def customized_cudagraph_wrapper(
+        f: Callable[..., Any], metadata: CUDAGraphWrapperMetadata
+    ) -> Any:
+        partition_id = metadata.partition_index
+        num_partitions = metadata.num_partitions
+        return StockCUDAGraphWrapper(
+            runnable=f,
+            vllm_config=vllm_config,
+            runtime_mode=CUDAGraphMode.PIECEWISE,
+            cudagraph_options=StockCUDAGraphOptions(
+                debug_log_enable=partition_id == 0,
+                gc_disable=partition_id != 0,
+                weak_ref_output=partition_id == num_partitions - 1,
+            ),
+        )
+
+    return customized_cudagraph_wrapper
+
+
 def install_cudagraph_partition_wrapper(vllm_config: VllmConfig) -> None:
-    """Persistently install the graph-partition cudagraph wrapper for the
+    """Persistently install the STOCK graph-partition cudagraph wrapper for the
     engine-global STOCK_TORCH_COMPILE path. Stock torch.compile is lazy (the real
     Inductor compile + post_compile partition wrapping run on the first forward),
     so a scoped context manager cannot bracket it the way VLLM_COMPILE does -- the
     install must outlive this call. Stock mode is engine-global and compiles the
     target once. It is never unset: any later graph_partition compile would also be
     wrapped, but the wrapper is a no-op pass-through unless a PIECEWISE forward
-    context dispatches to it (see CUDAGraphWrapper.__call__), so a stray compile is
+    context dispatches to it (StockCUDAGraphWrapper.__call__), so a stray compile is
     not wrongly captured. A scoped unset (around the capture phase) is a possible
     future hardening once a clean hook exists.
     """
     torch._inductor.utils.set_customized_partition_wrappers(
-        _make_cudagraph_partition_wrapper(vllm_config)
+        _make_stock_cudagraph_partition_wrapper(vllm_config)
     )
 
 

--- a/vllm/compilation/passes/inductor_pass.py
+++ b/vllm/compilation/passes/inductor_pass.py
@@ -54,6 +54,20 @@ def pass_context(compile_range: Range) -> Generator[None, None, None]:
         _pass_context = prev_context
 
 
+def set_pass_context(compile_range: Range) -> None:
+    """Install a process-global PassContext that outlives this call.
+
+    Unlike the ``pass_context`` context manager (used by VllmBackend around each
+    synchronous per-range compile), STOCK_TORCH_COMPILE is engine-global and its
+    Inductor compiles run lazily during later forwards, so there is no single
+    span to scope. The pre/post-grad vLLM passes and PostGradPassManager.uuid()
+    must all observe one live PassContext; this installs exactly that. No
+    VllmBackend runs in a stock engine, so there is nothing to restore.
+    """
+    global _pass_context
+    _pass_context = PassContext(compile_range)
+
+
 @functools.cache
 def _hash_source_cached(*srcs: str | type | types.FunctionType) -> str:
     hasher = hashlib.sha256()

--- a/vllm/compilation/stock_cudagraph.py
+++ b/vllm/compilation/stock_cudagraph.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Stock-torch.compile cudagraph wrapper.
+
+Decoupled copy of the capture/replay logic in ``vllm/compilation/cuda_graph.py``
+for the STOCK_TORCH_COMPILE path. It is intentionally NOT the shared
+``CUDAGraphWrapper``: that class is also used by vLLM's non-torch.compile full
+cudagraph path, and keeping the stock path on its own wrapper lets vLLM evolve
+full cudagraphs without affecting torch.compile (and vice versa). The capture
+semantics mirror ``CUDAGraphWrapper`` (batch-descriptor keyed capture/replay,
+shared graph pool, weak-ref outputs); vLLM still owns padding, persistent input
+buffers, and the forward-context mode/descriptor dispatch.
+"""
+
+import dataclasses
+import weakref
+from collections.abc import Callable
+from contextlib import ExitStack
+from typing import Any, ClassVar
+from unittest.mock import patch
+
+import torch
+
+import vllm.envs as envs
+from vllm.compilation.counter import compilation_counter
+from vllm.compilation.monitor import validate_cudagraph_capturing_enabled
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.distributed.device_communicators.pynccl_allocator import set_graph_pool_id
+from vllm.forward_context import (
+    BatchDescriptor,
+    get_forward_context,
+    is_forward_context_available,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.offloader.base import get_offloader
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import current_stream, weak_ref_tensors
+
+logger = init_logger(__name__)
+
+
+@dataclasses.dataclass
+class StockCUDAGraphEntry:
+    batch_descriptor: BatchDescriptor
+    cudagraph: torch.cuda.CUDAGraph | None = None
+    output: Any | None = None
+    # For debugging: input addresses at capture, checked to be stable on replay.
+    input_addresses: list[int] | None = None
+
+
+@dataclasses.dataclass
+class StockCUDAGraphOptions:
+    debug_log_enable: bool = True
+    gc_disable: bool = False
+    weak_ref_output: bool = True
+
+
+class StockCUDAGraphWrapper:
+    """Capture/replay a runnable as a cudagraph, keyed on the forward-context
+    batch descriptor. See the module docstring for why this is a separate class
+    from the shared ``CUDAGraphWrapper``."""
+
+    _all_instances: ClassVar[weakref.WeakSet["StockCUDAGraphWrapper"]] = (
+        weakref.WeakSet()
+    )
+
+    @classmethod
+    def clear_all_graphs(cls) -> None:
+        for instance in list(cls._all_instances):
+            instance.clear_graphs()
+
+    def __init__(
+        self,
+        runnable: Callable[..., Any],
+        vllm_config: VllmConfig,
+        runtime_mode: CUDAGraphMode,
+        cudagraph_options: StockCUDAGraphOptions | None = None,
+    ) -> None:
+        self.runnable = runnable
+        self.vllm_config = vllm_config
+        self.runtime_mode = runtime_mode
+        self.compilation_config = vllm_config.compilation_config
+
+        self.is_debugging_mode = envs.VLLM_LOGGING_LEVEL == "DEBUG"
+        self._runnable_str = str(runnable) if self.is_debugging_mode else None
+
+        assert self.runtime_mode != CUDAGraphMode.NONE
+        self.graph_pool = current_platform.get_global_graph_pool()
+
+        if cudagraph_options is None:
+            cudagraph_options = StockCUDAGraphOptions()
+        self.cudagraph_options = cudagraph_options
+        self.concrete_cudagraph_entries: dict[BatchDescriptor, StockCUDAGraphEntry] = {}
+
+        StockCUDAGraphWrapper._all_instances.add(self)
+
+    def __getattr__(self, key: str) -> Any:
+        if hasattr(self.runnable, key):
+            return getattr(self.runnable, key)
+        if self.is_debugging_mode:
+            raise AttributeError(
+                f"Attribute {key} not exists in the runnable of "
+                f"stock cudagraph wrapper: {self._runnable_str}"
+            )
+        raise AttributeError
+
+    def unwrap(self) -> Callable[..., Any]:
+        return self.runnable
+
+    @property
+    def cudagraph_wrapper(self) -> "StockCUDAGraphWrapper":
+        return self
+
+    def clear_graphs(self) -> None:
+        self.concrete_cudagraph_entries.clear()
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any | None:
+        if not is_forward_context_available():
+            # Outside the normal inference path (e.g. a vision encoder forward).
+            return self.runnable(*args, **kwargs)
+
+        forward_context = get_forward_context()
+        batch_descriptor = forward_context.batch_descriptor
+        cudagraph_runtime_mode = forward_context.cudagraph_runtime_mode
+
+        if (
+            cudagraph_runtime_mode == CUDAGraphMode.NONE
+            or cudagraph_runtime_mode != self.runtime_mode
+        ):
+            # Profile/warmup run, no cudagraph, or a mode meant for a different
+            # (nested) wrapper: run directly.
+            return self.runnable(*args, **kwargs)
+
+        assert batch_descriptor is not None
+        if batch_descriptor not in self.concrete_cudagraph_entries:
+            self.concrete_cudagraph_entries[batch_descriptor] = StockCUDAGraphEntry(
+                batch_descriptor=batch_descriptor
+            )
+
+        entry = self.concrete_cudagraph_entries[batch_descriptor]
+
+        if entry.cudagraph is None:
+            if self.cudagraph_options.debug_log_enable:
+                logger.debug(
+                    "Capturing a cudagraph on (%s,%s)",
+                    self.runtime_mode.name,
+                    entry.batch_descriptor,
+                )
+            validate_cudagraph_capturing_enabled()
+
+            entry.input_addresses = [
+                x.data_ptr() for x in args if isinstance(x, torch.Tensor)
+            ]
+            cudagraph = torch.cuda.CUDAGraph()
+
+            with ExitStack() as stack:
+                if self.cudagraph_options.gc_disable:
+                    # Piecewise mode captures one graph per partition; running gc
+                    # per partition is very slow, so gc only for the first.
+                    stack.enter_context(
+                        patch("gc.collect", lambda *args, **kwargs: None)
+                    )
+                    stack.enter_context(
+                        patch(
+                            "torch.accelerator.empty_cache",
+                            lambda *args, **kwargs: None,
+                        )
+                    )
+
+                if self.graph_pool is not None:
+                    set_graph_pool_id(self.graph_pool)
+                else:
+                    set_graph_pool_id(current_platform.graph_pool_handle())
+
+                get_offloader().sync_prev_onload()
+
+                with torch.cuda.graph(
+                    cudagraph,
+                    pool=self.graph_pool,
+                    stream=current_stream(),
+                ):
+                    output = self.runnable(*args, **kwargs)
+                    get_offloader().join_after_forward()
+                    if self.cudagraph_options.weak_ref_output:
+                        # Safe only for the last graph in piecewise mode: its
+                        # output is not consumed by another captured graph.
+                        output = weak_ref_tensors(output)
+
+            entry.output = weak_ref_tensors(output)
+            entry.cudagraph = cudagraph
+
+            compilation_counter.num_cudagraph_captured += 1
+
+            # Return the real output (not the weak ref) so pytorch manages the
+            # cudagraph-pool memory correctly during capture.
+            return output
+
+        if self.is_debugging_mode:
+            new_input_addresses = [
+                x.data_ptr() for x in args if isinstance(x, torch.Tensor)
+            ]
+            assert new_input_addresses == entry.input_addresses, (
+                f"Input addresses for cudagraphs are different during replay. "
+                f"Expected {entry.input_addresses}, got {new_input_addresses}"
+            )
+
+        get_offloader().sync_prev_onload()
+        entry.cudagraph.replay()
+        return entry.output

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -430,7 +430,8 @@ class CompilationConfig:
     model.
 
     - None: If None, we will select the default compilation mode.
-      For V1 engine this is 3.
+      For V1 engine this is 3 (VLLM_COMPILE) for most architectures; architectures
+      declaring SupportsStockCompile default to 1 (STOCK_TORCH_COMPILE).
     - 0: NONE: No torch.compile compilation is applied, model runs in fully
          eager pytorch mode. The model runs as-is.
     - 1: STOCK_TORCH_COMPILE: The standard `torch.compile` compilation pipeline.
@@ -1100,7 +1101,25 @@ class CompilationConfig:
         # To compatible with OOT hardware plugin platform (for example vllm-ascend)
         # which currently only supports sequence parallelism in eager mode.
         if self.mode != CompilationMode.VLLM_COMPILE:
-            if self.splitting_ops is None:
+            # STOCK_TORCH_COMPILE recovers piecewise cudagraphs through Inductor graph
+            # partition (step 2 of the VllmBackend migration): Inductor partitions at
+            # the attention ops and routes each partition's capture through the
+            # external wrapper, so splitting_ops must name the attention ops exactly as
+            # the VLLM_COMPILE partition path does. Without graph partition the stock
+            # path is whole-graph (FULL_DECODE_ONLY / no piecewise), so splitting_ops
+            # stays empty.
+            if (
+                self.mode == CompilationMode.STOCK_TORCH_COMPILE
+                and self.use_inductor_graph_partition
+            ):
+                # Partition on -> always partition at the attention ops, populating
+                # even when the user passed an explicit empty list: an empty
+                # splitting_ops would otherwise leave FULL_AND_PIECEWISE with zero
+                # piecewise partitions (no piecewise capture, attention wrongly inside
+                # the cudagraph) and emit no warning.
+                if not self.splitting_ops:
+                    self.splitting_ops = list(self._attention_ops)
+            elif self.splitting_ops is None:
                 self.splitting_ops = []
             return
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -772,6 +772,68 @@ class VllmConfig:
         )
         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
+    def _downgrade_piecewise_cudagraph_for_non_vllm_compile(self) -> None:
+        """Clamp a piecewise-requiring cudagraph_mode to NONE for any non
+        VLLM_COMPILE mode. Piecewise cudagraphs need VllmBackend's FX splitting;
+        the stock torch.compile path can only use the external full / no-cudagraph
+        wrapper. Called three times: before and after the pooler/enc-dec/KV-connector
+        overrides, and again after current_platform.check_and_update_config, since
+        each of those can re-introduce PIECEWISE; clamping at each point keeps such
+        a mode from surviving to the final piecewise-mode assert. The stock
+        use_inductor_graph_partition path is intentionally NOT clamped: it provides
+        piecewise cudagraphs via Inductor graph partition, so the clamp is a no-op
+        there."""
+        cc = self.compilation_config
+        # STOCK_TORCH_COMPILE provides piecewise cudagraphs through Inductor graph
+        # partition (step 2 of the VllmBackend migration): Inductor partitions at the
+        # attention ops and routes each partition to the external wrapper, so it does
+        # not need VllmBackend's FX splitting. Only clamp when that path is off.
+        stock_inductor_piecewise = (
+            cc.mode == CompilationMode.STOCK_TORCH_COMPILE
+            and cc.use_inductor_graph_partition
+        )
+        if (
+            cc.cudagraph_mode is not None
+            and cc.cudagraph_mode.requires_piecewise_compilation()
+            and cc.mode != CompilationMode.VLLM_COMPILE
+            and not stock_inductor_piecewise
+            and not envs.VLLM_USE_BREAKABLE_CUDAGRAPH
+        ):
+            logger.info_once(
+                "Piecewise cudagraphs (%s) are not supported with compilation "
+                "mode %s; disabling piecewise cudagraphs.",
+                cc.cudagraph_mode.name,
+                cc.mode.name,
+            )
+            cc.cudagraph_mode = CUDAGraphMode.NONE
+
+    def _maybe_fallback_stock_to_vllm_compile_for_drafter(self) -> None:
+        """Fall back STOCK_TORCH_COMPILE to VLLM_COMPILE when a model-backed
+        speculative-decode drafter is configured. The stock path compiles only the
+        target in the model runner (GPUModelRunner._compile_model_stock); a drafter's
+        own @support_torch_compile decorator is disabled under STOCK and never
+        compiled by the runner, so it would run eager. Falling back the (engine-global)
+        mode restores the pre-migration path where VllmBackend compiles the drafter.
+        Algorithmic drafters (ngram / ngram_gpu / suffix) have no model and keep the
+        stock path. This intentionally overrides an explicit mode=STOCK, since an
+        uncompiled drafter is a correctness regression, not a perf preference."""
+        if self.compilation_config.mode != CompilationMode.STOCK_TORCH_COMPILE:
+            return
+        if self.speculative_config is None:
+            return
+        # Exclusion form (fail-safe): unknown/future methods fall back to VLLM_COMPILE.
+        if self.speculative_config.method in ("ngram", "ngram_gpu", "suffix"):
+            return
+        logger.warning_once(
+            "Speculative decoding with a draft model (method=%s) is not yet "
+            "supported on CompilationMode.STOCK_TORCH_COMPILE (the drafter would run "
+            "uncompiled). Falling back to CompilationMode.VLLM_COMPILE so the drafter "
+            "is compiled as before; this fallback is removed once drafter "
+            "architectures are migrated to the stock path.",
+            self.speculative_config.method,
+        )
+        self.compilation_config.mode = CompilationMode.VLLM_COMPILE
+
     def _post_init_kv_transfer_config(self) -> None:
         """Update KVTransferConfig based on top-level configs in VllmConfig.
 
@@ -849,6 +911,104 @@ class VllmConfig:
             "(sleep mode does this automatically and also "
             "routes KV allocations through CuMemAllocator's pool, where "
             "expandable_segments is automatically disabled)."
+        )
+
+    def _stock_compile_supported(self) -> bool:
+        """Whether the primary model architecture is allowlisted for the stock
+        torch.compile migration path (declares SupportsStockCompile). Migrated
+        architectures default to STOCK_TORCH_COMPILE; everything else (incl. the
+        Transformers backend, which lacks the flag) stays on VllmBackend. Any
+        resolution error returns False (the safe default)."""
+        if self.model_config is None:
+            return False
+        try:
+            return self.model_config.registry.is_stock_compile_supported_model(
+                self.model_config.architectures, self.model_config
+            )
+        except Exception:
+            return False
+
+    def _warn_ignored_vllm_backend_only_flags(self) -> None:
+        """Warn when a model is running on STOCK_TORCH_COMPILE but the user set
+        compilation options that only VllmBackend honors. On the stock path these
+        are inert (shape specialization, FX splitting, the vLLM compile cache) or
+        downgraded (piecewise cudagraphs), so without this they read as active but
+        do nothing. Runs before the opt-level defaults and auto-population so the
+        fields still reflect user input rather than resolved values (cudagraph_mode
+        and splitting_ops/ranges are all None until later)."""
+        cc = self.compilation_config
+        if cc.mode != CompilationMode.STOCK_TORCH_COMPILE:
+            return
+        if self.model_config is None:
+            return
+
+        ignored = []
+        if cc.compile_sizes:
+            ignored.append("compile_sizes (per-size shape specialization)")
+        # NOTE: compile_ranges_endpoints is intentionally NOT checked here. It is
+        # auto-populated (sorted, with any user values merged in) by _set_compile_ranges
+        # later in __post_init__, and __post_init__ may re-run on a reused
+        # compilation_config, so by the time this runs the field can already be a
+        # non-empty resolved value even when the user set nothing -> false positive.
+        # We do not claim every VllmBackend-only flag is covered here; the
+        # user-facing shape-specialization flag (compile_sizes, above) is covered.
+        # use_inductor_graph_partition is NOT inert on the stock path: it enables
+        # piecewise cudagraphs via Inductor graph partition (step 2). When it is on,
+        # splitting_ops is auto-populated with the attention ops (it is the partition
+        # boundary, not VllmBackend FX splitting), so neither is warned. splitting_ops
+        # is only inert when set WITHOUT graph partition (whole-graph stock).
+        if cc.splitting_ops and not cc.use_inductor_graph_partition:
+            ignored.append("splitting_ops (FX graph splitting)")
+        if cc.cudagraph_copy_inputs:
+            ignored.append("cudagraph_copy_inputs")
+        # vLLM's own compile cache is unused on the stock path (torch.compile uses
+        # its own cache). compile_cache_save_format defaults from an env var, so
+        # compare against that default to detect an explicit field override.
+        if cc.cache_dir:
+            ignored.append("cache_dir (vLLM compile cache; stock uses torch's cache)")
+        if cc.compile_cache_save_format != envs.VLLM_COMPILE_CACHE_SAVE_FORMAT:
+            ignored.append("compile_cache_save_format (vLLM compile cache)")
+        if envs.VLLM_DISABLE_COMPILE_CACHE:
+            ignored.append(
+                "VLLM_DISABLE_COMPILE_CACHE (vLLM compile cache; stock uses "
+                "torch's cache)"
+            )
+
+        overridden = []
+        # With use_inductor_graph_partition the stock path DOES provide piecewise
+        # cudagraphs (Inductor partitions at attention and routes capture to the
+        # external wrapper), so only warn about a piecewise downgrade when partition
+        # is off (then it really is clamped to FULL_DECODE_ONLY / NONE).
+        if (
+            cc.cudagraph_mode
+            in (CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL_AND_PIECEWISE)
+            and not cc.use_inductor_graph_partition
+        ):
+            overridden.append(
+                f"cudagraph_mode={cc.cudagraph_mode.name} clamped to NONE "
+                "(no cudagraphs); piecewise cudagraphs need "
+                "use_inductor_graph_partition=true on the stock path, or set "
+                "cudagraph_mode=FULL_DECODE_ONLY for decode-only cudagraphs"
+            )
+
+        if not ignored and not overridden:
+            return
+
+        parts = []
+        if ignored:
+            parts.append("ignored: " + ", ".join(ignored))
+        if overridden:
+            parts.append("overridden: " + ", ".join(overridden))
+        logger.warning_once(
+            "Model architecture %s is running on CompilationMode.STOCK_TORCH_COMPILE "
+            "(stock torch.compile). The following options are only honored by "
+            "CompilationMode.VLLM_COMPILE (the legacy custom backend) and have no "
+            "effect here -- %s. To restore the previous behavior, force the legacy "
+            "backend explicitly with `--compilation-config '{\"mode\": 3}'`. The "
+            "legacy backend (mode 3) is deprecated and will be removed once "
+            "VllmBackend is retired.",
+            ", ".join(self.model_config.architectures),
+            "; ".join(parts),
         )
 
     def __post_init__(self):
@@ -1058,6 +1218,20 @@ class VllmConfig:
                 "precision for chunked prefill triton kernels."
             )
 
+        # Capture whether the user explicitly set cudagraph_mode before any
+        # resolution step writes it (enforce_eager below, opt-level defaults
+        # later). The @config pydantic dataclass exposes no fields-set tracking,
+        # so None (the field default) is the only reliable "unset" signal and it
+        # must be read here, before the first writer mutates it.
+        user_set_cudagraph_mode = self.compilation_config.cudagraph_mode is not None
+        # Same rationale: capture whether the user set use_inductor_graph_partition
+        # before the opt-level defaults write it to False, so the stock path can
+        # default it on (graph-partition piecewise) without overriding an explicit
+        # user choice.
+        user_set_graph_partition = (
+            self.compilation_config.use_inductor_graph_partition is not None
+        )
+
         if self.model_config is not None and self.model_config.enforce_eager:
             logger.warning(
                 "Enforce eager set, disabling torch.compile and CUDAGraphs. "
@@ -1134,9 +1308,27 @@ class VllmConfig:
 
         if self.compilation_config.mode is None:
             if self.optimization_level > OptimizationLevel.O0:
-                self.compilation_config.mode = CompilationMode.VLLM_COMPILE
+                # Model-by-model migration off VllmBackend: architectures
+                # allowlisted via SupportsStockCompile run the stock torch.compile
+                # path (codegen + external cudagraph + Inductor-hook fusion); all
+                # others stay on VllmBackend (the default). Users can force via -cc.
+                self.compilation_config.mode = (
+                    CompilationMode.STOCK_TORCH_COMPILE
+                    if self._stock_compile_supported()
+                    else CompilationMode.VLLM_COMPILE
+                )
             else:
                 self.compilation_config.mode = CompilationMode.NONE
+
+        # Spec-decode drafters are compiled by their own @support_torch_compile
+        # decorator under VLLM_COMPILE; the stock path only compiles the target, so
+        # fall back to VLLM_COMPILE when a model-backed drafter is configured.
+        self._maybe_fallback_stock_to_vllm_compile_for_drafter()
+
+        # Warn about VllmBackend-only options that are inert on the stock path.
+        # Runs here (before opt-level defaults / cudagraph + splitting_ops
+        # auto-population) so the fields still reflect what the user actually set.
+        self._warn_ignored_vllm_backend_only_flags()
 
         # By default, enable torch wrapping only when using custom Inductor lowering
         if self.compilation_config.ir_enable_torch_wrap is None:
@@ -1169,18 +1361,55 @@ class VllmConfig:
 
         self._maybe_override_dynamic_sd_cudagraph_mode()
 
+        self._downgrade_piecewise_cudagraph_for_non_vllm_compile()
+
+        # STOCK (vanilla torch.compile) is the full-parity replacement path: use
+        # Inductor for codegen only and let vLLM's own FULL_DECODE_ONLY cudagraph
+        # wrapper capture/replay the whole compiled decode forward (the serving-grade
+        # external cudagraph path), instead of running with no cudagraphs. Only
+        # auto-promote when the user did not set cudagraph_mode (so an explicit
+        # NONE stays NONE) and dynamic spec decode is not in use (it deliberately
+        # avoids full-decode capture because the verification length varies).
+        # The dynamic-SD term is load-bearing, NOT redundant with the drafter
+        # fallback: ngram/suffix drafters stay on STOCK (no model to compile) yet
+        # can still be dynamic, so this is the only guard for that combination.
+        uses_dynamic_sd = (
+            self.speculative_config is not None
+            and self.speculative_config.uses_dynamic_speculative_decoding()
+        )
         if (
-            self.compilation_config.cudagraph_mode.requires_piecewise_compilation()
-            and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
-            and not envs.VLLM_USE_BREAKABLE_CUDAGRAPH
+            self.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE
+            and self.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+            and not user_set_cudagraph_mode
+            and not uses_dynamic_sd
         ):
-            logger.info(
-                "Cudagraph mode %s is not compatible with compilation mode %s."
-                "Overriding to NONE.",
-                self.compilation_config.cudagraph_mode,
-                self.compilation_config.mode,
-            )
-            self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+            # SupportsStockCompile models default to graph-partition piecewise: it
+            # recovers prefill cudagraphs at throughput parity and is validated as
+            # part of marking an arch stock-compatible. Inductor graph partition
+            # requires torch>=2.9; on older torch (or if the user explicitly set the
+            # flag) fall back to the choice below. A whole-graph stock compile can
+            # only do a decode-only external cudagraph.
+            from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+            if not user_set_graph_partition and is_torch_equal_or_newer("2.9.0.dev"):
+                self.compilation_config.use_inductor_graph_partition = True
+            if self.compilation_config.use_inductor_graph_partition:
+                self.compilation_config.cudagraph_mode = (
+                    CUDAGraphMode.FULL_AND_PIECEWISE
+                )
+                logger.info_once(
+                    "Using FULL_AND_PIECEWISE cudagraphs for stock torch.compile "
+                    "(decode captured externally; prefill/mixed piecewise-captured "
+                    "via Inductor graph partition)."
+                )
+            else:
+                self.compilation_config.cudagraph_mode = (
+                    CUDAGraphMode.FULL_DECODE_ONLY
+                )
+                logger.info_once(
+                    "Using FULL_DECODE_ONLY external cudagraphs for stock "
+                    "torch.compile (decode captured; prefill/mixed run uncaptured)."
+                )
 
         # async tp is built on top of sequence parallelism and requires it.
         pass_config = self.compilation_config.pass_config
@@ -1282,6 +1511,12 @@ class VllmConfig:
                         self.compilation_config.cudagraph_mode.name,
                     )
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+
+            # The pooler / KV-connector overrides above can re-introduce PIECEWISE;
+            # clamp it back to NONE for non-VLLM_COMPILE modes so a stock model
+            # (e.g. a future pooling arch) falls back to no cudagraphs instead of
+            # tripping the piecewise-mode assert below.
+            self._downgrade_piecewise_cudagraph_for_non_vllm_compile()
 
             # disable cudagraph when enforce eager execution
             if self.model_config is not None and self.model_config.enforce_eager:
@@ -1391,6 +1626,14 @@ class VllmConfig:
                         "pipeline parallelism",
                     )
 
+        # current_platform.check_and_update_config above can itself re-introduce a
+        # PIECEWISE cudagraph_mode (e.g. ROCm with decode/prefill context
+        # parallel). Clamp it back to NONE for non-VLLM_COMPILE modes so a stock
+        # model on the no-partition path falls back to no cudagraphs instead of
+        # tripping the piecewise-mode assert below. On stock + graph partition
+        # this is a no-op (that path legitimately supports piecewise cudagraphs).
+        self._downgrade_piecewise_cudagraph_for_non_vllm_compile()
+
         # final check of cudagraph mode after all possible updates
         if current_platform.is_cuda_alike():
             if (
@@ -1406,11 +1649,21 @@ class VllmConfig:
                 )
 
             if self.compilation_config.cudagraph_mode.requires_piecewise_compilation():
+                # STOCK_TORCH_COMPILE also provides piecewise cudagraphs when Inductor
+                # graph partition is on (it partitions at the attention ops and routes
+                # capture through the external wrapper), so it is a valid mode here.
+                stock_inductor_piecewise = (
+                    self.compilation_config.mode
+                    == CompilationMode.STOCK_TORCH_COMPILE
+                    and self.compilation_config.use_inductor_graph_partition
+                )
                 assert (
                     self.compilation_config.mode == CompilationMode.VLLM_COMPILE
+                    or stock_inductor_piecewise
                     or envs.VLLM_USE_BREAKABLE_CUDAGRAPH
                 ), (
                     "Compilation mode should be CompilationMode.VLLM_COMPILE "
+                    "(or STOCK_TORCH_COMPILE with use_inductor_graph_partition) "
                     "when cudagraph_mode piecewise cudagraphs is used, "
                     f"cudagraph_mode={self.compilation_config.cudagraph_mode}"
                 )

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -12,7 +12,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed import P2POp
 
-from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphWrapper
 from vllm.compilation.wrapper import reset_compile_wrapper
 from vllm.config import (
@@ -487,16 +486,13 @@ class ElasticEPScalingExecutor:
             self.worker.vllm_config.compilation_config.mode
             == CompilationMode.STOCK_TORCH_COMPILE
         ):
-            # NOTE(yongji): when using stock torch.compile,
-            # torch.compile is triggered during GPUModelRunner's load_model()
-            # TODO(yongji):check do we need to re-trigger torch.compile here?
-            # any changes to the tensor shapes in execution should already
-            # be handled internally by torch.compile.
-            backend = self.worker.vllm_config.compilation_config.init_backend(
-                self.worker.vllm_config
-            )
-            compilation_counter.stock_torch_compile_count += 1
-            self.worker.model_runner.model.compile(fullgraph=True, backend=backend)
+            # NOTE(yongji): when using stock torch.compile, the model was first
+            # compiled during GPUModelRunner.load_model(). After an EP scale event
+            # the expert layout changes, so re-trigger the stock compile through the
+            # shared helper to keep the fusion pass manager + pre-grad pass + pass
+            # context identical to the initial compile (a bare model.compile() here
+            # would silently drop them for fusion-needing models).
+            self.worker.model_runner._compile_model_stock()
 
         multi_block_table = self.worker.model_runner.input_batch.block_table
         saved_block_tables: list[tuple[torch.Tensor, torch.Tensor]] = []

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -57,6 +57,7 @@ from .interfaces import (
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
+    SupportsStockCompile,
 )
 from .utils import (
     AutoWeightsLoader,
@@ -1134,7 +1135,12 @@ class GptOssModel(nn.Module, EagleModelMixin):
 
 
 class GptOssForCausalLM(
-    nn.Module, SupportsPP, SupportsEagle, SupportsEagle3, SupportsLoRA
+    nn.Module,
+    SupportsPP,
+    SupportsEagle,
+    SupportsEagle3,
+    SupportsLoRA,
+    SupportsStockCompile,
 ):
     is_3d_moe_weight: bool = True
     packed_modules_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -788,6 +788,39 @@ def is_attention_free(
 
 
 @runtime_checkable
+class SupportsStockCompile(Protocol):
+    """The interface for models validated to run on the stock torch.compile path
+    (backend="inductor" + vLLM's external cudagraph wrapper + Inductor-hook fusion
+    passes) instead of the custom VllmBackend. Opt in per architecture as it passes
+    the migration gate; models without this flag stay on VllmBackend."""
+
+    supports_stock_compile: ClassVar[Literal[True]] = True
+    """
+    A flag that indicates this model is validated for the stock torch.compile path.
+
+    Note:
+        There is no need to redefine this flag if this class is in the
+        MRO of your model class.
+    """
+
+
+@overload
+def supports_stock_compile(model: object) -> TypeIs[SupportsStockCompile]: ...
+
+
+@overload
+def supports_stock_compile(
+    model: type[object],
+) -> TypeIs[type[SupportsStockCompile]]: ...
+
+
+def supports_stock_compile(
+    model: type[object] | object,
+) -> TypeIs[type[SupportsStockCompile]] | TypeIs[SupportsStockCompile]:
+    return getattr(model, "supports_stock_compile", False)
+
+
+@runtime_checkable
 class IsHybrid(Protocol):
     """The interface required for all models like Jamba that have both
     attention and mamba blocks, indicates that

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -55,6 +55,7 @@ from .interfaces import (
     supports_multimodal_encoder_tp_data,
     supports_multimodal_raw_input_only,
     supports_pp,
+    supports_stock_compile,
     supports_transcription,
 )
 from .interfaces_base import (
@@ -756,6 +757,7 @@ class _ModelInfo:
     requires_raw_input_tokens: bool
     supports_multimodal_encoder_tp_data: bool
     supports_pp: bool
+    supports_stock_compile: bool
     has_inner_state: bool
     is_attention_free: bool
     is_hybrid: bool
@@ -783,6 +785,7 @@ class _ModelInfo:
                 model
             ),
             supports_pp=supports_pp(model),
+            supports_stock_compile=supports_stock_compile(model),
             has_inner_state=has_inner_state(model),
             is_attention_free=is_attention_free(model),
             is_hybrid=is_hybrid(model),
@@ -1347,6 +1350,14 @@ class _ModelRegistry:
     ) -> bool:
         model_cls, _ = self.inspect_model_cls(architectures, model_config)
         return model_cls.has_noops
+
+    def is_stock_compile_supported_model(
+        self,
+        architectures: str | list[str],
+        model_config: ModelConfig,
+    ) -> bool:
+        model_cls, _ = self.inspect_model_cls(architectures, model_config)
+        return model_cls.supports_stock_compile
 
     def is_transcription_model(
         self,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5286,13 +5286,13 @@ class GPUModelRunner(
             self.vllm_config.compilation_config.mode
             == CompilationMode.STOCK_TORCH_COMPILE
         ):
-            from vllm.env_override import _apply_constrain_to_fx_strides_patch
-
-            _apply_constrain_to_fx_strides_patch()
-            backend = self.vllm_config.compilation_config.init_backend(self.vllm_config)
-            compilation_counter.stock_torch_compile_count += 1
-            self.model.compile(fullgraph=True, backend=backend)
-            return
+            self._compile_model_stock()
+            if not self.compilation_config.cudagraph_mode.has_full_cudagraphs():
+                return
+            # else: fall through to attach vLLM's external FULL cudagraph wrapper
+            # over the vanilla-compiled model (Inductor for codegen only, no
+            # Inductor cudagraphs). Driven by cudagraph_mode, which config sets to
+            # FULL_DECODE_ONLY for migrated stock models.
         # for other compilation modes, cudagraph behavior is controlled by
         # CudagraphWrapper and CudagraphDispatcher of vllm.
 
@@ -5328,6 +5328,113 @@ class GPUModelRunner(
                 )
 
         get_offloader().post_init()
+
+    def _compile_model_stock(self) -> None:
+        """Compile self.model with stock torch.compile (Inductor codegen) for
+        STOCK_TORCH_COMPILE mode. Shared by load_model and the elastic-EP rescale
+        path so the two compile sites cannot diverge on options / pass registration.
+        """
+        from vllm.env_override import _apply_constrain_to_fx_strides_patch
+
+        _apply_constrain_to_fx_strides_patch()
+        backend = self.vllm_config.compilation_config.init_backend(self.vllm_config)
+        compilation_counter.stock_torch_compile_count += 1
+        options = self._stock_inductor_options()
+        if options is not None and backend != "inductor":
+            raise ValueError(
+                "STOCK_TORCH_COMPILE with active fusion passes requires "
+                f"backend='inductor', but got backend={backend!r}. vLLM fusion "
+                "passes are registered through Inductor's custom-pass hooks and "
+                "have no effect on other backends; disable fusion or use inductor."
+            )
+        options = self._maybe_enable_stock_graph_partition(options, backend)
+        self.model.compile(fullgraph=True, backend=backend, options=options)
+
+    def _maybe_enable_stock_graph_partition(
+        self, options: dict[str, Any] | None, backend: str
+    ) -> dict[str, Any] | None:
+        """Step 2 of the VllmBackend migration: recover piecewise cudagraphs on the
+        stock path. For STOCK_TORCH_COMPILE + use_inductor_graph_partition, tell
+        Inductor to partition at the attention ops (via the scoped compile options)
+        and route each partition's capture through vLLM's external PIECEWISE cudagraph
+        wrapper; the whole decode forward is still captured by the FULL wrapper
+        (FULL_AND_PIECEWISE). The partition wrapper is installed persistently because
+        stock torch.compile is lazy (the real compile runs on the first forward).
+        """
+        cc = self.compilation_config
+        if not (
+            cc.cudagraph_mode.has_piecewise_cudagraphs()
+            and cc.use_inductor_graph_partition
+        ):
+            return options
+        if backend != "inductor":
+            raise ValueError(
+                "STOCK_TORCH_COMPILE piecewise cudagraphs require backend='inductor' "
+                f"(Inductor graph partition), but got backend={backend!r}."
+            )
+        from vllm.compilation.decorators import install_cudagraph_partition_wrapper
+
+        options = dict(options or {})
+        options["graph_partition"] = True
+        options["custom_should_partition_ops"] = list(cc.splitting_ops or [])
+        install_cudagraph_partition_wrapper(self.vllm_config)
+        return options
+
+    def _stock_inductor_options(self) -> dict[str, Any] | None:
+        """torch.compile options for STOCK_TORCH_COMPILE mode.
+
+        When the model has active fusion passes (quantized / TP-collective models),
+        register vLLM's PostGradPassManager (rms+quant / act+quant / allreduce+rmsnorm
+        / sequence-parallel fusions) and the pre-grad vLLM-IR functionalization pass
+        via Inductor's standard custom-pass hooks, so they keep their fusions without
+        the custom VllmBackend. For dense bf16 (no active fusion) we leave the stock
+        compile untouched: registering the pass manager there only adds its default
+        IR/cleanup passes, which both buy nothing and measurably regress perf.
+        """
+        import torch._inductor.config as inductor_config
+
+        from vllm.compilation.passes.inductor_pass import set_pass_context
+        from vllm.compilation.passes.ir.inplace_functionalization import (
+            VllmIRInplaceFunctionalizationPass,
+        )
+        from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
+        from vllm.config.utils import Range
+        from vllm.utils.import_utils import resolve_obj_by_qualname
+
+        pass_manager = resolve_obj_by_qualname(
+            current_platform.get_pass_manager_cls()
+        )()
+        pass_manager.configure(self.vllm_config)
+
+        # Gate registration on whether configure() produced a real fusion/IR pass,
+        # not a hand-maintained flag list that drifts from PostGradPassManager (the
+        # old list had already dropped enable_qk_norm_rope_fusion). NoOp elimination
+        # is always registered (eliminate_noops defaults True) but on its own buys
+        # nothing for dense bf16 and registering the manager there measurably
+        # regresses perf, so it does not count as active fusion.
+        has_fusion = any(
+            not isinstance(p, NoOpEliminationPass) for p in pass_manager.passes
+        )
+        if not has_fusion:
+            return None
+
+        # The vLLM passes (pre/post-grad) and PostGradPassManager.uuid() read
+        # get_pass_context(); torch.compile here is lazy (the real Inductor compile +
+        # passes run during a later forward) and STOCK mode is engine-global, so we
+        # install a persistent full-range pass context instead of scoping a context
+        # manager. The range is intentionally FULL: stock is a single lazy compile
+        # covering every shape (no per-range piecewise recompile), so a finite range
+        # could only drop range-gated passes, never grant specialization.
+        set_pass_context(Range(start=0, end=2**31 - 1))
+
+        options = dict(self.compilation_config.inductor_compile_config)
+        pre_grad_key = "pre_grad_custom_pass"
+        options[pre_grad_key] = VllmIRInplaceFunctionalizationPass(self.vllm_config)
+        options["_cache_config_ignore_prefix"] = (
+            inductor_config._cache_config_ignore_prefix + [pre_grad_key]
+        )
+        options[current_platform.pass_key] = pass_manager
+        return options
 
     def _setup_eagle3_aux_hidden_state_outputs(self) -> None:
         if not self.use_aux_hidden_state_outputs:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -28,6 +28,7 @@ from vllm.compilation.breakable_cudagraph import (
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphStat, CUDAGraphWrapper
 from vllm.compilation.monitor import set_cudagraph_capturing_enabled
+from vllm.compilation.stock_cudagraph import StockCUDAGraphWrapper
 from vllm.config import (
     CompilationMode,
     CUDAGraphMode,
@@ -5314,9 +5315,16 @@ class GPUModelRunner(
             cudagraph_mode.has_full_cudagraphs()
             and not self.parallel_config.use_ubatching
         ):
-            self.model = CUDAGraphWrapper(
-                self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
-            )
+            if self.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE:
+                # Stock path uses its own decoupled wrapper, not the shared
+                # CUDAGraphWrapper (which is coupled to vLLM full cudagraphs).
+                self.model = StockCUDAGraphWrapper(
+                    self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
+                )
+            else:
+                self.model = CUDAGraphWrapper(
+                    self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
+                )
         elif self.parallel_config.use_ubatching:
             if cudagraph_mode.has_full_cudagraphs():
                 self.model = UBatchWrapper(
@@ -6469,6 +6477,7 @@ class GPUModelRunner(
             # graph destruction can surface HSA faults in the next engine startup.
             CUDAGraphWrapper.clear_all_graphs()
             BreakableCUDAGraphWrapper.clear_all_graphs()
+            StockCUDAGraphWrapper.clear_all_graphs()
             self.encoder_cudagraph_manager = None
         self.compilation_config.static_forward_context.clear()
         self.model = None  # type: ignore[assignment]
@@ -6593,8 +6602,10 @@ class GPUModelRunner(
         profiling_pool = current_platform.graph_pool_handle()
         encoder_profiling_pool = current_platform.graph_pool_handle()
         original_pools: dict[int, Any] = {}
-        all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
-            BreakableCUDAGraphWrapper._all_instances
+        all_wrappers = (
+            list(CUDAGraphWrapper._all_instances)
+            + list(BreakableCUDAGraphWrapper._all_instances)
+            + list(StockCUDAGraphWrapper._all_instances)
         )
         for instance in all_wrappers:
             original_pools[id(instance)] = instance.graph_pool
@@ -6668,10 +6679,13 @@ class GPUModelRunner(
             set_cudagraph_capturing_enabled(False)
             CUDAGraphWrapper.clear_all_graphs()
             BreakableCUDAGraphWrapper.clear_all_graphs()
+            StockCUDAGraphWrapper.clear_all_graphs()
             if encoder_cudagraph_manager is not None:
                 encoder_cudagraph_manager.clear()
-            all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
-                BreakableCUDAGraphWrapper._all_instances
+            all_wrappers = (
+                list(CUDAGraphWrapper._all_instances)
+                + list(BreakableCUDAGraphWrapper._all_instances)
+                + list(StockCUDAGraphWrapper._all_instances)
             )
             for instance in all_wrappers:
                 if id(instance) in original_pools:


### PR DESCRIPTION
## Purpose (draft -- stacks on #46423)

Follow-up to the `SupportsStockCompile` migration (#46423): **decouple the stock
torch.compile cudagraph capture from vLLM's shared `CUDAGraphWrapper`**
(`vllm/compilation/cuda_graph.py`). That class is also used by vLLM's *non*-torch.compile
"full cudagraphs" path (`gpu_model_runner.py` FULL wrapper, `gpu_ubatch_wrapper.py`), so
reusing it on the torch.compile path couples the two -- vLLM can't evolve full cudagraphs
without risking the torch.compile path.

## What this does
Adds a decoupled **`StockCUDAGraphWrapper`** (`vllm/compilation/stock_cudagraph.py`) with
its own capture/replay (same batch-descriptor-keyed semantics, shared graph pool,
weak-ref outputs). The stock path now uses it **exclusively**:
- the FULL decode wrapper (`gpu_model_runner`) attaches `StockCUDAGraphWrapper` for stock
  mode instead of the shared `CUDAGraphWrapper`;
- the Inductor graph-partition PIECEWISE partition wrappers (via
  `set_customized_partition_wrappers`) build `StockCUDAGraphWrapper`;
- the runner capture-phase lifecycle (`clear_all_graphs`, and the profiling-pool
  save/restore over `_all_instances`) includes `StockCUDAGraphWrapper` so it participates
  like the other wrapper classes.

Result: the stock torch.compile path shares **no capture code** with vLLM's full-cudagraph
head path.

## Test results
- GPT-OSS-120B (H100): captures via `StockCUDAGraphWrapper` only (**0** shared-wrapper
  instances), correct output; 3075 graphs captured across the piecewise partitions + full
  decode buckets, no errors.
- `pytest tests/compile/test_config.py -k "stock or downgrade or graph_partition or warn"`
  + the registry marker: **42 passed**. New forked test
  `test_stock_uses_decoupled_cudagraph_wrapper` asserts the stock path uses
  `StockCUDAGraphWrapper` and never the shared `CUDAGraphWrapper`; the existing piecewise
  test still captures the same 14 graphs through the decoupled wrapper.

## Why not Inductor's built-in cudagraphs (cudagraph_trees)?
An earlier revision of this branch attempted that (Inductor self-captures the partitions,
no vLLM wrapper at all). It is **blocked**: `cudagraph_trees` asserts every
graph-partition output is tensor/int/None, but vLLM passes the attention layer name as a
non-tensor `LayerName` (`OpaqueBase`) which crosses the partition boundary
(`torch/_inductor/cudagraph_trees.py` `CUDAGraphNode.__init__` AssertionError). Making
that work needs upstream changes (keep `LayerName` out of the graph, or have
`cudagraph_trees` tolerate opaque partition I/O). The decoupled wrapper here is the
working path that still satisfies the "don't share head-model code" constraint; it trades
some duplicated capture logic for that decoupling.

## Context vs #46423
- #46423 (parent) uses the shared `CUDAGraphWrapper` -- it works and is the perf/correctness
  baseline (throughput parity/better, latency parity, gsm8k parity, GPU traces ~identical).
- This PR swaps only the **capture wrapper** to the decoupled `StockCUDAGraphWrapper`;
  config resolution, Inductor graph partition, and dispatch are unchanged.

This PR was authored with the assistance of an AI coding assistant.
