### PR TITLE
Update algos.py for speculators style causal dflash config

### DIFF
--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -120,6 +120,9 @@ def update_dflash(config_dict: dict, pre_trained_config: dict) -> None:
         "mask_token_id": config_dict["mask_token_id"],
         "target_layer_ids": [i - 1 for i in aux_layer_ids],
     }
+    pre_trained_config["dflash_config"]["causal"] = not config_dict.get(
+        "sliding_window_non_causal", True
+    )
 
 
 @register_speculator("dspark")


### PR DESCRIPTION
## Purpose

Wire up the `causal` field in `dflash_config` when loading speculators-format DFlash models.

Currently, `update_dflash()` builds the `dflash_config` dict with only `mask_token_id` and `target_layer_ids`, but does not set the `causal` field. Downstream, `DFlashProposer.__init__` reads `dflash_config.get("causal", False)` (in `vllm/v1/spec_decode/dflash.py:73`), so all speculators-format DFlash models default to non-causal attention regardless of how they were trained.

The speculators library exposes a `sliding_window_non_causal` config field (default `False`) that controls whether sliding-window attention layers use causal or bidirectional masking within draft blocks. This PR maps that field into `dflash_config["causal"]` so that models trained with causal sliding-window attention run correctly in vLLM:

```python
pre_trained_config["dflash_config"]["causal"] = not config_dict.get(
    "sliding_window_non_causal", True
)
```

The mapping logic:
| `sliding_window_non_causal` | `causal` | Attention behavior |
|---|---|---|
| `True` | `False` | Non-causal (bidirectional) |
| `False` | `True` | Causal |
| absent | `False` (default) | Non-causal — preserves backward compat |

The default of `True` when the field is absent maintains backward compatibility: existing published DFlash models (e.g., `RedHatAI/Qwen3-8B-speculator.dflash`, `RedHatAI/gemma-4-31B-it-speculator.dflash`) do not include `sliding_window_non_causal` in their configs and currently run as non-causal, which is the correct behavior for those checkpoints.

Relates to the causal DFlash infrastructure added in #43445.

## Test Plan

- Load an existing speculators DFlash model (e.g., `RedHatAI/Qwen3-8B-speculator.dflash`) and verify `dflash_config["causal"]` is `False` (backward compat — config lacks `sliding_window_non_causal`).
- Load/construct a speculators DFlash config with `sliding_window_non_causal: false` and verify `dflash_config["causal"]` is `True`.
- Load/construct a speculators DFlash config with `sliding_window_non_causal: true` and verify `dflash_config["causal"]` is `False`.
- Run inference with a DFlash model and confirm speculative decoding still works end-to-end:
  ```bash
  python -m vllm.entrypoints.openai.api_server \
      --model Qwen/Qwen3-8B \
      --speculative-model RedHatAI/Qwen3-8B-speculator.dflash \
      --speculative-config '{"method": "dflash"}' \
      --max-model-len 4096
  ```

## Test Result

*(To be filled by the PR author after running the test plan.)*

---

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
