### PR TITLE
fix(v1): surface worker init failure root cause to the parent

### DIFF
--- a/tests/v1/executor/test_worker_init_failure.py
+++ b/tests/v1/executor/test_worker_init_failure.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression for #47415: a WorkerProc init failure used to raise a generic
+message and swallow the worker's root-cause traceback (only stderr had it)."""
+
+import multiprocessing
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.v1.executor.multiproc_executor import WorkerProc
+
+
+def test_wait_for_ready_surfaces_worker_root_cause():
+    reader, writer = multiprocessing.Pipe(duplex=False)
+    writer.send(
+        {
+            "status": WorkerProc.FAILED_STR,
+            "exception": "ValueError: To serve ... KV cache is needed",
+        }
+    )
+    handle = SimpleNamespace(ready_pipe=reader, rank=0)
+
+    with pytest.raises(Exception, match="KV cache is needed"):
+        WorkerProc.wait_for_ready([handle])
+
+
+def test_wait_for_ready_falls_back_when_no_exception_sent():
+    # Worker died hard (e.g. segfault/OOM-kill) before sending FAILED.
+    reader, writer = multiprocessing.Pipe(duplex=False)
+    writer.close()  # parent sees EOF
+    handle = SimpleNamespace(ready_pipe=reader, rank=0)
+
+    with pytest.raises(Exception, match="See stack trace for root cause"):
+        WorkerProc.wait_for_ready([handle])

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
 import multiprocessing
 import os
 import pickle
@@ -555,6 +556,7 @@ class WorkerProc:
     """Wrapper that runs one Worker in a separate process."""
 
     READY_STR = "READY"
+    FAILED_STR = "FAILED"
     rpc_broadcast_mq: MessageQueue | None
     worker_response_mq: MessageQueue | None
 
@@ -751,6 +753,12 @@ class WorkerProc:
                     unready_proc_handle = pipes.pop(pipe)
                     response: dict[str, Any] = pipe.recv()
                     if response["status"] != "READY":
+                        root_cause = response.get("exception")
+                        if root_cause is not None:
+                            raise Exception(
+                                "WorkerProc initialization failed. Root cause "
+                                f"from the worker process:\n{root_cause}"
+                            )
                         raise e
 
                     idx = unready_proc_handle.rank % len(ready_proc_handles)
@@ -896,6 +904,16 @@ class WorkerProc:
 
             if ready_writer is not None:
                 logger.exception("WorkerProc failed to start.")
+                # Send the root cause to the parent so wait_for_ready can
+                # surface it, instead of only logging it to this worker's
+                # stderr (see #47415).
+                with contextlib.suppress(Exception):
+                    ready_writer.send(
+                        {
+                            "status": WorkerProc.FAILED_STR,
+                            "exception": traceback.format_exc(),
+                        }
+                    )
             elif shutdown_requested.is_set():
                 logger.debug_once(
                     "[shutdown] WorkerProc: exiting after shutdown request"


### PR DESCRIPTION
Fixes #47415

On a WorkerProc init failure (KV-cache ValueError, OOM, arch mismatch, …) the worker only logged the real error to its own stderr. The parent then hit EOF on the ready pipe and raised a generic `WorkerProc initialization failed ... See stack trace for root cause`, so the actual exception never made it into what the caller sees.

Send the traceback over the ready pipe on failure and surface it in `wait_for_ready`. The EOF path stays as a fallback for hard deaths (segfault / OOM-kill) where the worker can't send anything. Test drives the pipe with a FAILED response + the EOF fallback.