### PR TITLE
[Rust Frontend]: Added olmo3 reasoning parser

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -384,6 +384,6 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, inkling, kimi, kimi_k2, kimi_k3, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, inkling, kimi, kimi_k2, kimi_k3, minimax_m2, minimax_m3, nemotron_v3, olmo3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
     }
 }

--- a/rust/src/chat/src/parser/reasoning/mod.rs
+++ b/rust/src/chat/src/parser/reasoning/mod.rs
@@ -9,8 +9,8 @@ pub use vllm_parser::reasoning::{
     CohereCmdReasoningParser, DeepSeekR1ReasoningParser, DeepSeekV3ReasoningParser,
     DeepSeekV4ReasoningParser, Glm45ReasoningParser, KimiK2ReasoningParser, KimiReasoningParser,
     MiniMaxM2ReasoningParser, MiniMaxM3ReasoningParser, NemotronV3ReasoningParser,
-    Qwen3ReasoningParser, ReasoningDelta, ReasoningError, ReasoningParser, SeedOssReasoningParser,
-    Step3ReasoningParser, Step3p5ReasoningParser,
+    Olmo3ReasoningParser, Qwen3ReasoningParser, ReasoningDelta, ReasoningError, ReasoningParser,
+    SeedOssReasoningParser, Step3ReasoningParser, Step3p5ReasoningParser,
 };
 use vllm_tokenizer::DynTokenizer;
 
