### PR TITLE
[Feature]: Support min_tokens in beam search

### DIFF
--- a/docs/models/generative_models.md
+++ b/docs/models/generative_models.md
@@ -71,7 +71,7 @@ from vllm import LLM
 from vllm.sampling_params import BeamSearchParams
 
 llm = LLM(model="facebook/opt-125m")
-params = BeamSearchParams(beam_width=5, max_tokens=50)
+params = BeamSearchParams(beam_width=5, max_tokens=50, min_tokens=5)
 outputs = llm.beam_search([{"prompt": "Hello, my name is "}], params)
 
 for output in outputs:

--- a/tests/samplers/test_beam_search_online.py
+++ b/tests/samplers/test_beam_search_online.py
@@ -72,3 +72,34 @@ async def test_beam_search_handles_extra_logprob_candidates() -> None:
     assert outputs[0].outputs[0].finish_reason == "stop"
     assert outputs[0].outputs[0].token_ids == []
     assert outputs[0].outputs[0].cumulative_logprob == pytest.approx(-0.1)
+
+
+@pytest.mark.asyncio
+async def test_beam_search_respects_min_tokens_before_eos() -> None:
+    prompt = {
+        "type": "token",
+        "prompt": "prompt",
+        "prompt_token_ids": [1],
+    }
+    params = BeamSearchParams(beam_width=1, max_tokens=2, min_tokens=1)
+
+    outputs = [
+        output async for output in _Serving().beam_search(prompt, "request", params)
+    ]
+
+    assert len(outputs) == 1
+    assert outputs[0].outputs[0].finish_reason == "stop"
+    assert outputs[0].outputs[0].token_ids == [11]
+    assert outputs[0].outputs[0].cumulative_logprob == pytest.approx(-1.1)
+
+
+def test_beam_search_params_validate_min_tokens() -> None:
+    BeamSearchParams(beam_width=1, max_tokens=2, min_tokens=2)
+
+    with pytest.raises(
+        ValueError, match="min_tokens must be greater than or equal to 0"
+    ):
+        BeamSearchParams(beam_width=1, max_tokens=2, min_tokens=-1)
+
+    with pytest.raises(ValueError, match="min_tokens must be less than or equal to"):
+        BeamSearchParams(beam_width=1, max_tokens=2, min_tokens=3)

--- a/vllm/entrypoints/generate/beam_search/offline.py
+++ b/vllm/entrypoints/generate/beam_search/offline.py
@@ -26,6 +26,7 @@ from .utils import (
     BeamSearchOutput,
     BeamSearchSequence,
     create_sort_beams_key_function,
+    get_generated_token_count,
 )
 
 logger = init_logger(__name__)
@@ -82,6 +83,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
         temperature = params.temperature
         ignore_eos = params.ignore_eos
         length_penalty = params.length_penalty
+        min_tokens = params.min_tokens
 
         tokenizer = self.renderer.get_tokenizer()
         eos_token_id = tokenizer.eos_token_id
@@ -168,6 +170,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
                         structured_output_backend=structured_output_backend,
                         structured_output_key=structured_output_key,
                         structured_output_bitmask=structured_output_bitmask,
+                        min_tokens=min_tokens,
                     )
                     if should_stop:
                         break
@@ -201,6 +204,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
         structured_output_backend: StructuredOutputBackend | None,
         structured_output_key: tuple | None,
         structured_output_bitmask: torch.Tensor | None,
