### PR TITLE
Detect CUDA toolchain/driver PTX mismatch on GB10, clarify removed env var

### DIFF
--- a/tests/cuda/test_ptx_driver_compat.py
+++ b/tests/cuda/test_ptx_driver_compat.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the consumer-Blackwell CUDA toolchain/driver PTX mismatch guard.
+
+`_vllm_fa2_C` ships no native cubin for sm_120/121 and falls back to PTX
+JIT, which fails if vLLM was built with a newer CUDA toolkit than the
+installed driver supports. `_check_flash_attn_ptx_compat` detects this
+ahead of time; see https://github.com/vllm-project/vllm/issues/47397.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import vllm.platforms.cuda as cuda_platform
+from vllm.platforms.cuda import (
+    _build_cuda_version,
+    _check_flash_attn_ptx_compat,
+    _driver_max_cuda_version,
+)
+from vllm.platforms.interface import DeviceCapability
+
+
+def test_no_error_on_non_blackwell_consumer_gpu():
+    """The guard only applies to sm_120/121; other capabilities are untouched
+    even if build/driver versions would otherwise mismatch."""
+    with (
+        patch.object(cuda_platform, "_build_cuda_version", return_value=(13, 3)),
+        patch.object(cuda_platform, "_driver_max_cuda_version", return_value=(13, 0)),
+    ):
+        _check_flash_attn_ptx_compat(DeviceCapability(9, 0))
+
+
+@pytest.mark.parametrize(
+    "device_capability", [DeviceCapability(12, 0), DeviceCapability(12, 1)]
+)
+def test_raises_on_build_newer_than_driver(device_capability):
+    with (
+        patch.object(cuda_platform, "_build_cuda_version", return_value=(13, 3)),
+        patch.object(cuda_platform, "_driver_max_cuda_version", return_value=(13, 0)),
+        pytest.raises(RuntimeError, match="cudaErrorUnsupportedPtxVersion"),
+    ):
+        _check_flash_attn_ptx_compat(device_capability)
+
+
+def test_no_error_when_driver_covers_build():
+    with (
+        patch.object(cuda_platform, "_build_cuda_version", return_value=(13, 0)),
+        patch.object(cuda_platform, "_driver_max_cuda_version", return_value=(13, 3)),
+    ):
+        _check_flash_attn_ptx_compat(DeviceCapability(12, 1))
+
+
+def test_no_error_when_versions_match():
+    with (
+        patch.object(cuda_platform, "_build_cuda_version", return_value=(13, 0)),
+        patch.object(cuda_platform, "_driver_max_cuda_version", return_value=(13, 0)),
+    ):
+        _check_flash_attn_ptx_compat(DeviceCapability(12, 1))
+
+
+def test_no_error_when_build_version_undetermined():
+    """If we can't tell what CUDA version compiled the extensions, don't
+    guess -- skip the check rather than risk a false positive."""
+    with (
+        patch.object(cuda_platform, "_build_cuda_version", return_value=None),
+        patch.object(cuda_platform, "_driver_max_cuda_version", return_value=(13, 0)),
+    ):
+        _check_flash_attn_ptx_compat(DeviceCapability(12, 1))
+
+
+def test_no_error_when_driver_version_undetermined():
+    with (
+        patch.object(cuda_platform, "_build_cuda_version", return_value=(13, 3)),
+        patch.object(cuda_platform, "_driver_max_cuda_version", return_value=None),
+    ):
+        _check_flash_attn_ptx_compat(DeviceCapability(12, 1))
+
+
+def test_build_cuda_version_parses_local_version_suffix():
+    with patch(
+        "importlib.metadata.version",
+        return_value="0.1.dev18154+g491f07501.cu133",
+    ):
+        assert _build_cuda_version() == (13, 3)
+
+
+def test_build_cuda_version_falls_back_to_main_cuda_version():
+    """setup.py's get_vllm_version() only appends a `cuXYZ` suffix when the
+    build CUDA version differs from VLLM_MAIN_CUDA_VERSION -- a build against
+    exactly the main version has no suffix at all."""
+    with (
+        patch("importlib.metadata.version", return_value="0.1.dev18154+g491f07501"),
+        patch.object(cuda_platform.envs, "VLLM_MAIN_CUDA_VERSION", "13.0"),
+    ):
+        assert _build_cuda_version() == (13, 0)
+
+
+def test_driver_max_cuda_version_handles_nvml_init_failure():
+    """nvmlInit() failing (e.g. NVML unavailable) must degrade to None, not
+    propagate -- this used to crash via the shared @with_nvml_context
+    decorator, which doesn't guard nvmlInit() itself."""
+    with patch.object(
+        cuda_platform.pynvml,
+        "nvmlInit",
+        side_effect=cuda_platform.pynvml.NVMLError(999),
+    ):
+        assert _driver_max_cuda_version() is None
+
+
+def test_driver_max_cuda_version_shuts_down_nvml_on_query_failure():
+    with (
+        patch.object(cuda_platform.pynvml, "nvmlInit") as mock_init,
+        patch.object(
+            cuda_platform.pynvml,
+            "nvmlSystemGetCudaDriverVersion_v2",
+            side_effect=cuda_platform.pynvml.NVMLError(999),
+        ),
+        patch.object(cuda_platform.pynvml, "nvmlShutdown") as mock_shutdown,
+    ):
+        assert _driver_max_cuda_version() is None
+        mock_init.assert_called_once()
+        mock_shutdown.assert_called_once()

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -14,7 +14,56 @@ from vllm.envs import (
     env_set_with_choices,
     env_with_choices,
     environment_variables,
+    validate_environ,
 )
