### PR TITLE
Ignore non-engine DP handshake messages

### DIFF
--- a/tests/v1/test_engine_utils.py
+++ b/tests/v1/test_engine_utils.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.v1.engine.utils import CoreEngine, _get_engine_for_handshake_identity
+
+
+def test_get_engine_for_handshake_identity_matches_expected_engine():
+    engines = [CoreEngine(index=0), CoreEngine(index=1)]
+
+    engine = _get_engine_for_handshake_identity(engines[1].identity, engines)
+
+    assert engine is engines[1]
+
+
+def test_get_engine_for_handshake_identity_ignores_non_engine_identity():
+    engines = [CoreEngine(index=0)]
+
+    engine = _get_engine_for_handshake_identity(b"GET /metrics HTTP/1.1", engines)
+
+    assert engine is None
+
+
+def test_get_engine_for_handshake_identity_rejects_unexpected_engine_rank():
+    engines = [CoreEngine(index=0)]
+
+    with pytest.raises(
+        RuntimeError, match="unexpected data parallel rank: 1"
+    ):
+        _get_engine_for_handshake_identity((1).to_bytes(2, "little"), engines)

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 STARTUP_POLL_PERIOD_MS = 10000
+CORE_ENGINE_IDENTITY_BYTES = 2
 
 
 class CoreEngineState(Enum):
@@ -53,7 +54,7 @@ class CoreEngine:
 
     def __init__(self, index: int = 0, local: bool = True):
         self.local = local
-        self.identity = index.to_bytes(2, "little")
+        self.identity = index.to_bytes(CORE_ENGINE_IDENTITY_BYTES, "little")
 
         self.state = CoreEngineState.NEW
 
@@ -1277,12 +1278,10 @@ def wait_for_engine_startup(
 
         # Receive HELLO and READY messages from the input socket.
         eng_identity, ready_msg_bytes = handshake_socket.recv_multipart()
-        eng_index = int.from_bytes(eng_identity, "little")
-        engine = next((e for e in core_engines if e.identity == eng_identity), None)
+        engine = _get_engine_for_handshake_identity(eng_identity, core_engines)
         if engine is None:
-            raise RuntimeError(
-                f"Message from engine with unexpected data parallel rank: {eng_index}"
-            )
+            continue
+        eng_index = int.from_bytes(eng_identity, "little")
         msg = msgspec.msgpack.decode(ready_msg_bytes)
         status, local, headless = msg["status"], msg["local"], msg["headless"]
         if local != engine.local:
@@ -1363,3 +1362,24 @@ def wait_for_engine_startup(
             "local" if local else "remote",
             eng_index,
         )
+
+
+def _get_engine_for_handshake_identity(
+    eng_identity: bytes, core_engines: list[CoreEngine]
+) -> CoreEngine | None:
+    engine = next((e for e in core_engines if e.identity == eng_identity), None)
+    if engine is not None:
+        return engine
+
+    if len(eng_identity) != CORE_ENGINE_IDENTITY_BYTES:
+        logger.warning(
+            "Ignoring non-engine message on data parallel handshake socket "
+            "with identity length %d.",
+            len(eng_identity),
+        )
+        return None
+
+    eng_index = int.from_bytes(eng_identity, "little")
+    raise RuntimeError(
+        f"Message from engine with unexpected data parallel rank: {eng_index}"
+    )


### PR DESCRIPTION
Fixes #38677

## Purpose

In multi-node data-parallel startup, the DP handshake socket can receive non-engine traffic, such as an HTTP metrics scrape sent to `--data-parallel-rpc-port`. Previously, `wait_for_engine_startup` interpreted the incoming identity bytes as a data-parallel rank and failed startup with an unexpected-rank error.

This PR ignores handshake messages whose identity length does not match vLLM engine identities, while preserving the existing hard failure for well-formed engine identities that map to an unexpected data-parallel rank. This keeps real DP configuration errors visible while preventing unrelated invalid traffic from crashing startup.

This is not duplicating an existing PR: I checked open PRs for #38677, `unexpected data parallel rank`, `data_parallel_rpc_port` invalid traffic, and DP handshake socket handling. I did not find an open PR addressing this specific invalid-traffic startup failure.

This PR was prepared with OpenAI Codex assistance.

## Test Plan

- Compile the modified engine utility and regression test.
- Run focused regression tests for DP handshake identity handling.
- Check for whitespace errors.

## Test Result

```text
python -m py_compile vllm/v1/engine/utils.py tests/v1/test_engine_utils.py
passed

git diff --check
passed

python -m pytest tests/v1/test_engine_utils.py -q --confcutdir=tests/v1
blocked locally: current Windows conda environment fails while importing transformers/sklearn due to a pyarrow DLL load error