### PR TITLE
[BUGFIX] Fix opencua processor on transformers 5

### DIFF
--- a/vllm/model_executor/models/opencua.py
+++ b/vllm/model_executor/models/opencua.py
@@ -84,12 +84,16 @@ class OpenCUAProcessor(Qwen2VLProcessor):
 
     def __init__(
         self,
-        vision_config: dict,
-        tokenizer: TokenizerLike,
+        image_processor=None,
+        tokenizer: TokenizerLike = None,
+        video_processor=None,
+        vision_config: dict | None = None,
         **kwargs,
     ):
-        image_processor = Qwen2VLImageProcessor(**vision_config)
-        video_processor = Qwen2VLVideoProcessor(**vision_config)
+        if image_processor is None:
+            image_processor = Qwen2VLImageProcessor(**vision_config)
+        if video_processor is None:
+            video_processor = Qwen2VLVideoProcessor(**vision_config)
         chat_template = kwargs.pop("chat_template", None)
 
         super().__init__(


### PR DESCRIPTION



## Purpose
Fix opencua models with new transformers version
## Test Plan
vllm serve xlangai/OpenCUA-7B --dtype bfloat16 --tensor-parallel-size 1 --max-model-len 8192 --gpu-memory-utilization 0.85 -cc '{"inductor_compile_config":{"benchmark_combo_kernel":false}}' --port 8000 --trust-remote-code --limit-mm-per-prompt '{"image": 1}'

## Test Result
### Before:
(APIServer pid=9416) INFO 07-02 13:05:45 [api_utils.py:339] 
(APIServer pid=9416) INFO 07-02 13:05:45 [api_utils.py:339]        █     █     █▄   ▄█
(APIServer pid=9416) INFO 07-02 13:05:45 [api_utils.py:339]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.23.1rc1.dev717+g8cf528f27
(APIServer pid=9416) INFO 07-02 13:05:45 [api_utils.py:339]   █▄█▀ █     █     █     █  model   xlangai/OpenCUA-7B
(APIServer pid=9416) INFO 07-02 13:05:45 [api_utils.py:339]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=9416) INFO 07-02 13:05:45 [api_utils.py:339] 
(APIServer pid=9416) INFO 07-02 13:05:45 [api_utils.py:273] non-default args: {'model_tag': 'xlangai/OpenCUA-7B', 'model': 'xlangai/OpenCUA-7B', 'trust_remote_code': True, 'dtype': 'bfloat16', 'max_model_len': 8192, 'gpu_memory_utilization': 0.85, 'limit_mm_per_prompt': {'image': 1}, 'compilation_config': {'mode': None, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': [], 'ir_enable_torch_wrap': None, 'splitting_ops': None, 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': None, 'compile_ranges_endpoints': None, 'inductor_compile_config': {'benchmark_combo_kernel': False, 'enable_auto_functionalized_v2': False}, 'inductor_passes': {}, 'cudagraph_mode': None, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': None, 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': None, 'pass_config': {}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': None, 'static_all_moe_layers': []}}
(APIServer pid=9416) INFO 07-02 13:05:59 [model.py:606] Resolved architecture: OpenCUAForConditionalGeneration
(APIServer pid=9416) INFO 07-02 13:05:59 [model.py:1736] Using max model len 8192
(APIServer pid=9416) INFO 07-02 13:05:59 [vllm.py:1040] Asynchronous scheduling is enabled.
(APIServer pid=9416) INFO 07-02 13:05:59 [kernel.py:286] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(APIServer pid=9416) WARNING 07-02 13:05:59 [xpu.py:274] XPU Graph is disabled by environment variable, please set VLLM_XPU_ENABLE_XPU_GRAPH=1 to enable it.
(APIServer pid=9416) INFO 07-02 13:05:59 [xpu.py:323] XPU platform: set server shutdown_timeout=5.
(APIServer pid=9416) Could not extract SentencePiece model from /root/.cache/huggingface/hub/models--xlangai--OpenCUA-7B/snapshots/a2efb7d2b104d477a4a2666a357e79550a28aafc/tiktoken.model using sentencepiece library due to Error parsing message with type 'sentencepiece.ModelProto'. Falling back to TikToken extractor.
(APIServer pid=9416) Traceback (most recent call last):
(APIServer pid=9416)   File "/opt/venv/bin/vllm", line 10, in <module>
(APIServer pid=9416)     sys.exit(main())
(APIServer pid=9416)              ^^^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/entrypoints/cli/main.py", line 95, in main
(APIServer pid=9416)     args.dispatch_function(args)
(APIServer pid=9416)   File "/root/vllm/vllm/entrypoints/cli/serve.py", line 148, in cmd
(APIServer pid=9416)     uvloop.run(run_server(args))
(APIServer pid=9416)   File "/opt/venv/lib/python3.12/site-packages/uvloop/__init__.py", line 96, in run
(APIServer pid=9416)     return __asyncio.run(
(APIServer pid=9416)            ^^^^^^^^^^^^^^
(APIServer pid=9416)   File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
(APIServer pid=9416)     return runner.run(main)
(APIServer pid=9416)            ^^^^^^^^^^^^^^^^
(APIServer pid=9416)   File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
(APIServer pid=9416)     return self._loop.run_until_complete(task)
(APIServer pid=9416)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=9416)   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
(APIServer pid=9416)   File "/opt/venv/lib/python3.12/site-packages/uvloop/__init__.py", line 48, in wrapper
(APIServer pid=9416)     return await main
(APIServer pid=9416)            ^^^^^^^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/entrypoints/openai/api_server.py", line 692, in run_server
(APIServer pid=9416)     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
(APIServer pid=9416)   File "/root/vllm/vllm/entrypoints/openai/api_server.py", line 706, in run_server_worker
(APIServer pid=9416)     async with build_async_engine_client(
(APIServer pid=9416)   File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
(APIServer pid=9416)     return await anext(self.gen)
(APIServer pid=9416)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/entrypoints/openai/api_server.py", line 100, in build_async_engine_client
(APIServer pid=9416)     async with build_async_engine_client_from_engine_args(
(APIServer pid=9416)   File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
(APIServer pid=9416)     return await anext(self.gen)
(APIServer pid=9416)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/entrypoints/openai/api_server.py", line 136, in build_async_engine_client_from_engine_args
(APIServer pid=9416)     async_llm = AsyncLLM.from_vllm_config(
(APIServer pid=9416)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/v1/engine/async_llm.py", line 217, in from_vllm_config
(APIServer pid=9416)     return cls(
(APIServer pid=9416)            ^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/v1/engine/async_llm.py", line 135, in __init__
(APIServer pid=9416)     self.input_processor = InputProcessor(self.vllm_config, renderer)
(APIServer pid=9416)                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/v1/engine/input_processor.py", line 62, in __init__
(APIServer pid=9416)     mm_budget = MultiModalBudget(vllm_config, mm_registry)
(APIServer pid=9416)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/multimodal/encoder_budget.py", line 87, in __init__
(APIServer pid=9416)     all_mm_max_toks_per_item = get_mm_max_toks_per_item(
(APIServer pid=9416)                                ^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/multimodal/encoder_budget.py", line 25, in get_mm_max_toks_per_item
(APIServer pid=9416)     max_tokens_per_item = processor.info.get_mm_max_tokens_per_item(
(APIServer pid=9416)                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/model_executor/models/qwen2_vl.py", line 859, in get_mm_max_tokens_per_item
(APIServer pid=9416)     max_image_tokens = self.get_max_image_tokens()
(APIServer pid=9416)                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/model_executor/models/qwen2_vl.py", line 1002, in get_max_image_tokens
(APIServer pid=9416)     image_processor = self.get_image_processor()
(APIServer pid=9416)                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=9416)   File "/root/vllm/vllm/model_executor/models/qwen2_vl.py", line 843, in get_image_processor
(APIServer pid=9416)     return self.get_hf_processor(**kwargs).image_processor
(APIServer pid=9416)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=9416) AttributeError: 'OpenCUAProcessor' object has no attribute 'image_processor'

### After:
(APIServer pid=3910) INFO 07-02 12:33:58 [api_utils.py:339]
(APIServer pid=3910) INFO 07-02 12:33:58 [api_utils.py:339]        █     █     █▄   ▄█
(APIServer pid=3910) INFO 07-02 12:33:58 [api_utils.py:339]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.23.1rc1.dev717+g8cf528f27
(APIServer pid=3910) INFO 07-02 12:33:58 [api_utils.py:339]   █▄█▀ █     █     █     █  model   xlangai/OpenCUA-7B
(APIServer pid=3910) INFO 07-02 12:33:58 [api_utils.py:339]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=3910) INFO 07-02 12:33:58 [api_utils.py:339]
(APIServer pid=3910) INFO 07-02 12:33:58 [api_utils.py:273] non-default args: {'model_tag': 'xlangai/OpenCUA-7B', 'model': 'xlangai/OpenCUA-7B', 'trust_remote_code': True, 'dtype': 'bfloat16', 'max_model_len': 8192, 'gpu_memory_utilization': 0.85, 'limit_mm_per_prompt': {'image': 1}, 'compilation_config': {'mode': None, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': [], 'ir_enable_torch_wrap': None, 'splitting_ops': None, 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': None, 'compile_ranges_endpoints': None, 'inductor_compile_config': {'benchmark_combo_kernel': False, 'enable_auto_functionalized_v2': False}, 'inductor_passes': {}, 'cudagraph_mode': None, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': None, 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': None, 'pass_config': {}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': None, 'static_all_moe_layers': []}}
(APIServer pid=3910) INFO 07-02 12:34:11 [model.py:606] Resolved architecture: OpenCUAForConditionalGeneration
(APIServer pid=3910) INFO 07-02 12:34:11 [model.py:1736] Using max model len 8192
(APIServer pid=3910) INFO 07-02 12:34:12 [vllm.py:1040] Asynchronous scheduling is enabled.
(APIServer pid=3910) INFO 07-02 12:34:12 [kernel.py:286] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(APIServer pid=3910) WARNING 07-02 12:34:12 [xpu.py:274] XPU Graph is disabled by environment variable, please set VLLM_XPU_ENABLE_XPU_GRAPH=1 to enable it.
(APIServer pid=3910) INFO 07-02 12:34:12 [xpu.py:323] XPU platform: set server shutdown_timeout=5.
(APIServer pid=3910) Could not extract SentencePiece model from /root/.cache/huggingface/hub/models--xlangai--OpenCUA-7B/snapshots/a2efb7d2b104d477a4a2666a357e79550a28aafc/tiktoken.model using sentencepiece library due to Error parsing message with type 'sentencepiece.ModelProto'. Falling back to TikToken extractor.
(EngineCore pid=4470) INFO 07-02 12:34:27 [core.py:114] Initializing a V1 LLM engine (v0.23.1rc1.dev717+g8cf528f27) with config: model='xlangai/OpenCUA-7B', speculative_config=None, tokenizer='xlangai/OpenCUA-7B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=8192, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=True, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=xpu, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False, jit_monitor_mode='warn', jit_monitor_verbose=False), seed=0, served_model_name=xlangai/OpenCUA-7B, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::qwen_gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::hpc_rope_norm_forward', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [2048], 'inductor_compile_config': {'benchmark_combo_kernel': False, 'enable_auto_functionalized_v2': False}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, enable_cutedsl_warmup=True, moe_backend='auto', linear_backend='auto')
(EngineCore pid=4470) Could not extract SentencePiece model from /root/.cache/huggingface/hub/models--xlangai--OpenCUA-7B/snapshots/a2efb7d2b104d477a4a2666a357e79550a28aafc/tiktoken.model using sentencepiece library due to Error parsing message with type 'sentencepiece.ModelProto'. Falling back to TikToken extractor.
(EngineCore pid=4470) INFO 07-02 12:34:45 [parallel_state.py:1588] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://10.54.109.211:44989 backend=xccl
(EngineCore pid=4470) INFO 07-02 12:34:45 [parallel_state.py:1923] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
2026:07:02-12:34:45: 4470 |CCL_WARN| value of CCL_ATL_TRANSPORT changed to be ofi (default:mpi)
2026:07:02-12:34:45: 4470 |CCL_WARN| could not get local_idx/count from environment variables, trying to get them from ATL
(EngineCore pid=4470) INFO 07-02 12:34:47 [xpu_worker.py:108] Using V2 Model Runner
(EngineCore pid=4470) INFO 07-02 12:34:48 [model_runner.py:281] Loading model from scratch...
(EngineCore pid=4470) INFO 07-02 12:34:49 [xpu.py:200] Using backend AttentionBackendEnum.FLASH_ATTN for vit attention
(EngineCore pid=4470) INFO 07-02 12:34:49 [mm_encoder_attention.py:373] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
(EngineCore pid=4470) INFO 07-02 12:34:49 [vllm.py:1040] Asynchronous scheduling is enabled.
(EngineCore pid=4470) INFO 07-02 12:34:49 [kernel.py:286] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(EngineCore pid=4470) WARNING 07-02 12:34:49 [xpu.py:274] XPU Graph is disabled by environment variable, please set VLLM_XPU_ENABLE_XPU_GRAPH=1 to enable it.
(EngineCore pid=4470) INFO 07-02 12:34:49 [xpu.py:130] Setting VLLM_KV_CACHE_LAYOUT to 'NHD' for XPU; only NHD layout is supported by XPU attention kernels.
(EngineCore pid=4470) INFO 07-02 12:34:49 [xpu.py:158] Using Flash Attention backend.
(EngineCore pid=4470) INFO 07-02 12:34:49 [flash_attn.py:718] Using FlashAttention version 2
(EngineCore pid=4470) INFO 07-02 12:36:58 [weight_utils.py:530] Time spent downloading weights for xlangai/OpenCUA-7B: 127.582933 seconds
(EngineCore pid=4470) INFO 07-02 12:36:58 [weight_utils.py:849] Filesystem type for checkpoints: EXT4. Checkpoint size: 15.45 GiB. Available RAM: 396.91 GiB.
(EngineCore pid=4470) INFO 07-02 12:36:58 [weight_utils.py:872] Auto-prefetch is disabled because the filesystem (EXT4) is not a recognized network FS (NFS/Lustre). If you want to force prefetching, start vLLM with --safetensors-load-strategy=prefetch.
(EngineCore pid=4470)
Loading safetensors checkpoint shards:   0% Completed | 0/28 [00:00<?, ?it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:   4% Completed | 1/28 [00:01<00:34,  1.28s/it]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:   7% Completed | 2/28 [00:01<00:16,  1.62it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  14% Completed | 4/28 [00:01<00:06,  3.72it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  21% Completed | 6/28 [00:01<00:03,  5.83it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  29% Completed | 8/28 [00:01<00:02,  7.19it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  36% Completed | 10/28 [00:01<00:02,  8.87it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  43% Completed | 12/28 [00:02<00:01, 10.46it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  50% Completed | 14/28 [00:02<00:01, 11.81it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  57% Completed | 16/28 [00:02<00:00, 12.79it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  64% Completed | 18/28 [00:02<00:00, 13.64it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  71% Completed | 20/28 [00:02<00:00, 14.14it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  79% Completed | 22/28 [00:02<00:00, 14.65it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  86% Completed | 24/28 [00:02<00:00, 14.91it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards:  93% Completed | 26/28 [00:03<00:00, 15.21it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards: 100% Completed | 28/28 [00:04<00:00,  5.08it/s]
(EngineCore pid=4470)
Loading safetensors checkpoint shards: 100% Completed | 28/28 [00:04<00:00,  6.98it/s]
(EngineCore pid=4470)
(EngineCore pid=4470) INFO 07-02 12:37:02 [default_loader.py:430] Loading weights took 4.09 seconds
(EngineCore pid=4470) INFO 07-02 12:37:03 [model_runner.py:302] Model loading took 15.54 GiB and 135.171348 seconds
(EngineCore pid=4470) INFO 07-02 12:37:03 [interface.py:620] Setting kv cache block size to 64 for FLASH_ATTN backend.
(EngineCore pid=4470) INFO 07-02 12:37:03 [utils.py:90] `_KV_CACHE_LAYOUT_OVERRIDE` variable detected. Setting KV cache layout to NHD.
(EngineCore pid=4470) INFO 07-02 12:37:10 [backends.py:1089] Using cache directory: /root/.cache/vllm/torch_compile_cache/e367637815/rank_0_0/backbone for vLLM's torch.compile
(EngineCore pid=4470) INFO 07-02 12:37:10 [backends.py:1148] Dynamo bytecode transform time: 4.78 s
(EngineCore pid=4470) INFO 07-02 12:37:23 [backends.py:393] Compiling a graph for compile range (1, 2048) takes 13.67 s
(EngineCore pid=4470) INFO 07-02 12:37:25 [backends.py:915] collected artifacts: 29 entries, 4 artifacts, 5397970 bytes total
(EngineCore pid=4470) INFO 07-02 12:37:25 [decorators.py:708] saved AOT compiled function to /root/.cache/vllm/torch_compile_cache/torch_aot_compile/2952d52e2cc02db6582946479bcf8a1d1d99cfde3e770d8aa528900978832659/rank_0_0/model
(EngineCore pid=4470) INFO 07-02 12:37:25 [monitor.py:53] torch.compile took 20.63 s in total
(EngineCore pid=4470) INFO 07-02 12:37:28 [monitor.py:81] Initial profiling/warmup run took 2.88 s
(EngineCore pid=4470) INFO 07-02 12:37:42 [gpu_worker.py:538] Available KV cache memory: 3.12 GiB
(EngineCore pid=4470) INFO 07-02 12:37:42 [kv_cache_utils.py:2146] GPU KV cache size: 58,432 tokens
(EngineCore pid=4470) INFO 07-02 12:37:42 [kv_cache_utils.py:2147] Maximum concurrency for 8,192 tokens per request: 7.13x
(EngineCore pid=4470) INFO 07-02 12:37:42 [gpu_worker.py:752] Compile and warming up model for size 2048
(EngineCore pid=4470) INFO 07-02 12:37:43 [cutedsl_warmup.py:92] Skipping CuTeDSL warmup on non-CUDA platform.
(EngineCore pid=4470) WARNING 07-02 12:37:43 [model_runner.py:687] Skipping CUDA graph capture. To turn on CUDA graph capture, ensure `cudagraph_mode` was not manually set to `NONE`
(EngineCore pid=4470) INFO 07-02 12:39:11 [jit_monitor.py:72] Kernel JIT monitor activated; monitored JIT compilations during inference will use mode=warn.
(EngineCore pid=4470) INFO 07-02 12:39:12 [core.py:337] init engine (profile, create kv cache, warmup model) took 129.36 s (compilation: 20.63 s)
(EngineCore pid=4470) INFO 07-02 12:39:12 [kernel.py:286] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(APIServer pid=3910) INFO 07-02 12:39:12 [api_server.py:606] Supported tasks: ['generate']
(APIServer pid=3910) `OpenCUAProcessor` defines `image_processor_class = 'AutoImageProcessor'`, which is deprecated. Register the correct mapping in `AutoImageProcessor` instead.
(APIServer pid=3910) Could not extract SentencePiece model from /root/.cache/huggingface/hub/models--xlangai--OpenCUA-7B/snapshots/a2efb7d2b104d477a4a2666a357e79550a28aafc/tiktoken.model using sentencepiece library due to Error parsing message with type 'sentencepiece.ModelProto'. Falling back to TikToken extractor.
(APIServer pid=3910) `OpenCUAProcessor` defines `video_processor_class = 'AutoVideoProcessor'`, which is deprecated. Register the correct mapping in `AutoVideoProcessor` instead.
(APIServer pid=3910) INFO 07-02 12:39:19 [hf.py:548] Detected the chat template content format to be 'openai'. You can set `--chat-template-content-format` to override this.
(APIServer pid=3910) INFO 07-02 12:39:20 [base.py:236] Multi-modal warmup completed in 0.831s
(APIServer pid=3910) INFO 07-02 12:39:20 [base.py:236] Readonly multi-modal warmup completed in 0.652s
(APIServer pid=3910) INFO 07-02 12:39:21 [api_server.py:610] Starting vLLM server on http://0.0.0.0:8000
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:37] Available routes are:
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/chat/completions/batch, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /generative_scoring, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/chat/completions/derender, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /v1/completions/derender, Methods: POST
(APIServer pid=3910) INFO 07-02 12:39:21 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=3910) INFO:     Started server process [3910]
(APIServer pid=3910) INFO:     Waiting for application startup.
(APIServer pid=3910) INFO:     Application startup complete.
(APIServer pid=3910) INFO:     127.0.0.1:46378 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=3910) INFO 07-02 12:42:31 [loggers.py:273] Engine 000: Avg prompt throughput: 2.3 tokens/s, Avg generation throughput: 4.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, MM cache hit rate: 0.0%
(APIServer pid=3910) INFO 07-02 12:42:41 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, MM cache hit rate: 0.0%

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

