### PR TITLE
[Core][Model Loader] Enable safetensors auto-prefetch on CephFS

### DIFF
--- a/vllm/config/load.py
+++ b/vllm/config/load.py
@@ -64,16 +64,17 @@ class LoadConfig:
     """
     Specifies the loading strategy for safetensors weights.
 
-    - None (default): Uses memory-mapped (lazy) loading. When an NFS
-      filesystem is detected and the total checkpoint size fits within 90%%
-      of available RAM, prefetching is enabled automatically.
+    - None (default): Uses memory-mapped (lazy) loading. When an NFS, Lustre,
+      or Ceph filesystem is detected and the total checkpoint size fits within
+      90%% of available RAM, prefetching is enabled automatically.
     - "lazy": Weights are memory-mapped from the file. This enables
       on-demand loading and is highly efficient for models on local storage.
-      Unlike the default (None), auto-prefetch on NFS is not performed.
+      Unlike the default (None), auto-prefetch on network filesystems is not
+      performed.
     - "eager": The entire file is read into CPU memory upfront before loading.
-      This is recommended for models on network filesystems (e.g., Lustre, NFS)
-      as it avoids inefficient random reads, significantly speeding up model
-      initialization. However, it uses more CPU RAM.
+      This is recommended for models on network filesystems (e.g., NFS, Lustre,
+      Ceph) as it avoids inefficient random reads, significantly speeding up
+      model initialization. However, it uses more CPU RAM.
     - "prefetch": Checkpoint files are read into the OS page cache before
       workers load them, speeding up the model loading phase. Useful on
       network or high-latency storage.

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -839,7 +839,7 @@ def safetensors_weights_iterator(
     sorted_files = sorted(hf_weights_files, key=_natural_sort_key)
 
     fs_type = _get_fs_type(sorted_files)
-    is_net_fs = fs_type in ("nfs", "nfs4", "lustre")
+    is_net_fs = fs_type in ("nfs", "nfs4", "lustre", "ceph")
     total_bytes = _get_checkpoints_size_bytes(sorted_files)
     avail_bytes = _get_available_ram_bytes()
     ram_threshold_pct = 90
@@ -871,14 +871,14 @@ def safetensors_weights_iterator(
         elif not is_net_fs and fits_in_ram:
             logger.info_once(
                 "Auto-prefetch is disabled because the filesystem (%s) is not a "
-                "recognized network FS (NFS/Lustre). If you want to force "
+                "recognized network FS (NFS/Lustre/Ceph). If you want to force "
                 "prefetching, start vLLM with --safetensors-load-strategy=prefetch.",
                 fs_name,
             )
         elif not is_net_fs and not fits_in_ram:
             logger.info_once(
                 "Auto-prefetch is disabled because the filesystem (%s) is not a "
-                "recognized network FS (NFS/Lustre) and the checkpoint size "
+                "recognized network FS (NFS/Lustre/Ceph) and the checkpoint size "
                 "(%.2f GiB) exceeds %d%% of available RAM (%.2f GiB).",
                 fs_name,
                 total_bytes / 1024**3,


### PR DESCRIPTION
## Purpose
A simple PR that enables safetensors auto-prefetch on CephFS.

CephFS is a network filesystem and has similar random-read latency concerns as NFS/Lustre when loading large safetensors checkpoints through mmap. This PR treats `ceph` as a recognized network filesystem for safetensors auto-prefetch when the checkpoint fits within the existing RAM threshold.

## Test Plan
Put the model file on a CephFS based location, then try to load the model.

## Test Result
around 6s/it before <img width="1512" height="490" alt="截圖 2026-07-02 15 30 19" src="https://github.com/user-attachments/assets/77436a0d-7aa5-42c9-9ac4-5acc78f94a11" /> 
`--safetensors-load-strategy=prefetch` did fix this, but adding auto-enabling helps.
The result after prefetching is less than 1s/it
<img width="924" height="795" alt="截圖 2026-07-02 15 35 42" src="https://github.com/user-attachments/assets/78f01efa-5d88-417c-94eb-f2e9bb04207a" />