@@ -32,6 +32,7 @@ pub mod names {
     pub const MINIMAX_M3: &str = "minimax_m3";
     pub const NEMOTRON_V3: &str = "nemotron_v3";
     pub const QWEN3: &str = "qwen3";
+    pub const OLMO3: &str = "olmo3";
     pub const SEED_OSS: &str = "seed_oss";
     pub const STEP3: &str = "step3";
     pub const STEP3P5: &str = "step3p5";
@@ -73,6 +74,7 @@ impl ReasoningParserFactory {
             .register_parser::<MiniMaxM2ReasoningParser>(names::MINIMAX_M2)
             .register_parser::<MiniMaxM3ReasoningParser>(names::MINIMAX_M3)
             .register_parser::<NemotronV3ReasoningParser>(names::NEMOTRON_V3)
+            .register_parser::<Olmo3ReasoningParser>(names::OLMO3)
             .register_parser::<Qwen3ReasoningParser>(names::QWEN3)
             .register_parser::<SeedOssReasoningParser>(names::SEED_OSS)
             .register_parser::<Step3ReasoningParser>(names::STEP3)
@@ -100,6 +102,9 @@ impl ReasoningParserFactory {
             .register_pattern("step3", names::STEP3)
             .register_pattern("seed-oss", names::SEED_OSS)
             .register_pattern("seedoss", names::SEED_OSS)
+            .register_pattern("olmo-3", names::OLMO3)
+            .register_pattern("olmo3", names::OLMO3)
+            .register_pattern("olmo", names::OLMO3)
             .register_pattern("minimax-m3", names::MINIMAX_M3)
             .register_pattern("mm-m3", names::MINIMAX_M3)
             .register_pattern("minimax", names::MINIMAX_M2)

--- a/rust/src/chat/src/parser/reasoning/mod.rs
+++ b/rust/src/chat/src/parser/reasoning/mod.rs
@@ -104,7 +104,6 @@ impl ReasoningParserFactory {
             .register_pattern("seedoss", names::SEED_OSS)
             .register_pattern("olmo-3", names::OLMO3)
             .register_pattern("olmo3", names::OLMO3)
-            .register_pattern("olmo", names::OLMO3)
             .register_pattern("minimax-m3", names::MINIMAX_M3)
             .register_pattern("mm-m3", names::MINIMAX_M3)
             .register_pattern("minimax", names::MINIMAX_M2)

--- a/rust/src/chat/src/parser/reasoning/tests.rs
+++ b/rust/src/chat/src/parser/reasoning/tests.rs
@@ -16,12 +16,14 @@ fn factory_contains_and_lists_registered_parsers() {
     assert!(factory.contains(names::STEP3P5));
     assert!(factory.contains(names::MINIMAX_M3));
     assert!(factory.contains(names::GEMMA4));
+    assert!(factory.contains(names::OLMO3));
     assert!(factory.list().contains(&names::QWEN3.to_string()));
     assert!(factory.list().contains(&names::DEEPSEEK_V4.to_string()));
     assert!(factory.list().contains(&names::SEED_OSS.to_string()));
     assert!(factory.list().contains(&names::STEP3P5.to_string()));
     assert!(factory.list().contains(&names::MINIMAX_M3.to_string()));
     assert!(factory.list().contains(&names::GEMMA4.to_string()));
+    assert!(factory.list().contains(&names::OLMO3.to_string()));
 }
 
 #[test]
@@ -69,6 +71,23 @@ fn factory_routes_seed_oss_models() {
     assert_eq!(
         factory.resolve_name_for_model("seedoss-7b"),
         Some(names::SEED_OSS)
+    );
+}
+
+#[test]
+fn factory_routes_olmo_models() {
+    let factory = ReasoningParserFactory::new();
+    assert_eq!(
+        factory.resolve_name_for_model("allenai/OLMo-3-1124-Instruct"),
+        Some(names::OLMO3)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("olmo3-base"),
+        Some(names::OLMO3)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("olmo-7b"),
+        Some(names::OLMO3)
     );
 }
 

--- a/rust/src/chat/src/parser/reasoning/tests.rs
+++ b/rust/src/chat/src/parser/reasoning/tests.rs
@@ -85,10 +85,6 @@ fn factory_routes_olmo_models() {
         factory.resolve_name_for_model("olmo3-base"),
         Some(names::OLMO3)
     );
-    assert_eq!(
-        factory.resolve_name_for_model("olmo-7b"),
-        Some(names::OLMO3)
-    );
 }
 
 #[test]

--- a/rust/src/parser/src/reasoning/delimited.rs
+++ b/rust/src/parser/src/reasoning/delimited.rs
@@ -22,8 +22,8 @@ pub(crate) struct DelimitedReasoningParser {
     buffer: String,
     start_token: String,
     end_token: String,
-    start_token_id: u32,
-    end_token_id: u32,
+    start_token_id: Option<u32>,
+    end_token_id: Option<u32>,
     default_in_reasoning: bool,
 }
 
@@ -54,21 +54,47 @@ impl DelimitedReasoningParser {
             buffer: String::new(),
             start_token: start_token.to_string(),
             end_token: end_token.to_string(),
-            start_token_id,
-            end_token_id,
+            start_token_id: Some(start_token_id),
+            end_token_id: Some(end_token_id),
             default_in_reasoning,
         })
     }
 
+    /// Create one delimited parser state machine without requiring tokens to exist in the tokenizer.
+    pub(crate) fn new_optional(
+        tokenizer: DynTokenizer,
+        start_token: &'static str,
+        end_token: &'static str,
+        default_in_reasoning: bool,
+    ) -> Self {
+        let start_token_id = tokenizer.token_to_id(start_token);
+        let end_token_id = tokenizer.token_to_id(end_token);
+
+        Self {
+            tokenizer,
+            current_in_reasoning: default_in_reasoning,
+            buffer: String::new(),
+            start_token: start_token.to_string(),
+            end_token: end_token.to_string(),
+            start_token_id,
+            end_token_id,
+            default_in_reasoning,
+        }
+    }
+
     /// Initialize the starting state from prompt token IDs.
     pub(crate) fn initialize(&mut self, prompt_token_ids: &[u32]) {
-        self.current_in_reasoning = last_reasoning_boundary(
-            prompt_token_ids,
-            self.start_token_id,
-            self.end_token_id,
-            self.tokenizer.as_ref(),
-        )
-        .unwrap_or(self.default_in_reasoning);
+        if let (Some(start_id), Some(end_id)) = (self.start_token_id, self.end_token_id) {
+            self.current_in_reasoning = last_reasoning_boundary(
+                prompt_token_ids,
+                start_id,
+                end_id,
+                self.tokenizer.as_ref(),
+            )
+            .unwrap_or(self.default_in_reasoning);
+        } else {
+            self.current_in_reasoning = self.default_in_reasoning;
+        }
     }
 
     /// Return whether the parser is currently inside a reasoning section.

--- a/rust/src/parser/src/reasoning/mod.rs
+++ b/rust/src/parser/src/reasoning/mod.rs
@@ -22,6 +22,7 @@ mod deepseek_r1;
 mod delimited;
 mod kimi;
 mod minimax_m3;
+mod olmo3;
 mod qwen3;
 mod seed_oss;
 mod step3p5;
@@ -34,6 +35,7 @@ pub use self::deepseek_r1::DeepSeekR1ReasoningParser;
 pub(crate) use self::delimited::{DelimitedReasoningParser, last_reasoning_boundary};
 pub use self::kimi::KimiReasoningParser;
 pub use self::minimax_m3::MiniMaxM3ReasoningParser;
+pub use self::olmo3::Olmo3ReasoningParser;
 pub use self::qwen3::Qwen3ReasoningParser;
 pub use self::seed_oss::SeedOssReasoningParser;
 pub use self::step3p5::Step3p5ReasoningParser;
@@ -54,8 +56,6 @@ pub type MiniMaxM2ReasoningParser = Qwen3ReasoningParser;
 pub type NemotronV3ReasoningParser = Qwen3ReasoningParser;
 /// Step3 currently shares the standard `<think>...</think>` parser.
 pub type Step3ReasoningParser = Qwen3ReasoningParser;
-/// olmo3 currently shares the standard `<think>...</think>` parser.
-pub type Olmo3ReasoningParser = Qwen3ReasoningParser;
 
 /// Result alias for reasoning parser operations.
 pub type Result<T> = std::result::Result<T, ReasoningError>;

--- a/rust/src/parser/src/reasoning/mod.rs
+++ b/rust/src/parser/src/reasoning/mod.rs
@@ -54,6 +54,8 @@ pub type MiniMaxM2ReasoningParser = Qwen3ReasoningParser;
 pub type NemotronV3ReasoningParser = Qwen3ReasoningParser;
 /// Step3 currently shares the standard `<think>...</think>` parser.
 pub type Step3ReasoningParser = Qwen3ReasoningParser;
+/// olmo3 currently shares the standard `<think>...</think>` parser.
+pub type Olmo3ReasoningParser = Qwen3ReasoningParser;
 
 /// Result alias for reasoning parser operations.
 pub type Result<T> = std::result::Result<T, ReasoningError>;

--- a/rust/src/parser/src/reasoning/olmo3.rs
+++ b/rust/src/parser/src/reasoning/olmo3.rs
@@ -13,7 +13,7 @@ pub struct Olmo3ReasoningParser {
     /// True until the first response text is classified. Only this position may
     /// drop a response-leading `<think>` prefix.
     at_response_start: bool,
-    /// Holds an initial prefix like `<thi` while it may still complete into the
+    /// Holds an initial prefix like `<th` while it may still complete into the
     /// leading opener on a later chunk.
     leading_start_buffer: String,
 }

--- a/rust/src/parser/src/reasoning/olmo3.rs
+++ b/rust/src/parser/src/reasoning/olmo3.rs
@@ -1,0 +1,97 @@
+use vllm_tokenizer::DynTokenizer;
+
+use super::{DelimitedReasoningParser, ReasoningDelta, ReasoningParser, Result};
+
+/// Reasoning parser for the Olmo3 family.
+///
+/// Olmo3 uses standard `<think>...</think>` delimiters but does not have them as
+/// single tokens in its tokenizer vocabulary. It starts in reasoning mode by
+/// default, and handles optionally stripping a response-leading `<think>`
+/// prefix.
+pub struct Olmo3ReasoningParser {
+    inner: DelimitedReasoningParser,
+    /// True until the first response text is classified. Only this position may
+    /// drop a response-leading `<think>` prefix.
+    at_response_start: bool,
+    /// Holds an initial prefix like `<thi` while it may still complete into the
+    /// leading opener on a later chunk.
+    leading_start_buffer: String,
+}
+
+impl Olmo3ReasoningParser {
+    /// Create an Olmo3 parser backed by the shared delimited state machine.
+    pub fn new(tokenizer: DynTokenizer) -> Self {
+        Self {
+            inner: DelimitedReasoningParser::new_optional(tokenizer, "<think>", "</think>", true),
+            at_response_start: true,
+            leading_start_buffer: String::new(),
+        }
+    }
+
+    /// Drop a response-leading `<think>` prefix if present.
+    fn push_inner(&mut self, delta: &str) -> ReasoningDelta {
+        if self.at_response_start {
+            self.leading_start_buffer.push_str(delta);
+            let buffered = std::mem::take(&mut self.leading_start_buffer);
+
+            if buffered.is_empty() {
+                return ReasoningDelta::default();
+            }
+
+            if let Some(rest) = buffered.strip_prefix("<think>") {
+                self.at_response_start = false;
+                return self.inner.push(rest);
+            }
+
+            if "<think>".starts_with(buffered.as_str()) {
+                self.leading_start_buffer = buffered;
+                return ReasoningDelta::default();
+            }
+
+            self.at_response_start = false;
+            return self.inner.push(&buffered);
+        }
+
+        self.inner.push(delta)
+    }
+}
+
+fn append_delta(target: &mut ReasoningDelta, delta: ReasoningDelta) {
+    if let Some(reasoning) = delta.reasoning {
+        target.push_reasoning(&reasoning);
+    }
+    if let Some(content) = delta.content {
+        target.push_content(&content);
+    }
+}
+
+impl ReasoningParser for Olmo3ReasoningParser {
+    fn create(tokenizer: DynTokenizer) -> Result<Box<dyn ReasoningParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tokenizer)))
+    }
+
+    fn initialize(&mut self, prompt_token_ids: &[u32]) -> Result<()> {
+        self.inner.initialize(prompt_token_ids);
+        self.at_response_start = true;
+        self.leading_start_buffer.clear();
+        Ok(())
+    }
+
+    fn push(&mut self, delta: &str) -> Result<ReasoningDelta> {
+        Ok(self.push_inner(delta))
+    }
+
+    fn finish(&mut self) -> Result<ReasoningDelta> {
+        let mut delta = ReasoningDelta::default();
+        if !self.leading_start_buffer.is_empty() {
+            let pending = std::mem::take(&mut self.leading_start_buffer);
+            self.at_response_start = false;
+            append_delta(&mut delta, self.inner.push(&pending));
+        }
+        append_delta(&mut delta, self.inner.finish());
+        Ok(delta)
+    }
+}

