### PR TITLE
[AMD] Add a guard for EPLB/DBO plus fused share expert conflict

### DIFF
--- a/tests/platforms/test_rocm_fused_shared_experts_guard.py
+++ b/tests/platforms/test_rocm_fused_shared_experts_guard.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ``RocmPlatform._verify_aiter_fused_shared_experts``.
+
+These verify that enabling AITER fused shared-experts
+(``VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS``) together with features that
+reason about the per-rank routed-expert layout (EPLB, dual/two batch overlap)
+is rejected up front with a clear error, and that otherwise-valid combinations
+are left untouched.
+
+The guard only reads ``enable_eplb`` and ``use_ubatching`` off the parallel
+config, so we use a lightweight stub instead of a real ``ParallelConfig``
+(constructing one with ``enable_eplb=True`` triggers a CUDA-platform check that
+is unrelated to what we exercise here).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import vllm._aiter_ops as aiter_ops_mod
+from vllm.platforms.rocm import RocmPlatform
+
+
+def _parallel_config(*, enable_eplb=False, use_ubatching=False):
+    return SimpleNamespace(enable_eplb=enable_eplb, use_ubatching=use_ubatching)
+
+
+@pytest.fixture
+def set_fused_se(monkeypatch):
+    """Return a setter that forces the fused shared-experts capability flag."""
+
+    def _set(enabled: bool):
+        monkeypatch.setattr(
+            aiter_ops_mod.rocm_aiter_ops,
+            "is_fusion_moe_shared_experts_enabled",
+            classmethod(lambda cls: enabled),
+        )
+
+    return _set
+
+
+def test_no_conflict_when_fused_se_disabled(set_fused_se):
+    set_fused_se(False)
+    # Even with both features on, a disabled fused-SE must not raise.
+    parallel_config = _parallel_config(enable_eplb=True, use_ubatching=True)
+    RocmPlatform._verify_aiter_fused_shared_experts(parallel_config)
+
+
+def test_fused_se_alone_is_allowed(set_fused_se):
+    set_fused_se(True)
+    parallel_config = _parallel_config(enable_eplb=False, use_ubatching=False)
+    RocmPlatform._verify_aiter_fused_shared_experts(parallel_config)
+
+
+def test_fused_se_with_eplb_raises(set_fused_se):
+    set_fused_se(True)
+    parallel_config = _parallel_config(enable_eplb=True)
+    with pytest.raises(ValueError, match="EPLB"):
+        RocmPlatform._verify_aiter_fused_shared_experts(parallel_config)
+
+
+def test_fused_se_with_ubatching_raises(set_fused_se):
+    set_fused_se(True)
+    parallel_config = _parallel_config(use_ubatching=True)
+    with pytest.raises(ValueError, match="batch overlap"):
+        RocmPlatform._verify_aiter_fused_shared_experts(parallel_config)
+
+
+def test_eplb_conflict_checked_before_ubatching(set_fused_se):
+    # When both conflict, EPLB is reported first (deterministic message).
+    set_fused_se(True)
+    parallel_config = _parallel_config(enable_eplb=True, use_ubatching=True)
+    with pytest.raises(ValueError, match="EPLB"):
+        RocmPlatform._verify_aiter_fused_shared_experts(parallel_config)

--- a/tests/platforms/test_rocm_fused_shared_experts_guard.py
+++ b/tests/platforms/test_rocm_fused_shared_experts_guard.py
@@ -1,17 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for ``RocmPlatform._verify_aiter_fused_shared_experts``.
+"""Tests for ``RocmPlatform._verify_aiter_fused_shared_experts``.
 
-These verify that enabling AITER fused shared-experts
-(``VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS``) together with features that
-reason about the per-rank routed-expert layout (EPLB, dual/two batch overlap)
-is rejected up front with a clear error, and that otherwise-valid combinations
-are left untouched.
-
-The guard only reads ``enable_eplb`` and ``use_ubatching`` off the parallel
-config, so we use a lightweight stub instead of a real ``ParallelConfig``
-(constructing one with ``enable_eplb=True`` triggers a CUDA-platform check that
-is unrelated to what we exercise here).
+The guard only reads ``enable_eplb`` and ``use_ubatching``, so we use a stub
+instead of a real ``ParallelConfig`` (which validates the platform on init).
 """
 
 from types import SimpleNamespace
