### PR TITLE
[Bugfix] DeepSeekV32: warn instead of ERROR-tracing when a streamed tool call closes with non-JSON model arguments

### DIFF
--- a/tests/tool_parsers/test_deepseekv32_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv32_tool_parser.py
@@ -7,6 +7,7 @@ These tests use a minimal mock tokenizer so no real model weights are required.
 """
 
 import json
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -590,6 +591,71 @@ class TestExtractToolCallsStreaming:
                     if tc.index == tool_index and tc.function and tc.function.arguments:
                         fragments.append(tc.function.arguments)
         return "".join(fragments)
+
+    def test_malformed_args_close_warns_with_payload_and_still_streams(
+        self, parser, caplog
+    ):
+        # A model can emit non-JSON inside an array/object-typed parameter —
+        # observed in production: shell syntax appended after a JSON array in
+        # `run_git` arguments. Such parameters stream RAW (their value is
+        # already on the wire before close, so no coercion is possible), so
+        # closing the call hits json.loads on an invalid accumulated string.
+        # The close must not raise, the raw arguments must still reach the
+        # client (which validates them, per the OpenAI contract), and the
+        # failure must be logged at WARNING with the offending payload rather
+        # than an ERROR traceback (it is model misbehavior, not a server bug).
+        tool = ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(
+                name="run_git",
+                parameters={
+                    "type": "object",
+                    "properties": {"args": {"type": "array"}},
+                },
+            ),
+        )
+        parser = make_parser(tools=[tool])
+        request = make_request([tool])
+        # The value must span several deltas to take the raw-streaming path.
+        chunks = [
+            f"{FC_START}\n",
+            f'{INV_START}run_git">\n',
+            f'{PARAM_START}args" string="false">',
+            '["show", ',
+            '"a.rs"] 2>/dev/null; ',
+            'echo "x"',
+            f"{PARAM_END}\n",
+            f"{INV_END}\n{FC_END}",
+        ]
+        deltas = []
+        prev = ""
+        with caplog.at_level(logging.WARNING):
+            for chunk in chunks:
+                curr = prev + chunk
+                result = parser.extract_tool_calls_streaming(
+                    previous_text=prev,
+                    current_text=curr,
+                    delta_text=chunk,
+                    previous_token_ids=[],
+                    current_token_ids=[],
+                    delta_token_ids=[1],
+                    request=request,
+                )
+                prev = curr
+                if result is not None:
+                    deltas.append(result)
+        args_str = self._reconstruct_args(deltas)
+        assert "2>/dev/null" in args_str, "raw arguments still stream to the client"
+        # The finalize fallback keeps the `{}` initialized at call start.
+        assert parser.prev_tool_call_arr[0]["arguments"] == {}
+        assert [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "non-JSON" in r.getMessage()
+        ], "the malformed close is logged at WARNING with the payload"
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR], (
+            "no ERROR traceback for model-generated malformed arguments"
+        )
 
     def test_plain_content_no_tool(self, parser):
         full_text = "Hello, world!"

--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -382,7 +382,24 @@ class DeepSeekV32ToolParser(ToolParser):
                 "name": self._active_tool_name,
                 "arguments": json.loads(self.streamed_args_for_tool[index]),
             }
-        except (json.JSONDecodeError, IndexError):
+        except json.JSONDecodeError:
+            # Model-generated arguments are not guaranteed to be valid JSON
+            # (e.g. shell syntax written inside a typed parameter). The raw
+            # arguments have already been streamed to the client, which per the
+            # OpenAI contract must validate them — so this is expected model
+            # misbehavior, not a server error: log it at WARNING with the
+            # offending payload (an ERROR traceback here carries no payload and
+            # reads as a server fault), and keep the `{}` arguments initialized
+            # when the call started.
+            logger.warning(
+                "DeepSeek DSML streaming tool call %r closed with non-JSON "
+                "arguments: %.500r",
+                self._active_tool_name,
+                self.streamed_args_for_tool[index],
+            )
+        except IndexError:
+            # No bookkeeping slot for the active tool index — a parser-state
+            # bug (not model output), so keep the traceback.
             logger.exception("Failed to finalize DeepSeek DSML streaming tool call")
 
         self._active_tool_index = None


### PR DESCRIPTION
## Purpose

When a DeepSeek-V3.2/V4 model streams a tool call whose argument value is
array- or object-typed, that value is streamed **raw** (it is on the wire
before the closing `</｜DSML｜parameter>` tag, so no close-time coercion is
possible). If the model writes something that is not valid JSON inside such a
parameter, `_close_streaming_tool_call` calls `json.loads()` on the invalid
accumulated string and today logs it with `logger.exception(...)` — an
**ERROR-level traceback with no payload**.

This is expected model misbehavior, not a server fault: the OpenAI streaming
contract already allows `tool_calls[].function.arguments` to be incomplete or
invalid JSON, and clients are responsible for validating it. Logging it as an
ERROR traceback (a) reads as a vLLM bug to operators and (b) provides nothing
actionable — it omits both the tool name and the offending arguments.

Observed in production against `DeepSeek-V4-Flash-DSpark`: an agent tool wrote
shell syntax after a JSON array inside a `run_git` argument
(`{"args":["show", "a.rs"] 2>/dev/null; echo "x"}`), producing a stream of
`ERROR ... Failed to finalize DeepSeek DSML streaming tool call /
JSONDecodeError: Expecting ',' delimiter` lines with no way to see what the
model actually sent.

## Changes

Split the finalize handler in `DeepSeekV32ToolParser._close_streaming_tool_call`:

- `json.JSONDecodeError` (invalid model-generated arguments) → `logger.warning`
  that names the tool and includes the offending payload (capped to 500 chars),
  keeping the `{}` arguments that were initialized when the call started. The
  raw arguments have already streamed to the client for validation, so behavior
  is unchanged; only the log level and message are.
- `IndexError` (a parser-state bookkeeping bug, not model output) keeps the
  existing `logger.exception` traceback.

No behavioral change to what is streamed to clients.

## Test

Adds `test_malformed_args_close_warns_with_payload_and_still_streams` to
`tests/tool_parsers/test_deepseekv32_tool_parser.py`, reproducing the exact
production shape: a multi-delta array-typed parameter carrying non-JSON. It
asserts the raw arguments still reach the client, the close does not raise, the
`{}` fallback is kept, and the failure is logged at WARNING (with the payload)
rather than ERROR. The test fails on `main` (no WARNING is emitted) and passes
with this change.

```
$ pytest tests/tool_parsers/test_deepseekv32_tool_parser.py -q
50 passed
```

## AI assistance disclosure

This change was prepared with AI assistance (Claude). The offending payload and
failure signature came from a real production incident; the human submitter
reviewed every changed line, reproduced the parser state locally, and confirmed
the test is red on `main` and green with the fix. See the `Co-authored-by:`
trailer on the commit.
