### PR TITLE
[ModelRunner V2] Fix Mamba2 crash on non-spec-decode

### DIFF
--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -246,7 +246,7 @@ class MambaHybridModelState(DefaultModelState):
         # compute them during actual (non-capture) forward execution.
         num_accepted_tokens = None
         num_decode_draft_tokens_cpu = None
-        if not for_capture:
+        if not for_capture and self.vllm_config.num_speculative_tokens > 0:
             num_accepted_tokens = self.num_accepted_tokens_gpu.new_ones(num_reqs)
             num_accepted_tokens[: input_batch.num_reqs] = self.num_accepted_tokens_gpu[
                 input_batch.idx_mapping


### PR DESCRIPTION
`MambaHybridModelState.build_metadata` populated num_accepted_tokens on every forward pass, so the Mamba2 attention builder passed a wrongly shaped tensor `(num_reqs, not num_decodes)` straight into `selective_state_update`, tripping `assert num_accepted_tokens.shape == (N,)`. This crashed hybrid Mamba2 + MoE models (e.g. `GraniteMoeHybrid`) now routed to V2.

Gate the population on speculative decoding being enabled, matching the V1 runner which only passes `num_accepted_tokens`/`num_decode_draft_tokens` to the Mamba2/GDN builder under use_spec_decode. num_speculative_tokens is the same signal the builders use for use_spec_decode; the conv/ssm kernels treat None as the neutral (offset 0) value, so this is a no-op versus V1 for non-spec-decode steps and also avoids a redundant per-step gather that GDN discards.

This also avoids doing some redundant work in non-spec-decode cases.

Verified on GPU: GraniteMoeHybrid runs to completion on V2 and produces output numerically identical to V1; Falcon-H1 (Mamba2, non-MoE) passes test_hybrid on both V1 and V2.

Bug found with help from Claude