### PR TITLE
[LoRA] Add DoRA support for serving and linear layers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1450,6 +1450,19 @@ def num_gpus_available():
     return current_platform.device_count()
 
 
+@pytest.fixture(scope="session")
+def qwen25_05b_dora_files():
+    return snapshot_download(repo_id="Dhanushkumaramk/healthcare-qwen2.5-0.5B-dora")
+
+
+@pytest.fixture(scope="session")
+def qwen25_05b_lora_files(tmp_path_factory, qwen25_05b_dora_files):
+    from tests.lora.utils import convert_dora_checkpoint_to_lora
+
+    lora_dir = tmp_path_factory.mktemp("qwen25_05b_lora_from_dora")
+    return convert_dora_checkpoint_to_lora(qwen25_05b_dora_files, lora_dir)
+
+
 temp_dir = tempfile.gettempdir()
 _dummy_opt_path = os.path.join(temp_dir, "dummy_opt")
 _dummy_llava_path = os.path.join(temp_dir, "dummy_llava")

--- a/tests/entrypoints/serve/lora/test_dora_adapters.py
+++ b/tests/entrypoints/serve/lora/test_dora_adapters.py
@@ -12,7 +12,6 @@ from tests.utils import RemoteOpenAIServer
 MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
 DORA_ADAPTER_NAME = "qwen25-dora"
 DYNAMIC_DORA_ADAPTER_NAME = "qwen25-dora-dynamic"
-DORA_ADAPTER_REPO = "Dhanushkumaramk/healthcare-qwen2.5-0.5B-dora"
 COMPLETION_PROMPT = "The capital of France is"
 
 
@@ -33,14 +32,6 @@ async def _unload_lora_adapter(client: openai.AsyncOpenAI, lora_name: str) -> No
         cast_to=str,
         body={"lora_name": lora_name},
     )
-
-
-@pytest.fixture(scope="session")
-def qwen25_05b_dora_files():
-    """Download Qwen2.5 DoRA files once per test session."""
-    from huggingface_hub import snapshot_download
-
-    return snapshot_download(repo_id=DORA_ADAPTER_REPO)
 
 
 @pytest.fixture(scope="module")
@@ -86,7 +77,7 @@ async def client(server_with_dora):
 
 
 @pytest.mark.asyncio
