### PR TITLE
[Bugfix][CPU] Ship examples/ in the CPU release image

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -301,6 +301,12 @@ LABEL ai.vllm.build.cpu-x86="${VLLM_CPU_X86:-false}"
 LABEL ai.vllm.build.cpu-arm-bf16="${VLLM_CPU_ARM_BF16:-false}"
 LABEL ai.vllm.build.python-version="${PYTHON_VERSION:-3.12}"
 
+# Copy the examples directory (including the chat/tool templates) so it is
+# present in the released image, as the CUDA image ships it too. The vllm-test
+# stage above adds examples/ for testing only, so without this the published
+# vllm-openai-cpu image would not ship examples/*.jinja.
+COPY examples examples
+
 ENTRYPOINT ["vllm", "serve"]
 
 


### PR DESCRIPTION
## Purpose

Fixes #47401. The `vllm/vllm-openai-cpu` image is missing `examples/` (e.g. `examples/tool_chat_template_gemma4.jinja`), so `--chat-template examples/*.jinja` and the documented example paths don't work out of the box on CPU.

The `vllm-openai` release stage in `docker/Dockerfile.cpu` is `FROM base`, and never copies `examples/`. The `ADD ./examples/ ./examples/` that already exists in the file is in the `vllm-test` stage, which is only used to run the test suite — it doesn't reach the released image. So this isn't a stale-tag issue; a nightly/next build wouldn't include `examples/` either. The CUDA image, by contrast, ships `examples/`.

This copies `examples/` into the CPU `vllm-openai` stage (inherited by `vllm-openai-zen`), restoring parity with the CUDA image.

## Test Plan

Build the CPU release image and check the examples are present:

```bash
docker build -f docker/Dockerfile.cpu --target vllm-openai -t vllm-cpu-test .
docker run --rm --entrypoint ls vllm-cpu-test examples/tool_chat_template_gemma4.jinja
```

## Test Result

Before: `examples/` absent from the `vllm-openai` / `vllm-openai-zen` CPU images. After: `examples/` (including the `*.jinja` templates) is present, matching the CUDA image.
