### PR TITLE
[V1][Spec Decode] Overlap bonus sampling with target verification via maybe_execute_in_parallel

### DIFF
--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -12,6 +12,8 @@ import torch.nn as nn
 
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
+from vllm.utils.multi_stream_utils import maybe_execute_in_parallel
+from vllm.utils.torch_utils import aux_stream
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
 from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -84,6 +86,14 @@ class RejectionSampler(nn.Module):
                 device=device,
             )
         self.synthetic_mode = self.synthetic_conditional_rates is not None
+        # Overlap bonus-token sampling with target verification via vLLM's
+        # event-synchronized multi-stream helper (shared aux_stream singleton).
+        self._sampler_aux_stream = aux_stream()
+        self._sampler_ms_events = (
+            (torch.cuda.Event(), torch.cuda.Event())
+            if self._sampler_aux_stream is not None
+            else (None, None)
+        )
 
     def forward(
         self,
@@ -126,45 +136,47 @@ class RejectionSampler(nn.Module):
         # logits tensor. This means any in-place operations on bonus_logits
         # won't affect the original logits tensor.
         assert logits is not None
-        bonus_logits = logits[bonus_logits_indices]
-        bonus_sampler_output = self.sampler(
-            logits=bonus_logits,
-            sampling_metadata=replace(
-                sampling_metadata,
-                max_num_logprobs=-1,
-            ),
-            predict_bonus_token=True,
-            # Override the logprobs mode to return logits because they are
-            # needed later to compute the accepted token logprobs.
-            logprobs_mode_override="processed_logits"
-            if self.is_processed_logprobs_mode
-            else "raw_logits",
+
+        def _verify_target():
+            # Shape the target distribution at the draft positions (logits
+            # processors + temperature/top-k/top-p). Runs on the default
+            # stream (fn0). Returns (shaped, raw) since both are needed.
+            raw = logits[target_logits_indices].to(torch.float32)
+            shaped = raw if self.is_processed_logprobs_mode else raw.clone()
+            shaped = self.apply_logits_processors(shaped, sampling_metadata, metadata)
+            shaped = apply_sampling_constraints(
+                shaped, metadata.cu_num_draft_tokens, sampling_metadata
+            )
+            return shaped, raw
+
+        def _sample_bonus():
+            # Sample the bonus token. Runs on the aux stream (fn1),
+            # overlapping the target verification above.
+            bonus_logits = logits[bonus_logits_indices]
+            return self.sampler(
+                logits=bonus_logits,
+                sampling_metadata=replace(sampling_metadata, max_num_logprobs=-1),
+                predict_bonus_token=True,
+                logprobs_mode_override="processed_logits"
+                if self.is_processed_logprobs_mode
+                else "raw_logits",
+            )
+
+        # fn0 runs to completion on the CPU before fn1 in
+        # maybe_execute_in_parallel, so run bonus sampling as fn0 to preserve
+        # the original CPU ordering of stateful logits processors
+        # (thinking_budget update_state before the verification's read), while
+        # the heavier verification kernels overlap on the aux stream.
+        bonus_sampler_output, (target_logits, raw_target_logits) = (
+            maybe_execute_in_parallel(
+                _sample_bonus,
+                _verify_target,
+                self._sampler_ms_events[0],
+                self._sampler_ms_events[1],
+                self._sampler_aux_stream,
+            )
         )
         bonus_token_ids = bonus_sampler_output.sampled_token_ids
-
-        # Just like `bonus_logits`, `target_logits` is a new tensor with
-        # separate storage from the original `logits` tensor. Therefore,
-        # it is safe to update `target_logits` in place.
-        raw_target_logits = logits[target_logits_indices]
-        # Use float32 for the target_logits.
-        raw_target_logits = raw_target_logits.to(torch.float32)
-        target_logits = raw_target_logits
-        if not self.is_processed_logprobs_mode:
-            # Clone raw_target_logits before applying processors to preserve
-            # the original raw logits for logprobs computation, since
-            # apply_logits_processors modifies the tensor in-place.
-            target_logits = target_logits.clone()
-        target_logits = self.apply_logits_processors(
-            target_logits, sampling_metadata, metadata
-        )
-        # [num_tokens, vocab_size]
-        # NOTE(woosuk): `target_logits` can be updated in place inside the
-        # `apply_sampling_constraints` function.
-        target_logits = apply_sampling_constraints(
-            target_logits,
-            metadata.cu_num_draft_tokens,
-            sampling_metadata,
-        )
 
         output_token_ids = rejection_sample(
             metadata.draft_token_ids,


### PR DESCRIPTION
In RejectionSampler.forward, bonus-token sampling and the target-logits verification (logits processors + temperature/top-k/top-p shaping) read disjoint rows of the model logits and only join at rejection_sample. The slowdown is more evident when more tokens are processed. Run them concurrently via maybe_execute_in_parallel so their GPU kernels overlap, hiding the bonus-sampling work under the heavier verification (~300-400us/step recovered at MTP3 on qwen3.6).

Bonus sampling is passed as fn0 so its CPU-side work -- including stateful logits processors such as the thinking-budget holder's update_state -- runs before the verification's reads, preserving the original serial ordering; only the GPU kernels overlap (verification kernels on the aux stream). Falls back to sequential when no aux stream is available.

### Before: 
BS=32 Qwen3.6 nvfp4 on B200 MTP3 step, [topk=20, topp=0.95](https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4/blob/main/generation_config.json), takes 1.5ms for sampling step.
<img width="2599" height="613" alt="image" src="https://github.com/user-attachments/assets/a8d1efb4-e283-4577-a0e8-8120fb101dc0" />

### After:
1.23ms for sampling step. 
<img width="2670" height="629" alt="image" src="https://github.com/user-attachments/assets/a8bbc70e-f454-4043-b4fb-ccdf265bb088" />





## Purpose

## Test Plan
### Acceptance: 
### Setup
- Model: RedHatAI/Qwen3.6-35B-A3B-NVFP4 (qwen3_5_moe), MTP draft_length=3
- Harness: Model-Optimizer/examples/specdec_bench/run.py --engine VLLM
  --speculative_algorithm MTP, MT-bench (80 questions / 8 categories), conc=1, B200 TP1
- AR = average accepted tokens per step (max 4 = 1 + MTP3)
- before/after = git checkout 8632c884d (baseline) vs commit 56b6a0932 (dual-stream)

## Acceptance length (AR) — greedy (temperature=0)
| category    | after (dual-stream) | baseline | delta |
|-------------|---------------------|----------|-------|
| writing     | 3.0977469740621553  | 3.0977469740621553 | 0 |
| roleplay    | 2.8270731808744305  | 2.8270731808744305 | 0 |
| reasoning   | 3.1184673029037002  | 3.1176605555622990 | +0.00081 |
| math        | 3.4857725728979063  | 3.4857725728979063 | 0 |
| coding      | 3.2459065033477734  | 3.2460900466578337 | -0.00018 |
| extraction  | 3.4485142299755360  | 3.4485142299755360 | 0 |
| stem        | 2.9248935169306780  | 2.9248935169306780 | 0 |
| humanities  | 2.7647147352057857  | 2.7647147352057857 | 0 |
| OVERALL     | 3.1141361270247456  | 3.1140582265208280 | +0.00008 |
(6/8 bit-identical; reasoning/coding differ at FP tie-break level -> behavior-neutral)

## Acceptance length (AR) — temp=0.7, top_p=0.9
vLLM uses a deterministic default seed -> after and baseline generated
bit-identical tokens -> AR is identical (clean attribution for OTPS).
| category    | after = baseline |
|-------------|------------------|
| writing     | 3.010947240979914 |
| roleplay    | 2.7481504295777084 |
| reasoning   | 3.0410760699356034 |
| math        | 3.4517191562870706 |
| coding      | 3.1661781522676895 |
| extraction  | 3.4177396648174487 |
| stem        | 2.8588774463673263 |
| humanities  | 2.6495481615882968 |
| OVERALL     | 3.043029540227632 |

### Higher concurrency

### Acceptance length (behavior-neutral)
| conc | AR after | AR baseline | Δ |
|------|----------|-------------|-------|
| 1    | 3.043    | 3.043       |  0.000 |
| 2    | 3.042    | 3.035       | +0.007 |
| 4    | 3.040    | 3.041       | −0.001 |
| 8    | 3.036    | 3.035       | +0.001 |
| 16   | 3.040    | 3.039       | +0.001 |
| 32   | 3.034    | 3.032       | +0.003 |

Acceptance is identical within run-to-run noise at every concurrency (same-code after-vs-after variance
is ±0.02–0.03/category, larger than any after-vs-baseline delta) → the change never alters spec-decode outputs.

### Throughput (Output TPS) and per-step latency
| conc | OTPS after | OTPS baseline | ΔOTPS | step ms after | step ms baseline | Δstep ms |
|------|-----------|---------------|-------|---------------|------------------|----------|
| 1    | 471.4     | 464.6         | +1.5% | 6.30          | 6.40             | −0.10    |
| 2    | 907.1     | 907.6         | −0.1% | 6.50          | 6.50             |  0.00    |
| 4    | 1630.5    | 1603.5        | +1.7% | 7.10          | 7.10             |  0.00    |
| 8    | 2691.0    | 2533.0        | +6.2% | 8.30          | 9.00             | −0.70    |
| 16   | 4124.0    | 3824.0        | +7.8% | 10.40         | 11.30            | −0.90    |
| 32   | 5201.5    | 5217.9        | −0.3% | 15.30         | 15.20            | +0.10    |

## Note:
Tried using FlashInfer AirTopP kernel but a unified topk_topp_kernel is faster.

No problem when there's no sampling.
<img width="1772" height="599" alt="image" src="https://github.com/user-attachments/assets/5d339ea9-dcd7-4b01-99a9-85450ff94b38" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

