### PR TITLE
[macOS][CPU][Installation] Fix the broken installation of vllm 0.24.0 in macos + cpu

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -25,7 +25,7 @@ nvidia-cutlass-dsl[cu13]==4.5.2
 quack-kernels>=0.3.3
 
 # Tokenspeed_MLA for faster mla with spec decode
-tokenspeed-mla==0.1.2
+tokenspeed-mla==0.1.2; platform_system == "Linux"
 
 # Humming kernels for quantization gemm
 humming-kernels[cu13]==0.1.6


### PR DESCRIPTION

## Problem

vllm-metal installation is broken, because it cannot compile the vllm dependency on mac before this PR. 

`tokenspeed-mla==0.1.2` in `requirements/cuda.txt` has no platform marker, but the package itself only publishes `manylinux` wheels (no sdist). Since `setup.py`'s `get_requirements()` copies this file's lines verbatim into vLLM's published `install_requires`, the unconditional requirement ships in every release regardless of installer platform. Result: `pip install vllm==0.24.0` fails to resolve on macOS entirely, before any build-time device detection even runs.

<details>
<summary>Repro logs (macOS/arm64/M5 Pro)</summary>

```
$ uv pip install vllm==0.24.0
Using Python 3.12.13 environment at: repro-before
  × No solution found when resolving dependencies:
  ╰─▶ Because tokenspeed-mla==0.1.2 has no wheels with a matching
      platform tag (e.g., `macosx_26_0_arm64`) and vllm==0.24.0 depends on
      tokenspeed-mla==0.1.2, we can conclude that vllm==0.24.0 cannot be used.
      And because you require vllm==0.24.0, we can conclude that your
      requirements are unsatisfiable.

hint: Wheels are available for `tokenspeed-mla` (v0.1.2) on the following
platforms: `manylinux_2_28_aarch64`, `manylinux_2_28_x86_64`

$ uv pip install tokenspeed-mla==0.1.2   # isolated, no vllm involved
Using Python 3.12.13 environment at: repro-before
  × No solution found when resolving dependencies:
  ╰─▶ Because tokenspeed-mla==0.1.2 has no wheels with a matching platform tag
      (e.g., `macosx_26_0_arm64`) and you require tokenspeed-mla==0.1.2, we
      can conclude that your requirements are unsatisfiable.

hint: Wheels are available for `tokenspeed-mla` (v0.1.2) on the following
platforms: `manylinux_2_28_aarch64`, `manylinux_2_28_x86_64`
```

</details>

## Fix

`tokenspeed-mla==0.1.2` → `tokenspeed-mla==0.1.2; platform_system == "Linux"`

## Why a Linux marker is correct here, even proposed from macOS

Platform markers are evaluated by the installer against the machine running `pip install`, not against whatever machine built the wheel — that's the whole mechanism that makes this fix work at all. `tokenspeed-mla` only ships Linux wheels, so gating on `platform_system == "Linux"` is exactly true where the package can install and exactly false everywhere the current unconditional requirement breaks today.

<details>
<summary>Verification logs</summary>

```
$ python3 -c "from packaging.requirements import Requirement; \
    req = Requirement('tokenspeed-mla==0.1.2; platform_system == \"Linux\"'); \
    print('marker:', req.marker); \
    print('evaluates on THIS machine (Darwin):', req.marker.evaluate()); \
    print('evaluates if platform_system=Linux :', req.marker.evaluate({'platform_system': 'Linux'}))"
marker: platform_system == "Linux"
evaluates on THIS machine (Darwin): False
evaluates if platform_system=Linux : True

$ uv pip install 'tokenspeed-mla==0.1.2; platform_system == "Linux"'   # same package, marker added
Using Python 3.12.13 environment at: repro-after
Checked 1 package in 0.37ms
```

</details>

Also confirmed `setup.py`'s own `_read_requirements()` parsing preserves the marker unmodified when reading `requirements/cuda.txt`.

## Test Plan & Test Result

Added repro log, before and after. 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