@@ -28,7 +20,7 @@ def _parallel_config(*, enable_eplb=False, use_ubatching=False):
 
 @pytest.fixture
 def set_fused_se(monkeypatch):
-    """Return a setter that forces the fused shared-experts capability flag."""
+    """Force the fused shared-experts capability flag."""
 
     def _set(enabled: bool):
         monkeypatch.setattr(
@@ -42,7 +34,7 @@ def set_fused_se(monkeypatch):
 
 def test_no_conflict_when_fused_se_disabled(set_fused_se):
     set_fused_se(False)
-    # Even with both features on, a disabled fused-SE must not raise.
+    # Disabled fused-SE must not raise even with both features on.
     parallel_config = _parallel_config(enable_eplb=True, use_ubatching=True)
     RocmPlatform._verify_aiter_fused_shared_experts(parallel_config)
 
@@ -68,7 +60,7 @@ def test_fused_se_with_ubatching_raises(set_fused_se):
 
 
 def test_eplb_conflict_checked_before_ubatching(set_fused_se):
-    # When both conflict, EPLB is reported first (deterministic message).
+    # EPLB is reported first when both conflict.
     set_fused_se(True)
     parallel_config = _parallel_config(enable_eplb=True, use_ubatching=True)
     with pytest.raises(ValueError, match="EPLB"):

--- a/tests/platforms/test_rocm_fused_shared_experts_guard.py
+++ b/tests/platforms/test_rocm_fused_shared_experts_guard.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for ``RocmPlatform._verify_aiter_fused_shared_experts``.
+"""Tests for ``RocmPlatform._maybe_disable_aiter_fused_shared_experts``.
 
 The guard only reads ``enable_eplb`` and ``use_ubatching``, so we use a stub
 instead of a real ``ParallelConfig`` (which validates the platform on init).
@@ -11,7 +11,10 @@ from types import SimpleNamespace
 import pytest
 
 import vllm._aiter_ops as aiter_ops_mod
+import vllm.platforms.rocm as rocm_mod
 from vllm.platforms.rocm import RocmPlatform
+
+_FSE_ENV = "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS"
 
 
 def _parallel_config(*, enable_eplb=False, use_ubatching=False):
@@ -19,49 +22,99 @@ def _parallel_config(*, enable_eplb=False, use_ubatching=False):
 
 
 @pytest.fixture
-def set_fused_se(monkeypatch):
-    """Force the fused shared-experts capability flag."""
+def fused_se(monkeypatch):
+    """Control the fused shared-experts flag and record warnings.
+
+    Returns a state dict: ``set(bool)`` forces the reported capability flag and
+    ``warnings`` captures ``logger.warning_once`` messages. ``refresh_env_variables``
+    is stubbed to mirror the env var into the capability flag.
+    """
+    state = {"enabled": False, "warnings": []}
+
+    monkeypatch.setenv(_FSE_ENV, "1")
+
+    def _is_enabled(cls):
+        return state["enabled"]
+
+    def _refresh(cls):
+        import os
+
+        state["enabled"] = os.environ.get(_FSE_ENV, "0").lower() in ("true", "1")
+
+    monkeypatch.setattr(
+        aiter_ops_mod.rocm_aiter_ops,
+        "is_fusion_moe_shared_experts_enabled",
+        classmethod(_is_enabled),
+    )
+    monkeypatch.setattr(
+        aiter_ops_mod.rocm_aiter_ops,
+        "refresh_env_variables",
+        classmethod(_refresh),
+    )
+    monkeypatch.setattr(
+        rocm_mod.logger,
+        "warning_once",
+        lambda msg, *a, **k: state["warnings"].append(msg % a if a else msg),
+    )
 
     def _set(enabled: bool):
-        monkeypatch.setattr(
-            aiter_ops_mod.rocm_aiter_ops,
-            "is_fusion_moe_shared_experts_enabled",
-            classmethod(lambda cls: enabled),
-        )
+        state["enabled"] = enabled
 
-    return _set
+    state["set"] = _set
+    return state
 
 
-def test_no_conflict_when_fused_se_disabled(set_fused_se):
-    set_fused_se(False)
-    # Disabled fused-SE must not raise even with both features on.
-    parallel_config = _parallel_config(enable_eplb=True, use_ubatching=True)
-    RocmPlatform._verify_aiter_fused_shared_experts(parallel_config)
+def test_noop_when_fused_se_disabled(fused_se):
+    fused_se["set"](False)
+    # Nothing to disable even if both conflicting features are on.
+    RocmPlatform._maybe_disable_aiter_fused_shared_experts(
+        _parallel_config(enable_eplb=True, use_ubatching=True)
+    )
+    import os
+
+    assert os.environ[_FSE_ENV] == "1"
+    assert fused_se["warnings"] == []
 
 
-def test_fused_se_alone_is_allowed(set_fused_se):
-    set_fused_se(True)
-    parallel_config = _parallel_config(enable_eplb=False, use_ubatching=False)
-    RocmPlatform._verify_aiter_fused_shared_experts(parallel_config)
+def test_fused_se_kept_when_no_conflict(fused_se):
+    fused_se["set"](True)
+    RocmPlatform._maybe_disable_aiter_fused_shared_experts(_parallel_config())
+    import os
+
+    assert os.environ[_FSE_ENV] == "1"
+    assert fused_se["enabled"] is True
+    assert fused_se["warnings"] == []
 
 
-def test_fused_se_with_eplb_raises(set_fused_se):
-    set_fused_se(True)
-    parallel_config = _parallel_config(enable_eplb=True)
-    with pytest.raises(ValueError, match="EPLB"):
-        RocmPlatform._verify_aiter_fused_shared_experts(parallel_config)
+def test_fused_se_disabled_on_eplb(fused_se):
+    fused_se["set"](True)
+    RocmPlatform._maybe_disable_aiter_fused_shared_experts(
+        _parallel_config(enable_eplb=True)
+    )
+    import os
+
+    assert os.environ[_FSE_ENV] == "0"
+    assert fused_se["enabled"] is False
+    assert len(fused_se["warnings"]) == 1
+    assert "EPLB" in fused_se["warnings"][0]
 
 
-def test_fused_se_with_ubatching_raises(set_fused_se):
-    set_fused_se(True)
-    parallel_config = _parallel_config(use_ubatching=True)
-    with pytest.raises(ValueError, match="batch overlap"):
-        RocmPlatform._verify_aiter_fused_shared_experts(parallel_config)
+def test_fused_se_disabled_on_dbo(fused_se):
+    fused_se["set"](True)
+    RocmPlatform._maybe_disable_aiter_fused_shared_experts(
+        _parallel_config(use_ubatching=True)
+    )
+    import os
+
+    assert os.environ[_FSE_ENV] == "0"
+    assert fused_se["enabled"] is False
+    assert "DBO" in fused_se["warnings"][0]
 
 
-def test_eplb_conflict_checked_before_ubatching(set_fused_se):
-    # EPLB is reported first when both conflict.
-    set_fused_se(True)
-    parallel_config = _parallel_config(enable_eplb=True, use_ubatching=True)
-    with pytest.raises(ValueError, match="EPLB"):
-        RocmPlatform._verify_aiter_fused_shared_experts(parallel_config)
+def test_warning_lists_all_conflicts(fused_se):
+    fused_se["set"](True)
+    RocmPlatform._maybe_disable_aiter_fused_shared_experts(
+        _parallel_config(enable_eplb=True, use_ubatching=True)
+    )
+    msg = fused_se["warnings"][0]
+    assert "EPLB" in msg and "DBO" in msg

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -843,11 +843,17 @@ class RocmPlatform(Platform):
 
         VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS fuses the shared expert into
         the routed-expert MoE by appending a per-rank shared-expert slot. That
-        extra slot changes the routed-expert count each rank sees, which is
-        incompatible with EPLB's per-expert bookkeeping/relocation. Reject the
-        combination up front with a clear message instead of failing deep in
-        the MoE path. This is the single place to extend as other mutually
-        exclusive features (e.g. batch-overlap schedulers) are added.
+        extra slot changes the routed-expert count each rank sees, which breaks
+        features that reason about the per-rank routed-expert layout:
+
+        - EPLB relies on a stable routed-expert count for its per-expert
+          bookkeeping/relocation.
+        - Dual/two batch overlap (DBO, aka batch-overlap microbatching) splits
+          the batch across ubatches that share the fused MoE layout.
+
+        Reject these combinations up front with a clear message instead of
+        failing deep in the MoE path. This is the single place to extend as
+        other mutually exclusive features are added.
         """
         from vllm._aiter_ops import rocm_aiter_ops
 
@@ -861,6 +867,16 @@ class RocmPlatform(Platform):
                 "count and breaks EPLB's per-expert bookkeeping. Disable one of "
                 "them (unset VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS or run "
                 "without --enable-eplb)."
+            )
+
+        if parallel_config.use_ubatching:
+            raise ValueError(
+                "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS is incompatible with "
+                "dual/two batch overlap (DBO): the fused shared-expert slot "
+                "changes the routed-expert count and is not supported by the "
+                "batch-overlap microbatching path. Disable one of them (unset "
+                "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS, or run without "
+                "--enable-dbo and with --ubatch-size<=1)."
             )
 
     @classmethod

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -839,21 +839,10 @@ class RocmPlatform(Platform):
     def _verify_aiter_fused_shared_experts(
         cls, parallel_config: "ParallelConfig"
     ) -> None:
