### PR TITLE
[Bugfix][Hardware][XPU] Fix Gemma4 performance regression by allowing platform-native attention

### DIFF
--- a/tests/model_executor/test_gemma4_xpu_config.py
+++ b/tests/model_executor/test_gemma4_xpu_config.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from unittest.mock import MagicMock, patch
+
+from vllm.config import VllmConfig
+from vllm.model_executor.models.config import Gemma4Config
+
+
+def test_gemma4_config_xpu():
+    # 1. Create a mock configuration with heterogeneous head dimensions
+    vllm_config = MagicMock(spec=VllmConfig)
+    vllm_config.model_config.hf_text_config.head_dim = 256
+    vllm_config.model_config.hf_text_config.global_head_dim = 192
+    vllm_config.attention_config.backend = None
+    vllm_config.attention_config.flash_attn_version = None
+
+    # 2. Mock current_platform.is_xpu to return True
+    with patch("vllm.platforms.current_platform.is_xpu", return_value=True):
+        Gemma4Config.verify_and_update_config(vllm_config)
+
+    # 3. Assert that the attention backend remained untouched (None)
+    # so the platform's default attention backend is used instead of forcing TRITON_ATTN
+    assert vllm_config.attention_config.backend is None

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -201,6 +201,12 @@ class Gemma4Config(VerifyAndUpdateConfig):
         uniform kernel path and avoiding the mixed FA3+FA4 penalty.
         When FA4 is not available we fall back to Triton.
         """
+        # XPU platform natively supports heterogeneous head dimensions with
+        # its default FLASH_ATTN backend, so we do not force TRITON_ATTN.
+        from vllm.platforms import current_platform
+
+        if current_platform.is_xpu():
+            return
         hf_text_config = vllm_config.model_config.hf_text_config
         head_dim = getattr(hf_text_config, "head_dim", None)
         global_head_dim = getattr(hf_text_config, "global_head_dim", None)


### PR DESCRIPTION
Co-authored-by: Gemini
Signed-off-by: Vinay12345-neutron vinayrjumani@gmail.com




## Purpose
As identified and profiled by @Hoborific in #47347 , `Gemma4Config` currently forces the `TRITON_ATTN` backend when `is_fa_version_supported(4)` is false.  

On XPU platforms, standard CUDA/ROCm FA4 is not available, which results in an automatic fallback to Triton attention. However, as shown in the issue's benchmark, XPU's default `FLASH_ATTN` backend (which uses XPU FA2) is 3.77× faster than Triton for this model. 

This PR bypasses the CUDA-specific Triton fallback when running on XPU, allowing the model to use the default XPU attention backend, subject to review by the Intel/XPU maintainers.

Fixes #47347 

## Test Plan
We verify the configuration logic by running the newly added unit test:

`pytest tests/model_executor/test_gemma4_xpu_config.py`

## Test Result
The unit test successfully mocks the XPU platform and asserts that the attention backend is kept as None (allowing it to fall back to the platform default FLASH_ATTN), rather than being forced to TRITON_ATTN:
```
=============================== test session starts ===============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/k8s-admin/Vinay/vllm
configfile: pyproject.toml
plugins: forked-1.6.0, asyncio-1.4.0, anyio-4.14.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                  

tests/model_executor/test_gemma4_xpu_config.py .                            [100%]

================================ warnings summary =================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/model_executor/test_gemma4_xpu_config.py: 14 warnings
  /home/k8s-admin/Vinay/vllm/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================= 1 passed, 16 warnings in 0.28s ==========================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
(Note: The warnings observed are standard deprecation warnings from upstream PyTorch/Swig dependencies and are unrelated to the proposed configuration change.)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

