### PR TITLE
[Bugfix] Cap available ram at the amount reported by cgroups if possible

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -701,11 +701,11 @@ def _get_available_ram_bytes() -> int:
         try:
             with open("/sys/fs/cgroup/memory.max", "r") as f:
                 cgroup_max = int(f.read())
+                if cgroup_max < mem_avail:
+                    mem_avail = cgroup_max
         except Exception:
             pass
 
-        if cgroup_max < mem_avail:
-            mem_avail = cgroup_max
 
     return mem_avail
 

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -690,7 +690,24 @@ def _get_available_ram_bytes() -> int:
     """Return the available RAM in bytes."""
     import psutil
 
-    return psutil.virtual_memory().available
+    mem_avail = psutil.virtual_memory().available
+
+    # In containers, mem_avail sometimes returns host memory available
+    # which may be limited by the container. Cap mem_avail by the
+    # max allowed by the container in order to prevent the loader from
+    # thinking that a lot of memory is available and then caching the
+    # weights when this actually causes low memory in the container
+    if os.path.exists("/sys/fs/cgroup/memory.max"):
+        try:
+            with open("/sys/fs/cgroup/memory.max", "r") as f:
+                cgroup_max = int(f.read())
+        except Exception:
+            pass
+
+        if cgroup_max < mem_avail:
+            mem_avail = cgroup_max
+
+    return mem_avail
 
 
 def _get_fs_type(files: list[str]) -> str:


### PR DESCRIPTION

## Purpose
In docker containers with limited memory, psutil returns an incorrect amount of memory, see https://github.com/giampaolo/psutil/issues/2100

This is undesirable because vLLM will try to place model weights in cache, which doesn't work because the container doesn't actually have access to this much cache, and then will cause some thrashing.

## Test Plan
On my container, I tested the new Python function by running it in a Repl.

## Test Result
It returned the actual amount of memory available to the system (32 GB) rather than the host's memory (200 GB).
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

