### PR TITLE
Fix OOB scale reads in Triton MXFP4 matmul kernel causing NaN outputs

### DIFF
--- a/cmake/external_projects/triton_kernels.cmake
+++ b/cmake/external_projects/triton_kernels.cmake
@@ -39,6 +39,22 @@ endif()
 
 message (STATUS "[triton_kernels] triton_kernels is available at ${TRITON_KERNELS_PYTHON_DIR}")
 
+# Patch _matmul_ogs.py to fix OOB reads on Hopper-swizzled MXFP4 scale values.
+# The unmasked tl.load can read 0xff from uninitialized memory past the valid
+# K dimension, which gets interpreted as NaN. Upstream fix from
+# triton-lang/triton commit 0add6826.
+set(_patch_script "${CMAKE_SOURCE_DIR}/tools/patch_triton_kernels_matmul_ogs.py")
+set(_matmul_ogs "${TRITON_KERNELS_PYTHON_DIR}/matmul_ogs_details/_matmul_ogs.py")
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" "${_patch_script}" "${_matmul_ogs}"
+  OUTPUT_VARIABLE _patch_output
+  ERROR_VARIABLE _patch_error
+  RESULT_VARIABLE _patch_result)
+if(NOT _patch_result EQUAL 0)
+  message(FATAL_ERROR "[triton_kernels] Failed to patch _matmul_ogs.py: ${_patch_error}")
+endif()
+message(STATUS "[triton_kernels] ${_patch_output}")
+
 add_custom_target(triton_kernels)
 
 # Ensure the vllm/third_party directory exists before installation

--- a/tools/patch_triton_kernels_matmul_ogs.py
+++ b/tools/patch_triton_kernels_matmul_ogs.py
@@ -1,0 +1,48 @@
+"""
+Patch the vendored Triton MXFP4 matmul kernel to fix OOB scale reads.
+
+Triton v3.5.1's _matmul_ogs performs an unmasked tl.load of Hopper-swizzled
+scale values. When EVEN_K=False, the last tile reads past K, pulling 0xff
+from uninitialized memory which gets interpreted as NaN in MXFP4 scale decode.
+
+Upstream fix: triton-lang/triton commit 0add6826
+"""
+
+import sys
+
+
+def patch_file(filepath: str) -> bool:
+    with open(filepath) as f:
+        content = f.read()
+
+    old = "w_scales = unswizzle_mxfp4_scale_hopper(tl.load(WMxScalePtrs), mx_axis=1, num_warps=num_warps)"
+
+    new = (
+        "if EVEN_K:\n"
+        "                    hopper_scale_mask = tl.full([PACKED_MX_BLOCK], True, dtype=tl.int1)\n"
+        "                else:\n"
+        '                    # Mask out the swizzled K tail to prevent OOB reads.\n'
+        "                    hopper_scale_mask = (offs_k_scale // 32) * MX_PACK_DIVISOR < k\n"
+        "                w_scales = unswizzle_mxfp4_scale_hopper(\n"
+        "                    tl.load(WMxScalePtrs, mask=hopper_scale_mask[None, :], other=0),\n"
+        "                    mx_axis=1,\n"
+        "                    num_warps=num_warps,\n"
+        "                )"
+    )
+
+    if old not in content:
+        print(f"No match in {filepath} -- already patched or unexpected version")
+        return False
+
+    content = content.replace(old, new, 1)
+
+    with open(filepath, "w") as f:
+        f.write(content)
+    print(f"Patched {filepath}")
+    return True
+
+
+if __name__ == "__main__":
+    filepath = sys.argv[1]
+    success = patch_file(filepath)
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
Fixes #47303

**Root cause:** The vendored Triton `_matmul_ogs` kernel (v3.5.1) performs an unmasked `tl.load` of Hopper-swizzled MXFP4 scale values. When `EVEN_K=False`, the last tile reads past the valid K dimension, pulling `0xff` from uninitialized memory, which gets interpreted as NaN in `unswizzle_mxfp4_scale_hopper`.

**Fix:** Adds a mask `hopper_scale_mask` that guards the `tl.load` call, matching the upstream fix in `triton-lang/triton` (commit `0add6826`):
- When `EVEN_K`: full mask of `True`
- Otherwise: mask out the swizzled K tail via `(offs_k_scale // 32) * MX_PACK_DIVISOR < k`

Manifests as corrupted output (0% accuracy on BFCL benchmarks) when concurrent GPU memory allocations leave `0xff` in MXFP4 scale regions.

**Changes:**
- `tools/patch_triton_kernels_matmul_ogs.py` — Python patch script
- `cmake/external_projects/triton_kernels.cmake` — apply the patch after fetch