--- a/rust/src/parser/src/reasoning/tests.rs
+++ b/rust/src/parser/src/reasoning/tests.rs
@@ -255,3 +255,26 @@ fn olmo3_tolerates_old_and_new_formats() {
     assert_eq!(new.reasoning.as_deref(), Some("reason"));
     assert_eq!(new.content.as_deref(), Some("answer"));
 }
+
+#[test]
+fn olmo3_without_think_tokens_in_vocab_still_splits() {
+    let tokenizer = Arc::new(TestTokenizer::new()); // no <think>/</think> in vocab
+    let mut parser = Olmo3ReasoningParser::new(tokenizer);
+    let delta = parser.push("reason</think>answer").unwrap();
+    assert_eq!(delta.reasoning.as_deref(), Some("reason"));
+    assert_eq!(delta.content.as_deref(), Some("answer"));
+}
+
+#[test]
+fn olmo3_streams_leading_think_across_chunks() {
+    let mut parser = Olmo3ReasoningParser::new(Arc::new(fake_tokenizer()));
+    assert!(parser.push("<th").unwrap().is_empty());
+    assert_eq!(
+        parser.push("ink>reason").unwrap().reasoning.as_deref(),
+        Some("reason")
+    );
+    assert_eq!(
+        parser.push("</think>answer").unwrap().content.as_deref(),
+        Some("answer")
+    );
+}

