### PR TITLE
fix(metrics): fix TPOT accounting for MTP multi-token outputs

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -49,7 +49,7 @@ The subset of metrics exposed in the Grafana dashboard gives us an indication of
 - `vllm:e2e_request_latency_seconds_bucket` - End to end request latency measured in seconds.
 - `vllm:prompt_tokens` - Prompt tokens.
 - `vllm:generation_tokens` - Generation tokens.
-- `vllm:inter_token_latency_seconds` - Inter-token latency (Time Per Output Token, TPOT) in seconds.
+- `vllm:inter_token_latency_seconds` - Inter-token latency (Time Per Output Token, TPOT) in seconds. When one engine iteration commits multiple output tokens, the interval is evenly apportioned across the committed tokens.
 - `vllm:time_to_first_token_seconds` - Time to First Token (TTFT) latency in seconds.
 - `vllm:num_requests_running` (also, `_swapped` and `_waiting`) - Number of requests in the RUNNING, WAITING, and SWAPPED states.
 - `vllm:kv_cache_usage_perc` - Percentage of used cache blocks by vLLM.
@@ -239,7 +239,9 @@ statistics relating to that iteration:
 - The prefill intervals for any requests that completed prefill in
   this iteration.
 - The inter-token intervals (Time Per Output Token, TPOT), for all
-  requests included in this iteration.
+  requests included in this iteration. If one engine iteration commits
+  multiple output tokens for a request, the interval is evenly
+  apportioned across those committed tokens.
 - The Time-To-First-Token (TTFT) for any requests that completed
   prefill in this iteration. However, we calculate this interval
   relative to when the request was first received by the frontend

