### PR TITLE
Add jitter to LoRA adapter_config.json load retries

### DIFF
--- a/tests/lora/test_peft_helper.py
+++ b/tests/lora/test_peft_helper.py
@@ -8,6 +8,7 @@ import shutil
 import pytest
 
 from vllm.config.lora import LoRAConfig
+from vllm.lora import peft_helper as peft_helper_module
 from vllm.lora.peft_helper import PEFTHelper
 
 ERROR_CASES = [
@@ -68,6 +69,53 @@ def test_peft_helper_pass(llama32_lora_files, tmp_path):
     peft_helper.validate_legal(lora_config)
     scaling = peft_helper.lora_alpha / math.sqrt(peft_helper.r)
     assert abs(peft_helper.vllm_lora_scaling_factor - scaling) < 1e-3
+
+
+def test_peft_helper_retries_adapter_config_load_with_jitter(
+    llama32_lora_files, monkeypatch
+):
+    original_json_load = json.load
+    attempts = 0
+    jitter_calls = []
+    sleep_calls = []
+
+    def flaky_json_load(f):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise json.JSONDecodeError("partial config", "{", 0)
+        return original_json_load(f)
+
+    def fake_jitter(start, stop):
+        jitter_calls.append((start, stop))
+        return 0.0
+
+    monkeypatch.setattr(peft_helper_module.json, "load", flaky_json_load)
+    monkeypatch.setattr(peft_helper_module.random, "uniform", fake_jitter)
+    monkeypatch.setattr(
+        peft_helper_module.time, "sleep", lambda sleep_s: sleep_calls.append(sleep_s)
+    )
+
+    peft_helper = PEFTHelper.from_local_dir(
+        llama32_lora_files, max_position_embeddings=4096
+    )
+
+    assert attempts == 2
+    assert jitter_calls
+    assert sleep_calls == [0.0]
+    assert peft_helper.r == 8
+
+
+def test_peft_helper_reraises_adapter_config_load_after_timeout(
+    tmp_path, monkeypatch
+):
+    monotonic_values = iter([0.0, 2.0])
+    monkeypatch.setattr(
+        peft_helper_module.time, "monotonic", lambda: next(monotonic_values)
+    )
+
+    with pytest.raises(FileNotFoundError):
+        PEFTHelper.from_local_dir(tmp_path, max_position_embeddings=4096)
 
 
 @pytest.mark.parametrize("test_name,config_change,expected_error", ERROR_CASES)

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -6,6 +6,8 @@
 import json
 import math
 import os
+import random
+import time
 from dataclasses import MISSING, dataclass, field, fields
 from typing import Literal
 
@@ -14,6 +16,10 @@ from vllm.logger import init_logger
 from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
 
 logger = init_logger(__name__)
+
+_ADAPTER_CONFIG_LOAD_TIMEOUT_S = 1.0
+_ADAPTER_CONFIG_LOAD_INITIAL_BACKOFF_S = 0.05
+_ADAPTER_CONFIG_LOAD_MAX_BACKOFF_S = 1.0
 
 
 @dataclass
@@ -77,6 +83,26 @@ class PEFTHelper:
         filtered_dict = {k: v for k, v in config_dict.items() if k in class_fields}
         return cls(**filtered_dict)
 
+    @staticmethod
+    def _load_adapter_config(lora_config_path: str) -> dict:
+        deadline = time.monotonic() + _ADAPTER_CONFIG_LOAD_TIMEOUT_S
+        interval = _ADAPTER_CONFIG_LOAD_INITIAL_BACKOFF_S
+
+        while True:
+            try:
+                with open(lora_config_path) as f:
+                    return json.load(f)
+            except (FileNotFoundError, json.JSONDecodeError):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise
+                sleep_s = random.uniform(
+                    0.0,
+                    min(interval, _ADAPTER_CONFIG_LOAD_MAX_BACKOFF_S, remaining),
+                )
+                time.sleep(sleep_s)
+                interval *= 2
+
     @classmethod
     def from_local_dir(
         cls,
@@ -107,8 +133,7 @@ class PEFTHelper:
             )
 
         else:
-            with open(lora_config_path) as f:
-                config = json.load(f)
+            config = cls._load_adapter_config(lora_config_path)
 
         config["vllm_max_position_embeddings"] = max_position_embeddings
         return cls.from_dict(config)


### PR DESCRIPTION
When many vLLM workers load a new LoRA adapter simultaneously and the remote adapter_config.json is temporarily unavailable (e.g. HF Hub cache miss, NFS lag), deterministic exponential backoff causes all workers to retry in lockstep — amplifying load on upstream storage.

This adds full jitter `[0, backoff)` to each retry, bounded by the remaining time before a 1-second hard deadline, and extracts the retry loop into `PEFTHelper._load_adapter_config()`.

Closes #44245

**Checklist**
- [x] Tests added for retry-on-JSONDecodeError and retry-on-FileNotFoundError
- [x] All existing LoRA tests unchanged