--- a/rust/src/parser/src/reasoning/tests.rs
+++ b/rust/src/parser/src/reasoning/tests.rs
@@ -7,7 +7,7 @@ use vllm_tokenizer::test_utils::TestTokenizer;
 
 use super::{
     DeepSeekR1ReasoningParser, DelimitedReasoningParser, MiniMaxM3ReasoningParser,
-    Qwen3ReasoningParser, ReasoningParser,
+    Olmo3ReasoningParser, Qwen3ReasoningParser, ReasoningParser,
 };
 
 pub(crate) const THINK_START_ID: u32 = 256;
@@ -217,4 +217,41 @@ fn minimax_m3_uses_prompt_prefilled_end_marker() {
     let delta = parser.push("answer").unwrap();
     assert_eq!(delta.reasoning, None);
     assert_eq!(delta.content.as_deref(), Some("answer"));
+}
+
+#[test]
+fn olmo3_without_prompt_markers_expects_start_token() {
+    let tokenizer = Arc::new(fake_tokenizer());
+    let mut parser = Olmo3ReasoningParser::new(tokenizer).unwrap();
+
+    let delta = parser.push("reason</think>answer").unwrap();
+    assert_eq!(delta.reasoning, None);
+    assert_eq!(delta.content.as_deref(), Some("reason</think>answer"));
+}
+
+#[test]
+fn olmo3_prompt_end_marker_starts_in_content() {
+    let tokenizer = Arc::new(fake_tokenizer());
+    let mut parser = Olmo3ReasoningParser::new(tokenizer).unwrap();
+    parser.initialize(&[THINK_END_ID]).unwrap();
+
+    let delta = parser.push("answer").unwrap();
+    assert_eq!(delta.reasoning, None);
+    assert_eq!(delta.content.as_deref(), Some("answer"));
+}
+
+#[test]
+fn olmo3_tolerates_old_and_new_formats() {
+    let tokenizer = Arc::new(fake_tokenizer());
+
+    let mut old_parser = Olmo3ReasoningParser::new(tokenizer.clone()).unwrap();
+    let old = old_parser.push("<think>reason</think>answer").unwrap();
+    assert_eq!(old.reasoning.as_deref(), Some("reason"));
+    assert_eq!(old.content.as_deref(), Some("answer"));
+
+    let mut new_parser = Olmo3ReasoningParser::new(tokenizer).unwrap();
+    new_parser.initialize(&[THINK_START_ID]).unwrap();
+    let new = new_parser.push("reason</think>answer").unwrap();
+    assert_eq!(new.reasoning.as_deref(), Some("reason"));
+    assert_eq!(new.content.as_deref(), Some("answer"));
 }

