### PR TITLE
[Bugfix] Fix Gemma4 audio crash with variable-length batched inputs

### DIFF
--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -10,6 +10,7 @@ from PIL import Image as PILImage
 from vllm.model_executor.models.gemma4_mm import (
     Gemma4ForConditionalGeneration,
     Gemma4ImagePixelInputs,
+    _pad_and_stack,
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import MultiModalFieldConfig
@@ -50,6 +51,43 @@ def test_gemma4_image_batching_keeps_variable_patch_counts_unstacked():
         torch.Size([10080, 768]),
         torch.Size([2520, 768]),
     ]
+
+
+def test_gemma4_audio_batching_keeps_variable_lengths_unstacked():
+    field = MultiModalFieldConfig.batched("audio").field
+    elems = field.build_elems(
+        "audio",
+        "input_features_padded",
+        [torch.randn(3, 80), torch.randn(5, 80)],
+    )
+
+    reduced = field.reduce_data(list(elems))
+
+    # Clips of differing frame counts can't be stacked, so batched() hands the
+    # model a plain list -- the input that used to crash _process_audio_input
+    # via `list.squeeze(1)`.
+    assert isinstance(reduced, list)
+    assert [tensor.shape for tensor in reduced] == [
+        torch.Size([3, 80]),
+        torch.Size([5, 80]),
+    ]
+
+
+def test_gemma4_pad_and_stack_pads_variable_length_audio_to_batch_max():
+    features = [torch.randn(3, 80), torch.randn(5, 80)]
+    masks = [
+        torch.ones(3, dtype=torch.bool),
+        torch.ones(5, dtype=torch.bool),
+    ]
+
+    padded_features = _pad_and_stack(features)
+    padded_masks = _pad_and_stack(masks)
+
+    assert padded_features.shape == (2, 5, 80)
+    assert torch.equal(padded_features[0, :3], features[0])  # real frames kept
+    assert torch.all(padded_features[0, 3:] == 0)  # short clip zero-padded
+    assert padded_masks.shape == (2, 5)
+    assert padded_masks[0].tolist() == [True, True, True, False, False]  # pad=False
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -965,6 +965,16 @@ class Gemma4MultimodalEmbedder(nn.Module):
 # ---------------------------------------------------------------------------
 
 
+def _pad_and_stack(tensors: list[torch.Tensor]) -> torch.Tensor:
+    """Right-pad a list of variable-length tensors along dim 0 and stack them.
+
+    ``MultiModalFieldConfig.batched()`` returns a plain list instead of a
+    stacked tensor when batched audio items differ in length. Pad them back to
+    the batch max so the audio tower receives one ``(N, s_max, ...)`` tensor.
+    """
+    return nn.utils.rnn.pad_sequence(tensors, batch_first=True)
+
+
 @MULTIMODAL_REGISTRY.register_processor(
     Gemma4MultiModalProcessor,
     info=Gemma4ProcessingInfo,
@@ -1467,8 +1477,17 @@ class Gemma4ForConditionalGeneration(
         self,
         audio_input: Gemma4AudioInputs,
     ) -> list[torch.Tensor]:
-        input_features = audio_input["input_features_padded"].squeeze(1)
-        input_features_mask = audio_input["input_features_mask"].squeeze(1)
+        input_features = audio_input["input_features_padded"]
+        input_features_mask = audio_input["input_features_mask"]
+        # Variable-length audios in one batch arrive as a list (batched() can't
+        # stack differing shapes); pad to the batch max. Otherwise squeeze the
+        # already-stacked tensor as before.
+        if isinstance(input_features, list):
+            input_features = _pad_and_stack(input_features)
+            input_features_mask = _pad_and_stack(input_features_mask)
+        else:
+            input_features = input_features.squeeze(1)
+            input_features_mask = input_features_mask.squeeze(1)
 
         # Run audio tower — mask convention: True=valid, False=padding.
         audio_outputs = self.audio_tower(input_features, input_features_mask)


### PR DESCRIPTION
## Purpose

When two audio requests with different lengths are batched into one step, `MultiModalFieldConfig.batched()` returns a list of per-clip tensors instead of a stacked tensor (it only stacks items of equal shape). `_process_audio_input` assumed a stacked tensor and called `.squeeze(1)` on the list, raising `AttributeError` and taking down the engine.

Pad the variable-length features and masks to the batch max before the audio tower, which already takes a padded batch plus a validity mask and strips the padding afterward. The single/equal-length tensor path is unchanged.

The same `batched()` list case comes up in other audio models (ultravox, granite_speech, voxtral each pad and stack it separately), so this is a broader pattern; a shared helper or padded field variant would avoid handling it per model, but that's out of scope here.

## Test

Two CPU tests in `tests/models/multimodal/processing/test_gemma4.py`, mirroring the existing image batching test: one checks `batched("audio")` returns a list for variable-length clips, the other checks the padding and mask.