--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -4,6 +4,7 @@ from vllm.v1.core.sched.output import ScheduledEncoderInputStats, SchedulerOutpu
 from vllm.v1.engine import EngineCoreOutput, EngineCoreOutputs, FinishReason
 from vllm.v1.metrics.stats import (
     IterationStats,
+    LoRARequestStates,
     PrefillStats,
     PromptTokenStats,
     RequestStateStats,
@@ -12,14 +13,6 @@ from vllm.v1.metrics.stats import (
 )
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm.v1.utils import compute_iteration_details
-
-
-class _DummyLoRAStates:
-    def request_waiting(self, req_id: str, lora_name: str | None) -> None:
-        pass
-
-    def request_running(self, req_id: str, lora_name: str | None) -> None:
-        pass
 
 
 def test_iteration_stats_repr():
@@ -301,7 +294,7 @@ def test_prompt_token_stats_full_external_transfer_recompute():
 def test_inter_token_latency_tracks_each_committed_decode_token():
     iteration_stats = IterationStats()
     req_stats = RequestStateStats(arrival_time=0.0)
-    lora_states = _DummyLoRAStates()
+    lora_states = LoRARequestStates()
 
     iteration_stats.update_from_output(
         EngineCoreOutput(request_id="req", new_token_ids=[1]),
@@ -339,7 +332,38 @@ def test_inter_token_latency_tracks_each_committed_decode_token():
     assert iteration_stats.num_generation_tokens == 6
     assert req_stats.num_generation_tokens == 6
     assert iteration_stats.inter_token_latencies_iter == [1.0] * 3 + [2.0] * 2
-    assert len(iteration_stats.inter_token_latencies_iter) == 5
     assert sum(iteration_stats.inter_token_latencies_iter) == 7.0
     assert req_stats.first_token_ts == 1.0
     assert req_stats.last_token_ts == 8.0
+
+
+def test_tokenless_first_output_still_advances_last_token_ts():
+    """Pooling and aborted/failed prefill requests emit a first output with no
+    new tokens; finished-request latencies must stay non-negative."""
+    iteration_stats = IterationStats()
+    req_stats = RequestStateStats(arrival_time=0.0)
+    req_stats.scheduled_ts = 0.5
+    lora_states = LoRARequestStates()
+
+    iteration_stats.update_from_output(
+        EngineCoreOutput(request_id="req", new_token_ids=[]),
+        engine_core_timestamp=2.0,
+        is_prefilling=True,
+        req_stats=req_stats,
+        lora_states=lora_states,
+        lora_name=None,
+    )
+
+    assert req_stats.last_token_ts == 2.0
+    assert not iteration_stats.inter_token_latencies_iter
+
+    iteration_stats.update_from_finished_request(
+        finish_reason=FinishReason.ABORT,
+        request_id="req",
+        num_prompt_tokens=10,
+        max_tokens_param=None,
+        req_stats=req_stats,
+    )
+    finished = iteration_stats.finished_requests[0]
+    assert finished.decode_time == 0.0
+    assert finished.inference_time == 1.5

--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from vllm.v1.core.sched.output import ScheduledEncoderInputStats, SchedulerOutput
-from vllm.v1.engine import EngineCoreOutputs, FinishReason
+from vllm.v1.engine import EngineCoreOutput, EngineCoreOutputs, FinishReason
 from vllm.v1.metrics.stats import (
     IterationStats,
     PrefillStats,
@@ -12,6 +12,14 @@ from vllm.v1.metrics.stats import (
 )
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm.v1.utils import compute_iteration_details
+
+
+class _DummyLoRAStates:
+    def request_waiting(self, req_id: str, lora_name: str | None) -> None:
+        pass
+
+    def request_running(self, req_id: str, lora_name: str | None) -> None:
+        pass
 
 
 def test_iteration_stats_repr():
@@ -288,3 +296,50 @@ def test_prompt_token_stats_full_external_transfer_recompute():
     assert stats.external_kv_transfer == 999
     assert stats.cached_tokens == 999
     assert stats.total == 1000
+
+
+def test_inter_token_latency_tracks_each_committed_decode_token():
+    iteration_stats = IterationStats()
+    req_stats = RequestStateStats(arrival_time=0.0)
+    lora_states = _DummyLoRAStates()
+
+    iteration_stats.update_from_output(
+        EngineCoreOutput(request_id="req", new_token_ids=[1]),
+        engine_core_timestamp=1.0,
+        is_prefilling=True,
+        req_stats=req_stats,
+        lora_states=lora_states,
+        lora_name=None,
+    )
+    iteration_stats.update_from_output(
+        EngineCoreOutput(request_id="req", new_token_ids=[2, 3, 4]),
+        engine_core_timestamp=4.0,
+        is_prefilling=False,
+        req_stats=req_stats,
+        lora_states=lora_states,
+        lora_name=None,
+    )
+    iteration_stats.update_from_output(
+        EngineCoreOutput(request_id="req", new_token_ids=[]),
+        engine_core_timestamp=6.0,
+        is_prefilling=False,
+        req_stats=req_stats,
+        lora_states=lora_states,
+        lora_name=None,
+    )
+    iteration_stats.update_from_output(
+        EngineCoreOutput(request_id="req", new_token_ids=[5, 6]),
+        engine_core_timestamp=8.0,
+        is_prefilling=False,
+        req_stats=req_stats,
+        lora_states=lora_states,
+        lora_name=None,
+    )
+
+    assert iteration_stats.num_generation_tokens == 6
+    assert req_stats.num_generation_tokens == 6
+    assert iteration_stats.inter_token_latencies_iter == [1.0] * 3 + [2.0] * 2
+    assert len(iteration_stats.inter_token_latencies_iter) == 5
+    assert sum(iteration_stats.inter_token_latencies_iter) == 7.0
+    assert req_stats.first_token_ts == 1.0
+    assert req_stats.last_token_ts == 8.0

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -426,7 +426,10 @@ class IterationStats:
                 [per_token_itl] * num_new_generation_tokens
             )
 
-        if num_new_generation_tokens > 0:
+        # The first output may carry no tokens (pooling requests, aborted or
+        # failed prefills); last_token_ts must still advance so finished
+        # request latencies stay non-negative.
+        if is_prefilling or num_new_generation_tokens > 0:
             req_stats.last_token_ts = engine_core_timestamp
 
     def update_from_events(

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -419,11 +419,15 @@ class IterationStats:
         # Process the batch-level "new tokens" engine core event
         if is_prefilling:
             req_stats.first_token_ts = engine_core_timestamp
-        else:
+        elif num_new_generation_tokens > 0:
             itl = engine_core_timestamp - req_stats.last_token_ts
-            self.inter_token_latencies_iter.append(itl)
+            per_token_itl = itl / num_new_generation_tokens
+            self.inter_token_latencies_iter.extend(
+                [per_token_itl] * num_new_generation_tokens
+            )
 
-        req_stats.last_token_ts = engine_core_timestamp
+        if num_new_generation_tokens > 0:
+            req_stats.last_token_ts = engine_core_timestamp
 
     def update_from_events(
         self,


### PR DESCRIPTION
## Purpose

Fix `vllm:inter_token_latency_seconds` for multi-token decode outputs.

This shows up most clearly in MTP and other speculative decoding paths. In those cases, one engine iteration can commit multiple output tokens, but `IterationStats.update_from_output()` only records one inter-token latency sample for the whole step. As a result, the metric is effectively measured per decode step instead of per committed token, inflating the reported per-token latency when an iteration commits multiple tokens.

This change apportions the step interval across the committed tokens. Because the engine output only has a batch timestamp, individual token timestamps are unavailable; equal apportioning preserves both the total decode interval and the number of per-token samples. A tokenless first output still advances `last_token_ts` so finished-request latencies remain non-negative. Later tokenless decode outputs are ignored for both sampling and last-token timestamp tracking, so they cannot shorten the next real token interval. This keeps `vllm:inter_token_latency_seconds` aligned with its documented TPOT meaning while leaving the single-token-per-step path unchanged.

## Related Work / Duplicate Check

Related to #27485, which reports the same class of ITL overcounting when one streamed output chunk represents multiple tokens. A contributor specifically called out a server-side fix as the more robust follow-up there; the issue author and project collaborator confirmed the underlying bug remained relevant.

This does not duplicate #46652: that PR fixes ITL calculation in the `vllm bench serve` OpenAI chat client. This PR fixes the server-side Prometheus metric at the `EngineCoreOutput` accounting boundary, so non-benchmark metric consumers are covered as well. Searches for `inter_token_latency_seconds`, `inter-token latency` with speculative decoding, and `TPOT MTP` found no other PR implementing this server-side fix.



## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/metrics/test_stats.py -v
```

## Test Result

After the latest commit:

```text
============================= test session starts ==============================
collected 14 items

============================== 14 passed in 1.42s ==============================
```

Additional changed-file checks:

```bash
.venv/bin/ruff check tests/v1/metrics/test_stats.py vllm/v1/metrics/stats.py
.venv/bin/ruff format --check tests/v1/metrics/test_stats.py vllm/v1/metrics/stats.py
git diff --check origin/main...HEAD
```

All changed-file checks and commit-time pre-commit hooks passed, including Ruff, mypy, typos, SPDX, and sign-off validation.

The additional command `.venv/bin/python -m pytest tests/v1/engine/test_output_processor.py -k iteration_stats -v` could not reach the selected test because its fixture requires authenticated access to the gated `meta-llama/Llama-3.2-1B` tokenizer; setup failed with HTTP 401 before exercising this change.

## AI Use

This PR was prepared with AI assistance.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>




+ @kebe7jun 