### PR TITLE
[Bugfix] Skip cache-served mm items in tower/connector LoRA mapping

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -329,13 +329,13 @@ def test_set_active_mm_loras_builds_tower_and_connector_mappings():
     encoder_cache = EncoderCache()
     encoder_cache.mm_features["req-with-lora"] = [
         MultiModalFeatureSpec(
-            data=None,
+            data=Mock(),
             modality="image",
             identifier="img-0",
             mm_position=PlaceholderRange(offset=0, length=2),
         ),
         MultiModalFeatureSpec(
-            data=None,
+            data=Mock(),
             modality="image",
             identifier="img-1",
             mm_position=PlaceholderRange(offset=2, length=3),
@@ -343,7 +343,7 @@ def test_set_active_mm_loras_builds_tower_and_connector_mappings():
     ]
     encoder_cache.mm_features["req-no-lora"] = [
         MultiModalFeatureSpec(
-            data=None,
+            data=Mock(),
             modality="image",
             identifier="img-2",
             mm_position=PlaceholderRange(offset=0, length=1),
@@ -388,6 +388,76 @@ def test_set_active_mm_loras_builds_tower_and_connector_mappings():
     assert connector_mapping.type is LoRAMappingType.CONNECTOR
     assert connector_mapping.prompt_mapping == (7, 7, 0)
     assert connector_mapping.index_mapping == ((7,) * 14 + (7,) * 13 + (0,) * 12)
+
+
+def test_set_active_mm_loras_skips_items_without_data():
+    """Cache-served items (data=None) are skipped by
+    EncoderRunner.prepare_mm_inputs, so they must not add mapping rows."""
+    model = Mock()
+    model.get_num_mm_encoder_tokens.side_effect = lambda num_embeds: num_embeds + 1
+    model.get_mm_mapping.return_value = SimpleNamespace(connector=True)
+    model.get_num_mm_connector_tokens.side_effect = lambda num_tokens: num_tokens + 10
+
+    lora_manager = Mock()
+    lora_manager.supports_tower_connector_lora.return_value = True
+
+    encoder_cache = EncoderCache()
+    encoder_cache.mm_features["req-with-lora"] = [
+        MultiModalFeatureSpec(
+            data=Mock(),
+            modality="image",
+            identifier="img-0",
+            mm_position=PlaceholderRange(offset=0, length=2),
+        ),
+        MultiModalFeatureSpec(
+            data=None,
+            modality="image",
+            identifier="img-1",
+            mm_position=PlaceholderRange(offset=2, length=3),
+        ),
+    ]
+
+    lora_state = LoraState(max_num_reqs=4)
+    lora_request = LoRARequest("vision-lora", 7, "/tmp/vision-lora")
+    lora_state.add_request("req-with-lora", 0, lora_request)
+
+    set_active_mm_loras(
+        model=model,
+        lora_manager=lora_manager,
+        encoder_cache=encoder_cache,
+        req_id_to_index={"req-with-lora": 0},
+        lora_state=lora_state,
+        scheduled_encoder_inputs={"req-with-lora": [0, 1]},
+    )
+
+    # Only img-0 (data present) contributes rows: 2 embeds -> 3 tower and
+    # 13 connector tokens. The cache-served img-1 adds nothing, matching
+    # EncoderRunner.prepare_mm_inputs.
+    assert lora_manager.set_active_adapters.call_count == 2
+    tower_mapping = lora_manager.set_active_adapters.call_args_list[0].args[1]
+    assert tower_mapping.prompt_mapping == (7,)
+    assert tower_mapping.index_mapping == (7, 7, 7)
+    connector_mapping = lora_manager.set_active_adapters.call_args_list[1].args[1]
+    assert connector_mapping.prompt_mapping == (7,)
+    assert connector_mapping.index_mapping == (7,) * 13
+
+    # A step where every scheduled item is cache-served maps nothing.
+    lora_manager.reset_mock()
+    encoder_cache.mm_features["req-with-lora"][0] = MultiModalFeatureSpec(
+        data=None,
+        modality="image",
+        identifier="img-0",
+        mm_position=PlaceholderRange(offset=0, length=2),
+    )
+    set_active_mm_loras(
+        model=model,
+        lora_manager=lora_manager,
+        encoder_cache=encoder_cache,
+        req_id_to_index={"req-with-lora": 0},
+        lora_state=lora_state,
+        scheduled_encoder_inputs={"req-with-lora": [0, 1]},
+    )
+    lora_manager.set_active_adapters.assert_not_called()
 
 
 def test_update_states_new_request(model_runner, dist_init):

--- a/vllm/v1/worker/gpu/mm/lora.py
+++ b/vllm/v1/worker/gpu/mm/lora.py
@@ -41,7 +41,13 @@ def set_active_mm_loras(
 
         # iterate through visual tokens
         for mm_input_id in encoder_input_ids:
-            pos_info = mm_features[mm_input_id].mm_position
+            mm_feature = mm_features[mm_input_id]
+            if mm_feature.data is None:
+                # Served from the encoder cache: EncoderRunner.prepare_mm_inputs
+                # skips it in the forward, so it must not contribute mapping
+                # rows, or every later item's rows shift onto the wrong LoRA.
+                continue
+            pos_info = mm_feature.mm_position
             num_tokens = model.get_num_mm_encoder_tokens(pos_info.get_num_embeds())
             prompt_lora_mapping.append(lora_id)
             token_lora_mapping.extend([lora_id] * num_tokens)


### PR DESCRIPTION
## Bug

`set_active_mm_loras` (`vllm/v1/worker/gpu/mm/lora.py`) counts every scheduled mm item into the TOWER/CONNECTOR LoRA mappings, but the encoder forward skips cache-served items: `EncoderRunner.prepare_mm_inputs` (`vllm/v1/worker/gpu/mm/encoder_runner.py:44-45`) does `if mm_feature.data is None: continue` (the V1 runner has the same skip at `gpu_model_runner.py:2908`). Both sides iterate `scheduled_encoder_inputs` in the same order, so when a `data=None` item is scheduled, the LoRA mapping contains rows for an item the flattened encoder batch doesn't — and since punica consumes the mapping positionally, every subsequent item's rows shift onto the **wrong adapter**.

## Fix

Mirror the exact skip when building the mappings (6 lines). If every scheduled item is cache-served, the existing empty-mapping early return kicks in and nothing is set — matching the forward, which runs nothing.

## Tests

Updated `test_set_active_mm_loras_builds_tower_and_connector_mappings` fixtures to carry real (sentinel) `data` — with the fix, all-`None` fixtures would be skipped entirely — keeping every existing assertion unchanged. Added `test_set_active_mm_loras_skips_items_without_data`: a present-data item mixed with a cache-served one contributes exactly its own rows, and an all-cache-served step maps nothing.

Run on an A100 (vllm `0.23.1rc1.dev715+g2665ed704.cu129`, torch 2.11.0+cu128), module patched with this diff:

```
python -m pytest tests/v1/worker/test_gpu_model_runner.py -k set_active_mm_loras -v
================ 2 passed, 32 deselected in 7.16s =================
```

RED check — the new test against the **unpatched** module fails as expected:
```
FAILED test_gpu_model_runner.py::test_set_active_mm_loras_skips_items_without_data
```

## Not a duplicate

`gh pr list --state open --search "set_active_mm_loras"` / `"tower connector lora"`: no open PR touches this path. Related but distinct: #42662 (approved) migrates the token-count *interface* on the V1 runner path — this fix is independent of it and applies either way (noted on that PR's thread).

## Note

AI assistance (Claude Code) was used. Every changed line was reviewed and the tests above were run by the submitter.