+
+
+class TestValidateEnviron:
+    """Test cases for validate_environ's handling of removed env vars."""
+
+    def test_removed_var_warns_with_actionable_message(self, caplog):
+        with (
+            patch.dict(os.environ, {"VLLM_ATTENTION_BACKEND": "flashinfer"}),
+            caplog.at_level("WARNING"),
+        ):
+            validate_environ(hard_fail=False)
+        assert any(
+            "VLLM_ATTENTION_BACKEND is no longer read by vLLM" in message
+            and "--attention-backend" in message
+            for message in caplog.messages
+        )
+
+    def test_removed_var_does_not_raise_even_with_hard_fail(self, caplog):
+        """Removed vars are a no-op, not a typo -- hard_fail must not treat
+        them the same as an unrecognized VLLM_ variable."""
+        with (
+            patch.dict(os.environ, {"VLLM_ATTENTION_BACKEND": "flashinfer"}),
+            caplog.at_level("WARNING"),
+        ):
+            validate_environ(hard_fail=True)
+        assert any(
+            "VLLM_ATTENTION_BACKEND is no longer read by vLLM" in message
+            for message in caplog.messages
+        )
+
+    def test_unrecognized_var_still_raises_with_hard_fail(self):
+        with (
+            patch.dict(os.environ, {"VLLM_THIS_IS_NOT_A_REAL_VAR": "1"}),
+            pytest.raises(ValueError, match="Unknown vLLM environment variable"),
+        ):
+            validate_environ(hard_fail=True)
+
+    def test_unrecognized_var_warns_without_hard_fail(self, caplog):
+        with (
+            patch.dict(os.environ, {"VLLM_THIS_IS_NOT_A_REAL_VAR": "1"}),
+            caplog.at_level("WARNING"),
+        ):
+            validate_environ(hard_fail=False)
+        assert any(
+            "Unknown vLLM environment variable detected: VLLM_THIS_IS_NOT_A_REAL_VAR"
+            in message
+            for message in caplog.messages
+        )
 
 
 def test_getattr_without_cache(monkeypatch: pytest.MonkeyPatch):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2026,9 +2026,24 @@ def is_set(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+# Env vars vLLM used to read that were removed in favor of a CLI flag or a
+# different env var. Setting one now has no effect; the generic "unknown
+# variable" warning below doesn't say why, so call these out by name.
+REMOVED_ENVIRONMENT_VARIABLES: dict[str, str] = {
+    "VLLM_ATTENTION_BACKEND": "the --attention-backend CLI flag",
+}
+
+
 def validate_environ(hard_fail: bool) -> None:
     for env in os.environ:
-        if env.startswith("VLLM_") and env not in environment_variables:
+        if env in REMOVED_ENVIRONMENT_VARIABLES:
+            logger.warning(
+                "Environment variable %s is no longer read by vLLM and has "
+                "no effect; use %s instead.",
+                env,
+                REMOVED_ENVIRONMENT_VARIABLES[env],
+            )
+        elif env.startswith("VLLM_") and env not in environment_variables:
             if hard_fail:
                 raise ValueError(f"Unknown vLLM environment variable detected: {env}")
             else:

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -194,15 +194,23 @@ def with_nvml_context(fn: Callable[_P, _R]) -> Callable[_P, _R]:
 _BLACKWELL_CONSUMER_CAPABILITIES = (DeviceCapability(12, 0), DeviceCapability(12, 1))
 
 
-@with_nvml_context
 def _driver_max_cuda_version() -> tuple[int, int] | None:
     """Highest CUDA version the installed driver can PTX-JIT for, or None
-    if it can't be determined (e.g. NVML unavailable)."""
+    if it can't be determined (e.g. NVML unavailable). Deliberately doesn't
+    use `@with_nvml_context`: that decorator lets `nvmlInit()` failures
+    propagate, which would crash attention-backend selection instead of
+    letting this optional check degrade gracefully."""
     try:
-        raw = pynvml.nvmlSystemGetCudaDriverVersion_v2()
+        pynvml.nvmlInit()
     except pynvml.NVMLError:
         return None
-    return (raw // 1000, (raw % 1000) // 10)
+    try:
+        raw = pynvml.nvmlSystemGetCudaDriverVersion_v2()
+        return (raw // 1000, (raw % 1000) // 10)
+    except pynvml.NVMLError:
+        return None
+    finally:
+        pynvml.nvmlShutdown()
 
 
 _VLLM_LOCAL_VERSION_CUDA_RE = re.compile(r"\bcu(\d{3})\b")
@@ -212,7 +220,10 @@ def _build_cuda_version() -> tuple[int, int] | None:
     """CUDA toolkit version vLLM's own C++/CUDA extensions were compiled
     with, read off the installed package's local version label (e.g.
     `0.1.dev1+g491f075.cu133` -> (13, 3)), the same `cu\\d{3}` convention
