### PR TITLE
[ROCm][Perf] Enable fused indexer-Q RoPE+quant kernel for DeepSeek/GLM sparse attention

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -216,7 +216,7 @@ def fused_indexer_q_rope_quant(
     head_scale: float,
     is_neox: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    assert current_platform.is_cuda_alike() 
+    assert current_platform.is_cuda_alike()
     assert q.dtype == torch.bfloat16
     assert q.shape[-1] == 128
     assert cos_sin_cache.shape[-1] == 64

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -216,7 +216,7 @@ def fused_indexer_q_rope_quant(
     head_scale: float,
     is_neox: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    assert current_platform.is_cuda() or current_platform.is_rocm()
+    assert current_platform.is_cuda_alike() 
     assert q.dtype == torch.bfloat16
     assert q.shape[-1] == 128
     assert cos_sin_cache.shape[-1] == 64

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -216,7 +216,7 @@ def fused_indexer_q_rope_quant(
     head_scale: float,
     is_neox: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    assert current_platform.is_cuda()
+    assert current_platform.is_cuda() or current_platform.is_rocm()
     assert q.dtype == torch.bfloat16
     assert q.shape[-1] == 128
     assert cos_sin_cache.shape[-1] == 64

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -718,7 +718,7 @@ class Indexer(nn.Module):
         self.is_inplace_rope = is_inplace_rope
         self.n_head_scale = self.n_head**-0.5
         self.use_fused_indexer_q = (
-            current_platform.is_cuda()
+            (current_platform.is_cuda() or current_platform.is_rocm())
             and self.quant_block_size == self.head_dim
             and self.head_dim == 128
             and self.rope_dim == 64

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -718,7 +718,7 @@ class Indexer(nn.Module):
         self.is_inplace_rope = is_inplace_rope
         self.n_head_scale = self.n_head**-0.5
         self.use_fused_indexer_q = (
-            current_platform.is_cuda_alike() 
+            current_platform.is_cuda_alike()
             and self.quant_block_size == self.head_dim
             and self.head_dim == 128
             and self.rope_dim == 64

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -718,7 +718,7 @@ class Indexer(nn.Module):
         self.is_inplace_rope = is_inplace_rope
         self.n_head_scale = self.n_head**-0.5
         self.use_fused_indexer_q = (
-            (current_platform.is_cuda() or current_platform.is_rocm())
+            current_platform.is_cuda_alike() 
             and self.quant_block_size == self.head_dim
             and self.head_dim == 128
             and self.rope_dim == 64

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -736,7 +736,7 @@ class Indexer(nn.Module):
         self.is_inplace_rope = is_inplace_rope
         self.n_head_scale = self.n_head**-0.5
         self.use_fused_indexer_q = (
-            (current_platform.is_cuda() or current_platform.is_rocm())
+            current_platform.is_cuda_alike() 
             and self.quant_block_size == self.head_dim
             and self.head_dim == 128
             and self.rope_dim == 64

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -736,7 +736,7 @@ class Indexer(nn.Module):
         self.is_inplace_rope = is_inplace_rope
         self.n_head_scale = self.n_head**-0.5
         self.use_fused_indexer_q = (
-            current_platform.is_cuda_alike() 
+            current_platform.is_cuda_alike()
             and self.quant_block_size == self.head_dim
             and self.head_dim == 128
             and self.rope_dim == 64

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -736,7 +736,7 @@ class Indexer(nn.Module):
         self.is_inplace_rope = is_inplace_rope
         self.n_head_scale = self.n_head**-0.5
         self.use_fused_indexer_q = (
-            current_platform.is_cuda()
+            (current_platform.is_cuda() or current_platform.is_rocm())
             and self.quant_block_size == self.head_dim
             and self.head_dim == 128
             and self.rope_dim == 64


### PR DESCRIPTION
## Summary

Enables the existing fused indexer-Q kernel (`fused_indexer_q_rope_quant`) on
ROCm for the DeepSeek Sparse Attention (DSA) indexer used by GLM-5.2 /
DeepSeek-V3.2-style models. On CUDA this kernel already collapses the indexer's
query-side RoPE + FP8 quantization + weight-scale fold into a single launch; on
ROCm the same work was falling back to a chain of small Triton/elementwise
kernels per sparse layer per decode token.

This is a low-risk, 2-line enablement — the kernel is already on vllm and is
architecture-aware. It **removes redundant kernels and HBM round-trips** on the
ROCm decode path (4 Q-side kernels → 1), yielding a small but consistent decode
improvement with **no CUDA-side change** and no measured regression.

## Kernel-level evidence (torch.profiler, GLM-5.2-FP8, MI325X / gfx942, TP8, rank 0)

Before/after self-CUDA over the same steady-state decode capture. The indexer
decode kernels are the ones with ~21.5k calls (per decoded token × sparse
layers).

**Fused away** (present in baseline, gone after):

| Kernel | Role | Self CUDA | Calls |
|---|---|---|---|
| `per_token_group_quant_8bit_kernel` | q → FP8 (ue8m0) quant | 99.8 ms | 21546 |
| `triton_poi_fused_3` | RoPE/cat elementwise | 95.8 ms | 21526 |
| `triton_poi_fused_2` | RoPE/cat elementwise | 89.0 ms | 20521 |
| `triton_poi_fused_mul_slice_unsqueeze_view_4` | weights scale-fold | 85.3 ms | 20500 |

**Introduced**:

| Kernel | Role | Self CUDA | Calls |
|---|---|---|---|
| `_fused_indexer_q_rope_quant_kernel` | fused q RoPE + FP8 quant + weight-fold (decode) | 103.7 ms | 21546 |
| `_fused_indexer_q_rope_quant_kernel_0` | same, prefill variant | 6.3 ms | 42 |
| `triton_poi_fused_add_copy_index_select_mul_slice_…` | residual K-side RoPE (now its own kernel) | 90.6 ms | 20500 |

The Q-side collapses from **4 dedicated kernels → 1** (the two `triton_poi_fused_2/_3`
RoPE kernels did q *and* k together; after the change q's RoPE is absorbed and
only a single K-RoPE kernel remains). Net ≈ **170 ms** self-CUDA
reclaimed on rank 0 over the capture (≈0.7% of the ~24.9 s total). Untouched:
`k_norm`, `indexer_k_quant_and_cache`, `_gluon_deepgemm_fp8_paged_mqa_logits`,
`topKPerRowDecode`.


## Accuracy 

GLM-5.2-FP8, TP=8 on gfx942

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9469|±  |0.0062|
|     |       |strict-match    |     5|exact_match|↑  |0.9469|±  |0.0062|


## End-to-end performance (GLM-5.2-FP8, TP8, MI325X / gfx942)

`vllm bench serve`, random dataset, `--ignore-eos`, `--random-range-ratio 0.0`.

Decode runs under CUDA graphs.

| ISL | OSL | conc | TPOT_p50 base | TPOT_p50 fused | TPOT | ITL_p50 base | ITL_p50 fused | ITL | tok/s base | tok/s fused | tput |
|---|---|---|---|---|---|---|---|---|---|---|---|
| 1024 | 1024 | 1  | 14.98 | 14.93 | 1.004x | 14.98 | 14.94 | 1.003x | 66.32 | 66.34 | 1.000x |
| 1024 | 1024 | 8  | 18.39 | 18.32 | 1.004x | 18.40 | 18.30 | 1.005x | 422.81 | 423.68 | 1.002x |
| 1024 | 1024 | 32 | 24.83 | 24.71 | 1.005x | 24.31 | 24.19 | 1.005x | 1220.94 | 1222.21 | 1.001x |
| 1024 | 1024 | 64 | 32.39 | 32.30 | 1.003x | 31.25 | 31.00 | 1.008x | 1835.24 | 1842.09 | 1.004x |
| 8192 | 1024 | 1  | 16.01 | 15.90 | 1.006x | 15.98 | 15.88 | 1.006x | 60.18 | 60.55 | 1.006x |
| 8192 | 1024 | 8  | 22.26 | 22.06 | 1.009x | 19.86 | 19.79 | 1.004x | 323.27 | 324.17 | 1.003x |
| 8192 | 1024 | 32 | 38.86 | 39.73 | 0.978x* | 25.14 | 24.98 | 1.006x | 715.20 | 718.98 | 1.005x |
| 8192 | 1024 | 64 | 63.69 | 63.66 | 1.001x | 29.72 | 29.80 | 0.997x | 925.56 | 925.84 | 1.000x |

Consistent small improvement across the sweep (~0.3–0.9%), with no credible
regression. *The single `8192/32` TPOT dip is run-to-run variance: ITL (1.006x)
and throughput (1.005x) both improve at that same point.


## Related work / positioning

- **#43907** (`[ROCm][Perf] DSv3.2: fuse indexer Q-RoPE+quant + K-norm/RoPE/quant/cache`)
  fuses Q **and** K via an **AITER** kernel, but **explicitly excludes GLM**
  (`model_type != "glm_moe_dsa"`) and depends on a companion aiter kernel behind
  an env flag. This PR covers `glm_moe_dsa` using the **in-tree Triton** kernel
  with no aiter dependency and no new flags — complementary, not overlapping.
- **#44527** (`[ROCm][DSv3.2] Eliminate per-decode FillFunctor launches`) removes
  the `Fill` kernels in the same hot loop; stacks cleanly on top of this change.

## Risk / compatibility

Low. CUDA behavior is bit-for-bit unchanged; the ROCm change is opt-in via the
same static guard and only alters the previously-fragmented eager path. The
end-to-end gain is intentionally modest (kernel/HBM-traffic reduction under CUDA
graphs), but the change is trivial, carries no measured regression, and compounds
with related sparse-indexer cleanups (#44527). Requires the fused branch to fire
(`is_inplace_rope == False`), which is the default under `torch.compile`/Inductor.