### PR TITLE
[Bugfix][Logging] Redact structured-outputs schema in crash dumps

### DIFF
--- a/tests/v1/core/test_dump_input_anon.py
+++ b/tests/v1/core/test_dump_input_anon.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression: crash dumps must not leak structured-output schemas.
+
+``NewRequestData.anon_repr`` obfuscates the prompt but used to emit
+``sampling_params`` verbatim, so the full json/regex/grammar/structural_tag
+was written to the logs at ERROR level on an engine crash.
+"""
+
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.v1.core.sched.output import NewRequestData
+
+
+def test_structured_outputs_anonymized_redacts_content():
+    schema = '{"properties": {"buyerCompanyName": {"type": "string"}}}'
+    anon = StructuredOutputsParams(json=schema).anonymized()
+    assert schema not in repr(anon)
+    assert anon.json == f"<redacted len={len(schema)}>"
+    # exactly-one-constraint invariant still holds
+    assert anon.regex is None and anon.grammar is None
+
+
+def test_anonymized_preserves_non_content_flags():
+    anon = StructuredOutputsParams(
+        regex="secret.*pattern", disable_any_whitespace=True
+    ).anonymized()
+    assert "secret" not in anon.regex
+    assert anon.disable_any_whitespace is True
+
+
+def test_new_request_data_anon_repr_hides_schema():
+    schema = '{"properties": {"ssn": {"type": "string"}}}'
+    req = NewRequestData(
+        req_id="r0",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=[],
+        sampling_params=SamplingParams(
+            structured_outputs=StructuredOutputsParams(json=schema)
+        ),
+        pooling_params=None,
+        block_ids=([],),
+        num_computed_tokens=0,
+        lora_request=None,
+    )
+    dumped = req.anon_repr()
+    assert "ssn" not in dumped
+    assert schema not in dumped
+    # the non-anonymized repr still carries it (debug-only, opt-in)
+    assert "ssn" in repr(req)

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -5,7 +5,7 @@
 import copy
 import json as json_mod
 import math
-from dataclasses import field
+from dataclasses import field, replace
 from enum import Enum, IntEnum
 from functools import cached_property
 from typing import Annotated, Any
@@ -109,6 +109,34 @@ class StructuredOutputsParams:
                 "You must use one kind of structured outputs constraint "
                 f"but none are specified: {self.__dict__}"
             )
+
+    def anonymized(self) -> "StructuredOutputsParams":
+        """Return a copy with user-supplied content redacted.
+
+        The schema/regex/grammar/structural_tag carry request content and must
+        not be logged (e.g. in ``dump_engine_exception``). Content is replaced
+        with a length marker while the constraint kind is preserved, so exactly
+        one constraint stays set and ``__post_init__`` still validates.
+        """
+
+        def _redact(value: Any) -> Any:
+            if value is None:
+                return None
+            if isinstance(value, str):
+                return f"<redacted len={len(value)}>"
+            if isinstance(value, (dict, list)):
+                return f"<redacted n={len(value)}>"
+            return "<redacted>"
+
+        return replace(
+            self,
+            json=_redact(self.json),
+            regex=_redact(self.regex),
+            choice=_redact(self.choice),
+            grammar=_redact(self.grammar),
+            whitespace_pattern=_redact(self.whitespace_pattern),
+            structural_tag=_redact(self.structural_tag),
+        )
 
     def all_constraints_none(self) -> bool:
         """

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -5,7 +5,7 @@
 import copy
 import json as json_mod
 import math
-from dataclasses import field
+from dataclasses import field, replace
 from enum import Enum, IntEnum
 from functools import cached_property
 from typing import Annotated, Any
@@ -125,6 +125,34 @@ class StructuredOutputsParams:
                 "You must use one kind of structured outputs constraint "
                 f"but none are specified: {self.__dict__}"
             )
