### PR TITLE
[Bugfix][MoE] Plumb swigluoai activation into FlashInfer b12x MoE

### DIFF
--- a/tests/kernels/moe/test_flashinfer_b12x_moe.py
+++ b/tests/kernels/moe/test_flashinfer_b12x_moe.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from types import SimpleNamespace
+import dataclasses
 
 import pytest
 import torch
@@ -10,28 +10,33 @@ from vllm.platforms import current_platform
 
 if not current_platform.is_device_capability_family(120):
     pytest.skip(
-        reason="FlashInfer B12x MoE requires SM120 (RTX Pro 6000 / DGX Spark).",
+        reason="FlashInfer CuteDSL SM12x MoE requires SM120 "
+        "(RTX Pro 6000 / DGX Spark).",
         allow_module_level=True,
     )
 
-from vllm.utils.flashinfer import has_flashinfer_b12x_moe
+from vllm.utils.flashinfer import (
+    has_flashinfer_b12x_moe,
+    has_flashinfer_b12x_moe_activation,
+)
 
 if not has_flashinfer_b12x_moe():
     pytest.skip(
         reason=(
-            "FlashInfer B12xMoEWrapper not available in installed "
-            "FlashInfer (needs PR #3080)."
+            "b12x_fused_moe / convert_sf_to_mma_layout not available in "
+            "installed FlashInfer."
         ),
         allow_module_level=True,
     )
 
