### PR TITLE
[Bugfix] Respect explicit target device on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,11 @@ def has_precompiled_rust_extensions() -> bool:
     return not get_missing_precompiled_rust_extension_modules()
 
 
-if sys.platform.startswith("darwin") and VLLM_TARGET_DEVICE != "cpu":
+if (
+    sys.platform.startswith("darwin")
+    and os.getenv("VLLM_TARGET_DEVICE") is None
+    and VLLM_TARGET_DEVICE != "cpu"
+):
     logger.warning("VLLM_TARGET_DEVICE automatically set to `cpu` due to macOS")
     VLLM_TARGET_DEVICE = "cpu"
 elif not (sys.platform.startswith("linux") or sys.platform.startswith("darwin")):


### PR DESCRIPTION
Fixes #47339.

On macOS, `setup.py` currently defaults vLLM source builds to CPU. This keeps that fallback for ordinary macOS installs where `VLLM_TARGET_DEVICE` is unset, but stops overriding an explicit target such as `VLLM_TARGET_DEVICE=tpu`.

Validation:

```sh
git diff --check upstream/main...HEAD
python3 -m py_compile setup.py
pre-commit run --files setup.py
```

This PR was prepared with assistance from OpenAI Codex.