-async def test_static_dora_lineage_and_completion(
+async def test_static_dora_lineage(
     client: openai.AsyncOpenAI,
     qwen25_05b_dora_files,
 ):
@@ -100,13 +91,6 @@ async def test_static_dora_lineage_and_completion(
     assert dora_model.id == DORA_ADAPTER_NAME
     assert dora_model.root == qwen25_05b_dora_files
     assert dora_model.parent == MODEL_NAME
-
-    completion = await client.completions.create(
-        model=DORA_ADAPTER_NAME,
-        prompt=COMPLETION_PROMPT,
-        max_tokens=4,
-    )
-    assert completion.choices
 
 
 @pytest.mark.asyncio
@@ -155,7 +139,6 @@ async def test_dynamic_dora_load_unload_reload_and_lineage(
         )
         assert "success" in response.lower()
         loaded = True
-        await _complete_text(client, adapter_name)
     finally:
         if loaded:
             await _unload_lora_adapter(client, adapter_name)

--- a/tests/entrypoints/serve/lora/test_dora_adapters.py
+++ b/tests/entrypoints/serve/lora/test_dora_adapters.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import openai  # use the official client for correctness check
+import pytest
+import pytest_asyncio
+
+from tests.utils import RemoteOpenAIServer
+
+MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
+DORA_ADAPTER_NAME = "qwen25-dora"
+DYNAMIC_DORA_ADAPTER_NAME = "qwen25-dora-dynamic"
+DORA_ADAPTER_REPO = "Dhanushkumaramk/healthcare-qwen2.5-0.5B-dora"
+
+
+@pytest.fixture(scope="session")
+def qwen25_05b_dora_files():
+    """Download Qwen2.5 DoRA files once per test session."""
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(repo_id=DORA_ADAPTER_REPO)
+
+
+@pytest.fixture(scope="module")
+def server_with_dora(qwen25_05b_dora_files):
+    lora_module = {
+        "name": DORA_ADAPTER_NAME,
+        "path": qwen25_05b_dora_files,
+        "base_model_name": MODEL_NAME,
+    }
+
+    args = [
+        # use half precision for speed and memory savings in CI environment
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "2048",
+        "--enforce-eager",
+        # lora config below
+        "--enable-lora",
+        "--lora-modules",
+        json.dumps(lora_module),
+        "--max-lora-rank",
+        "16",
+        "--max-loras",
+        "2",
+        "--max-cpu-loras",
+        "2",
+        "--max-num-seqs",
+        "16",
+    ]
+
+    # Enable the /v1/load_lora_adapter endpoint.
+    envs = {"VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True"}
+
+    with RemoteOpenAIServer(MODEL_NAME, args, env_dict=envs) as remote_server:
+        yield remote_server
+
+
+@pytest_asyncio.fixture
+async def client(server_with_dora):
+    async with server_with_dora.get_async_client() as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+async def test_static_dora_lineage_and_completion(
+    client: openai.AsyncOpenAI,
+    qwen25_05b_dora_files,
+):
+    models = await client.models.list()
+    models = models.data
+    served_model = models[0]
+    dora_model = next(model for model in models if model.id == DORA_ADAPTER_NAME)
+    assert served_model.id == MODEL_NAME
+    assert served_model.root == MODEL_NAME
+    assert served_model.parent is None
+    assert dora_model.id == DORA_ADAPTER_NAME
+    assert dora_model.root == qwen25_05b_dora_files
+    assert dora_model.parent == MODEL_NAME
+
+    completion = await client.completions.create(
+        model=DORA_ADAPTER_NAME,
+        prompt="The capital of France is",
+        max_tokens=4,
+    )
+    assert completion.choices
+
+
+@pytest.mark.asyncio
+async def test_dynamic_dora_lineage_and_completion(
+    client: openai.AsyncOpenAI,
+    qwen25_05b_dora_files,
+):
+    response = await client.post(
+        "load_lora_adapter",
+        cast_to=str,
+        body={
+            "lora_name": DYNAMIC_DORA_ADAPTER_NAME,
+            "lora_path": qwen25_05b_dora_files,
+        },
+    )
+    assert "success" in response.lower()
+
+    models = await client.models.list()
+    dynamic_dora_model = next(
+        model for model in models.data if model.id == DYNAMIC_DORA_ADAPTER_NAME
+    )
+    assert dynamic_dora_model.root == qwen25_05b_dora_files
+    assert dynamic_dora_model.parent == MODEL_NAME
+
+    completion = await client.completions.create(
+        model=DYNAMIC_DORA_ADAPTER_NAME,
+        prompt="The capital of France is",
+        max_tokens=4,
+    )
+    assert completion.choices

--- a/tests/entrypoints/serve/lora/test_dora_adapters.py
+++ b/tests/entrypoints/serve/lora/test_dora_adapters.py
@@ -1,17 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
 import json
 
 import openai  # use the official client for correctness check
 import pytest
 import pytest_asyncio
 
+from tests.lora.utils import convert_dora_checkpoint_to_lora
 from tests.utils import RemoteOpenAIServer
 
 MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
 DORA_ADAPTER_NAME = "qwen25-dora"
 DYNAMIC_DORA_ADAPTER_NAME = "qwen25-dora-dynamic"
+LORA_ADAPTER_NAME = "qwen25-lora-from-dora"
 DORA_ADAPTER_REPO = "Dhanushkumaramk/healthcare-qwen2.5-0.5B-dora"
 
 
@@ -21,6 +24,12 @@ def qwen25_05b_dora_files():
     from huggingface_hub import snapshot_download
 
     return snapshot_download(repo_id=DORA_ADAPTER_REPO)
+
+
+@pytest.fixture(scope="module")
+def qwen25_05b_lora_files(tmp_path_factory, qwen25_05b_dora_files):
+    lora_dir = tmp_path_factory.mktemp("qwen25_05b_lora_from_dora")
+    return convert_dora_checkpoint_to_lora(qwen25_05b_dora_files, lora_dir)
 
 
 @pytest.fixture(scope="module")
@@ -45,9 +54,9 @@ def server_with_dora(qwen25_05b_dora_files):
         "--max-lora-rank",
         "16",
         "--max-loras",
-        "2",
+        "4",
         "--max-cpu-loras",
-        "2",
+        "4",
         "--max-num-seqs",
         "16",
     ]
@@ -117,3 +126,41 @@ async def test_dynamic_dora_lineage_and_completion(
         max_tokens=4,
     )
     assert completion.choices
+
+
+@pytest.mark.asyncio
+async def test_concurrent_base_lora_and_dora_requests(
+    client: openai.AsyncOpenAI,
+    qwen25_05b_lora_files,
+):
+    response = await client.post(
+        "load_lora_adapter",
+        cast_to=str,
+        body={
+            "lora_name": LORA_ADAPTER_NAME,
+            "lora_path": qwen25_05b_lora_files,
+            "load_inplace": True,
+        },
+    )
+    assert "success" in response.lower()
+
+    models = await client.models.list()
+    model_ids = {model.id for model in models.data}
+    assert MODEL_NAME in model_ids
+    assert DORA_ADAPTER_NAME in model_ids
+    assert LORA_ADAPTER_NAME in model_ids
+
+    async def complete(model: str):
+        return await client.completions.create(
+            model=model,
+            prompt="The capital of France is",
+            max_tokens=4,
+        )
+
+    completions = await asyncio.gather(
+        complete(MODEL_NAME),
+        complete(LORA_ADAPTER_NAME),
+        complete(DORA_ADAPTER_NAME),
+    )
+    for completion in completions:
+        assert completion.choices

--- a/tests/entrypoints/serve/lora/test_dora_adapters.py
+++ b/tests/entrypoints/serve/lora/test_dora_adapters.py
@@ -3,10 +3,13 @@
 
 import asyncio
 import json
+import shutil
+from contextlib import suppress
 
 import openai  # use the official client for correctness check
 import pytest
 import pytest_asyncio
+from safetensors.torch import load_file, save_file
 
 from tests.lora.utils import convert_dora_checkpoint_to_lora
 from tests.utils import RemoteOpenAIServer
@@ -16,6 +19,33 @@ DORA_ADAPTER_NAME = "qwen25-dora"
 DYNAMIC_DORA_ADAPTER_NAME = "qwen25-dora-dynamic"
 LORA_ADAPTER_NAME = "qwen25-lora-from-dora"
 DORA_ADAPTER_REPO = "Dhanushkumaramk/healthcare-qwen2.5-0.5B-dora"
+COMPLETION_PROMPT = "The capital of France is"
+
+
+async def _complete_text(client: openai.AsyncOpenAI, model: str) -> str:
+    completion = await client.completions.create(
+        model=model,
+        prompt=COMPLETION_PROMPT,
+        max_tokens=4,
+        temperature=0,
+    )
+    assert completion.choices
+    return completion.choices[0].text
+
+
+async def _unload_lora_adapter(client: openai.AsyncOpenAI, lora_name: str) -> None:
+    await client.post(
+        "unload_lora_adapter",
+        cast_to=str,
+        body={"lora_name": lora_name},
+    )
+
+
+async def _unload_lora_adapter_if_exists(
+    client: openai.AsyncOpenAI, lora_name: str
+) -> None:
+    with suppress(openai.NotFoundError):
+        await _unload_lora_adapter(client, lora_name)
 
 
 @pytest.fixture(scope="session")
@@ -92,7 +122,7 @@ async def test_static_dora_lineage_and_completion(
 
     completion = await client.completions.create(
         model=DORA_ADAPTER_NAME,
-        prompt="The capital of France is",
+        prompt=COMPLETION_PROMPT,
         max_tokens=4,
     )
     assert completion.choices
@@ -103,29 +133,30 @@ async def test_dynamic_dora_lineage_and_completion(
     client: openai.AsyncOpenAI,
     qwen25_05b_dora_files,
 ):
-    response = await client.post(
-        "load_lora_adapter",
-        cast_to=str,
-        body={
-            "lora_name": DYNAMIC_DORA_ADAPTER_NAME,
-            "lora_path": qwen25_05b_dora_files,
-        },
-    )
-    assert "success" in response.lower()
+    loaded = False
+    try:
+        response = await client.post(
+            "load_lora_adapter",
+            cast_to=str,
+            body={
+                "lora_name": DYNAMIC_DORA_ADAPTER_NAME,
+                "lora_path": qwen25_05b_dora_files,
+            },
+        )
+        assert "success" in response.lower()
+        loaded = True
 
-    models = await client.models.list()
-    dynamic_dora_model = next(
-        model for model in models.data if model.id == DYNAMIC_DORA_ADAPTER_NAME
-    )
-    assert dynamic_dora_model.root == qwen25_05b_dora_files
-    assert dynamic_dora_model.parent == MODEL_NAME
+        models = await client.models.list()
+        dynamic_dora_model = next(
+            model for model in models.data if model.id == DYNAMIC_DORA_ADAPTER_NAME
+        )
+        assert dynamic_dora_model.root == qwen25_05b_dora_files
+        assert dynamic_dora_model.parent == MODEL_NAME
 
-    completion = await client.completions.create(
-        model=DYNAMIC_DORA_ADAPTER_NAME,
-        prompt="The capital of France is",
-        max_tokens=4,
-    )
-    assert completion.choices
+        await _complete_text(client, DYNAMIC_DORA_ADAPTER_NAME)
+    finally:
+        if loaded:
+            await _unload_lora_adapter(client, DYNAMIC_DORA_ADAPTER_NAME)
 
 
 @pytest.mark.asyncio
@@ -133,34 +164,175 @@ async def test_concurrent_base_lora_and_dora_requests(
     client: openai.AsyncOpenAI,
     qwen25_05b_lora_files,
 ):
-    response = await client.post(
-        "load_lora_adapter",
-        cast_to=str,
-        body={
-            "lora_name": LORA_ADAPTER_NAME,
-            "lora_path": qwen25_05b_lora_files,
-            "load_inplace": True,
-        },
-    )
-    assert "success" in response.lower()
+    loaded = False
+    try:
+        response = await client.post(
+            "load_lora_adapter",
+            cast_to=str,
+            body={
+                "lora_name": LORA_ADAPTER_NAME,
+                "lora_path": qwen25_05b_lora_files,
+                "load_inplace": True,
+            },
+        )
+        assert "success" in response.lower()
+        loaded = True
 
+        models = await client.models.list()
+        model_ids = {model.id for model in models.data}
+        assert MODEL_NAME in model_ids
+        assert DORA_ADAPTER_NAME in model_ids
+        assert LORA_ADAPTER_NAME in model_ids
+
+        async def complete(model: str):
+            return await client.completions.create(
+                model=model,
+                prompt=COMPLETION_PROMPT,
+                max_tokens=4,
+            )
+
+        completions = await asyncio.gather(
+            complete(MODEL_NAME),
+            complete(LORA_ADAPTER_NAME),
+            complete(DORA_ADAPTER_NAME),
+        )
+        for completion in completions:
+            assert completion.choices
+    finally:
+        if loaded:
+            await _unload_lora_adapter(client, LORA_ADAPTER_NAME)
+
+
+@pytest.mark.asyncio
+async def test_dora_unload_reload_and_replace_clears_slot_state(
+    client: openai.AsyncOpenAI,
+    qwen25_05b_dora_files,
+    qwen25_05b_lora_files,
+):
+    adapter_name = "replaceable-dora"
+    clean_adapter_name = "clean-lora-from-dora"
+
+    try:
+        response = await client.post(
+            "load_lora_adapter",
+            cast_to=str,
+            body={"lora_name": adapter_name, "lora_path": qwen25_05b_dora_files},
+        )
+        assert "success" in response.lower()
+        await _complete_text(client, adapter_name)
+
+        response = await client.post(
+            "unload_lora_adapter",
+            cast_to=str,
+            body={"lora_name": adapter_name},
+        )
+        assert "success" in response.lower()
+        models = await client.models.list()
+        assert adapter_name not in {model.id for model in models.data}
+
+        response = await client.post(
+            "load_lora_adapter",
+            cast_to=str,
+            body={"lora_name": adapter_name, "lora_path": qwen25_05b_dora_files},
+        )
+        assert "success" in response.lower()
+        await _complete_text(client, adapter_name)
+
+        response = await client.post(
+            "load_lora_adapter",
+            cast_to=str,
+            body={
+                "lora_name": adapter_name,
+                "lora_path": qwen25_05b_lora_files,
+                "load_inplace": True,
+            },
+        )
+        assert "success" in response.lower()
+        replaced_lora_text = await _complete_text(client, adapter_name)
+
+        response = await client.post(
+            "load_lora_adapter",
+            cast_to=str,
+            body={
+                "lora_name": clean_adapter_name,
+                "lora_path": qwen25_05b_lora_files,
+            },
+        )
+        assert "success" in response.lower()
+        assert replaced_lora_text == await _complete_text(client, clean_adapter_name)
+    finally:
+        for lora_name in (adapter_name, clean_adapter_name):
+            await _unload_lora_adapter_if_exists(client, lora_name)
+
+
+@pytest.mark.asyncio
+async def test_multiple_dora_adapters_concurrently(
+    client: openai.AsyncOpenAI,
+    qwen25_05b_dora_files,
+):
+    async def load_and_run_adapter(adapter_name: str):
+        loaded = False
+        try:
+            response = await client.post(
+                "load_lora_adapter",
+                cast_to=str,
+                body={"lora_name": adapter_name, "lora_path": qwen25_05b_dora_files},
+            )
+            assert "success" in response.lower()
+            loaded = True
+            for _ in range(2):
+                await _complete_text(client, adapter_name)
+        finally:
+            if loaded:
+                await _unload_lora_adapter(client, adapter_name)
+
+    tasks = [
+        asyncio.create_task(load_and_run_adapter(f"dynamic-dora-{i}"))
+        for i in range(3)
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    for result in results:
+        assert not isinstance(result, Exception), f"Got exception {result}"
+
+
+@pytest.mark.asyncio
+async def test_invalid_dora_adapter_does_not_break_loaded_dora(
+    client: openai.AsyncOpenAI,
+    tmp_path,
+    qwen25_05b_dora_files,
+):
+    invalid_files = tmp_path / "invalid_dora_missing_magnitude"
+    shutil.copytree(qwen25_05b_dora_files, invalid_files)
+
+    weights_path = invalid_files / "adapter_model.safetensors"
+    tensors = load_file(weights_path)
+    tensors = {
+        name: tensor
+        for name, tensor in tensors.items()
+        if not name.endswith("lora_magnitude_vector")
+    }
+    save_file(tensors, weights_path)
+
+    for idx in range(3):
+        with pytest.raises(
+            openai.InternalServerError, match="missing lora_magnitude_vector"
+        ):
+            await client.post(
+                "load_lora_adapter",
+                cast_to=str,
+                body={
+                    "lora_name": f"invalid-dora-{idx}",
+                    "lora_path": str(invalid_files),
+                },
+            )
+
+    completion = await client.completions.create(
+        model=DORA_ADAPTER_NAME,
+        prompt=COMPLETION_PROMPT,
+        max_tokens=4,
+    )
+    assert completion.choices
     models = await client.models.list()
     model_ids = {model.id for model in models.data}
-    assert MODEL_NAME in model_ids
-    assert DORA_ADAPTER_NAME in model_ids
-    assert LORA_ADAPTER_NAME in model_ids
-
-    async def complete(model: str):
-        return await client.completions.create(
-            model=model,
-            prompt="The capital of France is",
-            max_tokens=4,
-        )
-
-    completions = await asyncio.gather(
-        complete(MODEL_NAME),
-        complete(LORA_ADAPTER_NAME),
-        complete(DORA_ADAPTER_NAME),
-    )
-    for completion in completions:
-        assert completion.choices
+    for idx in range(3):
+        assert f"invalid-dora-{idx}" not in model_ids

--- a/tests/entrypoints/serve/lora/test_dora_adapters.py
+++ b/tests/entrypoints/serve/lora/test_dora_adapters.py
@@ -34,7 +34,7 @@ def server_with_dora(qwen25_05b_dora_files):
     args = [
         # use half precision for speed and memory savings in CI environment
         "--dtype",
-        "bfloat16",
+        "float16",
         "--max-model-len",
         "2048",
         "--enforce-eager",

--- a/tests/entrypoints/serve/lora/test_dora_adapters.py
+++ b/tests/entrypoints/serve/lora/test_dora_adapters.py
@@ -1,23 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import asyncio
 import json
-import shutil
-from contextlib import suppress
 
 import openai  # use the official client for correctness check
 import pytest
 import pytest_asyncio
-from safetensors.torch import load_file, save_file
 
-from tests.lora.utils import convert_dora_checkpoint_to_lora
 from tests.utils import RemoteOpenAIServer
 
 MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
 DORA_ADAPTER_NAME = "qwen25-dora"
 DYNAMIC_DORA_ADAPTER_NAME = "qwen25-dora-dynamic"
-LORA_ADAPTER_NAME = "qwen25-lora-from-dora"
 DORA_ADAPTER_REPO = "Dhanushkumaramk/healthcare-qwen2.5-0.5B-dora"
 COMPLETION_PROMPT = "The capital of France is"
 
@@ -41,25 +35,12 @@ async def _unload_lora_adapter(client: openai.AsyncOpenAI, lora_name: str) -> No
     )
 
 
-async def _unload_lora_adapter_if_exists(
-    client: openai.AsyncOpenAI, lora_name: str
-) -> None:
-    with suppress(openai.NotFoundError):
-        await _unload_lora_adapter(client, lora_name)
-
-
 @pytest.fixture(scope="session")
 def qwen25_05b_dora_files():
     """Download Qwen2.5 DoRA files once per test session."""
     from huggingface_hub import snapshot_download
 
     return snapshot_download(repo_id=DORA_ADAPTER_REPO)
-
-
-@pytest.fixture(scope="module")
-def qwen25_05b_lora_files(tmp_path_factory, qwen25_05b_dora_files):
-    lora_dir = tmp_path_factory.mktemp("qwen25_05b_lora_from_dora")
-    return convert_dora_checkpoint_to_lora(qwen25_05b_dora_files, lora_dir)
 
 
 @pytest.fixture(scope="module")
@@ -129,17 +110,18 @@ async def test_static_dora_lineage_and_completion(
 
 
 @pytest.mark.asyncio
-async def test_dynamic_dora_lineage_and_completion(
+async def test_dynamic_dora_load_unload_reload_and_lineage(
     client: openai.AsyncOpenAI,
     qwen25_05b_dora_files,
 ):
+    adapter_name = DYNAMIC_DORA_ADAPTER_NAME
     loaded = False
     try:
         response = await client.post(
             "load_lora_adapter",
             cast_to=str,
             body={
-                "lora_name": DYNAMIC_DORA_ADAPTER_NAME,
+                "lora_name": adapter_name,
                 "lora_path": qwen25_05b_dora_files,
             },
         )
@@ -148,77 +130,11 @@ async def test_dynamic_dora_lineage_and_completion(
 
         models = await client.models.list()
         dynamic_dora_model = next(
-            model for model in models.data if model.id == DYNAMIC_DORA_ADAPTER_NAME
+            model for model in models.data if model.id == adapter_name
         )
         assert dynamic_dora_model.root == qwen25_05b_dora_files
         assert dynamic_dora_model.parent == MODEL_NAME
 
-        await _complete_text(client, DYNAMIC_DORA_ADAPTER_NAME)
-    finally:
-        if loaded:
-            await _unload_lora_adapter(client, DYNAMIC_DORA_ADAPTER_NAME)
-
-
-@pytest.mark.asyncio
-async def test_concurrent_base_lora_and_dora_requests(
-    client: openai.AsyncOpenAI,
-    qwen25_05b_lora_files,
-):
-    loaded = False
-    try:
-        response = await client.post(
-            "load_lora_adapter",
-            cast_to=str,
-            body={
-                "lora_name": LORA_ADAPTER_NAME,
-                "lora_path": qwen25_05b_lora_files,
-                "load_inplace": True,
-            },
-        )
-        assert "success" in response.lower()
-        loaded = True
-
-        models = await client.models.list()
-        model_ids = {model.id for model in models.data}
-        assert MODEL_NAME in model_ids
-        assert DORA_ADAPTER_NAME in model_ids
-        assert LORA_ADAPTER_NAME in model_ids
-
-        async def complete(model: str):
-            return await client.completions.create(
-                model=model,
-                prompt=COMPLETION_PROMPT,
-                max_tokens=4,
-            )
-
-        completions = await asyncio.gather(
-            complete(MODEL_NAME),
-            complete(LORA_ADAPTER_NAME),
-            complete(DORA_ADAPTER_NAME),
-        )
-        for completion in completions:
-            assert completion.choices
-    finally:
-        if loaded:
-            await _unload_lora_adapter(client, LORA_ADAPTER_NAME)
-
-
-@pytest.mark.asyncio
-async def test_dora_unload_reload_and_replace_clears_slot_state(
-    client: openai.AsyncOpenAI,
-    qwen25_05b_dora_files,
-    qwen25_05b_lora_files,
-):
-    adapter_name = "replaceable-dora"
-    clean_adapter_name = "clean-lora-from-dora"
-
-    try:
-        response = await client.post(
-            "load_lora_adapter",
-            cast_to=str,
-            body={"lora_name": adapter_name, "lora_path": qwen25_05b_dora_files},
-        )
-        assert "success" in response.lower()
         await _complete_text(client, adapter_name)
 
         response = await client.post(
@@ -227,6 +143,8 @@ async def test_dora_unload_reload_and_replace_clears_slot_state(
             body={"lora_name": adapter_name},
         )
         assert "success" in response.lower()
+        loaded = False
+
         models = await client.models.list()
         assert adapter_name not in {model.id for model in models.data}
 
@@ -236,103 +154,8 @@ async def test_dora_unload_reload_and_replace_clears_slot_state(
             body={"lora_name": adapter_name, "lora_path": qwen25_05b_dora_files},
         )
         assert "success" in response.lower()
+        loaded = True
         await _complete_text(client, adapter_name)
-
-        response = await client.post(
-            "load_lora_adapter",
-            cast_to=str,
-            body={
-                "lora_name": adapter_name,
-                "lora_path": qwen25_05b_lora_files,
-                "load_inplace": True,
-            },
-        )
-        assert "success" in response.lower()
-        replaced_lora_text = await _complete_text(client, adapter_name)
-
-        response = await client.post(
-            "load_lora_adapter",
-            cast_to=str,
-            body={
-                "lora_name": clean_adapter_name,
-                "lora_path": qwen25_05b_lora_files,
-            },
-        )
-        assert "success" in response.lower()
-        assert replaced_lora_text == await _complete_text(client, clean_adapter_name)
     finally:
-        for lora_name in (adapter_name, clean_adapter_name):
-            await _unload_lora_adapter_if_exists(client, lora_name)
-
-
-@pytest.mark.asyncio
-async def test_multiple_dora_adapters_concurrently(
-    client: openai.AsyncOpenAI,
-    qwen25_05b_dora_files,
-):
-    async def load_and_run_adapter(adapter_name: str):
-        loaded = False
-        try:
-            response = await client.post(
-                "load_lora_adapter",
-                cast_to=str,
-                body={"lora_name": adapter_name, "lora_path": qwen25_05b_dora_files},
-            )
-            assert "success" in response.lower()
-            loaded = True
-            for _ in range(2):
-                await _complete_text(client, adapter_name)
-        finally:
-            if loaded:
-                await _unload_lora_adapter(client, adapter_name)
-
-    tasks = [
-        asyncio.create_task(load_and_run_adapter(f"dynamic-dora-{i}"))
-        for i in range(3)
-    ]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    for result in results:
-        assert not isinstance(result, Exception), f"Got exception {result}"
-
-
-@pytest.mark.asyncio
-async def test_invalid_dora_adapter_does_not_break_loaded_dora(
-    client: openai.AsyncOpenAI,
-    tmp_path,
-    qwen25_05b_dora_files,
-):
-    invalid_files = tmp_path / "invalid_dora_missing_magnitude"
-    shutil.copytree(qwen25_05b_dora_files, invalid_files)
-
-    weights_path = invalid_files / "adapter_model.safetensors"
-    tensors = load_file(weights_path)
-    tensors = {
-        name: tensor
-        for name, tensor in tensors.items()
-        if not name.endswith("lora_magnitude_vector")
-    }
-    save_file(tensors, weights_path)
-
-    for idx in range(3):
-        with pytest.raises(
-            openai.InternalServerError, match="missing lora_magnitude_vector"
-        ):
-            await client.post(
-                "load_lora_adapter",
-                cast_to=str,
-                body={
-                    "lora_name": f"invalid-dora-{idx}",
-                    "lora_path": str(invalid_files),
-                },
-            )
-
-    completion = await client.completions.create(
-        model=DORA_ADAPTER_NAME,
-        prompt=COMPLETION_PROMPT,
-        max_tokens=4,
-    )
-    assert completion.choices
-    models = await client.models.list()
-    model_ids = {model.id for model in models.data}
-    for idx in range(3):
-        assert f"invalid-dora-{idx}" not in model_ids
+        if loaded:
+            await _unload_lora_adapter(client, adapter_name)

--- a/tests/entrypoints/serve/lora/test_lora_adapters.py
+++ b/tests/entrypoints/serve/lora/test_lora_adapters.py
@@ -22,7 +22,7 @@ BADREQUEST_CASES = [
         {"r": 1024},
         "is greater than max_lora_rank",
     ),
-    ("test_dora", {"use_dora": True}, "does not yet support DoRA"),
+    ("test_dora", {"use_dora": True}, "DoRA adapter loading is not implemented yet"),
     (
         "test_modules_to_save",
         {"modules_to_save": ["lm_head"]},

--- a/tests/entrypoints/serve/lora/test_lora_adapters.py
+++ b/tests/entrypoints/serve/lora/test_lora_adapters.py
@@ -22,7 +22,11 @@ BADREQUEST_CASES = [
         {"r": 1024},
         "is greater than max_lora_rank",
     ),
-    ("test_dora", {"use_dora": True}, "DoRA adapter loading is not implemented yet"),
+    (
+        "test_dora",
+        {"use_dora": True},
+        "DoRA adapter is missing lora_magnitude_vector",
+    ),
     (
         "test_modules_to_save",
         {"modules_to_save": ["lm_head"]},

--- a/tests/entrypoints/serve/lora/test_serving_models.py
+++ b/tests/entrypoints/serve/lora/test_serving_models.py
@@ -114,6 +114,42 @@ async def test_unload_lora_adapter_success():
     response = await serving_models.unload_lora_adapter(request)
     assert response == LORA_UNLOADING_SUCCESS_MESSAGE.format(lora_name="adapter1")
     assert len(serving_models.lora_requests) == 0
+    serving_models.engine_client.remove_lora.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_unload_lora_adapter_removes_frontend_entry_if_backend_evicted():
+    serving_models = await _async_serving_models_init()
+    request = LoadLoRAAdapterRequest(
+        lora_name="adapter1", lora_path="/path/to/adapter1"
+    )
+    response = await serving_models.load_lora_adapter(request)
+    assert response == LORA_LOADING_SUCCESS_MESSAGE.format(lora_name="adapter1")
+    serving_models.engine_client.remove_lora.return_value = False
+
+    request = UnloadLoRAAdapterRequest(lora_name="adapter1")
+    response = await serving_models.unload_lora_adapter(request)
+    assert response == LORA_UNLOADING_SUCCESS_MESSAGE.format(lora_name="adapter1")
+    assert len(serving_models.lora_requests) == 0
+    serving_models.engine_client.remove_lora.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_unload_lora_adapter_keeps_frontend_entry_on_backend_error():
+    serving_models = await _async_serving_models_init()
+    request = LoadLoRAAdapterRequest(
+        lora_name="adapter1", lora_path="/path/to/adapter1"
+    )
+    response = await serving_models.load_lora_adapter(request)
+    assert response == LORA_LOADING_SUCCESS_MESSAGE.format(lora_name="adapter1")
+    serving_models.engine_client.remove_lora.side_effect = RuntimeError("boom")
+
+    request = UnloadLoRAAdapterRequest(lora_name="adapter1")
+    response = await serving_models.unload_lora_adapter(request)
+    assert isinstance(response, ErrorResponse)
+    assert response.error.type == "InternalServerError"
+    assert len(serving_models.lora_requests) == 1
+    serving_models.engine_client.remove_lora.assert_called_once_with(1)
 
 
 @pytest.mark.asyncio

--- a/tests/lora/conftest.py
+++ b/tests/lora/conftest.py
@@ -299,11 +299,6 @@ def llama32_lora_files(llama32_lora_huggingface_id):
 
 
 @pytest.fixture(scope="session")
-def qwen25_05b_dora_files():
-    return snapshot_download(repo_id="Dhanushkumaramk/healthcare-qwen2.5-0.5B-dora")
-
-
-@pytest.fixture(scope="session")
 def whisper_lora_files():
     return snapshot_download(repo_id="chengyili2005/whisper-small-mandarin-lora")
 

--- a/tests/lora/conftest.py
+++ b/tests/lora/conftest.py
@@ -299,6 +299,11 @@ def llama32_lora_files(llama32_lora_huggingface_id):
 
 
 @pytest.fixture(scope="session")
+def qwen25_05b_dora_files():
+    return snapshot_download(repo_id="Dhanushkumaramk/healthcare-qwen2.5-0.5B-dora")
+
+
+@pytest.fixture(scope="session")
 def whisper_lora_files():
     return snapshot_download(repo_id="chengyili2005/whisper-small-mandarin-lora")
 

--- a/tests/lora/test_dora_mixed_batch.py
+++ b/tests/lora/test_dora_mixed_batch.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from tests.lora.utils import convert_dora_checkpoint_to_lora
+from vllm import LLM, SamplingParams
+from vllm.lora.request import LoRARequest
+from vllm.platforms import current_platform
+
+MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
+DORA_ADAPTER_NAME = "qwen25-dora"
+LORA_ADAPTER_NAME = "qwen25-lora-from-dora"
+
+
+@pytest.fixture(scope="module")
+def qwen25_05b_lora_files(tmp_path_factory, qwen25_05b_dora_files):
+    lora_dir = tmp_path_factory.mktemp("qwen25_05b_lora_from_dora")
+    return convert_dora_checkpoint_to_lora(qwen25_05b_dora_files, lora_dir)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="DoRA forward support is CUDA-only.",
+)
+def test_mixed_batch_base_lora_and_dora_requests(
+    qwen25_05b_dora_files,
+    qwen25_05b_lora_files,
+):
+    llm = LLM(
+        model=MODEL_NAME,
+        dtype="float16",
+        max_model_len=2048,
+        enable_lora=True,
+        max_lora_rank=16,
+        max_loras=2,
+        max_cpu_loras=2,
+        max_num_seqs=8,
+        gpu_memory_utilization=0.4,
+        enforce_eager=True,
+    )
+    prompts = [
+        "The capital of France is",
+        "A doctor can help with",
+        "The capital of France is",
+    ]
+    lora_requests = [
+        None,
+        LoRARequest(LORA_ADAPTER_NAME, 1, qwen25_05b_lora_files),
+        LoRARequest(DORA_ADAPTER_NAME, 2, qwen25_05b_dora_files),
+    ]
+
+    outputs = llm.generate(
+        prompts,
+        SamplingParams(temperature=0, max_tokens=4),
+        lora_request=lora_requests,
+        use_tqdm=False,
+    )
+
+    assert [output.lora_request for output in outputs] == lora_requests
+    assert all(output.outputs for output in outputs)

--- a/tests/lora/test_dora_mixed_batch.py
+++ b/tests/lora/test_dora_mixed_batch.py
@@ -3,7 +3,6 @@
 
 import pytest
 
-from tests.lora.utils import convert_dora_checkpoint_to_lora
 from vllm import LLM, SamplingParams
 from vllm.lora.request import LoRARequest
 from vllm.platforms import current_platform
@@ -11,12 +10,6 @@ from vllm.platforms import current_platform
 MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
 DORA_ADAPTER_NAME = "qwen25-dora"
 LORA_ADAPTER_NAME = "qwen25-lora-from-dora"
-
-
-@pytest.fixture(scope="module")
-def qwen25_05b_lora_files(tmp_path_factory, qwen25_05b_dora_files):
-    lora_dir = tmp_path_factory.mktemp("qwen25_05b_lora_from_dora")
-    return convert_dora_checkpoint_to_lora(qwen25_05b_dora_files, lora_dir)
 
 
 @pytest.mark.skipif(

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -1072,7 +1072,8 @@ def test_row_parallel_dora_forward_tp2(
     lora_linear = RowParallelLinearWithLoRA(linear)
     lora_linear.create_lora_weights(max_loras, lora_config)
     lora_linear.set_mapping(punica_wrapper)
-    x_local = x[:, start:stop]
+    x_local = x[:, start:stop].contiguous()
+
     local_dora_weight = dora_magnitude.float().unsqueeze(1)
     local_dora_weight = local_dora_weight * (
         base_weight[:, start:stop].float()
@@ -1082,12 +1083,18 @@ def test_row_parallel_dora_forward_tp2(
     expected_local = x_local.float() @ base_weight[:, start:stop].float().T
     expected_local[dora_rows] = x_local[dora_rows].float() @ local_dora_weight.T
 
+    norm_reduce_called = False
+    output_reduce_called = False
+
     def fake_all_reduce(tensor: torch.Tensor) -> torch.Tensor:
+        nonlocal norm_reduce_called, output_reduce_called
         if tensor.ndim == 1:
+            norm_reduce_called = True
             torch.testing.assert_close(
                 tensor, local_norm_sq[tp_rank], rtol=1e-3, atol=1e-3
             )
             return global_norm_sq.to(device=tensor.device, dtype=tensor.dtype)
+        output_reduce_called = True
         torch.testing.assert_close(
             tensor,
             expected_local.to(dtype=tensor.dtype),
@@ -1108,6 +1115,8 @@ def test_row_parallel_dora_forward_tp2(
         )
         actual = lora_linear(x_local)[0]
 
+    assert norm_reduce_called
+    assert output_reduce_called
     rtol, atol = TOLERANCES[actual.dtype]
     torch.testing.assert_close(
         actual, expected.to(dtype=actual.dtype), rtol=rtol, atol=atol

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -641,30 +641,30 @@ def test_linear_dora_scale_stacked(default_vllm_config, dist_init, device) -> No
     lora_linear = ReplicatedLinearWithLoRA(linear)
     lora_linear.create_lora_weights(max_loras, lora_config)
 
-    lora_a = torch.tensor(
+    dora_lora_a = torch.tensor(
         [[0.5, 0.25, -0.5, 1.0], [1.5, -0.25, 0.75, -1.0]],
         dtype=dtype,
         device=device,
     )
-    lora_b = torch.tensor(
+    dora_lora_b = torch.tensor(
         [[0.25, -0.5], [1.0, 0.5], [-0.75, 1.25]],
         dtype=dtype,
         device=device,
     )
-    magnitude = torch.tensor([2.0, 3.0, 4.0], dtype=dtype, device=device)
+    dora_magnitude = torch.tensor([2.0, 3.0, 4.0], dtype=dtype, device=device)
 
     lora_linear.set_lora(
         1,
-        lora_a=lora_a,
-        lora_b=lora_b,
-        lora_magnitude_vector=magnitude,
+        lora_a=dora_lora_a,
+        lora_b=dora_lora_b,
+        lora_magnitude_vector=dora_magnitude,
     )
 
-    expected_delta = lora_b.float() @ lora_a.float()
+    expected_delta = dora_lora_b.float() @ dora_lora_a.float()
     expected_norm = torch.linalg.vector_norm(
         linear.weight.float() + expected_delta, dim=1
     )
-    expected_scale = magnitude.float() / expected_norm
+    expected_scale = dora_magnitude.float() / expected_norm
 
     assert lora_linear.dora_enabled_stacked[1]
     torch.testing.assert_close(
@@ -679,6 +679,115 @@ def test_linear_dora_scale_stacked(default_vllm_config, dist_init, device) -> No
     torch.testing.assert_close(
         lora_linear.dora_scale_stacked[1],
         torch.ones_like(lora_linear.dora_scale_stacked[1]),
+    )
+
+
+@torch.inference_mode()
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Phase 1 DoRA forward support is CUDA-only.",
+)
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("stage", STAGES)
+def test_linear_dora_forward(default_vllm_config, dist_init, device, stage) -> None:
+    torch.accelerator.set_device_index(device)
+    torch.set_default_device(device)
+    dtype = torch.float16
+    max_loras = 3
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=8,
+        lora_dtype=dtype,
+    )
+    punica_wrapper = get_punica_wrapper(16, 4, device, lora_config=lora_config)
+
+    linear = ReplicatedLinear(4, 3, bias=False, params_dtype=dtype)
+    linear.weight.data = torch.tensor(
+        [
+            [0.5, -0.25, 0.75, 1.0],
+            [-1.0, 0.5, 0.25, -0.75],
+            [0.25, 1.25, -0.5, 0.5],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    lora_linear = ReplicatedLinearWithLoRA(linear)
+    lora_linear.create_lora_weights(max_loras, lora_config)
+    lora_linear.set_mapping(punica_wrapper)
+
+    dora_lora_a = torch.tensor(
+        [[0.5, 0.25, -0.5, 1.0], [1.5, -0.25, 0.75, -1.0]],
+        dtype=dtype,
+        device=device,
+    )
+    dora_lora_b = torch.tensor(
+        [[0.25, -0.5], [1.0, 0.5], [-0.75, 1.25]],
+        dtype=dtype,
+        device=device,
+    )
+    dora_magnitude = torch.tensor([2.0, 3.0, 4.0], dtype=dtype, device=device)
+    standard_lora_a = torch.tensor(
+        [[-0.25, 0.75, 1.0, 0.5], [0.5, -1.0, 0.25, -0.75]],
+        dtype=dtype,
+        device=device,
+    )
+    standard_lora_b = torch.tensor(
+        [[0.5, 0.25], [-0.5, 1.0], [1.25, -0.25]],
+        dtype=dtype,
+        device=device,
+    )
+
+    id_to_index = [None, 1, 2]
+    dora_slot = 1
+    standard_slot = 2
+    lora_linear.set_lora(
+        dora_slot,
+        lora_a=dora_lora_a,
+        lora_b=dora_lora_b,
+        lora_magnitude_vector=dora_magnitude,
+    )
+    lora_linear.set_lora(
+        standard_slot,
+        lora_a=standard_lora_a,
+        lora_b=standard_lora_b,
+    )
+
+    x = torch.tensor(
+        [
+            [0.5, -1.0, 0.25, 1.5],
+            [-0.25, 0.75, 1.25, -0.5],
+            [0.75, -0.5, 1.5, 0.25],
+            [1.0, 0.5, -0.75, 0.25],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    token_lora_ids = [1, 2, 0, 1]
+    lora_mapping = LoRAMapping(
+        token_lora_ids,
+        token_lora_ids,
+        is_prefill=stage,
+    )
+    punica_wrapper.update_metadata(lora_mapping, id_to_index, max_loras, 512)
+
+    actual = lora_linear(x)[0]
+
+    delta_weight = dora_lora_b.float() @ dora_lora_a.float()
+    merged_weight = linear.weight.float() + delta_weight
+    weight_norm = torch.linalg.vector_norm(merged_weight, dim=1, keepdim=True)
+    dora_weight = dora_magnitude.float().unsqueeze(1) * merged_weight / weight_norm
+    expected = x.float() @ linear.weight.float().T
+    standard_rows = torch.tensor([False, True, False, False], device=device)
+    standard_delta = x[standard_rows].float() @ standard_lora_a.float().T
+    expected[standard_rows] = (
+        expected[standard_rows] + standard_delta @ standard_lora_b.float().T
+    )
+    dora_rows = torch.tensor([True, False, False, True], device=device)
+    expected[dora_rows] = x[dora_rows].float() @ dora_weight.T
+
+    rtol, atol = TOLERANCES[actual.dtype]
+    torch.testing.assert_close(
+        actual, expected.to(dtype=actual.dtype), rtol=rtol, atol=atol
     )
 
 

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -756,7 +756,7 @@ def test_packed_qkv_dora_scale_stacked(
     max_loras = 2
     lora_config = LoRAConfig(
         max_loras=max_loras,
-        max_lora_rank=4,
+        max_lora_rank=8,
         lora_dtype=dtype,
     )
     base_weight, lora_a, lora_b, dora_magnitude = _create_test_qkv_dora_tensors(
@@ -856,7 +856,7 @@ def test_packed_qkv_dora_forward(
     max_loras = 3
     lora_config = LoRAConfig(
         max_loras=max_loras,
-        max_lora_rank=4,
+        max_lora_rank=8,
         lora_dtype=dtype,
     )
     punica_wrapper = get_punica_wrapper(16, 4, device, lora_config=lora_config)

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -682,6 +682,296 @@ def test_linear_dora_scale_stacked(default_vllm_config, dist_init, device) -> No
     )
 
 
+def _create_test_qkv_dora_tensors(
+    dtype: torch.dtype,
+    device: torch.types.Device,
+) -> tuple[
+    torch.Tensor,
+    list[torch.Tensor],
+    list[torch.Tensor],
+    list[torch.Tensor],
+]:
+    base_weight = torch.tensor(
+        [
+            [0.5, -0.25, 0.75, 1.0],
+            [-1.0, 0.5, 0.25, -0.75],
+            [0.25, 1.25, -0.5, 0.5],
+            [1.0, -1.5, 0.5, 0.25],
+            [-0.5, 0.75, 1.25, -1.0],
+            [1.5, 0.25, -0.75, 0.5],
+            [0.75, -1.25, 1.0, -0.5],
+            [-1.0, -0.5, 0.25, 1.25],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    lora_a = [
+        torch.tensor(
+            [[0.5, 0.25, -0.5, 1.0], [1.5, -0.25, 0.75, -1.0]],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor(
+            [[-0.25, 0.75, 1.0, 0.5], [0.5, -1.0, 0.25, -0.75]],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor(
+            [[1.0, -0.5, 0.25, 0.75], [-0.75, 0.5, 1.25, -0.25]],
+            dtype=dtype,
+            device=device,
+        ),
+    ]
+    lora_b = [
+        torch.tensor(
+            [[0.25, -0.5], [1.0, 0.5], [-0.75, 1.25], [0.5, -1.0]],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor([[0.75, -0.25], [-1.0, 0.5]], dtype=dtype, device=device),
+        torch.tensor([[1.25, 0.5], [-0.5, -0.75]], dtype=dtype, device=device),
+    ]
+    dora_magnitude = [
+        torch.tensor([2.0, 3.0, 4.0, 5.0], dtype=dtype, device=device),
+        torch.tensor([1.5, 2.5], dtype=dtype, device=device),
+        torch.tensor([3.5, 4.5], dtype=dtype, device=device),
+    ]
+    return base_weight, lora_a, lora_b, dora_magnitude
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("device", DEVICES)
+def test_packed_qkv_dora_scale_stacked(
+    default_vllm_config, dist_init, device
+) -> None:
+    if current_platform.is_cuda_alike() or current_platform.is_xpu():
+        torch.accelerator.set_device_index(device)
+
+    torch.set_default_device(device)
+    dtype = (
+        torch.float16
+        if current_platform.is_cuda_alike() or current_platform.is_xpu()
+        else torch.float32
+    )
+    max_loras = 2
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=4,
+        lora_dtype=dtype,
+    )
+    base_weight, lora_a, lora_b, dora_magnitude = _create_test_qkv_dora_tensors(
+        dtype, device
+    )
+
+    linear = QKVParallelLinear(
+        4,
+        2,
+        2,
+        total_num_kv_heads=1,
+        bias=False,
+        params_dtype=dtype,
+        prefix="dora_qkv",
+    )
+    linear.weight.data.copy_(base_weight)
+    lora_linear = MergedQKVParallelLinearWithLoRA(linear)
+    lora_linear.create_lora_weights(max_loras, lora_config)
+
+    lora_linear.set_lora(
+        1,
+        lora_a=lora_a,
+        lora_b=lora_b,
+        lora_magnitude_vector=dora_magnitude,
+    )
+
+    expected_scales = []
+    offset = 0
+    for lora_a_i, lora_b_i, magnitude_i in zip(lora_a, lora_b, dora_magnitude):
+        output_size = lora_b_i.shape[0]
+        delta_weight = lora_b_i.float() @ lora_a_i.float()
+        merged_weight = base_weight[offset : offset + output_size].float()
+        merged_weight = merged_weight + delta_weight
+        expected_norm = torch.linalg.vector_norm(merged_weight, dim=1)
+        expected_scales.append(magnitude_i.float() / expected_norm)
+        offset += output_size
+    expected_scale = torch.cat(expected_scales)
+
+    assert lora_linear.dora_enabled_stacked[1]
+    torch.testing.assert_close(
+        lora_linear.dora_scale_stacked[1].float(),
+        expected_scale,
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+    partial_lora_a = [None, lora_a[1], None]
+    partial_lora_b = [None, lora_b[1], None]
+    partial_dora_magnitude = [None, dora_magnitude[1], None]
+    lora_linear.set_lora(
+        0,
+        lora_a=partial_lora_a,
+        lora_b=partial_lora_b,
+        lora_magnitude_vector=partial_dora_magnitude,
+    )
+    expected_partial_scale = torch.ones_like(lora_linear.dora_scale_stacked[0]).float()
+    partial_offset = lora_b[0].shape[0]
+    partial_delta = lora_b[1].float() @ lora_a[1].float()
+    partial_merged = base_weight[
+        partial_offset : partial_offset + lora_b[1].shape[0]
+    ].float()
+    partial_merged = partial_merged + partial_delta
+    partial_norm = torch.linalg.vector_norm(partial_merged, dim=1)
+    expected_partial_scale[
+        partial_offset : partial_offset + lora_b[1].shape[0]
+    ] = dora_magnitude[1].float() / partial_norm
+    assert lora_linear.dora_enabled_stacked[0]
+    torch.testing.assert_close(
+        lora_linear.dora_scale_stacked[0].float(),
+        expected_partial_scale,
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+    lora_linear.reset_lora(1)
+    assert not lora_linear.dora_enabled_stacked[1]
+    torch.testing.assert_close(
+        lora_linear.dora_scale_stacked[1],
+        torch.ones_like(lora_linear.dora_scale_stacked[1]),
+    )
+
+
+@torch.inference_mode()
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="DoRA forward support is CUDA-only.",
+)
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("stage", STAGES)
+def test_packed_qkv_dora_forward(
+    default_vllm_config, dist_init, device, stage
+) -> None:
+    torch.accelerator.set_device_index(device)
+    torch.set_default_device(device)
+    dtype = torch.float16
+    max_loras = 3
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=4,
+        lora_dtype=dtype,
+    )
+    punica_wrapper = get_punica_wrapper(16, 4, device, lora_config=lora_config)
+    base_weight, lora_a, lora_b, dora_magnitude = _create_test_qkv_dora_tensors(
+        dtype, device
+    )
+
+    linear = QKVParallelLinear(
+        4,
+        2,
+        2,
+        total_num_kv_heads=1,
+        bias=False,
+        params_dtype=dtype,
+        prefix="dora_qkv_forward",
+    )
+    linear.weight.data.copy_(base_weight)
+    lora_linear = MergedQKVParallelLinearWithLoRA(linear)
+    lora_linear.create_lora_weights(max_loras, lora_config)
+    lora_linear.set_mapping(punica_wrapper)
+
+    standard_lora_a = [
+        torch.tensor(
+            [[-0.25, 0.75, 1.0, 0.5], [0.5, -1.0, 0.25, -0.75]],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor(
+            [[0.5, 0.25, -0.5, 1.0], [1.5, -0.25, 0.75, -1.0]],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor(
+            [[1.0, -0.5, 0.25, 0.75], [-0.75, 0.5, 1.25, -0.25]],
+            dtype=dtype,
+            device=device,
+        ),
+    ]
+    standard_lora_b = [
+        torch.tensor(
+            [[0.5, 0.25], [-0.5, 1.0], [1.25, -0.25], [0.75, 0.5]],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor([[0.25, -0.5], [1.0, 0.5]], dtype=dtype, device=device),
+        torch.tensor([[-0.75, 1.25], [0.5, -1.0]], dtype=dtype, device=device),
+    ]
+
+    dora_slot = 1
+    standard_slot = 2
+    lora_linear.set_lora(
+        dora_slot,
+        lora_a=lora_a,
+        lora_b=lora_b,
+        lora_magnitude_vector=dora_magnitude,
+    )
+    lora_linear.set_lora(
+        standard_slot,
+        lora_a=standard_lora_a,
+        lora_b=standard_lora_b,
+    )
+
+    x = torch.tensor(
+        [
+            [0.5, -1.0, 0.25, 1.5],
+            [-0.25, 0.75, 1.25, -0.5],
+            [0.75, -0.5, 1.5, 0.25],
+            [1.0, 0.5, -0.75, 0.25],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    token_lora_ids = [1, 2, 0, 1]
+    lora_mapping = LoRAMapping(
+        token_lora_ids,
+        token_lora_ids,
+        is_prefill=stage,
+    )
+    punica_wrapper.update_metadata(lora_mapping, [None, 1, 2], max_loras, 512)
+
+    actual = lora_linear(x)[0]
+
+    expected = x.float() @ base_weight.float().T
+    dora_weight_slices = []
+    offset = 0
+    for lora_a_i, lora_b_i, magnitude_i in zip(lora_a, lora_b, dora_magnitude):
+        output_size = lora_b_i.shape[0]
+        delta_weight = lora_b_i.float() @ lora_a_i.float()
+        merged_weight = base_weight[offset : offset + output_size].float()
+        merged_weight = merged_weight + delta_weight
+        weight_norm = torch.linalg.vector_norm(merged_weight, dim=1, keepdim=True)
+        dora_weight_slices.append(
+            magnitude_i.float().unsqueeze(1) * merged_weight / weight_norm
+        )
+        offset += output_size
+    dora_weight = torch.cat(dora_weight_slices, dim=0)
+    dora_rows = torch.tensor([True, False, False, True], device=device)
+    expected[dora_rows] = x[dora_rows].float() @ dora_weight.T
+
+    standard_rows = torch.tensor([False, True, False, False], device=device)
+    standard_offset = 0
+    for lora_a_i, lora_b_i in zip(standard_lora_a, standard_lora_b):
+        output_size = lora_b_i.shape[0]
+        standard_delta = x[standard_rows].float() @ lora_a_i.float().T
+        expected[
+            standard_rows,
+            standard_offset : standard_offset + output_size,
+        ] += standard_delta @ lora_b_i.float().T
+        standard_offset += output_size
+
+    rtol, atol = TOLERANCES[actual.dtype]
+    torch.testing.assert_close(
+        actual, expected.to(dtype=actual.dtype), rtol=rtol, atol=atol
+    )
+
+
 @torch.inference_mode()
 @pytest.mark.skipif(
     not current_platform.is_cuda_alike(),

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -846,8 +846,9 @@ def test_packed_qkv_dora_scale_stacked(
 )
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("stage", STAGES)
+@pytest.mark.parametrize("bias", [False, True])
 def test_packed_qkv_dora_forward(
-    default_vllm_config, dist_init, device, stage
+    default_vllm_config, dist_init, device, stage, bias
 ) -> None:
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
@@ -868,11 +869,19 @@ def test_packed_qkv_dora_forward(
         2,
         2,
         total_num_kv_heads=1,
-        bias=False,
+        bias=bias,
         params_dtype=dtype,
         prefix="dora_qkv_forward",
     )
     linear.weight.data.copy_(base_weight)
+    if bias:
+        linear.bias.data.copy_(
+            torch.tensor(
+                [0.25, -0.5, 0.75, -1.0, 0.5, -0.25, 1.25, -0.75],
+                dtype=dtype,
+                device=device,
+            )
+        )
     lora_linear = MergedQKVParallelLinearWithLoRA(linear)
     lora_linear.create_lora_weights(max_loras, lora_config)
     lora_linear.set_mapping(punica_wrapper)
@@ -965,6 +974,8 @@ def test_packed_qkv_dora_forward(
             standard_offset : standard_offset + output_size,
         ] += standard_delta @ lora_b_i.float().T
         standard_offset += output_size
+    if bias:
+        expected += linear.bias.float()
 
     rtol, atol = TOLERANCES[actual.dtype]
     torch.testing.assert_close(
@@ -979,7 +990,10 @@ def test_packed_qkv_dora_forward(
 )
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("stage", STAGES)
-def test_linear_dora_forward(default_vllm_config, dist_init, device, stage) -> None:
+@pytest.mark.parametrize("bias", [False, True])
+def test_linear_dora_forward(
+    default_vllm_config, dist_init, device, stage, bias
+) -> None:
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
     dtype = torch.float16
@@ -991,7 +1005,7 @@ def test_linear_dora_forward(default_vllm_config, dist_init, device, stage) -> N
     )
     punica_wrapper = get_punica_wrapper(16, 4, device, lora_config=lora_config)
 
-    linear = ReplicatedLinear(4, 3, bias=False, params_dtype=dtype)
+    linear = ReplicatedLinear(4, 3, bias=bias, params_dtype=dtype)
     linear.weight.data = torch.tensor(
         [
             [0.5, -0.25, 0.75, 1.0],
@@ -1001,6 +1015,10 @@ def test_linear_dora_forward(default_vllm_config, dist_init, device, stage) -> N
         dtype=dtype,
         device=device,
     )
+    if bias:
+        linear.bias.data.copy_(
+            torch.tensor([0.25, -0.5, 0.75], dtype=dtype, device=device)
+        )
     lora_linear = ReplicatedLinearWithLoRA(linear)
     lora_linear.create_lora_weights(max_loras, lora_config)
     lora_linear.set_mapping(punica_wrapper)
@@ -1074,6 +1092,8 @@ def test_linear_dora_forward(default_vllm_config, dist_init, device, stage) -> N
     )
     dora_rows = torch.tensor([True, False, False, True], device=device)
     expected[dora_rows] = x[dora_rows].float() @ dora_weight.T
+    if bias:
+        expected += linear.bias.float()
 
     rtol, atol = TOLERANCES[actual.dtype]
     torch.testing.assert_close(

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -632,7 +632,7 @@ def test_linear_dora_scale_stacked(default_vllm_config, dist_init, device) -> No
     max_loras = 2
     lora_config = LoRAConfig(
         max_loras=max_loras,
-        max_lora_rank=2,
+        max_lora_rank=8,
         lora_dtype=dtype,
     )
 

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -792,6 +792,112 @@ def test_linear_dora_forward(default_vllm_config, dist_init, device, stage) -> N
 
 
 @torch.inference_mode()
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Phase 1 DoRA forward support is CUDA-only.",
+)
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("stage", STAGES)
+def test_linear_dora_forward_matches_peft(
+    default_vllm_config, dist_init, device, stage
+) -> None:
+    peft = pytest.importorskip("peft")
+
+    class TinyLinear(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(4, 3, bias=False)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.linear(x)
+
+    torch.accelerator.set_device_index(device)
+    torch.set_default_device(device)
+    dtype = torch.float16
+    max_loras = 2
+    rank = 2
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=8,
+        lora_dtype=dtype,
+    )
+    punica_wrapper = get_punica_wrapper(16, 4, device, lora_config=lora_config)
+
+    base_weight = torch.tensor(
+        [
+            [0.5, -0.25, 0.75, 1.0],
+            [-1.0, 0.5, 0.25, -0.75],
+            [0.25, 1.25, -0.5, 0.5],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    lora_a = torch.tensor(
+        [[0.5, 0.25, -0.5, 1.0], [1.5, -0.25, 0.75, -1.0]],
+        dtype=dtype,
+        device=device,
+    )
+    lora_b = torch.tensor(
+        [[0.25, -0.5], [1.0, 0.5], [-0.75, 1.25]],
+        dtype=dtype,
+        device=device,
+    )
+    dora_magnitude = torch.tensor([2.0, 3.0, 4.0], dtype=dtype, device=device)
+    x = torch.tensor(
+        [
+            [0.5, -1.0, 0.25, 1.5],
+            [-0.25, 0.75, 1.25, -0.5],
+            [1.0, 0.5, -0.75, 0.25],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+
+    peft_model = peft.get_peft_model(
+        TinyLinear().to(device=device, dtype=dtype),
+        peft.LoraConfig(
+            r=rank,
+            lora_alpha=rank,
+            target_modules=["linear"],
+            use_dora=True,
+            bias="none",
+        ),
+    )
+    peft_linear = peft_model.base_model.model.linear
+    peft_linear.base_layer.weight.data.copy_(base_weight)
+    peft_linear.lora_A["default"].weight.data.copy_(lora_a)
+    peft_linear.lora_B["default"].weight.data.copy_(lora_b)
+    peft_linear.lora_magnitude_vector["default"].weight.data.copy_(dora_magnitude)
+    expected = peft_model(x)
+
+    linear = ReplicatedLinear(4, 3, bias=False, params_dtype=dtype)
+    linear.weight.data.copy_(base_weight)
+    lora_linear = ReplicatedLinearWithLoRA(linear)
+    lora_linear.create_lora_weights(max_loras, lora_config)
+    lora_linear.set_mapping(punica_wrapper)
+    dora_id = 1
+    dora_slot = 1
+    lora_linear.set_lora(
+        dora_slot,
+        lora_a=lora_a,
+        lora_b=lora_b,
+        lora_magnitude_vector=dora_magnitude,
+    )
+    token_lora_ids = [dora_id] * x.shape[0]
+    lora_mapping = LoRAMapping(
+        token_lora_ids,
+        token_lora_ids,
+        is_prefill=stage,
+    )
+    punica_wrapper.update_metadata(lora_mapping, [None, dora_id], max_loras, 512)
+
+    actual = lora_linear(x)[0]
+
+    rtol, atol = TOLERANCES[actual.dtype]
+    torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
+
+
+@torch.inference_mode()
 @pytest.mark.parametrize("num_loras", [1, 2, 4])
 @pytest.mark.parametrize("orientation", ["row", "column"])
 @pytest.mark.parametrize("fully_shard", [True, False])

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -655,9 +655,9 @@ def test_linear_dora_scale_stacked(default_vllm_config, dist_init, device) -> No
 
     lora_linear.set_lora(
         1,
-        lora_a=dora_lora_a,
-        lora_b=dora_lora_b,
-        lora_magnitude_vector=dora_magnitude,
+        lora_a=dora_lora_a.cpu(),
+        lora_b=dora_lora_b.cpu(),
+        lora_magnitude_vector=dora_magnitude.cpu(),
     )
 
     expected_delta = dora_lora_b.float() @ dora_lora_a.float()
@@ -778,9 +778,9 @@ def test_packed_qkv_dora_scale_stacked(
 
     lora_linear.set_lora(
         1,
-        lora_a=lora_a,
-        lora_b=lora_b,
-        lora_magnitude_vector=dora_magnitude,
+        lora_a=[lora.cpu() for lora in lora_a],
+        lora_b=[lora.cpu() for lora in lora_b],
+        lora_magnitude_vector=[magnitude.cpu() for magnitude in dora_magnitude],
     )
 
     expected_scales = []

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -618,6 +618,71 @@ def test_linear_replicated(
 
 
 @torch.inference_mode()
+@pytest.mark.parametrize("device", DEVICES)
+def test_linear_dora_scale_stacked(default_vllm_config, dist_init, device) -> None:
+    if current_platform.is_cuda_alike() or current_platform.is_xpu():
+        torch.accelerator.set_device_index(device)
+
+    torch.set_default_device(device)
+    dtype = (
+        torch.float16
+        if current_platform.is_cuda_alike() or current_platform.is_xpu()
+        else torch.float32
+    )
+    max_loras = 2
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=2,
+        lora_dtype=dtype,
+    )
+
+    linear = ReplicatedLinear(4, 3, bias=False, params_dtype=dtype)
+    linear.weight.data = torch.arange(12, dtype=dtype, device=device).reshape(3, 4)
+    lora_linear = ReplicatedLinearWithLoRA(linear)
+    lora_linear.create_lora_weights(max_loras, lora_config)
+
+    lora_a = torch.tensor(
+        [[0.5, 0.25, -0.5, 1.0], [1.5, -0.25, 0.75, -1.0]],
+        dtype=dtype,
+        device=device,
+    )
+    lora_b = torch.tensor(
+        [[0.25, -0.5], [1.0, 0.5], [-0.75, 1.25]],
+        dtype=dtype,
+        device=device,
+    )
+    magnitude = torch.tensor([2.0, 3.0, 4.0], dtype=dtype, device=device)
+
+    lora_linear.set_lora(
+        1,
+        lora_a=lora_a,
+        lora_b=lora_b,
+        lora_magnitude_vector=magnitude,
+    )
+
+    expected_delta = lora_b.float() @ lora_a.float()
+    expected_norm = torch.linalg.vector_norm(
+        linear.weight.float() + expected_delta, dim=1
+    )
+    expected_scale = magnitude.float() / expected_norm
+
+    assert lora_linear.dora_enabled_stacked[1]
+    torch.testing.assert_close(
+        lora_linear.dora_scale_stacked[1].float(),
+        expected_scale,
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+    lora_linear.reset_lora(1)
+    assert not lora_linear.dora_enabled_stacked[1]
+    torch.testing.assert_close(
+        lora_linear.dora_scale_stacked[1],
+        torch.ones_like(lora_linear.dora_scale_stacked[1]),
+    )
+
+
+@torch.inference_mode()
 @pytest.mark.parametrize("num_loras", [1, 2, 4])
 @pytest.mark.parametrize("orientation", ["row", "column"])
 @pytest.mark.parametrize("fully_shard", [True, False])

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -803,18 +803,6 @@ def test_column_parallel_dora_scale_stacked_tp2(
             rtol=1e-3,
             atol=1e-3,
         )
-        torch.testing.assert_close(
-            lora_linear.lora_a_stacked[0][1, 0, : lora_a.shape[0]].float(),
-            lora_a.float(),
-            rtol=1e-3,
-            atol=1e-3,
-        )
-        torch.testing.assert_close(
-            lora_linear.lora_b_stacked[0][1, 0, :rows_per_rank].float(),
-            lora_b[start:stop].float(),
-            rtol=1e-3,
-            atol=1e-3,
-        )
 
 
 @torch.inference_mode()
@@ -906,18 +894,6 @@ def test_row_parallel_dora_scale_stacked_tp2(
         torch.testing.assert_close(
             lora_linear.dora_scale_stacked[1].float(),
             expected_scale,
-            rtol=1e-3,
-            atol=1e-3,
-        )
-        torch.testing.assert_close(
-            lora_linear.lora_a_stacked[0][1, 0, : lora_a.shape[0]].float(),
-            lora_a[:, start:stop].float(),
-            rtol=1e-3,
-            atol=1e-3,
-        )
-        torch.testing.assert_close(
-            lora_linear.lora_b_stacked[0][1, 0, : lora_b.shape[0]].float(),
-            lora_b.float(),
             rtol=1e-3,
             atol=1e-3,
         )
@@ -1195,6 +1171,347 @@ def _create_test_qkv_dora_tensors(
     return base_weight, lora_a, lora_b, dora_magnitude
 
 
+def _create_test_gate_up_dora_tensors(
+    dtype: torch.dtype,
+    device: torch.types.Device,
+) -> tuple[
+    torch.Tensor,
+    list[torch.Tensor],
+    list[torch.Tensor],
+    list[torch.Tensor],
+]:
+    base_weight = torch.tensor(
+        [
+            [0.5, -0.25, 0.75, 1.0],
+            [-1.0, 0.5, 0.25, -0.75],
+            [0.25, 1.25, -0.5, 0.5],
+            [1.0, -1.5, 0.5, 0.25],
+            [-0.5, 0.75, 1.25, -1.0],
+            [1.5, 0.25, -0.75, 0.5],
+            [0.75, -1.25, 1.0, -0.5],
+            [-1.0, -0.5, 0.25, 1.25],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    lora_a = [
+        torch.tensor(
+            [[0.5, 0.25, -0.5, 1.0], [1.5, -0.25, 0.75, -1.0]],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor(
+            [[-0.25, 0.75, 1.0, 0.5], [0.5, -1.0, 0.25, -0.75]],
+            dtype=dtype,
+            device=device,
+        ),
+    ]
+    lora_b = [
+        torch.tensor(
+            [[0.25, -0.5], [1.0, 0.5], [-0.75, 1.25], [0.5, -1.0]],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor(
+            [[0.75, -0.25], [-1.0, 0.5], [1.25, 0.5], [-0.5, -0.75]],
+            dtype=dtype,
+            device=device,
+        ),
+    ]
+    dora_magnitude = [
+        torch.tensor([2.0, 3.0, 4.0, 5.0], dtype=dtype, device=device),
+        torch.tensor([1.5, 2.5, 3.5, 4.5], dtype=dtype, device=device),
+    ]
+    return base_weight, lora_a, lora_b, dora_magnitude
+
+
+def _merged_column_local_rows(
+    tensor: torch.Tensor,
+    output_sizes: list[int],
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    rows = []
+    offset = 0
+    for output_size in output_sizes:
+        shard_size = output_size // tp_size
+        start = offset + tp_rank * shard_size
+        rows.append(tensor[start : start + shard_size])
+        offset += output_size
+    return torch.cat(rows, dim=0)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("device", DEVICES)
+def test_packed_gate_up_dora_scale_stacked_tp2(
+    default_vllm_config, dist_init, device
+) -> None:
+    if current_platform.is_cuda_alike() or current_platform.is_xpu():
+        torch.accelerator.set_device_index(device)
+
+    torch.set_default_device(device)
+    dtype = (
+        torch.float16
+        if current_platform.is_cuda_alike() or current_platform.is_xpu()
+        else torch.float32
+    )
+    tp_size = 2
+    max_loras = 2
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=8,
+        lora_dtype=dtype,
+    )
+    base_weight, lora_a, lora_b, dora_magnitude = (
+        _create_test_gate_up_dora_tensors(dtype, device)
+    )
+    output_sizes = [lora_b_i.shape[0] for lora_b_i in lora_b]
+    expected_scale = []
+    offset = 0
+    for lora_a_i, lora_b_i, magnitude_i in zip(lora_a, lora_b, dora_magnitude):
+        output_size = lora_b_i.shape[0]
+        expected_scale.append(
+            _expected_dora_scale(
+                base_weight[offset : offset + output_size],
+                lora_a_i,
+                lora_b_i,
+                magnitude_i,
+            )
+        )
+        offset += output_size
+    expected_scale = torch.cat(expected_scale)
+
+    for tp_rank in range(tp_size):
+        with (
+            patch(
+                "vllm.model_executor.layers.linear."
+                "get_tensor_model_parallel_world_size",
+                return_value=tp_size,
+            ),
+            patch(
+                "vllm.model_executor.layers.linear."
+                "get_tensor_model_parallel_rank",
+                return_value=tp_rank,
+            ),
+        ):
+            linear = MergedColumnParallelLinear(
+                base_weight.shape[1],
+                output_sizes,
+                bias=False,
+                params_dtype=dtype,
+                prefix=f"dora_gate_up_tp{tp_rank}",
+            )
+        local_base_weight = _merged_column_local_rows(
+            base_weight, output_sizes, tp_rank, tp_size
+        )
+        linear.weight.data.copy_(local_base_weight)
+        lora_linear = MergedColumnParallelLinearWithLoRA(linear)
+        lora_linear.create_lora_weights(max_loras, lora_config)
+
+        lora_linear.set_lora(
+            1,
+            lora_a=[lora.cpu() for lora in lora_a],
+            lora_b=[lora.cpu() for lora in lora_b],
+            lora_magnitude_vector=[
+                magnitude.cpu() for magnitude in dora_magnitude
+            ],
+        )
+
+        expected_local_scale = _merged_column_local_rows(
+            expected_scale, output_sizes, tp_rank, tp_size
+        )
+        torch.testing.assert_close(
+            lora_linear.dora_scale_stacked[1].float(),
+            expected_local_scale,
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+    partial_lora_a = [None, lora_a[1]]
+    partial_lora_b = [None, lora_b[1]]
+    partial_dora_magnitude = [None, dora_magnitude[1]]
+    linear = MergedColumnParallelLinear(
+        base_weight.shape[1],
+        output_sizes,
+        bias=False,
+        params_dtype=dtype,
+        prefix="dora_gate_up_partial",
+    )
+    linear.weight.data.copy_(base_weight)
+    lora_linear = MergedColumnParallelLinearWithLoRA(linear)
+    lora_linear.create_lora_weights(max_loras, lora_config)
+    lora_linear.set_lora(
+        0,
+        lora_a=partial_lora_a,
+        lora_b=partial_lora_b,
+        lora_magnitude_vector=partial_dora_magnitude,
+    )
+    expected_partial_scale = torch.ones_like(lora_linear.dora_scale_stacked[0]).float()
+    expected_partial_scale[output_sizes[0] :] = expected_scale[output_sizes[0] :]
+    torch.testing.assert_close(
+        lora_linear.dora_scale_stacked[0].float(),
+        expected_partial_scale,
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+
+@torch.inference_mode()
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="DoRA forward support is CUDA-only.",
+)
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("bias", [False, True])
+def test_packed_gate_up_dora_forward_tp2(
+    default_vllm_config, dist_init, device, bias
+) -> None:
+    torch.accelerator.set_device_index(device)
+    torch.set_default_device(device)
+    dtype = torch.float16
+    tp_size = 2
+    max_loras = 3
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=8,
+        lora_dtype=dtype,
+    )
+    punica_wrapper = get_punica_wrapper(16, 4, device, lora_config=lora_config)
+    base_weight, lora_a, lora_b, dora_magnitude = (
+        _create_test_gate_up_dora_tensors(dtype, device)
+    )
+    output_sizes = [lora_b_i.shape[0] for lora_b_i in lora_b]
+    standard_lora_a = [
+        torch.tensor(
+            [[-0.25, 0.75, 1.0, 0.5], [0.5, -1.0, 0.25, -0.75]],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor(
+            [[1.0, -0.5, 0.25, 0.75], [-0.75, 0.5, 1.25, -0.25]],
+            dtype=dtype,
+            device=device,
+        ),
+    ]
+    standard_lora_b = [
+        torch.tensor(
+            [[0.5, 0.25], [-0.5, 1.0], [1.25, -0.25], [0.75, 0.5]],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor(
+            [[0.25, -0.5], [1.0, 0.5], [-0.75, 1.25], [0.5, -1.0]],
+            dtype=dtype,
+            device=device,
+        ),
+    ]
+    merged_weight = base_weight.float()
+    dora_weight_slices = []
+    offset = 0
+    for lora_a_i, lora_b_i, magnitude_i in zip(lora_a, lora_b, dora_magnitude):
+        output_size = lora_b_i.shape[0]
+        delta_weight = lora_b_i.float() @ lora_a_i.float()
+        dora_merged_weight = merged_weight[offset : offset + output_size]
+        dora_merged_weight = dora_merged_weight + delta_weight
+        weight_norm = torch.linalg.vector_norm(
+            dora_merged_weight, dim=1, keepdim=True
+        )
+        dora_weight_slices.append(
+            magnitude_i.float().unsqueeze(1) * dora_merged_weight / weight_norm
+        )
+        offset += output_size
+    dora_weight = torch.cat(dora_weight_slices)
+
+    x = torch.tensor(
+        [
+            [0.5, -1.0, 0.25, 1.5],
+            [-0.25, 0.75, 1.25, -0.5],
+            [0.75, -0.5, 1.5, 0.25],
+            [1.0, 0.5, -0.75, 0.25],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    token_lora_ids = [1, 2, 0, 1]
+    lora_mapping = LoRAMapping(
+        token_lora_ids,
+        token_lora_ids,
+        is_prefill=True,
+    )
+    punica_wrapper.update_metadata(lora_mapping, [None, 1, 2], max_loras, 512)
+    dora_rows = torch.tensor([True, False, False, True], device=device)
+    standard_rows = torch.tensor([False, True, False, False], device=device)
+
+    for tp_rank in range(tp_size):
+        with (
+            patch(
+                "vllm.model_executor.layers.linear."
+                "get_tensor_model_parallel_world_size",
+                return_value=tp_size,
+            ),
+            patch(
+                "vllm.model_executor.layers.linear."
+                "get_tensor_model_parallel_rank",
+                return_value=tp_rank,
+            ),
+        ):
+            linear = MergedColumnParallelLinear(
+                base_weight.shape[1],
+                output_sizes,
+                bias=bias,
+                params_dtype=dtype,
+                prefix=f"dora_gate_up_forward_tp{tp_rank}",
+            )
+        local_base_weight = _merged_column_local_rows(
+            base_weight, output_sizes, tp_rank, tp_size
+        )
+        linear.weight.data.copy_(local_base_weight)
+        if bias:
+            full_bias = torch.tensor(
+                [0.25, -0.5, 0.75, -1.0, 0.5, -0.25, 1.25, -0.75],
+                dtype=dtype,
+                device=device,
+            )
+            linear.bias.data.copy_(
+                _merged_column_local_rows(full_bias, output_sizes, tp_rank, tp_size)
+            )
+        lora_linear = MergedColumnParallelLinearWithLoRA(linear)
+        lora_linear.create_lora_weights(max_loras, lora_config)
+        lora_linear.set_mapping(punica_wrapper)
+        lora_linear.set_lora(
+            1,
+            lora_a=lora_a,
+            lora_b=lora_b,
+            lora_magnitude_vector=dora_magnitude,
+        )
+        lora_linear.set_lora(2, lora_a=standard_lora_a, lora_b=standard_lora_b)
+
+        actual = lora_linear(x)[0]
+        expected = x.float() @ local_base_weight.float().T
+        local_dora_weight = _merged_column_local_rows(
+            dora_weight, output_sizes, tp_rank, tp_size
+        )
+        expected[dora_rows] = x[dora_rows].float() @ local_dora_weight.T
+        local_offset = 0
+        for lora_a_i, lora_b_i in zip(standard_lora_a, standard_lora_b):
+            shard_size = lora_b_i.shape[0] // tp_size
+            start = tp_rank * shard_size
+            local_lora_b_i = lora_b_i[start : start + shard_size]
+            standard_delta = x[standard_rows].float() @ lora_a_i.float().T
+            expected[
+                standard_rows,
+                local_offset : local_offset + shard_size,
+            ] += standard_delta @ local_lora_b_i.float().T
+            local_offset += shard_size
+        if bias:
+            expected += linear.bias.float()
+
+        rtol, atol = TOLERANCES[actual.dtype]
+        torch.testing.assert_close(
+            actual, expected.to(dtype=actual.dtype), rtol=rtol, atol=atol
+        )
+
+
 @torch.inference_mode()
 @pytest.mark.parametrize("device", DEVICES)
 def test_packed_qkv_dora_scale_stacked(
@@ -1287,13 +1604,6 @@ def test_packed_qkv_dora_scale_stacked(
         atol=1e-3,
     )
 
-    lora_linear.reset_lora(1)
-    assert not lora_linear.dora_enabled_stacked[1]
-    torch.testing.assert_close(
-        lora_linear.dora_scale_stacked[1],
-        torch.ones_like(lora_linear.dora_scale_stacked[1]),
-    )
-
 
 @torch.inference_mode()
 @pytest.mark.skipif(
@@ -1301,10 +1611,9 @@ def test_packed_qkv_dora_scale_stacked(
     reason="DoRA forward support is CUDA-only.",
 )
 @pytest.mark.parametrize("device", DEVICES)
-@pytest.mark.parametrize("stage", STAGES)
 @pytest.mark.parametrize("bias", [False, True])
 def test_packed_qkv_dora_forward(
-    default_vllm_config, dist_init, device, stage, bias
+    default_vllm_config, dist_init, device, bias
 ) -> None:
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
@@ -1397,7 +1706,7 @@ def test_packed_qkv_dora_forward(
     lora_mapping = LoRAMapping(
         token_lora_ids,
         token_lora_ids,
-        is_prefill=stage,
+        is_prefill=True,
     )
     punica_wrapper.update_metadata(lora_mapping, [None, 1, 2], max_loras, 512)
 
@@ -1563,9 +1872,8 @@ def test_linear_dora_forward(
     reason="Phase 1 DoRA forward support is CUDA-only.",
 )
 @pytest.mark.parametrize("device", DEVICES)
-@pytest.mark.parametrize("stage", STAGES)
 def test_linear_dora_forward_matches_peft(
-    default_vllm_config, dist_init, device, stage
+    default_vllm_config, dist_init, device
 ) -> None:
     peft = pytest.importorskip("peft")
 
@@ -1653,7 +1961,7 @@ def test_linear_dora_forward_matches_peft(
     lora_mapping = LoRAMapping(
         token_lora_ids,
         token_lora_ids,
-        is_prefill=stage,
+        is_prefill=True,
     )
     punica_wrapper.update_metadata(lora_mapping, [None, dora_id], max_loras, 512)
 

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -682,6 +682,462 @@ def test_linear_dora_scale_stacked(default_vllm_config, dist_init, device) -> No
     )
 
 
+def _create_dense_tp_dora_tensors(
+    dtype: torch.dtype,
+    device: torch.types.Device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    base_weight = torch.tensor(
+        [
+            [0.5, -0.25, 0.75, 1.0],
+            [-1.0, 0.5, 0.25, -0.75],
+            [0.25, 1.25, -0.5, 0.5],
+            [1.0, -1.5, 0.5, 0.25],
+            [-0.5, 0.75, 1.25, -1.0],
+            [1.5, 0.25, -0.75, 0.5],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    lora_a = torch.tensor(
+        [[0.5, 0.25, -0.5, 1.0], [1.5, -0.25, 0.75, -1.0]],
+        dtype=dtype,
+        device=device,
+    )
+    lora_b = torch.tensor(
+        [
+            [0.25, -0.5],
+            [1.0, 0.5],
+            [-0.75, 1.25],
+            [0.5, -1.0],
+            [0.75, -0.25],
+            [-1.0, 0.5],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    dora_magnitude = torch.tensor(
+        [2.0, 3.0, 4.0, 5.0, 1.5, 2.5],
+        dtype=dtype,
+        device=device,
+    )
+    return base_weight, lora_a, lora_b, dora_magnitude
+
+
+def _expected_dora_scale(
+    base_weight: torch.Tensor,
+    lora_a: torch.Tensor,
+    lora_b: torch.Tensor,
+    dora_magnitude: torch.Tensor,
+) -> torch.Tensor:
+    merged_weight = base_weight.float() + lora_b.float() @ lora_a.float()
+    weight_norm = torch.linalg.vector_norm(merged_weight, dim=1)
+    weight_norm = torch.clamp(weight_norm, min=torch.finfo(weight_norm.dtype).eps)
+    return dora_magnitude.float() / weight_norm
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("device", DEVICES)
+def test_column_parallel_dora_scale_stacked_tp2(
+    default_vllm_config, dist_init, device
+) -> None:
+    if current_platform.is_cuda_alike() or current_platform.is_xpu():
+        torch.accelerator.set_device_index(device)
+
+    torch.set_default_device(device)
+    dtype = (
+        torch.float16
+        if current_platform.is_cuda_alike() or current_platform.is_xpu()
+        else torch.float32
+    )
+    tp_size = 2
+    max_loras = 2
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=8,
+        lora_dtype=dtype,
+    )
+    base_weight, lora_a, lora_b, dora_magnitude = _create_dense_tp_dora_tensors(
+        dtype, device
+    )
+    expected_scale = _expected_dora_scale(
+        base_weight, lora_a, lora_b, dora_magnitude
+    )
+    rows_per_rank = base_weight.shape[0] // tp_size
+
+    for tp_rank in range(tp_size):
+        with (
+            patch(
+                "vllm.model_executor.layers.linear."
+                "get_tensor_model_parallel_world_size",
+                return_value=tp_size,
+            ),
+            patch(
+                "vllm.model_executor.layers.linear."
+                "get_tensor_model_parallel_rank",
+                return_value=tp_rank,
+            ),
+        ):
+            linear = ColumnParallelLinear(
+                base_weight.shape[1],
+                base_weight.shape[0],
+                bias=False,
+                params_dtype=dtype,
+                prefix=f"dora_column_tp{tp_rank}",
+            )
+        start = tp_rank * rows_per_rank
+        stop = start + rows_per_rank
+        linear.weight.data.copy_(base_weight[start:stop])
+        lora_linear = ColumnParallelLinearWithLoRA(linear)
+        lora_linear.create_lora_weights(max_loras, lora_config)
+
+        lora_linear.set_lora(
+            1,
+            lora_a=lora_a.cpu(),
+            lora_b=lora_b.cpu(),
+            lora_magnitude_vector=dora_magnitude.cpu(),
+        )
+
+        torch.testing.assert_close(
+            lora_linear.dora_scale_stacked[1].float(),
+            expected_scale[start:stop],
+            rtol=1e-3,
+            atol=1e-3,
+        )
+        torch.testing.assert_close(
+            lora_linear.lora_a_stacked[0][1, 0, : lora_a.shape[0]].float(),
+            lora_a.float(),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+        torch.testing.assert_close(
+            lora_linear.lora_b_stacked[0][1, 0, :rows_per_rank].float(),
+            lora_b[start:stop].float(),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("device", DEVICES)
+def test_row_parallel_dora_scale_stacked_tp2(
+    default_vllm_config, dist_init, device
+) -> None:
+    if current_platform.is_cuda_alike() or current_platform.is_xpu():
+        torch.accelerator.set_device_index(device)
+
+    torch.set_default_device(device)
+    dtype = (
+        torch.float16
+        if current_platform.is_cuda_alike() or current_platform.is_xpu()
+        else torch.float32
+    )
+    tp_size = 2
+    max_loras = 2
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=8,
+        lora_dtype=dtype,
+    )
+    base_weight, lora_a, lora_b, dora_magnitude = _create_dense_tp_dora_tensors(
+        dtype, device
+    )
+    expected_scale = _expected_dora_scale(
+        base_weight, lora_a, lora_b, dora_magnitude
+    )
+    cols_per_rank = base_weight.shape[1] // tp_size
+    local_norm_sq = []
+    for tp_rank in range(tp_size):
+        start = tp_rank * cols_per_rank
+        stop = start + cols_per_rank
+        local_lora_a = lora_a[:, start:stop]
+        local_merged = base_weight[:, start:stop].float()
+        local_merged = local_merged + lora_b.float() @ local_lora_a.float()
+        local_norm_sq.append(local_merged.square().sum(dim=1))
+    global_norm_sq = sum(local_norm_sq)
+
+    for tp_rank in range(tp_size):
+        with (
+            patch(
+                "vllm.model_executor.layers.linear."
+                "get_tensor_model_parallel_world_size",
+                return_value=tp_size,
+            ),
+            patch(
+                "vllm.model_executor.layers.linear."
+                "get_tensor_model_parallel_rank",
+                return_value=tp_rank,
+            ),
+        ):
+            linear = RowParallelLinear(
+                base_weight.shape[1],
+                base_weight.shape[0],
+                bias=False,
+                params_dtype=dtype,
+                prefix=f"dora_row_tp{tp_rank}",
+            )
+        start = tp_rank * cols_per_rank
+        stop = start + cols_per_rank
+        linear.weight.data.copy_(base_weight[:, start:stop])
+        lora_linear = RowParallelLinearWithLoRA(linear)
+        lora_linear.create_lora_weights(max_loras, lora_config)
+        all_reduce_calls = 0
+
+        def fake_all_reduce(norm_sq: torch.Tensor) -> torch.Tensor:
+            nonlocal all_reduce_calls
+            all_reduce_calls += 1
+            torch.testing.assert_close(
+                norm_sq, local_norm_sq[tp_rank], rtol=1e-3, atol=1e-3
+            )
+            return global_norm_sq.to(device=norm_sq.device, dtype=norm_sq.dtype)
+
+        with patch(
+            "vllm.lora.layers.row_parallel_linear."
+            "tensor_model_parallel_all_reduce",
+            side_effect=fake_all_reduce,
+        ):
+            lora_linear.set_lora(
+                1,
+                lora_a=lora_a.cpu(),
+                lora_b=lora_b.cpu(),
+                lora_magnitude_vector=dora_magnitude.cpu(),
+            )
+
+        assert all_reduce_calls == 1
+        torch.testing.assert_close(
+            lora_linear.dora_scale_stacked[1].float(),
+            expected_scale,
+            rtol=1e-3,
+            atol=1e-3,
+        )
+        torch.testing.assert_close(
+            lora_linear.lora_a_stacked[0][1, 0, : lora_a.shape[0]].float(),
+            lora_a[:, start:stop].float(),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+        torch.testing.assert_close(
+            lora_linear.lora_b_stacked[0][1, 0, : lora_b.shape[0]].float(),
+            lora_b.float(),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+@torch.inference_mode()
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="DoRA forward support is CUDA-only.",
+)
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("stage", STAGES)
+def test_column_parallel_dora_forward_tp2(
+    default_vllm_config, dist_init, device, stage
+) -> None:
+    torch.accelerator.set_device_index(device)
+    torch.set_default_device(device)
+    dtype = torch.float16
+    tp_size = 2
+    max_loras = 2
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=8,
+        lora_dtype=dtype,
+    )
+    punica_wrapper = get_punica_wrapper(16, 4, device, lora_config=lora_config)
+    base_weight, lora_a, lora_b, dora_magnitude = _create_dense_tp_dora_tensors(
+        dtype, device
+    )
+    rows_per_rank = base_weight.shape[0] // tp_size
+    x = torch.tensor(
+        [
+            [0.5, -1.0, 0.25, 1.5],
+            [-0.25, 0.75, 1.25, -0.5],
+            [1.0, 0.5, -0.75, 0.25],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    token_lora_ids = [1, 0, 1]
+    lora_mapping = LoRAMapping(
+        token_lora_ids,
+        token_lora_ids,
+        is_prefill=stage,
+    )
+    punica_wrapper.update_metadata(lora_mapping, [None, 1], max_loras, 512)
+    merged_weight = base_weight.float() + lora_b.float() @ lora_a.float()
+    weight_norm = torch.linalg.vector_norm(merged_weight, dim=1, keepdim=True)
+    dora_weight = dora_magnitude.float().unsqueeze(1) * merged_weight / weight_norm
+    dora_rows = torch.tensor([True, False, True], device=device)
+
+    for tp_rank in range(tp_size):
+        with (
+            patch(
+                "vllm.model_executor.layers.linear."
+                "get_tensor_model_parallel_world_size",
+                return_value=tp_size,
+            ),
+            patch(
+                "vllm.model_executor.layers.linear."
+                "get_tensor_model_parallel_rank",
+                return_value=tp_rank,
+            ),
+        ):
+            linear = ColumnParallelLinear(
+                base_weight.shape[1],
+                base_weight.shape[0],
+                bias=False,
+                params_dtype=dtype,
+                prefix=f"dora_column_forward_tp{tp_rank}",
+            )
+        start = tp_rank * rows_per_rank
+        stop = start + rows_per_rank
+        linear.weight.data.copy_(base_weight[start:stop])
+        lora_linear = ColumnParallelLinearWithLoRA(linear)
+        lora_linear.create_lora_weights(max_loras, lora_config)
+        lora_linear.set_mapping(punica_wrapper)
+        lora_linear.set_lora(
+            1,
+            lora_a=lora_a,
+            lora_b=lora_b,
+            lora_magnitude_vector=dora_magnitude,
+        )
+
+        actual = lora_linear(x)[0]
+        expected = x.float() @ base_weight[start:stop].float().T
+        expected[dora_rows] = x[dora_rows].float() @ dora_weight[start:stop].T
+
+        rtol, atol = TOLERANCES[actual.dtype]
+        torch.testing.assert_close(
+            actual, expected.to(dtype=actual.dtype), rtol=rtol, atol=atol
+        )
+
+
+@torch.inference_mode()
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="DoRA forward support is CUDA-only.",
+)
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("stage", STAGES)
+def test_row_parallel_dora_forward_tp2(
+    default_vllm_config, dist_init, device, stage
+) -> None:
+    torch.accelerator.set_device_index(device)
+    torch.set_default_device(device)
+    dtype = torch.float16
+    tp_size = 2
+    tp_rank = 0
+    max_loras = 2
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=8,
+        lora_dtype=dtype,
+    )
+    punica_wrapper = get_punica_wrapper(16, 4, device, lora_config=lora_config)
+    base_weight, lora_a, lora_b, dora_magnitude = _create_dense_tp_dora_tensors(
+        dtype, device
+    )
+    cols_per_rank = base_weight.shape[1] // tp_size
+    x = torch.tensor(
+        [
+            [0.5, -1.0, 0.25, 1.5],
+            [-0.25, 0.75, 1.25, -0.5],
+            [1.0, 0.5, -0.75, 0.25],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    token_lora_ids = [1, 0, 1]
+    lora_mapping = LoRAMapping(
+        token_lora_ids,
+        token_lora_ids,
+        is_prefill=stage,
+    )
+    punica_wrapper.update_metadata(lora_mapping, [None, 1], max_loras, 512)
+
+    local_norm_sq = []
+    for rank in range(tp_size):
+        start = rank * cols_per_rank
+        stop = start + cols_per_rank
+        local_lora_a = lora_a[:, start:stop]
+        local_merged = base_weight[:, start:stop].float()
+        local_merged = local_merged + lora_b.float() @ local_lora_a.float()
+        local_norm_sq.append(local_merged.square().sum(dim=1))
+    global_norm_sq = sum(local_norm_sq)
+    weight_norm = torch.sqrt(global_norm_sq).unsqueeze(1)
+    merged_weight = base_weight.float() + lora_b.float() @ lora_a.float()
+    dora_weight = dora_magnitude.float().unsqueeze(1) * merged_weight / weight_norm
+    dora_rows = torch.tensor([True, False, True], device=device)
+    expected = x.float() @ base_weight.float().T
+    expected[dora_rows] = x[dora_rows].float() @ dora_weight.T
+
+    start = tp_rank * cols_per_rank
+    stop = start + cols_per_rank
+    with (
+        patch(
+            "vllm.model_executor.layers.linear."
+            "get_tensor_model_parallel_world_size",
+            return_value=tp_size,
+        ),
+        patch(
+            "vllm.model_executor.layers.linear."
+            "get_tensor_model_parallel_rank",
+            return_value=tp_rank,
+        ),
+    ):
+        linear = RowParallelLinear(
+            base_weight.shape[1],
+            base_weight.shape[0],
+            bias=False,
+            params_dtype=dtype,
+            prefix="dora_row_forward_tp0",
+        )
+    linear.weight.data.copy_(base_weight[:, start:stop])
+    lora_linear = RowParallelLinearWithLoRA(linear)
+    lora_linear.create_lora_weights(max_loras, lora_config)
+    lora_linear.set_mapping(punica_wrapper)
+    x_local = x[:, start:stop]
+    local_dora_weight = dora_magnitude.float().unsqueeze(1)
+    local_dora_weight = local_dora_weight * (
+        base_weight[:, start:stop].float()
+        + lora_b.float() @ lora_a[:, start:stop].float()
+    )
+    local_dora_weight = local_dora_weight / weight_norm
+    expected_local = x_local.float() @ base_weight[:, start:stop].float().T
+    expected_local[dora_rows] = x_local[dora_rows].float() @ local_dora_weight.T
+
+    def fake_all_reduce(tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.ndim == 1:
+            torch.testing.assert_close(
+                tensor, local_norm_sq[tp_rank], rtol=1e-3, atol=1e-3
+            )
+            return global_norm_sq.to(device=tensor.device, dtype=tensor.dtype)
+        torch.testing.assert_close(
+            tensor,
+            expected_local.to(dtype=tensor.dtype),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+        return expected.to(device=tensor.device, dtype=tensor.dtype)
+
+    with patch(
+        "vllm.lora.layers.row_parallel_linear.tensor_model_parallel_all_reduce",
+        side_effect=fake_all_reduce,
+    ):
+        lora_linear.set_lora(
+            1,
+            lora_a=lora_a,
+            lora_b=lora_b,
+            lora_magnitude_vector=dora_magnitude,
+        )
+        actual = lora_linear(x_local)[0]
+
+    rtol, atol = TOLERANCES[actual.dtype]
+    torch.testing.assert_close(
+        actual, expected.to(dtype=actual.dtype), rtol=rtol, atol=atol
+    )
+
+
 def _create_test_qkv_dora_tensors(
     dtype: torch.dtype,
     device: torch.types.Device,

--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -28,14 +28,12 @@ MOCK_PACKED_MAPPING = {
 }
 
 
-def _make_peft_helper(use_dora: bool) -> PEFTHelper:
-    return PEFTHelper.from_dict(
-        {
-            "r": 2,
-            "lora_alpha": 4,
-            "target_modules": ["linear"],
-            "use_dora": use_dora,
-        }
+def _linear_peft_helper(*, use_dora: bool) -> PEFTHelper:
+    return PEFTHelper(
+        r=2,
+        lora_alpha=4,
+        target_modules=["linear"],
+        use_dora=use_dora,
     )
 
 
@@ -185,7 +183,7 @@ def test_load_dora_tensors(disable_lora_pin_memory):
     lora_model = LoRAModel.from_lora_tensors(
         1,
         tensors,
-        _make_peft_helper(use_dora=True),
+        _linear_peft_helper(use_dora=True),
         device="cpu",
     )
 
@@ -245,7 +243,7 @@ def test_load_lora_tensors_rejects_unconfigured_dora_magnitude(
         LoRAModel.from_lora_tensors(
             1,
             tensors,
-            _make_peft_helper(use_dora=False),
+            _linear_peft_helper(use_dora=False),
             device="cpu",
         )
 
@@ -261,6 +259,6 @@ def test_load_dora_tensors_rejects_missing_magnitude(disable_lora_pin_memory):
         LoRAModel.from_lora_tensors(
             1,
             tensors,
-            _make_peft_helper(use_dora=True),
+            _linear_peft_helper(use_dora=True),
             device="cpu",
         )

--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -38,6 +38,11 @@ def _make_peft_helper(use_dora: bool) -> PEFTHelper:
     )
 
 
+@pytest.fixture
+def disable_lora_pin_memory(monkeypatch):
+    monkeypatch.setattr("vllm.lora.lora_model.is_pin_memory_available", lambda: False)
+
+
 @pytest.mark.parametrize("lora_name", lora_lst)
 def test_load_checkpoints(
     lora_name,
@@ -168,7 +173,8 @@ def test_gemma4_moe_lora_weights_mapping():
     )
 
 
-def test_load_dora_tensors():
+@pytest.mark.skip_global_cleanup
+def test_load_dora_tensors(disable_lora_pin_memory):
     tensors = {
         "base_model.model.linear.lora_A.weight": torch.randn(2, 3),
         "base_model.model.linear.lora_B.weight": torch.randn(4, 2),
@@ -195,7 +201,10 @@ def test_load_dora_tensors():
     )
 
 
-def test_load_lora_tensors_rejects_unconfigured_dora_magnitude():
+@pytest.mark.skip_global_cleanup
+def test_load_lora_tensors_rejects_unconfigured_dora_magnitude(
+    disable_lora_pin_memory,
+):
     tensors = {
         "base_model.model.linear.lora_A.weight": torch.randn(2, 3),
         "base_model.model.linear.lora_B.weight": torch.randn(4, 2),
@@ -211,7 +220,8 @@ def test_load_lora_tensors_rejects_unconfigured_dora_magnitude():
         )
 
 
-def test_load_dora_tensors_rejects_missing_magnitude():
+@pytest.mark.skip_global_cleanup
+def test_load_dora_tensors_rejects_missing_magnitude(disable_lora_pin_memory):
     tensors = {
         "base_model.model.linear.lora_A.weight": torch.randn(2, 3),
         "base_model.model.linear.lora_B.weight": torch.randn(4, 2),

--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+import torch
 
 from vllm.lora.lora_model import LoRAModel
 from vllm.lora.peft_helper import PEFTHelper
@@ -24,6 +25,17 @@ MOCK_PACKED_MAPPING = {
         "up_proj",
     ],
 }
+
+
+def _make_peft_helper(use_dora: bool) -> PEFTHelper:
+    return PEFTHelper.from_dict(
+        {
+            "r": 2,
+            "lora_alpha": 4,
+            "target_modules": ["linear"],
+            "use_dora": use_dora,
+        }
+    )
 
 
 @pytest.mark.parametrize("lora_name", lora_lst)
@@ -154,3 +166,46 @@ def test_gemma4_moe_lora_weights_mapping():
         "model.layers.9.moe.gate_up_proj",
         "lora_b",
     )
+
+
+def test_load_dora_tensors():
+    tensors = {
+        "base_model.model.linear.lora_A.weight": torch.randn(2, 3),
+        "base_model.model.linear.lora_B.weight": torch.randn(4, 2),
+        "base_model.model.linear.lora_magnitude_vector": torch.randn(4),
+    }
+
+    lora_model = LoRAModel.from_lora_tensors(
+        1,
+        tensors,
+        _make_peft_helper(use_dora=True),
+        device="cpu",
+    )
+
+    lora = lora_model.loras["linear"]
+    assert lora.use_dora
+    assert isinstance(lora.lora_a, torch.Tensor)
+    assert isinstance(lora.lora_b, torch.Tensor)
+    assert isinstance(lora.lora_magnitude_vector, torch.Tensor)
+    assert torch.equal(lora.lora_a, tensors["base_model.model.linear.lora_A.weight"])
+    assert torch.equal(lora.lora_b, tensors["base_model.model.linear.lora_B.weight"])
+    assert torch.equal(
+        lora.lora_magnitude_vector,
+        tensors["base_model.model.linear.lora_magnitude_vector"],
+    )
+
+
+def test_load_lora_tensors_rejects_unconfigured_dora_magnitude():
+    tensors = {
+        "base_model.model.linear.lora_A.weight": torch.randn(2, 3),
+        "base_model.model.linear.lora_B.weight": torch.randn(4, 2),
+        "base_model.model.linear.lora_magnitude_vector": torch.randn(4),
+    }
+
+    with pytest.raises(ValueError, match="use_dora=False"):
+        LoRAModel.from_lora_tensors(
+            1,
+            tensors,
+            _make_peft_helper(use_dora=False),
+            device="cpu",
+        )

--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -209,3 +209,18 @@ def test_load_lora_tensors_rejects_unconfigured_dora_magnitude():
             _make_peft_helper(use_dora=False),
             device="cpu",
         )
+
+
+def test_load_dora_tensors_rejects_missing_magnitude():
+    tensors = {
+        "base_model.model.linear.lora_A.weight": torch.randn(2, 3),
+        "base_model.model.linear.lora_B.weight": torch.randn(4, 2),
+    }
+
+    with pytest.raises(ValueError, match="missing lora_magnitude_vector"):
+        LoRAModel.from_lora_tensors(
+            1,
+            tensors,
+            _make_peft_helper(use_dora=True),
+            device="cpu",
+        )

--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -140,7 +140,7 @@ def test_gemma4_lora_weights_mapping():
     name = "base_model.model.model.language_model.layers.9.mlp.down_proj.lora_A.weight"
     assert parse_fine_tuned_lora_name(name, mapper) == (
         "model.layers.9.mlp.down_proj",
-        True,
+        "lora_a",
     )
 
 
@@ -152,5 +152,5 @@ def test_gemma4_moe_lora_weights_mapping():
     )
     assert parse_fine_tuned_lora_name(name, mapper) == (
         "model.layers.9.moe.gate_up_proj",
-        False,
+        "lora_b",
     )

--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from vllm.lora.lora_model import LoRAModel
+from vllm.lora.lora_weights import LoRALayerWeights, PackedLoRALayerWeights
 from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.utils import parse_fine_tuned_lora_name
 from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
@@ -199,6 +200,35 @@ def test_load_dora_tensors(disable_lora_pin_memory):
         lora.lora_magnitude_vector,
         tensors["base_model.model.linear.lora_magnitude_vector"],
     )
+
+
+@pytest.mark.skip_global_cleanup
+def test_pack_dora_lora_weights() -> None:
+    dtype = torch.float32
+    rank = 2
+    loras = [
+        LoRALayerWeights(
+            f"proj_{i}",
+            rank=rank,
+            lora_alpha=rank,
+            lora_a=torch.full((rank, 4), 0.1 * (i + 1), dtype=dtype),
+            lora_b=torch.full((out_size, rank), 0.2 * (i + 1), dtype=dtype),
+            lora_magnitude_vector=torch.full((out_size,), i + 1, dtype=dtype),
+            use_dora=True,
+        )
+        for i, out_size in enumerate([4, 2, 2])
+    ]
+
+    packed_lora = PackedLoRALayerWeights.pack(loras)
+
+    assert packed_lora.use_dora
+    assert isinstance(packed_lora.lora_magnitude_vector, list)
+    for i, lora in enumerate(loras):
+        torch.testing.assert_close(packed_lora.lora_a[i], lora.lora_a)
+        torch.testing.assert_close(packed_lora.lora_b[i], lora.lora_b)
+        torch.testing.assert_close(
+            packed_lora.lora_magnitude_vector[i], lora.lora_magnitude_vector
+        )
 
 
 @pytest.mark.skip_global_cleanup

--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -41,7 +41,7 @@ def _make_peft_helper(use_dora: bool) -> PEFTHelper:
 
 @pytest.fixture
 def disable_lora_pin_memory(monkeypatch):
-    monkeypatch.setattr("vllm.lora.lora_model.is_pin_memory_available", lambda: False)
+    monkeypatch.setattr("vllm.lora.lora_model.PIN_MEMORY", False)
 
 
 @pytest.mark.parametrize("lora_name", lora_lst)

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -75,35 +75,27 @@ def test_from_lora_tensors(qwen3_lora_files, device):
 
 
 def create_lora(
-    lora_id: int, model: nn.Module, sub_modules: list[str], device: torch.device
+    lora_id: int,
+    model: nn.Module,
+    sub_modules: list[str],
+    device: torch.device,
+    *,
+    use_dora: bool = False,
 ) -> LoRAModel:
     loras: dict[str, LoRALayerWeights] = {}
     for name in sub_modules:
         w = model.get_submodule(name).weight
-        loras[name] = LoRALayerWeights(
-            name,
-            8,
-            16,
-            torch.rand([8, w.shape[1]], device=device),
-            torch.rand([w.shape[0], 8], device=device),
+        lora_magnitude_vector = (
+            torch.ones(w.shape[0], device=device) if use_dora else None
         )
-    return LoRAModel(lora_id, 8, loras)
-
-
-def create_dora(
-    lora_id: int, model: nn.Module, sub_modules: list[str], device: torch.device
-) -> LoRAModel:
-    loras: dict[str, LoRALayerWeights] = {}
-    for name in sub_modules:
-        w = model.get_submodule(name).weight
         loras[name] = LoRALayerWeights(
             name,
             8,
             16,
             torch.rand([8, w.shape[1]], device=device),
             torch.rand([w.shape[0], 8], device=device),
-            lora_magnitude_vector=torch.ones(w.shape[0], device=device),
-            use_dora=True,
+            lora_magnitude_vector=lora_magnitude_vector,
+            use_dora=use_dora,
         )
     return LoRAModel(lora_id, 8, loras)
 
@@ -454,7 +446,7 @@ def test_lora_model_manager_deactivate_resets_dora_slot(
     default_vllm_config, dist_init, dummy_model, device
 ):
     model = dummy_model
-    model_lora = create_dora(1, model, ["dense1"], device=device)
+    model_lora = create_lora(1, model, ["dense1"], device=device, use_dora=True)
     manager = LoRAModelManager(
         model,
         2,
@@ -488,7 +480,9 @@ def test_lora_model_manager_activation_failure_resets_dora_slot(
     default_vllm_config, dist_init, dummy_model, device
 ):
     model = dummy_model
-    model_lora = create_dora(1, model, ["dense1", "lm_head"], device=device)
+    model_lora = create_lora(
+        1, model, ["dense1", "lm_head"], device=device, use_dora=True
+    )
     manager = LoRAModelManager(
         model,
         2,

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -456,6 +456,7 @@ def test_lora_model_manager_deactivate_resets_dora_slot(
             max_lora_rank=8, max_cpu_loras=2, max_loras=2, lora_dtype=DEFAULT_DTYPE
         ),
         device=device,
+        vllm_config=default_vllm_config,
     )
     lora_layer = manager.model.get_submodule("dense1")
     assert isinstance(lora_layer, ColumnParallelLinearWithLoRA)
@@ -492,6 +493,7 @@ def test_lora_model_manager_activation_failure_resets_dora_slot(
             max_lora_rank=8, max_cpu_loras=2, max_loras=2, lora_dtype=DEFAULT_DTYPE
         ),
         device=device,
+        vllm_config=default_vllm_config,
     )
     lora_layer = manager.model.get_submodule("dense1")
     assert isinstance(lora_layer, ColumnParallelLinearWithLoRA)

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -90,6 +90,24 @@ def create_lora(
     return LoRAModel(lora_id, 8, loras)
 
 
+def create_dora(
+    lora_id: int, model: nn.Module, sub_modules: list[str], device: torch.device
+) -> LoRAModel:
+    loras: dict[str, LoRALayerWeights] = {}
+    for name in sub_modules:
+        w = model.get_submodule(name).weight
+        loras[name] = LoRALayerWeights(
+            name,
+            8,
+            16,
+            torch.rand([8, w.shape[1]], device=device),
+            torch.rand([w.shape[0], 8], device=device),
+            lora_magnitude_vector=torch.ones(w.shape[0], device=device),
+            use_dora=True,
+        )
+    return LoRAModel(lora_id, 8, loras)
+
+
 def create_packed_lora(
     lora_id: int,
     model: nn.Module,
@@ -429,6 +447,40 @@ def test_lora_model_manager(default_vllm_config, dist_init, dummy_model, device)
         "lm_head",
         "output",
     ]
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_lora_model_manager_deactivate_resets_dora_slot(
+    default_vllm_config, dist_init, dummy_model, device
+):
+    model = dummy_model
+    model_lora = create_dora(1, model, ["dense1"], device=device)
+    manager = LoRAModelManager(
+        model,
+        2,
+        2,
+        2,
+        LoRAConfig(
+            max_lora_rank=8, max_cpu_loras=2, max_loras=2, lora_dtype=DEFAULT_DTYPE
+        ),
+        device=device,
+    )
+    lora_layer = manager.model.get_submodule("dense1")
+    assert isinstance(lora_layer, ColumnParallelLinearWithLoRA)
+
+    assert manager.add_adapter(model_lora)
+    assert manager.activate_adapter(1)
+    assert lora_layer.dora_enabled_stacked[0]
+    assert lora_layer._dora_active_slots == {0}
+
+    assert manager.remove_adapter(1)
+    assert manager.lora_index_to_id[0] is None
+    assert not lora_layer.dora_enabled_stacked[0]
+    assert not lora_layer._dora_active_slots
+    torch.testing.assert_close(
+        lora_layer.dora_scale_stacked[0],
+        torch.ones_like(lora_layer.dora_scale_stacked[0]),
+    )
 
 
 @pytest.mark.parametrize("device", DEVICES)

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -484,6 +484,43 @@ def test_lora_model_manager_deactivate_resets_dora_slot(
 
 
 @pytest.mark.parametrize("device", DEVICES)
+def test_lora_model_manager_activation_failure_resets_dora_slot(
+    default_vllm_config, dist_init, dummy_model, device
+):
+    model = dummy_model
+    model_lora = create_dora(1, model, ["dense1", "lm_head"], device=device)
+    manager = LoRAModelManager(
+        model,
+        2,
+        2,
+        2,
+        LoRAConfig(
+            max_lora_rank=8, max_cpu_loras=2, max_loras=2, lora_dtype=DEFAULT_DTYPE
+        ),
+        device=device,
+    )
+    lora_layer = manager.model.get_submodule("dense1")
+    assert isinstance(lora_layer, ColumnParallelLinearWithLoRA)
+
+    assert manager.add_adapter(model_lora)
+    with pytest.raises(NotImplementedError, match="DoRA is not supported"):
+        manager.activate_adapter(1)
+
+    assert manager.lora_index_to_id == [None, None]
+    assert not lora_layer.dora_enabled_stacked[0]
+    assert not lora_layer._dora_active_slots
+    torch.testing.assert_close(
+        lora_layer.dora_scale_stacked[0],
+        torch.ones_like(lora_layer.dora_scale_stacked[0]),
+    )
+
+    clean_lora = create_lora(2, model, ["dense1"], device=device)
+    assert manager.add_adapter(clean_lora)
+    assert manager.activate_adapter(2)
+    assert manager.lora_index_to_id[0] == 2
+
+
+@pytest.mark.parametrize("device", DEVICES)
 def test_lora_lru_cache_model_manager(
     default_vllm_config, dist_init, dummy_model, device
 ):

--- a/tests/lora/test_peft_helper.py
+++ b/tests/lora/test_peft_helper.py
@@ -16,7 +16,6 @@ ERROR_CASES = [
         {"r": 1024},
         "is greater than max_lora_rank",
     ),
-    ("test_dora", {"use_dora": True}, "does not yet support DoRA"),
     (
         "test_modules_to_save",
         {"modules_to_save": ["lm_head"]},
@@ -68,6 +67,22 @@ def test_peft_helper_pass(llama32_lora_files, tmp_path):
     peft_helper.validate_legal(lora_config)
     scaling = peft_helper.lora_alpha / math.sqrt(peft_helper.r)
     assert abs(peft_helper.vllm_lora_scaling_factor - scaling) < 1e-3
+
+    dora_config = dict(use_dora=True)
+    test_dir = tmp_path / "test_dora"
+    shutil.copytree(llama32_lora_files, test_dir)
+
+    config_path = test_dir / "adapter_config.json"
+    with open(config_path) as f:
+        adapter_config = json.load(f)
+    adapter_config.update(dora_config)
+
+    with open(config_path, "w") as f:
+        json.dump(adapter_config, f)
+
+    peft_helper = PEFTHelper.from_local_dir(test_dir, max_position_embeddings=4096)
+    peft_helper.validate_legal(lora_config)
+    assert peft_helper.use_dora
 
 
 @pytest.mark.parametrize("test_name,config_change,expected_error", ERROR_CASES)

--- a/tests/lora/test_utils.py
+++ b/tests/lora/test_utils.py
@@ -24,6 +24,7 @@ class LoRANameParserTestConfig(NamedTuple):
     weights_mapper: WeightsMapper | None = None
 
 
+@pytest.mark.skip_global_cleanup
 def test_parse_fine_tuned_lora_name_valid():
     fixture = [
         LoRANameParserTestConfig(
@@ -115,6 +116,7 @@ def test_parse_fine_tuned_lora_name_valid():
         )
 
 
+@pytest.mark.skip_global_cleanup
 def test_parse_fine_tuned_lora_name_invalid():
     fixture = {
         "base_model.weight",

--- a/tests/lora/test_utils.py
+++ b/tests/lora/test_utils.py
@@ -27,10 +27,10 @@ class LoRANameParserTestConfig(NamedTuple):
 def test_parse_fine_tuned_lora_name_valid():
     fixture = [
         LoRANameParserTestConfig(
-            "base_model.model.lm_head.lora_A.weight", "lm_head", "lora_a", False
+            "base_model.model.lm_head.lora_A.weight", "lm_head", "lora_a"
         ),
         LoRANameParserTestConfig(
-            "base_model.model.lm_head.lora_B.weight", "lm_head", "lora_b", False
+            "base_model.model.lm_head.lora_B.weight", "lm_head", "lora_b"
         ),
         LoRANameParserTestConfig(
             "base_model.model.model.embed_tokens.lora_embedding_A",

--- a/tests/lora/test_utils.py
+++ b/tests/lora/test_utils.py
@@ -24,7 +24,6 @@ class LoRANameParserTestConfig(NamedTuple):
     weights_mapper: WeightsMapper | None = None
 
 
-@pytest.mark.skip_global_cleanup
 def test_parse_fine_tuned_lora_name_valid():
     fixture = [
         LoRANameParserTestConfig(
@@ -116,7 +115,6 @@ def test_parse_fine_tuned_lora_name_valid():
         )
 
 
-@pytest.mark.skip_global_cleanup
 def test_parse_fine_tuned_lora_name_invalid():
     fixture = {
         "base_model.weight",

--- a/tests/lora/test_utils.py
+++ b/tests/lora/test_utils.py
@@ -20,53 +20,58 @@ from vllm.model_executor.models.utils import WeightsMapper
 class LoRANameParserTestConfig(NamedTuple):
     name: str
     module_name: str
-    is_lora_a: bool
+    weight_type: str
     weights_mapper: WeightsMapper | None = None
 
 
 def test_parse_fine_tuned_lora_name_valid():
     fixture = [
         LoRANameParserTestConfig(
-            "base_model.model.lm_head.lora_A.weight", "lm_head", True, False
+            "base_model.model.lm_head.lora_A.weight", "lm_head", "lora_a", False
         ),
         LoRANameParserTestConfig(
-            "base_model.model.lm_head.lora_B.weight", "lm_head", False, False
+            "base_model.model.lm_head.lora_B.weight", "lm_head", "lora_b", False
         ),
         LoRANameParserTestConfig(
             "base_model.model.model.embed_tokens.lora_embedding_A",
             "model.embed_tokens",
-            True,
+            "lora_a",
         ),
         LoRANameParserTestConfig(
             "base_model.model.model.embed_tokens.lora_embedding_B",
             "model.embed_tokens",
-            False,
+            "lora_b",
         ),
         LoRANameParserTestConfig(
             "base_model.model.model.layers.9.mlp.down_proj.lora_A.weight",
             "model.layers.9.mlp.down_proj",
-            True,
+            "lora_a",
         ),
         LoRANameParserTestConfig(
             "base_model.model.model.layers.9.mlp.down_proj.lora_B.weight",
             "model.layers.9.mlp.down_proj",
-            False,
+            "lora_b",
+        ),
+        LoRANameParserTestConfig(
+            "base_model.model.model.layers.9.mlp.down_proj.lora_magnitude_vector",
+            "model.layers.9.mlp.down_proj",
+            "dora_magnitude",
         ),
         LoRANameParserTestConfig(
             "language_model.layers.9.mlp.down_proj.lora_A.weight",
             "language_model.layers.9.mlp.down_proj",
-            True,
+            "lora_a",
         ),
         LoRANameParserTestConfig(
             "language_model.layers.9.mlp.down_proj.lora_B.weight",
             "language_model.layers.9.mlp.down_proj",
-            False,
+            "lora_b",
         ),
         # Test with WeightsMapper
         LoRANameParserTestConfig(
             "base_model.model.model.layers.9.mlp.down_proj.lora_A.weight",
             "language_model.model.layers.9.mlp.down_proj",
-            True,
+            "lora_a",
             weights_mapper=WeightsMapper(
                 orig_to_new_prefix={"model.": "language_model.model."}
             ),
@@ -74,7 +79,15 @@ def test_parse_fine_tuned_lora_name_valid():
         LoRANameParserTestConfig(
             "base_model.model.model.layers.9.mlp.down_proj.lora_B.weight",
             "language_model.model.layers.9.mlp.down_proj",
-            False,
+            "lora_b",
+            weights_mapper=WeightsMapper(
+                orig_to_new_prefix={"model.": "language_model.model."}
+            ),
+        ),
+        LoRANameParserTestConfig(
+            "base_model.model.model.layers.9.mlp.down_proj.lora_magnitude_vector",
+            "language_model.model.layers.9.mlp.down_proj",
+            "dora_magnitude",
             weights_mapper=WeightsMapper(
                 orig_to_new_prefix={"model.": "language_model.model."}
             ),
@@ -82,7 +95,7 @@ def test_parse_fine_tuned_lora_name_valid():
         LoRANameParserTestConfig(
             "model.layers.9.mlp.down_proj.lora_A.weight",
             "language_model.model.layers.9.mlp.down_proj",
-            True,
+            "lora_a",
             weights_mapper=WeightsMapper(
                 orig_to_new_prefix={"model.": "language_model.model."}
             ),
@@ -90,14 +103,14 @@ def test_parse_fine_tuned_lora_name_valid():
         LoRANameParserTestConfig(
             "model.layers.9.mlp.down_proj.lora_B.weight",
             "language_model.model.layers.9.mlp.down_proj",
-            False,
+            "lora_b",
             weights_mapper=WeightsMapper(
                 orig_to_new_prefix={"model.": "language_model.model."}
             ),
         ),
     ]
-    for name, module_name, is_lora_a, weights_mapper in fixture:
-        assert (module_name, is_lora_a) == parse_fine_tuned_lora_name(
+    for name, module_name, weight_type, weights_mapper in fixture:
+        assert (module_name, weight_type) == parse_fine_tuned_lora_name(
             name, weights_mapper
         )
 

--- a/tests/lora/utils.py
+++ b/tests/lora/utils.py
@@ -3,10 +3,11 @@
 
 import json
 import os
+import shutil
 from dataclasses import dataclass
 
 import torch
-from safetensors.torch import save_file
+from safetensors.torch import load_file, save_file
 
 from vllm.lora.lora_weights import LoRALayerWeights, PackedLoRALayerWeights
 from vllm.platforms import current_platform
@@ -102,6 +103,36 @@ def assert_close(a, b):
         torch.float32: (1e-2, 1e-2),
     }[a.dtype]
     torch.testing.assert_close(a, b, rtol=rtol, atol=atol)
+
+
+def convert_dora_checkpoint_to_lora(
+    dora_dir: str, lora_dir: str | os.PathLike[str]
+) -> str:
+    """Copy a DoRA adapter and strip DoRA-only state."""
+    lora_dir = os.fspath(lora_dir)
+    shutil.copytree(dora_dir, lora_dir, dirs_exist_ok=True)
+
+    config_path = os.path.join(lora_dir, "adapter_config.json")
+    with open(config_path, encoding="utf-8") as f:
+        adapter_config = json.load(f)
+    assert adapter_config["use_dora"]
+    adapter_config["use_dora"] = False
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump(adapter_config, f, indent=2)
+
+    weights_path = os.path.join(lora_dir, "adapter_model.safetensors")
+    tensors = load_file(weights_path)
+    dora_tensor_count = sum(
+        name.endswith("lora_magnitude_vector") for name in tensors
+    )
+    assert dora_tensor_count > 0
+    tensors = {
+        name: tensor
+        for name, tensor in tensors.items()
+        if not name.endswith("lora_magnitude_vector")
+    }
+    save_file(tensors, weights_path)
+    return str(lora_dir)
 
 
 @dataclass

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -181,6 +181,11 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
+    async def remove_lora(self, lora_id: int) -> bool:
+        """Remove an already loaded LoRA adapter."""
+        ...
+
+    @abstractmethod
     async def pause_generation(
         self,
         *,

--- a/vllm/entrypoints/openai/models/serving.py
+++ b/vllm/entrypoints/openai/models/serving.py
@@ -229,7 +229,26 @@ class OpenAIServingModels:
             if error_check_ret is not None:
                 return error_check_ret
 
-            # Safe to delete now since we hold the lock
+            # Safe to remove now since we hold the lock. Remove from the
+            # engine before dropping the frontend registry entry so adapter
+            # slot state is cleared even when a name is reused later.
+            lora_request = self.lora_requests[lora_name]
+            try:
+                removed = await self.engine_client.remove_lora(
+                    lora_request.lora_int_id
+                )
+            except Exception as e:
+                return create_error_response(
+                    message=str(e),
+                    err_type="InternalServerError",
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
+            if not removed:
+                logger.info(
+                    "LoRA adapter '%s' was not present in the engine cache "
+                    "during unload.",
+                    lora_name,
+                )
             del self.lora_requests[lora_name]
             logger.info("Removed LoRA adapter: name '%s'", lora_name)
             return f"Success: LoRA adapter '{lora_name}' removed successfully."

--- a/vllm/lora/layers/base.py
+++ b/vllm/lora/layers/base.py
@@ -56,6 +56,7 @@ class BaseLayerWithLoRA(nn.Module):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: torch.Tensor | None = None,
     ):
         """Overwrites lora tensors at index."""
         ...

--- a/vllm/lora/layers/base.py
+++ b/vllm/lora/layers/base.py
@@ -56,7 +56,9 @@ class BaseLayerWithLoRA(nn.Module):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
     ):
         """Overwrites lora tensors at index."""
         ...

--- a/vllm/lora/layers/base_linear.py
+++ b/vllm/lora/layers/base_linear.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.linear import (
     QuantizeMethodBase,
     ReplicatedLinear,
     RowParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.platforms import current_platform
 from vllm.utils.multi_stream_utils import maybe_execute_in_parallel
@@ -82,6 +83,7 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
         self.output_slices: tuple[int, ...]
         self.output_size: int
         self.n_slices: int
+        self._dora_active_slots: set[int] = set()
 
     def _init_lora_stream_context(self) -> None:
         if not self._enable_aux_cuda_stream:
@@ -159,6 +161,7 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             dtype=torch.bool,
             device=self.device,
         )
+        self._dora_active_slots.clear()
         self.output_slices = (self.lora_b_stacked[0].shape[2],)
 
     def reset_lora(self, index: int):
@@ -167,6 +170,15 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             self.lora_b_stacked[s_index][index] = 0
         self.dora_scale_stacked[index] = 1
         self.dora_enabled_stacked[index] = False
+        self._dora_active_slots.discard(index)
+
+    @staticmethod
+    def _raise_if_dora_unsupported(
+        lora_magnitude_vector: torch.Tensor | None,
+        feature: str,
+    ) -> None:
+        if lora_magnitude_vector is not None:
+            raise NotImplementedError(f"DoRA is not supported for {feature}.")
 
     def set_lora(
         self,
@@ -219,6 +231,8 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             raise NotImplementedError("DoRA currently only supports TP=1.")
         if self.n_slices != 1:
             raise NotImplementedError("DoRA is not supported for packed LoRA layers.")
+        if not isinstance(self.base_layer.quant_method, UnquantizedLinearMethod):
+            raise NotImplementedError("DoRA is not supported for quantized layers.")
         if not hasattr(self.base_layer, "weight"):
             raise NotImplementedError(
                 "DoRA requires access to the unquantized base layer weight."
@@ -248,30 +262,99 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             non_blocking=True,
         )
         self.dora_enabled_stacked[index] = True
+        self._dora_active_slots.add(index)
+
+    def _get_dora_token_mask(
+        self,
+        num_tokens: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        token_lora_indices = self.punica_wrapper.token_lora_indices[:num_tokens]
+        has_adapter = token_lora_indices >= 0
+        safe_token_lora_indices = torch.where(
+            has_adapter, token_lora_indices, torch.zeros_like(token_lora_indices)
+        )
+        has_dora = has_adapter & self.dora_enabled_stacked[safe_token_lora_indices]
+        return token_lora_indices, has_dora
 
     def apply(self, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
         # is_forward_context_available for tower modules
-        if self._enable_aux_cuda_stream and is_forward_context_available():
+        if (
+            self._enable_aux_cuda_stream
+            and is_forward_context_available()
+            and not self._dora_active_slots
+        ):
             output_size = sum(self.output_slices)
             return torch.ops.vllm.lora_linear_async(
                 self.layer_name, output_size, x, bias
             )
-        else:
-            return self._apply_sync(x, bias)
+        return self._apply_sync(x, bias)
 
     def _apply_sync(
         self, x: torch.Tensor, bias: torch.Tensor | None = None
     ) -> torch.Tensor:
         output = self._get_quant_method().apply(self.base_layer, x, bias)
-        return self._apply_lora_to_output(x, output)
+        return self._apply_lora_to_output(x, output, bias_was_added=bias is not None)
 
     def _apply_base_forward(self, x: torch.Tensor) -> torch.Tensor:
         base_output = self.base_layer(x)
         output = base_output[0] if isinstance(base_output, tuple) else base_output
-        return self._apply_lora_to_output(x, output)
+        bias_was_added = self.bias is not None and not self.base_layer.skip_bias_add
+        return self._apply_lora_to_output(x, output, bias_was_added=bias_was_added)
+
+    def _apply_standard_lora(
+        self,
+        x: torch.Tensor,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        lora_output: torch.Tensor | None = self.punica_wrapper.add_lora_linear(
+            output,
+            x,
+            self.lora_a_stacked,
+            self.lora_b_stacked,
+            1.0,
+            self.output_slices,
+        )
+        if current_platform.can_update_inplace():
+            return output
+        assert lora_output is not None
+        return lora_output
+
+    def _compute_lora_delta(
+        self,
+        x: torch.Tensor,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        lora_delta = torch.zeros_like(output)
+        lora_output: torch.Tensor | None = self.punica_wrapper.add_lora_linear(
+            lora_delta,
+            x,
+            self.lora_a_stacked,
+            self.lora_b_stacked,
+            1.0,
+            self.output_slices,
+            add_inputs=False,
+        )
+        if current_platform.can_update_inplace():
+            return lora_delta
+        assert lora_output is not None
+        return lora_output
+
+    def _apply_dora_scale(
+        self,
+        output: torch.Tensor,
+        token_lora_indices: torch.Tensor,
+        has_dora: torch.Tensor,
+    ) -> torch.Tensor:
+        dora_scale = self.dora_scale_stacked[token_lora_indices[has_dora]]
+        output[has_dora] = output[has_dora] * dora_scale.to(dtype=output.dtype)
+        return output
 
     def _apply_lora_to_output(
-        self, x: torch.Tensor, output: torch.Tensor
+        self,
+        x: torch.Tensor,
+        output: torch.Tensor,
+        *,
+        bias_was_added: bool = False,
     ) -> torch.Tensor:
         original_shape = output.shape if output.ndim == 3 else None
 
@@ -282,11 +365,25 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             output = output.flatten(0, 1)
             x = x.flatten(0, 1)
 
-        lora_output: torch.Tensor | None = self.punica_wrapper.add_lora_linear(
-            output, x, self.lora_a_stacked, self.lora_b_stacked, 1.0, self.output_slices
-        )
-        if not current_platform.can_update_inplace():
-            output = lora_output
+        if self._dora_active_slots:
+            token_lora_indices, has_dora = self._get_dora_token_mask(x.shape[0])
+            if has_dora.any().item():
+                if not current_platform.is_cuda_alike():
+                    raise NotImplementedError("DoRA currently only supports CUDA.")
+                if bias_was_added:
+                    raise NotImplementedError(
+                        "DoRA currently only supports linear layers without "
+                        "an added bias in the base output."
+                    )
+
+                # DoRA needs the unscaled base-plus-LoRA value before applying
+                # the per-output magnitude scale for DoRA tokens only.
+                output.add_(self._compute_lora_delta(x, output))
+                output = self._apply_dora_scale(output, token_lora_indices, has_dora)
+            else:
+                output = self._apply_standard_lora(x, output)
+        else:
+            output = self._apply_standard_lora(x, output)
 
         # Reshape the flattened output back to its original shape,
         # as some MM encoders cannot handle flattened inputs.

--- a/vllm/lora/layers/base_linear.py
+++ b/vllm/lora/layers/base_linear.py
@@ -312,13 +312,19 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
         self, x: torch.Tensor, bias: torch.Tensor | None = None
     ) -> torch.Tensor:
         output = self._get_quant_method().apply(self.base_layer, x, bias)
-        return self._apply_lora_to_output(x, output, bias_was_added=bias is not None)
+        return self._apply_lora_to_output(x, output, base_output_bias=bias)
 
     def _apply_base_forward(self, x: torch.Tensor) -> torch.Tensor:
         base_output = self.base_layer(x)
         output = base_output[0] if isinstance(base_output, tuple) else base_output
-        bias_was_added = self.bias is not None and not self.base_layer.skip_bias_add
-        return self._apply_lora_to_output(x, output, bias_was_added=bias_was_added)
+        base_output_bias = (
+            self.bias
+            if self.bias is not None and not self.base_layer.skip_bias_add
+            else None
+        )
+        return self._apply_lora_to_output(
+            x, output, base_output_bias=base_output_bias
+        )
 
     def _apply_standard_lora(
         self,
@@ -363,9 +369,21 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
         output: torch.Tensor,
         token_lora_indices: torch.Tensor,
         has_dora: torch.Tensor,
+        base_output_bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        dora_scale = self.dora_scale_stacked[token_lora_indices[has_dora]]
-        output[has_dora] = output[has_dora] * dora_scale.to(dtype=output.dtype)
+        dora_scale = self.dora_scale_stacked[token_lora_indices[has_dora]].to(
+            dtype=output.dtype
+        )
+        dora_output = output[has_dora]
+        if base_output_bias is not None:
+            # DoRA scales only the weight path. If the base linear already
+            # added bias, remove it before scaling and add it back after.
+            bias = base_output_bias.to(dtype=output.dtype)
+            dora_output = (dora_output - bias) * dora_scale
+            dora_output = dora_output + bias
+        else:
+            dora_output = dora_output * dora_scale
+        output[has_dora] = dora_output
         return output
 
     def _apply_lora_to_output(
@@ -373,7 +391,7 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
         x: torch.Tensor,
         output: torch.Tensor,
         *,
-        bias_was_added: bool = False,
+        base_output_bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         original_shape = output.shape if output.ndim == 3 else None
 
@@ -389,16 +407,16 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             if has_dora.any().item():
                 if not current_platform.is_cuda_alike():
                     raise NotImplementedError("DoRA currently only supports CUDA.")
-                if bias_was_added:
-                    raise NotImplementedError(
-                        "DoRA currently only supports linear layers without "
-                        "an added bias in the base output."
-                    )
 
                 # DoRA needs the unscaled base-plus-LoRA value before applying
                 # the per-output magnitude scale for DoRA tokens only.
                 output.add_(self._compute_lora_delta(x, output))
-                output = self._apply_dora_scale(output, token_lora_indices, has_dora)
+                output = self._apply_dora_scale(
+                    output,
+                    token_lora_indices,
+                    has_dora,
+                    base_output_bias=base_output_bias,
+                )
             else:
                 output = self._apply_standard_lora(x, output)
         else:

--- a/vllm/lora/layers/base_linear.py
+++ b/vllm/lora/layers/base_linear.py
@@ -148,18 +148,32 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             )
             for _ in range(self.n_slices)
         )
+        self.dora_scale_stacked = torch.ones(
+            max_loras,
+            lora_b_out_size,
+            dtype=lora_config.lora_dtype,
+            device=self.device,
+        )
+        self.dora_enabled_stacked = torch.zeros(
+            max_loras,
+            dtype=torch.bool,
+            device=self.device,
+        )
         self.output_slices = (self.lora_b_stacked[0].shape[2],)
 
     def reset_lora(self, index: int):
         for s_index in range(self.n_slices):
             self.lora_a_stacked[s_index][index] = 0
             self.lora_b_stacked[s_index][index] = 0
+        self.dora_scale_stacked[index] = 1
+        self.dora_enabled_stacked[index] = False
 
     def set_lora(
         self,
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: torch.Tensor | None = None,
     ):
         # Except for QKVParallelLinearWithLoRA and
         # MergedColumnParallelLinearWithLoRA, all other linear LoRA layers
@@ -176,6 +190,9 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             lora_a = self.slice_lora_a(lora_a)
             lora_b = self.slice_lora_b(lora_b)
 
+        if lora_magnitude_vector is not None:
+            self._set_dora_scale(index, lora_a, lora_b, lora_magnitude_vector)
+
         self.lora_a_stacked[0][index, 0, : lora_a.shape[0], : lora_a.shape[1]].copy_(
             lora_a, non_blocking=True
         )
@@ -190,6 +207,47 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
                 f"{type(self.base_layer).__name__} must define quant_method for LoRA."
             )
         return quant_method
+
+    def _set_dora_scale(
+        self,
+        index: int,
+        lora_a: torch.Tensor,
+        lora_b: torch.Tensor,
+        lora_magnitude_vector: torch.Tensor,
+    ) -> None:
+        if self.tp_size != 1:
+            raise NotImplementedError("DoRA currently only supports TP=1.")
+        if self.n_slices != 1:
+            raise NotImplementedError("DoRA is not supported for packed LoRA layers.")
+        if not hasattr(self.base_layer, "weight"):
+            raise NotImplementedError(
+                "DoRA requires access to the unquantized base layer weight."
+            )
+
+        base_weight = self.base_layer.weight
+        if base_weight.shape != (lora_b.shape[0], lora_a.shape[1]):
+            raise ValueError(
+                "DoRA weight shapes are incompatible with the base layer: "
+                f"base_weight={tuple(base_weight.shape)}, "
+                f"lora_a={tuple(lora_a.shape)}, lora_b={tuple(lora_b.shape)}."
+            )
+        if lora_magnitude_vector.shape[0] != lora_b.shape[0]:
+            raise ValueError(
+                "DoRA magnitude vector shape is incompatible with lora_b: "
+                f"magnitude={tuple(lora_magnitude_vector.shape)}, "
+                f"lora_b={tuple(lora_b.shape)}."
+            )
+
+        delta_weight = lora_b.float() @ lora_a.float()
+        merged_weight = base_weight.float() + delta_weight
+        weight_norm = torch.linalg.vector_norm(merged_weight, dim=1)
+        weight_norm = torch.clamp(weight_norm, min=torch.finfo(weight_norm.dtype).eps)
+        dora_scale = lora_magnitude_vector.float() / weight_norm
+        self.dora_scale_stacked[index, : dora_scale.shape[0]].copy_(
+            dora_scale.to(dtype=self.dora_scale_stacked.dtype),
+            non_blocking=True,
+        )
+        self.dora_enabled_stacked[index] = True
 
     def apply(self, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
         # is_forward_context_available for tower modules

--- a/vllm/lora/layers/base_linear.py
+++ b/vllm/lora/layers/base_linear.py
@@ -277,6 +277,11 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
                 f"lora_b={tuple(lora_b.shape)}."
             )
 
+        lora_a = lora_a.to(device=base_weight.device, non_blocking=True)
+        lora_b = lora_b.to(device=base_weight.device, non_blocking=True)
+        lora_magnitude_vector = lora_magnitude_vector.to(
+            device=base_weight.device, non_blocking=True
+        )
         delta_weight = lora_b.float() @ lora_a.float()
         merged_weight = base_weight.float() + delta_weight
         weight_norm = torch.linalg.vector_norm(merged_weight, dim=1)

--- a/vllm/lora/layers/base_linear.py
+++ b/vllm/lora/layers/base_linear.py
@@ -174,7 +174,9 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
 
     @staticmethod
     def _raise_if_dora_unsupported(
-        lora_magnitude_vector: torch.Tensor | None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ),
         feature: str,
     ) -> None:
         if lora_magnitude_vector is not None:
@@ -185,7 +187,9 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
     ):
         # Except for QKVParallelLinearWithLoRA and
         # MergedColumnParallelLinearWithLoRA, all other linear LoRA layers
@@ -203,6 +207,7 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             lora_b = self.slice_lora_b(lora_b)
 
         if lora_magnitude_vector is not None:
+            assert isinstance(lora_magnitude_vector, torch.Tensor)
             self._set_dora_scale(index, lora_a, lora_b, lora_magnitude_vector)
 
         self.lora_a_stacked[0][index, 0, : lora_a.shape[0], : lora_a.shape[1]].copy_(
@@ -239,6 +244,26 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             )
 
         base_weight = self.base_layer.weight
+        dora_scale = self._get_dora_scale(
+            base_weight,
+            lora_a,
+            lora_b,
+            lora_magnitude_vector,
+        )
+        self.dora_scale_stacked[index, : dora_scale.shape[0]].copy_(
+            dora_scale.to(dtype=self.dora_scale_stacked.dtype),
+            non_blocking=True,
+        )
+        self.dora_enabled_stacked[index] = True
+        self._dora_active_slots.add(index)
+
+    @staticmethod
+    def _get_dora_scale(
+        base_weight: torch.Tensor,
+        lora_a: torch.Tensor,
+        lora_b: torch.Tensor,
+        lora_magnitude_vector: torch.Tensor,
+    ) -> torch.Tensor:
         if base_weight.shape != (lora_b.shape[0], lora_a.shape[1]):
             raise ValueError(
                 "DoRA weight shapes are incompatible with the base layer: "
@@ -256,13 +281,7 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
         merged_weight = base_weight.float() + delta_weight
         weight_norm = torch.linalg.vector_norm(merged_weight, dim=1)
         weight_norm = torch.clamp(weight_norm, min=torch.finfo(weight_norm.dtype).eps)
-        dora_scale = lora_magnitude_vector.float() / weight_norm
-        self.dora_scale_stacked[index, : dora_scale.shape[0]].copy_(
-            dora_scale.to(dtype=self.dora_scale_stacked.dtype),
-            non_blocking=True,
-        )
-        self.dora_enabled_stacked[index] = True
-        self._dora_active_slots.add(index)
+        return lora_magnitude_vector.float() / weight_norm
 
     def _get_dora_token_mask(
         self,

--- a/vllm/lora/layers/base_linear.py
+++ b/vllm/lora/layers/base_linear.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Callable
 
 import torch
 from transformers import PretrainedConfig
@@ -202,13 +203,14 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
         )
 
         self.reset_lora(index)
-        if self.tp_size > 1:
-            lora_a = self.slice_lora_a(lora_a)
-            lora_b = self.slice_lora_b(lora_b)
 
         if lora_magnitude_vector is not None:
             assert isinstance(lora_magnitude_vector, torch.Tensor)
             self._set_dora_scale(index, lora_a, lora_b, lora_magnitude_vector)
+
+        if self.tp_size > 1:
+            lora_a = self.slice_lora_a(lora_a)
+            lora_b = self.slice_lora_b(lora_b)
 
         self.lora_a_stacked[0][index, 0, : lora_a.shape[0], : lora_a.shape[1]].copy_(
             lora_a, non_blocking=True
@@ -236,20 +238,26 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             raise NotImplementedError("DoRA currently only supports TP=1.")
         if self.n_slices != 1:
             raise NotImplementedError("DoRA is not supported for packed LoRA layers.")
-        if not isinstance(self.base_layer.quant_method, UnquantizedLinearMethod):
-            raise NotImplementedError("DoRA is not supported for quantized layers.")
-        if not hasattr(self.base_layer, "weight"):
-            raise NotImplementedError(
-                "DoRA requires access to the unquantized base layer weight."
-            )
 
-        base_weight = self.base_layer.weight
+        base_weight = self._get_dora_base_weight()
         dora_scale = self._get_dora_scale(
             base_weight,
             lora_a,
             lora_b,
             lora_magnitude_vector,
         )
+        self._store_dora_scale(index, dora_scale)
+
+    def _get_dora_base_weight(self) -> torch.Tensor:
+        if not isinstance(self.base_layer.quant_method, UnquantizedLinearMethod):
+            raise NotImplementedError("DoRA is not supported for quantized layers.")
+        if not hasattr(self.base_layer, "weight"):
+            raise NotImplementedError(
+                "DoRA requires access to the unquantized base layer weight."
+            )
+        return self.base_layer.weight
+
+    def _store_dora_scale(self, index: int, dora_scale: torch.Tensor) -> None:
         self.dora_scale_stacked[index, : dora_scale.shape[0]].copy_(
             dora_scale.to(dtype=self.dora_scale_stacked.dtype),
             non_blocking=True,
@@ -263,6 +271,7 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
         lora_a: torch.Tensor,
         lora_b: torch.Tensor,
         lora_magnitude_vector: torch.Tensor,
+        norm_sq_reduce: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> torch.Tensor:
         if base_weight.shape != (lora_b.shape[0], lora_a.shape[1]):
             raise ValueError(
@@ -284,7 +293,10 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
         )
         delta_weight = lora_b.float() @ lora_a.float()
         merged_weight = base_weight.float() + delta_weight
-        weight_norm = torch.linalg.vector_norm(merged_weight, dim=1)
+        norm_sq = merged_weight.square().sum(dim=1)
+        if norm_sq_reduce is not None:
+            norm_sq = norm_sq_reduce(norm_sq)
+        weight_norm = torch.sqrt(norm_sq)
         weight_norm = torch.clamp(weight_norm, min=torch.finfo(weight_norm.dtype).eps)
         return lora_magnitude_vector.float() / weight_norm
 

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -255,6 +255,7 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
             dtype=torch.bool,
             device=self.device,
         )
+        self._dora_active_slots.clear()
 
     def slice_lora_a(
         self, lora_a: list[torch.Tensor | None]
@@ -317,8 +318,9 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         lora_b: torch.Tensor | list[torch.Tensor],
         lora_magnitude_vector: torch.Tensor | None = None,
     ):
-        if lora_magnitude_vector is not None:
-            raise NotImplementedError("DoRA is not supported for packed LoRA layers.")
+        self._raise_if_dora_unsupported(
+            lora_magnitude_vector, "packed LoRA layers"
+        )
         self.reset_lora(index)
 
         # Expand packed adapter groups when they don't match n_slices.
@@ -533,6 +535,18 @@ class ColumnParallelLinearWithShardedLoRA(ColumnParallelLinearWithLoRA):
         lora_a = lora_a[start_idx : start_idx + shard_size, :]
         return lora_a
 
+    def set_lora(
+        self,
+        index: int,
+        lora_a: torch.Tensor | list[torch.Tensor],
+        lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: torch.Tensor | None = None,
+    ):
+        self._raise_if_dora_unsupported(
+            lora_magnitude_vector, "fully sharded LoRA"
+        )
+        super().set_lora(index, lora_a, lora_b)
+
     def apply(self, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
         return _mcp_apply(x, bias, self)
 
@@ -612,6 +626,18 @@ class QKVParallelLinearWithShardedLoRA(QKVParallelLinearWithLoRA):
         start_idx = self.tp_rank * shard_size
         lora_a = lora_a[start_idx : start_idx + shard_size, :]
         return lora_a
+
+    def set_lora(
+        self,
+        index: int,
+        lora_a: torch.Tensor | list[torch.Tensor],
+        lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: torch.Tensor | None = None,
+    ):
+        self._raise_if_dora_unsupported(
+            lora_magnitude_vector, "fully sharded LoRA"
+        )
+        super().set_lora(index, lora_a, lora_b)
 
     def apply(self, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
         return _mcp_apply(x, bias, self)
@@ -738,8 +764,9 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
     ):
         """Override to handle single tensor weights
         that need to be split into slices."""
-        if lora_magnitude_vector is not None:
-            raise NotImplementedError("DoRA is not supported for packed LoRA layers.")
+        self._raise_if_dora_unsupported(
+            lora_magnitude_vector, "packed LoRA layers"
+        )
         self.reset_lora(index)
 
         # Handle case where checkpoint has single tensor weights

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
     QKVParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.platforms import current_platform
 
@@ -34,6 +35,12 @@ def _mcp_apply(x, bias, layer: "ColumnParallelLinearWithLoRA"):
     )
 
     output = layer._get_quant_method().apply(layer.base_layer, x, bias)
+    if layer._dora_active_slots:
+        return layer._apply_lora_to_output(
+            x,
+            output,
+            bias_was_added=bias is not None,
+        )
 
     x = x.view(-1, x.shape[-1])
     output, out_orig_shape = output.view(-1, output.shape[-1]), output.shape
@@ -277,17 +284,27 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
 
     def expand_packed_lora(
         self,
-        lora_a: list[torch.Tensor],
-        lora_b: list[torch.Tensor],
-    ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+        lora_a: list[torch.Tensor | None],
+        lora_b: list[torch.Tensor | None],
+        lora_magnitude_vector: list[torch.Tensor | None] | None = None,
+    ) -> tuple[
+        list[torch.Tensor | None],
+        list[torch.Tensor | None],
+        list[torch.Tensor | None] | None,
+    ]:
         """
         Expand packed adapter groups when they don't match n_slices.
         E.g. in_proj_qkv (covers Q+K+V) + in_proj_z
         """
-        expanded_a: list[torch.Tensor] = []
-        expanded_b: list[torch.Tensor] = []
+        expanded_a: list[torch.Tensor | None] = []
+        expanded_b: list[torch.Tensor | None] = []
+        expanded_magnitude_vector: list[torch.Tensor | None] | None = (
+            [] if lora_magnitude_vector is not None else None
+        )
         start_idx = 0
-        for a_i, b_i in zip(lora_a, lora_b):
+        for group_idx, (a_i, b_i) in enumerate(zip(lora_a, lora_b)):
+            assert b_i is not None
+
             # Determine which output slices this b_i covers.
             b_rows, cu_rows, covered = b_i.shape[0], 0, 0
             for i in range(start_idx, self.n_slices):
@@ -307,31 +324,110 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
                 size = self.output_sizes[start_idx + j]
                 expanded_b.append(b_i[start : start + size, :])
                 expanded_a.append(a_i)
+                if expanded_magnitude_vector is not None:
+                    assert lora_magnitude_vector is not None
+                    magnitude_vector_i = lora_magnitude_vector[group_idx]
+                    expanded_magnitude_vector.append(
+                        None
+                        if magnitude_vector_i is None
+                        else magnitude_vector_i[start : start + size]
+                    )
                 start += size
             start_idx += covered
-        return expanded_a, expanded_b
+        return expanded_a, expanded_b, expanded_magnitude_vector
+
+    def _set_packed_dora_scale(
+        self,
+        index: int,
+        lora_a: list[torch.Tensor | None],
+        lora_b: list[torch.Tensor | None],
+        lora_magnitude_vector: list[torch.Tensor | None],
+    ) -> None:
+        if self.tp_size != 1:
+            raise NotImplementedError("DoRA currently only supports TP=1.")
+        if not isinstance(self.base_layer.quant_method, UnquantizedLinearMethod):
+            raise NotImplementedError("DoRA is not supported for quantized layers.")
+        if not hasattr(self.base_layer, "weight"):
+            raise NotImplementedError(
+                "DoRA requires access to the unquantized base layer weight."
+            )
+
+        base_weight = self.base_layer.weight
+        output_offset = 0
+        has_dora = False
+        for i, output_size in enumerate(self.output_slices):
+            lora_a_i = lora_a[i]
+            lora_b_i = lora_b[i]
+            magnitude_vector_i = lora_magnitude_vector[i]
+            if lora_a_i is None and lora_b_i is None and magnitude_vector_i is None:
+                output_offset += output_size
+                continue
+            assert lora_a_i is not None
+            assert lora_b_i is not None
+            assert magnitude_vector_i is not None
+
+            dora_scale = self._get_dora_scale(
+                base_weight[output_offset : output_offset + output_size, :],
+                lora_a_i,
+                lora_b_i,
+                magnitude_vector_i,
+            )
+            self.dora_scale_stacked[
+                index, output_offset : output_offset + dora_scale.shape[0]
+            ].copy_(
+                dora_scale.to(dtype=self.dora_scale_stacked.dtype),
+                non_blocking=True,
+            )
+            output_offset += output_size
+            has_dora = True
+
+        if has_dora:
+            self.dora_enabled_stacked[index] = True
+            self._dora_active_slots.add(index)
 
     def set_lora(
         self,
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
     ):
-        self._raise_if_dora_unsupported(
-            lora_magnitude_vector, "packed LoRA layers"
-        )
         self.reset_lora(index)
+        assert isinstance(lora_a, list)
+        assert isinstance(lora_b, list)
+        assert len(lora_a) == len(lora_b)
+        if lora_magnitude_vector is not None:
+            if type(self.base_layer) is maybe_get_oot_by_class(
+                MergedColumnParallelLinear
+            ):
+                raise NotImplementedError(
+                    "DoRA is not supported for MergedColumnParallelLinear "
+                    "packed LoRA layers."
+                )
+            assert isinstance(lora_magnitude_vector, list)
+            assert len(lora_magnitude_vector) == len(lora_b)
 
         # Expand packed adapter groups when they don't match n_slices.
         # E.g. in_proj_qkv (covers Q+K+V) + in_proj_z as 2 groups for a
         # 4-slice layer: split b_qkv by output_sizes and replicate a_qkv.
-        if isinstance(lora_b, list) and len(lora_b) != self.n_slices:
-            lora_a, lora_b = self.expand_packed_lora(lora_a, lora_b)
+        if len(lora_b) != self.n_slices:
+            lora_a, lora_b, lora_magnitude_vector = self.expand_packed_lora(
+                lora_a, lora_b, lora_magnitude_vector
+            )
+
+        if lora_magnitude_vector is not None and self.tp_size > 1:
+            raise NotImplementedError("DoRA currently only supports TP=1.")
 
         if self.tp_size > 1:
             lora_a = self.slice_lora_a(lora_a)
             lora_b = self.slice_lora_b(lora_b)
+
+        if lora_magnitude_vector is not None:
+            self._set_packed_dora_scale(
+                index, lora_a, lora_b, lora_magnitude_vector
+            )
 
         for i in range(self.n_slices):
             if (lora_a_i := lora_a[i]) is not None:
@@ -540,7 +636,9 @@ class ColumnParallelLinearWithShardedLoRA(ColumnParallelLinearWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
     ):
         self._raise_if_dora_unsupported(
             lora_magnitude_vector, "fully sharded LoRA"
@@ -590,6 +688,20 @@ class MergedColumnParallelLinearWithShardedLoRA(MergedColumnParallelLinearWithLo
             for i in range(len(lora_a))
         ]
 
+    def set_lora(
+        self,
+        index: int,
+        lora_a: torch.Tensor | list[torch.Tensor],
+        lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
+    ):
+        self._raise_if_dora_unsupported(
+            lora_magnitude_vector, "fully sharded LoRA"
+        )
+        super().set_lora(index, lora_a, lora_b)
+
     def apply(self, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
         return _mcp_apply(x, bias, self)
 
@@ -632,7 +744,9 @@ class QKVParallelLinearWithShardedLoRA(QKVParallelLinearWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
     ):
         self._raise_if_dora_unsupported(
             lora_magnitude_vector, "fully sharded LoRA"
@@ -687,6 +801,20 @@ class MergedQKVParallelLinearWithShardedLoRA(MergedQKVParallelLinearWithLoRA):
             else None,
         ]
         return lora_a
+
+    def set_lora(
+        self,
+        index: int,
+        lora_a: torch.Tensor | list[torch.Tensor],
+        lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
+    ):
+        self._raise_if_dora_unsupported(
+            lora_magnitude_vector, "fully sharded LoRA"
+        )
+        super().set_lora(index, lora_a, lora_b)
 
     def apply(self, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
         return _mcp_apply(x, bias, self)
@@ -760,7 +888,9 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
     ):
         """Override to handle single tensor weights
         that need to be split into slices."""

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -39,7 +39,7 @@ def _mcp_apply(x, bias, layer: "ColumnParallelLinearWithLoRA"):
         return layer._apply_lora_to_output(
             x,
             output,
-            bias_was_added=bias is not None,
+            base_output_bias=bias,
         )
 
     x = x.view(-1, x.shape[-1])

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -244,6 +244,17 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
             )
             for output_size in self.output_slices
         )
+        self.dora_scale_stacked = torch.ones(
+            max_loras,
+            sum(self.output_slices),
+            dtype=lora_config.lora_dtype,
+            device=self.device,
+        )
+        self.dora_enabled_stacked = torch.zeros(
+            max_loras,
+            dtype=torch.bool,
+            device=self.device,
+        )
 
     def slice_lora_a(
         self, lora_a: list[torch.Tensor | None]
@@ -304,7 +315,10 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: torch.Tensor | None = None,
     ):
+        if lora_magnitude_vector is not None:
+            raise NotImplementedError("DoRA is not supported for packed LoRA layers.")
         self.reset_lora(index)
 
         # Expand packed adapter groups when they don't match n_slices.
@@ -720,9 +734,12 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: torch.Tensor | None = None,
     ):
         """Override to handle single tensor weights
         that need to be split into slices."""
+        if lora_magnitude_vector is not None:
+            raise NotImplementedError("DoRA is not supported for packed LoRA layers.")
         self.reset_lora(index)
 
         # Handle case where checkpoint has single tensor weights

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -136,6 +136,40 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
             lora_b = lora_b[start_idx:end_idx, :]
         return lora_b
 
+    def slice_lora_magnitude_vector(
+        self, lora_magnitude_vector: torch.Tensor
+    ) -> torch.Tensor:
+        return self.slice_lora_b(lora_magnitude_vector[:, None]).squeeze(1)
+
+    def _set_dora_scale(
+        self,
+        index: int,
+        lora_a: torch.Tensor,
+        lora_b: torch.Tensor,
+        lora_magnitude_vector: torch.Tensor,
+    ) -> None:
+        if self.n_slices != 1:
+            raise NotImplementedError("DoRA is not supported for packed LoRA layers.")
+        if self.tp_size > 1 and self.is_merged_col_linear:
+            raise NotImplementedError(
+                "DoRA is not supported for MergedColumnParallelLinear with TP>1."
+            )
+
+        base_weight = self._get_dora_base_weight()
+        if self.tp_size > 1:
+            lora_b = self.slice_lora_b(lora_b)
+            lora_magnitude_vector = self.slice_lora_magnitude_vector(
+                lora_magnitude_vector
+            )
+
+        dora_scale = self._get_dora_scale(
+            base_weight,
+            lora_a,
+            lora_b,
+            lora_magnitude_vector,
+        )
+        self._store_dora_scale(index, dora_scale)
+
     def forward(
         self, input_: torch.Tensor
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -14,7 +14,6 @@ from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
     QKVParallelLinear,
-    UnquantizedLinearMethod,
 )
 from vllm.platforms import current_platform
 
@@ -303,18 +302,27 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
     ) -> list[torch.Tensor | None]:
         return lora_a
 
-    def slice_lora_b(
-        self, lora_b: list[torch.Tensor | None]
+    def _slice_output_shards(
+        self, tensors: list[torch.Tensor | None]
     ) -> list[torch.Tensor | None]:
-        sliced_lora_b = [None] * self.n_slices
+        sliced_tensors = [None] * self.n_slices
         for i, (shard_id, shard_size) in enumerate(
             zip(self.output_ids, self.output_slices)
         ):
-            if (lora_b_i := lora_b[i]) is not None:
-                sliced_lora_b[i] = lora_b_i[
-                    shard_size * shard_id : shard_size * (shard_id + 1), :
-                ]
-        return sliced_lora_b
+            if (tensor_i := tensors[i]) is not None:
+                start = shard_size * shard_id
+                sliced_tensors[i] = tensor_i[start : start + shard_size, ...]
+        return sliced_tensors
+
+    def slice_lora_b(
+        self, lora_b: list[torch.Tensor | None]
+    ) -> list[torch.Tensor | None]:
+        return self._slice_output_shards(lora_b)
+
+    def slice_lora_magnitude_vector(
+        self, lora_magnitude_vector: list[torch.Tensor | None]
+    ) -> list[torch.Tensor | None]:
+        return self._slice_output_shards(lora_magnitude_vector)
 
     def expand_packed_lora(
         self,
@@ -377,16 +385,11 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         lora_b: list[torch.Tensor | None],
         lora_magnitude_vector: list[torch.Tensor | None],
     ) -> None:
-        if self.tp_size != 1:
-            raise NotImplementedError("DoRA currently only supports TP=1.")
-        if not isinstance(self.base_layer.quant_method, UnquantizedLinearMethod):
-            raise NotImplementedError("DoRA is not supported for quantized layers.")
-        if not hasattr(self.base_layer, "weight"):
-            raise NotImplementedError(
-                "DoRA requires access to the unquantized base layer weight."
-            )
-
-        base_weight = self.base_layer.weight
+        base_weight = self._get_dora_base_weight()
+        lora_b = self.slice_lora_b(lora_b)
+        lora_magnitude_vector = self.slice_lora_magnitude_vector(
+            lora_magnitude_vector
+        )
         output_offset = 0
         has_dora = False
         for i, output_size in enumerate(self.output_slices):
@@ -433,13 +436,6 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         assert isinstance(lora_b, list)
         assert len(lora_a) == len(lora_b)
         if lora_magnitude_vector is not None:
-            if type(self.base_layer) is maybe_get_oot_by_class(
-                MergedColumnParallelLinear
-            ):
-                raise NotImplementedError(
-                    "DoRA is not supported for MergedColumnParallelLinear "
-                    "packed LoRA layers."
-                )
             assert isinstance(lora_magnitude_vector, list)
             assert len(lora_magnitude_vector) == len(lora_b)
 
@@ -451,17 +447,14 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
                 lora_a, lora_b, lora_magnitude_vector
             )
 
-        if lora_magnitude_vector is not None and self.tp_size > 1:
-            raise NotImplementedError("DoRA currently only supports TP=1.")
-
-        if self.tp_size > 1:
-            lora_a = self.slice_lora_a(lora_a)
-            lora_b = self.slice_lora_b(lora_b)
-
         if lora_magnitude_vector is not None:
             self._set_packed_dora_scale(
                 index, lora_a, lora_b, lora_magnitude_vector
             )
+
+        if self.tp_size > 1:
+            lora_a = self.slice_lora_a(lora_a)
+            lora_b = self.slice_lora_b(lora_b)
 
         for i in range(self.n_slices):
             if (lora_a_i := lora_a[i]) is not None:

--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -357,7 +357,9 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
     ):
         """Overwrites lora tensors at index."""
         if lora_magnitude_vector is not None:
@@ -554,7 +556,9 @@ class FusedMoE3DWithLoRA(FusedMoEWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
     ):
         """Overwrites lora tensors at index."""
         if lora_magnitude_vector is not None:

--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -357,8 +357,11 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: torch.Tensor | None = None,
     ):
         """Overwrites lora tensors at index."""
+        if lora_magnitude_vector is not None:
+            raise NotImplementedError("DoRA is not supported for fused MoE LoRA.")
         # Make mypy happy
         assert isinstance(lora_a, list)
         assert isinstance(lora_b, list)
@@ -551,8 +554,11 @@ class FusedMoE3DWithLoRA(FusedMoEWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: torch.Tensor | None = None,
     ):
         """Overwrites lora tensors at index."""
+        if lora_magnitude_vector is not None:
+            raise NotImplementedError("DoRA is not supported for fused MoE LoRA.")
         # Make mypy happy
         assert isinstance(lora_a, list)
         assert isinstance(lora_b, list)

--- a/vllm/lora/layers/logits_processor.py
+++ b/vllm/lora/layers/logits_processor.py
@@ -127,7 +127,9 @@ class LogitsProcessorWithLoRA(BaseLayerWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
     ):
         if lora_magnitude_vector is not None:
             raise NotImplementedError("DoRA is not supported for logits processor.")

--- a/vllm/lora/layers/logits_processor.py
+++ b/vllm/lora/layers/logits_processor.py
@@ -127,7 +127,10 @@ class LogitsProcessorWithLoRA(BaseLayerWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: torch.Tensor | None = None,
     ):
+        if lora_magnitude_vector is not None:
+            raise NotImplementedError("DoRA is not supported for logits processor.")
         assert isinstance(lora_a, torch.Tensor)
         assert isinstance(lora_b, torch.Tensor)
         self.reset_lora(index)

--- a/vllm/lora/layers/row_parallel_linear.py
+++ b/vllm/lora/layers/row_parallel_linear.py
@@ -115,6 +115,18 @@ class RowParallelLinearWithShardedLoRA(RowParallelLinearWithLoRA):
         lora_b = lora_b[start_idx:end_idx, :]
         return lora_b
 
+    def set_lora(
+        self,
+        index: int,
+        lora_a: torch.Tensor | list[torch.Tensor],
+        lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: torch.Tensor | None = None,
+    ):
+        self._raise_if_dora_unsupported(
+            lora_magnitude_vector, "fully sharded LoRA"
+        )
+        super().set_lora(index, lora_a, lora_b)
+
     def apply(self, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
         output = self._get_quant_method().apply(self.base_layer, x, bias)
 

--- a/vllm/lora/layers/row_parallel_linear.py
+++ b/vllm/lora/layers/row_parallel_linear.py
@@ -120,7 +120,9 @@ class RowParallelLinearWithShardedLoRA(RowParallelLinearWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
     ):
         self._raise_if_dora_unsupported(
             lora_magnitude_vector, "fully sharded LoRA"

--- a/vllm/lora/layers/row_parallel_linear.py
+++ b/vllm/lora/layers/row_parallel_linear.py
@@ -39,6 +39,31 @@ class RowParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
     def slice_lora_b(self, lora_b: torch.Tensor) -> torch.Tensor:
         return lora_b
 
+    def _set_dora_scale(
+        self,
+        index: int,
+        lora_a: torch.Tensor,
+        lora_b: torch.Tensor,
+        lora_magnitude_vector: torch.Tensor,
+    ) -> None:
+        if self.n_slices != 1:
+            raise NotImplementedError("DoRA is not supported for packed LoRA layers.")
+
+        base_weight = self._get_dora_base_weight()
+        if self.tp_size > 1:
+            lora_a = self.slice_lora_a(lora_a)
+
+        dora_scale = self._get_dora_scale(
+            base_weight,
+            lora_a,
+            lora_b,
+            lora_magnitude_vector,
+            norm_sq_reduce=(
+                tensor_model_parallel_all_reduce if self.tp_size > 1 else None
+            ),
+        )
+        self._store_dora_scale(index, dora_scale)
+
     def forward(
         self, input_: torch.Tensor
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:

--- a/vllm/lora/layers/vocal_parallel_embedding.py
+++ b/vllm/lora/layers/vocal_parallel_embedding.py
@@ -79,7 +79,10 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
+        lora_magnitude_vector: torch.Tensor | None = None,
     ):
+        if lora_magnitude_vector is not None:
+            raise NotImplementedError("DoRA is not supported for embeddings.")
         assert isinstance(lora_a, torch.Tensor)
         assert isinstance(lora_b, torch.Tensor)
         self.reset_lora(index)

--- a/vllm/lora/layers/vocal_parallel_embedding.py
+++ b/vllm/lora/layers/vocal_parallel_embedding.py
@@ -79,7 +79,9 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
         index: int,
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
     ):
         if lora_magnitude_vector is not None:
             raise NotImplementedError("DoRA is not supported for embeddings.")

--- a/vllm/lora/lora_model.py
+++ b/vllm/lora/lora_model.py
@@ -177,6 +177,18 @@ class LoRAModel:
                 if pin_memory:
                     module_lora.lora_b = module_lora.lora_b.pin_memory()
 
+        if peft_helper.use_dora:
+            missing_magnitude = [
+                module_name
+                for module_name, module_lora in loras.items()
+                if module_lora.lora_magnitude_vector is None
+            ]
+            if missing_magnitude:
+                raise ValueError(
+                    "DoRA adapter is missing lora_magnitude_vector for "
+                    f"module(s): {missing_magnitude}."
+                )
+
         return cls(lora_model_id, peft_helper.r, loras)
 
     @classmethod

--- a/vllm/lora/lora_model.py
+++ b/vllm/lora/lora_model.py
@@ -126,13 +126,6 @@ class LoRAModel:
         skip_prefixes: list[str] | None = None,
     ) -> "LoRAModel":
         """Create a LoRAModel from a dictionary of tensors."""
-        if peft_helper.use_dora:
-            raise NotImplementedError(
-                "DoRA adapter loading is not implemented yet. "
-                "DoRA config validation and magnitude vector name parsing are "
-                "supported, but DoRA weight storage is still pending."
-            )
-
         pin_memory = str(device) == "cpu" and PIN_MEMORY
         loras: dict[str, LoRALayerWeights] = {}
         for tensor_name, tensor in tensors.items():
@@ -148,12 +141,22 @@ class LoRAModel:
                 loras[module_name] = LoRALayerWeights.from_config(
                     module_name, peft_helper
                 )
+            module_lora = loras[module_name]
 
             if weight_type == "dora_magnitude":
-                raise NotImplementedError(
-                    "DoRA magnitude vector parsing is recognized, but DoRA "
-                    "weight storage is not implemented yet."
+                if not peft_helper.use_dora:
+                    raise ValueError(
+                        f"Received DoRA lora_magnitude_vector for module "
+                        f"{module_name}, but adapter_config.json has use_dora=False."
+                    )
+                module_lora.lora_magnitude_vector = tensor.to(
+                    device=device, dtype=dtype
                 )
+                if pin_memory:
+                    module_lora.lora_magnitude_vector = (
+                        module_lora.lora_magnitude_vector.pin_memory()
+                    )
+                continue
 
             if weight_type == "lora_a":
                 if (
@@ -165,14 +168,14 @@ class LoRAModel:
                         f"The embedding LoRA size({tensor.shape[1]}) must be consistent"
                         f" with the base model's vocabulary size({model_vocab_size})."
                     )
-                loras[module_name].lora_a = tensor.to(device=device, dtype=dtype)
+                module_lora.lora_a = tensor.to(device=device, dtype=dtype)
                 if pin_memory:
-                    loras[module_name].lora_a = loras[module_name].lora_a.pin_memory()
+                    module_lora.lora_a = module_lora.lora_a.pin_memory()
             else:
-                loras[module_name].lora_b = tensor.to(device=device, dtype=dtype)
+                module_lora.lora_b = tensor.to(device=device, dtype=dtype)
 
                 if pin_memory:
-                    loras[module_name].lora_b = loras[module_name].lora_b.pin_memory()
+                    module_lora.lora_b = module_lora.lora_b.pin_memory()
 
         return cls(lora_model_id, peft_helper.r, loras)
 

--- a/vllm/lora/lora_model.py
+++ b/vllm/lora/lora_model.py
@@ -126,6 +126,13 @@ class LoRAModel:
         skip_prefixes: list[str] | None = None,
     ) -> "LoRAModel":
         """Create a LoRAModel from a dictionary of tensors."""
+        if peft_helper.use_dora:
+            raise NotImplementedError(
+                "DoRA adapter loading is not implemented yet. "
+                "DoRA config validation and magnitude vector name parsing are "
+                "supported, but DoRA weight storage is still pending."
+            )
+
         pin_memory = str(device) == "cpu" and PIN_MEMORY
         loras: dict[str, LoRALayerWeights] = {}
         for tensor_name, tensor in tensors.items():
@@ -134,7 +141,7 @@ class LoRAModel:
             # Skip modules based on model-defined prefixes (e.g., MTP layers)
             if skip_prefixes and cls._should_skip_module(tensor_name, skip_prefixes):
                 continue
-            module_name, is_lora_a = parse_fine_tuned_lora_name(
+            module_name, weight_type = parse_fine_tuned_lora_name(
                 tensor_name, weights_mapper
             )
             if module_name not in loras:
@@ -142,7 +149,13 @@ class LoRAModel:
                     module_name, peft_helper
                 )
 
-            if is_lora_a:
+            if weight_type == "dora_magnitude":
+                raise NotImplementedError(
+                    "DoRA magnitude vector parsing is recognized, but DoRA "
+                    "weight storage is not implemented yet."
+                )
+
+            if weight_type == "lora_a":
                 if (
                     "lora_embedding_A" in tensor_name
                     and model_vocab_size is not None

--- a/vllm/lora/lora_weights.py
+++ b/vllm/lora/lora_weights.py
@@ -20,6 +20,8 @@ class LoRALayerWeights:
         lora_alpha: int,
         lora_a: torch.Tensor,
         lora_b: torch.Tensor,
+        lora_magnitude_vector: torch.Tensor | None = None,
+        use_dora: bool = False,
         scaling: float | None = None,
     ) -> None:
         self.module_name = module_name
@@ -27,6 +29,8 @@ class LoRALayerWeights:
         self.lora_alpha = lora_alpha
         self.lora_a = lora_a
         self.lora_b = lora_b
+        self.lora_magnitude_vector = lora_magnitude_vector
+        self.use_dora = use_dora
 
         if scaling is None:
             self.scaling = self.lora_alpha / self.rank
@@ -61,12 +65,13 @@ class LoRALayerWeights:
     ) -> "LoRALayerWeights":
         # lora_a and lora_b are set to None for config-based construction
         return cls(
-            module_name,
-            peft_helper.r,
-            peft_helper.lora_alpha,
-            None,
-            None,
-            peft_helper.vllm_lora_scaling_factor,
+            module_name=module_name,
+            rank=peft_helper.r,
+            lora_alpha=peft_helper.lora_alpha,
+            lora_a=None,
+            lora_b=None,
+            use_dora=peft_helper.use_dora,
+            scaling=peft_helper.vllm_lora_scaling_factor,
         )
 
     @classmethod
@@ -135,6 +140,8 @@ class PackedLoRALayerWeights(LoRALayerWeights):
         for lora in loras:
             if lora is None:
                 continue
+            if lora.use_dora:
+                raise NotImplementedError("DoRA is not supported for packed LoRA.")
             lora.optimize()
         rank = first_lora.rank
         module_name = first_lora.module_name
@@ -165,6 +172,9 @@ class PackedLoRALayerWeights(LoRALayerWeights):
 
         first_lora = next(lora for lora in loras if lora is not None)
         assert first_lora is not None
+        for lora in loras:
+            if lora is not None and lora.use_dora:
+                raise NotImplementedError("DoRA is not supported for MoE LoRA.")
         rank = first_lora.rank
         lora_alpha = first_lora.lora_alpha
         assert len(loras) % 3 == 0

--- a/vllm/lora/lora_weights.py
+++ b/vllm/lora/lora_weights.py
@@ -20,7 +20,9 @@ class LoRALayerWeights:
         lora_alpha: int,
         lora_a: torch.Tensor,
         lora_b: torch.Tensor,
-        lora_magnitude_vector: torch.Tensor | None = None,
+        lora_magnitude_vector: (
+            torch.Tensor | list[torch.Tensor | None] | None
+        ) = None,
         use_dora: bool = False,
         scaling: float | None = None,
     ) -> None:
@@ -111,6 +113,8 @@ class PackedLoRALayerWeights(LoRALayerWeights):
         lora_alphas: list[int | None],
         lora_a: list[torch.Tensor | None],
         lora_b: list[torch.Tensor | None],
+        lora_magnitude_vector: list[torch.Tensor | None] | None = None,
+        use_dora: bool = False,
         scaling: list[float] | None = None,
     ) -> None:
         super().__init__(
@@ -119,6 +123,8 @@ class PackedLoRALayerWeights(LoRALayerWeights):
             lora_alpha=0,
             lora_a=lora_a,
             lora_b=lora_b,
+            lora_magnitude_vector=lora_magnitude_vector,
+            use_dora=use_dora,
             scaling=scaling,  # type: ignore
         )
         self.lora_alphas = lora_alphas
@@ -137,11 +143,19 @@ class PackedLoRALayerWeights(LoRALayerWeights):
         If LoRA is None, it signifies that the submodule does not have a LoRA.
         """
         first_lora = next(lora for lora in loras if lora is not None)
+        use_dora = any(lora is not None and lora.use_dora for lora in loras)
+        lora_magnitude_vector: list[torch.Tensor | None] | None = (
+            [] if use_dora else None
+        )
         for lora in loras:
             if lora is None:
+                if lora_magnitude_vector is not None:
+                    lora_magnitude_vector.append(None)
                 continue
-            if lora.use_dora:
-                raise NotImplementedError("DoRA is not supported for packed LoRA.")
+            assert lora.use_dora == use_dora
+            if lora_magnitude_vector is not None:
+                assert isinstance(lora.lora_magnitude_vector, torch.Tensor)
+                lora_magnitude_vector.append(lora.lora_magnitude_vector)
             lora.optimize()
         rank = first_lora.rank
         module_name = first_lora.module_name
@@ -151,6 +165,8 @@ class PackedLoRALayerWeights(LoRALayerWeights):
             [lora.lora_alpha if lora is not None else None for lora in loras],
             [lora.lora_a if lora is not None else None for lora in loras],
             [lora.lora_b if lora is not None else None for lora in loras],
+            lora_magnitude_vector,
+            use_dora=use_dora,
             scaling=[
                 1 if lora is not None else None  # type: ignore
                 for lora in loras

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -299,23 +299,32 @@ class LoRAModelManager:
         """Move LoRA into a GPU buffer to be used in the forward pass."""
         if lora_id in self._active_adapters:
             return False
-        first_free_slot = next(
+        index = next(
             (
-                (i, lora_id)
-                for i, lora_id in enumerate(self.lora_index_to_id)
-                if lora_id is None
+                i
+                for i, active_lora_id in enumerate(self.lora_index_to_id)
+                if active_lora_id is None
             ),
             None,
         )
-        if first_free_slot is None:
+        if index is None:
             raise ValueError("No free lora slots")
-        index, _ = first_free_slot
-        self._active_adapters[lora_id] = None
         lora_model = self._registered_adapters[lora_id]
         logger.debug(
             "Activating LoRA. int id: %d, slot index: %d", lora_model.id, index
         )
+
+        try:
+            self._load_adapter_into_slot(index, lora_model)
+        except Exception:
+            self._reset_lora_slot(index)
+            raise
+
         self.lora_index_to_id[index] = lora_model.id
+        self._active_adapters[lora_id] = None
+        return True
+
+    def _load_adapter_into_slot(self, index: int, lora_model: LoRAModel) -> None:
         for module_name, module in self.modules.items():
             module_lora = self._get_lora_layer_weights(lora_model, module_name)
             if not module_lora:
@@ -331,8 +340,9 @@ class LoRAModelManager:
                 module_lora.lora_b,
                 lora_magnitude_vector=module_lora.lora_magnitude_vector,
             )
-            logger.debug("Successfully loaded LoRA weights for module %s.", module_name)
-        return True
+            logger.debug(
+                "Successfully loaded LoRA weights for module %s.", module_name
+            )
 
     def _reset_lora_slot(self, index: int) -> None:
         for module in self.modules.values():

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -334,12 +334,17 @@ class LoRAModelManager:
             logger.debug("Successfully loaded LoRA weights for module %s.", module_name)
         return True
 
+    def _reset_lora_slot(self, index: int) -> None:
+        for module in self.modules.values():
+            module.reset_lora(index)
+
     def _deactivate_adapter(self, lora_id: int):
         try:
             index = self.lora_index_to_id.index(lora_id)
             self.lora_index_to_id[index] = None
         except ValueError:
-            pass
+            return
+        self._reset_lora_slot(index)
 
     def _add_adapter(self, lora: LoRAModel):
         self._create_merged_loras_inplace(lora)
@@ -379,9 +384,15 @@ class LoRAModelManager:
 
     def remove_all_adapters(self):
         """Remove all LoRAModels from the manager."""
+        active_indices = [
+            index for index, lora_id in enumerate(self.lora_index_to_id)
+            if lora_id is not None
+        ]
         self._registered_adapters.clear()
         self.lora_index_to_id = [None] * self.lora_slots
         self._active_adapters.clear()
+        for index in active_indices:
+            self._reset_lora_slot(index)
 
     def _create_lora_modules(self):
         def _parent_module(module_name: str) -> str:

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -329,6 +329,7 @@ class LoRAModelManager:
                 index,
                 module_lora.lora_a,
                 module_lora.lora_b,
+                lora_magnitude_vector=module_lora.lora_magnitude_vector,
             )
             logger.debug("Successfully loaded LoRA weights for module %s.", module_name)
         return True

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -46,8 +46,6 @@ class PEFTHelper:
         error_msg = []
         if self.modules_to_save:
             error_msg.append("vLLM only supports modules_to_save being None.")
-        if self.use_dora:
-            error_msg.append("vLLM does not yet support DoRA.")
         return error_msg
 
     def __post_init__(self):

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import regex as re
 from huggingface_hub.utils import HfHubHTTPError, HFValidationError
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
 
 logger = init_logger(__name__)
+
+LoRAWeightType = Literal["lora_a", "lora_b", "dora_magnitude"]
 
 
 def get_captured_lora_counts(max_loras: int, specialize: bool) -> list[int]:
@@ -154,7 +156,7 @@ def replace_submodule(
 
 def parse_fine_tuned_lora_name(
     name: str, weights_mapper: "WeightsMapper | None" = None
-) -> tuple[str, bool]:
+) -> tuple[str, LoRAWeightType]:
     """Parse the name of lora weights.
 
     args:
@@ -162,10 +164,10 @@ def parse_fine_tuned_lora_name(
             base_model.model.dense1.weight
         weights_mapper: maps the name of weight, e.g.
             `model.` -> `language_model.model.`,
-    return:
-        tuple(module_name, is_lora_a):
+    Returns:
+        tuple(module_name, weight_type):
             module_name: the name of the module, e.g. model.dense1,
-            is_lora_a whether the tensor is lora_a or lora_b.
+            weight_type: the kind of adapter tensor.
     """
 
     # LoRA weight qualified name usually starts with `base_model.model.`,
@@ -198,11 +200,15 @@ def parse_fine_tuned_lora_name(
         and (parts[-2] == "lora_A" or parts[-2] == "lora_B")
     ):
         new_name = ".".join(parts[start_index:-2])
-        return new_name, parts[-2] == "lora_A"
+        return new_name, "lora_a" if parts[-2] == "lora_A" else "lora_b"
 
     if parts[-1] == "lora_embedding_A" or parts[-1] == "lora_embedding_B":
         new_name = ".".join(parts[start_index:-1])
-        return new_name, parts[-1] == "lora_embedding_A"
+        return new_name, "lora_a" if parts[-1] == "lora_embedding_A" else "lora_b"
+
+    if parts[-1] == "lora_magnitude_vector":
+        new_name = ".".join(parts[start_index:-1])
+        return new_name, "dora_magnitude"
 
     raise ValueError(f"{name} is unsupported LoRA weight")
 


### PR DESCRIPTION
## Purpose

 #10849 
  This PR adds initial DoRA support for vLLM LoRA serving. The supported scope is the dense linear path, runtime adapter loading, mixed LoRA/DoRA batches,tensor parallel dense linear layers, and common packed linear layers such as QKV and gate-up projections.

 The implementation follows PEFT DoRA semantics by loading `lora_magnitude_vector`, precomputing the per-output DoRA scale from `magnitude / ||W + BA||`, and applying that scale only to requests using a DoRA adapter. Bias handling is kept consistent with DoRA: the scale is applied to the weight path, not to the added bias.

Unsupported paths fail closed instead of silently producing incorrect outputs. This includes quantized layers, embeddings, logits processor, fused MoE LoRA, and fully sharded LoRA paths.Follow-up PRs can add quantized backends, MoE/EP support, and Punica/Triton  fusion with benchmarks once the supported correctness path is in place.


  ## Test Plan

  Added focused coverage for DoRA checkpoint loading, magnitude-vector validation,DoRA scale computation, PEFT parity, bias handling, mixed base/LoRA/DoRA  batches, TP=2 row/column linear paths, and packed QKV/gate-up projections.

  Also added serving tests for static and runtime-loaded DoRA adapters, concurrent base/LoRA/DoRA requests, unload/reload/replace behavior, and failed adapter loads that should not corrupt existing adapters.


  ## Test Result

  All tests passed.

  ```bash
  .venv/bin/python -m pytest tests/lora/test_peft_helper.py tests/lora/test_lora_checkpoints.py
  tests/lora/test_lora_manager.py tests/lora/test_layers.py tests/lora/test_dora_mixed_batch.py -v

  .venv/bin/python -m pytest tests/entrypoints/serve/lora/test_dora_adapters.py tests/entrypoints/
  serve/lora/test_lora_adapters.py tests/entrypoints/serve/lora/test_serving_models.py -v
```

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>


- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
  </details>