-# Import fp4_quantize after the skip guard — FlashInfer must be installed.
+# Import fp4_quantize after the skip guard; FlashInfer must be installed.
 from flashinfer.fp4_quantization import fp4_quantize
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from tests.kernels.moe.utils import make_dummy_moe_config
-from tests.kernels.utils import torch_moe
+from tests.kernels.utils import torch_experts
 from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.activation import SiluAndMulWithClamp
 from vllm.model_executor.layers.fused_moe import fused_topk
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.all2all_utils import (
@@ -40,6 +45,10 @@ from vllm.model_executor.layers.fused_moe.all2all_utils import (
 from vllm.model_executor.layers.fused_moe.config import nvfp4_moe_quant_config
 from vllm.model_executor.layers.fused_moe.experts.flashinfer_b12x_moe import (
     FlashInferB12xExperts,
+)
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoeBackend
+from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
+    prepare_nvfp4_moe_layer_for_fi_or_cutlass,
 )
 from vllm.utils.torch_utils import set_random_seed
 
@@ -52,44 +61,62 @@ MNK_FACTORS = [
     (64, 256, 512),
 ]
 
+# MiniMax-M3 SwiGLU-OAI parameters.
+SWIGLU_ALPHA = 1.702
+SWIGLU_BETA = 1.0
+SWIGLU_LIMIT = 7.0
 
-def _reorder_gate_up_to_up_gate(
-    w: torch.Tensor,
-    w_s: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Swap gate and up-projection halves along dim=1 to [up, gate] order.
 
-    The B12x kernel expects weights in [up (w3), gate (w1)] order while the
-    BF16 reference uses [gate (w1), up (w3)].  This replicates the reordering
-    done at model-load time by ``prepare_nvfp4_moe_layer_for_fi_or_cutlass``.
-    """
-    n = w.shape[1] // 2
+def _quantize_nvfp4_linear_sf(w_bf16: torch.Tensor):
+    """Quantize per expert in checkpoint layout: linear block scales,
+    global_scale=1.0."""
+    e, rows, cols = w_bf16.shape
+    gs = torch.ones(1, device="cuda", dtype=torch.float32)
+    q, sf = fp4_quantize(
+        w_bf16.reshape(e * rows, cols),
+        global_scale=gs,
+        sf_vec_size=16,
+        is_sf_swizzled_layout=False,
+    )
+    sf = sf.view(torch.float8_e4m3fn)
+    return q.view(e, rows, cols // 2), sf.view(e, rows, cols // 16)
+
+
+def _torch_ref(
+    a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation, alpha=SWIGLU_ALPHA
+):
+    """BF16 reference on the original [gate, up] weights."""
+    if activation == MoEActivation.SILU:
+        return torch_experts(
+            a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation=activation
+        )
+    assert activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
+    act = SiluAndMulWithClamp(SWIGLU_LIMIT, alpha, SWIGLU_BETA)
+    m, k = a.shape
+    topk = topk_ids.shape[1]
+    a_rep = a.view(m, 1, k).repeat(1, topk, 1).reshape(-1, k)
+    ids_flat = topk_ids.view(-1)
+    out = torch.zeros(m * topk, k, dtype=a.dtype, device=a.device)
+    for i in range(w13_bf16.shape[0]):
+        mask = ids_flat == i
+        if mask.sum():
+            h = a_rep[mask] @ w13_bf16[i].t()
+            out[mask] = act(h) @ w2_bf16[i].t()
     return (
-        torch.cat([w[:, n:, :], w[:, :n, :]], dim=1),
-        torch.cat([w_s[:, n:, :], w_s[:, :n, :]], dim=1),
+        (out.view(m, topk, k).float() * topk_weights.view(m, topk, 1))
+        .sum(dim=1)
+        .to(a.dtype)
     )
-
-
-def _process_b12x_weights(
-    experts: FlashInferB12xExperts,
-    w1_scale: torch.Tensor,
-    w2_scale: torch.Tensor,
-    w1_scale_2: torch.Tensor,
-    w2_scale_2: torch.Tensor,
-) -> None:
-    layer = SimpleNamespace(
-        w13_weight_scale=w1_scale,
-        w13_weight_scale_2=w1_scale_2,
-        w2_weight_scale=w2_scale,
-        w2_weight_scale_2=w2_scale_2,
-    )
-    experts.process_weights_after_loading(layer)
 
 
 @pytest.mark.parametrize("m,n,k", MNK_FACTORS)
 @pytest.mark.parametrize("e", [8, 16])
 @pytest.mark.parametrize("topk", [1, 2, 4])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize(
+    "activation",
+    [MoEActivation.SILU, MoEActivation.SWIGLUOAI_UNINTERLEAVE],
+)
 @torch.inference_mode()
 def test_flashinfer_b12x_moe(
     m: int,
@@ -98,105 +125,98 @@ def test_flashinfer_b12x_moe(
     e: int,
     topk: int,
     dtype: torch.dtype,
+    activation: MoEActivation,
     workspace_init,
 ):
     """Test FlashInferB12xExperts against a BF16 torch reference.
 
-    The SM12x kernel takes BF16 hidden states directly and fuses token
-    dispatch, W1 GEMM, SwiGLU, and W2 GEMM into one call.  We verify
-    correctness against ``torch_moe`` using generous tolerances to account
-    for the internal FP4 quantization of activations and weights.
+    Weights start in checkpoint layout (fused FC1 as [gate, up], linear
+    block scales) and go through the production weight pipeline
+    (``prepare_nvfp4_moe_layer_for_fi_or_cutlass`` +
+    ``process_weights_after_loading``), so the test catches a broken
+    [gate, up] -> [up, gate] reorder or unplumbed activation params (the
+    garbled MiniMax-M3 swigluoai output).
 
-    Scale convention
-    ----------------
-    The SM12x kernel uses ``w1_alpha`` as *both* the activation-quantisation
-    global scale and the weight dequantisation factor.  These two roles are
-    conflated into a single parameter in ``launch_sm120_moe``, so they must
-    equal the same value.  We use ``global_scale = 1.0`` for
-    ``fp4_quantize`` so that ``w1_alpha = ones`` satisfies both roles
-    simultaneously.  The alternative — vLLM's convention of baking a large
-    ``w_gs`` into block-scale values and compensating with
-    ``g1_alphas = 1/w_gs`` — is incompatible with this kernel.
+    Scale convention: the SM12x kernel uses ``w1_alpha`` as *both* the
+    activation-quantisation global scale and the weight dequantisation
+    factor, so we quantise with ``global_scale = 1.0`` and ``w1_alpha =
+    ones``; vLLM's bake-a-large-``w_gs``-into-block-scales convention is
+    incompatible with this kernel.
     """
+    is_swigluoai = activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
+    if is_swigluoai and not has_flashinfer_b12x_moe_activation():
+        pytest.skip("Installed FlashInfer b12x_fused_moe lacks swigluoai support.")
+
     set_random_seed(7)
     with set_current_vllm_config(
         VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
     ):
-        a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+        # O(1)-magnitude outputs; smaller scalings make any comparison
+        # metric pass regardless of kernel correctness.
+        a = torch.randn((m, k), device="cuda", dtype=dtype) / 2
 
-        # Generate BF16 reference weights in [gate, up] order.
-        # Shape: w1=(e, 2n, k), w2=(e, k, n).
-        w1_bf16 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 15
-        w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 15
+        # BF16 reference weights in checkpoint [gate, up] order.
+        w13_bf16 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 8
+        w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 8
 
-        # ------------------------------------------------------------------ #
-        # Quantise weights for the SM12x kernel using FlashInfer's convention:
-        #   global_scale = 1.0   →   block_scale = max_abs_block / fp4_max
-        #   w1_alpha = 1.0       (no extra global factor to compensate)
-        #
-        # The scale factors returned by fp4_quantize(..., is_sf_swizzled_layout=True)
-        # are already in the swizzled 2D layout expected by convert_sf_to_mma_layout.
-        # No additional swizzle_blockscale() call is needed.
-        # ------------------------------------------------------------------ #
-        gs = torch.ones(1, device="cuda", dtype=torch.float32)
-        sf_vec_size = 16
-
-        # W1: reorder BF16 from [gate, up] → [up, gate], then quantise.
-        w1_reordered = torch.cat(
-            [w1_bf16[:, n:, :], w1_bf16[:, :n, :]], dim=1
-        )  # shape (e, 2n, k), [up, gate]
-        w1_flat = w1_reordered.reshape(e * 2 * n, k)
-        w1_q_flat, w1_sf_flat = fp4_quantize(
-            w1_flat,
-            global_scale=gs,
-            sf_vec_size=sf_vec_size,
-            is_sf_swizzled_layout=True,
-        )
-        w1_q = w1_q_flat.view(e, 2 * n, k // 2)  # uint8, packed FP4
-        w1_blockscale = w1_sf_flat.view(e, 2 * n, w1_sf_flat.shape[1])  # float8
-
-        # W2: no row reordering needed for the down-projection.
-        w2_flat = w2_bf16.reshape(e * k, n)
-        w2_q_flat, w2_sf_flat = fp4_quantize(
-            w2_flat,
-            global_scale=gs,
-            sf_vec_size=sf_vec_size,
-            is_sf_swizzled_layout=True,
-        )
-        w2_q = w2_q_flat.view(e, k, n // 2)  # uint8, packed FP4
-        w2_blockscale = w2_sf_flat.view(e, k, w2_sf_flat.shape[1])  # float8
+        w13_q, w13_sf = _quantize_nvfp4_linear_sf(w13_bf16)
+        w2_q, w2_sf = _quantize_nvfp4_linear_sf(w2_bf16)
 
         # All per-expert alphas are 1.0 (global_scale = 1.0, no compensation).
         ones_e = torch.ones(e, device="cuda", dtype=torch.float32)
 
+        layer = torch.nn.Module()
+        layer.activation = activation
+        (w13_q, w13_sf, _, _, w2_q, w2_sf, _, _) = (
+            prepare_nvfp4_moe_layer_for_fi_or_cutlass(
+                backend=NvFp4MoeBackend.FLASHINFER_B12X,
+                layer=layer,
+                w13=w13_q,
+                w13_scale=w13_sf,
+                w13_scale_2=ones_e.clone(),
+                a13_scale=torch.ones(e, 2, device="cuda", dtype=torch.float32),
+                w2=w2_q,
+                w2_scale=w2_sf,
+                w2_scale_2=ones_e.clone(),
+                a2_scale=torch.ones(e, 1, device="cuda", dtype=torch.float32),
+                is_act_and_mul=True,
+            )
+        )
+        layer.w13_weight = w13_q
+        layer.w13_weight_scale = w13_sf
+        layer.w13_weight_scale_2 = ones_e.clone()
+        layer.w2_weight = w2_q
+        layer.w2_weight_scale = w2_sf
+        layer.w2_weight_scale_2 = ones_e.clone()
+
         quant_config = nvfp4_moe_quant_config(
-            g1_alphas=ones_e,
-            g2_alphas=ones_e,
-            a1_gscale=ones_e,
-            a2_gscale=ones_e,
-            w1_scale=w1_blockscale,
-            w2_scale=w2_blockscale,
+            g1_alphas=ones_e.clone(),
+            g2_alphas=ones_e.clone(),
+            a1_gscale=ones_e.clone(),
+            a2_gscale=ones_e.clone(),
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
         )
 
-        moe_config = make_dummy_moe_config(
-            num_experts=e,
-            experts_per_token=topk,
-            hidden_dim=k,
-            intermediate_size=n,
-            in_dtype=dtype,
+        moe_config = dataclasses.replace(
+            make_dummy_moe_config(
+                num_experts=e,
+                experts_per_token=topk,
+                hidden_dim=k,
+                intermediate_size=n,
+                in_dtype=dtype,
+            ),
+            activation=activation,
+            swiglu_alpha=SWIGLU_ALPHA if is_swigluoai else None,
+            swiglu_beta=SWIGLU_BETA if is_swigluoai else None,
+            swiglu_limit=SWIGLU_LIMIT if is_swigluoai else None,
         )
 
         experts = FlashInferB12xExperts(
             moe_config=moe_config,
             quant_config=quant_config,
         )
-        _process_b12x_weights(
-            experts,
-            w1_blockscale,
-            w2_blockscale,
-            ones_e,
-            ones_e,
-        )
+        experts.process_weights_after_loading(layer)
 
         kernel = mk.FusedMoEKernel(
             maybe_make_prepare_finalize(
@@ -213,151 +233,39 @@ def test_flashinfer_b12x_moe(
 
         sm12x_output = kernel.apply(
             hidden_states=a,
-            w1=w1_q,
-            w2=w2_q,
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             global_num_experts=e,
-            activation=MoEActivation.SILU,
+            activation=activation,
             apply_router_weight_on_input=False,
             expert_map=None,
         )
 
-        # Reference: BF16 torch MoE using original [gate, up] BF16 weights.
-        # torch_moe's SiluAndMul expects [gate, up] order, matching w1_bf16.
-        torch_output = torch_moe(a, w1_bf16, w2_bf16, score, topk)
-
-        torch.testing.assert_close(sm12x_output, torch_output, atol=2e-1, rtol=2e-1)
-
-
-@pytest.mark.parametrize("m,n,k", MNK_FACTORS)
-@pytest.mark.parametrize("e", [8, 16])
-@pytest.mark.parametrize("topk", [1, 2, 4])
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
-@torch.inference_mode()
-def test_flashinfer_b12x_moe_relu2(
-    m: int,
-    n: int,
-    k: int,
-    e: int,
-    topk: int,
-    dtype: torch.dtype,
-    workspace_init,
-):
-    """Test FlashInferB12xExperts with ReLU2 (non-gated) activation.
-
-    ReLU2 is used by Nemotron-H style models.  Unlike the gated SiLU
-    path, w1 has shape [E, N, K] (not [E, 2N, K]) and the activation
-    is relu(x)^2 without a gate/up split.
-    """
-    set_random_seed(7)
-    with set_current_vllm_config(
-        VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
-    ):
-        a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
-
-        # Non-gated: w1 shape is (e, n, k), not (e, 2n, k).
-        w1_bf16 = torch.randn((e, n, k), device="cuda", dtype=dtype) / 15
-        w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 15
-
-        gs = torch.ones(1, device="cuda", dtype=torch.float32)
-        sf_vec_size = 16
-
-        # W1: no gate/up reordering for non-gated.
-        w1_flat = w1_bf16.reshape(e * n, k)
-        w1_q_flat, w1_sf_flat = fp4_quantize(
-            w1_flat,
-            global_scale=gs,
-            sf_vec_size=sf_vec_size,
-            is_sf_swizzled_layout=True,
-        )
-        w1_q = w1_q_flat.view(e, n, k // 2)
-        w1_blockscale = w1_sf_flat.view(e, n, w1_sf_flat.shape[1])
-
-        w2_flat = w2_bf16.reshape(e * k, n)
-        w2_q_flat, w2_sf_flat = fp4_quantize(
-            w2_flat,
-            global_scale=gs,
-            sf_vec_size=sf_vec_size,
-            is_sf_swizzled_layout=True,
-        )
-        w2_q = w2_q_flat.view(e, k, n // 2)
-        w2_blockscale = w2_sf_flat.view(e, k, w2_sf_flat.shape[1])
-
-        ones_e = torch.ones(e, device="cuda", dtype=torch.float32)
-
-        quant_config = nvfp4_moe_quant_config(
-            g1_alphas=ones_e,
-            g2_alphas=ones_e,
-            a1_gscale=ones_e,
-            a2_gscale=ones_e,
-            w1_scale=w1_blockscale,
-            w2_scale=w2_blockscale,
+        torch_output = _torch_ref(
+            a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation
         )
 
-        moe_config = make_dummy_moe_config(
-            num_experts=e,
-            experts_per_token=topk,
-            hidden_dim=k,
-            intermediate_size=n,
-            in_dtype=dtype,
-            activation=MoEActivation.RELU2_NO_MUL,
-        )
+        # NVFP4 error is proportional to the signal, so an elementwise
+        # atol/rtol check cannot separate quantisation noise from a swapped
+        # gate/up ordering or a wrong activation; relative Frobenius error can.
+        diff = sm12x_output.float() - torch_output.float()
+        rel_fro = (diff.norm() / torch_output.float().norm()).item()
+        assert rel_fro < 0.45, f"rel_fro={rel_fro:.3f} (expected < 0.45)"
 
-        experts = FlashInferB12xExperts(
-            moe_config=moe_config,
-            quant_config=quant_config,
-        )
-        _process_b12x_weights(
-            experts,
-            w1_blockscale,
-            w2_blockscale,
-            ones_e,
-            ones_e,
-        )
-
-        kernel = mk.FusedMoEKernel(
-            maybe_make_prepare_finalize(
-                moe=moe_config,
-                quant_config=quant_config,
-                allow_new_interface=True,
-                use_monolithic=False,
-            ),
-            experts,
-            inplace=False,
-        )
-
-        score = torch.randn((m, e), device="cuda", dtype=dtype)
-        topk_weights, topk_ids, _ = fused_topk(a, score, topk, renormalize=False)
-
-        b12x_output = kernel.apply(
-            hidden_states=a,
-            w1=w1_q,
-            w2=w2_q,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            global_num_experts=e,
-            activation=MoEActivation.RELU2_NO_MUL,
-            apply_router_weight_on_input=False,
-            expert_map=None,
-        )
-
-        torch_output = torch_moe(
-            a,
-            w1_bf16,
-            w2_bf16,
-            score,
-            topk,
-            activation=MoEActivation.RELU2_NO_MUL,
-        )
-
-        torch.testing.assert_close(
-            b12x_output,
-            torch_output,
-            atol=2e-1,
-            rtol=2e-1,
-        )
-
-
-if __name__ == "__main__":
-    test_flashinfer_b12x_moe(16, 128, 256, 8, 2, torch.bfloat16)
+        if is_swigluoai:
+            # An alpha regression shifts outputs too little for the threshold
+            # above. Compare against an alpha=1.0 reference instead: the
+            # quantisation noise is common to both, so whichever reference
+            # matches the kernel's actual alpha wins.
+            wrong_alpha_ref = _torch_ref(
+                a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation, alpha=1.0
+            )
+            wrong_diff = sm12x_output.float() - wrong_alpha_ref.float()
+            wrong_rel_fro = (wrong_diff.norm() / wrong_alpha_ref.float().norm()).item()
+            assert rel_fro < wrong_rel_fro, (
+                f"output matches alpha=1.0 reference better than "
+                f"alpha={SWIGLU_ALPHA} ({wrong_rel_fro:.3f} <= {rel_fro:.3f}); "
+                f"swiglu_alpha is likely not reaching the kernel"
+            )

--- a/tests/kernels/moe/test_flashinfer_b12x_moe.py
+++ b/tests/kernels/moe/test_flashinfer_b12x_moe.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import dataclasses
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -34,7 +35,7 @@ from flashinfer.fp4_quantization import fp4_quantize
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from tests.kernels.moe.utils import make_dummy_moe_config
-from tests.kernels.utils import torch_experts
+from tests.kernels.utils import torch_experts, torch_moe
 from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.activation import SiluAndMulWithClamp
 from vllm.model_executor.layers.fused_moe import fused_topk
@@ -83,7 +84,14 @@ def _quantize_nvfp4_linear_sf(w_bf16: torch.Tensor):
 
 
 def _torch_ref(
-    a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation, alpha=SWIGLU_ALPHA
+    a,
+    w13_bf16,
+    w2_bf16,
+    topk_weights,
+    topk_ids,
+    activation,
+    alpha=SWIGLU_ALPHA,
+    limit=SWIGLU_LIMIT,
 ):
     """BF16 reference on the original [gate, up] weights."""
     if activation == MoEActivation.SILU:
@@ -91,7 +99,9 @@ def _torch_ref(
             a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation=activation
         )
     assert activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
-    act = SiluAndMulWithClamp(SWIGLU_LIMIT, alpha, SWIGLU_BETA)
+    act = SiluAndMulWithClamp(
+        float("inf") if limit is None else limit, alpha, SWIGLU_BETA
+    )
     m, k = a.shape
     topk = topk_ids.shape[1]
     a_rep = a.view(m, 1, k).repeat(1, topk, 1).reshape(-1, k)
@@ -114,8 +124,12 @@ def _torch_ref(
 @pytest.mark.parametrize("topk", [1, 2, 4])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize(
-    "activation",
-    [MoEActivation.SILU, MoEActivation.SWIGLUOAI_UNINTERLEAVE],
+    "activation,swiglu_limit",
+    [
+        (MoEActivation.SILU, None),
+        (MoEActivation.SWIGLUOAI_UNINTERLEAVE, SWIGLU_LIMIT),
+        (MoEActivation.SWIGLUOAI_UNINTERLEAVE, None),
+    ],
 )
 @torch.inference_mode()
 def test_flashinfer_b12x_moe(
@@ -126,6 +140,7 @@ def test_flashinfer_b12x_moe(
     topk: int,
     dtype: torch.dtype,
     activation: MoEActivation,
+    swiglu_limit: float | None,
     workspace_init,
 ):
     """Test FlashInferB12xExperts against a BF16 torch reference.
@@ -176,7 +191,7 @@ def test_flashinfer_b12x_moe(
             activation=activation,
             swiglu_alpha=SWIGLU_ALPHA if is_swigluoai else None,
             swiglu_beta=SWIGLU_BETA if is_swigluoai else None,
-            swiglu_limit=SWIGLU_LIMIT if is_swigluoai else None,
+            swiglu_limit=swiglu_limit,
         )
 
         layer = torch.nn.Module()
@@ -245,7 +260,7 @@ def test_flashinfer_b12x_moe(
         )
 
         torch_output = _torch_ref(
-            a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation
+            a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation, limit=swiglu_limit
         )
 
         # NVFP4 error is proportional to the signal, so an elementwise
@@ -261,7 +276,14 @@ def test_flashinfer_b12x_moe(
             # quantisation noise is common to both, so whichever reference
             # matches the kernel's actual alpha wins.
             wrong_alpha_ref = _torch_ref(
-                a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation, alpha=1.0
+                a,
+                w13_bf16,
+                w2_bf16,
+                topk_weights,
+                topk_ids,
+                activation,
+                alpha=1.0,
+                limit=swiglu_limit,
             )
             wrong_diff = sm12x_output.float() - wrong_alpha_ref.float()
             wrong_rel_fro = (wrong_diff.norm() / wrong_alpha_ref.float().norm()).item()
@@ -270,3 +292,132 @@ def test_flashinfer_b12x_moe(
                 f"alpha={SWIGLU_ALPHA} ({wrong_rel_fro:.3f} <= {rel_fro:.3f}); "
                 f"swiglu_alpha is likely not reaching the kernel"
             )
+
+
+@pytest.mark.parametrize("m,n,k", MNK_FACTORS)
+@pytest.mark.parametrize("e", [8, 16])
+@pytest.mark.parametrize("topk", [1, 2, 4])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.inference_mode()
+def test_flashinfer_b12x_moe_relu2(
+    m: int,
+    n: int,
+    k: int,
+    e: int,
+    topk: int,
+    dtype: torch.dtype,
+    workspace_init,
+):
+    """Test FlashInferB12xExperts with ReLU2 (non-gated) activation.
+
+    ReLU2 is used by Nemotron-H style models.  Unlike the gated SiLU
+    path, w1 has shape [E, N, K] (not [E, 2N, K]) and the activation
+    is relu(x)^2 without a gate/up split.
+    """
+    set_random_seed(7)
+    with set_current_vllm_config(
+        VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
+    ):
+        a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+
+        # Non-gated: w1 shape is (e, n, k), not (e, 2n, k).
+        w1_bf16 = torch.randn((e, n, k), device="cuda", dtype=dtype) / 15
+        w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 15
+
+        gs = torch.ones(1, device="cuda", dtype=torch.float32)
+        sf_vec_size = 16
+
+        # W1: no gate/up reordering for non-gated.
+        w1_flat = w1_bf16.reshape(e * n, k)
+        w1_q_flat, w1_sf_flat = fp4_quantize(
+            w1_flat,
+            global_scale=gs,
+            sf_vec_size=sf_vec_size,
+            is_sf_swizzled_layout=True,
+        )
+        w1_q = w1_q_flat.view(e, n, k // 2)
+        w1_blockscale = w1_sf_flat.view(e, n, w1_sf_flat.shape[1])
+
+        w2_flat = w2_bf16.reshape(e * k, n)
+        w2_q_flat, w2_sf_flat = fp4_quantize(
+            w2_flat,
+            global_scale=gs,
+            sf_vec_size=sf_vec_size,
+            is_sf_swizzled_layout=True,
+        )
+        w2_q = w2_q_flat.view(e, k, n // 2)
+        w2_blockscale = w2_sf_flat.view(e, k, w2_sf_flat.shape[1])
+
+        ones_e = torch.ones(e, device="cuda", dtype=torch.float32)
+
+        quant_config = nvfp4_moe_quant_config(
+            g1_alphas=ones_e,
+            g2_alphas=ones_e,
+            a1_gscale=ones_e,
+            a2_gscale=ones_e,
+            w1_scale=w1_blockscale,
+            w2_scale=w2_blockscale,
+        )
+
+        moe_config = make_dummy_moe_config(
+            num_experts=e,
+            experts_per_token=topk,
+            hidden_dim=k,
+            intermediate_size=n,
+            in_dtype=dtype,
+            activation=MoEActivation.RELU2_NO_MUL,
+        )
+
+        experts = FlashInferB12xExperts(
+            moe_config=moe_config,
+            quant_config=quant_config,
+        )
+        experts.process_weights_after_loading(
+            SimpleNamespace(
+                w13_weight_scale=w1_blockscale,
+                w13_weight_scale_2=ones_e,
+                w2_weight_scale=w2_blockscale,
+                w2_weight_scale_2=ones_e,
+            )
+        )
+
+        kernel = mk.FusedMoEKernel(
+            maybe_make_prepare_finalize(
+                moe=moe_config,
+                quant_config=quant_config,
+                allow_new_interface=True,
+                use_monolithic=False,
+            ),
+            experts,
+        )
+
+        score = torch.randn((m, e), device="cuda", dtype=dtype)
+        topk_weights, topk_ids, _ = fused_topk(a, score, topk, renormalize=False)
+
+        b12x_output = kernel.apply(
+            hidden_states=a,
+            w1=w1_q,
+            w2=w2_q,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            global_num_experts=e,
+            activation=MoEActivation.RELU2_NO_MUL,
+            apply_router_weight_on_input=False,
+            expert_map=None,
+        )
+
+        torch_output = torch_moe(
+            a,
+            w1_bf16,
+            w2_bf16,
+            score,
+            topk,
+            activation=MoEActivation.RELU2_NO_MUL,
+        )
+
+        torch.testing.assert_close(
+            b12x_output,
+            torch_output,
+            atol=2e-1,
+            rtol=2e-1,
+        )

--- a/tests/kernels/moe/test_flashinfer_b12x_moe.py
+++ b/tests/kernels/moe/test_flashinfer_b12x_moe.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from types import SimpleNamespace
+import dataclasses
 
 import pytest
 import torch
@@ -10,28 +10,33 @@ from vllm.platforms import current_platform
 
 if not current_platform.is_device_capability_family(120):
     pytest.skip(
-        reason="FlashInfer B12x MoE requires SM120 (RTX Pro 6000 / DGX Spark).",
+        reason="FlashInfer CuteDSL SM12x MoE requires SM120 "
+        "(RTX Pro 6000 / DGX Spark).",
         allow_module_level=True,
     )
 
-from vllm.utils.flashinfer import has_flashinfer_b12x_moe
+from vllm.utils.flashinfer import (
+    has_flashinfer_b12x_moe,
+    has_flashinfer_b12x_moe_activation,
+)
 
 if not has_flashinfer_b12x_moe():
     pytest.skip(
         reason=(
-            "FlashInfer B12xMoEWrapper not available in installed "
-            "FlashInfer (needs PR #3080)."
+            "b12x_fused_moe / convert_sf_to_mma_layout not available in "
+            "installed FlashInfer."
         ),
         allow_module_level=True,
     )
 
-# Import fp4_quantize after the skip guard — FlashInfer must be installed.
+# Import fp4_quantize after the skip guard; FlashInfer must be installed.
 from flashinfer.fp4_quantization import fp4_quantize
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from tests.kernels.moe.utils import make_dummy_moe_config
-from tests.kernels.utils import torch_moe
+from tests.kernels.utils import torch_experts
 from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.activation import SiluAndMulWithClamp
 from vllm.model_executor.layers.fused_moe import fused_topk
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.all2all_utils import (
@@ -41,8 +46,9 @@ from vllm.model_executor.layers.fused_moe.config import nvfp4_moe_quant_config
 from vllm.model_executor.layers.fused_moe.experts.flashinfer_b12x_moe import (
     FlashInferB12xExperts,
 )
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoeBackend
 from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
-    reorder_w1w3_to_w3w1,
+    prepare_nvfp4_moe_layer_for_fi_or_cutlass,
 )
 from vllm.utils.torch_utils import set_random_seed
 
@@ -55,27 +61,62 @@ MNK_FACTORS = [
     (64, 256, 512),
 ]
 
+# MiniMax-M3 SwiGLU-OAI parameters.
+SWIGLU_ALPHA = 1.702
+SWIGLU_BETA = 1.0
+SWIGLU_LIMIT = 7.0
 
-def _process_b12x_weights(
-    experts: FlashInferB12xExperts,
-    w1_scale: torch.Tensor,
-    w2_scale: torch.Tensor,
-    w1_scale_2: torch.Tensor,
-    w2_scale_2: torch.Tensor,
-) -> None:
-    layer = SimpleNamespace(
-        w13_weight_scale=w1_scale,
-        w13_weight_scale_2=w1_scale_2,
-        w2_weight_scale=w2_scale,
-        w2_weight_scale_2=w2_scale_2,
+
+def _quantize_nvfp4_linear_sf(w_bf16: torch.Tensor):
+    """Quantize per expert in checkpoint layout: linear block scales,
+    global_scale=1.0."""
+    e, rows, cols = w_bf16.shape
+    gs = torch.ones(1, device="cuda", dtype=torch.float32)
+    q, sf = fp4_quantize(
+        w_bf16.reshape(e * rows, cols),
+        global_scale=gs,
+        sf_vec_size=16,
+        is_sf_swizzled_layout=False,
     )
-    experts.process_weights_after_loading(layer)
+    sf = sf.view(torch.float8_e4m3fn)
+    return q.view(e, rows, cols // 2), sf.view(e, rows, cols // 16)
+
+
+def _torch_ref(
+    a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation, alpha=SWIGLU_ALPHA
+):
+    """BF16 reference on the original [gate, up] weights."""
+    if activation == MoEActivation.SILU:
+        return torch_experts(
+            a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation=activation
+        )
+    assert activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
+    act = SiluAndMulWithClamp(SWIGLU_LIMIT, alpha, SWIGLU_BETA)
+    m, k = a.shape
+    topk = topk_ids.shape[1]
+    a_rep = a.view(m, 1, k).repeat(1, topk, 1).reshape(-1, k)
+    ids_flat = topk_ids.view(-1)
+    out = torch.zeros(m * topk, k, dtype=a.dtype, device=a.device)
+    for i in range(w13_bf16.shape[0]):
+        mask = ids_flat == i
+        if mask.sum():
+            h = a_rep[mask] @ w13_bf16[i].t()
+            out[mask] = act(h) @ w2_bf16[i].t()
+    return (
+        (out.view(m, topk, k).float() * topk_weights.view(m, topk, 1))
+        .sum(dim=1)
+        .to(a.dtype)
+    )
 
 
 @pytest.mark.parametrize("m,n,k", MNK_FACTORS)
 @pytest.mark.parametrize("e", [8, 16])
 @pytest.mark.parametrize("topk", [1, 2, 4])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize(
+    "activation",
+    [MoEActivation.SILU, MoEActivation.SWIGLUOAI_UNINTERLEAVE],
+)
 @torch.inference_mode()
 def test_flashinfer_b12x_moe(
     m: int,
@@ -84,111 +125,99 @@ def test_flashinfer_b12x_moe(
     e: int,
     topk: int,
     dtype: torch.dtype,
+    activation: MoEActivation,
     workspace_init,
 ):
     """Test FlashInferB12xExperts against a BF16 torch reference.
 
-    The SM12x kernel takes BF16 hidden states directly and fuses token
-    dispatch, W1 GEMM, SwiGLU, and W2 GEMM into one call.  We verify
-    correctness against ``torch_moe`` using generous tolerances to account
-    for the internal FP4 quantization of activations and weights.
+    Weights start in checkpoint layout (fused FC1 as [gate, up], linear
+    block scales) and go through the production weight pipeline
+    (``prepare_nvfp4_moe_layer_for_fi_or_cutlass`` +
+    ``process_weights_after_loading``), so the test catches a broken
+    [gate, up] -> [up, gate] reorder or unplumbed activation params (the
+    garbled MiniMax-M3 swigluoai output).
 
-    Scale convention
-    ----------------
-    The SM12x kernel uses ``w1_alpha`` as *both* the activation-quantisation
-    global scale and the weight dequantisation factor.  These two roles are
-    conflated into a single parameter in ``launch_sm120_moe``, so they must
-    equal the same value.  We use ``global_scale = 1.0`` for
-    ``fp4_quantize`` so that ``w1_alpha = ones`` satisfies both roles
-    simultaneously.  The alternative — vLLM's convention of baking a large
-    ``w_gs`` into block-scale values and compensating with
-    ``g1_alphas = 1/w_gs`` — is incompatible with this kernel.
+    Scale convention: the SM12x kernel uses ``w1_alpha`` as *both* the
+    activation-quantisation global scale and the weight dequantisation
+    factor, so we quantise with ``global_scale = 1.0`` and ``w1_alpha =
+    ones``; vLLM's bake-a-large-``w_gs``-into-block-scales convention is
+    incompatible with this kernel.
     """
+    is_swigluoai = activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
+    if is_swigluoai and not has_flashinfer_b12x_moe_activation():
+        pytest.skip("Installed FlashInfer b12x_fused_moe lacks swigluoai support.")
+
     set_random_seed(7)
     with set_current_vllm_config(
         VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
     ):
-        a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+        # O(1)-magnitude outputs; smaller scalings make any comparison
+        # metric pass regardless of kernel correctness.
+        a = torch.randn((m, k), device="cuda", dtype=dtype) / 2
 
-        # Generate BF16 reference weights in [gate, up] order.
-        # Shape: w1=(e, 2n, k), w2=(e, k, n).
-        w1_bf16 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 15
-        w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 15
+        # BF16 reference weights in checkpoint [gate, up] order.
+        w13_bf16 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 8
+        w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 8
 
-        # ------------------------------------------------------------------ #
-        # Quantise weights for the SM12x kernel using FlashInfer's convention:
-        #   global_scale = 1.0   →   block_scale = max_abs_block / fp4_max
-        #   w1_alpha = 1.0       (no extra global factor to compensate)
-        #
-        # The scale factors returned by fp4_quantize(..., is_sf_swizzled_layout=True)
-        # are already in the swizzled 2D layout expected by convert_sf_to_mma_layout.
-        # No additional swizzle_blockscale() call is needed.
-        # ------------------------------------------------------------------ #
-        gs = torch.ones(1, device="cuda", dtype=torch.float32)
-        sf_vec_size = 16
-
-        # W1: reorder BF16 from [gate, up] → [up, gate], then quantise.
-        # Note: in reorder_w1w3_to_w3w1, "w1" refers to the gate projection
-        # and "w3" refers to the up projection.
-        # A dummy scale is passed and discarded; real scales come from
-        # fp4_quantize after reordering.
-        w1_reordered, _ = reorder_w1w3_to_w3w1(
-            w1_bf16.clone(),
-            torch.ones((e, 2 * n, 1), device="cuda", dtype=torch.float32),
-        )
-        w1_flat = w1_reordered.reshape(e * 2 * n, k)
-        w1_q_flat, w1_sf_flat = fp4_quantize(
-            w1_flat,
-            global_scale=gs,
-            sf_vec_size=sf_vec_size,
-            is_sf_swizzled_layout=True,
-        )
-        w1_q = w1_q_flat.view(e, 2 * n, k // 2)  # uint8, packed FP4
-        w1_blockscale = w1_sf_flat.view(e, 2 * n, w1_sf_flat.shape[1])  # float8
-
-        # W2: no row reordering needed for the down-projection.
-        w2_flat = w2_bf16.reshape(e * k, n)
-        w2_q_flat, w2_sf_flat = fp4_quantize(
-            w2_flat,
-            global_scale=gs,
-            sf_vec_size=sf_vec_size,
-            is_sf_swizzled_layout=True,
-        )
-        w2_q = w2_q_flat.view(e, k, n // 2)  # uint8, packed FP4
-        w2_blockscale = w2_sf_flat.view(e, k, w2_sf_flat.shape[1])  # float8
+        w13_q, w13_sf = _quantize_nvfp4_linear_sf(w13_bf16)
+        w2_q, w2_sf = _quantize_nvfp4_linear_sf(w2_bf16)
 
         # All per-expert alphas are 1.0 (global_scale = 1.0, no compensation).
         ones_e = torch.ones(e, device="cuda", dtype=torch.float32)
 
-        quant_config = nvfp4_moe_quant_config(
-            g1_alphas=ones_e,
-            g2_alphas=ones_e,
-            a1_gscale=ones_e,
-            a2_gscale=ones_e,
-            w1_scale=w1_blockscale,
-            w2_scale=w2_blockscale,
+        moe_config = dataclasses.replace(
+            make_dummy_moe_config(
+                num_experts=e,
+                experts_per_token=topk,
+                hidden_dim=k,
+                intermediate_size=n,
+                in_dtype=dtype,
+            ),
+            activation=activation,
+            swiglu_alpha=SWIGLU_ALPHA if is_swigluoai else None,
+            swiglu_beta=SWIGLU_BETA if is_swigluoai else None,
+            swiglu_limit=SWIGLU_LIMIT if is_swigluoai else None,
         )
 
-        moe_config = make_dummy_moe_config(
-            num_experts=e,
-            experts_per_token=topk,
-            hidden_dim=k,
-            intermediate_size=n,
-            in_dtype=dtype,
+        layer = torch.nn.Module()
+        layer.activation = activation
+        layer.moe_config = moe_config
+        (w13_q, w13_sf, _, _, w2_q, w2_sf, _, _) = (
+            prepare_nvfp4_moe_layer_for_fi_or_cutlass(
+                backend=NvFp4MoeBackend.FLASHINFER_B12X,
+                layer=layer,
+                w13=w13_q,
+                w13_scale=w13_sf,
+                w13_scale_2=ones_e.clone(),
+                a13_scale=torch.ones(e, 2, device="cuda", dtype=torch.float32),
+                w2=w2_q,
+                w2_scale=w2_sf,
+                w2_scale_2=ones_e.clone(),
+                a2_scale=torch.ones(e, 1, device="cuda", dtype=torch.float32),
+                is_act_and_mul=True,
+            )
+        )
+        layer.w13_weight = w13_q
+        layer.w13_weight_scale = w13_sf
+        layer.w13_weight_scale_2 = ones_e.clone()
+        layer.w2_weight = w2_q
+        layer.w2_weight_scale = w2_sf
+        layer.w2_weight_scale_2 = ones_e.clone()
+
+        quant_config = nvfp4_moe_quant_config(
+            g1_alphas=ones_e.clone(),
+            g2_alphas=ones_e.clone(),
+            a1_gscale=ones_e.clone(),
+            a2_gscale=ones_e.clone(),
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
         )
 
         experts = FlashInferB12xExperts(
             moe_config=moe_config,
             quant_config=quant_config,
         )
-
-        _process_b12x_weights(
-            experts,
-            w1_blockscale,
-            w2_blockscale,
-            ones_e,
-            ones_e,
-        )
+        experts.process_weights_after_loading(layer)
 
         kernel = mk.FusedMoEKernel(
             maybe_make_prepare_finalize(
@@ -205,150 +234,39 @@ def test_flashinfer_b12x_moe(
 
         sm12x_output = kernel.apply(
             hidden_states=a,
-            w1=w1_q,
-            w2=w2_q,
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             global_num_experts=e,
-            activation=MoEActivation.SILU,
+            activation=activation,
             apply_router_weight_on_input=False,
             expert_map=None,
         )
 
-        # Reference: BF16 torch MoE using original [gate, up] BF16 weights.
-        # torch_moe's SiluAndMul expects [gate, up] order, matching w1_bf16.
-        torch_output = torch_moe(a, w1_bf16, w2_bf16, score, topk)
-
-        torch.testing.assert_close(sm12x_output, torch_output, atol=2e-1, rtol=2e-1)
-
-
-@pytest.mark.parametrize("m,n,k", MNK_FACTORS)
-@pytest.mark.parametrize("e", [8, 16])
-@pytest.mark.parametrize("topk", [1, 2, 4])
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
-@torch.inference_mode()
-def test_flashinfer_b12x_moe_relu2(
-    m: int,
-    n: int,
-    k: int,
-    e: int,
-    topk: int,
-    dtype: torch.dtype,
-    workspace_init,
-):
-    """Test FlashInferB12xExperts with ReLU2 (non-gated) activation.
-
-    ReLU2 is used by Nemotron-H style models.  Unlike the gated SiLU
-    path, w1 has shape [E, N, K] (not [E, 2N, K]) and the activation
-    is relu(x)^2 without a gate/up split.
-    """
-    set_random_seed(7)
-    with set_current_vllm_config(
-        VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
-    ):
-        a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
-
-        # Non-gated: w1 shape is (e, n, k), not (e, 2n, k).
-        w1_bf16 = torch.randn((e, n, k), device="cuda", dtype=dtype) / 15
-        w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 15
-
-        gs = torch.ones(1, device="cuda", dtype=torch.float32)
-        sf_vec_size = 16
-
-        # W1: no gate/up reordering for non-gated.
-        w1_flat = w1_bf16.reshape(e * n, k)
-        w1_q_flat, w1_sf_flat = fp4_quantize(
-            w1_flat,
-            global_scale=gs,
-            sf_vec_size=sf_vec_size,
-            is_sf_swizzled_layout=True,
-        )
-        w1_q = w1_q_flat.view(e, n, k // 2)
-        w1_blockscale = w1_sf_flat.view(e, n, w1_sf_flat.shape[1])
-
-        w2_flat = w2_bf16.reshape(e * k, n)
-        w2_q_flat, w2_sf_flat = fp4_quantize(
-            w2_flat,
-            global_scale=gs,
-            sf_vec_size=sf_vec_size,
-            is_sf_swizzled_layout=True,
-        )
-        w2_q = w2_q_flat.view(e, k, n // 2)
-        w2_blockscale = w2_sf_flat.view(e, k, w2_sf_flat.shape[1])
-
-        ones_e = torch.ones(e, device="cuda", dtype=torch.float32)
-
-        quant_config = nvfp4_moe_quant_config(
-            g1_alphas=ones_e,
-            g2_alphas=ones_e,
-            a1_gscale=ones_e,
-            a2_gscale=ones_e,
-            w1_scale=w1_blockscale,
-            w2_scale=w2_blockscale,
+        torch_output = _torch_ref(
+            a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation
         )
 
-        moe_config = make_dummy_moe_config(
-            num_experts=e,
-            experts_per_token=topk,
-            hidden_dim=k,
-            intermediate_size=n,
-            in_dtype=dtype,
-            activation=MoEActivation.RELU2_NO_MUL,
-        )
+        # NVFP4 error is proportional to the signal, so an elementwise
+        # atol/rtol check cannot separate quantisation noise from a swapped
+        # gate/up ordering or a wrong activation; relative Frobenius error can.
+        diff = sm12x_output.float() - torch_output.float()
+        rel_fro = (diff.norm() / torch_output.float().norm()).item()
+        assert rel_fro < 0.45, f"rel_fro={rel_fro:.3f} (expected < 0.45)"
 
-        experts = FlashInferB12xExperts(
-            moe_config=moe_config,
-            quant_config=quant_config,
-        )
-        _process_b12x_weights(
-            experts,
-            w1_blockscale,
-            w2_blockscale,
-            ones_e,
-            ones_e,
-        )
-
-        kernel = mk.FusedMoEKernel(
-            maybe_make_prepare_finalize(
-                moe=moe_config,
-                quant_config=quant_config,
-                allow_new_interface=True,
-                use_monolithic=False,
-            ),
-            experts,
-        )
-
-        score = torch.randn((m, e), device="cuda", dtype=dtype)
-        topk_weights, topk_ids, _ = fused_topk(a, score, topk, renormalize=False)
-
-        b12x_output = kernel.apply(
-            hidden_states=a,
-            w1=w1_q,
-            w2=w2_q,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            global_num_experts=e,
-            activation=MoEActivation.RELU2_NO_MUL,
-            apply_router_weight_on_input=False,
-            expert_map=None,
-        )
-
-        torch_output = torch_moe(
-            a,
-            w1_bf16,
-            w2_bf16,
-            score,
-            topk,
-            activation=MoEActivation.RELU2_NO_MUL,
-        )
-
-        torch.testing.assert_close(
-            b12x_output,
-            torch_output,
-            atol=2e-1,
-            rtol=2e-1,
-        )
-
-
-if __name__ == "__main__":
-    test_flashinfer_b12x_moe(16, 128, 256, 8, 2, torch.bfloat16)
+        if is_swigluoai:
+            # An alpha regression shifts outputs too little for the threshold
+            # above. Compare against an alpha=1.0 reference instead: the
+            # quantisation noise is common to both, so whichever reference
+            # matches the kernel's actual alpha wins.
+            wrong_alpha_ref = _torch_ref(
+                a, w13_bf16, w2_bf16, topk_weights, topk_ids, activation, alpha=1.0
+            )
+            wrong_diff = sm12x_output.float() - wrong_alpha_ref.float()
+            wrong_rel_fro = (wrong_diff.norm() / wrong_alpha_ref.float().norm()).item()
+            assert rel_fro < wrong_rel_fro, (
+                f"output matches alpha=1.0 reference better than "
+                f"alpha={SWIGLU_ALPHA} ({wrong_rel_fro:.3f} <= {rel_fro:.3f}); "
+                f"swiglu_alpha is likely not reaching the kernel"
+            )

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -24,6 +24,7 @@ from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_convert_sf_to_mma_layout,
     has_flashinfer_b12x_moe,
+    has_flashinfer_b12x_moe_activation,
 )
 
 
@@ -46,6 +47,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
     _ACTIVATION_MAP: dict[MoEActivation, str] = {
         MoEActivation.SILU: "silu",
         MoEActivation.RELU2_NO_MUL: "relu2",
+        MoEActivation.SWIGLUOAI_UNINTERLEAVE: "swigluoai_uninterleave",
     }
 
     def __init__(
@@ -84,6 +86,28 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
                 f"Supported: {list(self._ACTIVATION_MAP.keys())}"
             )
         self._activation_str = self._ACTIVATION_MAP[activation]
+
+        # ModelOpt NVFP4 checkpoints carry swiglu params on moe_config,
+        # not quant_config.
+        def _resolve(quant_val: float | None, moe_val: float | None) -> float | None:
+            return quant_val if quant_val is not None else moe_val
+
+        self.swiglu_alpha = _resolve(quant_config.gemm1_alpha, moe_config.swiglu_alpha)
+        self.swiglu_beta = _resolve(quant_config.gemm1_beta, moe_config.swiglu_beta)
+        self.swiglu_limit = _resolve(
+            quant_config.gemm1_clamp_limit, moe_config.swiglu_limit
+        )
+        if activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:
+            if self.swiglu_limit is None:
+                raise ValueError(
+                    "swigluoai_uninterleave requires swiglu_limit "
+                    "(gemm1_clamp_limit), but none was provided."
+                )
+        elif self.swiglu_limit is not None:
+            raise ValueError(
+                "FlashInferB12xExperts only applies swiglu_limit with the "
+                f"swigluoai_uninterleave activation, got {activation}."
+            )
 
         # Lazily created on first apply() call.
         self._wrapper: Any | None = None
@@ -188,7 +212,12 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        return activation in (MoEActivation.SILU, MoEActivation.RELU2_NO_MUL)
+        if activation in (MoEActivation.SILU, MoEActivation.RELU2_NO_MUL):
+            return True
+        return (
+            activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
+            and has_flashinfer_b12x_moe_activation()
+        )
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
@@ -234,6 +263,17 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
         from flashinfer.fused_moe import B12xMoEWrapper
 
+        swiglu_kwargs: dict[str, float] = {}
+        if self.swiglu_limit is not None:
+            # Unset alpha/beta mean silu-with-clamp in vLLM
+            # (apply_moe_activation); the kernel defaults are
+            # gpt-oss-oriented (1.702/1.0), so pass explicitly.
+            swiglu_kwargs = {
+                "swiglu_limit": self.swiglu_limit,
+                "swiglu_alpha": 1.0 if self.swiglu_alpha is None else self.swiglu_alpha,
+                "swiglu_beta": 0.0 if self.swiglu_beta is None else self.swiglu_beta,
+            }
+
         self._wrapper = B12xMoEWrapper(
             num_experts=self.global_num_experts,
             top_k=self.topk,
@@ -243,6 +283,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             max_num_tokens=self.max_num_tokens,
             num_local_experts=self.num_local_experts,
             activation=self._activation_str,
+            **swiglu_kwargs,
         )
 
     def apply(

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -98,13 +98,10 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         self.swiglu_limit = _resolve(
             quant_config.gemm1_clamp_limit, moe_config.swiglu_limit
         )
-        if activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:
-            if self.swiglu_limit is None:
-                raise ValueError(
-                    "swigluoai_uninterleave requires swiglu_limit "
-                    "(gemm1_clamp_limit), but none was provided."
-                )
-        elif self.swiglu_limit is not None:
+        if (
+            activation != MoEActivation.SWIGLUOAI_UNINTERLEAVE
+            and self.swiglu_limit is not None
+        ):
             raise ValueError(
                 "FlashInferB12xExperts only applies swiglu_limit with the "
                 f"swigluoai_uninterleave activation, got {activation}."
@@ -268,11 +265,10 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
         from flashinfer.fused_moe import B12xMoEWrapper
 
-        swiglu_kwargs: dict[str, float] = {}
-        if self.swiglu_limit is not None:
-            # Unset alpha/beta mean silu-with-clamp in vLLM
-            # (apply_moe_activation); the kernel defaults are
-            # gpt-oss-oriented (1.702/1.0), so pass explicitly.
+        swiglu_kwargs: dict[str, float | None] = {}
+        if self._activation_str == "swigluoai_uninterleave":
+            # vLLM treats unset alpha/beta as 1.0/0.0; the kernel defaults
+            # to gpt-oss 1.702/1.0, so pass explicitly.
             swiglu_kwargs = {
                 "swiglu_limit": self.swiglu_limit,
                 "swiglu_alpha": 1.0 if self.swiglu_alpha is None else self.swiglu_alpha,

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -24,6 +24,7 @@ from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_convert_sf_to_mma_layout,
     has_flashinfer_b12x_moe,
+    has_flashinfer_b12x_moe_activation,
 )
 
 
@@ -47,6 +48,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         MoEActivation.SILU: "silu",
         MoEActivation.GELU_TANH: "gelu_tanh",
         MoEActivation.RELU2_NO_MUL: "relu2",
+        MoEActivation.SWIGLUOAI_UNINTERLEAVE: "swigluoai_uninterleave",
     }
 
     def __init__(
@@ -85,6 +87,28 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
                 f"Supported: {list(self._ACTIVATION_MAP.keys())}"
             )
         self._activation_str = self._ACTIVATION_MAP[activation]
+
+        # ModelOpt NVFP4 checkpoints carry swiglu params on moe_config,
+        # not quant_config.
+        def _resolve(quant_val: float | None, moe_val: float | None) -> float | None:
+            return quant_val if quant_val is not None else moe_val
+
+        self.swiglu_alpha = _resolve(quant_config.gemm1_alpha, moe_config.swiglu_alpha)
+        self.swiglu_beta = _resolve(quant_config.gemm1_beta, moe_config.swiglu_beta)
+        self.swiglu_limit = _resolve(
+            quant_config.gemm1_clamp_limit, moe_config.swiglu_limit
+        )
+        if activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:
+            if self.swiglu_limit is None:
+                raise ValueError(
+                    "swigluoai_uninterleave requires swiglu_limit "
+                    "(gemm1_clamp_limit), but none was provided."
+                )
+        elif self.swiglu_limit is not None:
+            raise ValueError(
+                "FlashInferB12xExperts only applies swiglu_limit with the "
+                f"swigluoai_uninterleave activation, got {activation}."
+            )
 
         # Lazily created on first apply() call.
         self._wrapper: Any | None = None
@@ -189,10 +213,15 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        return activation in (
+        if activation in (
             MoEActivation.SILU,
             MoEActivation.GELU_TANH,
             MoEActivation.RELU2_NO_MUL,
+        ):
+            return True
+        return (
+            activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
+            and has_flashinfer_b12x_moe_activation()
         )
 
     @staticmethod
@@ -239,6 +268,17 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
         from flashinfer.fused_moe import B12xMoEWrapper
 
+        swiglu_kwargs: dict[str, float] = {}
+        if self.swiglu_limit is not None:
+            # Unset alpha/beta mean silu-with-clamp in vLLM
+            # (apply_moe_activation); the kernel defaults are
+            # gpt-oss-oriented (1.702/1.0), so pass explicitly.
+            swiglu_kwargs = {
+                "swiglu_limit": self.swiglu_limit,
+                "swiglu_alpha": 1.0 if self.swiglu_alpha is None else self.swiglu_alpha,
+                "swiglu_beta": 0.0 if self.swiglu_beta is None else self.swiglu_beta,
+            }
+
         self._wrapper = B12xMoEWrapper(
             num_experts=self.global_num_experts,
             top_k=self.topk,
@@ -248,6 +288,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             max_num_tokens=self.max_num_tokens,
             num_local_experts=self.num_local_experts,
             activation=self._activation_str,
+            **swiglu_kwargs,
         )
 
     def apply(

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -8,6 +8,7 @@ import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.config.kernel import MoEBackend
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.all2all_utils import (
     maybe_make_prepare_finalize,
 )
@@ -31,6 +32,7 @@ from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import 
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
 )
+from vllm.utils.flashinfer import has_flashinfer_b12x_moe_activation
 
 logger = init_logger(__name__)
 
@@ -192,6 +194,12 @@ def select_nvfp4_moe_backend(
         NvFp4MoeBackend.FLASHINFER_CUTLASS,
         NvFp4MoeBackend.MARLIN,
     }
+    # b12x applies the clamp only inside its swigluoai_uninterleave activation.
+    if (
+        config.activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
+        and has_flashinfer_b12x_moe_activation()
+    ):
+        NVFP4_BACKENDS_WITH_CLAMP.add(NvFp4MoeBackend.FLASHINFER_B12X)
 
     if config.swiglu_limit is not None:
         AVAILABLE_BACKENDS = [
@@ -259,7 +267,9 @@ def select_nvfp4_moe_backend(
                 f"Model sets swiglu_limit={config.swiglu_limit}, but the "
                 f"explicitly requested moe_backend={runner_backend!r} does "
                 f"not apply the SwiGLU clamp. Use 'flashinfer_trtllm' or "
-                f"'flashinfer_cutlass' instead."
+                f"'flashinfer_cutlass' instead; on SM12x, 'flashinfer_b12x' "
+                f"applies the clamp for swigluoai_uninterleave when the "
+                f"installed FlashInfer supports the swiglu kwargs."
             )
         return _return_or_raise(
             requested_backend, config, weight_key, activation_key, activation_format

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -8,6 +8,7 @@ import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm import envs
 from vllm.config.kernel import MoEBackend
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.all2all_utils import (
     maybe_make_prepare_finalize,
 )
@@ -35,6 +36,7 @@ from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import 
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
 )
+from vllm.utils.flashinfer import has_flashinfer_b12x_moe_activation
 
 logger = init_logger(__name__)
 
@@ -214,6 +216,12 @@ def select_nvfp4_moe_backend(
         NvFp4MoeBackend.EMULATION,
         NvFp4MoeBackend.HUMMING,
     }
+    # b12x applies the clamp only inside its swigluoai_uninterleave activation.
+    if (
+        config.activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
+        and has_flashinfer_b12x_moe_activation()
+    ):
+        NVFP4_BACKENDS_WITH_CLAMP.add(NvFp4MoeBackend.FLASHINFER_B12X)
 
     if config.swiglu_limit is not None:
         AVAILABLE_BACKENDS = [
@@ -284,7 +292,10 @@ def select_nvfp4_moe_backend(
                 f"explicitly requested moe_backend={runner_backend!r} does "
                 f"not apply the SwiGLU clamp. Use 'flashinfer_trtllm', "
                 f"'flashinfer_cutlass', 'flashinfer_cutedsl', 'cutlass', "
-                f"'b12x', 'marlin', or 'humming' instead."
+                f"'b12x', 'marlin', or 'humming' instead; on SM12x, "
+                f"'flashinfer_b12x' applies the clamp for "
+                f"swigluoai_uninterleave when the installed FlashInfer "
+                f"supports the swiglu kwargs."
             )
         return _return_or_raise(
             requested_backend, config, weight_key, activation_key, activation_format

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -9,6 +9,7 @@ import contextlib
 import functools
 import importlib
 import importlib.util
+import inspect
 import os
 import shutil
 from collections.abc import Callable
@@ -340,6 +341,17 @@ def has_flashinfer_b12x_moe() -> bool:
         if not mod or not hasattr(mod, attr_name):
             return False
     return True
+
+
+@functools.cache
+def has_flashinfer_b12x_moe_activation() -> bool:
+    """Return ``True`` if ``B12xMoEWrapper`` accepts the ``swiglu_*`` kwargs."""
+    if not has_flashinfer_b12x_moe():
+        return False
+    mod = _get_submodule("flashinfer.fused_moe")
+    if mod is None or not hasattr(mod, "B12xMoEWrapper"):
+        return False
+    return "swiglu_limit" in inspect.signature(mod.B12xMoEWrapper).parameters
 
 
 @functools.cache
@@ -1041,6 +1053,7 @@ __all__ = [
     "has_flashinfer_cutedsl_grouped_gemm_nt_masked",
     "has_flashinfer_cutedsl_moe_nvfp4",
     "has_flashinfer_b12x_moe",
+    "has_flashinfer_b12x_moe_activation",
     "has_flashinfer_b12x_gemm",
     "has_flashinfer_fp8_blockscale_gemm",
     "has_nvidia_artifactory",

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -9,6 +9,7 @@ import contextlib
 import functools
 import importlib
 import importlib.util
+import inspect
 import os
 import shutil
 from collections.abc import Callable
@@ -361,6 +362,17 @@ def has_flashinfer_b12x_moe() -> bool:
         if not mod or not hasattr(mod, attr_name):
             return False
     return True
+
+
+@functools.cache
+def has_flashinfer_b12x_moe_activation() -> bool:
+    """Return ``True`` if ``B12xMoEWrapper`` accepts the ``swiglu_*`` kwargs."""
+    if not has_flashinfer_b12x_moe():
+        return False
+    mod = _get_submodule("flashinfer.fused_moe")
+    if mod is None or not hasattr(mod, "B12xMoEWrapper"):
+        return False
+    return "swiglu_limit" in inspect.signature(mod.B12xMoEWrapper).parameters
 
 
 @functools.cache
@@ -1102,6 +1114,7 @@ __all__ = [
     "has_flashinfer_cutedsl_grouped_gemm_nt_masked",
     "has_flashinfer_cutedsl_moe_nvfp4",
     "has_flashinfer_b12x_moe",
+    "has_flashinfer_b12x_moe_activation",
     "has_flashinfer_b12x_gemm",
     "has_flashinfer_fp8_blockscale_gemm",
     "has_nvidia_artifactory",


### PR DESCRIPTION
## Purpose

Models with a clamped SwiGLU-OAI MoE activation (`swigluoai_uninterleave`,
e.g. [nvidia/MiniMax-M3-NVFP4](https://huggingface.co/nvidia/MiniMax-M3-NVFP4))
cannot use the FlashInfer b12x MoE backend: `FlashInferB12xExperts` handles
only silu and relu2. This matters on SM120/SM121: FlashInfer TRT-LLM MoE
requires SM100-family GPUs and FlashInfer CUTLASS lacks this activation, so
such models have no FlashInfer MoE path there.

FlashInfer supports `swigluoai_uninterleave` on this kernel since
flashinfer-ai/flashinfer#3744; this PR adds it to `FlashInferB12xExperts` and
passes `swiglu_alpha/beta/limit` to the `B12xMoEWrapper`, gated on the
installed FlashInfer supporting them. Behavior with the current pin (0.6.13,
which predates the kernel support) is unchanged; a later pin bump enables
these models on b12x with no further vLLM changes.

The unit test now drives the production weight-processing path instead of
hand-preparing weights, covers silu and swigluoai, and uses a relative-error
check that actually fails on a wrong gate/up ordering or activation (the old
tolerances passed under any kernel behavior). This guards the whole b12x
weight pipeline, not just the new activation.

Not a duplicate of #47001, which widens b12x `_supports_activation` without
plumbing the activation into the kernel call.

## Test Plan

```
pytest tests/kernels/moe/test_flashinfer_b12x_moe.py
```

Needs SM120 and FlashInfer at/past flashinfer-ai/flashinfer#3744 for the
swigluoai cases; they skip on the current pin.

## Test Result

RTX 5080, FlashInfer at the #3744 merge commit: 48 passed with the fix.
Without the fix, all 24 swigluoai cases fail (relative error 0.60 vs the 0.45
bound) and the 24 silu cases pass. On pre-#3744 FlashInfer the swigluoai
cases skip and silu passes.

Developed with AI assistance (Claude Code).
