### PR TITLE
[KV Offload] Add tier_idx to SecondaryTierManager for per-tier metrics

### DIFF
--- a/tests/v1/kv_offload/tiering/test_factory.py
+++ b/tests/v1/kv_offload/tiering/test_factory.py
@@ -65,11 +65,12 @@ def test_create_tier_from_registry():
     tier_config = {"type": "example"}
 
     tier = SecondaryTierFactory.create_secondary_tier(
-        tier_config, primary_kv_view, offloading_spec
+        tier_config, primary_kv_view, offloading_spec, tier_idx=0
     )
 
     assert isinstance(tier, SecondaryTierManager)
     assert tier.tier_type == "example"
+    assert tier.tier_idx == 0
 
 
 def test_create_multiple_tiers():
@@ -82,14 +83,16 @@ def test_create_multiple_tiers():
 
     tiers = [
         SecondaryTierFactory.create_secondary_tier(
-            cfg.copy(), primary_kv_view, offloading_spec
+            cfg.copy(), primary_kv_view, offloading_spec, i
         )
-        for cfg in configs
+        for i, cfg in enumerate(configs)
     ]
 
     assert len(tiers) == 2
     assert all(tier.tier_type == "example" for tier in tiers)
     assert all(isinstance(tier, ExampleSecondaryTierManager) for tier in tiers)
+    assert tiers[0].tier_idx == 0
+    assert tiers[1].tier_idx == 1
 
 
 def test_register_new_tier_type():
@@ -110,10 +113,12 @@ def test_register_new_tier_type():
         {"type": "custom_tier", "custom_param": 99},
         primary_kv_view,
         offloading_spec,
+        tier_idx=0,
     )
 
     assert tier.tier_type == "custom_tier"
     assert isinstance(tier, ExampleSecondaryTierManager)
+    assert tier.tier_idx == 0
 
 
 # ---------------------------------------------------------------------------
@@ -128,7 +133,7 @@ def test_missing_tier_type_raises():
 
     with pytest.raises(ValueError, match="must include 'type'"):
         SecondaryTierFactory.create_secondary_tier(
-            tier_config, primary_kv_view, offloading_spec
+            tier_config, primary_kv_view, offloading_spec, tier_idx=0
         )
 
 
@@ -142,7 +147,7 @@ def test_unknown_tier_type_raises():
         match=r"Unknown secondary tier type.*Supported types:",
     ):
         SecondaryTierFactory.create_secondary_tier(
-            tier_config, primary_kv_view, offloading_spec
+            tier_config, primary_kv_view, offloading_spec, tier_idx=0
         )
 
 
@@ -150,3 +155,24 @@ def test_duplicate_registration_raises():
     """register_tier with existing type → ValueError."""
     with pytest.raises(ValueError, match="is already registered"):
         SecondaryTierFactory.register_tier("example", "some.module", "SomeClass")
+
+
+def test_tier_idx_assigned():
+    """tier_idx is correctly assigned for each secondary tier."""
+    primary_kv_view, offloading_spec = _make_mock_args()
+    configs = [
+        {"type": "example", "custom_param": 10},
+        {"type": "example", "custom_param": 20},
+        {"type": "example", "custom_param": 30},
+    ]
+
+    tiers = [
+        SecondaryTierFactory.create_secondary_tier(
+            cfg.copy(), primary_kv_view, offloading_spec, i
+        )
+        for i, cfg in enumerate(configs)
+    ]
+
+    assert len(tiers) == 3
+    for i, tier in enumerate(tiers):
+        assert tier.tier_idx == i, f"tier #{i} has wrong tier_idx: {tier.tier_idx}"

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -143,6 +143,7 @@ def test_tiering_manager_aggregates_secondary_stats():
         offloading_spec=_MOCK_OFFLOADING_SPEC,
         primary_kv_view=mock_region.create_kv_memoryview(),
         tier_type="test_metrics",
+        tier_idx=0,
     )
     secondary_stats = OffloadingConnectorStats()
     secondary_stats.increase_counter(
@@ -182,6 +183,7 @@ class TestExampleSecondaryTierManager:
             offloading_spec=_MOCK_OFFLOADING_SPEC,
             primary_kv_view=mock_view,
             tier_type="example",
+            tier_idx=0,
             custom_param=67,
         )
 
@@ -219,11 +221,13 @@ class TestTieringOffloadingManager:
             offloading_spec=_MOCK_OFFLOADING_SPEC,
             primary_kv_view=mock_view,
             tier_type="example",
+            tier_idx=0,
         )
         self.secondary_tier2 = ExampleSecondaryTierManager(
             offloading_spec=_MOCK_OFFLOADING_SPEC,
             primary_kv_view=mock_view,
             tier_type="example",
+            tier_idx=1,
         )
 
         # Create tiered manager

--- a/vllm/v1/kv_offload/tiering/base.py
+++ b/vllm/v1/kv_offload/tiering/base.py
@@ -68,6 +68,7 @@ class SecondaryTierManager(ABC):
         offloading_spec: "OffloadingSpec",
         primary_kv_view: memoryview,
         tier_type: str,
+        tier_idx: int,
     ) -> None:
         """
         Args:
@@ -75,10 +76,12 @@ class SecondaryTierManager(ABC):
             primary_kv_view: Memoryview of the primary tier's CPU KV cache.
             tier_type: Tier type identifier, set by SecondaryTierFactory
                 from the registered tier type.
+            tier_idx: Index of this secondary tier in the configuration list.
         """
         self._offloading_spec = offloading_spec
         self._primary_kv_view: memoryview = primary_kv_view
         self.tier_type = tier_type
+        self.tier_idx = tier_idx
 
     @abstractmethod
     def lookup(self, key: OffloadKey, req_context: ReqContext) -> LookupResult:

--- a/vllm/v1/kv_offload/tiering/example/manager.py
+++ b/vllm/v1/kv_offload/tiering/example/manager.py
@@ -47,18 +47,21 @@ class ExampleSecondaryTierManager(SecondaryTierManager):
         offloading_spec: "OffloadingSpec",
         primary_kv_view: memoryview,
         tier_type: str,
+        tier_idx: int,
         custom_param: int = 0,
     ):
         """
         Initialize the example secondary tier.
 
         Args:
+            tier_idx: Index of this secondary tier in the configuration list.
             custom_param: Dummy parameter demonstrating custom args.
         """
         super().__init__(
             offloading_spec=offloading_spec,
             primary_kv_view=primary_kv_view,
             tier_type=tier_type,
+            tier_idx=tier_idx,
         )
 
         logger.info(

--- a/vllm/v1/kv_offload/tiering/factory.py
+++ b/vllm/v1/kv_offload/tiering/factory.py
@@ -30,6 +30,7 @@ class SecondaryTierFactory:
         tier_config: dict,
         primary_kv_view: memoryview,
         offloading_spec: "OffloadingSpec",
+        tier_idx: int,
     ) -> SecondaryTierManager:
         tier_cls = cls.get_tier_class(tier_config)
         config = tier_config.copy()
@@ -38,6 +39,7 @@ class SecondaryTierFactory:
             offloading_spec=offloading_spec,
             primary_kv_view=primary_kv_view,
             tier_type=tier_type,
+            tier_idx=tier_idx,
             **config,
         )
 

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -97,6 +97,7 @@ class FileSystemTierManager(SecondaryTierManager):
         offloading_spec: "OffloadingSpec",
         primary_kv_view: memoryview,
         tier_type: str,
+        tier_idx: int,
         root_dir: str,
         n_read_threads: int = 16,
         n_write_threads: int = 16,
@@ -107,11 +108,12 @@ class FileSystemTierManager(SecondaryTierManager):
                 and block_size_factor.
             primary_kv_view: Memoryview of the primary tier's CPU KV cache.
             tier_type: Tier type identifier, set by SecondaryTierFactory.
+            tier_idx: Index of this secondary tier in the configuration list.
             root_dir: Root directory for block files.
             n_read_threads: Number of read-priority I/O threads.
             n_write_threads: Number of write-priority I/O threads.
         """
-        super().__init__(offloading_spec, primary_kv_view, tier_type)
+        super().__init__(offloading_spec, primary_kv_view, tier_type, tier_idx)
 
         # Extract block size from primary view
         assert primary_kv_view.strides is not None, (

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -95,11 +95,12 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         offloading_spec: "OffloadingSpec",
         primary_kv_view: memoryview,
         tier_type: str,
+        tier_idx: int,
         store_config: dict,
         prefix: str = "",
         io_threads: int = 4,
     ):
-        super().__init__(offloading_spec, primary_kv_view, tier_type)
+        super().__init__(offloading_spec, primary_kv_view, tier_type, tier_idx)
         agent_config = nixl_agent_config(backends=[])
         self._agent = nixl_agent("ObjAgent", agent_config)
         obj_config = ObjStoreConfig(**store_config)

--- a/vllm/v1/kv_offload/tiering/p2p/manager.py
+++ b/vllm/v1/kv_offload/tiering/p2p/manager.py
@@ -111,6 +111,7 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         offloading_spec: OffloadingSpec,
         primary_kv_view: memoryview,
         tier_type: str = "p2p",
+        tier_idx: int = 0,
         host: str = "0.0.0.0",
         port: int = 7777,
         backends: list[str] | None = None,
@@ -130,6 +131,7 @@ class P2PSecondaryTierManager(SecondaryTierManager):
             primary_kv_view: Memoryview over the CPU primary tier; the
                 NIXL agent registers this region for RDMA transfers.
             tier_type: Tier identifier (defaults to ``"p2p"``).
+            tier_idx: Index of this secondary tier in the configuration list.
             host: Address the ZMQ control socket binds to.
             port: Port for the ZMQ control socket. Must be reachable
                 from peers.
@@ -144,7 +146,7 @@ class P2PSecondaryTierManager(SecondaryTierManager):
                 entry.
             **kwargs: Reserved for future tier-specific options.
         """
-        super().__init__(offloading_spec, primary_kv_view, tier_type)
+        super().__init__(offloading_spec, primary_kv_view, tier_type, tier_idx)
         port = int(port)
         self._local_id = f"{host}:{port}"
 

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -146,7 +146,7 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
             for i, tier_config in enumerate(self.secondary_tier_configs):
                 try:
                     tier = SecondaryTierFactory.create_secondary_tier(
-                        tier_config, primary_kv_view, self
+                        tier_config, primary_kv_view, self, i
                     )
                     secondary_tiers.append(tier)
                     logger.info(


### PR DESCRIPTION
## Purpose

Add `tier_idx` to `SecondaryTierManager` so that secondary tiers can identify their position in the tier list. This is needed for per-tier metrics (e.g. `TIERING_BLOCK_QUERIES`, `TIERING_BLOCK_HITS`) to distinguish between multiple tiers in a multi-tier deployment.

## Changes

- Add `tier_idx: int` to `SecondaryTierManager.__init__` and save as `self.tier_idx`
- Update `SecondaryTierFactory.create_secondary_tier` to accept and pass `tier_idx`
- Update `TieringOffloadingSpec._create_manager` to pass the loop index `i`
- Update all tier manager implementations (example, fs, obj, p2p)
- Update tests to verify `tier_idx` is correctly assigned

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/kv_offload/tiering/test_factory.py tests/v1/kv_offload/tiering/test_tiering_offloading.py -v
```

## Test Result

34 passed.