--- a/rust/src/parser/src/reasoning/tests.rs
+++ b/rust/src/parser/src/reasoning/tests.rs
@@ -220,19 +220,19 @@ fn minimax_m3_uses_prompt_prefilled_end_marker() {
 }
 
 #[test]
-fn olmo3_without_prompt_markers_expects_start_token() {
+fn olmo3_without_prompt_markers_defaults_to_reasoning() {
     let tokenizer = Arc::new(fake_tokenizer());
-    let mut parser = Olmo3ReasoningParser::new(tokenizer).unwrap();
+    let mut parser = Olmo3ReasoningParser::new(tokenizer);
 
     let delta = parser.push("reason</think>answer").unwrap();
-    assert_eq!(delta.reasoning, None);
-    assert_eq!(delta.content.as_deref(), Some("reason</think>answer"));
+    assert_eq!(delta.reasoning.as_deref(), Some("reason"));
+    assert_eq!(delta.content.as_deref(), Some("answer"));
 }
 
 #[test]
 fn olmo3_prompt_end_marker_starts_in_content() {
     let tokenizer = Arc::new(fake_tokenizer());
-    let mut parser = Olmo3ReasoningParser::new(tokenizer).unwrap();
+    let mut parser = Olmo3ReasoningParser::new(tokenizer);
     parser.initialize(&[THINK_END_ID]).unwrap();
 
     let delta = parser.push("answer").unwrap();
@@ -244,12 +244,12 @@ fn olmo3_prompt_end_marker_starts_in_content() {
 fn olmo3_tolerates_old_and_new_formats() {
     let tokenizer = Arc::new(fake_tokenizer());
 
-    let mut old_parser = Olmo3ReasoningParser::new(tokenizer.clone()).unwrap();
+    let mut old_parser = Olmo3ReasoningParser::new(tokenizer.clone());
     let old = old_parser.push("<think>reason</think>answer").unwrap();
     assert_eq!(old.reasoning.as_deref(), Some("reason"));
     assert_eq!(old.content.as_deref(), Some("answer"));
 
-    let mut new_parser = Olmo3ReasoningParser::new(tokenizer).unwrap();
+    let mut new_parser = Olmo3ReasoningParser::new(tokenizer);
     new_parser.initialize(&[THINK_START_ID]).unwrap();
     let new = new_parser.push("reason</think>answer").unwrap();
     assert_eq!(new.reasoning.as_deref(), Some("reason"));


### PR DESCRIPTION
This pull request adds support for the Olmo3 reasoning parser to the codebase. The main changes involve implementing the `Olmo3ReasoningParser`, registering it with the reasoning parser factory, updating pattern matching for model names, and adding comprehensive tests to ensure correct behavior. It also improves the flexibility of the delimited parser to handle cases where delimiter tokens may not be present in the tokenizer vocabulary.

**Olmo3 Reasoning Parser Integration:**

* Added the `Olmo3ReasoningParser` implementation in `olmo3.rs`, which handles reasoning sections delimited by `<think>...</think>`, including cases where these tokens are not present in the tokenizer vocabulary. It also correctly strips a response-leading `<think>` prefix and supports streaming input across chunks.
* Registered `Olmo3ReasoningParser` in the reasoning parser factory and updated model name patterns (`olmo-3`, `olmo3`) to resolve to this parser. [[1]](diffhunk://#diff-72e54296c3d5051e89b9845d64bb4c338a8d0fa0b37c0c7f55f91db7edac433bL12-R13) [[2]](diffhunk://#diff-72e54296c3d5051e89b9845d64bb4c338a8d0fa0b37c0c7f55f91db7edac433bR34) [[3]](diffhunk://#diff-72e54296c3d5051e89b9845d64bb4c338a8d0fa0b37c0c7f55f91db7edac433bR75) [[4]](diffhunk://#diff-72e54296c3d5051e89b9845d64bb4c338a8d0fa0b37c0c7f55f91db7edac433bR103-R104)

**Delimited Parser Improvements:**

* Updated `DelimitedReasoningParser` to make delimiter token IDs optional, allowing it to work even when delimiter tokens are missing from the tokenizer vocabulary. Added a new constructor `new_optional` and adjusted initialization logic accordingly. [[1]](diffhunk://#diff-f19244e9be0eae0bb6e14c93d8a8df1602ba2ce3eebebd157c550e047d7dad14L25-R26) [[2]](diffhunk://#diff-f19244e9be0eae0bb6e14c93d8a8df1602ba2ce3eebebd157c550e047d7dad14R52-R73) [[3]](diffhunk://#diff-f19244e9be0eae0bb6e14c93d8a8df1602ba2ce3eebebd157c550e047d7dad14L60-R97)

**Testing:**

* Added extensive unit tests for `Olmo3ReasoningParser`, covering default behavior, prompt marker handling, compatibility with old and new formats, operation without delimiter tokens in the vocabulary, and streaming of leading delimiters across input chunks.
* Updated parser registration and listing tests to include Olmo3.
* Added model name resolution tests for Olmo3 patterns.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>