-    `setup.py`'s `detect_system_cuda_variant` writes at build time.
+    `setup.py`'s `get_vllm_version()` writes at build time. That suffix is
+    only appended when the build's CUDA version differs from vLLM's pinned
+    main version (`envs.VLLM_MAIN_CUDA_VERSION`) -- when it matches exactly,
+    no suffix is written, so fall back to the main version in that case.
 
     Deliberately not `torch.version.cuda`: that reflects the CUDA version
     the pre-built torch *wheel* was compiled with, which is a separate build
@@ -223,12 +234,16 @@ def _build_cuda_version() -> tuple[int, int] | None:
     try:
         version_str = importlib.metadata.version("vllm")
     except importlib.metadata.PackageNotFoundError:
-        return None
+        version_str = ""
     match = _VLLM_LOCAL_VERSION_CUDA_RE.search(version_str)
-    if match is None:
+    if match is not None:
+        digits = match.group(1)
+        return (int(digits[:2]), int(digits[2]))
+    try:
+        major_str, minor_str = envs.VLLM_MAIN_CUDA_VERSION.split(".")[:2]
+        return (int(major_str), int(minor_str))
+    except ValueError:
         return None
-    digits = match.group(1)
-    return (int(digits[:2]), int(digits[2]))
 
 
 def _check_flash_attn_ptx_compat(device_capability: DeviceCapability) -> None:

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -7,6 +7,7 @@ pynvml. However, it should not initialize cuda context.
 from __future__ import annotations
 
 import contextlib