-        """Guard AITER fused shared-experts against incompatible features.
+        """Reject AITER fused shared-experts + incompatible features.
 
-        VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS fuses the shared expert into
-        the routed-expert MoE by appending a per-rank shared-expert slot. That
-        extra slot changes the routed-expert count each rank sees, which breaks
-        features that reason about the per-rank routed-expert layout:
-
-        - EPLB relies on a stable routed-expert count for its per-expert
-          bookkeeping/relocation.
-        - Dual/two batch overlap (DBO, aka batch-overlap microbatching) splits
-          the batch across ubatches that share the fused MoE layout.
-
-        Reject these combinations up front with a clear message instead of
-        failing deep in the MoE path. This is the single place to extend as
-        other mutually exclusive features are added.
+        The fused shared-expert slot changes the per-rank routed-expert count,
+        which breaks EPLB bookkeeping and dual batch overlap (DBO).
         """
         from vllm._aiter_ops import rocm_aiter_ops
 
@@ -863,20 +852,13 @@ class RocmPlatform(Platform):
         if parallel_config.enable_eplb:
             raise ValueError(
                 "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS is incompatible with "
-                "EPLB: the fused shared-expert slot changes the routed-expert "
-                "count and breaks EPLB's per-expert bookkeeping. Disable one of "
-                "them (unset VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS or run "
-                "without --enable-eplb)."
+                "EPLB. Disable one of them."
             )
 
         if parallel_config.use_ubatching:
             raise ValueError(
                 "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS is incompatible with "
-                "dual/two batch overlap (DBO): the fused shared-expert slot "
-                "changes the routed-expert count and is not supported by the "
-                "batch-overlap microbatching path. Disable one of them (unset "
-                "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS, or run without "
-                "--enable-dbo and with --ubatch-size<=1)."
+                "dual batch overlap (DBO). Disable one of them."
             )
 
     @classmethod

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -18,7 +18,7 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from .interface import DeviceCapability, Platform, PlatformEnum
 
 if TYPE_CHECKING:
-    from vllm.config import VllmConfig
+    from vllm.config import ParallelConfig, VllmConfig
     from vllm.config.kernel import IrOpPriorityConfig
     from vllm.v1.attention.selector import AttentionSelectorConfig
 
@@ -832,6 +832,36 @@ class RocmPlatform(Platform):
 
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm.v1.worker.gpu_worker.Worker"
+
+        cls._verify_aiter_fused_shared_experts(parallel_config)
+
+    @classmethod
+    def _verify_aiter_fused_shared_experts(
+        cls, parallel_config: "ParallelConfig"
+    ) -> None:
+        """Guard AITER fused shared-experts against incompatible features.
+
+        VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS fuses the shared expert into
+        the routed-expert MoE by appending a per-rank shared-expert slot. That
+        extra slot changes the routed-expert count each rank sees, which is
+        incompatible with EPLB's per-expert bookkeeping/relocation. Reject the
+        combination up front with a clear message instead of failing deep in
+        the MoE path. This is the single place to extend as other mutually
+        exclusive features (e.g. batch-overlap schedulers) are added.
+        """
+        from vllm._aiter_ops import rocm_aiter_ops
+
+        if not rocm_aiter_ops.is_fusion_moe_shared_experts_enabled():
+            return
+
+        if parallel_config.enable_eplb:
+            raise ValueError(
+                "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS is incompatible with "
+                "EPLB: the fused shared-expert slot changes the routed-expert "
+                "count and breaks EPLB's per-expert bookkeeping. Disable one of "
+                "them (unset VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS or run "
+                "without --enable-eplb)."
+            )
 
     @classmethod
     def verify_model_arch(cls, model_arch: str) -> None:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -833,33 +833,38 @@ class RocmPlatform(Platform):
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm.v1.worker.gpu_worker.Worker"
 
-        cls._verify_aiter_fused_shared_experts(parallel_config)
+        cls._maybe_disable_aiter_fused_shared_experts(parallel_config)
 
     @classmethod
-    def _verify_aiter_fused_shared_experts(
+    def _maybe_disable_aiter_fused_shared_experts(
         cls, parallel_config: "ParallelConfig"
     ) -> None:
-        """Reject AITER fused shared-experts + incompatible features.
+        """Auto-disable AITER fused shared-experts on incompatible configs.
 
         The fused shared-expert slot changes the per-rank routed-expert count,
-        which breaks EPLB bookkeeping and dual batch overlap (DBO).
+        which breaks EPLB bookkeeping and dual batch overlap (DBO). When either
+        is enabled, disable fusion (with a warning) instead of erroring out.
         """
         from vllm._aiter_ops import rocm_aiter_ops
 
         if not rocm_aiter_ops.is_fusion_moe_shared_experts_enabled():
             return
 
