### PR TITLE
[Attention] Overlap sparse MLA indexer on a native CUDA side stream

### DIFF
--- a/tests/compile/test_aot_compile.py
+++ b/tests/compile/test_aot_compile.py
@@ -20,6 +20,7 @@ from vllm.compilation.caching import (
 )
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.decorators import support_torch_compile
+from vllm.compilation.side_stream import register_side_stream
 from vllm.config import (
     CompilationConfig,
     CompilationMode,
@@ -75,6 +76,32 @@ class CompiledModTuple(torch.nn.Module):
 
     def forward(self, x: torch.Tensor):
         return reference_fn_tuple(x)
+
+
+@support_torch_compile
+class SideStreamCompiledMod(torch.nn.Module):
+    # Shared across instances, mirroring how Indexer owns the side stream:
+    # only one side stream per process is supported.
+    side_stream: torch.cuda.Stream | None = None
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        if SideStreamCompiledMod.side_stream is None:
+            _, high_priority = torch.cuda.Stream.priority_range()
+            SideStreamCompiledMod.side_stream = torch.cuda.Stream(
+                priority=high_priority
+            )
+            register_side_stream(SideStreamCompiledMod.side_stream)
+        self.stream = SideStreamCompiledMod.side_stream
+
+    def forward(self, x: torch.Tensor):
+        assert self.stream is not None
+        self.stream.wait_stream(torch.accelerator.current_stream())
+        with self.stream:
+            side = x + 1
+        main = x * 2
+        torch.accelerator.current_stream().wait_stream(self.stream)
+        return main + side
 
 
 def make_vllm_config() -> VllmConfig:
@@ -156,6 +183,34 @@ def test_save_and_load(monkeypatch: pytest.MonkeyPatch):
                 "Expected was_aot_compile_fn_loaded_from_disk to be True"
             )
             assert torch.allclose(ret, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA-only test")
+@pytest.mark.skipif(not is_torch_equal_or_newer("2.13.0"), reason="requires torch 2.13")
+def test_side_stream_save_and_load(monkeypatch: pytest.MonkeyPatch):
+    from torch._dynamo.graph_bytecode_inputs import reset_user_object_tracking
+
+    with tempfile.TemporaryDirectory() as tmpdirname, monkeypatch.context() as m:
+        m.setenv("VLLM_CACHE_ROOT", tmpdirname)
+        m.setenv("VLLM_USE_AOT_COMPILE", "1")
+        m.setenv("VLLM_USE_MEGA_AOT_ARTIFACT", "1")
+        m.setenv("VLLM_USE_STANDALONE_COMPILE", "1")
+        x = torch.randn(16, device="cuda")
+        expected = 3 * x + 1
+
+        vllm_config = make_vllm_config()
+        with use_vllm_config(vllm_config):
+            compiled_mod = SideStreamCompiledMod(vllm_config=vllm_config)
+            torch.testing.assert_close(compiled_mod(x), expected)
+
+        disable_envs_cache()
+        m.setenv("VLLM_FORCE_AOT_LOAD", "1")
+        reset_user_object_tracking()
+        vllm_config = make_vllm_config()
+        with use_vllm_config(vllm_config):
+            cached_mod = SideStreamCompiledMod(vllm_config=vllm_config)
+            torch.testing.assert_close(cached_mod(x), expected)
+        assert cached_mod.was_aot_compile_fn_loaded_from_disk
 
 
 @pytest.mark.skipif(not is_torch_equal_or_newer("2.10.0"), reason="requires torch 2.10")

--- a/tests/compile/test_side_stream.py
+++ b/tests/compile/test_side_stream.py
@@ -14,6 +14,13 @@ from vllm.config import CompilationConfig, CUDAGraphMode, VllmConfig
 from vllm.platforms import current_platform
 
 
+@pytest.fixture(autouse=True)
+def resolver_installed() -> None:
+    """register_side_stream() installs the resolver; these tests exercise it
+    without registering a real stream."""
+    side_stream._install_stream_index_resolver()
+
+
 def test_stream_index_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
     """Index 0 resolves to the current stream dynamically, registry hits
     resolve normally, and a registry miss falls back to the side stream -

--- a/tests/compile/test_side_stream.py
+++ b/tests/compile/test_side_stream.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import weakref
+
+import pytest
+import torch
+from torch._dynamo.graph_bytecode_inputs import index_to_external_object_weakref
+from torch._dynamo.testing import EagerAndRecordGraphs
+
+import vllm.compilation.side_stream as side_stream
+from vllm.compilation.backends import wrap_with_cudagraph_if_needed
+from vllm.config import CompilationConfig, CUDAGraphMode, VllmConfig
+from vllm.platforms import current_platform
+
+
+def test_stream_index_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Index 0 resolves to the current stream dynamically, registry hits
+    resolve normally, and a registry miss falls back to the side stream -
+    the only external object vLLM registers - so artifacts stay executable
+    without dynamo's registry-repopulating bytecode."""
+    from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
+
+    class ExternalObject:
+        pass
+
+    current = ExternalObject()
+    side = ExternalObject()
+    unrelated = ExternalObject()
+    monkeypatch.setattr(side_stream, "current_stream", lambda: current)
+    monkeypatch.setattr(side_stream, "_side_stream", side)
+    monkeypatch.setitem(index_to_external_object_weakref, 9, weakref.ref(unrelated))
+    index_to_external_object_weakref.pop(7, None)
+
+    resolver = get_external_object_by_index
+    assert getattr(resolver, "_vllm_stream_resolver", False)
+
+    assert resolver(0) is current
+    assert resolver(9) is unrelated
+    assert resolver(7) is side
+
+
+def test_stream_index_resolver_reraises_without_side_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
+
+    monkeypatch.setattr(side_stream, "_side_stream", None)
+    index_to_external_object_weakref.pop(7, None)
+    with pytest.raises(AssertionError, match="not registered"):
+        get_external_object_by_index(7)
+
+
+def test_stream_piece_skips_independent_cudagraph_capture() -> None:
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        )
+    )
+    runnable = object()
+
+    wrapped = wrap_with_cudagraph_if_needed(
+        runnable,
+        vllm_config,
+        vllm_config.compilation_config,
+        is_first_graph=False,
+        is_last_graph=False,
+        uses_side_stream=True,
+    )
+
+    assert wrapped is runnable
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA-only test")
+def test_side_stream_uses_native_compile_context() -> None:
+    _, high_priority = torch.cuda.Stream.priority_range()
+    stream = torch.cuda.Stream(priority=high_priority)
+    backend = EagerAndRecordGraphs()
+
+    def run(x: torch.Tensor) -> torch.Tensor:
+        stream.wait_stream(torch.accelerator.current_stream())
+        with stream:
+            return x + 1
+
+    x = torch.zeros(4, device="cuda")
+    actual = torch.compile(run, backend=backend, fullgraph=True)(x)
+    assert torch.equal(actual, x + 1)
+    assert len(backend.graphs) == 1
+
+    annotated_nodes = [
+        node
+        for node in backend.graphs[0].graph.nodes
+        if node.meta.get("custom", {}).get("stream") not in (None, 0)
+    ]
+    assert annotated_nodes

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -52,6 +52,7 @@ from .partition_rules import (
 from .passes.inductor_pass import InductorPass, pass_context
 from .passes.ir.inplace_functionalization import VllmIRInplaceFunctionalizationPass
 from .passes.pass_manager import PostGradPassManager
+from .side_stream import graph_uses_side_stream
 
 logger = init_logger(__name__)
 
@@ -636,6 +637,7 @@ def wrap_with_cudagraph_if_needed(
     compilation_config: CompilationConfig,
     is_first_graph: bool,
     is_last_graph: bool,
+    uses_side_stream: bool = False,
 ) -> Any:
     """
     Wrap a piecewise backend with CUDA graph wrapper if needed.
@@ -648,6 +650,7 @@ def wrap_with_cudagraph_if_needed(
         compilation_config: The compilation configuration
         is_first_graph: Whether this is the first graph in the sequence
         is_last_graph: Whether this is the last graph in the sequence
+        uses_side_stream: Whether this graph runs work on the side stream
 
     Returns:
         The wrapped backend if CUDA graphs are enabled, otherwise the original backend
@@ -655,6 +658,7 @@ def wrap_with_cudagraph_if_needed(
     if (
         not compilation_config.cudagraph_mode.has_piecewise_cudagraphs()
         or compilation_config.use_inductor_graph_partition
+        or uses_side_stream
     ):
         return piecewise_backend
 
@@ -752,6 +756,9 @@ class PiecewiseCompileInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
 
             from .piecewise_backend import PiecewiseBackend
 
+            uses_side_stream = graph_uses_side_stream(submod)
+            self.vllm_backend.uses_side_stream[target] = uses_side_stream
+
             piecewise_backend = PiecewiseBackend(
                 submod,
                 self.vllm_config,
@@ -769,6 +776,7 @@ class PiecewiseCompileInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
                 self.compilation_config,
                 piecewise_backend.is_first_graph,
                 piecewise_backend.is_last_graph,
+                uses_side_stream,
             )
 
             compilation_counter.num_piecewise_capturable_graphs_seen += 1
@@ -1168,6 +1176,7 @@ class VllmBackend:
         assert not self._called, "VllmBackend can only be called once"
 
         self.graph = graph
+        self.uses_side_stream: dict[str, bool] = {}
         self.configure_post_pass()
 
         if self.compilation_config.use_inductor_graph_partition:

--- a/vllm/compilation/caching.py
+++ b/vllm/compilation/caching.py
@@ -260,11 +260,15 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
         for node in state["graph_module"].graph.nodes:
             node.meta.pop("source_fn_stack", None)
             node.meta.pop("nn_module_stack", None)
+            if isinstance(node.meta.get("example_value"), torch.Stream):
+                node.meta.pop("example_value")
         for name, submod in state["graph_module"].named_children():
             if hasattr(submod, "graph"):
                 for node in submod.graph.nodes:
                     node.meta.pop("source_fn_stack", None)
                     node.meta.pop("nn_module_stack", None)
+                    if isinstance(node.meta.get("example_value"), torch.Stream):
+                        node.meta.pop("example_value")
 
         if state.get("sym_tensor_indices"):
             # put tensor inputs on meta device since their data
@@ -294,6 +298,7 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
             state["standalone_compile_artifacts"] = standalone_compile_artifacts
             state["sym_shape_indices_map"] = sym_shape_indices_map
             state["returns_tuple_map"] = returns_tuple_map
+            state["uses_side_stream"] = compiled_fn.vllm_backend.uses_side_stream
         return pickle.dumps(state)
 
     @classmethod
@@ -309,6 +314,7 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
         standalone_compile_artifacts = state.pop("standalone_compile_artifacts", None)
         sym_shape_indices_map = state.pop("sym_shape_indices_map", {})
         returns_tuple_map = state.pop("returns_tuple_map", {})
+        uses_side_stream = state.pop("uses_side_stream", {})
 
         saved_aot_autograd_config = state["aot_autograd_config"]
         if saved_aot_autograd_config is not None:
@@ -329,6 +335,7 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
                     vllm_config=get_current_vllm_config(),
                     sym_shape_indices_map=sym_shape_indices_map,
                     returns_tuple_map=returns_tuple_map,
+                    uses_side_stream=uses_side_stream,
                     fake_mode=fake_mode,
                 )
 
@@ -414,6 +421,7 @@ def reconstruct_serializable_fn_from_mega_artifact(
     vllm_config: VllmConfig,
     sym_shape_indices_map: dict[str, list[int]],
     returns_tuple_map: dict[str, bool],
+    uses_side_stream: dict[str, bool],
     fake_mode: FakeTensorMode,
 ) -> "VllmSerializableFunction":
     """Construct a VllmSerializableFunction from cached inductor artifacts.
@@ -444,6 +452,7 @@ def reconstruct_serializable_fn_from_mega_artifact(
         vllm_config: The vLLM configuration.
         sym_shape_indices_map: Mapping from submod_name to sym_shape_indices.
         returns_tuple_map: Mapping from submod_name to returns_tuple.
+        uses_side_stream: Which compiled submodules run side-stream work.
 
     Returns:
         A VllmSerializableFunction that can be called directly.
@@ -516,6 +525,7 @@ def reconstruct_serializable_fn_from_mega_artifact(
             compilation_config,
             is_first,
             is_last,
+            uses_side_stream.get(submod_name, False),
         )
 
         submod_callables[submod_name] = wrapped_backend

--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -14,6 +14,7 @@ import torch.fx as fx
 
 import vllm.envs as envs
 from vllm.compilation.counter import compilation_counter
+from vllm.compilation.side_stream import graph_uses_side_stream
 from vllm.config import VllmConfig
 from vllm.config.utils import Range
 from vllm.env_override import _apply_constrain_to_fx_strides_patch
@@ -290,6 +291,8 @@ class InductorStandaloneAdaptor(CompilerInterface):
         current_config = {}
         if compiler_config is not None:
             current_config.update(compiler_config)
+        if graph_uses_side_stream(graph):
+            current_config["triton.autotune_at_compile_time"] = False
         set_inductor_config(current_config, compile_range)
         set_functorch_config()
 

--- a/vllm/compilation/side_stream.py
+++ b/vllm/compilation/side_stream.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared high-priority CUDA side stream."""
+
+from typing import Any
+
+import torch
+import torch.fx as fx
+from torch._dynamo.graph_bytecode_inputs import CURRENT_STREAM_INDEX
+
+from vllm.logger import init_logger
+from vllm.utils.torch_utils import current_stream
+
+logger = init_logger(__name__)
+
+_side_stream: torch.cuda.Stream | None = None
+
+
+def register_side_stream(stream: torch.cuda.Stream) -> None:
+    """Publish the side stream so compiled artifacts can resolve it by index.
+
+    Callers own the stream and pass it to their consumers directly; this only
+    gives the index resolver below a handle on it. Only one side stream per
+    process is supported, since an artifact's stream indices carry no way to
+    tell two of them apart.
+    """
+    global _side_stream
+    assert _side_stream is None or _side_stream is stream, (
+        "only one side stream per process is supported"
+    )
+    _side_stream = stream
+
+
+def graph_uses_side_stream(graph: fx.GraphModule) -> bool:
+    return any(
+        node.meta.get("custom", {}).get("stream") not in (None, 0)
+        or (node.op == "call_function" and str(node.target).startswith("streams."))
+        for node in graph.graph.nodes
+    )
+
+
+def _install_stream_index_resolver() -> None:
+    """Resolve stream external-object indices without dynamo's bytecode.
+
+    Compiled artifacts reference streams by external-object index from the
+    inductor wrapper prologue and from the int args of torch.ops.streams.*.
+    Dynamo resolves both through a process-local registry that its generated
+    bytecode repopulates on every call; vLLM invokes compiled pieces directly,
+    so that registry is empty on AOT reload and is cleared again whenever
+    anything else is traced.
+
+    Two rules cover every index. CURRENT_STREAM_INDEX is dynamo's reserved
+    index for the current stream, resolved dynamically here because a registry
+    entry would pin whichever stream was current at trace time - wrong under
+    cudagraph capture. Every other index refers to the side stream, the only
+    stream object vLLM graphs capture, so a registry miss falls back to it.
+    Violations fail loudly: torch's _get_stream_by_index and
+    _get_event_by_index assert the type of the resolved object.
+    """
+    import torch._dynamo.graph_bytecode_inputs as gbi
+    import torch._dynamo.variables.streams as dynamo_streams
+
+    if getattr(gbi.get_external_object_by_index, "_vllm_stream_resolver", False):
+        return
+    original = gbi.get_external_object_by_index
+
+    def resolver(index: int) -> Any:
+        if index == CURRENT_STREAM_INDEX:
+            return current_stream()
+        try:
+            return original(index)
+        except AssertionError:
+            if _side_stream is None:
+                raise
+            logger.debug_once(
+                "Resolved unregistered external-object index %d to the side "
+                "stream; this is expected for AOT-loaded graphs.",
+                index,
+            )
+            return _side_stream
+
+    resolver._vllm_stream_resolver = True  # type: ignore[attr-defined]
+    gbi.get_external_object_by_index = resolver
+    # variables.streams binds the name at import time, so the streams.* op
+    # implementations (_get_stream_by_index) need their own rebind.
+    dynamo_streams.get_external_object_by_index = resolver
+
+
+# Install at import: deserialized artifacts bind the resolver name when their
+# generated modules are exec'd, which can happen before any compile runs.
+_install_stream_index_resolver()

--- a/vllm/compilation/side_stream.py
+++ b/vllm/compilation/side_stream.py
@@ -29,6 +29,11 @@ def register_side_stream(stream: torch.cuda.Stream) -> None:
         "only one side stream per process is supported"
     )
     _side_stream = stream
+    # Layers register during model construction, before anything is compiled or
+    # any AOT artifact module is exec'd, so this is early enough to catch every
+    # binding of the resolver name - and it keeps the patch off processes that
+    # never use a side stream.
+    _install_stream_index_resolver()
 
 
 def graph_uses_side_stream(graph: fx.GraphModule) -> bool:
@@ -84,8 +89,3 @@ def _install_stream_index_resolver() -> None:
     # variables.streams binds the name at import time, so the streams.* op
     # implementations (_get_stream_by_index) need their own rebind.
     dynamo_streams.get_external_object_by_index = resolver
-
-
-# Install at import: deserialized artifacts bind the resolver name when their
-# generated modules are exec'd, which can happen before any compile runs.
-_install_stream_index_resolver()

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -27,6 +27,8 @@ class MLAModules:
     is_sparse: bool
     topk_indices_buffer: torch.Tensor | None
     indexer_rotary_emb: torch.nn.Module | None = None
+    # Stream the indexer forks onto; the wrapper joins it before attention.
+    indexer_side_stream: torch.cuda.Stream | None = None
 
 
 # --8<-- [start:multi_head_latent_attention]
@@ -85,6 +87,7 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         self.rotary_emb = mla_modules.rotary_emb
         self.o_proj = mla_modules.o_proj
         self.indexer = mla_modules.indexer
+        self.indexer_side_stream = mla_modules.indexer_side_stream
         self.indexer_rope_emb = mla_modules.indexer_rotary_emb
         self.is_sparse = mla_modules.is_sparse
 
@@ -161,6 +164,12 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             q_proj_layer = self.q_proj
             q_proj_input = hidden_states
 
+        # Issued before the q projection so the indexer's side-stream work
+        # overlaps the main stream's path to attention; joined below.
+        indexer = self.indexer if self.is_sparse and not self.skip_topk else None
+        if indexer is not None:
+            indexer(hidden_states, q_c, positions, self.indexer_rope_emb)
+
         kv_c, k_pe = kv_lora.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
         kv_c_normed = self.kv_a_layernorm(kv_c)
         # Add head dim of 1 to k_pe
@@ -177,9 +186,6 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
                 positions, q[..., self.qk_nope_head_dim :], k_pe
             )
 
-        if self.indexer and self.is_sparse and not self.skip_topk:
-            self.indexer(hidden_states, q_c, positions, self.indexer_rope_emb)
-
         if llama_4_scaling is not None:
             q *= llama_4_scaling
 
@@ -187,6 +193,8 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         if self.dcp_q_replicate:
             q_dcp_replicated, q = q, q_proj_layer._local_view(q)
 
+        if indexer is not None and self.indexer_side_stream is not None:
+            torch.accelerator.current_stream().wait_stream(self.indexer_side_stream)
         attn_out = self.mla_attn(
             q,
             kv_c_normed,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -36,6 +36,7 @@ import vllm._custom_ops as ops
 import vllm.envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.decorators import support_torch_compile
+from vllm.compilation.side_stream import register_side_stream
 from vllm.config import CacheConfig, ParallelConfig, VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_ep_group,
@@ -643,6 +644,11 @@ class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
 
 
 class Indexer(nn.Module):
+    # One high-priority stream shared by every indexer layer. Class-level
+    # because the join in MultiHeadLatentAttentionWrapper and the compiled
+    # artifacts must all reference this exact object.
+    side_stream: torch.cuda.Stream | None = None
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -716,6 +722,10 @@ class Indexer(nn.Module):
         )
 
         self.is_inplace_rope = is_inplace_rope
+        if current_platform.is_cuda() and Indexer.side_stream is None:
+            _, high_priority = torch.cuda.Stream.priority_range()
+            Indexer.side_stream = torch.cuda.Stream(priority=high_priority)
+            register_side_stream(Indexer.side_stream)
         self.n_head_scale = self.n_head**-0.5
         self.use_fused_indexer_q = (
             current_platform.is_cuda()
@@ -726,6 +736,17 @@ class Indexer(nn.Module):
         )
 
     def forward(
+        self, hidden_states: torch.Tensor, qr: torch.Tensor, positions, rotary_emb
+    ) -> torch.Tensor:
+        if self.side_stream is None:
+            return self._forward(hidden_states, qr, positions, rotary_emb)
+        # Fork onto the side stream; MultiHeadLatentAttentionWrapper joins it
+        # before attention, so the indexer overlaps the q projection and rope.
+        self.side_stream.wait_stream(torch.accelerator.current_stream())
+        with self.side_stream:
+            return self._forward(hidden_states, qr, positions, rotary_emb)
+
+    def _forward(
         self, hidden_states: torch.Tensor, qr: torch.Tensor, positions, rotary_emb
     ) -> torch.Tensor:
         q, _ = self.wq_b(qr)
@@ -1150,6 +1171,7 @@ class DeepseekV2MLAAttention(nn.Module):
             q_proj=self.q_proj if self.q_lora_rank is None else None,
             indexer=self.indexer,
             indexer_rotary_emb=self.indexer_rope_emb,
+            indexer_side_stream=Indexer.side_stream,
             is_sparse=self.is_v32,
             topk_indices_buffer=topk_indices_buffer,
         )


### PR DESCRIPTION
## Summary

Runs the sparse-MLA (DSA) indexer on a shared high-priority CUDA stream so it
overlaps the main stream's path to attention. The indexer is independent of the
q projection, kv layernorm and rope that precede attention; only
`topk_indices_buffer` couples it to attention, so a single join immediately
before the attention call is sufficient.

Rebased on current `main` (PyTorch 2.13) and uses PyTorch's **native compiled
stream operations** — no side-stream begin/end custom ops, and no per-graph
stream mappings.

### Mechanics

- `Indexer` owns the stream as a class attribute and hands it to
  `MultiHeadLatentAttentionWrapper` via `MLAModules`. Class-level because the
  fork, the join and the compiled artifacts must reference the same object.
- `Indexer.forward` forks (`wait_stream` + `with stream:`); the wrapper joins
  with `current_stream().wait_stream(side)` just before `self.mla_attn(...)`.
  Both are plain stream ops, so torch.compile traces them into native stream
  nodes.
- The indexer is issued right after the q_a/kv_a projections rather than after
  rope, so there is main-stream work left to overlap with.
- Fork and join land in **different compiled pieces** (the indexer is a
  splitting op), so a piece carrying side-stream work cannot be captured as an
  independent piecewise cudagraph — capture would end with unjoined work. Those
  pieces skip that capture and run inside the full graph instead.
- vLLM invokes compiled pieces without dynamo's registry-repopulating bytecode,
  so stream external-object indices are resolved by a small resolver: dynamo's
  reserved index means "current stream", any other index means the side stream.
  It is installed only once a layer registers a side stream.
- Compile-time Triton autotuning is disabled only for graphs containing a
  non-default stream; PyTorch 2.13's compile-time autotune wrapper does not
  initialize the user-stream handle.

## Results

GLM-5.2-NVFP4, TP=4, B200, `torch.compile` + `FULL_AND_PIECEWISE` CUDA graphs
(**not** eager, **not** piecewise-only).

### Kernel overlap

Measured per steady-state decode iteration as
`union(indexer) + union(other) − union(indexer ∪ other)`, at **~9.6k-token
context, batch 4**. Stream IDs are unreliable for cudagraph-replayed kernels, so
this is time overlap, not stream attribution.

| config | main | this PR |
| --- | --- | --- |
| TP=4 | 3.5% | **71.0%** |
| TP=4 + DCP=4 | 1.8% | **30.2%** |

**TP=4, no DCP** — the main-stream row gaps open exactly where the indexer runs
on `main`, and runs straight through it with the side stream:

![overlap TP=4](https://raw.githubusercontent.com/LucasWilkinson/vllm/assets/pr47355-profiles/overlap-tp4-nodcp.png)

**TP=4 + DCP=4** — lower, because the DCP-only tail of the indexer chain
(`pack_dcp_topk_candidates` → top-k all-gather → stable merge) overlaps poorly:
the top-k all-gather is 0.330 ms at 2.7%.

![overlap TP=4 DCP=4](https://raw.githubusercontent.com/LucasWilkinson/vllm/assets/pr47355-profiles/overlap-tp4-dcp4.png)

Per kernel class, TP=4 without DCP:

| kernel class | main | this PR |
| --- | --- | --- |
| k quant + cache | 4.9% | 98.0% |
| top-k select/merge | 0.7% | 74.3% |
| q rope + quant | 5.2% | 64.1% |
| logits (MQA) | 6.9% | 45.7% |

### End-to-end

`vllm bench latency`, 10 iterations at 4k / 5 at 32k, warmup excluded.

| config | main | this PR | delta |
| --- | --- | --- | --- |
| 32k in / 128 out / batch 8, TP=4 | 11.6437 s | 11.5420 s | **+0.87%** |
| 32k in / 128 out / batch 8, TP=4 + DCP=4 | 20.1777 s | 19.9829 s | **+0.97%** |
| 4k in / 256 out / batch 16, TP=4 | 5.7858 s | 5.9437 s | **−2.73%** |
| 4k in / 256 out / batch 16, TP=4 + DCP=4 | 9.7436 s | 9.9133 s | **−1.74%** |

**This regresses short-context decode.** Reporting it because it is real and
reproducible — the distributions do not overlap (main's slowest 4k run is faster
than this PR's fastest), sd ≤ 0.03 s.

Two contributing mechanisms are measured; a third is suspected:

1. **Concurrency widens the indexer chain.** Same kernels, run alongside the
   main stream, take longer: 4.340 → 5.608 ms (+29%) without DCP, 0.975 → 1.014
   ms with. On a saturated device concurrency partitions SMs rather than adding
   throughput. You get 71% of a bigger number.
2. **The prize is small at short context.** At 4k/batch-16 the indexer is ~4% of
   decode, so perfect hiding saves ≤4%; a 2–3% slowdown of the critical path
   erases it. At 32k the indexer's share grows — it scans the whole KV while
   sparse attention stays fixed at `topk_tokens`.
3. **Suspected, not yet isolated:** pieces carrying side-stream work skip
   piecewise cudagraph capture. Decode uses full graphs so it is unaffected, but
   prefill runs piecewise and now runs uncaptured. That cost is roughly fixed
   per prefill while the decode benefit scales with context, which would explain
   the sign flipping with the prefill:decode ratio rather than with DCP.

### Accuracy

GSM8K, 300 questions, 5-shot, 0% invalid:

| config | accuracy |
| --- | --- |
| main, TP=4 | 0.9367 |
| this PR, TP=4 | 0.9500 |
| this PR, TP=4 + DCP=4 | 0.9433 |

A 4-question spread on 300 is inside one standard error; no regression.

## Not a duplicate

This updates the existing side-stream PR rather than opening another.
Related but distinct: #48196 is the DCP output-merge optimization; #45964
(merged) is DCP query replication.

Prior art worth naming: an earlier unlanded branch of mine
(`5012b439`) did the same overlap using `dcp_indexer_stream_begin/restore`
custom ops that call `torch.cuda.set_stream` at runtime, scoped to DCP > 1, and
placed the join after the DCP query all-gather. This PR replaces the custom ops
with native traced streams. I re-tested that later join placement here and it
made no measurable difference (30.7% → 30.2% overlap, e2e slightly worse), so it
is not carried over.

## Testing

```
pytest tests/compile/test_side_stream.py           # 4 passed
pytest tests/compile/test_aot_compile.py           # 28 passed, 1 skipped
pre-commit run --files <changed>                   # passed, incl. manual-stage mypy
```

`test_aot_compile.py` includes a new AOT save/reload round-trip of a graph that
uses a side stream, covering the index resolver.

## Caveats

- Profiles are at ~9.6k tokens / batch 4; the benches at 32k and 4k. Different
  operating points — the overlap percentages do not transfer directly to the
  end-to-end numbers.
- Single model (GLM-5.2-NVFP4) and single machine (4×B200).
- The short-context regression should be understood before merge; if mechanism 3
  above is confirmed, it is fixable rather than inherent.

## AI assistance

AI assistance (Claude, and Codex for earlier revisions) was used to implement,
profile and test this change. The submitter has reviewed every changed line and
is responsible for the results reported here.
