### PR TITLE
fix(security): bound MRoPE temporal positions to prevent engine crash

### DIFF
--- a/tests/model_executor/test_mrope_position_bounds.py
+++ b/tests/model_executor/test_mrope_position_bounds.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for MRoPE position bounds checking (security fix).
+
+Validates that:
+1. MRotaryEmbedding rejects out-of-bounds positions with ValueError
+2. Model get_mrope_input_positions clamps temporal positions when t_factor
+   would produce indices exceeding the cache size
+3. second_per_grid_ts is floored to prevent near-zero fps from producing
+   unbounded temporal multipliers
+"""
+
+from dataclasses import dataclass, field
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.rotary_embedding.mrope import MRotaryEmbedding
+from vllm.model_executor.models.qwen2_5_vl import (
+    Qwen2_5_VLForConditionalGeneration,
+)
+from vllm.model_executor.models.qwen2_vl import (
+    Qwen2VLForConditionalGeneration,
+)
+from vllm.multimodal.inputs import (
+    MultiModalFeatureSpec,
+    MultiModalFieldElem,
+    MultiModalKwargsItem,
+    PlaceholderRange,
+)
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _force_cpu_default_device():
+    original = torch.get_default_device()
+    torch.set_default_device("cpu")
+    yield
+    torch.set_default_device(original)
+
+
+# --- MRotaryEmbedding bounds check tests ---
+
+
+class TestMRotaryEmbeddingBoundsCheck:
+    """Test that MRotaryEmbedding raises ValueError for OOB positions."""
+
+    def _make_mrope(self, max_position_embeddings=128):
+        return MRotaryEmbedding(
+            head_size=64,
+            rotary_dim=64,
+            max_position_embeddings=max_position_embeddings,
+            base=10000.0,
+            is_neox_style=True,
+            dtype=torch.float32,
+            mrope_section=[16, 8, 8],
+        )
+
+    def test_valid_positions_pass(self, default_vllm_config):
+        mrope = self._make_mrope(max_position_embeddings=128)
+        # Cache size = 128 * 4 = 512
+        positions = torch.randint(0, 511, (3, 10))
+        query = torch.randn(10, 64)
+        key = torch.randn(10, 64)
+        q, k = mrope.forward_native(positions, query, key)
+        assert q.shape == query.shape
+        assert k.shape == key.shape
+
+    def test_oob_positions_raise_valueerror(self, default_vllm_config):
+        mrope = self._make_mrope(max_position_embeddings=128)
+        # Cache size = 128 * 4 = 512; position 1000 is out of bounds
+        positions = torch.tensor([[0, 1, 1000], [0, 1, 2], [0, 1, 2]])
+        query = torch.randn(3, 64)
+        key = torch.randn(3, 64)
+        with pytest.raises(ValueError, match="exceeds the rotary embedding cache"):
+            mrope.forward_native(positions, query, key)
+
+    def test_boundary_position_raises(self, default_vllm_config):
+        mrope = self._make_mrope(max_position_embeddings=128)
+        # Exactly at cache size (512) should fail
+        positions = torch.tensor([[512], [0], [0]])
+        query = torch.randn(1, 64)
+        key = torch.randn(1, 64)
+        with pytest.raises(ValueError, match="exceeds the rotary embedding cache"):
+            mrope.forward_native(positions, query, key)
+
+    def test_negative_positions_raise_valueerror(self, default_vllm_config):
+        mrope = self._make_mrope(max_position_embeddings=128)
+        positions = torch.tensor([[0, -1, 2], [0, 1, 2], [0, 1, 2]])
+        query = torch.randn(3, 64)
+        key = torch.randn(3, 64)
+        with pytest.raises(ValueError, match="is negative"):
+            mrope.forward_native(positions, query, key)
+
+    def test_max_valid_position_passes(self, default_vllm_config):
+        mrope = self._make_mrope(max_position_embeddings=128)
+        # max_position_embeddings * 4 - 1 = 511 should pass
+        positions = torch.tensor([[511], [0], [0]])
+        query = torch.randn(1, 64)
+        key = torch.randn(1, 64)
+        q, k = mrope.forward_native(positions, query, key)
+        assert q.shape == query.shape
+
+
+# --- Model position clamping tests ---
+
+
+@dataclass
+class DummyVisionConfig:
+    spatial_merge_size: int = 2
+    tokens_per_second: float = 1.0
+    patch_size: int = 14
+
+
+@dataclass
+class DummyConfig:
+    image_token_id: int = 151655
+    video_token_id: int = 151654
+    vision_start_token_id: int = 151652
+    vision_end_token_id: int = 151653
+    max_position_embeddings: int = 128
+    vision_config: DummyVisionConfig = field(default_factory=DummyVisionConfig)
+
+
+def _make_qwen25vl_model(config=None):
+    if config is None:
+        config = DummyConfig()
+    model = object.__new__(Qwen2_5_VLForConditionalGeneration)
+    model.config = config
+    return model
+
+
+def _make_qwen2vl_model(config=None):
+    if config is None:
+        config = DummyConfig()
+    model = object.__new__(Qwen2VLForConditionalGeneration)
+    model.config = config
+    return model
+
+
+def _make_video_feature(
+    offset: int, grid_thw: tuple[int, int, int], second_per_grid_ts: float
+) -> MultiModalFeatureSpec:
+    data = {
+        "video_grid_thw": MultiModalFieldElem(
+            data=torch.tensor(grid_thw),
+            field=None,
+        ),
+        "second_per_grid_ts": MultiModalFieldElem(
+            data=torch.tensor(second_per_grid_ts),
+            field=None,
+        ),
+    }
+    t, h, w = grid_thw
+    spatial_merge_size = 2
+    length = t * (h // spatial_merge_size) * (w // spatial_merge_size)
+    return MultiModalFeatureSpec(
+        data=MultiModalKwargsItem(data),
+        modality="video",
+        identifier="DUMMY",
+        mm_position=PlaceholderRange(offset=offset, length=length),
+    )
+
+
+class TestQwen25VLPositionClamping:
+    """Test that Qwen2.5-VL clamps positions when t_factor is extreme."""
+
+    def test_normal_t_factor(self):
+        model = _make_qwen25vl_model()
+        # Normal case: second_per_grid_ts=1.0, tokens_per_second=1.0
+        # t_factor = 1.0, no clamping needed
+        feature = _make_video_feature(
+            offset=0, grid_thw=(4, 4, 4), second_per_grid_ts=1.0
+        )
+        input_tokens = list(range(4 * 2 * 2))  # t * (h/merge) * (w/merge)
+        positions, delta = model.get_mrope_input_positions(input_tokens, [feature])
+        assert positions.shape == (3, len(input_tokens))
+        # All positions should be within bounds
+        max_pos = model.config.max_position_embeddings * 4
+        assert positions.max().item() < max_pos
+
+    def test_extreme_t_factor_is_clamped(self):
+        model = _make_qwen25vl_model()
+        # Extreme second_per_grid_ts simulating near-zero fps
+        # t_factor = 1e6 * 1.0 = 1e6, would produce indices >> cache size
+        feature = _make_video_feature(
+            offset=0, grid_thw=(4, 4, 4), second_per_grid_ts=1e6
+        )
+        input_tokens = list(range(4 * 2 * 2))
+        positions, delta = model.get_mrope_input_positions(input_tokens, [feature])
+        max_pos = model.config.max_position_embeddings * 4
+        assert positions.max().item() < max_pos
+
+    def test_second_per_grid_ts_floor(self):
+        """Verify near-zero second_per_grid_ts is floored to 1e-3."""
+        model = _make_qwen25vl_model()
+        feature = _make_video_feature(
+            offset=0, grid_thw=(4, 4, 4), second_per_grid_ts=1e-15
+        )
+        input_tokens = list(range(4 * 2 * 2))
+        # Should not crash due to extreme values
+        positions, delta = model.get_mrope_input_positions(input_tokens, [feature])
+        assert positions.shape == (3, len(input_tokens))
+
+
+class TestQwen2VLPositionClamping:
+    """Test that Qwen2-VL has the same protection."""
+
+    def test_extreme_t_factor_is_clamped(self):
+        model = _make_qwen2vl_model()
+        feature = _make_video_feature(
+            offset=0, grid_thw=(4, 4, 4), second_per_grid_ts=1e6
+        )
+        input_tokens = list(range(4 * 2 * 2))
+        positions, delta = model.get_mrope_input_positions(input_tokens, [feature])
+        max_pos = model.config.max_position_embeddings * 4
+        assert positions.max().item() < max_pos
+
+
+class TestSecondPerGridTsValidation:
+    """Test that the floor on second_per_grid_ts works across models."""
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [0.0, -1.0, 1e-15, 1e-100, float("inf"), float("-inf"), float("nan")],
+    )
+    def test_near_zero_fps_does_not_crash(self, bad_value):
+        model = _make_qwen25vl_model()
+        feature = _make_video_feature(
+            offset=0, grid_thw=(2, 4, 4), second_per_grid_ts=bad_value
+        )
+        input_tokens = list(range(2 * 2 * 2))
+        positions, delta = model.get_mrope_input_positions(input_tokens, [feature])
+        max_pos = model.config.max_position_embeddings * 4
+        assert positions.max().item() < max_pos
+
+    def test_large_second_per_grid_ts_clamped(self):
+        """Simulate fps near zero → second_per_grid_ts near infinity."""
+        config = DummyConfig()
+        config.vision_config.tokens_per_second = 25.0
+        model = _make_qwen25vl_model(config)
+        # second_per_grid_ts=1000 with tokens_per_second=25 → t_factor=25000
+        feature = _make_video_feature(
+            offset=0, grid_thw=(10, 4, 4), second_per_grid_ts=1000.0
+        )
+        input_tokens = list(range(10 * 2 * 2))
+        positions, delta = model.get_mrope_input_positions(input_tokens, [feature])
+        max_pos = config.max_position_embeddings * 4
+        assert positions.max().item() < max_pos

--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -260,6 +260,23 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
             return super()._compute_cos_sin_cache()
         return YaRNScalingRotaryEmbedding._compute_cos_sin_cache(self)
 
+    def _validate_positions(self, positions: torch.Tensor, cache_size: int) -> None:
+        """Raise ValueError if any position index exceeds the cache bounds."""
+        min_pos = positions.min().item()
+        if min_pos < 0:
+            raise ValueError(
+                f"MRoPE position index {min_pos} is negative. "
+                f"This likely indicates a video with an extreme or "
+                f"near-zero frame rate producing invalid positions."
+            )
+        max_pos = positions.max().item()
+        if max_pos >= cache_size:
+            raise ValueError(
+                f"MRoPE position index {max_pos} exceeds the rotary "
+                f"embedding cache size {cache_size}. This likely indicates "
+                f"a video with an extreme or near-zero frame rate."
+            )
+
     def forward_native(
         self,
         positions: torch.Tensor,
@@ -281,6 +298,7 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
 
         cos_sin_cache = self._match_cos_sin_cache_dtype(query)
         num_tokens = positions.shape[-1]
+        self._validate_positions(positions, cos_sin_cache.shape[0])
         cos_sin = cos_sin_cache[positions]
         cos, sin = cos_sin.chunk(2, dim=-1)
         if positions.ndim == 2:
@@ -333,6 +351,7 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
 
         cos_sin_cache = self._match_cos_sin_cache_dtype(query)
         num_tokens = positions.shape[-1]
+        self._validate_positions(positions, cos_sin_cache.shape[0])
         cos_sin = cos_sin_cache[positions]
         cos, sin = cos_sin.chunk(2, dim=-1)
         query_shape = query.shape

--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -36,6 +36,7 @@ from vllm.config.multimodal import BaseDummyOptions
 from vllm.distributed import parallel_state
 from vllm.distributed import utils as dist_utils
 from vllm.inputs import MultiModalDataDict
+from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import (
     MMEncoderAttention,
 )
@@ -80,6 +81,8 @@ from .utils import (
     maybe_prefix,
 )
 from .vision import get_vit_attn_backend
+
+logger = init_logger(__name__)
 
 
 def smart_resize(
@@ -1035,6 +1038,9 @@ class PaddleOCRVLForConditionalGeneration(nn.Module, SupportsMultiModal, Support
                     second_per_grid_ts = mm_feature.data[
                         "second_per_grid_ts"
                     ].data.item()
+                if not np.isfinite(second_per_grid_ts):
+                    second_per_grid_ts = 1.0
+                second_per_grid_ts = max(second_per_grid_ts, 1e-3)
                 t_factor = second_per_grid_ts * tokens_per_second
                 yield (
                     offset,
@@ -1051,6 +1057,8 @@ class PaddleOCRVLForConditionalGeneration(nn.Module, SupportsMultiModal, Support
         input_tokens: list[int],
         mm_features: list[MultiModalFeatureSpec],
     ) -> tuple[torch.Tensor, int]:
+        max_mrope_pos = getattr(self.config, "max_position_embeddings", 32768) * 4
+
         llm_pos_ids_list: list = []
         st = 0
 
@@ -1069,7 +1077,10 @@ class PaddleOCRVLForConditionalGeneration(nn.Module, SupportsMultiModal, Support
 
             grid_indices = np.indices((llm_grid_t, llm_grid_h, llm_grid_w))
             if t_factor != 1.0:
-                grid_indices[0] = (grid_indices[0] * t_factor).astype(np.int64)
+                grid_indices[0] = np.minimum(
+                    grid_indices[0] * t_factor,
+                    max_mrope_pos - 1,
+                ).astype(np.int64)
 
             llm_pos_ids_list.append(grid_indices.reshape(3, -1) + text_len + st_idx)
             st = offset + llm_grid_t * llm_grid_h * llm_grid_w
@@ -1082,6 +1093,14 @@ class PaddleOCRVLForConditionalGeneration(nn.Module, SupportsMultiModal, Support
             )
 
         llm_positions = np.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
+        if llm_positions.max() >= max_mrope_pos:
+            logger.warning(
+                "MRoPE positions exceed cache bounds (max=%d, limit=%d). "
+                "Clamping to prevent out-of-bounds access.",
+                llm_positions.max(),
+                max_mrope_pos,
+            )
+            np.clip(llm_positions, 0, max_mrope_pos - 1, out=llm_positions)
         mrope_position_delta = (llm_positions.max() + 1 - len(input_tokens)).item()
 
         return torch.from_numpy(llm_positions), mrope_position_delta

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -1213,6 +1213,9 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
                     second_per_grid_ts = mm_feature.data[
                         "second_per_grid_ts"
                     ].data.item()
+                if not np.isfinite(second_per_grid_ts):
+                    second_per_grid_ts = 1.0
+                second_per_grid_ts = max(second_per_grid_ts, 1e-3)
                 use_audio_in_video = False
                 if mm_feature.data.get("use_audio_in_video"):
                     use_audio_in_video = bool(
@@ -1252,6 +1255,7 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
         audio_len = data["audio_feature_length"]
 
         thinker_config = self.config
+        max_mrope_pos = getattr(thinker_config, "max_position_embeddings", 32768) * 4
         tokens_per_second = getattr(
             thinker_config.vision_config, "tokens_per_second", 25
         )
@@ -1259,7 +1263,10 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
         t_ntoken_per_chunk = int(tokens_per_second * seconds_per_chunk)
 
         # Temporal indices with scaling
-        t_index = (np.arange(grid_t) * t_factor).astype(np.int64)
+        t_index = np.minimum(
+            np.arange(grid_t) * t_factor,
+            max_mrope_pos - 1,
+        ).astype(np.int64)
 
         # Split temporal indices into chunks
         t_index_split_chunk: list[list[int]] = [
@@ -1331,6 +1338,8 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
             |V_1 ...    V_n|A_1 ...   A_n|V_n+1 ... V_2n|A_n+1 ... A_2n|...
             |vision chunk 1|audio chunk 1|vision chunk 2|audio chunk 2 |...
         """