+        conflicts = []
         if parallel_config.enable_eplb:
-            raise ValueError(
-                "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS is incompatible with "
-                "EPLB. Disable one of them."
-            )
-
+            conflicts.append("EPLB")
         if parallel_config.use_ubatching:
-            raise ValueError(
-                "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS is incompatible with "
-                "dual batch overlap (DBO). Disable one of them."
-            )
+            conflicts.append("dual batch overlap (DBO)")
+        if not conflicts:
+            return
+
+        os.environ["VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS"] = "0"
+        rocm_aiter_ops.refresh_env_variables()
+        logger.warning_once(
+            "Disabling VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS because it is "
+            "incompatible with %s; shared experts will run unfused.",
+            " and ".join(conflicts),
+        )
 
     @classmethod
     def verify_model_arch(cls, model_arch: str) -> None:


### PR DESCRIPTION
## Purpose
VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS fuses the shared expert into the routed-expert MoE by appending a per-rank shared-expert slot. That extra slot changes the routed-expert count each rank sees, which silently breaks features that assume a stable per-rank routed-expert layout:

* EPLB – per-expert bookkeeping/relocation relies on a consistent routed-expert count (the fused slot inflates it), so enabling both produces wrong expert accounting.
* Dual batch overlap (DBO / AITER "TBO") – the batch-overlap microbatching path (enable_dbo / ubatch_size > 1) is not compatible with the fused MoE layout.

Today these combinations fail deep in the MoE path (or produce incorrect results) instead of a clear config-time error. This PR adds a single, centralized guard in RocmPlatform.check_and_update_config that rejects fused shared-experts together with EPLB or DBO up front. It's the natural place to extend as other mutually exclusive features are added.

This is a follow-up to #47220 (Enable EPLB for Quark OCP MXFP4 MoE), moving the incompatibility check out of the per-quant-method supports_eplb property and into config validation so it applies to all MoE methods, not just Quark MXFP4.

## Test Plan
Added unit tests

## Test Result
```
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /tmp
plugins: asyncio-1.4.0, anyio-4.14.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 5 items
test_guard.py::test_no_conflict_when_fused_se_disabled PASSED            [ 20%]
test_guard.py::test_fused_se_alone_is_allowed PASSED                     [ 40%]
test_guard.py::test_fused_se_with_eplb_raises PASSED                     [ 60%]
test_guard.py::test_fused_se_with_ubatching_raises PASSED                [ 80%]
test_guard.py::test_eplb_conflict_checked_before_ubatching PASSED        [100%]
=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
../usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: 14 warnings
  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 5 passed, 16 warnings in 3.63s ========================
---
```

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

