### PR TITLE
[multimodal] Refactor IPC calculation out of gpu_worker

### DIFF
--- a/tests/multimodal/test_gpu_ipc_memory.py
+++ b/tests/multimodal/test_gpu_ipc_memory.py
@@ -3,16 +3,49 @@
 
 import threading
 import time
+from types import SimpleNamespace
 
 import pytest
 
+import vllm.multimodal.gpu_ipc_memory as gpu_ipc_memory
 from vllm.multimodal.gpu_ipc_memory import (
     MultiModalGPUMemoryPool,
+    get_mm_gpu_ipc_memory_reservation,
     get_mm_gpu_ipc_pool,
     maybe_init_mm_gpu_ipc_pool,
     set_mm_gpu_ipc_pool,
 )
+from vllm.multimodal.video import (
+    PYNVVIDEOCODEC_CUDA_CONTEXT_BYTES,
+    PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES,
+    PYNVVIDEOCODEC_MAX_RETAINED_DECODERS,
+    PYNVVIDEOCODEC_VIDEO_BACKEND,
+)
 from vllm.utils.mem_constants import GiB_bytes
+
+
+def _mm_config(
+    *,
+    mm_ipc_gpu_memory_gb: float = 0,
+    video_backend: str | None = None,
+    codec_backend: str | None = None,
+) -> SimpleNamespace:
+    video_kwargs = {}
+    if video_backend is not None:
+        video_kwargs["video_backend"] = video_backend
+    if codec_backend is not None:
+        video_kwargs["backend"] = codec_backend
+    return SimpleNamespace(
+        mm_ipc_gpu_memory_gb=mm_ipc_gpu_memory_gb,
+        media_io_kwargs={"video": video_kwargs} if video_kwargs else {},
+    )
+
+
+def _pynvvideocodec_decoder_budget(api_process_count: int = 1) -> int:
+    return api_process_count * (
+        PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES * PYNVVIDEOCODEC_MAX_RETAINED_DECODERS
+        + PYNVVIDEOCODEC_CUDA_CONTEXT_BYTES
+    )
 
 
 def test_acquire_release_accounting():
@@ -143,3 +176,91 @@ def test_global_pool_splits_budget_across_api_processes():
 def test_global_pool_rejects_invalid_api_process_count():
     with pytest.raises(ValueError):
         maybe_init_mm_gpu_ipc_pool(2, api_process_count=0)
