### PR TITLE
fix: support Qwen3.5 family for DSpark

### DIFF
--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -380,6 +380,8 @@ class DFlashQwen3Model(nn.Module):
                 num_features_to_use = len(drafter_config["target_layer_ids"])
             elif "layer_ids" in drafter_config:
                 num_features_to_use = len(drafter_config["layer_ids"])
+            elif getattr(self.config, "target_layer_ids", None):
+                num_features_to_use = len(self.config.target_layer_ids)
             if hasattr(self.config, "target_hidden_size"):
                 fc_input_size = self.config.target_hidden_size * num_features_to_use
             else:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1076,6 +1076,12 @@ def unify_kv_cache_spec_page_size(
     for layer_name, layer_spec in kv_cache_spec.items():
         if layer_spec.page_size_bytes == max_page_size:
             new_kv_cache_spec[layer_name] = layer_spec
+        elif isinstance(layer_spec, MambaSpec):
+            # Mamba page size is fixed by state shapes (block_size scaling is a
+            # no-op), so pad the page to max_page_size instead.
+            new_spec: KVCacheSpec = replace(layer_spec, page_size_padded=max_page_size)
+            assert new_spec.page_size_bytes == max_page_size
+            new_kv_cache_spec[layer_name] = new_spec
         else:
             layer_page_size = layer_spec.page_size_bytes
             if max_page_size % layer_page_size == 0:

--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -52,7 +52,11 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
             del draft_inner.embed_tokens
         draft_inner.embed_tokens = target_embed
 
-    target_lm_head = getattr(target_model, "lm_head", None)
+    # lm_head lives on the language model, not the (possibly multimodal) outer
+    # wrapper (e.g. Qwen3.5-MoE), whose top-level lm_head is None.
+    target_lm_head = getattr(target_language_model, "lm_head", None)
+    if target_lm_head is None:
+        target_lm_head = getattr(target_model, "lm_head", None)
     draft_lm_head = getattr(draft_model, "lm_head", None)
     if target_lm_head is not None and _should_share(
         draft_model, "has_own_lm_head", draft_lm_head, target_lm_head


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix DSpark support for Qwen3.5 family models.

Follow up on #46995 by @benchislett .

Part of the KV cache fix is inherited from #45207.

## Test Plan

We have an internal DSpark checkpoint trained using [TorchSpec](https://github.com/lightseekorg/TorchSpec) that we directly load and run our custom benchmark against. Unfortunately I can't share the model.

## Test Result

Before the model only got ~1.3 acceptance on Qwen3.6 35B, considering the bonus token it is near random. Also the `lm_head` weights were empty when inspected. After applying the fixes it got around ~4.5 for block size 8.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
 