### PR TITLE
[Bugfix][Spec Decode] Pad mixed running decode batches

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1356,6 +1356,55 @@ def test_spec_decode_padding_first_decode_step():
     assert out.scheduled_spec_decode_tokens[r2.request_id] == [-1] * num_spec
 
 
+def test_spec_decode_padding_running_decode_without_drafts():
+    """A running decode without drafts is padded when another running request
+    verifies speculative tokens in the same batch, preserving a uniform decode
+    shape for the worker.
+    """
+    num_spec = 3
+    scheduler = create_scheduler(num_speculative_tokens=num_spec)
+    r_normal, r_spec = create_requests(num_requests=2, num_tokens=1, max_tokens=16)
+
+    scheduler.add_request(r_normal)
+    scheduler.add_request(r_spec)
+    out = scheduler.schedule()
+    _model_output(scheduler, out, [[100], [101]])
+
+    scheduler.update_draft_token_ids(DraftTokenIds([r_spec.request_id], [[1, 2, 3]]))
+    out = scheduler.schedule()
+
+    assert out.num_scheduled_tokens[r_spec.request_id] == 1 + num_spec
+    assert out.scheduled_spec_decode_tokens[r_spec.request_id] == [1, 2, 3]
+    assert out.num_scheduled_tokens[r_normal.request_id] == 1 + num_spec
+    assert out.scheduled_spec_decode_tokens[r_normal.request_id] == [-1] * num_spec
+
+
+def test_spec_decode_padding_skips_running_decode_when_padding_exceeds_budget():
+    """A normal running decode is skipped rather than scheduled unpadded when
+    another running request uses spec decode and there is not enough remaining
+    token budget to keep the normal decode at the uniform spec-decode shape.
+    """
+    num_spec = 3
+    scheduler = create_scheduler(
+        max_num_batched_tokens=5,
+        num_speculative_tokens=num_spec,
+    )
+    r_spec, r_normal = create_requests(num_requests=2, num_tokens=1, max_tokens=16)
+
+    scheduler.add_request(r_spec)
+    scheduler.add_request(r_normal)
+    out = scheduler.schedule()
+    _model_output(scheduler, out, [[100], [101]])
+
+    scheduler.update_draft_token_ids(DraftTokenIds([r_spec.request_id], [[1, 2, 3]]))
+    out = scheduler.schedule()
+
+    assert out.num_scheduled_tokens[r_spec.request_id] == 1 + num_spec
+    assert out.scheduled_spec_decode_tokens[r_spec.request_id] == [1, 2, 3]
+    assert r_normal.request_id not in out.num_scheduled_tokens
+    assert r_normal.request_id not in out.scheduled_spec_decode_tokens
+
+
 def test_spec_decode_padding_skipped_with_prefill_in_batch():
     """Padding is skipped when the batch contains a prefill chunk: the batch is
     already mixed/non-uniform, so padding a new decode request buys nothing.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -435,9 +435,16 @@ class Scheduler(SchedulerInterface):
         ) and any(not r.is_prefill_chunk for r in self.running)
 
         # First, schedule the RUNNING requests.
+        running_has_spec_decode = (
+            self.num_spec_tokens > 0
+            and self.dynamic_sd_lookup is None
+            and any(r.spec_token_ids for r in self.running)
+        )
+        running_has_prefill_chunk = any(r.is_prefill_chunk for r in self.running)
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
+            pad_spec_decode = False
 
             if (
                 request.num_output_placeholders > 0
@@ -484,6 +491,25 @@ class Scheduler(SchedulerInterface):
                 - request.num_computed_tokens
                 - self.num_sampled_tokens_per_step,
             )
+            if (
+                running_has_spec_decode
+                and not running_has_prefill_chunk
+                and not request.spec_token_ids
+                and num_new_tokens == 1
+            ):
+                padded_num_new_tokens = 1 + self.num_spec_tokens
+                if (
+                    padded_num_new_tokens <= token_budget
+                    and request.num_computed_tokens
+                    + padded_num_new_tokens
+                    + self.num_sampled_tokens_per_step
+                    <= self.max_model_len
+                ):
+                    num_new_tokens = padded_num_new_tokens
+                    pad_spec_decode = True
+                else:
+                    req_index += 1
+                    continue
 
             # Schedule encoder inputs.
             encoder_inputs_to_schedule = None
@@ -604,6 +630,10 @@ class Scheduler(SchedulerInterface):
                 # New spec tokens will be set in `update_draft_token_ids` before the
                 # next step when applicable.
                 request.spec_token_ids = []
+            elif pad_spec_decode:
+                scheduled_spec_decode_tokens[request.request_id] = [
+                    -1
+                ] * self.num_spec_tokens
 
             # Encoder-related.
             if encoder_inputs_to_schedule:


### PR DESCRIPTION
## Purpose

Related to #36122.

When speculative decoding is enabled, one running request may verify draft tokens while another running request in the same scheduler step is still a normal 1-token decode. That can produce a mixed normal/spec decode batch shape and trigger backends that require uniform decode batches.

This PR pads normal running decodes with `-1` placeholder draft tokens when another running request in the same batch verifies speculative tokens. This keeps the batch shape at `1 + num_spec_tokens`. Existing worker-side handling clamps scheduler placeholders before embedding lookup, and speculative decode accounting rejects placeholder drafts, so the request only advances by the real sampled token.

Padding is skipped when a prefill chunk is present in the batch, since the batch is already mixed/non-uniform. If padding cannot fit the remaining token budget or model length, the normal running decode is skipped rather than scheduled unpadded.

## Duplicate check

I checked open PRs/issues for #36122, mixed normal/spec decode batches, `scheduled_spec_decode_tokens`, and placeholder padding.

This is related to #36918, but not the same fix: #36918 disables spec decode for a near-`max_model_len` mixed-batch case, while this PR preserves uniform shape by padding normal running decodes when another running request verifies speculative tokens. Other related PRs such as #46899, #46574, and #46947 handle stale or invalid placeholders in worker/async paths rather than this scheduler batching case.

## Testing

```bash
.venv/bin/python -m py_compile vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
git diff --check upstream/main...HEAD
timeout 120 .venv/bin/pytest \
  tests/v1/core/test_scheduler.py::test_spec_decode_padding_running_decode_without_drafts \
  tests/v1/core/test_scheduler.py::test_spec_decode_padding_first_decode_step \
  tests/v1/core/test_scheduler.py::test_spec_decode_padding_skipped_with_prefill_in_batch \
  -q --confcutdir=tests/v1/core
```

Results:
- `py_compile`: passed
- `git diff --check`: passed
- Targeted pytest: blocked locally by Hugging Face metadata access for `facebook/opt-125m`; without network it fails during `ModelConfig` validation, and with network permission it timed out after 120 seconds before reaching assertions.

## AI assistance

This PR was prepared with OpenAI Codex assistance. I reviewed the changed lines and test results.