+
+
+@pytest.mark.parametrize("video_backend", [None, "opencv"])
+def test_mm_gpu_ipc_reservation_raw_frame_budget_only(
+    monkeypatch: pytest.MonkeyPatch,
+    video_backend: str | None,
+):
+    monkeypatch.setattr(
+        gpu_ipc_memory.envs,
+        "VLLM_VIDEO_LOADER_BACKEND",
+        "opencv",
+    )
+
+    reservation = get_mm_gpu_ipc_memory_reservation(
+        _mm_config(mm_ipc_gpu_memory_gb=0.25, video_backend=video_backend)
+    )
+
+    assert reservation.raw_frame_bytes == int(0.25 * GiB_bytes)
+    assert reservation.decoder_bytes == 0
+    assert reservation.total_bytes == int(0.25 * GiB_bytes)
+
+
+@pytest.mark.parametrize(
+    ("video_backend", "codec_backend"),
+    [
+        (PYNVVIDEOCODEC_VIDEO_BACKEND, None),
+        (None, PYNVVIDEOCODEC_VIDEO_BACKEND),
+    ],
+)
+def test_mm_gpu_ipc_reservation_includes_pynvvideocodec_decoder_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    video_backend: str | None,
+    codec_backend: str | None,
+):
+    monkeypatch.setattr(
+        gpu_ipc_memory.envs,
+        "VLLM_VIDEO_LOADER_BACKEND",
+        "opencv",
+    )
+
+    reservation = get_mm_gpu_ipc_memory_reservation(
+        _mm_config(
+            mm_ipc_gpu_memory_gb=0.25,
+            video_backend=video_backend,
+            codec_backend=codec_backend,
+        )
+    )
+
+    assert reservation.raw_frame_bytes == int(0.25 * GiB_bytes)
+    assert reservation.decoder_bytes == _pynvvideocodec_decoder_budget()
+    assert reservation.total_bytes == (
+        int(0.25 * GiB_bytes) + _pynvvideocodec_decoder_budget()
+    )
+
+
+def test_mm_gpu_ipc_reservation_uses_env_video_backend(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        gpu_ipc_memory.envs,
+        "VLLM_VIDEO_LOADER_BACKEND",
+        PYNVVIDEOCODEC_VIDEO_BACKEND,
+    )
+
+    reservation = get_mm_gpu_ipc_memory_reservation(_mm_config())
+
+    assert reservation.decoder_bytes == _pynvvideocodec_decoder_budget()
+    assert reservation.total_bytes == _pynvvideocodec_decoder_budget()
+
+
+def test_mm_gpu_ipc_reservation_scales_pynvvideocodec_budget_by_api_servers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        gpu_ipc_memory.envs,
+        "VLLM_VIDEO_LOADER_BACKEND",
+        PYNVVIDEOCODEC_VIDEO_BACKEND,
+    )
+
+    reservation = get_mm_gpu_ipc_memory_reservation(_mm_config(), api_process_count=3)
+
+    assert reservation.api_process_count == 3
+    assert reservation.decoder_bytes == _pynvvideocodec_decoder_budget(
+        api_process_count=3
+    )
+    assert reservation.total_bytes == _pynvvideocodec_decoder_budget(
+        api_process_count=3
+    )

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -6,12 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 import vllm.v1.worker.gpu_worker as gpu_worker_module
-from vllm.multimodal.video import (
-    PYNVVIDEOCODEC_CUDA_CONTEXT_BYTES,
-    PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES,
-    PYNVVIDEOCODEC_MAX_RETAINED_DECODERS,
-    PYNVVIDEOCODEC_VIDEO_BACKEND,
-)
+from vllm.multimodal.gpu_ipc_memory import MultiModalGPUMemoryReservation
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.v1.worker.gpu_worker import Worker
 