+import importlib.metadata
 import os
 import platform
 from collections.abc import Callable
@@ -14,6 +15,7 @@ from datetime import timedelta
 from functools import cache, lru_cache, wraps
 from typing import TYPE_CHECKING, NamedTuple, TypeVar
 
+import regex as re
 import torch
 from torch.distributed import PrefixStore, ProcessGroup
 from torch.distributed.distributed_c10d import is_nccl_available
@@ -184,6 +186,80 @@ def with_nvml_context(fn: Callable[_P, _R]) -> Callable[_P, _R]:
             pynvml.nvmlShutdown()
 
     return wrapper
+
+
+# Consumer Blackwell (sm_120/121, e.g. RTX Pro 6000, GB10/DGX Spark). Unlike
+# datacenter Blackwell, `_vllm_fa2_C` ships no native cubin for these and
+# always falls back to PTX JIT.
+_BLACKWELL_CONSUMER_CAPABILITIES = (DeviceCapability(12, 0), DeviceCapability(12, 1))
+
+
+@with_nvml_context
+def _driver_max_cuda_version() -> tuple[int, int] | None:
+    """Highest CUDA version the installed driver can PTX-JIT for, or None
+    if it can't be determined (e.g. NVML unavailable)."""
+    try:
+        raw = pynvml.nvmlSystemGetCudaDriverVersion_v2()
+    except pynvml.NVMLError:
+        return None
+    return (raw // 1000, (raw % 1000) // 10)
+
+
+_VLLM_LOCAL_VERSION_CUDA_RE = re.compile(r"\bcu(\d{3})\b")
+
+
+def _build_cuda_version() -> tuple[int, int] | None:
+    """CUDA toolkit version vLLM's own C++/CUDA extensions were compiled
+    with, read off the installed package's local version label (e.g.
+    `0.1.dev1+g491f075.cu133` -> (13, 3)), the same `cu\\d{3}` convention
+    `setup.py`'s `detect_system_cuda_variant` writes at build time.
+
+    Deliberately not `torch.version.cuda`: that reflects the CUDA version
+    the pre-built torch *wheel* was compiled with, which is a separate build
+    step from vLLM's own from-source extension compilation and can disagree
+    with it (e.g. a from-source vLLM build using a newer local `nvcc` than
+    the torch wheel it links against).
+    """
+    try:
+        version_str = importlib.metadata.version("vllm")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+    match = _VLLM_LOCAL_VERSION_CUDA_RE.search(version_str)
+    if match is None:
+        return None
+    digits = match.group(1)
+    return (int(digits[:2]), int(digits[2]))
+
+
+def _check_flash_attn_ptx_compat(device_capability: DeviceCapability) -> None:
+    """`_vllm_fa2_C` has no native cubin on consumer Blackwell, so it PTX-JITs
+    at kernel-launch time. If vLLM was built with a newer CUDA toolkit than
+    the installed driver supports, that JIT fails with
+    `cudaErrorUnsupportedPtxVersion` deep inside CUDA graph capture, often
+    after minutes of weight loading. Fail fast here instead.
+    See https://github.com/vllm-project/vllm/issues/47397.
+    """
+    if device_capability not in _BLACKWELL_CONSUMER_CAPABILITIES:
+        return
+    build_cuda = _build_cuda_version()
+    if build_cuda is None:
+        return
+    driver_cuda = _driver_max_cuda_version()
+    if driver_cuda is None:
+        return
+    if build_cuda > driver_cuda:
+        raise RuntimeError(
+            f"vLLM was built with CUDA {build_cuda[0]}.{build_cuda[1]}, but "
+            f"the installed driver only supports CUDA {driver_cuda[0]}."
+            f"{driver_cuda[1]} for runtime PTX compilation. The FLASH_ATTN "
+            f"backend (_vllm_fa2_C) has no native cubin for this GPU "
+            f"(sm_{device_capability.major}{device_capability.minor}) and "
+            "requires PTX JIT, which will fail with "
+            "cudaErrorUnsupportedPtxVersion. Fix: update your driver, "
+            "rebuild vLLM against a CUDA toolkit <= the driver's supported "
+            "version, or pass --attention-backend flashinfer (or "
+            "TRITON_ATTN) to avoid this kernel."
+        )
 
 
 @cache
@@ -413,6 +489,8 @@ class CudaPlatformBase(Platform):
                     f"this configuration. Reason: {invalid_reasons}"
                 )
             else:
