### PR TITLE
Revert "[Bugfix][Kernel] Correct FlashInfer CUTLASS MoE tuning token bound" (#46838)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -93,6 +93,7 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         # - pass per-block weight scales to the kernel
         # - skip input activation quantization (kernel applies scaling)
         self.use_deepseek_fp8_block_scale = quant_config.is_block_quantized
+        self.max_capture_size = moe_config.max_capture_size
         self.gemm1_clamp_limit: torch.Tensor | None = None
         if quant_config.gemm1_clamp_limit is not None:
             self.gemm1_clamp_limit = torch.tensor(
@@ -397,6 +398,7 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             use_deepseek_fp8_block_scale=self.use_deepseek_fp8_block_scale,
             use_mxfp8_act_scaling=use_mxfp8_act_scaling,
             use_w4_group_scaling=use_w4_group_scaling,
+            tune_max_num_tokens=max(self.max_capture_size, 1),
         )
 
     def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:


### PR DESCRIPTION
## Revert of https://github.com/vllm-project/vllm/pull/46838

This reverts the merge commit 2665ed704b04219dd67a6bb82636cd51bbe98183.

### Reason

This PR is linked to **1 new CI failure** in nightly build [#75919](https://buildkite.com/vllm/ci/builds/75919):
- **MoE Refactor Integration Test (B200 DP - TEMPORARY)** — 4 Qwen3-30B FP8/FP4 MoE configs with FlashInfer CUTLASS/DeepEP backends failed with server startup timeout

The PR changed the FlashInfer CUTLASS MoE tuning token bound, which may have caused MoE DP server startup timeouts for FP8/FP4 configurations.

---
*Auto-generated by CI failure analyzer*