### PR TITLE
[Bugfix][Build] Respect explicit VLLM_TARGET_DEVICE on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ def has_precompiled_rust_extensions() -> bool:
     return not get_missing_precompiled_rust_extension_modules()
 
 
-if sys.platform.startswith("darwin") and VLLM_TARGET_DEVICE != "cpu":
+if sys.platform.startswith("darwin") and os.getenv("VLLM_TARGET_DEVICE") is None:
     logger.warning("VLLM_TARGET_DEVICE automatically set to `cpu` due to macOS")
     VLLM_TARGET_DEVICE = "cpu"
 elif not (sys.platform.startswith("linux") or sys.platform.startswith("darwin")):

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ def is_metadata_only_build() -> bool:
     return bool({"egg_info", "dist_info"}.intersection(sys.argv[1:]))
 
 
-if sys.platform.startswith("darwin") and VLLM_TARGET_DEVICE != "cpu":
+if sys.platform.startswith("darwin") and os.getenv("VLLM_TARGET_DEVICE") is None:
     logger.warning("VLLM_TARGET_DEVICE automatically set to `cpu` due to macOS")
     VLLM_TARGET_DEVICE = "cpu"
 elif not (sys.platform.startswith("linux") or sys.platform.startswith("darwin")):


### PR DESCRIPTION
Fixes #47339

macOS forced `VLLM_TARGET_DEVICE=cpu` whenever the target wasn't already cpu — even if the caller set it explicitly (e.g. `tpu`), so `setup.py egg_info` produced `.cpu` metadata + CPU requirements for a non-cpu build. Linux only auto-detects when the env var is absent; this makes macOS follow the same rule (guard on `os.getenv(...) is None`).

One-liner; the affected path is macOS-only so I can't run the repro here (on Linux the darwin branch never executes) — behavior mirrors the existing Linux guard right below it.