+                if selected_backend == AttentionBackendEnum.FLASH_ATTN:
+                    _check_flash_attn_ptx_compat(device_capability)
                 logger.info("Using %s backend.", selected_backend)
                 return _backend_cls_path(backend_class)
 
@@ -472,6 +550,9 @@ class CudaPlatformBase(Platform):
                     names,
                     selected_backend.name,
                 )
+
+        if selected_backend == AttentionBackendEnum.FLASH_ATTN:
+            _check_flash_attn_ptx_compat(device_capability)
 
         logger.info_once(
             "Using %s attention backend out of potential backends: %s.",


### PR DESCRIPTION
## Summary
- Detect a CUDA toolchain/driver PTX-JIT version mismatch when the `FLASH_ATTN` backend is selected on consumer Blackwell (sm_120/121), and fail fast with an actionable `RuntimeError` instead of letting it crash later as a cryptic `cudaErrorUnsupportedPtxVersion` during CUDA graph capture.
- Call out `VLLM_ATTENTION_BACKEND` by name when set: it was removed in favor of the `--attention-backend` CLI flag, but currently falls through to the generic "unknown environment variable" warning, which is easy to miss and gives no indication of what changed or what to use instead.

## Why

`_vllm_fa2_C` (vLLM's bundled FlashAttention-2 op) ships only an sm_80 baseline cubin — no native build for sm_120/121 — so on consumer Blackwell it always falls back to runtime PTX JIT. If vLLM was compiled with a newer CUDA toolkit than the installed driver supports (e.g. built with local `nvcc` 13.3 against a driver capped at CUDA 13.0 for PTX JIT), that JIT fails with `cudaErrorUnsupportedPtxVersion`, but only surfaces after the model finishes loading and CUDA graph capture begins — which can be 10+ minutes into a run for larger checkpoints.

Root-caused on a from-source build on a single NVIDIA GB10 (DGX Spark). Full diagnosis writeup, including a dead end worth knowing about (`torch.version.cuda` is *not* a reliable signal for what CUDA version compiled vLLM's own extensions — it reflects the pre-built torch wheel's CUDA version, a separate build step): https://gist.github.com/zbrad/3c86a180abce1be172877a23edb8e23f

Fixes #47397 (opened by me after hitting this).

## Duplicate-work check (AGENTS.md)

- No open PR addresses this exact path. The closest related work is **#36579** ("Guard AWQ-Marlin auto-selection on CUDA driver/toolkit mismatch"), which independently built similar driver-vs-toolkit detection (`vllm/env_override.py`, using the same `pynvml.nvmlSystemGetCudaDriverVersion_v2()` approach) for a different kernel path (Marlin repack, fixing #36235) and a different strategy (warn + auto-fallback to a non-Marlin kernel). This PR is scoped to `_vllm_fa2_C`/`FLASH_ATTN` specifically, which has no equivalent same-quality fallback the oracle can silently substitute, so it fails fast with a clear message rather than warning and continuing. Flagging the overlap here in case a future cleanup wants to consolidate the driver-version-detection helper into one shared utility — right now there'd be two independent (but consistent) implementations of essentially the same NVML call.
- #38669 / #46601 (Marlin repack PTX incompatibility on H100/H200) are also related-but-different: datacenter Blackwell/Hopper, Marlin repack CMake arch coverage, not this code path.

## Test plan

- `pre-commit run ruff-check --files vllm/platforms/cuda.py vllm/envs.py` — passed
- `pre-commit run ruff-format --files vllm/platforms/cuda.py vllm/envs.py` — passed
- Full `pre-commit` hook suite via `git commit` (includes `mypy` for Python 3.10, `check-forbidden-imports`, SPDX header check, etc.) — all passed; `check-forbidden-imports` caught a `re` vs `regex` violation on the first attempt, fixed before landing
- Live verification on an NVIDIA GB10 (DGX Spark, sm_121), build CUDA 13.3 / driver max CUDA 13.0 (the exact mismatch this guards):
  - **Before this change**: `vllm serve Qwen/Qwen3-Coder-30B-A3B-Instruct` (no `--attention-backend`) → ~11 minutes of weight loading (56.9 GiB checkpoint) → crash during CUDA graph capture with raw `cudaErrorUnsupportedPtxVersion`.
  - **After this change**: same command → fails in ~1 second, immediately after "Starting to load model", with the new `RuntimeError` message quoting the actual build/driver CUDA versions and the workaround flag.
  - `VLLM_ATTENTION_BACKEND=flashinfer python -c "import vllm.envs as envs; envs.validate_environ(hard_fail=False)"` → logs `Environment variable VLLM_ATTENTION_BACKEND is no longer read by vLLM and has no effect; use the --attention-backend CLI flag instead.` instead of the generic unknown-variable warning.
  - `vllm serve Qwen/Qwen3-Coder-30B-A3B-Instruct --attention-backend flashinfer` → starts cleanly, serves a correct completion.
- Isolated the failure down to a minimal `nvcc`/`cudaLaunchKernel` repro (no vLLM involved) to confirm the guard's condition is exactly right rather than over- or under-scoped. Same box (driver `580.159.03`, GB10, sm_121), all three built with the same nvcc 13.3:

  | PTX emitted for... | JIT'd to sm_121 | Result |
  |---|---|---|
  | `-arch=compute_80` (`_vllm_fa2_C`'s actual baseline) | forward-JIT across a big arch gap | `cudaGetLastError()` → `cudaErrorUnsupportedPtxVersion` |
  | `-arch=compute_121` (matches GPU natively) | direct match, no forward-JIT | runs correctly, no error |
  | `-arch=compute_80`, recompiled with nvcc **13.0** instead of 13.3 | forward-JIT | runs correctly, no error |

  This confirms the failure needs *both* a toolkit/driver version skew *and* PTX targeting an old baseline arch that must be forward-JIT'd across a large gap — which is exactly `_vllm_fa2_C`'s situation on consumer Blackwell (no native cubin, sm_80 baseline only) and not a general property of every CUDA extension built this way. It's why the guard is scoped to `FLASH_ATTN`/Blackwell-consumer specifically rather than a blanket driver-vs-toolkit check for all kernels. Also surfaced a sharper edge while isolating this: the failure is silent unless `cudaGetLastError()` is checked immediately after the launch — `cudaDeviceSynchronize()` alone reports no error even though the kernel never ran. Full writeup: https://gist.github.com/zbrad/41440487f9fe7d548075b02b87879ee7
- No unit tests added yet for `_build_cuda_version`/`_driver_max_cuda_version`/`_check_flash_attn_ptx_compat` — happy to add if maintainers want them before merge; #36579's `tests/quantization/test_marlin_toolchain_guard.py` is a reasonable template for the monkeypatch structure if useful here too.

## AI assistance disclosure

Root-causing, implementation, and this PR description were AI-assisted (Claude). I reviewed the diff and ran the verification above myself on the affected hardware before opening this.