+
+    def anonymized(self) -> "StructuredOutputsParams":
+        """Return a copy with user-supplied content redacted.
+
+        The schema/regex/grammar/structural_tag carry request content and must
+        not be logged (e.g. in ``dump_engine_exception``). Content is replaced
+        with a length marker while the constraint kind is preserved, so exactly
+        one constraint stays set and ``__post_init__`` still validates.
+        """
+
+        def _redact(value: Any) -> Any:
+            if value is None:
+                return None
+            if isinstance(value, str):
+                return f"<redacted len={len(value)}>"
+            if isinstance(value, (dict, list)):
+                return f"<redacted n={len(value)}>"
+            return "<redacted>"
+
+        return replace(
+            self,
+            json=_redact(self.json),
+            regex=_redact(self.regex),
+            choice=_redact(self.choice),
+            grammar=_redact(self.grammar),
+            whitespace_pattern=_redact(self.whitespace_pattern),
+            structural_tag=_redact(self.structural_tag),
+        )
 
     def all_constraints_none(self) -> bool:
         """

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+import msgspec
+
 from vllm.config.ec_manager_config import EncoderCacheManagerMetadata
 from vllm.multimodal.utils import strip_covered_mm_data
 
@@ -113,13 +115,24 @@ class NewRequestData:
         prefill_token_ids_len = (
             len(self.prefill_token_ids) if self.prefill_token_ids is not None else None
         )
+        # Redact structured-outputs content (json/regex/grammar/structural_tag)
+        # so request schemas don't leak into error-level crash dumps.
+        sampling_params = self.sampling_params
+        if (
+            sampling_params is not None
+            and sampling_params.structured_outputs is not None
+        ):
+            sampling_params = msgspec.structs.replace(
+                sampling_params,
+                structured_outputs=sampling_params.structured_outputs.anonymized(),
+            )
         return (
             f"NewRequestData("
             f"req_id={self.req_id},"
             f"prompt_token_ids_len={prompt_token_ids_len},"
             f"prefill_token_ids_len={prefill_token_ids_len},"
             f"mm_features={self.mm_features},"
-            f"sampling_params={self.sampling_params},"
+            f"sampling_params={sampling_params},"
             f"block_ids={self.block_ids},"
             f"num_computed_tokens={self.num_computed_tokens},"
             f"lora_request={self.lora_request},"

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+import msgspec
+
 from vllm.config.ec_manager_config import EncoderCacheManagerMetadata
 
 if TYPE_CHECKING:
@@ -97,13 +99,24 @@ class NewRequestData:
         prefill_token_ids_len = (
             len(self.prefill_token_ids) if self.prefill_token_ids is not None else None
         )
+        # Redact structured-outputs content (json/regex/grammar/structural_tag)
+        # so request schemas don't leak into error-level crash dumps.
+        sampling_params = self.sampling_params
+        if (
+            sampling_params is not None
+            and sampling_params.structured_outputs is not None
+        ):
+            sampling_params = msgspec.structs.replace(
+                sampling_params,
+                structured_outputs=sampling_params.structured_outputs.anonymized(),
+            )
         return (
             f"NewRequestData("
             f"req_id={self.req_id},"
             f"prompt_token_ids_len={prompt_token_ids_len},"
             f"prefill_token_ids_len={prefill_token_ids_len},"
             f"mm_features={self.mm_features},"
-            f"sampling_params={self.sampling_params},"
+            f"sampling_params={sampling_params},"
             f"block_ids={self.block_ids},"
             f"num_computed_tokens={self.num_computed_tokens},"
             f"lora_request={self.lora_request},"


### PR DESCRIPTION
Fixes #47364

`NewRequestData.anon_repr` obfuscates the prompt token IDs but printed `sampling_params` verbatim, so `StructuredOutputsParams` (json/regex/grammar/structural_tag) got written in full at ERROR level via `dump_engine_exception` on an engine crash — request schemas leaking into logs.

Added `StructuredOutputsParams.anonymized()` (replaces content with a length marker, keeps the constraint kind so the exactly-one-constraint invariant still validates) and apply it in `anon_repr` via `msgspec.structs.replace`. Non-content flags (`json_object`, `disable_*`) are untouched; the full `__repr__` is unchanged (debug-only). Regression test in tests/v1/core/test_dump_input_anon.py.