### PR TITLE
Drop response format for auto tool choice

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_tool_parser_adjust_request.py
+++ b/tests/entrypoints/openai/chat_completion/test_tool_parser_adjust_request.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.tool_parsers.abstract_tool_parser import ToolParser
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "add_numbers",
+            "description": "Adds two numbers.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "number"},
+                    "b": {"type": "number"},
+                },
+                "required": ["a", "b"],
+            },
+        },
+    }
+]
+
+
+def _make_request(
+    *,
+    tool_choice="auto",
+    response_format=None,
+) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "What is 42 + 58?"}],
+        tools=TOOLS,
+        tool_choice=tool_choice,
+        response_format=response_format,
+    )
+
+
+def _make_parser() -> ToolParser:
+    parser = ToolParser.__new__(ToolParser)
+    parser.tools = TOOLS
+    return parser
+
+
+def test_auto_tool_choice_drops_response_format_constraint() -> None:
+    request = _make_request(
+        tool_choice="auto",
+        response_format={"type": "json_object"},
+    )
+
+    _make_parser().adjust_request(request)
+
+    assert request.response_format is None
+    assert request.structured_outputs is None
+
+
+def test_required_tool_choice_keeps_forced_tool_schema() -> None:
+    request = _make_request(
+        tool_choice="required",
+        response_format={"type": "json_object"},
+    )
+
+    _make_parser().adjust_request(request)
+
+    assert request.response_format is None
+    assert request.structured_outputs is not None
+    assert request.structured_outputs.json is not None
+
+
+def test_tool_choice_none_keeps_response_format_constraint() -> None:
+    request = _make_request(
+        tool_choice="none",
+        response_format={"type": "json_object"},
+    )
+
+    _make_parser().adjust_request(request)
+
+    assert request.response_format is not None
+    assert request.response_format.type == "json_object"
+    assert request.structured_outputs is None

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -134,6 +134,14 @@ class ToolParser:
         ):
             return request
 
+        if (
+            isinstance(request, ChatCompletionRequest)
+            and request.tool_choice == "auto"
+            and request.response_format is not None
+        ):
+            # Let the model choose between a tool call and a text response.
+            request.response_format = None
+
         json_schema_from_tool = get_json_schema_from_tools(
             tool_choice=request.tool_choice, tools=request.tools
         )


### PR DESCRIPTION
Fixes #39929

## Purpose

When Chat Completions requests include both `tools` with `tool_choice: "auto"` and `response_format`, vLLM currently converts the response format into structured-output constraints before generation. That can force the model to produce JSON text immediately and prevent it from choosing a tool call.

This PR clears `response_format` during tool-parser request adjustment for Chat Completions requests that use `tool_choice: "auto"` with tools. This lets the model choose between emitting a tool call and producing a text response, matching the existing tool-parser adjustment flow used for tool calling.

The existing forced-tool behavior is preserved: `tool_choice: "required"` and named tool choices still install the tool-derived structured output schema, and `tool_choice: "none"` keeps the original response format constraint.

This is not duplicating an existing PR: I checked open PRs for #39929, `response_format` + `tool_choice`, and structured-output/tool-choice handling. I did not find an open PR addressing this Chat Completions `tool_choice: "auto"` response-format suppression issue.

This PR was prepared with OpenAI Codex assistance.

## Test Plan

- Compile the modified tool parser and focused regression test.
- Run focused regression tests for tool-parser request adjustment.
- Check for whitespace errors.

## Test Result

```text
python -m py_compile vllm/tool_parsers/abstract_tool_parser.py tests/entrypoints/openai/chat_completion/test_tool_parser_adjust_request.py
passed

git diff --check
passed

python -m pytest tests/entrypoints/openai/chat_completion/test_tool_parser_adjust_request.py -q --confcutdir=tests/entrypoints/openai/chat_completion
blocked locally: current Windows conda environment does not match vLLM main dependencies; after updating openai/cbor2, import still fails because the installed transformers package lacks ALLOWED_LAYER_TYPES