### PR TITLE
[Bugfix] Guard ModelOpt step-4 fallback by packed_modules_mapping

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -133,6 +133,20 @@ def test_modelopt_mixed_precision_quantizes_parallel_lm_head():
     assert isinstance(method, ModelOptNvFp4LinearMethod)
 
 
+@pytest.mark.skip_global_cleanup
+def test_modelopt_mixed_precision_parent_fallback_requires_packed_module():
+    config = _mixed_precision_config(
+        {
+            "model.layers.0.mixer.in_proj": {
+                "quant_algo": "FP8",
+            },
+        }
+    )
+    config.packed_modules_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}
+
+    assert config._resolve_quant_algo("model.layers.0.mixer.conv1d") is None
+
+
 def test_vocab_parallel_embedding_weight_loader_accepts_scalar_scale():
     holder = Mock()
     scale = torch.nn.Parameter(torch.empty(1))

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -2451,6 +2451,13 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
                     return info["quant_algo"].upper()
 
         # 4. Parent-prefix fallback for fused projections (qkv_proj, gate_up_proj).
+        # Only apply to genuine fused projections (same guard as step 2). Without
+        # this, unquantized siblings (e.g. Mamba conv1d/norm in a MIXED_PRECISION
+        # checkpoint) inherit their quantized siblings' algo and get corrupted.
+        if not (
+            self.packed_modules_mapping and proj_name in self.packed_modules_mapping
+        ):
+            return None
         for candidate in self._quantized_layer_prefix_candidates(prefix):
             parent_dot = candidate.rsplit(".", 1)[0] + "."
             algos = {


### PR DESCRIPTION
## Purpose

Fixes #47241. Step 4 ("parent-prefix fallback") of `ModelOptMixedPrecisionConfig._resolve_quant_algo` (added in #46756) lacks the `packed_modules_mapping` guard that **step 2** has, so it fires for *every* prefix — not just genuine fused projections (`qkv_proj`, `gate_up_proj`). On a `MIXED_PRECISION` checkpoint this makes a genuinely-unquantized layer inherit the quant_algo of a quantized sibling.

Concretely, for **Nemotron-3-Super-120B NVFP4** it promotes the Mamba `conv1d` and `norm` (and `gate`) from bf16 → **FP8**, because they sit next to FP8 `in_proj`/`out_proj`. Quantizing a causal-conv1d and a norm corrupts the Mamba mixer, and generation degenerates (compounding over length). Nano is plain NVFP4 (not `MIXED_PRECISION`) so it never enters this path — which is why Nano was unaffected and only Super regressed.

Config trace, current `main` vs `debec6440^` — the layers that flip:

```
conv1d   None -> FP8   backbone.layers.N.mixer.conv1d   (must stay bf16)
norm     None -> FP8   backbone.layers.N.mixer.norm     (must stay bf16)
gate     None -> FP8   backbone.layers.N.mixer.gate
```

The routed MoE experts are correctly resolved by step 3 and stay `NVFP4` — only step 4 over-reaches onto non-fused layers.

## Fix

Give step 4 the same guard step 2 already has, so it only applies to real fused projections (keys in `packed_modules_mapping`). With the guard, `conv1d`/`norm`/`gate`/`in`/`out`/`q`/`k`/`v_proj`/`fc2_latent_proj`/`shared_experts` all revert FP8 → bf16 (exactly the pre-#46756 resolution), while routed experts stay NVFP4. One-file, 7-line change.

## Test Plan / Result

Loaded `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` (`moe_backend=marlin`, `enforce_eager=True`, `max_model_len=2048`) and ran the prompts that degenerated on unpatched `main`, on two Blackwell arches:

| GPU | `2+2` | largest planet | `5 apples − 2` | `60 km / 2 h` |
|---|---|---|---|---|
| RTX PRO 6000 (sm120) | `4` | `Jupiter` | `3` | `30` |
| DGX Spark GB10 (sm121) | `4` | `Jupiter` | `3` | `30` |

Before: the "5 apples" prompt degenerated into unrelated rambling. After: clean `3` on both. Nano remains correct (unchanged path).

---
*AI-assistance disclosure: the root-cause analysis and this patch were prepared with Claude (Anthropic); all builds and the GPU validation above were run and reviewed by me.*
