### PR TITLE
[KV Connector] Use prefill block content to overwrite decode bad blocks

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -749,6 +749,49 @@ def test_nixl_metadata_hybrid_ssm_block_ids():
     assert len(req_meta.remote.block_ids[0]) != len(req_meta.remote.block_ids[1])
 
 
+@pytest.mark.cpu_test
+def test_nixl_meta_marks_loaded_attention_blocks_to_skip_zeroing():
+    """Remote loads overwrite FA blocks, but not Mamba state blocks."""
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+    scheduler = make_nixl_scheduler(
+        has_mamba=True, is_hma_required=True, heartbeat=True
+    )
+    scheduler.kv_cache_config = make_kv_cache_config(block_size=16, mamba_enabled=True)
+
+    req = create_request(do_remote_prefill=True)
+    assert req.kv_transfer_params is not None
+    req.kv_transfer_params["remote_block_ids"] = ([100, 101], [200])
+
+    scheduler._reqs_need_recv[req.request_id] = (req, ([10, 11], [20]))
+
+    meta = scheduler.build_connector_meta(SchedulerOutput.make_empty())
+
+    assert meta.get_blocks_to_skip_kv_cache_zeroing() == {10, 11}
+
+
+@pytest.mark.cpu_test
+def test_scheduler_filters_connector_loaded_blocks_from_zeroing():
+    """Blocks that will be loaded by the connector must not be zeroed."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+        NixlConnectorMetadata,
+    )
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    class FakeKVCacheManager:
+        def take_new_block_ids(self):
+            return [9, 10, 11, 12]
+
+    scheduler = object.__new__(Scheduler)
+    scheduler.needs_kv_cache_zeroing = True
+    scheduler.kv_cache_manager = FakeKVCacheManager()
+
+    metadata = NixlConnectorMetadata()
+    metadata.add_blocks_to_skip_kv_cache_zeroing({10, 12})
+
+    assert scheduler._get_new_block_ids_to_zero(metadata) == [9, 11]
+
+
 # ── Mamba N-1 prefill tests ──────────────────────────────────────────────
 
 

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -523,6 +523,7 @@ def make_nixl_scheduler(
         sched.side_channel_port = 5555
         sched.blocks_per_sw = []
         sched.is_bidirectional_kv_xfer_enabled = False
+        sched.kv_cache_config = make_kv_cache_config(block_size=16)
     return sched
 
 
@@ -562,6 +563,9 @@ def make_nixl_push_scheduler(
     sched.side_channel_port = 5600
     sched.is_bidirectional_kv_xfer_enabled = is_bidirectional_kv_xfer_enabled
     sched._has_mamba = has_mamba
+    sched.kv_cache_config = make_kv_cache_config(
+        block_size=16, mamba_enabled=has_mamba
+    )
 
     # vllm_config is consulted for parallel_config.tensor_parallel_size.
     vllm_config = MagicMock()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -144,7 +144,9 @@ class KVConnectorMetadata(ABC):  # noqa: B024
     Scheduler KVConnector -> Worker KVConnector.
     """
 
-    pass
+    def get_blocks_to_skip_kv_cache_zeroing(self) -> set[int]:
+        """Return block IDs that will be overwritten by connector loads."""
+        return set()
 
 
 class KVConnectorWorkerMetadata(ABC):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -388,6 +388,21 @@ class NixlBaseConnectorScheduler:
                 # Therefore, only pop if `not is_partial`.
                 self._reqs_need_save.pop(req_id)
 
+    def _get_attention_blocks_to_skip_zeroing(self, block_ids: BlockIds) -> set[int]:
+        """Return local attention blocks that remote KV loads will overwrite."""
+        if not block_ids:
+            return set()
+
+        blocks_to_skip: set[int] = set()
+        assert len(block_ids) == len(self.kv_cache_config.kv_cache_groups), (
+            "Number of KV cache groups must match"
+        )
+        for i, group_block_ids in enumerate(block_ids):
+            kv_cache_spec = self.kv_cache_config.kv_cache_groups[i].kv_cache_spec
+            if isinstance(kv_cache_spec, FullAttentionSpec):
+                blocks_to_skip.update(group_block_ids)
+        return blocks_to_skip
+
     def build_connector_meta(
         self,
         scheduler_output: SchedulerOutput,
@@ -401,6 +416,9 @@ class NixlBaseConnectorScheduler:
                 request_id=req_id,
                 local_block_ids=block_ids,
                 kv_transfer_params=req.kv_transfer_params,
+            )
+            meta.add_blocks_to_skip_kv_cache_zeroing(
+                self._get_attention_blocks_to_skip_zeroing(block_ids)
             )
 
         if self.use_host_buffer:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -184,6 +184,10 @@ class NixlConnectorMetadata(KVConnectorMetadata):
         # Push mode (P side): newly finished request blocks to be matched
         # against pending D registrations on the P worker.
         self.push_finished_blocks: dict[ReqId, BlockIds] = {}