+        min_tokens: int,
     ) -> bool:
         """Run one token step of beam search across a batch of instances.
 
@@ -302,6 +306,13 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
                     allowed = allowed_sets[i]
                     for token_id, logprob_obj in logprobs.items():
                         if allowed is not None and token_id not in allowed:
+                            continue
+                        generated_tokens = get_generated_token_count(current_beam)
+                        if (
+                            token_id == eos_token_id
+                            and not ignore_eos
+                            and generated_tokens < min_tokens
+                        ):
                             continue
                         new_beam = BeamSearchSequence(
                             current_beam.orig_prompt,

--- a/vllm/entrypoints/generate/beam_search/online.py
+++ b/vllm/entrypoints/generate/beam_search/online.py
@@ -16,7 +16,11 @@ from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.utils import random_uuid
 from vllm.utils.async_utils import collect_from_async_generator
 
-from .utils import BeamSearchSequence, create_sort_beams_key_function
+from .utils import (
+    BeamSearchSequence,
+    create_sort_beams_key_function,
+    get_generated_token_count,
+)
 
 
 class BeamSearchOnlineMixin(ABC):
@@ -38,6 +42,7 @@ class BeamSearchOnlineMixin(ABC):
         ignore_eos = params.ignore_eos
         temperature = params.temperature
         length_penalty = params.length_penalty
+        min_tokens = params.min_tokens
         include_stop_str_in_output = params.include_stop_str_in_output
 
         tokenizer = self.renderer.get_tokenizer()
@@ -131,6 +136,9 @@ class BeamSearchOnlineMixin(ABC):
                             current_beam.cum_logprob + logprob_obj.logprob
                         )
                         if token_id == eos_token_id and not ignore_eos:
+                            generated_tokens = get_generated_token_count(current_beam)
+                            if generated_tokens < min_tokens:
+                                continue
                             completed.append(
                                 BeamSearchSequence(
                                     orig_prompt=prompt,

--- a/vllm/entrypoints/generate/beam_search/utils.py
+++ b/vllm/entrypoints/generate/beam_search/utils.py
@@ -160,3 +160,9 @@ def create_sort_beams_key_function(eos_token_id: int, length_penalty: float):
         )
 
     return sort_beams_key
+
+
+def get_generated_token_count(sequence: BeamSearchSequence) -> int:
+    prompt = sequence.orig_prompt
+    decoder_prompt = prompt if prompt["type"] != "enc_dec" else prompt["decoder_prompt"]
+    return len(sequence.tokens) - len(decoder_prompt["prompt_token_ids"])

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -579,6 +579,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             ignore_eos=self.ignore_eos,
             temperature=temperature,
             length_penalty=self.length_penalty,
+            min_tokens=self.min_tokens,
             include_stop_str_in_output=self.include_stop_str_in_output,
         )
 

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -254,6 +254,7 @@ class CompletionRequest(OpenAIBaseModel):
             ignore_eos=self.ignore_eos,
             temperature=temperature,
             length_penalty=self.length_penalty,
+            min_tokens=self.min_tokens,
             include_stop_str_in_output=self.include_stop_str_in_output,
         )
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -1099,5 +1099,17 @@ class BeamSearchParams(
     ignore_eos: bool = False
     temperature: float = 0.0
     length_penalty: float = 1.0
+    min_tokens: int = 0
     include_stop_str_in_output: bool = False
     structured_outputs: StructuredOutputsParams | None = None
+
+    def __post_init__(self) -> None:
+        if self.min_tokens < 0:
+            raise ValueError(
+                f"min_tokens must be greater than or equal to 0, got {self.min_tokens}."
+            )
+        if self.min_tokens > self.max_tokens:
+            raise ValueError(
+                f"min_tokens must be less than or equal to "
+                f"max_tokens={self.max_tokens}, got {self.min_tokens}."
+            )


### PR DESCRIPTION
## Purpose

Support `min_tokens` in beam search.

This PR adds `min_tokens` to `BeamSearchParams`, propagates the OpenAI request
field into beam-search params, and suppresses EOS beam finalization until the
current beam has generated at least `min_tokens` tokens.

Closes #47409

## Test Plan

Run the online beam-search unit tests, including coverage for EOS suppression before `min_tokens` and `BeamSearchParams` validation.

## Test Result

Commands run:

```bash
.venv/bin/python -m py_compile \
  vllm/entrypoints/generate/beam_search/offline.py \
  vllm/entrypoints/generate/beam_search/online.py \
  vllm/sampling_params.py
```

```bash
.venv/bin/python -m pytest tests/samplers/test_beam_search_online.py -v
```

```bash
.venv/bin/python -m py_compile \
  vllm/entrypoints/generate/beam_search/offline.py \
  vllm/entrypoints/generate/beam_search/online.py \
  vllm/sampling_params.py \
  tests/samplers/test_beam_search_online.py
```

```bash
.venv/bin/pre-commit run markdownlint-cli2 --files PR_DESCRIPTION.md
```

Result: passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