@@ -27,90 +22,70 @@ def _worker_with_mm_config(
     return worker
 
 
-def _mm_config(
-    *,
-    mm_ipc_gpu_memory_gb: float = 0,
-    video_backend: str | None = None,
-) -> SimpleNamespace:
-    video_kwargs = {} if video_backend is None else {"video_backend": video_backend}
-    return SimpleNamespace(
-        mm_ipc_gpu_memory_gb=mm_ipc_gpu_memory_gb,
-        media_io_kwargs={"video": video_kwargs} if video_kwargs else {},
-    )
+def _mm_config() -> SimpleNamespace:
+    return SimpleNamespace()
 
 
-def _pynvvideocodec_decoder_budget(api_process_count: int = 1) -> int:
-    return api_process_count * (
-        PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES * PYNVVIDEOCODEC_MAX_RETAINED_DECODERS
-        + PYNVVIDEOCODEC_CUDA_CONTEXT_BYTES
-    )
-
-
-@pytest.mark.parametrize("video_backend", [None, "opencv"])
-def test_reserve_mm_ipc_gpu_memory_raw_frame_budget_only(
-    monkeypatch: pytest.MonkeyPatch,
-    video_backend: str | None,
-):
-    monkeypatch.setattr(
-        gpu_worker_module.envs,
-        "VLLM_VIDEO_LOADER_BACKEND",
-        "opencv",
-    )
-    worker = _worker_with_mm_config(
-        _mm_config(mm_ipc_gpu_memory_gb=0.25, video_backend=video_backend)
-    )
-
-    assert worker._reserve_mm_ipc_gpu_memory(GiB_bytes) == int(0.75 * GiB_bytes)
-
-
-def test_reserve_mm_ipc_gpu_memory_includes_pynvvideocodec_decoder_budget(
+def test_reserve_mm_ipc_gpu_memory_subtracts_reservation(
     monkeypatch: pytest.MonkeyPatch,
 ):
+    worker = _worker_with_mm_config(_mm_config(), api_process_count=2)
+    reservation = MultiModalGPUMemoryReservation(
+        raw_frame_bytes=10,
+        decoder_bytes=20,
+        per_server_decoder_bytes=10,
+        api_process_count=2,
+    )
+
     monkeypatch.setattr(
-        gpu_worker_module.envs,
-        "VLLM_VIDEO_LOADER_BACKEND",
-        "opencv",
-    )
-    worker = _worker_with_mm_config(
-        _mm_config(
-            mm_ipc_gpu_memory_gb=0.25,
-            video_backend=PYNVVIDEOCODEC_VIDEO_BACKEND,
-        )
-    )
-    available_bytes = 4 * GiB_bytes
-
-    assert worker._reserve_mm_ipc_gpu_memory(available_bytes) == (
-        available_bytes - int(0.25 * GiB_bytes) - _pynvvideocodec_decoder_budget()
+        gpu_worker_module,
+        "get_mm_gpu_ipc_memory_reservation",
+        lambda *_: reservation,
     )
 
+    assert worker._reserve_mm_ipc_gpu_memory(100) == 70
 
-def test_reserve_mm_ipc_gpu_memory_uses_env_video_backend(
+
+def test_reserve_mm_ipc_gpu_memory_raises_when_reservation_exceeds_available(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setattr(
-        gpu_worker_module.envs,
-        "VLLM_VIDEO_LOADER_BACKEND",
-        PYNVVIDEOCODEC_VIDEO_BACKEND,
-    )
     worker = _worker_with_mm_config(_mm_config())
-    available_bytes = 4 * GiB_bytes
-
-    assert worker._reserve_mm_ipc_gpu_memory(available_bytes) == (
-        available_bytes - _pynvvideocodec_decoder_budget()
+    reservation = MultiModalGPUMemoryReservation(
+        raw_frame_bytes=60,
+        decoder_bytes=50,
+        per_server_decoder_bytes=50,
+        api_process_count=1,
     )
 
+    monkeypatch.setattr(
+        gpu_worker_module,
+        "get_mm_gpu_ipc_memory_reservation",
+        lambda *_: reservation,
+    )
 
-def test_reserve_mm_ipc_gpu_memory_scales_pynvvideocodec_budget_by_api_servers(
+    with pytest.raises(ValueError, match="frontend multimodal GPU decoding"):
+        worker._reserve_mm_ipc_gpu_memory(100)
+
+
+def test_determine_available_memory_preserves_explicit_kv_cache_memory(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setattr(
-        gpu_worker_module.envs,
-        "VLLM_VIDEO_LOADER_BACKEND",
-        PYNVVIDEOCODEC_VIDEO_BACKEND,
-    )
-    worker = _worker_with_mm_config(_mm_config(), api_process_count=3)
-    available_bytes = 8 * GiB_bytes
+    worker = _worker_with_mm_config(_mm_config())
+    worker.cache_config = SimpleNamespace(kv_cache_memory_bytes=GiB_bytes)
+    worker.init_snapshot = SimpleNamespace(free_memory=4 * GiB_bytes)
 
-    assert worker._reserve_mm_ipc_gpu_memory(available_bytes) == (
-        available_bytes - _pynvvideocodec_decoder_budget(api_process_count=3)
+    profile_run_called = False
+
+    def profile_run():
+        nonlocal profile_run_called
+        profile_run_called = True
+
+    worker.model_runner = SimpleNamespace(profile_run=profile_run)
+    monkeypatch.setattr(
+        worker,
+        "_reserve_mm_ipc_gpu_memory",
+        lambda _: pytest.fail("explicit KV cache memory must not be reduced"),
     )
+
+    assert worker.determine_available_memory() == GiB_bytes
+    assert profile_run_called

--- a/vllm/multimodal/gpu_ipc_memory.py
+++ b/vllm/multimodal/gpu_ipc_memory.py
@@ -17,11 +17,76 @@ amount out of its KV-cache budget so the headroom physically exists.
 """
 
 import threading
+from dataclasses import dataclass
+from typing import Any
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.utils.mem_constants import GiB_bytes
 
 logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class MultiModalGPUMemoryReservation:
+    raw_frame_bytes: int = 0
+    decoder_bytes: int = 0
+    per_server_decoder_bytes: int = 0
+    api_process_count: int = 1
+
+    @property
+    def total_bytes(self) -> int:
+        return self.raw_frame_bytes + self.decoder_bytes
+
+
+def _uses_pynvvideocodec_video_backend(mm_config: Any) -> bool:
+    from vllm.multimodal.video import PYNVVIDEOCODEC_VIDEO_BACKEND
+
+    media_io_kwargs = getattr(mm_config, "media_io_kwargs", {}) or {}
+    video_kwargs = media_io_kwargs.get("video", {})
+    video_loader_backend = (
+        video_kwargs.get("video_backend") or envs.VLLM_VIDEO_LOADER_BACKEND
+    )
+    codec_backend = video_kwargs.get("backend")
+    return (
+        video_loader_backend == PYNVVIDEOCODEC_VIDEO_BACKEND
+        or codec_backend == PYNVVIDEOCODEC_VIDEO_BACKEND
+    )
+
+
+def get_mm_gpu_ipc_memory_reservation(
+    mm_config: Any | None,
+    api_process_count: int = 1,
+) -> MultiModalGPUMemoryReservation:
+    """Return the frontend multimodal GPU memory budget to reserve."""
+    num_api_servers = max(1, api_process_count)
+    if mm_config is None:
+        return MultiModalGPUMemoryReservation(api_process_count=num_api_servers)
+
+    raw_frame_bytes = int(getattr(mm_config, "mm_ipc_gpu_memory_gb", 0) * GiB_bytes)
+    per_server_decoder_bytes = 0
+    decoder_bytes = 0
+    if _uses_pynvvideocodec_video_backend(mm_config):
+        from vllm.multimodal.video import (
+            PYNVVIDEOCODEC_CUDA_CONTEXT_BYTES,
+            PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES,
+            PYNVVIDEOCODEC_MAX_RETAINED_DECODERS,
+        )
+
+        # Each API server process has its own decoder surfaces and CUDA context.
+        per_server_decoder_bytes = (
+            PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES
+            * PYNVVIDEOCODEC_MAX_RETAINED_DECODERS
+            + PYNVVIDEOCODEC_CUDA_CONTEXT_BYTES
+        )
+        decoder_bytes = num_api_servers * per_server_decoder_bytes
+
+    return MultiModalGPUMemoryReservation(
+        raw_frame_bytes=raw_frame_bytes,
+        decoder_bytes=decoder_bytes,
+        per_server_decoder_bytes=per_server_decoder_bytes,
+        api_process_count=num_api_servers,
+    )
 
 
 class MultiModalGPUMemoryLease:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -51,11 +51,8 @@ from vllm.distributed.weight_transfer import (
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor.warmup.kernel_warmup import kernel_warmup
-from vllm.multimodal.video import (
-    PYNVVIDEOCODEC_CUDA_CONTEXT_BYTES,
-    PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES,
-    PYNVVIDEOCODEC_MAX_RETAINED_DECODERS,
-    PYNVVIDEOCODEC_VIDEO_BACKEND,
+from vllm.multimodal.gpu_ipc_memory import (
+    get_mm_gpu_ipc_memory_reservation,
 )
 from vllm.platforms import current_platform
 from vllm.profiler.wrapper import CudaProfilerWrapper, TorchProfilerWrapper
@@ -444,7 +441,7 @@ class Worker(WorkerBase):
                 "correspondingly."
             )
             logger.info(msg)
-            return self._reserve_mm_ipc_gpu_memory(kv_cache_memory_bytes)
+            return kv_cache_memory_bytes
 
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
@@ -570,18 +567,6 @@ class Worker(WorkerBase):
             int(self.available_kv_cache_memory_bytes)
         )
 
-    @staticmethod
-    def _uses_pynvvideocodec_video_backend(mm_config) -> bool:
-        video_kwargs = mm_config.media_io_kwargs.get("video", {})
-        video_loader_backend = (
-            video_kwargs.get("video_backend") or envs.VLLM_VIDEO_LOADER_BACKEND
-        )
-        codec_backend = video_kwargs.get("backend")
-        return (
-            video_loader_backend == PYNVVIDEOCODEC_VIDEO_BACKEND
-            or codec_backend == PYNVVIDEOCODEC_VIDEO_BACKEND
-        )
-
     def _reserve_mm_ipc_gpu_memory(self, available_kv_cache_memory_bytes: int) -> int:
         """Carve frontend multimodal GPU memory out of the KV cache.
 
@@ -591,29 +576,11 @@ class Worker(WorkerBase):
         decoders also keep persistent surfaces around; reserve a fixed upper
         bound for those when the corresponding backend is configured.
         """
-        mm_config = self.model_config.multimodal_config
-        if mm_config is None:
-            return available_kv_cache_memory_bytes
-
-        raw_frame_reserved_bytes = int(mm_config.mm_ipc_gpu_memory_gb * GiB_bytes)
-        # Each api_server_count process runs its OWN decoder surfaces + NVDEC/CUVID
-        # CUDA context on the GPU, outside this (worker) memory pool. Reserve that
-        # per-server footprint x api_server_count so gpu_memory_utilization bounds
-        # TOTAL GPU usage across all API-server processes. Without the multiply,
-        # HW decode overshoots the budget by ~(api_server_count-1) x per-server and
-        # OOMs at high gmu, while SW decode (no per-server GPU allocation) does not.
-        num_api_servers = max(1, getattr(self.parallel_config, "_api_process_count", 1))
-        per_server_decoder_bytes = (
-            PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES
-            * PYNVVIDEOCODEC_MAX_RETAINED_DECODERS
-            + PYNVVIDEOCODEC_CUDA_CONTEXT_BYTES
+        reservation = get_mm_gpu_ipc_memory_reservation(
+            self.model_config.multimodal_config,
+            getattr(self.parallel_config, "_api_process_count", 1),
         )
-        decoder_reserved_bytes = (
-            num_api_servers * per_server_decoder_bytes
-            if self._uses_pynvvideocodec_video_backend(mm_config)
-            else 0
-        )
-        reserved_bytes = raw_frame_reserved_bytes + decoder_reserved_bytes
+        reserved_bytes = reservation.total_bytes
         if reserved_bytes <= 0:
             return available_kv_cache_memory_bytes
 
@@ -622,8 +589,8 @@ class Worker(WorkerBase):
             raise ValueError(
                 f"frontend multimodal GPU decoding reserves "
                 f"{format_gib(reserved_bytes)} GiB "
-                f"({format_gib(raw_frame_reserved_bytes)} GiB raw-frame budget, "
-                f"{format_gib(decoder_reserved_bytes)} GiB decoder cache budget), "
+                f"({format_gib(reservation.raw_frame_bytes)} GiB raw-frame budget, "
+                f"{format_gib(reservation.decoder_bytes)} GiB decoder cache budget), "
                 f"but only {format_gib(available_kv_cache_memory_bytes)} GiB is "
                 "available for the KV cache. Reduce mm_ipc_gpu_memory_gb, use a "
                 "different video backend, or increase gpu_memory_utilization."
@@ -634,10 +601,10 @@ class Worker(WorkerBase):
             "across %d API server(s) @ %s GiB/server); "
             "KV cache memory reduced to %s GiB.",
             format_gib(reserved_bytes),
-            format_gib(raw_frame_reserved_bytes),
-            format_gib(decoder_reserved_bytes),
-            num_api_servers,
-            format_gib(per_server_decoder_bytes),
+            format_gib(reservation.raw_frame_bytes),
+            format_gib(reservation.decoder_bytes),
+            reservation.api_process_count,
+            format_gib(reservation.per_server_decoder_bytes),
             format_gib(remaining),
         )
         return remaining


### PR DESCRIPTION


## Purpose

Following up in https://github.com/vllm-project/vllm/pull/44465#pullrequestreview-4583089688 on @njhill 's requests to refactor a couple of calculations away from the main gpu_worker code function for now. 

## Test Plan

```
(vllm) $ pytest -s -v tests/multimodal/test_video.py -k pynv

tests/multimodal/test_video.py::test_pynvvideocodec_backend_accounts_raw_decoded_frames PASSED
tests/multimodal/test_video.py::test_pynvvideocodec_codec_uses_dynamic_sampling_strategy PASSED
tests/multimodal/test_video.py::test_pynvvideocodec_decoder_slots_are_bounded PASSED
tests/multimodal/test_video.py::test_pynvvideocodec_decoder_slot_retains_simple_decoder PASSED
```

No issues serving via
```
vllm serve Qwen/Qwen3-VL-4B-Instruct --media-io-kwargs.video.backend=pynvvideocodec
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