+        # Local attention blocks that will be overwritten by remote KV loads
+        # in this step. The scheduler can skip zeroing them to avoid racing the
+        # async RDMA transfer.
+        self.blocks_to_skip_kv_cache_zeroing: set[int] = set()
 
     def _add_new_req(
         self,
@@ -223,3 +227,9 @@ class NixlConnectorMetadata(KVConnectorMetadata):
             port=kv_transfer_params["remote_port"],
         )
         self.reqs_to_recv[request_id] = req
+
+    def add_blocks_to_skip_kv_cache_zeroing(self, block_ids: set[int]) -> None:
+        self.blocks_to_skip_kv_cache_zeroing.update(block_ids)
+
+    def get_blocks_to_skip_kv_cache_zeroing(self) -> set[int]:
+        return self.blocks_to_skip_kv_cache_zeroing

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1067,12 +1067,6 @@ class Scheduler(SchedulerInterface):
             self.prev_step_scheduled_req_ids.clear()
             self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
 
-        new_block_ids_to_zero = (
-            (self.kv_cache_manager.take_new_block_ids() or None)
-            if self.needs_kv_cache_zeroing
-            else None
-        )
-
         # Dynamic speculative decoding: compute optimal K
         num_spec_tokens_to_schedule = self.num_spec_tokens
         if self.dynamic_sd_lookup is not None and len(num_scheduled_tokens) > 0:
@@ -1095,7 +1089,6 @@ class Scheduler(SchedulerInterface):
             # the previous and the current steps.
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
-            new_block_ids_to_zero=new_block_ids_to_zero,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
         )
 
@@ -1106,6 +1099,10 @@ class Scheduler(SchedulerInterface):
         if self.connector is not None:
             meta = self._build_kv_connector_meta(self.connector, scheduler_output)
             scheduler_output.kv_connector_metadata = meta
+
+        scheduler_output.new_block_ids_to_zero = self._get_new_block_ids_to_zero(
+            scheduler_output.kv_connector_metadata
+        )
 
         # Build the connector meta for ECConnector
         if self.ec_connector is not None:
@@ -1127,6 +1124,27 @@ class Scheduler(SchedulerInterface):
         self, connector: KVConnectorBase_V1, scheduler_output: SchedulerOutput
     ) -> KVConnectorMetadata:
         return connector.build_connector_meta(scheduler_output)
+
+    def _get_new_block_ids_to_zero(
+        self, kv_connector_metadata: KVConnectorMetadata | None
+    ) -> list[int] | None:
+        if not self.needs_kv_cache_zeroing:
+            return None
+
+        new_block_ids_to_zero = self.kv_cache_manager.take_new_block_ids()
+        if not new_block_ids_to_zero:
+            return None
+
+        if kv_connector_metadata is not None:
+            blocks_to_skip = kv_connector_metadata.get_blocks_to_skip_kv_cache_zeroing()
+            if blocks_to_skip:
+                new_block_ids_to_zero = [
+                    block_id
+                    for block_id in new_block_ids_to_zero
+                    if block_id not in blocks_to_skip
+                ]
+
+        return new_block_ids_to_zero or None
 
     def _preempt_request(self, request: Request, timestamp: float) -> None:
         """Preempt a request and put it back to the waiting queue.


### PR DESCRIPTION
## Summary
This PR fixes an accuracy regression in PD disaggregation with async scheduling for hybrid attention + SSM/GDN models.
When a decode-side request receives KV blocks from a remote prefill worker, the newly allocated attention blocks are overwritten by the incoming NIXL transfer. For hybrid models, vLLM also schedules KV cache zeroing for newly allocated attention blocks. Under async scheduling, that zeroing kernel can be queued behind a previous forward pass while the NIXL RDMA transfer writes directly into GPU memory. If the RDMA transfer completes first, the delayed zeroing kernel can erase the received attention KV, causing severe accuracy degradation.
The fix makes NIXL metadata report the local attention blocks that will be overwritten by remote KV loads. The scheduler then excludes those blocks from , while preserving zeroing for other newly allocated attention blocks.
This keeps the change scoped to connector-loaded attention blocks and avoids adding a CUDA synchronization point to the async pipeline.

## Test Plan
"The problem described [here](https://github.com/vllm-project/vllm/pull/45357#issuecomment-4770870119) has been resolved with this PR applied. 
The following tests were run on Qwen3.5-35B-A3B with async scheduling enabled.
| Metrics | Baseline (No-PD + async) | PD + async |
|---|---|---|
| Accuracy | 0.853 | 0.839 |
| Invalid rate | 0.000 | 0.000 |
| Latency | 243.797s | 211.849s |
| QPS | 5.410 | 6.226 |
| Tokens/s | 779.342 | 905.812 |