### PR TITLE
fix(sampling_params): replace asserts with explicit Type/ValueErrors for robust input validation under optimized mode (-O)

### DIFF
--- a/tests/samplers/test_sampling_params_validation.py
+++ b/tests/samplers/test_sampling_params_validation.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm import SamplingParams
+
+@pytest.mark.skip_global_cleanup
+def test_stop_token_ids_validation():
+    # Valid stop_token_ids
+    params = SamplingParams(stop_token_ids=[1, 2, 3])
+    assert params.stop_token_ids == [1, 2, 3]
+
+    # Invalid type
+    with pytest.raises(TypeError, match="stop_token_ids must be a list"):
+        SamplingParams(stop_token_ids="not_a_list")
+
+    # Invalid element type
+    with pytest.raises(ValueError, match="stop_token_ids must contain only integers"):
+        SamplingParams(stop_token_ids=[1, "not_an_int", 3])
+
+@pytest.mark.skip_global_cleanup
+def test_stop_validation():
+    # Valid stop strings
+    params = SamplingParams(stop=["END", "STOP"])
+    assert params.stop == ["END", "STOP"]
+
+    # Invalid type
+    with pytest.raises(TypeError, match="stop must be a list"):
+        SamplingParams(stop=123)
+
+    # Empty string in stop
+    with pytest.raises(ValueError, match="stop cannot contain an empty string"):
+        SamplingParams(stop=["END", ""])
+
+@pytest.mark.skip_global_cleanup
+def test_bad_words_validation():
+    # Valid bad words
+    params = SamplingParams(bad_words=["bad", "word"])
+    assert params.bad_words == ["bad", "word"]
+
+    # Invalid type
+    with pytest.raises(TypeError, match="bad_words must be a list"):
+        SamplingParams(bad_words={"bad": "word"})
+
+    # Empty string in bad_words
+    with pytest.raises(ValueError, match="bad_words cannot contain an empty string"):
+        SamplingParams(bad_words=["bad", ""])
+
+@pytest.mark.skip_global_cleanup
+def test_update_from_generation_config():
+    params = SamplingParams()
+    params.stop_token_ids = None  # Force it to None to test the check
+    with pytest.raises(ValueError, match="stop_token_ids must not be None"):
+        params.update_from_generation_config({"eos_token_id": 45}, eos_token_id=50)
+
+
+@pytest.mark.skip_global_cleanup
+def test_validation_under_optimized_mode():
+    import subprocess
+    import sys
+    code = """
+from vllm import SamplingParams
+try:
+    SamplingParams(stop_token_ids="not_a_list")
+    print("FAILED")
+except TypeError:
+    print("PASSED")
+"""
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+    assert result.stdout.strip().endswith("PASSED")
+

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -455,6 +455,19 @@ class SamplingParams(
         if self.bad_words is None:
             self.bad_words = []
 
+        if not isinstance(self.stop, list):
+            raise TypeError(
+                f"stop must be a list, got {type(self.stop).__name__}."
+            )
+        if not isinstance(self.stop_token_ids, list):
+            raise TypeError(
+                f"stop_token_ids must be a list, got {type(self.stop_token_ids).__name__}."
+            )
+        if not isinstance(self.bad_words, list):
+            raise TypeError(
+                f"bad_words must be a list, got {type(self.bad_words).__name__}."
+            )
+
         if self.logprobs is True:
             self.logprobs = 1
 
@@ -581,12 +594,18 @@ class SamplingParams(
                 parameter="prompt_logprobs",
                 value=self.prompt_logprobs,
             )
-        assert isinstance(self.stop_token_ids, list)
+        if not isinstance(self.stop_token_ids, list):
+            raise TypeError(
+                f"stop_token_ids must be a list, got {type(self.stop_token_ids).__name__}."
+            )
         if not all(isinstance(st_id, int) for st_id in self.stop_token_ids):
             raise ValueError(
                 f"stop_token_ids must contain only integers, got {self.stop_token_ids}."
             )
-        assert isinstance(self.stop, list)
+        if not isinstance(self.stop, list):
+            raise TypeError(
+                f"stop must be a list, got {type(self.stop).__name__}."
+            )
         if any(not stop_str for stop_str in self.stop):
             raise ValueError("stop cannot contain an empty string.")
         if self.stop and not self.detokenize:
@@ -594,7 +613,10 @@ class SamplingParams(
                 "stop strings are only supported when detokenize is True. "
                 "Set detokenize=True to use stop."
             )
-        assert isinstance(self.bad_words, list)
+        if not isinstance(self.bad_words, list):
+            raise TypeError(
+                f"bad_words must be a list, got {type(self.bad_words).__name__}."
+            )
         if any(not bad_word for bad_word in self.bad_words):
             raise ValueError(
                 f"bad_words cannot contain an empty string. "
@@ -631,7 +653,8 @@ class SamplingParams(
             if eos_ids:
                 self._all_stop_token_ids.update(eos_ids)
                 if not self.ignore_eos:
-                    assert self.stop_token_ids is not None
+                    if self.stop_token_ids is None:
+                        raise ValueError("stop_token_ids must not be None")
                     eos_ids.update(self.stop_token_ids)
                     self.stop_token_ids = list(eos_ids)
 


### PR DESCRIPTION
### Description
Fixes #44798.

In `vllm/sampling_params.py`, `assert isinstance(...)` was used to validate fields such as `stop_token_ids`, `stop`, and `bad_words`, and `assert self.stop_token_ids is not None` was used in `update_from_generation_config()`.

Since Python's `-O` (optimize) flag completely strips out `assert` statements from compiled bytecode, running vLLM in optimized mode bypassed these critical input validations. This allowed malformed inputs to pass through silently, leading to hard-to-debug type or iteration errors further down the engine stack.

This PR replaces the fragile `assert` validations with explicit type/value checks raising `TypeError` or `ValueError`. We validate these list types during `__post_init__` to catch invalid inputs immediately before any buffer length calculations are computed, and keep the validations in `_verify_args()` / `update_from_generation_config()` to cover late modifications.

### Verification
- Created `tests/samplers/test_sampling_params_validation.py` to verify the inputs are correctly rejected.
- Added a subprocess test execution under optimized mode (`python -O`) to verify that the validations are always enforced and never skipped.