+        max_mrope_pos = getattr(self.config, "max_position_embeddings", 32768) * 4
+
         llm_pos_ids_list: list[np.ndarray] = []
         st = 0
 
@@ -1363,7 +1372,10 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
 
                 grid_indices = np.indices((grid_t, grid_h, grid_w))
                 if t_factor != 1.0:
-                    grid_indices[0] = (grid_indices[0] * t_factor).astype(np.int64)
+                    grid_indices[0] = np.minimum(
+                        grid_indices[0] * t_factor,
+                        max_mrope_pos - 1,
+                    ).astype(np.int64)
                 llm_pos_ids_list.append(grid_indices.reshape(3, -1) + st_idx)
                 st = offset + grid_t * grid_h * grid_w
 
@@ -1377,7 +1389,10 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
                     # Simple video (same as Qwen2-VL)
                     grid_indices = np.indices((grid_t, grid_h, grid_w))
                     if t_factor != 1.0:
-                        grid_indices[0] = (grid_indices[0] * t_factor).astype(np.int64)
+                        grid_indices[0] = np.minimum(
+                            grid_indices[0] * t_factor,
+                            max_mrope_pos - 1,
+                        ).astype(np.int64)
                     llm_pos_ids_list.append(grid_indices.reshape(3, -1) + st_idx)
                     st = offset + grid_t * grid_h * grid_w
                 else:
@@ -1397,6 +1412,14 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
             )
 
         llm_positions = np.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
+        if llm_positions.max() >= max_mrope_pos:
+            logger.warning(
+                "MRoPE positions exceed cache bounds (max=%d, limit=%d). "
+                "Clamping to prevent out-of-bounds access.",
+                llm_positions.max(),
+                max_mrope_pos,
+            )
+            np.clip(llm_positions, 0, max_mrope_pos - 1, out=llm_positions)
         mrope_position_delta = int(llm_positions.max()) + 1 - len(input_tokens)
 
         return torch.from_numpy(llm_positions), mrope_position_delta

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -1282,6 +1282,9 @@ class Qwen2_5_VLForConditionalGeneration(
                     second_per_grid_ts = mm_feature.data[
                         "second_per_grid_ts"
                     ].data.item()
+                if not np.isfinite(second_per_grid_ts):
+                    second_per_grid_ts = 1.0
+                second_per_grid_ts = max(second_per_grid_ts, 1e-3)
                 t_factor = second_per_grid_ts * tokens_per_second
                 yield (
                     offset,
@@ -1298,6 +1301,8 @@ class Qwen2_5_VLForConditionalGeneration(
         input_tokens: list[int],
         mm_features: list[MultiModalFeatureSpec],
     ) -> tuple[torch.Tensor, int]:
+        max_mrope_pos = getattr(self.config, "max_position_embeddings", 32768) * 4
+
         llm_pos_ids_list: list = []
         st = 0
 
@@ -1316,7 +1321,10 @@ class Qwen2_5_VLForConditionalGeneration(
 
             grid_indices = np.indices((llm_grid_t, llm_grid_h, llm_grid_w))
             if t_factor != 1.0:
-                grid_indices[0] = (grid_indices[0] * t_factor).astype(np.int64)
+                grid_indices[0] = np.minimum(
+                    grid_indices[0] * t_factor,
+                    max_mrope_pos - 1,
+                ).astype(np.int64)
             llm_pos_ids_list.append(grid_indices.reshape(3, -1) + text_len + st_idx)
             st = offset + llm_grid_t * llm_grid_h * llm_grid_w
 
@@ -1328,6 +1336,14 @@ class Qwen2_5_VLForConditionalGeneration(
             )
 
         llm_positions = np.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
+        if llm_positions.max() >= max_mrope_pos:
+            logger.warning(
+                "MRoPE positions exceed cache bounds (max=%d, limit=%d). "
+                "Clamping to prevent out-of-bounds access.",
+                llm_positions.max(),
+                max_mrope_pos,
+            )
+            np.clip(llm_positions, 0, max_mrope_pos - 1, out=llm_positions)
         mrope_position_delta = (llm_positions.max() + 1 - len(input_tokens)).item()
 
         return torch.from_numpy(llm_positions), mrope_position_delta

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -1209,6 +1209,9 @@ class Qwen2VLForConditionalGeneration(
                     second_per_grid_ts = mm_feature.data[
                         "second_per_grid_ts"
                     ].data.item()
+                if not np.isfinite(second_per_grid_ts):
+                    second_per_grid_ts = 1.0
+                second_per_grid_ts = max(second_per_grid_ts, 1e-3)
                 t_factor = second_per_grid_ts * tokens_per_second
                 yield (
                     offset,
@@ -1225,6 +1228,8 @@ class Qwen2VLForConditionalGeneration(
         input_tokens: list[int],
         mm_features: list[MultiModalFeatureSpec],
     ) -> tuple[torch.Tensor, int]:
+        max_mrope_pos = getattr(self.config, "max_position_embeddings", 32768) * 4
+
         llm_pos_ids_list: list = []
         st = 0
 
@@ -1243,7 +1248,10 @@ class Qwen2VLForConditionalGeneration(
 
             grid_indices = np.indices((llm_grid_t, llm_grid_h, llm_grid_w))
             if t_factor != 1.0:
-                grid_indices[0] = (grid_indices[0] * t_factor).astype(np.int64)
+                grid_indices[0] = np.minimum(
+                    grid_indices[0] * t_factor,
+                    max_mrope_pos - 1,
+                ).astype(np.int64)
             llm_pos_ids_list.append(grid_indices.reshape(3, -1) + text_len + st_idx)
             st = offset + llm_grid_t * llm_grid_h * llm_grid_w
 
@@ -1255,6 +1263,14 @@ class Qwen2VLForConditionalGeneration(
             )
 
         llm_positions = np.concatenate(llm_pos_ids_list, axis=1).reshape(3, -1)
+        if llm_positions.max() >= max_mrope_pos:
+            logger.warning(
+                "MRoPE positions exceed cache bounds (max=%d, limit=%d). "
+                "Clamping to prevent out-of-bounds access.",
+                llm_positions.max(),
+                max_mrope_pos,
+            )
+            np.clip(llm_positions, 0, max_mrope_pos - 1, out=llm_positions)
         mrope_position_delta = (llm_positions.max() + 1 - len(input_tokens)).item()
 
         return torch.from_numpy(llm_positions), mrope_position_delta

--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -2059,6 +2059,9 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
                     second_per_grid_ts = mm_feature.data[
                         "second_per_grid_ts"
                     ].data.item()
+                if not np.isfinite(second_per_grid_ts):
+                    second_per_grid_ts = 2.0
+                second_per_grid_ts = max(second_per_grid_ts, 1e-3)
                 use_audio_in_video = bool(
                     mm_feature.data.get("use_audio_in_video")
                     and mm_feature.data["use_audio_in_video"].data.item()
@@ -2096,6 +2099,7 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
         t_factor = data["t_factor"]
         audio_feature_length = data["audio_feature_length"]
 
+        max_mrope_pos = getattr(self.config, "max_position_embeddings", 32768) * 4
         audio_len = self._compute_audio_token_count(audio_feature_length)
 
         h_index = np.tile(
@@ -2105,7 +2109,10 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
             np.arange(grid_w).reshape(1, 1, -1), (grid_t, grid_h, 1)
         ).flatten()
         t_index_raw = np.arange(grid_t)
-        t_index_scaled = (t_index_raw * t_factor).astype(np.int64)
+        t_index_scaled = np.minimum(
+            t_index_raw * t_factor,
+            max_mrope_pos - 1,
+        ).astype(np.int64)
         t_index = np.repeat(t_index_scaled, grid_h * grid_w)
 
         video_pos = np.stack([t_index, h_index, w_index]) + start_idx
@@ -2210,6 +2217,7 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
     ) -> tuple[torch.Tensor, int]:
         """Compute M-RoPE input positions using mm_features directly."""
         seq_len = len(input_tokens)
+        max_mrope_pos = getattr(self.config, "max_position_embeddings", 32768) * 4
 
         llm_pos_ids_list: list[np.ndarray] = []
         st = 0
@@ -2250,7 +2258,10 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
 
                 grid_indices = np.indices((grid_t, grid_h, grid_w))
                 if t_factor != 1.0:
-                    grid_indices[0] = (grid_indices[0] * t_factor).astype(np.int64)
+                    grid_indices[0] = np.minimum(
+                        grid_indices[0] * t_factor,
+                        max_mrope_pos - 1,
+                    ).astype(np.int64)
                 llm_pos_ids_list.append(grid_indices.reshape(3, -1) + st_idx)
 
                 image_len = grid_t * grid_h * grid_w
@@ -2269,7 +2280,10 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
                 if not data["use_audio_in_video"]:
                     grid_indices = np.indices((grid_t, grid_h, grid_w))
                     if t_factor != 1.0:
-                        grid_indices[0] = (grid_indices[0] * t_factor).astype(np.int64)
+                        grid_indices[0] = np.minimum(
+                            grid_indices[0] * t_factor,
+                            max_mrope_pos - 1,
+                        ).astype(np.int64)
                     llm_pos_ids_list.append(grid_indices.reshape(3, -1) + st_idx)
 
                     video_len = grid_t * grid_h * grid_w
@@ -2307,6 +2321,14 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
         if llm_positions.shape[1] != seq_len:
             raise RuntimeError("Position ids length mismatch with input ids length")
 
+        if llm_positions.max() >= max_mrope_pos:
+            logger.warning(
+                "MRoPE positions exceed cache bounds (max=%d, limit=%d). "
+                "Clamping to prevent out-of-bounds access.",
+                llm_positions.max(),
+                max_mrope_pos,
+            )
+            np.clip(llm_positions, 0, max_mrope_pos - 1, out=llm_positions)
         mrope_position_delta = int(llm_positions.max()) + 1 - seq_len
         return torch.from_numpy(llm_positions), mrope_position_delta
 


### PR DESCRIPTION
An unbounded temporal multiplier (t_factor) in MRoPE position calculation could produce position indices exceeding the cos_sin_cache size, causing an out-of-bounds index that fatally crashes the EngineCore process via a single unauthenticated request. Defense-in-depth fix:
- Add _validate_positions() bounds check in MRotaryEmbedding that raises ValueError instead of allowing CUDA illegal memory access
- Clamp grid_indices[0] * t_factor to max_position_embeddings * 4 - 1 in get_mrope_input_positions across all affected models
- Floor second_per_grid_ts to 1e-3 to reject near-zero fps values from HF processor output Affected models: Qwen2-VL, Qwen2.5-VL, PaddleOCR-VL, Qwen2.5-Omni-Thinker, Qwen3-Omni-MoE-Thinker.
